### PR TITLE
[6.x] Optimize next available job in database queue

### DIFF
--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -212,7 +212,7 @@ class DatabaseQueue extends Queue implements QueueContract
     protected function getNextAvailableJob($queue)
     {
         $job = $this->database->table($this->table)
-                    ->lockForUpdate()
+                    ->lock($this->getLockForPopping())
                     ->where('id', function ($query) use ($queue) {
                         $query->select('id')
                               ->from($this->table)

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -213,11 +213,11 @@ class DatabaseQueue extends Queue implements QueueContract
     {
         $job = $this->database->table($this->table)
                     ->lockForUpdate()
-                    ->where('id', function($query) use ($queue) {
+                    ->where('id', function ($query) use ($queue) {
                         $query->select('id')
                               ->from($this->table)
                               ->where('queue', $this->getQueue($queue))
-                              ->where(function($query) {
+                              ->where(function ($query) {
                                   $this->isAvailable($query);
                                   $this->isReservedButExpired($query);
                               })


### PR DESCRIPTION
Current getNextAvailableJob queue selects all columns in the jobs database. This can cause database performance issues if the jobs table has many rows and the payload column is large. Added subquery to find the next available job prior to selecting all columns in the database. Fully backwards compatible.