### PR TITLE
[9.x] Use PSR container interface instead of Laravel contract

### DIFF
--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -7,13 +7,13 @@ use Exception;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Broadcasting\Factory as BroadcastFactory;
 use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
-use Illuminate\Contracts\Container\Container as ContainerContract;
 use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Support\Traits\ReflectsClosures;
+use Psr\Container\ContainerInterface;
 use ReflectionClass;
 
 class Dispatcher implements DispatcherContract
@@ -23,7 +23,7 @@ class Dispatcher implements DispatcherContract
     /**
      * The IoC container instance.
      *
-     * @var \Illuminate\Contracts\Container\Container
+     * @var \Psr\Container\ContainerInterface
      */
     protected $container;
 
@@ -58,10 +58,10 @@ class Dispatcher implements DispatcherContract
     /**
      * Create a new event dispatcher instance.
      *
-     * @param  \Illuminate\Contracts\Container\Container|null  $container
+     * @param  \Psr\Container\ContainerInterface|null  $container
      * @return void
      */
-    public function __construct(ContainerContract $container = null)
+    public function __construct(ContainerInterface $container = null)
     {
         $this->container = $container ?: new Container;
     }
@@ -191,7 +191,7 @@ class Dispatcher implements DispatcherContract
     protected function resolveSubscriber($subscriber)
     {
         if (is_string($subscriber)) {
-            return $this->container->make($subscriber);
+            return $this->container->get($subscriber);
         }
 
         return $subscriber;
@@ -304,7 +304,7 @@ class Dispatcher implements DispatcherContract
      */
     protected function broadcastEvent($event)
     {
-        $this->container->make(BroadcastFactory::class)->queue($event);
+        $this->container->get(BroadcastFactory::class)->queue($event);
     }
 
     /**
@@ -432,7 +432,7 @@ class Dispatcher implements DispatcherContract
             return $this->createQueuedHandlerCallable($class, $method);
         }
 
-        return [$this->container->make($class), $method];
+        return [$this->container->get($class), $method];
     }
 
     /**
@@ -492,7 +492,7 @@ class Dispatcher implements DispatcherContract
      */
     protected function handlerWantsToBeQueued($class, $arguments)
     {
-        $instance = $this->container->make($class);
+        $instance = $this->container->get($class);
 
         if (method_exists($instance, 'shouldQueue')) {
             return $instance->shouldQueue($arguments[0]);

--- a/tests/Events/BroadcastedEventsTest.php
+++ b/tests/Events/BroadcastedEventsTest.php
@@ -37,7 +37,7 @@ class BroadcastedEventsTest extends TestCase
         $d = new Dispatcher($container = m::mock(Container::class));
         $broadcast = m::mock(BroadcastFactory::class);
         $broadcast->shouldReceive('queue')->once();
-        $container->shouldReceive('make')->once()->with(BroadcastFactory::class)->andReturn($broadcast);
+        $container->shouldReceive('get')->once()->with(BroadcastFactory::class)->andReturn($broadcast);
 
         $d->listen(AlwaysBroadcastEvent::class, function ($payload) {
             $_SERVER['__event.test'] = $payload;

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -115,7 +115,7 @@ class EventsDispatcherTest extends TestCase
     public function testContainerResolutionOfEventHandlers()
     {
         $d = new Dispatcher($container = m::mock(Container::class));
-        $container->shouldReceive('make')->once()->with(TestEventListener::class)->andReturn(new TestEventListener);
+        $container->shouldReceive('get')->once()->with(TestEventListener::class)->andReturn(new TestEventListener);
         $d->listen('foo', TestEventListener::class.'@onFooEvent');
         $response = $d->dispatch('foo', ['foo', 'bar']);
 

--- a/tests/Events/EventsSubscriberTest.php
+++ b/tests/Events/EventsSubscriberTest.php
@@ -19,7 +19,7 @@ class EventsSubscriberTest extends TestCase
         $d = new Dispatcher($container = m::mock(Container::class));
         $subs = m::mock(ExampleSubscriber::class);
         $subs->shouldReceive('subscribe')->once()->with($d);
-        $container->shouldReceive('make')->once()->with(ExampleSubscriber::class)->andReturn($subs);
+        $container->shouldReceive('get')->once()->with(ExampleSubscriber::class)->andReturn($subs);
 
         $d->subscribe(ExampleSubscriber::class);
         $this->assertTrue(true);


### PR DESCRIPTION
We are using the Laravel contract but we could use a more precise (Interface segregation principle) and flexible interface (PSR is widely used).

(https://github.com/laravel/framework/pull/35013 but target for master)