### PR TITLE
[8.x] Fixed typo in `make:seeder` command name inside ModelMakeCommand

### DIFF
--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -108,7 +108,7 @@ class ModelMakeCommand extends GeneratorCommand
     {
         $seeder = Str::studly(class_basename($this->argument('name')));
 
-        $this->call('make:seed', [
+        $this->call('make:seeder', [
             'name' => "{$seeder}Seeder",
         ]);
     }


### PR DESCRIPTION
`Illuminate\Foundation\Console\ModelMakeCommand` call `make:seed` instead of `make:seeder`.