### PR TITLE
[8.x] Set chain queue and connection only when explicitly configured

### DIFF
--- a/src/Illuminate/Foundation/Bus/PendingChain.php
+++ b/src/Illuminate/Foundation/Bus/PendingChain.php
@@ -143,8 +143,14 @@ class PendingChain
             $firstJob = $this->job;
         }
 
-        $firstJob->allOnConnection($this->connection);
-        $firstJob->allOnQueue($this->queue);
+        if ($this->connection) {
+            $firstJob->allOnConnection($this->connection);
+        }
+
+        if ($this->queue) {
+            $firstJob->allOnQueue($this->queue);
+        }
+
         $firstJob->chain($this->chain);
         $firstJob->delay($this->delay);
         $firstJob->chainCatchCallbacks = $this->catchCallbacks();

--- a/src/Illuminate/Foundation/Bus/PendingChain.php
+++ b/src/Illuminate/Foundation/Bus/PendingChain.php
@@ -144,15 +144,17 @@ class PendingChain
         }
 
         if ($this->connection) {
-            $firstJob->allOnConnection($this->connection);
+            $firstJob->chainConnection = $this->connection;
+            $firstJob->connection = $firstJob->connection ?: $this->connection;
         }
 
         if ($this->queue) {
-            $firstJob->allOnQueue($this->queue);
+            $firstJob->chainQueue = $this->queue;
+            $firstJob->queue = $firstJob->queue ?: $this->queue;
         }
 
         if ($this->delay) {
-            $firstJob->delay($this->delay);
+            $firstJob->delay = ! is_null($firstJob->delay) ? $firstJob->delay : $this->delay;
         }
 
         $firstJob->chain($this->chain);

--- a/src/Illuminate/Foundation/Bus/PendingChain.php
+++ b/src/Illuminate/Foundation/Bus/PendingChain.php
@@ -151,8 +151,11 @@ class PendingChain
             $firstJob->allOnQueue($this->queue);
         }
 
+        if ($this->delay) {
+            $firstJob->delay($this->delay);
+        }
+
         $firstJob->chain($this->chain);
-        $firstJob->delay($this->delay);
         $firstJob->chainCatchCallbacks = $this->catchCallbacks();
 
         return app(Dispatcher::class)->dispatch($firstJob);


### PR DESCRIPTION
This PR fixes https://github.com/laravel/framework/issues/35041

It sets the chain queue and connection only when specified. Otherwise the dispatcher will push each job in the chain to the queue/connection assigned to it.