### PR TITLE
[8.x] Add ability to use middlewares in HttpClient when using Http:fake()

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -644,11 +644,11 @@ class PendingRequest
         return tap(HandlerStack::create(), function ($stack) {
             $stack->push($this->buildBeforeSendingHandler());
             $stack->push($this->buildRecorderHandler());
-            $stack->push($this->buildStubHandler());
-
             $this->middleware->each(function ($middleware) use ($stack) {
                 $stack->push($middleware);
             });
+
+            $stack->push($this->buildStubHandler());
         });
     }
 

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -34,6 +34,25 @@ class HttpClientTest extends TestCase
         $this->assertTrue($response->ok());
     }
 
+    public function testMiddlewareGetsCalled()
+    {
+        $this->factory->fake();
+
+        $middlewareWasCalled = false;
+
+        $middleware = function ($handler) use (&$middlewareWasCalled) {
+            return function ($request, $options) use ($handler, &$middlewareWasCalled) {
+                $middlewareWasCalled = true;
+                return $handler($request, $options);
+            };
+        };
+
+        $response = $this->factory->withMiddleware($middleware)->post('http://laravel.com/test-missing-page');
+
+        $this->assertTrue($response->ok());
+        $this->assertTrue($middlewareWasCalled);
+    }
+
     public function testResponseBodyCasting()
     {
         $this->factory->fake([

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -43,6 +43,7 @@ class HttpClientTest extends TestCase
         $middleware = function ($handler) use (&$middlewareWasCalled) {
             return function ($request, $options) use ($handler, &$middlewareWasCalled) {
                 $middlewareWasCalled = true;
+
                 return $handler($request, $options);
             };
         };


### PR DESCRIPTION
## What is happening?

The `HttpClient` provides the ability to have Guzzle Middlewares by using the `Http::withMiddleware()` method.

This method works just fine when using the __HttpClient__ in production code. But when using `Http::fake()`, usually when testing external services, the `Http::withMiddleware()` method has no effect.

## Why does it happen?

This happens because Guzzle will always stop going through any other handlers when the Laravel `StubHandler` is executed. 

## How to fix?

The fix should be very simple, given the builtIn `stubHandler` is meant to give just the response we need it to give, we can move this stub handler to be executed as the last middleware in the stack.

## Why?

Having the `Http::WithMiddleware()` method work as expected in tests and in production code is good for consistency in the framework and allows developers to test Middlewares in a __Feature/Integration__ way which reflects the functionality as similar as in production.

## Use cases for this?

A good use case for this, is having a Guzzle Middleware log, which logs requests and responses for better traceability

```php
Http::withMiddleware(
    Middleware::log(app(LogManager::class)->channel(), new MessageFormatter())
)->post($url, $payload);
```

There are so many guzzle-middlewares for things like, requesting Oauth tokens, having custom error handlers, caching request/responses, logging, retrying on failures, etc. 

## Discussed Previously in:

Some words were discussed in #34505 and I know it could be a closed PR due to this, but I wanted to expand on the topic and propose a simple solution. Thanks!!