### PR TITLE
[8.x] Add types for casting encrypted strings to objects

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -72,6 +72,10 @@ trait HasAttributes
         'decimal',
         'double',
         'encrypted',
+        'encrypted:array',
+        'encrypted:collection',
+        'encrypted:json',
+        'encrypted:object',
         'float',
         'int',
         'integer',
@@ -525,6 +529,14 @@ trait HasAttributes
             return $value;
         }
 
+        // If the key is one of the encrypted castable types, we'll first decrypt
+        // the value and update the cast type so we may leverage the following
+        // logic for casting the value to any additionally specified type.
+        if ($this->isEncryptedCastable($key)) {
+            $value = $this->fromEncryptedString($value);
+            $castType = Str::after($castType, 'encrypted:');
+        }
+
         switch ($castType) {
             case 'int':
             case 'integer':
@@ -554,8 +566,6 @@ trait HasAttributes
                 return $this->asDateTime($value);
             case 'timestamp':
                 return $this->asTimestamp($value);
-            case 'encrypted':
-                return $this->fromEncryptedString($value);
         }
 
         if ($this->isClassCastable($key)) {
@@ -1112,7 +1122,7 @@ trait HasAttributes
      */
     protected function isJsonCastable($key)
     {
-        return $this->hasCast($key, ['array', 'json', 'object', 'collection']);
+        return $this->hasCast($key, ['array', 'json', 'object', 'collection', 'encrypted:array', 'encrypted:collection', 'encrypted:json', 'encrypted:object']);
     }
 
     /**
@@ -1123,7 +1133,7 @@ trait HasAttributes
      */
     protected function isEncryptedCastable($key)
     {
-        return $this->hasCast($key, ['encrypted']);
+        return $this->hasCast($key, ['encrypted', 'encrypted:array', 'encrypted:collection', 'encrypted:json', 'encrypted:object']);
     }
 
     /**

--- a/tests/Integration/Database/EloquentModelEncryptedCastingTest.php
+++ b/tests/Integration/Database/EloquentModelEncryptedCastingTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Integration\Database;
 use Illuminate\Contracts\Encryption\Encrypter;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\Schema;
 
@@ -25,6 +26,10 @@ class EloquentModelEncryptedCastingTest extends DatabaseTestCase
         Schema::create('encrypted_casts', function (Blueprint $table) {
             $table->increments('id');
             $table->string('secret', 1000)->nullable();
+            $table->text('secret_array')->nullable();
+            $table->text('secret_json')->nullable();
+            $table->text('secret_object')->nullable();
+            $table->text('secret_collection')->nullable();
         });
     }
 
@@ -37,21 +42,116 @@ class EloquentModelEncryptedCastingTest extends DatabaseTestCase
             ->with('encrypted-secret-string')
             ->andReturn('this is a secret string');
 
-        /** @var \Illuminate\Tests\Integration\Database\EncryptedCast $object */
-        $object = EncryptedCast::create([
+        /** @var \Illuminate\Tests\Integration\Database\EncryptedCast $subject */
+        $subject = EncryptedCast::create([
             'secret' => 'this is a secret string',
         ]);
 
-        $this->assertSame('this is a secret string', $object->secret);
+        $this->assertSame('this is a secret string', $subject->secret);
+        $this->assertDatabaseHas('encrypted_casts', [
+            'id' => $subject->id,
+            'secret' => 'encrypted-secret-string',
+        ]);
+    }
+
+    public function testArraysAreCastable()
+    {
+        $this->encrypter->expects('encryptString')
+            ->with('{"key1":"value1"}')
+            ->andReturn('encrypted-secret-array-string');
+        $this->encrypter->expects('decryptString')
+            ->with('encrypted-secret-array-string')
+            ->andReturn('{"key1":"value1"}');
+
+        /** @var \Illuminate\Tests\Integration\Database\EncryptedCast $subject */
+        $subject = EncryptedCast::create([
+            'secret_array' => ['key1' => 'value1'],
+        ]);
+
+        $this->assertSame(['key1' => 'value1'], $subject->secret_array);
+        $this->assertDatabaseHas('encrypted_casts', [
+            'id' => $subject->id,
+            'secret_array' => 'encrypted-secret-array-string',
+        ]);
+    }
+
+    public function testJsonIsCastable()
+    {
+        $this->encrypter->expects('encryptString')
+            ->with('{"key1":"value1"}')
+            ->andReturn('encrypted-secret-json-string');
+        $this->encrypter->expects('decryptString')
+            ->with('encrypted-secret-json-string')
+            ->andReturn('{"key1":"value1"}');
+
+        /** @var \Illuminate\Tests\Integration\Database\EncryptedCast $subject */
+        $subject = EncryptedCast::create([
+            'secret_json' => ['key1' => 'value1'],
+        ]);
+
+        $this->assertSame(['key1' => 'value1'], $subject->secret_json);
+        $this->assertDatabaseHas('encrypted_casts', [
+            'id' => $subject->id,
+            'secret_json' => 'encrypted-secret-json-string',
+        ]);
+    }
+
+    public function testObjectIsCastable()
+    {
+        $object = new \stdClass();
+        $object->key1 = 'value1';
+
+        $this->encrypter->expects('encryptString')
+            ->with('{"key1":"value1"}')
+            ->andReturn('encrypted-secret-object-string');
+        $this->encrypter->expects('decryptString')
+            ->twice()
+            ->with('encrypted-secret-object-string')
+            ->andReturn('{"key1":"value1"}');
+
+        /** @var \Illuminate\Tests\Integration\Database\EncryptedCast $object */
+        $object = EncryptedCast::create([
+            'secret_object' => $object,
+        ]);
+
+        $this->assertInstanceOf(\stdClass::class, $object->secret_object);
+        $this->assertSame('value1', $object->secret_object->key1);
         $this->assertDatabaseHas('encrypted_casts', [
             'id' => $object->id,
-            'secret' => 'encrypted-secret-string',
+            'secret_object' => 'encrypted-secret-object-string',
+        ]);
+    }
+
+    public function testCollectionIsCastable()
+    {
+        $this->encrypter->expects('encryptString')
+            ->with('{"key1":"value1"}')
+            ->andReturn('encrypted-secret-collection-string');
+        $this->encrypter->expects('decryptString')
+            ->twice()
+            ->with('encrypted-secret-collection-string')
+            ->andReturn('{"key1":"value1"}');
+
+        /** @var \Illuminate\Tests\Integration\Database\EncryptedCast $subject */
+        $subject = EncryptedCast::create([
+            'secret_collection' => new Collection(['key1' => 'value1']),
+        ]);
+
+        $this->assertInstanceOf(Collection::class, $subject->secret_collection);
+        $this->assertSame('value1', $subject->secret_collection->get('key1'));
+        $this->assertDatabaseHas('encrypted_casts', [
+            'id' => $subject->id,
+            'secret_collection' => 'encrypted-secret-collection-string',
         ]);
     }
 }
 
 /**
  * @property $secret
+ * @property $secret_array
+ * @property $secret_json
+ * @property $secret_object
+ * @property $secret_collection
  */
 class EncryptedCast extends Model
 {
@@ -60,5 +160,9 @@ class EncryptedCast extends Model
 
     public $casts = [
         'secret' => 'encrypted',
+        'secret_array' => 'encrypted:array',
+        'secret_json' => 'encrypted:json',
+        'secret_object' => 'encrypted:object',
+        'secret_collection' => 'encrypted:collection',
     ];
 }


### PR DESCRIPTION
Per the discussion in #34937, this is a fast-follow PR to add "types" or "formats" to specify additional casts for encrypted attributes.

This allows you to persist complex types like arrays, json, objects, or collections as encrypted values, while working with them naturally within your application.

Example:

```php
public $casts = [
    'user_ids' => 'encrypted:array',
    'preferences' => 'encrypted:json',
    'payment_method' => 'encrypted:object',
    'dependents' => 'encrypted:collection',
];
```

I feel this rounds out this feature by covering the most common use cases. For anything more, a custom cast may be used.

**Note:** Since these are stored encrypted, you will most like want to use a `text` field for any attributes using these casts.