### PR TITLE
[6.x] Query with where after union has false ordering

### DIFF
--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -936,8 +936,8 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('users');
         $builder->union($this->getBuilder()->select('*')->from('dogs'));
         $builder->where('name', 'test');
-        $this->assertSame('(select * from "users") union (select * from "dogs") where "name" = ?', $builder->toSql());
-        $this->assertEquals([0 => 1], $builder->getBindings());
+        $this->assertSame('(select * from "users" where "name" = ?) union (select * from "dogs" where "name" = ?)', $builder->toSql());
+        $this->assertEquals([0 => 2], $builder->getBindings());
     }
 
     public function testMySqlUnionOrderBys()

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -930,6 +930,16 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 
+    public function testUnionWithWhere()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users');
+        $builder->union($this->getBuilder()->select('*')->from('dogs'));
+        $builder->where('name', 'test');
+        $this->assertSame('(select * from "users") union (select * from "dogs") where "name" = ?', $builder->toSql());
+        $this->assertEquals([0 => 1], $builder->getBindings());
+    }
+
     public function testMySqlUnionOrderBys()
     {
         $builder = $this->getMySqlBuilder();


### PR DESCRIPTION
This PR implements a test that highlights an issue that was reported on StackOverflow [4 years ago](https://stackoverflow.com/q/37408758/1796523). If a query is built with a union and subsequent where, the where clause is applied only to the original query (without union) and not to the whole query (with union). Is this considered a bug?

Test output:
```diff
1) Illuminate\Tests\Database\DatabaseQueryBuilderTest::testUnionWithWhere
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'(select * from "users" where "name" = ?) union (select * from "dogs" where "name" = ?)'
+'(select * from "users" where "name" = ?) union (select * from "dogs")'
```