### PR TITLE
Fix undefined variable error for id

### DIFF
--- a/src/Illuminate/Queue/Console/RetryBatchCommand.php
+++ b/src/Illuminate/Queue/Console/RetryBatchCommand.php
@@ -28,7 +28,7 @@ class RetryBatchCommand extends Command
      */
     public function handle()
     {
-        $batch = $this->laravel[BatchRepository::class]->find($this->argument('id'));
+        $batch = $this->laravel[BatchRepository::class]->find($id = $this->argument('id'));
 
         if (! $batch) {
             $this->error("Unable to find a batch with ID [{$id}].");


### PR DESCRIPTION
`$id` was referenced here https://github.com/laravel/framework/blob/master/src/Illuminate/Queue/Console/RetryBatchCommand.php#L34, but it wasn't defined before. This PR fixes that.