### PR TITLE
[8.x] Set intended URL before email verification

### DIFF
--- a/src/Illuminate/Auth/Middleware/EnsureEmailIsVerified.php
+++ b/src/Illuminate/Auth/Middleware/EnsureEmailIsVerified.php
@@ -23,7 +23,7 @@ class EnsureEmailIsVerified
             ! $request->user()->hasVerifiedEmail())) {
             return $request->expectsJson()
                     ? abort(403, 'Your email address is not verified.')
-                    : Redirect::route($redirectToRoute ?: 'verification.notice');
+                    : Redirect::guest(route($redirectToRoute ?: 'verification.notice'));
         }
 
         return $next($request);


### PR DESCRIPTION
This brings the same behavior to the `verified` middleware as the `auth` and `password.confirm` middleware. When a user is trying to access a protected route before they have verified their email, they are redirected to the `verification.notice` route. Then, when they click the email verification link, they are redirected to the home page, instead of the protected page they intended to access.

Example with `laravel/fortify`:
1. User goes to `/user/profile`.
2. If they haven't verified their email, they are redirected to `/email/verify`.
3. User checks their email, and click on `/email/verify/{id}/{hash}`.
4. After the verification,  they are redirected to `/home` or the home page set in `config/fortify.php`.

The same also applies to `laravel/ui`.

With this PR, the intended URL will be `/user/profile`, so with some modifications on the Fortify (I'll submit a PR), we can redirect users to the intended page instead.

P.S.: Can I submit PR to `laravel/ui` as well?