### PR TITLE
[6.x] Strip forward slash from password reset token

### DIFF
--- a/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
+++ b/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
@@ -117,7 +117,9 @@ class DatabaseTokenRepository implements TokenRepositoryInterface
      */
     protected function getPayload($email, $token)
     {
-        return ['email' => $email, 'token' => $this->hasher->make($token), 'created_at' => new Carbon];
+        $token = str_replace('/', '.', $this->hasher->make($token));
+
+        return ['email' => $email, 'token' => $token, 'created_at' => new Carbon];
     }
 
     /**


### PR DESCRIPTION
This change will prevent password reset tokens from containing forward slashes which can conflict with building the route for password resets. Normally this cannot happen when you're not overwriting any framework internals (like the OP of the bug noted) but given the nature that these tokens are typically used in urls it makes sense to be a bit pragmatic here.

The only thing I'm a bit concerned with is that this basically breaks the hashing of the token. If anyone is specifically relying on that (even though the token was never intended to be used as such) this will break any such implementations.

Fixes https://github.com/laravel/framework/issues/34687