### PR TITLE
[8.x] Add MorphOneTo And MorphManyTo  to support polymorphism, direct one-to-one or many relationship

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -397,7 +397,6 @@ trait HasRelationships
         return new MorphManyTo($query, $parent, $localKey, $foreignKey, $type, $relation);
     }
 
-
     /**
      * Define a polymorphic, direct one-to-one relationship.
      *

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -13,7 +13,9 @@ use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\HasOneThrough;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Database\Eloquent\Relations\MorphManyTo;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
+use Illuminate\Database\Eloquent\Relations\MorphOneTo;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Database\Eloquent\Relations\Relation;
@@ -312,6 +314,169 @@ trait HasRelationships
     protected function newMorphTo(Builder $query, Model $parent, $foreignKey, $ownerKey, $type, $relation)
     {
         return new MorphTo($query, $parent, $foreignKey, $ownerKey, $type, $relation);
+    }
+
+    /**
+     * Define a polymorphic, direct one-to-many relationship.
+     *
+     * @param  string|null  $name
+     * @param  string|null  $type
+     * @param  string|null  $id
+     * @param  string|null  $foreignKey
+     * @return \Illuminate\Database\Eloquent\Relations\MorphManyTo
+     */
+    public function morphManyTo($name = null, $type = null, $id = null, $foreignKey = null)
+    {
+        // If no name is provided, we will use the backtrace to get the function name
+        // since that is most likely the name of the polymorphic interface. We can
+        // use that to get both the class and foreign key that will be utilized.
+        $name = $name ?: $this->guessBelongsToRelation();
+
+        [$type, $id] = $this->getMorphs(
+            Str::snake($name), $type, $id
+        );
+
+        // If the type value is null it is probably safe to assume we're eager loading
+        // the relationship. In this case we'll just pass in a dummy query where we
+        // need to remove any eager loads that may already be defined on a model.
+        return empty($class = $this->{$type})
+            ? $this->morphManyEagerTo($name, $type, $id, $foreignKey)
+            : $this->morphManyInstanceTo($class, $name, $type, $id, $foreignKey);
+    }
+
+    /**
+     * Define a polymorphic, direct one-to-many relationship.
+     *
+     * @param  string  $name
+     * @param  string  $type
+     * @param  string  $id
+     * @param  string  $foreignKey
+     * @return \Illuminate\Database\Eloquent\Relations\MorphManyTo
+     */
+    protected function morphManyEagerTo($name, $type, $id, $foreignKey)
+    {
+        return $this->newMorphManyTo(
+            $this->newQuery()->setEagerLoads([]), $this, $id, $foreignKey, $type, $name
+        );
+    }
+
+    /**
+     * Define a polymorphic, direct one-to-many relationship.
+     *
+     * @param  string  $target
+     * @param  string  $name
+     * @param  string  $type
+     * @param  string  $id
+     * @param  string  $foreignKey
+     * @return \Illuminate\Database\Eloquent\Relations\MorphManyTo
+     */
+    protected function morphManyInstanceTo($target, $name, $type, $id, $foreignKey)
+    {
+        $instance = $this->newRelatedInstance(
+            static::getActualClassNameForMorph($target)
+        );
+
+        return $this->newMorphManyTo(
+            $instance->newQuery(), $this, $id, $foreignKey ?? $instance->getKeyName(), $type, $name
+        );
+    }
+
+    /**
+     * Instantiate a new MorphManyTo relationship.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  \Illuminate\Database\Eloquent\Model  $parent
+     * @param  string  $localKey
+     * @param  string  $foreignKey
+     * @param  string  $type
+     * @param  string  $relation
+     * @return \Illuminate\Database\Eloquent\Relations\MorphManyTo
+     */
+    protected function newMorphManyTo(Builder $query, Model $parent, $localKey, $foreignKey, $type, $relation)
+    {
+        return new MorphManyTo($query, $parent, $localKey, $foreignKey, $type, $relation);
+    }
+
+
+    /**
+     * Define a polymorphic, direct one-to-one relationship.
+     *
+     * @param  string|null  $name
+     * @param  string|null  $type
+     * @param  string|null  $id
+     * @param  string|null  $foreignKey
+     * @return \Illuminate\Database\Eloquent\Relations\MorphOneTo
+     */
+    public function morphOneTo($name = null, $type = null, $id = null, $foreignKey = null)
+    {
+        // If no name is provided, we will use the backtrace to get the function name
+        // since that is most likely the name of the polymorphic interface. We can
+        // use that to get both the class and foreign key that will be utilized.
+        $name = $name ?: $this->guessBelongsToRelation();
+
+        [$type, $id] = $this->getMorphs(
+            Str::snake($name), $type, $id
+        );
+
+        // If the type value is null it is probably safe to assume we're eager loading
+        // the relationship. In this case we'll just pass in a dummy query where we
+        // need to remove any eager loads that may already be defined on a model.
+        return empty($class = $this->{$type})
+            ? $this->morphOneEagerTo($name, $type, $id, $foreignKey)
+            : $this->morphOneInstanceTo($class, $name, $type, $id, $foreignKey);
+    }
+
+    /**
+     * Define a polymorphic, direct one-to-one relationship.
+     *
+     * @param  string  $name
+     * @param  string  $type
+     * @param  string  $id
+     * @param  string  $foreignKey
+     * @return \Illuminate\Database\Eloquent\Relations\MorphOneTo
+     */
+    protected function morphOneEagerTo($name, $type, $id, $foreignKey)
+    {
+        return $this->newMorphOneTo(
+            $this->newQuery()->setEagerLoads([]), $this, $id, $foreignKey, $type, $name
+        );
+    }
+
+    /**
+     * Define a polymorphic, direct one-to-one relationship.
+     *
+     * @param  string  $target
+     * @param  string  $name
+     * @param  string  $type
+     * @param  string  $id
+     * @param  string  $foreignKey
+     * @return \Illuminate\Database\Eloquent\Relations\MorphOneTo
+     */
+    protected function morphOneInstanceTo($target, $name, $type, $id, $foreignKey)
+    {
+        $instance = $this->newRelatedInstance(
+            static::getActualClassNameForMorph($target)
+        );
+
+        return $this->newMorphOneTo(
+            $instance->newQuery(), $this, $id, $foreignKey ?? $instance->getKeyName(), $type, $name
+        );
+    }
+
+    /**
+     * Instantiate a new MorphOneTo relationship.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  \Illuminate\Database\Eloquent\Model  $parent
+     * @param  string  $localKey
+     * @param  string  $foreignKey
+     * @param  string  $type
+     * @param  string  $relation
+     * @return \Illuminate\Database\Eloquent\Relations\MorphOneTo
+     */
+    protected function newMorphOneTo(Builder $query, Model $parent, $localKey, $foreignKey, $type, $relation)
+    {
+        return new MorphOneTo($query, $parent, $localKey, $foreignKey, $type, $relation);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/MorphManyTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphManyTo.php
@@ -6,7 +6,6 @@ use Illuminate\Database\Eloquent\Collection;
 
 class MorphManyTo extends MorphOneOrManyTo
 {
-
     /**
      * Match the results for a given type to their parents.
      *

--- a/src/Illuminate/Database/Eloquent/Relations/MorphManyTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphManyTo.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Relations;
+
+use Illuminate\Database\Eloquent\Collection;
+
+class MorphManyTo extends MorphOneOrManyTo
+{
+
+    /**
+     * Match the results for a given type to their parents.
+     *
+     * @param  string  $type
+     * @param  \Illuminate\Database\Eloquent\Collection  $results
+     * @return void
+     */
+    protected function matchToMorphParents($type, Collection $results)
+    {
+        if ($results->isNotEmpty()) {
+            $result = $results->first();
+            $ownerKey = $this->ownerKey ?? $result->getKeyName();
+            $results = $results->groupBy($ownerKey);
+        }
+        $keys = array_keys($this->dictionary[$type]);
+        foreach ($keys as $key) {
+            $result = $results[$key] ?? $this->related->newCollection();
+            if (isset($this->dictionary[$type][$key])) {
+                foreach ($this->dictionary[$type][$key] as $model) {
+                    $model->setRelation($this->relationName, $result);
+                }
+            }
+        }
+    }
+
+    /**
+     * Get the results of the relationship.
+     *
+     * @return mixed
+     */
+    public function getResults()
+    {
+        if (is_null($this->child->{$this->foreignKey})) {
+            return $this->getDefaultFor($this->parent);
+        }
+
+        return $this->query->get() ?: $this->getDefaultFor($this->parent);
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOneOrManyTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOneOrManyTo.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Relations;
+
+use Illuminate\Database\Eloquent\Model;
+
+class MorphOneOrManyTo extends MorphTo
+{
+    /**
+     * Associate the model instance to the given parent.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    public function associate($model)
+    {
+        $this->parent->setAttribute(
+            $this->morphType, $model instanceof Model ? $model->getMorphClass() : null
+        );
+
+        return $this->parent->setRelation($this->relationName, $model);
+    }
+
+    /**
+     * Dissociate previously associated model from the given parent.
+     *
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    public function dissociate()
+    {
+        $this->parent->setAttribute($this->morphType, null);
+
+        return $this->parent->setRelation($this->relationName, null);
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOneTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOneTo.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Relations;
+
+class MorphOneTo extends MorphOneOrManyTo
+{
+
+}

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOneTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOneTo.php
@@ -4,5 +4,4 @@ namespace Illuminate\Database\Eloquent\Relations;
 
 class MorphOneTo extends MorphOneOrManyTo
 {
-
 }

--- a/tests/Integration/Database/EloquentMorphManyToEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentMorphManyToEagerLoadingTest.php
@@ -64,7 +64,7 @@ class EloquentMorphManyToEagerLoadingTest extends DatabaseTestCase
             ->with([
                 'deals' => function (MorphManyTo $morphManyTo) {
                     $morphManyTo->morphWith([FundDeal::class => ['user']]);
-                }
+                },
             ])
             ->get();
 
@@ -79,7 +79,7 @@ class EloquentMorphManyToEagerLoadingTest extends DatabaseTestCase
             ->with([
                 'deals' => function (MorphManyTo $morphManyTo) {
                     $morphManyTo->morphWith([FundDeal::class => 'user']);
-                }
+                },
             ])
             ->get();
 

--- a/tests/Integration/Database/EloquentMorphManyToEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentMorphManyToEagerLoadingTest.php
@@ -4,7 +4,6 @@ namespace Illuminate\Tests\Integration\Database\EloquentMorphManyToEagerLoadingT
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphManyTo;
-use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
@@ -62,9 +61,11 @@ class EloquentMorphManyToEagerLoadingTest extends DatabaseTestCase
     public function testWithMorphLoading()
     {
         $organizations = Organization::query()
-            ->with(['deals' => function (MorphManyTo $morphManyTo) {
-                $morphManyTo->morphWith([FundDeal::class => ['user']]);
-            }])
+            ->with([
+                'deals' => function (MorphManyTo $morphManyTo) {
+                    $morphManyTo->morphWith([FundDeal::class => ['user']]);
+                }
+            ])
             ->get();
 
         $this->assertTrue($organizations[0]->relationLoaded('deals'));
@@ -75,9 +76,11 @@ class EloquentMorphManyToEagerLoadingTest extends DatabaseTestCase
     public function testWithMorphLoadingWithSingleRelation()
     {
         $organizations = Organization::query()
-            ->with(['deals' => function (MorphManyTo $morphManyTo) {
-                $morphManyTo->morphWith([FundDeal::class => 'user']);
-            }])
+            ->with([
+                'deals' => function (MorphManyTo $morphManyTo) {
+                    $morphManyTo->morphWith([FundDeal::class => 'user']);
+                }
+            ])
             ->get();
 
         $this->assertTrue($organizations[0]->relationLoaded('deals'));
@@ -89,7 +92,6 @@ class User extends Model
 {
     public $timestamps = false;
 }
-
 
 class Organization extends Model
 {

--- a/tests/Integration/Database/EloquentMorphManyToEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentMorphManyToEagerLoadingTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentMorphManyToEagerLoadingTest;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphManyTo;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+/**
+ * @group integration
+ */
+class EloquentMorphManyToEagerLoadingTest extends DatabaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::dropIfExists('org_deals');
+        Schema::dropIfExists('fund_deals');
+        Schema::dropIfExists('organizations');
+        Schema::dropIfExists('users');
+
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+        });
+
+        Schema::create('org_deals', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('org_id');
+            $table->string('investment')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('fund_deals', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('org_id');
+            $table->string('call')->nullable();
+            $table->unsignedInteger('user_id');
+            $table->timestamps();
+        });
+
+        Schema::create('organizations', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('org_type')->nullable();
+        });
+
+        $user = User::create();
+
+        /** @var Organization $org */
+        $org = Organization::query()->create();
+        $fundDeal = tap((new FundDeal(['org_id' => $org->getKey()]))->user()->associate($user))->save();
+        $org->deals()->associate($fundDeal)->save();
+
+        $org = Organization::query()->create();
+        $orgDeal = OrgDeal::query()->create(['org_id' => $org->getKey()]);
+        $org->deals()->associate($orgDeal)->save();
+    }
+
+    public function testWithMorphLoading()
+    {
+        $organizations = Organization::query()
+            ->with(['deals' => function (MorphManyTo $morphManyTo) {
+                $morphManyTo->morphWith([FundDeal::class => ['user']]);
+            }])
+            ->get();
+
+        $this->assertTrue($organizations[0]->relationLoaded('deals'));
+        $this->assertTrue($organizations[0]->deals->first()->relationLoaded('user'));
+        $this->assertTrue($organizations[1]->relationLoaded('deals'));
+    }
+
+    public function testWithMorphLoadingWithSingleRelation()
+    {
+        $organizations = Organization::query()
+            ->with(['deals' => function (MorphManyTo $morphManyTo) {
+                $morphManyTo->morphWith([FundDeal::class => 'user']);
+            }])
+            ->get();
+
+        $this->assertTrue($organizations[0]->relationLoaded('deals'));
+        $this->assertTrue($organizations[0]->deals->first()->relationLoaded('user'));
+    }
+}
+
+class User extends Model
+{
+    public $timestamps = false;
+}
+
+
+class Organization extends Model
+{
+    public $timestamps = false;
+
+    public function deals()
+    {
+        return $this->morphManyTo('deals', 'org_type', 'id', 'org_id');
+    }
+}
+
+class FundDeal extends Model
+{
+    protected $guarded = [];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}
+
+class OrgDeal extends Model
+{
+    protected $guarded = [];
+}

