### PR TITLE
[9.x] Optimize listen method in dispatcher

### DIFF
--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -78,13 +78,11 @@ class Dispatcher implements DispatcherContract
         if ($events instanceof Closure) {
             return $this->listen($this->firstClosureParameterType($events), $events);
         } elseif ($events instanceof QueuedClosure) {
-            return $this->listen($this->firstClosureParameterType($events->closure), $events->resolve());
-        } elseif ($listener instanceof QueuedClosure) {
-            $listener = $listener->resolve();
+            return $this->listen($this->firstClosureParameterType($events->closure), $events);
         }
 
         foreach ((array) $events as $event) {
-            if (Str::contains($event, '*')) {
+            if (mb_strpos($event, '*') !== false) {
                 $this->setupWildcardListen($event, $listener);
             } else {
                 $this->listeners[$event][] = $listener;
@@ -375,6 +373,10 @@ class Dispatcher implements DispatcherContract
      */
     public function makeListener($listener, $wildcard = false)
     {
+        if ($listener instanceof QueuedClosure) {
+            $listener = $listener->resolve();
+        }
+
         if (is_string($listener)) {
             return $this->createClassListener($listener, $wildcard);
         }

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -87,7 +87,7 @@ class Dispatcher implements DispatcherContract
             if (Str::contains($event, '*')) {
                 $this->setupWildcardListen($event, $listener);
             } else {
-                $this->listeners[$event][] = $this->makeListener($listener);
+                $this->listeners[$event][] = $listener;
             }
         }
     }
@@ -315,7 +315,7 @@ class Dispatcher implements DispatcherContract
      */
     public function getListeners($eventName)
     {
-        $listeners = $this->listeners[$eventName] ?? [];
+        $listeners = $this->prepareListeners($eventName);
 
         $listeners = array_merge(
             $listeners,
@@ -357,7 +357,7 @@ class Dispatcher implements DispatcherContract
     {
         foreach (class_implements($eventName) as $interface) {
             if (isset($this->listeners[$interface])) {
-                foreach ($this->listeners[$interface] as $names) {
+                foreach ($this->prepareListeners($interface) as $names) {
                     $listeners = array_merge($listeners, (array) $names);
                 }
             }
@@ -618,5 +618,21 @@ class Dispatcher implements DispatcherContract
         $this->queueResolver = $resolver;
 
         return $this;
+    }
+
+    /**
+     * prepares the listeners of an event.
+     *
+     * @param  string  $eventName
+     * @return \Closure[]
+     */
+    protected function prepareListeners(string $eventName)
+    {
+        $listeners = [];
+        foreach ($this->listeners[$eventName] ?? [] as $rawListener) {
+            $listeners[] = $this->makeListener($rawListener);
+        }
+
+        return $listeners;
     }
 }


### PR DESCRIPTION
This PR makes calling the `makeListener` method lazy so that we avoid calling it many times during the boot time.
Listeners only get closurified when the event is fired and they are about to be called.
I think it will consume less memory.
- It does not change the public API

### Backward compatibility:
Should mostly be ok except someone plays around directly with the values of protected $listener in a subclass.
You may even want this on laravel 8.

The wildcard property can also undergo the same process, but it is rarely used (so no need to optimize it), but anyway you may want to change that also for consistency purposes of the stored value types.

### Other Benefits:
- Makes `Event::mute('my_event', 'classs@method')` possible to implement. (Good for testing)
- Also brings yet another nice debug feature: You can easily make the command `artisan event:list` show the entire list of event-listeners in the entire application. (Currently, it can only show what is written in EventServiceProvider which is pretty useless since it is hard-coded there, ready to be seen in the editor) 

Because currently, the $listener parameter passed to `listen` method is immediately wrapped in a closure, the original user input gets hidden in it, and we can not show the string class@method listeners in the command-line at the end of the boot process. (This technique is what laravel-microscope does to show the list of listeners of any event)