### PR TITLE
[8.x] Model::encryptUsing()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -124,6 +124,13 @@ trait HasAttributes
     protected static $mutatorCache = [];
 
     /**
+     * The encrypter instance that is used to encrypt attributes.
+     *
+     * @var \Illuminate\Contracts\Encryption\Encrypter
+     */
+    public static $encrypter;
+
+    /**
      * Convert the model's attributes to an array.
      *
      * @return array
@@ -883,15 +890,14 @@ trait HasAttributes
     }
 
     /**
-     * Decode the given encrypted string.
+     * Decrypt the given encrypted string.
      *
      * @param  string  $value
-     * @param  bool  $asObject
      * @return mixed
      */
     public function fromEncryptedString($value)
     {
-        return Crypt::decryptString($value);
+        return (static::$encrypter ?? Crypt::getFacadeRoot())->decrypt($value, false);
     }
 
     /**
@@ -903,7 +909,18 @@ trait HasAttributes
      */
     protected function castAttributeAsEncryptedString($key, $value)
     {
-        return Crypt::encryptString($value);
+        return (static::$encrypter ?? Crypt::getFacadeRoot())->encrypt($value, false);
+    }
+
+    /**
+     * Set the encrypter instance that will be used to encrypt attributes.
+     *
+     * @param  \Illuminate\Contracts\Encryption\Encrypter  $encrypter
+     * @return void
+     */
+    public static function encryptUsing($encrypter)
+    {
+        static::$encrypter = $encrypter;
     }
 
     /**


### PR DESCRIPTION
`encrypted` casts have been added to Laravel recently. While this feature is extremely useful, sometimes developers may want to use the separate key to encrypt database values. Currently, that's not possible. However, this PR introduces this ability by adding `Model::encryptUsing()` method that accepts encrypter instance that will be used to perform encryption-related casts.

The most typical use of this would be a similar piece of code in `AppServiceProvider` or in a separate service provider:

```php
use Illuminate\Database\Eloquent\Model;
use Illuminate\Encryption\Encrypter;

$databaseEncryptionKey = config('database.encryption_key');

$encrypter = new Encrypter($databaseEncryptionKey);

Model::encryptUsing($encrypter);
```