--- a/tests/Integration/Database/EloquentMorphManyToLazyEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentMorphManyToLazyEagerLoadingTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentMorphManyToLazyEagerLoadingTest;
+
+use DB;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+/**
+ * @group integration
+ */
+class EloquentMorphManyToLazyEagerLoadingTest extends DatabaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::dropIfExists('org_deals');
+        Schema::dropIfExists('fund_deals');
+        Schema::dropIfExists('organizations');
+        Schema::dropIfExists('users');
+
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+        });
+
+        Schema::create('org_deals', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('org_id');
+            $table->string('investment')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('fund_deals', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('org_id');
+            $table->string('call')->nullable();
+            $table->unsignedInteger('user_id');
+            $table->timestamps();
+        });
+
+        Schema::create('organizations', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('org_type')->nullable();
+        });
+
+        $user = User::create();
+
+        /** @var Organization $org */
+        $org = Organization::query()->create();
+        $fundDeal = tap((new FundDeal(['org_id' => $org->getKey()]))->user()->associate($user))->save();
+        $org->deals()->associate($fundDeal)->save();
+
+        $org = Organization::query()->create();
+        $orgDeal = OrgDeal::query()->create(['org_id' => $org->getKey()]);
+        $org->deals()->associate($orgDeal)->save();
+    }
+
+    public function testLazyEagerLoading()
+    {
+        $organizations = Organization::all();
+
+        DB::enableQueryLog();
+
+        $organizations->load('deals');
+
+        $this->assertCount(3, DB::getQueryLog());
+        $this->assertTrue($organizations[0]->relationLoaded('deals'));
+        $this->assertTrue($organizations[0]->deals->first()->relationLoaded('user'));
+        $this->assertTrue($organizations[1]->relationLoaded('deals'));
+    }
+}
+
+
+class User extends Model
+{
+    public $timestamps = false;
+}
+
+
+class Organization extends Model
+{
+    public $timestamps = false;
+
+    public function deals()
+    {
+        return $this->morphManyTo('deals', 'org_type', 'id', 'org_id');
+    }
+}
+
+class FundDeal extends Model
+{
+    protected $guarded = [];
+
+    protected $with = ['user'];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}
+
+class OrgDeal extends Model
+{
+    protected $guarded = [];
+}
+

