### PR TITLE
[8.x] Use assertSame for strings comparison

### DIFF
--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -672,7 +672,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertSame('Not allowed to view as it is not published.', $response->message());
         $this->assertFalse($response->allowed());
         $this->assertTrue($response->denied());
-        $this->assertEquals('unpublished', $response->code());
+        $this->assertSame('unpublished', $response->code());
     }
 
     public function testAuthorizeReturnsAnAllowedResponseForATruthyReturn()

--- a/tests/Auth/AuthorizeMiddlewareTest.php
+++ b/tests/Auth/AuthorizeMiddlewareTest.php
@@ -87,7 +87,7 @@ class AuthorizeMiddlewareTest extends TestCase
 
         $response = $this->router->dispatch(Request::create('dashboard', 'GET'));
 
-        $this->assertEquals('success', $response->content());
+        $this->assertSame('success', $response->content());
     }
 
     public function testSimpleAbilityWithStringParameter()
@@ -105,7 +105,7 @@ class AuthorizeMiddlewareTest extends TestCase
 
         $response = $this->router->dispatch(Request::create('dashboard', 'GET'));
 
-        $this->assertEquals('success', $response->content());
+        $this->assertSame('success', $response->content());
     }
 
     public function testSimpleAbilityWithNullParameter()
@@ -154,10 +154,10 @@ class AuthorizeMiddlewareTest extends TestCase
         ]);
 
         $response = $this->router->dispatch(Request::create('posts/1/comments', 'GET'));
-        $this->assertEquals('success', $response->content());
+        $this->assertSame('success', $response->content());
 
         $response = $this->router->dispatch(Request::create('comments', 'GET'));
-        $this->assertEquals('success', $response->content());
+        $this->assertSame('success', $response->content());
     }
 
     public function testSimpleAbilityWithStringParameterFromRouteParameter()
@@ -175,7 +175,7 @@ class AuthorizeMiddlewareTest extends TestCase
 
         $response = $this->router->dispatch(Request::create('dashboard/true', 'GET'));
 
-        $this->assertEquals('success', $response->content());
+        $this->assertSame('success', $response->content());
     }
 
     public function testModelTypeUnauthorized()
@@ -184,7 +184,7 @@ class AuthorizeMiddlewareTest extends TestCase
         $this->expectExceptionMessage('This action is unauthorized.');
 
         $this->gate()->define('create', function ($user, $model) {
-            $this->assertEquals('App\User', $model);
+            $this->assertSame('App\User', $model);
 
             return false;
         });
@@ -202,7 +202,7 @@ class AuthorizeMiddlewareTest extends TestCase
     public function testModelTypeAuthorized()
     {
         $this->gate()->define('create', function ($user, $model) {
-            $this->assertEquals('App\User', $model);
+            $this->assertSame('App\User', $model);
 
             return true;
         });
@@ -216,7 +216,7 @@ class AuthorizeMiddlewareTest extends TestCase
 
         $response = $this->router->dispatch(Request::create('users/create', 'GET'));
 
-        $this->assertEquals('success', $response->content());
+        $this->assertSame('success', $response->content());
     }
 
     public function testModelUnauthorized()
@@ -269,7 +269,7 @@ class AuthorizeMiddlewareTest extends TestCase
 
         $response = $this->router->dispatch(Request::create('posts/1/edit', 'GET'));
 
-        $this->assertEquals('success', $response->content());
+        $this->assertSame('success', $response->content());
     }
 
     public function testModelInstanceAsParameter()

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -240,7 +240,7 @@ class CacheRepositoryTest extends TestCase
         $repo::macro(__CLASS__, function () {
             return 'Taylor';
         });
-        $this->assertEquals('Taylor', $repo->{__CLASS__}());
+        $this->assertSame('Taylor', $repo->{__CLASS__}());
     }
 
     public function testForgettingCacheKey()

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -398,7 +398,7 @@ class ContainerTest extends TestCase
     {
         $container = new Container;
         $container->alias('ConcreteStub', 'foo');
-        $this->assertEquals('ConcreteStub', $container->getAlias('foo'));
+        $this->assertSame('ConcreteStub', $container->getAlias('foo'));
     }
 
     public function testItThrowsExceptionWhenAbstractIsSameAsAlias()

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -1220,8 +1220,8 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $defaultConnectionPost = EloquentTestPhoto::with('imageable')->first()->imageable;
         $secondConnectionPost = EloquentTestPhoto::on('second_connection')->with('imageable')->first()->imageable;
 
