### PR TITLE
[8.x] Modify has() method to support MorphTo relations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -9,7 +9,6 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Support\Str;
-use RuntimeException;
 
 trait QueriesRelationships
 {
@@ -36,7 +35,7 @@ trait QueriesRelationships
         }
 
         if ($relation instanceof MorphTo) {
-            throw new RuntimeException('Please use whereHasMorph() for MorphTo relationships.');
+            return $this->hasMorph($relation, ['*'], $operator, $count, $boolean, $callback);
         }
 
         // If we only need to check for the existence of the relation, then we can optimize
@@ -189,7 +188,7 @@ trait QueriesRelationships
     /**
      * Add a polymorphic relationship count / exists condition to the query.
      *
-     * @param  string  $relation
+     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation
      * @param  string|array  $types
      * @param  string  $operator
      * @param  int  $count
@@ -199,7 +198,9 @@ trait QueriesRelationships
      */
     public function hasMorph($relation, $types, $operator = '>=', $count = 1, $boolean = 'and', Closure $callback = null)
     {
-        $relation = $this->getRelationWithoutConstraints($relation);
+        if (is_string($relation)) {
+            $relation = $this->getRelationWithoutConstraints($relation);
+        }
 
         $types = (array) $types;
 
@@ -254,7 +255,7 @@ trait QueriesRelationships
     /**
      * Add a polymorphic relationship count / exists condition to the query with an "or".
      *
-     * @param  string  $relation
+     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation
      * @param  string|array  $types
      * @param  string  $operator
      * @param  int  $count
@@ -268,7 +269,7 @@ trait QueriesRelationships
     /**
      * Add a polymorphic relationship count / exists condition to the query.
      *
-     * @param  string  $relation
+     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation
      * @param  string|array  $types
      * @param  string  $boolean
      * @param  \Closure|null  $callback
@@ -294,7 +295,7 @@ trait QueriesRelationships
     /**
      * Add a polymorphic relationship count / exists condition to the query with where clauses.
      *
-     * @param  string  $relation
+     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation
      * @param  string|array  $types
      * @param  \Closure|null  $callback
      * @param  string  $operator
@@ -309,7 +310,7 @@ trait QueriesRelationships
     /**
      * Add a polymorphic relationship count / exists condition to the query with where clauses and an "or".
      *
-     * @param  string  $relation
+     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation
      * @param  string|array  $types
      * @param  \Closure|null  $callback
      * @param  string  $operator

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -283,7 +283,7 @@ trait QueriesRelationships
     /**
      * Add a polymorphic relationship count / exists condition to the query with an "or".
      *
-     * @param  string  $relation
+     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation
      * @param  string|array  $types
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
@@ -325,7 +325,7 @@ trait QueriesRelationships
     /**
      * Add a polymorphic relationship count / exists condition to the query with where clauses.
      *
-     * @param  string  $relation
+     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation
      * @param  string|array  $types
      * @param  \Closure|null  $callback
      * @return \Illuminate\Database\Eloquent\Builder|static
@@ -338,7 +338,7 @@ trait QueriesRelationships
     /**
      * Add a polymorphic relationship count / exists condition to the query with where clauses and an "or".
      *
-     * @param  string  $relation
+     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation
      * @param  string|array  $types
      * @param  \Closure|null  $callback
      * @return \Illuminate\Database\Eloquent\Builder|static

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -22,7 +22,6 @@ use Illuminate\Support\Facades\Date;
 use Illuminate\Tests\Integration\Database\Fixtures\Post;
 use Illuminate\Tests\Integration\Database\Fixtures\User;
 use PHPUnit\Framework\TestCase;
-use RuntimeException;
 
 class DatabaseEloquentIntegrationTest extends TestCase
 {
@@ -785,9 +784,12 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
     public function testHasOnMorphToRelationship()
     {
-        $this->expectException(RuntimeException::class);
+        $post = EloquentTestPost::create(['name' => 'Morph Post', 'user_id' => 1]);
+        (new EloquentTestPhoto)->imageable()->associate($post)->fill(['name' => 'Morph Photo'])->save();
 
-        EloquentTestPhoto::has('imageable')->get();
+        $photos = EloquentTestPhoto::has('imageable')->get();
+
+        $this->assertEquals(1, $photos->count());
     }
 
     public function testBelongsToManyRelationshipModelsAreProperlyHydratedOverChunkedRequest()


### PR DESCRIPTION
This PR modifies the `has()` method **with min changes** to support `MorphTo` relations.
Also, the following descendants of `has()` method inherit this feature:

```php
protected function hasNested(...)
public function orHas(...)
public function doesntHave(...)
public function orDoesntHave(...)
public function whereHas(...)
public function orWhereHas(...)
public function whereDoesntHave(...)
```

In addition to the above feature the `hasMorph()` method and its descendants support the `MorphTo` relation as first argument (`MorphTo|string`):

```php
/**
 * Add a polymorphic relationship count / exists condition to the query.
 *
 * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation
 * ....
 */
public function hasMorph($relation, ...)

public function orHasMorph($relation,...)
public function doesntHaveMorph($relation, ...)
public function whereHasMorph($relation, ...)
public function orWhereHasMorph($relation, ...)
public function orHasMorph($relation, ...)
public function doesntHaveMorph($relation, ...)
public function orDoesntHaveMorph($relation,...)
```

