### PR TITLE
[8.x] Reference to same type and not same instance

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -244,7 +244,7 @@ class Builder
     /**
      * Add a subselect expression to the query.
      *
-     * @param  \Closure|$this|string  $query
+     * @param  \Closure|\Illuminate\Database\Query\Builder|string  $query
      * @param  string  $as
      * @return $this
      *


### PR DESCRIPTION
When try execute PSALM with `Illuminate\Database\Query\Builder::selectSub`, I have an error:

`Argument 1 of Illuminate\Database\Query\Builder::selectSub expects Closure|Illuminate\Database\Query\Builder&static|string, parent type Illuminate\Database\Query\Builder provided`

It's because use `$this`, check if the value is same instance and not aonly is the same type.

See: https://github.com/php-fig/fig-standards/blob/master/proposed/phpdoc.md#appendix-a-types

Wee can use `self` but how other methods use class signature I kept that pattern.