### PR TITLE
[8.x] Updated fillables to allow wildcard fillables

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
@@ -249,7 +249,7 @@ trait GuardsAttributes
 
             foreach ($attributes as $key => $value) {
                 $allFillableKeys = $this->getAllFillableKeys($key);
-                if(array_intersect($allFillableKeys, $this->getFillable())) {
+                if (array_intersect($allFillableKeys, $this->getFillable())) {
                     $fillables[$key] = $value;
                 }
             }
@@ -262,7 +262,7 @@ trait GuardsAttributes
 
     /**
      * Get the all fillable keys with JSON
-     * E.g. 'foo->bar->baz' will return ['foo->*', 'foo->bar->*']
+     * E.g. 'foo->bar->baz' will return ['foo->*', 'foo->bar->*'].
      * @param       $key
      */
     private function getAllFillableKeys($key)
@@ -273,10 +273,11 @@ trait GuardsAttributes
 
             do {
                 $attr = Str::beforeLast($tempKey, '->');
-                $jsonKeys[] = $attr . '->*';
+                $jsonKeys[] = $attr.'->*';
                 $tempKey = $attr;
             } while (strpos($tempKey, '->') != false);
         }
+
         return $jsonKeys;
     }
 }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1072,7 +1072,6 @@ class DatabaseEloquentModelTest extends TestCase
         );
     }
 
-
     public function testFillingJSONAttributesAllowWildcard()
     {
         // test nested JSON cannot be filled when fillable is not empty

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1072,6 +1072,55 @@ class DatabaseEloquentModelTest extends TestCase
         );
     }
 
+
+    public function testFillingJSONAttributesAllowWildcard()
+    {
+        // test nested JSON cannot be filled when fillable is not empty
+        $model = new EloquentModelStub;
+        $model->fillable(['baz']);
+        $model->fill(['meta->name' => 'foo']);
+        $this->assertEquals(
+            [],
+            $model->toArray()
+        );
+
+        // test wildcard fillsables can be used for single level
+        $model = new EloquentModelStub;
+        $model->fillable(['meta->*']);
+        $model->fill(['meta->name' => 'foo']);
+        $this->assertEquals(
+            ['meta' => json_encode(['name' => 'foo'])],
+            $model->toArray()
+        );
+
+        // test wildcard fillables can be used for multilevel
+        $model = new EloquentModelStub;
+        $model->fillable(['meta->*']);
+        $model->fill(['meta->name->foo' => 'bar']);
+        $this->assertEquals(
+            ['meta' => json_encode(['name' => ['foo' => 'bar']])],
+            $model->toArray()
+        );
+
+        // test attribute will not be filled if the key is not correct
+        $model = new EloquentModelStub;
+        $model->fillable(['meta->age']);
+        $model->fill(['meta->name->foo' => 'bar']);
+        $this->assertEquals(
+            [],
+            $model->toArray()
+        );
+
+        // test multilevel wildcard fillables can be used for multilevel
+        $model = new EloquentModelStub;
+        $model->fillable(['meta->age->*']);
+        $model->fill(['meta->age->foo->bar' => 'baz']);
+        $this->assertEquals(
+            ['meta' => json_encode(['age' => ['foo' => ['bar' => 'baz']]])],
+            $model->toArray()
+        );
+    }
+
     public function testUnguardAllowsAnythingToBeSet()
     {
         $model = new EloquentModelStub;


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

## Issue

In the recent update: https://blog.laravel.com/security-release-laravel-61835-7240 the ability to update JSON columns using arrow sign (`->`) without explicitly include the attribute name (e.g. set `$fillables = ['meta->foo']` in order to update `$object->update(['meta->foo' => 'bar'])`) has been removed for security reason.

This has caused issues for the developers that have been developing their applications using the existing approach as specified in the documentations: https://laravel.com/docs/8.x/queries#updating-json-columns . It was well understood that the changes were made due to security reasons however including every single column inside the `$fillables` attribute is not feasible as the applications may require dynamic fields. Refer to discussions in: https://github.com/laravel/framework/issues/33975 and https://github.com/laravel/framework/issues/34630 . A several PR has also been sent such as: https://github.com/laravel/framework/pull/34299 and https://github.com/laravel/framework/pull/34631 but were rejected.

Some of the solutions that has been implemented by other include bypassing the `isGuardableColumn` as the following:

```
    protected function isGuardableColumn($key)
    {
        return true;
    }
```


## Proposed solution

Instead requiring users to submit all the nested attributes (such as `$fillables = ['foo->bar']`), this PR allowed the user to specify the fillable columns using asterisk as while card. For example, if a user wanted to update using `$object->update(['foo->bar' => 'baz'])`, he / she only need to specify `$fillables = ['foo->*'];` in order to allow it. The `$fillables` also allow nested wildcard assignment, e.g. `$fillables = ['meta->age->*']` will allow the update using `$object->update(['meta->age->foo->bar' => 'baz'])` but not `$object->update(['meta->phone'])`


