### PR TITLE
[8.x] Change loadRoutesFrom to accept group $attributes

### DIFF
--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Foundation\CachesConfiguration;
 use Illuminate\Contracts\Foundation\CachesRoutes;
 use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Database\Eloquent\Factory as ModelFactory;
+use Illuminate\Support\Facades\Route;
 use Illuminate\View\Compilers\BladeCompiler;
 
 abstract class ServiceProvider
@@ -136,12 +137,14 @@ abstract class ServiceProvider
      * Load the given routes file if routes are not already cached.
      *
      * @param  string  $path
+     * @param  array  $attributes
+     *
      * @return void
      */
-    protected function loadRoutesFrom($path)
+    protected function loadRoutesFrom($path, array $attributes = [])
     {
         if (! ($this->app instanceof CachesRoutes && $this->app->routesAreCached())) {
-            require $path;
+            Route::group($attributes, $path);
         }
     }
 


### PR DESCRIPTION
When we define routes it is often needed to include a couple of middleware groups (especially `web` or `api`) on the loaded routes in the files.

This PR makes it possible to refactor out the `Route::group` call in the manually loaded route files and make them flatter while maintaining the proper route-caching.
Plus, it brings the `$route` object back and makes it consistent with default route files.

- Let me note that calling `Route::group($attr, $path);` directly in the boot method (instead of `loadRoutesFrom`) requires knowledge of how the route caching is done in that particular version of laravel or they will not get cached.
### Performance hit:
On production, it should have zero-hit on performance, since the routes are cached.

### Before
```php
// boot method
$this->loadRoutesFrom($somePath);
```
```php
// my_routes.php 
Route::group(['middleware' => 'web'], function () {
    Route::get(...);
    Route::post(...);
    ...
});
```

### After:
```php
// boot method
$this->loadRoutesFrom($somePath, ['middleware' => 'web']);
```
```php
// my_routes.php 
// Route::group(['middleware' => 'web'], function () {
Route::get(...);
Route::post(...);
...
//});
```

### Backward-compatibility:
This is mostly backward compatible except for method signature issues, which arise when overriding methods in subclasses, which is very rare.

- The imported Route facade is already in the `illuminate\support` package.