### PR TITLE
[8.x] Update param type

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/cast.stub
+++ b/src/Illuminate/Foundation/Console/stubs/cast.stub
@@ -25,7 +25,7 @@ class DummyClass implements CastsAttributes
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @param  string  $key
-     * @param  array  $value
+     * @param  mixed  $value
      * @param  array  $attributes
      * @return mixed
      */


### PR DESCRIPTION
There's no reason why a set value will always be an array.
Typo I think.