### PR TITLE
[9.x] Add support for lazy loading commands

### DIFF
--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -292,7 +292,7 @@ class Application extends SymfonyApplication implements ApplicationContract
     }
 
     /**
-     * Set the Container Command Loader
+     * Set the Container Command Loader.
      *
      * @return $this
      */

--- a/src/Illuminate/Console/ContainerCommandLoader.php
+++ b/src/Illuminate/Console/ContainerCommandLoader.php
@@ -17,7 +17,7 @@ class ContainerCommandLoader implements CommandLoaderInterface
 
     /**
      * A map of command names to classes.
-     * 
+     *
      * @var array
      */
     protected $commandMap;
@@ -42,7 +42,7 @@ class ContainerCommandLoader implements CommandLoaderInterface
      */
     public function get(string $name)
     {
-        if (!$this->has($name)) {
+        if (! $this->has($name)) {
             throw new CommandNotFoundException(sprintf('Command "%s" does not exist.', $name));
         }
 
@@ -62,7 +62,7 @@ class ContainerCommandLoader implements CommandLoaderInterface
 
     /**
      * Get the command names.
-     * 
+     *
      * @return string[]
      */
     public function getNames()

--- a/src/Illuminate/Console/ContainerCommandLoader.php
+++ b/src/Illuminate/Console/ContainerCommandLoader.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Illuminate\Console;
+
+use Psr\Container\ContainerInterface;
+use Symfony\Component\Console\CommandLoader\CommandLoaderInterface;
+use Symfony\Component\Console\Exception\CommandNotFoundException;
+
+class ContainerCommandLoader implements CommandLoaderInterface
+{
+    /**
+     * The container instance.
+     *
+     * @var \Psr\Container\ContainerInterface
+     */
+    protected $container;
+
+    /**
+     * A map of command names to classes.
+     * 
+     * @var array
+     */
+    protected $commandMap;
+
+    /**
+     * @param  \Psr\Container\ContainerInterface $container
+     * @param  array  $commandMap
+     */
+    public function __construct(ContainerInterface $container, array $commandMap)
+    {
+        $this->container = $container;
+        $this->commandMap = $commandMap;
+    }
+
+    /**
+     * Loads a command.
+     *
+     * @param  string  $name
+     * @return \Symfony\Component\Console\Command\Command
+     *
+     * @throws \Symfony\Component\Console\Exception\CommandNotFoundException
+     */
+    public function get(string $name)
+    {
+        if (!$this->has($name)) {
+            throw new CommandNotFoundException(sprintf('Command "%s" does not exist.', $name));
+        }
+
+        return $this->container->get($this->commandMap[$name]);
+    }
+
+    /**
+     * Checks if a command exists.
+     *
+     * @param  string  $name
+     * @return bool
+     */
+    public function has(string $name)
+    {
+        return $name && isset($this->commandMap[$name]);
+    }
+
+    /**
+     * Get the command names.
+     * 
+     * @return string[]
+     */
+    public function getNames()
+    {
+        return array_keys($this->commandMap);
+    }
+}

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -327,8 +327,10 @@ class Kernel implements KernelContract
     protected function getArtisan()
     {
         if (is_null($this->artisan)) {
-            return $this->artisan = (new Artisan($this->app, $this->events, $this->app->version()))
-                                ->resolveCommands($this->commands);
+            $this->artisan = (new Artisan($this->app, $this->events, $this->app->version()))
+                            ->resolveCommands($this->commands);
+
+            return $this->artisan->setContainerCommandLoader();
         }
 
         return $this->artisan;

--- a/src/Illuminate/Foundation/Console/stubs/console.stub
+++ b/src/Illuminate/Foundation/Console/stubs/console.stub
@@ -14,6 +14,13 @@ class {{ class }} extends Command
     protected $signature = '{{ command }}';
 
     /**
+     * The default command name for lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = '{{ command }}';
+
+    /**
      * The console command description.
      *
      * @var string


### PR DESCRIPTION
Currently, all commands in Laravel have to be instantiated to be registered in the console application. That could be a problem for commands with big dependency graphs as all the dependencies are loaded in memory. See https://github.com/laravel/ideas/issues/1399.

Symfony has had lazy loading support for commands since version 3.4. This PR extends Symfony's lazy loading to Laravel. To allow for lazy loading, Laravel package console commands and/or app console commands just need to set the static `$defaultName` property like so:

```php
/**
 * The default command name for lazy loading.
 *
 * @var string|null
*/
protected static $defaultName = 'command:name';
```

Since the PR changes the return type of `Application::resolve` (adds a null return type), I'm sending this to master instead of 8x. If this PR is accepted, I can send across another PR to lazy load the commands shipped with Laravel.