### PR TITLE
[8.x] Add `explain()` to Query\Builder and Eloquent\Builder

### DIFF
--- a/src/Illuminate/Database/Concerns/ExplainsQueries.php
+++ b/src/Illuminate/Database/Concerns/ExplainsQueries.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Illuminate\Database\Concerns;
+
+use Illuminate\Support\Collection;
+
+trait ExplainsQueries
+{
+    /**
+     * Explains the query.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function explain()
+    {
+        $sql = $this->toSql();
+
+        $bindings = $this->getBindings();
+
+        $explanation = $this->getConnection()->select('EXPLAIN '.$sql, $bindings);
+
+        return new Collection($explanation);
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -24,7 +24,7 @@ use ReflectionMethod;
  */
 class Builder
 {
-    use BuildsQueries, Concerns\QueriesRelationships, ForwardsCalls, ExplainsQueries;
+    use BuildsQueries, Concerns\QueriesRelationships, ExplainsQueries, ForwardsCalls;
 
     /**
      * The base query builder instance.

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -7,6 +7,7 @@ use Closure;
 use Exception;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Concerns\BuildsQueries;
+use Illuminate\Database\Concerns\ExplainsQueries;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Pagination\Paginator;
@@ -23,7 +24,7 @@ use ReflectionMethod;
  */
 class Builder
 {
-    use BuildsQueries, Concerns\QueriesRelationships, ForwardsCalls;
+    use BuildsQueries, Concerns\QueriesRelationships, ForwardsCalls, ExplainsQueries;
 
     /**
      * The base query builder instance.

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -24,7 +24,7 @@ use RuntimeException;
 
 class Builder
 {
-    use BuildsQueries, ForwardsCalls, ExplainsQueries, Macroable {
+    use BuildsQueries, ExplainsQueries, ForwardsCalls, Macroable {
         __call as macroCall;
     }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -6,6 +6,7 @@ use Closure;
 use DateTimeInterface;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Concerns\BuildsQueries;
+use Illuminate\Database\Concerns\ExplainsQueries;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Relations\Relation;
@@ -23,7 +24,7 @@ use RuntimeException;
 
 class Builder
 {
-    use BuildsQueries, ForwardsCalls, Macroable {
+    use BuildsQueries, ForwardsCalls, ExplainsQueries, Macroable {
         __call as macroCall;
     }
 


### PR DESCRIPTION
`explain()` method allows you to receive the explanation from the builder (both Query and Eloquent).

Before you would typically call `toSql()`, copy the result, open `TablePlus`, prepend the query with `EXPLAIN `, replace all `?`, and check the result.

Now you can just call `explain()` to return the explanation or `explain()->dd()` to die & dump the explanation.

```php
>>> Webhook::where('event', 'users.registered')->explain()
=> Illuminate\Support\Collection {#15414
     all: [
       {#15407
         +"id": 1,
         +"select_type": "SIMPLE",
         +"table": "webhooks",
         +"partitions": null,
         +"type": "ref",
         +"possible_keys": "webhooks_event_index",
         +"key": "webhooks_event_index",
         +"key_len": "1022",
         +"ref": "const",
         +"rows": 1,
         +"filtered": 10.0,
         +"Extra": "Using where",
       },
     ],
   }
>>> DB::table('webhooks')->where('event', 'users.registered')->explain()
=> Illuminate\Support\Collection {#5350
     all: [
       {#5448
         +"id": 1,
         +"select_type": "SIMPLE",
         +"table": "webhooks",
         +"partitions": null,
         +"type": "ref",
         +"possible_keys": "webhooks_event_index",
         +"key": "webhooks_event_index",
         +"key_len": "1022",
         +"ref": "const",
         +"rows": 1,
         +"filtered": 100.0,
         +"Extra": null,
       },
     ],
   }
>>> User::where('name', 'Illia Sakovich')->explain()
=> Illuminate\Support\Collection {#5344
     all: [
       {#15407
         +"id": 1,
         +"select_type": "SIMPLE",
         +"table": "users",
         +"partitions": null,
         +"type": "ALL",
         +"possible_keys": null,
         +"key": null,
         +"key_len": null,
         +"ref": null,
         +"rows": 9,
         +"filtered": 11.11111164093,
         +"Extra": "Using where",
       },
     ],
   }
>>> DB::table('users')->where('name', 'Illia Sakovich')->explain()
=> Illuminate\Support\Collection {#5348
     all: [
       {#5342
         +"id": 1,
         +"select_type": "SIMPLE",
         +"table": "users",
         +"partitions": null,
         +"type": "ALL",
         +"possible_keys": null,
         +"key": null,
         +"key_len": null,
         +"ref": null,
         +"rows": 9,
         +"filtered": 11.11111164093,
         +"Extra": "Using where",
       },
     ],
   }
```