### PR TITLE
[9.x] Added push method to Cache Repository 

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -14,6 +14,7 @@ use Illuminate\Contracts\Cache\Repository as CacheContract;
 use Illuminate\Contracts\Cache\Store;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
 use Illuminate\Support\InteractsWithTime;
 use Illuminate\Support\Traits\Macroable;
 
@@ -181,6 +182,23 @@ class Repository implements ArrayAccess, CacheContract
     {
         return tap($this->get($key, $default), function () use ($key) {
             $this->forget($key);
+        });
+    }
+
+    /**
+     * Push an item into existing cache key
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  \DateTimeInterface|\DateInterval|int|null  $ttl
+     * @return Collection
+     */
+    public function push($key, $value, $ttl = null)
+    {
+        return tap(collect($this->get($key)), function ($collection) use ($value, $key, $ttl) {
+            $collection->push($value);
+
+            $this->put($key, $collection, $ttl);
         });
     }
 

--- a/src/Illuminate/Support/Facades/Cache.php
+++ b/src/Illuminate/Support/Facades/Cache.php
@@ -13,7 +13,7 @@ namespace Illuminate\Support\Facades;
  * @method static bool forget(string $key)
  * @method static bool has(string $key)
  * @method static bool missing(string $key)
- * @method static bool push(string $key, $value, \DateTimeInterface|\DateInterval|int $ttl = null)
+ * @method static \Illuminate\Support\Collection push(string $key, $value, \DateTimeInterface|\DateInterval|int $ttl = null)
  * @method static bool put(string $key, $value, \DateTimeInterface|\DateInterval|int $ttl = null)
  * @method static int|bool decrement(string $key, $value = 1)
  * @method static int|bool increment(string $key, $value = 1)

--- a/src/Illuminate/Support/Facades/Cache.php
+++ b/src/Illuminate/Support/Facades/Cache.php
@@ -13,6 +13,7 @@ namespace Illuminate\Support\Facades;
  * @method static bool forget(string $key)
  * @method static bool has(string $key)
  * @method static bool missing(string $key)
+ * @method static bool push(string $key, $value, \DateTimeInterface|\DateInterval|int $ttl = null)
  * @method static bool put(string $key, $value, \DateTimeInterface|\DateInterval|int $ttl = null)
  * @method static int|bool decrement(string $key, $value = 1)
  * @method static int|bool increment(string $key, $value = 1)

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -15,6 +15,7 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\Cache\Store;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
@@ -131,6 +132,16 @@ class CacheRepositoryTest extends TestCase
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('putMany')->once()->with(['foo' => 'bar', 'bar' => 'baz'], 1);
         $repo->put(['foo' => 'bar', 'bar' => 'baz'], 1);
+    }
+
+    public function testPushingItemIntoExistingCacheKey()
+    {
+        $repo = $this->getRepository();
+        $repo->getStore()->shouldReceive('get')->times(2)->with('foo')->andReturn(m::type(Collection::class));
+        $repo->getStore()->shouldReceive('forever')->times(2)->with('foo', m::type(Collection::class))->andReturn(true);
+        $repo->push('foo', 'bar');
+        $repo->push('foo', 'baz');
+        //TODO actual test that ensure the foo key have two items and instance of collection
     }
 
     public function testSettingMultipleItemsInCacheArray()


### PR DESCRIPTION
Hello laravel,

This PR added `push()` method to Cache Repository which allow to pushing items into exist cache key and return the items in collection instance.

```php
//before
Cache::put('foo', 'bar');

$key = Cache::get('foo');

$key[] = 'baz';

Cache::put('foo', $key);

Cache::get('foo');
// ['bar', 'baz]
```

```php
//after
Cache::push('items.key', 'bar');
// ['bar']

$items = Cache::push('items.key', 'baz');
// ['bar', 'baz]
```