### PR TITLE
[9.x] Strict comparison for Str::replaceFirst and Str::is

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -251,7 +251,7 @@ class Str
             // If the given value is an exact match we can of course return true right
             // from the beginning. Otherwise, we will translate asterisks and do an
             // actual pattern match against the two strings to see if they match.
-            if ($pattern == $value) {
+            if ($pattern === $value) {
                 return true;
             }
 
@@ -501,7 +501,7 @@ class Str
      */
     public static function replaceFirst($search, $replace, $subject)
     {
-        $search = (string)$search;
+        $search = (string) $search;
         if ($search === '') {
             return $subject;
         }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -502,6 +502,7 @@ class Str
     public static function replaceFirst($search, $replace, $subject)
     {
         $search = (string) $search;
+
         if ($search === '') {
             return $subject;
         }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -501,7 +501,8 @@ class Str
      */
     public static function replaceFirst($search, $replace, $subject)
     {
-        if ($search == '') {
+        $search = (string)$search;
+        if ($search === '') {
             return $subject;
         }
 

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -348,6 +348,7 @@ class SupportStrTest extends TestCase
         $this->assertSame('foo foobar', Str::replaceFirst('bar', '', 'foobar foobar'));
         $this->assertSame('foobar foobar', Str::replaceFirst('xxx', 'yyy', 'foobar foobar'));
         $this->assertSame('foobar foobar', Str::replaceFirst('', 'yyy', 'foobar foobar'));
+        $this->assertSame('1', Str::replaceFirst(0, '1', '0'));
         // Test for multibyte string support
         $this->assertSame('Jxxxnköping Malmö', Str::replaceFirst('ö', 'xxx', 'Jönköping Malmö'));
         $this->assertSame('Jönköping Malmö', Str::replaceFirst('', 'yyy', 'Jönköping Malmö'));

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -264,6 +264,10 @@ class SupportStrTest extends TestCase
 
         // empty patterns
         $this->assertFalse(Str::is([], 'test'));
+
+        $this->assertFalse(Str::is('', 0));
+        $this->assertFalse(Str::is([null], 0));
+        $this->assertTrue(Str::is([null], null));
     }
 
     /**


### PR DESCRIPTION
Add strict comparison for Str::replaceFirst and Str::is