### PR TITLE
[8.x] Support times() with raw()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -177,7 +177,13 @@ abstract class Factory
      */
     public function raw($attributes = [], ?Model $parent = null)
     {
-        return $this->state($attributes)->getExpandedAttributes($parent);
+        if ($this->count === null) {
+            return $this->state($attributes)->getExpandedAttributes($parent);
+        }
+
+        return array_map(function () use ($attributes, $parent) {
+            return $this->state($attributes)->getExpandedAttributes($parent);
+        }, range(1, $this->count));
     }
 
     /**

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -154,6 +154,14 @@ class DatabaseEloquentFactoryTest extends TestCase
         $this->assertSame('Test Title', $post['title']);
     }
 
+    public function test_multiple_model_attributes_can_be_created()
+    {
+        $posts = FactoryTestPostFactory::new()->times(10)->raw();
+        $this->assertIsArray($posts);
+
+        $this->assertCount(10, $posts);
+    }
+
     public function test_after_creating_and_making_callbacks_are_called()
     {
         $user = FactoryTestUserFactory::new()


### PR DESCRIPTION
With legacy model factories it was possible to get an array of raw attributes.

```php
$posts = factory(Post::class, 10)->raw();

$posts->count() === 10;
```

However, the `raw` method I added in an earlier PR doesn't respect the `times()` method. Calling it made no effect on the returned result.

This PR now respects `times()` and returns an array of raw attributes when set.

```php
// Before this PR:
Post::factory()->times(10)->raw(); // [...raw attributes of post]

// Following this PR:
Post::factory()->times(10)->raw(); // [array of 10 arrays with raw attributes of post]
```