### PR TITLE
[9.x] Lazy load Laravel commands

### DIFF
--- a/src/Illuminate/Auth/Console/ClearResetsCommand.php
+++ b/src/Illuminate/Auth/Console/ClearResetsCommand.php
@@ -14,6 +14,15 @@ class ClearResetsCommand extends Command
     protected $signature = 'auth:clear-resets {name? : The name of the password broker}';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'auth:clear-resets';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Cache/Console/CacheTableCommand.php
+++ b/src/Illuminate/Cache/Console/CacheTableCommand.php
@@ -16,6 +16,15 @@ class CacheTableCommand extends Command
     protected $name = 'cache:table';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'cache:table';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Cache/Console/ClearCommand.php
+++ b/src/Illuminate/Cache/Console/ClearCommand.php
@@ -18,6 +18,15 @@ class ClearCommand extends Command
     protected $name = 'cache:clear';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'cache:clear';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Cache/Console/ForgetCommand.php
+++ b/src/Illuminate/Cache/Console/ForgetCommand.php
@@ -15,6 +15,15 @@ class ForgetCommand extends Command
     protected $signature = 'cache:forget {key : The key to remove} {store? : The store to remove the key from}';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'cache:forget';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Console/Scheduling/ScheduleFinishCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleFinishCommand.php
@@ -14,6 +14,15 @@ class ScheduleFinishCommand extends Command
     protected $signature = 'schedule:finish {id} {code=0}';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'schedule:finish';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -22,6 +22,15 @@ class ScheduleRunCommand extends Command
     protected $name = 'schedule:run';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'schedule:run';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
@@ -16,6 +16,15 @@ class ScheduleWorkCommand extends Command
     protected $name = 'schedule:work';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'schedule:work';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Database/Console/DumpCommand.php
+++ b/src/Illuminate/Database/Console/DumpCommand.php
@@ -22,6 +22,15 @@ class DumpCommand extends Command
                 {--prune : Delete all existing migration files}';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'schema:dump';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
+++ b/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
@@ -16,6 +16,15 @@ class FactoryMakeCommand extends GeneratorCommand
     protected $name = 'make:factory';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'make:factory';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Database/Console/Seeds/SeedCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeedCommand.php
@@ -20,6 +20,15 @@ class SeedCommand extends Command
     protected $name = 'db:seed';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'db:seed';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Database/Console/Seeds/SeederMakeCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeederMakeCommand.php
@@ -14,6 +14,15 @@ class SeederMakeCommand extends GeneratorCommand
     protected $name = 'make:seeder';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'make:seeder';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Database/Console/WipeCommand.php
+++ b/src/Illuminate/Database/Console/WipeCommand.php
@@ -18,6 +18,15 @@ class WipeCommand extends Command
     protected $name = 'db:wipe';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'db:wipe';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Database/MigrationServiceProvider.php
