### PR TITLE
[8.x] Add expects to built-in Facade testing methods

### DIFF
--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -91,6 +91,22 @@ abstract class Facade
     }
 
     /**
+     * Initiate a mock expectation on the facade.
+     *
+     * @return \Mockery\Expectation
+     */
+    public static function expects()
+    {
+        $name = static::getFacadeAccessor();
+
+        $mock = static::isMock()
+            ? static::$resolvedInstance[$name]
+            : static::createFreshMockInstance();
+
+        return $mock->expects(...func_get_args());
+    }
+
+    /**
      * Create a fresh mock instance for the given class.
      *
      * @return \Mockery\MockInterface

--- a/tests/Support/SupportFacadeTest.php
+++ b/tests/Support/SupportFacadeTest.php
@@ -70,6 +70,16 @@ class SupportFacadeTest extends TestCase
         FacadeStub::shouldReceive('foo')->once()->andReturn('bar');
         $this->assertSame('bar', FacadeStub::foo());
     }
+
+    public function testExpectsReturnsAMockeryMockWithExpectationRequired()
+    {
+        $app = new ApplicationStub;
+        $app->setAttributes(['foo' => new stdClass]);
+        FacadeStub::setFacadeApplication($app);
+
+        $this->assertInstanceOf(MockInterface::class, $mock = FacadeStub::expects('foo')->with('bar')->andReturn('baz')->getMock());
+        $this->assertSame('baz', $app['foo']->foo('bar'));
+    }
 }
 
 class FacadeStub extends Facade


### PR DESCRIPTION
The built-in testing layer for Facades wraps many underlying _Mockery_ methods which is very great. But it's missing one of the most important testing methods - `expects`.

Currently `shouldReceive` is the only out of the box expectation. However, in most cases, `shouldReceive` does not provide the desired confidence. This can be confusing when new to testing.

In the end, just because something _should receive_ a call, **doesn't mean it did**. So `shouldReceive` must included a _count modifier_ such as `once`, `twice`, etc to trigger the desired behavior.

Given that it's often the case where you want to ensure something was called, I believe adding `expects` can help improve the testing experience within Laravel.

Within Mockery `expects` is simply an alias for `shouldRecieve()->once()`, yet it's a far more expressive method (which aligns nicely with Laravel), streamlines the code, and avoids the footgun scenario described above.

**Before**:

```php
Cache::shouldReceive('remember')
        ->with('testing', 'is', 'important')
        ->once();
```

**After:**
```php
Cache::expects('remember')
        ->with('testing', 'is', 'important');
```
