### PR TITLE
[8.x] Add upsert to Eloquent and Base Query Builders

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -809,7 +809,7 @@ class Builder
      */
     public function upsert(array $values, $uniqueBy)
     {
-        return $this->toBase()->upsert(collect($values)->map(function($value, $key) {
+        return $this->toBase()->upsert(collect($values)->map(function ($value, $key) {
             return $this->addUpdatedAtColumn($value);
         })->toArray(), $uniqueBy);
     }

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -801,6 +801,20 @@ class Builder
     }
 
     /**
+     * Insert new records or update the existing ones.
+     *
+     * @param  array  $values
+     * @param  array|string  $uniqueBy
+     * @return int
+     */
+    public function upsert(array $values, $uniqueBy)
+    {
+        return $this->toBase()->upsert(collect($values)->map(function($value, $key) {
+            return $this->addUpdatedAtColumn($value);
+        })->toArray(), $uniqueBy);
+    }
+
+    /**
      * Increment a column's value by a given amount.
      *
      * @param  string  $column

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2924,6 +2924,35 @@ class Builder
     }
 
     /**
+     * Insert new records or update the existing ones.
+     *
+     * @param  array  $values
+     * @param  array|string  $uniqueBy
+     * @return int
+     */
+    public function upsert(array $values, $uniqueBy)
+    {
+        if (empty($values)) {
+            return 0;
+        }
+
+        if (! is_array(reset($values))) {
+            $values = [$values];
+        } else {
+            foreach ($values as $key => $value) {
+                ksort($value);
+
+                $values[$key] = $value;
+            }
+        }
+
+        return $this->connection->affectingStatement(
+            $this->grammar->compileUpsert($this, $values, (array) $uniqueBy),
+            $this->cleanBindings(Arr::flatten($values, 1))
+        );
+    }
+
+    /**
      * Increment a column's value by a given amount.
      *
      * @param  string  $column

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -996,6 +996,21 @@ class Grammar extends BaseGrammar
     }
 
     /**
+     * Compile an "upsert" statement into SQL.
+     *
+     * @param  \Illuminate\Database\Query\Builder $query
+     * @param  array $values
+     * @param  array $uniqueBy
+     * @return  string
+     *
+     * @throws \RuntimeException
+     */
+    public function compileUpsert(Builder $query, array $values, array $uniqueBy)
+    {
+        throw new RuntimeException('This database engine does not support upserts.');
+    }
+
+    /**
      * Prepare the bindings for an update statement.
      *
      * @param  array  $bindings

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -154,6 +154,25 @@ class MySqlGrammar extends Grammar
     }
 
     /**
+     * Compile an "upsert" statement into SQL.
+     *
+     * @param  \Illuminate\Database\Query\Builder $query
+     * @param  array $values
+     * @param  array $uniqueBy
+     * @return  string
+     */
+    public function compileUpsert(Builder $query, array $values, array $uniqueBy)
+    {
+        $sql = $this->compileInsert($query, $values).' on duplicate key update ';
+
+        $columns = collect(array_keys(reset($values)))->map(function ($value, $key) {
+            return $this->wrap($value).' = values('.$this->wrap($value).')';
+        })->implode(', ');
+
+        return $sql.$columns;
+    }
+
+    /**
      * Prepare a JSON column being updated using the JSON_SET function.
      *
      * @param  string  $key

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -219,6 +219,27 @@ class PostgresGrammar extends Grammar
     }
 
     /**
+     * Compile an "upsert" statement into SQL.
+     *
+     * @param  \Illuminate\Database\Query\Builder $query
+     * @param  array $values
+     * @param  array $uniqueBy
+     * @return  string
+     */
+    public function compileUpsert(Builder $query, array $values, array $uniqueBy)
+    {
+        $sql = $this->compileInsert($query, $values);
+
+        $sql .= ' on conflict ('.$this->columnize($uniqueBy).') do update set ';
+
+        $columns = collect(array_keys(reset($values)))->map(function ($value, $key) {
+            return $this->wrap($value).' = '.$this->wrapValue('excluded').'.'.$this->wrap($value);
+        })->implode(', ');
+
+        return $sql.$columns;
+    }
+
+    /**
      * Prepares a JSON column being updated using the JSONB_SET function.
      *
      * @param  string  $key

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -183,6 +183,27 @@ class SQLiteGrammar extends Grammar
     }
 
     /**
+     * Compile an "upsert" statement into SQL.
+     *
+     * @param  \Illuminate\Database\Query\Builder $query
+     * @param  array $values
+     * @param  array $uniqueBy
+     * @return  string
+     */
+    public function compileUpsert(Builder $query, array $values, array $uniqueBy)
+    {
+        $sql = $this->compileInsert($query, $values);
+
+        $sql .= ' on conflict ('.$this->columnize($uniqueBy).') do update set ';
+
+        $columns = collect(array_keys(reset($values)))->map(function ($value, $key) {
+            return $this->wrap($value).' = '.$this->wrapValue('excluded').'.'.$this->wrap($value);
+        })->implode(', ');
+
+        return $sql.$columns;
+    }
+
+    /**
      * Group the nested JSON columns.
      *
      * @param  array  $values

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1315,6 +1315,29 @@ class DatabaseEloquentBuilderTest extends TestCase
         Carbon::setTestNow(null);
     }
 
+    public function testUpsert()
+    {
+        Carbon::setTestNow($now = '2017-10-10 10:10:10');
+
+        $query = m::mock(BaseBuilder::class);
+        $query->shouldReceive('from')->with('foo_table')->andReturn('foo_table');
+        $query->from = 'foo_table';
+
+        $builder = new Builder($query);
+        $model = new EloquentBuilderTestStubStringPrimaryKey;
+        $builder->setModel($model);
+
+        $query->shouldReceive('upsert')->once()
+            ->with([
+                ['email' => 'foo', 'name' => 'bar', 'foo_table.updated_at' => $now], 
+                ['name' => 'bar2', 'email' => 'foo2', 'foo_table.updated_at' => $now]], 'email')->andReturn(2);
+        
+        $result = $builder->upsert([['email' => 'foo', 'name' => 'bar'], ['name' => 'bar2', 'email' => 'foo2']], 'email');
+        $this->assertEquals(2, $result);
+
+        Carbon::setTestNow(null);
+    }
+
     public function testWithCastsMethod()
     {
         $builder = new Builder($this->getMockQueryBuilder());

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1329,7 +1329,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $query->shouldReceive('upsert')->once()
             ->with([
-                ['email' => 'foo', 'name' => 'bar', 'foo_table.updated_at' => $now], 
+                ['email' => 'foo', 'name' => 'bar', 'foo_table.updated_at' => $now],
                 ['name' => 'bar2', 'email' => 'foo2', 'foo_table.updated_at' => $now], ], 'email')->andReturn(2);
 
         $result = $builder->upsert([['email' => 'foo', 'name' => 'bar'], ['name' => 'bar2', 'email' => 'foo2']], 'email');

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1330,8 +1330,8 @@ class DatabaseEloquentBuilderTest extends TestCase
         $query->shouldReceive('upsert')->once()
             ->with([
                 ['email' => 'foo', 'name' => 'bar', 'foo_table.updated_at' => $now], 
-                ['name' => 'bar2', 'email' => 'foo2', 'foo_table.updated_at' => $now]], 'email')->andReturn(2);
-        
+                ['name' => 'bar2', 'email' => 'foo2', 'foo_table.updated_at' => $now], ], 'email')->andReturn(2);
+
         $result = $builder->upsert([['email' => 'foo', 'name' => 'bar'], ['name' => 'bar2', 'email' => 'foo2']], 'email');
         $this->assertEquals(2, $result);
 


### PR DESCRIPTION
**Motivation**
Laravel already supports bulk inserts, bulk insert/ignores. It's only logical to also support bulk upserts, which are already supported on frameworks such as Rails.

**Bulk Inserts Already Supported**

- Bulk inserts: errors out on any row with invalid data
```php
DB::table('users')->insert([
    ['email' => 'taylor@example.com', 'votes' => 0],
    ['email' => 'dayle@example.com', 'votes' => 0],
]);
```

- Bulk insert or ignore: rows with invalid data are ignored
```php
DB::table('users')->insertOrIgnore([
    ['id' => 1, 'email' => 'taylor@example.com'],
    ['id' => 2, 'email' => 'dayle@example.com'],
]);
```

**Bulk Upsert (This PR)**

This PR supports bulk upserts (insert and on duplicate key, update) like so:
```php
DB::table('users')->upsert([
    ['id' => 1, 'email' => 'taylor@example.com'],
    ['id' => 2, 'email' => 'dayle@example.com'],
], 'email');
```

The first argument is the values to insert/update and the second argument is the column(s) that uniquely identify records. All databases except SQL Server require these columns to have a PRIMARY or UNIQUE index. This is similar to Rails `upsert_all` without the `returning` support.

Eloquent upsets are also supported like so:
```php
User::upsert([
    ['id' => 1, 'email' => 'taylor@example.com'],
    ['id' => 2, 'email' => 'dayle@example.com'],
], 'email');
```

If the model uses the `updated_at` timestamp, `upsert()` will also add the updated_at timestamp columns. Inspired from https://github.com/staudenmeir/laravel-upsert with some slight modifications. Ping @staudenmeir 