### PR TITLE
[8.x] Add server private IP address helper to trust hosts middleware

### DIFF
--- a/src/Illuminate/Http/Middleware/TrustHosts.php
+++ b/src/Illuminate/Http/Middleware/TrustHosts.php
@@ -70,4 +70,18 @@ abstract class TrustHosts
             return '^(.+\.)?'.preg_quote($host).'$';
         }
     }
+
+    /**
+     * Get a regular expression matching the private IP address of the server.
+     *
+     * @return string|null
+     */
+    protected function privateIpAddressOfServer()
+    {
+        $server = $this->app['request']->server;
+
+        if ($ipAddress = $server->get('SERVER_ADDR') ?: $server->get('LOCAL_ADDR')) {
+            return '^'.preg_quote($ipAddress).'$';
+        }
+    }
 }


### PR DESCRIPTION
This PR adds a small helper function to the trust hosts middleware, allowing requests to be made to the server's own private IP address. It is used in the same way as the `allSubdomainsOfApplicationUrl()` helper already present in the middleware now, and can be used alongside it depending on the use case.

Example:
```php
class TrustHosts extends Middleware
{
    public function hosts()
    {
        return [
            $this->allSubdomainsOfApplicationUrl(),
            $this->privateIpAddressOfServer(),
        ];
    }
}
```

My use case:
I had to add the `TrustHosts` middleware to a load balanced application, causing the load balancer's health checks on the individual servers to fail (because it calls them directly). I wrote this function in my application initially and then thought it may be useful to others as well.