### PR TITLE
[8.x] Support created_at timestamps on upserts

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -809,7 +809,7 @@ class Builder
      */
     public function upsert(array $values, $uniqueBy)
     {
-        return $this->toBase()->upsert(collect($values)->map(function($value, $key) {
+        return $this->toBase()->upsert(collect($values)->map(function ($value, $key) {
             return $this->addUpdatedAtColumn($value);
         })->toArray(), $uniqueBy);
     }

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -801,6 +801,20 @@ class Builder
     }
 
     /**
+     * Insert new records or update the existing ones.
+     *
+     * @param  array  $values
+     * @param  array|string  $uniqueBy
+     * @return int
+     */
+    public function upsert(array $values, $uniqueBy)
+    {
+        return $this->toBase()->upsert(collect($values)->map(function($value, $key) {
+            return $this->addUpdatedAtColumn($value);
+        })->toArray(), $uniqueBy);
+    }
+
+    /**
      * Increment a column's value by a given amount.
      *
      * @param  string  $column

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -805,13 +805,28 @@ class Builder
      *
      * @param  array  $values
      * @param  array|string  $uniqueBy
+     * @param  array|null  $update
      * @return int
      */
-    public function upsert(array $values, $uniqueBy)
+    public function upsert(array $values, $uniqueBy, $update = null)
     {
-        return $this->toBase()->upsert(collect($values)->map(function ($value, $key) {
-            return $this->addUpdatedAtColumn($value);
-        })->toArray(), $uniqueBy);
+        if (empty($values)) {
+            return 0;
+        }
+
+        if (!is_array(reset($values))) {
+            $values = [$values];
+        }
+
+        if (is_null($update)) {
+            $update = array_keys(reset($values));
+        }
+
+        $values = $this->addTimestampsToValues($values);
+
+        $update = $this->addUpdatedAtToColumns($update);
+
+        return $this->toBase()->upsert($values, $uniqueBy, $update);
     }
 
     /**
@@ -842,6 +857,52 @@ class Builder
         return $this->toBase()->decrement(
             $column, $amount, $this->addUpdatedAtColumn($extra)
         );
+    }
+
+    /**
+     * Add timestamps to the inserted values.
+     *
+     * @param array $values
+     * @return array
+     */
+    protected function addTimestampsToValues(array $values)
+    {
+        if (!$this->model->usesTimestamps()) {
+            return $values;
+        }
+
+        $timestamp = $this->model->freshTimestampString();
+
+        $columns = array_filter([$this->model->getCreatedAtColumn(), $this->model->getUpdatedAtColumn()]);
+
+        foreach ($columns as $column) {
+            foreach ($values as &$row) {
+                $row = array_merge([$column => $timestamp], $row);
+            }
+        }
+
+        return $values;
+    }
+
+    /**
+     * Add the "updated at" column to the updated columns.
+     *
+     * @param array $update
+     * @return array
+     */
+    protected function addUpdatedAtToColumns(array $update)
+    {
+        if (!$this->model->usesTimestamps()) {
+            return $update;
+        }
+
+        $column = $this->model->getUpdatedAtColumn();
+
+        if (!is_null($column) && !array_key_exists($column, $update) && !in_array($column, $update)) {
+            $update[] = $column;
+        }
+
+        return $update;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -814,7 +814,7 @@ class Builder
             return 0;
         }
 
-        if (!is_array(reset($values))) {
+        if (! is_array(reset($values))) {
             $values = [$values];
         }
 
@@ -867,7 +867,7 @@ class Builder
      */
     protected function addTimestampsToValues(array $values)
     {
-        if (!$this->model->usesTimestamps()) {
+        if (! $this->model->usesTimestamps()) {
             return $values;
         }
 
@@ -892,13 +892,13 @@ class Builder
      */
     protected function addUpdatedAtToColumns(array $update)
     {
-        if (!$this->model->usesTimestamps()) {
+        if (! $this->model->usesTimestamps()) {
             return $update;
         }
 
         $column = $this->model->getUpdatedAtColumn();
 
-        if (!is_null($column) && !array_key_exists($column, $update) && !in_array($column, $update)) {
+        if (! is_null($column) && ! array_key_exists($column, $update) && ! in_array($column, $update)) {
             $update[] = $column;
         }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2924,6 +2924,35 @@ class Builder
     }
 
     /**
+     * Insert new records or update the existing ones.
+     *
+     * @param  array  $values
+     * @param  array|string  $uniqueBy
+     * @return int
+     */
+    public function upsert(array $values, $uniqueBy)
+    {
+        if (empty($values)) {
+            return 0;
+        }
+
+        if (! is_array(reset($values))) {
+            $values = [$values];
+        } else {
+            foreach ($values as $key => $value) {
+                ksort($value);
+
+                $values[$key] = $value;
+            }
+        }
+
+        return $this->connection->affectingStatement(
+            $this->grammar->compileUpsert($this, $values, (array) $uniqueBy),
+            $this->cleanBindings(Arr::flatten($values, 1))
+        );
+    }
+
+    /**
      * Increment a column's value by a given amount.
      *
      * @param  string  $column

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -1001,11 +1001,12 @@ class Grammar extends BaseGrammar
      * @param  \Illuminate\Database\Query\Builder $query
      * @param  array $values
      * @param  array $uniqueBy
+     * @param  array $update
      * @return  string
      *
      * @throws \RuntimeException
      */
-    public function compileUpsert(Builder $query, array $values, array $uniqueBy)
+    public function compileUpsert(Builder $query, array $values, array $uniqueBy, array $update)
     {
         throw new RuntimeException('This database engine does not support upserts.');
     }

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -996,6 +996,21 @@ class Grammar extends BaseGrammar
     }
 
     /**
+     * Compile an "upsert" statement into SQL.
+     *
+     * @param  \Illuminate\Database\Query\Builder $query
+     * @param  array $values
+     * @param  array $uniqueBy
+     * @return  string
+     *
+     * @throws \RuntimeException
+     */
+    public function compileUpsert(Builder $query, array $values, array $uniqueBy)
+    {
+        throw new RuntimeException('This database engine does not support upserts.');
+    }
+
+    /**
      * Prepare the bindings for an update statement.
      *
      * @param  array  $bindings

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -154,6 +154,25 @@ class MySqlGrammar extends Grammar
     }
 
     /**
+     * Compile an "upsert" statement into SQL.
+     *
+     * @param  \Illuminate\Database\Query\Builder $query
+     * @param  array $values
+     * @param  array $uniqueBy
+     * @return  string
+     */
+    public function compileUpsert(Builder $query, array $values, array $uniqueBy)
+    {
+        $sql = $this->compileInsert($query, $values).' on duplicate key update ';
+
+        $columns = collect(array_keys(reset($values)))->map(function ($value, $key) {
+            return $this->wrap($value).' = values('.$this->wrap($value).')';
+        })->implode(', ');
+
+        return $sql.$columns;
+    }
+
+    /**
      * Prepare a JSON column being updated using the JSON_SET function.
      *
      * @param  string  $key

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -159,14 +159,17 @@ class MySqlGrammar extends Grammar
      * @param  \Illuminate\Database\Query\Builder $query
      * @param  array $values
      * @param  array $uniqueBy
+     * @param  array $update
      * @return  string
      */
-    public function compileUpsert(Builder $query, array $values, array $uniqueBy)
+    public function compileUpsert(Builder $query, array $values, array $uniqueBy, array $update)
     {
         $sql = $this->compileInsert($query, $values).' on duplicate key update ';
 
-        $columns = collect(array_keys(reset($values)))->map(function ($value, $key) {
-            return $this->wrap($value).' = values('.$this->wrap($value).')';
+        $columns = collect($update)->map(function ($value, $key) {
+            return is_numeric($key)
+                ? $this->wrap($value).' = values('.$this->wrap($value).')'
+                : $this->wrap($key).' = '.$this->parameter($value);
         })->implode(', ');
 
         return $sql.$columns;

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -224,16 +224,19 @@ class PostgresGrammar extends Grammar
      * @param  \Illuminate\Database\Query\Builder $query
      * @param  array $values
      * @param  array $uniqueBy
+     * @param  array $update
      * @return  string
      */
-    public function compileUpsert(Builder $query, array $values, array $uniqueBy)
+    public function compileUpsert(Builder $query, array $values, array $uniqueBy, array $update)
     {
         $sql = $this->compileInsert($query, $values);
 
         $sql .= ' on conflict ('.$this->columnize($uniqueBy).') do update set ';
 
-        $columns = collect(array_keys(reset($values)))->map(function ($value, $key) {
-            return $this->wrap($value).' = '.$this->wrapValue('excluded').'.'.$this->wrap($value);
+        $columns = collect($update)->map(function ($value, $key) {
+            return is_numeric($key)
+                ? $this->wrap($value).' = '.$this->wrapValue('excluded').'.'.$this->wrap($value)
+                : $this->wrap($key).' = '.$this->parameter($value);
         })->implode(', ');
 
         return $sql.$columns;

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -219,6 +219,27 @@ class PostgresGrammar extends Grammar
     }
 
     /**
+     * Compile an "upsert" statement into SQL.
+     *
+     * @param  \Illuminate\Database\Query\Builder $query
+     * @param  array $values
+     * @param  array $uniqueBy
+     * @return  string
+     */
+    public function compileUpsert(Builder $query, array $values, array $uniqueBy)
+    {
+        $sql = $this->compileInsert($query, $values);
+
+        $sql .= ' on conflict ('.$this->columnize($uniqueBy).') do update set ';
+
+        $columns = collect(array_keys(reset($values)))->map(function ($value, $key) {
+            return $this->wrap($value).' = '.$this->wrapValue('excluded').'.'.$this->wrap($value);
+        })->implode(', ');
+
+        return $sql.$columns;
+    }
+
+    /**
      * Prepares a JSON column being updated using the JSONB_SET function.
      *
      * @param  string  $key

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -188,16 +188,19 @@ class SQLiteGrammar extends Grammar
      * @param  \Illuminate\Database\Query\Builder $query
      * @param  array $values
      * @param  array $uniqueBy
+     * @param  array $update
      * @return  string
      */
-    public function compileUpsert(Builder $query, array $values, array $uniqueBy)
+    public function compileUpsert(Builder $query, array $values, array $uniqueBy, array $update)
     {
         $sql = $this->compileInsert($query, $values);
 
         $sql .= ' on conflict ('.$this->columnize($uniqueBy).') do update set ';
 
-        $columns = collect(array_keys(reset($values)))->map(function ($value, $key) {
-            return $this->wrap($value).' = '.$this->wrapValue('excluded').'.'.$this->wrap($value);
+        $columns = collect($update)->map(function ($value, $key) {
+            return is_numeric($key)
+                ? $this->wrap($value).' = '.$this->wrapValue('excluded').'.'.$this->wrap($value)
+                : $this->wrap($key).' = '.$this->parameter($value);
         })->implode(', ');
 
         return $sql.$columns;

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -183,6 +183,27 @@ class SQLiteGrammar extends Grammar
     }
 
     /**
+     * Compile an "upsert" statement into SQL.
+     *
+     * @param  \Illuminate\Database\Query\Builder $query
+     * @param  array $values
+     * @param  array $uniqueBy
+     * @return  string
+     */
+    public function compileUpsert(Builder $query, array $values, array $uniqueBy)
+    {
+        $sql = $this->compileInsert($query, $values);
+
+        $sql .= ' on conflict ('.$this->columnize($uniqueBy).') do update set ';
+
+        $columns = collect(array_keys(reset($values)))->map(function ($value, $key) {
+            return $this->wrap($value).' = '.$this->wrapValue('excluded').'.'.$this->wrap($value);
+        })->implode(', ');
+
+        return $sql.$columns;
+    }
+
+    /**
      * Group the nested JSON columns.
      *
      * @param  array  $values

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1315,6 +1315,29 @@ class DatabaseEloquentBuilderTest extends TestCase
         Carbon::setTestNow(null);
     }
 
+    public function testUpsert()
+    {
+        Carbon::setTestNow($now = '2017-10-10 10:10:10');
+
+        $query = m::mock(BaseBuilder::class);
+        $query->shouldReceive('from')->with('foo_table')->andReturn('foo_table');
+        $query->from = 'foo_table';
+
+        $builder = new Builder($query);
+        $model = new EloquentBuilderTestStubStringPrimaryKey;
+        $builder->setModel($model);
+
+        $query->shouldReceive('upsert')->once()
+            ->with([
+                ['email' => 'foo', 'name' => 'bar', 'foo_table.updated_at' => $now], 
+                ['name' => 'bar2', 'email' => 'foo2', 'foo_table.updated_at' => $now]], 'email')->andReturn(2);
+        
+        $result = $builder->upsert([['email' => 'foo', 'name' => 'bar'], ['name' => 'bar2', 'email' => 'foo2']], 'email');
+        $this->assertEquals(2, $result);
+
+        Carbon::setTestNow(null);
+    }
+
     public function testWithCastsMethod()
     {
         $builder = new Builder($this->getMockQueryBuilder());

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1329,7 +1329,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $query->shouldReceive('upsert')->once()
             ->with([
-                ['email' => 'foo', 'name' => 'bar', 'foo_table.updated_at' => $now], 
+                ['email' => 'foo', 'name' => 'bar', 'foo_table.updated_at' => $now],
                 ['name' => 'bar2', 'email' => 'foo2', 'foo_table.updated_at' => $now], ], 'email')->andReturn(2);
 
         $result = $builder->upsert([['email' => 'foo', 'name' => 'bar'], ['name' => 'bar2', 'email' => 'foo2']], 'email');

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1329,10 +1329,11 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $query->shouldReceive('upsert')->once()
             ->with([
-                ['email' => 'foo', 'name' => 'bar', 'foo_table.updated_at' => $now],
-                ['name' => 'bar2', 'email' => 'foo2', 'foo_table.updated_at' => $now], ], 'email')->andReturn(2);
+                ['email' => 'foo', 'name' => 'bar', 'updated_at' => $now, 'created_at' => $now],
+                ['name' => 'bar2', 'email' => 'foo2', 'updated_at' => $now, 'created_at' => $now],
+            ], ['email'], ['email', 'name', 'updated_at'])->andReturn(2);
 
-        $result = $builder->upsert([['email' => 'foo', 'name' => 'bar'], ['name' => 'bar2', 'email' => 'foo2']], 'email');
+        $result = $builder->upsert([['email' => 'foo', 'name' => 'bar'], ['name' => 'bar2', 'email' => 'foo2']], ['email']);
         $this->assertEquals(2, $result);
 
         Carbon::setTestNow(null);

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1330,8 +1330,8 @@ class DatabaseEloquentBuilderTest extends TestCase
         $query->shouldReceive('upsert')->once()
             ->with([
                 ['email' => 'foo', 'name' => 'bar', 'foo_table.updated_at' => $now], 
-                ['name' => 'bar2', 'email' => 'foo2', 'foo_table.updated_at' => $now]], 'email')->andReturn(2);
-        
+                ['name' => 'bar2', 'email' => 'foo2', 'foo_table.updated_at' => $now], ], 'email')->andReturn(2);
+
         $result = $builder->upsert([['email' => 'foo', 'name' => 'bar'], ['name' => 'bar2', 'email' => 'foo2']], 'email');
         $this->assertEquals(2, $result);
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2206,7 +2206,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(2, $result);
 
         $builder = $this->getSqlServerBuilder();
-        $builder->getConnection()->shouldReceive('affectingStatement')->once()->with('merge [users] using (values (?, ?), (?, ?)) [laravel_source] ([email], [name]) on [laravel_source].[email] = [users].[email] when not matched then insert ([email], [name]) values ([email], [name])', ['foo', 'bar', 'foo2', 'bar2'])->andReturn(2);
+        $builder->getConnection()->shouldReceive('affectingStatement')->once()->with('merge [users] using (values (?, ?), (?, ?)) [laravel_source] ([email], [name]) on [laravel_source].[email] = [users].[email] when matched then update set [email] = [laravel_source].[email], [name] = [laravel_source].[name] when not matched then insert ([email], [name]) values ([email], [name])', ['foo', 'bar', 'foo2', 'bar2'])->andReturn(2);
         $result = $builder->from('users')->upsert([['email' => 'foo', 'name' => 'bar'], ['name' => 'bar2', 'email' => 'foo2']], 'email');
         $this->assertEquals(2, $result);
     }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2211,6 +2211,29 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(2, $result);
     }
 
+    public function testUpsertMethodWithUpdateColumns()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->getConnection()->shouldReceive('affectingStatement')->once()->with('insert into `users` (`email`, `name`) values (?, ?), (?, ?) on duplicate key update `name` = values(`name`)', ['foo', 'bar', 'foo2', 'bar2'])->andReturn(2);
+        $result = $builder->from('users')->upsert([['email' => 'foo', 'name' => 'bar'], ['name' => 'bar2', 'email' => 'foo2']], 'email', ['name']);
+        $this->assertEquals(2, $result);
+
+        $builder = $this->getPostgresBuilder();
+        $builder->getConnection()->shouldReceive('affectingStatement')->once()->with('insert into "users" ("email", "name") values (?, ?), (?, ?) on conflict ("email") do update set "name" = "excluded"."name"', ['foo', 'bar', 'foo2', 'bar2'])->andReturn(2);
+        $result = $builder->from('users')->upsert([['email' => 'foo', 'name' => 'bar'], ['name' => 'bar2', 'email' => 'foo2']], 'email', ['name']);
+        $this->assertEquals(2, $result);
+
+        $builder = $this->getSQLiteBuilder();
+        $builder->getConnection()->shouldReceive('affectingStatement')->once()->with('insert into "users" ("email", "name") values (?, ?), (?, ?) on conflict ("email") do update set "name" = "excluded"."name"', ['foo', 'bar', 'foo2', 'bar2'])->andReturn(2);
+        $result = $builder->from('users')->upsert([['email' => 'foo', 'name' => 'bar'], ['name' => 'bar2', 'email' => 'foo2']], 'email', ['name']);
+        $this->assertEquals(2, $result);
+
+        $builder = $this->getSqlServerBuilder();
+        $builder->getConnection()->shouldReceive('affectingStatement')->once()->with('merge [users] using (values (?, ?), (?, ?)) [laravel_source] ([email], [name]) on [laravel_source].[email] = [users].[email] when matched then update set [name] = [laravel_source].[name] when not matched then insert ([email], [name]) values ([email], [name])', ['foo', 'bar', 'foo2', 'bar2'])->andReturn(2);
+        $result = $builder->from('users')->upsert([['email' => 'foo', 'name' => 'bar'], ['name' => 'bar2', 'email' => 'foo2']], 'email', ['name']);
+        $this->assertEquals(2, $result);
+    }
+
     public function testUpdateMethodWithJoins()
     {
         $builder = $this->getBuilder();

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -7,7 +7,6 @@ use DateTime;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Query\Builder;
-
 use Illuminate\Database\Query\Expression as Raw;
 use Illuminate\Database\Query\Grammars\Grammar;
 use Illuminate\Database\Query\Grammars\MySqlGrammar;


### PR DESCRIPTION
As a follow-up to https://github.com/laravel/framework/pull/34698, this PR adds support for updating `created_at` timestamps on upserts.

I've modified the signature of the `upsert` method to include an optional third argument to be an array of the columns to be updated. If not provided, all columns will be updated.
