### PR TITLE
[8.x] Cast collection to array in Arr::shuffle

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -589,6 +589,8 @@ class Arr
      */
     public static function shuffle($array, $seed = null)
     {
+        $array = $array instanceof Collection ? $array->all() : $array;
+
         if (is_null($seed)) {
             shuffle($array);
         } else {


### PR DESCRIPTION
This PR casts the first parameter of the `shuffle` method of the `Illuminate\Support\Arr.php` class to an array if you pass a collection instance to it.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->