### PR TITLE
[8.x] Updated queue:work output to include releasing event

### DIFF
--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Queue\Job;
 use Illuminate\Queue\Events\JobFailed;
 use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Queue\Events\JobProcessing;
+use Illuminate\Queue\Events\JobRestarted;
 use Illuminate\Queue\Worker;
 use Illuminate\Queue\WorkerOptions;
 use Illuminate\Support\Carbon;
@@ -157,6 +158,10 @@ class WorkCommand extends Command
             $this->writeOutput($event->job, 'success');
         });
 
+        $this->laravel['events']->listen(JobRestarted::class, function ($event) {
+            $this->writeOutput($event->job, 'restarting');
+        });
+
         $this->laravel['events']->listen(JobFailed::class, function ($event) {
             $this->writeOutput($event->job, 'failed');
 
@@ -180,6 +185,8 @@ class WorkCommand extends Command
                 return $this->writeStatus($job, 'Processed', 'info');
             case 'failed':
                 return $this->writeStatus($job, 'Failed', 'error');
+            case 'restarting':
+                return $this->writeStatus($job, 'Restarting', 'info');
         }
     }
 

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -8,7 +8,7 @@ use Illuminate\Contracts\Queue\Job;
 use Illuminate\Queue\Events\JobFailed;
 use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Queue\Events\JobProcessing;
-use Illuminate\Queue\Events\JobRestarted;
+use Illuminate\Queue\Events\JobReleased;
 use Illuminate\Queue\Worker;
 use Illuminate\Queue\WorkerOptions;
 use Illuminate\Support\Carbon;
@@ -158,8 +158,8 @@ class WorkCommand extends Command
             $this->writeOutput($event->job, 'success');
         });
 
-        $this->laravel['events']->listen(JobRestarted::class, function ($event) {
-            $this->writeOutput($event->job, 'restarting');
+        $this->laravel['events']->listen(JobReleased::class, function ($event) {
+            $this->writeOutput($event->job, 'releasing');
         });
 
         $this->laravel['events']->listen(JobFailed::class, function ($event) {

--- a/src/Illuminate/Queue/Events/JobReleased.php
+++ b/src/Illuminate/Queue/Events/JobReleased.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Queue\Events;
 
-class JobRestarted
+class JobReleased
 {
     /**
      * The connection name.

--- a/src/Illuminate/Queue/Events/JobRestarted.php
+++ b/src/Illuminate/Queue/Events/JobRestarted.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Illuminate\Queue\Events;
+
+class JobRestarted
+{
+    /**
+     * The connection name.
+     *
+     * @var string
+     */
+    public $connectionName;
+
+    /**
+     * The job instance.
+     *
+     * @var \Illuminate\Contracts\Queue\Job
+     */
+    public $job;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  string  $connectionName
+     * @param  \Illuminate\Contracts\Queue\Job  $job
+     * @return void
+     */
+    public function __construct($connectionName, $job)
+    {
+        $this->job = $job;
+        $this->connectionName = $connectionName;
+    }
+}

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -447,7 +447,6 @@ class Worker
             // so it is not lost entirely. This'll let the job be retried at a later time by
             // another listener (or this same one). We will re-throw this exception after.
             if (! $job->isDeleted() && ! $job->isReleased() && ! $job->hasFailed()) {
-
                 $this->raiseRestartingJobEvent(
                     $connectionName, $job
                 );

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -10,7 +10,7 @@ use Illuminate\Database\DetectsLostConnections;
 use Illuminate\Queue\Events\JobExceptionOccurred;
 use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Queue\Events\JobProcessing;
-use Illuminate\Queue\Events\JobRestarted;
+use Illuminate\Queue\Events\JobReleased;
 use Illuminate\Queue\Events\Looping;
 use Illuminate\Queue\Events\WorkerStopping;
 use Illuminate\Support\Carbon;
@@ -447,7 +447,7 @@ class Worker
             // so it is not lost entirely. This'll let the job be retried at a later time by
             // another listener (or this same one). We will re-throw this exception after.
             if (! $job->isDeleted() && ! $job->isReleased() && ! $job->hasFailed()) {
-                $this->raiseRestartingJobEvent(
+                $this->raiseReleasingJobEvent(
                     $connectionName, $job
                 );
 
@@ -618,9 +618,9 @@ class Worker
      * @param  \Illuminate\Contracts\Queue\Job  $job
      * @return void
      */
-    protected function raiseRestartingJobEvent($connectionName, $job)
+    protected function raiseReleasingJobEvent($connectionName, $job)
     {
-        $this->events->dispatch(new JobRestarted(
+        $this->events->dispatch(new JobReleased(
             $connectionName, $job
         ));
     }


### PR DESCRIPTION
If retries are set for queue jobs, end user has no notion of what is happening as the output hangs in `Processing` all up until the job actually fails. This PR adds a helpful `Restarting` message to it.

Before and after:

![image](https://user-images.githubusercontent.com/11718157/95302351-22f22f80-0882-11eb-9655-360b1aaf1511.png)
