### PR TITLE
[8.x] Add `newLine()` method to `InteractsWithIO` trait

### DIFF
--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -332,7 +332,18 @@ trait InteractsWithIO
         $this->comment('*     '.$string.'     *');
         $this->comment(str_repeat('*', $length));
 
-        $this->output->newLine();
+        $this->newLine();
+    }
+
+    /**
+     * Write newline(s).
+     *
+     * @param  int  $count
+     * @return void
+     */
+    public function newLine($count = 1)
+    {
+        $this->output->newLine($count);
     }
 
     /**

--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -336,7 +336,7 @@ trait InteractsWithIO
     }
 
     /**
-     * Write newline(s).
+     * Write a blank line.
      *
      * @param  int  $count
      * @return void


### PR DESCRIPTION
When generating output in artisan commands and needing to output a blank line, I am constantly finding myself doing things like this:

```php
$this->info('');
$this->info('Parsing CSV file');
$this->info('');

// or:

$this->info("\nParsing CSV file\n");

// or even worse:

$this->info(PHP_EOL . "Parsing CSV file" . PHP_EOL);
```

You can do it the "right" way by calling the `newLine()` method defined in [the Symfony console StyleInterface](https://github.com/symfony/console/blob/3b597067ee2b07ef6fbbebfe2afa0e88fae9a8a7/Style/StyleInterface.php#L116):

```php
$this->getOutput()->newLine();
```

That feel's a bit too verbose/heavy though. This PR simply makes the `newLine()` method directly accessible from the command itself:

```php
$this->newLine();
```

Doing it this way ensures that the newline is output according to the current `OutputStyle`.

No tests are included in the PR because I wasn't able to find any existing tests that checked command output.