### PR TITLE
[8.x] Align Collection::pluck()/Arr:pluck() DocBlock with data_get()

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -409,7 +409,7 @@ class Arr
      * Pluck an array of values from an array.
      *
      * @param  iterable  $array
-     * @param  string|array  $value
+     * @param  string|array|int|null  $value
      * @param  string|array|null  $key
      * @return array
      */

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -608,7 +608,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get the values of a given key.
      *
-     * @param  string|array  $value
+     * @param  string|array|int|null  $value
      * @param  string|null  $key
      * @return static
      */


### PR DESCRIPTION
`Arr::pluck()` supports `int` and `null` for its `$value` param in addition the the already documented `string|array`, because it calls `data_get()` under the hood, which supports those types. `Collection::pluck()` just forwards the call to `Arr:pluck()`, so it supports the same types.

This PR aligns the DocBlocks to reflect this.

For reference, `data_get()` DocBlock: https://github.com/laravel/framework/blob/8a6bf870bcfa1597e514a9c7ee6df44db98abb54/src/Illuminate/Collections/helpers.php#L35-L43