### PR TITLE
[8.x] Added support to MySQL dump and import using socket

### DIFF
--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -138,7 +138,7 @@ class MySqlSchemaState extends SchemaState
     }
 
     /**
-     * Generate a common connection string (--socket, --host, --port, --user, --password)
+     * Generate a common connection string (--socket, --host, --port, --user, --password).
      *
      * @return string
      */

--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -83,7 +83,13 @@ class MySqlSchemaState extends SchemaState
      */
     protected function baseDumpCommand()
     {
-        return 'mysqldump '.$this->connectionString().' --skip-add-drop-table --skip-add-locks --skip-comments --skip-set-charset --tz-utc "${:LARAVEL_LOAD_DATABASE}"';
+        $cmd = 'mysqldump '.$this->connectionString().' --skip-add-locks --skip-comments --skip-set-charset --tz-utc';
+
+        if ($this->connection->isMaria()) {
+            $cmd .= ' --column-statistics=0 --set-gtid-purged=OFF';
+        }
+
+        return $cmd.' "${:LARAVEL_LOAD_DATABASE}"';
     }
 
     /**


### PR DESCRIPTION
If your MySQL server only allow socket as connection (`skip-networking`) you can not dump or import the `database/schema/mysql-schema.dump` file.

This PR check the `DB_SOCKET` value to generate the `mysql`/`mysqldump` command string with `--socket` instead `--host` and `--port`.

I haven't found any test about `schema:dump` artisan command. Checked on local and servers with MySQL 8 with the different `.env` `DB_` configurations and enabling or disabling network connections on database server.