### PR TITLE
[8.x] Add the ability to transform paginator items

### DIFF
--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -336,6 +336,19 @@ abstract class AbstractPaginator implements Htmlable
     }
 
     /**
+     * Transform each item in the slice of items using a callback.
+     *
+     * @param  callable  $callback
+     * @return $this
+     */
+    public function through(callable $callback)
+    {
+        $this->items->transform($callback);
+
+        return $this;
+    }
+
+    /**
      * Get the number of items shown per page.
      *
      * @return int

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -346,7 +346,7 @@ abstract class AbstractPaginator implements Htmlable
         $this->items->transform($callback);
 
         return $this;
-    }
+    }    
 
     /**
      * Get the number of items shown per page.

--- a/tests/Pagination/PaginatorTest.php
+++ b/tests/Pagination/PaginatorTest.php
@@ -62,4 +62,17 @@ class PaginatorTest extends TestCase
 
         $this->assertSame($p->path(), 'http://website.com/test');
     }
+
+    public function testCanTransformPaginatorItems()
+    {
+        $p = new Paginator($array = ['item1', 'item2', 'item3'], 3, 1,
+                                    ['path' => 'http://website.com/test']);
+
+        $p->through(function ($item) {
+            return substr($item, 4, 1);
+        });
+
+        $this->assertInstanceOf(Paginator::class, $p);
+        $this->assertSame(['1', '2', '3'], $p->items());
+    }
 }


### PR DESCRIPTION
This PR adds the ability to transform paginator items via a new `through()` method, which returns an instance of the `Paginator`, and *not* the underlying `Collection`.

Here's an example use case:

```php
return Inertia::render('Contacts/Index', [
    'contacts' => Contact::paginate()->through(function ($contact) {
        return [
            'id' => $contact->id,
            'name' => $contact->name,
            'phone' => $contact->phone,
            'city' => $contact->city,
            'organization' => optional($contact->organization)->only('name')
        ];
    }),
]);
```

This is needed since it's very common to want to map the data prior to the paginator being JSON encoded. However, right now there is no way to do that, since calling `map()` or `transform()` on the paginator object forwards calls to the underlying collection, which returns an instance of the `Collection`, *not* the `Paginator`.

Meaning, if you call `$paginator->transform()`, you'll only get the data back, and not the paginator `toArray()` structure (`data`, `links`, `current_page`, `total`, etc).

We could also call this `transformItems()`, but I think `through()` is more expressive.