### PR TITLE
[8.x] use $name to define the factory class name

### DIFF
--- a/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
+++ b/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
@@ -79,7 +79,7 @@ class FactoryMakeCommand extends GeneratorCommand
             '{{namespacedModel}}' => $namespaceModel,
             'DummyModel' => $model,
             '{{ model }}' => $model,
-            '{{model}}' => $model,
+            '{{ name }}' => $name,
         ];
 
         return str_replace(

--- a/src/Illuminate/Database/Console/Factories/stubs/factory.stub
+++ b/src/Illuminate/Database/Console/Factories/stubs/factory.stub
@@ -5,7 +5,7 @@ namespace {{ factoryNamespace }};
 use Illuminate\Database\Eloquent\Factories\Factory;
 use {{ namespacedModel }};
 
-class {{ model }}Factory extends Factory
+class {{ name }}Factory extends Factory
 {
     /**
      * The name of the factory's corresponding model.


### PR DESCRIPTION

When you create a new Factory the class name is not set correctly, currently use the `{{ model }}` variable instead `$name`  

Running this command
![image](https://user-images.githubusercontent.com/198571/95286289-8c455480-0828-11eb-9697-4f89369ef2d6.png)

The generated code is this:
![image](https://user-images.githubusercontent.com/198571/95286312-9b2c0700-0828-11eb-9488-0bdffcfa5218.png)

