### PR TITLE
[8.x] Add support for passing array of conditions to orWhere

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -770,6 +770,10 @@ class Builder
         return $this->whereNested(function ($query) use ($column, $method, $boolean) {
             foreach ($column as $key => $value) {
                 if (is_numeric($key) && is_array($value)) {
+                    $value = array_pad($value, 3, null);
+                    if (count($value) === 3) {
+                        $value[] = $boolean;
+                    }
                     $query->{$method}(...array_values($value));
                 } else {
                     $query->$method($key, '=', $value, $boolean);


### PR DESCRIPTION
Consider the following code:
```
        $models = Model::orWhere([
            ['column1', '=', 'value1'],
            ['column2', '=', 'value2'],
            ['column3', '=', 'value3'],
        ])->get();

        //Alternatively
        $models = Model::orWhere([
            ['column1', 'value1'],
            ['column2', 'value2'],
            ['column3', 'value3'],
        ])->get();
```

The expected generated SQL should be: 
```
select * from `models` where (`column1` = value1 or `column2` = value2 or `column3` = value3)
```

Instead we get(notice the `and` conditions instead of `or`):
```
select * from `models` where (`column1` = value1 and `column2` = value2 and `column3` = value3)
```

This is because the value `$boolean` falls away in the `addArrayOfWheres` if you pass an array like this. The `$value` does not include the boolean value. 

This should maybe be considered a breaking change and should maybe be deferred to version 9.x.