### PR TITLE
[8.x] Add pg_dump --no-owner and --no-acl to avoid owner/permission issues

### DIFF
--- a/src/Illuminate/Database/Schema/PostgresSchemaState.php
+++ b/src/Illuminate/Database/Schema/PostgresSchemaState.php
@@ -65,7 +65,7 @@ class PostgresSchemaState extends SchemaState
      */
     protected function baseDumpCommand()
     {
-        return 'PGPASSWORD=$LARAVEL_LOAD_PASSWORD pg_dump -Fc --host=$LARAVEL_LOAD_HOST --port=$LARAVEL_LOAD_PORT --username=$LARAVEL_LOAD_USER $LARAVEL_LOAD_DATABASE';
+        return 'PGPASSWORD=$LARAVEL_LOAD_PASSWORD pg_dump --no-owner --no-acl -Fc --host=$LARAVEL_LOAD_HOST --port=$LARAVEL_LOAD_PORT --username=$LARAVEL_LOAD_USER $LARAVEL_LOAD_DATABASE';
     }
 
     /**


### PR DESCRIPTION
Hey,

https://github.com/laravel/framework/commit/fcf175b246a646e81c13fb0e6c212f0b21cdfe51 changed PostgreSQL schema loading to use `pg_restore` but it fails when you dump schema on one computer and restore it on another (let's say one developer dumps schema, another one loads it) due to owner/permission issues (see below). 
You can add `--no-owner` and `--no-acl` options to either `pg_dump` or `pg_restore` but I think it doesn't make sense to commit a schema with owners/permissions in the case (might be wrong, no problem to change - let me know).

```
Symfony\Component\Process\Exception\ProcessFailedException 

The command "PGPASSWORD=$LARAVEL_LOAD_PASSWORD pg_restore --host=$LARAVEL_LOAD_HOST --port=$LARAVEL_LOAD_PORT --username=$LARAVEL_LOAD_USER --dbname=$LARAVEL_LOAD_DATABASE $LARAVEL_LOAD_PATH" failed.

Exit Code: 1(General error)

Working directory: /Users/rihardssceredins/Code/api-diet

Output:
================

Error Output:
================
pg_restore: while PROCESSING TOC:
pg_restore: from TOC entry 8; 2615 415790 SCHEMA public janisozolins
pg_restore: error: could not execute query: ERROR:  schema "public" already exists
Command was: CREATE SCHEMA public;

pg_restore: error: could not execute query: ERROR:  role "janisozolins" does not exist
Command was: ALTER SCHEMA public OWNER TO janisozolins;

pg_restore: from TOC entry 420; 1255 415886 FUNCTION datediff(character varying, timestamp without time zone, timestamp without time zone) janisozolins
pg_restore: error: could not execute query: ERROR:  role "janisozolins" does not exist
```

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
