### PR TITLE
[8.x] QueryBuilder add clone()

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3234,6 +3234,16 @@ class Builder
     }
 
     /**
+     * Clone the query.
+     *
+     * @return static
+     */
+    public function clone()
+    {
+        return clone $this;
+    }
+
+    /**
      * Clone the query without the given properties.
      *
      * @param  array  $properties
@@ -3241,7 +3251,7 @@ class Builder
      */
     public function cloneWithout(array $properties)
     {
-        return tap(clone $this, function ($clone) use ($properties) {
+        return tap($this->clone(), function ($clone) use ($properties) {
             foreach ($properties as $property) {
                 $clone->{$property} = null;
             }
@@ -3256,7 +3266,7 @@ class Builder
      */
     public function cloneWithoutBindings(array $except)
     {
-        return tap(clone $this, function ($clone) use ($except) {
+        return tap($this->clone(), function ($clone) use ($except) {
             foreach ($except as $type) {
                 $clone->bindings[$type] = [];
             }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -3749,6 +3749,29 @@ SQL;
         $this->assertSame('select * from "users" where "roles" ??& ?', $builder->toSql());
     }
 
+    public function testCloneWithout()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('email', 'foo')->orderBy('email');
+        $clone = $builder->cloneWithout(['orders']);
+
+        $this->assertSame('select * from "users" where "email" = ? order by "email" asc', $builder->toSql());
+        $this->assertSame('select * from "users" where "email" = ?', $clone->toSql());
+    }
+
+    public function testCloneWithoutBindings()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('email', 'foo')->orderBy('email');
+        $clone = $builder->cloneWithout(['wheres'])->cloneWithoutBindings(['where']);
+
+        $this->assertSame('select * from "users" where "email" = ? order by "email" asc', $builder->toSql());
+        $this->assertEquals([0 => 'foo'], $builder->getBindings());
+
+        $this->assertSame('select * from "users" order by "email" asc', $clone->toSql());
+        $this->assertEquals([], $clone->getBindings());
+    }
+
     protected function getConnection()
     {
         $connection = m::mock(ConnectionInterface::class);

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -3749,6 +3749,17 @@ SQL;
         $this->assertSame('select * from "users" where "roles" ??& ?', $builder->toSql());
     }
 
+    public function testClone()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users');
+        $clone = $builder->clone()->where('email', 'foo');
+
+        $this->assertNotSame($builder, $clone);
+        $this->assertSame('select * from "users"', $builder->toSql());
+        $this->assertSame('select * from "users" where "email" = ?', $clone->toSql());
+    }
+
     public function testCloneWithout()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
Hey Guys!

Sometimes you have to do multiple things with the same "base" query.
To avoid unwanted behavior we should `clone` the `QueryBuilder`.

We can already archive with `clone`.
```php
(clone $query)
```

With this PR we could just chain it.
```php
$query->clone()
```

In case you don't want this you can grab the first commit so `cloneWithout()` and `cloneWithoutBindings()` are covered with tests.

Cheers Adrian

---
Inspired by @calebporzio [livewire screencast](https://laravel-livewire.com/screencasts/s7-select-all)