### PR TITLE
Determine if the request is made by a bot / search engine.

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -262,6 +262,16 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     }
 
     /**
+     * Determine if the request is made by a bot / search engine.
+     *
+     * @return bool
+     */
+    public function bot()
+    {
+        return preg_match('/bot|crawl|slurp|spider|mediapartners/i', $this->userAgent());
+    }
+
+    /**
      * Determine if the request is over HTTPS.
      *
      * @return bool


### PR DESCRIPTION
Simple request function to check if the current request was made by a bot agent.

If you need to be very sure if it is a bot or not it is better to compare to a list such as this: [bot list](https://github.com/matomo-org/device-detector/blob/master/regexes/bots.yml)

Can be used when deciding to:

- include style/script resources
- not to store cookies
- ignore location logging
- skip a landing page
- tracking / analytics