### PR TITLE
[8.x] Preserve eloquent collection type after calling ->fresh()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -300,10 +300,10 @@ class Collection extends BaseCollection implements QueueableCollection
             ->get()
             ->getDictionary();
 
-        return $this->map(function ($model) use ($freshModels) {
+        return new static($this->map(function ($model) use ($freshModels) {
             return $model->exists && isset($freshModels[$model->getKey()])
                     ? $freshModels[$model->getKey()] : null;
-        });
+        }));
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -300,10 +300,12 @@ class Collection extends BaseCollection implements QueueableCollection
             ->get()
             ->getDictionary();
 
-        return new static($this->map(function ($model) use ($freshModels) {
-            return $model->exists && isset($freshModels[$model->getKey()])
-                    ? $freshModels[$model->getKey()] : null;
-        }));
+        return $this->filter(function ($model) use ($freshModels) {
+            return $model->exists && isset($freshModels[$model->getKey()]);
+        })
+        ->map(function ($model) use ($freshModels) {
+            return $freshModels[$model->getKey()];
+        });
     }
 
     /**

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -1340,10 +1340,15 @@ class DatabaseEloquentIntegrationTest extends TestCase
         EloquentTestUser::find(1)->update(['name' => 'Mathieu TUDISCO']);
         EloquentTestUser::find(2)->update(['email' => 'dev@mathieutu.ovh']);
 
-        $this->assertEquals($users->map->fresh(), $users->fresh());
+        $this->assertCount(3, $users);
+        $this->assertNotEquals('Mathieu TUDISCO', $users[0]->name);
+        $this->assertNotEquals('dev@mathieutu.ovh', $users[1]->email);
 
-        $users = new Collection;
-        $this->assertEquals($users->map->fresh(), $users->fresh());
+        $refreshedUsers = $users->fresh();
+
+        $this->assertCount(2, $refreshedUsers);
+        $this->assertEquals('Mathieu TUDISCO', $refreshedUsers[0]->name);
+        $this->assertEquals('dev@mathieutu.ovh', $refreshedUsers[1]->email);
     }
 
     public function testTimestampsUsingDefaultDateFormat()

--- a/tests/Integration/Database/EloquentCollectionFreshTest.php
+++ b/tests/Integration/Database/EloquentCollectionFreshTest.php
@@ -31,11 +31,11 @@ class EloquentCollectionFreshTest extends DatabaseTestCase
 
         $collection = User::all();
 
-        User::whereKey($collection->pluck('id')->toArray())->delete();
+        $collection->first()->delete();
 
         $freshCollection = $collection->fresh();
 
-        $this->assertEmpty($freshCollection->filter());
+        $this->assertCount(1, $freshCollection);
         $this->assertInstanceOf(EloquentCollection::class, $freshCollection);
     }
 }

--- a/tests/Integration/Database/EloquentCollectionFreshTest.php
+++ b/tests/Integration/Database/EloquentCollectionFreshTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Integration\Database;
 
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Tests\Integration\Database\Fixtures\User;
 
@@ -32,6 +33,9 @@ class EloquentCollectionFreshTest extends DatabaseTestCase
 
         User::whereKey($collection->pluck('id')->toArray())->delete();
 
-        $this->assertEmpty($collection->fresh()->filter());
+        $freshCollection = $collection->fresh();
+
+        $this->assertEmpty($freshCollection->filter());
+        $this->assertInstanceOf(EloquentCollection::class, $freshCollection);
     }
 }

--- a/tests/Integration/Database/EloquentCollectionFreshTest.php
+++ b/tests/Integration/Database/EloquentCollectionFreshTest.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Tests\Integration\Database;
 
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Tests\Integration\Database\Fixtures\User;
 


### PR DESCRIPTION
This PR fixes unexpected behavior of an Eloquent collection's `->fresh()` method.

**Current Behavior:**
```php
$users = User::all();
$users->fresh(); // Returns instance of "Illuminate\Database\Eloquent\Collection"

$users = User::all()
$users->first()->delete();
$users->fresh(); //  // Returns instance of "Illuminate\Support\Collection"
```

**New Behavior:**
```php
$users = User::all();
$users->fresh(); // Returns instance of "Illuminate\Database\Eloquent\Collection"

$users = User::all()
$users->first()->delete();
$users->fresh(); //  // Returns instance of "Illuminate\Database\Eloquent\Collection" as well
```

**Cause of bug:**
Calling `->fresh()` will not remove non-existent models, it will set them to null.

Now that the collection contains null values, `->fresh()`'s internal `->map` call will detect that the collection contains non-model values and return a "Illuminate\Support\Collection" instead.

**Current Proposed Solution:**
* Wrap the `->map` call in a `new static` to ensure that the class matches the original eloquent collection type (will even support custom eloquent collections this way).

**Ideal Solution: (But potentially breaking)**
* When calling `->fresh()` on a model collection, REMOVE the items that are not in the database completely (instead of replacing them with null values)

**Why I Care:**
Livewire supports setting public properties as eloquent collections.

If a developer deletes one of the items in the collection and then calls `->fresh()`, because the collection will now be a normal collection and not a model one, Livewire will not recognize it and will break.

I'm happy to PR the "Ideal" solution if it can be merged to 8.x.

Thanks!