### PR TITLE
[8.x] Custom casts can implement increment/decrement logic

### DIFF
--- a/src/Illuminate/Contracts/Database/Eloquent/DeviatesCastableAttributes.php
+++ b/src/Illuminate/Contracts/Database/Eloquent/DeviatesCastableAttributes.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Illuminate\Contracts\Database\Eloquent;
+
+interface DeviatesCastableAttributes
+{
+    /**
+     * Increment the attribute.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  array  $attributes
+     * @return mixed
+     */
+    public function increment($model, string $key, $value, array $attributes);
+
+    /**
+     * Decrement the attribute.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  array  $attributes
+     * @return mixed
+     */
+    public function decrement($model, string $key, $value, array $attributes);
+}

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -609,6 +609,21 @@ trait HasAttributes
     }
 
     /**
+     * Increment or decrement the given attribute using the custom cast class.
+     *
+     * @param  string  $method
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return mixed
+     */
+    protected function deviateClassCastableAttribute($method, $key, $value)
+    {
+        return $this->resolveCasterClass($key)->{$method}(
+            $this, $key, $value, $this->attributes
+        );
+    }
+
+    /**
      * Serialize the given attribute using the custom cast class.
      *
      * @param  string  $key
@@ -1106,6 +1121,21 @@ trait HasAttributes
         }
 
         throw new InvalidCastException($this->getModel(), $key, $castType);
+    }
+
+    /**
+     * Determine if the key is deviable using a custom class.
+     *
+     * @param  string  $key
+     * @return bool
+     *
+     * @throws \Illuminate\Database\Eloquent\InvalidCastException
+     */
+    protected function isClassDeviable($key)
+    {
+        return $this->isClassCastable($key) &&
+            method_exists($castType = $this->parseCasterClass($this->getCasts()[$key]), 'increment') &&
+            method_exists($castType, 'decrement');
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -612,7 +612,9 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
             return $query->{$method}($column, $amount, $extra);
         }
 
-        $this->{$column} = $this->{$column} + ($method === 'increment' ? $amount : $amount * -1);
+        $this->{$column} = $this->isClassDeviable($column)
+            ? $this->deviateClassCastableAttribute($method, $column, $amount)
+            : $this->{$column} = $this->{$column} + ($method === 'increment' ? $amount : $amount * -1);
 
         $this->forceFill($extra);
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -614,7 +614,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
 
         $this->{$column} = $this->isClassDeviable($column)
             ? $this->deviateClassCastableAttribute($method, $column, $amount)
-            : $this->{$column} = $this->{$column} + ($method === 'increment' ? $amount : $amount * -1);
+            : $this->{$column} + ($method === 'increment' ? $amount : $amount * -1);
 
         $this->forceFill($extra);
 

--- a/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
@@ -155,11 +155,11 @@ class DatabaseEloquentModelCustomCastingTest extends DatabaseTestCase
         $model->price = '123.456';
         $model->save();
 
-        $model->increasePrice('530.865');
+        $model->increment('price', '530.865');
 
         $this->assertSame((new Decimal('654.321'))->getValue(), $model->price->getValue());
 
-        $model->decreasePrice('333.333');
+        $model->decrement('price', '333.333');
 
         $this->assertSame((new Decimal('320.988'))->getValue(), $model->price->getValue());
     }
@@ -290,22 +290,6 @@ class TestEloquentModelWithCustomCast extends Model
         'undefined_cast_column' => UndefinedCast::class,
         'birthday_at' => DateObjectCaster::class,
     ];
-
-    /**
-     * @param  float|int  $amount
-     */
-    public function increasePrice($amount)
-    {
-        $this->increment('price', $amount);
-    }
-
-    /**
-     * @param  float|int  $amount
-     */
-    public function decreasePrice($amount)
-    {
-        $this->decrement('price', $amount);
-    }
 }
 
 class HashCaster implements CastsInboundAttributes


### PR DESCRIPTION
This PR allows developers to add support of increment and decrement operations on their custom castable attributes. There are no breaking change, new functionality is covered with tests.

### Reasoning

Consider a custom caster that casts the value to a value object, for example Money.
As we all know, PHP doesn't support operator overloading, and even if it once will - there's no guarantee that it will be implemented in value object implementation.
Which leads us to the following problem when trying to increment or decrement castable attribute:
`Object of class Money\Money could not be converted to number` in `Model::incrementOrDecrement` method:
```php
$this->{$column} = $this->{$column} + ($method === 'increment' ? $amount : $amount * -1);
```

**Why do we ever need this?**
- Consistency of value objects with simple numeric types;
- Transparent usage when increments/decrements needed on multiple fields - no workaround logic needed;
- Increment and decrement operations are atomic at database level - no explicit transactions required;
- There are no excuse to dropping support of increment/decrement operations for custom castable attributes.

**Naming problem**
I've used word _deviate_ as aggregate term for both _increment_ and _decrement_. For example:
- IncrementsAndDecrementsCastableAttributes -> DeviatesCastableAttributes;
- incrementOrDecrementClassCastableAttribute -> deviateClassCastableAttribute;
- isClassIncrementableAndDecrementable -> isClassDeviable.

It looks much more clean and, in my opinion, still perfectly describes logic behind it.
I'm welcome to adopt a better alternative if any.

### Conclusion

This is my first PR ever, so please don't judge too much.
For my test I've reused Decimal value object class and DecimalCaster from PR #34702.
Also mentioned PR was good starting point and reference for my work.