### PR TITLE
[8.x] Chainable casts

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -878,9 +878,7 @@ trait HasAttributes
 
         if ($value === false) {
             throw JsonEncodingException::forAttribute(
-                $this,
-                $key,
-                json_last_error_msg()
+                $this, $key, json_last_error_msg()
             );
         }
 
@@ -1025,8 +1023,7 @@ trait HasAttributes
         // when checking the field. We will just return the DateTime right away.
         if ($value instanceof DateTimeInterface) {
             return Date::parse(
-                $value->format('Y-m-d H:i:s.u'),
-                $value->getTimezone()
+                $value->format('Y-m-d H:i:s.u'), $value->getTimezone()
             );
         }
 
@@ -1412,8 +1409,7 @@ trait HasAttributes
     public function getOriginal($key = null, $default = null)
     {
         return (new static)->setRawAttributes(
-            $this->original,
-            $sync = true
+            $this->original, $sync = true
         )->getOriginalWithoutRewindingModel($key, $default);
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -141,16 +141,14 @@ trait HasAttributes
         );
 
         $attributes = $this->addMutatedAttributesToArray(
-            $attributes,
-            $mutatedAttributes = $this->getMutatedAttributes()
+            $attributes, $mutatedAttributes = $this->getMutatedAttributes()
         );
 
         // Next we will handle any casts that have been setup for this model and cast
         // the values to their appropriate type. If the attribute has a mutator we
         // will not perform the cast on those attributes to avoid any confusion.
         $attributes = $this->addCastAttributesToArray(
-            $attributes,
-            $mutatedAttributes
+            $attributes, $mutatedAttributes
         );
 
         // Here we will grab all of the appended, calculated attributes to this model
@@ -205,8 +203,7 @@ trait HasAttributes
             // mutated attribute's actual values. After we finish mutating each of the
             // attributes we will return this final array of the mutated attributes.
             $attributes[$key] = $this->mutateAttributeForArray(
-                $key,
-                $attributes[$key]
+                $key, $attributes[$key]
             );
         }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -233,8 +233,7 @@ trait HasAttributes
             // then we will serialize the date for the array. This will convert the dates
             // to strings based on the date format specified for these Eloquent models.
             $attributes[$key] = $this->castAttribute(
-                $key,
-                $attributes[$key]
+                $key, $attributes[$key]
             );
 
             if (is_iterable($value)) {
@@ -462,16 +461,12 @@ trait HasAttributes
         if (! $relation instanceof Relation) {
             if (is_null($relation)) {
                 throw new LogicException(sprintf(
-                    '%s::%s must return a relationship instance, but "null" was returned. Was the "return" keyword used?',
-                    static::class,
-                    $method
+                    '%s::%s must return a relationship instance, but "null" was returned. Was the "return" keyword used?', static::class, $method
                 ));
             }
 
             throw new LogicException(sprintf(
-                '%s::%s must return a relationship instance.',
-                static::class,
-                $method
+                '%s::%s must return a relationship instance.', static::class, $method
             ));
         }
 
@@ -648,10 +643,7 @@ trait HasAttributes
     protected function serializeClassCastableAttribute($key, $value)
     {
         return $this->resolveCasterClass($key)->serialize(
-            $this,
-            $key,
-            $value,
-            $this->attributes
+            $this, $key, $value, $this->attributes
         );
     }
 
@@ -805,9 +797,7 @@ trait HasAttributes
         [$key, $path] = explode('->', $key, 2);
 
         $this->attributes[$key] = $this->asJson($this->getArrayAttributeWithValue(
-            $path,
-            $key,
-            $value
+            $path, $key, $value
         ));
 
         return $this;
@@ -829,20 +819,14 @@ trait HasAttributes
                 function () {
                 },
                 $this->normalizeCastClassResponse($key, $caster->set(
-                    $this,
-                    $key,
-                    $this->{$key},
-                    $this->attributes
+                    $this, $key, $this->{$key}, $this->attributes
                 ))
             ));
         } else {
             $this->attributes = array_merge(
                 $this->attributes,
                 $this->normalizeCastClassResponse($key, $caster->set(
-                    $this,
-                    $key,
-                    $value,
-                    $this->attributes
+                    $this, $key, $value, $this->attributes
                 ))
             );
         }
