### PR TITLE
[8.x] Fix assertEquals misordered arguments

### DIFF
--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -672,7 +672,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertSame('Not allowed to view as it is not published.', $response->message());
         $this->assertFalse($response->allowed());
         $this->assertTrue($response->denied());
-        $this->assertEquals($response->code(), 'unpublished');
+        $this->assertEquals('unpublished', $response->code());
     }
 
     public function testAuthorizeReturnsAnAllowedResponseForATruthyReturn()

--- a/tests/Auth/AuthorizeMiddlewareTest.php
+++ b/tests/Auth/AuthorizeMiddlewareTest.php
@@ -87,7 +87,7 @@ class AuthorizeMiddlewareTest extends TestCase
 
         $response = $this->router->dispatch(Request::create('dashboard', 'GET'));
 
-        $this->assertEquals($response->content(), 'success');
+        $this->assertEquals('success', $response->content());
     }
 
     public function testSimpleAbilityWithStringParameter()
@@ -105,7 +105,7 @@ class AuthorizeMiddlewareTest extends TestCase
 
         $response = $this->router->dispatch(Request::create('dashboard', 'GET'));
 
-        $this->assertEquals($response->content(), 'success');
+        $this->assertEquals('success', $response->content());
     }
 
     public function testSimpleAbilityWithNullParameter()
@@ -154,10 +154,10 @@ class AuthorizeMiddlewareTest extends TestCase
         ]);
 
         $response = $this->router->dispatch(Request::create('posts/1/comments', 'GET'));
-        $this->assertEquals($response->content(), 'success');
+        $this->assertEquals('success', $response->content());
 
         $response = $this->router->dispatch(Request::create('comments', 'GET'));
-        $this->assertEquals($response->content(), 'success');
+        $this->assertEquals('success', $response->content());
     }
 
     public function testSimpleAbilityWithStringParameterFromRouteParameter()
@@ -175,7 +175,7 @@ class AuthorizeMiddlewareTest extends TestCase
 
         $response = $this->router->dispatch(Request::create('dashboard/true', 'GET'));
 
-        $this->assertEquals($response->content(), 'success');
+        $this->assertEquals('success', $response->content());
     }
 
     public function testModelTypeUnauthorized()
@@ -184,7 +184,7 @@ class AuthorizeMiddlewareTest extends TestCase
         $this->expectExceptionMessage('This action is unauthorized.');
 
         $this->gate()->define('create', function ($user, $model) {
-            $this->assertEquals($model, 'App\User');
+            $this->assertEquals('App\User', $model);
 
             return false;
         });
@@ -202,7 +202,7 @@ class AuthorizeMiddlewareTest extends TestCase
     public function testModelTypeAuthorized()
     {
         $this->gate()->define('create', function ($user, $model) {
-            $this->assertEquals($model, 'App\User');
+            $this->assertEquals('App\User', $model);
 
             return true;
         });
@@ -216,7 +216,7 @@ class AuthorizeMiddlewareTest extends TestCase
 
         $response = $this->router->dispatch(Request::create('users/create', 'GET'));
 
-        $this->assertEquals($response->content(), 'success');
+        $this->assertEquals('success', $response->content());
     }
 
     public function testModelUnauthorized()
@@ -269,7 +269,7 @@ class AuthorizeMiddlewareTest extends TestCase
 
         $response = $this->router->dispatch(Request::create('posts/1/edit', 'GET'));
 
-        $this->assertEquals($response->content(), 'success');
+        $this->assertEquals('success', $response->content());
     }
 
     public function testModelInstanceAsParameter()

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -240,7 +240,7 @@ class CacheRepositoryTest extends TestCase
         $repo::macro(__CLASS__, function () {
             return 'Taylor';
         });
-        $this->assertEquals($repo->{__CLASS__}(), 'Taylor');
+        $this->assertEquals('Taylor', $repo->{__CLASS__}());
     }
 
     public function testForgettingCacheKey()

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -398,7 +398,7 @@ class ContainerTest extends TestCase
     {
         $container = new Container;
         $container->alias('ConcreteStub', 'foo');
-        $this->assertEquals($container->getAlias('foo'), 'ConcreteStub');
+        $this->assertEquals('ConcreteStub', $container->getAlias('foo'));
     }
 
     public function testItThrowsExceptionWhenAbstractIsSameAsAlias()

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -352,7 +352,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         );
 
         $this->assertSame('Mohamed Said', $user3->name);
-        $this->assertEquals(EloquentTestUser::count(), 2);
+        $this->assertEquals(2, EloquentTestUser::count());
     }
 
     public function testUpdateOrCreateOnDifferentConnection()
@@ -369,8 +369,8 @@ class DatabaseEloquentIntegrationTest extends TestCase
             ['name' => 'Mohamed Said']
         );
 
