### PR TITLE
[8.x] Bring Rate Limiters to Jobs

### DIFF
--- a/src/Illuminate/Queue/Middleware/RateLimitsJobs.php
+++ b/src/Illuminate/Queue/Middleware/RateLimitsJobs.php
@@ -4,6 +4,7 @@ namespace Illuminate\Queue\Middleware;
 
 use Illuminate\Cache\RateLimiter;
 use Illuminate\Cache\RateLimiting\Unlimited;
+use Illuminate\Container\Container;
 use Illuminate\Support\Arr;
 
 class RateLimitsJobs
@@ -31,7 +32,7 @@ class RateLimitsJobs
      */
     public function __construct($limiterName)
     {
-        $this->limiter = app(RateLimiter::class);
+        $this->limiter = Container::getInstance()->make(RateLimiter::class);
         $this->limiterName = $limiterName;
     }
 

--- a/src/Illuminate/Queue/Middleware/RateLimitsJobs.php
+++ b/src/Illuminate/Queue/Middleware/RateLimitsJobs.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Illuminate\Queue\Middleware;
+
+use Illuminate\Cache\RateLimiter;
+use Illuminate\Cache\RateLimiting\Unlimited;
+use Illuminate\Support\Arr;
+
+class RateLimitsJobs
+{
+    /**
+     * The rate limiter instance.
+     *
+     * @var \Illuminate\Cache\RateLimiter
+     */
+    protected $limiter;
+
+    /**
+     * The name of the rate limiter.
+     *
+     * @var string
+     */
+    protected $limiterName;
+
+    /**
+     * Create a new rate limiter middleware instance.
+     *
+     * @param  string  $limiterName
+     *
+     * @return void
+     */
+    public function __construct($limiterName)
+    {
+        $this->limiter = app(RateLimiter::class);
+        $this->limiterName = $limiterName;
+    }
+
+    /**
+     * Process the job.
+     *
+     * @param  mixed  $job
+     * @param  callable  $next
+     * @return mixed
+     */
+    public function handle($job, $next)
+    {
+        if (! is_null($limiter = $this->limiter->limiter($this->limiterName))) {
+            $limiterResponse = call_user_func($limiter, $job);
+
+            if ($limiterResponse instanceof Unlimited) {
+                return $next($job);
+            }
+
+            return $this->handleJob(
+                $job,
+                $next,
+                collect(Arr::wrap($limiterResponse))->map(function ($limit) {
+                    return (object) [
+                        'key' => md5($this->limiterName.$limit->key),
+                        'maxAttempts' => $limit->maxAttempts,
+                        'decayMinutes' => $limit->decayMinutes,
+                    ];
+                })->all()
+            );
+        } else {
+            return $next($job);
+        }
+    }
+
+    /**
+     * Handle a rate limited job.
+     *
+     * @param  mixed  $job
+     * @param  callable  $next
+     * @param  array  $limits
+     * @return mixed
+     */
+    protected function handleJob($job, $next, array $limits)
+    {
+        foreach ($limits as $limit) {
+            if ($this->limiter->tooManyAttempts($limit->key, $limit->maxAttempts)) {
+                return $job->release($this->getTimeUntilNextRetry($limit->key));
+            }
+
+            $this->limiter->hit($limit->key, $limit->decayMinutes * 60);
+        }
+
+        return $next($job);
+    }
+
+    /**
+     * Get the number of seconds until the next retry.
+     *
+     * @param  string  $key
+     * @return int
+     */
+    protected function getTimeUntilNextRetry($key)
+    {
+        return $this->limiter->availableIn($key);
+    }
+}

