### PR TITLE
Allow all data types when using travelTo

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTime.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTime.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Foundation\Testing\Concerns;
 
-use DateTimeInterface;
 use Illuminate\Foundation\Testing\Wormhole;
 use Illuminate\Support\Carbon;
 
@@ -22,11 +21,11 @@ trait InteractsWithTime
     /**
      * Travel to another time.
      *
-     * @param  \DateTimeInterface  $date
+     * @param  mixed  $date
      * @param  callable|null  $callback
      * @return mixed
      */
-    public function travelTo(DateTimeInterface $date, $callback = null)
+    public function travelTo($date, $callback = null)
     {
         Carbon::setTestNow($date);
 


### PR DESCRIPTION
[travelTo](https://github.com/laravel/framework/blob/8.x/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTime.php#L29) currently only accepts a `DateTimeInterface` but it is passed to Carbons [setTestNow](https://github.com/briannesbitt/Carbon/blob/7deba26bbaee1af29f265bce2422db6d0b99e28b/src/Carbon/Traits/Test.php#L48) which accepts all data types.

Before:
```php
$this->travelTo(now()->parse('12:00'));
```

After:
```php
$this->travelTo('12:00');
```

