### PR TITLE
[8.x] Fix StatefulGuard phpdoc return type

### DIFF
--- a/src/Illuminate/Contracts/Auth/StatefulGuard.php
+++ b/src/Illuminate/Contracts/Auth/StatefulGuard.php
@@ -35,7 +35,7 @@ interface StatefulGuard extends Guard
      *
      * @param  mixed  $id
      * @param  bool  $remember
-     * @return \Illuminate\Contracts\Auth\Authenticatable
+     * @return \Illuminate\Contracts\Auth\Authenticatable|null
      */
     public function loginUsingId($id, $remember = false);
 

--- a/src/Illuminate/Contracts/Auth/StatefulGuard.php
+++ b/src/Illuminate/Contracts/Auth/StatefulGuard.php
@@ -35,7 +35,7 @@ interface StatefulGuard extends Guard
      *
      * @param  mixed  $id
      * @param  bool  $remember
-     * @return \Illuminate\Contracts\Auth\Authenticatable|null
+     * @return \Illuminate\Contracts\Auth\Authenticatable|bool
      */
     public function loginUsingId($id, $remember = false);
 


### PR DESCRIPTION
Hey!

I was working on an implementation of the StatefulGuard contract when I stumbled upon the loginUsingId method. Its @return annotation does not specify what should be done when no matching user can be found.

So I went and looked at how it's implemented in Laravel's source. [https://github.com/laravel/framework/blob/86d08e4b743a37269790482a516936e63f4e881b/tests/Auth/AuthGuardTest.php#L441](https://github.com/laravel/framework/blob/86d08e4b743a37269790482a516936e63f4e881b/tests/Auth/AuthGuardTest.php#L441)

It appears that it is expected that this method returns false when no matching user is found. Which seems logic as all of the other methods in this contract return false in equivalent situations.

So here's a fix :)

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
