### PR TITLE
[7.x] Add php 8 support for Illuminate Testing 7.x

### DIFF
--- a/src/Illuminate/Testing/composer.json
+++ b/src/Illuminate/Testing/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.5",
+        "php": "^7.2.5|^8.0",
         "illuminate/contracts": "^7.0",
         "illuminate/support": "^7.0",
         "symfony/polyfill-php73": "^1.17"


### PR DESCRIPTION
I was trying to change the Lumen Framework 7.x `composer.json` to allow php 8, since you guys already made it compatible in Illuminate 6/7/8, but surprisingly the Illuminate Testing package has not been updated to allow php 8. Was that on purpose?

Looks like a mistake to me since it is php 8 compatible in 8.x and I found no comments on that in related php 8 PR’s. If it is intentionally, you may close this PR :)