### PR TITLE
[8.x] Fix higher order messaging annotations

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -35,7 +35,11 @@ use Traversable;
  * @property-read HigherOrderCollectionProxy $some
  * @property-read HigherOrderCollectionProxy $sortBy
  * @property-read HigherOrderCollectionProxy $sortByDesc
+ * @property-read HigherOrderCollectionProxy $skipUntil
+ * @property-read HigherOrderCollectionProxy $skipWhile
  * @property-read HigherOrderCollectionProxy $sum
+ * @property-read HigherOrderCollectionProxy $takeUntil
+ * @property-read HigherOrderCollectionProxy $takeWhile
  * @property-read HigherOrderCollectionProxy $unique
  * @property-read HigherOrderCollectionProxy $until
  */


### PR DESCRIPTION
My list of todos [here](https://github.com/Sustainabil-IT/phpstan-higher-order-collections/issues/10) was copied from this list and I ran into a discrepancy, figured I'd fix it. 

I'm aware this is a very niche PR: it only applies to a very select set of methods on Higher Order Messaging for Collections, and then only for people who rely on docblocks for this sort of thing.

I _think_ this qualifies as a bugfix and should therefore be merged into all currently supported versions of Laravel, but I'm not sure.