### PR TITLE
[8.x] Adds createIfNotExists method

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -258,7 +258,7 @@ class Blueprint
     public function creating()
     {
         return collect($this->commands)->contains(function ($command) {
-            return $command->name === 'create';
+            return $command->name === 'create' || $command->name === 'createIfNotExists';
         });
     }
 
@@ -270,6 +270,16 @@ class Blueprint
     public function create()
     {
         return $this->addCommand('create');
+    }
+
+    /**
+     * Indicate that the table needs to be created if it does not exist.
+     *
+     * @return \Illuminate\Support\Fluent
+     */
+    public function createIfNotExists()
+    {
+        return $this->addCommand('createIfNotExists');
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -201,6 +201,22 @@ class Builder
     }
 
     /**
+     * Create a new table on the schema if it does not exist.
+     *
+     * @param  string  $table
+     * @param  \Closure  $callback
+     * @return void
+     */
+    public function createIfNotExists($table, Closure $callback)
+    {
+        $this->build(tap($this->createBlueprint($table), function ($blueprint) use ($callback) {
+            $blueprint->createIfNotExists();
+
+            $callback($blueprint);
+        }));
+    }
+
+    /**
      * Drop a table from the schema.
      *
      * @param  string  $table

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -96,11 +96,9 @@ class MySqlGrammar extends Grammar
         // Finally, we will append the engine configuration onto this SQL statement as
         // the final thing we do before returning this finished SQL. Once this gets
         // added the query will be ready to execute against the real connections.
-        return array_values(array_filter(array_merge([
-            $this->compileCreateEngine(
-                $sql, $connection, $blueprint
-            )
-        ], $this->compileAutoIncrementStartingValues($blueprint))));
+        return array_values(array_filter(array_merge([$this->compileCreateEngine(
+            $sql, $connection, $blueprint
+        )], $this->compileAutoIncrementStartingValues($blueprint))));
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -88,14 +88,12 @@ class PostgresGrammar extends Grammar
      */
     protected function compileCreateTable($blueprint, $ifNotExists = false)
     {
-        return array_values(array_filter(array_merge([
-            sprintf('%s table %s%s (%s)',
-                $blueprint->temporary ? 'create temporary' : 'create',
-                $ifNotExists ? 'if not exists ' : '',
-                $this->wrapTable($blueprint),
-                implode(', ', $this->getColumns($blueprint))
-            )
-        ], $this->compileAutoIncrementStartingValues($blueprint))));
+        return array_values(array_filter(array_merge([sprintf('%s table %s%s (%s)',
+            $blueprint->temporary ? 'create temporary' : 'create',
+            $ifNotExists ? 'if not exists ' : '',
+            $this->wrapTable($blueprint),
+            implode(', ', $this->getColumns($blueprint))
+        )], $this->compileAutoIncrementStartingValues($blueprint))));
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -64,11 +64,38 @@ class PostgresGrammar extends Grammar
      */
     public function compileCreate(Blueprint $blueprint, Fluent $command)
     {
-        return array_values(array_filter(array_merge([sprintf('%s table %s (%s)',
-            $blueprint->temporary ? 'create temporary' : 'create',
-            $this->wrapTable($blueprint),
-            implode(', ', $this->getColumns($blueprint))
-        )], $this->compileAutoIncrementStartingValues($blueprint))));
+        return $this->compileCreateTable($blueprint);
+    }
+
+    /**
+     * Compile a create table (if not exists) command.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param \Illuminate\Support\Fluent $command
+     * @return array
+     */
+    public function compileCreateIfNotExists(Blueprint $blueprint, Fluent $command)
+    {
+        return $this->compileCreateTable($blueprint, true);
+    }
+
+    /**
+     * Create the actual create table clause.
+     *
+     * @param \Illuminate\Database\Schema\Blueprint $blueprint
+     * @param bool $ifNotExists
+     * @return array
+     */
+    protected function compileCreateTable($blueprint, $ifNotExists = false)
+    {
+        return array_values(array_filter(array_merge([
+            sprintf('%s table %s%s (%s)',
+                $blueprint->temporary ? 'create temporary' : 'create',
+                $ifNotExists ? 'if not exists ' : '',
+                $this->wrapTable($blueprint),
+                implode(', ', $this->getColumns($blueprint))
+            )
+        ], $this->compileAutoIncrementStartingValues($blueprint))));
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -84,8 +84,8 @@ class SQLiteGrammar extends Grammar
             $ifNotExists ? 'if not exists ' : '',
             $this->wrapTable($blueprint),
             implode(', ', $this->getColumns($blueprint)),
-            (string)$this->addForeignKeys($blueprint),
-            (string)$this->addPrimaryKeys($blueprint)
+            (string) $this->addForeignKeys($blueprint),
+            (string) $this->addPrimaryKeys($blueprint)
         );
     }
 

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -55,12 +55,37 @@ class SQLiteGrammar extends Grammar
      */
     public function compileCreate(Blueprint $blueprint, Fluent $command)
     {
-        return sprintf('%s table %s (%s%s%s)',
+        return $this->compileCreateTable($blueprint);
+    }
+
+    /**
+     * Compile a create table (if not exists) command.
+     *
+     * @param \Illuminate\Database\Schema\Blueprint $blueprint
+     * @param \Illuminate\Support\Fluent $command
+     * @return string
+     */
+    public function compileCreateIfNotExists(Blueprint $blueprint, Fluent $command)
+    {
+        return $this->compileCreateTable($blueprint, true);
+    }
+
+    /**
+     * Create the actual create table clause.
+     *
+     * @param \Illuminate\Database\Schema\Blueprint $blueprint
+     * @param bool $ifNotExists
+     * @return string
+     */
+    protected function compileCreateTable($blueprint, $ifNotExists = false)
+    {
+        return sprintf('%s table %s%s (%s%s%s)',
             $blueprint->temporary ? 'create temporary' : 'create',
+            $ifNotExists ? 'if not exists ' : '',
             $this->wrapTable($blueprint),
             implode(', ', $this->getColumns($blueprint)),
-            (string) $this->addForeignKeys($blueprint),
-            (string) $this->addPrimaryKeys($blueprint)
+            (string)$this->addForeignKeys($blueprint),
+            (string)$this->addPrimaryKeys($blueprint)
         );
     }
 

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -47,6 +47,25 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertSame('alter table `users` add `id` int unsigned not null auto_increment primary key, add `email` varchar(255) not null', $statements[0]);
     }
 
