### PR TITLE
[8.x] Add encrypted string Eloquent cast

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection as BaseCollection;
+use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
@@ -70,6 +71,7 @@ trait HasAttributes
         'datetime',
         'decimal',
         'double',
+        'encrypted',
         'float',
         'int',
         'integer',
@@ -552,6 +554,8 @@ trait HasAttributes
                 return $this->asDateTime($value);
             case 'timestamp':
                 return $this->asTimestamp($value);
+            case 'encrypted':
+                return $this->fromEncryptedString($value);
         }
 
         if ($this->isClassCastable($key)) {
@@ -683,6 +687,10 @@ trait HasAttributes
         // attribute in the array's value in the case of deeply nested items.
         if (Str::contains($key, '->')) {
             return $this->fillJsonAttribute($key, $value);
+        }
+
+        if (! is_null($value) && $this->isEncryptedCastable($key)) {
+            $value = $this->castAttributeAsEncryptedString($key, $value);
         }
 
         $this->attributes[$key] = $value;
@@ -846,6 +854,30 @@ trait HasAttributes
     public function fromJson($value, $asObject = false)
     {
         return json_decode($value, ! $asObject);
+    }
+
+    /**
+     * Decode the given encrypted string.
+     *
+     * @param  string  $value
+     * @param  bool  $asObject
+     * @return mixed
+     */
+    public function fromEncryptedString($value)
+    {
+        return Crypt::decryptString($value);
+    }
+
+    /**
+     * Cast the given attribute to an encrypted string.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return string
+     */
+    protected function castAttributeAsEncryptedString($key, $value)
+    {
+        return Crypt::encryptString($value);
     }
 
     /**
@@ -1081,6 +1113,17 @@ trait HasAttributes
     protected function isJsonCastable($key)
     {
         return $this->hasCast($key, ['array', 'json', 'object', 'collection']);
+    }
+
+    /**
+     * Determine whether a value is an encrypted castable for inbound manipulation.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    protected function isEncryptedCastable($key)
+    {
+        return $this->hasCast($key, ['encrypted']);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -678,7 +678,7 @@ trait HasAttributes
             return $this;
         }
 
-        if ($this->isJsonCastable($key) && ! is_null($value)) {
+        if (! is_null($value) && $this->isJsonCastable($key)) {
             $value = $this->castAttributeAsJson($key, $value);
         }
 

--- a/tests/Integration/Database/EloquentModelEncryptedCastingTest.php
+++ b/tests/Integration/Database/EloquentModelEncryptedCastingTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Contracts\Encryption\Encrypter;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * @group integration
+ */
+class EloquentModelEncryptedCastingTest extends DatabaseTestCase
+{
+    protected $encrypter;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->encrypter = $this->mock(Encrypter::class);
+        Crypt::swap($this->encrypter);
+
+        Schema::create('encrypted_casts', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('secret', 1000)->nullable();
+        });
+    }
+
+    public function testStringsAreCastable()
+    {
+        $this->encrypter->expects('encryptString')
+            ->with('this is a secret string')
+            ->andReturn('encrypted-secret-string');
+        $this->encrypter->expects('decryptString')
+            ->with('encrypted-secret-string')
+            ->andReturn('this is a secret string');
+
+        /** @var \Illuminate\Tests\Integration\Database\EncryptedCast $object */
+        $object = EncryptedCast::create([
+            'secret' => 'this is a secret string',
+        ]);
+
+        $this->assertSame('this is a secret string', $object->secret);
+        $this->assertDatabaseHas('encrypted_casts', [
+            'id' => $object->id,
+            'secret' => 'encrypted-secret-string',
+        ]);
+    }
+}
+
+/**
+ * @property $secret
+ */
+class EncryptedCast extends Model
+{
+    public $timestamps = false;
+    protected $guarded = [];
+
+    public $casts = [
+        'secret' => 'encrypted',
+    ];
+}


### PR DESCRIPTION
I know this has been attempted and closed before. Please hear me out...

First, Laravel has evolved since this was first attempted way back in Laravel 5.3. The framework includes many more quality of life improvements which help developers with every day tasks. I consider encryption to be one of those tasks.

Second, the common reason for closing this before was that it may be done with a custom cast or accessor/mutator. Be that as it may, this creates just that tiny bit of friction which may prevent developers from securing their data. As encryption is a first-class feature within Laravel, so too should be _persisting_ encrypted data.

For those reasons, I am reviving this as a fresh PR to include a built-in Eloquent cast of `encrypted`.

This cast will automatically handle the encryption and decryption of simple string. For anything more complex, I defer to custom model casts or future PRs.

Example:

```php
public $casts = [
    'access_token' => 'encrypted',
];
```