### PR TITLE
[8.x] Add is() method to 1-1 relations for model comparison

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -5,11 +5,12 @@ namespace Illuminate\Database\Eloquent\Relations;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Concerns\ComparesWithModels;
 use Illuminate\Database\Eloquent\Relations\Concerns\SupportsDefaultModels;
 
 class BelongsTo extends Relation
 {
-    use SupportsDefaultModels;
+    use ComparesWithModels, SupportsDefaultModels;
 
     /**
      * The child model instance of the relation.
@@ -341,6 +342,16 @@ class BelongsTo extends Relation
     }
 
     /**
+     * Get the key value of the child's foreign key.
+     *
+     * @return mixed
+     */
+    public function getParentKey()
+    {
+        return $this->child->{$this->foreignKey};
+    }
+
+    /**
      * Get the associated key of the relationship.
      *
      * @return string
@@ -358,6 +369,17 @@ class BelongsTo extends Relation
     public function getQualifiedOwnerKeyName()
     {
         return $this->related->qualifyColumn($this->ownerKey);
+    }
+
+    /**
+     * Get the value of the model's associated key.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return mixed
+     */
+    protected function getRelatedKeyFrom(Model $model)
+    {
+        return $model->{$this->ownerKey};
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/ComparesWithModels.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/ComparesWithModels.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Relations\Concerns;
+
+use Illuminate\Database\Eloquent\Model;
+
+trait ComparesWithModels
+{
+    /**
+     * Determine if the model is the related instance of the relationship.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model|null  $model
+     * @return bool
+     */
+    public function is($model)
+    {
+        return ! is_null($model) &&
+               $this->compareKeys($this->getParentKey(), $this->getRelatedKeyFrom($model)) &&
+               $this->related->getTable() === $model->getTable() &&
+               $this->related->getConnectionName() === $model->getConnectionName();
+    }
+
+    /**
+     * Determine if the model is not the related instance of the relationship.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model|null  $model
+     * @return bool
+     */
+    public function isNot($model)
+    {
+        return ! $this->is($model);
+    }
+
+    /**
+     * Get the value of the parent model's key.
+     *
+     * @return mixed
+     */
+    abstract public function getParentKey();
+
+    /**
+     * Get the value of the model's related key.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return mixed
+     */
+    abstract protected function getRelatedKeyFrom(Model $model);
+
+    /**
+     * Compare the parent key with the related key.
+     *
+     * @param  mixed  $parentKey
+     * @param  mixed  $relatedKey
+     * @return bool
+     */
+    protected function compareKeys($parentKey, $relatedKey)
+    {
+        if (empty($parentKey) || empty($relatedKey)) {
+            return false;
+        }
+
+        if (is_int($parentKey) || is_int($relatedKey)) {
+            return (int) $parentKey === (int) $relatedKey;
+        }
+
+        return $parentKey === $relatedKey;
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Relations/HasOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOne.php
@@ -4,11 +4,12 @@ namespace Illuminate\Database\Eloquent\Relations;
 
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Concerns\ComparesWithModels;
 use Illuminate\Database\Eloquent\Relations\Concerns\SupportsDefaultModels;
 
 class HasOne extends HasOneOrMany
 {
-    use SupportsDefaultModels;
+    use ComparesWithModels, SupportsDefaultModels;
 
     /**
      * Get the results of the relationship.
@@ -64,5 +65,16 @@ class HasOne extends HasOneOrMany
         return $this->related->newInstance()->setAttribute(
             $this->getForeignKeyName(), $parent->{$this->localKey}
         );
+    }
+
+    /**
+     * Get the value of the model's foreign key.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return mixed
+     */
+    protected function getRelatedKeyFrom(Model $model)
+    {
+        return $model->getAttribute($this->getForeignKeyName());
     }
 }

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOne.php
@@ -4,11 +4,12 @@ namespace Illuminate\Database\Eloquent\Relations;
 
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Concerns\ComparesWithModels;
 use Illuminate\Database\Eloquent\Relations\Concerns\SupportsDefaultModels;
 
 class MorphOne extends MorphOneOrMany
 {
-    use SupportsDefaultModels;
+    use ComparesWithModels, SupportsDefaultModels;
 
     /**
      * Get the results of the relationship.
@@ -64,5 +65,16 @@ class MorphOne extends MorphOneOrMany
         return $this->related->newInstance()
                     ->setAttribute($this->getForeignKeyName(), $parent->{$this->localKey})
                     ->setAttribute($this->getMorphType(), $this->morphClass);
+    }
+
+    /**
+     * Get the value of the model's foreign key.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return mixed
+     */
+    protected function getRelatedKeyFrom(Model $model)
+    {
+        return $model->getAttribute($this->getForeignKeyName());
     }
 }

--- a/tests/Database/DatabaseEloquentBelongsToTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToTest.php
@@ -181,6 +181,169 @@ class DatabaseEloquentBelongsToTest extends TestCase
         $relation->addEagerConstraints($models);
     }
 
+    public function testIsNotNull()
+    {
+        $relation = $this->getRelation();
+
+        $this->related->shouldReceive('getConnectionName')->never();
+
+        $this->assertFalse($relation->is(null));
+    }
+
+    public function testIsModel()
+    {
+        $relation = $this->getRelation();
+
+        $this->related->shouldReceive('getConnectionName')->once()->andReturn('relation');
+
+        $model = m::mock(Model::class);
+        $model->shouldReceive('getAttribute')->once()->with('id')->andReturn('foreign.value');
+        $model->shouldReceive('getTable')->once()->andReturn('relation');
+        $model->shouldReceive('getConnectionName')->once()->andReturn('relation');
+
+        $this->assertTrue($relation->is($model));
+    }
+
+    public function testIsModelWithIntegerParentKey()
+    {
+        $parent = m::mock(Model::class);
+
+        // when addConstraints is called we need to return the foreign value
+        $parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn('foreign.value');
+        // when getParentKey is called we want to return an integer
+        $parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn(1);
+
+        $relation = $this->getRelation($parent);
+
+        $this->related->shouldReceive('getConnectionName')->once()->andReturn('relation');
+
+        $model = m::mock(Model::class);
+        $model->shouldReceive('getAttribute')->once()->with('id')->andReturn('1');
+        $model->shouldReceive('getTable')->once()->andReturn('relation');
+        $model->shouldReceive('getConnectionName')->once()->andReturn('relation');
+
+        $this->assertTrue($relation->is($model));
+    }
+
+    public function testIsModelWithIntegerRelatedKey()
+    {
+        $parent = m::mock(Model::class);
+
+        // when addConstraints is called we need to return the foreign value
+        $parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn('foreign.value');
+        // when getParentKey is called we want to return a string
+        $parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn('1');
+
+        $relation = $this->getRelation($parent);
+
+        $this->related->shouldReceive('getConnectionName')->once()->andReturn('relation');
+
+        $model = m::mock(Model::class);
+        $model->shouldReceive('getAttribute')->once()->with('id')->andReturn(1);
+        $model->shouldReceive('getTable')->once()->andReturn('relation');
+        $model->shouldReceive('getConnectionName')->once()->andReturn('relation');
+
+        $this->assertTrue($relation->is($model));
+    }
+
+    public function testIsModelWithIntegerKeys()
+    {
+        $parent = m::mock(Model::class);
+
+        // when addConstraints is called we need to return the foreign value
+        $parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn('foreign.value');
+        // when getParentKey is called we want to return an integer
+        $parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn(1);
+
+        $relation = $this->getRelation($parent);
+
+        $this->related->shouldReceive('getConnectionName')->once()->andReturn('relation');
+
+        $model = m::mock(Model::class);
+        $model->shouldReceive('getAttribute')->once()->with('id')->andReturn(1);
+        $model->shouldReceive('getTable')->once()->andReturn('relation');
+        $model->shouldReceive('getConnectionName')->once()->andReturn('relation');
+
+        $this->assertTrue($relation->is($model));
+    }
+
+    public function testIsNotModelWithNullParentKey()
+    {
+        $parent = m::mock(Model::class);
+
+        // when addConstraints is called we need to return the foreign value
+        $parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn('foreign.value');
+        // when getParentKey is called we want to return null
+        $parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn(null);
+
+        $relation = $this->getRelation($parent);
+
+        $this->related->shouldReceive('getConnectionName')->never();
+
+        $model = m::mock(Model::class);
+        $model->shouldReceive('getAttribute')->once()->with('id')->andReturn('foreign.value');
+        $model->shouldReceive('getTable')->never();
+        $model->shouldReceive('getConnectionName')->never();
+
+        $this->assertFalse($relation->is($model));
+    }
+
+    public function testIsNotModelWithNullRelatedKey()
+    {
+        $relation = $this->getRelation();
+
+        $this->related->shouldReceive('getConnectionName')->never();
+
+        $model = m::mock(Model::class);
+        $model->shouldReceive('getAttribute')->once()->with('id')->andReturn(null);
+        $model->shouldReceive('getTable')->never();
+        $model->shouldReceive('getConnectionName')->never();
+
+        $this->assertFalse($relation->is($model));
+    }
+
+    public function testIsNotModelWithAnotherKey()
+    {
+        $relation = $this->getRelation();
+
+        $this->related->shouldReceive('getConnectionName')->never();
+
+        $model = m::mock(Model::class);
+        $model->shouldReceive('getAttribute')->once()->with('id')->andReturn('foreign.value.two');
+        $model->shouldReceive('getTable')->never();
+        $model->shouldReceive('getConnectionName')->never();
+
+        $this->assertFalse($relation->is($model));
+    }
+
+    public function testIsNotModelWithAnotherTable()
+    {
+        $relation = $this->getRelation();
+
+        $this->related->shouldReceive('getConnectionName')->never();
+
+        $model = m::mock(Model::class);
+        $model->shouldReceive('getAttribute')->once()->with('id')->andReturn('foreign.value');
+        $model->shouldReceive('getTable')->once()->andReturn('table.two');
+        $model->shouldReceive('getConnectionName')->never();
+
+        $this->assertFalse($relation->is($model));
+    }
+
+    public function testIsNotModelWithAnotherConnection()
+    {
+        $relation = $this->getRelation();
+
+        $this->related->shouldReceive('getConnectionName')->once()->andReturn('relation');
+
+        $model = m::mock(Model::class);
+        $model->shouldReceive('getAttribute')->once()->with('id')->andReturn('foreign.value');
+        $model->shouldReceive('getTable')->once()->andReturn('relation');
+        $model->shouldReceive('getConnectionName')->once()->andReturn('relation.two');
+
+        $this->assertFalse($relation->is($model));
+    }
+
     protected function getRelation($parent = null, $keyType = 'int')
     {
         $this->builder = m::mock(Builder::class);

--- a/tests/Database/DatabaseEloquentHasOneTest.php
+++ b/tests/Database/DatabaseEloquentHasOneTest.php
@@ -196,6 +196,106 @@ class DatabaseEloquentHasOneTest extends TestCase
         $relation->getRelationExistenceCountQuery($builder, $builder);
     }
 
+    public function testIsNotNull()
+    {
+        $relation = $this->getRelation();
+
+        $this->related->shouldReceive('getTable')->never();
+        $this->related->shouldReceive('getConnectionName')->never();
+
+        $this->assertFalse($relation->is(null));
+    }
+
+    public function testIsModel()
+    {
+        $relation = $this->getRelation();
+
+        $this->related->shouldReceive('getTable')->once()->andReturn('table');
+        $this->related->shouldReceive('getConnectionName')->once()->andReturn('connection');
+
+        $model = m::mock(Model::class);
+        $model->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn(1);
+        $model->shouldReceive('getTable')->once()->andReturn('table');
+        $model->shouldReceive('getConnectionName')->once()->andReturn('connection');
+
+        $this->assertTrue($relation->is($model));
+    }
+
+    public function testIsModelWithStringRelatedKey()
+    {
+        $relation = $this->getRelation();
+
+        $this->related->shouldReceive('getTable')->once()->andReturn('table');
+        $this->related->shouldReceive('getConnectionName')->once()->andReturn('connection');
+
+        $model = m::mock(Model::class);
+        $model->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn('1');
+        $model->shouldReceive('getTable')->once()->andReturn('table');
+        $model->shouldReceive('getConnectionName')->once()->andReturn('connection');
+
+        $this->assertTrue($relation->is($model));
+    }
+
+    public function testIsNotModelWithNullRelatedKey()
+    {
+        $relation = $this->getRelation();
+
+        $this->related->shouldReceive('getTable')->never();
+        $this->related->shouldReceive('getConnectionName')->never();
+
+        $model = m::mock(Model::class);
+        $model->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn(null);
+        $model->shouldReceive('getTable')->never();
+        $model->shouldReceive('getConnectionName')->never();
+
+        $this->assertFalse($relation->is($model));
+    }
+
+    public function testIsNotModelWithAnotherRelatedKey()
+    {
+        $relation = $this->getRelation();
+
+        $this->related->shouldReceive('getTable')->never();
+        $this->related->shouldReceive('getConnectionName')->never();
+
+        $model = m::mock(Model::class);
+        $model->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn(2);
+        $model->shouldReceive('getTable')->never();
+        $model->shouldReceive('getConnectionName')->never();
+
+        $this->assertFalse($relation->is($model));
+    }
+
+    public function testIsNotModelWithAnotherTable()
+    {
+        $relation = $this->getRelation();
+
+        $this->related->shouldReceive('getTable')->once()->andReturn('table');
+        $this->related->shouldReceive('getConnectionName')->never();
+
+        $model = m::mock(Model::class);
+        $model->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn(1);
+        $model->shouldReceive('getTable')->once()->andReturn('table.two');
+        $model->shouldReceive('getConnectionName')->never();
+
+        $this->assertFalse($relation->is($model));
+    }
+
+    public function testIsNotModelWithAnotherConnection()
+    {
+        $relation = $this->getRelation();
+
+        $this->related->shouldReceive('getTable')->once()->andReturn('table');
+        $this->related->shouldReceive('getConnectionName')->once()->andReturn('connection');
+
+        $model = m::mock(Model::class);
+        $model->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn(1);
+        $model->shouldReceive('getTable')->once()->andReturn('table');
+        $model->shouldReceive('getConnectionName')->once()->andReturn('connection.two');
+
+        $this->assertFalse($relation->is($model));
+    }
+
     protected function getRelation()
     {
         $this->builder = m::mock(Builder::class);

--- a/tests/Database/DatabaseEloquentMorphTest.php
+++ b/tests/Database/DatabaseEloquentMorphTest.php
@@ -253,6 +253,106 @@ class DatabaseEloquentMorphTest extends TestCase
         $this->assertEquals($created, $relation->create(['name' => 'taylor']));
     }
 
+    public function testIsNotNull()
+    {
+        $relation = $this->getOneRelation();
+
+        $relation->getRelated()->shouldReceive('getTable')->never();
+        $relation->getRelated()->shouldReceive('getConnectionName')->never();
+
+        $this->assertFalse($relation->is(null));
+    }
+
+    public function testIsModel()
+    {
+        $relation = $this->getOneRelation();
+
+        $relation->getRelated()->shouldReceive('getTable')->once()->andReturn('table');
+        $relation->getRelated()->shouldReceive('getConnectionName')->once()->andReturn('connection');
+
+        $model = m::mock(Model::class);
+        $model->shouldReceive('getAttribute')->once()->with('morph_id')->andReturn(1);
+        $model->shouldReceive('getTable')->once()->andReturn('table');
+        $model->shouldReceive('getConnectionName')->once()->andReturn('connection');
+
+        $this->assertTrue($relation->is($model));
+    }
+
+    public function testIsModelWithStringRelatedKey()
+    {
+        $relation = $this->getOneRelation();
+
+        $relation->getRelated()->shouldReceive('getTable')->once()->andReturn('table');
+        $relation->getRelated()->shouldReceive('getConnectionName')->once()->andReturn('connection');
+
+        $model = m::mock(Model::class);
+        $model->shouldReceive('getAttribute')->once()->with('morph_id')->andReturn('1');
+        $model->shouldReceive('getTable')->once()->andReturn('table');
+        $model->shouldReceive('getConnectionName')->once()->andReturn('connection');
+
+        $this->assertTrue($relation->is($model));
+    }
+
+    public function testIsNotModelWithNullRelatedKey()
+    {
+        $relation = $this->getOneRelation();
+
+        $relation->getRelated()->shouldReceive('getTable')->never();
+        $relation->getRelated()->shouldReceive('getConnectionName')->never();
+
+        $model = m::mock(Model::class);
+        $model->shouldReceive('getAttribute')->once()->with('morph_id')->andReturn(null);
+        $model->shouldReceive('getTable')->never();
+        $model->shouldReceive('getConnectionName')->never();
+
+        $this->assertFalse($relation->is($model));
+    }
+
+    public function testIsNotModelWithAnotherRelatedKey()
+    {
+        $relation = $this->getOneRelation();
+
+        $relation->getRelated()->shouldReceive('getTable')->never();
+        $relation->getRelated()->shouldReceive('getConnectionName')->never();
+
+        $model = m::mock(Model::class);
+        $model->shouldReceive('getAttribute')->once()->with('morph_id')->andReturn(2);
+        $model->shouldReceive('getTable')->never();
+        $model->shouldReceive('getConnectionName')->never();
+
+        $this->assertFalse($relation->is($model));
+    }
+
+    public function testIsNotModelWithAnotherTable()
+    {
+        $relation = $this->getOneRelation();
+
+        $relation->getRelated()->shouldReceive('getTable')->once()->andReturn('table');
+        $relation->getRelated()->shouldReceive('getConnectionName')->never();
+
+        $model = m::mock(Model::class);
+        $model->shouldReceive('getAttribute')->once()->with('morph_id')->andReturn(1);
+        $model->shouldReceive('getTable')->once()->andReturn('table.two');
+        $model->shouldReceive('getConnectionName')->never();
+
+        $this->assertFalse($relation->is($model));
+    }
+
+    public function testIsNotModelWithAnotherConnection()
+    {
+        $relation = $this->getOneRelation();
+
+        $relation->getRelated()->shouldReceive('getTable')->once()->andReturn('table');
+        $relation->getRelated()->shouldReceive('getConnectionName')->once()->andReturn('connection');
+
+        $model = m::mock(Model::class);
+        $model->shouldReceive('getAttribute')->once()->with('morph_id')->andReturn(1);
+        $model->shouldReceive('getTable')->once()->andReturn('table');
+        $model->shouldReceive('getConnectionName')->once()->andReturn('connection.two');
+
+        $this->assertFalse($relation->is($model));
+    }
+
     protected function getOneRelation()
     {
         $builder = m::mock(Builder::class);

--- a/tests/Database/DatabaseEloquentMorphToTest.php
+++ b/tests/Database/DatabaseEloquentMorphToTest.php
@@ -150,6 +150,169 @@ class DatabaseEloquentMorphToTest extends TestCase
         $relation->dissociate();
     }
 
+    public function testIsNotNull()
+    {
+        $relation = $this->getRelation();
+
+        $relation->getRelated()->shouldReceive('getTable')->never();
+        $relation->getRelated()->shouldReceive('getConnectionName')->never();
+
+        $this->assertFalse($relation->is(null));
+    }
+
+    public function testIsModel()
+    {
+        $relation = $this->getRelation();
+
+        $this->related->shouldReceive('getConnectionName')->once()->andReturn('relation');
+
+        $model = m::mock(Model::class);
+        $model->shouldReceive('getAttribute')->once()->with('id')->andReturn('foreign.value');
+        $model->shouldReceive('getTable')->once()->andReturn('relation');
+        $model->shouldReceive('getConnectionName')->once()->andReturn('relation');
+
+        $this->assertTrue($relation->is($model));
+    }
+
+    public function testIsModelWithIntegerParentKey()
+    {
+        $parent = m::mock(Model::class);
+        // when addConstraints is called we need to return the foreign value
+        $parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn('foreign.value');
+        // when getParentKey is called we want to return an integer
+        $parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn(1);
+
+        $relation = $this->getRelation($parent);
+
+        $this->related->shouldReceive('getConnectionName')->once()->andReturn('relation');
+
+        $model = m::mock(Model::class);
+        $model->shouldReceive('getAttribute')->once()->with('id')->andReturn('1');
+        $model->shouldReceive('getTable')->once()->andReturn('relation');
+        $model->shouldReceive('getConnectionName')->once()->andReturn('relation');
+
+        $this->assertTrue($relation->is($model));
+    }
+
+    public function testIsModelWithIntegerRelatedKey()
+    {
+        $parent = m::mock(Model::class);
+        // when addConstraints is called we need to return the foreign value
+        $parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn('foreign.value');
+        // when getParentKey is called we want to return a string
+        $parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn('1');
+
+        $relation = $this->getRelation($parent);
+
+        $this->related->shouldReceive('getConnectionName')->once()->andReturn('relation');
+
+        $model = m::mock(Model::class);
+        $model->shouldReceive('getAttribute')->once()->with('id')->andReturn(1);
+        $model->shouldReceive('getTable')->once()->andReturn('relation');
+        $model->shouldReceive('getConnectionName')->once()->andReturn('relation');
+
+        $this->assertTrue($relation->is($model));
+    }
+
+    public function testIsModelWithIntegerKeys()
+    {
+        $parent = m::mock(Model::class);
+
+        // when addConstraints is called we need to return the foreign value
+        $parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn('foreign.value');
+        // when getParentKey is called we want to return an integer
+        $parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn(1);
+
+        $relation = $this->getRelation($parent);
+
+        $this->related->shouldReceive('getConnectionName')->once()->andReturn('relation');
+
+        $model = m::mock(Model::class);
+        $model->shouldReceive('getAttribute')->once()->with('id')->andReturn(1);
+        $model->shouldReceive('getTable')->once()->andReturn('relation');
+        $model->shouldReceive('getConnectionName')->once()->andReturn('relation');
+
+        $this->assertTrue($relation->is($model));
+    }
+
+    public function testIsNotModelWithNullParentKey()
+    {
+        $parent = m::mock(Model::class);
+
+        // when addConstraints is called we need to return the foreign value
+        $parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn('foreign.value');
+        // when getParentKey is called we want to return null
+
+        $parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn(null);
+
+        $relation = $this->getRelation($parent);
+
+        $this->related->shouldReceive('getConnectionName')->never();
+
+        $model = m::mock(Model::class);
+        $model->shouldReceive('getAttribute')->once()->with('id')->andReturn('foreign.value');
+        $model->shouldReceive('getTable')->never();
+        $model->shouldReceive('getConnectionName')->never();
+
+        $this->assertFalse($relation->is($model));
+    }
+
+    public function testIsNotModelWithNullRelatedKey()
+    {
+        $relation = $this->getRelation();
+
+        $this->related->shouldReceive('getConnectionName')->never();
+
+        $model = m::mock(Model::class);
+        $model->shouldReceive('getAttribute')->once()->with('id')->andReturn(null);
+        $model->shouldReceive('getTable')->never();
+        $model->shouldReceive('getConnectionName')->never();
+
+        $this->assertFalse($relation->is($model));
+    }
+
+    public function testIsNotModelWithAnotherKey()
+    {
+        $relation = $this->getRelation();
+
+        $this->related->shouldReceive('getConnectionName')->never();
+
+        $model = m::mock(Model::class);
+        $model->shouldReceive('getAttribute')->once()->with('id')->andReturn('foreign.value.two');
+        $model->shouldReceive('getTable')->never();
+        $model->shouldReceive('getConnectionName')->never();
+
+        $this->assertFalse($relation->is($model));
+    }
+
+    public function testIsNotModelWithAnotherTable()
+    {
+        $relation = $this->getRelation();
+
+        $this->related->shouldReceive('getConnectionName')->never();
+
+        $model = m::mock(Model::class);
+        $model->shouldReceive('getAttribute')->once()->with('id')->andReturn('foreign.value');
+        $model->shouldReceive('getTable')->once()->andReturn('table.two');
+        $model->shouldReceive('getConnectionName')->never();
+
+        $this->assertFalse($relation->is($model));
+    }
+
+    public function testIsNotModelWithAnotherConnection()
+    {
+        $relation = $this->getRelation();
+
+        $this->related->shouldReceive('getConnectionName')->once()->andReturn('relation');
+
+        $model = m::mock(Model::class);
+        $model->shouldReceive('getAttribute')->once()->with('id')->andReturn('foreign.value');
+        $model->shouldReceive('getTable')->once()->andReturn('relation');
+        $model->shouldReceive('getConnectionName')->once()->andReturn('relation.two');
+
+        $this->assertFalse($relation->is($model));
+    }
+
     protected function getRelationAssociate($parent)
     {
         $builder = m::mock(Builder::class);

--- a/tests/Integration/Database/EloquentBelongsToTest.php
+++ b/tests/Integration/Database/EloquentBelongsToTest.php
@@ -74,6 +74,64 @@ class EloquentBelongsToTest extends DatabaseTestCase
         $this->assertEquals($child->id, $child->parent_id);
         $this->assertFalse($child->relationLoaded('parent'));
     }
+
+    public function testParentIsNotNull()
+    {
+        $child = User::has('parent')->first();
+        $parent = null;
+
+        $this->assertFalse($child->parent()->is($parent));
+        $this->assertTrue($child->parent()->isNot($parent));
+    }
+
+    public function testParentIsModel()
+    {
+        $child = User::has('parent')->first();
+        $parent = User::doesntHave('parent')->first();
+
+        $this->assertTrue($child->parent()->is($parent));
+        $this->assertFalse($child->parent()->isNot($parent));
+    }
+
+    public function testParentIsNotAnotherModel()
+    {
+        $child = User::has('parent')->first();
+        $parent = new User();
+        $parent->id = 3;
+
+        $this->assertFalse($child->parent()->is($parent));
+        $this->assertTrue($child->parent()->isNot($parent));
+    }
+
+    public function testNullParentIsNotModel()
+    {
+        $child = User::has('parent')->first();
+        $child->parent()->dissociate();
+        $parent = User::doesntHave('parent')->first();
+
+        $this->assertFalse($child->parent()->is($parent));
+        $this->assertTrue($child->parent()->isNot($parent));
+    }
+
+    public function testParentIsNotModelWithAnotherTable()
+    {
+        $child = User::has('parent')->first();
+        $parent = User::doesntHave('parent')->first();
+        $parent->setTable('foo');
+
+        $this->assertFalse($child->parent()->is($parent));
+        $this->assertTrue($child->parent()->isNot($parent));
+    }
+
+    public function testParentIsNotModelWithAnotherConnection()
+    {
+        $child = User::has('parent')->first();
+        $parent = User::doesntHave('parent')->first();
+        $parent->setConnection('foo');
+
+        $this->assertFalse($child->parent()->is($parent));
+        $this->assertTrue($child->parent()->isNot($parent));
+    }
 }
 
 class User extends Model

--- a/tests/Integration/Database/EloquentHasOneIsTest.php
+++ b/tests/Integration/Database/EloquentHasOneIsTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentHasOneIsTest;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+/**
+ * @group integration
+ */
+class EloquentHasOneIsTest extends DatabaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('posts', function (Blueprint $table) {
+            $table->increments('id');
+            $table->timestamps();
+        });
+
+        Schema::create('attachments', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('post_id')->nullable();
+        });
+
+        $post = Post::create();
+        $post->attachment()->create();
+    }
+
+    public function testChildIsNotNull()
+    {
+        $parent = Post::first();
+        $child = null;
+
+        $this->assertFalse($parent->attachment()->is($child));
+        $this->assertTrue($parent->attachment()->isNot($child));
+    }
+
+    public function testChildIsModel()
+    {
+        $parent = Post::first();
+        $child = Attachment::first();
+
+        $this->assertTrue($parent->attachment()->is($child));
+        $this->assertFalse($parent->attachment()->isNot($child));
+    }
+
+    public function testChildIsNotAnotherModel()
+    {
+        $parent = Post::first();
+        $child = new Attachment();
+        $child->id = 2;
+
+        $this->assertFalse($parent->attachment()->is($child));
+        $this->assertTrue($parent->attachment()->isNot($child));
+    }
+
+    public function testNullChildIsNotModel()
+    {
+        $parent = Post::first();
+        $child = Attachment::first();
+        $child->post_id = null;
+
+        $this->assertFalse($parent->attachment()->is($child));
+        $this->assertTrue($parent->attachment()->isNot($child));
+    }
+
+    public function testChildIsNotModelWithAnotherTable()
+    {
+        $parent = Post::first();
+        $child = Attachment::first();
+        $child->setTable('foo');
+
+        $this->assertFalse($parent->attachment()->is($child));
+        $this->assertTrue($parent->attachment()->isNot($child));
+    }
+
+    public function testChildIsNotModelWithAnotherConnection()
+    {
+        $parent = Post::first();
+        $child = Attachment::first();
+        $child->setConnection('foo');
+
+        $this->assertFalse($parent->attachment()->is($child));
+        $this->assertTrue($parent->attachment()->isNot($child));
+    }
+}
+
+class Attachment extends Model
+{
+    public $timestamps = false;
+}
+
+class Post extends Model
+{
+    public function attachment()
+    {
+        return $this->hasOne(Attachment::class);
+    }
+}

