### PR TITLE
[8.x] Fix queue clearing when blocking

### DIFF
--- a/src/Illuminate/Queue/LuaScripts.php
+++ b/src/Illuminate/Queue/LuaScripts.php
@@ -133,6 +133,7 @@ LUA;
      * KEYS[1] - The name of the primary queue
      * KEYS[2] - The name of the "delayed" queue
      * KEYS[3] - The name of the "reserved" queue
+     * KEYS[4] - The name of the "notify" queue
      *
      * @return string
      */
@@ -140,7 +141,7 @@ LUA;
     {
         return <<<'LUA'
 local size = redis.call('llen', KEYS[1]) + redis.call('zcard', KEYS[2]) + redis.call('zcard', KEYS[3])
-redis.call('del', KEYS[1], KEYS[2], KEYS[3])
+redis.call('del', KEYS[1], KEYS[2], KEYS[3], KEYS[4])
 return size
 LUA;
     }

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -298,7 +298,8 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
         $queue = $this->getQueue($queue);
 
         return $this->getConnection()->eval(
-            LuaScripts::clear(), 3, $queue, $queue.':delayed', $queue.':reserved'
+            LuaScripts::clear(), 4, $queue, $queue.':delayed', 
+            $queue.':reserved', $queue.':notify'
         );
     }
 

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -298,7 +298,7 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
         $queue = $this->getQueue($queue);
 
         return $this->getConnection()->eval(
-            LuaScripts::clear(), 4, $queue, $queue.':delayed', 
+            LuaScripts::clear(), 4, $queue, $queue.':delayed',
             $queue.':reserved', $queue.':notify'
         );
     }

--- a/tests/Queue/RedisQueueIntegrationTest.php
+++ b/tests/Queue/RedisQueueIntegrationTest.php
@@ -431,6 +431,7 @@ class RedisQueueIntegrationTest extends TestCase
 
         $this->assertEquals(2, $this->queue->clear(null));
         $this->assertEquals(0, $this->queue->size());
+        $this->assertEquals(0, $this->redis[$driver]->connection()->llen('queues:default:notify'));
     }
 
     /**


### PR DESCRIPTION
As a follow up to https://github.com/laravel/framework/pull/34330, I realised that the notification queue should also be cleared to allow for blocking to work. This PR fixes it. I've also added a failing test (to check the size of the notification queue) that passes with this PR.

@halaei can you please take a quick look to see everything is fine? Thanks

