### PR TITLE
[7.x] Fixed instance style callable routes

### DIFF
--- a/src/Illuminate/Routing/RouteAction.php
+++ b/src/Illuminate/Routing/RouteAction.php
@@ -29,7 +29,7 @@ class RouteAction
         // If the action is already a Closure instance, we will just set that instance
         // as the "uses" property, because there is nothing else we need to do when
         // it is available. Otherwise we will need to find it in the action list.
-        if (static::isCallable($action)) {
+        if (Reflector::isCallable($action, true)) {
             return ! is_array($action) ? ['uses' => $action] : [
                 'uses' => $action[0].'@'.$action[1],
                 'controller' => $action[0].'@'.$action[1],
@@ -74,23 +74,8 @@ class RouteAction
     protected static function findCallable(array $action)
     {
         return Arr::first($action, function ($value, $key) {
-            return static::isCallable($value) && is_numeric($key);
+            return Reflector::isCallable($value) && is_numeric($key);
         });
-    }
-
-    /**
-     * Determine if the given action is callable as a route.
-     *
-     * @param  mixed  $action
-     * @return bool
-     */
-    public static function isCallable($action)
-    {
-        if (! is_array($action)) {
-            return is_callable($action);
-        }
-
-        return isset($action[0], $action[1]) && is_string($action[0]) && is_string($action[1]) && Reflector::isMethodCallable($action[0], $action[1]);
     }
 
     /**

--- a/src/Illuminate/Routing/RouteAction.php
+++ b/src/Illuminate/Routing/RouteAction.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Routing;
 
 use Illuminate\Support\Arr;
+use Illuminate\Support\Reflector;
 use Illuminate\Support\Str;
 use LogicException;
 use UnexpectedValueException;
@@ -28,7 +29,7 @@ class RouteAction
         // If the action is already a Closure instance, we will just set that instance
         // as the "uses" property, because there is nothing else we need to do when
         // it is available. Otherwise we will need to find it in the action list.
-        if (is_callable($action, true)) {
+        if (static::isCallable($action)) {
             return ! is_array($action) ? ['uses' => $action] : [
                 'uses' => $action[0].'@'.$action[1],
                 'controller' => $action[0].'@'.$action[1],
@@ -73,8 +74,23 @@ class RouteAction
     protected static function findCallable(array $action)
     {
         return Arr::first($action, function ($value, $key) {
-            return is_callable($value) && is_numeric($key);
+            return static::isCallable($value) && is_numeric($key);
         });
+    }
+
+    /**
+     * Determine if the given action is callable as a route.
+     *
+     * @param  mixed  $action
+     * @return bool
+     */
+    public static function isCallable($action)
+    {
+        if (! is_array($action)) {
+            return is_callable($action);
+        }
+
+        return isset($action[0], $action[1]) && is_string($action[0]) && is_string($action[1]) && Reflector::isMethodCallable($action[0], $action[1]);
     }
 
     /**

--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -5,6 +5,7 @@ namespace Illuminate\Routing;
 use BadMethodCallException;
 use Closure;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Reflector;
 use InvalidArgumentException;
 
 /**
@@ -182,7 +183,7 @@ class RouteRegistrar
 
         if (is_array($action) &&
             ! Arr::isAssoc($action) &&
-            RouteAction::isCallable($action)) {
+            Reflector::isCallable($action)) {
             $action = [
                 'uses' => $action[0].'@'.$action[1],
                 'controller' => $action[0].'@'.$action[1],

--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -181,8 +181,8 @@ class RouteRegistrar
         }
 
         if (is_array($action) &&
-            is_callable($action) &&
-            ! Arr::isAssoc($action)) {
+            ! Arr::isAssoc($action) &&
+            RouteAction::isCallable($action)) {
             $action = [
                 'uses' => $action[0].'@'.$action[1],
                 'controller' => $action[0].'@'.$action[1],

--- a/src/Illuminate/Support/Reflector.php
+++ b/src/Illuminate/Support/Reflector.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Support;
 
 use ReflectionClass;
+use ReflectionMethod;
 use ReflectionNamedType;
 
 class Reflector
@@ -50,5 +51,29 @@ class Reflector
         return ($paramClassName && class_exists($paramClassName))
             ? (new ReflectionClass($paramClassName))->isSubclassOf($className)
             : false;
+    }
+
+    /**
+     * Determine if the class method is callable.
+     *
+     * @param  string  $class
+     * @param  string  $method
+     * @return bool
+     */
+    public static function isMethodCallable($class, $method)
+    {
+        if (! class_exists($class)) {
+            return false;
+        }
+
+        if (method_exists($class, $method)) {
+            return (new ReflectionMethod($class, $method))->isPublic();
+        }
+
+        if (method_exists($class, '__call')) {
+            return (new ReflectionMethod($class, '__call'))->isPublic();
+        }
+
+        return false;
     }
 }

--- a/src/Illuminate/Support/Reflector.php
+++ b/src/Illuminate/Support/Reflector.php
@@ -21,8 +21,8 @@ class Reflector
             return is_callable($var, $syntaxOnly);
         }
 
-        if (! isset($var[0]) && ! isset($var[1]) ||
-            ! is_string($var[1])) {
+        if ((! isset($var[0]) || ! isset($var[1])) ||
+            ! is_string($var[1] ?? null)) {
             return false;
         }
 
@@ -92,29 +92,5 @@ class Reflector
         return ($paramClassName && class_exists($paramClassName))
             ? (new ReflectionClass($paramClassName))->isSubclassOf($className)
             : false;
-    }
-
-    /**
-     * Determine if the class method is callable.
-     *
-     * @param  string  $class
-     * @param  string  $method
-     * @return bool
-     */
-    public static function isMethodCallable($class, $method)
-    {
-        if (! class_exists($class)) {
-            return false;
-        }
-
-        if (method_exists($class, $method)) {
-            return (new ReflectionMethod($class, $method))->isPublic();
-        }
-
-        if (method_exists($class, '__call')) {
-            return (new ReflectionMethod($class, '__call'))->isPublic();
-        }
-
-        return false;
     }
 }


### PR DESCRIPTION
PHP no longer considers `['Foo', 'bar']` callable when `Foo` is a class and `bar` is and instance method. It only considers it callable when `bar` is a static method. For the purposes of Laravel routing, we want to still allow instance methods even though they are not strictly "callable", since we're never gonna invoke them as "callables".