### PR TITLE
[8.x] Add yearlyOn() method to scheduler

### DIFF
--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -470,6 +470,22 @@ trait ManagesFrequencies
     }
 
     /**
+     * Schedule the event to run yearly on a given month, day and time.
+     *
+     * @param  int  $month
+     * @param  int  $day
+     * @param  string  $time
+     * @return $this
+     */
+    public function yearlyOn($month = 1, $day = 1, $time = '0:0')
+    {
+        $this->dailyAt($time);
+
+        return $this->spliceIntoPosition(3, $day)
+                    ->spliceIntoPosition(4, $month);
+    }
+
+    /**
      * Set the days of the week the command should run on.
      *
      * @param  array|mixed  $days

--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -470,7 +470,7 @@ trait ManagesFrequencies
     }
 
     /**
-     * Schedule the event to run yearly on a given month, day and time.
+     * Schedule the event to run yearly on a given month, day, and time.
      *
      * @param  int  $month
      * @param  int  $day

--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -164,6 +164,16 @@ class FrequencyTest extends TestCase
         $this->assertSame('0 0 1 1 *', $this->event->yearly()->getExpression());
     }
 
+    public function testYearlyOn()
+    {
+        $this->assertSame('8 15 5 4 *', $this->event->yearlyOn(4, 5, '15:08')->getExpression());
+    }
+
+    public function testYearlyOnTuesdays()
+    {
+        $this->assertSame('1 9 20 7 2', $this->event->tuesdays()->yearlyOn(7, 20, '09:01')->getExpression());
+    }
+
     public function testFrequencyMacro()
     {
         Event::macro('everyXMinutes', function ($x) {


### PR DESCRIPTION
### Premise

I need to run a task once a year on a specific month (when the university term ends). Currently there is no expressive way to accomplish this with the available frequency options.

As `weeklyOn($day, $time)` and `monthlyOn($day, $time)` already exist, I simply used them as a guide and created `yearlyOn($month, $day, $time)`.

```php
// https://crontab.guru/#0_0_1_7_*
// At 00:00 on day-of-month 1 in July.

// Before
$schedule->cron('0 0 1 7 *');

// After
$schedule->yearlyOn(7);
```