### PR TITLE
Make tests compatible with phpunit 10 and add some minor refactors

### DIFF
--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -672,7 +672,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertSame('Not allowed to view as it is not published.', $response->message());
         $this->assertFalse($response->allowed());
         $this->assertTrue($response->denied());
-        $this->assertEquals($response->code(), 'unpublished');
+        $this->assertEquals('unpublished', $response->code());
     }
 
     public function testAuthorizeReturnsAnAllowedResponseForATruthyReturn()

--- a/tests/Auth/AuthEloquentUserProviderTest.php
+++ b/tests/Auth/AuthEloquentUserProviderTest.php
@@ -125,7 +125,7 @@ class AuthEloquentUserProviderTest extends TestCase
     {
         $hasher = m::mock(Hasher::class);
 
-        return $this->getMockBuilder(EloquentUserProvider::class)->setMethods(['createModel'])->setConstructorArgs([$hasher, 'foo'])->getMock();
+        return $this->getMockBuilder(EloquentUserProvider::class)->onlyMethods(['createModel'])->setConstructorArgs([$hasher, 'foo'])->getMock();
     }
 }
 

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -13,7 +13,6 @@ use Illuminate\Auth\Events\Validated;
 use Illuminate\Auth\SessionGuard;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\UserProvider;
-use Illuminate\Contracts\Encryption\Encrypter;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Session\Session;
 use Illuminate\Cookie\CookieJar;