-        $this->assertEquals(EloquentTestUser::count(), 1);
-        $this->assertEquals(EloquentTestUser::on('second_connection')->count(), 2);
+        $this->assertEquals(1, EloquentTestUser::count());
+        $this->assertEquals(2, EloquentTestUser::on('second_connection')->count());
     }
 
     public function testCheckAndCreateMethodsOnMultiConnections()
@@ -1220,8 +1220,8 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $defaultConnectionPost = EloquentTestPhoto::with('imageable')->first()->imageable;
         $secondConnectionPost = EloquentTestPhoto::on('second_connection')->with('imageable')->first()->imageable;
 
-        $this->assertEquals($defaultConnectionPost->name, 'Default Connection Post');
-        $this->assertEquals($secondConnectionPost->name, 'Second Connection Post');
+        $this->assertEquals('Default Connection Post', $defaultConnectionPost->name);
+        $this->assertEquals('Second Connection Post', $secondConnectionPost->name);
     }
 
     public function testBelongsToManyCustomPivot()

--- a/tests/Database/DatabaseSchemaBuilderTest.php
+++ b/tests/Database/DatabaseSchemaBuilderTest.php
@@ -53,6 +53,6 @@ class DatabaseSchemaBuilderTest extends TestCase
         $column->shouldReceive('getType')->once()->andReturn($type);
         $type->shouldReceive('getName')->once()->andReturn('integer');
 
-        $this->assertEquals($builder->getColumnType('users', 'id'), 'integer');
+        $this->assertEquals('integer', $builder->getColumnType('users', 'id'));
     }
 }

--- a/tests/Events/EventsSubscriberTest.php
+++ b/tests/Events/EventsSubscriberTest.php
@@ -41,10 +41,10 @@ class EventsSubscriberTest extends TestCase
         $d->subscribe(DeclarativeSubscriber::class);
 
         $d->dispatch('myEvent1');
-        $this->assertEquals(DeclarativeSubscriber::$string, 'L1_L2_');
+        $this->assertEquals('L1_L2_', DeclarativeSubscriber::$string);
 
         $d->dispatch('myEvent2');
-        $this->assertEquals(DeclarativeSubscriber::$string, 'L1_L2_L3');
+        $this->assertEquals('L1_L2_L3', DeclarativeSubscriber::$string);
     }
 }
 

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -145,7 +145,7 @@ class FoundationApplicationTest extends TestCase
         $app->setDeferredServices(['foo' => ApplicationDeferredServiceProviderStub::class]);
         $app->instance('foo', 'bar');
         $instance = $app->make('foo');
-        $this->assertEquals($instance, 'bar');
+        $this->assertEquals('bar', $instance);
     }
 
     public function testDeferredServicesAreLazilyInitialized()
@@ -192,7 +192,7 @@ class FoundationApplicationTest extends TestCase
             SampleImplementation::class => SampleImplementationDeferredServiceProvider::class,
         ]);
         $instance = $app->make(SampleInterface::class);
-        $this->assertEquals($instance->getPrimitive(), 'foo');
+        $this->assertEquals('foo', $instance->getPrimitive());
     }
 
     public function testEnvironment()

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -1022,19 +1022,19 @@ class HttpRequestTest extends TestCase
         $request = Request::create('/', 'GET', ['foo' => 'bar', 'empty' => '']);
 
         // Parameter 'foo' is 'bar', then it ISSET and is NOT EMPTY.
-        $this->assertEquals($request->foo, 'bar');
-        $this->assertEquals(isset($request->foo), true);
-        $this->assertEquals(empty($request->foo), false);
+        $this->assertEquals('bar', $request->foo);
+        $this->assertEquals(true, isset($request->foo));
+        $this->assertEquals(false, empty($request->foo));
 
         // Parameter 'empty' is '', then it ISSET and is EMPTY.
-        $this->assertEquals($request->empty, '');
+        $this->assertEquals('', $request->empty);
         $this->assertTrue(isset($request->empty));
         $this->assertEmpty($request->empty);
 
         // Parameter 'undefined' is undefined/null, then it NOT ISSET and is EMPTY.
-        $this->assertEquals($request->undefined, null);
-        $this->assertEquals(isset($request->undefined), false);
-        $this->assertEquals(empty($request->undefined), true);
+        $this->assertEquals(null, $request->undefined);
+        $this->assertEquals(false, isset($request->undefined));
+        $this->assertEquals(true, empty($request->undefined));
 
         // Simulates Route parameters.
         $request = Request::create('/example/bar', 'GET', ['xyz' => 'overwritten']);
