### PR TITLE
[8.x] Remove redundant unreachable return statements

### DIFF
--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -155,8 +155,6 @@ class DatabaseStore implements LockProvider, Store
                     'expiration' => $expiration,
                 ]) >= 1;
         }
-
-        return false;
     }
 
     /**

--- a/src/Illuminate/Database/Console/Migrations/ResetCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/ResetCommand.php
@@ -67,8 +67,6 @@ class ResetCommand extends BaseCommand
                 $this->getMigrationPaths(), $this->option('pretend')
             );
         });
-
-        return 0;
     }
 
     /**


### PR DESCRIPTION
Removes a couple of `return` statements where the statements above always `return`, thus making the removed `return` calls pratically dead code.

 - `\Illuminate\Cache\DatabaseStore::add`
 - `\Illuminate\Database\Console\Migrations\ResetCommand::handle`

Both functions above contain other unconditional `return` statements, effectively making the `return` call this commit removes has no impact.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
