### PR TITLE
[9.x] Add rate limiting per second

### DIFF
--- a/src/Illuminate/Cache/RateLimiting/GlobalLimit.php
+++ b/src/Illuminate/Cache/RateLimiting/GlobalLimit.php
@@ -8,11 +8,11 @@ class GlobalLimit extends Limit
      * Create a new limit instance.
      *
      * @param  int  $maxAttempts
-     * @param  int  $decayMinutes
+     * @param  int  $decaySeconds
      * @return void
      */
-    public function __construct(int $maxAttempts, int $decayMinutes = 1)
+    public function __construct(int $maxAttempts, int $decaySeconds = 60)
     {
-        parent::__construct('', $maxAttempts, $decayMinutes);
+        parent::__construct('', $maxAttempts, $decaySeconds);
     }
 }

--- a/src/Illuminate/Cache/RateLimiting/Limit.php
+++ b/src/Illuminate/Cache/RateLimiting/Limit.php
@@ -19,11 +19,11 @@ class Limit
     public $maxAttempts;
 
     /**
-     * The number of minutes until the rate limit is reset.
+     * The number of seconds until the rate limit is reset.
      *
      * @var int
      */
-    public $decayMinutes;
+    public $decaySeconds;
 
     /**
      * The response generator callback.
@@ -37,25 +37,40 @@ class Limit
      *
      * @param  mixed|string  $key
      * @param  int  $maxAttempts
-     * @param  int  $decayMinutes
+     * @param  int  $decaySeconds
      * @return void
      */
-    public function __construct($key = '', int $maxAttempts = 60, int $decayMinutes = 1)
+    public function __construct($key = '', int $maxAttempts = 60, int $decaySeconds = 60)
     {
         $this->key = $key;
         $this->maxAttempts = $maxAttempts;
-        $this->decayMinutes = $decayMinutes;
+        $this->decaySeconds = $decaySeconds;
     }
 
     /**
      * Create a new rate limit.
      *
-     * @param  int  $maxAttempts
+     * @param int $maxAttempts
+     * @param int $decayMinutes
+     *
      * @return static
      */
-    public static function perMinute($maxAttempts)
+    public static function perMinute($maxAttempts, $decayMinutes = 1)
     {
-        return new static('', $maxAttempts);
+        return new static('', $maxAttempts, $decayMinutes * 60);
+    }
+
+    /**
+     * Create a new rate limit.
+     *
+     * @param int $maxAttempts
+     * @param int $decaySeconds
+     *
+     * @return static
+     */
+    public static function perSecond($maxAttempts, $decaySeconds = 1)
+    {
+        return new static('', $maxAttempts, $decaySeconds);
     }
 
     /**
@@ -67,7 +82,7 @@ class Limit
      */
     public static function perHour($maxAttempts, $decayHours = 1)
     {
-        return new static('', $maxAttempts, 60 * $decayHours);
+        return new static('', $maxAttempts, 60 * 60 * $decayHours);
     }
 
     /**
@@ -79,7 +94,7 @@ class Limit
      */
     public static function perDay($maxAttempts, $decayDays = 1)
     {
-        return new static('', $maxAttempts, 60 * 24 * $decayDays);
+        return new static('', $maxAttempts, 60 * 60 * 24 * $decayDays);
     }
 
     /**

--- a/src/Illuminate/Routing/Middleware/ThrottleRequests.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequests.php
@@ -62,7 +62,7 @@ class ThrottleRequests
                 (object) [
                     'key' => $prefix.$this->resolveRequestSignature($request),
                     'maxAttempts' => $this->resolveMaxAttempts($request, $maxAttempts),
-                    'decayMinutes' => $decayMinutes,
+                    'decaySeconds' => $decayMinutes * 60,
                     'responseCallback' => null,
                 ],
             ]
@@ -97,7 +97,7 @@ class ThrottleRequests
                 return (object) [
                     'key' => md5($limiterName.$limit->key),
                     'maxAttempts' => $limit->maxAttempts,
-                    'decayMinutes' => $limit->decayMinutes,
+                    'decaySeconds' => $limit->decaySeconds,
                     'responseCallback' => $limit->responseCallback,
                 ];
             })->all()
@@ -121,7 +121,7 @@ class ThrottleRequests
                 throw $this->buildException($request, $limit->key, $limit->maxAttempts, $limit->responseCallback);
             }
 
-            $this->limiter->hit($limit->key, $limit->decayMinutes * 60);
+            $this->limiter->hit($limit->key, $limit->decaySeconds);
         }
 
         $response = $next($request);

--- a/src/Illuminate/Routing/Middleware/ThrottleRequestsWithRedis.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequestsWithRedis.php
@@ -57,7 +57,7 @@ class ThrottleRequestsWithRedis extends ThrottleRequests
     protected function handleRequest($request, Closure $next, array $limits)
     {
         foreach ($limits as $limit) {
-            if ($this->tooManyAttempts($limit->key, $limit->maxAttempts, $limit->decayMinutes)) {
+            if ($this->tooManyAttempts($limit->key, $limit->maxAttempts, $limit->decaySeconds)) {
                 throw $this->buildException($request, $limit->key, $limit->maxAttempts, $limit->responseCallback);
             }
         }
@@ -80,13 +80,13 @@ class ThrottleRequestsWithRedis extends ThrottleRequests
      *
      * @param  string  $key
      * @param  int  $maxAttempts
-     * @param  int  $decayMinutes
+     * @param  int  $decaySeconds
      * @return mixed
      */
-    protected function tooManyAttempts($key, $maxAttempts, $decayMinutes)
+    protected function tooManyAttempts($key, $maxAttempts, $decaySeconds)
     {
         $limiter = new DurationLimiter(
-            $this->redis, $key, $maxAttempts, $decayMinutes * 60
+            $this->redis, $key, $maxAttempts, $decaySeconds
         );
 
         return tap(! $limiter->acquire(), function () use ($key, $limiter) {

--- a/tests/Integration/Http/ThrottleRequestsTest.php
+++ b/tests/Integration/Http/ThrottleRequestsTest.php
@@ -66,7 +66,7 @@ class ThrottleRequestsTest extends TestCase
         $rateLimiter = Container::getInstance()->make(RateLimiter::class);
 
         $rateLimiter->for('test', function ($request) {
-            return new GlobalLimit(2, 1);
+            return new GlobalLimit(2, 60);
         });
 
         Carbon::setTestNow(Carbon::create(2018, 1, 1, 0, 0, 0));


### PR DESCRIPTION
This adds the possibility to rate limit requests per second.

**Why?**
We are working on an REST API which needs to limit requests to certain endpoints. It is fine if the user sends 500 requests averaged in a minute but we have a problem if the user sends them in just one second. For such cases we need the possibility to limit requests per second as well.

You could combine per-second limiting with per-minute limiting:

```php
RateLimiter::for('job-creation', function (Request $request) {
    return [
        Limit::perSecond(20),
        Limit::perMinute(500)
    ];
});
```

This also allows to set limits for any time spans < 1 minute:
```php
Limit::perSecond(100, 10) // allow 100 per 10 seconds
```

This is a breaking change because it changes the constructor of `Limit` and `GlobalLimit`, so I am sending this to master.
