### PR TITLE
[8.x] Call getter instead of property directly

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -859,7 +859,7 @@ class Blueprint
             $model = new $model;
         }
 
-        return $model->getKeyType() === 'int' && $model->incrementing
+        return $model->getKeyType() === 'int' && $model->getIncrementing()
                     ? $this->foreignId($column ?: $model->getForeignKey())
                     : $this->foreignUuid($column ?: $model->getForeignKey());
     }


### PR DESCRIPTION
This PR suggest using `Model:: getIncrementing()` instead of `Model::$incrementing`. This allows for calling any overwritten logic for the `getIncrementing` getter.