### PR TITLE
[8.x] Fix qualified column in withAggregate

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -381,9 +381,17 @@ trait QueriesRelationships
 
             $relation = $this->getRelationWithoutConstraints($name);
 
-            $expression = $function
-                ? sprintf('%s(%s)', $function, $this->getQuery()->getGrammar()->wrap($column))
-                : $column;
+            if ($function) {
+                $expression = sprintf(
+                    '%s(%s)',
+                    $function,
+                    $this->getQuery()->getGrammar()->wrap(
+                        $column === '*' ? $column : $relation->getRelated()->qualifyColumn($column)
+                    )
+                );
+            } else {
+                $expression = $column;
+            }
 
             // Here, we will grab the relationship sub-query and prepare to add it to the main query
             // as a sub-select. First, we'll get the "has" query and use that to get the relation

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -816,6 +816,24 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertSame('select "id", (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" limit 1) as "foo_count" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
     }
 
+    public function testWithMin()
+    {
+        $model = new EloquentBuilderTestModelParentStub;
+
+        $builder = $model->withMin('foo', 'price');
+
+        $this->assertSame('select "eloquent_builder_test_model_parent_stubs".*, (select min("eloquent_builder_test_model_close_related_stubs"."price") from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" limit 1) as "foo_min_price" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
+    }
+
+    public function testWithMinOnBelongsToMany()
+    {
+        $model = new EloquentBuilderTestModelParentStub;
+
+        $builder = $model->withMin('roles', 'id');
+
+        $this->assertSame('select "eloquent_builder_test_model_parent_stubs".*, (select min("eloquent_builder_test_model_far_related_stubs"."id") from "eloquent_builder_test_model_far_related_stubs" inner join "user_role" on "eloquent_builder_test_model_far_related_stubs"."id" = "user_role"."related_id" where "eloquent_builder_test_model_parent_stubs"."id" = "user_role"."self_id" limit 1) as "roles_min_id" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
+    }
+
     public function testWithCountAndConstraintsAndHaving()
     {
         $model = new EloquentBuilderTestModelParentStub;
@@ -1481,6 +1499,16 @@ class EloquentBuilderTestModelParentStub extends Model
     public function activeFoo()
     {
         return $this->belongsTo(EloquentBuilderTestModelCloseRelatedStub::class, 'foo_id')->where('active', true);
+    }
+
+    public function roles()
+    {
+        return $this->belongsToMany(
+            EloquentBuilderTestModelFarRelatedStub::class,
+            'user_role',
+            'self_id',
+            'related_id'
+        );
     }
 }
 


### PR DESCRIPTION
This PR fixes a QueryException when using the new Builder features `withAggregate`, `withMin`, `withSum`, etc.

When using `User::withMin('roles', 'id')` on a `belongsToMany` relation the current implementation creates a query like 
```sql
select users.*, (select min(`id`) from roles inner join role_user on ...) as ...
```
which can cause an SQL error:

```
SQLSTATE[23000]: Integrity constraint violation: 1052 Column 'id' in field list is ambiguous
```
This PR passes the `$column` through `$relation->getRelated()->qualifyColumn($column)` to ensure fully qualified names:
```sql
select users.*, (select min(`roles`.`id`) from roles inner join role_user on ...) as ...
```