### PR TITLE
[8.x] Use Symfony's constant

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/console.stub
+++ b/src/Illuminate/Foundation/Console/stubs/console.stub
@@ -37,6 +37,6 @@ class {{ class }} extends Command
      */
     public function handle()
     {
-        return 0;
+        return Command::SUCCESS;
     }
 }


### PR DESCRIPTION
This PR changes the `0` to a Symfony constant. 

`0` is the successful console response code, but this might not be clear for the first look. We might consider using Symfony's built-in constant.