### PR TITLE
[8.x] Set the factory namespace based on the name argument

### DIFF
--- a/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
+++ b/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
@@ -66,11 +66,9 @@ class FactoryMakeCommand extends GeneratorCommand
 
         $model = class_basename($namespaceModel);
 
-        if (Str::startsWith($namespaceModel, 'App\\Models')) {
-            $namespace = Str::beforeLast('Database\\Factories\\'.Str::after($namespaceModel, 'App\\Models\\'), '\\');
-        } else {
-            $namespace = 'Database\\Factories';
-        }
+        $namespace = Str::of('Database\\Factories\\' . $this->argument('name'))
+            ->replace('/', '\\')
+            ->beforeLast('\\');
 
         $replace = [
             '{{ factoryNamespace }}' => $namespace,


### PR DESCRIPTION
I don't understand why assigning the namespace of a factory based on the model namespace when it should be assigned based on the name argument. For example, 

I have a model in `App\Models\Cat`.

I want to create a factory for that model in the namespace `Database\Factories\Cats\CatFactory`

But if i run `php artisan make:factory Cats/CatFactory` the file was created correctly, but the factory namespace is still `Database\Factories`.

I think I am unaware of something about how this command works, however, this PR fix that.