### PR TITLE
[9.x] Move PendingChain to Illuminate\Bus so it can be used with Lumen

### DIFF
--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -7,7 +7,7 @@ use Illuminate\Contracts\Bus\QueueingDispatcher;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Queue\Queue;
 use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Foundation\Bus\PendingChain;
+use Illuminate\Bus\PendingChain;
 use Illuminate\Pipeline\Pipeline;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\Jobs\SyncJob;
@@ -158,7 +158,7 @@ class Dispatcher implements QueueingDispatcher
      * Create a new chain of queueable jobs.
      *
      * @param  \Illuminate\Support\Collection|array  $jobs
-     * @return \Illuminate\Foundation\Bus\PendingChain
+     * @return \Illuminate\Bus\PendingChain
      */
     public function chain($jobs)
     {

--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -7,7 +7,6 @@ use Illuminate\Contracts\Bus\QueueingDispatcher;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Queue\Queue;
 use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Bus\PendingChain;
 use Illuminate\Pipeline\Pipeline;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\Jobs\SyncJob;

--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -163,7 +163,7 @@ class Dispatcher implements QueueingDispatcher
     {
         $jobs = Collection::wrap($jobs);
 
-        return new PendingChain($jobs->shift(), $jobs->toArray());
+        return new PendingChain($this->container, $jobs->shift(), $jobs->toArray());
     }
 
     /**

--- a/src/Illuminate/Bus/PendingChain.php
+++ b/src/Illuminate/Bus/PendingChain.php
@@ -45,14 +45,23 @@ class PendingChain
     public $catchCallbacks = [];
 
     /**
+     * The IoC container instance.
+     *
+     * @var \Illuminate\Contracts\Container\Container
+     */
+    protected $container;
+
+    /**
      * Create a new PendingChain instance.
      *
+     * @param  \Illuminate\Contracts\Container\Container $container
      * @param  mixed  $job
      * @param  array  $chain
      * @return void
      */
-    public function __construct($job, $chain)
+    public function __construct($container, $job, $chain)
     {
+        $this->container = $container;
         $this->job = $job;
         $this->chain = $chain;
     }
@@ -128,6 +137,6 @@ class PendingChain
         $firstJob->chain($this->chain);
         $firstJob->chainCatchCallbacks = $this->catchCallbacks();
 
-        return app(Dispatcher::class)->dispatch($firstJob);
+        return $this->container->make(Dispatcher::class)->dispatch($firstJob);
     }
 }

--- a/src/Illuminate/Bus/PendingChain.php
+++ b/src/Illuminate/Bus/PendingChain.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Foundation\Bus;
+namespace Illuminate\Bus;
 
 use Closure;
 use Illuminate\Contracts\Bus\Dispatcher;

--- a/src/Illuminate/Foundation/Bus/Dispatchable.php
+++ b/src/Illuminate/Foundation/Bus/Dispatchable.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Foundation\Bus;
 
-use Illuminate\Bus\PendingChain;
 use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Support\Fluent;
 
@@ -84,6 +83,6 @@ trait Dispatchable
      */
     public static function withChain($chain)
     {
-        return new PendingChain(static::class, $chain);
+        return app(Dispatcher::class)->chain([static::class, ...$chain]);
     }
 }

--- a/src/Illuminate/Foundation/Bus/Dispatchable.php
+++ b/src/Illuminate/Foundation/Bus/Dispatchable.php
@@ -83,6 +83,6 @@ trait Dispatchable
      */
     public static function withChain($chain)
     {
-        return app(Dispatcher::class)->chain([static::class, ...$chain]);
+        return app(Dispatcher::class)->chain(array_merge([static::class], $chain));
     }
 }

--- a/src/Illuminate/Foundation/Bus/Dispatchable.php
+++ b/src/Illuminate/Foundation/Bus/Dispatchable.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Bus;
 
+use Illuminate\Bus\PendingChain;
 use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Support\Fluent;
 
