### PR TITLE
[8.x] SchemaState: `migrations` table can be renamed.

### DIFF
--- a/src/Illuminate/Database/Console/DumpCommand.php
+++ b/src/Illuminate/Database/Console/DumpCommand.php
@@ -63,6 +63,7 @@ class DumpCommand extends Command
     protected function schemaState(Connection $connection)
     {
         return $connection->getSchemaState()
+                ->setMigrationsTableName($this->laravel['config']['database.migrations'])
                 ->handleOutputUsing(function ($type, $buffer) {
                     $this->output->write($buffer);
                 });

--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -53,7 +53,7 @@ class MySqlSchemaState extends SchemaState
     protected function appendMigrationData(string $path)
     {
         $process = $this->executeDumpProcess($this->makeProcess(
-            $this->baseDumpCommand().' migrations --no-create-info --skip-extended-insert --skip-routines --compact'
+            $this->baseDumpCommand().' "'.$this->migrationsTableName.'" --no-create-info --skip-extended-insert --skip-routines --compact'
         ), null, array_merge($this->baseVariables($this->connection->getConfig()), [
             //
         ]));

--- a/src/Illuminate/Database/Schema/PostgresSchemaState.php
+++ b/src/Illuminate/Database/Schema/PostgresSchemaState.php
@@ -19,7 +19,7 @@ class PostgresSchemaState extends SchemaState
         $excludedTables = collect($connection->getSchemaBuilder()->getAllTables())
                         ->map->tablename
                         ->reject(function ($table) {
-                            return $table === 'migrations';
+                            return $table === $this->migrationsTableName;
                         })->map(function ($table) {
                             return '--exclude-table-data='.$table;
                         })->implode(' ');

--- a/src/Illuminate/Database/Schema/SchemaState.php
+++ b/src/Illuminate/Database/Schema/SchemaState.php
@@ -37,6 +37,13 @@ abstract class SchemaState
     protected $output;
 
     /**
+     * The `migrations` table names.
+     *
+     * @var string
+     */
+    protected $migrationsTableName = 'migrations';
+
+    /**
      * Create a new dumper instance.
      *
      * @param  \Illuminate\Database\Connection  $connection
@@ -96,6 +103,19 @@ abstract class SchemaState
     public function handleOutputUsing(callable $output)
     {
         $this->output = $output;
+
+        return $this;
+    }
+
+    /**
+     * Specify the `migrations` table name.
+     *
+     * @param string $name
+     * @return $this
+     */
+    public function setMigrationsTableName(string $name)
+    {
+        $this->migrationsTableName = $name;
 
         return $this;
     }

--- a/src/Illuminate/Database/Schema/SqliteSchemaState.php
+++ b/src/Illuminate/Database/Schema/SqliteSchemaState.php
@@ -39,7 +39,7 @@ class SqliteSchemaState extends SchemaState
     protected function appendMigrationData(string $path)
     {
         with($process = $this->makeProcess(
-            $this->baseCommand().' ".dump \'migrations\'"'
+            $this->baseCommand().' ".dump \''.$this->migrationsTableName.'\'"'
         ))->mustRun(null, array_merge($this->baseVariables($this->connection->getConfig()), [
             //
         ]));


### PR DESCRIPTION
The `migrations` table can be renamed in `config/database.php`, but `src/Illuminate/Database/Schema/*SchemaState.php` always use the hardcoded `migrations` string.

https://github.com/laravel/framework/blob/9561987ebf570befc346e63ec45b9ecd1c161048/src/Illuminate/Database/Schema/MySqlSchemaState.php#L56

https://github.com/laravel/framework/blob/9561987ebf570befc346e63ec45b9ecd1c161048/src/Illuminate/Database/Schema/PostgresSchemaState.php#L22

https://github.com/laravel/framework/blob/9561987ebf570befc346e63ec45b9ecd1c161048/src/Illuminate/Database/Schema/SqliteSchemaState.php#L42

This PR allows us to configure `migrations` table name, but please note, I tested it only for `mysql` (so it should be tested for pg and sqlite before merging).

Fixes #35108
