### PR TITLE
[8.x] Fix typo $dispatcher

### DIFF
--- a/src/Illuminate/Events/NullDispatcher.php
+++ b/src/Illuminate/Events/NullDispatcher.php
@@ -12,7 +12,7 @@ class NullDispatcher implements DispatcherContract
     /**
      * The underlying event dispatcher instance.
      *
-     * @var \Illuminate\Contracts\Bus\Dispatcher
+     * @var \Illuminate\Contracts\Events\Dispatcher
      */
     protected $dispatcher;
 


### PR DESCRIPTION
The event dispatcher should look like this.  You can reference lines 20 and 25.

- `\Illuminate\Contracts\Events\Dispatcher`