### PR TITLE
[8.x] Error when try to delete a primary key with a custom name

### DIFF
--- a/tests/Database/DatabaseMigratorIntegrationTest.php
+++ b/tests/Database/DatabaseMigratorIntegrationTest.php
@@ -28,8 +28,14 @@ class DatabaseMigratorIntegrationTest extends TestCase
         $this->db = $db = new DB;
 
         $db->addConnection([
-            'driver' => 'sqlite',
-            'database' => ':memory:',
+            'driver'    => 'pgsql',
+            'host'      => 'postgres',
+            'database'  => 'dblimpia',
+            'username'  => 'zataca',
+            'password'  => 'zataca',
+            'charset'   => 'utf8',
+            'collation' => 'utf8_unicode_ci',
+            'prefix'    => '',
         ]);
 
         $db->addConnection([
@@ -82,6 +88,17 @@ class DatabaseMigratorIntegrationTest extends TestCase
 
         $this->assertTrue(Str::contains($ran[0], 'users'));
         $this->assertTrue(Str::contains($ran[1], 'password_resets'));
+    }
+
+    public function testBasicMigrationOfSingleFolderWithTableRenameInPostgres()
+    {
+        $ran = $this->migrator->run([__DIR__.'/migrations/three']);
+
+        $this->assertTrue($this->db->schema()->hasTable('test_renamed'));
+
+        $this->assertTrue(Str::contains($ran[0], 'create'));
+        $this->assertTrue(Str::contains($ran[1], 'rename'));
+        $this->assertTrue(Str::contains($ran[2], 'delete'));
     }
 
     public function testMigrationsCanBeRolledBack()

--- a/tests/Database/migrations/three/2016_01_01_000000_create_test_table.php
+++ b/tests/Database/migrations/three/2016_01_01_000000_create_test_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateTestTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('test', function (Blueprint $table) {
+            $table->integer('number');
+            $table->primary('number', 'primary_key_custom_name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('test');
+    }
+}

--- a/tests/Database/migrations/three/2016_01_01_100000_rename_test_table.php
+++ b/tests/Database/migrations/three/2016_01_01_100000_rename_test_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class RenameTestTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::rename("test", "test_renamed");
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::rename("test_renamed", "test");
+    }
+}

--- a/tests/Database/migrations/three/2016_01_01_200000_delete_primary_key.php
+++ b/tests/Database/migrations/three/2016_01_01_200000_delete_primary_key.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class DeletePrimaryKey extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('test_renamed', function (Blueprint $table) {
+            $table->dropPrimary('primary_key_custom_name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('test_renamed', function (Blueprint $table) {
+            $table->primary('number', 'primary_key_custom_name');
+        });
+    }
+}


### PR DESCRIPTION
Custom primary key names are ignored when you create a table, always are create with tablename_pkey.

I made a test that create a table with custom name for the primary key, then rename the table and finally try to remove the primary key. The test run ok with sqlite2 but fails with postgres so you will need a postgres database and configure the credentials on the setup method.

The result of the test with postgres is this:

