### PR TITLE
[8.x] Fix fresh and refresh on pivots and morph pivots

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1207,9 +1207,8 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
             return;
         }
 
-        return static::newQueryWithoutScopes()
+        return $this->setKeysForSaveQuery(static::newQueryWithoutScopes())
                         ->with(is_string($with) ? func_get_args() : $with)
-                        ->where($this->getKeyName(), $this->getKey())
                         ->first();
     }
 
@@ -1225,7 +1224,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
         }
 
         $this->setRawAttributes(
-            static::newQueryWithoutScopes()->findOrFail($this->getKey())->attributes
+            $this->setKeysForSaveQuery(static::newQueryWithoutScopes())->firstOrFail()->attributes
         );
 
         $this->load(collect($this->relations)->reject(function ($relation) {


### PR DESCRIPTION
Currently the `Model::fresh()` and `Model::refresh()` methods cannot be used on pivots, because they reference the model key directly. This PR alters these methods slightly to take advantage of the `Model::setKeysForSaveQuery()` method which already allows methods such as `Model::delete()` to work on pivots.

The following is now possible:
```
$model->relation->pivot->refresh()
$model->relation->pivot->fresh()
```
