### PR TITLE
Fix increment or decrementing mutated attributes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -612,7 +612,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
             return $query->{$method}($column, $amount, $extra);
         }
 
-        $this->{$column} = $this->{$column} + ($method === 'increment' ? $amount : $amount * -1);
+        $this->{$column} = $this->getRawOriginal($column) + ($method === 'increment' ? $amount : $amount * -1);
 
         $this->forceFill($extra);
 


### PR DESCRIPTION
**increment** and **decrement** functions use mutated values by default thus leading to a "**A non well formed numeric value encountered**". With adding **getRawOriginal** function, we easily overcome this issue by getting the original, non-mutated field.