### PR TITLE
[8.x] Add route regex registration methods

### DIFF
--- a/src/Illuminate/Routing/PendingResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingResourceRegistration.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Traits\Macroable;
 
 class PendingResourceRegistration
 {
-    use Macroable;
+    use Macroable, RouteRegexConstraintTrait;
 
     /**
      * The resource registrar.

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -21,7 +21,7 @@ use Symfony\Component\Routing\Route as SymfonyRoute;
 
 class Route
 {
-    use Macroable, RouteDependencyResolverTrait;
+    use Macroable, RouteDependencyResolverTrait, RouteRegexConstraintTrait;
 
     /**
      * The URI pattern the route responds to.

--- a/src/Illuminate/Routing/RouteRegexConstraintTrait.php
+++ b/src/Illuminate/Routing/RouteRegexConstraintTrait.php
@@ -39,7 +39,7 @@ trait RouteRegexConstraintTrait
      * @param  string|array $parameter
      * @return $this
      */
-    public function whereString(...$parameters)
+    public function whereAlpha(...$parameters)
     {
         $this->applyRouteRegex($parameters, '[a-zA-Z]+');
 

--- a/src/Illuminate/Routing/RouteRegexConstraintTrait.php
+++ b/src/Illuminate/Routing/RouteRegexConstraintTrait.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Illuminate\Routing;
+
+trait RouteRegexConstraintTrait
+{
+    /**
+     * Apply a route regex requirement to the route.
+     *
+     * @param  array  $parameters
+     * @param  string $regex
+     * @return void
+     */
+    protected function applyRouteRegex(array $parameters, string $regex)
+    {
+        foreach ($parameters as $parameter) {
+            is_string($parameter)
+                ? $this->where([$parameter => $regex])
+                : $this->applyRouteRegex($parameter, $regex);
+        }
+    }
+
+    /**
+     * Set a number as regular expression requirement on the route.
+     *
+     * @param  string $parameters
+     * @return $this
+     */
+    public function whereNumber(...$parameters)
+    {
+        $this->applyRouteRegex($parameters, '[0-9]+');
+
+        return $this;
+    }
+
+    /**
+     * Set any character between a-z or A-Z as regular expression requirement on the route.
+     *
+     * @param  string|array $parameter
+     * @return $this
+     */
+    public function whereString(...$parameters)
+    {
+        $this->applyRouteRegex($parameters, '[a-zA-Z]+');
+
+        return $this;
+    }
+}

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -594,6 +594,32 @@ class RouteRegistrarTest extends TestCase
         }
     }
 
+    public function testWhereNumberRegistration()
+    {
+        $wheres = ['foo' => '[0-9]+', 'bar' => '[0-9]+'];
+
+        $this->router->get('/{foo}/{bar}')->whereNumber(['foo', 'bar']);
+        $this->router->get('/api/{bar}/{foo}')->whereNumber('bar', 'foo');
+
+        /** @var \Illuminate\Routing\Route $route */
+        foreach ($this->router->getRoutes() as $route) {
+            $this->assertEquals($wheres, $route->wheres);
+        }
+    }
+
+    public function testWhereStringRegistration()
+    {
+        $wheres = ['foo' => '[a-zA-Z]+', 'bar' => '[a-zA-Z]+'];
+
+        $this->router->get('/{foo}/{bar}')->whereString(['foo', 'bar']);
+        $this->router->get('/api/{bar}/{foo}')->whereString('bar', 'foo');
+
+        /** @var \Illuminate\Routing\Route $route */
+        foreach ($this->router->getRoutes() as $route) {
+            $this->assertEquals($wheres, $route->wheres);
+        }
+    }
+
     public function testCanSetRouteName()
     {
         $this->router->as('users.index')->get('users', function () {

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -611,8 +611,8 @@ class RouteRegistrarTest extends TestCase
     {
         $wheres = ['foo' => '[a-zA-Z]+', 'bar' => '[a-zA-Z]+'];
 
-        $this->router->get('/{foo}/{bar}')->whereString(['foo', 'bar']);
-        $this->router->get('/api/{bar}/{foo}')->whereString('bar', 'foo');
+        $this->router->get('/{foo}/{bar}')->whereAlpha(['foo', 'bar']);
+        $this->router->get('/api/{bar}/{foo}')->whereAlpha('bar', 'foo');
 
         /** @var \Illuminate\Routing\Route $route */
         foreach ($this->router->getRoutes() as $route) {

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -607,7 +607,7 @@ class RouteRegistrarTest extends TestCase
         }
     }
 
-    public function testWhereStringRegistration()
+    public function testWhereAlphaRegistration()
     {
         $wheres = ['foo' => '[a-zA-Z]+', 'bar' => '[a-zA-Z]+'];
 


### PR DESCRIPTION
This PR allows the developer to set restrictions on the route registration in a simple way. Also, drop unnecessary methods of  #34361


**Instead of having a statement similar to the following.**

```php
Route::get('authors/{author}/{book}')->where(['author' => '[0-9]+', 'book' => '[a-zA-Z]+']);
```

This same statement could be simplified with the following.

```php
Route::get('authors/{author}/{book}')->whereNumber('author')->whereString('book');
```

This also supports declaration of multiple parameters of the same grouped type.

```php
Route::get('authors/{author}/{book}')->whereString('author', 'book');
```