### PR TITLE
[8.x] Tweak factory generator

### DIFF
--- a/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
+++ b/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
@@ -66,6 +66,9 @@ class FactoryMakeCommand extends GeneratorCommand
 
         $model = class_basename($namespaceModel);
 
+        $namespaceFactory = Str::ucfirst(str_replace('Factory', '', $name));
+        $factory = class_basename($namespaceFactory);
+
         if (Str::startsWith($namespaceModel, 'App\\Models')) {
             $namespace = Str::beforeLast('Database\\Factories\\'.Str::after($namespaceModel, 'App\\Models\\'), '\\');
         } else {
@@ -80,6 +83,8 @@ class FactoryMakeCommand extends GeneratorCommand
             'DummyModel' => $model,
             '{{ model }}' => $model,
             '{{model}}' => $model,
+            '{{ factory }}' => $factory,
+            '{{factory}}' => $factory,
         ];
 
         return str_replace(

--- a/src/Illuminate/Database/Console/Factories/stubs/factory.stub
+++ b/src/Illuminate/Database/Console/Factories/stubs/factory.stub
@@ -5,7 +5,7 @@ namespace {{ factoryNamespace }};
 use Illuminate\Database\Eloquent\Factories\Factory;
 use {{ namespacedModel }};
 
-class {{ model }}Factory extends Factory
+class {{ factory }}Factory extends Factory
 {
     /**
      * The name of the factory's corresponding model.


### PR DESCRIPTION
Hello,

first of all I would like to say this is my first PR targeting large application(framework) like Laravel.

I recently switched to Laravel 8.0 and found that, when generating factory, first argument (factory name) is ignored (only used to generate file name). This PR fixes this behavior so, class name is same as file name. I am not sure if current behavior is intentional, but I found that factory class name does not necessary match model name **in my case**. Did not find any tests for factory generation. Please, feel free to leave any feedback!

### Current behavior

My models
* Parameter\Parameter
* Parameter\Layout

`$ php artisan make:factory ParameterLayoutFactory`

Creates (Model `ParameterLayout` not found)

`class ModelFactory extends Factory`

### Expected behavior

`$ php artisan make:factory ParameterLayoutFactory`

Creates (class name inherited from name argument)

`class ParameterLayoutFactory extends Factory`

Thanks.