### PR TITLE
[8.x] Fix router inconsistency for namespaced route groups

### DIFF
--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -183,6 +183,10 @@ class RouteRegistrar
         if (is_array($action) &&
             is_callable($action) &&
             ! Arr::isAssoc($action)) {
+            // Start with a backslash, if it is not already starting with.
+            if (strncmp($action[0], '\\', 1)) {
+                $action[0] = '\\'.$action[0];
+            }
             $action = [
                 'uses' => $action[0].'@'.$action[1],
                 'controller' => $action[0].'@'.$action[1],

--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -183,10 +183,10 @@ class RouteRegistrar
         if (is_array($action) &&
             is_callable($action) &&
             ! Arr::isAssoc($action)) {
-            // Start with a backslash, if it is not already starting with.
             if (strncmp($action[0], '\\', 1)) {
                 $action[0] = '\\'.$action[0];
             }
+
             $action = [
                 'uses' => $action[0].'@'.$action[1],
                 'controller' => $action[0].'@'.$action[1],

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -149,6 +149,25 @@ class RouteRegistrarTest extends TestCase
         $this->seeMiddleware('controller-middleware');
     }
 
+    public function testCanRegisterNamespacedGroupRouteWithControllerActionArray()
+    {
+        $this->router->group(['namespace' => 'WhatEver'], function () {
+            $this->router->middleware('controller-middleware')
+                ->get('users', [RouteRegistrarControllerStub::class, 'index']);
+        });
+
+        $this->seeResponse('controller', Request::create('users', 'GET'));
+        $this->seeMiddleware('controller-middleware');
+
+        $this->router->group(['namespace' => 'WhatEver'], function () {
+            $this->router->middleware('controller-middleware')
+                ->get('users', ['\\'.RouteRegistrarControllerStub::class, 'index']);
+        });
+
+        $this->seeResponse('controller', Request::create('users', 'GET'));
+        $this->seeMiddleware('controller-middleware');
+    }
+
     public function testCanRegisterRouteWithArrayAndControllerAction()
     {
         $this->router->middleware('controller-middleware')->put('users', [


### PR DESCRIPTION
Following my previous PR which was rejected https://github.com/laravel/framework/pull/34784, I wanted to shed more light on the situation.
From laravel 5.6 https://github.com/laravel/framework/pull/24385 til laravel 8.x we can define our routes like this:
```php
use use App\Http\Controllers\TasksController;

Route::group(['namespace' => 'Whatever'], function () {
    Route::get('{task}/edit', [TasksController::class, 'edit'])->middleware('auth');
});
```
and it works. The `'Whatever'` namespace does NOT get appended, since we have used the `array notation` to refer to the controller method.

**All and all, the order in which the `middleware(...`  and `get(...` methods are called in the chain, should have NO effect on their behavior or how they accept parameters.**  (according to the docs.)

But if we only reverse the order of `get` and `middleware` method calls in the example above suddenly the  `'Whatever'` namespace gets appended to the controller and stops working.
```php
use use App\Http\Controllers\TasksController;

Route::group(['namespace' => 'Whatever'], function () {
    Route::middleware('auth')->get('{task}/edit', [TasksController::class, 'edit']);
});
```
and that is definitely wrong.

