### PR TITLE
[6.x] Fix incorrect PHPDoc type for queryParameters

### DIFF
--- a/src/Illuminate/Http/Resources/Json/ResourceCollection.php
+++ b/src/Illuminate/Http/Resources/Json/ResourceCollection.php
@@ -35,7 +35,7 @@ class ResourceCollection extends JsonResource implements Countable, IteratorAggr
     /**
      * The query parameters that should be added to the pagination links.
      *
-     * @var array
+     * @var array|null
      */
     protected $queryParameters;
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

`$queryParameters` is not initialized in the constructor, therefore, it can also be `null`.

There is actually a conditional [here](https://github.com/laravel/framework/blob/8de2c9deb6fef5e8bb8a1f8e40b21827c998f578/src/Illuminate/Http/Resources/Json/ResourceCollection.php#L128) here that checks whether `$queryParameters` is `null`. 