### PR TITLE
[6.x] Bump minimum PHP version to v7.2.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2.5",
         "ext-json": "*",
         "ext-mbstring": "*",
         "ext-openssl": "*",

--- a/src/Illuminate/Auth/composer.json
+++ b/src/Illuminate/Auth/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2.5",
         "illuminate/contracts": "^6.0",
         "illuminate/http": "^6.0",
         "illuminate/queue": "^6.0",

--- a/src/Illuminate/Broadcasting/composer.json
+++ b/src/Illuminate/Broadcasting/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2.5",
         "ext-json": "*",
         "psr/log": "^1.0",
         "illuminate/bus": "^6.0",

--- a/src/Illuminate/Bus/composer.json
+++ b/src/Illuminate/Bus/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2.5",
         "illuminate/contracts": "^6.0",
         "illuminate/pipeline": "^6.0",
         "illuminate/support": "^6.0"

--- a/src/Illuminate/Cache/composer.json
+++ b/src/Illuminate/Cache/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2.5",
         "illuminate/contracts": "^6.0",
         "illuminate/support": "^6.0"
     },

--- a/src/Illuminate/Config/composer.json
+++ b/src/Illuminate/Config/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2.5",
         "illuminate/contracts": "^6.0",
         "illuminate/support": "^6.0"
     },

--- a/src/Illuminate/Console/composer.json
+++ b/src/Illuminate/Console/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2.5",
         "illuminate/contracts": "^6.0",
         "illuminate/support": "^6.0",
         "symfony/console": "^4.3.4",

--- a/src/Illuminate/Container/composer.json
+++ b/src/Illuminate/Container/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2.5",
         "illuminate/contracts": "^6.0",
         "psr/container": "^1.0"
     },

--- a/src/Illuminate/Contracts/composer.json
+++ b/src/Illuminate/Contracts/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2.5",
         "psr/container": "^1.0",
         "psr/simple-cache": "^1.0"
     },

--- a/src/Illuminate/Cookie/composer.json
+++ b/src/Illuminate/Cookie/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2.5",
         "illuminate/contracts": "^6.0",
         "illuminate/support": "^6.0",
         "symfony/http-foundation": "^4.3.4",

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2.5",
         "ext-json": "*",
         "illuminate/container": "^6.0",
         "illuminate/contracts": "^6.0",

--- a/src/Illuminate/Encryption/composer.json
+++ b/src/Illuminate/Encryption/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2.5",
         "ext-json": "*",
         "ext-mbstring": "*",
         "ext-openssl": "*",

--- a/src/Illuminate/Events/composer.json
+++ b/src/Illuminate/Events/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2.5",
         "illuminate/container": "^6.0",
         "illuminate/contracts": "^6.0",
         "illuminate/support": "^6.0"

--- a/src/Illuminate/Filesystem/composer.json
+++ b/src/Illuminate/Filesystem/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2.5",
         "illuminate/contracts": "^6.0",
         "illuminate/support": "^6.0",
         "symfony/finder": "^4.3.4"

--- a/src/Illuminate/Hashing/composer.json
+++ b/src/Illuminate/Hashing/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2.5",
         "illuminate/contracts": "^6.0",
         "illuminate/support": "^6.0"
     },

--- a/src/Illuminate/Http/composer.json
+++ b/src/Illuminate/Http/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2.5",
         "ext-json": "*",
         "illuminate/session": "^6.0",
         "illuminate/support": "^6.0",

--- a/src/Illuminate/Log/composer.json
+++ b/src/Illuminate/Log/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2.5",
         "illuminate/contracts": "^6.0",
         "illuminate/support": "^6.0",
         "monolog/monolog": "^1.12|^2.0"

--- a/src/Illuminate/Mail/composer.json
+++ b/src/Illuminate/Mail/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2.5",
         "ext-json": "*",
         "illuminate/container": "^6.0",
         "illuminate/contracts": "^6.0",

--- a/src/Illuminate/Notifications/composer.json
+++ b/src/Illuminate/Notifications/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2.5",
         "illuminate/broadcasting": "^6.0",
         "illuminate/bus": "^6.0",
         "illuminate/container": "^6.0",

--- a/src/Illuminate/Pagination/composer.json
+++ b/src/Illuminate/Pagination/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2.5",
         "ext-json": "*",
         "illuminate/contracts": "^6.0",
         "illuminate/support": "^6.0"

--- a/src/Illuminate/Pipeline/composer.json
+++ b/src/Illuminate/Pipeline/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2.5",
         "illuminate/contracts": "^6.0",
         "illuminate/support": "^6.0",
         "symfony/debug": "^4.3.4"

--- a/src/Illuminate/Queue/composer.json
+++ b/src/Illuminate/Queue/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2.5",
         "ext-json": "*",
         "illuminate/console": "^6.0",
         "illuminate/container": "^6.0",

--- a/src/Illuminate/Redis/composer.json
+++ b/src/Illuminate/Redis/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2.5",
         "illuminate/contracts": "^6.0",
         "illuminate/support": "^6.0"
     },

--- a/src/Illuminate/Routing/composer.json
+++ b/src/Illuminate/Routing/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2.5",
         "ext-json": "*",
         "illuminate/container": "^6.0",
         "illuminate/contracts": "^6.0",

--- a/src/Illuminate/Session/composer.json
+++ b/src/Illuminate/Session/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2.5",
         "ext-json": "*",
         "illuminate/contracts": "^6.0",
         "illuminate/filesystem": "^6.0",

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2.5",
         "ext-json": "*",
         "ext-mbstring": "*",
         "doctrine/inflector": "^1.4|^2.0",

--- a/src/Illuminate/Translation/composer.json
+++ b/src/Illuminate/Translation/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2.5",
         "ext-json": "*",
         "illuminate/contracts": "^6.0",
         "illuminate/filesystem": "^6.0",

--- a/src/Illuminate/Validation/composer.json
+++ b/src/Illuminate/Validation/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2.5",
         "ext-json": "*",
         "egulias/email-validator": "^2.1.10",
         "illuminate/container": "^6.0",

--- a/src/Illuminate/View/composer.json
+++ b/src/Illuminate/View/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2.5",
         "ext-json": "*",
         "illuminate/container": "^6.0",
         "illuminate/contracts": "^6.0",


### PR DESCRIPTION
Because we merged https://github.com/laravel/framework/pull/34884, Flysystem indirectly bumps Laravel 6.x to v7.2.5. It makes sense to make this more explicit now through Laravel's own version constraint.