### PR TITLE
[8.x] Move dispatching of DatabaseRefreshed event to fire before seeders are run

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/FreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/FreshCommand.php
@@ -55,14 +55,14 @@ class FreshCommand extends Command
             '--step' => $this->option('step'),
         ]));
 
-        if ($this->needsSeeding()) {
-            $this->runSeeder($database);
-        }
-
         if ($this->laravel->bound(Dispatcher::class)) {
             $this->laravel[Dispatcher::class]->dispatch(
                 new DatabaseRefreshed
             );
+        }
+
+        if ($this->needsSeeding()) {
+            $this->runSeeder($database);
         }
 
         return 0;

--- a/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
@@ -65,14 +65,14 @@ class RefreshCommand extends Command
             '--force' => true,
         ]));
 
-        if ($this->needsSeeding()) {
-            $this->runSeeder($database);
-        }
-
         if ($this->laravel->bound(Dispatcher::class)) {
             $this->laravel[Dispatcher::class]->dispatch(
                 new DatabaseRefreshed
             );
+        }
+
+        if ($this->needsSeeding()) {
+            $this->runSeeder($database);
         }
 
         return 0;


### PR DESCRIPTION
This is a small patch based of the nice work done in #34952.

The `DatabaseRefreshed` event is very handy in terms of triggering maintenance tasks etc. after running `migrate:fresh` or `migrate:refresh`, but right now there is a difference in behaviour depending on if you run `artisan migrate:fresh --seed` or `artisan migrate:fresh && artisan db:seed`. This PR just moves the dispatching so it is done before the seeding.

Tests from #34952 should still apply here.