### PR TITLE
[8.x] Replace a `preg_split` call with `explode`

### DIFF
--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -323,7 +323,7 @@ class PendingCommand
             $table->render();
 
             $lines = array_filter(
-                preg_split("/\n/", $output->fetch())
+                explode("\n", $output->fetch())
             );
 
             foreach ($lines as $line) {


### PR DESCRIPTION
Replaces a `preg_split()` call with `explode()` because the the delimiter is a simple new-line character.
`explode()` is faster for this case and provides identical results.

From [php.net preg_split](https://www.php.net/manual/function.preg-split.php):

> If you don't need the power of regular expressions, you can choose faster (albeit simpler) alternatives like explode() or str_split().

