### PR TITLE
[8.x] Add ability to create observers with custom path

### DIFF
--- a/src/Illuminate/Foundation/Console/ObserverMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ObserverMakeCommand.php
@@ -52,8 +52,21 @@ class ObserverMakeCommand extends GeneratorCommand
     protected function getStub()
     {
         return $this->option('model')
-                    ? __DIR__.'/stubs/observer.stub'
-                    : __DIR__.'/stubs/observer.plain.stub';
+            ? $this->resolveStubPath('/stubs/observer.stub')
+            : $this->resolveStubPath('/stubs/observer.plain.stub');
+    }
+
+    /**
+     * Resolve the fully-qualified path to the stub.
+     *
+     * @param  string  $stub
+     * @return string
+     */
+    protected function resolveStubPath($stub)
+    {
+        return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
+            ? $customPath
+            : __DIR__.$stub;
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/StubPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/StubPublishCommand.php
@@ -37,6 +37,8 @@ class StubPublishCommand extends Command
             __DIR__.'/stubs/job.stub' => $stubsPath.'/job.stub',
             __DIR__.'/stubs/model.pivot.stub' => $stubsPath.'/model.pivot.stub',
             __DIR__.'/stubs/model.stub' => $stubsPath.'/model.stub',
+            __DIR__.'/stubs/observer.stub' => $stubsPath.'/observer.stub',
+            __DIR__.'/stubs/observer.plain.stub' => $stubsPath.'/observer.plain.stub',
             __DIR__.'/stubs/request.stub' => $stubsPath.'/request.stub',
             __DIR__.'/stubs/resource.stub' => $stubsPath.'/resource.stub',
             __DIR__.'/stubs/resource-collection.stub' => $stubsPath.'/resource-collection.stub',

--- a/src/Illuminate/Foundation/Console/stubs/observer.plain.stub
+++ b/src/Illuminate/Foundation/Console/stubs/observer.plain.stub
@@ -1,8 +1,8 @@
 <?php
 
-namespace DummyNamespace;
+namespace {{ namespace }};
 
-class DummyClass
+class {{ class }}
 {
     //
 }

--- a/src/Illuminate/Foundation/Console/stubs/observer.stub
+++ b/src/Illuminate/Foundation/Console/stubs/observer.stub
@@ -1,18 +1,18 @@
 <?php
 
-namespace DummyNamespace;
+namespace {{ namespace }};
 
-use NamespacedDummyModel;
+use {{ namespacedModel }};
 
-class DummyClass
+class {{ class }}
 {
     /**
      * Handle the DocDummyModel "created" event.
      *
-     * @param  \NamespacedDummyModel  $dummyModel
+     * @param  \{{ namespacedModel }}  ${{ modelVariable }}
      * @return void
      */
-    public function created(DummyModel $dummyModel)
+    public function created({{ model }} ${{ modelVariable }})
     {
         //
     }
@@ -20,10 +20,10 @@ class DummyClass
     /**
      * Handle the DocDummyModel "updated" event.
      *
-     * @param  \NamespacedDummyModel  $dummyModel
+     * @param  \{{ namespacedModel }}  ${{ modelVariable }}
      * @return void
      */
-    public function updated(DummyModel $dummyModel)
+    public function updated({{ model }} ${{ modelVariable }})
     {
         //
     }
@@ -31,10 +31,10 @@ class DummyClass
     /**
      * Handle the DocDummyModel "deleted" event.
      *
-     * @param  \NamespacedDummyModel  $dummyModel
+     * @param  \{{ namespacedModel }}  ${{ modelVariable }}
      * @return void
      */
-    public function deleted(DummyModel $dummyModel)
+    public function deleted({{ model }} ${{ modelVariable }})
     {
         //
     }
@@ -42,10 +42,10 @@ class DummyClass
     /**
      * Handle the DocDummyModel "restored" event.
      *
-     * @param  \NamespacedDummyModel  $dummyModel
+     * @param  \{{ namespacedModel }}  ${{ modelVariable }}
      * @return void
      */
-    public function restored(DummyModel $dummyModel)
+    public function restored({{ model }} ${{ modelVariable }})
     {
         //
     }
@@ -53,10 +53,10 @@ class DummyClass
     /**
      * Handle the DocDummyModel "force deleted" event.
      *
-     * @param  \NamespacedDummyModel  $dummyModel
+     * @param  \{{ namespacedModel }}  ${{ modelVariable }}
      * @return void
      */
-    public function forceDeleted(DummyModel $dummyModel)
+    public function forceDeleted({{ model }} ${{ modelVariable }})
     {
         //
     }

--- a/src/Illuminate/Foundation/Console/stubs/observer.stub
+++ b/src/Illuminate/Foundation/Console/stubs/observer.stub
@@ -7,7 +7,7 @@ use {{ namespacedModel }};
 class {{ class }}
 {
     /**
-     * Handle the DocDummyModel "created" event.
+     * Handle the {{ model }} "created" event.
      *
      * @param  \{{ namespacedModel }}  ${{ modelVariable }}
      * @return void
@@ -18,7 +18,7 @@ class {{ class }}
     }
 
     /**
-     * Handle the DocDummyModel "updated" event.
+     * Handle the {{ model }} "updated" event.
      *
      * @param  \{{ namespacedModel }}  ${{ modelVariable }}
      * @return void
@@ -29,7 +29,7 @@ class {{ class }}
     }
 
     /**
-     * Handle the DocDummyModel "deleted" event.
+     * Handle the {{ model }} "deleted" event.
      *
      * @param  \{{ namespacedModel }}  ${{ modelVariable }}
      * @return void
@@ -40,7 +40,7 @@ class {{ class }}
     }
 
     /**
-     * Handle the DocDummyModel "restored" event.
+     * Handle the {{ model }} "restored" event.
      *
      * @param  \{{ namespacedModel }}  ${{ modelVariable }}
      * @return void
@@ -51,7 +51,7 @@ class {{ class }}
     }
 
     /**
-     * Handle the DocDummyModel "force deleted" event.
+     * Handle the {{ model }} "force deleted" event.
      *
      * @param  \{{ namespacedModel }}  ${{ modelVariable }}
      * @return void


### PR DESCRIPTION
When working with Stub files I noticed that the command make: observer does not have the possibility of use Stubs.

This pr adds the ability to edit and customize the default state of observer.stub and observer.plain.stub files.