### PR TITLE
[8.x] Add missing force flag to queue:clear command

### DIFF
--- a/src/Illuminate/Queue/Console/ClearCommand.php
+++ b/src/Illuminate/Queue/Console/ClearCommand.php
@@ -6,6 +6,8 @@ use Illuminate\Console\Command;
 use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Contracts\Queue\ClearableQueue;
 use ReflectionClass;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
 
 class ClearCommand extends Command
 {
@@ -16,9 +18,7 @@ class ClearCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'queue:clear
-                            {connection? : The name of the queue connection to clear}
-                            {--queue= : The name of the queue to clear}';
+    protected $signature = 'queue:clear';
 
     /**
      * The console command description.
@@ -70,5 +70,31 @@ class ClearCommand extends Command
         return $this->option('queue') ?: $this->laravel['config']->get(
             "queue.connections.{$connection}.queue", 'default'
         );
+    }
+
+    /**
+     *  Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return [
+            ['connection', null, InputArgument::OPTIONAL, 'The name of the queue connection to clear'],
+        ];
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['queue', null, InputOption::VALUE_OPTIONAL, 'The name of the queue to clear'],
+
+            ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production'],
+        ];
     }
 }


### PR DESCRIPTION
Hi 👋 ,

I was recently deploying an application to production, where Laravel forge will run the `php artisan queue:clear` command. However, I was not able to call the command without confirming the confirmation.

If you run this command manually it will ask for confirmation when running this command on production.
```
$ php artisan queue:clear
**************************************
*     Application In Production!     *
**************************************

 Do you really wish to run this command? (yes/no) [no]:
 > 
```
There is a trait included that makes this possible called `ConfirmableTrait`. This makes it possible to make sure the user confirms the command before it's executed. You can work around `confirmToProceed` method by providing the `--force` option flag. However, the `queue:clear` command doesn't have a `--force` option at this point. 

This PR adds the missing `--force` option. I was also so free to update the command to be in line with the other clear commands.