### PR TITLE
[8.x] Revert "fix LengthAwarePaginator translations issue (#34710)"

### DIFF
--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -115,11 +115,11 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
             });
         })->prepend([
             'url' => $this->previousPageUrl(),
-            'label' => __('pagination.previous'),
+            'label' => 'Previous',
             'active' => false,
         ])->push([
             'url' => $this->nextPageUrl(),
-            'label' => __('pagination.next'),
+            'label' => 'Next',
             'active' => false,
         ]);
     }


### PR DESCRIPTION
If someone is using `LengthAwarePagination` outside of Laravel app, will now get this error:

```php
$pagination = new Illuminate\Pagination\LengthAwarePaginator(['a', 'b', 'c'], 3, 1);

// Fatal error: Uncaught Error: Call to undefined function Illuminate\Pagination\__() […]
var_dump($pagination->toArray());
```