### PR TITLE
[8.x] Fixing column id in session table and app path style fixed

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -322,7 +322,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
     public function path($path = '')
     {
         return $this->appPath.($path ? DIRECTORY_SEPARATOR.$path : $path)
-            ?: $this->basePath.DIRECTORY_SEPARATOR.'app';
+            ?: $this->basePath.DIRECTORY_SEPARATOR.'app'.($path ? DIRECTORY_SEPARATOR.$path : $path);
     }
 
     /**

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -321,9 +321,8 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function path($path = '')
     {
-        $appPath = $this->appPath ?: $this->basePath.DIRECTORY_SEPARATOR.'app';
-
-        return $appPath.($path ? DIRECTORY_SEPARATOR.$path : $path);
+        return $this->appPath.($path ? DIRECTORY_SEPARATOR.$path : $path)
+            ?: $this->basePath.DIRECTORY_SEPARATOR.'app';
     }
 
     /**

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -321,8 +321,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function path($path = '')
     {
-        return $this->appPath.($path ? DIRECTORY_SEPARATOR.$path : $path)
-            ?: $this->basePath.DIRECTORY_SEPARATOR.'app'.($path ? DIRECTORY_SEPARATOR.$path : $path);
+        return ($this->appPath ?: $this->basePath.DIRECTORY_SEPARATOR.'app').($path ? DIRECTORY_SEPARATOR.$path : $path);
     }
 
     /**

--- a/src/Illuminate/Session/Console/stubs/database.stub
+++ b/src/Illuminate/Session/Console/stubs/database.stub
@@ -14,7 +14,7 @@ class CreateSessionsTable extends Migration
     public function up()
     {
         Schema::create('sessions', function (Blueprint $table) {
-            $table->id()->primary();
+            $table->string('id')->primary();
             $table->foreignId('user_id')->nullable()->index();
             $table->string('ip_address', 45)->nullable();
             $table->text('user_agent')->nullable();

--- a/src/Illuminate/Session/Console/stubs/database.stub
+++ b/src/Illuminate/Session/Console/stubs/database.stub
@@ -14,7 +14,7 @@ class CreateSessionsTable extends Migration
     public function up()
     {
         Schema::create('sessions', function (Blueprint $table) {
-            $table->string('id')->primary();
+            $table->id()->primary();
             $table->foreignId('user_id')->nullable()->index();
             $table->string('ip_address', 45)->nullable();
             $table->text('user_agent')->nullable();


### PR DESCRIPTION
- Fix to get path to "app" directory.
- Standard usage for id column in the sessions table has been implemented.

**This PR :** It allows it to get the 'id' column required for the sessions table from its function in the Eloquent structure. Applies style fixes for the app directory.