+++ b/src/Illuminate/Database/MigrationServiceProvider.php
@@ -25,14 +25,14 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
      * @var array
      */
     protected $commands = [
-        'Migrate' => 'command.migrate',
-        'MigrateFresh' => 'command.migrate.fresh',
-        'MigrateInstall' => 'command.migrate.install',
-        'MigrateRefresh' => 'command.migrate.refresh',
-        'MigrateReset' => 'command.migrate.reset',
-        'MigrateRollback' => 'command.migrate.rollback',
-        'MigrateStatus' => 'command.migrate.status',
-        'MigrateMake' => 'command.migrate.make',
+        'Migrate' => MigrateCommand::class,
+        'MigrateFresh' => FreshCommand::class,
+        'MigrateInstall' => InstallCommand::class,
+        'MigrateRefresh' => RefreshCommand::class,
+        'MigrateReset' => ResetCommand::class,
+        'MigrateRollback' => RollbackCommand::class,
+        'MigrateStatus' => StatusCommand::class,
+        'MigrateMake' => MigrateMakeCommand::class,
     ];
 
     /**
@@ -116,7 +116,7 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
      */
     protected function registerMigrateCommand()
     {
-        $this->app->singleton('command.migrate', function ($app) {
+        $this->app->singleton(MigrateCommand::class, function ($app) {
             return new MigrateCommand($app['migrator'], $app[Dispatcher::class]);
         });
     }
@@ -128,9 +128,7 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
      */
     protected function registerMigrateFreshCommand()
     {
-        $this->app->singleton('command.migrate.fresh', function () {
-            return new FreshCommand;
-        });
+        $this->app->singleton(FreshCommand::class);
     }
 
     /**
@@ -140,7 +138,7 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
      */
     protected function registerMigrateInstallCommand()
     {
-        $this->app->singleton('command.migrate.install', function ($app) {
+        $this->app->singleton(InstallCommand::class, function ($app) {
             return new InstallCommand($app['migration.repository']);
         });
     }
@@ -152,7 +150,7 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
      */
     protected function registerMigrateMakeCommand()
     {
-        $this->app->singleton('command.migrate.make', function ($app) {
+        $this->app->singleton(MigrateMakeCommand::class, function ($app) {
             // Once we have the migration creator registered, we will create the command
             // and inject the creator. The creator is responsible for the actual file
             // creation of the migrations, and may be extended by these developers.
@@ -171,9 +169,7 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
      */
     protected function registerMigrateRefreshCommand()
     {
-        $this->app->singleton('command.migrate.refresh', function () {
-            return new RefreshCommand;
-        });
+        $this->app->singleton(RefreshCommand::class);
     }
 
     /**
@@ -183,7 +179,7 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
      */
     protected function registerMigrateResetCommand()
     {
-        $this->app->singleton('command.migrate.reset', function ($app) {
+        $this->app->singleton(ResetCommand::class, function ($app) {
             return new ResetCommand($app['migrator']);
         });
     }
@@ -195,7 +191,7 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
      */
     protected function registerMigrateRollbackCommand()
     {
-        $this->app->singleton('command.migrate.rollback', function ($app) {
+        $this->app->singleton(RollbackCommand::class, function ($app) {
             return new RollbackCommand($app['migrator']);
         });
     }
@@ -207,7 +203,7 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
      */
     protected function registerMigrateStatusCommand()
     {
-        $this->app->singleton('command.migrate.status', function ($app) {
+        $this->app->singleton(StatusCommand::class, function ($app) {
             return new StatusCommand($app['migrator']);
         });
     }

--- a/src/Illuminate/Foundation/Console/CastMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/CastMakeCommand.php
@@ -14,6 +14,15 @@ class CastMakeCommand extends GeneratorCommand
     protected $name = 'make:cast';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'make:cast';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/ChannelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ChannelMakeCommand.php
@@ -14,6 +14,15 @@ class ChannelMakeCommand extends GeneratorCommand
     protected $name = 'make:channel';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'make:channel';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/ClearCompiledCommand.php
+++ b/src/Illuminate/Foundation/Console/ClearCompiledCommand.php
@@ -14,6 +14,15 @@ class ClearCompiledCommand extends Command
     protected $name = 'clear-compiled';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'clear-compiled';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
@@ -17,6 +17,15 @@ class ComponentMakeCommand extends GeneratorCommand
     protected $name = 'make:component';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'make:component';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
@@ -18,6 +18,15 @@ class ConfigCacheCommand extends Command
     protected $name = 'config:cache';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'config:cache';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/ConfigClearCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigClearCommand.php
@@ -15,6 +15,15 @@ class ConfigClearCommand extends Command
     protected $name = 'config:clear';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'config:clear';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/ConsoleMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ConsoleMakeCommand.php
@@ -16,6 +16,15 @@ class ConsoleMakeCommand extends GeneratorCommand
     protected $name = 'make:command';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'make:command';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -21,6 +21,15 @@ class DownCommand extends Command
                                  {--status=503 : The status code that should be used when returning the maintenance mode response}';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'down';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/EnvironmentCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentCommand.php
@@ -14,6 +14,15 @@ class EnvironmentCommand extends Command
     protected $name = 'env';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'env';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/EventCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/EventCacheCommand.php
@@ -15,6 +15,15 @@ class EventCacheCommand extends Command
     protected $signature = 'event:cache';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'event:cache';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/EventClearCommand.php
+++ b/src/Illuminate/Foundation/Console/EventClearCommand.php
@@ -15,6 +15,15 @@ class EventClearCommand extends Command
     protected $name = 'event:clear';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'event:clear';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/EventGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/EventGenerateCommand.php
@@ -16,6 +16,15 @@ class EventGenerateCommand extends Command
     protected $name = 'event:generate';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'event:generate';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/EventListCommand.php
+++ b/src/Illuminate/Foundation/Console/EventListCommand.php
@@ -16,6 +16,15 @@ class EventListCommand extends Command
     protected $signature = 'event:list {--event= : Filter the events by name}';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'event:list';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/EventMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/EventMakeCommand.php
@@ -14,6 +14,15 @@ class EventMakeCommand extends GeneratorCommand
     protected $name = 'make:event';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'make:event';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/ExceptionMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ExceptionMakeCommand.php
@@ -15,6 +15,15 @@ class ExceptionMakeCommand extends GeneratorCommand
     protected $name = 'make:exception';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'make:exception';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/JobMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/JobMakeCommand.php
@@ -15,6 +15,15 @@ class JobMakeCommand extends GeneratorCommand
     protected $name = 'make:job';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'make:job';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -20,6 +20,15 @@ class KeyGenerateCommand extends Command
                     {--force : Force the operation to run when in production}';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'key:generate';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
@@ -16,6 +16,15 @@ class ListenerMakeCommand extends GeneratorCommand
     protected $name = 'make:listener';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'make:listener';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/MailMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/MailMakeCommand.php
@@ -15,6 +15,15 @@ class MailMakeCommand extends GeneratorCommand
     protected $name = 'make:mail';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'make:mail';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -16,6 +16,15 @@ class ModelMakeCommand extends GeneratorCommand
     protected $name = 'make:model';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'make:model';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/NotificationMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/NotificationMakeCommand.php
@@ -15,6 +15,15 @@ class NotificationMakeCommand extends GeneratorCommand
     protected $name = 'make:notification';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'make:notification';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/ObserverMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ObserverMakeCommand.php
@@ -16,6 +16,15 @@ class ObserverMakeCommand extends GeneratorCommand
     protected $name = 'make:observer';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'make:observer';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/OptimizeClearCommand.php
+++ b/src/Illuminate/Foundation/Console/OptimizeClearCommand.php
@@ -14,6 +14,15 @@ class OptimizeClearCommand extends Command
     protected $name = 'optimize:clear';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'optimize:clear';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/OptimizeCommand.php
+++ b/src/Illuminate/Foundation/Console/OptimizeCommand.php
@@ -14,6 +14,15 @@ class OptimizeCommand extends Command
     protected $name = 'optimize';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'optimize';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/PackageDiscoverCommand.php
+++ b/src/Illuminate/Foundation/Console/PackageDiscoverCommand.php
@@ -15,6 +15,15 @@ class PackageDiscoverCommand extends Command
     protected $signature = 'package:discover';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'package:discover';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
@@ -17,6 +17,15 @@ class PolicyMakeCommand extends GeneratorCommand
     protected $name = 'make:policy';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'make:policy';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/ProviderMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ProviderMakeCommand.php
@@ -14,6 +14,15 @@ class ProviderMakeCommand extends GeneratorCommand
     protected $name = 'make:provider';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'make:provider';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/RequestMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/RequestMakeCommand.php
@@ -14,6 +14,15 @@ class RequestMakeCommand extends GeneratorCommand
     protected $name = 'make:request';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'make:request';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/ResourceMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ResourceMakeCommand.php
@@ -16,6 +16,15 @@ class ResourceMakeCommand extends GeneratorCommand
     protected $name = 'make:resource';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'make:resource';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/RouteCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteCacheCommand.php
@@ -17,6 +17,15 @@ class RouteCacheCommand extends Command
     protected $name = 'route:cache';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'route:cache';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/RouteClearCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteClearCommand.php
@@ -15,6 +15,15 @@ class RouteClearCommand extends Command
     protected $name = 'route:clear';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'route:clear';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -20,6 +20,15 @@ class RouteListCommand extends Command
     protected $name = 'route:list';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'route:list';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/RuleMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/RuleMakeCommand.php
@@ -14,6 +14,15 @@ class RuleMakeCommand extends GeneratorCommand
     protected $name = 'make:rule';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'make:rule';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -18,6 +18,15 @@ class ServeCommand extends Command
     protected $name = 'serve';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'serve';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/StorageLinkCommand.php
+++ b/src/Illuminate/Foundation/Console/StorageLinkCommand.php
@@ -14,6 +14,15 @@ class StorageLinkCommand extends Command
     protected $signature = 'storage:link {--relative : Create the symbolic link using relative paths}';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'storage:link';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/StubPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/StubPublishCommand.php
@@ -15,6 +15,15 @@ class StubPublishCommand extends Command
     protected $signature = 'stub:publish {--force : Overwrite any existing files}';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'stub:publish';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/TestMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/TestMakeCommand.php
@@ -16,6 +16,15 @@ class TestMakeCommand extends GeneratorCommand
     protected $name = 'make:test';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'make:test';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/UpCommand.php
+++ b/src/Illuminate/Foundation/Console/UpCommand.php
@@ -15,6 +15,15 @@ class UpCommand extends Command
     protected $name = 'up';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'up';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -44,6 +44,15 @@ class VendorPublishCommand extends Command
                     {--tag=* : One or many tags that have assets you want to publish}';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'vendor:publish';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/ViewCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewCacheCommand.php
@@ -17,6 +17,15 @@ class ViewCacheCommand extends Command
     protected $signature = 'view:cache';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'view:cache';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/ViewClearCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewClearCommand.php
@@ -16,6 +16,15 @@ class ViewClearCommand extends Command
     protected $name = 'view:clear';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'view:clear';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -82,43 +82,43 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      * @var array
      */
     protected $commands = [
-        'CacheClear' => 'command.cache.clear',
-        'CacheForget' => 'command.cache.forget',
-        'ClearCompiled' => 'command.clear-compiled',
-        'ClearResets' => 'command.auth.resets.clear',
-        'ConfigCache' => 'command.config.cache',
-        'ConfigClear' => 'command.config.clear',
-        'DbWipe' => 'command.db.wipe',
-        'Down' => 'command.down',
-        'Environment' => 'command.environment',
-        'EventCache' => 'command.event.cache',
-        'EventClear' => 'command.event.clear',
-        'EventList' => 'command.event.list',
-        'KeyGenerate' => 'command.key.generate',
-        'Optimize' => 'command.optimize',
-        'OptimizeClear' => 'command.optimize.clear',
-        'PackageDiscover' => 'command.package.discover',
-        'QueueClear' => 'command.queue.clear',
-        'QueueFailed' => 'command.queue.failed',
-        'QueueFlush' => 'command.queue.flush',
-        'QueueForget' => 'command.queue.forget',
-        'QueueListen' => 'command.queue.listen',
-        'QueueRestart' => 'command.queue.restart',
-        'QueueRetry' => 'command.queue.retry',
-        'QueueRetryBatch' => 'command.queue.retry-batch',
-        'QueueWork' => 'command.queue.work',
-        'RouteCache' => 'command.route.cache',
-        'RouteClear' => 'command.route.clear',
-        'RouteList' => 'command.route.list',
-        'SchemaDump' => 'command.schema.dump',
-        'Seed' => 'command.seed',
+        'CacheClear' => CacheClearCommand::class,
+        'CacheForget' => CacheForgetCommand::class,
+        'ClearCompiled' => ClearCompiledCommand::class,
+        'ClearResets' => ClearResetsCommand::class,
+        'ConfigCache' => ConfigCacheCommand::class,
+        'ConfigClear' => ConfigClearCommand::class,
+        'DbWipe' => WipeCommand::class,
+        'Down' => DownCommand::class,
+        'Environment' => EnvironmentCommand::class,
+        'EventCache' => EventCacheCommand::class,
+        'EventClear' => EventClearCommand::class,
+        'EventList' => EventListCommand::class,
+        'KeyGenerate' => KeyGenerateCommand::class,
+        'Optimize' => OptimizeCommand::class,
+        'OptimizeClear' => OptimizeClearCommand::class,
+        'PackageDiscover' => PackageDiscoverCommand::class,
+        'QueueClear' => QueueClearCommand::class,
+        'QueueFailed' => ListFailedQueueCommand::class,
+        'QueueFlush' => FlushFailedQueueCommand::class,
+        'QueueForget' => ForgetFailedQueueCommand::class,
+        'QueueListen' => QueueListenCommand::class,
+        'QueueRestart' => QueueRestartCommand::class,
+        'QueueRetry' => QueueRetryCommand::class,
+        'QueueRetryBatch' => QueueRetryBatchCommand::class,
+        'QueueWork' => QueueWorkCommand::class,
+        'RouteCache' => RouteCacheCommand::class,
+        'RouteClear' => RouteClearCommand::class,
+        'RouteList' => RouteListCommand::class,
+        'SchemaDump' => DumpCommand::class,
+        'Seed' => SeedCommand::class,
         'ScheduleFinish' => ScheduleFinishCommand::class,
         'ScheduleRun' => ScheduleRunCommand::class,
         'ScheduleWork' => ScheduleWorkCommand::class,
-        'StorageLink' => 'command.storage.link',
-        'Up' => 'command.up',
-        'ViewCache' => 'command.view.cache',
-        'ViewClear' => 'command.view.clear',
+        'StorageLink' => StorageLinkCommand::class,
+        'Up' => UpCommand::class,
+        'ViewCache' => ViewCacheCommand::class,
+        'ViewClear' => ViewClearCommand::class,
     ];
 
     /**
@@ -127,38 +127,38 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      * @var array
      */
     protected $devCommands = [
-        'CacheTable' => 'command.cache.table',
-        'CastMake' => 'command.cast.make',
-        'ChannelMake' => 'command.channel.make',
-        'ComponentMake' => 'command.component.make',
-        'ConsoleMake' => 'command.console.make',
-        'ControllerMake' => 'command.controller.make',
-        'EventGenerate' => 'command.event.generate',
-        'EventMake' => 'command.event.make',
-        'ExceptionMake' => 'command.exception.make',
-        'FactoryMake' => 'command.factory.make',
-        'JobMake' => 'command.job.make',
-        'ListenerMake' => 'command.listener.make',
-        'MailMake' => 'command.mail.make',
-        'MiddlewareMake' => 'command.middleware.make',
-        'ModelMake' => 'command.model.make',
-        'NotificationMake' => 'command.notification.make',
-        'NotificationTable' => 'command.notification.table',
-        'ObserverMake' => 'command.observer.make',
-        'PolicyMake' => 'command.policy.make',
-        'ProviderMake' => 'command.provider.make',
-        'QueueFailedTable' => 'command.queue.failed-table',
-        'QueueTable' => 'command.queue.table',
-        'QueueBatchesTable' => 'command.queue.batches-table',
-        'RequestMake' => 'command.request.make',
-        'ResourceMake' => 'command.resource.make',
-        'RuleMake' => 'command.rule.make',
-        'SeederMake' => 'command.seeder.make',
-        'SessionTable' => 'command.session.table',
-        'Serve' => 'command.serve',
-        'StubPublish' => 'command.stub.publish',
-        'TestMake' => 'command.test.make',
-        'VendorPublish' => 'command.vendor.publish',
+        'CacheTable' => CacheTableCommand::class,
+        'CastMake' => CastMakeCommand::class,
+        'ChannelMake' => ChannelMakeCommand::class,
+        'ComponentMake' => ComponentMakeCommand::class,
+        'ConsoleMake' => ConsoleMakeCommand::class,
+        'ControllerMake' => ControllerMakeCommand::class,
+        'EventGenerate' => EventGenerateCommand::class,
+        'EventMake' => EventMakeCommand::class,
+        'ExceptionMake' => ExceptionMakeCommand::class,
+        'FactoryMake' => FactoryMakeCommand::class,
+        'JobMake' => JobMakeCommand::class,
+        'ListenerMake' => ListenerMakeCommand::class,
+        'MailMake' => MailMakeCommand::class,
+        'MiddlewareMake' => MiddlewareMakeCommand::class,
+        'ModelMake' => ModelMakeCommand::class,
+        'NotificationMake' => NotificationMakeCommand::class,
+        'NotificationTable' => NotificationTableCommand::class,
+        'ObserverMake' => ObserverMakeCommand::class,
+        'PolicyMake' => PolicyMakeCommand::class,
+        'ProviderMake' => ProviderMakeCommand::class,
+        'QueueFailedTable' => FailedTableCommand::class,
+        'QueueTable' => TableCommand::class,
+        'QueueBatchesTable' => BatchesTableCommand::class,
+        'RequestMake' => RequestMakeCommand::class,
+        'ResourceMake' => ResourceMakeCommand::class,
+        'RuleMake' => RuleMakeCommand::class,
+        'SeederMake' => SeederMakeCommand::class,
+        'SessionTable' => SessionTableCommand::class,
+        'Serve' => ServeCommand::class,
+        'StubPublish' => StubPublishCommand::class,
+        'TestMake' => TestMakeCommand::class,
+        'VendorPublish' => VendorPublishCommand::class,
     ];
 
     /**
@@ -195,7 +195,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerCacheClearCommand()
     {
-        $this->app->singleton('command.cache.clear', function ($app) {
+        $this->app->singleton(CacheClearCommand::class, function ($app) {
             return new CacheClearCommand($app['cache'], $app['files']);
         });
     }
@@ -207,7 +207,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerCacheForgetCommand()
     {
-        $this->app->singleton('command.cache.forget', function ($app) {
+        $this->app->singleton(CacheForgetCommand::class, function ($app) {
             return new CacheForgetCommand($app['cache']);
         });
     }
@@ -219,7 +219,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerCacheTableCommand()
     {
-        $this->app->singleton('command.cache.table', function ($app) {
+        $this->app->singleton(CacheTableCommand::class, function ($app) {
             return new CacheTableCommand($app['files'], $app['composer']);
         });
     }
@@ -231,7 +231,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerCastMakeCommand()
     {
-        $this->app->singleton('command.cast.make', function ($app) {
+        $this->app->singleton(CastMakeCommand::class, function ($app) {
             return new CastMakeCommand($app['files']);
         });
     }
@@ -243,7 +243,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerChannelMakeCommand()
     {
-        $this->app->singleton('command.channel.make', function ($app) {
+        $this->app->singleton(ChannelMakeCommand::class, function ($app) {
             return new ChannelMakeCommand($app['files']);
         });
     }
@@ -255,9 +255,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerClearCompiledCommand()
     {
-        $this->app->singleton('command.clear-compiled', function () {
-            return new ClearCompiledCommand;
-        });
+        $this->app->singleton(ClearCompiledCommand::class);
     }
 
     /**
@@ -267,9 +265,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerClearResetsCommand()
     {
-        $this->app->singleton('command.auth.resets.clear', function () {
-            return new ClearResetsCommand;
-        });
+        $this->app->singleton(ClearResetsCommand::class);
     }
 
     /**
@@ -279,7 +275,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerComponentMakeCommand()
     {
-        $this->app->singleton('command.component.make', function ($app) {
+        $this->app->singleton(ComponentMakeCommand::class, function ($app) {
             return new ComponentMakeCommand($app['files']);
         });
     }
@@ -291,7 +287,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerConfigCacheCommand()
     {
-        $this->app->singleton('command.config.cache', function ($app) {
+        $this->app->singleton(ConfigCacheCommand::class, function ($app) {
             return new ConfigCacheCommand($app['files']);
         });
     }
@@ -303,7 +299,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerConfigClearCommand()
     {
-        $this->app->singleton('command.config.clear', function ($app) {
+        $this->app->singleton(ConfigClearCommand::class, function ($app) {
             return new ConfigClearCommand($app['files']);
         });
     }
@@ -315,7 +311,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerConsoleMakeCommand()
     {
-        $this->app->singleton('command.console.make', function ($app) {
+        $this->app->singleton(ConsoleMakeCommand::class, function ($app) {
             return new ConsoleMakeCommand($app['files']);
         });
     }
@@ -327,7 +323,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerControllerMakeCommand()
     {
-        $this->app->singleton('command.controller.make', function ($app) {
+        $this->app->singleton(ControllerMakeCommand::class, function ($app) {
             return new ControllerMakeCommand($app['files']);
         });
     }
@@ -339,9 +335,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerDbWipeCommand()
     {
-        $this->app->singleton('command.db.wipe', function () {
-            return new WipeCommand;
-        });
+        $this->app->singleton(WipeCommand::class);
     }
 
     /**
@@ -351,9 +345,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerEventGenerateCommand()
     {
-        $this->app->singleton('command.event.generate', function () {
-            return new EventGenerateCommand;
-        });
+        $this->app->singleton(EventGenerateCommand::class);
     }
 
     /**
@@ -363,7 +355,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerEventMakeCommand()
     {
-        $this->app->singleton('command.event.make', function ($app) {
+        $this->app->singleton(EventMakeCommand::class, function ($app) {
             return new EventMakeCommand($app['files']);
         });
     }
@@ -375,7 +367,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerExceptionMakeCommand()
     {
-        $this->app->singleton('command.exception.make', function ($app) {
+        $this->app->singleton(ExceptionMakeCommand::class, function ($app) {
             return new ExceptionMakeCommand($app['files']);
         });
     }
@@ -387,7 +379,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerFactoryMakeCommand()
     {
-        $this->app->singleton('command.factory.make', function ($app) {
+        $this->app->singleton(FactoryMakeCommand::class, function ($app) {
             return new FactoryMakeCommand($app['files']);
         });
     }
@@ -399,9 +391,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerDownCommand()
     {
-        $this->app->singleton('command.down', function () {
-            return new DownCommand;
-        });
+        $this->app->singleton(DownCommand::class);
     }
 
     /**
@@ -411,9 +401,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerEnvironmentCommand()
     {
-        $this->app->singleton('command.environment', function () {
-            return new EnvironmentCommand;
-        });
+        $this->app->singleton(EnvironmentCommand::class);
     }
 
     /**
@@ -423,9 +411,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerEventCacheCommand()
     {
-        $this->app->singleton('command.event.cache', function () {
-            return new EventCacheCommand;
-        });
+        $this->app->singleton(EventCacheCommand::class);
     }
 
     /**
@@ -435,7 +421,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerEventClearCommand()
     {
-        $this->app->singleton('command.event.clear', function ($app) {
+        $this->app->singleton(EventClearCommand::class, function ($app) {
             return new EventClearCommand($app['files']);
         });
     }
@@ -447,9 +433,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerEventListCommand()
     {
-        $this->app->singleton('command.event.list', function () {
-            return new EventListCommand();
-        });
+        $this->app->singleton(EventListCommand::class);
     }
 
     /**
@@ -459,7 +443,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerJobMakeCommand()
     {
-        $this->app->singleton('command.job.make', function ($app) {
+        $this->app->singleton(JobMakeCommand::class, function ($app) {
             return new JobMakeCommand($app['files']);
         });
     }
@@ -471,9 +455,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerKeyGenerateCommand()
     {
-        $this->app->singleton('command.key.generate', function () {
-            return new KeyGenerateCommand;
-        });
+        $this->app->singleton(KeyGenerateCommand::class);
     }
 
     /**
@@ -483,7 +465,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerListenerMakeCommand()
     {
-        $this->app->singleton('command.listener.make', function ($app) {
+        $this->app->singleton(ListenerMakeCommand::class, function ($app) {
             return new ListenerMakeCommand($app['files']);
         });
     }
@@ -495,7 +477,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerMailMakeCommand()
     {
-        $this->app->singleton('command.mail.make', function ($app) {
+        $this->app->singleton(MailMakeCommand::class, function ($app) {
             return new MailMakeCommand($app['files']);
         });
     }
@@ -507,7 +489,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerMiddlewareMakeCommand()
     {
-        $this->app->singleton('command.middleware.make', function ($app) {
+        $this->app->singleton(MiddlewareMakeCommand::class, function ($app) {
             return new MiddlewareMakeCommand($app['files']);
         });
     }
@@ -519,7 +501,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerModelMakeCommand()
     {
-        $this->app->singleton('command.model.make', function ($app) {
+        $this->app->singleton(ModelMakeCommand::class, function ($app) {
             return new ModelMakeCommand($app['files']);
         });
     }
@@ -531,7 +513,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerNotificationMakeCommand()
     {
-        $this->app->singleton('command.notification.make', function ($app) {
+        $this->app->singleton(NotificationMakeCommand::class, function ($app) {
             return new NotificationMakeCommand($app['files']);
         });
     }
@@ -543,7 +525,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerNotificationTableCommand()
     {
-        $this->app->singleton('command.notification.table', function ($app) {
+        $this->app->singleton(NotificationTableCommand::class, function ($app) {
             return new NotificationTableCommand($app['files'], $app['composer']);
         });
     }
@@ -555,9 +537,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerOptimizeCommand()
     {
-        $this->app->singleton('command.optimize', function () {
-            return new OptimizeCommand;
-        });
+        $this->app->singleton(OptimizeCommand::class);
     }
 
     /**
@@ -567,7 +547,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerObserverMakeCommand()
     {
-        $this->app->singleton('command.observer.make', function ($app) {
+        $this->app->singleton(ObserverMakeCommand::class, function ($app) {
             return new ObserverMakeCommand($app['files']);
         });
     }
@@ -579,9 +559,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerOptimizeClearCommand()
     {
-        $this->app->singleton('command.optimize.clear', function () {
-            return new OptimizeClearCommand;
-        });
+        $this->app->singleton(OptimizeClearCommand::class);
     }
 
     /**
@@ -591,9 +569,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerPackageDiscoverCommand()
     {
-        $this->app->singleton('command.package.discover', function () {
-            return new PackageDiscoverCommand;
-        });
+        $this->app->singleton(PackageDiscoverCommand::class);
     }
 
     /**
@@ -603,7 +579,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerPolicyMakeCommand()
     {
-        $this->app->singleton('command.policy.make', function ($app) {
+        $this->app->singleton(PolicyMakeCommand::class, function ($app) {
             return new PolicyMakeCommand($app['files']);
         });
     }
@@ -615,7 +591,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerProviderMakeCommand()
     {
-        $this->app->singleton('command.provider.make', function ($app) {
+        $this->app->singleton(ProviderMakeCommand::class, function ($app) {
             return new ProviderMakeCommand($app['files']);
         });
     }
@@ -627,9 +603,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerQueueFailedCommand()
     {
-        $this->app->singleton('command.queue.failed', function () {
-            return new ListFailedQueueCommand;
-        });
+        $this->app->singleton(ListFailedQueueCommand::class);
     }
 
     /**
@@ -639,9 +613,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerQueueForgetCommand()
     {
-        $this->app->singleton('command.queue.forget', function () {
-            return new ForgetFailedQueueCommand;
-        });
+        $this->app->singleton(ForgetFailedQueueCommand::class);
     }
 
     /**
@@ -651,9 +623,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerQueueFlushCommand()
     {
-        $this->app->singleton('command.queue.flush', function () {
-            return new FlushFailedQueueCommand;
-        });
+        $this->app->singleton(FlushFailedQueueCommand::class);
     }
 
     /**
@@ -663,7 +633,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerQueueListenCommand()
     {
-        $this->app->singleton('command.queue.listen', function ($app) {
+        $this->app->singleton(QueueListenCommand::class, function ($app) {
             return new QueueListenCommand($app['queue.listener']);
         });
     }
@@ -675,7 +645,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerQueueRestartCommand()
     {
-        $this->app->singleton('command.queue.restart', function ($app) {
+        $this->app->singleton(QueueRestartCommand::class, function ($app) {
             return new QueueRestartCommand($app['cache.store']);
         });
     }
@@ -687,9 +657,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerQueueRetryCommand()
     {
-        $this->app->singleton('command.queue.retry', function () {
-            return new QueueRetryCommand;
-        });
+        $this->app->singleton(QueueRetryCommand::class);
     }
 
     /**
@@ -699,9 +667,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerQueueRetryBatchCommand()
     {
-        $this->app->singleton('command.queue.retry-batch', function () {
-            return new QueueRetryBatchCommand;
-        });
+        $this->app->singleton(QueueRetryBatchCommand::class);
     }
 
     /**
@@ -711,7 +677,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerQueueWorkCommand()
     {
-        $this->app->singleton('command.queue.work', function ($app) {
+        $this->app->singleton(QueueWorkCommand::class, function ($app) {
             return new QueueWorkCommand($app['queue.worker'], $app['cache.store']);
         });
     }
@@ -723,9 +689,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerQueueClearCommand()
     {
-        $this->app->singleton('command.queue.clear', function () {
-            return new QueueClearCommand;
-        });
+        $this->app->singleton(QueueClearCommand::class);
     }
 
     /**
@@ -735,7 +699,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerQueueFailedTableCommand()
     {
-        $this->app->singleton('command.queue.failed-table', function ($app) {
+        $this->app->singleton(FailedTableCommand::class, function ($app) {
             return new FailedTableCommand($app['files'], $app['composer']);
         });
     }
@@ -747,7 +711,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerQueueTableCommand()
     {
-        $this->app->singleton('command.queue.table', function ($app) {
+        $this->app->singleton(TableCommand::class, function ($app) {
             return new TableCommand($app['files'], $app['composer']);
         });
     }
@@ -759,7 +723,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerQueueBatchesTableCommand()
     {
-        $this->app->singleton('command.queue.batches-table', function ($app) {
+        $this->app->singleton(BatchesTableCommand::class, function ($app) {
             return new BatchesTableCommand($app['files'], $app['composer']);
         });
     }
@@ -771,7 +735,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerRequestMakeCommand()
     {
-        $this->app->singleton('command.request.make', function ($app) {
+        $this->app->singleton(RequestMakeCommand::class, function ($app) {
             return new RequestMakeCommand($app['files']);
         });
     }
@@ -783,7 +747,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerResourceMakeCommand()
     {
-        $this->app->singleton('command.resource.make', function ($app) {
+        $this->app->singleton(ResourceMakeCommand::class, function ($app) {
             return new ResourceMakeCommand($app['files']);
         });
     }
@@ -795,7 +759,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerRuleMakeCommand()
     {
-        $this->app->singleton('command.rule.make', function ($app) {
+        $this->app->singleton(RuleMakeCommand::class, function ($app) {
             return new RuleMakeCommand($app['files']);
         });
     }
@@ -807,7 +771,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerSeederMakeCommand()
     {
-        $this->app->singleton('command.seeder.make', function ($app) {
+        $this->app->singleton(SeederMakeCommand::class, function ($app) {
             return new SeederMakeCommand($app['files'], $app['composer']);
         });
     }
@@ -819,7 +783,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerSessionTableCommand()
     {
-        $this->app->singleton('command.session.table', function ($app) {
+        $this->app->singleton(SessionTableCommand::class, function ($app) {
             return new SessionTableCommand($app['files'], $app['composer']);
         });
     }
@@ -831,9 +795,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerStorageLinkCommand()
     {
-        $this->app->singleton('command.storage.link', function () {
-            return new StorageLinkCommand;
-        });
+        $this->app->singleton(StorageLinkCommand::class);
     }
 
     /**
@@ -843,7 +805,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerRouteCacheCommand()
     {
-        $this->app->singleton('command.route.cache', function ($app) {
+        $this->app->singleton(RouteCacheCommand::class, function ($app) {
             return new RouteCacheCommand($app['files']);
         });
     }
@@ -855,7 +817,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerRouteClearCommand()
     {
-        $this->app->singleton('command.route.clear', function ($app) {
+        $this->app->singleton(RouteClearCommand::class, function ($app) {
             return new RouteClearCommand($app['files']);
         });
     }
@@ -867,7 +829,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerRouteListCommand()
     {
-        $this->app->singleton('command.route.list', function ($app) {
+        $this->app->singleton(RouteListCommand::class, function ($app) {
             return new RouteListCommand($app['router']);
         });
     }
@@ -879,9 +841,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerSchemaDumpCommand()
     {
-        $this->app->singleton('command.schema.dump', function () {
-            return new DumpCommand;
-        });
+        $this->app->singleton(DumpCommand::class);
     }
 
     /**
@@ -891,7 +851,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerSeedCommand()
     {
-        $this->app->singleton('command.seed', function ($app) {
+        $this->app->singleton(SeedCommand::class, function ($app) {
             return new SeedCommand($app['db']);
         });
     }
@@ -933,9 +893,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerServeCommand()
     {
-        $this->app->singleton('command.serve', function () {
-            return new ServeCommand;
-        });
+        $this->app->singleton(ServeCommand::class);
     }
 
     /**
@@ -945,9 +903,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerStubPublishCommand()
     {
-        $this->app->singleton('command.stub.publish', function () {
-            return new StubPublishCommand;
-        });
+        $this->app->singleton(StubPublishCommand::class);
     }
 
     /**
@@ -957,7 +913,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerTestMakeCommand()
     {
-        $this->app->singleton('command.test.make', function ($app) {
+        $this->app->singleton(TestMakeCommand::class, function ($app) {
             return new TestMakeCommand($app['files']);
         });
     }
@@ -969,9 +925,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerUpCommand()
     {
-        $this->app->singleton('command.up', function () {
-            return new UpCommand;
-        });
+        $this->app->singleton(UpCommand::class);
     }
 
     /**
@@ -981,7 +935,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerVendorPublishCommand()
     {
-        $this->app->singleton('command.vendor.publish', function ($app) {
+        $this->app->singleton(VendorPublishCommand::class, function ($app) {
             return new VendorPublishCommand($app['files']);
         });
     }
@@ -993,9 +947,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerViewCacheCommand()
     {
-        $this->app->singleton('command.view.cache', function () {
-            return new ViewCacheCommand;
-        });
+        $this->app->singleton(ViewCacheCommand::class);
     }
 
     /**
@@ -1005,7 +957,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerViewClearCommand()
     {
-        $this->app->singleton('command.view.clear', function ($app) {
+        $this->app->singleton(ViewClearCommand::class, function ($app) {
             return new ViewClearCommand($app['files']);
         });
     }

--- a/src/Illuminate/Notifications/Console/NotificationTableCommand.php
+++ b/src/Illuminate/Notifications/Console/NotificationTableCommand.php
@@ -16,6 +16,15 @@ class NotificationTableCommand extends Command
     protected $name = 'notifications:table';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'notifications:table';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Queue/Console/BatchesTableCommand.php
+++ b/src/Illuminate/Queue/Console/BatchesTableCommand.php
@@ -17,6 +17,15 @@ class BatchesTableCommand extends Command
     protected $name = 'queue:batches-table';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'queue:batches-table';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Queue/Console/ClearCommand.php
+++ b/src/Illuminate/Queue/Console/ClearCommand.php
@@ -21,6 +21,15 @@ class ClearCommand extends Command
     protected $name = 'queue:clear';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'queue:clear';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Queue/Console/FailedTableCommand.php
+++ b/src/Illuminate/Queue/Console/FailedTableCommand.php
@@ -17,6 +17,15 @@ class FailedTableCommand extends Command
     protected $name = 'queue:failed-table';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'queue:failed-table';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Queue/Console/FlushFailedCommand.php
+++ b/src/Illuminate/Queue/Console/FlushFailedCommand.php
@@ -14,6 +14,15 @@ class FlushFailedCommand extends Command
     protected $name = 'queue:flush';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'queue:flush';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Queue/Console/ForgetFailedCommand.php
+++ b/src/Illuminate/Queue/Console/ForgetFailedCommand.php
@@ -14,6 +14,15 @@ class ForgetFailedCommand extends Command
     protected $signature = 'queue:forget {id : The ID of the failed job}';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'queue:forget';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Queue/Console/ListFailedCommand.php
+++ b/src/Illuminate/Queue/Console/ListFailedCommand.php
@@ -15,6 +15,15 @@ class ListFailedCommand extends Command
     protected $name = 'queue:failed';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'queue:failed';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Queue/Console/ListenCommand.php
+++ b/src/Illuminate/Queue/Console/ListenCommand.php
@@ -26,6 +26,15 @@ class ListenCommand extends Command
                             {--tries=1 : Number of times to attempt a job before logging it failed}';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'queue:listen';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Queue/Console/RestartCommand.php
+++ b/src/Illuminate/Queue/Console/RestartCommand.php
@@ -18,6 +18,15 @@ class RestartCommand extends Command
     protected $name = 'queue:restart';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'queue:restart';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Queue/Console/RetryBatchCommand.php
+++ b/src/Illuminate/Queue/Console/RetryBatchCommand.php
@@ -15,6 +15,15 @@ class RetryBatchCommand extends Command
     protected $signature = 'queue:retry-batch {id : The ID of the batch whose failed jobs should be retried}';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'queue:retry-batch';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -17,6 +17,15 @@ class RetryCommand extends Command
                             {--range=* : Range of job IDs (numeric) to be retried}';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'queue:retry';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Queue/Console/TableCommand.php
+++ b/src/Illuminate/Queue/Console/TableCommand.php
@@ -17,6 +17,15 @@ class TableCommand extends Command
     protected $name = 'queue:table';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'queue:table';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -37,6 +37,15 @@ class WorkCommand extends Command
                             {--tries=1 : Number of times to attempt a job before logging it failed}';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'queue:work';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -16,6 +16,15 @@ class ControllerMakeCommand extends GeneratorCommand
     protected $name = 'make:controller';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'make:controller';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Routing/Console/MiddlewareMakeCommand.php
+++ b/src/Illuminate/Routing/Console/MiddlewareMakeCommand.php
@@ -14,6 +14,15 @@ class MiddlewareMakeCommand extends GeneratorCommand
     protected $name = 'make:middleware';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'make:middleware';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Session/Console/SessionTableCommand.php
+++ b/src/Illuminate/Session/Console/SessionTableCommand.php
@@ -16,6 +16,15 @@ class SessionTableCommand extends Command
     protected $name = 'session:table';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'session:table';
+
+    /**
      * The console command description.
      *
      * @var string


### PR DESCRIPTION
As a follow-up to https://github.com/laravel/framework/pull/34873, this PR lazy loads all commands shipped with Laravel.

**Breaking Changes**
All commands were previously bound with the `command.*` binding names and are now bound by class name. Why? Because lazy loading implementation requires the container to resolve by class name. The `command.*` binding keys were unused elsewhere in the framework but if we need to support those keys as well, I can modify the PR to add aliases for those keys.

**Memory Reduction**
I confirmed that after this PR, the constructors of the Laravel commands are no longer invoked. With `memory_get_usage`, I confirmed that memory usage is now reduced by ~130KB (by lazy loading the commands shipped with Laravel). I'm not quite sure if GC is playing a role here and the actual reduction is higher. Of course, coupled with package and app commands, the memory reduction would be higher.