-        $this->assertEquals('Default Connection Post', $defaultConnectionPost->name);
-        $this->assertEquals('Second Connection Post', $secondConnectionPost->name);
+        $this->assertSame('Default Connection Post', $defaultConnectionPost->name);
+        $this->assertSame('Second Connection Post', $secondConnectionPost->name);
     }
 
     public function testBelongsToManyCustomPivot()

--- a/tests/Database/DatabaseSchemaBuilderTest.php
+++ b/tests/Database/DatabaseSchemaBuilderTest.php
@@ -53,6 +53,6 @@ class DatabaseSchemaBuilderTest extends TestCase
         $column->shouldReceive('getType')->once()->andReturn($type);
         $type->shouldReceive('getName')->once()->andReturn('integer');
 
-        $this->assertEquals('integer', $builder->getColumnType('users', 'id'));
+        $this->assertSame('integer', $builder->getColumnType('users', 'id'));
     }
 }

--- a/tests/Events/EventsSubscriberTest.php
+++ b/tests/Events/EventsSubscriberTest.php
@@ -41,10 +41,10 @@ class EventsSubscriberTest extends TestCase
         $d->subscribe(DeclarativeSubscriber::class);
 
         $d->dispatch('myEvent1');
-        $this->assertEquals('L1_L2_', DeclarativeSubscriber::$string);
+        $this->assertSame('L1_L2_', DeclarativeSubscriber::$string);
 
         $d->dispatch('myEvent2');
-        $this->assertEquals('L1_L2_L3', DeclarativeSubscriber::$string);
+        $this->assertSame('L1_L2_L3', DeclarativeSubscriber::$string);
     }
 }
 

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -145,7 +145,7 @@ class FoundationApplicationTest extends TestCase
         $app->setDeferredServices(['foo' => ApplicationDeferredServiceProviderStub::class]);
         $app->instance('foo', 'bar');
         $instance = $app->make('foo');
-        $this->assertEquals('bar', $instance);
+        $this->assertSame('bar', $instance);
     }
 
     public function testDeferredServicesAreLazilyInitialized()
@@ -192,7 +192,7 @@ class FoundationApplicationTest extends TestCase
             SampleImplementation::class => SampleImplementationDeferredServiceProvider::class,
         ]);
         $instance = $app->make(SampleInterface::class);
-        $this->assertEquals('foo', $instance->getPrimitive());
+        $this->assertSame('foo', $instance->getPrimitive());
     }
 
     public function testEnvironment()

--- a/tests/Foundation/mix/mix-manifest.json
+++ b/tests/Foundation/mix/mix-manifest.json
@@ -1,3 +1,0 @@
-{
-    "/unversioned.css": "/versioned.css"
-}

--- a/tests/Foundation/mix/mix-manifest.json
+++ b/tests/Foundation/mix/mix-manifest.json
@@ -1,0 +1,3 @@
+{
+    "/unversioned.css": "/versioned.css"
+}

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -1022,12 +1022,12 @@ class HttpRequestTest extends TestCase
         $request = Request::create('/', 'GET', ['foo' => 'bar', 'empty' => '']);
 
         // Parameter 'foo' is 'bar', then it ISSET and is NOT EMPTY.
-        $this->assertEquals('bar', $request->foo);
+        $this->assertSame('bar', $request->foo);
         $this->assertTrue(isset($request->foo));
         $this->assertFalse(empty($request->foo));
 
         // Parameter 'empty' is '', then it ISSET and is EMPTY.
-        $this->assertEquals('', $request->empty);
+        $this->assertSame('', $request->empty);
         $this->assertTrue(isset($request->empty));
         $this->assertEmpty($request->empty);
 
@@ -1058,7 +1058,7 @@ class HttpRequestTest extends TestCase
 
         // Special case: router parameter 'xyz' is 'overwritten' by QueryString, then it ISSET and is NOT EMPTY.
         // Basically, QueryStrings have priority over router parameters.
-        $this->assertEquals('overwritten', $request->xyz);
+        $this->assertSame('overwritten', $request->xyz);
         $this->assertTrue(isset($request->foo));
         $this->assertFalse(empty($request->foo));
 

