### PR TITLE
[6.x] Remove throw in BoundMethod

### DIFF
--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Container;
 
 use Closure;
-use Illuminate\Contracts\Container\BindingResolutionException;
 use InvalidArgumentException;
 use ReflectionFunction;
 use ReflectionMethod;
@@ -174,10 +173,6 @@ class BoundMethod
             }
         } elseif ($parameter->isDefaultValueAvailable()) {
             $dependencies[] = $parameter->getDefaultValue();
-        } elseif (! $parameter->isOptional() && ! array_key_exists($paramName, $parameters)) {
-            $message = "Unable to resolve dependency [{$parameter}] in class {$parameter->getDeclaringClass()->getName()}";
-
-            throw new BindingResolutionException($message);
         }
     }
 

--- a/tests/Container/ContainerCallTest.php
+++ b/tests/Container/ContainerCallTest.php
@@ -91,6 +91,13 @@ class ContainerCallTest extends TestCase
         $this->assertSame('taylor', $result[1]);
     }
 
+    public function testCallWithUnnamedParameters()
+    {
+        $container = new Container;
+        $result = $container->call([new ContainerTestCallStub, 'unresolvable'], ['foo', 'bar']);
+        $this->assertEquals(['foo', 'bar'], $result);
+    }
+
     public function testBindMethodAcceptsAnArray()
     {
         $container = new Container;


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/34920