--- a/tests/Integration/Database/EloquentMorphOneIsTest.php
+++ b/tests/Integration/Database/EloquentMorphOneIsTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentMorphOneIsTest;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+/**
+ * @group integration
+ */
+class EloquentMorphOneIsTest extends DatabaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('posts', function (Blueprint $table) {
+            $table->increments('id');
+            $table->timestamps();
+        });
+
+        Schema::create('attachments', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('attachable_type')->nullable();
+            $table->integer('attachable_id')->nullable();
+        });
+
+        $post = Post::create();
+        $post->attachment()->create();
+    }
+
+    public function testChildIsNotNull()
+    {
+        $parent = Post::first();
+        $child = null;
+
+        $this->assertFalse($parent->attachment()->is($child));
+        $this->assertTrue($parent->attachment()->isNot($child));
+    }
+
+    public function testChildIsModel()
+    {
+        $parent = Post::first();
+        $child = Attachment::first();
+
+        $this->assertTrue($parent->attachment()->is($child));
+        $this->assertFalse($parent->attachment()->isNot($child));
+    }
+
+    public function testChildIsNotAnotherModel()
+    {
+        $parent = Post::first();
+        $child = new Attachment();
+        $child->id = 2;
+
+        $this->assertFalse($parent->attachment()->is($child));
+        $this->assertTrue($parent->attachment()->isNot($child));
+    }
+
+    public function testNullChildIsNotModel()
+    {
+        $parent = Post::first();
+        $child = Attachment::first();
+        $child->attachable_type = null;
+        $child->attachable_id = null;
+
+        $this->assertFalse($parent->attachment()->is($child));
+        $this->assertTrue($parent->attachment()->isNot($child));
+    }
+
+    public function testChildIsNotModelWithAnotherTable()
+    {
+        $parent = Post::first();
+        $child = Attachment::first();
+        $child->setTable('foo');
+
+        $this->assertFalse($parent->attachment()->is($child));
+        $this->assertTrue($parent->attachment()->isNot($child));
+    }
+
+    public function testChildIsNotModelWithAnotherConnection()
+    {
+        $parent = Post::first();
+        $child = Attachment::first();
+        $child->setConnection('foo');
+
+        $this->assertFalse($parent->attachment()->is($child));
+        $this->assertTrue($parent->attachment()->isNot($child));
+    }
+}
+
+class Attachment extends Model
+{
+    public $timestamps = false;
+}
+
+class Post extends Model
+{
+    public function attachment()
+    {
+        return $this->morphOne(Attachment::class, 'attachable');
+    }
+}

