### PR TITLE
[8.x] Add ability to create the referenced model on make:observer Command

### DIFF
--- a/src/Illuminate/Foundation/Console/ObserverMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ObserverMakeCommand.php
@@ -55,6 +55,12 @@ class ObserverMakeCommand extends GeneratorCommand
     {
         $modelClass = $this->parseModel($model);
 
+        if (! class_exists($modelClass)) {
+            if ($this->confirm("A {$modelClass} model does not exist. Do you want to generate it?", true)) {
+                $this->call('make:model', ['name' => $modelClass]);
+            }
+        }
+
         $replace = [
             'DummyFullModelClass' => $modelClass,
             '{{ namespacedModel }}' => $modelClass,


### PR DESCRIPTION
I saw this functionality in the make: controller command and I believe that make: observer would benefit even more from this.