### PR TITLE
[8.x] Add dropColumns method on the schema class

### DIFF
--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -405,4 +405,18 @@ class Builder
     {
         $this->resolver = $resolver;
     }
+
+    /**
+     * Drop columns from a table schema.
+     *
+     * @param  string  $table
+     * @param  string|array  $columns
+     * @return void
+     */
+    public function dropColumns($table, $columns)
+    {
+        $this->table($table, function (Blueprint $blueprint) use ($table, $columns) {
+            $blueprint->dropColumn($columns);
+        });
+    }
 }

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -415,7 +415,7 @@ class Builder
      */
     public function dropColumns($table, $columns)
     {
-        $this->table($table, function (Blueprint $blueprint) use ($table, $columns) {
+        $this->table($table, function (Blueprint $blueprint) use ($columns) {
             $blueprint->dropColumn($columns);
         });
     }

--- a/src/Illuminate/Support/Facades/Schema.php
+++ b/src/Illuminate/Support/Facades/Schema.php
@@ -12,6 +12,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Database\Schema\Builder table(string $table, \Closure $callback)
  * @method static bool hasColumn(string $table, string $column)
  * @method static bool hasColumns(string $table, array $columns)
+ * @method static bool dropColumns(string $table, array $columns)
  * @method static bool hasTable(string $table)
  * @method static void defaultStringLength(int $length)
  * @method static void registerCustomDoctrineType(string $class, string $name, string $type)


### PR DESCRIPTION
This thin wrapper, adds a little bit of syntactic sugar for `down` methods in migrations:

refactor this:
```php
public function down()
{
    Schema::table('posts', function (Blueprint $table) {
        $table->dropColumn('user_id');
        $table->dropColumn('state');
    });
}
```
into:
```php
public function down()
{
    Schema::dropColumns('posts', ['user_id', 'state']);
}
```
- Since the `Illuminate\Database\Schema\Builder` class is Not macroable, it is not very like to break something.
The only possible case is, if someone has extended the Builder class, and has the same method name in the subclass but with a different signature, which is very unlikely.

- If accepted, I will add tests in another PR.