### PR TITLE
[9.x] Add callback to exception ignore method

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -185,10 +185,10 @@ class Handler implements ExceptionHandlerContract
      * Indicate that the given exception type should not be reported.
      *
      * @param  string  $class
-     * @param  \Closure|null  $callback
+     * @param  callable|null  $callback
      * @return $this
      */
-    protected function ignore(string $class, Closure $callback = null)
+    protected function ignore(string $class, callable $callback = null)
     {
         $this->dontReport[$class] = $callback ?? true;
 
@@ -274,10 +274,10 @@ class Handler implements ExceptionHandlerContract
                 })
         );
 
-        return ! is_null($dontReport->first(function ($closure, $type) use ($e) {
+        return ! is_null($dontReport->first(function ($callback, $type) use ($e) {
             return $e instanceof $type && (
-                $closure instanceof Closure
-                    ? $closure($e) : $closure
+                is_callable($callback)
+                    ? $callback($e) : $callback
             );
         }));
     }

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Foundation;
 
 use Exception;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Config\Repository as Config;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Routing\ResponseFactory as ResponseFactoryContract;
@@ -67,6 +68,17 @@ class FoundationExceptionsHandlerTest extends TestCase
     protected function tearDown(): void
     {
         Container::setInstance(null);
+    }
+
+    public function testHandlerDoesntReportExceptionWithTruthyCallable()
+    {
+        $logger = m::mock(LoggerInterface::class);
+        $this->container->instance(LoggerInterface::class, $logger);
+        $logger->shouldNotReceive('error');
+
+        $handler = new ExceptionHandlerTest($this->container);
+
+        $handler->report(new AuthorizationException('Exception message'));
     }
 
     public function testHandlerDoesntReportExceptionWithTruthyClosure()

--- a/tests/Foundation/Testing/BackwardsCompatibleExceptionHandlerTest.php
+++ b/tests/Foundation/Testing/BackwardsCompatibleExceptionHandlerTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Testing;
+
+use Illuminate\Foundation\Exceptions\Handler;
+use LogicException;
+use RuntimeException;
+
+class BackwardsCompatibleExceptionHandlerTest extends Handler
+{
+    protected $dontReport = [
+        RuntimeException::class,
+        LogicException::class => false,
+    ];
+}

--- a/tests/Foundation/Testing/ExceptionHandlerTest.php
+++ b/tests/Foundation/Testing/ExceptionHandlerTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Testing;
+
+use Illuminate\Foundation\Exceptions\Handler;
+use RuntimeException;
+
+class ExceptionHandlerTest extends Handler
+{
+    public function register()
+    {
+        $this->ignore(RuntimeException::class, function (RuntimeException $exception) {
+            return $exception->getCode() === 429;
+        });
+    }
+}

--- a/tests/Foundation/Testing/ExceptionHandlerTest.php
+++ b/tests/Foundation/Testing/ExceptionHandlerTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Foundation\Testing;
 
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Foundation\Exceptions\Handler;
 use RuntimeException;
 
@@ -12,5 +13,7 @@ class ExceptionHandlerTest extends Handler
         $this->ignore(RuntimeException::class, function (RuntimeException $exception) {
             return $exception->getCode() === 429;
         });
+
+        $this->ignore(AuthorizationException::class, new ShouldntReportAuthorizationExceptionTest);
     }
 }

--- a/tests/Foundation/Testing/ShouldntReportAuthorizationExceptionTest.php
+++ b/tests/Foundation/Testing/ShouldntReportAuthorizationExceptionTest.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Testing;
+
+use Illuminate\Auth\Access\AuthorizationException;
+
+class ShouldntReportAuthorizationExceptionTest
+{
+    public function __invoke(AuthorizationException $exception)
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
This PR adds the ability to pass a callback to the `ignore()` method in the exception handler, in order to decide whether to report the exception at runtime. This is particularly useful when some exceptions provided by SDKs aren't specific and you need to dig a bit deeper into the exception itself to determine if it should be reported. For example if you get an `Aws\Ses\Exception\SesException` you may decide to not report it if it's to do with rate limiting.

This PR changes the `$dontReport` property to an associative array, as well as the `ignore` method signature. These are breaking changes.

This new functionality can be used in the `register()` method of the exception handler. Here the `FooException` will not be reported if the given callback evaluates to true. The callback will receive the exception instance as its only parameter.
```php
public function register()
{
    $this->ignore(FooException::class, function (FooException $exception) {
        return $exception->getCode() === 429;
    });
}
```

You can also pass a callable class:
```php
public function register()
{
    $this->ignore(FooException::class, new ShouldIgnoreFooException);
}

...

class ShouldIgnoreFooException
{
    public function __invoke(FooException $exception)
    {
        return true;
    }
}
```
