### PR TITLE
[8.x] Add 'multiple_of' validation rule

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1252,6 +1252,25 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate the value of an attribute is a multiple of a given value.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array  $parameters
+     * @return bool
+     */
+    public function validateMultipleOf($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(1, $parameters, 'multiple_of');
+
+        if (! $this->validateNumeric($attribute, $value) || ! $this->validateNumeric($attribute, $parameters[0])) {
+            return false;
+        }
+
+        return fmod($value, $parameters[0]) === 0.0;
+    }
+
+    /**
      * "Indicate" validation should pass if value is null.
      *
      * Always returns true, just lets us put "nullable" in rules.

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1847,6 +1847,82 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
+    /**
+     * @param mixed $input
+     * @param mixed $allowed
+     * @param bool $passes
+     *
+     * @dataProvider multipleOfDataProvider
+     */
+    public function testValidateMutlpleOf($input, $allowed, $passes)
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+
+        $v = new Validator($trans, ['foo' => $input], ['foo' => "multiple_of:{$allowed}"]);
+        $this->assertSame($passes, $v->passes());
+    }
+
+    public function multipleOfDataProvider()
+    {
+        return [
+            [0, 0, false], // zero (same)
+            [0, 10, true], // zero + integer
+            [10, 0, false],
+            [0, 10.1, true], // zero + float
+            [10.1, 0, false],
+            [0, -10, true], // zero + -integer
+            [-10, 0, false],
+            [0, -10.1, true], // zero + -float
+            [-10.1, 0, false],
+            [10, 10, true], // integer (same)
+            [10, 5, true], // integer + integer
+            [10, 4, false],
+            [20, 10, true],
+            [5, 10, false],
+            [10, -5, true], // integer + -integer
+            [10, -4, false],
+            [-20, 10, true],
+            [-5, 10, false],
+            [-10, -10, true], // -integer (same)
+            [-10, -5, true], // -integer + -integer
+            [-10, -4, false],
+            [-20, -10, true],
+            [-5, -10, false],
+            [10, 10.0, true], // integer + float (same)
+            [10, 5.0, true], // integer + float
+            [10, 4.0, false],
+            [20.0, 10, true],
+            [5.0, 10, false],
+            [10.0, -10.0, true], // integer + -float (same)
+            [10, -5.0, true], // integer + -float
+            [10, -4.0, false],
+            [-20.0, 10, true],
+            [-5.0, 10, false],
+            [10.0, -10.0, true], // -integer + float (same)
+            [-10, 5.0, true], // -integer + float
+            [-10, 4.0, false],
+            [20.0, -10, true],
+            [5.0, -10, false],
+            [10.5, 10.5, true], // float (same)
+            [10.5, 0.5, true], // float + float
+            [10.5, 0.3, false],
+            [31.5, 10.5, true],
+            [31.6, 10.5, false],
+            [10.5, -0.5, true], // float + -float
+            [10.5, -0.3, false],
+            [-31.5, 10.5, true],
+            [-31.6, 10.5, false],
+            [-10.5, -10.5, true], // -float (same)
+            [-10.5, -0.5, true], // -float + -float
+            [-10.5, -0.3, false],
+            [-31.5, -10.5, true],
+            [-31.6, -10.5, false],
+            ['foo', 1, false], // invalid values
+            [1, 'foo', false],
+            ['foo', 'foo', false],
+        ];
+    }
+
     public function testProperMessagesAreReturnedForSizes()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
This validation rule allows devs to validate that a given number is a "multiple of" another number. The naming for this rule comes from the [corresponding JSON schema validation rule](https://json-schema.org/understanding-json-schema/reference/numeric.html#multiples).

This validation rule can be useful if you use a number input with a `step` attribute.

Input...
```html
<input type="number" step="0.5" name="foo">
```

Validation...

```php
public function rules(): array
{
    return [
        'foo' => [
            'multiple_of:0.5',
        ]
    ];
}

```

Expected result
```
0 ✅
0.5 ✅
1 ✅
1.5 ✅
1.6 ❌
```

Would love you to just scan over the data provider and make sure it validates as you would expect.

If ya keen to merge this one I can PR the `laravel/laravel` repo with a translation, and  the `laravel/docs` repo with some documentation, unless someone jumps in to does it first (anyone reading thing, feel free 👍)