### PR TITLE
[8.x] Implement supportsTags() on the Cache Repository

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -477,7 +477,7 @@ class Repository implements ArrayAccess, CacheContract
      */
     public function tags($names)
     {
-        if (! method_exists($this->store, 'tags')) {
+        if (! $this->supportsTags()) {
             throw new BadMethodCallException('This cache store does not support tagging.');
         }
 
@@ -628,6 +628,16 @@ class Repository implements ArrayAccess, CacheContract
         }
 
         return (int) $duration > 0 ? $duration : 0;
+    }
+
+    /**
+     * Check if the current storage supports tags.
+     *
+     * @return bool
+     */
+    public function supportsTags()
+    {
+        return method_exists($this->store, 'tags');
     }
 
     /**

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -502,6 +502,33 @@ class Repository implements ArrayAccess, CacheContract
     }
 
     /**
+     * Calculate the number of seconds for the given TTL.
+     *
+     * @param  \DateTimeInterface|\DateInterval|int  $ttl
+     * @return int
+     */
+    protected function getSeconds($ttl)
+    {
+        $duration = $this->parseDateInterval($ttl);
+
+        if ($duration instanceof DateTimeInterface) {
+            $duration = Carbon::now()->diffInRealSeconds($duration, false);
+        }
+
+        return (int) $duration > 0 ? $duration : 0;
+    }
+
+    /**
+     * Determine if the current store supports tags.
+     *
+     * @return bool
+     */
+    public function supportsTags()
+    {
+        return method_exists($this->store, 'tags');
+    }
+
+    /**
      * Get the default cache time.
      *
      * @return int|null
@@ -611,33 +638,6 @@ class Repository implements ArrayAccess, CacheContract
     public function offsetUnset($key)
     {
         $this->forget($key);
-    }
-
-    /**
-     * Calculate the number of seconds for the given TTL.
-     *
-     * @param  \DateTimeInterface|\DateInterval|int  $ttl
-     * @return int
-     */
-    protected function getSeconds($ttl)
-    {
-        $duration = $this->parseDateInterval($ttl);
-
-        if ($duration instanceof DateTimeInterface) {
-            $duration = Carbon::now()->diffInRealSeconds($duration, false);
-        }
-
-        return (int) $duration > 0 ? $duration : 0;
-    }
-
-    /**
-     * Check if the current storage supports tags.
-     *
-     * @return bool
-     */
-    public function supportsTags()
-    {
-        return method_exists($this->store, 'tags');
     }
 
     /**

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -7,8 +7,10 @@ use DateInterval;
 use DateTime;
 use DateTimeImmutable;
 use Illuminate\Cache\ArrayStore;
+use Illuminate\Cache\FileStore;
 use Illuminate\Cache\RedisStore;
 use Illuminate\Cache\Repository;
+use Illuminate\Cache\TaggableStore;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Cache\Store;
 use Illuminate\Events\Dispatcher;
@@ -310,6 +312,22 @@ class CacheRepositoryTest extends TestCase
         $taggedCache->shouldReceive('setDefaultCacheTime');
         $store->shouldReceive('tags')->once()->with(['foo', 'bar', 'baz'])->andReturn($taggedCache);
         $repo->tags('foo', 'bar', 'baz');
+    }
+
+    public function testTaggableRepositoriesSupportTags()
+    {
+        $taggable = m::mock(TaggableStore::class);
+        $taggableRepo = new Repository($taggable);
+
+        $this->assertTrue($taggableRepo->supportsTags());
+    }
+
+    public function testNonTaggableRepositoryDoesNotSupportTags()
+    {
+        $taggable = m::mock(FileStore::class);
+        $taggableRepo = new Repository($taggable);
+
+        $this->assertFalse($taggableRepo->supportsTags());
     }
 
     protected function getRepository()

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -324,10 +324,10 @@ class CacheRepositoryTest extends TestCase
 
     public function testNonTaggableRepositoryDoesNotSupportTags()
     {
-        $taggable = m::mock(FileStore::class);
-        $taggableRepo = new Repository($taggable);
+        $nonTaggable = m::mock(FileStore::class);
+        $nonTaggableRepo = new Repository($nonTaggable);
 
-        $this->assertFalse($taggableRepo->supportsTags());
+        $this->assertFalse($nonTaggableRepo->supportsTags());
     }
 
     protected function getRepository()


### PR DESCRIPTION
This small enhancement would be a benefit to all those users using something like Redis in their production environment, but can't setup locally any redis or other taggable Cache Store. Currently, if your cache driver does not support tags (e.g. locally, you would have to wrap the `tags()` call in a try catch block. In my opinion that is quite verbose.

In order to find out more elegantly if the currently chosen cache store supports tags, a new method `supportsTags()` is proposed on the Cache Repository. With this method, they can execute the "tagging" part of the cache logic only if their chosen cache store supports that feature.

It does not affect any other caching behaviour, neither does it touch any other aspect of the framework itself, so this should be a safe one. 