### PR TITLE
[6.x] Remove redundant trait from not queued job stub

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/job.stub
+++ b/src/Illuminate/Foundation/Console/stubs/job.stub
@@ -2,12 +2,11 @@
 
 namespace DummyNamespace;
 
-use Illuminate\Bus\Queueable;
 use Illuminate\Foundation\Bus\Dispatchable;
 
 class DummyClass
 {
-    use Dispatchable, Queueable;
+    use Dispatchable;
 
     /**
      * Create a new job instance.


### PR DESCRIPTION
This PR removes `Illuminate\Bus\Queueable` trait from the `job.stub` file because this stub is not meant to be queued. There is `job-queued.stub` which has this trait.