### PR TITLE
[8.x] Remove trailing comma

### DIFF
--- a/src/Illuminate/Bus/BusServiceProvider.php
+++ b/src/Illuminate/Bus/BusServiceProvider.php
@@ -47,7 +47,7 @@ class BusServiceProvider extends ServiceProvider implements DeferrableProvider
             return new DatabaseBatchRepository(
                 $app->make(BatchFactory::class),
                 $app->make('db')->connection(config('queue.batching.database')),
-                config('queue.batching.table', 'job_batches'),
+                config('queue.batching.table', 'job_batches')
             );
         });
     }


### PR DESCRIPTION
This probably isn't worth all the influx of prs and issues we've been getting since releasing Laravel 8.