### PR TITLE
[8.x] Fix router for array action within namespaced groups

### DIFF
--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -183,6 +183,10 @@ class RouteRegistrar
         if (is_array($action) &&
             is_callable($action) &&
             ! Arr::isAssoc($action)) {
+            // Start with a backslash, if it is not already starting with.
+            if (strncmp($action[0], '\\', 1)) {
+                $action[0] = '\\'.$action[0];
+            }
             $action = [
                 'uses' => $action[0].'@'.$action[1],
                 'controller' => $action[0].'@'.$action[1],

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -149,6 +149,25 @@ class RouteRegistrarTest extends TestCase
         $this->seeMiddleware('controller-middleware');
     }
 
+    public function testCanRegisterNamespacedGroupRouteWithControllerActionArray()
+    {
+        $this->router->group(['namespace' => 'WhatEver'], function () {
+            $this->router->middleware('controller-middleware')
+                ->get('users', [RouteRegistrarControllerStub::class, 'index']);
+        });
+
+        $this->seeResponse('controller', Request::create('users', 'GET'));
+        $this->seeMiddleware('controller-middleware');
+
+        $this->router->group(['namespace' => 'WhatEver'], function () {
+            $this->router->middleware('controller-middleware')
+                ->get('users', ['\\'.RouteRegistrarControllerStub::class, 'index']);
+        });
+
+        $this->seeResponse('controller', Request::create('users', 'GET'));
+        $this->seeMiddleware('controller-middleware');
+    }
+
     public function testCanRegisterRouteWithArrayAndControllerAction()
     {
         $this->router->middleware('controller-middleware')->put('users', [


### PR DESCRIPTION
While coding in a typical project I found that the router has an inconsistency:

This does not work in `web.php` since the root namespace of the group gets prepended to the imported controller.
```php

use App\Http\Controllers\TasksController;

Route::middleware(['auth'])->get('{task}/edit', [TasksController::class, 'edit']);
``` 

Error: **App\Http\Controllers\App\Http\Controllers\TasksController** does not exist.

But the original feature does not expect that: https://github.com/laravel/framework/pull/24385

===========

There are 2 solution:

1- if we add a backslash at the start of controller '\\'.TasksController:
```php
Route::middleware(['auth'])->get('{task}/edit', ['\\'.TasksController::class, 'edit']);
``` 

2-  we call the middleware method "After" controller
```php
Route::get('{task}/edit', [TasksController::class, 'edit'])->middleware(['auth']);
``` 

- I added a test to demonstrate the bug, without the change it does not pass.
- To be fully backward-compatible it only adds backslash if it is not already included.