### PR TITLE
[8.x] Add ability to replicate eloquent collection

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -280,6 +280,22 @@ class Collection extends BaseCollection implements QueueableCollection
         }) ? $result->toBase() : $result;
     }
 
+     /**
+     *  Run a replicate over each of the items. 
+     * 
+     * @param  callable|null  $callback
+     * @param  array|null  $except
+     * @return static
+     */
+    public function replicate(array $except = null)
+    {
+        $items = $this->map(function ($model) use ($except) {
+            return  $model->replicate($except);           
+        });
+        return new static($items);
+        
+    }
+
     /**
      * Reload a fresh model instance from the database for all the entities.
      *

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -282,7 +282,7 @@ class Collection extends BaseCollection implements QueueableCollection
 
     /**
      *  Run a replicate over each of the items. 
-     * 
+     *
      * @param  callable|null  $callback
      * @param  array|null  $except
      * @return static
@@ -290,9 +290,7 @@ class Collection extends BaseCollection implements QueueableCollection
     public function replicate(array $except = null)
     {
         $items = $this->map(function ($model) use ($except) {
-
-            return  $model->replicate($except);     
-
+            return  $model->replicate($except);
         });
         return new static($items);
     }

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -280,7 +280,7 @@ class Collection extends BaseCollection implements QueueableCollection
         }) ? $result->toBase() : $result;
     }
 
-     /**
+    /**
      *  Run a replicate over each of the items. 
      * 
      * @param  callable|null  $callback
@@ -290,10 +290,11 @@ class Collection extends BaseCollection implements QueueableCollection
     public function replicate(array $except = null)
     {
         $items = $this->map(function ($model) use ($except) {
-            return  $model->replicate($except);           
+
+            return  $model->replicate($except);     
+
         });
         return new static($items);
-        
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -290,7 +290,7 @@ class Collection extends BaseCollection implements QueueableCollection
     {
         return $this->map(function ($model) use ($except) {
             return $model->replicate($except);
-        });             
+        });           
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -281,7 +281,7 @@ class Collection extends BaseCollection implements QueueableCollection
     }
 
     /**
-     *  Replicates every item in the collection .
+     * Replicates every item in the collection.
      *
      * @param  array|null  $except
      * @return static

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -288,11 +288,10 @@ class Collection extends BaseCollection implements QueueableCollection
      */
     public function replicate(array $except = null)
     {
-        $items = $this->map(function ($model) use ($except) {
+        return $this->map(function ($model) use ($except) {
             return $model->replicate($except);
         });
-
-        return new static($items);
+             
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -281,7 +281,7 @@ class Collection extends BaseCollection implements QueueableCollection
     }
 
     /**
-     *  Run a replicate over each of the items. 
+     *  Run a replicate over each of the items.
      *
      * @param  callable|null  $callback
      * @param  array|null  $except
@@ -292,6 +292,7 @@ class Collection extends BaseCollection implements QueueableCollection
         $items = $this->map(function ($model) use ($except) {
             return  $model->replicate($except);
         });
+        
         return new static($items);
     }
 

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -290,8 +290,7 @@ class Collection extends BaseCollection implements QueueableCollection
     {
         return $this->map(function ($model) use ($except) {
             return $model->replicate($except);
-        });
-             
+        });             
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -281,18 +281,17 @@ class Collection extends BaseCollection implements QueueableCollection
     }
 
     /**
-     *  Run a replicate over each of the items.
+     *  Replicates every item in the collection .
      *
-     * @param  callable|null  $callback
      * @param  array|null  $except
      * @return static
      */
     public function replicate(array $except = null)
     {
         $items = $this->map(function ($model) use ($except) {
-            return  $model->replicate($except);
+            return $model->replicate($except);
         });
-        
+
         return new static($items);
     }
 

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -92,6 +92,20 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertFalse($c->contains(3));
     }
 
+    public function testReplicateIsReplicateEloquentCollection(){
+
+        $model1 = (new TestEloquentCollectionModel)->forceFill(['id' => 1,'name'=> 'taylor']);
+        $model2 = (new TestEloquentCollectionModel)->forceFill(['id' => 2,'name'=> 'adam']);
+        $model3 = (new TestEloquentCollectionModel)->forceFill(['id' => 3,'name' => 'abdelaal']);
+        $c = new Collection([$model1 , $model2 , $model3]);
+        $replicatedCollection = $c->replicate();
+        
+        $this->assertInstanceOf(Collection::class , $replicatedCollection);
+        $this->assertFalse($replicatedCollection->contains($model3));
+        $this->assertFalse($replicatedCollection->contains($model2));
+        $this->assertFalse($replicatedCollection->contains($model1));
+    }
+
     public function testContainsKeyAndValueIndicatesIfModelInArray()
     {
         $mockModel1 = m::mock(Model::class);

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -94,13 +94,13 @@ class DatabaseEloquentCollectionTest extends TestCase
 
     public function testReplicateIsReplicateEloquentCollection()
     {
-        $model1 = (new TestEloquentCollectionModel)->forceFill(['id' => 1,'name'=> 'taylor']);
-        $model2 = (new TestEloquentCollectionModel)->forceFill(['id' => 2,'name'=> 'adam']);
-        $model3 = (new TestEloquentCollectionModel)->forceFill(['id' => 3,'name' => 'abdelaal']);
-        $c = new Collection([$model1 , $model2 , $model3]);
+        $model1 = (new TestEloquentCollectionModel)->forceFill(['id' => 1, 'name'=> 'taylor']);
+        $model2 = (new TestEloquentCollectionModel)->forceFill(['id' => 2, 'name'=> 'adam']);
+        $model3 = (new TestEloquentCollectionModel)->forceFill(['id' => 3, 'name' => 'abdelaal']);
+        $c = new Collection([$model1, $model2, $model3]);
         $replicatedCollection = $c->replicate();
-        
-        $this->assertInstanceOf(Collection::class , $replicatedCollection);
+   
+        $this->assertInstanceOf(Collection::class, $replicatedCollection);
         $this->assertFalse($replicatedCollection->contains($model3));
         $this->assertFalse($replicatedCollection->contains($model2));
         $this->assertFalse($replicatedCollection->contains($model1));

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -92,7 +92,8 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertFalse($c->contains(3));
     }
 
-    public function testReplicateIsReplicateEloquentCollection(){
+    public function testReplicateIsReplicateEloquentCollection()
+    {
 
         $model1 = (new TestEloquentCollectionModel)->forceFill(['id' => 1,'name'=> 'taylor']);
         $model2 = (new TestEloquentCollectionModel)->forceFill(['id' => 2,'name'=> 'adam']);

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -99,7 +99,7 @@ class DatabaseEloquentCollectionTest extends TestCase
         $model3 = (new TestEloquentCollectionModel)->forceFill(['id' => 3, 'name' => 'abdelaal']);
         $c = new Collection([$model1, $model2, $model3]);
         $replicatedCollection = $c->replicate();
-   
+    
         $this->assertInstanceOf(Collection::class, $replicatedCollection);
         $this->assertFalse($replicatedCollection->contains($model3));
         $this->assertFalse($replicatedCollection->contains($model2));

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -99,7 +99,7 @@ class DatabaseEloquentCollectionTest extends TestCase
         $model3 = (new TestEloquentCollectionModel)->forceFill(['id' => 3, 'name' => 'abdelaal']);
         $c = new Collection([$model1, $model2, $model3]);
         $replicatedCollection = $c->replicate();
-    
+
         $this->assertInstanceOf(Collection::class, $replicatedCollection);
         $this->assertFalse($replicatedCollection->contains($model3));
         $this->assertFalse($replicatedCollection->contains($model2));

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -94,7 +94,6 @@ class DatabaseEloquentCollectionTest extends TestCase
 
     public function testReplicateIsReplicateEloquentCollection()
     {
-
         $model1 = (new TestEloquentCollectionModel)->forceFill(['id' => 1,'name'=> 'taylor']);
         $model2 = (new TestEloquentCollectionModel)->forceFill(['id' => 2,'name'=> 'adam']);
         $model3 = (new TestEloquentCollectionModel)->forceFill(['id' => 3,'name' => 'abdelaal']);


### PR DESCRIPTION
This PR add ability replicate eloquent collection ->replicate() method.

l had situation that i want to replicate excursions with their relations and change a bit in excursion attribute  

**before replicate** 

```
Excursion::with('availableDates')
    ->get()
    ->each(function ($excursion) {
        $replicatedExcursion = $excursion->replicate(['title_lowered']);
        $replicatedExcursion->is_active =false ;
        $excursion->save();
        $availableDates =$replicatedExcursion->availableDates->map(function($availableDate){
            return $availableDate->replicate(['is_active']);
        });
        $replicatedExcursion->availableDates()->saveMany($availableDates);
    
    });
```

```
         $availableDates =$replicatedExcursion->availableDates->map(function($availableDate){
            return $availableDate->replicate(['is_active']);
        });
        $replicatedExcursion->availableDates()->saveMany($availableDates);
```

 **After replicate** 
 ```
Excursion::with('availableDates')
    ->get()
    ->replicate(['title_lowered'])
    ->each(function ($replicatedExcursion) {
        $replicatedExcursion->is_active =false ;
        $replicatedExcursion->save();
        $replicatedExcursion->availableDates()->saveMany($new_excursion->availableDates->replicate(['is_active']));
       
    });
```
`        $replicatedExcursion->availableDates()->saveMany($new_excursion->availableDates->replicate(['is_active']));
`


   I think writing it this way is **readable** .
 **i using replicate method as  macro**  in my current project .
  thank you 