--- a/src/Illuminate/Queue/Middleware/RateLimitsJobsWithRedis.php
+++ b/src/Illuminate/Queue/Middleware/RateLimitsJobsWithRedis.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Illuminate\Queue\Middleware;
+
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Redis\Factory as Redis;
+use Illuminate\Redis\Limiters\DurationLimiter;
+use Illuminate\Support\InteractsWithTime;
+
+class RateLimitsJobsWithRedis extends RateLimitsJobs
+{
+    use InteractsWithTime;
+
+    /**
+     * The Redis factory implementation.
+     *
+     * @var \Illuminate\Contracts\Redis\Factory
+     */
+    protected $redis;
+
+    /**
+     * The timestamp of the end of the current duration by key.
+     *
+     * @var array
+     */
+    public $decaysAt = [];
+
+    /**
+     * Create a new rate limiter middleware instance.
+     *
+     * @param  string  $limiterName
+     *
+     * @return void
+     */
+    public function __construct($limiterName)
+    {
+        parent::__construct($limiterName);
+
+        $this->redis = Container::getInstance()->make(Redis::class);
+    }
+
+    /**
+     * Handle a rate limited job.
+     *
+     * @param  mixed  $job
+     * @param  callable  $next
+     * @param  array  $limits
+     * @return mixed
+     */
+    protected function handleJob($job, $next, array $limits)
+    {
+        foreach ($limits as $limit) {
+            if ($this->tooManyAttempts($limit->key, $limit->maxAttempts, $limit->decayMinutes)) {
+                return $job->release($this->getTimeUntilNextRetry($limit->key));
+            }
+        }
+
+        return $next($job);
+    }
+
+    /**
+     * Determine if the given key has been "accessed" too many times.
+     *
+     * @param  string  $key
+     * @param  int  $maxAttempts
+     * @param  int  $decayMinutes
+     * @return bool
+     */
+    protected function tooManyAttempts($key, $maxAttempts, $decayMinutes)
+    {
+        $limiter = new DurationLimiter(
+            $this->redis, $key, $maxAttempts, $decayMinutes * 60
+        );
+
+        return tap(! $limiter->acquire(), function () use ($key, $limiter) {
+            $this->decaysAt[$key] = $limiter->decaysAt;
+        });
+    }
+
+    /**
+     * Get the number of seconds until the lock is released.
+     *
+     * @param  string  $key
+     * @return int
+     */
+    protected function getTimeUntilNextRetry($key)
+    {
+        return $this->decaysAt[$key] - $this->currentTime();
+    }
+}

--- a/tests/Integration/Queue/RateLimitsJobsTest.php
+++ b/tests/Integration/Queue/RateLimitsJobsTest.php
@@ -63,7 +63,7 @@ class RateLimitsJobsTest extends TestCase
 
         $this->assertJobRanSuccessfully(AdminTestJob::class);
         $this->assertJobRanSuccessfully(AdminTestJob::class);
-        
+
         $this->assertJobRanSuccessfully(NonAdminTestJob::class);
         $this->assertJobWasReleased(NonAdminTestJob::class);
     }

