### PR TITLE
[8.x] Added isNotEmpty method to HtmlString

### DIFF
--- a/src/Illuminate/Support/HtmlString.php
+++ b/src/Illuminate/Support/HtmlString.php
@@ -45,6 +45,16 @@ class HtmlString implements Htmlable
     }
 
     /**
+     * Determine if the given HTML string is not empty.
+     *
+     * @return bool
+     */
+    public function isNotEmpty()
+    {
+        return $this->html !== '';
+    }
+
+    /**
      * Get the HTML string.
      *
      * @return string

--- a/tests/Support/SupportHtmlStringTest.php
+++ b/tests/Support/SupportHtmlStringTest.php
@@ -20,4 +20,14 @@ class SupportHtmlStringTest extends TestCase
         $html = new HtmlString('<h1>foo</h1>');
         $this->assertEquals($str, (string) $html);
     }
+
+    public function testIsEmpty()
+    {
+        $this->assertTrue((new HtmlString(''))->isEmpty());
+    }
+
+    public function testIsNotEmpty()
+    {
+        $this->assertTrue((new HtmlString('foo'))->isNotEmpty());
+    }
 }


### PR DESCRIPTION
When working with blade components I've often found myself reaching for an `->isNotEmpty()` method on the default slot. This PR adds that method to `HtmlString` so that it feels more in line with other Laravel objects like collections.

**Before**
```
@if (!$slot->isEmpty())
    <span class="...">{{ $slot }}</span>
@endif
```
**After**
```
@if ($slot->isNotEmpty())
    <span class="...">{{ $slot }}</span>
@endif
```

The tests may not be necessary, but I decided it was better to submit the PR with tests than without them. 

Thanks for considering!
