### PR TITLE
[8.x] Restrict symfony/http-foundation to <5.2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "symfony/console": "^5.1",
         "symfony/error-handler": "^5.1",
         "symfony/finder": "^5.1",
-        "symfony/http-foundation": "^5.1",
+        "symfony/http-foundation": "^5.1,<5.2.0",
         "symfony/http-kernel": "^5.1",
         "symfony/mime": "^5.1",
         "symfony/process": "^5.1",


### PR DESCRIPTION
Laravel's `\Illuminate\Http\Request` contains a `toArray()` method. Symfony's `Symfony\Component\HttpFoundation\Request` (which Laravel's `Request` extends) currently does not have such a method, but it was newly introduced in https://github.com/symfony/http-foundation/commit/af8a5353c61d7d656768cba750e35d846228ea32, which is going to be released as part of v5.2.0.

Unfortunately, the method signatures are incompatible, as Symfony's method declares an `array` return type and Laravel's doesn't. This will cause errors ("Declaration of Illuminate\Http\Request::toArray() must be compatible with Symfony\Component\HttpFoundation\Request::toArray(): array"), unless Laravel's `toArray()` also declares an `array` return type. So once http-foundation v5.2.0 releases and composer starts pulling in the update, people's projects will break.

Changing the return type of Laravel's `toArray()` would break BC, as everyone currently extending Laravel's `Request` and overriding `toArray()` would have to make that change as well. So I think we need to stick to http-foundation < 5.2.0 for Laravel 8.x.

See https://github.com/laravel/framework/issues/34660.