--- a/tests/Integration/Queue/RateLimitsJobsTest.php
+++ b/tests/Integration/Queue/RateLimitsJobsTest.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Queue;
+
+use Illuminate\Bus\Dispatcher;
+use Illuminate\Bus\Queueable;
+use Illuminate\Cache\RateLimiter;
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Contracts\Queue\Job;
+use Illuminate\Queue\CallQueuedHandler;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\Middleware\RateLimitsJobs;
+use Mockery as m;
+use Orchestra\Testbench\TestCase;
+
+/**
+ * @group integration
+ */
+class RateLimitsJobsTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        m::close();
+    }
+
+    public function testUnlimitedJobsAreExecuted()
+    {
+        $rateLimiter = $this->app->make(RateLimiter::class);
+
+        $rateLimiter->for('test', function ($job) {
+            return Limit::none();
+        });
+
+        $this->assertJobRanSuccessfully(RateLimitedTestJob::class);
+        $this->assertJobRanSuccessfully(RateLimitedTestJob::class);
+    }
+
+    public function testRateLimitedJobsAreNotExecutedOnLimitReached()
+    {
+        $rateLimiter = $this->app->make(RateLimiter::class);
+
+        $rateLimiter->for('test', function ($job) {
+            return Limit::perHour(1);
+        });
+
+        $this->assertJobRanSuccessfully(RateLimitedTestJob::class);
+        $this->assertJobWasReleased(RateLimitedTestJob::class);
+    }
+
+    public function testJobsCanHaveConditionalRateLimits()
+    {
+        $rateLimiter = $this->app->make(RateLimiter::class);
+
+        $rateLimiter->for('test', function ($job) {
+            if ($job->isAdmin()) {
+                return Limit::none();
+            }
+
+            return Limit::perHour(1);
+        });
+
+        $this->assertJobRanSuccessfully(AdminTestJob::class);
+        $this->assertJobRanSuccessfully(AdminTestJob::class);
+        
+        $this->assertJobRanSuccessfully(NonAdminTestJob::class);
+        $this->assertJobWasReleased(NonAdminTestJob::class);
+    }
+
+    protected function assertJobRanSuccessfully($class)
+    {
+        $class::$handled = false;
+        $instance = new CallQueuedHandler(new Dispatcher($this->app), $this->app);
+
+        $job = m::mock(Job::class);
+
+        $job->shouldReceive('hasFailed')->once()->andReturn(false);
+        $job->shouldReceive('isReleased')->once()->andReturn(false);
+        $job->shouldReceive('isDeletedOrReleased')->once()->andReturn(false);
+        $job->shouldReceive('delete')->once();
+
+        $instance->call($job, [
+            'command' => serialize($command = new $class),
+        ]);
+
+        $this->assertTrue($class::$handled);
+    }
+
+    protected function assertJobWasReleased($class)
+    {
+        $class::$handled = false;
+        $instance = new CallQueuedHandler(new Dispatcher($this->app), $this->app);
+
+        $job = m::mock(Job::class);
+
+        $job->shouldReceive('hasFailed')->once()->andReturn(false);
+        $job->shouldReceive('release')->once();
+        $job->shouldReceive('isReleased')->once()->andReturn(true);
+        $job->shouldReceive('isDeletedOrReleased')->once()->andReturn(true);
+
+        $instance->call($job, [
+            'command' => serialize($command = new $class),
+        ]);
+
+        $this->assertFalse($class::$handled);
+    }
+}
+
+class RateLimitedTestJob
+{
+    use InteractsWithQueue, Queueable;
+
+    public static $handled = false;
+
+    public function handle()
+    {
+        static::$handled = true;
+    }
+
+    public function middleware()
+    {
+        return [new RateLimitsJobs('test')];
+    }
+}
+
+class AdminTestJob extends RateLimitedTestJob
+{
+    public function isAdmin()
+    {
+        return true;
+    }
+}
+
+class NonAdminTestJob extends RateLimitedTestJob
+{
+    public function isAdmin()
+    {
+        return false;
+    }
+}

--- a/tests/Integration/Queue/RateLimitsJobsWithRedisTest.php
+++ b/tests/Integration/Queue/RateLimitsJobsWithRedisTest.php
@@ -144,7 +144,8 @@ class RateLimitedTestJob
 
     public static $handled = false;
 
