### PR TITLE
[8.x] RateLimited or RateLimitedWithRedis formatting fixing.

### DIFF
--- a/src/Illuminate/Queue/Middleware/RateLimited.php
+++ b/src/Illuminate/Queue/Middleware/RateLimited.php
@@ -88,7 +88,7 @@ class RateLimited
         foreach ($limits as $limit) {
             if ($this->limiter->tooManyAttempts($limit->key, $limit->maxAttempts)) {
                 return $this->shouldRelease
-                    ?: $job->release($this->getTimeUntilNextRetry($limit->key));
+                    ? $job->release($this->getTimeUntilNextRetry($limit->key));
             }
 
             $this->limiter->hit($limit->key, $limit->decayMinutes * 60);

--- a/src/Illuminate/Queue/Middleware/RateLimited.php
+++ b/src/Illuminate/Queue/Middleware/RateLimited.php
@@ -28,7 +28,7 @@ class RateLimited
      *
      * @var bool
      */
-    public $shouldRelease = true;
+    public $shouldRelease;
 
     /**
      * Create a new middleware instance.
@@ -88,8 +88,7 @@ class RateLimited
         foreach ($limits as $limit) {
             if ($this->limiter->tooManyAttempts($limit->key, $limit->maxAttempts)) {
                 return $this->shouldRelease
-                        ? $job->release($this->getTimeUntilNextRetry($limit->key))
-                        : false;
+                    ?: $job->release($this->getTimeUntilNextRetry($limit->key));
             }
 
             $this->limiter->hit($limit->key, $limit->decayMinutes * 60);

--- a/src/Illuminate/Queue/Middleware/RateLimitedWithRedis.php
+++ b/src/Illuminate/Queue/Middleware/RateLimitedWithRedis.php
@@ -51,7 +51,7 @@ class RateLimitedWithRedis extends RateLimited
         foreach ($limits as $limit) {
             if ($this->tooManyAttempts($limit->key, $limit->maxAttempts, $limit->decayMinutes)) {
                 return $this->shouldRelease
-                    ?: $job->release($this->getTimeUntilNextRetry($limit->key));
+                    ? $job->release($this->getTimeUntilNextRetry($limit->key));
             }
         }
 

--- a/src/Illuminate/Queue/Middleware/RateLimitedWithRedis.php
+++ b/src/Illuminate/Queue/Middleware/RateLimitedWithRedis.php
@@ -51,8 +51,7 @@ class RateLimitedWithRedis extends RateLimited
         foreach ($limits as $limit) {
             if ($this->tooManyAttempts($limit->key, $limit->maxAttempts, $limit->decayMinutes)) {
                 return $this->shouldRelease
-                    ? $job->release($this->getTimeUntilNextRetry($limit->key))
-                    : false;
+                    ?: $job->release($this->getTimeUntilNextRetry($limit->key));
             }
         }
 


### PR DESCRIPTION
There is no need to specify a default value with this PR. 

- If shouldRelease comes blank, there is no limit anyway.
- If "dontRelease()" is added, it returns false and the job is removed from the queue.


