### PR TITLE
[6.x] Turn the eloquent collection into a base collection if mapWithKeys loses models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -261,7 +261,7 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Run an associative map over each of the items.
      *
-     * The callback should return an associative array with a single key/value pair.
+     * The callback should return an associative array with a single key / value pair.
      *
      * @param  callable  $callback
      * @return \Illuminate\Support\Collection|static

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -259,6 +259,23 @@ class Collection extends BaseCollection implements QueueableCollection
     }
 
     /**
+     * Run an associative map over each of the items.
+     *
+     * The callback should return an associative array with a single key/value pair.
+     *
+     * @param  callable  $callback
+     * @return \Illuminate\Support\Collection|static
+     */
+    public function mapWithKeys(callable $callback)
+    {
+        $result = parent::mapWithKeys($callback);
+
+        return $result->contains(function ($item) {
+            return ! $item instanceof Model;
+        }) ? $result->toBase() : $result;
+    }
+
+    /**
      * Reload a fresh model instance from the database for all the entities.
      *
      * @param  array|string  $with

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -228,6 +228,35 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertEquals(BaseCollection::class, get_class($c));
     }
 
+    public function testMapWithKeys()
+    {
+        $one = m::mock(Model::class);
+        $two = m::mock(Model::class);
+
+        $c = new Collection([$one, $two]);
+
+        $key = 0;
+        $cAfterMap = $c->mapWithKeys(function ($item) use (&$key) {
+            return [$key++ => $item];
+        });
+
+        $this->assertEquals($c->all(), $cAfterMap->all());
+        $this->assertInstanceOf(Collection::class, $cAfterMap);
+    }
+
+    public function testMapWithKeysToNonModelsReturnsABaseCollection()
+    {
+        $one = m::mock(Model::class);
+        $two = m::mock(Model::class);
+
+        $key = 0;
+        $c = (new Collection([$one, $two]))->mapWithKeys(function ($item) use (&$key) {
+            return [$key++ => 'not-a-model'];
+        });
+
+        $this->assertEquals(BaseCollection::class, get_class($c));
+    }
+
     public function testCollectionDiffsWithGivenCollection()
     {
         $one = m::mock(Model::class);


### PR DESCRIPTION
Hey guys.

If you `map` over an eloquent collection and return an `array` instead of a `model` you will receive a support collection.

But if you use `mapWithKeys` it will lead to errors.

If you try to serialize, it will explode in the sky because of [this check](https://github.com/laravel/framework/blob/957232ce3b59a2160e240fdc99bf7a3efce5add7/src/Illuminate/Database/Eloquent/Collection.php#L526).

I noticed `map` has a custom implementation on the eloquent collection to I added one for `mapWithKeys` with the same behavior.

I didn't extract the code to check and decide which collection type to return, to keep this PR light.

Also noticed there is a `mapToDictionary`, should we handle this too?

Have a nice day
Adrian