-    public function __construct() {
+    public function __construct()
+    {
         $this->key = Str::random(10);
     }
 

--- a/tests/Integration/Queue/RateLimitsJobsWithRedisTest.php
+++ b/tests/Integration/Queue/RateLimitsJobsWithRedisTest.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Queue;
+
+use Illuminate\Bus\Dispatcher;
+use Illuminate\Bus\Queueable;
+use Illuminate\Cache\RateLimiter;
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Contracts\Queue\Job;
+use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
+use Illuminate\Queue\CallQueuedHandler;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\Middleware\RateLimitsJobsWithRedis;
+use Illuminate\Support\Str;
+use Mockery as m;
+use Orchestra\Testbench\TestCase;
+
+/**
+ * @group integration
+ */
+class RateLimitsJobsWithRedisTest extends TestCase
+{
+    use InteractsWithRedis;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->setUpRedis();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        $this->tearDownRedis();
+
+        m::close();
+    }
+
+    public function testUnlimitedJobsAreExecuted()
+    {
+        $rateLimiter = $this->app->make(RateLimiter::class);
+
+        $testJob = new RateLimitedTestJob;
+
+        $rateLimiter->for($testJob->key, function ($job) {
+            return Limit::none();
+        });
+
+        $this->assertJobRanSuccessfully($testJob);
+        $this->assertJobRanSuccessfully($testJob);
+    }
+
+    public function testRateLimitedJobsAreNotExecutedOnLimitReached()
+    {
+        $rateLimiter = $this->app->make(RateLimiter::class);
+
+        $testJob = new RateLimitedTestJob;
+
+        $rateLimiter->for($testJob->key, function ($job) {
+            return Limit::perMinute(1);
+        });
+
+        $this->assertJobRanSuccessfully($testJob);
+        $this->assertJobWasReleased($testJob);
+    }
+
+    public function testJobsCanHaveConditionalRateLimits()
+    {
+        $rateLimiter = $this->app->make(RateLimiter::class);
+
+        $adminJob = new AdminTestJob;
+
+        $rateLimiter->for($adminJob->key, function ($job) {
+            if ($job->isAdmin()) {
+                return Limit::none();
+            }
+
+            return Limit::perMinute(1);
+        });
+
+        $this->assertJobRanSuccessfully($adminJob);
+        $this->assertJobRanSuccessfully($adminJob);
+
+        $nonAdminJob = new NonAdminTestJob;
+
+        $rateLimiter->for($nonAdminJob->key, function ($job) {
+            if ($job->isAdmin()) {
+                return Limit::none();
+            }
+
+            return Limit::perMinute(1);
+        });
+
+        $this->assertJobRanSuccessfully($nonAdminJob);
+        $this->assertJobWasReleased($nonAdminJob);
+    }
+
+    protected function assertJobRanSuccessfully($testJob)
+    {
+        $testJob::$handled = false;
+        $instance = new CallQueuedHandler(new Dispatcher($this->app), $this->app);
+
+        $job = m::mock(Job::class);
+
+        $job->shouldReceive('hasFailed')->once()->andReturn(false);
+        $job->shouldReceive('isReleased')->once()->andReturn(false);
+        $job->shouldReceive('isDeletedOrReleased')->once()->andReturn(false);
+        $job->shouldReceive('delete')->once();
+
+        $instance->call($job, [
+            'command' => serialize($testJob),
+        ]);
+
+        $this->assertTrue($testJob::$handled);
+    }
+
+    protected function assertJobWasReleased($testJob)
+    {
+        $testJob::$handled = false;
+        $instance = new CallQueuedHandler(new Dispatcher($this->app), $this->app);
+
+        $job = m::mock(Job::class);
+
+        $job->shouldReceive('hasFailed')->once()->andReturn(false);
+        $job->shouldReceive('release')->once();
+        $job->shouldReceive('isReleased')->once()->andReturn(true);
+        $job->shouldReceive('isDeletedOrReleased')->once()->andReturn(true);
+
+        $instance->call($job, [
+            'command' => serialize($testJob),
+        ]);
+
+        $this->assertFalse($testJob::$handled);
+    }
+}
+
+class RateLimitedTestJob
+{
+    use InteractsWithQueue, Queueable;
+
+    public $key;
+
+    public static $handled = false;
+
+    public function __construct() {
+        $this->key = Str::random(10);
+    }
+
+    public function handle()
+    {
+        static::$handled = true;
+    }
+
+    public function middleware()
+    {
+        return [new RateLimitsJobsWithRedis($this->key)];
+    }
+}
+
+class AdminTestJob extends RateLimitedTestJob
+{
+    public function isAdmin()
+    {
+        return true;
+    }
+}
+
+class NonAdminTestJob extends RateLimitedTestJob
+{
+    public function isAdmin()
+    {
+        return false;
+    }
+}

