### PR TITLE
[9.x] Add a separate Rate Limiting Service Provider (Deferrable)

### DIFF
--- a/src/Illuminate/Cache/CacheServiceProvider.php
+++ b/src/Illuminate/Cache/CacheServiceProvider.php
@@ -30,8 +30,6 @@ class CacheServiceProvider extends ServiceProvider implements DeferrableProvider
         $this->app->singleton('memcached.connector', function () {
             return new MemcachedConnector;
         });
-
-        $this->app->singleton(RateLimiter::class);
     }
 
     /**
@@ -42,7 +40,7 @@ class CacheServiceProvider extends ServiceProvider implements DeferrableProvider
     public function provides()
     {
         return [
-            'cache', 'cache.store', 'cache.psr6', 'memcached.connector', RateLimiter::class,
+            'cache', 'cache.store', 'cache.psr6', 'memcached.connector',
         ];
     }
 }

--- a/src/Illuminate/Cache/RateLimitingServiceProvider.php
+++ b/src/Illuminate/Cache/RateLimitingServiceProvider.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Illuminate\Cache;
+
+use Illuminate\Contracts\Support\DeferrableProvider;
+use Illuminate\Support\ServiceProvider;
+
+class RateLimitingServiceProvider extends ServiceProvider implements DeferrableProvider
+{
+    /**
+     * Register the service provider.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        $this->app->singleton(RateLimiter::class);
+    }
+
+    /**
+     * Get the services provided by the provider.
+     *
+     * @return array
+     */
+    public function provides()
+    {
+        return [
+            RateLimiter::class,
+        ];
+    }
+}

--- a/tests/Integration/Http/ThrottleRequestsTest.php
+++ b/tests/Integration/Http/ThrottleRequestsTest.php
@@ -3,8 +3,8 @@
 namespace Illuminate\Tests\Integration\Http;
 
 use Illuminate\Cache\RateLimiter;
-use Illuminate\Cache\RateLimitingServiceProvider;
 use Illuminate\Cache\RateLimiting\GlobalLimit;
+use Illuminate\Cache\RateLimitingServiceProvider;
 use Illuminate\Container\Container;
 use Illuminate\Http\Exceptions\ThrottleRequestsException;
 use Illuminate\Routing\Middleware\ThrottleRequests;

--- a/tests/Integration/Http/ThrottleRequestsTest.php
+++ b/tests/Integration/Http/ThrottleRequestsTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Integration\Http;
 
 use Illuminate\Cache\RateLimiter;
+use Illuminate\Cache\RateLimitingServiceProvider;
 use Illuminate\Cache\RateLimiting\GlobalLimit;
 use Illuminate\Container\Container;
 use Illuminate\Http\Exceptions\ThrottleRequestsException;
@@ -97,5 +98,10 @@ class ThrottleRequestsTest extends TestCase
             $this->assertEquals(2, $e->getHeaders()['Retry-After']);
             $this->assertEquals(Carbon::now()->addSeconds(2)->getTimestamp(), $e->getHeaders()['X-RateLimit-Reset']);
         }
+    }
+
+    protected function getPackageProviders($app)
+    {
+        return [RateLimitingServiceProvider::class];
     }
 }

--- a/tests/Integration/Http/ThrottleRequestsWithRedisTest.php
+++ b/tests/Integration/Http/ThrottleRequestsWithRedisTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Http;
 
+use Illuminate\Cache\RateLimitingServiceProvider;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
 use Illuminate\Routing\Middleware\ThrottleRequestsWithRedis;
 use Illuminate\Support\Carbon;
@@ -60,5 +61,10 @@ class ThrottleRequestsWithRedisTest extends TestCase
                 // $this->assertTrue(in_array($e->getHeaders()['X-RateLimit-Reset'], [$finish->getTimestamp() + 2, $finish->getTimestamp() + 3]));
             }
         });
+    }
+
+    protected function getPackageProviders($app)
+    {
+        return [RateLimitingServiceProvider::class];
     }
 }


### PR DESCRIPTION
With expanding the scope of RateLimiters to jobs as well (https://github.com/laravel/framework/pull/34829), it might be the right time to introduce a `RateLimitingServiceProvider` in 9.x. This can be where users can register all their rate limiters so that there's a dedicated provider to do so (instead of using `AppServiceProvider` for jobs and `RouteServiceProvider` for routes). 

Also, this should improve performance slightly as it is a deferrable provider, so the named rate limiter registrations would only trigger when the app resolves the `RateLimiter`.

This is a breaking change because I'm extracting out the `RateLimiter` singleton registration to a separate provider. That's why this PR targets master.

If this PR is accepted, I'll send across a PR to the Laravel skeleton repo for a `RateLimiterServiceProvider` in the `app/Providers` directory that extends the base provider in this PR and registers the named rate limiters in the `boot` method.