### PR TITLE
[8.x] Add lock support for file and null cache drivers

### DIFF
--- a/src/Illuminate/Cache/ApcStore.php
+++ b/src/Illuminate/Cache/ApcStore.php
@@ -2,11 +2,9 @@
 
 namespace Illuminate\Cache;
 
-use Illuminate\Contracts\Cache\LockProvider;
-
-class ApcStore extends TaggableStore implements LockProvider
+class ApcStore extends TaggableStore
 {
-    use RetrievesMultipleKeys, HasCacheLock;
+    use RetrievesMultipleKeys;
 
     /**
      * The APC wrapper instance.

--- a/src/Illuminate/Cache/ApcStore.php
+++ b/src/Illuminate/Cache/ApcStore.php
@@ -2,9 +2,11 @@
 
 namespace Illuminate\Cache;
 
-class ApcStore extends TaggableStore
+use Illuminate\Contracts\Cache\LockProvider;
+
+class ApcStore extends TaggableStore implements LockProvider
 {
-    use RetrievesMultipleKeys;
+    use RetrievesMultipleKeys, HasCacheLock;
 
     /**
      * The APC wrapper instance.

--- a/src/Illuminate/Cache/CacheLock.php
+++ b/src/Illuminate/Cache/CacheLock.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Illuminate\Cache;
+
+class CacheLock extends Lock
+{
+    /**
+     * The cache store implementation.
+     *
+     * @var \Illuminate\Contracts\Cache\Store
+     */
+    protected $store;
+
+    /**
+     * Create a new lock instance.
+     *
+     * @var \Illuminate\Contracts\Cache\Store
+     * @param  string  $name
+     * @param  int  $seconds
+     * @param  string|null  $owner
+     * @return void
+     */
+    public function __construct($store, $name, $seconds, $owner = null)
+    {
+        parent::__construct($name, $seconds, $owner);
+
+        $this->store = $store;
+    }
+
+    /**
+     * Attempt to acquire the lock.
+     *
+     * @return bool
+     */
+    public function acquire()
+    {
+        if (method_exists($this->store, 'add') && $this->seconds > 0) {
+            return $this->store->add(
+                $this->name, $this->owner, $this->seconds
+            );
+        }
+
+        if (! is_null($this->store->get($this->name))) {
+            return false;
+        }
+
+        return ($this->seconds > 0)
+                ? $this->store->put($this->name, $this->owner, $this->seconds)
+                : $this->store->forever($this->name, $this->owner, $this->seconds);
+    }
+
+    /**
+     * Release the lock.
+     *
+     * @return bool
+     */
+    public function release()
+    {
+        if ($this->isOwnedByCurrentProcess()) {
+            return $this->store->forget($this->name);
+        }
+
+        return false;
+    }
+
+    /**
+     * Releases this lock in disregard of ownership.
+     *
+     * @return void
+     */
+    public function forceRelease()
+    {
+        $this->store->forget($this->name);
+    }
+
+    /**
+     * Returns the owner value written into the driver for this lock.
+     *
+     * @return mixed
+     */
+    protected function getCurrentOwner()
+    {
+        return $this->store->get($this->name);
+    }
+}

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -3,13 +3,14 @@
 namespace Illuminate\Cache;
 
 use Exception;
+use Illuminate\Contracts\Cache\LockProvider;
 use Illuminate\Contracts\Cache\Store;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\InteractsWithTime;
 
