### PR TITLE
[8.x] FIX: PhpRedis (v5.3.2) cluster - set default connection context to null 

### DIFF
--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -157,7 +157,7 @@ class PhpRedisConnector implements Connector
         }
 
         if (version_compare(phpversion('redis'), '5.3.2', '>=')) {
-            $parameters[] = Arr::get($options, 'context', []);
+            $parameters[] = Arr::get($options, 'context');
         }
 
         return tap(new RedisCluster(...$parameters), function ($client) use ($options) {


### PR DESCRIPTION
There is an issue in phpredis version 5.3.2 
https://github.com/phpredis/phpredis/issues/1864

When context is [] then connection fails with SSL error. Setting it to null fixes the problem.

This is not Laravel version specific. 

I encountered this on 7.28.4 and for workaround added `context=>null` to `database.redis.options` which accomplishes same result.