### PR TITLE
[8.x] Add prefix to logging message

### DIFF
--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -491,6 +491,7 @@ class LogManager implements LoggerInterface
 
     /**
      * Specify caller class and function  to front of log message.
+     *
      * @param  string  $message
      * @return string
      */

--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -501,7 +501,7 @@ class LogManager implements LoggerInterface
 
         [$one, $two, $three, $caller] = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 4);
 
-        return "{$caller['class']}::{$caller['function']}() >>> {$message}";
+        return sprintf('%s::%s() >>> %s', $caller['class'] ?? '', $caller['function'] ?? '', $message);
     }
 
     /**

--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -490,6 +490,20 @@ class LogManager implements LoggerInterface
     }
 
     /**
+     * Specify caller class and function  to front of log message.
+     * @param  string  $message
+     * @return string
+     */
+    public function addPrefixToMessage($message)
+    {
+        if (! $this->app['config']['logging.prefix']) return $message;
+
+        [$one, $two, $three, $caller] = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 4);
+
+        return "{$caller['class']}::{$caller['function']}() >>> {$message}";
+    }
+
+    /**
      * System is unusable.
      *
      * @param  string  $message
@@ -499,6 +513,8 @@ class LogManager implements LoggerInterface
      */
     public function emergency($message, array $context = [])
     {
+        $message = $this->addPrefixToMessage($message);
+
         $this->driver()->emergency($message, $context);
     }
 
@@ -515,6 +531,8 @@ class LogManager implements LoggerInterface
      */
     public function alert($message, array $context = [])
     {
+        $message = $this->addPrefixToMessage($message);
+
         $this->driver()->alert($message, $context);
     }
 
@@ -530,6 +548,8 @@ class LogManager implements LoggerInterface
      */
     public function critical($message, array $context = [])
     {
+        $message = $this->addPrefixToMessage($message);
+
         $this->driver()->critical($message, $context);
     }
 
@@ -544,6 +564,8 @@ class LogManager implements LoggerInterface
      */
     public function error($message, array $context = [])
     {
+        $message = $this->addPrefixToMessage($message);
+
         $this->driver()->error($message, $context);
     }
 
@@ -560,6 +582,8 @@ class LogManager implements LoggerInterface
      */
     public function warning($message, array $context = [])
     {
+        $message = $this->addPrefixToMessage($message);
+
         $this->driver()->warning($message, $context);
     }
 
@@ -573,6 +597,8 @@ class LogManager implements LoggerInterface
      */
     public function notice($message, array $context = [])
     {
+        $message = $this->addPrefixToMessage($message);
+
         $this->driver()->notice($message, $context);
     }
 
@@ -588,6 +614,8 @@ class LogManager implements LoggerInterface
      */
     public function info($message, array $context = [])
     {
+        $message = $this->addPrefixToMessage($message);
+
         $this->driver()->info($message, $context);
     }
 
@@ -601,6 +629,8 @@ class LogManager implements LoggerInterface
      */
     public function debug($message, array $context = [])
     {
+        $message = $this->addPrefixToMessage($message);
+
         $this->driver()->debug($message, $context);
     }
 
@@ -615,6 +645,8 @@ class LogManager implements LoggerInterface
      */
     public function log($level, $message, array $context = [])
     {
+        $message = $this->addPrefixToMessage($message);
+
         $this->driver()->log($level, $message, $context);
     }
 


### PR DESCRIPTION
This feature allows you to add caller class and function information to the front of the log message, 
To be able to specify the location of the log.

**Log  message example:**
```
[Y-m-d h:i:s] local.INFO: App\Http\Controllers\MyController::myFunction() >>> Log message
```

This feature come to solve problem in large application that add log and hard to filter message you want.