### PR TITLE
[6.x] Add missing nullable type declaration for the model timestamp fields

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
@@ -110,7 +110,7 @@ trait HasTimestamps
     /**
      * Get the name of the "created at" column.
      *
-     * @return string
+     * @return string|null
      */
     public function getCreatedAtColumn()
     {
@@ -120,7 +120,7 @@ trait HasTimestamps
     /**
      * Get the name of the "updated at" column.
      *
-     * @return string
+     * @return string|null
      */
     public function getUpdatedAtColumn()
     {

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -144,14 +144,14 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     /**
      * The name of the "created at" column.
      *
-     * @var string
+     * @var string|null
      */
     const CREATED_AT = 'created_at';
 
     /**
      * The name of the "updated at" column.
      *
-     * @var string
+     * @var string|null
      */
     const UPDATED_AT = 'updated_at';
 


### PR DESCRIPTION
This PR replaces #34785 targeted to 8.x because @GrahamCampbell said to target this changes to 6.x

Eloquent Model constants `CREATED_AT` & `UPDATED_AT` are nullable. There are checks for null values, but `null` is not documented in PHPDoc.

```php
public function updateTimestamps()
{
    $time = $this->freshTimestamp();

    $updatedAtColumn = $this->getUpdatedAtColumn();

    if (! is_null($updatedAtColumn) && ! $this->isDirty($updatedAtColumn)) {
        $this->setUpdatedAt($time);
    }

    $createdAtColumn = $this->getCreatedAtColumn();

    if (! $this->exists && ! is_null($createdAtColumn) && ! $this->isDirty($createdAtColumn)) {
        $this->setCreatedAt($time);
    }
}
```