### PR TITLE
[8.x] Add assertUrlIs and assertRouteIs testing methods

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithRequest.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithRequest.php
@@ -4,7 +4,7 @@ namespace Illuminate\Foundation\Testing\Concerns;
 
 use Illuminate\Testing\Assert as PHPUnit;
 
-trait InteractsWithResponse
+trait InteractsWithRequest
 {
     /**
      * Assert that the given URL is the current request URL.
@@ -43,6 +43,6 @@ trait InteractsWithResponse
      */
     public function getCurrentUrl()
     {
-         return $this->app['url']->current();
+        return $this->app['url']->current();
     }
 }

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithResponse.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithResponse.php
@@ -2,15 +2,7 @@
 
 namespace Illuminate\Foundation\Testing\Concerns;
 
-use Illuminate\Contracts\Support\Jsonable;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Support\Arr;
-use Illuminate\Support\Facades\DB;
-use Illuminate\Testing\Constraints\CountInDatabase;
-use Illuminate\Testing\Constraints\HasInDatabase;
-use Illuminate\Testing\Constraints\SoftDeletedInDatabase;
-use PHPUnit\Framework\Constraint\LogicalNot as ReverseConstraint;
+use Illuminate\Testing\Assert as PHPUnit;
 
 trait InteractsWithResponse
 {

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithResponse.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithResponse.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Illuminate\Foundation\Testing\Concerns;
+
+use Illuminate\Contracts\Support\Jsonable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Testing\Constraints\CountInDatabase;
+use Illuminate\Testing\Constraints\HasInDatabase;
+use Illuminate\Testing\Constraints\SoftDeletedInDatabase;
+use PHPUnit\Framework\Constraint\LogicalNot as ReverseConstraint;
+
+trait InteractsWithResponse
+{
+    /**
+     * Assert that the given URL is the current request URL.
+     *
+     * @param  string  $url
+     * @return $this
+     */
+    public function assertUrlIs(string $url)
+    {
+        $expectedUrl = $this->app['url']->to($url);
+
+        PHPUnit::assertEquals(
+            $expectedUrl,
+            $this->getCurrentUrl(),
+            'Current URL ['.$this->getCurrentUrl().'] does not match expected URL ['.$expectedUrl.'].'
+        );
+
+        return $this;
+    }
+
+    /**
+     * Assert that the given route URL is the current request URL..
+     *
+     * @param  string  $route
+     * @return $this
+     */
+    public function assertRouteIs(string $route)
+    {
+        return $this->assertUrlIs($this->app['url']->route($route));
+    }
+
+    /**
+     * Get the current request URL.
+     *
+     * @return string
+     */
+    public function getCurrentUrl()
+    {
+         return $this->app['url']->current();
+    }
+}

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithResponse.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithResponse.php
@@ -34,7 +34,7 @@ trait InteractsWithResponse
     }
 
     /**
-     * Assert that the given route URL is the current request URL..
+     * Assert that the given route URL is the current request URL.
      *
      * @param  string  $route
      * @return $this

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -21,7 +21,7 @@ abstract class TestCase extends BaseTestCase
         Concerns\InteractsWithConsole,
         Concerns\InteractsWithDatabase,
         Concerns\InteractsWithExceptionHandling,
-        Concerns\InteractsWithResponse,
+        Concerns\InteractsWithRequest,
         Concerns\InteractsWithSession,
         Concerns\InteractsWithTime,
         Concerns\InteractsWithViews,

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -21,6 +21,7 @@ abstract class TestCase extends BaseTestCase
         Concerns\InteractsWithConsole,
         Concerns\InteractsWithDatabase,
         Concerns\InteractsWithExceptionHandling,
+        Concerns\InteractsWithResponse,
         Concerns\InteractsWithSession,
         Concerns\InteractsWithTime,
         Concerns\InteractsWithViews,


### PR DESCRIPTION
This PR adds a method that allows us to assert the current URL. is a given URL. It's been on my helpers for awhile — I use it specially when following redirects —, and I think it might be useful to other people.

There are no breaking changes. 