### PR TITLE
[8.x] Fix missing import in TestView.php

### DIFF
--- a/src/Illuminate/Testing/TestView.php
+++ b/src/Illuminate/Testing/TestView.php
@@ -2,9 +2,9 @@
 
 namespace Illuminate\Testing;
 
-use Illuminate\Testing\Constraints\SeeInOrder;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Testing\Assert as PHPUnit;
+use Illuminate\Testing\Constraints\SeeInOrder;
 use Illuminate\View\View;
 
 class TestView

--- a/src/Illuminate/Testing/TestView.php
+++ b/src/Illuminate/Testing/TestView.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Testing;
 
+use Illuminate\Testing\Constraints\SeeInOrder;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Testing\Assert as PHPUnit;
 use Illuminate\View\View;


### PR DESCRIPTION
The `TestView` class was missing the import for `SeeInOrder`.

This resulted in a error when trying to use `$this->view()->assertSeeTextInOrder()` in a test.

This PR adds the missing import