### PR TITLE
[8.x] Make assertSee, assertSeeText, assertDontSee and assertDontSeeText accept an array

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -389,17 +389,25 @@ class TestResponse implements ArrayAccess
     }
 
     /**
-     * Assert that the given string is contained within the response.
+     * Assert that the given string or array of strings are contained within the response.
      *
-     * @param  string  $value
+     * @param  string|array  $value
      * @param  bool  $escape
      * @return $this
      */
     public function assertSee($value, $escape = true)
     {
-        $value = $escape ? e($value) : $value;
+        if (is_array($value)) {
+            $values = $escape ? array_map('e', ($value)) : $value;
 
-        PHPUnit::assertStringContainsString((string) $value, $this->getContent());
+            foreach ($values as $value) {
+                PHPUnit::assertStringContainsString((string) $value, $this->getContent());
+            }
+        } else {
+            $value = $escape ? e($value) : $value;
+
+            PHPUnit::assertStringContainsString((string) $value, $this->getContent());
+        }
 
         return $this;
     }
@@ -421,17 +429,27 @@ class TestResponse implements ArrayAccess
     }
 
     /**
-     * Assert that the given string is contained within the response text.
+     * Assert that the given string or array of strings are contained within the response text.
      *
-     * @param  string  $value
+     * @param  string|array  $value
      * @param  bool  $escape
      * @return $this
      */
     public function assertSeeText($value, $escape = true)
     {
-        $value = $escape ? e($value) : $value;
+        if (is_array($value)) {
+            $values = $escape ? array_map('e', ($value)) : $value;
 
-        PHPUnit::assertStringContainsString((string) $value, strip_tags($this->getContent()));
+            tap(strip_tags($this->getContent()), function($content) use($values) {
+                foreach ($values as $value) {
+                    PHPUnit::assertStringContainsString((string) $value, $content);
+                }
+            });
+        } else {
+            $value = $escape ? e($value) : $value;
+
+            PHPUnit::assertStringContainsString((string) $value, strip_tags($this->getContent()));
+        }
 
         return $this;
     }