-class FileStore implements Store
+class FileStore implements Store, LockProvider
 {
-    use InteractsWithTime, RetrievesMultipleKeys;
+    use InteractsWithTime, RetrievesMultipleKeys, HasCacheLock;
 
     /**
      * The Illuminate Filesystem instance.

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -5,6 +5,7 @@ namespace Illuminate\Cache;
 use Exception;
 use Illuminate\Contracts\Cache\LockProvider;
 use Illuminate\Contracts\Cache\Store;
+use Illuminate\Contracts\Filesystem\LockTimeoutException;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\InteractsWithTime;
 
@@ -80,6 +81,45 @@ class FileStore implements Store, LockProvider
 
             return true;
         }
+
+        return false;
+    }
+
+    /**
+     * Store an item in the cache if the key doesn't exist.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  int  $seconds
+     * @return bool
+     */
+    public function add($key, $value, $seconds)
+    {
+        $this->ensureCacheDirectoryExists($path = $this->path($key));
+
+        $file = $this->files->newFileForReadWrite($path);
+
+        try {
+            $file->getExclusiveLock();
+        } catch (LockTimeoutException $e) {
+            $file->close();
+
+            return false;
+        }
+
+        $expire = $file->read(10);
+
+        if (empty($expire) || $this->currentTime() >= $expire) {
+            $file->truncate()
+                ->write($this->expiration($seconds).serialize($value))
+                ->close();
+
+            $this->ensureFileHasCorrectPermissions($path);
+
+            return true;
+        }
+
+        $file->close();
 
         return false;
     }

--- a/src/Illuminate/Cache/HasCacheLock.php
+++ b/src/Illuminate/Cache/HasCacheLock.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Illuminate\Cache;
+
+trait HasCacheLock
+{
+    /**
+     * Get a lock instance.
+     *
+     * @param  string  $name
+     * @param  int  $seconds
+     * @param  string|null  $owner
+     * @return \Illuminate\Contracts\Cache\Lock
+     */
+    public function lock($name, $seconds = 0, $owner = null)
+    {
+        return new CacheLock($this, $name, $seconds, $owner);
+    }
+
+    /**
+     * Restore a lock instance using the owner identifier.
+     *
+     * @param  string  $name
+     * @param  string  $owner
+     * @return \Illuminate\Contracts\Cache\Lock
+     */
+    public function restoreLock($name, $owner)
+    {
+        return $this->lock($name, 0, $owner);
+    }
+}

--- a/src/Illuminate/Cache/NoLock.php
+++ b/src/Illuminate/Cache/NoLock.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Illuminate\Cache;
+
+class NoLock extends Lock
+{
+    /**
+     * Attempt to acquire the lock.
+     *
+     * @return bool
+     */
+    public function acquire()
+    {
+        return true;
+    }
+
+    /**
+     * Release the lock.
+     *
+     * @return bool
+     */
+    public function release()
+    {
+        return true;
+    }
+
+    /**
+     * Releases this lock in disregard of ownership.
+     *
+     * @return void
+     */
+    public function forceRelease()
+    {
+        //
+    }
+
+    /**
+     * Returns the owner value written into the driver for this lock.
+     *
+     * @return mixed
+     */
+    protected function getCurrentOwner()
+    {
+        return $this->owner;
+    }
+}

--- a/src/Illuminate/Cache/NullStore.php
+++ b/src/Illuminate/Cache/NullStore.php
@@ -2,9 +2,11 @@
 
 namespace Illuminate\Cache;
 
-class NullStore extends TaggableStore
+use Illuminate\Contracts\Cache\LockProvider;
+
+class NullStore extends TaggableStore implements LockProvider
 {
-    use RetrievesMultipleKeys;
+    use RetrievesMultipleKeys, HasCacheLock;
 
     /**
      * Retrieve an item from the cache by key.

--- a/src/Illuminate/Cache/NullStore.php
+++ b/src/Illuminate/Cache/NullStore.php
@@ -6,7 +6,7 @@ use Illuminate\Contracts\Cache\LockProvider;
 
 class NullStore extends TaggableStore implements LockProvider
 {
-    use RetrievesMultipleKeys, HasCacheLock;
+    use RetrievesMultipleKeys;
 
     /**
      * Retrieve an item from the cache by key.
@@ -97,5 +97,30 @@ class NullStore extends TaggableStore implements LockProvider
     public function getPrefix()
     {
         return '';
+    }
+
+    /**
+     * Get a lock instance.
+     *
+     * @param  string  $name
+     * @param  int  $seconds
+     * @param  string|null  $owner
+     * @return \Illuminate\Contracts\Cache\Lock
+     */
+    public function lock($name, $seconds = 0, $owner = null)
+    {
+        return new NoLock($name, $seconds, $owner);
+    }
+
+    /**
+     * Restore a lock instance using the owner identifier.
+     *
+     * @param  string  $name
+     * @param  string  $owner
+     * @return \Illuminate\Contracts\Cache\Lock
+     */
+    public function restoreLock($name, $owner)
+    {
+        return $this->lock($name, 0, $owner);
     }
 }

--- a/src/Illuminate/Contracts/Filesystem/LockTimeoutException.php
+++ b/src/Illuminate/Contracts/Filesystem/LockTimeoutException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Contracts\Filesystem;
+
+use Exception;
+
+class LockTimeoutException extends Exception
+{
+    //
+}

--- a/src/Illuminate/Filesystem/File.php
+++ b/src/Illuminate/Filesystem/File.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace Illuminate\Filesystem;
+
+use Illuminate\Contracts\Filesystem\LockTimeoutException;
+
+class File
+{
+    /**
+     * The file resource.
+     *
+     * @var resource
+     */
+    protected $handle;
+
+    /**
+     * The Illuminate Filesystem instance.
+     *
+     * @var \Illuminate\Filesystem\Filesystem
+     */
+    protected $files;
+
+    /**
+     * The file path.
+     *
+     * @var string
+     */
+    protected $path;
+
+    /**
+     * Determine if the file is locked.
+     *
+     * @var bool
+     */
+    protected $isLocked = false;
+
+    /**
+     * Create a new File instance.
+     *
+     * @param  string  $path
+     * @param  string  $mode
+     * @return void
+     */
+    public function __construct(Filesystem $files, $path, $mode)
+    {
+        $this->files = $files;
+        $this->path = $path;
+
+        $this->ensureDirectoryExists($path);
+        $this->createResource($path, $mode);
+    }
+
+    /**
+     * Read the file contents.
+     *
+     * @param  int|null  $length
+     * @return string
+     */
+    public function read($length = null)
+    {
+        clearstatcache(true, $this->path);
+
+        return fread($this->handle, $length ?? ($this->size() ?: 1));
+    }
+
+    /**
+     * Write to the file.
+     *
+     * @param  string  $contents
+     * @return string
+     */
+    public function write($contents)
+    {
+        fwrite($this->handle, $contents);
+
+        fflush($this->handle);
+
+        return $this;
+    }
+
+    /**
+     * Truncate the file.
+     *
+     * @return $this
+     */
+    public function truncate()
+    {
+        rewind($this->handle);
+
+        ftruncate($this->handle, 0);
+
+        return $this;
+    }
+
+    /**
+     * Get a shared lock on the file.
+     *
+     * @return $this
+     */
+    public function getSharedLock($block = false)
+    {
+        if (! flock($this->handle, LOCK_SH | ($block ? 0 : LOCK_NB))) {
+            throw new LockTimeoutException("Unable to acquire file lock at path {$path}.");
+        }
+
+        $this->isLocked = true;
+
+        return $this;
+    }
+
+    /**
+     * Get an exclusive lock on the file.
+     *
+     * @return bool
+     */
+    public function getExclusiveLock($block = false)
+    {
+        if (! flock($this->handle, LOCK_EX | ($block ? 0 : LOCK_NB))) {
+            throw new LockTimeoutException("Unable to acquire file lock at path {$path}.");
+        }
+
+        $this->isLocked = true;
+
+        return $this;
+    }
+
+    /**
+     * Release the lock on the file.
+     *
+     * @return $this
+     */
+    public function releaseLock()
+    {
+        flock($this->handle, LOCK_UN);
+
+        $this->isLocked = false;
+
+        return $this;
+    }
+
+    /**
+     * Close the file.
+     *
+     * @return bool
+     */
+    public function close()
+    {
+        if ($this->isLocked) {
+            $this->releaseLock();
+        }
+
+        return fclose($this->handle);
+    }
+
+    /**
+     * Get the file size.
+     *
+     * @return int
+     */
+    public function size()
+    {
+        return filesize($this->path);
+    }
+
+    /**
+     * Create the file resource.
+     *
+     * @return void
+     */
+    protected function createResource($path, $mode)
+    {
+        $this->handle = @fopen($path, $mode);
+    }
+
+    /**
+     * Create the file directory if necessary.
+     *
+     * @param  string  $path
+     * @return void
+     */
+    protected function ensureDirectoryExists($path)
+    {
+        if (! $this->files->exists(dirname($path))) {
+            $this->files->makeDirectory(dirname($path), 0777, true, true);
+        }
+    }
+}

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -186,6 +186,26 @@ class Filesystem
     }
 
     /**
+     * Create a new File instance for read and write.
+     *
+     * @return  \Illuminate\Filesystem\File
+     */
+    public function newFileForReadWrite($path)
+    {
+        return new File($this, $path, 'c+');
+    }
+
+    /**
+     * Create a new File instance for read and write.
+     *
+     * @return  \Illuminate\Filesystem\File
+     */
+    public function newFileForRead($path)
+    {
+        return new File($this, $path, 'r');
+    }
+
+    /**
      * Write the contents of a file, replacing it atomically if it already exists.
      *
      * @param  string  $path

--- a/tests/Integration/Cache/FileCacheLockTest.php
+++ b/tests/Integration/Cache/FileCacheLockTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Cache;
+
+use Exception;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Cache;
+use Orchestra\Testbench\TestCase;
+
+/**
+ * @group integration
+ */
+class FileCacheLockTest extends TestCase
+{
+    /**
+     * Define environment setup.
+     *
+     * @param  \Illuminate\Foundation\Application  $app
+     * @return void
+     */
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('cache.default', 'file');
+    }
+
+    public function testLocksCanBeAcquiredAndReleased()
+    {
+        Cache::lock('foo')->forceRelease();
+
+        $lock = Cache::lock('foo', 10);
+        $this->assertTrue($lock->get());
+        $this->assertFalse(Cache::lock('foo', 10)->get());
+        $lock->release();
+
+        $lock = Cache::lock('foo', 10);
+        $this->assertTrue($lock->get());
+        $this->assertFalse(Cache::lock('foo', 10)->get());
+        Cache::lock('foo')->release();
+    }
+
+    public function testLocksCanBlockForSeconds()
+    {
+        Carbon::setTestNow();
+
+        Cache::lock('foo')->forceRelease();
+        $this->assertSame('taylor', Cache::lock('foo', 10)->block(1, function () {
+            return 'taylor';
+        }));
+
+        Cache::lock('foo')->forceRelease();
+        $this->assertTrue(Cache::lock('foo', 10)->block(1));
+    }
+
+    public function testConcurrentLocksAreReleasedSafely()
+    {
+        Cache::lock('foo')->forceRelease();
+
+        $firstLock = Cache::lock('foo', 1);
+        $this->assertTrue($firstLock->get());
+        sleep(2);
+
+        $secondLock = Cache::lock('foo', 10);
+        $this->assertTrue($secondLock->get());
+
+        $firstLock->release();
+
+        $this->assertFalse(Cache::lock('foo')->get());
+    }
+
+    public function testLocksWithFailedBlockCallbackAreReleased()
+    {
+        Cache::lock('foo')->forceRelease();
+
+        $firstLock = Cache::lock('foo', 10);
+
+        try {
+            $firstLock->block(1, function () {
+                throw new Exception('failed');
+            });
+        } catch (Exception $e) {
+            // Not testing the exception, just testing the lock
+            // is released regardless of the how the exception
+            // thrown by the callback was handled.
+        }
+
+        $secondLock = Cache::lock('foo', 1);
+
+        $this->assertTrue($secondLock->get());
+    }
+
+    public function testLocksCanBeReleasedUsingOwnerToken()
+    {
+        Cache::lock('foo')->forceRelease();
+
+        $firstLock = Cache::lock('foo', 10);
+        $this->assertTrue($firstLock->get());
+        $owner = $firstLock->owner();
+
+        $secondLock = Cache::store('file')->restoreLock('foo', $owner);
+        $secondLock->release();
+
+        $this->assertTrue(Cache::lock('foo')->get());
+    }
+}

