### PR TITLE
[8.x] Fix appendable attributes in Blade components

### DIFF
--- a/src/Illuminate/View/AppendableAttributeValue.php
+++ b/src/Illuminate/View/AppendableAttributeValue.php
@@ -22,6 +22,11 @@ class AppendableAttributeValue
         $this->value = $value;
     }
 
+    /**
+     * Get the raw string value.
+     *
+     * @return string
+     */
     public function __toString()
     {
         return (string) $this->value;

--- a/src/Illuminate/View/AppendableAttributeValue.php
+++ b/src/Illuminate/View/AppendableAttributeValue.php
@@ -24,6 +24,6 @@ class AppendableAttributeValue
 
     public function __toString()
     {
-        return (string)$this->value;
+        return (string) $this->value;
     }
 }

--- a/src/Illuminate/View/AppendableAttributeValue.php
+++ b/src/Illuminate/View/AppendableAttributeValue.php
@@ -23,7 +23,7 @@ class AppendableAttributeValue
     }
 
     /**
-     * Get the raw string value.
+     * Get the string value.
      *
      * @return string
      */

--- a/src/Illuminate/View/AppendableAttributeValue.php
+++ b/src/Illuminate/View/AppendableAttributeValue.php
@@ -21,7 +21,7 @@ class AppendableAttributeValue
     {
         $this->value = $value;
     }
-    
+
     public function __toString()
     {
         return (string)$this->value;

--- a/src/Illuminate/View/AppendableAttributeValue.php
+++ b/src/Illuminate/View/AppendableAttributeValue.php
@@ -21,4 +21,9 @@ class AppendableAttributeValue
     {
         $this->value = $value;
     }
+    
+    public function __toString()
+    {
+        return (string)$this->value;
+    }
 }

--- a/tests/Integration/View/BladeTest.php
+++ b/tests/Integration/View/BladeTest.php
@@ -50,13 +50,15 @@ class BladeTest extends TestCase
 
     public function test_appendable_attributes()
     {
-        $view = View::make('uses-appendable-panel', ['name' => 'Taylor'])->render();
+        $view = View::make('uses-appendable-panel', ['name' => 'Taylor', 'withOutside' => true])->render();
 
         $this->assertSame('<div class="mt-4 bg-gray-100" data-controller="inside-controller outside-controller" foo="bar">
     Hello Taylor
-</div>
+</div>', trim($view));
 
-<div class="mt-4 bg-gray-100" data-controller="inside-controller" foo="bar">
+        $view = View::make('uses-appendable-panel', ['name' => 'Taylor', 'withOutside' => false])->render();
+
+        $this->assertSame('<div class="mt-4 bg-gray-100" data-controller="inside-controller" foo="bar">
     Hello Taylor
 </div>', trim($view));
     }

--- a/tests/Integration/View/BladeTest.php
+++ b/tests/Integration/View/BladeTest.php
@@ -42,7 +42,7 @@ class BladeTest extends TestCase
         $this->assertSame('<span class="text-medium">
     Hello Taylor
 </span>
-
+  
  <span >
     Hello Samuel
 </span>', trim($view));

--- a/tests/Integration/View/BladeTest.php
+++ b/tests/Integration/View/BladeTest.php
@@ -42,7 +42,7 @@ class BladeTest extends TestCase
         $this->assertSame('<span class="text-medium">
     Hello Taylor
 </span>
-  
+
  <span >
     Hello Samuel
 </span>', trim($view));
@@ -53,6 +53,10 @@ class BladeTest extends TestCase
         $view = View::make('uses-appendable-panel', ['name' => 'Taylor'])->render();
 
         $this->assertSame('<div class="mt-4 bg-gray-100" data-controller="inside-controller outside-controller" foo="bar">
+    Hello Taylor
+</div>
+
+<div class="mt-4 bg-gray-100" data-controller="inside-controller" foo="bar">
     Hello Taylor
 </div>', trim($view));
     }

--- a/tests/Integration/View/templates/components/hello-span.blade.php
+++ b/tests/Integration/View/templates/components/hello-span.blade.php
@@ -1,6 +1,7 @@
 @props([
     'name',
 ])
+
 <span {{ $attributes }}>
     Hello {{ $name }}
 </span>

--- a/tests/Integration/View/templates/components/hello-span.blade.php
+++ b/tests/Integration/View/templates/components/hello-span.blade.php
@@ -1,7 +1,6 @@
 @props([
     'name',
 ])
-
 <span {{ $attributes }}>
     Hello {{ $name }}
 </span>

--- a/tests/Integration/View/templates/uses-appendable-panel.blade.php
+++ b/tests/Integration/View/templates/uses-appendable-panel.blade.php
@@ -1,7 +1,9 @@
-<x-appendable-panel class="bg-gray-100" :name="$name" data-controller="outside-controller" foo="bar">
-    Panel contents
-</x-appendable-panel>
-
-<x-appendable-panel class="bg-gray-100" :name="$name" foo="bar">
-    Panel contents
-</x-appendable-panel>
+@if ($withOutside)
+    <x-appendable-panel class="bg-gray-100" :name="$name" data-controller="outside-controller" foo="bar">
+        Panel contents
+    </x-appendable-panel>
+@else
+    <x-appendable-panel class="bg-gray-100" :name="$name" foo="bar">
+        Panel contents
+    </x-appendable-panel>
+@endif

--- a/tests/Integration/View/templates/uses-appendable-panel.blade.php
+++ b/tests/Integration/View/templates/uses-appendable-panel.blade.php
@@ -1,3 +1,7 @@
 <x-appendable-panel class="bg-gray-100" :name="$name" data-controller="outside-controller" foo="bar">
     Panel contents
 </x-appendable-panel>
+
+<x-appendable-panel class="bg-gray-100" :name="$name" foo="bar">
+    Panel contents
+</x-appendable-panel>


### PR DESCRIPTION
Currently, attempting to render a component which prepends a non-class attribute in it's template without actually overriding it in the calling template yields an Exception.

For example, given the following component called `test-component`:

```blade
<div {{ $attributes->merge(['data-controller' => $attributes->prepends('profile-controller')]) }}>
    {{ $slot }}
</div>
```

Rendering this component like so: `<x-test-component data-controller="some-controller" />` works as expected.

Rendering this component like so: `<x-test-component />` yields the following error:

<img width="1209" alt="Screen Shot 2020-11-06 at 13 59 09" src="https://user-images.githubusercontent.com/6180087/98340888-41417b80-2038-11eb-852c-a6815f5f7b72.png">

This PR fixes this behavior. `<x-test-component />` will now properly render as
```
<div data-controller="profile-controller"></div>
```

See #35128 for more details.
