### PR TITLE
[8.x] Make `multiple_of` validation rule handle non-integer values

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1267,7 +1267,12 @@ trait ValidatesAttributes
             return false;
         }
 
-        return fmod($value, $parameters[0]) === 0.0;
+        // We know it's not a multiple of 0 without even attempting to divide by zero.
+        if ((float) $parameters[0] === 0.0) {
+            return false;
+        }
+
+        return bcmod($value, $parameters[0], 16) === '0.0000000000000000';
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1267,7 +1267,6 @@ trait ValidatesAttributes
             return false;
         }
 
-        // We know it's not a multiple of 0 without even attempting to divide by zero.
         if ((float) $parameters[0] === 0.0) {
             return false;
         }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1912,18 +1912,21 @@ class ValidationValidatorTest extends TestCase
             [5.0, -10, false],
             [10.5, 10.5, true], // float (same)
             [10.5, 0.5, true], // float + float
-            [10.5, 0.3, false],
+            [10.5, 0.3, true], // 10.5/.3 = 35, tricky for floating point division
             [31.5, 10.5, true],
             [31.6, 10.5, false],
             [10.5, -0.5, true], // float + -float
-            [10.5, -0.3, false],
+            [10.5, -0.3, true], // 10.5/.3 = 35, tricky for floating point division
             [-31.5, 10.5, true],
             [-31.6, 10.5, false],
             [-10.5, -10.5, true], // -float (same)
             [-10.5, -0.5, true], // -float + -float
-            [-10.5, -0.3, false],
+            [-10.5, -0.3, true], // 10.5/.3 = 35, tricky for floating point division
             [-31.5, -10.5, true],
             [-31.6, -10.5, false],
+            [2, .1, true], // fmod does this "wrong", it should be 0, but fmod(2, .1) = .1
+            [.75, .05, true], // fmod does this "wrong", it should be 0, but fmod(.75, .05) = .05
+            [.9, .3, true], // .9/.3 = 3, tricky for floating point division
             ['foo', 1, false], // invalid values
             [1, 'foo', false],
             ['foo', 'foo', false],


### PR DESCRIPTION
Currently `multiple_of` does not validate some of the cases where the input is an integer multiple of the step because `fmod` does not produce a zero on some of the cases, e.g. `fmod(2, .1) = .1` and `fmod(.9, .3) = some really small but non zero value`.

This addes the tests for those cases and solves the issue by using `bcmod` and checking the first 16 digits after the decimal point.

Linked: discussion in #34960 and initial PR #34959 which I set to branch that I didn't intend to.