### PR TITLE
[8.x] Use `is_iterable` where possible

### DIFF
--- a/src/Illuminate/Notifications/Messages/MailMessage.php
+++ b/src/Illuminate/Notifications/Messages/MailMessage.php
@@ -6,7 +6,6 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Mail\Markdown;
-use Traversable;
 
 class MailMessage extends SimpleMessage implements Renderable
 {
@@ -297,9 +296,7 @@ class MailMessage extends SimpleMessage implements Renderable
      */
     protected function arrayOfAddresses($address)
     {
-        return is_array($address) ||
-               $address instanceof Arrayable ||
-               $address instanceof Traversable;
+        return is_iterable($address) || $address instanceof Arrayable;
     }
 
     /**


### PR DESCRIPTION
PHP 7.1 provides [`is_iterable`](https://www.php.net/manual/function.is-iterable.php) function in PHP 7.1 that is identical to `is_array() || instanceof Traversable`.


Updated such call in `\Illuminate\Notifications\Messages\MailMessage::arrayOfAddresses`.