@@ -79,7 +80,7 @@ trait Dispatchable
      * Set the jobs that should run if this job is successful.
      *
      * @param  array  $chain
-     * @return \Illuminate\Foundation\Bus\PendingChain
+     * @return \Illuminate\Bus\PendingChain
      */
     public static function withChain($chain)
     {

--- a/src/Illuminate/Support/Facades/Bus.php
+++ b/src/Illuminate/Support/Facades/Bus.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Support\Facades;
 
 use Illuminate\Contracts\Bus\Dispatcher as BusDispatcherContract;
-use Illuminate\Foundation\Bus\PendingChain;
+use Illuminate\Bus\PendingChain;
 use Illuminate\Support\Testing\Fakes\BusFake;
 
 /**
@@ -11,7 +11,7 @@ use Illuminate\Support\Testing\Fakes\BusFake;
  * @method static \Illuminate\Bus\PendingBatch batch(array $jobs)
  * @method static \Illuminate\Contracts\Bus\Dispatcher map(array $map)
  * @method static \Illuminate\Contracts\Bus\Dispatcher pipeThrough(array $pipes)
- * @method static \Illuminate\Foundation\Bus\PendingChain chain(array $jobs)
+ * @method static \Illuminate\Bus\PendingChain chain(array $jobs)
  * @method static bool hasCommandHandler($command)
  * @method static bool|mixed getCommandHandler($command)
  * @method static mixed dispatch($command)

--- a/src/Illuminate/Support/Facades/Bus.php
+++ b/src/Illuminate/Support/Facades/Bus.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Support\Facades;
 
-use Illuminate\Bus\PendingChain;
 use Illuminate\Contracts\Bus\Dispatcher as BusDispatcherContract;
 use Illuminate\Support\Testing\Fakes\BusFake;
 
@@ -35,20 +34,6 @@ class Bus extends Facade
         static::swap($fake = new BusFake(static::getFacadeRoot(), $jobsToFake));
 
         return $fake;
-    }
-
-    /**
-     * Dispatch the given chain of jobs.
-     *
-     * @param  array|mixed  $jobs
-     * @return \Illuminate\Foundation\Bus\PendingDispatch
-     */
-    public static function dispatchChain($jobs)
-    {
-        $jobs = is_array($jobs) ? $jobs : func_get_args();
-
-        return (new PendingChain(array_shift($jobs), $jobs))
-                    ->dispatch();
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Bus.php
+++ b/src/Illuminate/Support/Facades/Bus.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Support\Facades;
 
-use Illuminate\Contracts\Bus\Dispatcher as BusDispatcherContract;
 use Illuminate\Bus\PendingChain;
+use Illuminate\Contracts\Bus\Dispatcher as BusDispatcherContract;
 use Illuminate\Support\Testing\Fakes\BusFake;
 
 /**

--- a/tests/Integration/Queue/JobChainingTest.php
+++ b/tests/Integration/Queue/JobChainingTest.php
@@ -62,21 +62,10 @@ class JobChainingTest extends TestCase
 
     public function testJobsCanBeChainedOnSuccessUsingBusFacade()
     {
-        Bus::dispatchChain([
+        Bus::chain([
             new JobChainingTestFirstJob(),
             new JobChainingTestSecondJob(),
-        ]);
-
-        $this->assertTrue(JobChainingTestFirstJob::$ran);
-        $this->assertTrue(JobChainingTestSecondJob::$ran);
-    }
-
-    public function testJobsCanBeChainedOnSuccessUsingBusFacadeAsArguments()
-    {
-        Bus::dispatchChain(
-            new JobChainingTestFirstJob(),
-            new JobChainingTestSecondJob()
-        );
+        ])->dispatch();
 
         $this->assertTrue(JobChainingTestFirstJob::$ran);
         $this->assertTrue(JobChainingTestSecondJob::$ran);


### PR DESCRIPTION
Today, Bus::chain cannot be used with Lumen as PendingChain is part of the Foundation package.

Moving it to Illuminate\Bus makes it available to Lumen.

Fix laravel/lumen-framework#1117