### PR TITLE
[8.x] Support custom app namespace in HasFactory

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -686,9 +686,11 @@ abstract class Factory
     public static function resolveFactoryName(string $modelName)
     {
         $resolver = static::$factoryNameResolver ?: function (string $modelName) {
-            $modelName = Str::startsWith($modelName, 'App\\Models\\')
-                ? Str::after($modelName, 'App\\Models\\')
-                : Str::after($modelName, 'App\\');
+            $rootNamespace = Container::getInstance()->getNamespace();
+
+            $modelName = Str::startsWith($modelName, $rootNamespace.'Models\\')
+                ? Str::after($modelName, $rootNamespace.'Models\\')
+                : Str::after($modelName, $rootNamespace);
 
             return static::$namespace.$modelName.'Factory';
         };


### PR DESCRIPTION
Currently, the `HasFactory` trait doesn't work for apps that have custom namespaces. This PR fixes that by resolving the namespace from the `Container`.