### PR TITLE
[8.x] Add docblock for `Storage::extend()`

### DIFF
--- a/src/Illuminate/Support/Facades/Storage.php
+++ b/src/Illuminate/Support/Facades/Storage.php
@@ -18,6 +18,7 @@ use Illuminate\Filesystem\Filesystem;
  * @method static bool delete(string|array $paths)
  * @method static bool deleteDirectory(string $directory)
  * @method static bool exists(string $path)
+ * @method static \Illuminate\Filesystem\FilesystemManager extend(string $driver, \Closure $callback)
  * @method static bool makeDirectory(string $path)
  * @method static bool move(string $from, string $to)
  * @method static bool prepend(string $path, string $data)


### PR DESCRIPTION
While `Storage::extend()` is [documented](https://laravel.com/docs/8.x/filesystem#custom-filesystems), and it belongs to the public API of the `FilesystemManager`, the docblock is missing in the `Storage` facade.