### PR TITLE
[8.x] Add failing test for decrypting an array cookie with encrypted values

### DIFF
--- a/tests/Cookie/Middleware/EncryptCookiesTest.php
+++ b/tests/Cookie/Middleware/EncryptCookiesTest.php
@@ -110,11 +110,6 @@ class EncryptCookiesTestController extends Controller
     {
         return new Response;
     }
-
-    public function decryptCookies()
-    {
-        return new Response;
-    }
 }
 
 class EncryptCookiesTestMiddleware extends EncryptCookies


### PR DESCRIPTION
I added a test that shows that when you have an array cookie that contains an encrypted value it fails.

This can be tested/verified in the browser.
When you already have an encrypted cookie like `laravel_session` and you rename it to `laravel_session[test]`. It will decrypt the value as expected but in the code we now do a strpos on an array which fails.

I do not know what the solution should be so i only added the failing test.

The code that causes this can be found here:
https://github.com/laravel/framework/blob/8.x/src/Illuminate/Cookie/Middleware/EncryptCookies.php#L84-L86

The decryptCookie method can return a string and an array but strpos only accepts a string