### PR TITLE
[8.x] Compile `view:cache` views using a fresh app instance

### DIFF
--- a/src/Illuminate/Foundation/Console/ViewCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewCacheCommand.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Contracts\Console\Kernel as ConsoleKernelContract;
 use Illuminate\Support\Collection;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
@@ -47,10 +48,22 @@ class ViewCacheCommand extends Command
      */
     protected function compileViews(Collection $views)
     {
-        $compiler = $this->laravel['view']->getEngineResolver()->resolve('blade')->getCompiler();
+        $compiler = $this->getFreshApplication()['view']->getEngineResolver()->resolve('blade')->getCompiler();
 
         $views->map(function (SplFileInfo $file) use ($compiler) {
             $compiler->compile($file->getRealPath());
+        });
+    }
+
+    /**
+     * Get a fresh application instance.
+     *
+     * @return \Illuminate\Contracts\Foundation\Application
+     */
+    protected function getFreshApplication()
+    {
+        return tap(require $this->laravel->bootstrapPath().'/app.php', function ($app) {
+            $app->make(ConsoleKernelContract::class)->bootstrap();
         });
     }
 


### PR DESCRIPTION
[The `view:cache` command was recently appended to the `optimize` command](https://github.com/laravel/framework/commit/14726eb755f3097096d02cc3680d049fd5f3af10). This breaks `optimize` in situations where views need to be compiled based on the cache created by `config:cache`.

I ran into this issue when trying to run `optimize` in a project that uses the `blade-ui-kit/blade-icons` package. Running `optimize` would throw a "component class name not found" error, however running `config:cache` and then `view:cache` worked as expected.

This PR creates a fresh instance of the app before compiling any views in the `view:cache` command. This way the cached config generated by `config:cache` can be used in the view compilation step. 