--- a/tests/Integration/Cache/NoLockTest.php
+++ b/tests/Integration/Cache/NoLockTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Cache;
+
+use Exception;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Cache;
+use Orchestra\Testbench\TestCase;
+
+/**
+ * @group integration
+ */
+class NoLockTest extends TestCase
+{
+    /**
+     * Define environment setup.
+     *
+     * @param  \Illuminate\Foundation\Application  $app
+     * @return void
+     */
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('cache.default', 'null');
+
+        $app['config']->set('cache.stores', [
+            'null' => [
+                'driver' => 'null',
+            ],
+        ]);
+    }
+
+    public function testLocksCanAlwaysBeAcquiredAndReleased()
+    {
+        Cache::lock('foo')->forceRelease();
+
+        $lock = Cache::lock('foo', 10);
+        $this->assertTrue($lock->get());
+        $this->assertTrue(Cache::lock('foo', 10)->get());
+        $this->assertTrue($lock->release());
+        $this->assertTrue($lock->release());
+    }
+
+    public function testLocksCanBlockForSeconds()
+    {
+        Carbon::setTestNow();
+
+        Cache::lock('foo')->forceRelease();
+        $this->assertSame('taylor', Cache::lock('foo', 10)->block(1, function () {
+            return 'taylor';
+        }));
+
+        Cache::lock('foo')->forceRelease();
+        $this->assertTrue(Cache::lock('foo', 10)->block(1));
+    }
+}

--- a/tests/Integration/Cache/NoLockTest.php
+++ b/tests/Integration/Cache/NoLockTest.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Tests\Integration\Cache;
 
-use Exception;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
 use Orchestra\Testbench\TestCase;


### PR DESCRIPTION
This PR adds a generic cache lock class that can implement a lock with any cache store implementation (kind of a bridge that takes a cache store and returns a cache lock). With this PR, we can now support locks for all cache drivers (including file, apc and null).

Laravel uses locks for several things including session blocking, `WithoutOverlapping` job middleware and unique jobs. This PR allows users to use these features for all cache drivers.  