### PR TITLE
[8.x] Add when() and unless() methods to MailMessage

### DIFF
--- a/src/Illuminate/Notifications/Messages/MailMessage.php
+++ b/src/Illuminate/Notifications/Messages/MailMessage.php
@@ -332,4 +332,42 @@ class MailMessage extends SimpleMessage implements Renderable
 
         return $this;
     }
+
+    /**
+     * Apply the callback's message changes if the given "value" is true.
+     *
+     * @param  mixed  $value
+     * @param  callable  $callback
+     * @param  callable|null  $default
+     * @return mixed|$this
+     */
+    public function when($value, $callback, $default = null)
+    {
+        if ($value) {
+            return $callback($this, $value) ?: $this;
+        } elseif ($default) {
+            return $default($this, $value) ?: $this;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Apply the callback's message changes if the given "value" is false.
+     *
+     * @param  mixed  $value
+     * @param  callable  $callback
+     * @param  callable|null  $default
+     * @return mixed|$this
+     */
+    public function unless($value, $callback, $default = null)
+    {
+        if (! $value) {
+            return $callback($this, $value) ?: $this;
+        } elseif ($default) {
+            return $default($this, $value) ?: $this;
+        }
+
+        return $this;
+    }
 }


### PR DESCRIPTION
This PR adds `when()` and `unless()` methods to the `MailMessage` class. The implementation is identical to the `Illuminate\Database\Concerns\BuildsQueries::when()` and `Illuminate\Database\Concerns\BuildsQueries::unless()` equivalents.

An example use case:
```php
public function toMail(User $user)
{
    return (new MailMessage)
        ->when(
            $this->offer->acceptation_comment,
            function(MailMessage $message, $comment) {
                $message->line('Your offer has been rejected with a comment:')
                        ->line($comment);
            },
            function(MailMessage $message) {
                $message->line('Your offer has been rejected.');
            }
        );
}
```

During implementation I noticed I could just copy the methods from `BuildsQueries` trait without any changes, similar with the tests. I think this may be a good time to refactor these methods out of the `BuildsQueries` trait to something more generic and utilize them in other places without code duplication. I cannot think of any good place for them, though. What do you think? 

Removing them from `BuildsQueries` and putting them somewhere else could however break backwards compatibility if someone uses this trait directly but that would need further testing to confirm.
