### PR TITLE
[8.x] Fix pagination i18n

### DIFF
--- a/src/Illuminate/Pagination/resources/views/tailwind.blade.php
+++ b/src/Illuminate/Pagination/resources/views/tailwind.blade.php
@@ -34,7 +34,7 @@
                         <span class="font-medium">{{ $paginator->total() }}</span>
                         {!! __('results') !!}
                     @else
-                        {!! trans_choice('pagination.summary', [
+                        {!! trans_choice('pagination.summary', $paginator->total(), [
                             'first-item' => '<span class="font-medium">'.$paginator->firstItem().'</span>',
                             'last-item' => '<span class="font-medium">'.$paginator->lastItem().'</span>',
                             'total' => '<span class="font-medium">'.$paginator->total().'</span>',

--- a/src/Illuminate/Pagination/resources/views/tailwind.blade.php
+++ b/src/Illuminate/Pagination/resources/views/tailwind.blade.php
@@ -25,7 +25,7 @@
         <div class="hidden sm:flex-1 sm:flex sm:items-center sm:justify-between">
             <div>
                 <p class="text-sm text-gray-700 leading-5">
-                    @if (__('Showing :first-item to :last-item of :total results') === 'Showing :first-item to :last-item of :total results')
+                    @if (__('pagination.summary') === 'pagination.summary')
                         {!! __('Showing') !!}
                         <span class="font-medium">{{ $paginator->firstItem() }}</span>
                         {!! __('to') !!}
@@ -34,7 +34,7 @@
                         <span class="font-medium">{{ $paginator->total() }}</span>
                         {!! __('results') !!}
                     @else
-                        {!! __('Showing :first-item to :last-item of :total results', [
+                        {!! trans_choice('pagination.summary', [
                             'first-item' => '<span class="font-medium">'.$paginator->firstItem().'</span>',
                             'last-item' => '<span class="font-medium">'.$paginator->lastItem().'</span>',
                             'total' => '<span class="font-medium">'.$paginator->total().'</span>',

--- a/src/Illuminate/Pagination/resources/views/tailwind.blade.php
+++ b/src/Illuminate/Pagination/resources/views/tailwind.blade.php
@@ -25,11 +25,21 @@
         <div class="hidden sm:flex-1 sm:flex sm:items-center sm:justify-between">
             <div>
                 <p class="text-sm text-gray-700 leading-5">
-                    {!! __('Showing :first-item to :last-item of :total results', [
-                        'first-item' => '<span class="font-medium">' . $paginator->firstItem() . '</span>',
-                        'last-item' => '<span class="font-medium">' . $paginator->lastItem() . '</span>',
-                        'total' => '<span class="font-medium">' . $paginator->total() . '</span>',
-                    ]) !!}
+                    @if (__('Showing :first-item to :last-item of :total results') === 'Showing :first-item to :last-item of :total results')
+                        {!! __('Showing') !!}
+                        <span class="font-medium">{{ $paginator->firstItem() }}</span>
+                        {!! __('to') !!}
+                        <span class="font-medium">{{ $paginator->lastItem() }}</span>
+                        {!! __('of') !!}
+                        <span class="font-medium">{{ $paginator->total() }}</span>
+                        {!! __('results') !!}
+                    @else
+                        {!! __('Showing :first-item to :last-item of :total results', [
+                            'first-item' => '<span class="font-medium">' . 11 . '</span>',
+                            'last-item' => '<span class="font-medium">' . 20 . '</span>',
+                            'total' => '<span class="font-medium">' . 100 . '</span>',
+                        ]) !!}
+                    @endif
                 </p>
             </div>
 

--- a/src/Illuminate/Pagination/resources/views/tailwind.blade.php
+++ b/src/Illuminate/Pagination/resources/views/tailwind.blade.php
@@ -35,9 +35,9 @@
                         {!! __('results') !!}
                     @else
                         {!! __('Showing :first-item to :last-item of :total results', [
-                            'first-item' => '<span class="font-medium">' . 11 . '</span>',
-                            'last-item' => '<span class="font-medium">' . 20 . '</span>',
-                            'total' => '<span class="font-medium">' . 100 . '</span>',
+                            'first-item' => '<span class="font-medium">'.$paginator->firstItem().'</span>',
+                            'last-item' => '<span class="font-medium">'.$paginator->lastItem().'</span>',
+                            'total' => '<span class="font-medium">'.$paginator->total().'</span>',
                         ]) !!}
                     @endif
                 </p>

--- a/src/Illuminate/Pagination/resources/views/tailwind.blade.php
+++ b/src/Illuminate/Pagination/resources/views/tailwind.blade.php
@@ -25,13 +25,11 @@
         <div class="hidden sm:flex-1 sm:flex sm:items-center sm:justify-between">
             <div>
                 <p class="text-sm text-gray-700 leading-5">
-                    {!! __('Showing') !!}
-                    <span class="font-medium">{{ $paginator->firstItem() }}</span>
-                    {!! __('to') !!}
-                    <span class="font-medium">{{ $paginator->lastItem() }}</span>
-                    {!! __('of') !!}
-                    <span class="font-medium">{{ $paginator->total() }}</span>
-                    {!! __('results') !!}
+                    {!! __('Showing :first-item to :last-item of :total results', [
+                        'first-item' => '<span class="font-medium">' . $paginator->firstItem() . '</span>',
+                        'last-item' => '<span class="font-medium">' . $paginator->lastItem() . '</span>',
+                        'total' => '<span class="font-medium">' . $paginator->total() . '</span>',
+                    ]) !!}
                 </p>
             </div>
 


### PR DESCRIPTION
Translation need to keep sentences complete. Words "to" or "of" are way to vague for proper translation (can conflict with other meanings and force the translator to dig into the code). And the splitting can make bad or event impossible to translate when the destination languages needs a reordering. 