### PR TITLE
[8.x] Add attachMany method to the PendingRequest.php

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -200,6 +200,21 @@ class PendingRequest
 
         return $this;
     }
+    
+    /**
+     * Attach multiple files to the request. Accepts an array containing arrays of files
+     *
+     * @param  array  $files
+     * @return $this
+     */
+    public function attachMany(array $files)
+    {
+        foreach ($files as $file) {
+            $this->attach(...$file);
+        }
+
+        return $this;
+    }
 
     /**
      * Indicate the request is a multi-part form request.

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -202,7 +202,7 @@ class PendingRequest
     }
     
     /**
-     * Attach multiple files to the request. Accepts an array containing arrays of files
+     * Attach multiple files to the request.
      *
      * @param  array  $files
      * @return $this


### PR DESCRIPTION
With this method, we can attach multiple files once, instead of using `attach` for each file.

Usage:
```php
$response = Http::attachMany(
    ['image1', file_get_contents('cat1.jpg'), 'photo1.jpg'],
    ['image2', file_get_contents('cat2.jpg'), 'photo2.jpg'],
    ['image3', file_get_contents('cat3.jpg'), 'photo3.jpg'],
)->post('http://test.com/posts');

```