### PR TITLE
[8.x] Differentiate between day of the month and day of the week in the scheduler

### DIFF
--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -276,7 +276,7 @@ trait ManagesFrequencies
      */
     public function weekdays()
     {
-        return $this->spliceIntoPosition(5, '1-5');
+        return $this->days('1-5');
     }
 
     /**
@@ -286,7 +286,7 @@ trait ManagesFrequencies
      */
     public function weekends()
     {
-        return $this->spliceIntoPosition(5, '0,6');
+        return $this->days('0,6');
     }
 
     /**
@@ -382,7 +382,7 @@ trait ManagesFrequencies
     {
         $this->dailyAt($time);
 
-        return $this->spliceIntoPosition(5, $day);
+        return $this->days($day);
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -374,15 +374,15 @@ trait ManagesFrequencies
     /**
      * Schedule the event to run weekly on a given day and time.
      *
-     * @param  int  $day
+     * @param  int  $dayOfWeek
      * @param  string  $time
      * @return $this
      */
-    public function weeklyOn($day, $time = '0:0')
+    public function weeklyOn($dayOfWeek, $time = '0:0')
     {
         $this->dailyAt($time);
 
-        return $this->days($day);
+        return $this->days($dayOfWeek);
     }
 
     /**
@@ -400,15 +400,15 @@ trait ManagesFrequencies
     /**
      * Schedule the event to run monthly on a given day and time.
      *
-     * @param  int  $day
+     * @param  int  $dayOfMonth
      * @param  string  $time
      * @return $this
      */
-    public function monthlyOn($day = 1, $time = '0:0')
+    public function monthlyOn($dayOfMonth = 1, $time = '0:0')
     {
         $this->dailyAt($time);
 
-        return $this->spliceIntoPosition(3, $day);
+        return $this->spliceIntoPosition(3, $dayOfMonth);
     }
 
     /**
@@ -421,13 +421,13 @@ trait ManagesFrequencies
      */
     public function twiceMonthly($first = 1, $second = 16, $time = '0:0')
     {
-        $days = $first.','.$second;
+        $daysOfMonth = $first.','.$second;
 
         $this->dailyAt($time);
 
         return $this->spliceIntoPosition(1, 0)
             ->spliceIntoPosition(2, 0)
-            ->spliceIntoPosition(3, $days);
+            ->spliceIntoPosition(3, $daysOfMonth);
     }
 
     /**
@@ -473,15 +473,15 @@ trait ManagesFrequencies
      * Schedule the event to run yearly on a given month, day, and time.
      *
      * @param  int  $month
-     * @param  int  $day
+     * @param  int  $dayOfMonth
      * @param  string  $time
      * @return $this
      */
-    public function yearlyOn($month = 1, $day = 1, $time = '0:0')
+    public function yearlyOn($month = 1, $dayOfMonth = 1, $time = '0:0')
     {
         $this->dailyAt($time);
 
-        return $this->spliceIntoPosition(3, $day)
+        return $this->spliceIntoPosition(3, $dayOfMonth)
                     ->spliceIntoPosition(4, $month);
     }
 


### PR DESCRIPTION
This PR contains 2 minor code improvements to the scheduler:

1. Be explicit when a variable refers to the day of the month (position 3 // `1-31`) versus the day of the week (position 5 // `0-7`)
1. Make use of existing method: `days()` when dealing with position 5 of a cron