### PR TITLE
[8.x] Remove overridden methods with exact same parent

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -132,14 +132,4 @@ class MigrateMakeCommand extends BaseCommand
 
         return parent::getMigrationPath();
     }
-
-    /**
-     * Determine if the given path(s) are pre-resolved "real" paths.
-     *
-     * @return bool
-     */
-    protected function usingRealPath()
-    {
-        return $this->input->hasOption('realpath') && $this->option('realpath');
-    }
 }

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -240,16 +240,6 @@ class MorphTo extends BelongsTo
     }
 
     /**
-     * Alias for the "dissociate" method.
-     *
-     * @return \Illuminate\Database\Eloquent\Model
-     */
-    public function disassociate()
-    {
-        return $this->dissociate();
-    }
-
-    /**
      * Touch all of the related models for the relationship.
      *
      * @return void


### PR DESCRIPTION
Removes 2 overriden class methods where the overridden code is exactly the same, with no visibility, parameter, or return type differences.

 - `\Illuminate\Database\Console\Migrations\MigrateMakeCommand::usingRealPath` is identical to the parent `\Illuminate\Database\Console\Migrations\BaseCommand::usingRealPath`.
 - `\Illuminate\Database\Eloquent\Relations\MorphTo::disassociate` is identical to the parent `\Illuminate\Database\Eloquent\Relations\BelongsTo::disassociate`.

Similar code in fakes or mixins are not removed.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
