### PR TITLE
[8.x] Include between hours in Cron expressions

### DIFF
--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -31,20 +31,20 @@ trait ManagesFrequencies
         // Cron often supports hourly ranges so include `between` hours, even
         // if their minutes cannot not be expressed.
         $oldHours = explode(' ', $this->expression)[1] ?? null;
-        if ($oldHours[0] === '*') {
-            // Preserve existing 'every' like "*/5".
-            $oldHoursEvery = ($slash = strpos($oldHours, '/'))
-                ? substr($oldHours, $slash)
-                : '';
-            $startHour = Carbon::parse($startTime, $this->timezone)->hour;
-            $endHour = Carbon::parse($endTime, $this->timezone)->hour;
-            // Don't bother unless range is more than the same hour.
-            if ($endHour > $startHour) {
-                $this->spliceIntoPosition(
-                    2,
-                    "$startHour-$endHour$oldHoursEvery"
-                );
-            }
+        // Preserve existing 'every' like "*/5" but not earlier range "1-2".
+        $oldHoursEvery = ($slash = strpos($oldHours, '/'))
+            ? substr($oldHours, $slash)
+            : '';
+        $startHour = Carbon::parse($startTime, $this->timezone)->hour;
+        $endHour = Carbon::parse($endTime, $this->timezone)->hour;
+        // Don't bother unless range is more than the same hour.
+        if ($endHour > $startHour) {
+            $this->spliceIntoPosition(
+                2,
+                "$startHour-$endHour$oldHoursEvery"
+            );
+        } else {
+            $this->spliceIntoPosition(2, "*$oldHoursEvery");
         }
 
         return $this->when($this->inTimeInterval($startTime, $endTime));

--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -61,6 +61,14 @@ class FrequencyTest extends TestCase
         $this->assertSame('0 */6 * * *', $this->event->everySixHours()->getExpression());
     }
 
+    public function testBetweenHours()
+    {
+        $this->assertSame('* 1-13 * * *', $this->event->between('1am', '1pm')->getExpression());
+        $this->assertSame('*/10 2-12 * * *', $this->event->everyTenMinutes()->between('02:00', '12:00')->getExpression());
+        $this->assertSame('0 3-13/2 * * *', (clone $this->event)->everyTwoHours()->between('03:00', '13:00')->getExpression());
+        $this->assertSame('0 4-14/3 * * *', (clone $this->event)->everyThreeHours()->between('00:00', '01:00')->between('04:00', '14:00')->getExpression());
+    }
+
     public function testMonthlyOn()
     {
         $this->assertSame('0 15 4 * *', $this->event->monthlyOn(4, '15:00')->getExpression());


### PR DESCRIPTION
Include hours of 'between' range in the Cron expressions--where practical--to aid packages and services such as [spatie/laravel-schedule-monitor](https://github.com/spatie/laravel-schedule-monitor).

For example this makes it possible to call `->hourlyAt(30)->between('5am', '10pm')` and get an expression like `30 5-20 * * *`.

This should be a low risk change since the current behavior of a call like `->between('5am', '10pm')` already produces a less consistent Cron expression such as `* * * * *` instead of `* 5-20 * * *`.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