--- a/tests/Integration/Database/EloquentMorphToIsTest.php
+++ b/tests/Integration/Database/EloquentMorphToIsTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentMorphToIsTest;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+/**
+ * @group integration
+ */
+class EloquentMorphToIsTest extends DatabaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('posts', function (Blueprint $table) {
+            $table->increments('id');
+            $table->timestamps();
+        });
+
+        Schema::create('comments', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('commentable_type');
+            $table->integer('commentable_id');
+        });
+
+        $post = Post::create();
+        (new Comment)->commentable()->associate($post)->save();
+    }
+
+    public function testParentIsNotNull()
+    {
+        $child = Comment::first();
+        $parent = null;
+
+        $this->assertFalse($child->commentable()->is($parent));
+        $this->assertTrue($child->commentable()->isNot($parent));
+    }
+
+    public function testParentIsModel()
+    {
+        $child = Comment::first();
+        $parent = Post::first();
+
+        $this->assertTrue($child->commentable()->is($parent));
+        $this->assertFalse($child->commentable()->isNot($parent));
+    }
+
+    public function testParentIsNotAnotherModel()
+    {
+        $child = Comment::first();
+        $parent = new Post();
+        $parent->id = 2;
+
+        $this->assertFalse($child->commentable()->is($parent));
+        $this->assertTrue($child->commentable()->isNot($parent));
+    }
+
+    public function testNullParentIsNotModel()
+    {
+        $child = Comment::first();
+        $child->commentable()->dissociate();
+        $parent = Post::first();
+
+        $this->assertFalse($child->commentable()->is($parent));
+        $this->assertTrue($child->commentable()->isNot($parent));
+    }
+
+    public function testParentIsNotModelWithAnotherTable()
+    {
+        $child = Comment::first();
+        $parent = Post::first();
+        $parent->setTable('foo');
+
+        $this->assertFalse($child->commentable()->is($parent));
+        $this->assertTrue($child->commentable()->isNot($parent));
+    }
+
+    public function testParentIsNotModelWithAnotherConnection()
+    {
+        $child = Comment::first();
+        $parent = Post::first();
+        $parent->setConnection('foo');
+
+        $this->assertFalse($child->commentable()->is($parent));
+        $this->assertTrue($child->commentable()->isNot($parent));
+    }
+}
+
+class Comment extends Model
+{
+    public $timestamps = false;
+
+    public function commentable()
+    {
+        return $this->morphTo();
+    }
+}
+
+class Post extends Model
+{
+    //
+}


