### PR TITLE
[8.x] Change return type hint for UploadedFile::get() to 'false|string'

### DIFF
--- a/src/Illuminate/Http/UploadedFile.php
+++ b/src/Illuminate/Http/UploadedFile.php
@@ -91,7 +91,7 @@ class UploadedFile extends SymfonyUploadedFile
     /**
      * Get the contents of the uploaded file.
      *
-     * @return bool|string
+     * @return false|string
      *
      * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
      */


### PR DESCRIPTION
As `file_get_contents` returns `false|string` so should `UploadedFile::get`.
This makes makes the check for readable content easier as one only needs to check that the return variable is `!== false`.

Otherwise it would be neccessary to assert that the return variable is `!== true` as well.
