### PR TITLE
[8.x] Add lazy method in eloquent factory

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -241,7 +241,7 @@ abstract class Factory
     }
 
     /**
-     * Create a model and persist it in the database if requested.
+     * Create a callback that persists a model in the database when invoked.
      *
      * @param  array  $attributes
      * @param  \Illuminate\Database\Eloquent\Model|null  $parent

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -241,6 +241,20 @@ abstract class Factory
     }
 
     /**
+     * Create a model and persist it in the database if requested.
+     *
+     * @param  array  $attributes
+     * @param  \Illuminate\Database\Eloquent\Model|null  $parent
+     * @return \Closure
+     */
+    public function lazy(array $attributes = [], ?Model $parent = null)
+    {
+        return function () use ($attributes, $parent) {
+            return $this->create($attributes, $parent);
+        };
+    }
+
+    /**
      * Set the connection name on the results and store them.
      *
      * @param  \Illuminate\Support\Collection  $results

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -154,6 +154,20 @@ class DatabaseEloquentFactoryTest extends TestCase
         $this->assertSame('Test Title', $post['title']);
     }
 
+    public function test_lazy_model_attributes_can_be_created()
+    {
+        $userFunction = FactoryTestUserFactory::new()->lazy();
+        $this->assertIsCallable($userFunction);
+        $this->assertInstanceOf(Eloquent::class, $userFunction());
+
+        $userFunction = FactoryTestUserFactory::new()->lazy(['name' => 'Taylor Otwell']);
+        $this->assertIsCallable($userFunction);
+
+        $user = $userFunction();
+        $this->assertInstanceOf(Eloquent::class, $user);
+        $this->assertSame('Taylor Otwell', $user->name);
+    }
+
     public function test_multiple_model_attributes_can_be_created()
     {
         $posts = FactoryTestPostFactory::new()->times(10)->raw();


### PR DESCRIPTION
Hi folks. 

Previously, we had a lazy method on factory, which was only a way to create a model, later, only if needed. 

With the factory change in L8, this helper disapeared.

This PR adds it again.

Thanks.