--- a/tests/Integration/View/BladeTest.php
+++ b/tests/Integration/View/BladeTest.php
@@ -21,7 +21,7 @@ class BladeTest extends TestCase
     {
         $view = View::make('uses-panel', ['name' => 'Taylor'])->render();
 
-        $this->assertEquals('<div class="ml-2">
+        $this->assertSame('<div class="ml-2">
     Hello Taylor
 </div>', trim($view));
     }
@@ -39,10 +39,10 @@ class BladeTest extends TestCase
     {
         $view = View::make('varied-dynamic-calls')->render();
 
-        $this->assertEquals('<span class="text-medium">
+        $this->assertSame('<span class="text-medium">
     Hello Taylor
 </span>
-  
+
  <span >
     Hello Samuel
 </span>', trim($view));
@@ -52,7 +52,7 @@ class BladeTest extends TestCase
     {
         $view = View::make('uses-appendable-panel', ['name' => 'Taylor'])->render();
 
-        $this->assertEquals('<div class="mt-4 bg-gray-100" data-controller="inside-controller outside-controller" foo="bar">
+        $this->assertSame('<div class="mt-4 bg-gray-100" data-controller="inside-controller outside-controller" foo="bar">
     Hello Taylor
 </div>', trim($view));
     }

--- a/tests/Integration/View/BladeTest.php
+++ b/tests/Integration/View/BladeTest.php
@@ -21,7 +21,7 @@ class BladeTest extends TestCase
     {
         $view = View::make('uses-panel', ['name' => 'Taylor'])->render();
 
-        $this->assertEquals('<div class="ml-2">
+        $this->assertSame('<div class="ml-2">
     Hello Taylor
 </div>', trim($view));
     }
@@ -52,7 +52,7 @@ class BladeTest extends TestCase
     {
         $view = View::make('uses-appendable-panel', ['name' => 'Taylor'])->render();
 
-        $this->assertEquals('<div class="mt-4 bg-gray-100" data-controller="inside-controller outside-controller" foo="bar">
+        $this->assertSame('<div class="mt-4 bg-gray-100" data-controller="inside-controller outside-controller" foo="bar">
     Hello Taylor
 </div>', trim($view));
     }

--- a/tests/Integration/View/BladeTest.php
+++ b/tests/Integration/View/BladeTest.php
@@ -39,10 +39,10 @@ class BladeTest extends TestCase
     {
         $view = View::make('varied-dynamic-calls')->render();
 
-        $this->assertEquals('<span class="text-medium">
+        $this->assertSame('<span class="text-medium">
     Hello Taylor
 </span>
-
+  
  <span >
     Hello Samuel
 </span>', trim($view));

--- a/tests/Integration/View/BladeTest.php
+++ b/tests/Integration/View/BladeTest.php
@@ -21,7 +21,7 @@ class BladeTest extends TestCase
     {
         $view = View::make('uses-panel', ['name' => 'Taylor'])->render();
 
-        $this->assertSame('<div class="ml-2">
+        $this->assertEquals('<div class="ml-2">
     Hello Taylor
 </div>', trim($view));
     }
@@ -39,7 +39,7 @@ class BladeTest extends TestCase
     {
         $view = View::make('varied-dynamic-calls')->render();
 
-        $this->assertSame('<span class="text-medium">
+        $this->assertEquals('<span class="text-medium">
     Hello Taylor
 </span>
 
@@ -52,7 +52,7 @@ class BladeTest extends TestCase
     {
         $view = View::make('uses-appendable-panel', ['name' => 'Taylor'])->render();
 
-        $this->assertSame('<div class="mt-4 bg-gray-100" data-controller="inside-controller outside-controller" foo="bar">
+        $this->assertEquals('<div class="mt-4 bg-gray-100" data-controller="inside-controller outside-controller" foo="bar">
     Hello Taylor
 </div>', trim($view));
     }

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -433,7 +433,7 @@ class SessionStoreTest extends TestCase
         $session = $this->getSession();
         $this->assertEquals($session->getName(), $this->getSessionName());
         $session->setName('foo');
-        $this->assertEquals('foo', $session->getName());
+        $this->assertSame('foo', $session->getName());
     }
 
     public function testKeyExists()


### PR DESCRIPTION
Use more strict assertion `assertSame` for strings comparison to exact text match.