```
PHPUnit 9.4.2 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.4.11
Configuration: /var/www/html3/framework/phpunit.xml.dist

E                                                                   1 / 1 (100%)

Time: 00:00.176, Memory: 112.50 MB

There was 1 error:

1) Illuminate\Tests\Database\DatabaseMigratorIntegrationTest::testBasicMigrationOfSingleFolderWithTableRenameInPostgres
Illuminate\Database\QueryException: SQLSTATE[42704]: Undefined object: 7 ERROR:  no existe la restricción «test_renamed_pkey» en la relación «test_renamed» (SQL: alter table "test_renamed" drop constraint "test_renamed_pkey")

/var/www/html3/framework/src/Illuminate/Database/Connection.php:671
/var/www/html3/framework/src/Illuminate/Database/Connection.php:631
/var/www/html3/framework/src/Illuminate/Database/Connection.php:465
/var/www/html3/framework/src/Illuminate/Database/Schema/Blueprint.php:103
/var/www/html3/framework/src/Illuminate/Database/Schema/Builder.php:337
/var/www/html3/framework/src/Illuminate/Database/Schema/Builder.php:184
/var/www/html3/framework/src/Illuminate/Support/Facades/Facade.php:261
/var/www/html3/framework/tests/Database/migrations/three/2016_01_01_200000_delete_primary_key.php:18
/var/www/html3/framework/src/Illuminate/Database/Migrations/Migrator.php:392
/var/www/html3/framework/src/Illuminate/Database/Concerns/ManagesTransactions.php:28
/var/www/html3/framework/src/Illuminate/Database/Migrations/Migrator.php:400
/var/www/html3/framework/src/Illuminate/Database/Migrations/Migrator.php:200
/var/www/html3/framework/src/Illuminate/Database/Migrations/Migrator.php:165
/var/www/html3/framework/src/Illuminate/Database/Migrations/Migrator.php:110
/var/www/html3/framework/tests/Database/DatabaseMigratorIntegrationTest.php:96

Caused by
Doctrine\DBAL\Driver\PDO\Exception: SQLSTATE[42704]: Undefined object: 7 ERROR:  no existe la restricción «test_renamed_pkey» en la relación «test_renamed»

/var/www/html3/framework/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDO/Exception.php:18
/var/www/html3/framework/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOStatement.php:117
/var/www/html3/framework/src/Illuminate/Database/Connection.php:464
/var/www/html3/framework/src/Illuminate/Database/Connection.php:664
/var/www/html3/framework/src/Illuminate/Database/Connection.php:631
/var/www/html3/framework/src/Illuminate/Database/Connection.php:465
/var/www/html3/framework/src/Illuminate/Database/Schema/Blueprint.php:103
/var/www/html3/framework/src/Illuminate/Database/Schema/Builder.php:337
/var/www/html3/framework/src/Illuminate/Database/Schema/Builder.php:184
/var/www/html3/framework/src/Illuminate/Support/Facades/Facade.php:261
/var/www/html3/framework/tests/Database/migrations/three/2016_01_01_200000_delete_primary_key.php:18
/var/www/html3/framework/src/Illuminate/Database/Migrations/Migrator.php:392
/var/www/html3/framework/src/Illuminate/Database/Concerns/ManagesTransactions.php:28
/var/www/html3/framework/src/Illuminate/Database/Migrations/Migrator.php:400
/var/www/html3/framework/src/Illuminate/Database/Migrations/Migrator.php:200
/var/www/html3/framework/src/Illuminate/Database/Migrations/Migrator.php:165
/var/www/html3/framework/src/Illuminate/Database/Migrations/Migrator.php:110
/var/www/html3/framework/tests/Database/DatabaseMigratorIntegrationTest.php:96

Caused by
PDOException: SQLSTATE[42704]: Undefined object: 7 ERROR:  no existe la restricción «test_renamed_pkey» en la relación «test_renamed»

/var/www/html3/framework/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOStatement.php:115
/var/www/html3/framework/src/Illuminate/Database/Connection.php:464
/var/www/html3/framework/src/Illuminate/Database/Connection.php:664
/var/www/html3/framework/src/Illuminate/Database/Connection.php:631
/var/www/html3/framework/src/Illuminate/Database/Connection.php:465
/var/www/html3/framework/src/Illuminate/Database/Schema/Blueprint.php:103
/var/www/html3/framework/src/Illuminate/Database/Schema/Builder.php:337
/var/www/html3/framework/src/Illuminate/Database/Schema/Builder.php:184
/var/www/html3/framework/src/Illuminate/Support/Facades/Facade.php:261
/var/www/html3/framework/tests/Database/migrations/three/2016_01_01_200000_delete_primary_key.php:18
/var/www/html3/framework/src/Illuminate/Database/Migrations/Migrator.php:392
/var/www/html3/framework/src/Illuminate/Database/Concerns/ManagesTransactions.php:28
/var/www/html3/framework/src/Illuminate/Database/Migrations/Migrator.php:400
/var/www/html3/framework/src/Illuminate/Database/Migrations/Migrator.php:200
/var/www/html3/framework/src/Illuminate/Database/Migrations/Migrator.php:165
/var/www/html3/framework/src/Illuminate/Database/Migrations/Migrator.php:110
/var/www/html3/framework/tests/Database/DatabaseMigratorIntegrationTest.php:96

ERRORS!
Tests: 1, Assertions: 0, Errors: 1.
```