### PR TITLE
[8.x] Add defaultOptions method on Http Client

### DIFF
--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Traits\Macroable;
 use PHPUnit\Framework\Assert as PHPUnit;
 
 /**
+ * @method \Illuminate\Http\Client\Factory defaultOptions(array $options)
  * @method \Illuminate\Http\Client\PendingRequest accept(string $contentType)
  * @method \Illuminate\Http\Client\PendingRequest acceptJson()
  * @method \Illuminate\Http\Client\PendingRequest asForm()
@@ -77,6 +78,13 @@ class Factory
     protected $responseSequences = [];
 
     /**
+     * PendingRequest object with user defined default options
+     *
+     * @var \Illuminate\Http\Client\PendingRequest
+     */
+    protected $pendingRequest = null;
+
+    /**
      * Create a new factory instance.
      *
      * @return void
@@ -84,6 +92,19 @@ class Factory
     public function __construct()
     {
         $this->stubCallbacks = collect();
+    }
+
+    /**
+     * Set de default options that the client will user for all requests
+     *
+     * @param array $options
+     * @return $this
+     */
+    public function defaultOptions(array $options)
+    {
+        $this->pendingRequest = tap(new PendingRequest($this))->withOptions($options);
+
+        return $this;
     }
 
     /**
@@ -311,7 +332,7 @@ class Factory
             return $this->macroCall($method, $parameters);
         }
 
-        return tap(new PendingRequest($this), function ($request) {
+        return tap($this->pendingRequest ?? new PendingRequest($this), function ($request) {
             $request->stub($this->stubCallbacks);
         })->{$method}(...$parameters);
     }

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -78,7 +78,7 @@ class Factory
     protected $responseSequences = [];
 
     /**
-     * PendingRequest object with user defined default options
+     * PendingRequest object with user defined default options.
      *
      * @var \Illuminate\Http\Client\PendingRequest
      */
@@ -95,7 +95,7 @@ class Factory
     }
 
     /**
-     * Set de default options that the client will user for all requests
+     * Set de default options that the client will user for all requests.
      *
      * @param array $options
      * @return $this

--- a/src/Illuminate/Support/Facades/Http.php
+++ b/src/Illuminate/Support/Facades/Http.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Client\Factory;
 /**
  * @method static \GuzzleHttp\Promise\PromiseInterface response($body = null, $status = 200, $headers = [])
  * @method static \Illuminate\Http\Client\Factory fake($callback = null)
+ * @method static \Illuminate\Http\Client\Factory defaultOptions(array $options)
  * @method static \Illuminate\Http\Client\PendingRequest accept(string $contentType)
  * @method static \Illuminate\Http\Client\PendingRequest acceptJson()
  * @method static \Illuminate\Http\Client\PendingRequest asForm()

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -616,11 +616,11 @@ class HttpClientTest extends TestCase
         $this->factory->defaultOptions([
             'headers' => [
                 'X-Test-Header' => 'testing/1.0',
-            ]
+            ],
         ]);
 
         $this->factory->fake([
-            'foo.com/*'
+            'foo.com/*',
         ]);
 
         $this->factory->get('http://foo.com/test');

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -610,4 +610,23 @@ class HttpClientTest extends TestCase
 
         $this->assertSame(json_encode(['page' => 'foo']), stream_get_contents($resource));
     }
+
+    public function testSettingDefaultOptions()
+    {
+        $this->factory->defaultOptions([
+            'headers' => [
+                'X-Test-Header' => 'testing/1.0',
+            ]
+        ]);
+
+        $this->factory->fake([
+            'foo.com/*'
+        ]);
+
+        $this->factory->get('http://foo.com/test');
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->hasHeaders('X-Test-Header');
+        });
+    }
 }


### PR DESCRIPTION
This PR adds the `defaultOptions` method on the Http Client Factory.

This metod provides the ability to set wide global options for the client.

In this way we can reuse common options by simply defining them into a service provider.

### Example

Imagine we have to make calls to a service that requires basic auth. Actually the only way to achieve this is to use the `withBasicAuth` method in every call we make to the service. Instead, we can set that option as a default

```php
// Service Provider boot method

...

Http::defaultOptions([
    'base_uri' => 'https://foo.com',
    'auth' => ['username', 'password']
]);
```

So now we can reuse the basic auth options every time we make a request

```php
// Somewhere in the code

...

Http::get('my-endpoint');
```

This PR is full backwords compatible, since the only things that are changing is the way we call methods on the PendingRequest object:

If we define options via the `defaultOptions` method, a `PendingRequest` object with the user defined options will be used into the `__call` method,  otherwise a new one will be created.