### PR TITLE
[8.x] Add closure to exception reporting

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -260,11 +260,19 @@ class Handler implements ExceptionHandlerContract
      */
     protected function shouldntReport(Throwable $e)
     {
-        $dontReport = collect($this->internalDontReport)
-            ->mapWithKeys(function ($type) {
-                return [$type => true];
-            })
-            ->merge($this->dontReport);
+        $dontReport = collect($this->dontReport)
+            ->mapWithKeys(function ($value, $key) {
+                return is_numeric($key)
+                    ? [$value => true]
+                    : [$key => $value];
+            });
+
+        $dontReport = $dontReport->merge(
+            collect($this->internalDontReport)
+                ->mapWithKeys(function ($type) {
+                    return [$type => true];
+                })
+        );
 
         return ! is_null($dontReport->first(function ($closure, $type) use ($e) {
             return $e instanceof $type && (

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -185,11 +185,12 @@ class Handler implements ExceptionHandlerContract
      * Indicate that the given exception type should not be reported.
      *
      * @param  string  $class
+     * @param  \Closure|null  $closure
      * @return $this
      */
-    protected function ignore(string $class)
+    protected function ignore(string $class, Closure $closure = null)
     {
-        $this->dontReport[] = $class;
+        $this->dontReport[$class] = $closure ?? true;
 
         return $this;
     }
@@ -259,10 +260,17 @@ class Handler implements ExceptionHandlerContract
      */
     protected function shouldntReport(Throwable $e)
     {
-        $dontReport = array_merge($this->dontReport, $this->internalDontReport);
+        $dontReport = collect($this->internalDontReport)
+            ->mapWithKeys(function ($type) {
+                return [$type => true];
+            })
+            ->merge($this->dontReport);
 
-        return ! is_null(Arr::first($dontReport, function ($type) use ($e) {
-            return $e instanceof $type;
+        return ! is_null($dontReport->first(function ($closure, $type) use ($e) {
+            return $e instanceof $type && (
+                $closure instanceof Closure
+                    ? $closure($e) : $closure
+            );
         }));
     }
 

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Tests\Foundation;
 
 use Exception;
-use LogicException;
 use Illuminate\Config\Repository as Config;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Routing\ResponseFactory as ResponseFactoryContract;
@@ -15,9 +14,11 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Redirector;
 use Illuminate\Routing\ResponseFactory;
 use Illuminate\Support\MessageBag;
+use Illuminate\Tests\Foundation\Testing\BackwardsCompatibleExceptionHandlerTest;
 use Illuminate\Tests\Foundation\Testing\ExceptionHandlerTest;
 use Illuminate\Validation\ValidationException;
 use Illuminate\Validation\Validator;
+use LogicException;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -28,7 +29,6 @@ use Symfony\Component\HttpFoundation\Exception\SuspiciousOperationException;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
-use Illuminate\Tests\Foundation\Testing\BackwardsCompatibleExceptionHandlerTest;
 
 class FoundationExceptionsHandlerTest extends TestCase
 {

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -26,6 +26,7 @@ use Symfony\Component\HttpFoundation\Exception\SuspiciousOperationException;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
+use Illuminate\Tests\Foundation\Testing\ExceptionHandlerTest;
 
 class FoundationExceptionsHandlerTest extends TestCase
 {
@@ -64,6 +65,28 @@ class FoundationExceptionsHandlerTest extends TestCase
     protected function tearDown(): void
     {
         Container::setInstance(null);
+    }
+
+    public function testHandlerDoesntReportExceptionWithTruthyClosure()
+    {
+        $logger = m::mock(LoggerInterface::class);
+        $this->container->instance(LoggerInterface::class, $logger);
+        $logger->shouldNotReceive('error');
+
+        $handler = new ExceptionHandlerTest($this->container);
+
+        $handler->report(new RuntimeException('Exception message', 429));
+    }
+
+    public function testHandlerDoesReportExceptionWithFalseyClosure()
+    {
+        $logger = m::mock(LoggerInterface::class);
+        $this->container->instance(LoggerInterface::class, $logger);
+        $logger->shouldReceive('error');
+
+        $handler = new ExceptionHandlerTest($this->container);
+
+        $handler->report(new RuntimeException('Exception message', 400));
     }
 
     public function testHandlerReportsExceptionAsContext()

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -14,6 +14,7 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Redirector;
 use Illuminate\Routing\ResponseFactory;
 use Illuminate\Support\MessageBag;
+use Illuminate\Tests\Foundation\Testing\ExceptionHandlerTest;
 use Illuminate\Validation\ValidationException;
 use Illuminate\Validation\Validator;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
@@ -26,7 +27,6 @@ use Symfony\Component\HttpFoundation\Exception\SuspiciousOperationException;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
-use Illuminate\Tests\Foundation\Testing\ExceptionHandlerTest;
 
 class FoundationExceptionsHandlerTest extends TestCase
 {

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Foundation;
 
 use Exception;
+use LogicException;
 use Illuminate\Config\Repository as Config;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Routing\ResponseFactory as ResponseFactoryContract;
@@ -27,6 +28,7 @@ use Symfony\Component\HttpFoundation\Exception\SuspiciousOperationException;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
+use Illuminate\Tests\Foundation\Testing\BackwardsCompatibleExceptionHandlerTest;
 
 class FoundationExceptionsHandlerTest extends TestCase
 {
@@ -87,6 +89,28 @@ class FoundationExceptionsHandlerTest extends TestCase
         $handler = new ExceptionHandlerTest($this->container);
 
         $handler->report(new RuntimeException('Exception message', 400));
+    }
+
+    public function testHandlerDoesntReportExceptionWithNonAssociativeDontReportsProperty()
+    {
+        $logger = m::mock(LoggerInterface::class);
+        $this->container->instance(LoggerInterface::class, $logger);
+        $logger->shouldNotReceive('error');
+
+        $handler = new BackwardsCompatibleExceptionHandlerTest($this->container);
+
+        $handler->report(new RuntimeException('Exception message'));
+    }
+
+    public function testHandlerDoesReportExceptionWithNonAssociativeDontReportsProperty()
+    {
+        $logger = m::mock(LoggerInterface::class);
+        $this->container->instance(LoggerInterface::class, $logger);
+        $logger->shouldReceive('error');
+
+        $handler = new BackwardsCompatibleExceptionHandlerTest($this->container);
+
+        $handler->report(new LogicException('Exception message'));
     }
 
     public function testHandlerReportsExceptionAsContext()

--- a/tests/Foundation/Testing/BackwardsCompatibleExceptionHandlerTest.php
+++ b/tests/Foundation/Testing/BackwardsCompatibleExceptionHandlerTest.php
@@ -3,8 +3,8 @@
 namespace Illuminate\Tests\Foundation\Testing;
 
 use Illuminate\Foundation\Exceptions\Handler;
-use RuntimeException;
 use LogicException;
+use RuntimeException;
 
 class BackwardsCompatibleExceptionHandlerTest extends Handler
 {

--- a/tests/Foundation/Testing/BackwardsCompatibleExceptionHandlerTest.php
+++ b/tests/Foundation/Testing/BackwardsCompatibleExceptionHandlerTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Testing;
+
+use Illuminate\Foundation\Exceptions\Handler;
+use RuntimeException;
+use LogicException;
+
+class BackwardsCompatibleExceptionHandlerTest extends Handler
+{
+    protected $dontReport = [
+        RuntimeException::class,
+        LogicException::class => false,
+    ];
+}

--- a/tests/Foundation/Testing/ExceptionHandlerTest.php
+++ b/tests/Foundation/Testing/ExceptionHandlerTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Testing;
+
+use RuntimeException;
+use Illuminate\Foundation\Exceptions\Handler;
+
+class ExceptionHandlerTest extends Handler
+{
+    public function register()
+    {
+        $this->ignore(RuntimeException::class, function (RuntimeException $exception) {
+            return $exception->getCode() === 429;
+        });
+    }
+}

--- a/tests/Foundation/Testing/ExceptionHandlerTest.php
+++ b/tests/Foundation/Testing/ExceptionHandlerTest.php
@@ -2,15 +2,15 @@
 
 namespace Illuminate\Tests\Foundation\Testing;
 
-use RuntimeException;
 use Illuminate\Foundation\Exceptions\Handler;
+use RuntimeException;
 
 class ExceptionHandlerTest extends Handler
 {
-    public function register()
-    {
-        $this->ignore(RuntimeException::class, function (RuntimeException $exception) {
-            return $exception->getCode() === 429;
-        });
-    }
+public function register()
+{
+    $this->ignore(RuntimeException::class, function (RuntimeException $exception) {
+        return $exception->getCode() === 429;
+    });
+}
 }

--- a/tests/Foundation/Testing/ExceptionHandlerTest.php
+++ b/tests/Foundation/Testing/ExceptionHandlerTest.php
@@ -7,10 +7,10 @@ use RuntimeException;
 
 class ExceptionHandlerTest extends Handler
 {
-public function register()
-{
-    $this->ignore(RuntimeException::class, function (RuntimeException $exception) {
-        return $exception->getCode() === 429;
-    });
-}
+    public function register()
+    {
+        $this->ignore(RuntimeException::class, function (RuntimeException $exception) {
+            return $exception->getCode() === 429;
+        });
+    }
 }


### PR DESCRIPTION
This PR adds the ability to pass a closure to the `ignore()` method in the exception handler, in order to decide whether to report the exception at runtime. This is particularly useful when some exceptions provided by SDKs aren't specific and you need to dig a bit deeper into the exception itself to determine if it should be reported. For example if you get an `Aws\Ses\Exception\SesException` you may decide to not report it if it's to do with rate limiting.

This PR changes the `$dontReport` property to an associative array which could be a breaking change if any users are relying on this. This feature could be added in a backwards compatible way of course, but I'm submitting it as-is to see if there is interest in adding this to the framework - and if so - I can amend the PR to be backwards compatible.

This new functionality can be used in the `register()` method of the exception handler:
```php
public function register()
{
    $this->ignore(FooException::class, function (FooException $exception) {
        return $exception->getCode() === 429;
    });
}
```