@@ -105,7 +104,7 @@ class AuthGuardTest extends TestCase
     public function testAttemptReturnsUserInterface()
     {
         [$session, $provider, $request, $cookie] = $this->getMocks();
-        $guard = $this->getMockBuilder(SessionGuard::class)->setMethods(['login'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
+        $guard = $this->getMockBuilder(SessionGuard::class)->onlyMethods(['login'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
         $guard->setDispatcher($events = m::mock(Dispatcher::class));
         $events->shouldReceive('dispatch')->once()->with(m::type(Attempting::class));
         $events->shouldReceive('dispatch')->once()->with(m::type(Validated::class));
@@ -130,7 +129,7 @@ class AuthGuardTest extends TestCase
     public function testLoginStoresIdentifierInSession()
     {
         [$session, $provider, $request, $cookie] = $this->getMocks();
-        $mock = $this->getMockBuilder(SessionGuard::class)->setMethods(['getName'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
+        $mock = $this->getMockBuilder(SessionGuard::class)->onlyMethods(['getName'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
         $user = m::mock(Authenticatable::class);
         $mock->expects($this->once())->method('getName')->willReturn('foo');
         $user->shouldReceive('getAuthIdentifier')->once()->andReturn('bar');
@@ -155,7 +154,7 @@ class AuthGuardTest extends TestCase
     public function testLoginFiresLoginAndAuthenticatedEvents()
     {
         [$session, $provider, $request, $cookie] = $this->getMocks();
-        $mock = $this->getMockBuilder(SessionGuard::class)->setMethods(['getName'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
+        $mock = $this->getMockBuilder(SessionGuard::class)->onlyMethods(['getName'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
         $mock->setDispatcher($events = m::mock(Dispatcher::class));
         $user = m::mock(Authenticatable::class);
         $events->shouldReceive('dispatch')->once()->with(m::type(Login::class));
@@ -234,7 +233,7 @@ class AuthGuardTest extends TestCase
     public function testIsAuthedReturnsFalseWhenUserIsNull()
     {
         [$session, $provider, $request, $cookie] = $this->getMocks();
-        $mock = $this->getMockBuilder(SessionGuard::class)->setMethods(['user'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
+        $mock = $this->getMockBuilder(SessionGuard::class)->onlyMethods(['user'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
         $mock->expects($this->exactly(2))->method('user')->willReturn(null);
         $this->assertFalse($mock->check());
         $this->assertTrue($mock->guest());
@@ -268,7 +267,7 @@ class AuthGuardTest extends TestCase
     public function testLogoutRemovesSessionTokenAndRememberMeCookie()
     {
         [$session, $provider, $request, $cookie] = $this->getMocks();
-        $mock = $this->getMockBuilder(SessionGuard::class)->setMethods(['getName', 'getRecallerName', 'recaller'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
+        $mock = $this->getMockBuilder(SessionGuard::class)->onlyMethods(['getName', 'getRecallerName', 'recaller'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
         $mock->setCookieJar($cookies = m::mock(CookieJar::class));
         $user = m::mock(Authenticatable::class);
         $user->shouldReceive('getRememberToken')->once()->andReturn('a');
@@ -290,7 +289,7 @@ class AuthGuardTest extends TestCase
     public function testLogoutDoesNotEnqueueRememberMeCookieForDeletionIfCookieDoesntExist()
     {
         [$session, $provider, $request, $cookie] = $this->getMocks();
-        $mock = $this->getMockBuilder(SessionGuard::class)->setMethods(['getName', 'recaller'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
+        $mock = $this->getMockBuilder(SessionGuard::class)->onlyMethods(['getName', 'recaller'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
         $mock->setCookieJar($cookies = m::mock(CookieJar::class));
         $user = m::mock(Authenticatable::class);
         $user->shouldReceive('getRememberToken')->andReturn(null);
@@ -306,7 +305,7 @@ class AuthGuardTest extends TestCase
     public function testLogoutFiresLogoutEvent()
     {
         [$session, $provider, $request, $cookie] = $this->getMocks();
-        $mock = $this->getMockBuilder(SessionGuard::class)->setMethods(['clearUserDataFromStorage'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
+        $mock = $this->getMockBuilder(SessionGuard::class)->onlyMethods(['clearUserDataFromStorage'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
         $mock->expects($this->once())->method('clearUserDataFromStorage');
         $mock->setDispatcher($events = m::mock(Dispatcher::class));
         $user = m::mock(Authenticatable::class);
@@ -320,7 +319,7 @@ class AuthGuardTest extends TestCase
     public function testLogoutDoesNotSetRememberTokenIfNotPreviouslySet()
     {
         [$session, $provider, $request] = $this->getMocks();
-        $mock = $this->getMockBuilder(SessionGuard::class)->setMethods(['clearUserDataFromStorage'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
+        $mock = $this->getMockBuilder(SessionGuard::class)->onlyMethods(['clearUserDataFromStorage'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
         $user = m::mock(Authenticatable::class);
 
         $user->shouldReceive('getRememberToken')->andReturn(null);
@@ -334,7 +333,7 @@ class AuthGuardTest extends TestCase
     public function testLogoutCurrentDeviceRemovesRememberMeCookie()
     {
         [$session, $provider, $request, $cookie] = $this->getMocks();
-        $mock = $this->getMockBuilder(SessionGuard::class)->setMethods(['getName', 'getRecallerName', 'recaller'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
+        $mock = $this->getMockBuilder(SessionGuard::class)->onlyMethods(['getName', 'getRecallerName', 'recaller'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
         $mock->setCookieJar($cookies = m::mock(CookieJar::class));
         $user = m::mock(Authenticatable::class);
         $mock->expects($this->once())->method('getName')->willReturn('foo');
@@ -353,7 +352,7 @@ class AuthGuardTest extends TestCase
     public function testLogoutCurrentDeviceDoesNotEnqueueRememberMeCookieForDeletionIfCookieDoesntExist()
     {
         [$session, $provider, $request, $cookie] = $this->getMocks();
-        $mock = $this->getMockBuilder(SessionGuard::class)->setMethods(['getName', 'recaller'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
+        $mock = $this->getMockBuilder(SessionGuard::class)->onlyMethods(['getName', 'recaller'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
         $mock->setCookieJar($cookies = m::mock(CookieJar::class));
         $user = m::mock(Authenticatable::class);
         $user->shouldReceive('getRememberToken')->andReturn(null);
@@ -369,7 +368,7 @@ class AuthGuardTest extends TestCase
     public function testLogoutCurrentDeviceFiresLogoutEvent()
     {
         [$session, $provider, $request, $cookie] = $this->getMocks();
-        $mock = $this->getMockBuilder(SessionGuard::class)->setMethods(['clearUserDataFromStorage'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
+        $mock = $this->getMockBuilder(SessionGuard::class)->onlyMethods(['clearUserDataFromStorage'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
         $mock->expects($this->once())->method('clearUserDataFromStorage');
         $mock->setDispatcher($events = m::mock(Dispatcher::class));
         $user = m::mock(Authenticatable::class);
@@ -521,6 +520,6 @@ class AuthGuardTest extends TestCase
 
     protected function getCookieJar()
     {
-        return new CookieJar(Request::create('/foo', 'GET'), m::mock(Encrypter::class), ['domain' => 'foo.com', 'path' => '/', 'secure' => false, 'httpOnly' => false]);
+        return new CookieJar();
     }
 }

--- a/tests/Auth/AuthPasswordBrokerTest.php
+++ b/tests/Auth/AuthPasswordBrokerTest.php
@@ -23,7 +23,11 @@ class AuthPasswordBrokerTest extends TestCase
     public function testIfUserIsNotFoundErrorRedirectIsReturned()
     {
         $mocks = $this->getMocks();
-        $broker = $this->getMockBuilder(PasswordBroker::class)->setMethods(['getUser', 'makeErrorRedirect'])->setConstructorArgs(array_values($mocks))->getMock();
+        $broker = $this->getMockBuilder(PasswordBroker::class)
+            ->onlyMethods(['getUser'])
+            ->addMethods(['makeErrorRedirect'])
+            ->setConstructorArgs(array_values($mocks))
+            ->getMock();
         $broker->expects($this->once())->method('getUser')->willReturn(null);
 
         $this->assertSame(PasswordBrokerContract::INVALID_USER, $broker->sendResetLink(['credentials']));
@@ -32,7 +36,7 @@ class AuthPasswordBrokerTest extends TestCase
     public function testIfTokenIsRecentlyCreated()
     {
         $mocks = $this->getMocks();
-        $broker = $this->getMockBuilder(PasswordBroker::class)->setMethods(['emailResetLink', 'getUri'])->setConstructorArgs(array_values($mocks))->getMock();
+        $broker = $this->getMockBuilder(PasswordBroker::class)->addMethods(['emailResetLink', 'getUri'])->setConstructorArgs(array_values($mocks))->getMock();
         $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(['foo'])->andReturn($user = m::mock(CanResetPassword::class));
         $mocks['tokens']->shouldReceive('recentlyCreatedToken')->once()->with($user)->andReturn(true);
         $user->shouldReceive('sendPasswordResetNotification')->with('token');
@@ -62,7 +66,7 @@ class AuthPasswordBrokerTest extends TestCase
     public function testBrokerCreatesTokenAndRedirectsWithoutError()
     {
         $mocks = $this->getMocks();
-        $broker = $this->getMockBuilder(PasswordBroker::class)->setMethods(['emailResetLink', 'getUri'])->setConstructorArgs(array_values($mocks))->getMock();
+        $broker = $this->getMockBuilder(PasswordBroker::class)->addMethods(['emailResetLink', 'getUri'])->setConstructorArgs(array_values($mocks))->getMock();
         $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(['foo'])->andReturn($user = m::mock(CanResetPassword::class));
         $mocks['tokens']->shouldReceive('recentlyCreatedToken')->once()->with($user)->andReturn(false);
         $mocks['tokens']->shouldReceive('create')->once()->with($user)->andReturn('token');
@@ -96,7 +100,11 @@ class AuthPasswordBrokerTest extends TestCase
     public function testResetRemovesRecordOnReminderTableAndCallsCallback()
     {
         unset($_SERVER['__password.reset.test']);
-        $broker = $this->getMockBuilder(PasswordBroker::class)->setMethods(['validateReset', 'getPassword', 'getToken'])->setConstructorArgs(array_values($mocks = $this->getMocks()))->getMock();
+        $broker = $this->getMockBuilder(PasswordBroker::class)
+            ->onlyMethods(['validateReset'])
+            ->addMethods(['getPassword', 'getToken'])
+            ->setConstructorArgs(array_values($mocks = $this->getMocks()))
+            ->getMock();
         $broker->expects($this->once())->method('validateReset')->willReturn($user = m::mock(CanResetPassword::class));
         $mocks['tokens']->shouldReceive('delete')->once()->with($user);
         $callback = function ($user, $password) {
@@ -118,7 +126,7 @@ class AuthPasswordBrokerTest extends TestCase
         };
 
         $mocks = $this->getMocks();
-        $broker = $this->getMockBuilder(PasswordBroker::class)->setMethods(['emailResetLink', 'getUri'])->setConstructorArgs(array_values($mocks))->getMock();
+        $broker = $this->getMockBuilder(PasswordBroker::class)->addMethods(['emailResetLink', 'getUri'])->setConstructorArgs(array_values($mocks))->getMock();
         $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(['foo'])->andReturn($user = m::mock(CanResetPassword::class));
         $mocks['tokens']->shouldReceive('recentlyCreatedToken')->once()->with($user)->andReturn(false);
         $mocks['tokens']->shouldReceive('create')->once()->with($user)->andReturn('token');
@@ -131,16 +139,14 @@ class AuthPasswordBrokerTest extends TestCase
 
     protected function getBroker($mocks)
     {
-        return new PasswordBroker($mocks['tokens'], $mocks['users'], $mocks['mailer'], $mocks['view']);
+        return new PasswordBroker($mocks['tokens'], $mocks['users']);
     }
 
     protected function getMocks()
     {
         return [
             'tokens' => m::mock(TokenRepositoryInterface::class),
-            'users'  => m::mock(UserProvider::class),
-            'mailer' => m::mock(Mailer::class),
-            'view'   => 'resetLinkView',
+            'users'  => m::mock(UserProvider::class)
         ];
     }
 }

--- a/tests/Auth/AuthPasswordBrokerTest.php
+++ b/tests/Auth/AuthPasswordBrokerTest.php
@@ -7,7 +7,6 @@ use Illuminate\Auth\Passwords\TokenRepositoryInterface;
 use Illuminate\Contracts\Auth\CanResetPassword;
 use Illuminate\Contracts\Auth\PasswordBroker as PasswordBrokerContract;
 use Illuminate\Contracts\Auth\UserProvider;
-use Illuminate\Contracts\Mail\Mailer;
 use Illuminate\Support\Arr;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;

--- a/tests/Auth/AuthPasswordBrokerTest.php
+++ b/tests/Auth/AuthPasswordBrokerTest.php
@@ -146,7 +146,7 @@ class AuthPasswordBrokerTest extends TestCase
     {
         return [
             'tokens' => m::mock(TokenRepositoryInterface::class),
-            'users'  => m::mock(UserProvider::class)
+            'users'  => m::mock(UserProvider::class),
         ];
     }
 }

--- a/tests/Auth/AuthenticateMiddlewareTest.php
+++ b/tests/Auth/AuthenticateMiddlewareTest.php
@@ -58,7 +58,7 @@ class AuthenticateMiddlewareTest extends TestCase
             return;
         }
 
-        return $this->fail();
+        $this->fail();
     }
 
     public function testDefaultAuthenticatedKeepsDefaultDriver()
@@ -109,7 +109,7 @@ class AuthenticateMiddlewareTest extends TestCase
             return;
         }
 
-        return $this->fail();
+        $this->fail();
     }
 
     public function testMultipleDriversAuthenticatedUpdatesDefault()

--- a/tests/Auth/AuthorizeMiddlewareTest.php
+++ b/tests/Auth/AuthorizeMiddlewareTest.php
@@ -87,7 +87,7 @@ class AuthorizeMiddlewareTest extends TestCase
 
         $response = $this->router->dispatch(Request::create('dashboard', 'GET'));
 
-        $this->assertEquals($response->content(), 'success');
+        $this->assertEquals('success', $response->content());
     }
 
     public function testSimpleAbilityWithStringParameter()
@@ -105,7 +105,7 @@ class AuthorizeMiddlewareTest extends TestCase
 
         $response = $this->router->dispatch(Request::create('dashboard', 'GET'));
 
-        $this->assertEquals($response->content(), 'success');
+        $this->assertEquals('success', $response->content());
     }
 
     public function testSimpleAbilityWithNullParameter()
@@ -154,10 +154,10 @@ class AuthorizeMiddlewareTest extends TestCase
         ]);
 
         $response = $this->router->dispatch(Request::create('posts/1/comments', 'GET'));
-        $this->assertEquals($response->content(), 'success');
+        $this->assertEquals('success', $response->content());
 
         $response = $this->router->dispatch(Request::create('comments', 'GET'));
-        $this->assertEquals($response->content(), 'success');
+        $this->assertEquals('success', $response->content());
     }
 
     public function testSimpleAbilityWithStringParameterFromRouteParameter()
@@ -175,7 +175,7 @@ class AuthorizeMiddlewareTest extends TestCase
 
         $response = $this->router->dispatch(Request::create('dashboard/true', 'GET'));
 
-        $this->assertEquals($response->content(), 'success');
+        $this->assertEquals('success', $response->content());
     }
 
     public function testModelTypeUnauthorized()
@@ -184,7 +184,7 @@ class AuthorizeMiddlewareTest extends TestCase
         $this->expectExceptionMessage('This action is unauthorized.');
 
         $this->gate()->define('create', function ($user, $model) {
-            $this->assertEquals($model, 'App\User');
+            $this->assertEquals('App\User', $model);
 
             return false;
         });
@@ -202,7 +202,7 @@ class AuthorizeMiddlewareTest extends TestCase
     public function testModelTypeAuthorized()
     {
         $this->gate()->define('create', function ($user, $model) {
-            $this->assertEquals($model, 'App\User');
+            $this->assertEquals('App\User', $model);
 
             return true;
         });
@@ -216,7 +216,7 @@ class AuthorizeMiddlewareTest extends TestCase
 
         $response = $this->router->dispatch(Request::create('users/create', 'GET'));
 
-        $this->assertEquals($response->content(), 'success');
+        $this->assertEquals('success', $response->content());
     }
 
     public function testModelUnauthorized()
@@ -269,7 +269,7 @@ class AuthorizeMiddlewareTest extends TestCase
 
         $response = $this->router->dispatch(Request::create('posts/1/edit', 'GET'));
 
-        $this->assertEquals($response->content(), 'success');
+        $this->assertEquals('success', $response->content());
     }
 
     public function testModelInstanceAsParameter()

--- a/tests/Cache/CacheApcStoreTest.php
+++ b/tests/Cache/CacheApcStoreTest.php
@@ -10,7 +10,7 @@ class CacheApcStoreTest extends TestCase
 {
     public function testGetReturnsNullWhenNotFound()
     {
-        $apc = $this->getMockBuilder(ApcWrapper::class)->setMethods(['get'])->getMock();
+        $apc = $this->getMockBuilder(ApcWrapper::class)->onlyMethods(['get'])->getMock();
         $apc->expects($this->once())->method('get')->with($this->equalTo('foobar'))->willReturn(null);
         $store = new ApcStore($apc, 'foo');
         $this->assertNull($store->get('bar'));
@@ -18,7 +18,7 @@ class CacheApcStoreTest extends TestCase
 
     public function testAPCValueIsReturned()
     {
-        $apc = $this->getMockBuilder(ApcWrapper::class)->setMethods(['get'])->getMock();
+        $apc = $this->getMockBuilder(ApcWrapper::class)->onlyMethods(['get'])->getMock();
         $apc->expects($this->once())->method('get')->willReturn('bar');
         $store = new ApcStore($apc);
         $this->assertSame('bar', $store->get('foo'));
@@ -26,7 +26,7 @@ class CacheApcStoreTest extends TestCase
 
     public function testGetMultipleReturnsNullWhenNotFoundAndValueWhenFound()
     {
-        $apc = $this->getMockBuilder(ApcWrapper::class)->setMethods(['get'])->getMock();
+        $apc = $this->getMockBuilder(ApcWrapper::class)->onlyMethods(['get'])->getMock();
         $apc->expects($this->exactly(3))->method('get')->willReturnMap([
             ['foo', 'qux'],
             ['bar', null],
@@ -42,7 +42,7 @@ class CacheApcStoreTest extends TestCase
 
     public function testSetMethodProperlyCallsAPC()
     {
-        $apc = $this->getMockBuilder(ApcWrapper::class)->setMethods(['put'])->getMock();
+        $apc = $this->getMockBuilder(ApcWrapper::class)->onlyMethods(['put'])->getMock();
         $apc->expects($this->once())
             ->method('put')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(60))
             ->willReturn(true);
@@ -53,7 +53,7 @@ class CacheApcStoreTest extends TestCase
 
     public function testSetMultipleMethodProperlyCallsAPC()
     {
-        $apc = $this->getMockBuilder(ApcWrapper::class)->setMethods(['put'])->getMock();
+        $apc = $this->getMockBuilder(ApcWrapper::class)->onlyMethods(['put'])->getMock();
         $apc->expects($this->exactly(3))->method('put')->withConsecutive([
             $this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(60),
         ], [
@@ -72,7 +72,7 @@ class CacheApcStoreTest extends TestCase
 
     public function testIncrementMethodProperlyCallsAPC()
     {
-        $apc = $this->getMockBuilder(ApcWrapper::class)->setMethods(['increment'])->getMock();
+        $apc = $this->getMockBuilder(ApcWrapper::class)->onlyMethods(['increment'])->getMock();
         $apc->expects($this->once())->method('increment')->with($this->equalTo('foo'), $this->equalTo(5));
         $store = new ApcStore($apc);
         $store->increment('foo', 5);
@@ -80,7 +80,7 @@ class CacheApcStoreTest extends TestCase
 
     public function testDecrementMethodProperlyCallsAPC()
     {
-        $apc = $this->getMockBuilder(ApcWrapper::class)->setMethods(['decrement'])->getMock();
+        $apc = $this->getMockBuilder(ApcWrapper::class)->onlyMethods(['decrement'])->getMock();
         $apc->expects($this->once())->method('decrement')->with($this->equalTo('foo'), $this->equalTo(5));
         $store = new ApcStore($apc);
         $store->decrement('foo', 5);
@@ -88,7 +88,7 @@ class CacheApcStoreTest extends TestCase
 
     public function testStoreItemForeverProperlyCallsAPC()
     {
-        $apc = $this->getMockBuilder(ApcWrapper::class)->setMethods(['put'])->getMock();
+        $apc = $this->getMockBuilder(ApcWrapper::class)->onlyMethods(['put'])->getMock();
         $apc->expects($this->once())
             ->method('put')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(0))
             ->willReturn(true);
@@ -99,7 +99,7 @@ class CacheApcStoreTest extends TestCase
 
     public function testForgetMethodProperlyCallsAPC()
     {
-        $apc = $this->getMockBuilder(ApcWrapper::class)->setMethods(['delete'])->getMock();
+        $apc = $this->getMockBuilder(ApcWrapper::class)->onlyMethods(['delete'])->getMock();
         $apc->expects($this->once())->method('delete')->with($this->equalTo('foo'))->willReturn(true);
         $store = new ApcStore($apc);
         $result = $store->forget('foo');
@@ -108,7 +108,7 @@ class CacheApcStoreTest extends TestCase
 
     public function testFlushesCached()
     {
-        $apc = $this->getMockBuilder(ApcWrapper::class)->setMethods(['flush'])->getMock();
+        $apc = $this->getMockBuilder(ApcWrapper::class)->onlyMethods(['flush'])->getMock();
         $apc->expects($this->once())->method('flush')->willReturn(true);
         $store = new ApcStore($apc);
         $result = $store->flush();

--- a/tests/Cache/CacheArrayStoreTest.php
+++ b/tests/Cache/CacheArrayStoreTest.php
@@ -49,7 +49,7 @@ class CacheArrayStoreTest extends TestCase
 
     public function testStoreItemForeverProperlyStoresInArray()
     {
-        $mock = $this->getMockBuilder(ArrayStore::class)->setMethods(['put'])->getMock();
+        $mock = $this->getMockBuilder(ArrayStore::class)->onlyMethods(['put'])->getMock();
         $mock->expects($this->once())
             ->method('put')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(0))
             ->willReturn(true);

--- a/tests/Cache/CacheDatabaseStoreTest.php
+++ b/tests/Cache/CacheDatabaseStoreTest.php
@@ -31,7 +31,7 @@ class CacheDatabaseStoreTest extends TestCase
 
     public function testNullIsReturnedAndItemDeletedWhenItemIsExpired()
     {
-        $store = $this->getMockBuilder(DatabaseStore::class)->setMethods(['forget'])->setConstructorArgs($this->getMocks())->getMock();
+        $store = $this->getMockBuilder(DatabaseStore::class)->onlyMethods(['forget'])->setConstructorArgs($this->getMocks())->getMock();
         $table = m::mock(stdClass::class);
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
         $table->shouldReceive('where')->once()->with('key', '=', 'prefixfoo')->andReturn($table);
@@ -65,7 +65,7 @@ class CacheDatabaseStoreTest extends TestCase
 
     public function testValueIsInsertedWhenNoExceptionsAreThrown()
     {
-        $store = $this->getMockBuilder(DatabaseStore::class)->setMethods(['getTime'])->setConstructorArgs($this->getMocks())->getMock();
+        $store = $this->getMockBuilder(DatabaseStore::class)->onlyMethods(['getTime'])->setConstructorArgs($this->getMocks())->getMock();
         $table = m::mock(stdClass::class);
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
         $store->expects($this->once())->method('getTime')->willReturn(1);
@@ -77,7 +77,7 @@ class CacheDatabaseStoreTest extends TestCase
 
     public function testValueIsUpdatedWhenInsertThrowsException()
     {
-        $store = $this->getMockBuilder(DatabaseStore::class)->setMethods(['getTime'])->setConstructorArgs($this->getMocks())->getMock();
+        $store = $this->getMockBuilder(DatabaseStore::class)->onlyMethods(['getTime'])->setConstructorArgs($this->getMocks())->getMock();
         $table = m::mock(stdClass::class);
         $store->getConnection()->shouldReceive('table')->with('table')->andReturn($table);
         $store->expects($this->once())->method('getTime')->willReturn(1);
@@ -93,7 +93,7 @@ class CacheDatabaseStoreTest extends TestCase
 
     public function testValueIsInsertedOnPostgres()
     {
-        $store = $this->getMockBuilder(DatabaseStore::class)->setMethods(['getTime'])->setConstructorArgs($this->getPostgresMocks())->getMock();
+        $store = $this->getMockBuilder(DatabaseStore::class)->onlyMethods(['getTime'])->setConstructorArgs($this->getPostgresMocks())->getMock();
         $table = m::mock(stdClass::class);
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
         $store->expects($this->once())->method('getTime')->willReturn(1);
@@ -105,7 +105,7 @@ class CacheDatabaseStoreTest extends TestCase
 
     public function testForeverCallsStoreItemWithReallyLongTime()
     {
-        $store = $this->getMockBuilder(DatabaseStore::class)->setMethods(['put'])->setConstructorArgs($this->getMocks())->getMock();
+        $store = $this->getMockBuilder(DatabaseStore::class)->onlyMethods(['put'])->setConstructorArgs($this->getMocks())->getMock();
         $store->expects($this->once())->method('put')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(315360000))->willReturn(true);
         $result = $store->forever('foo', 'bar');
         $this->assertTrue($result);

--- a/tests/Cache/CacheFileStoreTest.php
+++ b/tests/Cache/CacheFileStoreTest.php
@@ -52,7 +52,7 @@ class CacheFileStoreTest extends TestCase
         $files = $this->mockFilesystem();
         $contents = '0000000000';
         $files->expects($this->once())->method('get')->willReturn($contents);
-        $store = $this->getMockBuilder(FileStore::class)->setMethods(['forget'])->setConstructorArgs([$files, __DIR__])->getMock();
+        $store = $this->getMockBuilder(FileStore::class)->onlyMethods(['forget'])->setConstructorArgs([$files, __DIR__])->getMock();
         $store->expects($this->once())->method('forget');
         $value = $store->get('foo');
         $this->assertNull($value);
@@ -70,7 +70,7 @@ class CacheFileStoreTest extends TestCase
     public function testStoreItemProperlyStoresValues()
     {
         $files = $this->mockFilesystem();
-        $store = $this->getMockBuilder(FileStore::class)->setMethods(['expiration'])->setConstructorArgs([$files, __DIR__])->getMock();
+        $store = $this->getMockBuilder(FileStore::class)->onlyMethods(['expiration'])->setConstructorArgs([$files, __DIR__])->getMock();
         $store->expects($this->once())->method('expiration')->with($this->equalTo(10))->willReturn(1111111111);
         $contents = '1111111111'.serialize('Hello World');
         $hash = sha1('foo');
@@ -84,7 +84,7 @@ class CacheFileStoreTest extends TestCase
     {
         $files = m::mock(Filesystem::class);
         $files->shouldIgnoreMissing();
-        $store = $this->getMockBuilder(FileStore::class)->setMethods(['expiration'])->setConstructorArgs([$files, __DIR__, 0644])->getMock();
+        $store = $this->getMockBuilder(FileStore::class)->onlyMethods(['expiration'])->setConstructorArgs([$files, __DIR__, 0644])->getMock();
         $hash = sha1('foo');
         $cache_dir = substr($hash, 0, 2).'/'.substr($hash, 2, 2);
         $files->shouldReceive('put')->withArgs([__DIR__.'/'.$cache_dir.'/'.$hash, m::any(), m::any()])->andReturnUsing(function ($name, $value) {

--- a/tests/Cache/CacheMemcachedConnectorTest.php
+++ b/tests/Cache/CacheMemcachedConnectorTest.php
@@ -103,7 +103,7 @@ class CacheMemcachedConnectorTest extends TestCase
 
     protected function connectorMock()
     {
-        return $this->getMockBuilder(MemcachedConnector::class)->setMethods(['createMemcachedInstance'])->getMock();
+        return $this->getMockBuilder(MemcachedConnector::class)->onlyMethods(['createMemcachedInstance'])->getMock();
     }
 
     protected function connect(

--- a/tests/Cache/CacheMemcachedStoreTest.php
+++ b/tests/Cache/CacheMemcachedStoreTest.php
@@ -16,7 +16,7 @@ class CacheMemcachedStoreTest extends TestCase
             $this->markTestSkipped('Memcached module not installed');
         }
 
-        $memcache = $this->getMockBuilder(stdClass::class)->setMethods(['get', 'getResultCode'])->getMock();
+        $memcache = $this->getMockBuilder(stdClass::class)->addMethods(['get', 'getResultCode'])->getMock();
         $memcache->expects($this->once())->method('get')->with($this->equalTo('foo:bar'))->willReturn(null);
         $memcache->expects($this->once())->method('getResultCode')->willReturn(1);
         $store = new MemcachedStore($memcache, 'foo');
@@ -29,7 +29,7 @@ class CacheMemcachedStoreTest extends TestCase
             $this->markTestSkipped('Memcached module not installed');
         }
 
-        $memcache = $this->getMockBuilder(stdClass::class)->setMethods(['get', 'getResultCode'])->getMock();
+        $memcache = $this->getMockBuilder(stdClass::class)->addMethods(['get', 'getResultCode'])->getMock();
         $memcache->expects($this->once())->method('get')->willReturn('bar');
         $memcache->expects($this->once())->method('getResultCode')->willReturn(0);
         $store = new MemcachedStore($memcache);
@@ -42,7 +42,7 @@ class CacheMemcachedStoreTest extends TestCase
             $this->markTestSkipped('Memcached module not installed');
         }
 
-        $memcache = $this->getMockBuilder(stdClass::class)->setMethods(['getMulti', 'getResultCode'])->getMock();
+        $memcache = $this->getMockBuilder(stdClass::class)->addMethods(['getMulti', 'getResultCode'])->getMock();
         $memcache->expects($this->once())->method('getMulti')->with(
             ['foo:foo', 'foo:bar', 'foo:baz']
         )->willReturn([
@@ -66,7 +66,7 @@ class CacheMemcachedStoreTest extends TestCase
         }
 
         Carbon::setTestNow($now = Carbon::now());
-        $memcache = $this->getMockBuilder(Memcached::class)->setMethods(['set'])->getMock();
+        $memcache = $this->getMockBuilder(Memcached::class)->onlyMethods(['set'])->getMock();
         $memcache->expects($this->once())->method('set')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo($now->timestamp + 60))->willReturn(true);
         $store = new MemcachedStore($memcache);
         $result = $store->put('foo', 'bar', 60);
@@ -80,7 +80,7 @@ class CacheMemcachedStoreTest extends TestCase
             $this->markTestSkipped('Memcached module not installed');
         }
 
-        $memcache = $this->getMockBuilder(Memcached::class)->setMethods(['increment'])->getMock();
+        $memcache = $this->getMockBuilder(Memcached::class)->onlyMethods(['increment'])->getMock();
         $memcache->expects($this->once())->method('increment')->with($this->equalTo('foo'), $this->equalTo(5));
         $store = new MemcachedStore($memcache);
         $store->increment('foo', 5);
@@ -92,7 +92,7 @@ class CacheMemcachedStoreTest extends TestCase
             $this->markTestSkipped('Memcached module not installed');
         }
 
-        $memcache = $this->getMockBuilder(Memcached::class)->setMethods(['decrement'])->getMock();
+        $memcache = $this->getMockBuilder(Memcached::class)->onlyMethods(['decrement'])->getMock();
         $memcache->expects($this->once())->method('decrement')->with($this->equalTo('foo'), $this->equalTo(5));
         $store = new MemcachedStore($memcache);
         $store->decrement('foo', 5);
@@ -104,7 +104,7 @@ class CacheMemcachedStoreTest extends TestCase
             $this->markTestSkipped('Memcached module not installed');
         }
 
-        $memcache = $this->getMockBuilder(Memcached::class)->setMethods(['set'])->getMock();
+        $memcache = $this->getMockBuilder(Memcached::class)->onlyMethods(['set'])->getMock();
         $memcache->expects($this->once())->method('set')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(0))->willReturn(true);
         $store = new MemcachedStore($memcache);
         $result = $store->forever('foo', 'bar');
@@ -117,7 +117,7 @@ class CacheMemcachedStoreTest extends TestCase
             $this->markTestSkipped('Memcached module not installed');
         }
 
-        $memcache = $this->getMockBuilder(Memcached::class)->setMethods(['delete'])->getMock();
+        $memcache = $this->getMockBuilder(Memcached::class)->onlyMethods(['delete'])->getMock();
         $memcache->expects($this->once())->method('delete')->with($this->equalTo('foo'));
         $store = new MemcachedStore($memcache);
         $store->forget('foo');
@@ -129,7 +129,7 @@ class CacheMemcachedStoreTest extends TestCase
             $this->markTestSkipped('Memcached module not installed');
         }
 
-        $memcache = $this->getMockBuilder(Memcached::class)->setMethods(['flush'])->getMock();
+        $memcache = $this->getMockBuilder(Memcached::class)->onlyMethods(['flush'])->getMock();
         $memcache->expects($this->once())->method('flush')->willReturn(true);
         $store = new MemcachedStore($memcache);
         $result = $store->flush();

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -240,7 +240,7 @@ class CacheRepositoryTest extends TestCase
         $repo::macro(__CLASS__, function () {
             return 'Taylor';
         });
-        $this->assertEquals($repo->{__CLASS__}(), 'Taylor');
+        $this->assertEquals('Taylor', $repo->{__CLASS__}());
     }
 
     public function testForgettingCacheKey()

--- a/tests/Console/ConsoleApplicationTest.php
+++ b/tests/Console/ConsoleApplicationTest.php
@@ -82,7 +82,7 @@ class ConsoleApplicationTest extends TestCase
         $app = m::mock(ApplicationContract::class, ['version' => '6.0']);
         $events = m::mock(Dispatcher::class, ['dispatch' => null]);
 
-        return $this->getMockBuilder(Application::class)->setMethods($methods)->setConstructorArgs([
+        return $this->getMockBuilder(Application::class)->onlyMethods($methods)->setConstructorArgs([
             $app, $events, 'test-version',
         ])->getMock();
     }

--- a/tests/Container/ContainerCallTest.php
+++ b/tests/Container/ContainerCallTest.php
@@ -193,7 +193,7 @@ class ContainerCallTest extends TestCase
         $this->expectExceptionMessage('Unable to resolve dependency [Parameter #0 [ <required> $foo ]] in class Illuminate\Tests\Container\ContainerCallTest');
 
         $container = new Container;
-        $foo = $container->call(function ($foo, $bar = 'default') {
+        $container->call(function ($foo, $bar = 'default') {
             return $foo;
         });
     }

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -398,7 +398,7 @@ class ContainerTest extends TestCase
     {
         $container = new Container;
         $container->alias('ConcreteStub', 'foo');
-        $this->assertEquals($container->getAlias('foo'), 'ConcreteStub');
+        $this->assertEquals('ConcreteStub', $container->getAlias('foo'));
     }
 
     public function testItThrowsExceptionWhenAbstractIsSameAsAlias()
@@ -424,7 +424,7 @@ class ContainerTest extends TestCase
     public function testMakeWithMethodIsAnAliasForMakeMethod()
     {
         $mock = $this->getMockBuilder(Container::class)
-                     ->setMethods(['make'])
+                     ->onlyMethods(['make'])
                      ->getMock();
 
         $mock->expects($this->once())

--- a/tests/Database/DatabaseConnectorTest.php
+++ b/tests/Database/DatabaseConnectorTest.php
@@ -31,7 +31,7 @@ class DatabaseConnectorTest extends TestCase
      */
     public function testMySqlConnectCallsCreateConnectionWithProperArguments($dsn, $config)
     {
-        $connector = $this->getMockBuilder(MySqlConnector::class)->setMethods(['createConnection', 'getOptions'])->getMock();
+        $connector = $this->getMockBuilder(MySqlConnector::class)->onlyMethods(['createConnection', 'getOptions'])->getMock();
         $connection = m::mock(PDO::class);
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
         $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->willReturn($connection);
@@ -57,7 +57,7 @@ class DatabaseConnectorTest extends TestCase
         $dsn = 'mysql:host=foo;dbname=bar';
         $config = ['host' => 'foo', 'database' => 'bar', 'collation' => 'utf8_unicode_ci', 'charset' => 'utf8', 'isolation_level' => 'REPEATABLE READ'];
 
-        $connector = $this->getMockBuilder(MySqlConnector::class)->setMethods(['createConnection', 'getOptions'])->getMock();
+        $connector = $this->getMockBuilder(MySqlConnector::class)->onlyMethods(['createConnection', 'getOptions'])->getMock();
         $connection = m::mock(PDO::class);
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
         $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->willReturn($connection);
@@ -74,7 +74,7 @@ class DatabaseConnectorTest extends TestCase
     {
         $dsn = 'pgsql:host=foo;dbname=bar;port=111';
         $config = ['host' => 'foo', 'database' => 'bar', 'port' => 111, 'charset' => 'utf8'];
-        $connector = $this->getMockBuilder(PostgresConnector::class)->setMethods(['createConnection', 'getOptions'])->getMock();
+        $connector = $this->getMockBuilder(PostgresConnector::class)->onlyMethods(['createConnection', 'getOptions'])->getMock();
         $connection = m::mock(stdClass::class);
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
         $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->willReturn($connection);
@@ -89,7 +89,7 @@ class DatabaseConnectorTest extends TestCase
     {
         $dsn = 'pgsql:host=foo;dbname=bar';
         $config = ['host' => 'foo', 'database' => 'bar', 'schema' => 'public', 'charset' => 'utf8'];
-        $connector = $this->getMockBuilder(PostgresConnector::class)->setMethods(['createConnection', 'getOptions'])->getMock();
+        $connector = $this->getMockBuilder(PostgresConnector::class)->onlyMethods(['createConnection', 'getOptions'])->getMock();
         $connection = m::mock(stdClass::class);
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
         $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->willReturn($connection);
@@ -105,7 +105,7 @@ class DatabaseConnectorTest extends TestCase
     {
         $dsn = 'pgsql:host=foo;dbname=bar';
         $config = ['host' => 'foo', 'database' => 'bar', 'schema' => ['public', 'user'], 'charset' => 'utf8'];
-        $connector = $this->getMockBuilder(PostgresConnector::class)->setMethods(['createConnection', 'getOptions'])->getMock();
+        $connector = $this->getMockBuilder(PostgresConnector::class)->onlyMethods(['createConnection', 'getOptions'])->getMock();
         $connection = m::mock(stdClass::class);
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
         $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->willReturn($connection);
@@ -121,7 +121,7 @@ class DatabaseConnectorTest extends TestCase
     {
         $dsn = 'pgsql:host=foo;dbname=bar';
         $config = ['host' => 'foo', 'database' => 'bar', 'charset' => 'utf8', 'application_name' => 'Laravel App'];
-        $connector = $this->getMockBuilder(PostgresConnector::class)->setMethods(['createConnection', 'getOptions'])->getMock();
+        $connector = $this->getMockBuilder(PostgresConnector::class)->onlyMethods(['createConnection', 'getOptions'])->getMock();
         $connection = m::mock(stdClass::class);
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
         $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->willReturn($connection);
@@ -137,7 +137,7 @@ class DatabaseConnectorTest extends TestCase
     {
         $dsn = 'sqlite::memory:';
         $config = ['database' => ':memory:'];
-        $connector = $this->getMockBuilder(SQLiteConnector::class)->setMethods(['createConnection', 'getOptions'])->getMock();
+        $connector = $this->getMockBuilder(SQLiteConnector::class)->onlyMethods(['createConnection', 'getOptions'])->getMock();
         $connection = m::mock(stdClass::class);
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
         $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->willReturn($connection);
@@ -150,7 +150,7 @@ class DatabaseConnectorTest extends TestCase
     {
         $dsn = 'sqlite:'.__DIR__;
         $config = ['database' => __DIR__];
-        $connector = $this->getMockBuilder(SQLiteConnector::class)->setMethods(['createConnection', 'getOptions'])->getMock();
+        $connector = $this->getMockBuilder(SQLiteConnector::class)->onlyMethods(['createConnection', 'getOptions'])->getMock();
         $connection = m::mock(stdClass::class);
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
         $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->willReturn($connection);
@@ -163,7 +163,7 @@ class DatabaseConnectorTest extends TestCase
     {
         $config = ['host' => 'foo', 'database' => 'bar', 'port' => 111];
         $dsn = $this->getDsn($config);
-        $connector = $this->getMockBuilder(SqlServerConnector::class)->setMethods(['createConnection', 'getOptions'])->getMock();
+        $connector = $this->getMockBuilder(SqlServerConnector::class)->onlyMethods(['createConnection', 'getOptions'])->getMock();
         $connection = m::mock(stdClass::class);
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
         $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->willReturn($connection);
@@ -176,7 +176,7 @@ class DatabaseConnectorTest extends TestCase
     {
         $config = ['host' => 'foo', 'database' => 'bar', 'port' => 111, 'readonly' => true, 'charset' => 'utf-8', 'pooling' => false, 'appname' => 'baz'];
         $dsn = $this->getDsn($config);
-        $connector = $this->getMockBuilder(SqlServerConnector::class)->setMethods(['createConnection', 'getOptions'])->getMock();
+        $connector = $this->getMockBuilder(SqlServerConnector::class)->onlyMethods(['createConnection', 'getOptions'])->getMock();
         $connection = m::mock(stdClass::class);
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
         $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->willReturn($connection);
@@ -193,7 +193,7 @@ class DatabaseConnectorTest extends TestCase
 
         $config = ['odbc' => true, 'odbc_datasource_name' => 'server=localhost;database=test;'];
         $dsn = $this->getDsn($config);
-        $connector = $this->getMockBuilder(SqlServerConnector::class)->setMethods(['createConnection', 'getOptions'])->getMock();
+        $connector = $this->getMockBuilder(SqlServerConnector::class)->onlyMethods(['createConnection', 'getOptions'])->getMock();
         $connection = m::mock(stdClass::class);
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
         $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->willReturn($connection);

--- a/tests/Database/DatabaseEloquentBelongsToManyWithDefaultAttributesTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyWithDefaultAttributesTest.php
@@ -18,13 +18,13 @@ class DatabaseEloquentBelongsToManyWithDefaultAttributesTest extends TestCase
 
     public function testWithPivotValueMethodSetsWhereConditionsForFetching()
     {
-        $relation = $this->getMockBuilder(BelongsToMany::class)->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation = $this->getMockBuilder(BelongsToMany::class)->onlyMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $relation->withPivotValue(['is_admin' => 1]);
     }
 
     public function testWithPivotValueMethodSetsDefaultArgumentsForInsertion()
     {
-        $relation = $this->getMockBuilder(BelongsToMany::class)->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation = $this->getMockBuilder(BelongsToMany::class)->onlyMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $relation->withPivotValue(['is_admin' => 1]);
 
         $query = m::mock(stdClass::class);

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -465,7 +465,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder = $this->getBuilder();
 
         $this->assertTrue(Builder::hasGlobalMacro('foo'));
-        $this->assertEquals($builder->foo('bar'), 'bar');
+        $this->assertEquals('bar', $builder->foo('bar'));
         $this->assertEquals($builder->bam(), $builder->getQuery());
     }
 
@@ -489,7 +489,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model->shouldReceive('hydrate')->once()->with($records)->andReturn(new Collection(['hydrated']));
         $models = $builder->getModels(['foo']);
 
-        $this->assertEquals($models, ['hydrated']);
+        $this->assertEquals(['hydrated'], $models);
     }
 
     public function testEagerLoadRelationsLoadTopLevelRelationships()

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -159,7 +159,7 @@ class DatabaseEloquentCollectionTest extends TestCase
 
     public function testLoadMethodEagerLoadsGivenRelationships()
     {
-        $c = $this->getMockBuilder(Collection::class)->setMethods(['first'])->setConstructorArgs([['foo']])->getMock();
+        $c = $this->getMockBuilder(Collection::class)->onlyMethods(['first'])->setConstructorArgs([['foo']])->getMock();
         $mockItem = m::mock(stdClass::class);
         $c->expects($this->once())->method('first')->willReturn($mockItem);
         $mockItem->shouldReceive('newQueryWithoutRelationships')->once()->andReturn($mockItem);

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -174,23 +174,19 @@ class DatabaseEloquentFactoryTest extends TestCase
 
     public function test_has_many_relationship()
     {
-        $users = FactoryTestUserFactory::times(10)
-                        ->has(
-                            FactoryTestPostFactory::times(3)
-                                    ->state(function ($attributes, $user) {
-                                        // Test parent is passed to child state mutations...
-                                        $_SERVER['__test.post.state-user'] = $user;
+        $postFactory = FactoryTestPostFactory::times(3)
+            ->state(function ($attributes, $user) {
+                // Test parent is passed to child state mutations...
+                $_SERVER['__test.post.state-user'] = $user;
 
-                                        return [];
-                                    })
-                                    // Test parents passed to callback...
-                                    ->afterCreating(function ($post, $user) {
-                                        $_SERVER['__test.post.creating-post'] = $post;
-                                        $_SERVER['__test.post.creating-user'] = $user;
-                                    }),
-                            'posts'
-                        )
-                        ->create();
+                return [];
+            })
+            // Test parents passed to callback...
+            ->afterCreating(function ($post, $user) {
+                $_SERVER['__test.post.creating-post'] = $post;
+                $_SERVER['__test.post.creating-user'] = $user;
+            });
+        FactoryTestUserFactory::times(10)->has($postFactory, 'posts')->create();
 
         $this->assertCount(10, FactoryTestUser::all());
         $this->assertCount(30, FactoryTestPost::all());
@@ -221,9 +217,9 @@ class DatabaseEloquentFactoryTest extends TestCase
 
     public function test_morph_to_relationship()
     {
-        $posts = FactoryTestCommentFactory::times(3)
-                        ->for(FactoryTestPostFactory::new(['title' => 'Test Title']), 'commentable')
-                        ->create();
+        FactoryTestCommentFactory::times(3)
+            ->for(FactoryTestPostFactory::new(['title' => 'Test Title']), 'commentable')
+            ->create();
 
         $this->assertSame('Test Title', FactoryTestPost::first()->title);
         $this->assertCount(3, FactoryTestPost::first()->comments);
@@ -234,16 +230,11 @@ class DatabaseEloquentFactoryTest extends TestCase
 
     public function test_belongs_to_many_relationship()
     {
-        $users = FactoryTestUserFactory::times(3)
-                        ->hasAttached(
-                            FactoryTestRoleFactory::times(3)->afterCreating(function ($role, $user) {
-                                $_SERVER['__test.role.creating-role'] = $role;
-                                $_SERVER['__test.role.creating-user'] = $user;
-                            }),
-                            ['admin' => 'Y'],
-                            'roles'
-                        )
-                        ->create();
+        $roleFactory = FactoryTestRoleFactory::times(3)->afterCreating(function ($role, $user) {
+            $_SERVER['__test.role.creating-role'] = $role;
+            $_SERVER['__test.role.creating-user'] = $user;
+        });
+        FactoryTestUserFactory::times(3)->hasAttached($roleFactory, ['admin' => 'Y'], 'roles')->create();
 
         $this->assertCount(9, FactoryTestRole::all());
 

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -290,7 +290,7 @@ class DatabaseEloquentHasManyTest extends TestCase
 
     protected function expectNewModel($relation, $attributes = null)
     {
-        $model = $this->getMockBuilder(Model::class)->setMethods(['setAttribute', 'save'])->getMock();
+        $model = $this->getMockBuilder(Model::class)->onlyMethods(['setAttribute', 'save'])->getMock();
         $relation->getRelated()->shouldReceive('newInstance')->with($attributes)->andReturn($model);
         $model->expects($this->once())->method('setAttribute')->with('foreign_key', 1);
 

--- a/tests/Database/DatabaseEloquentHasOneTest.php
+++ b/tests/Database/DatabaseEloquentHasOneTest.php
@@ -99,7 +99,7 @@ class DatabaseEloquentHasOneTest extends TestCase
     public function testMakeMethodDoesNotSaveNewModel()
     {
         $relation = $this->getRelation();
-        $instance = $this->getMockBuilder(Model::class)->setMethods(['save', 'newInstance', 'setAttribute'])->getMock();
+        $instance = $this->getMockBuilder(Model::class)->onlyMethods(['save', 'newInstance', 'setAttribute'])->getMock();
         $relation->getRelated()->shouldReceive('newInstance')->with(['name' => 'taylor'])->andReturn($instance);
         $instance->expects($this->once())->method('setAttribute')->with('foreign_key', 1);
         $instance->expects($this->never())->method('save');
@@ -110,7 +110,7 @@ class DatabaseEloquentHasOneTest extends TestCase
     public function testSaveMethodSetsForeignKeyOnModel()
     {
         $relation = $this->getRelation();
-        $mockModel = $this->getMockBuilder(Model::class)->setMethods(['save'])->getMock();
+        $mockModel = $this->getMockBuilder(Model::class)->onlyMethods(['save'])->getMock();
         $mockModel->expects($this->once())->method('save')->willReturn(true);
         $result = $relation->save($mockModel);
 
@@ -121,7 +121,7 @@ class DatabaseEloquentHasOneTest extends TestCase
     public function testCreateMethodProperlyCreatesNewModel()
     {
         $relation = $this->getRelation();
-        $created = $this->getMockBuilder(Model::class)->setMethods(['save', 'getKey', 'setAttribute'])->getMock();
+        $created = $this->getMockBuilder(Model::class)->onlyMethods(['save', 'getKey', 'setAttribute'])->getMock();
         $created->expects($this->once())->method('save')->willReturn(true);
         $relation->getRelated()->shouldReceive('newInstance')->once()->with(['name' => 'taylor'])->andReturn($created);
         $created->expects($this->once())->method('setAttribute')->with('foreign_key', 1);

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -352,7 +352,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         );
 
         $this->assertSame('Mohamed Said', $user3->name);
-        $this->assertEquals(EloquentTestUser::count(), 2);
+        $this->assertEquals(2, EloquentTestUser::count());
     }
 
     public function testUpdateOrCreateOnDifferentConnection()
@@ -369,8 +369,8 @@ class DatabaseEloquentIntegrationTest extends TestCase
             ['name' => 'Mohamed Said']
         );
 
-        $this->assertEquals(EloquentTestUser::count(), 1);
-        $this->assertEquals(EloquentTestUser::on('second_connection')->count(), 2);
+        $this->assertEquals(1, EloquentTestUser::count());
+        $this->assertEquals(2, EloquentTestUser::on('second_connection')->count());
     }
 
     public function testCheckAndCreateMethodsOnMultiConnections()
@@ -1220,8 +1220,8 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $defaultConnectionPost = EloquentTestPhoto::with('imageable')->first()->imageable;
         $secondConnectionPost = EloquentTestPhoto::on('second_connection')->with('imageable')->first()->imageable;
 
-        $this->assertEquals($defaultConnectionPost->name, 'Default Connection Post');
-        $this->assertEquals($secondConnectionPost->name, 'Second Connection Post');
+        $this->assertEquals('Default Connection Post', $defaultConnectionPost->name);
+        $this->assertEquals('Second Connection Post', $secondConnectionPost->name);
     }
 
     public function testBelongsToManyCustomPivot()

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -207,11 +207,11 @@ class DatabaseEloquentModelTest extends TestCase
         unset($model['table']);
 
         $this->assertTrue(isset($model['attributes']));
-        $this->assertEquals($model['attributes'], 1);
+        $this->assertEquals(1, $model['attributes']);
         $this->assertTrue(isset($model['connection']));
-        $this->assertEquals($model['connection'], 2);
+        $this->assertEquals(2, $model['connection']);
         $this->assertFalse(isset($model['table']));
-        $this->assertEquals($model['table'], null);
+        $this->assertEquals(null, $model['table']);
         $this->assertFalse(isset($model['with']));
     }
 
@@ -327,7 +327,7 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testUpdateProcess()
     {
-        $model = $this->getMockBuilder(EloquentModelStub::class)->setMethods(['newModelQuery', 'updateTimestamps'])->getMock();
+        $model = $this->getMockBuilder(EloquentModelStub::class)->onlyMethods(['newModelQuery', 'updateTimestamps'])->getMock();
         $query = m::mock(Builder::class);
         $query->shouldReceive('where')->once()->with('id', '=', 1);
         $query->shouldReceive('update')->once()->with(['name' => 'taylor'])->andReturn(1);
@@ -350,7 +350,7 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testUpdateProcessDoesntOverrideTimestamps()
     {
-        $model = $this->getMockBuilder(EloquentModelStub::class)->setMethods(['newModelQuery'])->getMock();
+        $model = $this->getMockBuilder(EloquentModelStub::class)->onlyMethods(['newModelQuery'])->getMock();
         $query = m::mock(Builder::class);
         $query->shouldReceive('where')->once()->with('id', '=', 1);
         $query->shouldReceive('update')->once()->with(['created_at' => 'foo', 'updated_at' => 'bar'])->andReturn(1);
@@ -369,7 +369,7 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testSaveIsCanceledIfSavingEventReturnsFalse()
     {
-        $model = $this->getMockBuilder(EloquentModelStub::class)->setMethods(['newModelQuery'])->getMock();
+        $model = $this->getMockBuilder(EloquentModelStub::class)->onlyMethods(['newModelQuery'])->getMock();
         $query = m::mock(Builder::class);
         $model->expects($this->once())->method('newModelQuery')->willReturn($query);
         $model->setEventDispatcher($events = m::mock(Dispatcher::class));
@@ -381,7 +381,7 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testUpdateIsCanceledIfUpdatingEventReturnsFalse()
     {
-        $model = $this->getMockBuilder(EloquentModelStub::class)->setMethods(['newModelQuery'])->getMock();
+        $model = $this->getMockBuilder(EloquentModelStub::class)->onlyMethods(['newModelQuery'])->getMock();
         $query = m::mock(Builder::class);
         $model->expects($this->once())->method('newModelQuery')->willReturn($query);
         $model->setEventDispatcher($events = m::mock(Dispatcher::class));
@@ -395,7 +395,7 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testEventsCanBeFiredWithCustomEventObjects()
     {
-        $model = $this->getMockBuilder(EloquentModelEventObjectStub::class)->setMethods(['newModelQuery'])->getMock();
+        $model = $this->getMockBuilder(EloquentModelEventObjectStub::class)->onlyMethods(['newModelQuery'])->getMock();
         $query = m::mock(Builder::class);
         $model->expects($this->once())->method('newModelQuery')->willReturn($query);
         $model->setEventDispatcher($events = m::mock(Dispatcher::class));
@@ -407,7 +407,7 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testUpdateProcessWithoutTimestamps()
     {
-        $model = $this->getMockBuilder(EloquentModelEventObjectStub::class)->setMethods(['newModelQuery', 'updateTimestamps', 'fireModelEvent'])->getMock();
+        $model = $this->getMockBuilder(EloquentModelEventObjectStub::class)->onlyMethods(['newModelQuery', 'updateTimestamps', 'fireModelEvent'])->getMock();
         $model->timestamps = false;
         $query = m::mock(Builder::class);
         $query->shouldReceive('where')->once()->with('id', '=', 1);
@@ -425,7 +425,7 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testUpdateUsesOldPrimaryKey()
     {
-        $model = $this->getMockBuilder(EloquentModelStub::class)->setMethods(['newModelQuery', 'updateTimestamps'])->getMock();
+        $model = $this->getMockBuilder(EloquentModelStub::class)->onlyMethods(['newModelQuery', 'updateTimestamps'])->getMock();
         $query = m::mock(Builder::class);
         $query->shouldReceive('where')->once()->with('id', '=', 1);
         $query->shouldReceive('update')->once()->with(['id' => 2, 'foo' => 'bar'])->andReturn(1);
@@ -448,7 +448,7 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testTimestampsAreReturnedAsObjects()
     {
-        $model = $this->getMockBuilder(EloquentDateModelStub::class)->setMethods(['getDateFormat'])->getMock();
+        $model = $this->getMockBuilder(EloquentDateModelStub::class)->onlyMethods(['getDateFormat'])->getMock();
         $model->expects($this->any())->method('getDateFormat')->willReturn('Y-m-d');
         $model->setRawAttributes([
             'created_at' => '2012-12-04',
@@ -461,7 +461,7 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testTimestampsAreReturnedAsObjectsFromPlainDatesAndTimestamps()
     {
-        $model = $this->getMockBuilder(EloquentDateModelStub::class)->setMethods(['getDateFormat'])->getMock();
+        $model = $this->getMockBuilder(EloquentDateModelStub::class)->onlyMethods(['getDateFormat'])->getMock();
         $model->expects($this->any())->method('getDateFormat')->willReturn('Y-m-d H:i:s');
         $model->setRawAttributes([
             'created_at' => '2012-12-04',
@@ -558,7 +558,7 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testFromDateTimeMilliseconds()
     {
-        $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentDateModelStub')->setMethods(['getDateFormat'])->getMock();
+        $model = $this->getMockBuilder('Illuminate\Tests\Database\EloquentDateModelStub')->onlyMethods(['getDateFormat'])->getMock();
         $model->expects($this->any())->method('getDateFormat')->willReturn('Y-m-d H:s.vi');
         $model->setRawAttributes([
             'created_at' => '2012-12-04 22:59.32130',
@@ -570,7 +570,7 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testInsertProcess()
     {
-        $model = $this->getMockBuilder(EloquentModelStub::class)->setMethods(['newModelQuery', 'updateTimestamps', 'refresh'])->getMock();
+        $model = $this->getMockBuilder(EloquentModelStub::class)->onlyMethods(['newModelQuery', 'updateTimestamps', 'refresh'])->getMock();
         $query = m::mock(Builder::class);
         $query->shouldReceive('insertGetId')->once()->with(['name' => 'taylor'], 'id')->andReturn(1);
         $query->shouldReceive('getConnection')->once();
@@ -589,7 +589,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals(1, $model->id);
         $this->assertTrue($model->exists);
 
-        $model = $this->getMockBuilder(EloquentModelStub::class)->setMethods(['newModelQuery', 'updateTimestamps', 'refresh'])->getMock();
+        $model = $this->getMockBuilder(EloquentModelStub::class)->onlyMethods(['newModelQuery', 'updateTimestamps', 'refresh'])->getMock();
         $query = m::mock(Builder::class);
         $query->shouldReceive('insert')->once()->with(['name' => 'taylor']);
         $query->shouldReceive('getConnection')->once();
@@ -612,7 +612,7 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testInsertIsCanceledIfCreatingEventReturnsFalse()
     {
-        $model = $this->getMockBuilder(EloquentModelStub::class)->setMethods(['newModelQuery'])->getMock();
+        $model = $this->getMockBuilder(EloquentModelStub::class)->onlyMethods(['newModelQuery'])->getMock();
         $query = m::mock(Builder::class);
         $query->shouldReceive('getConnection')->once();
         $model->expects($this->once())->method('newModelQuery')->willReturn($query);
@@ -626,7 +626,7 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testDeleteProperlyDeletesModel()
     {
-        $model = $this->getMockBuilder(Model::class)->setMethods(['newModelQuery', 'updateTimestamps', 'touchOwners'])->getMock();
+        $model = $this->getMockBuilder(Model::class)->onlyMethods(['newModelQuery', 'updateTimestamps', 'touchOwners'])->getMock();
         $query = m::mock(Builder::class);
         $query->shouldReceive('where')->once()->with('id', '=', 1)->andReturn($query);
         $query->shouldReceive('delete')->once();
@@ -639,7 +639,7 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testPushNoRelations()
     {
-        $model = $this->getMockBuilder(EloquentModelStub::class)->setMethods(['newModelQuery', 'updateTimestamps', 'refresh'])->getMock();
+        $model = $this->getMockBuilder(EloquentModelStub::class)->onlyMethods(['newModelQuery', 'updateTimestamps', 'refresh'])->getMock();
         $query = m::mock(Builder::class);
         $query->shouldReceive('insertGetId')->once()->with(['name' => 'taylor'], 'id')->andReturn(1);
         $query->shouldReceive('getConnection')->once();
@@ -656,7 +656,7 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testPushEmptyOneRelation()
     {
-        $model = $this->getMockBuilder(EloquentModelStub::class)->setMethods(['newModelQuery', 'updateTimestamps', 'refresh'])->getMock();
+        $model = $this->getMockBuilder(EloquentModelStub::class)->onlyMethods(['newModelQuery', 'updateTimestamps', 'refresh'])->getMock();
         $query = m::mock(Builder::class);
         $query->shouldReceive('insertGetId')->once()->with(['name' => 'taylor'], 'id')->andReturn(1);
         $query->shouldReceive('getConnection')->once();
@@ -675,7 +675,7 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testPushOneRelation()
     {
-        $related1 = $this->getMockBuilder(EloquentModelStub::class)->setMethods(['newModelQuery', 'updateTimestamps', 'refresh'])->getMock();
+        $related1 = $this->getMockBuilder(EloquentModelStub::class)->onlyMethods(['newModelQuery', 'updateTimestamps', 'refresh'])->getMock();
         $query = m::mock(Builder::class);
         $query->shouldReceive('insertGetId')->once()->with(['name' => 'related1'], 'id')->andReturn(2);
         $query->shouldReceive('getConnection')->once();
@@ -684,7 +684,7 @@ class DatabaseEloquentModelTest extends TestCase
         $related1->name = 'related1';
         $related1->exists = false;
 
-        $model = $this->getMockBuilder(EloquentModelStub::class)->setMethods(['newModelQuery', 'updateTimestamps', 'refresh'])->getMock();
+        $model = $this->getMockBuilder(EloquentModelStub::class)->onlyMethods(['newModelQuery', 'updateTimestamps', 'refresh'])->getMock();
         $query = m::mock(Builder::class);
         $query->shouldReceive('insertGetId')->once()->with(['name' => 'taylor'], 'id')->andReturn(1);
         $query->shouldReceive('getConnection')->once();
@@ -706,7 +706,7 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testPushEmptyManyRelation()
     {
-        $model = $this->getMockBuilder(EloquentModelStub::class)->setMethods(['newModelQuery', 'updateTimestamps', 'refresh'])->getMock();
+        $model = $this->getMockBuilder(EloquentModelStub::class)->onlyMethods(['newModelQuery', 'updateTimestamps', 'refresh'])->getMock();
         $query = m::mock(Builder::class);
         $query->shouldReceive('insertGetId')->once()->with(['name' => 'taylor'], 'id')->andReturn(1);
         $query->shouldReceive('getConnection')->once();
@@ -725,7 +725,7 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testPushManyRelation()
     {
-        $related1 = $this->getMockBuilder(EloquentModelStub::class)->setMethods(['newModelQuery', 'updateTimestamps', 'refresh'])->getMock();
+        $related1 = $this->getMockBuilder(EloquentModelStub::class)->onlyMethods(['newModelQuery', 'updateTimestamps', 'refresh'])->getMock();
         $query = m::mock(Builder::class);
         $query->shouldReceive('insertGetId')->once()->with(['name' => 'related1'], 'id')->andReturn(2);
         $query->shouldReceive('getConnection')->once();
@@ -734,7 +734,7 @@ class DatabaseEloquentModelTest extends TestCase
         $related1->name = 'related1';
         $related1->exists = false;
 
-        $related2 = $this->getMockBuilder(EloquentModelStub::class)->setMethods(['newModelQuery', 'updateTimestamps', 'refresh'])->getMock();
+        $related2 = $this->getMockBuilder(EloquentModelStub::class)->onlyMethods(['newModelQuery', 'updateTimestamps', 'refresh'])->getMock();
         $query = m::mock(Builder::class);
         $query->shouldReceive('insertGetId')->once()->with(['name' => 'related2'], 'id')->andReturn(3);
         $query->shouldReceive('getConnection')->once();
@@ -743,7 +743,7 @@ class DatabaseEloquentModelTest extends TestCase
         $related2->name = 'related2';
         $related2->exists = false;
 
-        $model = $this->getMockBuilder(EloquentModelStub::class)->setMethods(['newModelQuery', 'updateTimestamps', 'refresh'])->getMock();
+        $model = $this->getMockBuilder(EloquentModelStub::class)->onlyMethods(['newModelQuery', 'updateTimestamps', 'refresh'])->getMock();
         $query = m::mock(Builder::class);
         $query->shouldReceive('insertGetId')->once()->with(['name' => 'taylor'], 'id')->andReturn(1);
         $query->shouldReceive('getConnection')->once();
@@ -1684,7 +1684,7 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testRelationshipTouchOwnersIsPropagated()
     {
-        $relation = $this->getMockBuilder(BelongsTo::class)->setMethods(['touch'])->disableOriginalConstructor()->getMock();
+        $relation = $this->getMockBuilder(BelongsTo::class)->onlyMethods(['touch'])->disableOriginalConstructor()->getMock();
         $relation->expects($this->once())->method('touch');
 
         $model = m::mock(EloquentModelStub::class.'[partner]');
@@ -1701,7 +1701,7 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testRelationshipTouchOwnersIsNotPropagatedIfNoRelationshipResult()
     {
-        $relation = $this->getMockBuilder(BelongsTo::class)->setMethods(['touch'])->disableOriginalConstructor()->getMock();
+        $relation = $this->getMockBuilder(BelongsTo::class)->onlyMethods(['touch'])->disableOriginalConstructor()->getMock();
         $relation->expects($this->once())->method('touch');
 
         $model = m::mock(EloquentModelStub::class.'[partner]');
@@ -1941,7 +1941,7 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testIntKeyTypePreserved()
     {
-        $model = $this->getMockBuilder(EloquentModelStub::class)->setMethods(['newModelQuery', 'updateTimestamps', 'refresh'])->getMock();
+        $model = $this->getMockBuilder(EloquentModelStub::class)->onlyMethods(['newModelQuery', 'updateTimestamps', 'refresh'])->getMock();
         $query = m::mock(Builder::class);
         $query->shouldReceive('insertGetId')->once()->with([], 'id')->andReturn(1);
         $query->shouldReceive('getConnection')->once();
@@ -1953,7 +1953,7 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testStringKeyTypePreserved()
     {
-        $model = $this->getMockBuilder(EloquentKeyTypeModelStub::class)->setMethods(['newModelQuery', 'updateTimestamps', 'refresh'])->getMock();
+        $model = $this->getMockBuilder(EloquentKeyTypeModelStub::class)->onlyMethods(['newModelQuery', 'updateTimestamps', 'refresh'])->getMock();
         $query = m::mock(Builder::class);
         $query->shouldReceive('insertGetId')->once()->with([], 'id')->andReturn('string id');
         $query->shouldReceive('getConnection')->once();

--- a/tests/Database/DatabaseEloquentMorphToManyTest.php
+++ b/tests/Database/DatabaseEloquentMorphToManyTest.php
@@ -32,7 +32,7 @@ class DatabaseEloquentMorphToManyTest extends TestCase
 
     public function testAttachInsertsPivotTableRecord()
     {
-        $relation = $this->getMockBuilder(MorphToMany::class)->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation = $this->getMockBuilder(MorphToMany::class)->onlyMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $query = m::mock(stdClass::class);
         $query->shouldReceive('from')->once()->with('taggables')->andReturn($query);
         $query->shouldReceive('insert')->once()->with([['taggable_id' => 1, 'taggable_type' => get_class($relation->getParent()), 'tag_id' => 2, 'foo' => 'bar']])->andReturn(true);
@@ -45,7 +45,7 @@ class DatabaseEloquentMorphToManyTest extends TestCase
 
     public function testDetachRemovesPivotTableRecord()
     {
-        $relation = $this->getMockBuilder(MorphToMany::class)->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation = $this->getMockBuilder(MorphToMany::class)->onlyMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $query = m::mock(stdClass::class);
         $query->shouldReceive('from')->once()->with('taggables')->andReturn($query);
         $query->shouldReceive('where')->once()->with('taggable_id', 1)->andReturn($query);
@@ -61,7 +61,7 @@ class DatabaseEloquentMorphToManyTest extends TestCase
 
     public function testDetachMethodClearsAllPivotRecordsWhenNoIDsAreGiven()
     {
-        $relation = $this->getMockBuilder(MorphToMany::class)->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $relation = $this->getMockBuilder(MorphToMany::class)->onlyMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $query = m::mock(stdClass::class);
         $query->shouldReceive('from')->once()->with('taggables')->andReturn($query);
         $query->shouldReceive('where')->once()->with('taggable_id', 1)->andReturn($query);

--- a/tests/Database/DatabaseEloquentPivotTest.php
+++ b/tests/Database/DatabaseEloquentPivotTest.php
@@ -111,7 +111,7 @@ class DatabaseEloquentPivotTest extends TestCase
 
     public function testDeleteMethodDeletesModelByKeys()
     {
-        $pivot = $this->getMockBuilder(Pivot::class)->setMethods(['newQueryWithoutRelationships'])->getMock();
+        $pivot = $this->getMockBuilder(Pivot::class)->onlyMethods(['newQueryWithoutRelationships'])->getMock();
         $pivot->setPivotKeys('foreign', 'other');
         $pivot->foreign = 'foreign.value';
         $pivot->other = 'other.value';

--- a/tests/Database/DatabaseMigrationCreatorTest.php
+++ b/tests/Database/DatabaseMigrationCreatorTest.php
@@ -102,7 +102,7 @@ class DatabaseMigrationCreatorTest extends TestCase
         $customStubs = 'stubs';
 
         return $this->getMockBuilder(MigrationCreator::class)
-            ->setMethods(['getDatePrefix'])
+            ->onlyMethods(['getDatePrefix'])
             ->setConstructorArgs([$files, $customStubs])
             ->getMock();
     }

--- a/tests/Database/DatabaseMigrationMigrateCommandTest.php
+++ b/tests/Database/DatabaseMigrationMigrateCommandTest.php
@@ -67,7 +67,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
     public function testMigrationRepositoryCreatedWhenNecessary()
     {
         $params = [$migrator = m::mock(Migrator::class), $dispatcher = m::mock(Dispatcher::class)];
-        $command = $this->getMockBuilder(MigrateCommand::class)->setMethods(['call'])->setConstructorArgs($params)->getMock();
+        $command = $this->getMockBuilder(MigrateCommand::class)->onlyMethods(['call'])->setConstructorArgs($params)->getMock();
         $app = new ApplicationDatabaseMigrationStub(['path.database' => __DIR__]);
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);

--- a/tests/Database/DatabaseMigrationRepositoryTest.php
+++ b/tests/Database/DatabaseMigrationRepositoryTest.php
@@ -35,7 +35,7 @@ class DatabaseMigrationRepositoryTest extends TestCase
 
     public function testGetLastMigrationsGetsAllMigrationsWithTheLatestBatchNumber()
     {
-        $repo = $this->getMockBuilder(DatabaseMigrationRepository::class)->setMethods(['getLastBatchNumber'])->setConstructorArgs([
+        $repo = $this->getMockBuilder(DatabaseMigrationRepository::class)->onlyMethods(['getLastBatchNumber'])->setConstructorArgs([
             $resolver = m::mock(ConnectionResolverInterface::class), 'migrations',
         ])->getMock();
         $repo->expects($this->once())->method('getLastBatchNumber')->willReturn(1);
@@ -81,7 +81,7 @@ class DatabaseMigrationRepositoryTest extends TestCase
 
     public function testGetNextBatchNumberReturnsLastBatchNumberPlusOne()
     {
-        $repo = $this->getMockBuilder(DatabaseMigrationRepository::class)->setMethods(['getLastBatchNumber'])->setConstructorArgs([
+        $repo = $this->getMockBuilder(DatabaseMigrationRepository::class)->onlyMethods(['getLastBatchNumber'])->setConstructorArgs([
             m::mock(ConnectionResolverInterface::class), 'migrations',
         ])->getMock();
         $repo->expects($this->once())->method('getLastBatchNumber')->willReturn(1);

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -198,13 +198,13 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testWhenCallbackWithDefault()
     {
         $callback = function ($query, $condition) {
-            $this->assertEquals($condition, 'truthy');
+            $this->assertEquals('truthy', $condition);
 
             $query->where('id', '=', 1);
         };
 
         $default = function ($query, $condition) {
-            $this->assertEquals($condition, 0);
+            $this->assertEquals(0, $condition);
 
             $query->where('id', '=', 2);
         };
@@ -257,13 +257,13 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testUnlessCallbackWithDefault()
     {
         $callback = function ($query, $condition) {
-            $this->assertEquals($condition, 0);
+            $this->assertEquals(0, $condition);
 
             $query->where('id', '=', 1);
         };
 
         $default = function ($query, $condition) {
-            $this->assertEquals($condition, 'truthy');
+            $this->assertEquals('truthy', $condition);
 
             $query->where('id', '=', 2);
         };

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -26,7 +26,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $conn->shouldReceive('statement')->once()->with('foo');
         $conn->shouldReceive('statement')->once()->with('bar');
         $grammar = m::mock(MySqlGrammar::class);
-        $blueprint = $this->getMockBuilder(Blueprint::class)->setMethods(['toSql'])->setConstructorArgs(['users'])->getMock();
+        $blueprint = $this->getMockBuilder(Blueprint::class)->onlyMethods(['toSql'])->setConstructorArgs(['users'])->getMock();
         $blueprint->expects($this->once())->method('toSql')->with($this->equalTo($conn), $this->equalTo($grammar))->willReturn(['foo', 'bar']);
 
         $blueprint->build($conn, $grammar);

--- a/tests/Database/DatabaseSchemaBuilderTest.php
+++ b/tests/Database/DatabaseSchemaBuilderTest.php
@@ -53,6 +53,6 @@ class DatabaseSchemaBuilderTest extends TestCase
         $column->shouldReceive('getType')->once()->andReturn($type);
         $type->shouldReceive('getName')->once()->andReturn('integer');
 
-        $this->assertEquals($builder->getColumnType('users', 'id'), 'integer');
+        $this->assertEquals('integer', $builder->getColumnType('users', 'id'));
     }
 }

--- a/tests/Events/EventsSubscriberTest.php
+++ b/tests/Events/EventsSubscriberTest.php
@@ -41,10 +41,10 @@ class EventsSubscriberTest extends TestCase
         $d->subscribe(DeclarativeSubscriber::class);
 
         $d->dispatch('myEvent1');
-        $this->assertEquals(DeclarativeSubscriber::$string, 'L1_L2_');
+        $this->assertEquals('L1_L2_', DeclarativeSubscriber::$string);
 
         $d->dispatch('myEvent2');
-        $this->assertEquals(DeclarativeSubscriber::$string, 'L1_L2_L3');
+        $this->assertEquals('L1_L2_L3', DeclarativeSubscriber::$string);
     }
 }
 

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -145,7 +145,7 @@ class FoundationApplicationTest extends TestCase
         $app->setDeferredServices(['foo' => ApplicationDeferredServiceProviderStub::class]);
         $app->instance('foo', 'bar');
         $instance = $app->make('foo');
-        $this->assertEquals($instance, 'bar');
+        $this->assertEquals('bar', $instance);
     }
 
     public function testDeferredServicesAreLazilyInitialized()
@@ -192,7 +192,7 @@ class FoundationApplicationTest extends TestCase
             SampleImplementation::class => SampleImplementationDeferredServiceProvider::class,
         ]);
         $instance = $app->make(SampleInterface::class);
-        $this->assertEquals($instance->getPrimitive(), 'foo');
+        $this->assertEquals('foo', $instance->getPrimitive());
     }
 
     public function testEnvironment()

--- a/tests/Foundation/FoundationAuthenticationTest.php
+++ b/tests/Foundation/FoundationAuthenticationTest.php
@@ -16,7 +16,7 @@ class FoundationAuthenticationTest extends TestCase
     use InteractsWithAuthentication;
 
     /**
-     * @var \Mockery
+     * @var m
      */
     protected $app;
 
@@ -29,7 +29,7 @@ class FoundationAuthenticationTest extends TestCase
     ];
 
     /**
-     * @var \Mockery
+     * @return Guard|m\LegacyMockInterface|m\MockInterface
      */
     protected function mockGuard()
     {

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -1022,19 +1022,19 @@ class HttpRequestTest extends TestCase
         $request = Request::create('/', 'GET', ['foo' => 'bar', 'empty' => '']);
 
         // Parameter 'foo' is 'bar', then it ISSET and is NOT EMPTY.
-        $this->assertEquals($request->foo, 'bar');
-        $this->assertEquals(isset($request->foo), true);
-        $this->assertEquals(empty($request->foo), false);
+        $this->assertEquals('bar', $request->foo);
+        $this->assertEquals(true, isset($request->foo));
+        $this->assertEquals(false, empty($request->foo));
 
         // Parameter 'empty' is '', then it ISSET and is EMPTY.
-        $this->assertEquals($request->empty, '');
+        $this->assertEquals('', $request->empty);
         $this->assertTrue(isset($request->empty));
         $this->assertEmpty($request->empty);
 
         // Parameter 'undefined' is undefined/null, then it NOT ISSET and is EMPTY.
-        $this->assertEquals($request->undefined, null);
-        $this->assertEquals(isset($request->undefined), false);
-        $this->assertEquals(empty($request->undefined), true);
+        $this->assertEquals(null, $request->undefined);
+        $this->assertEquals(false, isset($request->undefined));
+        $this->assertEquals(true, empty($request->undefined));
 
         // Simulates Route parameters.
         $request = Request::create('/example/bar', 'GET', ['xyz' => 'overwritten']);
@@ -1048,19 +1048,19 @@ class HttpRequestTest extends TestCase
         // Router parameter 'foo' is 'bar', then it ISSET and is NOT EMPTY.
         $this->assertSame('bar', $request->foo);
         $this->assertSame('bar', $request['foo']);
-        $this->assertEquals(isset($request->foo), true);
-        $this->assertEquals(empty($request->foo), false);
+        $this->assertEquals(true, isset($request->foo));
+        $this->assertEquals(false, empty($request->foo));
 
         // Router parameter 'undefined' is undefined/null, then it NOT ISSET and is EMPTY.
-        $this->assertEquals($request->undefined, null);
-        $this->assertEquals(isset($request->undefined), false);
-        $this->assertEquals(empty($request->undefined), true);
+        $this->assertEquals(null, $request->undefined);
+        $this->assertEquals(false, isset($request->undefined));
+        $this->assertEquals(true, empty($request->undefined));
 
         // Special case: router parameter 'xyz' is 'overwritten' by QueryString, then it ISSET and is NOT EMPTY.
         // Basically, QueryStrings have priority over router parameters.
-        $this->assertEquals($request->xyz, 'overwritten');
-        $this->assertEquals(isset($request->foo), true);
-        $this->assertEquals(empty($request->foo), false);
+        $this->assertEquals('overwritten', $request->xyz);
+        $this->assertEquals(true, isset($request->foo));
+        $this->assertEquals(false, empty($request->foo));
 
         // Simulates empty QueryString and Routes.
         $request = Request::create('/', 'GET');
@@ -1072,18 +1072,18 @@ class HttpRequestTest extends TestCase
         });
 
         // Parameter 'undefined' is undefined/null, then it NOT ISSET and is EMPTY.
-        $this->assertEquals($request->undefined, null);
-        $this->assertEquals(isset($request->undefined), false);
-        $this->assertEquals(empty($request->undefined), true);
+        $this->assertEquals(null, $request->undefined);
+        $this->assertEquals(false, isset($request->undefined));
+        $this->assertEquals(true, empty($request->undefined));
 
         // Special case: simulates empty QueryString and Routes, without the Route Resolver.
         // It'll happen when you try to get a parameter outside a route.
         $request = Request::create('/', 'GET');
 
         // Parameter 'undefined' is undefined/null, then it NOT ISSET and is EMPTY.
-        $this->assertEquals($request->undefined, null);
-        $this->assertEquals(isset($request->undefined), false);
-        $this->assertEquals(empty($request->undefined), true);
+        $this->assertEquals(null, $request->undefined);
+        $this->assertEquals(false, isset($request->undefined));
+        $this->assertEquals(true, empty($request->undefined));
     }
 
     public function testHttpRequestFlashCallsSessionFlashInputWithInputData()

--- a/tests/Integration/Foundation/FoundationHelpersTest.php
+++ b/tests/Integration/Foundation/FoundationHelpersTest.php
@@ -15,19 +15,19 @@ class FoundationHelpersTest extends TestCase
 {
     public function testRescue()
     {
-        $this->assertEquals(rescue(function () {
+        $this->assertEquals('rescued!', rescue(function () {
             throw new Exception;
-        }, 'rescued!'), 'rescued!');
+        }, 'rescued!'));
 
-        $this->assertEquals(rescue(function () {
+        $this->assertEquals('rescued!', rescue(function () {
             throw new Exception;
         }, function () {
             return 'rescued!';
-        }), 'rescued!');
+        }));
 
-        $this->assertEquals(rescue(function () {
+        $this->assertEquals('no need to rescue', rescue(function () {
             return 'no need to rescue';
-        }, 'rescued!'), 'no need to rescue');
+        }, 'rescued!'));
 
         $testClass = new class {
             public function test(int $a)
@@ -36,9 +36,9 @@ class FoundationHelpersTest extends TestCase
             }
         };
 
-        $this->assertEquals(rescue(function () use ($testClass) {
+        $this->assertEquals('rescued!', rescue(function () use ($testClass) {
             $testClass->test([]);
-        }, 'rescued!'), 'rescued!');
+        }, 'rescued!'));
     }
 
     public function testMixReportsExceptionWhenAssetIsMissingFromManifest()

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -232,8 +232,8 @@ class ModelSerializationTest extends TestCase
 
         $unserialized = unserialize($serialized);
 
-        $this->assertEquals($unserialized->users->first()->email, 'taylor@laravel.com');
-        $this->assertEquals($unserialized->users->last()->email, 'mohamed@laravel.com');
+        $this->assertEquals('taylor@laravel.com', $unserialized->users->first()->email);
+        $this->assertEquals('mohamed@laravel.com', $unserialized->users->last()->email);
     }
 
     public function testItCanUnserializeACollectionInCorrectOrderAndHandleDeletedModels()
@@ -252,8 +252,8 @@ class ModelSerializationTest extends TestCase
 
         $this->assertCount(2, $unserialized->users);
 
-        $this->assertEquals($unserialized->users->first()->email, '3@laravel.com');
-        $this->assertEquals($unserialized->users->last()->email, '1@laravel.com');
+        $this->assertEquals('3@laravel.com', $unserialized->users->first()->email);
+        $this->assertEquals('1@laravel.com', $unserialized->users->last()->email);
     }
 
     public function testItCanUnserializeCustomCollection()

--- a/tests/Integration/Routing/RouteRedirectTest.php
+++ b/tests/Integration/Routing/RouteRedirectTest.php
@@ -31,7 +31,6 @@ class RouteRedirectTest extends TestCase
             'route redirect with two parameters' => ['from/{param}/{param2?}', 'to', '/from/value1/value2', '/to'],
             'route redirect with one parameter replacement' => ['users/{user}/repos', 'members/{user}/repos', '/users/22/repos', '/members/22/repos'],
             'route redirect with two parameter replacements' => ['users/{user}/repos/{repo}', 'members/{user}/projects/{repo}', '/users/22/repos/laravel-framework', '/members/22/projects/laravel-framework'],
-            'route redirect with two parameter replacements' => ['users/{user}/repos/{repo}', 'members/{user}/projects/{repo}', '/users/22/repos/laravel-framework', '/members/22/projects/laravel-framework'],
             'route redirect with non existent optional parameter replacements' => ['users/{user?}', 'members/{user?}', '/users', '/members'],
             'route redirect with existing parameter replacements' => ['users/{user?}', 'members/{user?}', '/users/22', '/members/22'],
             'route redirect with two optional replacements' => ['users/{user?}/{repo?}', 'members/{user?}', '/users/22', '/members/22'],

--- a/tests/Mail/MailMailerTest.php
+++ b/tests/Mail/MailMailerTest.php
@@ -26,7 +26,7 @@ class MailMailerTest extends TestCase
     public function testMailerSendSendsMessageWithProperViewContent()
     {
         unset($_SERVER['__mailer.test']);
-        $mailer = $this->getMockBuilder(Mailer::class)->setMethods(['createMessage'])->setConstructorArgs($this->getMocks())->getMock();
+        $mailer = $this->getMockBuilder(Mailer::class)->onlyMethods(['createMessage'])->setConstructorArgs($this->getMocks())->getMock();
         $message = m::mock(Swift_Mime_SimpleMessage::class);
         $mailer->expects($this->once())->method('createMessage')->willReturn($message);
         $view = m::mock(stdClass::class);
@@ -46,7 +46,7 @@ class MailMailerTest extends TestCase
     public function testMailerSendSendsMessageWithProperViewContentUsingHtmlStrings()
     {
         unset($_SERVER['__mailer.test']);
-        $mailer = $this->getMockBuilder(Mailer::class)->setMethods(['createMessage'])->setConstructorArgs($this->getMocks())->getMock();
+        $mailer = $this->getMockBuilder(Mailer::class)->onlyMethods(['createMessage'])->setConstructorArgs($this->getMocks())->getMock();
         $message = m::mock(Swift_Mime_SimpleMessage::class);
         $mailer->expects($this->once())->method('createMessage')->willReturn($message);
         $view = m::mock(stdClass::class);
@@ -67,7 +67,7 @@ class MailMailerTest extends TestCase
     public function testMailerSendSendsMessageWithProperViewContentUsingHtmlMethod()
     {
         unset($_SERVER['__mailer.test']);
-        $mailer = $this->getMockBuilder(Mailer::class)->setMethods(['createMessage'])->setConstructorArgs($this->getMocks())->getMock();
+        $mailer = $this->getMockBuilder(Mailer::class)->onlyMethods(['createMessage'])->setConstructorArgs($this->getMocks())->getMock();
         $message = m::mock(Swift_Mime_SimpleMessage::class);
         $mailer->expects($this->once())->method('createMessage')->willReturn($message);
         $view = m::mock(stdClass::class);
@@ -87,7 +87,7 @@ class MailMailerTest extends TestCase
     public function testMailerSendSendsMessageWithProperPlainViewContent()
     {
         unset($_SERVER['__mailer.test']);
-        $mailer = $this->getMockBuilder(Mailer::class)->setMethods(['createMessage'])->setConstructorArgs($this->getMocks())->getMock();
+        $mailer = $this->getMockBuilder(Mailer::class)->onlyMethods(['createMessage'])->setConstructorArgs($this->getMocks())->getMock();
         $message = m::mock(Swift_Mime_SimpleMessage::class);
         $mailer->expects($this->once())->method('createMessage')->willReturn($message);
         $view = m::mock(stdClass::class);
@@ -109,7 +109,7 @@ class MailMailerTest extends TestCase
     public function testMailerSendSendsMessageWithProperPlainViewContentWhenExplicit()
     {
         unset($_SERVER['__mailer.test']);
-        $mailer = $this->getMockBuilder(Mailer::class)->setMethods(['createMessage'])->setConstructorArgs($this->getMocks())->getMock();
+        $mailer = $this->getMockBuilder(Mailer::class)->onlyMethods(['createMessage'])->setConstructorArgs($this->getMocks())->getMock();
         $message = m::mock(Swift_Mime_SimpleMessage::class);
         $mailer->expects($this->once())->method('createMessage')->willReturn($message);
         $view = m::mock(stdClass::class);

--- a/tests/Mail/MailMessageTest.php
+++ b/tests/Mail/MailMessageTest.php
@@ -101,7 +101,7 @@ class MailMessageTest extends TestCase
     public function testBasicAttachment()
     {
         $swift = m::mock(stdClass::class);
-        $message = $this->getMockBuilder(Message::class)->setMethods(['createAttachmentFromPath'])->setConstructorArgs([$swift])->getMock();
+        $message = $this->getMockBuilder(Message::class)->onlyMethods(['createAttachmentFromPath'])->setConstructorArgs([$swift])->getMock();
         $attachment = m::mock(stdClass::class);
         $message->expects($this->once())->method('createAttachmentFromPath')->with($this->equalTo('foo.jpg'))->willReturn($attachment);
         $swift->shouldReceive('attach')->once()->with($attachment);
@@ -113,7 +113,7 @@ class MailMessageTest extends TestCase
     public function testDataAttachment()
     {
         $swift = m::mock(stdClass::class);
-        $message = $this->getMockBuilder(Message::class)->setMethods(['createAttachmentFromData'])->setConstructorArgs([$swift])->getMock();
+        $message = $this->getMockBuilder(Message::class)->onlyMethods(['createAttachmentFromData'])->setConstructorArgs([$swift])->getMock();
         $attachment = m::mock(stdClass::class);
         $message->expects($this->once())->method('createAttachmentFromData')->with($this->equalTo('foo'), $this->equalTo('name'))->willReturn($attachment);
         $swift->shouldReceive('attach')->once()->with($attachment);

--- a/tests/Mail/MailSesTransportTest.php
+++ b/tests/Mail/MailSesTransportTest.php
@@ -46,7 +46,7 @@ class MailSesTransportTest extends TestCase
         $message->setBcc('you@example.com');
 
         $client = $this->getMockBuilder(SesClient::class)
-            ->setMethods(['sendRawEmail'])
+            ->addMethods(['sendRawEmail'])
             ->disableOriginalConstructor()
             ->getMock();
         $transport = new SesTransport($client);

--- a/tests/Mail/MailableQueuedTest.php
+++ b/tests/Mail/MailableQueuedTest.php
@@ -29,7 +29,7 @@ class MailableQueuedTest extends TestCase
         $queueFake = new QueueFake(new Application);
         $mailer = $this->getMockBuilder(Mailer::class)
             ->setConstructorArgs($this->getMocks())
-            ->setMethods(['createMessage', 'to'])
+            ->onlyMethods(['createMessage', 'to'])
             ->getMock();
         $mailer->setQueue($queueFake);
         $mailable = new MailableQueableStub;
@@ -43,7 +43,7 @@ class MailableQueuedTest extends TestCase
         $queueFake = new QueueFake(new Application);
         $mailer = $this->getMockBuilder(Mailer::class)
             ->setConstructorArgs($this->getMocks())
-            ->setMethods(['createMessage'])
+            ->onlyMethods(['createMessage'])
             ->getMock();
         $mailer->setQueue($queueFake);
         $mailable = new MailableQueableStub;
@@ -72,7 +72,7 @@ class MailableQueuedTest extends TestCase
         $queueFake = new QueueFake($app);
         $mailer = $this->getMockBuilder(Mailer::class)
             ->setConstructorArgs($this->getMocks())
-            ->setMethods(['createMessage'])
+            ->onlyMethods(['createMessage'])
             ->getMock();
         $mailer->setQueue($queueFake);
         $mailable = new MailableQueableStub;

--- a/tests/Queue/QueueDatabaseQueueUnitTest.php
+++ b/tests/Queue/QueueDatabaseQueueUnitTest.php
@@ -26,7 +26,7 @@ class QueueDatabaseQueueUnitTest extends TestCase
             return $uuid;
         });
 
-        $queue = $this->getMockBuilder(DatabaseQueue::class)->setMethods(['currentTime'])->setConstructorArgs([$database = m::mock(Connection::class), 'table', 'default'])->getMock();
+        $queue = $this->getMockBuilder(DatabaseQueue::class)->onlyMethods(['currentTime'])->setConstructorArgs([$database = m::mock(Connection::class), 'table', 'default'])->getMock();
         $queue->expects($this->any())->method('currentTime')->willReturn('time');
         $database->shouldReceive('table')->with('table')->andReturn($query = m::mock(stdClass::class));
         $query->shouldReceive('insertGetId')->once()->andReturnUsing(function ($array) use ($uuid) {
@@ -51,7 +51,7 @@ class QueueDatabaseQueueUnitTest extends TestCase
         });
 
         $queue = $this->getMockBuilder(
-            DatabaseQueue::class)->setMethods(
+            DatabaseQueue::class)->onlyMethods(
             ['currentTime'])->setConstructorArgs(
             [$database = m::mock(Connection::class), 'table', 'default']
         )->getMock();
@@ -112,7 +112,7 @@ class QueueDatabaseQueueUnitTest extends TestCase
         });
 
         $database = m::mock(Connection::class);
-        $queue = $this->getMockBuilder(DatabaseQueue::class)->setMethods(['currentTime', 'availableAt'])->setConstructorArgs([$database, 'table', 'default'])->getMock();
+        $queue = $this->getMockBuilder(DatabaseQueue::class)->onlyMethods(['currentTime', 'availableAt'])->setConstructorArgs([$database, 'table', 'default'])->getMock();
         $queue->expects($this->any())->method('currentTime')->willReturn('created');
         $queue->expects($this->any())->method('availableAt')->willReturn('available');
         $database->shouldReceive('table')->with('table')->andReturn($query = m::mock(stdClass::class));

--- a/tests/Queue/QueueRedisQueueTest.php
+++ b/tests/Queue/QueueRedisQueueTest.php
@@ -26,7 +26,7 @@ class QueueRedisQueueTest extends TestCase
             return $uuid;
         });
 
-        $queue = $this->getMockBuilder(RedisQueue::class)->setMethods(['getRandomId'])->setConstructorArgs([$redis = m::mock(Factory::class), 'default'])->getMock();
+        $queue = $this->getMockBuilder(RedisQueue::class)->onlyMethods(['getRandomId'])->setConstructorArgs([$redis = m::mock(Factory::class), 'default'])->getMock();
         $queue->expects($this->once())->method('getRandomId')->willReturn('foo');
         $redis->shouldReceive('connection')->once()->andReturn($redis);
         $redis->shouldReceive('eval')->once()->with(LuaScripts::push(), 2, 'queues:default', 'queues:default:notify', json_encode(['uuid' => $uuid, 'displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'maxExceptions' => null, 'backoff' => null, 'timeout' => null, 'data' => ['data'], 'id' => 'foo', 'attempts' => 0]));
@@ -45,7 +45,7 @@ class QueueRedisQueueTest extends TestCase
             return $uuid;
         });
 
-        $queue = $this->getMockBuilder(RedisQueue::class)->setMethods(['getRandomId'])->setConstructorArgs([$redis = m::mock(Factory::class), 'default'])->getMock();
+        $queue = $this->getMockBuilder(RedisQueue::class)->onlyMethods(['getRandomId'])->setConstructorArgs([$redis = m::mock(Factory::class), 'default'])->getMock();
         $queue->expects($this->once())->method('getRandomId')->willReturn('foo');
         $redis->shouldReceive('connection')->once()->andReturn($redis);
         $redis->shouldReceive('eval')->once()->with(LuaScripts::push(), 2, 'queues:default', 'queues:default:notify', json_encode(['uuid' => $uuid, 'displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'maxExceptions' => null, 'backoff' => null, 'timeout' => null, 'data' => ['data'], 'custom' => 'taylor', 'id' => 'foo', 'attempts' => 0]));
@@ -70,7 +70,7 @@ class QueueRedisQueueTest extends TestCase
             return $uuid;
         });
 
-        $queue = $this->getMockBuilder(RedisQueue::class)->setMethods(['getRandomId'])->setConstructorArgs([$redis = m::mock(Factory::class), 'default'])->getMock();
+        $queue = $this->getMockBuilder(RedisQueue::class)->onlyMethods(['getRandomId'])->setConstructorArgs([$redis = m::mock(Factory::class), 'default'])->getMock();
         $queue->expects($this->once())->method('getRandomId')->willReturn('foo');
         $redis->shouldReceive('connection')->once()->andReturn($redis);
         $redis->shouldReceive('eval')->once()->with(LuaScripts::push(), 2, 'queues:default', 'queues:default:notify', json_encode(['uuid' => $uuid, 'displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'maxExceptions' => null, 'backoff' => null, 'timeout' => null, 'data' => ['data'], 'custom' => 'taylor', 'bar' => 'foo', 'id' => 'foo', 'attempts' => 0]));
@@ -99,7 +99,7 @@ class QueueRedisQueueTest extends TestCase
             return $uuid;
         });
 
-        $queue = $this->getMockBuilder(RedisQueue::class)->setMethods(['availableAt', 'getRandomId'])->setConstructorArgs([$redis = m::mock(Factory::class), 'default'])->getMock();
+        $queue = $this->getMockBuilder(RedisQueue::class)->onlyMethods(['availableAt', 'getRandomId'])->setConstructorArgs([$redis = m::mock(Factory::class), 'default'])->getMock();
         $queue->expects($this->once())->method('getRandomId')->willReturn('foo');
         $queue->expects($this->once())->method('availableAt')->with(1)->willReturn(2);
 
@@ -125,7 +125,7 @@ class QueueRedisQueueTest extends TestCase
         });
 
         $date = Carbon::now();
-        $queue = $this->getMockBuilder(RedisQueue::class)->setMethods(['availableAt', 'getRandomId'])->setConstructorArgs([$redis = m::mock(Factory::class), 'default'])->getMock();
+        $queue = $this->getMockBuilder(RedisQueue::class)->onlyMethods(['availableAt', 'getRandomId'])->setConstructorArgs([$redis = m::mock(Factory::class), 'default'])->getMock();
         $queue->expects($this->once())->method('getRandomId')->willReturn('foo');
         $queue->expects($this->once())->method('availableAt')->with($date)->willReturn(2);
 

--- a/tests/Queue/QueueSqsJobTest.php
+++ b/tests/Queue/QueueSqsJobTest.php
@@ -28,7 +28,7 @@ class QueueSqsJobTest extends TestCase
 
         // Get a mock of the SqsClient
         $this->mockedSqsClient = $this->getMockBuilder(SqsClient::class)
-            ->setMethods(['deleteMessage'])
+            ->addMethods(['deleteMessage'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -66,10 +66,10 @@ class QueueSqsJobTest extends TestCase
     public function testDeleteRemovesTheJobFromSqs()
     {
         $this->mockedSqsClient = $this->getMockBuilder(SqsClient::class)
-            ->setMethods(['deleteMessage'])
+            ->addMethods(['deleteMessage'])
             ->disableOriginalConstructor()
             ->getMock();
-        $queue = $this->getMockBuilder(SqsQueue::class)->setMethods(['getQueue'])->setConstructorArgs([$this->mockedSqsClient, $this->queueName, $this->account])->getMock();
+        $queue = $this->getMockBuilder(SqsQueue::class)->onlyMethods(['getQueue'])->setConstructorArgs([$this->mockedSqsClient, $this->queueName, $this->account])->getMock();
         $queue->setContainer($this->mockedContainer);
         $job = $this->getJob();
         $job->getSqs()->expects($this->once())->method('deleteMessage')->with(['QueueUrl' => $this->queueUrl, 'ReceiptHandle' => $this->mockedReceiptHandle]);
@@ -79,10 +79,10 @@ class QueueSqsJobTest extends TestCase
     public function testReleaseProperlyReleasesTheJobOntoSqs()
     {
         $this->mockedSqsClient = $this->getMockBuilder(SqsClient::class)
-            ->setMethods(['changeMessageVisibility'])
+            ->addMethods(['changeMessageVisibility'])
             ->disableOriginalConstructor()
             ->getMock();
-        $queue = $this->getMockBuilder(SqsQueue::class)->setMethods(['getQueue'])->setConstructorArgs([$this->mockedSqsClient, $this->queueName, $this->account])->getMock();
+        $queue = $this->getMockBuilder(SqsQueue::class)->onlyMethods(['getQueue'])->setConstructorArgs([$this->mockedSqsClient, $this->queueName, $this->account])->getMock();
         $queue->setContainer($this->mockedContainer);
         $job = $this->getJob();
         $job->getSqs()->expects($this->once())->method('changeMessageVisibility')->with(['QueueUrl' => $this->queueUrl, 'ReceiptHandle' => $this->mockedReceiptHandle, 'VisibilityTimeout' => $this->releaseDelay]);

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -70,7 +70,7 @@ class QueueSqsQueueTest extends TestCase
 
     public function testPopProperlyPopsJobOffOfSqs()
     {
-        $queue = $this->getMockBuilder(SqsQueue::class)->setMethods(['getQueue'])->setConstructorArgs([$this->sqs, $this->queueName, $this->account])->getMock();
+        $queue = $this->getMockBuilder(SqsQueue::class)->onlyMethods(['getQueue'])->setConstructorArgs([$this->sqs, $this->queueName, $this->account])->getMock();
         $queue->setContainer(m::mock(Container::class));
         $queue->expects($this->once())->method('getQueue')->with($this->queueName)->willReturn($this->queueUrl);
         $this->sqs->shouldReceive('receiveMessage')->once()->with(['QueueUrl' => $this->queueUrl, 'AttributeNames' => ['ApproximateReceiveCount']])->andReturn($this->mockedReceiveMessageResponseModel);
@@ -80,7 +80,7 @@ class QueueSqsQueueTest extends TestCase
 
     public function testPopProperlyHandlesEmptyMessage()
     {
-        $queue = $this->getMockBuilder(SqsQueue::class)->setMethods(['getQueue'])->setConstructorArgs([$this->sqs, $this->queueName, $this->account])->getMock();
+        $queue = $this->getMockBuilder(SqsQueue::class)->onlyMethods(['getQueue'])->setConstructorArgs([$this->sqs, $this->queueName, $this->account])->getMock();
         $queue->setContainer(m::mock(Container::class));
         $queue->expects($this->once())->method('getQueue')->with($this->queueName)->willReturn($this->queueUrl);
         $this->sqs->shouldReceive('receiveMessage')->once()->with(['QueueUrl' => $this->queueUrl, 'AttributeNames' => ['ApproximateReceiveCount']])->andReturn($this->mockedReceiveEmptyMessageResponseModel);
@@ -91,7 +91,7 @@ class QueueSqsQueueTest extends TestCase
     public function testDelayedPushWithDateTimeProperlyPushesJobOntoSqs()
     {
         $now = Carbon::now();
-        $queue = $this->getMockBuilder(SqsQueue::class)->setMethods(['createPayload', 'secondsUntil', 'getQueue'])->setConstructorArgs([$this->sqs, $this->queueName, $this->account])->getMock();
+        $queue = $this->getMockBuilder(SqsQueue::class)->onlyMethods(['createPayload', 'secondsUntil', 'getQueue'])->setConstructorArgs([$this->sqs, $this->queueName, $this->account])->getMock();
         $queue->expects($this->once())->method('createPayload')->with($this->mockedJob, $this->queueName, $this->mockedData)->willReturn($this->mockedPayload);
         $queue->expects($this->once())->method('secondsUntil')->with($now)->willReturn(5);
         $queue->expects($this->once())->method('getQueue')->with($this->queueName)->willReturn($this->queueUrl);
@@ -102,7 +102,7 @@ class QueueSqsQueueTest extends TestCase
 
     public function testDelayedPushProperlyPushesJobOntoSqs()
     {
-        $queue = $this->getMockBuilder(SqsQueue::class)->setMethods(['createPayload', 'secondsUntil', 'getQueue'])->setConstructorArgs([$this->sqs, $this->queueName, $this->account])->getMock();
+        $queue = $this->getMockBuilder(SqsQueue::class)->onlyMethods(['createPayload', 'secondsUntil', 'getQueue'])->setConstructorArgs([$this->sqs, $this->queueName, $this->account])->getMock();
         $queue->expects($this->once())->method('createPayload')->with($this->mockedJob, $this->queueName, $this->mockedData)->willReturn($this->mockedPayload);
         $queue->expects($this->once())->method('secondsUntil')->with($this->mockedDelay)->willReturn($this->mockedDelay);
         $queue->expects($this->once())->method('getQueue')->with($this->queueName)->willReturn($this->queueUrl);
@@ -113,7 +113,7 @@ class QueueSqsQueueTest extends TestCase
 
     public function testPushProperlyPushesJobOntoSqs()
     {
-        $queue = $this->getMockBuilder(SqsQueue::class)->setMethods(['createPayload', 'getQueue'])->setConstructorArgs([$this->sqs, $this->queueName, $this->account])->getMock();
+        $queue = $this->getMockBuilder(SqsQueue::class)->onlyMethods(['createPayload', 'getQueue'])->setConstructorArgs([$this->sqs, $this->queueName, $this->account])->getMock();
         $queue->expects($this->once())->method('createPayload')->with($this->mockedJob, $this->queueName, $this->mockedData)->willReturn($this->mockedPayload);
         $queue->expects($this->once())->method('getQueue')->with($this->queueName)->willReturn($this->queueUrl);
         $this->sqs->shouldReceive('sendMessage')->once()->with(['QueueUrl' => $this->queueUrl, 'MessageBody' => $this->mockedPayload])->andReturn($this->mockedSendMessageResponseModel);
@@ -123,11 +123,11 @@ class QueueSqsQueueTest extends TestCase
 
     public function testSizeProperlyReadsSqsQueueSize()
     {
-        $queue = $this->getMockBuilder(SqsQueue::class)->setMethods(['getQueue'])->setConstructorArgs([$this->sqs, $this->queueName, $this->account])->getMock();
+        $queue = $this->getMockBuilder(SqsQueue::class)->onlyMethods(['getQueue'])->setConstructorArgs([$this->sqs, $this->queueName, $this->account])->getMock();
         $queue->expects($this->once())->method('getQueue')->with($this->queueName)->willReturn($this->queueUrl);
         $this->sqs->shouldReceive('getQueueAttributes')->once()->with(['QueueUrl' => $this->queueUrl, 'AttributeNames' => ['ApproximateNumberOfMessages']])->andReturn($this->mockedQueueAttributesResponseModel);
         $size = $queue->size($this->queueName);
-        $this->assertEquals($size, 1);
+        $this->assertEquals(1, $size);
     }
 
     public function testGetQueueProperlyResolvesUrlWithPrefix()

--- a/tests/ReflectionHelpers.php
+++ b/tests/ReflectionHelpers.php
@@ -20,7 +20,7 @@ trait ReflectionHelpers
         $class = new ReflectionClass($obj);
         $method = $class->getMethod($name);
         $method->setAccessible(true);
-        
+
         return $method->invokeArgs($obj, $args);
     }
 

--- a/tests/ReflectionHelpers.php
+++ b/tests/ReflectionHelpers.php
@@ -20,6 +20,7 @@ trait ReflectionHelpers
         $class = new ReflectionClass($obj);
         $method = $class->getMethod($name);
         $method->setAccessible(true);
+        
         return $method->invokeArgs($obj, $args);
     }
 

--- a/tests/ReflectionHelpers.php
+++ b/tests/ReflectionHelpers.php
@@ -39,7 +39,6 @@ trait ReflectionHelpers
     }
 
     /**
-     * For setting private or protected property of an object
      * @param mixed $object
      * @param mixed $property
      * @param $value

--- a/tests/ReflectionHelpers.php
+++ b/tests/ReflectionHelpers.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Illuminate\Tests;
+
+use ReflectionClass;
+use ReflectionException;
+use ReflectionObject;
+
+trait ReflectionHelpers
+{
+    /**
+     * @param $obj
+     * @param $name
+     * @param array $args
+     * @return mixed
+     * @throws ReflectionException
+     */
+    protected static function privateCall($obj, $name, array $args = [])
+    {
+        $class = new ReflectionClass($obj);
+        $method = $class->getMethod($name);
+        $method->setAccessible(true);
+        return $method->invokeArgs($obj, $args);
+    }
+
+    /**
+     * @param $obj
+     * @param $name
+     * @return mixed
+     * @throws ReflectionException
+     */
+    protected static function getPrivateProperty($obj, $name)
+    {
+        $class = new ReflectionObject($obj);
+        $property = $class->getProperty($name);
+        $property->setAccessible(true);
+
+        return $property->getValue($obj);
+    }
+
+    /**
+     * For setting private or protected property of an object
+     * @param mixed $object
+     * @param mixed $property
+     * @param $value
+     * @throws ReflectionException
+     */
+    protected function setPrivateProperty($object, $property, $value)
+    {
+        $reflection = new ReflectionClass($object);
+        $reflectionProperty = $reflection->getProperty($property);
+        $reflectionProperty->setAccessible(true);
+        $reflectionProperty->setValue($object, $value);
+    }
+}

--- a/tests/Routing/RoutingRedirectorTest.php
+++ b/tests/Routing/RoutingRedirectorTest.php
@@ -182,7 +182,6 @@ class RoutingRedirectorTest extends TestCase
     {
         $this->session->shouldReceive('put')->once()->with('url.intended', 'http://foo.com/bar');
 
-        $result = $this->redirect->setIntendedUrl('http://foo.com/bar');
-        $this->assertNull($result);
+        $this->redirect->setIntendedUrl('http://foo.com/bar');
     }
 }

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -433,7 +433,7 @@ class SessionStoreTest extends TestCase
         $session = $this->getSession();
         $this->assertEquals($session->getName(), $this->getSessionName());
         $session->setName('foo');
-        $this->assertEquals($session->getName(), 'foo');
+        $this->assertEquals('foo', $session->getName());
     }
 
     public function testKeyExists()

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -110,7 +110,7 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['foo.bar' => []], $array);
 
         $array = Arr::dot(['name' => 'taylor', 'languages' => ['php' => true]]);
-        $this->assertEquals($array, ['name' => 'taylor', 'languages.php' => true]);
+        $this->assertEquals(['name' => 'taylor', 'languages.php' => true], $array);
     }
 
     public function testExcept()

--- a/tests/Support/SupportCapsuleManagerTraitTest.php
+++ b/tests/Support/SupportCapsuleManagerTraitTest.php
@@ -23,7 +23,7 @@ class SupportCapsuleManagerTraitTest extends TestCase
         $this->container = null;
         $app = new Container;
 
-        $this->assertNull($this->setupContainer($app));
+        $this->setupContainer($app);
         $this->assertEquals($app, $this->getContainer());
         $this->assertInstanceOf(Fluent::class, $app['config']);
     }
@@ -34,7 +34,7 @@ class SupportCapsuleManagerTraitTest extends TestCase
         $app = new Container;
         $app['config'] = m::mock(Repository::class);
 
-        $this->assertNull($this->setupContainer($app));
+        $this->setupContainer($app);
         $this->assertEquals($app, $this->getContainer());
         $this->assertInstanceOf(Repository::class, $app['config']);
     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -375,7 +375,7 @@ class SupportCollectionTest extends TestCase
      */
     public function testToJsonEncodesTheJsonSerializeResult($collection)
     {
-        $c = $this->getMockBuilder($collection)->setMethods(['jsonSerialize'])->getMock();
+        $c = $this->getMockBuilder($collection)->onlyMethods(['jsonSerialize'])->getMock();
         $c->expects($this->once())->method('jsonSerialize')->willReturn('foo');
         $results = $c->toJson();
         $this->assertJsonStringEqualsJsonString(json_encode('foo'), $results);
@@ -386,7 +386,7 @@ class SupportCollectionTest extends TestCase
      */
     public function testCastingToStringJsonEncodesTheToArrayResult($collection)
     {
-        $c = $this->getMockBuilder($collection)->setMethods(['jsonSerialize'])->getMock();
+        $c = $this->getMockBuilder($collection)->onlyMethods(['jsonSerialize'])->getMock();
         $c->expects($this->once())->method('jsonSerialize')->willReturn('foo');
 
         $this->assertJsonStringEqualsJsonString(json_encode('foo'), (string) $c);
@@ -4028,27 +4028,27 @@ class SupportCollectionTest extends TestCase
 
         [$tims, $others] = $data->partition('name', 'Tim')->all();
 
-        $this->assertEquals($tims->values()->all(), [
+        $this->assertEquals([
             ['name' => 'Tim', 'age' => 17],
             ['name' => 'Tim', 'age' => 41],
-        ]);
+        ], $tims->values()->all());
 
-        $this->assertEquals($others->values()->all(), [
+        $this->assertEquals([
             ['name' => 'Agatha', 'age' => 62],
             ['name' => 'Kristina', 'age' => 33],
-        ]);
+        ], $others->values()->all());
 
         [$adults, $minors] = $data->partition('age', '>=', 18)->all();
 
-        $this->assertEquals($adults->values()->all(), [
+        $this->assertEquals([
             ['name' => 'Agatha', 'age' => 62],
             ['name' => 'Kristina', 'age' => 33],
             ['name' => 'Tim', 'age' => 41],
-        ]);
+        ], $adults->values()->all());
 
-        $this->assertEquals($minors->values()->all(), [
+        $this->assertEquals([
             ['name' => 'Tim', 'age' => 17],
-        ]);
+        ], $minors->values()->all());
     }
 
     /**

--- a/tests/Support/SupportComposerTest.php
+++ b/tests/Support/SupportComposerTest.php
@@ -59,7 +59,7 @@ class SupportComposerTest extends TestCase
         $process->shouldReceive('run')->once();
 
         $composer = $this->getMockBuilder(Composer::class)
-            ->setMethods(['getProcess'])
+            ->onlyMethods(['getProcess'])
             ->setConstructorArgs([$files, $directory])
             ->getMock();
         $composer->expects($this->once())

--- a/tests/Support/SupportFluentTest.php
+++ b/tests/Support/SupportFluentTest.php
@@ -64,7 +64,7 @@ class SupportFluentTest extends TestCase
         $fluent = new Fluent(['attributes' => '1']);
 
         $this->assertTrue(isset($fluent['attributes']));
-        $this->assertEquals($fluent['attributes'], 1);
+        $this->assertEquals(1, $fluent['attributes']);
 
         $fluent->attributes();
 
@@ -107,7 +107,7 @@ class SupportFluentTest extends TestCase
 
     public function testToJsonEncodesTheToArrayResult()
     {
-        $fluent = $this->getMockBuilder(Fluent::class)->setMethods(['toArray'])->getMock();
+        $fluent = $this->getMockBuilder(Fluent::class)->onlyMethods(['toArray'])->getMock();
         $fluent->expects($this->once())->method('toArray')->willReturn('foo');
         $results = $fluent->toJson();
 

--- a/tests/Support/SupportNamespacedItemResolverTest.php
+++ b/tests/Support/SupportNamespacedItemResolverTest.php
@@ -19,7 +19,7 @@ class SupportNamespacedItemResolverTest extends TestCase
 
     public function testParsedItemsAreCached()
     {
-        $r = $this->getMockBuilder(NamespacedItemResolver::class)->setMethods(['parseBasicSegments', 'parseNamespacedSegments'])->getMock();
+        $r = $this->getMockBuilder(NamespacedItemResolver::class)->onlyMethods(['parseBasicSegments', 'parseNamespacedSegments'])->getMock();
         $r->setParsedKey('foo.bar', ['foo']);
         $r->expects($this->never())->method('parseBasicSegments');
         $r->expects($this->never())->method('parseNamespacedSegments');

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -1028,7 +1028,7 @@ class JsonSerializableMixedResourcesStub implements JsonSerializable
             ],
             'barfoo' => [
                 ['bar' => ['bar' => 'foo 0']],
-                ['bar' => ['bar' => 'foo 0', 'bar' => 'foo 0']],
+                ['bar' => ['bar' => 'foo 0', 'foo' => 'foo 0']],
                 ['bar' => ['foo' => 'bar 0', 'bar' => 'foo 0', 'rab' => 'rab 0']],
             ],
             'numeric_keys' => [

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -18,19 +18,19 @@ class TranslationTranslatorTest extends TestCase
 
     public function testHasMethodReturnsFalseWhenReturnedTranslationIsNull()
     {
-        $t = $this->getMockBuilder(Translator::class)->setMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
+        $t = $this->getMockBuilder(Translator::class)->onlyMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
         $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('bar'))->willReturn('foo');
         $this->assertFalse($t->has('foo', 'bar'));
 
-        $t = $this->getMockBuilder(Translator::class)->setMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en', 'sp'])->getMock();
+        $t = $this->getMockBuilder(Translator::class)->onlyMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en', 'sp'])->getMock();
         $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('bar'))->willReturn('bar');
         $this->assertTrue($t->has('foo', 'bar'));
 
-        $t = $this->getMockBuilder(Translator::class)->setMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
+        $t = $this->getMockBuilder(Translator::class)->onlyMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
         $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('bar'), false)->willReturn('bar');
         $this->assertTrue($t->hasForLocale('foo', 'bar'));
 
-        $t = $this->getMockBuilder(Translator::class)->setMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
+        $t = $this->getMockBuilder(Translator::class)->onlyMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
         $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('bar'), false)->willReturn('foo');
         $this->assertFalse($t->hasForLocale('foo', 'bar'));
 
@@ -76,7 +76,7 @@ class TranslationTranslatorTest extends TestCase
 
     public function testGetMethodProperlyLoadsAndRetrievesItemWithCapitalization()
     {
-        $t = $this->getMockBuilder(Translator::class)->setMethods(null)->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
+        $t = $this->getMockBuilder(Translator::class)->onlyMethods([])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
         $t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn(['foo' => 'foo', 'baz' => 'breeze :Foo :BAR']);
         $this->assertSame('breeze Bar FOO', $t->get('foo::bar.baz', ['foo' => 'bar', 'bar' => 'foo'], 'en'));
@@ -114,7 +114,7 @@ class TranslationTranslatorTest extends TestCase
 
     public function testChoiceMethodProperlyLoadsAndRetrievesItem()
     {
-        $t = $this->getMockBuilder(Translator::class)->setMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
+        $t = $this->getMockBuilder(Translator::class)->onlyMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
         $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo(['replace']), $this->equalTo('en'))->willReturn('line');
         $t->setSelector($selector = m::mock(MessageSelector::class));
         $selector->shouldReceive('choose')->once()->with('line', 10, 'en')->andReturn('choiced');
@@ -124,7 +124,7 @@ class TranslationTranslatorTest extends TestCase
 
     public function testChoiceMethodProperlyCountsCollectionsAndLoadsAndRetrievesItem()
     {
-        $t = $this->getMockBuilder(Translator::class)->setMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
+        $t = $this->getMockBuilder(Translator::class)->onlyMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
         $t->expects($this->exactly(2))->method('get')->with($this->equalTo('foo'), $this->equalTo(['replace']), $this->equalTo('en'))->willReturn('line');
         $t->setSelector($selector = m::mock(MessageSelector::class));
         $selector->shouldReceive('choose')->twice()->with('line', 3, 'en')->andReturn('choiced');

--- a/tests/Validation/ValidationFactoryTest.php
+++ b/tests/Validation/ValidationFactoryTest.php
@@ -73,7 +73,7 @@ class ValidationFactoryTest extends TestCase
             ['foo' => 'required']
         );
 
-        $this->assertEquals($validated, ['foo' => 'bar']);
+        $this->assertEquals(['foo' => 'bar'], $validated);
     }
 
     public function testCustomResolverIsCalled()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1301,9 +1301,9 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => [1, 'string']], ['lhs' => 'gt:rhs']);
         $this->assertTrue($v->fails());
 
-        $fileOne = $this->getMockBuilder(File::class)->setMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
+        $fileOne = $this->getMockBuilder(File::class)->onlyMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $fileOne->expects($this->any())->method('getSize')->willReturn(5472);
-        $fileTwo = $this->getMockBuilder(File::class)->setMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
+        $fileTwo = $this->getMockBuilder(File::class)->onlyMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $fileTwo->expects($this->any())->method('getSize')->willReturn(3151);
         $v = new Validator($trans, ['lhs' => $fileOne, 'rhs' => $fileTwo], ['lhs' => 'gt:rhs']);
         $this->assertTrue($v->passes());
@@ -1342,9 +1342,9 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => [1, 'string']], ['lhs' => 'lt:rhs']);
         $this->assertTrue($v->passes());
 
-        $fileOne = $this->getMockBuilder(File::class)->setMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
+        $fileOne = $this->getMockBuilder(File::class)->onlyMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $fileOne->expects($this->any())->method('getSize')->willReturn(5472);
-        $fileTwo = $this->getMockBuilder(File::class)->setMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
+        $fileTwo = $this->getMockBuilder(File::class)->onlyMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $fileTwo->expects($this->any())->method('getSize')->willReturn(3151);
         $v = new Validator($trans, ['lhs' => $fileOne, 'rhs' => $fileTwo], ['lhs' => 'lt:rhs']);
         $this->assertTrue($v->fails());
@@ -1383,9 +1383,9 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => [1, 'string']], ['lhs' => 'gte:rhs']);
         $this->assertTrue($v->fails());
 
-        $fileOne = $this->getMockBuilder(File::class)->setMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
+        $fileOne = $this->getMockBuilder(File::class)->onlyMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $fileOne->expects($this->any())->method('getSize')->willReturn(5472);
-        $fileTwo = $this->getMockBuilder(File::class)->setMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
+        $fileTwo = $this->getMockBuilder(File::class)->onlyMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $fileTwo->expects($this->any())->method('getSize')->willReturn(5472);
         $v = new Validator($trans, ['lhs' => $fileOne, 'rhs' => $fileTwo], ['lhs' => 'gte:rhs']);
         $this->assertTrue($v->passes());
@@ -1424,9 +1424,9 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => [1, 'string']], ['lhs' => 'lte:rhs']);
         $this->assertTrue($v->passes());
 
-        $fileOne = $this->getMockBuilder(File::class)->setMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
+        $fileOne = $this->getMockBuilder(File::class)->onlyMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $fileOne->expects($this->any())->method('getSize')->willReturn(5472);
-        $fileTwo = $this->getMockBuilder(File::class)->setMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
+        $fileTwo = $this->getMockBuilder(File::class)->onlyMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $fileTwo->expects($this->any())->method('getSize')->willReturn(5472);
         $v = new Validator($trans, ['lhs' => $fileOne, 'rhs' => $fileTwo], ['lhs' => 'lte:rhs']);
         $this->assertTrue($v->passes());
@@ -1727,12 +1727,12 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['foo' => [1, 2, 3]], ['foo' => 'Array|Size:4']);
         $this->assertFalse($v->passes());
 
-        $file = $this->getMockBuilder(File::class)->setMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
+        $file = $this->getMockBuilder(File::class)->onlyMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $file->expects($this->any())->method('getSize')->willReturn(3072);
         $v = new Validator($trans, ['photo' => $file], ['photo' => 'Size:3']);
         $this->assertTrue($v->passes());
 
-        $file = $this->getMockBuilder(File::class)->setMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
+        $file = $this->getMockBuilder(File::class)->onlyMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $file->expects($this->any())->method('getSize')->willReturn(4072);
         $v = new Validator($trans, ['photo' => $file], ['photo' => 'Size:3']);
         $this->assertFalse($v->passes());
@@ -1765,12 +1765,12 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['foo' => [1, 2, 3]], ['foo' => 'Array|Between:1,2']);
         $this->assertFalse($v->passes());
 
-        $file = $this->getMockBuilder(File::class)->setMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
+        $file = $this->getMockBuilder(File::class)->onlyMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $file->expects($this->any())->method('getSize')->willReturn(3072);
         $v = new Validator($trans, ['photo' => $file], ['photo' => 'Between:1,5']);
         $this->assertTrue($v->passes());
 
-        $file = $this->getMockBuilder(File::class)->setMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
+        $file = $this->getMockBuilder(File::class)->onlyMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $file->expects($this->any())->method('getSize')->willReturn(4072);
         $v = new Validator($trans, ['photo' => $file], ['photo' => 'Between:1,2']);
         $this->assertFalse($v->passes());
@@ -1797,12 +1797,12 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['foo' => [1, 2]], ['foo' => 'Array|Min:3']);
         $this->assertFalse($v->passes());
 
-        $file = $this->getMockBuilder(File::class)->setMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
+        $file = $this->getMockBuilder(File::class)->onlyMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $file->expects($this->any())->method('getSize')->willReturn(3072);
         $v = new Validator($trans, ['photo' => $file], ['photo' => 'Min:2']);
         $this->assertTrue($v->passes());
 
-        $file = $this->getMockBuilder(File::class)->setMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
+        $file = $this->getMockBuilder(File::class)->onlyMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $file->expects($this->any())->method('getSize')->willReturn(4072);
         $v = new Validator($trans, ['photo' => $file], ['photo' => 'Min:10']);
         $this->assertFalse($v->passes());
@@ -1829,19 +1829,19 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['foo' => [1, 2, 3]], ['foo' => 'Array|Max:2']);
         $this->assertFalse($v->passes());
 
-        $file = $this->getMockBuilder(UploadedFile::class)->setMethods(['isValid', 'getSize'])->setConstructorArgs([__FILE__, basename(__FILE__)])->getMock();
+        $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['isValid', 'getSize'])->setConstructorArgs([__FILE__, basename(__FILE__)])->getMock();
         $file->expects($this->any())->method('isValid')->willReturn(true);
-        $file->expects($this->at(1))->method('getSize')->willReturn(3072);
+        $file->expects($this->once())->method('getSize')->willReturn(3072);
         $v = new Validator($trans, ['photo' => $file], ['photo' => 'Max:10']);
         $this->assertTrue($v->passes());
 
-        $file = $this->getMockBuilder(UploadedFile::class)->setMethods(['isValid', 'getSize'])->setConstructorArgs([__FILE__, basename(__FILE__)])->getMock();
-        $file->expects($this->at(0))->method('isValid')->willReturn(true);
-        $file->expects($this->at(1))->method('getSize')->willReturn(4072);
+        $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['isValid', 'getSize'])->setConstructorArgs([__FILE__, basename(__FILE__)])->getMock();
+        $file->expects($this->any())->method('isValid')->willReturn(true);
+        $file->expects($this->once())->method('getSize')->willReturn(4072);
         $v = new Validator($trans, ['photo' => $file], ['photo' => 'Max:2']);
         $this->assertFalse($v->passes());
 
-        $file = $this->getMockBuilder(UploadedFile::class)->setMethods(['isValid'])->setConstructorArgs([__FILE__, basename(__FILE__)])->getMock();
+        $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['isValid'])->setConstructorArgs([__FILE__, basename(__FILE__)])->getMock();
         $file->expects($this->any())->method('isValid')->willReturn(false);
         $v = new Validator($trans, ['photo' => $file], ['photo' => 'Max:10']);
         $this->assertFalse($v->passes());
@@ -1861,7 +1861,7 @@ class ValidationValidatorTest extends TestCase
         $v->messages()->setFormat(':message');
         $this->assertSame('string', $v->messages()->first('name'));
 
-        $file = $this->getMockBuilder(UploadedFile::class)->setMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
+        $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
         $file->expects($this->any())->method('getSize')->willReturn(4072);
         $file->expects($this->any())->method('isValid')->willReturn(true);
         $v = new Validator($trans, ['photo' => $file], ['photo' => 'Max:3']);
@@ -1897,10 +1897,10 @@ class ValidationValidatorTest extends TestCase
         $v->messages()->setFormat(':message');
         $this->assertSame('minimum value', $v->messages()->first('max'));
 
-        $file = $this->getMockBuilder(UploadedFile::class)->setMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
+        $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
         $file->expects($this->any())->method('getSize')->willReturn(4072);
         $file->expects($this->any())->method('isValid')->willReturn(true);
-        $biggerFile = $this->getMockBuilder(UploadedFile::class)->setMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
+        $biggerFile = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
         $biggerFile->expects($this->any())->method('getSize')->willReturn(5120);
         $biggerFile->expects($this->any())->method('isValid')->willReturn(true);
         $v = new Validator($trans, ['photo' => $file, 'bigger' => $biggerFile], ['photo' => 'file|gt:bigger']);
@@ -1939,10 +1939,10 @@ class ValidationValidatorTest extends TestCase
         $v->messages()->setFormat(':message');
         $this->assertSame('maximum value', $v->messages()->first('min'));
 
-        $file = $this->getMockBuilder(UploadedFile::class)->setMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
+        $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
         $file->expects($this->any())->method('getSize')->willReturn(4072);
         $file->expects($this->any())->method('isValid')->willReturn(true);
-        $smallerFile = $this->getMockBuilder(UploadedFile::class)->setMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
+        $smallerFile = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
         $smallerFile->expects($this->any())->method('getSize')->willReturn(2048);
         $smallerFile->expects($this->any())->method('isValid')->willReturn(true);
         $v = new Validator($trans, ['photo' => $file, 'smaller' => $smallerFile], ['photo' => 'file|lt:smaller']);
@@ -1981,10 +1981,10 @@ class ValidationValidatorTest extends TestCase
         $v->messages()->setFormat(':message');
         $this->assertSame('minimum value', $v->messages()->first('max'));
 
-        $file = $this->getMockBuilder(UploadedFile::class)->setMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
+        $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
         $file->expects($this->any())->method('getSize')->willReturn(4072);
         $file->expects($this->any())->method('isValid')->willReturn(true);
-        $biggerFile = $this->getMockBuilder(UploadedFile::class)->setMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
+        $biggerFile = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
         $biggerFile->expects($this->any())->method('getSize')->willReturn(5120);
         $biggerFile->expects($this->any())->method('isValid')->willReturn(true);
         $v = new Validator($trans, ['photo' => $file, 'bigger' => $biggerFile], ['photo' => 'file|gte:bigger']);
@@ -2023,10 +2023,10 @@ class ValidationValidatorTest extends TestCase
         $v->messages()->setFormat(':message');
         $this->assertSame('maximum value', $v->messages()->first('min'));
 
-        $file = $this->getMockBuilder(UploadedFile::class)->setMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
+        $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
         $file->expects($this->any())->method('getSize')->willReturn(4072);
         $file->expects($this->any())->method('isValid')->willReturn(true);
-        $smallerFile = $this->getMockBuilder(UploadedFile::class)->setMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
+        $smallerFile = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
         $smallerFile->expects($this->any())->method('getSize')->willReturn(2048);
         $smallerFile->expects($this->any())->method('isValid')->willReturn(true);
         $v = new Validator($trans, ['photo' => $file, 'smaller' => $smallerFile], ['photo' => 'file|lte:smaller']);
@@ -2742,43 +2742,43 @@ class ValidationValidatorTest extends TestCase
         $trans = $this->getIlluminateArrayTranslator();
         $uploadedFile = [__FILE__, '', null, null, true];
 
-        $file = $this->getMockBuilder(UploadedFile::class)->setMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
+        $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
         $file->expects($this->any())->method('guessExtension')->willReturn('php');
         $file->expects($this->any())->method('getClientOriginalExtension')->willReturn('php');
         $v = new Validator($trans, ['x' => $file], ['x' => 'Image']);
         $this->assertFalse($v->passes());
 
-        $file2 = $this->getMockBuilder(UploadedFile::class)->setMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
+        $file2 = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
         $file2->expects($this->any())->method('guessExtension')->willReturn('jpeg');
         $file2->expects($this->any())->method('getClientOriginalExtension')->willReturn('jpeg');
         $v = new Validator($trans, ['x' => $file2], ['x' => 'Image']);
         $this->assertTrue($v->passes());
 
-        $file3 = $this->getMockBuilder(UploadedFile::class)->setMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
+        $file3 = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
         $file3->expects($this->any())->method('guessExtension')->willReturn('gif');
         $file3->expects($this->any())->method('getClientOriginalExtension')->willReturn('gif');
         $v = new Validator($trans, ['x' => $file3], ['x' => 'Image']);
         $this->assertTrue($v->passes());
 
-        $file4 = $this->getMockBuilder(UploadedFile::class)->setMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
+        $file4 = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
         $file4->expects($this->any())->method('guessExtension')->willReturn('bmp');
         $file4->expects($this->any())->method('getClientOriginalExtension')->willReturn('bmp');
         $v = new Validator($trans, ['x' => $file4], ['x' => 'Image']);
         $this->assertTrue($v->passes());
 
-        $file5 = $this->getMockBuilder(UploadedFile::class)->setMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
+        $file5 = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
         $file5->expects($this->any())->method('guessExtension')->willReturn('png');
         $file5->expects($this->any())->method('getClientOriginalExtension')->willReturn('png');
         $v = new Validator($trans, ['x' => $file5], ['x' => 'Image']);
         $this->assertTrue($v->passes());
 
-        $file6 = $this->getMockBuilder(UploadedFile::class)->setMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
+        $file6 = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
         $file6->expects($this->any())->method('guessExtension')->willReturn('svg');
         $file6->expects($this->any())->method('getClientOriginalExtension')->willReturn('svg');
         $v = new Validator($trans, ['x' => $file6], ['x' => 'Image']);
         $this->assertTrue($v->passes());
 
-        $file7 = $this->getMockBuilder(UploadedFile::class)->setMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
+        $file7 = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
         $file7->expects($this->any())->method('guessExtension')->willReturn('webp');
         $file7->expects($this->any())->method('getClientOriginalExtension')->willReturn('webp');
         $v = new Validator($trans, ['x' => $file7], ['x' => 'Image']);
@@ -2790,7 +2790,7 @@ class ValidationValidatorTest extends TestCase
         $trans = $this->getIlluminateArrayTranslator();
         $uploadedFile = [__FILE__, '', null, null, true];
 
-        $file = $this->getMockBuilder(UploadedFile::class)->setMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
+        $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
         $file->expects($this->any())->method('guessExtension')->willReturn('jpeg');
         $file->expects($this->any())->method('getClientOriginalExtension')->willReturn('php');
         $v = new Validator($trans, ['x' => $file], ['x' => 'Image']);
@@ -2914,7 +2914,7 @@ class ValidationValidatorTest extends TestCase
         $trans = $this->getIlluminateArrayTranslator();
         $uploadedFile = [__DIR__.'/ValidationRuleTest.php', '', null, null, true];
 
-        $file = $this->getMockBuilder(UploadedFile::class)->setMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
+        $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
         $file->expects($this->any())->method('guessExtension')->willReturn('rtf');
         $file->expects($this->any())->method('getClientOriginalExtension')->willReturn('rtf');
 
@@ -2927,13 +2927,13 @@ class ValidationValidatorTest extends TestCase
         $trans = $this->getIlluminateArrayTranslator();
         $uploadedFile = [__FILE__, '', null, null, true];
 
-        $file = $this->getMockBuilder(UploadedFile::class)->setMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
+        $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
         $file->expects($this->any())->method('guessExtension')->willReturn('pdf');
         $file->expects($this->any())->method('getClientOriginalExtension')->willReturn('pdf');
         $v = new Validator($trans, ['x' => $file], ['x' => 'mimes:pdf']);
         $this->assertTrue($v->passes());
 
-        $file2 = $this->getMockBuilder(UploadedFile::class)->setMethods(['guessExtension', 'isValid'])->setConstructorArgs($uploadedFile)->getMock();
+        $file2 = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['guessExtension', 'isValid'])->setConstructorArgs($uploadedFile)->getMock();
         $file2->expects($this->any())->method('guessExtension')->willReturn('pdf');
         $file2->expects($this->any())->method('isValid')->willReturn(false);
         $v = new Validator($trans, ['x' => $file2], ['x' => 'mimes:pdf']);
@@ -2945,13 +2945,13 @@ class ValidationValidatorTest extends TestCase
         $trans = $this->getIlluminateArrayTranslator();
         $uploadedFile = [__FILE__, '', null, null, true];
 
-        $file = $this->getMockBuilder(UploadedFile::class)->setMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
+        $file = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
         $file->expects($this->any())->method('guessExtension')->willReturn('pdf');
         $file->expects($this->any())->method('getClientOriginalExtension')->willReturn('php');
         $v = new Validator($trans, ['x' => $file], ['x' => 'mimes:pdf']);
         $this->assertFalse($v->passes());
 
-        $file2 = $this->getMockBuilder(UploadedFile::class)->setMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
+        $file2 = $this->getMockBuilder(UploadedFile::class)->onlyMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
         $file2->expects($this->any())->method('guessExtension')->willReturn('php');
         $file2->expects($this->any())->method('getClientOriginalExtension')->willReturn('php');
         $v = new Validator($trans, ['x' => $file2], ['x' => 'mimes:pdf,php']);
@@ -4665,10 +4665,10 @@ class ValidationValidatorTest extends TestCase
                 '*.name' => 'required',
             ]);
 
-        $this->assertEquals($v->invalid(), [
+        $this->assertEquals([
             1 => ['name' => null],
             2 => ['name' => ''],
-        ]);
+        ], $v->invalid());
 
         $v = new Validator($trans,
             [
@@ -4678,9 +4678,9 @@ class ValidationValidatorTest extends TestCase
                 'name' => 'required',
             ]);
 
-        $this->assertEquals($v->invalid(), [
+        $this->assertEquals([
             'name' => '',
-        ]);
+        ], $v->invalid());
     }
 
     public function testValidMethod()
@@ -4698,10 +4698,10 @@ class ValidationValidatorTest extends TestCase
                 '*.name' => 'required',
             ]);
 
-        $this->assertEquals($v->valid(), [
+        $this->assertEquals([
             0 => ['name' => 'John'],
             3 => ['name' => 'Doe'],
-        ]);
+        ], $v->valid());
 
         $v = new Validator($trans,
             [
@@ -4715,10 +4715,10 @@ class ValidationValidatorTest extends TestCase
                 'age' => 'required|int',
             ]);
 
-        $this->assertEquals($v->valid(), [
+        $this->assertEquals([
             'name' => 'Carlos',
             'gender' => 'male',
-        ]);
+        ], $v->valid());
     }
 
     public function testNestedInvalidMethod()
@@ -4741,12 +4741,12 @@ class ValidationValidatorTest extends TestCase
                 'regex:/[A-F]{3}[0-9]{3}/',
             ],
         ]);
-        $this->assertEquals($v->invalid(), [
+        $this->assertEquals([
             'testinvalid' => '',
             'records' => [
                 3 => 'ADCD23',
             ],
-        ]);
+        ], $v->invalid());
     }
 
     public function testMultipleFileUploads()

--- a/tests/View/Blade/BladeCustomTest.php
+++ b/tests/View/Blade/BladeCustomTest.php
@@ -2,10 +2,13 @@
 
 namespace Illuminate\Tests\View\Blade;
 
+use Illuminate\Tests\ReflectionHelpers;
 use InvalidArgumentException;
 
 class BladeCustomTest extends AbstractBladeTestCase
 {
+    use ReflectionHelpers;
+
     public function testCustomPhpCodeIsCorrectlyHandled()
     {
         $this->assertSame('<?php if($test): ?> <?php @show(\'test\'); ?> <?php endif; ?>', $this->compiler->compileString("@if(\$test) <?php @show('test'); ?> @endif"));
@@ -52,20 +55,17 @@ class BladeCustomTest extends AbstractBladeTestCase
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
-    public function testValidCustomNames()
+    /**
+     * @dataProvider customNamesDataProvider
+     * @param string $name
+     * @throws \ReflectionException
+     */
+    public function testValidCustomNames(string $name)
     {
-        $this->assertNull($this->compiler->directive('custom', function () {
+        $this->compiler->directive($name, function () {
             //
-        }));
-        $this->assertNull($this->compiler->directive('custom_custom', function () {
-            //
-        }));
-        $this->assertNull($this->compiler->directive('customCustom', function () {
-            //
-        }));
-        $this->assertNull($this->compiler->directive('custom::custom', function () {
-            //
-        }));
+        });
+        $this->assertArrayHasKey($name, $this->getPrivateProperty($this->compiler, 'customDirectives'));
     }
 
     public function testInvalidCustomNames()
@@ -222,5 +222,15 @@ class BladeCustomTest extends AbstractBladeTestCase
         $string = '@foreach';
         $expected = '<?php echo $__env->make(\'app.includes.foreach\', [], \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function customNamesDataProvider()
+    {
+        return [
+            ['custom'],
+            ['custom_custom'],
+            ['customCustom'],
+            ['custom::custom'],
+        ];
     }
 }

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -127,12 +127,12 @@ class ViewTest extends TestCase
     public function testViewGettersSetters()
     {
         $view = $this->getView(['foo' => 'bar']);
-        $this->assertEquals($view->name(), 'view');
-        $this->assertEquals($view->getPath(), 'path');
+        $this->assertEquals('view', $view->name());
+        $this->assertEquals('path', $view->getPath());
         $data = $view->getData();
-        $this->assertEquals($data['foo'], 'bar');
+        $this->assertEquals('bar', $data['foo']);
         $view->setPath('newPath');
-        $this->assertEquals($view->getPath(), 'newPath');
+        $this->assertEquals('newPath', $view->getPath());
     }
 
     public function testViewArrayAccess()
@@ -140,9 +140,9 @@ class ViewTest extends TestCase
         $view = $this->getView(['foo' => 'bar']);
         $this->assertInstanceOf(ArrayAccess::class, $view);
         $this->assertTrue($view->offsetExists('foo'));
-        $this->assertEquals($view->offsetGet('foo'), 'bar');
+        $this->assertEquals('bar', $view->offsetGet('foo'));
         $view->offsetSet('foo', 'baz');
-        $this->assertEquals($view->offsetGet('foo'), 'baz');
+        $this->assertEquals('baz', $view->offsetGet('foo'));
         $view->offsetUnset('foo');
         $this->assertFalse($view->offsetExists('foo'));
     }
@@ -152,9 +152,9 @@ class ViewTest extends TestCase
         $view = $this->getView(new DataObjectStub);
         $this->assertInstanceOf(ArrayAccess::class, $view);
         $this->assertTrue($view->offsetExists('foo'));
-        $this->assertEquals($view->offsetGet('foo'), 'bar');
+        $this->assertEquals('bar', $view->offsetGet('foo'));
         $view->offsetSet('foo', 'baz');
-        $this->assertEquals($view->offsetGet('foo'), 'baz');
+        $this->assertEquals('baz', $view->offsetGet('foo'));
         $view->offsetUnset('foo');
         $this->assertFalse($view->offsetExists('foo'));
     }
@@ -163,9 +163,9 @@ class ViewTest extends TestCase
     {
         $view = $this->getView(['foo' => 'bar']);
         $this->assertTrue(isset($view->foo));
-        $this->assertEquals($view->foo, 'bar');
+        $this->assertEquals('bar', $view->foo);
         $view->foo = 'baz';
-        $this->assertEquals($view->foo, 'baz');
+        $this->assertEquals('baz', $view->foo);
         $this->assertEquals($view['foo'], $view->foo);
         unset($view->foo);
         $this->assertFalse(isset($view->foo));
@@ -208,8 +208,8 @@ class ViewTest extends TestCase
 
         $view->getFactory()->shouldReceive('getSections')->once()->andReturn(['foo', 'bar']);
         $sections = $view->renderSections();
-        $this->assertEquals($sections[0], 'foo');
-        $this->assertEquals($sections[1], 'bar');
+        $this->assertEquals('foo', $sections[0]);
+        $this->assertEquals('bar', $sections[1]);
     }
 
     public function testWithErrors()
@@ -219,18 +219,18 @@ class ViewTest extends TestCase
         $this->assertSame($view, $view->withErrors($errors));
         $this->assertInstanceOf(ViewErrorBag::class, $view->errors);
         $foo = $view->errors->get('foo');
-        $this->assertEquals($foo[0], 'bar');
+        $this->assertEquals('bar', $foo[0]);
         $qu = $view->errors->get('qu');
-        $this->assertEquals($qu[0], 'ux');
+        $this->assertEquals('ux', $qu[0]);
         $data = ['foo' => 'baz'];
         $this->assertSame($view, $view->withErrors(new MessageBag($data)));
         $foo = $view->errors->get('foo');
-        $this->assertEquals($foo[0], 'baz');
+        $this->assertEquals('baz', $foo[0]);
         $foo = $view->errors->getBag('default')->get('foo');
-        $this->assertEquals($foo[0], 'baz');
+        $this->assertEquals('baz', $foo[0]);
         $this->assertSame($view, $view->withErrors(new MessageBag($data), 'login'));
         $foo = $view->errors->getBag('login')->get('foo');
-        $this->assertEquals($foo[0], 'baz');
+        $this->assertEquals('baz', $foo[0]);
     }
 
     protected function getView($data = [])


### PR DESCRIPTION
Make tests compatible to phpunit 10
Base on phpunit document [setMethods](https://github.com/sebastianbergmann/phpunit/pull/3687) and [at](https://github.com/sebastianbergmann/phpunit/issues/4297) will be removed. I removed these methods so it can be easily possible to use phpunit 10.