--- a/tests/Integration/Database/EloquentMorphManyToLazyEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentMorphManyToLazyEagerLoadingTest.php
@@ -73,12 +73,10 @@ class EloquentMorphManyToLazyEagerLoadingTest extends DatabaseTestCase
     }
 }
 
-
 class User extends Model
 {
     public $timestamps = false;
 }
-
 
 class Organization extends Model
 {
@@ -93,7 +91,6 @@ class Organization extends Model
 class FundDeal extends Model
 {
     protected $guarded = [];
-
     protected $with = ['user'];
 
     public function user()
@@ -106,4 +103,3 @@ class OrgDeal extends Model
 {
     protected $guarded = [];
 }
-

--- a/tests/Integration/Database/EloquentMorphManyToSelectTest.php
+++ b/tests/Integration/Database/EloquentMorphManyToSelectTest.php
@@ -112,9 +112,9 @@ class EloquentMorphManyToSelectTest extends DatabaseTestCase
     {
         $organization = Organization::first();
         $fundDeals = $organization->deals()->select('org_id')->get();
-        $this->assertInstanceOf(Collection::class,$fundDeals);
-        $this->assertInstanceOf(FundDeal::class,$fundDeals->first());
-        $this->assertEquals(['org_id' => $organization->getKey()],$fundDeals->first()->getAttributes());
+        $this->assertInstanceOf(Collection::class, $fundDeals);
+        $this->assertInstanceOf(FundDeal::class, $fundDeals->first());
+        $this->assertEquals(['org_id' => $organization->getKey()], $fundDeals->first()->getAttributes());
 
 
         $organization = Organization::query()->limit(1)->offset(1)->first();
@@ -138,7 +138,6 @@ class Organization extends Model
 class FundDeal extends Model
 {
     protected $guarded = [];
-
 }
 
 class OrgDeal extends Model

--- a/tests/Integration/Database/EloquentMorphManyToSelectTest.php
+++ b/tests/Integration/Database/EloquentMorphManyToSelectTest.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentMorphManyToSelectTest;
+
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+/**
+ * @group integration
+ */
+class EloquentMorphManyToSelectTest extends DatabaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::dropIfExists('org_deals');
+        Schema::dropIfExists('fund_deals');
+        Schema::dropIfExists('organizations');
+        Schema::create('org_deals', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('org_id');
+            $table->string('investment')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('fund_deals', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('org_id');
+            $table->string('call')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('organizations', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('org_type')->nullable();
+        });
+
+        /** @var Organization $org */
+        $org = Organization::query()->create();
+        $fundDeal = FundDeal::query()->create(['org_id' => $org->getKey()]);
+        $org->deals()->associate($fundDeal)->save();
+
+        $org = Organization::query()->create();
+        $orgDeal = OrgDeal::query()->create(['org_id' => $org->getKey()]);
+        $org->deals()->associate($orgDeal)->save();
+    }
+
+    public function testSelect()
+    {
+        $organizations = Organization::with('deals:org_id')->get();
+        $this->assertInstanceOf(Collection::class, $organizations[0]->deals);
+        $this->assertInstanceOf(FundDeal::class, $organizations[0]->deals->first());
+        $this->assertEquals(['org_id' => $organizations[0]->getKey()], $organizations[0]->deals->first()->getAttributes());
+
+        $this->assertInstanceOf(Collection::class, $organizations[1]->deals);
+        $this->assertInstanceOf(OrgDeal::class, $organizations[1]->deals->first());
+        $this->assertEquals(['org_id' => $organizations[1]->getKey()], $organizations[1]->deals->first()->getAttributes());
+    }
+
+    public function testSelectRaw()
+    {
+        $organizations = Organization::with(['deals' => function ($query) {
+            $query->selectRaw('org_id');
+        }])->get();
+
+        $this->assertInstanceOf(Collection::class, $organizations[0]->deals);
+        $this->assertInstanceOf(FundDeal::class, $organizations[0]->deals->first());
+        $this->assertEquals(['org_id' => $organizations[0]->getKey()], $organizations[0]->deals->first()->getAttributes());
+
+        $this->assertInstanceOf(Collection::class, $organizations[1]->deals);
+        $this->assertInstanceOf(OrgDeal::class, $organizations[1]->deals->first());
+        $this->assertEquals(['org_id' => $organizations[1]->getKey()], $organizations[1]->deals->first()->getAttributes());
+    }
+
+    public function testSelectSub()
+    {
+        $organizations = Organization::with(['deals' => function ($query) {
+            $query->selectSub(function ($query) {
+                $query->select('org_id');
+            }, 'org_id');
+        }])->get();
+
+        $this->assertInstanceOf(Collection::class, $organizations[0]->deals);
+        $this->assertInstanceOf(FundDeal::class, $organizations[0]->deals->first());
+        $this->assertEquals(['org_id' => $organizations[0]->getKey()], $organizations[0]->deals->first()->getAttributes());
+
+        $this->assertInstanceOf(Collection::class, $organizations[1]->deals);
+        $this->assertInstanceOf(OrgDeal::class, $organizations[1]->deals->first());
+        $this->assertEquals(['org_id' => $organizations[1]->getKey()], $organizations[1]->deals->first()->getAttributes());
+    }
+
+    public function testAddSelect()
+    {
+        $organizations = Organization::with(['deals' => function ($query) {
+            $query->addSelect('org_id');
+        }])->get();
+
+        $this->assertInstanceOf(Collection::class, $organizations[0]->deals);
+        $this->assertInstanceOf(FundDeal::class, $organizations[0]->deals->first());
+        $this->assertEquals(['org_id' => $organizations[0]->getKey()], $organizations[0]->deals->first()->getAttributes());
+
+        $this->assertInstanceOf(Collection::class, $organizations[1]->deals);
+        $this->assertInstanceOf(OrgDeal::class, $organizations[1]->deals->first());
+        $this->assertEquals(['org_id' => $organizations[1]->getKey()], $organizations[1]->deals->first()->getAttributes());
+    }
+
+    public function testLazyLoading()
+    {
+        $organization = Organization::first();
+        $fundDeals = $organization->deals()->select('org_id')->get();
+        $this->assertInstanceOf(Collection::class,$fundDeals);
+        $this->assertInstanceOf(FundDeal::class,$fundDeals->first());
+        $this->assertEquals(['org_id' => $organization->getKey()],$fundDeals->first()->getAttributes());
+
+
+        $organization = Organization::query()->limit(1)->offset(1)->first();
+        $orgDeals = $organization->deals()->select('org_id')->get();
+        $this->assertInstanceOf(Collection::class, $orgDeals);
+        $this->assertInstanceOf(OrgDeal::class, $orgDeals->first());
+        $this->assertEquals(['org_id' => $organization->getKey()], $orgDeals->first()->getAttributes());
+    }
+}
+
+class Organization extends Model
+{
+    public $timestamps = false;
+
+    public function deals()
+    {
+        return $this->morphManyTo('deals', 'org_type', 'id', 'org_id');
+    }
+}
+
+class FundDeal extends Model
+{
+    protected $guarded = [];
+
+}
+
+class OrgDeal extends Model
+{
+    protected $guarded = [];
+}

--- a/tests/Integration/Database/EloquentMorphManyToSelectTest.php
+++ b/tests/Integration/Database/EloquentMorphManyToSelectTest.php
@@ -116,7 +116,6 @@ class EloquentMorphManyToSelectTest extends DatabaseTestCase
         $this->assertInstanceOf(FundDeal::class, $fundDeals->first());
         $this->assertEquals(['org_id' => $organization->getKey()], $fundDeals->first()->getAttributes());
 
-
         $organization = Organization::query()->limit(1)->offset(1)->first();
         $orgDeals = $organization->deals()->select('org_id')->get();
         $this->assertInstanceOf(Collection::class, $orgDeals);

--- a/tests/Integration/Database/EloquentMorphOneToEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentMorphOneToEagerLoadingTest.php
@@ -4,7 +4,6 @@ namespace Illuminate\Tests\Integration\Database\EloquentMorphOneToEagerLoadingTe
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphOneTo;
-use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
@@ -38,7 +37,7 @@ class EloquentMorphOneToEagerLoadingTest extends DatabaseTestCase
             $table->increments('id');
             $table->unsignedInteger('org_id');
             $table->unsignedInteger('user_id');
-            $table->decimal('fund_size',30,5)->nullable();
+            $table->decimal('fund_size', 30, 5)->nullable();
             $table->timestamps();
         });
 

