### PR TITLE
[6.x] Optimize next available job in database queue

### DIFF
--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -213,11 +213,11 @@ class DatabaseQueue extends Queue implements QueueContract
     {
         $job = $this->database->table($this->table)
                     ->lockForUpdate()
-                    ->where('id', function($query) use ($queue) {
+                    ->where('id', function ($query) use ($queue) {
                         $query->select('id')
                               ->from($this->table)
                               ->where('queue', $this->getQueue($queue))
-                              ->where(function($query) {
+                              ->where(function ($query) {
                                   $this->isAvailable($query);
                                   $this->isReservedButExpired($query);
                               })


### PR DESCRIPTION
Current getNextAvailableJob queue selects all columns in the jobs database. This can cause database performance issues if the jobs table has many rows and the payload column is large. Added subquery to find the next available job prior to selecting all columns in the database. Fully backwards compatible.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
