### PR TITLE
[8.x] Improve Bus::batch() doc block

### DIFF
--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -146,7 +146,7 @@ class Dispatcher implements QueueingDispatcher
     /**
      * Create a new batch of queueable jobs.
      *
-     * @param  \Illuminate\Support\Collection|array  $jobs
+     * @param  \Illuminate\Support\Collection|array|mixed  $jobs
      * @return \Illuminate\Bus\PendingBatch
      */
     public function batch($jobs)

--- a/src/Illuminate/Support/Facades/Bus.php
+++ b/src/Illuminate/Support/Facades/Bus.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Testing\Fakes\BusFake;
 
 /**
  * @method static \Illuminate\Bus\Batch|null findBatch(string $batchId)
- * @method static \Illuminate\Bus\PendingBatch batch(array $jobs)
+ * @method static \Illuminate\Bus\PendingBatch batch(array|mixed $jobs)
  * @method static \Illuminate\Contracts\Bus\Dispatcher map(array $map)
  * @method static \Illuminate\Contracts\Bus\Dispatcher pipeThrough(array $pipes)
  * @method static \Illuminate\Foundation\Bus\PendingChain chain(array $jobs)


### PR DESCRIPTION
Improve `Bus::batch()` and `Dispatcher::batch()` doc blocks to include mixed, as single jobs are allowed as well (they are automatically wrapped in a Collection)