### PR TITLE
[8.x] Allow serializing custom casts when converting a model to an array

### DIFF
--- a/src/Illuminate/Contracts/Database/Eloquent/SerializesCastableAttributes.php
+++ b/src/Illuminate/Contracts/Database/Eloquent/SerializesCastableAttributes.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Illuminate\Contracts\Database\Eloquent;
+
+interface SerializesCastableAttributes
+{
+    /**
+     * Serialize the attribute when converting the model to an array.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  array  $attributes
+     * @return mixed
+     */
+    public function serialize($model, string $key, $value, array $attributes);
+}

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1112,7 +1112,8 @@ trait HasAttributes
      *
      * @param  string  $key
      * @return bool
-     * @throws InvalidCastException
+     *
+     * @throws \Illuminate\Database\Eloquent\InvalidCastException
      */
     protected function isClassSerializable($key)
     {

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1117,7 +1117,7 @@ trait HasAttributes
      */
     protected function isClassSerializable($key)
     {
-        if (!$this->isClassCastable($key)) {
+        if (! $this->isClassCastable($key)) {
             return false;
         }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1107,7 +1107,6 @@ trait HasAttributes
         throw new InvalidCastException($this->getModel(), $key, $castType);
     }
 
-
     /**
      * Determine if the key is serializable using a custom class.
      *


### PR DESCRIPTION
This PR allows serializing custom value objects when a model is converted to an array even if the value object does not implement the `Arrayable` interface. There are no breaking change, new functionality is covered with tests.

### Reasoning

Consider a custom caster that casts the value to a value object, say a [BigDecimal](https://github.com/brick/math/blob/master/src/BigDecimal.php) instance. When calling `$model->toArray()`, the value is not serialized to a primitive type like a string - it remains a `BigDecimal` object instance:

```php
$model->toArray(); // ["price" => Brick\Math\BigDecimal {#2254}]
```

This is inconsistent with dates, which are cast to `Carbon` instances, but serialized when converting the model to an array:

```php
$model->toArray(); // ["created_at" => "2020-10-05T07:49:06.000000Z"]
```

[A comment suggests](https://github.com/laravel/framework/issues/33257#issuecomment-646019049) that the value object should implement the `Arrayable` interface to serialize the value. However, there are cases where this may not be possible,  feasible or would not make sense for the class itself.

* If the value object is an instance of a 3rd party class that is declared `final`.
  Since `final` classes cannot be extended, the only way would be to use composition to create a custom wrapper around the `final` class. This might work fine for simpler classes, but for something like `BigDecimal`, the maintenance overhead and code duplication would make it non-feasible (some 30+ methods), especially for smaller projects and teams.
  This issue was brought up in laravel/deas as well: https://github.com/laravel/ideas/issues/2152
* Creating a `toArray()` method for a value object that represents basically a scalar value makes little sense. What would be the expected return value of `(new Decimal(123.45))->toArray()`?

Furthermore, dates already have special handling `serializeDate` in core (see below) - why not allow custom serialization for custom casts?
https://github.com/laravel/framework/blob/576dd3d3cfbd4ef5239eb277c4d6bd315d7503bd/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php#L226-L241

**What's the use case? Why do we need the values to be serialized in the array at all?**

* Consistency with how dates are handled
* Being able to produce a raw array of primitive model attributes with factories:
  ```php
   Product::factory()->make(['price' => 12.345]);
   // ['price' => '12.345' ] instead of ["price" => Brick\Math\BigDecimal {#2254}]
   ```
**Why not simply use `Jsonable` / `JsonSerializable` like suggested in https://github.com/laravel/ideas/issues/2152 ?**

This would probably work fine for most cases - but custom serialization adds more flexibility. If [dates already allow custom serialization/formats](https://laravel.com/docs/8.x/eloquent-mutators#date-casting) why not make it possible for custom casts as well?

**Why not cast the model to JSON and the decode it back to an array?**

I thought about it and while it's possible to do a little encoding dance:
```php
json_decode($model->toJson()); // ['price' => '123.45']
```
... it's far from elegant, adds extra overhead (including mental) and just feels ... meh.

### Conclusion

I think custom casts is a really powerful feature, especially if it's possible to ease the adoption when casting to 3rd party library classes.

This is my first PR to Laravel, so please go easy on me :) I've tried to follow the core naming and code structure conventions, however feel free to make edits or suggestions there.

If you think this contribution would be worthwhile but needs a different implementation, just let me know. I'm open to all ideas and suggestions.