### PR TITLE
[8.x] Fixing doc for exceptions.

### DIFF
--- a/src/Illuminate/Cache/DatabaseLock.php
+++ b/src/Illuminate/Cache/DatabaseLock.php
@@ -53,6 +53,8 @@ class DatabaseLock extends Lock
      * Attempt to acquire the lock.
      *
      * @return bool
+     *
+     * @throws QueryException
      */
     public function acquire()
     {

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -114,6 +114,8 @@ class DatabaseStore implements LockProvider, Store
      * @param  mixed  $value
      * @param  int  $seconds
      * @return bool
+     *
+     * @throws \Exception
      */
     public function put($key, $value, $seconds)
     {
@@ -137,6 +139,8 @@ class DatabaseStore implements LockProvider, Store
      * @param  mixed  $value
      * @param  int  $seconds
      * @return bool
+     *
+     * @throws QueryException
      */
     public function add($key, $value, $seconds)
     {

--- a/src/Illuminate/Cache/DynamoDbStore.php
+++ b/src/Illuminate/Cache/DynamoDbStore.php
@@ -253,6 +253,8 @@ class DynamoDbStore implements LockProvider, Store
      * @param  mixed  $value
      * @param  int  $seconds
      * @return bool
+     *
+     * @throws DynamoDbException
      */
     public function add($key, $value, $seconds)
     {
@@ -298,6 +300,8 @@ class DynamoDbStore implements LockProvider, Store
      * @param  string  $key
      * @param  mixed  $value
      * @return int|bool
+     *
+     * @throws DynamoDbException
      */
     public function increment($key, $value = 1)
     {
@@ -343,6 +347,8 @@ class DynamoDbStore implements LockProvider, Store
      * @param  string  $key
      * @param  mixed  $value
      * @return int|bool
+     *
+     * @throws DynamoDbException
      */
     public function decrement($key, $value = 1)
     {

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -194,6 +194,8 @@ class FileStore implements Store
      *
      * @param  string  $key
      * @return array
+     *
+     * @throws \Exception
      */
     protected function getPayload($key)
     {


### PR DESCRIPTION
The following files in the cache package are also :

- `Illuminate\Cache\DatabaseLock.php`
- `Illuminate\Cache\DatabaseStore.php`
- `Illuminate\Cache\DynamoDbStore.php`
- `Illuminate\Cache\FileStore.php`