@@ -1444,8 +1428,7 @@ trait HasAttributes
     {
         if ($key) {
             return $this->transformModelValue(
-                $key,
-                Arr::get($this->original, $key, $default)
+                $key, Arr::get($this->original, $key, $default)
             );
         }
 
@@ -1546,8 +1529,7 @@ trait HasAttributes
     public function isDirty($attributes = null)
     {
         return $this->hasChanges(
-            $this->getDirty(),
-            is_array($attributes) ? $attributes : func_get_args()
+            $this->getDirty(), is_array($attributes) ? $attributes : func_get_args()
         );
     }
 
@@ -1571,8 +1553,7 @@ trait HasAttributes
     public function wasChanged($attributes = null)
     {
         return $this->hasChanges(
-            $this->getChanges(),
-            is_array($attributes) ? $attributes : func_get_args()
+            $this->getChanges(), is_array($attributes) ? $attributes : func_get_args()
         );
     }
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -695,6 +695,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     public function save(array $options = [])
     {
         $this->mergeAttributesFromClassCasts();
+        $this->mergeAttributesFromChainCasts();
 
         $query = $this->newModelQuery();
 
@@ -936,6 +937,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     public function delete()
     {
         $this->mergeAttributesFromClassCasts();
+        $this->mergeAttributesFromChainCasts();
 
         if (is_null($this->getKeyName())) {
             throw new Exception('No primary key defined on model.');
@@ -1754,8 +1756,10 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     public function __sleep()
     {
         $this->mergeAttributesFromClassCasts();
+        $this->resetChainCasts();
 
         $this->classCastCache = [];
+        $this->chainCastCache = [];
 
         return array_keys(get_object_vars($this));
     }

--- a/tests/Integration/Database/DatabaseEloquentModelChainableCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelChainableCastingTest.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Contracts\Database\Eloquent\Castable;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Contracts\Database\Eloquent\CastsInboundAttributes;
+use Illuminate\Contracts\Database\Eloquent\SerializesCastableAttributes;
+use Illuminate\Database\Eloquent\InvalidCastException;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
+
+/**
+ * @group integration
+ */
+class DatabaseEloquentModelChainableCastingTest extends DatabaseTestCase
+{
+    public function testBasicChainedCast()
+    {
+        $model = new TestEloquentModelWithChainedCast;
+        $model->password = 'password';
+
+        dd($model->toArray());
+
+        $this->assertSame('TAYLOR', $model->password);
+        $this->assertSame('TAYLOR', $model->getAttributes()['uppercase']);
+        $this->assertSame('TAYLOR', $model->toArray()['uppercase']);
+
+        $unserializedModel = unserialize(serialize($model));
+
+        $this->assertSame('TAYLOR', $unserializedModel->uppercase);
+        $this->assertSame('TAYLOR', $unserializedModel->getAttributes()['uppercase']);
+        $this->assertSame('TAYLOR', $unserializedModel->toArray()['uppercase']);
+
+        $model->syncOriginal();
+        $model->uppercase = 'dries';
+        $this->assertSame('TAYLOR', $model->getOriginal('uppercase'));
+
+        $model = new TestEloquentModelWithChainedCast;
+        $model->uppercase = 'taylor';
+        $model->syncOriginal();
+        $model->uppercase = 'dries';
+        $model->getOriginal();
+
+        $this->assertSame('DRIES', $model->uppercase);
+
+        $model = new TestEloquentModelWithChainedCast;
+
+        $model->address = $address = new Address('110 Kingsbrook St.', 'My Childhood House');
+        $address->lineOne = '117 Spencer St.';
+        $this->assertSame('117 Spencer St.', $model->getAttributes()['address_line_one']);
+
+        $model = new TestEloquentModelWithChainedCast;
+
+        $model->setRawAttributes([
+            'address_line_one' => '110 Kingsbrook St.',
+            'address_line_two' => 'My Childhood House',
+        ]);
+
+        $this->assertSame('110 Kingsbrook St.', $model->address->lineOne);
+        $this->assertSame('My Childhood House', $model->address->lineTwo);
+
+        $this->assertSame('110 Kingsbrook St.', $model->toArray()['address_line_one']);
+        $this->assertSame('My Childhood House', $model->toArray()['address_line_two']);
+
+        $model->address->lineOne = '117 Spencer St.';
+
+        $this->assertFalse(isset($model->toArray()['address']));
+        $this->assertSame('117 Spencer St.', $model->toArray()['address_line_one']);
+        $this->assertSame('My Childhood House', $model->toArray()['address_line_two']);
+
+        $this->assertSame('117 Spencer St.', json_decode($model->toJson(), true)['address_line_one']);
+        $this->assertSame('My Childhood House', json_decode($model->toJson(), true)['address_line_two']);
+
+        $model->address = null;
+
+        $this->assertNull($model->toArray()['address_line_one']);
+        $this->assertNull($model->toArray()['address_line_two']);
+
+        $model->options = ['foo' => 'bar'];
+        $this->assertEquals(['foo' => 'bar'], $model->options);
+        $this->assertEquals(['foo' => 'bar'], $model->options);
+        $model->options = ['foo' => 'bar'];
+        $model->options = ['foo' => 'bar'];
+        $this->assertEquals(['foo' => 'bar'], $model->options);
+        $this->assertEquals(['foo' => 'bar'], $model->options);
+
+        $this->assertSame(json_encode(['foo' => 'bar']), $model->getAttributes()['options']);
+
+        $model = new TestEloquentModelWithChainedCast(['options' => []]);
+        $model->syncOriginal();
+        $model->options = ['foo' => 'bar'];
+        $this->assertTrue($model->isDirty('options'));
+
+        $model = new TestEloquentModelWithCustomCast;
+        $model->birthday_at = now();
+        $this->assertTrue(is_string($model->toArray()['birthday_at']));
+    }
+}
+
+class TestEloquentModelWithChainedCast extends Model
+{
+    /**
+     * The attributes that aren't mass assignable.
+     *
+     * @var string[]
+     */
+    protected $guarded = [];
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'password' => [
+           'string',
+           EncryptedCast::class,
+        ],
+        'account_number' => [
+            'integer',
+            EncryptedCast::class,
+        ],
+        'encrypted_array' => [
+            'array',
+            EncryptedCast::class,
+        ],
+        'encrypted_object' => [
+            'object',
+            EncryptedCast::class,
+        ],
+        'encrypted_collection' => [
+            'collection',
+            EncryptedCast::class,
+        ],
+        'undefined' => [
+           'string',
+            UndefinedCast::class,
+        ],
+    ];
+}

--- a/tests/Integration/Database/DatabaseEloquentModelChainableCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelChainableCastingTest.php
@@ -2,14 +2,9 @@
 
 namespace Illuminate\Tests\Integration\Database;
 
-use Illuminate\Contracts\Database\Eloquent\Castable;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Contracts\Database\Eloquent\CastsInboundAttributes;
-use Illuminate\Contracts\Database\Eloquent\SerializesCastableAttributes;
-use Illuminate\Database\Eloquent\InvalidCastException;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Carbon;
-use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Str;
 
 /**


### PR DESCRIPTION
This PR adds new functionality for "chainable casts", allowing for more reusable and flexible casting of attributes. Chainable casts are defined by using an array of cast types and/or custom cast classes.

For example, an attribute could first be cast as `json`, and then `encrypted`, all without needing to add new cast rules or create multiple custom casts. Chainable casts can contain as many casts as necessary, including custom cast classes.

```php
protected $casts = [
    'birth_date' => 'date',
    'password' => [
        'string',
        'encrypted',
    ],
    'number' => [
        'integer',
        'encrypted',
    ],
    'options' => [
        'array',
        'encrypted',
    ],
    'hash' => [
        ReverseCaster::class,
        SlugifyCaster::class,
        Base64Caster::class,
    ],
];
```