--- a/tests/Integration/Database/EloquentMorphOneToEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentMorphOneToEagerLoadingTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentMorphOneToEagerLoadingTest;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphOneTo;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+/**
+ * @group integration
+ */
+class EloquentMorphOneToEagerLoadingTest extends DatabaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::dropIfExists('users');
+
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+        });
+
+        Schema::dropIfExists('org_extensions');
+        Schema::dropIfExists('fund_extensions');
+        Schema::dropIfExists('organizations');
+        Schema::create('org_extensions', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('org_id');
+            $table->decimal('valuation', 30, 5)->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('fund_extensions', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('org_id');
+            $table->unsignedInteger('user_id');
+            $table->decimal('fund_size',30,5)->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('organizations', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('org_type')->nullable();
+        });
+
+        $user = User::create();
+
+        /** @var Organization $org */
+        $org = Organization::query()->create();
+        $fundExt = tap((new FundExtension(['org_id' => $org->getKey()]))->user()->associate($user))->save();
+        $org->extension()->associate($fundExt)->save();
+
+        $org = Organization::query()->create();
+        $orgExt = OrgExtension::query()->create(['org_id' => $org->getKey()]);
+        $org->extension()->associate($orgExt)->save();
+    }
+
+    public function testWithMorphLoading()
+    {
+        $organizations = Organization::query()
+            ->with(['extension' => function (MorphOneTo $morphOneTo) {
+                $morphOneTo->morphWith([FundExtension::class => ['user']]);
+            }])
+            ->get();
+
+        $this->assertTrue($organizations[0]->relationLoaded('extension'));
+        $this->assertTrue($organizations[0]->extension->relationLoaded('user'));
+        $this->assertTrue($organizations[1]->relationLoaded('extension'));
+    }
+
+    public function testWithMorphLoadingWithSingleRelation()
+    {
+        $organizations = Organization::query()
+            ->with(['extension' => function (MorphOneTo $morphOneTo) {
+                $morphOneTo->morphWith([FundExtension::class => 'user']);
+            }])
+            ->get();
+
+        $this->assertTrue($organizations[0]->relationLoaded('extension'));
+        $this->assertTrue($organizations[0]->extension->relationLoaded('user'));
+    }
+}
+
+class User extends Model
+{
+    public $timestamps = false;
+}
+
+class Organization extends Model
+{
+    public $timestamps = false;
+
+    public function extension()
+    {
+        return $this->morphOneTo('extension', 'org_type', 'id', 'org_id');
+    }
+}
+
+class FundExtension extends Model
+{
+    protected $guarded = [];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}
+
+class OrgExtension extends Model
+{
+    protected $guarded = [];
+}

