### PR TITLE
[8.x] Add mysql integration test for database introspection methods

### DIFF
--- a/tests/Integration/Database/DatabaseMySqlConnectionTest.php
+++ b/tests/Integration/Database/DatabaseMySqlConnectionTest.php
@@ -31,7 +31,7 @@ class DatabaseMySqlConnectionTest extends DatabaseMySqlTestCase
 
     protected function tearDown(): void
     {
-        DB::table(self::TABLE)->truncate();
+        Schema::drop(self::TABLE);
 
         parent::tearDown();
     }

--- a/tests/Integration/Database/DatabaseSchemaBuilderAlterTableWithEnumTest.php
+++ b/tests/Integration/Database/DatabaseSchemaBuilderAlterTableWithEnumTest.php
@@ -25,6 +25,26 @@ class DatabaseSchemaBuilderAlterTableWithEnumTest extends DatabaseMySqlTestCase
         $this->assertSame('integer', Schema::getColumnType('users', 'age'));
     }
 
+    public function testGetAllTablesAndColumnListing()
+    {
+        $tables = Schema::getAllTables();
+
+        $this->assertCount(1, $tables);
+        $this->assertEquals('stdClass', get_class($tables[0]));
+
+        $tableProperties = array_values((array) $tables[0]);
+        $this->assertEquals(['users', 'BASE TABLE'], $tableProperties);
+        $this->assertEquals(['id', 'name', 'age', 'color'], Schema::getColumnListing('users'));
+
+        Schema::create('posts', function (Blueprint $table) {
+            $table->integer('id');
+            $table->string('title');
+        });
+        $tables = Schema::getAllTables();
+        $this->assertCount(2, $tables);
+        Schema::drop('posts');
+    }
+
     protected function setUp(): void
     {
         parent::setUp();


### PR DESCRIPTION
The `getAllTables` and `getColumnListing` methods on the `Schema\Builder` class had no tests at all, so I added this for Mysql driver as some very basic tests.

- The first commit drops the "players" table in the tearDown method, instead of just deleting its rows and leaving the table there, because it was interfering with the current test suite in an unexpected way.