### PR TITLE
[8.x] Use `getRealPath` to ensure console command class names are generated correctly

### DIFF
--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -223,7 +223,7 @@ class Kernel implements KernelContract
             $command = $namespace.str_replace(
                 ['/', '.php'],
                 ['\\', ''],
-                Str::after($command->getPathname(), realpath(app_path()).DIRECTORY_SEPARATOR)
+                Str::after($command->getRealPath(), realpath(app_path()).DIRECTORY_SEPARATOR)
             );
 
             if (is_subclass_of($command, Command::class) &&


### PR DESCRIPTION
```php
protected function commands()
{
    $this->load(__DIR__.'/../Commands');

    require base_path('routes/console.php');
}
```

When trying to register a new path in the `Kernel` class of your application to load console commands, and the path contains `..`, the classname isn't generated correctly in https://github.com/laravel/framework/blob/8.x/src/Illuminate/Foundation/Console/Kernel.php#L223-L227

By using `getRealPath`, the real path is resolved and the classname can be generated correctly.