### PR TITLE
[8.x] Improve Rate Limiter With Lock

### DIFF
--- a/src/Illuminate/Cache/RateLimiter.php
+++ b/src/Illuminate/Cache/RateLimiter.php
@@ -90,7 +90,7 @@ class RateLimiter
      */
     public function hit($key, $decaySeconds = 60)
     {
-        if(! ($this->cache->getStore() instanceof LockProvider)) {
+        if (! ($this->cache->getStore() instanceof LockProvider)) {
             return $this->increment($key, $decaySeconds);
         }
 


### PR DESCRIPTION
The current rate limiter is not atomic, which can cause bugs with high frequency hits. This PR improves it by wrapping the `hit` operation in a blocking lock. Symfony's new RateLimiter component uses the same strategy.

This also makes it possible for us to allow rate limiting per second (https://github.com/laravel/framework/pull/34856). I'm not quite sure if this is considered a breaking change. If yes, I can send to master.