@@ -1048,19 +1048,19 @@ class HttpRequestTest extends TestCase
         // Router parameter 'foo' is 'bar', then it ISSET and is NOT EMPTY.
         $this->assertSame('bar', $request->foo);
         $this->assertSame('bar', $request['foo']);
-        $this->assertEquals(isset($request->foo), true);
-        $this->assertEquals(empty($request->foo), false);
+        $this->assertEquals(true, isset($request->foo));
+        $this->assertEquals(false, empty($request->foo));
 
         // Router parameter 'undefined' is undefined/null, then it NOT ISSET and is EMPTY.
-        $this->assertEquals($request->undefined, null);
-        $this->assertEquals(isset($request->undefined), false);
-        $this->assertEquals(empty($request->undefined), true);
+        $this->assertEquals(null, $request->undefined);
+        $this->assertEquals(false, isset($request->undefined));
+        $this->assertEquals(true, empty($request->undefined));
 
         // Special case: router parameter 'xyz' is 'overwritten' by QueryString, then it ISSET and is NOT EMPTY.
         // Basically, QueryStrings have priority over router parameters.
-        $this->assertEquals($request->xyz, 'overwritten');
-        $this->assertEquals(isset($request->foo), true);
-        $this->assertEquals(empty($request->foo), false);
+        $this->assertEquals('overwritten', $request->xyz);
+        $this->assertEquals(true, isset($request->foo));
+        $this->assertEquals(false, empty($request->foo));
 
         // Simulates empty QueryString and Routes.
         $request = Request::create('/', 'GET');
@@ -1072,18 +1072,18 @@ class HttpRequestTest extends TestCase
         });
 
         // Parameter 'undefined' is undefined/null, then it NOT ISSET and is EMPTY.
-        $this->assertEquals($request->undefined, null);
-        $this->assertEquals(isset($request->undefined), false);
-        $this->assertEquals(empty($request->undefined), true);
+        $this->assertEquals(null, $request->undefined);
+        $this->assertEquals(false, isset($request->undefined));
+        $this->assertEquals(true, empty($request->undefined));
 
         // Special case: simulates empty QueryString and Routes, without the Route Resolver.
         // It'll happen when you try to get a parameter outside a route.
         $request = Request::create('/', 'GET');
 
         // Parameter 'undefined' is undefined/null, then it NOT ISSET and is EMPTY.
-        $this->assertEquals($request->undefined, null);
-        $this->assertEquals(isset($request->undefined), false);
-        $this->assertEquals(empty($request->undefined), true);
+        $this->assertEquals(null, $request->undefined);
+        $this->assertEquals(false, isset($request->undefined));
+        $this->assertEquals(true, empty($request->undefined));
     }
 
     public function testHttpRequestFlashCallsSessionFlashInputWithInputData()

--- a/tests/Integration/Foundation/FoundationHelpersTest.php
+++ b/tests/Integration/Foundation/FoundationHelpersTest.php
@@ -15,19 +15,28 @@ class FoundationHelpersTest extends TestCase
 {
     public function testRescue()
     {
-        $this->assertEquals(rescue(function () {
-            throw new Exception;
-        }, 'rescued!'), 'rescued!');
+        $this->assertEquals(
+            'rescued!',
+            rescue(function () {
+                throw new Exception;
+            }, 'rescued!')
+        );
 
-        $this->assertEquals(rescue(function () {
-            throw new Exception;
-        }, function () {
-            return 'rescued!';
-        }), 'rescued!');
+        $this->assertEquals(
+            'rescued!',
+            rescue(function () {
+                throw new Exception;
+            }, function () {
+                return 'rescued!';
+            })
+        );
 
-        $this->assertEquals(rescue(function () {
-            return 'no need to rescue';
-        }, 'rescued!'), 'no need to rescue');
+        $this->assertEquals(
+            'no need to rescue',
+            rescue(function () {
+                return 'no need to rescue';
+            }, 'rescued!')
+        );
 
         $testClass = new class {
             public function test(int $a)
@@ -36,9 +45,12 @@ class FoundationHelpersTest extends TestCase
             }
         };
 
-        $this->assertEquals(rescue(function () use ($testClass) {
-            $testClass->test([]);
-        }, 'rescued!'), 'rescued!');
+        $this->assertEquals(
+            'rescued!',
+            rescue(function () use ($testClass) {
+                $testClass->test([]);
+            }, 'rescued!')
+        );
     }
 
     public function testMixReportsExceptionWhenAssetIsMissingFromManifest()

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -127,7 +127,7 @@ class QueueSqsQueueTest extends TestCase
         $queue->expects($this->once())->method('getQueue')->with($this->queueName)->willReturn($this->queueUrl);
         $this->sqs->shouldReceive('getQueueAttributes')->once()->with(['QueueUrl' => $this->queueUrl, 'AttributeNames' => ['ApproximateNumberOfMessages']])->andReturn($this->mockedQueueAttributesResponseModel);
         $size = $queue->size($this->queueName);
