### PR TITLE
php 7.4 syntax error 

### DIFF
--- a/src/Illuminate/Bus/BusServiceProvider.php
+++ b/src/Illuminate/Bus/BusServiceProvider.php
@@ -47,7 +47,7 @@ class BusServiceProvider extends ServiceProvider implements DeferrableProvider
             return new DatabaseBatchRepository(
                 $app->make(BatchFactory::class),
                 $app->make('db')->connection(config('queue.batching.database')),
-                config('queue.batching.table', 'job_batches'),
+                config('queue.batching.table', 'job_batches')
             );
         });
     }


### PR DESCRIPTION
php 7.4
Syntax error, unexpected ')' at vendor/laravel/framework/src/Illuminate/Bus/BusServiceProvider.php:51