--- a/tests/Integration/Database/EloquentMorphOneToLazyEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentMorphOneToLazyEagerLoadingTest.php
@@ -35,7 +35,7 @@ class EloquentMorphOneToLazyEagerLoadingTest extends DatabaseTestCase
             $table->increments('id');
             $table->unsignedInteger('org_id');
             $table->unsignedInteger('user_id');
-            $table->decimal('fund_size',30,5)->nullable();
+            $table->decimal('fund_size', 30, 5)->nullable();
             $table->timestamps();
         });
 
@@ -71,12 +71,10 @@ class EloquentMorphOneToLazyEagerLoadingTest extends DatabaseTestCase
     }
 }
 
-
 class User extends Model
 {
     public $timestamps = false;
 }
-
 
 class Organization extends Model
 {

--- a/tests/Integration/Database/EloquentMorphOneToLazyEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentMorphOneToLazyEagerLoadingTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentMorphOneToLazyEagerLoadingTest;
+
+use DB;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+/**
+ * @group integration
+ */
+class EloquentMorphOneToLazyEagerLoadingTest extends DatabaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::dropIfExists('users');
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+        });
+        Schema::dropIfExists('org_extensions');
+        Schema::dropIfExists('fund_extensions');
+        Schema::dropIfExists('organizations');
+        Schema::create('org_extensions', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('org_id');
+            $table->decimal('valuation', 30, 5)->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('fund_extensions', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('org_id');
+            $table->unsignedInteger('user_id');
+            $table->decimal('fund_size',30,5)->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('organizations', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('org_type')->nullable();
+        });
+
+        $user = User::create();
+
+        /** @var Organization $org */
+        $org = Organization::query()->create();
+        $fundExt = tap((new FundExtension(['org_id' => $org->getKey()]))->user()->associate($user))->save();
+        $org->extension()->associate($fundExt)->save();
+
+        $org = Organization::query()->create();
+        $orgExt = OrgExtension::query()->create(['org_id' => $org->getKey()]);
+        $org->extension()->associate($orgExt)->save();
+    }
+
+    public function testLazyEagerLoading()
+    {
+        $organizations = Organization::all();
+
+        DB::enableQueryLog();
+
+        $organizations->load('extension');
+
+        $this->assertCount(3, DB::getQueryLog());
+        $this->assertTrue($organizations[0]->relationLoaded('extension'));
+        $this->assertTrue($organizations[0]->extension->relationLoaded('user'));
+        $this->assertTrue($organizations[1]->relationLoaded('extension'));
+    }
+}
+
+
+class User extends Model
+{
+    public $timestamps = false;
+}
+
+
+class Organization extends Model
+{
+    public $timestamps = false;
+
+    public function extension()
+    {
+        return $this->morphOneTo('extension', 'org_type', 'id', 'org_id');
+    }
+}
+
+class FundExtension extends Model
+{
+    protected $guarded = [];
+    protected $with = ['user'];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}
+
+class OrgExtension extends Model
+{
+    protected $guarded = [];
+}

