### PR TITLE
[6.x] Replace `static::` calls on non-static funcs with `$this->`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1130,7 +1130,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
             return;
         }
 
-        return static::newQueryWithoutScopes()
+        return $this->newQueryWithoutScopes()
                         ->with(is_string($with) ? func_get_args() : $with)
                         ->where($this->getKeyName(), $this->getKey())
                         ->first();
@@ -1148,7 +1148,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
         }
 
         $this->setRawAttributes(
-            static::newQueryWithoutScopes()->findOrFail($this->getKey())->attributes
+            $this->newQueryWithoutScopes()->findOrFail($this->getKey())->attributes
         );
 
         $this->load(collect($this->relations)->reject(function ($relation) {


### PR DESCRIPTION
Updates a few method calls that use `static::foo()` pattern instead of standard `$this->foo()` pattern on non-static methods.

In PHP 8.0, it throws a fatal error if non-static methods are called with static resolver (`::`), but [with an exception for `static::`, `parent::`, and `self::`](https://php.watch/versions/8.0/non-static-static-call-fatal-error#static-this), so this is not a change required for PHP 8.0.

However, I think this change makes the code a bit more correct using the correct `$this->` calling pattern.