### PR TITLE
[8.x] Add chunk() to Fluent Strings

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -128,6 +128,17 @@ class Stringable
     }
 
     /**
+     * Split the string into a collection of chunks of a specified length.
+     *
+     * @param  int  $length
+     * @return \Illuminate\Support\Collection
+     */
+    public function chunk($length)
+    {
+        return collect(mb_str_split($this->value, $length));
+    }
+
+    /**
      * Determine if a given string contains a given substring.
      *
      * @param  string|array  $needles

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Support;
 
+use Illuminate\Support\Collection;
 use Illuminate\Support\Stringable;
 use PHPUnit\Framework\TestCase;
 
@@ -527,5 +528,13 @@ class SupportStringableTest extends TestCase
     {
         $this->assertSame('Alien-----', (string) $this->stringable('Alien')->padRight(10, '-'));
         $this->assertSame('Alien     ', (string) $this->stringable('Alien')->padRight(10));
+    }
+
+    public function testChunk()
+    {
+        $chunks = $this->stringable('foobarbaz')->chunk(3);
+
+        $this->assertInstanceOf(Collection::class, $chunks);
+        $this->assertSame(['foo', 'bar', 'baz'], $chunks->all());
     }
 }


### PR DESCRIPTION
Adds the `chunk()` method to fluent strings allowing a string to be "chunked" by a specified length and returning a collection of those chunks.

#### Example Usage

```php
Str::of('foobarbaz')->chunk(3); // Returns collect(['foo', 'bar', 'baz'])
```

This is particularly useful when chaining additional methods.

```php
Str::of('FooBarBaz')->lower()->chunk(3)->implode('-'); // Returns 'foo-bar-baz'
```

I decided to just open a PR instead of starting a discussion first because it was such a minor (non-breaking) change. Totally understand if this is not wanted.