### PR TITLE
[8.x] Add missing force flag to queue:clear command

### DIFF
--- a/src/Illuminate/Queue/Console/ClearCommand.php
+++ b/src/Illuminate/Queue/Console/ClearCommand.php
@@ -6,6 +6,8 @@ use Illuminate\Console\Command;
 use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Contracts\Queue\ClearableQueue;
 use ReflectionClass;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
 
 class ClearCommand extends Command
 {
@@ -16,9 +18,7 @@ class ClearCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'queue:clear
-                            {connection? : The name of the queue connection to clear}
-                            {--queue= : The name of the queue to clear}';
+    protected $name = 'queue:clear';
 
     /**
      * The console command description.
@@ -70,5 +70,31 @@ class ClearCommand extends Command
         return $this->option('queue') ?: $this->laravel['config']->get(
             "queue.connections.{$connection}.queue", 'default'
         );
+    }
+
+    /**
+     *  Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return [
+            ['connection', InputArgument::OPTIONAL, 'The name of the queue connection to clear'],
+        ];
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['queue', null, InputOption::VALUE_OPTIONAL, 'The name of the queue to clear'],
+
+            ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production'],
+        ];
     }
 }


### PR DESCRIPTION
Hi 👋 ,

**Note:** This is the same [PR](https://github.com/laravel/framework/pull/34795) as before, but this time the command actually shows up when running `php artisan queue:clear --help`

I was recently deploying an application to production, where Laravel forge will run the `php artisan queue:clear` command. However, I was not able to call the command without confirming the confirmation. This PR adds the missing --force option. I was also so free to update the command to be in line with the other clear commands.

You can test it by running `php artisan queue:clear --env=production --force` and it should run without confirmation.