### PR TITLE
[8.x] Add DatabaseRefreshed event to be emitted after database refreshed

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/FreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/FreshCommand.php
@@ -4,6 +4,9 @@ namespace Illuminate\Database\Console\Migrations;
 
 use Illuminate\Console\Command;
 use Illuminate\Console\ConfirmableTrait;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Database\Events\DatabaseRefreshed;
+use Illuminate\Database\Migrations\Migrator;
 use Symfony\Component\Console\Input\InputOption;
 
 class FreshCommand extends Command
@@ -23,6 +26,26 @@ class FreshCommand extends Command
      * @var string
      */
     protected $description = 'Drop all tables and re-run all migrations';
+
+    /**
+     * The event dispatcher instance.
+     *
+     * @var \Illuminate\Contracts\Events\Dispatcher
+     */
+    protected $dispatcher;
+
+    /**
+     * Create a new migration command instance.
+     *
+     * @param  \Illuminate\Contracts\Events\Dispatcher  $dispatcher
+     * @return void
+     */
+    public function __construct(Dispatcher $dispatcher)
+    {
+        parent::__construct();
+
+        $this->dispatcher = $dispatcher;
+    }
 
     /**
      * Execute the console command.
@@ -56,6 +79,10 @@ class FreshCommand extends Command
         if ($this->needsSeeding()) {
             $this->runSeeder($database);
         }
+
+        $this->dispatcher->dispatch(
+            new DatabaseRefreshed()
+        );
 
         return 0;
     }

--- a/src/Illuminate/Database/Console/Migrations/FreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/FreshCommand.php
@@ -6,7 +6,6 @@ use Illuminate\Console\Command;
 use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Events\DatabaseRefreshed;
-use Illuminate\Database\Migrations\Migrator;
 use Symfony\Component\Console\Input\InputOption;
 
 class FreshCommand extends Command

--- a/src/Illuminate/Database/Console/Migrations/FreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/FreshCommand.php
@@ -27,26 +27,6 @@ class FreshCommand extends Command
     protected $description = 'Drop all tables and re-run all migrations';
 
     /**
-     * The event dispatcher instance.
-     *
-     * @var \Illuminate\Contracts\Events\Dispatcher
-     */
-    protected $dispatcher;
-
-    /**
-     * Create a new migration command instance.
-     *
-     * @param  \Illuminate\Contracts\Events\Dispatcher  $dispatcher
-     * @return void
-     */
-    public function __construct(Dispatcher $dispatcher)
-    {
-        parent::__construct();
-
-        $this->dispatcher = $dispatcher;
-    }
-
-    /**
      * Execute the console command.
      *
      * @return int
@@ -79,7 +59,7 @@ class FreshCommand extends Command
             $this->runSeeder($database);
         }
 
-        $this->dispatcher->dispatch(
+        $this->laravel[Dispatcher::class]->dispatch(
             new DatabaseRefreshed()
         );
 

--- a/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
@@ -27,26 +27,6 @@ class RefreshCommand extends Command
     protected $description = 'Reset and re-run all migrations';
 
     /**
-     * The event dispatcher instance.
-     *
-     * @var \Illuminate\Contracts\Events\Dispatcher
-     */
-    protected $dispatcher;
-
-    /**
-     * Create a new migration command instance.
-     *
-     * @param  \Illuminate\Contracts\Events\Dispatcher  $dispatcher
-     * @return void
-     */
-    public function __construct(Dispatcher $dispatcher)
-    {
-        parent::__construct();
-
-        $this->dispatcher = $dispatcher;
-    }
-
-    /**
      * Execute the console command.
      *
      * @return int
@@ -89,7 +69,7 @@ class RefreshCommand extends Command
             $this->runSeeder($database);
         }
 
-        $this->dispatcher->dispatch(
+        $this->laravel[Dispatcher::class]->dispatch(
             new DatabaseRefreshed()
         );
 

--- a/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
@@ -4,6 +4,8 @@ namespace Illuminate\Database\Console\Migrations;
 
 use Illuminate\Console\Command;
 use Illuminate\Console\ConfirmableTrait;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Database\Events\DatabaseRefreshed;
 use Symfony\Component\Console\Input\InputOption;
 
 class RefreshCommand extends Command
@@ -23,6 +25,26 @@ class RefreshCommand extends Command
      * @var string
      */
     protected $description = 'Reset and re-run all migrations';
