### PR TITLE
[8.x] Add job middleware to prevent overlapping jobs

### DIFF
--- a/src/Illuminate/Queue/Middleware/PreventOverlappingJobs.php
+++ b/src/Illuminate/Queue/Middleware/PreventOverlappingJobs.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Illuminate\Queue\Middleware;
+
+use Illuminate\Contracts\Cache\Repository as Cache;
+
+class PreventOverlappingJobs
+{
+    /**
+     * The key of the job.
+     *
+     * @var string
+     */
+    public $key;
+
+    /**
+     * The prefix of the lock key.
+     *
+     * @var string
+     */
+    public $prefix;
+
+    /**
+     * Create a new overlapping jobs middleware instance.
+     *
+     * @param  string  $key
+     * @param  int  $expiresAt
+     * @param  string  $prefix
+     *
+     * @return void
+     */
+    public function __construct($key = '', $prefix = 'overlap:')
+    {
+        $this->key = $key;
+        $this->prefix = $prefix;
+    }
+
+    /**
+     * Process the job.
+     *
+     * @param  mixed  $job
+     * @param  callable  $next
+     * @return mixed
+     */
+    public function handle($job, $next)
+    {
+        $lock = app(Cache::class)->lock($this->getLockKey($job));
+
+        if ($lock->get()) {
+            $next($job);
+
+            $lock->release();
+        }
+    }
+
+    /**
+     * Set the prefix of the lock key.
+     *
+     * @param  string  $prefix
+     * @return $this
+     */
+    public function withPrefix($prefix)
+    {
+        $this->prefix = $prefix;
+
+        return $this;
+    }
+
+    /**
+     * Get the lock key.
+     *
+     * @param  mixed  $job
+     * @return string
+     */
+    public function getLockKey($job)
+    {
+        return $this->prefix.get_class($job).':'.$this->key;
+    }
+}

--- a/src/Illuminate/Queue/Middleware/PreventOverlappingJobs.php
+++ b/src/Illuminate/Queue/Middleware/PreventOverlappingJobs.php
@@ -33,7 +33,6 @@ class PreventOverlappingJobs
      * @param  string  $key
      * @param  string  $prefix
      * @param  int  $expiresAt
-     * @param  string  $prefix
      *
      * @return void
      */

--- a/src/Illuminate/Queue/Middleware/PreventOverlappingJobs.php
+++ b/src/Illuminate/Queue/Middleware/PreventOverlappingJobs.php
@@ -25,21 +25,28 @@ class PreventOverlappingJobs
      *
      * @var string
      */
-    public $prefix;
+    public $prefix = 'overlap:';
+
+    /**
+     * The delay (in seconds) to release the job back to the queue.
+     *
+     * @var int|null
+     */
+    public $releaseAfter;
 
     /**
      * Create a new overlapping jobs middleware instance.
      *
      * @param  string  $key
-     * @param  string  $prefix
+     * @param  int|null  $releaseAfter
      * @param  int  $expiresAt
      *
      * @return void
      */
-    public function __construct($key = '', $prefix = 'overlap:', $expiresAt = 0)
+    public function __construct($key = '', $releaseAfter = 0, $expiresAt = 0)
     {
         $this->key = $key;
-        $this->prefix = $prefix;
+        $this->releaseAfter = $releaseAfter;
         $this->expiresAt = $expiresAt;
     }
 
@@ -60,7 +67,21 @@ class PreventOverlappingJobs
             } finally {
                 $lock->release();
             }
+        } elseif (!is_null($this->releaseAfter)) {
+            $job->release($this->releaseAfter);
         }
+    }
+
+    /**
+     * Do not release the job back to the queue.
+     *
+     * @return $this
+     */
+    public function dontRelease()
+    {
+        $this->releaseAfter = null;
+
+        return $this;
     }
 
     /**
@@ -72,6 +93,19 @@ class PreventOverlappingJobs
     public function expireAt($expiresAt)
     {
         $this->expiresAt = $expiresAt;
+
+        return $this;
+    }
+
+    /**
+     * Set the delay (in seconds) to release the job back to the queue.
+     *
+     * @param  int  $releaseAfter
+     * @return $this
+     */
+    public function releaseAfter($releaseAfter)
+    {
+        $this->releaseAfter = $releaseAfter;
 
         return $this;
     }

--- a/src/Illuminate/Queue/Middleware/PreventOverlappingJobs.php
+++ b/src/Illuminate/Queue/Middleware/PreventOverlappingJobs.php
@@ -47,9 +47,11 @@ class PreventOverlappingJobs
         $lock = app(Cache::class)->lock($this->getLockKey($job));
 
         if ($lock->get()) {
-            $next($job);
-
-            $lock->release();
+            try {
+                $next($job);
+            } finally {
+                $lock->release();
+            }
         }
     }
 

--- a/src/Illuminate/Queue/Middleware/PreventOverlappingJobs.php
+++ b/src/Illuminate/Queue/Middleware/PreventOverlappingJobs.php
@@ -67,7 +67,7 @@ class PreventOverlappingJobs
             } finally {
                 $lock->release();
             }
-        } elseif (!is_null($this->releaseAfter)) {
+        } elseif (! is_null($this->releaseAfter)) {
             $job->release($this->releaseAfter);
         }
     }

--- a/src/Illuminate/Queue/Middleware/PreventOverlappingJobs.php
+++ b/src/Illuminate/Queue/Middleware/PreventOverlappingJobs.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Queue\Middleware;
 
+use Illuminate\Container\Container;
 use Illuminate\Contracts\Cache\Repository as Cache;
 
 class PreventOverlappingJobs
