### PR TITLE
[8.x] Add multiple_of custom replacer

### DIFF
--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -105,6 +105,20 @@ trait ReplacesAttributes
     }
 
     /**
+     * Replace all place-holders for the multiple_of rule.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array  $parameters
+     * @return string
+     */
+    protected function replaceMultipleOf($message, $attribute, $rule, $parameters)
+    {
+        return str_replace(':value', $parameters[0], $message);
+    }
+
+    /**
      * Replace all place-holders for the in rule.
      *
      * @param  string  $message

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1857,9 +1857,16 @@ class ValidationValidatorTest extends TestCase
     public function testValidateMutlpleOf($input, $allowed, $passes)
     {
         $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines(['validation.multiple_of' => 'The :attribute must be a multiple of :value'], 'en');
 
         $v = new Validator($trans, ['foo' => $input], ['foo' => "multiple_of:{$allowed}"]);
+
         $this->assertSame($passes, $v->passes());
+        if ($v->fails()) {
+            $this->assertSame("The foo must be a multiple of {$allowed}", $v->messages()->first('foo'));
+        } else {
+            $this->assertSame('', $v->messages()->first('foo'));
+        }
     }
 
     public function multipleOfDataProvider()
@@ -1920,6 +1927,8 @@ class ValidationValidatorTest extends TestCase
             ['foo', 1, false], // invalid values
             [1, 'foo', false],
             ['foo', 'foo', false],
+            [1, '', false],
+            [1, null, false],
         ];
     }
 


### PR DESCRIPTION
Initial PR introducing `multiple_of`: https://github.com/laravel/framework/pull/34788

- Adds custom replacer for: https://github.com/laravel/laravel/pull/5449
- Adds some extra tests for empty values
