### PR TITLE
[8.x] Remove decrypting array cookies

### DIFF
--- a/src/Illuminate/Cookie/Middleware/EncryptCookies.php
+++ b/src/Illuminate/Cookie/Middleware/EncryptCookies.php
@@ -106,8 +106,8 @@ class EncryptCookies
     protected function decryptCookie($name, $cookie)
     {
         return is_array($cookie)
-            ? $this->decryptArray($cookie)
-            : $this->encrypter->decrypt($cookie, static::serialized($name));
+                         ? $this->decryptArray($cookie)
+                         : $this->encrypter->decrypt($cookie, static::serialized($name));
     }
 
     /**

--- a/src/Illuminate/Cookie/Middleware/EncryptCookies.php
+++ b/src/Illuminate/Cookie/Middleware/EncryptCookies.php
@@ -100,12 +100,33 @@ class EncryptCookies
      * Decrypt the given cookie and return the value.
      *
      * @param  string  $name
-     * @param  string  $cookie
-     * @return string
+     * @param  string|array  $cookie
+     * @return string|array
      */
     protected function decryptCookie($name, $cookie)
     {
-        return $this->encrypter->decrypt($cookie, static::serialized($name));
+        return is_array($cookie)
+            ? $this->decryptArray($cookie)
+            : $this->encrypter->decrypt($cookie, static::serialized($name));
+    }
+
+    /**
+     * Decrypt an array based cookie.
+     *
+     * @param  array  $cookie
+     * @return array
+     */
+    protected function decryptArray(array $cookie)
+    {
+        $decrypted = [];
+
+        foreach ($cookie as $key => $value) {
+            if (is_string($value)) {
+                $decrypted[$key] = $this->encrypter->decrypt($value, static::serialized($key));
+            }
+        }
+
+        return $decrypted;
     }
 
     /**

--- a/src/Illuminate/Cookie/Middleware/EncryptCookies.php
+++ b/src/Illuminate/Cookie/Middleware/EncryptCookies.php
@@ -106,8 +106,8 @@ class EncryptCookies
     protected function decryptCookie($name, $cookie)
     {
         return is_array($cookie)
-                         ? $this->decryptArray($cookie)
-                         : $this->encrypter->decrypt($cookie, static::serialized($name));
+                        ? $this->decryptArray($cookie)
+                        : $this->encrypter->decrypt($cookie, static::serialized($name));
     }
 
     /**

--- a/src/Illuminate/Cookie/Middleware/EncryptCookies.php
+++ b/src/Illuminate/Cookie/Middleware/EncryptCookies.php
@@ -76,7 +76,7 @@ class EncryptCookies
     protected function decrypt(Request $request)
     {
         foreach ($request->cookies as $key => $cookie) {
-            if ($this->isDisabled($key)) {
+            if ($this->isDisabled($key) || is_array($cookie)) {
                 continue;
             }
 
@@ -100,33 +100,12 @@ class EncryptCookies
      * Decrypt the given cookie and return the value.
      *
      * @param  string  $name
-     * @param  string|array  $cookie
-     * @return string|array
+     * @param  string  $cookie
+     * @return string
      */
     protected function decryptCookie($name, $cookie)
     {
-        return is_array($cookie)
-                        ? $this->decryptArray($cookie)
-                        : $this->encrypter->decrypt($cookie, static::serialized($name));
-    }
-
-    /**
-     * Decrypt an array based cookie.
-     *
-     * @param  array  $cookie
-     * @return array
-     */
-    protected function decryptArray(array $cookie)
-    {
-        $decrypted = [];
-
-        foreach ($cookie as $key => $value) {
-            if (is_string($value)) {
-                $decrypted[$key] = $this->encrypter->decrypt($value, static::serialized($key));
-            }
-        }
-
-        return $decrypted;
+        return $this->encrypter->decrypt($cookie, static::serialized($name));
     }
 
     /**


### PR DESCRIPTION
This is a follow up on my previous merge request: #35105 

The problem is that when someone manually adjusts cookie names in the browser or through any other method it wil generate unnecessary errors.
```
ErrorException(code: 0): strpos() expects parameter 1 to be string, array given at /vendor/laravel/framework/src/Illuminate/Cookie/Middleware/EncryptCookies.php:86)
```

Because Laravel does not support setting cookie array's, the middleware will never encrypt array cookies. This means we can remove the support for decrypting array cookies.

When there are array cookies they will not be decrypted and just passthrough as is