### PR TITLE
[8.x] Fix formatting

### DIFF
--- a/CHANGELOG-8.x.md
+++ b/CHANGELOG-8.x.md
@@ -8,31 +8,31 @@
 ### Added
 - Allow for chains to be added to batches ([#34612](https://github.com/laravel/framework/pull/34612), [7b4a9ec](https://github.com/laravel/framework/commit/7b4a9ec6c58906eb73957015e4c78f73e780e944))
 - Added `is()` method to 1-1 relations for model comparison ([#34693](https://github.com/laravel/framework/pull/34693), [7ba2577](https://github.com/laravel/framework/commit/7ba257732d2342175a6ffe7db7a4ca847ca1d353))
-- Added `upsert` to Eloquent and Base Query Builders ([#34698](https://github.com/laravel/framework/pull/34698), [#34712](https://github.com/laravel/framework/pull/34712), [58a0e1b](https://github.com/laravel/framework/commit/58a0e1b7e2bb6df3923883c4fc8cf13b1bce7322))
+- Added `upsert()` to Eloquent and Base Query Builders ([#34698](https://github.com/laravel/framework/pull/34698), [#34712](https://github.com/laravel/framework/pull/34712), [58a0e1b](https://github.com/laravel/framework/commit/58a0e1b7e2bb6df3923883c4fc8cf13b1bce7322))
 - Support psql and pg_restore commands in schema load ([#34711](https://github.com/laravel/framework/pull/34711))
 - Added `Illuminate\Database\Schema\Builder::dropColumns()` method on the schema class ([#34720](https://github.com/laravel/framework/pull/34720))
-- Added yearlyOn() method to scheduler ([#34728](https://github.com/laravel/framework/pull/34728))
-- Added restrictOnDelete method to ForeignKeyDefinition class ([#34752](https://github.com/laravel/framework/pull/34752))
+- Added `yearlyOn()` method to scheduler ([#34728](https://github.com/laravel/framework/pull/34728))
+- Added `restrictOnDelete()` method to ForeignKeyDefinition class ([#34752](https://github.com/laravel/framework/pull/34752))
 - Added `newLine()` method to `InteractsWithIO` trait ([#34754](https://github.com/laravel/framework/pull/34754))
-- Added isNotEmpty method to HtmlString ([#34774](https://github.com/laravel/framework/pull/34774))
-- Added delay() to PendingChain ([#34789](https://github.com/laravel/framework/pull/34789))
-- Added 'multiple_of' validation rule ([#34788](https://github.com/laravel/framework/pull/34788))
-- Added custom methods proxy support for jobs ::dispatch() ([#34781](https://github.com/laravel/framework/pull/34781))
+- Added `isNotEmpty()` method to HtmlString ([#34774](https://github.com/laravel/framework/pull/34774))
+- Added `delay()` to PendingChain ([#34789](https://github.com/laravel/framework/pull/34789))
+- Added "multiple_of" validation rule ([#34788](https://github.com/laravel/framework/pull/34788))
+- Added custom methods proxy support for jobs `dispatch()` ([#34781](https://github.com/laravel/framework/pull/34781))
 - Added `QueryBuilder::clone()` ([#34780](https://github.com/laravel/framework/pull/34780))
 - Support bus chain on fake ([a952ac24](https://github.com/laravel/framework/commit/a952ac24f34b832270a2f80cd425c2afe4c61fc1))
-- Added missing force flag to queue:clear command ([#34809](https://github.com/laravel/framework/pull/34809))
-- Added `dropConstrainedForeignId` to `Blueprint ([#34806](https://github.com/laravel/framework/pull/34806))
-- Implement supportsTags() on the Cache Repository ([#34820](https://github.com/laravel/framework/pull/34820))
+- Added missing force flag to `queue:clear` command ([#34809](https://github.com/laravel/framework/pull/34809))
+- Added `dropConstrainedForeignId()` to `Blueprint ([#34806](https://github.com/laravel/framework/pull/34806))
+- Implement `supportsTags()` on the Cache Repository ([#34820](https://github.com/laravel/framework/pull/34820))
 - Added `canAny` to user model ([#34815](https://github.com/laravel/framework/pull/34815))
-- Added when() and unless() methods to MailMessage ([#34814](https://github.com/laravel/framework/pull/34814))
+- Added `when()` and `unless()` methods to MailMessage ([#34814](https://github.com/laravel/framework/pull/34814))
 
 ### Fixed
 - Fixed collection wrapping in `BelongsToManyRelationship` ([9245807](https://github.com/laravel/framework/commit/9245807f8a1132a30ce669513cf0e99e9e078267))
-- Fixed LengthAwarePaginator translations issue ([#34714](https://github.com/laravel/framework/pull/34714))
+- Fixed `LengthAwarePaginator` translations issue ([#34714](https://github.com/laravel/framework/pull/34714))
 
 ### Changed
 - Improve `schedule:work` command ([#34736](https://github.com/laravel/framework/pull/34736), [bbddba2](https://github.com/laravel/framework/commit/bbddba279bc781fc2868a6967430943de636614f))
-- Guard against invalid guard in make:policy ([#34792](https://github.com/laravel/framework/pull/34792))
+- Guard against invalid guard in `make:policy` ([#34792](https://github.com/laravel/framework/pull/34792))
 - Fixed router inconsistency for namespaced route groups ([#34793](https://github.com/laravel/framework/pull/34793))
 
 
@@ -41,7 +41,7 @@
 ### Added
 - Added support `times()` with `raw()` from `Illuminate\Database\Eloquent\Factories\Factory` ([#34667](https://github.com/laravel/framework/pull/34667))
 - Added `Illuminate\Pagination\AbstractPaginator::through()` ([#34657](https://github.com/laravel/framework/pull/34657))
-- Added `extendsFirst` method similar to `includesFirst` to view ([#34648](https://github.com/laravel/framework/pull/34648))
+- Added `extendsFirst()` method similar to `includesFirst()` to view ([#34648](https://github.com/laravel/framework/pull/34648))
 - Allowed `Illuminate\Http\Client\PendingRequest::attach()` method to accept many files ([#34697](https://github.com/laravel/framework/pull/34697), [1bb7ad6](https://github.com/laravel/framework/commit/1bb7ad664a3607f719af2d91c3f95cf71662dcd2))
 - Allowed serializing custom casts when converting a model to an array ([#34702](https://github.com/laravel/framework/pull/34702))
 
@@ -50,7 +50,7 @@
 - Fixed queue clearing when blocking ([#34659](https://github.com/laravel/framework/pull/34659))
 - Fixed missing import in TestView.php ([#34677](https://github.com/laravel/framework/pull/34677))
 - Use `getRealPath` to ensure console command class names are generated correctly in `Illuminate\Foundation\Console\Kernel` ([#34653](https://github.com/laravel/framework/pull/34653))
-- Added pg_dump --no-owner and --no-acl to avoid owner/permission issues in `Illuminate\Database\Schema\PostgresSchemaState::baseDumpCommand()` ([#34689](https://github.com/laravel/framework/pull/34689))
+- Added `pg_dump --no-owner` and `--no-acl` to avoid owner/permission issues in `Illuminate\Database\Schema\PostgresSchemaState::baseDumpCommand()` ([#34689](https://github.com/laravel/framework/pull/34689))
 - Fixed `queue:failed` command when Class not exists ([#34696](https://github.com/laravel/framework/pull/34696))
 
 ### Performance
@@ -83,16 +83,16 @@
 ## [v8.7.0 (2020-09-29)](https://github.com/laravel/framework/compare/v8.6.0...v8.7.0)
 
 ### Added
-- Added tg:// protocol in "url" validation rule ([#34464](https://github.com/laravel/framework/pull/34464))
+- Added `tg://` protocol in "url" validation rule ([#34464](https://github.com/laravel/framework/pull/34464))
 - Allow dynamic factory methods to obey newFactory method on model ([#34492](https://github.com/laravel/framework/pull/34492), [4708e9e](https://github.com/laravel/framework/commit/4708e9ef8f7cde617a5820f07cfd350daaba0e0f))
 - Added `no-reload` option to `serve` command ([9cc2622](https://github.com/laravel/framework/commit/9cc2622a9122f5108a694856055c13db8a5f80dc))
-- Added `perHour` and `perDay` methods to `Illuminate\Cache\RateLimiting\Limit` ([#34530](https://github.com/laravel/framework/pull/34530))
+- Added `perHour()` and `perDay()` methods to `Illuminate\Cache\RateLimiting\Limit` ([#34530](https://github.com/laravel/framework/pull/34530))
 - Added `Illuminate\Http\Client\Response::onError()` ([#34558](https://github.com/laravel/framework/pull/34558), [d034e2c](https://github.com/laravel/framework/commit/d034e2c55c6502fa0c2bebb6cbf99c5e685beaa5))
 - Added `X-Message-ID` to `Mailgun` and `Ses Transport` ([#34567](https://github.com/laravel/framework/pull/34567)) 
 
 ### Fixed
 - Fixed incompatibility with Lumen route function in `Illuminate\Session\Middleware\StartSession` ([#34491](https://github.com/laravel/framework/pull/34491))
-- Fixed: Eager loading MorphTo relationship does not honor each models $keyType ([#34531](https://github.com/laravel/framework/pull/34531), [c3f44c7](https://github.com/laravel/framework/commit/c3f44c712833d83061452e9a362a5e10fa424863))
+- Fixed: Eager loading MorphTo relationship does not honor each models `$keyType` ([#34531](https://github.com/laravel/framework/pull/34531), [c3f44c7](https://github.com/laravel/framework/commit/c3f44c712833d83061452e9a362a5e10fa424863))
 - Fixed translation label ("Pagination Navigation") for the Tailwind blade ([#34568](https://github.com/laravel/framework/pull/34568))
 - Fixed save keys on increment / decrement in Model ([77db028](https://github.com/laravel/framework/commit/77db028225ccd6ec6bc3359f69482f2e4cc95faf))
 
@@ -112,7 +112,7 @@
 - Fixed problems with dots in validator ([#34355](https://github.com/laravel/framework/pull/34355))
 - Maintenance mode: Fix empty Retry-After header ([#34412](https://github.com/laravel/framework/pull/34412))
 - Fixed bug with error handling in closure scheduled tasks ([#34420](https://github.com/laravel/framework/pull/34420))
-- Don't double escape on ComponentTagCompiler.php ([12ba0d9](https://github.com/laravel/framework/commit/12ba0d937d54e81eccf8f0a80150f0d70604e1c2))
+- Don't double escape on `ComponentTagCompiler.php` ([12ba0d9](https://github.com/laravel/framework/commit/12ba0d937d54e81eccf8f0a80150f0d70604e1c2))
 - Fixed `mysqldump: unknown variable 'column-statistics=0` for MariaDB schema dump ([#34442](https://github.com/laravel/framework/pull/34442))
 
 
@@ -122,12 +122,12 @@
 - Allow clearing an SQS queue by `queue:clear` command ([#34383](https://github.com/laravel/framework/pull/34383), [de811ea](https://github.com/laravel/framework/commit/de811ea7f7dc7ecfc686b25fba48e4b0dac473e6))
 - Added `Illuminate\Foundation\Auth\EmailVerificationRequest` ([4bde31b](https://github.com/laravel/framework/commit/4bde31b24bf01b4d4a35ad31fafd8e4ca203b0f2))
 - Auto handle `Jsonable` values passed to `castAsJson()` ([#34392](https://github.com/laravel/framework/pull/34392))
-- Added crossJoinSub method to the query builder ([#34400](https://github.com/laravel/framework/pull/34400))
+- Added `crossJoinSub()` method to the query builder ([#34400](https://github.com/laravel/framework/pull/34400))
 - Added `Illuminate\Session\Store::passwordConfirmed()` ([fb3f45a](https://github.com/laravel/framework/commit/fb3f45aa0142764c5c29b97e8bcf8328091986e9))
 
 ### Changed
 - Check for view existence first in `Illuminate\Mail\Markdown::render()` ([5f78c90](https://github.com/laravel/framework/commit/5f78c90a7af118dd07703a78da06586016973a66))
-- Guess the model name when using the make:factory command ([#34373](https://github.com/laravel/framework/pull/34373))
+- Guess the model name when using the `make:factory` command ([#34373](https://github.com/laravel/framework/pull/34373))
 
 
 ## [v8.4.0 (2020-09-16)](https://github.com/laravel/framework/compare/v8.3.0...v8.4.0)


### PR DESCRIPTION
- Align the use of `backticks` when referring to methods(), commands, and filenames