### PR TITLE
Remove forgotten comma in BusServiceProvider

### DIFF
--- a/src/Illuminate/Bus/BusServiceProvider.php
+++ b/src/Illuminate/Bus/BusServiceProvider.php
@@ -47,7 +47,7 @@ class BusServiceProvider extends ServiceProvider implements DeferrableProvider
             return new DatabaseBatchRepository(
                 $app->make(BatchFactory::class),
                 $app->make('db')->connection(config('queue.batching.database')),
-                config('queue.batching.table', 'job_batches'),
+                config('queue.batching.table', 'job_batches')
             );
         });
     }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3463291/96699733-498e8b00-1397-11eb-93de-d23f9d96bcc5.png)

I've notice the error when I visit `_ignition/health-check` page.