### PR TITLE
[8.x] Add `canAny` to user model

### DIFF
--- a/src/Illuminate/Foundation/Auth/Access/Authorizable.php
+++ b/src/Illuminate/Foundation/Auth/Access/Authorizable.php
@@ -19,6 +19,18 @@ trait Authorizable
     }
 
     /**
+     * Determine if the entity has any of the given abilities.
+     *
+     * @param  iterable|string  $abilities
+     * @param  array|mixed  $arguments
+     * @return bool
+     */
+    public function canany($abilities, $arguments = [])
+    {
+        return app(Gate::class)->forUser($this)->any($abilities, $arguments);
+    }
+
+    /**
      * Determine if the entity does not have the given abilities.
      *
      * @param  iterable|string  $abilities

--- a/src/Illuminate/Foundation/Auth/Access/Authorizable.php
+++ b/src/Illuminate/Foundation/Auth/Access/Authorizable.php
@@ -25,7 +25,7 @@ trait Authorizable
      * @param  array|mixed  $arguments
      * @return bool
      */
-    public function canany($abilities, $arguments = [])
+    public function canAny($abilities, $arguments = [])
     {
         return app(Gate::class)->forUser($this)->any($abilities, $arguments);
     }


### PR DESCRIPTION
Same as the blade [directive](https://github.com/laravel/framework/pull/24137), this will allow to use `$user->canAny(['permission-one', 'permission-two'])`