### PR TITLE
[8.x] Fix Postgres Dump

### DIFF
--- a/src/Illuminate/Database/Console/DumpCommand.php
+++ b/src/Illuminate/Database/Console/DumpCommand.php
@@ -35,9 +35,11 @@ class DumpCommand extends Command
      */
     public function handle(ConnectionResolverInterface $connections, Dispatcher $dispatcher)
     {
-        $this->schemaState(
-            $connection = $connections->connection($database = $this->input->getOption('database'))
-        )->dump($path = $this->path($connection));
+        $connection = $connections->connection($database = $this->input->getOption('database'));
+
+        $this->schemaState($connection)->dump(
+            $connection, $path = $this->path($connection)
+        );
 
         $dispatcher->dispatch(new SchemaDumped($connection, $path));
 

--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Schema;
 
 use Exception;
+use Illuminate\Database\Connection;
 use Illuminate\Support\Str;
 use Symfony\Component\Process\Process;
 
@@ -11,10 +12,11 @@ class MySqlSchemaState extends SchemaState
     /**
      * Dump the database's schema into a file.
      *
+     * @param  \Illuminate\Database\Connection  $connection
      * @param  string  $path
      * @return void
      */
-    public function dump($path)
+    public function dump(Connection $connection, $path)
     {
         $this->executeDumpProcess($this->makeProcess(
             $this->baseDumpCommand().' --routines --result-file="${:LARAVEL_LOAD_PATH}" --no-data'

--- a/src/Illuminate/Database/Schema/SchemaState.php
+++ b/src/Illuminate/Database/Schema/SchemaState.php
@@ -62,10 +62,11 @@ abstract class SchemaState
     /**
      * Dump the database's schema into a file.
      *
+     * @param  \Illuminate\Database\Connection  $connection
      * @param  string  $path
      * @return void
      */
-    abstract public function dump($path);
+    abstract public function dump(Connection $connection, $path);
 
     /**
      * Load the given schema file into the database.

--- a/src/Illuminate/Database/Schema/SqliteSchemaState.php
+++ b/src/Illuminate/Database/Schema/SqliteSchemaState.php
@@ -2,16 +2,18 @@
 
 namespace Illuminate\Database\Schema;
 
+use Illuminate\Database\Connection;
+
 class SqliteSchemaState extends SchemaState
 {
     /**
      * Dump the database's schema into a file.
      *
-     * @param string $path
-     *
+     * @param  \Illuminate\Database\Connection
+     * @param  string  $path
      * @return void
      */
-    public function dump($path)
+    public function dump(Connection $connection, $path)
     {
         with($process = $this->makeProcess(
             $this->baseCommand().' .schema'
@@ -53,8 +55,7 @@ class SqliteSchemaState extends SchemaState
     /**
      * Load the given schema file into the database.
      *
-     * @param string $path
-     *
+     * @param  string  $path
      * @return void
      */
     public function load($path)


### PR DESCRIPTION
I believe https://github.com/laravel/framework/pull/34293 broke Postgres dumps by breaking how migration table data was appended to the dump file. The migration data was never appended to the file because the `appendMigrationData` method was no longer able to parse them out of the binary dump.

This corrects this by using the connection to retrieve all table names then excluding table data for all tables EXCEPT the migrations table in the binary dump. 

I have tested this locally on my machine with Postgres.