--- a/tests/Integration/Queue/RateLimitsJobsWithRedisTest.php
+++ b/tests/Integration/Queue/RateLimitsJobsWithRedisTest.php
@@ -42,7 +42,7 @@ class RateLimitsJobsWithRedisTest extends TestCase
     {
         $rateLimiter = $this->app->make(RateLimiter::class);
 
-        $testJob = new RateLimitedTestJob;
+        $testJob = new RedisRateLimitedTestJob;
 
         $rateLimiter->for($testJob->key, function ($job) {
             return Limit::none();
@@ -56,7 +56,7 @@ class RateLimitsJobsWithRedisTest extends TestCase
     {
         $rateLimiter = $this->app->make(RateLimiter::class);
 
-        $testJob = new RateLimitedTestJob;
+        $testJob = new RedisRateLimitedTestJob;
 
         $rateLimiter->for($testJob->key, function ($job) {
             return Limit::perMinute(1);
@@ -70,7 +70,7 @@ class RateLimitsJobsWithRedisTest extends TestCase
     {
         $rateLimiter = $this->app->make(RateLimiter::class);
 
-        $adminJob = new AdminTestJob;
+        $adminJob = new RedisAdminTestJob;
 
         $rateLimiter->for($adminJob->key, function ($job) {
             if ($job->isAdmin()) {
@@ -83,7 +83,7 @@ class RateLimitsJobsWithRedisTest extends TestCase
         $this->assertJobRanSuccessfully($adminJob);
         $this->assertJobRanSuccessfully($adminJob);
 
-        $nonAdminJob = new NonAdminTestJob;
+        $nonAdminJob = new RedisNonAdminTestJob;
 
         $rateLimiter->for($nonAdminJob->key, function ($job) {
             if ($job->isAdmin()) {
@@ -136,7 +136,7 @@ class RateLimitsJobsWithRedisTest extends TestCase
     }
 }
 
-class RateLimitedTestJob
+class RedisRateLimitedTestJob
 {
     use InteractsWithQueue, Queueable;
 
@@ -160,7 +160,7 @@ class RateLimitedTestJob
     }
 }
 
-class AdminTestJob extends RateLimitedTestJob
+class RedisAdminTestJob extends RedisRateLimitedTestJob
 {
     public function isAdmin()
     {
@@ -168,7 +168,7 @@ class AdminTestJob extends RateLimitedTestJob
     }
 }
 
-class NonAdminTestJob extends RateLimitedTestJob
+class RedisNonAdminTestJob extends RedisRateLimitedTestJob
 {
     public function isAdmin()
     {


### PR DESCRIPTION
We already have rate limiters available for the request throttling middleware. This PR enables the same rate limiter classes and syntax to be used for rate limiting jobs!

You may define named rate limiters in your app service provider:

```php
use Illuminate\Cache\RateLimiting\Limit;
use Illuminate\Support\Facades\RateLimiter;

// Returning no rate limit for certain customers...
RateLimiter::for('analytics', function ($job) {
    if ($job->user->vipCustomer()) {
        return Limit::none();
    }

    return Limit::perHour(1)->by($job->user->id),
});

// Returning an array of rate limits the job must pass through...
RateLimiter::for('backups', function ($job) {
    return [
        Limit::perMinute(100),
        Limit::perMinute(3)->by($job->user->id),
    ];
});
```

You can attach these named rate limiters to jobs by passing their names to the RateLimitsJobs middleware:

```php
public function middleware()
{
    return [new RateLimitsJobs('backups')];
}
```
