### PR TITLE
[8.x] Add lcfirst (Make a string's first character lowercase)

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -723,6 +723,17 @@ class Str
     }
 
     /**
+     * Make a string's first character lowercase.
+     *
+     * @param  string  $string
+     * @return string
+     */
+    public static function lcfirst($string)
+    {
+        return static::lower(static::substr($string, 0, 1)).static::substr($string, 1);
+    }
+
+    /**
      * Generate a UUID (version 4).
      *
      * @return \Ramsey\Uuid\UuidInterface


### PR DESCRIPTION
Converts the first character of a string to lowercase.
The standard PHP function "lcfirst ()" does not work with Cyrillic.
For example, so that the lines "Купить телевизор" are converted to "купить телевизор", respectively.
