### PR TITLE
[9.x] Add test cases for `multiple_of` validation rule

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1272,7 +1272,7 @@ trait ValidatesAttributes
             return false;
         }
             
-        return bcmod($value, $parameters[0], 16) === "0.0000000000000000";
+        return bcmod($value, $parameters[0], 16) === '0.0000000000000000';
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1266,7 +1266,12 @@ trait ValidatesAttributes
         if (! $this->validateNumeric($attribute, $value) || ! $this->validateNumeric($attribute, $parameters[0])) {
             return false;
         }
-
+        
+        // We know it's not a multiple of 0 without even attempting to divide by zero.
+        if ((float) $parameters[0] === 0.0) {
+            return false;
+        }
+            
         return bcmod($value, $parameters[0], 16) === "0.0000000000000000";
     }
 

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1267,7 +1267,7 @@ trait ValidatesAttributes
             return false;
         }
 
-        return fmod($value, $parameters[0]) === 0.0;
+        return bcmod($value, $parameters[0], 16) === "0.0000000000000000";
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1927,7 +1927,6 @@ class ValidationValidatorTest extends TestCase
             [2, .1, true], // fmod does this "wrong", it should be 0, but fmod(2, .1) = .1
             [.75, .05, true], // fmod does this "wrong", it should be 0, but fmod(.75, .05) = .05
             [.9, .3, true], // floating point division does not produce a proper 0 here
-            [2, .3, true], // floating point division does not produce a proper 0 here
             ['foo', 1, false], // invalid values
             [1, 'foo', false],
             ['foo', 'foo', false],

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1912,18 +1912,22 @@ class ValidationValidatorTest extends TestCase
             [5.0, -10, false],
             [10.5, 10.5, true], // float (same)
             [10.5, 0.5, true], // float + float
-            [10.5, 0.3, false],
+            [10.5, 0.3, true], // 10.5/.3 = 35, but floating point division does not produce a proper 0 here
             [31.5, 10.5, true],
             [31.6, 10.5, false],
             [10.5, -0.5, true], // float + -float
-            [10.5, -0.3, false],
+            [10.5, -0.3, true], // 10.5/.3 = 35, but floating point division does not produce a proper 0 here
             [-31.5, 10.5, true],
             [-31.6, 10.5, false],
             [-10.5, -10.5, true], // -float (same)
             [-10.5, -0.5, true], // -float + -float
-            [-10.5, -0.3, false],
+            [-10.5, -0.3, true], // 10.5/.3 = 35, but floating point division does not produce a proper 0 here
             [-31.5, -10.5, true],
             [-31.6, -10.5, false],
+            [2, .1, true], // fmod does this "wrong", it should be 0, but fmod(2, .1) = .1
+            [.75, .05, true], // fmod does this "wrong", it should be 0, but fmod(.75, .05) = .05
+            [.9, .3, true], // floating point division does not produce a proper 0 here
+            [2, .3, true], // floating point division does not produce a proper 0 here
             ['foo', 1, false], // invalid values
             [1, 'foo', false],
             ['foo', 'foo', false],


### PR DESCRIPTION
Some of the test cases were not conforming to `step` constraint in HTML and (in my opinion) not correct per se, i.e. 10.5 is a multiple of .3 as much as it is a multiple of .5.

I also added a few more test cases where the behaviour of `multiple_of` is not what one would expect and not how HTML validation handles them (emphasis mine):

> Constraint validation: When the element has an allowed value step, and the result of applying the algorithm to convert a string to a number to the string given by the element's value is a number, and **that number subtracted from the step base is not an integral multiple of the allowed value step**, the element is suffering from a step mismatch.

Currently the validation rule fails some cases of recognizing that the value is "an integral multiple of the allowed value step" (because PHP's `fmod` fails that) and doesn't even attempt to tie the check together with `min`.

https://html.spec.whatwg.org/multipage/input.html#the-step-attribute