### PR TITLE
[8.x] Fixing docblock.

### DIFF
--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -36,6 +36,7 @@ class FoundationServiceProvider extends AggregateServiceProvider
      * Register the service provider.
      *
      * @return void
+     * @throws \Illuminate\Validation\ValidationException
      */
     public function register()
     {


### PR DESCRIPTION
"ValidationException" must be handled for the validation macro
