### PR TITLE
[8.x] Fixed config batching typo

### DIFF
--- a/src/Illuminate/Queue/Console/BatchesTableCommand.php
+++ b/src/Illuminate/Queue/Console/BatchesTableCommand.php
@@ -57,7 +57,7 @@ class BatchesTableCommand extends Command
      */
     public function handle()
     {
-        $table = $this->laravel['config']['queue.batches.table'] ?? 'job_batches';
+        $table = $this->laravel['config']['queue.batching.table'] ?? 'job_batches';
 
         $this->replaceMigration(
             $this->createBaseMigration($table), $table, Str::studly($table)


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Ensures the config key used for determining the table name in `queue:batches-table` console command is the same as the config key used when registering batch services in https://github.com/laravel/framework/blob/4063a5760b6c0d1feb1d12ede3ee3c04f15c3cc7/src/Illuminate/Bus/BusServiceProvider.php#L49-L50

Currently, the console command uses `queue.batches.table`, and when registering batch services `queue.batching.table` is used.