### PR DESCRIPTION
This PR adds replicates the `is()` and `isNot()`methods of the `Illuminate\Database\Eloquent\Model` to the 1-1 Eloquent relations: `BelongsTo`, `HasOne`, `MorphTo` and `MorphOne`.

We can now do model comparisons between related models, **without extra database calls**! This is especially useful in gates/policies when we need to know if a model is owned or owns another model.

Example on a `PostPolicy` with a simple `BelongsTo` relationship:
```php
public function publish(User $user, Post $post)
{
    // Before: foreign key is leaking from the post model
    return $post->author_id === $user->id;

    // Before: performs extra query to fetch the user model from the author relation
    return $post->author->is($user);

    // After 🚀
    return $post->author()->is($user);
}
```

Example with a polymorphic `MorphOne` relationship:
```php
// Before
return $attachment->attachable_id === $post->getKey()
    && $attachment->attachable_type === $post->getMorphClass();

// Before
return $post->attachment->is($attachment);

// After 🚀
return $post->attachment()->is($attachment);
```

The implementation is similar to the `Model`, it compares the keys, the tables, and the connections of two models. But instead of comparing the primary keys using `Model::getKey()`, it compares the parent key of the parent model of the relationship with the foreign key of the given model. Both key names are known to the relation instance, so the comparison is straightforward.

The only thing that is not really accurate is the type of the keys. A model usually has an integer or a string primary key, but the foreign keys are not cast to the related model's primary key type, or sometimes the relationships do not include any primary key, but are constrained by other keys. For this reason, if one of the keys is an integer, we are casting both keys to integers before comparing them, otherwise we are comparing them as they are.

For convenience, the functionality is defined in a `ComparesModels` trait, so it can be used on custom relationships.
This trait needs two methods to be implemented: 
1. the `getParentKey()` which already existed on `HasOne`/`MorphOne` relations
2. the `getRelatedKeyFrom($model)`, which is new, but is quite useful because it can be reused in many places in the existing relations codebase, instead of calling `$model->{$this->ownerKey}`, `$model->{$foreign}`, `$parent->{$this->localKey}`, etc. in so many different ways. I've refrained myself from refactoring these calls, but I can do that in a next PR.

This PR was inspired by this discussion on Reddit: https://www.reddit.com/r/laravel/comments/iylnnl/this_is_how_we_write_our_policies_now.

Both unit and integration tests are in place.

PS: I'm also pinging @staudenmeir since he has a deep understanding of eloquent relations.