### PR TITLE
[8.x] Wrap column in aggregate function

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -381,11 +381,15 @@ trait QueriesRelationships
 
             $relation = $this->getRelationWithoutConstraints($name);
 
+            $expression = $function
+                ? sprintf('%s(%s)', $function, $this->getGrammar()->wrap($column))
+                : $column;
+
             // Here, we will grab the relationship sub-query and prepare to add it to the main query
             // as a sub-select. First, we'll get the "has" query and use that to get the relation
             // sub-query. We'll format this relationship name and append this column if needed.
             $query = $relation->getRelationExistenceQuery(
-                $relation->getRelated()->newQuery(), $this, new Expression($function ? "$function($column)" : $column)
+                $relation->getRelated()->newQuery(), $this, new Expression($expression)
             )->setBindings([], 'select');
 
             $query->callScope($constraints);


### PR DESCRIPTION
In general, columns in raw expressions need to be wrapped for safety.

This PR wraps the `$column` parameter in the aggregate `$function`, because it's easy to pass arbitrary SQL as an argument to the `$column` parameter.