### PR TITLE
[8.x] Use migrations table name from configuration when dumping schema

### DIFF
--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -50,8 +50,10 @@ class MySqlSchemaState extends SchemaState
      */
     protected function appendMigrationData(string $path)
     {
+        $migrationsTable = config('database.migrations', 'migrations');
+
         $process = $this->executeDumpProcess($this->makeProcess(
-            $this->baseDumpCommand().' migrations --no-create-info --skip-extended-insert --skip-routines --compact'
+            $this->baseDumpCommand().' '.$migrationsTable.' --no-create-info --skip-extended-insert --skip-routines --compact'
         ), null, array_merge($this->baseVariables($this->connection->getConfig()), [
             //
         ]));

--- a/src/Illuminate/Database/Schema/PostgresSchemaState.php
+++ b/src/Illuminate/Database/Schema/PostgresSchemaState.php
@@ -29,8 +29,10 @@ class PostgresSchemaState extends SchemaState
      */
     protected function appendMigrationData(string $path)
     {
+        $migrationsTable = config('database.migrations', 'migrations');
+
         with($process = $this->makeProcess(
-            $this->baseDumpCommand().' --table=migrations --data-only --inserts'
+            $this->baseDumpCommand().' --table='.$migrationsTable.' --data-only --inserts'
         ))->setTimeout(null)->mustRun(null, array_merge($this->baseVariables($this->connection->getConfig()), [
             //
         ]));

--- a/src/Illuminate/Database/Schema/SqliteSchemaState.php
+++ b/src/Illuminate/Database/Schema/SqliteSchemaState.php
@@ -36,8 +36,10 @@ class SqliteSchemaState extends SchemaState
      */
     protected function appendMigrationData(string $path)
     {
+        $migrationsTable = config('database.migrations', 'migrations');
+
         with($process = $this->makeProcess(
-            $this->baseCommand().' ".dump \'migrations\'"'
+            $this->baseCommand().' ".dump \''.$migrationsTable.'\'"'
         ))->mustRun(null, array_merge($this->baseVariables($this->connection->getConfig()), [
             //
         ]));


### PR DESCRIPTION
This PR changes the table name used when using `schema:dump` from "migrations" to the value configured in the database config file. As it defaults to "migrations", there should be no breaking changes.