### PR TITLE
[8.x] Adding pushOrCreate to class Model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -672,21 +672,21 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
 
         return true;
     }
-    
+
     /**
      * Save the model and all of its relationships without throwing an Exception when parent isn't instanciated (unknown foreign key id).
      *
+     * @param string $fk_child_name	The laravel compliant foreign key name
      * @param mixed $fk_id			The id of the parent
-     * @param mixed $fk_name_child	The laravel compliant foreign key name
      * @return bool
      */
-   public function pushOrCreate(?mixed $fk_id = null, ?string $fk_name_child = null)
+   public function pushOrCreate(?string $fk_child_name = null, $fk_id = null)
    {
        // Sets the parent id to the child foreign key
        // The first call to pushOrCreate() will not specify the child name
        // Only set the foreign key id if the child doesn't exists already
-       if ($fk_name_child !== null && $this->{$fk_name_child} === null) {
-           $this->{$fk_name_child} = $fk_id;
+       if ($fk_child_name !== null && $this->{$fk_child_name} === null) {
+           $this->{$fk_child_name} = $fk_id;
        }
 
        // Save() gives us access to the record id
@@ -703,8 +703,9 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
 
            foreach (array_filter($models) as $model) {
                // Pass the parent id and the laravel compliant foreign key name to the child
-               $fk_name_parent = explode('\\', get_class($this));
-               if (!$model->pushOrCreate($this->id, "{Str::snake(end($fk_name_parent))}_id")) {
+               $fk_parent_class = explode('\\', get_class($this));
+               $fk_parent_name = Str::snake(end($fk_parent_class));
+               if (!$model->pushOrCreate("{$fk_parent_name}_id", $this->id)) {
                    return false;
                }
            }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -674,19 +674,19 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     }
 
     /**
-     * Save the model and all of its relationships without throwing an Exception when parent isn't instanciated (unknown foreign key id).
+     * Save the model and all of its relationships without throwing an Exception when parent isn't instanciated (undefined parent primary key).
      *
-     * @param string $fk_child_name	The laravel compliant foreign key name
-     * @param mixed $fk_id			The id of the parent
+     * @param string $fkChildName	The laravel compliant foreign key name
+     * @param mixed $fkId			The id of the parent
      * @return bool
      */
-   public function pushOrCreate(?string $fk_child_name = null, $fk_id = null)
+   public function pushOrCreate(?string $fkChildName = null, $fkId = null)
    {
        // Sets the parent id to the child foreign key
        // The first call to pushOrCreate() will not specify the child name
        // Only set the foreign key id if the child doesn't exists already
-       if ($fk_child_name !== null && $this->{$fk_child_name} === null) {
-           $this->{$fk_child_name} = $fk_id;
+       if ($fkChildName !== null && $this->{$fkChildName} === null) {
+           $this->{$fkChildName} = $fkId;
        }
 
        // Save() gives us access to the record id
@@ -703,9 +703,9 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
 
            foreach (array_filter($models) as $model) {
                // Pass the parent id and the laravel compliant foreign key name to the child
-               $fk_parent_class = explode('\\', get_class($this));
-               $fk_parent_name = Str::snake(end($fk_parent_class));
-               if (!$model->pushOrCreate("{$fk_parent_name}_id", $this->id)) {
+               $fkParentClass = explode('\\', get_class($this));
+               $fkParentName = Str::snake(end($fkParentClass));
+               if (!$model->pushOrCreate("{$fkParentName}_id", $this->id)) {
                    return false;
                }
            }


### PR DESCRIPTION
Hi,
It's my first time doing a pull request so please don't be too hard on me ^^'
I already made the mistake to make this pull request on Illuminate/Database so i really hope i am doing it right this time.

We have add some hard times at my workplace inserting nested objects in the database so i wanted to introduce the idea of a method the could create recursivly the records when they do not yet exists.
It is based on the laravel synthaxe to set the foreign key value of the child to the value of the Id of the parent.

I haven't found any discussion about it anywhere except for a few old post but that didn't quite matched my issue.

As an exemple i found myself with the need of instanciating weird XML files that i would have wanted to insert in my database.
The problem being that XML parsers dive into the elements, create children then parents.
With the database you want to insert parents before children to get the parent Id.
So i parse the XML tree and neste children in parents and then i want to save them.
Push method would have been the perfect match only if it didn't throw an error when it fails to create the child because the parent doesn't have an Id and i really don't want to allow null on my foreign key.

I am ready to take any idea you could throw at me that could solve my issue but i wanted to at least offer a solution.