### PR TITLE
[8.x] Add dontRelease option to RateLimited and RateLimitedWithRedis job middleware

### DIFF
--- a/src/Illuminate/Queue/Middleware/RateLimitedWithRedis.php
+++ b/src/Illuminate/Queue/Middleware/RateLimitedWithRedis.php
@@ -50,7 +50,9 @@ class RateLimitedWithRedis extends RateLimited
     {
         foreach ($limits as $limit) {
             if ($this->tooManyAttempts($limit->key, $limit->maxAttempts, $limit->decayMinutes)) {
-                return $job->release($this->getTimeUntilNextRetry($limit->key));
+                return $this->shouldRelease
+                    ? $job->release($this->getTimeUntilNextRetry($limit->key))
+                    : false;
             }
         }
 


### PR DESCRIPTION
Similar to the `WithoutOverlapping` middleware, this PR adds the `dontRelease` option to RateLimited job middleware like so:

```php
public function middleware()
{
    return [(new RateLimited('backups'))->dontRelease()];
}
```

If the `dontRelease` method is called, the job is not released back to the queue when the limit is exceeded.