@@ -59,7 +60,8 @@ class PreventOverlappingJobs
      */
     public function handle($job, $next)
     {
-        $lock = app(Cache::class)->lock($this->getLockKey($job), $this->expiresAt);
+        $lock = Container::getInstance()->make(Cache::class)
+            ->lock($this->getLockKey($job), $this->expiresAt);
 
         if ($lock->get()) {
             try {

--- a/tests/Integration/Queue/PreventOverlappingJobsTest.php
+++ b/tests/Integration/Queue/PreventOverlappingJobsTest.php
@@ -59,14 +59,16 @@ class PreventOverlappingJobsTest extends TestCase
 
         $this->expectException(\Exception::class);
 
-        $instance->call($job, [
-            'command' => serialize($command = new FailedOverlappingTestJob),
-        ]);
+        try {
+            $instance->call($job, [
+                'command' => serialize($command = new FailedOverlappingTestJob),
+            ]);
+        } finally {
+            $lockKey = (new PreventOverlappingJobs)->getLockKey($command);
 
-        $lockKey = (new PreventOverlappingJobs)->getLockKey($command);
-
-        $this->assertTrue(FailedOverlappingTestJob::$handled);
-        $this->assertTrue($this->app->get(Cache::class)->lock($lockKey, 10)->acquire());
+            $this->assertTrue(FailedOverlappingTestJob::$handled);
+            $this->assertTrue($this->app->get(Cache::class)->lock($lockKey, 10)->acquire());
+        }
     }
 
     public function testOverlappingJobsAreNotExecuted()

--- a/tests/Integration/Queue/PreventOverlappingJobsTest.php
+++ b/tests/Integration/Queue/PreventOverlappingJobsTest.php
@@ -43,7 +43,7 @@ class PreventOverlappingJobsTest extends TestCase
         $lockKey = (new PreventOverlappingJobs)->getLockKey($command);
 
         $this->assertTrue(OverlappingTestJob::$handled);
-        $this->assertNull($this->app->get(Cache::class)->get($lockKey));
+        $this->assertTrue($this->app->get(Cache::class)->lock($lockKey, 10)->acquire());
     }
 
     public function testOverlappingJobsAreNotExecuted()

--- a/tests/Integration/Queue/PreventOverlappingJobsTest.php
+++ b/tests/Integration/Queue/PreventOverlappingJobsTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Queue;
+
+use Illuminate\Bus\Dispatcher;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Cache\Repository as Cache;
+use Illuminate\Contracts\Queue\Job;
+use Illuminate\Queue\CallQueuedHandler;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\Middleware\PreventOverlappingJobs;
+use Mockery as m;
+use Orchestra\Testbench\TestCase;
+
+/**
+ * @group integration
+ */
+class PreventOverlappingJobsTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        m::close();
+    }
+
+    public function testNonOverlappingJobsAreExecuted()
+    {
+        OverlappingTestJob::$handled = false;
+        $instance = new CallQueuedHandler(new Dispatcher($this->app), $this->app);
+
+        $job = m::mock(Job::class);
+
+        $job->shouldReceive('hasFailed')->andReturn(false);
+        $job->shouldReceive('isReleased')->andReturn(false);
+        $job->shouldReceive('isDeletedOrReleased')->andReturn(false);
+        $job->shouldReceive('delete')->once();
+
+        $instance->call($job, [
+            'command' => serialize($command = new OverlappingTestJob),
+        ]);
+
+        $lockKey = (new PreventOverlappingJobs)->getLockKey($command);
+
+        $this->assertTrue(OverlappingTestJob::$handled);
+        $this->assertNull($this->app->get(Cache::class)->get($lockKey));
+    }
+
+    public function testOverlappingJobsAreNotExecuted()
+    {
+        OverlappingTestJob::$handled = false;
+        $instance = new CallQueuedHandler(new Dispatcher($this->app), $this->app);
+
+        $lockKey = (new PreventOverlappingJobs)->getLockKey($command = new OverlappingTestJob);
+        $this->app->get(Cache::class)->lock($lockKey, 10)->acquire();
+
+        $job = m::mock(Job::class);
+
+        $job->shouldReceive('hasFailed')->andReturn(false);
+        $job->shouldReceive('isReleased')->andReturn(false);
+        $job->shouldReceive('isDeletedOrReleased')->andReturn(false);
+        $job->shouldReceive('delete')->once();
+
+        $instance->call($job, [
+            'command' => serialize($command),
+        ]);
+
+        $this->assertFalse(OverlappingTestJob::$handled);
+    }
+}
+
+class OverlappingTestJob
+{
+    use InteractsWithQueue, Queueable;
+
+    public static $handled = false;
+
+    public function handle()
+    {
+        static::$handled = true;
+    }
+
+    public function middleware()
+    {
+        return [new PreventOverlappingJobs];
+    }
+}


### PR DESCRIPTION
Laravel ships many routing middleware classes out of the box, but there are no job middleware classes yet. I think it may be very useful if we also introduce job middleware out of the box for common use cases.

One common use case is to avoid overlapping jobs. An example use case could be to avoid processing a double refund on an order.

This PR introduces a `PreventOverlappingJobs` middleware that does just that (prevents overlapping jobs). For the refund processing job example above, we could use this middleware like so:

```php
public function middleware()
{
    return [
        new PreventOverlappingJobs($this->order->id)
    ];
}
```

If there is a need to avoid overlapping jobs globally (instead of say by order), we could use it as mentioned below. An example use case could be say updating the search index when a searchable model is updated.

```php
public function middleware()
{
    return [new PreventOverlappingJobs];
}
```