### PR TITLE
[8.x] Allow for chains to be added to batches via PendingChain

### DIFF
--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -180,6 +180,7 @@ class Batch implements Arrayable, JsonSerializable
                 $jobTotal += count($jobChain);
 
                 $chainHead = array_shift($jobChain);
+
                 return $chainHead->chain($jobChain);
             } else {
                 $job->withBatchId($this->id);

--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -169,9 +169,13 @@ class Batch implements Arrayable, JsonSerializable
 
             if (is_array($job)) {
                 $jobChain = $job;
-                foreach ($jobChain as $j) {
-                    $j->withBatchId($this->id);
-                }
+                $batchId = $this->id;
+                array_walk($jobChain, function (&$job) use ($batchId) {
+                    if ($job instanceof Closure) {
+                        $job = CallQueuedClosure::create($job);
+                    }
+                    $job->withBatchId($batchId);
+                });
 
                 $jobTotal += count($jobChain);
 

--- a/src/Illuminate/Foundation/Bus/PendingChain.php
+++ b/src/Illuminate/Foundation/Bus/PendingChain.php
@@ -109,11 +109,11 @@ class PendingChain
     }
 
     /**
-     * Dispatch the job with the given arguments.
+     * Prepare a job chain for dispatch with the given arguments
      *
-     * @return \Illuminate\Foundation\Bus\PendingDispatch
+     * @return CallQueuedClosure|mixed
      */
-    public function dispatch()
+    public function prepare()
     {
         if (is_string($this->job)) {
             $firstJob = new $this->job(...func_get_args());
@@ -128,6 +128,18 @@ class PendingChain
         $firstJob->chain($this->chain);
         $firstJob->chainCatchCallbacks = $this->catchCallbacks();
 
-        return app(Dispatcher::class)->dispatch($firstJob);
+        return $firstJob;
+    }
+
+    /**
+     * Dispatch the job with the given arguments.
+     *
+     * @return \Illuminate\Foundation\Bus\PendingDispatch
+     */
+    public function dispatch()
+    {
+        $preparedJob = $this->prepare();
+
+        return app(Dispatcher::class)->dispatch($preparedJob);
     }
 }

--- a/src/Illuminate/Foundation/Bus/PendingChain.php
+++ b/src/Illuminate/Foundation/Bus/PendingChain.php
@@ -109,7 +109,7 @@ class PendingChain
     }
 
     /**
-     * Prepare a job chain for dispatch with the given arguments
+     * Prepare a job chain for dispatch with the given arguments.
      *
      * @return CallQueuedClosure|mixed
      */

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -311,17 +311,11 @@ class BusBatchTest extends TestCase
 
         $batch = $this->createTestBatch($queue);
 
-        $chainHeadJob = new class implements ShouldQueue {
-            use Dispatchable, InteractsWithQueue, Queueable, SerializesModels, Batchable;
-        };
+        $chainHeadJob = new ChainHeadJob();
 
-        $secondJob = new class implements ShouldQueue {
-            use Dispatchable, InteractsWithQueue, Queueable, SerializesModels, Batchable;
-        };
+        $secondJob = new SecondTestJob();
 
-        $thirdJob = new class implements ShouldQueue {
-            use Dispatchable, InteractsWithQueue, Queueable, SerializesModels, Batchable;
-        };
+        $thirdJob = new ThirdTestJob();
 
         $queue->shouldReceive('connection')->once()
             ->with('test-connection')
@@ -390,4 +384,19 @@ class BusBatchTest extends TestCase
     {
         return $this->connection()->getSchemaBuilder();
     }
+}
+
+class ChainHeadJob implements ShouldQueue
+{
+    use Dispatchable, Queueable, Batchable;
+}
+
+class SecondTestJob implements ShouldQueue
+{
+    use Dispatchable, Queueable, Batchable;
+}
+
+class ThirdTestJob implements ShouldQueue
+{
+    use Dispatchable, Queueable, Batchable;
 }

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -16,8 +16,6 @@ use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\CallQueuedClosure;
-use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Queue\SerializesModels;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -335,7 +335,7 @@ class BusBatchTest extends TestCase
         }), '', 'test-queue');
 
         $batch = $batch->add([
-            [$chainHeadJob, $secondJob, $thirdJob]
+            [$chainHeadJob, $secondJob, $thirdJob],
         ]);
 
         $this->assertEquals(3, $batch->totalJobs);

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -317,14 +317,14 @@ class BusBatchTest extends TestCase
 
         $thirdJob = new ThirdTestJob();
 
-        $fourthJob = function (){
+        $fourthJob = function () {
         };
 
         $queue->shouldReceive('connection')->once()
             ->with('test-connection')
             ->andReturn($connection = m::mock(stdClass::class));
 
-        $connection->shouldReceive('bulk')->once()->with(\Mockery::on(function ($args) use ($firstJob, $secondJob, $thirdJob, $fourthJob) {
+        $connection->shouldReceive('bulk')->once()->with(\Mockery::on(function ($args) use ($firstJob, $secondJob, $thirdJob) {
             return
                 $args[0] == $firstJob
                 && $args[1] == $secondJob


### PR DESCRIPTION
This is an alternative to #34612 that uses the actual `Bus::chain` method rather than a nested array syntax.

It could be used as so:
```php
$batch = Bus::batch([
            new Test1Job(),
            Bus::chain([
                new Test2Job(),
                new Test3Job(),
                function() {
                    // closure
                },
            ]),
        ])->then(function (Batch $batch) {
            Log::info('Test Complete!');
        })->name('Test')->dispatch();
```

Each job, even each one in the chain including the closure, is given a batchId just as they normally would and the `then` only fires once all are completed.

Batching adds an amazing functionality of doing something once a bunch of things are completed. But it could be very helpful to include a chain within the "bunch of things" since sometimes certain things have to happen before the other. But it would be really beneficial if that all could be tracked and something is done once they all are completed within the batch.