### PR TITLE
[9.x] Use __invoke method in jobs & console commands stubs

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/console.stub
+++ b/src/Illuminate/Foundation/Console/stubs/console.stub
@@ -35,7 +35,7 @@ class {{ class }} extends Command
      *
      * @return mixed
      */
-    public function handle()
+    public function __invoke()
     {
         //
     }

--- a/src/Illuminate/Foundation/Console/stubs/job.queued.stub
+++ b/src/Illuminate/Foundation/Console/stubs/job.queued.stub
@@ -27,7 +27,7 @@ class {{ class }} implements ShouldQueue
      *
      * @return void
      */
-    public function handle()
+    public function __invoke()
     {
         //
     }

--- a/src/Illuminate/Foundation/Console/stubs/job.stub
+++ b/src/Illuminate/Foundation/Console/stubs/job.stub
@@ -24,7 +24,7 @@ class {{ class }}
      *
      * @return void
      */
-    public function handle()
+    public function __invoke()
     {
         //
     }


### PR DESCRIPTION
This PR replaces `handle` method with `__invoke` in jobs and console commands stubs.

Accordingly to the code base Jobs & Commands are using `__invoke` method if `handle` is missing. I think it is a good practice to make those classes invokable by default. Resolving dependencies out from the container in `__invoke` method looks more natural for me then from `handle`.

```php
class ExampleJob
{
    public function __construct(User $user) {}

    public function __invoke(Dispatcher $dispatcher) {}
}
```

```php
class ExampleCommand
{
    public function __invoke(Dispatcher $dispatcher) {}
}
```

`handle` is a good method name for the Listener class, because it handles the event passed as an argument.

```php
class ExampleListener
{
    public function __construct(Dispatcher $dispatcher) {}

    public function handle(UserRegisteredEvent $event) {}
}
```