### PR TITLE
[8.x] Use a more appropriate test for yearlyOn()

### DIFF
--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -473,7 +473,7 @@ trait ManagesFrequencies
      * Schedule the event to run yearly on a given month, day, and time.
      *
      * @param  int  $month
-     * @param  int  $dayOfMonth
+     * @param  int|string  $dayOfMonth
      * @param  string  $time
      * @return $this
      */

--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -171,7 +171,7 @@ class FrequencyTest extends TestCase
 
     public function testYearlyOnTuesdays()
     {
-        $this->assertSame('1 9 20 7 2', $this->event->tuesdays()->yearlyOn(7, 20, '09:01')->getExpression());
+        $this->assertSame('1 9 * 7 2', $this->event->tuesdays()->yearlyOn(7, '*', '09:01')->getExpression());
     }
 
     public function testFrequencyMacro()


### PR DESCRIPTION
If you wanted to schedule a task to run specifically on a Tuesday, you wouldn't also define a day of the month as this may not always fall on the desired day of the week. I've therefore updated the test to reflect this.

Relates to https://github.com/laravel/framework/pull/34728