### PR TITLE
validateBoolean() accepts 'true' and 'false' as strings

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -331,7 +331,7 @@ trait ValidatesAttributes
      */
     public function validateBoolean($attribute, $value)
     {
-        $acceptable = [true, false, 0, 1, '0', '1'];
+        $acceptable = [true, false, 'true', 'false', 0, 1, '0', '1'];
 
         return in_array($value, $acceptable, true);
     }


### PR DESCRIPTION
Some JS libs send boolean values as is (ex: `validated=true`) which then weren't validated by `validateBoolean()`