### PR TITLE
[8.x] Added rejectValues and keepValues methods to Collections

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -734,6 +734,38 @@ trait EnumeratesValues
     }
 
     /**
+     * Create a collection of all elements that aren't present in the given list of values.
+     *
+     * @param  array|static  $values
+     * @param  bool  $strict
+     * @return static
+     */
+    public function rejectValues($values, bool $strict = false)
+    {
+        $values = $values instanceof static ? $values->toArray() : $values;
+
+        return $this->filter(function ($value) use ($values, $strict) {
+            return ! in_array($value, $values, $strict);
+        });
+    }
+
+    /**
+     * Create a collection of all elements provided they exist in the given list of values.
+     *
+     * @param  array|static  $values
+     * @param  bool  $strict
+     * @return static
+     */
+    public function keepValues($values, bool $strict = false)
+    {
+        $values = $values instanceof static ? $values->toArray() : $values;
+
+        return $this->filter(function ($value) use ($values, $strict) {
+            return in_array($value, $values, $strict);
+        });
+    }
+
+    /**
      * Return only unique items from the collection array.
      *
      * @param  string|callable|null  $key

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3144,6 +3144,80 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testRejectValuesRemovesElementsWithLooseComparison($collection)
+    {
+        $c = new $collection(['foo', 'bar']);
+        $this->assertEquals(['foo', 'bar'], $c->rejectValues([])->values()->all());
+
+        $c = new $collection(['foo', 'bar']);
+        $this->assertEquals(['foo'], $c->rejectValues(['bar'])->values()->all());
+
+        $c = new $collection(['foo', 'bar']);
+        $this->assertEquals([], $c->rejectValues(['foo', 'bar'])->values()->all());
+
+        $c = new $collection(['foo', 'bar', null, 0]);
+        $this->assertEquals(['foo'], $c->rejectValues(['bar', null])->values()->all());
+
+        $c = new $collection(['foo', 'bar', '123']);
+        $this->assertEquals(['foo'], $c->rejectValues(['bar', 123])->values()->all());
+
+        $c = new $collection(['foo', 'bar']);
+        $toReject = new $collection(['bar']);
+        $this->assertEquals(['foo'], $c->rejectValues($toReject)->values()->all());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testRejectValuesRemovesElementsWithStrictComparison($collection)
+    {
+        $c = new $collection(['foo', 'bar', null, 0]);
+        $this->assertEquals(['foo', 0], $c->rejectValues(['bar', null], true)->values()->all());
+
+        $c = new $collection(['foo', 'bar', '123']);
+        $this->assertEquals(['foo', '123'], $c->rejectValues(['bar', 123], true)->values()->all());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testKeepValuesKeepsElementsWithLooseComparison($collection)
+    {
+        $c = new $collection(['foo', 'bar']);
+        $this->assertEquals([], $c->keepValues([])->values()->all());
+
+        $c = new $collection(['foo', 'bar']);
+        $this->assertEquals(['bar'], $c->keepValues(['bar'])->values()->all());
+
+        $c = new $collection(['foo', 'bar']);
+        $this->assertEquals(['foo', 'bar'], $c->keepValues(['foo', 'bar'])->values()->all());
+
+        $c = new $collection(['foo', 'bar', null, 0]);
+        $this->assertEquals(['bar', null, 0], $c->keepValues(['bar', null])->values()->all());
+
+        $c = new $collection(['foo', 'bar', '123']);
+        $this->assertEquals(['bar', '123'], $c->keepValues(['bar', 123])->values()->all());
+
+        $c = new $collection(['foo', 'bar']);
+        $toKeep = new $collection(['bar']);
+        $this->assertEquals(['bar'], $c->keepValues($toKeep)->values()->all());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testKeepValuesKeepsElementsWithStrictComparison($collection)
+    {
+        $c = new $collection(['foo', 'bar', null, 0]);
+        $this->assertEquals(['bar', null], $c->keepValues(['bar', null], true)->values()->all());
+
+        $c = new $collection(['foo', 'bar', '123']);
+        $this->assertEquals(['bar'], $c->keepValues(['bar', 123], true)->values()->all());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testSearchReturnsIndexOfFirstFoundItem($collection)
     {
         $c = new $collection([1, 2, 3, 4, 5, 2, 5, 'foo' => 'bar']);


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

The purpose of this PR is to add a small usability improvement when rejecting or filtering Collection values - giving more readable code.

## rejectValues()

The `rejectValues` method allows you to reject multiple values in one go without needing to pass a closure to `reject` or call it multiple times.

``` php
// original code
$files = collect(scandir($dir))->reject(fn($filename) => in_array($filename, ['.', '..']));
// or
$files = collect(scandir($dir))->reject('..')->reject('.');

// new code
$files = collect(scandir($dir))->rejectValues(['..', '.']);
```

This is similar to the `whereNotIn` method,  but compares each element instead of a particular key's value inside each element.

## keepValues()

The `keepValues` method performs the opposite action to `rejectValues`. It allows you to keep multiple Collection values without needing to pass a closure to `filter`.

``` php
// original code
$values = collect(['foo', 'bar'])->filter(fn($value) => in_array($value, ['foo', 'baz']));

// new code
$values = collect(['foo', 'bar'])->keepValues(['foo', 'baz']);
```

----

Both methods accept the list of values as an *array* or *Collection*.

Both methods have an optional second parameter to turn strict comparisons on (default = false),  which is consistent with Collection methods like `search`, `whereIn`, `whereNotIn` and PHP's `in_array`.

----

New methods were added and no other changes were made - so there shouldn't be any breaking changes.

Tests are included.