### PR TITLE
[8.x] Allow comparing custom casted attributes and their original values

### DIFF
--- a/src/Illuminate/Contracts/Database/Eloquent/ComparesCastableAttributes.php
+++ b/src/Illuminate/Contracts/Database/Eloquent/ComparesCastableAttributes.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Illuminate\Contracts\Database\Eloquent;
+
+interface ComparesCastableAttributes
+{
+    /**
+     * Compare current and original attribute values.
+     *
+     * @param  mixed  $value
+     * @param  mixed  $originalValue
+     * @return mixed
+     */
+    public function compare($value, $originalValue);
+}

--- a/src/Illuminate/Contracts/Database/Eloquent/ComparesCastableAttributes.php
+++ b/src/Illuminate/Contracts/Database/Eloquent/ComparesCastableAttributes.php
@@ -6,10 +6,11 @@ interface ComparesCastableAttributes
 {
     /**
      * Compare current and original attribute values.
+     * Returns true if values are equal and false otherwise.
      *
      * @param  mixed  $value
      * @param  mixed  $originalValue
-     * @return mixed
+     * @return bool
      */
     public function compare($value, $originalValue);
 }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1123,6 +1123,20 @@ trait HasAttributes
     }
 
     /**
+     * Determine if an attribute can be checked for being dirty using a custom class.
+     *
+     * @param  string  $key
+     * @return bool
+     *
+     * @throws \Illuminate\Database\Eloquent\InvalidCastException
+     */
+    protected function isClassComparable($key)
+    {
+        return $this->isClassCastable($key) &&
+            method_exists($this->parseCasterClass($this->getCasts()[$key]), 'compare');
+    }
+
+    /**
      * Resolve the custom caster class for a given key.
      *
      * @param  string  $key
@@ -1472,6 +1486,8 @@ trait HasAttributes
         } elseif ($this->hasCast($key, static::$primitiveCastTypes)) {
             return $this->castAttribute($key, $attribute) ===
                    $this->castAttribute($key, $original);
+        } elseif ($this->isClassComparable($key)) {
+            return $this->resolveCasterClass($key)->compare($attribute, $original);
         }
 
         return is_numeric($attribute) && is_numeric($original)

--- a/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
@@ -323,14 +323,6 @@ class UppercaseCaster implements CastsAttributes
     }
 }
 
-class UppercaseCasterComparable extends UppercaseCaster implements ComparesCastableAttributes
-{
-    public function compare($value, $originalValue)
-    {
-        return strtoupper($value) === strtoupper($originalValue);
-    }
-}
-
 class AddressCaster implements CastsAttributes
 {
     public function get($model, $key, $value, $attributes)


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR solves a problem described in #34724.

### Why

The problem is that we don't know how to compare custom casted attributes with their original values. Thus, when a custom casted attribute value is accessed or set, a caster is cached in `classCastCache` property, the result of its `set()` method is merged into `attributes` property. But the result of `set()` may differ from the attribute's original value even if the attribute hasn't been changed. Then if we call `getDirty()` on the model we get the wrong result.

The simplest example of such behaviour is decimal number formatting. Suppose we have a `amount` DB column created by the following migration statement:
```php
$table->decimal(32, 18);
```

Also, we have `DecimalCast` class:
```php
use Decimal\Decimal;

class DecimalCast implements CastsAttributes
{
    protected $precision;

    public function __construct($precision = 8)
    {
        $this->precision = $precision;
    }

    public function get($model, string $key, $value, array $attributes)
    {
        return new Decimal((string) $value, $this->precision);
    }

    public function set($model, string $key, $value, array $attributes)
    {
        if ($value instanceof Decimal) {
            return $value->toFixed($this->precision);
        }
        
        return (new Decimal((string) $value))->toFixed($this->precision);
    }
}
```

and a model:
```php
class Foo extends Model
{
    protected $casts = [
        'amount' => DecimalCast::class,
    ];
}
```

When the model is retrieved from DB, its `amount` attribute will have 18 decimal places. But the caster can format the attribute with other decimal places (maybe 18 places isn't necessary for every model). Then we can have a situation when the original value is `123.456000000000000000` and the value after calling caster `set` method is `123.45600000` (8 decimal places instead of 18). And when we call `getDirty()` on the model we get `['amount' => '123.45600000']` instead of empty array.

### Solution

The newly created `ComparesCastableAttributes` interface handles the comparison of current and original attribute values. `HasAttributes::originalIsEquivalent` checks if an attribute is class castable and the caster implements `ComparesCastableAttributes` interface. If so, it calls `compare` method passing current and original attribute's values.

Now we can improve our caster:
```php
class DecimalCast implements CastsAttributes, ComparesCastableAttributes
{
    protected $precision;

    public function __construct($precision = 8)
    {
        $this->precision = $precision;
    }

    public function get($model, string $key, $value, array $attributes)
    {
        return new Decimal((string) $value, $this->precision);
    }

    public function set($model, string $key, $value, array $attributes)
    {
        if ($value instanceof Decimal) {
            return $value->toFixed($this->precision);
        }

        return (new Decimal((string) $value))->toFixed($this->precision);
    }

    public function compare($value, $originalValue)
    {
        $value = new Decimal((string) $value);
        $originalValue = new Decimal((string) $originalValue);
        
        return $value->equals($originalValue);
    }
}
```

Now model `getDirty()` method returns empty array unless we **really** modify `amount` attribute.