### PR TITLE
[8.x] Guard against invalid guard in make:policy

### DIFF
--- a/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\GeneratorCommand;
 use Illuminate\Support\Str;
+use LogicException;
 use Symfony\Component\Console\Input\InputOption;
 
 class PolicyMakeCommand extends GeneratorCommand
@@ -81,7 +82,7 @@ class PolicyMakeCommand extends GeneratorCommand
         $guardProvider = $config->get('auth.guards.'.$guard.'.provider');
 
         if (is_null($guardProvider)) {
-            throw new \LogicException('The provided guard `'.$guard.'` does not exist in auth.guards.');
+            throw new LogicException('The ['.$guard.'] guard is not defined in your "auth" configuration file.');
         }
 
         return $config->get(

--- a/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
@@ -78,8 +78,14 @@ class PolicyMakeCommand extends GeneratorCommand
 
         $guard = $this->option('guard') ?: $config->get('auth.defaults.guard');
 
+        $guardProvider = $config->get('auth.guards.'.$guard.'.provider');
+        
+        if (is_null($guardProvider)) {
+            throw new \LogicException('The provided guard `'.$guard.'` does not exist in auth.guards.');
+        }
+
         return $config->get(
-            'auth.providers.'.$config->get('auth.guards.'.$guard.'.provider').'.model'
+            'auth.providers.'.$guardProvider.'.model'
         );
     }
 

--- a/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
@@ -79,9 +79,7 @@ class PolicyMakeCommand extends GeneratorCommand
 
         $guard = $this->option('guard') ?: $config->get('auth.defaults.guard');
 
-        $guardProvider = $config->get('auth.guards.'.$guard.'.provider');
-
-        if (is_null($guardProvider)) {
+        if (is_null($guardProvider = $config->get('auth.guards.'.$guard.'.provider'))) {
             throw new LogicException('The ['.$guard.'] guard is not defined in your "auth" configuration file.');
         }
 

--- a/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
@@ -79,7 +79,7 @@ class PolicyMakeCommand extends GeneratorCommand
         $guard = $this->option('guard') ?: $config->get('auth.defaults.guard');
 
         $guardProvider = $config->get('auth.guards.'.$guard.'.provider');
-        
+
         if (is_null($guardProvider)) {
             throw new \LogicException('The provided guard `'.$guard.'` does not exist in auth.guards.');
         }


### PR DESCRIPTION
### Problem:
When using artisan to make a policy, and an invalid guard is provided to the command, as is the case in this example,
 `php artisan make:policy --model=Project --guard=foo ProjectPolicy` the generated code for the policy is invalid.

The `$dummyUser` used in the replaceModel method is set to null, which then fails to generate correctly.

Sample code generated with bad guard. 
```php
<?php

namespace App\Policies;

use App\Models\Project;
use App\Models\User;
use Illuminate\Auth\Access\HandlesAuthorization;

/**
 * Class ProjectPolicy
 * @package App\Policies
 */
class ProjectPolicy
{
    use HandlesAuthorization;

    /**
     * Determine whether the user can view any Projects.
     *
     * @param  User  $
     * @return mixed
     */
    public function viewAny(User $)
    {
        //
    }

    /**
     * Determine whether the user can view the Project.
     *
     * @param  User  $
     * @param  Project  $project
     * @return mixed
     */
    public function view(User $, Project $project)
    {
        //
    }

    /**
     * Determine whether the user can create Projects.
     *
     * @param  User  $
     * @return mixed
     */
    public function create(User $)
    {
        //
    }

    /**
     * Determine whether the user can update the Project.
     *
     * @param  User  $
     * @param  Project  $project
     * @return mixed
     */
    public function update(User $, Project $project)
    {
        //
    }

    /**
     * Determine whether the user can delete the Project.
     *
     * @param  User  $
     * @param  Project  $project
     * @return mixed
     */
    public function delete(User $, Project $project)
    {
        //
    }

    /**
     * Determine whether the user can restore the Project.
     *
     * @param  User  $
     * @param  Project  $project
     * @return mixed
     */
    public function restore(User $, Project $project)
    {
        //
    }

    /**
     * Determine whether the user can permanently delete the Project.
     *
     * @param  User  $
     * @param  Project  $project
     * @return mixed
     */
    public function forceDelete(User $, Project $project)
    {
        //
    }
}
```

### Solution:
The solution proposed here is to check for the existence of the guard, and throw an exception if it is null. 