### PR TITLE
[8.x] Use assertNull, assertFalse & assertTrue methods

### DIFF
--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -1023,8 +1023,8 @@ class HttpRequestTest extends TestCase
 
         // Parameter 'foo' is 'bar', then it ISSET and is NOT EMPTY.
         $this->assertEquals('bar', $request->foo);
-        $this->assertEquals(true, isset($request->foo));
-        $this->assertEquals(false, empty($request->foo));
+        $this->assertTrue(isset($request->foo));
+        $this->assertFalse(empty($request->foo));
 
         // Parameter 'empty' is '', then it ISSET and is EMPTY.
         $this->assertEquals('', $request->empty);
@@ -1032,9 +1032,9 @@ class HttpRequestTest extends TestCase
         $this->assertEmpty($request->empty);
 
         // Parameter 'undefined' is undefined/null, then it NOT ISSET and is EMPTY.
-        $this->assertEquals(null, $request->undefined);
-        $this->assertEquals(false, isset($request->undefined));
-        $this->assertEquals(true, empty($request->undefined));
+        $this->assertNull($request->undefined);
+        $this->assertFalse(isset($request->undefined));
+        $this->assertTrue(empty($request->undefined));
 
         // Simulates Route parameters.
         $request = Request::create('/example/bar', 'GET', ['xyz' => 'overwritten']);
@@ -1048,19 +1048,19 @@ class HttpRequestTest extends TestCase
         // Router parameter 'foo' is 'bar', then it ISSET and is NOT EMPTY.
         $this->assertSame('bar', $request->foo);
         $this->assertSame('bar', $request['foo']);
-        $this->assertEquals(true, isset($request->foo));
-        $this->assertEquals(false, empty($request->foo));
+        $this->assertTrue(isset($request->foo));
+        $this->assertFalse(empty($request->foo));
 
         // Router parameter 'undefined' is undefined/null, then it NOT ISSET and is EMPTY.
-        $this->assertEquals(null, $request->undefined);
-        $this->assertEquals(false, isset($request->undefined));
-        $this->assertEquals(true, empty($request->undefined));
+        $this->assertNull($request->undefined);
+        $this->assertFalse(isset($request->undefined));
+        $this->assertTrue(empty($request->undefined));
 
         // Special case: router parameter 'xyz' is 'overwritten' by QueryString, then it ISSET and is NOT EMPTY.
         // Basically, QueryStrings have priority over router parameters.
         $this->assertEquals('overwritten', $request->xyz);
-        $this->assertEquals(true, isset($request->foo));
-        $this->assertEquals(false, empty($request->foo));
+        $this->assertTrue(isset($request->foo));
+        $this->assertFalse(empty($request->foo));
 
         // Simulates empty QueryString and Routes.
         $request = Request::create('/', 'GET');
@@ -1072,18 +1072,18 @@ class HttpRequestTest extends TestCase
         });
 
         // Parameter 'undefined' is undefined/null, then it NOT ISSET and is EMPTY.
-        $this->assertEquals(null, $request->undefined);
-        $this->assertEquals(false, isset($request->undefined));
-        $this->assertEquals(true, empty($request->undefined));
+        $this->assertNull($request->undefined);
+        $this->assertFalse(isset($request->undefined));
+        $this->assertTrue(empty($request->undefined));
 
         // Special case: simulates empty QueryString and Routes, without the Route Resolver.
         // It'll happen when you try to get a parameter outside a route.
         $request = Request::create('/', 'GET');
 
         // Parameter 'undefined' is undefined/null, then it NOT ISSET and is EMPTY.
-        $this->assertEquals(null, $request->undefined);
-        $this->assertEquals(false, isset($request->undefined));
-        $this->assertEquals(true, empty($request->undefined));
+        $this->assertNull($request->undefined);
+        $this->assertFalse(isset($request->undefined));
+        $this->assertTrue(empty($request->undefined));
     }
 
     public function testHttpRequestFlashCallsSessionFlashInputWithInputData()

--- a/tests/Integration/Database/EloquentModelLoadCountTest.php
+++ b/tests/Integration/Database/EloquentModelLoadCountTest.php
@@ -74,7 +74,7 @@ class EloquentModelLoadCountTest extends DatabaseTestCase
     {
         $model = BaseModel::first();
 
-        $this->assertEquals(null, $model->deletedrelated_count);
+        $this->assertNull($model->deletedrelated_count);
 
         $model->loadCount('deletedrelated');
 
@@ -84,7 +84,7 @@ class EloquentModelLoadCountTest extends DatabaseTestCase
 
         $model = BaseModel::first();
 
-        $this->assertEquals(null, $model->deletedrelated_count);
+        $this->assertNull($model->deletedrelated_count);
 
         $model->loadCount('deletedrelated');
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -144,7 +144,7 @@ class SupportCollectionTest extends TestCase
         $this->assertSame('Taylor', $data->shift());
         $this->assertSame('Otwell', $data->first());
         $this->assertSame('Otwell', $data->shift());
-        $this->assertEquals(null, $data->first());
+        $this->assertNull($data->first());
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4602,19 +4602,19 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, [], []);
 
         $implicit_no_connection = $v->parseTable(ImplicitTableModel::class);
-        $this->assertEquals(null, $implicit_no_connection[0]);
+        $this->assertNull($implicit_no_connection[0]);
         $this->assertSame('implicit_table_models', $implicit_no_connection[1]);
 
         $explicit_no_connection = $v->parseTable(ExplicitTableModel::class);
-        $this->assertEquals(null, $explicit_no_connection[0]);
+        $this->assertNull($explicit_no_connection[0]);
         $this->assertSame('explicits', $explicit_no_connection[1]);
 
         $noneloquent_no_connection = $v->parseTable(NonEloquentModel::class);
-        $this->assertEquals(null, $noneloquent_no_connection[0]);
+        $this->assertNull($noneloquent_no_connection[0]);
         $this->assertEquals(NonEloquentModel::class, $noneloquent_no_connection[1]);
 
         $raw_no_connection = $v->parseTable('table');
-        $this->assertEquals(null, $raw_no_connection[0]);
+        $this->assertNull($raw_no_connection[0]);
         $this->assertSame('table', $raw_no_connection[1]);
 
         $implicit_connection = $v->parseTable('connection.'.ImplicitTableModel::class);


### PR DESCRIPTION
This PR replaces `assertEquals` methods calls with `assertNull`, `assertFalse` & `assertTrue` methods where it's possible.