### PR TITLE
[8.x] Add support for returning message bags in custom rules

### DIFF
--- a/src/Illuminate/Contracts/Validation/Rule.php
+++ b/src/Illuminate/Contracts/Validation/Rule.php
@@ -16,7 +16,7 @@ interface Rule
     /**
      * Get the validation error message.
      *
-     * @return string|array
+     * @return string|array|\Illuminate\Contracts\Support\MessageBag
      */
     public function message();
 }

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -739,8 +739,8 @@ class Validator implements ValidatorContract
             $messages = $rule->message();
 
             if ($messages instanceof MessageBag) {
-                foreach ($messages->messages() as $childAttribute => $childMessages){
-                    foreach ($childMessages as $childMessage){
+                foreach ($messages->messages() as $childAttribute => $childMessages) {
+                    foreach ($childMessages as $childMessage) {
                         $this->messages->add("{$attribute}.{$childAttribute}", $this->makeReplacements(
                             $childMessage, '{$attribute}.{$childAttribute}', get_class($rule), []
                         ));

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -738,6 +738,18 @@ class Validator implements ValidatorContract
 
             $messages = $rule->message();
 
+            if ($messages instanceof MessageBag) {
+                foreach ($messages->messages() as $childAttribute => $childMessages){
+                    foreach ($childMessages as $childMessage){
+                        $this->messages->add("{$attribute}.{$childAttribute}", $this->makeReplacements(
+                            $childMessage, '{$attribute}.{$childAttribute}', get_class($rule), []
+                        ));
+                    }
+                }
+
+                return;
+            }
+
             $messages = $messages ? (array) $messages : [get_class($rule)];
 
             foreach ($messages as $message) {

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -5043,12 +5043,12 @@ class ValidationValidatorTest extends TestCase
 
                         public function passes($attribute, $value)
                         {
-                            $ArrayTranslator = new Translator(
+                            $arrayTranslator = new Translator(
                                 new ArrayLoader, 'en'
                             );
 
                             $this->validator = new Validator(
-                                $ArrayTranslator,
+                                $arrayTranslator,
                                 $value,
                                 ['name' => 'required', 'location' => 'required']
                             );
@@ -5084,12 +5084,12 @@ class ValidationValidatorTest extends TestCase
 
                         public function passes($attribute, $value)
                         {
-                            $ArrayTranslator = new Translator(
+                            $arrayTranslator = new Translator(
                                 new ArrayLoader, 'en'
                             );
 
                             $this->validator = new Validator(
-                                $ArrayTranslator,
+                                $arrayTranslator,
                                 $value,
                                 ['name' => 'required', 'location' => 'required']
                             );

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -5075,7 +5075,7 @@ class ValidationValidatorTest extends TestCase
             $this->getIlluminateArrayTranslator(),
             [
                 ['name' => 'taylor', 'location' => 'us'],
-                ['name' => 'adam']
+                ['name' => 'adam'],
             ],
             [
                 '*' => [

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -5030,6 +5030,85 @@ class ValidationValidatorTest extends TestCase
         $this->assertSame('name must be taylor', $v->errors()->get('name')[0]);
         $this->assertSame('name must be a first name', $v->errors()->get('name')[1]);
         $this->assertSame('validation.string', $v->errors()->get('name')[2]);
+
+        // Test messagebag return from validator
+
+        $v = new Validator(
+            $this->getIlluminateArrayTranslator(),
+            ['form' => ['name' => 'taylor']],
+            [
+                'form' => [
+                    new class implements Rule {
+                        private $validator;
+
+                        public function passes($attribute, $value)
+                        {
+                            $ArrayTranslator = new Translator(
+                                new ArrayLoader, 'en'
+                            );
+
+                            $this->validator = new Validator(
+                                $ArrayTranslator,
+                                $value,
+                                ['name' => 'required', 'location' => 'required']
+                            );
+
+                            return $this->validator->passes();
+                        }
+
+                        public function message()
+                        {
+                            return $this->validator->errors();
+                        }
+                    },
+                ],
+            ]
+        );
+
+        $this->assertTrue($v->fails());
+
+        $this->assertSame('validation.required', $v->errors()->get('form.location')[0]);
+
+        // Test messagebag return from validator with asterix
+
+        $v = new Validator(
+            $this->getIlluminateArrayTranslator(),
+            [
+                ['name' => 'taylor', 'location' => 'us'],
+                ['name' => 'adam']
+            ],
+            [
+                '*' => [
+                    new class implements Rule {
+                        private $validator;
+
+                        public function passes($attribute, $value)
+                        {
+                            $ArrayTranslator = new Translator(
+                                new ArrayLoader, 'en'
+                            );
+
+                            $this->validator = new Validator(
+                                $ArrayTranslator,
+                                $value,
+                                ['name' => 'required', 'location' => 'required']
+                            );
+
+                            return $this->validator->passes();
+                        }
+
+                        public function message()
+                        {
+                            return $this->validator->errors();
+                        }
+                    },
+                ],
+            ]
+        );
+
+        $this->assertTrue($v->fails());
+
+        $this->assertSame('validation.required', $v->errors()->get('1.location')[0]);
     }
 
     public function testCustomValidationObjectWithDotKeysIsCorrectlyPassedValue()


### PR DESCRIPTION

At this moment, we can return a `string` or `array` when we want to return a message from a custom validation rule. This PR adds the functionality to return a `MessageBag` object from a custom rule, which is quite handy when you want to build complex rules.

For example, let's say you have the following data:

```php
$data = [
    'custom_form' => [
        'name' => 'Ruben',
        'location' => 'Antwerp'
    ],
    'other_value' => 'foo',
];
```

And this data should be validated by the following rules:

```php
$rules = [
    'custom_form' => new CustomFormRule(['name', 'location', 'company']),
    'other_value' => ['required', 'string'],
];
```

Let's take a look at that custom form rule:

```php
class CustomFormRule implements Rule
{
    private array $fields;

    private string $message = '';

    public function __construct(array $fields)
    {
        $this->fields = $fields;
    }

    public function passes($attribute, $value): bool
    {
        $rules = collect($this->fields)
            ->mapWithKeys(fn(string $name) => [$name => ['required', 'string']])
            ->toArray();

        $v = Validator::make($value, $rules);

        $this->message = $v->errors()->first();

        return $v->passes();
    }

    public function message(): string
    {
        return $this->message;
    }
```

This is our current implementation, and there are two problems with it:
- In the validator using the rule when the validation fails, we now get that `custom_form` is invalid. Actually, it is the `company` field on `custom_form` that has failed. To show this correctly in the frontend, we need to know that `custom_form.company` is invalid.
- Not all the messages from the validator will be passed through, only the first one

With this PR, you can now do the following:

```php
class CustomFormRule implements Rule
{
    private array $fields;

    private ?Validator $validator = null;

    public function __construct(array $fields)
    {
        $this->fields = $fields;
    }

    public function passes($attribute, $value): bool
    {
        $rules = collect($this->fields)
            ->mapWithKeys(fn(string $name) => [$name => ['required', 'string']])
            ->toArray();

        $this->validator = Validator::make($value, $rules);

        return $this->validator->passes();
    }

    public function message(): MessageBag
    {
        return $this->validator->errors();
    }
```

The problems listed above are now solved:
- The validator using the rule now knows that `custom_form.company` is invalid
- All messages are passed through

This PR shouldn't break backward compatibility.
