### PR TITLE
[8.x] Allow custom broadcastWith in notification broadcast channel

### DIFF
--- a/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
+++ b/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
@@ -92,7 +92,7 @@ class BroadcastNotificationCreated implements ShouldBroadcast
      */
     public function broadcastWith()
     {
-        if(method_exists($this->notification, 'broadcastWith')) {
+        if (method_exists($this->notification, 'broadcastWith')) {
             return $this->notification->broadcastWith();
         }
 

--- a/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
+++ b/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
@@ -92,6 +92,11 @@ class BroadcastNotificationCreated implements ShouldBroadcast
      */
     public function broadcastWith()
     {
+        if(method_exists($this->notification, 'broadcastWith'))
+        {
+            return $this->notification->broadcastWith();
+        }
+
         return array_merge($this->data, [
             'id' => $this->notification->id,
             'type' => $this->broadcastType(),

--- a/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
+++ b/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
@@ -92,8 +92,7 @@ class BroadcastNotificationCreated implements ShouldBroadcast
      */
     public function broadcastWith()
     {
-        if(method_exists($this->notification, 'broadcastWith'))
-        {
+        if(method_exists($this->notification, 'broadcastWith')) {
             return $this->notification->broadcastWith();
         }
 

--- a/tests/Notifications/NotificationBroadcastChannelTest.php
+++ b/tests/Notifications/NotificationBroadcastChannelTest.php
@@ -88,6 +88,21 @@ class NotificationBroadcastChannelTest extends TestCase
         $channel = new BroadcastChannel($events);
         $channel->send($notifiable, $notification);
     }
+
+    public function testNotificationIsBroadcastedWithCustomAdditionalPayload()
+    {
+        $notification = new CustomBroadcastWithTestNotification;
+        $notification->id = 1;
+        $notifiable = m::mock();
+
+        $event = new BroadcastNotificationCreated(
+            $notifiable, $notification, $notification->toArray($notifiable)
+        );
+
+        $data = $event->broadcastWith();
+
+        $this->assertArrayHasKey('additional', $data);
+    }
 }
 
 class NotificationBroadcastChannelTestNotification extends Notification
@@ -134,5 +149,18 @@ class TestNotificationBroadCastedNow extends Notification
     public function toBroadcast()
     {
         return (new BroadcastMessage([]))->onConnection('sync');
+    }
+}
+
+class CustomBroadcastWithTestNotification extends Notification
+{
+    public function toArray($notifiable)
+    {
+        return ['invoice_id' => 1];
+    }
+
+    public function broadcastWith()
+    {
+        return ['id' => 1, 'type' => 'custom', 'additional' => 'custom'];
     }
 }


### PR DESCRIPTION
This allows overriding `broadcastWith` when broadcasting a notification. 

Beneficial over `toBroadcast` when you have custom data shared across multiple notifications or when you don't need `type`/`id` for any reason.