### PR TITLE
Allow Database specific grammar to be Macroable

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -5,10 +5,13 @@ namespace Illuminate\Database\Schema\Grammars;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Fluent;
+use Illuminate\Support\Traits\Macroable;
 use RuntimeException;
 
 class MySqlGrammar extends Grammar
 {
+    use Macroable;
+
     /**
      * The possible column modifiers.
      *

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -4,9 +4,12 @@ namespace Illuminate\Database\Schema\Grammars;
 
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Fluent;
+use Illuminate\Support\Traits\Macroable;
 
 class PostgresGrammar extends Grammar
 {
+    use Macroable;
+
     /**
      * If this Grammar supports schema changes wrapped in a transaction.
      *

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -7,10 +7,13 @@ use Illuminate\Database\Connection;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Fluent;
+use Illuminate\Support\Traits\Macroable;
 use RuntimeException;
 
 class SQLiteGrammar extends Grammar
 {
+    use Macroable;
+
     /**
      * The possible column modifiers.
      *

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -4,9 +4,12 @@ namespace Illuminate\Database\Schema\Grammars;
 
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Fluent;
+use Illuminate\Support\Traits\Macroable;
 
 class SqlServerGrammar extends Grammar
 {
+    use Macroable;
+
     /**
      * If this Grammar supports schema changes wrapped in a transaction.
      *


### PR DESCRIPTION
This PR allows database-specific grammar classes to be independently macroable.

Consider, a package like [michaeldyrynda/laravel-efficient-uuid](https://github.com/michaeldyrynda/laravel-efficient-uuid) which updates the resolver for each connection type and extending the base Grammer class for each Connection.

```php
       Connection::resolverFor('mysql', function ($connection, $database, $prefix, $config): MySqlConnection {
            return new MySqlConnection($connection, $database, $prefix, $config);
       }); 
       Connection::resolverFor('postgres', function ($connection, $database, $prefix, $config): PostgresConnection {
            return new PostgresConnection($connection, $database, $prefix, $config);
        });
        
        Connection::resolverFor('sqlite', function ($connection, $database, $prefix, $config): SQLiteConnection {
            return new SQLiteConnection($connection, $database, $prefix, $config);
        });
```

If you wanted to use another package which added additional functionality (in the same way) to the Grammar you would end up with a collision. One package would supersede the other. 

But Grammer is macroable already.....

However, if you are adding multiple conditions depending on the database type, as you would in a package you will end up with something like:

```php
        Grammar::macro('typeEncrypted', function (Fluent $column) {
            $className = (new \ReflectionClass($this))->getShortName();

            if ($className === "MySqlGrammar") {
                return 'blob';
            }

            if ($className === "PostgresGrammar") {
                return 'bytea';
            }

            if ($className === "SQLiteGrammar") {
                return 'blob';
            }

            if ($className === "SqlServerGrammar") {
                return 'varbinary(max)';
            }

            throw new UnknownGrammarClass;
        });
```

As you will need to use Reflection to determine the specific return value based on the grammar class which is calling it.
You cannot simply call in a more readable way:

```php
MySqlGrammar::macro('typeEncrypted', function (Fluent $column) {
      return 'blob';
});
SqlServerGrammar::macro('typeEncrypted', function (Fluent $column) {
      return 'varbinary(max)';
});
```

As only the last macro will be saved, as the macroable trait is only on the very base Grammer class, so it's impossible to apply to each specific Database Grammer accordingly. As currently they get overwritten each time.

This PR allows the above notation on a specific Database Grammer and keeps the base Grammer Macroable to avoid breaking changes.

