### PR TITLE
Allow `array` and `Countable` on `Str::plural()` and `Str::pluralStudly()`

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Support;
 
+use Countable;
 use Illuminate\Support\Traits\Macroable;
 use Ramsey\Uuid\Codec\TimestampFirstCombCodec;
 use Ramsey\Uuid\Generator\CombGenerator;
@@ -431,11 +432,15 @@ class Str
      * Get the plural form of an English word.
      *
      * @param  string  $value
-     * @param  int  $count
+     * @param  Countable|int|array  $count
      * @return string
      */
     public static function plural($value, $count = 2)
     {
+        if (is_array($count) || $count instanceof Countable) {
+            $count = count($count);
+        }
+
         return Pluralizer::plural($value, $count);
     }
 
@@ -443,11 +448,15 @@ class Str
      * Pluralize the last word of an English, studly caps case string.
      *
      * @param  string  $value
-     * @param  int  $count
+     * @param  Countable|int|array  $count
      * @return string
      */
     public static function pluralStudly($value, $count = 2)
     {
+        if (is_array($count) || $count instanceof Countable) {
+            $count = count($count);
+        }
+
         $parts = preg_split('/(.)(?=[A-Z])/u', $value, -1, PREG_SPLIT_DELIM_CAPTURE);
 
         $lastWord = array_pop($parts);

--- a/tests/Support/SupportPluralizerTest.php
+++ b/tests/Support/SupportPluralizerTest.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Tests\Support;
 
-use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Support\MessageBag;
 use Illuminate\Support\Str;
 use PHPUnit\Framework\TestCase;
 
@@ -86,9 +86,7 @@ class SupportPluralizerTest extends TestCase
         $this->assertSame('tests', Str::plural('test', collect([])));
         $this->assertSame('test', Str::plural('test', collect(['item1'])));
         $this->assertSame('tests', Str::plural('test', collect(['item1', 'item2'])));
-
-        $paginator = new LengthAwarePaginator(['item1', 'item2', 'item3'], 30, 10);
-        $this->assertSame('tests', Str::plural('test', $paginator));
+        $this->assertSame('tests', Str::plural('test', new MessageBag(['msg1', 'msg2'])));
     }
 
     public function testPluralStudyWithArray()
@@ -103,8 +101,6 @@ class SupportPluralizerTest extends TestCase
         $this->assertPluralStudly('RealHumans', 'RealHuman', collect([]));
         $this->assertPluralStudly('RealHuman', 'RealHuman', collect(['item1']));
         $this->assertPluralStudly('RealHumans', 'RealHuman', collect(['item1', 'item2']));
-
-        $paginator = new LengthAwarePaginator(['item1', 'item2', 'item3'], 30, 10);
-        $this->assertPluralStudly('RealHumans', 'RealHuman', $paginator);
+        $this->assertPluralStudly('RealHumans', 'RealHuman', new MessageBag(['msg1', 'msg2']));
     }
 }

--- a/tests/Support/SupportPluralizerTest.php
+++ b/tests/Support/SupportPluralizerTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Support;
 
+use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Str;
 use PHPUnit\Framework\TestCase;
 
@@ -71,5 +72,39 @@ class SupportPluralizerTest extends TestCase
     private function assertPluralStudly($expected, $value, $count = 2)
     {
         $this->assertSame($expected, Str::pluralStudly($value, $count));
+    }
+
+    public function testPluralWithArray()
+    {
+        $this->assertSame('tests', Str::plural('test', []));
+        $this->assertSame('test', Str::plural('test', ['item1']));
+        $this->assertSame('tests', Str::plural('test', ['item1', 'item2']));
+    }
+
+    public function testPluralWithCountables()
+    {
+        $this->assertSame('tests', Str::plural('test', collect([])));
+        $this->assertSame('test', Str::plural('test', collect(['item1'])));
+        $this->assertSame('tests', Str::plural('test', collect(['item1', 'item2'])));
+
+        $paginator = new LengthAwarePaginator(['item1', 'item2', 'item3'], 30, 10);
+        $this->assertSame('tests', Str::plural('test', $paginator));
+    }
+
+    public function testPluralStudyWithArray()
+    {
+        $this->assertPluralStudly('RealHumans', 'RealHuman', []);
+        $this->assertPluralStudly('RealHuman', 'RealHuman', ['item1']);
+        $this->assertPluralStudly('RealHumans', 'RealHuman', ['item1', 'item2']);
+    }
+
+    public function testPluralStudyWithCountables()
+    {
+        $this->assertPluralStudly('RealHumans', 'RealHuman', collect([]));
+        $this->assertPluralStudly('RealHuman', 'RealHuman', collect(['item1']));
+        $this->assertPluralStudly('RealHumans', 'RealHuman', collect(['item1', 'item2']));
+
+        $paginator = new LengthAwarePaginator(['item1', 'item2', 'item3'], 30, 10);
+        $this->assertPluralStudly('RealHumans', 'RealHuman', $paginator);
     }
 }


### PR DESCRIPTION
`Str::plural()` and `Str::pluralStudly()` currently require the count to be an `int`, which forces you to call `count()` on `array` and `Countable`. This PR allows you to pass the `array` or `Countable` itself to the method and it will count them for you.

### `array`

```php
$items = ['item1', 'item2', 'item3'];

// before:
echo Str::plural('item', count($items));

// after:
echo Str::plural('item', $items);
```

### `Countable`

```php
$items = collect(['item1', 'item2', 'item3']);

// before:
echo Str::plural('item', $items->count());

// after:
echo Str::plural('item', $items);
```

The tests check with an `array`, `Collection`, and `MessageBag`