### PR TITLE
[8.x] Outsource mail content creation to separate methods

### DIFF
--- a/src/Illuminate/Auth/Notifications/ResetPassword.php
+++ b/src/Illuminate/Auth/Notifications/ResetPassword.php
@@ -72,6 +72,17 @@ class ResetPassword extends Notification
             ], false));
         }
 
+        return $this->getMailMessage($url);
+    }
+
+    /**
+     * Get the actual contents for the notification.
+     *
+     * @param string $url
+     * @return \Illuminate\Notifications\Messages\MailMessage
+     */
+    protected function getMailMessage($url)
+    {
         return (new MailMessage)
             ->subject(Lang::get('Reset Password Notification'))
             ->line(Lang::get('You are receiving this email because we received a password reset request for your account.'))

--- a/src/Illuminate/Auth/Notifications/VerifyEmail.php
+++ b/src/Illuminate/Auth/Notifications/VerifyEmail.php
@@ -50,6 +50,17 @@ class VerifyEmail extends Notification
             return call_user_func(static::$toMailCallback, $notifiable, $verificationUrl);
         }
 
+        return $this->getMailMessage($verificationUrl);
+    }
+
+    /**
+     * Get the actual contents for the notification.
+     *
+     * @param string $verificationUrl
+     * @return \Illuminate\Notifications\Messages\MailMessage
+     */
+    protected function getMailMessage($verificationUrl)
+    {
         return (new MailMessage)
             ->subject(Lang::get('Verify Email Address'))
             ->line(Lang::get('Please click the button below to verify your email address.'))


### PR DESCRIPTION
Developers might want to change the contents of the VerifyEmail and the ResetPassword mail notifications. To do so, currently they need to override the whole `toMail($notifiable)` method in `Illuminate\Auth\Notifications\ResetPassword`/`VerifyEmail` which also contains logic to e.g. create URLs.

This PR moves the content creation part of the `toMail()` methods to separate `getMailMessage()` methods so that only these methods need to be overridden:

```
class MyOwnResetPasswordNotification extends \Illuminate\Auth\Notifications\ResetPassword
{
    protected function getMailMessage($url)
    {
        return (new MailMessage)
            ->subject(Lang::get('Reset Password Notification'))
            ->line(Lang::get('You are receiving this email because we received a password reset request for your account.'))
            ->line(Lang::get('WHY NOT ADD ANOTHER LINE HERE?!'))
            ->action(Lang::get('Reset Password'), $url)
            ->line(Lang::get('This password reset link will expire in :count minutes.', ['count' => config('auth.passwords.'.config('auth.defaults.passwords').'.expire')]))
            ->line(Lang::get('WHY NOT ANOTHER ONE HERE?!'))
            ->line(Lang::get('If you did not request a password reset, no further action is required.'));
    }
}
```

Also if the logic of the `toMail()` methods is changed in future Laravel releases the developer's code doesn't break without him noticing.