### PR TITLE
[7.x] Fix PendingRequest docblock

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -87,7 +87,7 @@ class PendingRequest
     /**
      * The callbacks that should execute before the request is sent.
      *
-     * @var array
+     * @var \Illuminate\Support\Collection
      */
     protected $beforeSendingCallbacks;
 


### PR DESCRIPTION
The `beforeSendingCallbacks` property of `PendingRequest` is initialized as an instance of Collection and aren't changed. So, it's docblock must be marked as `\Illuminate\Support\Collection`.