### PR TITLE
[8.x] Added missed typehints for controller stubs

### DIFF
--- a/src/Illuminate/Routing/Console/stubs/controller.api.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.api.stub
@@ -34,7 +34,7 @@ class {{ class }} extends Controller
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function show($id)
+    public function show(int $id)
     {
         //
     }
@@ -46,7 +46,7 @@ class {{ class }} extends Controller
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function update(Request $request, $id)
+    public function update(Request $request, int $id)
     {
         //
     }
@@ -57,7 +57,7 @@ class {{ class }} extends Controller
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function destroy($id)
+    public function destroy(int $id)
     {
         //
     }

--- a/src/Illuminate/Routing/Console/stubs/controller.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.stub
@@ -44,7 +44,7 @@ class {{ class }} extends Controller
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function show($id)
+    public function show(int $id)
     {
         //
     }
@@ -55,7 +55,7 @@ class {{ class }} extends Controller
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function edit($id)
+    public function edit(int $id)
     {
         //
     }
@@ -67,7 +67,7 @@ class {{ class }} extends Controller
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function update(Request $request, $id)
+    public function update(Request $request, int $id)
     {
         //
     }
@@ -78,7 +78,7 @@ class {{ class }} extends Controller
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function destroy($id)
+    public function destroy(int $id)
     {
         //
     }


### PR DESCRIPTION
Added `$id` parameter type hint for controller stubs to improve code readability and php type checking.

I think it's minor change because affect people only when create controller using artisan `make:controller` command.