### PR TITLE
[8.x] Added custom methods proxy support for jobs ::dispatch()

### DIFF
--- a/src/Illuminate/Foundation/Bus/PendingDispatch.php
+++ b/src/Illuminate/Foundation/Bus/PendingDispatch.php
@@ -126,11 +126,13 @@ class PendingDispatch
      *
      * @param  string  $method
      * @param  array  $parameters
-     * @return void
+     * @return $this
      */
     public function __call($method, $parameters)
     {
         $this->job->{$method}(...$parameters);
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Foundation/Bus/PendingDispatch.php
+++ b/src/Illuminate/Foundation/Bus/PendingDispatch.php
@@ -122,7 +122,7 @@ class PendingDispatch
     }
 
     /**
-     * Call methods within the job.
+     * Dynamically proxy methods to the underlying job.
      *
      * @param  string  $method
      * @param  array  $parameters

--- a/src/Illuminate/Foundation/Bus/PendingDispatch.php
+++ b/src/Illuminate/Foundation/Bus/PendingDispatch.php
@@ -122,6 +122,18 @@ class PendingDispatch
     }
 
     /**
+     * Call methods within the job.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return void
+     */
+    public function __call($method, $parameters)
+    {
+        $this->job->{$method}(...$parameters);
+    }
+
+    /**
      * Handle the object's destruction.
      *
      * @return void

--- a/tests/Integration/Queue/JobDispatchingTest.php
+++ b/tests/Integration/Queue/JobDispatchingTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Queue;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Orchestra\Testbench\TestCase;
+
+/**
+ * @group integration
+ */
+class JobDispatchingTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('app.debug', 'true');
+    }
+
+    protected function tearDown(): void
+    {
+        Job::$ran = false;
+    }
+
+    public function testJobCanUseCustomMethodsAfterDispatch()
+    {
+        Job::dispatch('test')->replaceValue('new-test');
+
+        $this->assertTrue(Job::$ran);
+        $this->assertEquals('new-test', Job::$value);
+    }
+}
+
+class Job implements ShouldQueue
+{
+    use Dispatchable, Queueable;
+
+    public static $ran = false;
+    public static $usedQueue = null;
+    public static $usedConnection = null;
+    public static $value = null;
+
+    public function __construct($value)
+    {
+        static::$value = $value;
+    }
+
+    public function handle()
+    {
+        static::$ran = true;
+    }
+
+    public function replaceValue($value)
+    {
+        static::$value = $value;
+    }
+}


### PR DESCRIPTION
This seems a bit too nested:

```php
dispatch(
    (new SomeJob('value1'))
        ->someMethod(1234)
        ->someOtherMethod('abc')
);
```

With the current changes, I find the `::dispatch()` method a bit more approachable:

```php
SomeJob::dispatch('value1')
    ->someMethod(1234)
    ->someOtherMethod('abc');
```

Both `someMethod` and `someOtherMethod` are custom methods within the job class.