### PR TITLE
[8.x] Combine multiple `isset()` calls to a single one

### DIFF
--- a/src/Illuminate/Support/Reflector.php
+++ b/src/Illuminate/Support/Reflector.php
@@ -21,8 +21,7 @@ class Reflector
             return is_callable($var, $syntaxOnly);
         }
 
-        if ((! isset($var[0]) || ! isset($var[1])) ||
-            ! is_string($var[1] ?? null)) {
+        if (! isset($var[0], $var[1]) || ! is_string($var[1] ?? null)) {
             return false;
         }
 

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -288,7 +288,7 @@ class ComponentTagCompiler
 
         $prefix = $segments[0];
 
-        if (! isset($this->namespaces[$prefix]) || ! isset($segments[1])) {
+        if (! isset($this->namespaces[$prefix], $segments[1])) {
             return;
         }
 


### PR DESCRIPTION
Combined multiple `isset()` calls into a single `isset()` call.

```php
isset($arr[1]) && isset($arr[2])
```

is identical the following, but simpler and easy to read:

```php
isset($arr[1], $arr[2])
```

This was changed in:

 - `\Illuminate\Support\Reflector::isCallable`
 - `\Illuminate\View\Compilers\ComponentTagCompiler::findClassByComponent`

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
