### PR TITLE
[8.x] Make validator missing value more unique

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -489,7 +489,7 @@ class Validator implements ValidatorContract
 
         $results = [];
 
-        $missingValue = Str::random(10);
+        $missingValue = new \stdClass();
 
         foreach (array_keys($this->getRules()) as $key) {
             $value = data_get($this->getData(), $key, $missingValue);


### PR DESCRIPTION
### How to reproduce

Change [`$missingValue`](https://github.com/laravel/framework/blob/v8.7.1/src/Illuminate/Validation/Validator.php#L492) to some predefined value (`'iCfjEUXRGm'` for example), then run following code

```php
$validator = new \Illuminate\Validation\Validator(
    new \Illuminate\Translation\Translator(
        new \Illuminate\Translation\ArrayLoader, 'en'
    ),
    ['foo' => 'iCfjEUXRGm'],
    ['foo' => 'required'],
);
// expected: ['foo' => 'iCfjEUXRGm']
// actual: []
dump($validator->validated());
```

### Tests

[`ValidationValidatorTest`](https://github.com/laravel/framework/blob/v8.7.1/tests/Validation/ValidationValidatorTest.php) should cover this change