### PR TITLE
[8.x] Fixing that Broadcast::socket() is not defined.

### DIFF
--- a/src/Illuminate/Support/Facades/Broadcast.php
+++ b/src/Illuminate/Support/Facades/Broadcast.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Broadcasting\Factory as BroadcastingFactoryContract;
  * @method static mixed auth(\Illuminate\Http\Request $request)
  * @method static void connection($name = null);
  * @method static void routes(array $attributes = null)
+ * @method static \Illuminate\Broadcasting\BroadcastManager socket($request = null)
  *
  * @see \Illuminate\Contracts\Broadcasting\Factory
  */


### PR DESCRIPTION
In InteractsWithSockets file Broadcaster::socket () is not a self function. The facade file has been defined and corrected.
