### PR TITLE
[8.x] Lazy data provider for Route::view

### DIFF
--- a/src/Illuminate/Routing/ViewController.php
+++ b/src/Illuminate/Routing/ViewController.php
@@ -2,7 +2,9 @@
 
 namespace Illuminate\Routing;
 
+use Illuminate\Container\Container;
 use Illuminate\Contracts\Routing\ResponseFactory;
+use Illuminate\Support\Arr;
 
 class ViewController extends Controller
 {
@@ -14,14 +16,23 @@ class ViewController extends Controller
     protected $response;
 
     /**
+     * The IoC container instance.
+     *
+     * @var \Illuminate\Container\Container
+     */
+    protected $container;
+
+    /**
      * Create a new controller instance.
      *
      * @param  \Illuminate\Contracts\Routing\ResponseFactory  $response
+     * @param  \Illuminate\Container\Container  $container
      * @return void
      */
-    public function __construct(ResponseFactory $response)
+    public function __construct(ResponseFactory $response, Container $container)
     {
         $this->response = $response;
+        $this->container = $container;
     }
 
     /**
@@ -33,6 +44,11 @@ class ViewController extends Controller
     public function __invoke(...$args)
     {
         [$view, $data, $status, $headers] = array_slice($args, -4);
+
+        if (! Arr::isAssoc($data)) {
+            $params = array_slice($args, 0, -4);
+            $data = $this->container->make($data[0])->{$data[1]}(...$params);
+        }
 
         return $this->response->view($view, $data, $status, $headers);
     }

--- a/tests/Integration/Routing/Fixtures/DataProvider.php
+++ b/tests/Integration/Routing/Fixtures/DataProvider.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Routing\Fixtures;
+
+class DataProvider
+{
+    public function data($a, $b)
+    {
+        return ['foo' => $a.$b];
+    }
+}

--- a/tests/Integration/Routing/RouteViewTest.php
+++ b/tests/Integration/Routing/RouteViewTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Integration\Routing;
 
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\View;
+use Illuminate\Tests\Integration\Routing\Fixtures\DataProvider;
 use Orchestra\Testbench\TestCase;
 
 /**
@@ -19,6 +20,16 @@ class RouteViewTest extends TestCase
 
         $this->assertStringContainsString('Test bar', $this->get('/route')->getContent());
         $this->assertSame(200, $this->get('/route')->status());
+    }
+
+    public function testRouteViewDataProvider()
+    {
+        Route::view('route/{a}/{b}', 'view', [DataProvider::class, 'data']);
+
+        View::addLocation(__DIR__.'/Fixtures');
+
+        $this->assertStringContainsString('Test 123', $this->get('/route/1/23')->getContent());
+        $this->assertSame(200, $this->get('/route/1/23')->status());
     }
 
     public function testRouteViewWithParams()


### PR DESCRIPTION
Currently we can define
 ```php
Route::view('/url', 'blade', ['assoc' => 'array']);
```
Actually the third parameter is not that much useful since it is eagerly providing data at route definition.


This PR makes it possible to reference a method on a class that is called Only when the route is matched.
 ```php
Route::view('/url', 'blade', [MyData::class, 'index']);
```

**Backward compatibility**: the third parameter is rarely used by users and it only works with associative arrays so there would be no collision if they pass a sequential array.

Later on it is possible to provide a json method like this:
 ```php
 Route::json('/api/url', 'mySerializer', [MyData::class, 'index']);
```
So that the users are able to reuse the same data provider to expose a simple json api.
