### PR TITLE
[8.x] Model::encryptUsing()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -124,6 +124,13 @@ trait HasAttributes
     protected static $mutatorCache = [];
 
     /**
+     * The encryptor instance that is used to encrypt attributes.
+     *
+     * @var \Illuminate\Contracts\Encryption\Encrypter
+     */
+    public static $encryptor;
+
+    /**
      * Convert the model's attributes to an array.
      *
      * @return array
@@ -883,15 +890,14 @@ trait HasAttributes
     }
 
     /**
-     * Decode the given encrypted string.
+     * Decrypt the given encrypted string.
      *
      * @param  string  $value
-     * @param  bool  $asObject
      * @return mixed
      */
     public function fromEncryptedString($value)
     {
-        return Crypt::decryptString($value);
+        return (static::$encryptor ?? Crypt::getFacadeRoot())->decrypt($value, false);
     }
 
     /**
@@ -903,7 +909,18 @@ trait HasAttributes
      */
     protected function castAttributeAsEncryptedString($key, $value)
     {
-        return Crypt::encryptString($value);
+        return (static::$encryptor ?? Crypt::getFacadeRoot())->encrypt($value, false);
+    }
+
+    /**
+     * Set the encryptor instance that will be used to encrypt attributes.
+     *
+     * @param  \Illuminate\Contracts\Encryption\Encrypter  $encryptor
+     * @return void
+     */
+    public static function encryptUsing($encryptor)
+    {
+        static::$encryptor = $encryptor;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -128,7 +128,7 @@ trait HasAttributes
      *
      * @var \Illuminate\Contracts\Encryption\Encrypter
      */
-    public static $encryptor;
+    public static $encrypter;
 
     /**
      * Convert the model's attributes to an array.
@@ -897,7 +897,7 @@ trait HasAttributes
      */
     public function fromEncryptedString($value)
     {
-        return (static::$encryptor ?? Crypt::getFacadeRoot())->decrypt($value, false);
+        return (static::$encrypter ?? Crypt::getFacadeRoot())->decrypt($value, false);
     }
 
     /**
@@ -909,18 +909,18 @@ trait HasAttributes
      */
     protected function castAttributeAsEncryptedString($key, $value)
     {
-        return (static::$encryptor ?? Crypt::getFacadeRoot())->encrypt($value, false);
+        return (static::$encrypter ?? Crypt::getFacadeRoot())->encrypt($value, false);
     }
 
     /**
      * Set the encryptor instance that will be used to encrypt attributes.
      *
-     * @param  \Illuminate\Contracts\Encryption\Encrypter  $encryptor
+     * @param  \Illuminate\Contracts\Encryption\Encrypter  $encrypter
      * @return void
      */
-    public static function encryptUsing($encryptor)
+    public static function encryptUsing($encrypter)
     {
-        static::$encryptor = $encryptor;
+        static::$encrypter = $encrypter;
     }
 
     /**

--- a/tests/Integration/Database/EloquentModelEncryptedCastingTest.php
+++ b/tests/Integration/Database/EloquentModelEncryptedCastingTest.php
@@ -151,11 +151,11 @@ class EloquentModelEncryptedCastingTest extends DatabaseTestCase
     {
         $customEncrypter = $this->mock(Encrypter::class);
 
-        $this->assertNull(Model::$encryptor);
+        $this->assertNull(Model::$encrypter);
 
         Model::encryptUsing($customEncrypter);
 
-        $this->assertSame($customEncrypter, Model::$encryptor);
+        $this->assertSame($customEncrypter, Model::$encrypter);
 
         $this->encrypter->expects('encrypt')
             ->never();

--- a/tests/Integration/Database/EloquentModelEncryptedCastingTest.php
+++ b/tests/Integration/Database/EloquentModelEncryptedCastingTest.php
@@ -147,7 +147,7 @@ class EloquentModelEncryptedCastingTest extends DatabaseTestCase
         ]);
     }
 
-    public function testCustomEncryptorCanBeSpecified()
+    public function testCustomEncrypterCanBeSpecified()
     {
         $customEncrypter = $this->mock(Encrypter::class);
 

--- a/tests/Integration/Database/EloquentModelEncryptedCastingTest.php
+++ b/tests/Integration/Database/EloquentModelEncryptedCastingTest.php
@@ -31,15 +31,17 @@ class EloquentModelEncryptedCastingTest extends DatabaseTestCase
             $table->text('secret_object')->nullable();
             $table->text('secret_collection')->nullable();
         });
+
+        Model::$encryptor = null;
     }
 
     public function testStringsAreCastable()
     {
-        $this->encrypter->expects('encryptString')
-            ->with('this is a secret string')
+        $this->encrypter->expects('encrypt')
+            ->with('this is a secret string', false)
             ->andReturn('encrypted-secret-string');
-        $this->encrypter->expects('decryptString')
-            ->with('encrypted-secret-string')
+        $this->encrypter->expects('decrypt')
+            ->with('encrypted-secret-string', false)
             ->andReturn('this is a secret string');
 
         /** @var \Illuminate\Tests\Integration\Database\EncryptedCast $subject */
@@ -56,11 +58,11 @@ class EloquentModelEncryptedCastingTest extends DatabaseTestCase
 
     public function testArraysAreCastable()
     {
-        $this->encrypter->expects('encryptString')
-            ->with('{"key1":"value1"}')
+        $this->encrypter->expects('encrypt')
+            ->with('{"key1":"value1"}', false)
             ->andReturn('encrypted-secret-array-string');
-        $this->encrypter->expects('decryptString')
-            ->with('encrypted-secret-array-string')
+        $this->encrypter->expects('decrypt')
+            ->with('encrypted-secret-array-string', false)
             ->andReturn('{"key1":"value1"}');
 
         /** @var \Illuminate\Tests\Integration\Database\EncryptedCast $subject */
@@ -77,11 +79,11 @@ class EloquentModelEncryptedCastingTest extends DatabaseTestCase
 
     public function testJsonIsCastable()
     {
-        $this->encrypter->expects('encryptString')
-            ->with('{"key1":"value1"}')
+        $this->encrypter->expects('encrypt')
+            ->with('{"key1":"value1"}', false)
             ->andReturn('encrypted-secret-json-string');
-        $this->encrypter->expects('decryptString')
-            ->with('encrypted-secret-json-string')
+        $this->encrypter->expects('decrypt')
+            ->with('encrypted-secret-json-string', false)
             ->andReturn('{"key1":"value1"}');
 
         /** @var \Illuminate\Tests\Integration\Database\EncryptedCast $subject */
@@ -101,12 +103,12 @@ class EloquentModelEncryptedCastingTest extends DatabaseTestCase
         $object = new \stdClass();
         $object->key1 = 'value1';
 
-        $this->encrypter->expects('encryptString')
-            ->with('{"key1":"value1"}')
+        $this->encrypter->expects('encrypt')
+            ->with('{"key1":"value1"}', false)
             ->andReturn('encrypted-secret-object-string');
-        $this->encrypter->expects('decryptString')
+        $this->encrypter->expects('decrypt')
             ->twice()
-            ->with('encrypted-secret-object-string')
+            ->with('encrypted-secret-object-string', false)
             ->andReturn('{"key1":"value1"}');
 
         /** @var \Illuminate\Tests\Integration\Database\EncryptedCast $object */
@@ -124,12 +126,12 @@ class EloquentModelEncryptedCastingTest extends DatabaseTestCase
 
     public function testCollectionIsCastable()
     {
-        $this->encrypter->expects('encryptString')
-            ->with('{"key1":"value1"}')
+        $this->encrypter->expects('encrypt')
+            ->with('{"key1":"value1"}', false)
             ->andReturn('encrypted-secret-collection-string');
-        $this->encrypter->expects('decryptString')
+        $this->encrypter->expects('decrypt')
             ->twice()
-            ->with('encrypted-secret-collection-string')
+            ->with('encrypted-secret-collection-string', false)
             ->andReturn('{"key1":"value1"}');
 
         /** @var \Illuminate\Tests\Integration\Database\EncryptedCast $subject */
@@ -142,6 +144,39 @@ class EloquentModelEncryptedCastingTest extends DatabaseTestCase
         $this->assertDatabaseHas('encrypted_casts', [
             'id' => $subject->id,
             'secret_collection' => 'encrypted-secret-collection-string',
+        ]);
+    }
+
+    public function testCustomEncryptorCanBeSpecified()
+    {
+        $customEncrypter = $this->mock(Encrypter::class);
+
+        $this->assertNull(Model::$encryptor);
+
+        Model::encryptUsing($customEncrypter);
+
+        $this->assertSame($customEncrypter, Model::$encryptor);
+
+        $this->encrypter->expects('encrypt')
+            ->never();
+        $this->encrypter->expects('decrypt')
+            ->never();
+        $customEncrypter->expects('encrypt')
+            ->with('this is a secret string', false)
+            ->andReturn('encrypted-secret-string');
+        $customEncrypter->expects('decrypt')
+            ->with('encrypted-secret-string', false)
+            ->andReturn('this is a secret string');
+
+        /** @var \Illuminate\Tests\Integration\Database\EncryptedCast $subject */
+        $subject = EncryptedCast::create([
+            'secret' => 'this is a secret string',
+        ]);
+
+        $this->assertSame('this is a secret string', $subject->secret);
+        $this->assertDatabaseHas('encrypted_casts', [
+            'id' => $subject->id,
+            'secret' => 'encrypted-secret-string',
         ]);
     }
 }


### PR DESCRIPTION
`encrypted` casts have been added to Laravel recently. While this feature is extremely useful, sometimes developers may want to use the separate key to encrypt database values. Currently, that's not possible. However, this PR introduces this ability by adding `Model::encryptUsing()` method that accepts encrypter instance that will be used to perform encryption-related casts.

The most typical use of this would be a similar piece of code in `AppServiceProvider` or in a separate service provider:

```php
use Illuminate\Database\Eloquent\Model;
use Illuminate\Encryption\Encrypter;

$databaseEncryptionKey = config('database.encryption_key');

$encrypter = new Encrypter($databaseEncryptionKey);

Model::encryptUsing($encrypter);
```