### PR TITLE
[8.x] Add tests to Dispatcher class

### DIFF
--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -26,6 +26,14 @@ class EventsDispatcherTest extends TestCase
 
         $this->assertEquals([null], $response);
         $this->assertSame('bar', $_SERVER['__event.test']);
+
+        // we can still add listeners after the event has fired
+        $d->listen('foo', function ($foo) {
+            $_SERVER['__event.test'] .= $foo;
+        });
+
+        $d->dispatch('foo', ['bar']);
+        $this->assertSame('barbar', $_SERVER['__event.test']);
     }
 
     public function testHaltingEventExecution()
@@ -382,6 +390,26 @@ class EventsDispatcherTest extends TestCase
 
         unset($_SERVER['__event.test1']);
         unset($_SERVER['__event.test2']);
+    }
+
+    public function testNestedEvent()
+    {
+        $_SERVER['__event.test'] = [];
+        $d = new Dispatcher;
+
+        $d->listen('event', function () use ($d) {
+            $d->listen('event', function () {
+                $_SERVER['__event.test'][] = 'fired 1';
+            });
+            $d->listen('event', function () {
+                $_SERVER['__event.test'][] = 'fired 2';
+            });
+        });
+
+        $d->dispatch('event');
+        $this->assertSame([], $_SERVER['__event.test']);
+        $d->dispatch('event');
+        $this->assertEquals(['fired 1', 'fired 2'], $_SERVER['__event.test']);
     }
 }
 


### PR DESCRIPTION
While playing around with Dispatcher internals for optimization purposes, I found that this behavior is tested nowhere else and I was able to ruin it with no failing test.

One relates to where we continue appending listeners after we fired the event.
The second one defines what happens if a listener setups for listeners for its own event.