--- a/tests/Integration/Database/EloquentMorphOneToSelectTest.php
+++ b/tests/Integration/Database/EloquentMorphOneToSelectTest.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentMorphOneToSelectTest;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+/**
+ * @group integration
+ */
+class EloquentMorphOneToSelectTest extends DatabaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::dropIfExists('org_extensions');
+        Schema::dropIfExists('fund_extensions');
+        Schema::dropIfExists('organizations');
+        Schema::create('org_extensions', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('org_id');
+            $table->decimal('valuation', 30, 5)->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('fund_extensions', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('org_id');
+            $table->decimal('fund_size',30,5)->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('organizations', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('org_type')->nullable();
+        });
+
+        /** @var Organization $org */
+        $org = Organization::query()->create();
+        $fundExtension = FundExtension::query()->create(['org_id' => $org->getKey()]);
+        $org->extension()->associate($fundExtension)->save();
+
+        $org = Organization::query()->create();
+        $orgExtension = OrgExtension::query()->create(['org_id' => $org->getKey()]);
+        $org->extension()->associate($orgExtension)->save();
+    }
+
+    public function testSelect()
+    {
+        $organizations = Organization::with('extension:org_id')->get();
+
+        $this->assertInstanceOf(FundExtension::class, $organizations[0]->extension);
+        $this->assertEquals(['org_id' => $organizations[0]->getKey()], $organizations[0]->extension->getAttributes());
+
+        $this->assertInstanceOf(OrgExtension::class, $organizations[1]->extension);
+        $this->assertEquals(['org_id' => $organizations[1]->getKey()], $organizations[1]->extension->getAttributes());
+    }
+
+    public function testSelectRaw()
+    {
+        $organizations = Organization::with(['extension' => function ($query) {
+            $query->selectRaw('org_id');
+        }])->get();
+
+        $this->assertInstanceOf(FundExtension::class, $organizations[0]->extension);
+        $this->assertEquals(['org_id' => $organizations[0]->getKey()], $organizations[0]->extension->getAttributes());
+
+        $this->assertInstanceOf(OrgExtension::class, $organizations[1]->extension);
+        $this->assertEquals(['org_id' => $organizations[1]->getKey()], $organizations[1]->extension->getAttributes());
+    }
+
+    public function testSelectSub()
+    {
+        $organizations = Organization::with(['extension' => function ($query) {
+            $query->selectSub(function ($query) {
+                $query->select('org_id');
+            }, 'org_id');
+        }])->get();
+
+        $this->assertInstanceOf(FundExtension::class, $organizations[0]->extension);
+        $this->assertEquals(['org_id' => $organizations[0]->getKey()], $organizations[0]->extension->getAttributes());
+
+        $this->assertInstanceOf(OrgExtension::class, $organizations[1]->extension);
+        $this->assertEquals(['org_id' => $organizations[1]->getKey()], $organizations[1]->extension->getAttributes());
+    }
+
+    public function testAddSelect()
+    {
+        $organizations = Organization::with(['extension' => function ($query) {
+            $query->addSelect('org_id');
+        }])->get();
+
+        $this->assertInstanceOf(FundExtension::class, $organizations[0]->extension);
+        $this->assertEquals(['org_id' => $organizations[0]->getKey()], $organizations[0]->extension->getAttributes());
+
+        $this->assertInstanceOf(OrgExtension::class, $organizations[1]->extension);
+        $this->assertEquals(['org_id' => $organizations[1]->getKey()], $organizations[1]->extension->getAttributes());
+    }
+
+    public function testLazyLoading()
+    {
+        $organization = Organization::first();
+        $entension = $organization->extension()->select('org_id')->first();
+
+        $this->assertEquals(['org_id' => 1], $entension->getAttributes());
+    }
+}
+
+class Organization extends Model
+{
+    public $timestamps = false;
+
+    public function extension()
+    {
+        return $this->morphOneTo('extension', 'org_type', 'id', 'org_id');
+    }
+}
+
+class FundExtension extends Model
+{
+    protected $guarded = [];
+
+}
+
+class OrgExtension extends Model
+{
+    protected $guarded = [];
+}
+

--- a/tests/Integration/Database/EloquentMorphOneToSelectTest.php
+++ b/tests/Integration/Database/EloquentMorphOneToSelectTest.php
@@ -29,7 +29,7 @@ class EloquentMorphOneToSelectTest extends DatabaseTestCase
         Schema::create('fund_extensions', function (Blueprint $table) {
             $table->increments('id');
             $table->unsignedInteger('org_id');
-            $table->decimal('fund_size',30,5)->nullable();
+            $table->decimal('fund_size', 30, 5)->nullable();
             $table->timestamps();
         });
 
@@ -122,11 +122,9 @@ class Organization extends Model
 class FundExtension extends Model
 {
     protected $guarded = [];
-
 }
 
 class OrgExtension extends Model
 {
     protected $guarded = [];
 }
-


### PR DESCRIPTION
Add MorphManyTo to support polymorphism, direct one-to-many relationship, Add MorphOneTo to support polymorphism, direct one-to-one relationship, and write related unit tests.

The current Relations cannot be used to represent polymorphism, direct one-to-one or many relationships.

See https://github.com/laravel/ideas/issues/2399

And the scenarios for which they apply can be reflected in the unit test for this commit.

These new relationships will not have any impact on the previous content, and the relevant unit tests I wrote have passed