+
+    /**
+     * The event dispatcher instance.
+     *
+     * @var \Illuminate\Contracts\Events\Dispatcher
+     */
+    protected $dispatcher;
+
+    /**
+     * Create a new migration command instance.
+     *
+     * @param  \Illuminate\Contracts\Events\Dispatcher  $dispatcher
+     * @return void
+     */
+    public function __construct(Dispatcher $dispatcher)
+    {
+        parent::__construct();
+
+        $this->dispatcher = $dispatcher;
+    }
 
     /**
      * Execute the console command.
@@ -66,6 +88,10 @@ class RefreshCommand extends Command
         if ($this->needsSeeding()) {
             $this->runSeeder($database);
         }
+
+        $this->dispatcher->dispatch(
+            new DatabaseRefreshed()
+        );
 
         return 0;
     }

--- a/src/Illuminate/Database/Events/DatabaseRefreshed.php
+++ b/src/Illuminate/Database/Events/DatabaseRefreshed.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Database\Events;
+
+use Illuminate\Contracts\Database\Events\MigrationEvent as MigrationEventContract;
+
+class DatabaseRefreshed implements MigrationEventContract
+{
+    //
+}

--- a/src/Illuminate/Database/MigrationServiceProvider.php
+++ b/src/Illuminate/Database/MigrationServiceProvider.php
@@ -128,8 +128,8 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
      */
     protected function registerMigrateFreshCommand()
     {
-        $this->app->singleton('command.migrate.fresh', function () {
-            return new FreshCommand;
+        $this->app->singleton('command.migrate.fresh', function ($app) {
+            return new FreshCommand($app[Dispatcher::class]);
         });
     }
 
@@ -171,8 +171,8 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
      */
     protected function registerMigrateRefreshCommand()
     {
-        $this->app->singleton('command.migrate.refresh', function () {
-            return new RefreshCommand;
+        $this->app->singleton('command.migrate.refresh', function ($app) {
+            return new RefreshCommand($app[Dispatcher::class]);
         });
     }
 

--- a/src/Illuminate/Database/MigrationServiceProvider.php
+++ b/src/Illuminate/Database/MigrationServiceProvider.php
@@ -128,8 +128,8 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
      */
     protected function registerMigrateFreshCommand()
     {
-        $this->app->singleton('command.migrate.fresh', function ($app) {
-            return new FreshCommand($app[Dispatcher::class]);
+        $this->app->singleton('command.migrate.fresh', function () {
+            return new FreshCommand;
         });
     }
 
@@ -171,8 +171,8 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
      */
     protected function registerMigrateRefreshCommand()
     {
-        $this->app->singleton('command.migrate.refresh', function ($app) {
-            return new RefreshCommand($app[Dispatcher::class]);
+        $this->app->singleton('command.migrate.refresh', function () {
+            return new RefreshCommand;
         });
     }
 

--- a/tests/Database/DatabaseMigrationRefreshCommandTest.php
+++ b/tests/Database/DatabaseMigrationRefreshCommandTest.php
@@ -24,9 +24,10 @@ class DatabaseMigrationRefreshCommandTest extends TestCase
 
     public function testRefreshCommandCallsCommandsWithProperArguments()
     {
-        $command = new RefreshCommand($dispatcher = m::mock(Dispatcher::class));
+        $command = new RefreshCommand();
 
         $app = new ApplicationDatabaseRefreshStub(['path.database' => __DIR__]);
+        $dispatcher = $app->instance(Dispatcher::class, $events = m::mock());
         $console = m::mock(ConsoleApplication::class)->makePartial();
         $console->__construct();
         $command->setLaravel($app);
@@ -48,9 +49,10 @@ class DatabaseMigrationRefreshCommandTest extends TestCase
 
     public function testRefreshCommandCallsCommandsWithStep()
     {
-        $command = new RefreshCommand($dispatcher = m::mock(Dispatcher::class));
+        $command = new RefreshCommand();
 
         $app = new ApplicationDatabaseRefreshStub(['path.database' => __DIR__]);
+        $dispatcher = $app->instance(Dispatcher::class, $events = m::mock());
         $console = m::mock(ConsoleApplication::class)->makePartial();
         $console->__construct();
         $command->setLaravel($app);

--- a/tests/Database/DatabaseMigrationRefreshCommandTest.php
+++ b/tests/Database/DatabaseMigrationRefreshCommandTest.php
@@ -2,10 +2,12 @@
 
 namespace Illuminate\Tests\Database;
 
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Console\Migrations\MigrateCommand;
 use Illuminate\Database\Console\Migrations\RefreshCommand;
 use Illuminate\Database\Console\Migrations\ResetCommand;
 use Illuminate\Database\Console\Migrations\RollbackCommand;
+use Illuminate\Database\Events\DatabaseRefreshed;
 use Illuminate\Foundation\Application;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -22,7 +24,7 @@ class DatabaseMigrationRefreshCommandTest extends TestCase
 
     public function testRefreshCommandCallsCommandsWithProperArguments()
     {
-        $command = new RefreshCommand();
+        $command = new RefreshCommand($dispatcher = m::mock(Dispatcher::class));
 
         $app = new ApplicationDatabaseRefreshStub(['path.database' => __DIR__]);
         $console = m::mock(ConsoleApplication::class)->makePartial();
@@ -35,6 +37,7 @@ class DatabaseMigrationRefreshCommandTest extends TestCase
 
         $console->shouldReceive('find')->with('migrate:reset')->andReturn($resetCommand);
         $console->shouldReceive('find')->with('migrate')->andReturn($migrateCommand);
+        $dispatcher->shouldReceive('dispatch')->once()->with(m::type(DatabaseRefreshed::class));
 
         $quote = DIRECTORY_SEPARATOR == '\\' ? '"' : "'";
         $resetCommand->shouldReceive('run')->with(new InputMatcher("--force=1 {$quote}migrate:reset{$quote}"), m::any());
@@ -45,7 +48,7 @@ class DatabaseMigrationRefreshCommandTest extends TestCase
 
     public function testRefreshCommandCallsCommandsWithStep()
     {
-        $command = new RefreshCommand();
+        $command = new RefreshCommand($dispatcher = m::mock(Dispatcher::class));
 
         $app = new ApplicationDatabaseRefreshStub(['path.database' => __DIR__]);
         $console = m::mock(ConsoleApplication::class)->makePartial();
@@ -58,6 +61,7 @@ class DatabaseMigrationRefreshCommandTest extends TestCase
 
         $console->shouldReceive('find')->with('migrate:rollback')->andReturn($rollbackCommand);
         $console->shouldReceive('find')->with('migrate')->andReturn($migrateCommand);
+        $dispatcher->shouldReceive('dispatch')->once()->with(m::type(DatabaseRefreshed::class));
 
         $quote = DIRECTORY_SEPARATOR == '\\' ? '"' : "'";
         $rollbackCommand->shouldReceive('run')->with(new InputMatcher("--step=2 --force=1 {$quote}migrate:rollback{$quote}"), m::any());


### PR DESCRIPTION
This PR adds a new `DatabaseRefreshed` event that is emitted after either `php artisan migrate:fresh` or `php artisan migrate:refresh` is run.

Being able to listen to this event will allow developers to perform secondary actions to their local environment after refreshing, for example clearing stale or invalid cookies or redefining environment variables related to obsolete data.