@@ -453,33 +471,51 @@ class TestResponse implements ArrayAccess
     }
 
     /**
-     * Assert that the given string is not contained within the response.
+     * Assert that the given string or array of strings are not contained within the response.
      *
-     * @param  string  $value
+     * @param  string|array  $value
      * @param  bool  $escape
      * @return $this
      */
     public function assertDontSee($value, $escape = true)
     {
-        $value = $escape ? e($value) : $value;
+        if (is_array($value)) {
+            $values = $escape ? array_map('e', ($value)) : $value;
 
-        PHPUnit::assertStringNotContainsString((string) $value, $this->getContent());
+            foreach ($values as $value) {
+                PHPUnit::assertStringNotContainsString((string) $value, $this->getContent());
+            }
+        } else {
+            $value = $escape ? e($value) : $value;
+
+            PHPUnit::assertStringNotContainsString((string) $value, $this->getContent());
+        }
 
         return $this;
     }
 
     /**
-     * Assert that the given string is not contained within the response text.
+     * Assert that the given string or array of strings are not contained within the response text.
      *
-     * @param  string  $value
+     * @param  string|array  $value
      * @param  bool  $escape
      * @return $this
      */
     public function assertDontSeeText($value, $escape = true)
     {
-        $value = $escape ? e($value) : $value;
+        if (is_array($value)) {
+            $values = $escape ? array_map('e', ($value)) : $value;
 
-        PHPUnit::assertStringNotContainsString((string) $value, strip_tags($this->getContent()));
+            tap(strip_tags($this->getContent()), function($content) use($values) {
+                foreach ($values as $value) {
+                    PHPUnit::assertStringNotContainsString((string) $value, $content);
+                }
+            });
+        } else {
+            $value = $escape ? e($value) : $value;
+
+            PHPUnit::assertStringNotContainsString((string) $value, strip_tags($this->getContent()));
+        }
 
         return $this;
     }

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -440,7 +440,7 @@ class TestResponse implements ArrayAccess
         if (is_array($value)) {
             $values = $escape ? array_map('e', ($value)) : $value;
 
-            tap(strip_tags($this->getContent()), function($content) use($values) {
+            tap(strip_tags($this->getContent()), function ($content) use ($values) {
                 foreach ($values as $value) {
                     PHPUnit::assertStringContainsString((string) $value, $content);
                 }
@@ -506,7 +506,7 @@ class TestResponse implements ArrayAccess
         if (is_array($value)) {
             $values = $escape ? array_map('e', ($value)) : $value;
 
-            tap(strip_tags($this->getContent()), function($content) use($values) {
+            tap(strip_tags($this->getContent()), function ($content) use ($values) {
                 foreach ($values as $value) {
                     PHPUnit::assertStringNotContainsString((string) $value, $content);
                 }

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -130,6 +130,50 @@ class TestResponseTest extends TestCase
         $response->assertViewMissing('foo.baz');
     }
 
+    public function testAssertSee()
+    {
+        $response = $this->makeMockResponse([
+            'render' => '<ul><li>foo</li><li>bar</li><li>baz</li><li>foo</li></ul>',
+        ]);
+
+        $response->assertSee('foo');
+        $response->assertSee(['baz', 'bar']);
+    }
+
+    public function testAssertSeeCanFail()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $response = $this->makeMockResponse([
+            'render' => '<ul><li>foo</li><li>bar</li><li>baz</li><li>foo</li></ul>',
+        ]);
+
+        $response->assertSee('item');
+        $response->assertSee(['not', 'found']);
+    }
+
+    public function testAssertSeeEscaped()
+    {
+        $response = $this->makeMockResponse([
+            'render' => 'laravel &amp; php &amp; friends',
+        ]);
+
+        $response->assertSee('laravel & php');
+        $response->assertSee(['php & friends', 'laravel & php']);
+    }
+
+    public function testAssertSeeEscapedCanFail()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $response = $this->makeMockResponse([
+            'render' => 'laravel &amp; php &amp; friends',
+        ]);
+
+        $response->assertSee('foo & bar');
+        $response->assertSee(['bar & baz', 'baz & qux']);
+    }
+
     public function testAssertSeeInOrder()
     {
         $response = $this->makeMockResponse([
@@ -166,19 +210,45 @@ class TestResponseTest extends TestCase
     public function testAssertSeeText()
     {
         $response = $this->makeMockResponse([
-            'render' => 'foo<strong>bar</strong>',
+            'render' => 'foo<strong>bar</strong>baz<strong>qux</strong>',
         ]);
 
         $response->assertSeeText('foobar');
+        $response->assertSeeText(['bazqux', 'foobar']);
+    }
+
+    public function testAssertSeeTextCanFail()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $response = $this->makeMockResponse([
+            'render' => 'foo<strong>bar</strong>',
+        ]);
+
+        $response->assertSeeText('bazfoo');
+        $response->assertSeeText(['bazfoo', 'barqux']);
     }
 
     public function testAssertSeeTextEscaped()
     {
         $response = $this->makeMockResponse([
-            'render' => 'laravel &amp; php',
+            'render' => 'laravel &amp; php &amp; friends',
         ]);
 
         $response->assertSeeText('laravel & php');
+        $response->assertSeeText(['php & friends', 'laravel & php']);
+    }
+
+    public function testAssertSeeTextEscapedCanFail()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $response = $this->makeMockResponse([
+            'render' => 'laravel &amp; php &amp; friends',
+        ]);
+
+        $response->assertSeeText('foo & bar');
+        $response->assertSeeText(['foo & bar', 'bar & baz']);
     }
 
     public function testAssertSeeTextInOrder()
@@ -221,6 +291,94 @@ class TestResponseTest extends TestCase
         ]);
 
         $response->assertSeeTextInOrder(['foobar', 'qux', 'baz']);
+    }
+
+    public function testAssertDontSee()
+    {
+        $response = $this->makeMockResponse([
+            'render' => '<ul><li>foo</li><li>bar</li><li>baz</li><li>foo</li></ul>',
+        ]);
+
+        $response->assertDontSee('laravel');
+        $response->assertDontSee(['php', 'friends']);
+    }
+
+    public function testAssertDontSeeCanFail()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $response = $this->makeMockResponse([
+            'render' => '<ul><li>foo</li><li>bar</li><li>baz</li><li>foo</li></ul>',
+        ]);
+
+        $response->assertDontSee('foo');
+        $response->assertDontSee(['baz', 'bar']);
+    }
+
+    public function testAssertDontSeeEscaped()
+    {
+        $response = $this->makeMockResponse([
+            'render' => 'laravel &amp; php &amp; friends',
+        ]);
+
+        $response->assertDontSee('foo & bar');
+        $response->assertDontSee(['bar & baz', 'foo & bar']);
+    }
+
+    public function testAssertDontSeeEscapedCanFail()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $response = $this->makeMockResponse([
+            'render' => 'laravel &amp; php &amp; friends',
+        ]);
+
+        $response->assertDontSee('laravel & php');
+        $response->assertDontSee(['php & friends', 'laravel & php']);
+    }
+
+    public function testAssertDontSeeText()
+    {
+        $response = $this->makeMockResponse([
+            'render' => 'foo<strong>bar</strong>baz<strong>qux</strong>',
+        ]);
+
+        $response->assertDontSeeText('laravelphp');
+        $response->assertDontSeeText(['phpfriends', 'laravelphp']);
+    }
+
+    public function testAssertDontSeeTextCanFail()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $response = $this->makeMockResponse([
+            'render' => 'foo<strong>bar</strong>baz<strong>qux</strong>',
+        ]);
+
+        $response->assertDontSeeText('foobar');
+        $response->assertDontSeeText(['bazqux', 'foobar']);
+    }
+
+    public function testAssertDontSeeTextEscaped()
+    {
+        $response = $this->makeMockResponse([
+            'render' => 'laravel &amp; php &amp; friends',
+        ]);
+
+        $response->assertDontSeeText('foo & bar');
+        $response->assertDontSeeText(['bar & baz', 'foo & bar']);
+    }
+
+    public function testAssertDontSeeTextEscapedCanFail()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $response = $this->makeMockResponse([
+            'render' => 'laravel &amp; php &amp; friends',
+        ]);
+
+        $response->assertDontSeeText('laravel & php');
+        $response->assertDontSeeText(['php & friends', 'laravel & php']);
     }
 
     public function testAssertOk()


### PR DESCRIPTION
This PR allows `assertSee`, `assertSeeText`, `assertDontSee` and `assertDontSeeText` to work with arrays. Unlike the `-InOrder` methods, these won't check the order.

Before:
```php
$this->get('/')
    ->assertSee('some')
    ->assertSee('piece')
    ->assertSee('of')
    ->assertSee('text');
```
After:
```php
$this->get('/')
    ->assertSee(['some', $foo, 'text', 'piece', 'of']);
```

### Benefits
It's mostly a code style change. In projects where the frontend can change unexpectedly, this will avoid errors because of the order while keeping things compact

### Notes
- I considered doing more type checking and throw a TypeError. The idea was to provide a bit more feedback than `htmlspecialchars() expects parameter 1 to be string, _______ given` but I'm not too sure about it.
- I'm running `assertStringContainsString` inside a foreach because I don't know if there's a better PHPUnit assertion for this case. This makes it so `OK (1 test, 3 assertions)` shows several assertions (one for each item in the array) which never bothered me. I'm guessing copying the strategy used in `Illuminate\Testing\Constraints\SeeInOrder` could deal with this?
- First PR here. Open to any correction or suggestion.