### PR TITLE
[8.x] Added restrictOnDelete method to ForeignKeyDefinition class

### DIFF
--- a/src/Illuminate/Database/Schema/ForeignKeyDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignKeyDefinition.php
@@ -35,6 +35,16 @@ class ForeignKeyDefinition extends Fluent
     }
 
     /**
+     * Indicate that deletes should be restricted.
+     *
+     * @return $this
+     */
+    public function restrictOnDelete()
+    {
+        return $this->onDelete('restrict');
+    }
+
+    /**
      * Indicate that deletes should set the foreign key value to null.
      *
      * @return $this


### PR DESCRIPTION
Added a simple method to avoid typing errors with `->onDelete('restrict')` and keeping consistency with `cascadeOn*` methods.

Regards.