### PR TITLE
[8.x] Minor update to queue:failed command 

### DIFF
--- a/src/Illuminate/Queue/Console/ListFailedCommand.php
+++ b/src/Illuminate/Queue/Console/ListFailedCommand.php
@@ -66,7 +66,7 @@ class ListFailedCommand extends Command
     {
         $row = array_values(Arr::except($failed, ['payload', 'exception']));
 
-        array_splice($row, 3, 0, $this->extractJobName($failed['payload']));
+        array_splice($row, 3, 0, $this->extractJobName($failed['payload']) ?: '');
 
         return $row;
     }


### PR DESCRIPTION
If `extractJobName` returns `null`, the resulting table is formatted wrong.
We are using Laravel for microservices, meaning incoming events don't need to have a class representation in the service.

Screenshot before and after:

![image](https://user-images.githubusercontent.com/11718157/95166684-9fb3d980-07ae-11eb-9f95-2ea18c96ec50.png)