-        $this->assertEquals($size, 1);
+        $this->assertEquals(1, $size);
     }
 
     public function testGetQueueProperlyResolvesUrlWithPrefix()

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -433,7 +433,7 @@ class SessionStoreTest extends TestCase
         $session = $this->getSession();
         $this->assertEquals($session->getName(), $this->getSessionName());
         $session->setName('foo');
-        $this->assertEquals($session->getName(), 'foo');
+        $this->assertEquals('foo', $session->getName());
     }
 
     public function testKeyExists()

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -110,7 +110,7 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['foo.bar' => []], $array);
 
         $array = Arr::dot(['name' => 'taylor', 'languages' => ['php' => true]]);
-        $this->assertEquals($array, ['name' => 'taylor', 'languages.php' => true]);
+        $this->assertEquals(['name' => 'taylor', 'languages.php' => true], $array);
     }
 
     public function testExcept()

--- a/tests/Support/SupportFluentTest.php
+++ b/tests/Support/SupportFluentTest.php
@@ -64,7 +64,7 @@ class SupportFluentTest extends TestCase
         $fluent = new Fluent(['attributes' => '1']);
 
         $this->assertTrue(isset($fluent['attributes']));
-        $this->assertEquals($fluent['attributes'], 1);
+        $this->assertEquals(1, $fluent['attributes']);
 
         $fluent->attributes();
 

--- a/tests/Validation/ValidationFactoryTest.php
+++ b/tests/Validation/ValidationFactoryTest.php
@@ -73,7 +73,7 @@ class ValidationFactoryTest extends TestCase
             ['foo' => 'required']
         );
 
-        $this->assertEquals($validated, ['foo' => 'bar']);
+        $this->assertEquals(['foo' => 'bar'], $validated);
     }
 
     public function testCustomResolverIsCalled()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4665,10 +4665,13 @@ class ValidationValidatorTest extends TestCase
                 '*.name' => 'required',
             ]);
 
-        $this->assertEquals($v->invalid(), [
-            1 => ['name' => null],
-            2 => ['name' => ''],
-        ]);
+        $this->assertEquals(
+            [
+                1 => ['name' => null],
+                2 => ['name' => ''],
+            ],
+            $v->invalid()
+        );
 
         $v = new Validator($trans,
             [
@@ -4678,9 +4681,12 @@ class ValidationValidatorTest extends TestCase
                 'name' => 'required',
             ]);
 
-        $this->assertEquals($v->invalid(), [
-            'name' => '',
-        ]);
+        $this->assertEquals(
+            [
+                'name' => '',
+            ],
+            $v->invalid()
+        );
     }
 
     public function testValidMethod()
@@ -4698,10 +4704,13 @@ class ValidationValidatorTest extends TestCase
                 '*.name' => 'required',
             ]);
 
-        $this->assertEquals($v->valid(), [
-            0 => ['name' => 'John'],
-            3 => ['name' => 'Doe'],
-        ]);
+        $this->assertEquals(
+            [
+                0 => ['name' => 'John'],
+                3 => ['name' => 'Doe'],
+            ],
+            $v->valid()
+        );
 
         $v = new Validator($trans,
             [
@@ -4715,10 +4724,13 @@ class ValidationValidatorTest extends TestCase
                 'age' => 'required|int',
             ]);
 
-        $this->assertEquals($v->valid(), [
-            'name' => 'Carlos',
-            'gender' => 'male',
-        ]);
+        $this->assertEquals(
+            [
+                'name' => 'Carlos',
+                'gender' => 'male',
+            ],
+            $v->valid()
+        );
     }
 
     public function testNestedInvalidMethod()
@@ -4741,12 +4753,15 @@ class ValidationValidatorTest extends TestCase
                 'regex:/[A-F]{3}[0-9]{3}/',
             ],
         ]);
-        $this->assertEquals($v->invalid(), [
-            'testinvalid' => '',
-            'records' => [
-                3 => 'ADCD23',
+        $this->assertEquals(
+            [
+                'testinvalid' => '',
+                'records' => [
+                    3 => 'ADCD23',
+                ],
             ],
-        ]);
+            $v->invalid()
+        );
     }
 
     public function testMultipleFileUploads()


### PR DESCRIPTION
This PR fixes assertEquals arguments order in tests. First argument is expected value. In case of error it will produce incorrect error message. It looks like assertSame doesn't have this issues.

This changes could be automatically merged to 6.x, 7.x and 8.x as well.

Replaces #34665 because of https://github.com/laravel/framework/pull/34665#issuecomment-703314977