### PR TITLE
Optimize next available job in database queue

### DIFF
--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -212,13 +212,18 @@ class DatabaseQueue extends Queue implements QueueContract
     protected function getNextAvailableJob($queue)
     {
         $job = $this->database->table($this->table)
-                    ->lock($this->getLockForPopping())
-                    ->where('queue', $this->getQueue($queue))
-                    ->where(function ($query) {
-                        $this->isAvailable($query);
-                        $this->isReservedButExpired($query);
+                    ->lockForUpdate()
+                    ->where('id', function($query) {
+                        $query->select('id')
+                              ->from($this->table)
+                              ->where('queue', $this->getQueue(false))
+                              ->where(function ($query) {
+                                  $this->isAvailable($query);
+                                  $this->isReservedButExpired($query);
+                              })
+                              ->orderBy('id', 'asc')
+                              ->limit(1);
                     })
-                    ->orderBy('id', 'asc')
                     ->first();
 
         return $job ? new DatabaseJobRecord((object) $job) : null;


### PR DESCRIPTION
Current getNextAvailableJob queue selects all columns in the jobs database. This can cause database performance issues if the jobs table has many rows and the payload column is large. Added subquery to find the next available job prior to selecting all columns in the database. Fully backwards compatible.