+    public function testBasicCreateTableIfNotExists()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->createIfNotExists();
+        $blueprint->increments('id');
+        $blueprint->string('email');
+
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getConfig')->once()->with('charset')->andReturn('utf8');
+        $conn->shouldReceive('getConfig')->once()->with('collation')->andReturn('utf8_unicode_ci');
+        $conn->shouldReceive('getConfig')->once()->with('engine')->andReturn(null);
+
+        $statements = $blueprint->toSql($conn, $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame("create table if not exists `users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) not null) default character set utf8 collate 'utf8_unicode_ci'",
+            $statements[0]);
+    }
+
     public function testAutoIncrementStartingValue()
     {
         $blueprint = new Blueprint('users');
@@ -165,6 +184,23 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
         $this->assertCount(1, $statements);
         $this->assertSame('create temporary table `users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) not null)', $statements[0]);
+    }
+
+    public function testCreateTemporaryTableIfNotExists()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->createIfNotExists();
+        $blueprint->temporary();
+        $blueprint->increments('id');
+        $blueprint->string('email');
+
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getConfig')->andReturn(null);
+
+        $statements = $blueprint->toSql($conn, $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('create temporary table if not exists `users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) not null)', $statements[0]);
     }
 
     public function testDropTable()

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -37,6 +37,19 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertSame('alter table "users" add column "id" serial primary key not null, add column "email" varchar(255) not null', $statements[0]);
     }
 
+    public function testBasicCreateTableIfNotExists()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->createIfNotExists();
+        $blueprint->increments('id');
+        $blueprint->string('email');
+        $blueprint->string('name')->collation('nb_NO.utf8');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('create table if not exists "users" ("id" serial primary key not null, "email" varchar(255) not null, "name" varchar(255) collate "nb_NO.utf8" not null)', $statements[0]);
+    }
+
     public function testCreateTableWithAutoIncrementStartingValue()
     {
         $blueprint = new Blueprint('users');
@@ -75,6 +88,19 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
         $this->assertCount(1, $statements);
         $this->assertSame('create temporary table "users" ("id" serial primary key not null, "email" varchar(255) not null)', $statements[0]);
+    }
+
+    public function testCreateTemporaryTableIfNotExists()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->createIfNotExists();
+        $blueprint->temporary();
+        $blueprint->increments('id');
+        $blueprint->string('email');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('create temporary table if not exists "users" ("id" serial primary key not null, "email" varchar(255) not null)', $statements[0]);
     }
 
     public function testDropTable()

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -43,6 +43,18 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertEquals($expected, $statements);
     }
 
+    public function testCreateTableIfNotExists()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->createIfNotExists();
+        $blueprint->increments('id');
+        $blueprint->string('email');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('create table if not exists "users" ("id" integer not null primary key autoincrement, "email" varchar not null)', $statements[0]);
+    }
+
     public function testCreateTemporaryTable()
     {
         $blueprint = new Blueprint('users');
@@ -54,6 +66,19 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
         $this->assertCount(1, $statements);
         $this->assertSame('create temporary table "users" ("id" integer not null primary key autoincrement, "email" varchar not null)', $statements[0]);
+    }
+
+     public function testCreateTemporaryTableIfNotExists()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->createIfNotExists();
+        $blueprint->temporary();
+        $blueprint->increments('id');
+        $blueprint->string('email');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('create temporary table if not exists "users" ("id" integer not null primary key autoincrement, "email" varchar not null)', $statements[0]);
     }
 
     public function testDropTable()

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -68,7 +68,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertSame('create temporary table "users" ("id" integer not null primary key autoincrement, "email" varchar not null)', $statements[0]);
     }
 
-     public function testCreateTemporaryTableIfNotExists()
+    public function testCreateTemporaryTableIfNotExists()
     {
         $blueprint = new Blueprint('users');
         $blueprint->createIfNotExists();


### PR DESCRIPTION
The method generates the `CREATE TABLE IF NOT EXISTS` [statement](https://dev.mysql.com/doc/refman/8.0/en/create-table.html) for MySql, Postgres and SQLite.
It allows to safely create tables in your migrations, equivalent to `dropIfExists`.

Before:
```php
if (!Schema::hasTable('table')) {
    Schema::create('table', function (Blueprint $table) {
        // ...
    });
}
```
now:
```php
Schema::createIfNotExists('table', function (Blueprint $table) {
    // ...
});
```