### PR TITLE
[8.x] Extract pending request creation for HTTP client

### DIFF
--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -299,6 +299,16 @@ class Factory
     }
 
     /**
+     * Create a new pending request instance for this factory.
+     *
+     * @return PendingRequest
+     */
+    protected function newPendingRequest()
+    {
+        return new PendingRequest($this);
+    }
+
+    /**
      * Execute a method against a new pending request instance.
      *
      * @param  string  $method
@@ -311,7 +321,7 @@ class Factory
             return $this->macroCall($method, $parameters);
         }
 
-        return tap(new PendingRequest($this), function ($request) {
+        return tap($this->newPendingRequest(), function ($request) {
             $request->stub($this->stubCallbacks);
         })->{$method}(...$parameters);
     }

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -301,7 +301,7 @@ class Factory
     /**
      * Create a new pending request instance for this factory.
      *
-     * @return PendingRequest
+     * @return \Illuminate\Http\Client\PendingRequest
      */
     protected function newPendingRequest()
     {


### PR DESCRIPTION
This adds a `newPendingRequest()` method to the HTTP client factory. It allows for easier modification of the pending request instance when extending the HTTP client factory.

A common use case might be a service class that serves as an API wrapper by extending the factory class.

```php
class MyService extends Illuminate\Http\Client\Factory
{
    /**
     * @return \Illuminate\Http\Client\Response
     */
    public function getSomeSpecificResourceDataFromServiceApi($id)
    {
        return $this->get('resource/' . $id);
    }

    // e.g. other methods to call the service API

    /**
     * @inheritdoc
     */
    protected function newPendingRequest()
    {
        return parent::newPendingRequest()
            ->baseUrl('https://www.my-service.io/api/v1')
            ->withoutVerifying();
    }
}
```