### PR TITLE
[8.x] Use array_key_first instead of foreach

### DIFF
--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -139,9 +139,7 @@ class EloquentUserProvider implements UserProvider
      */
     protected function firstCredentialKey(array $credentials)
     {
-        foreach ($credentials as $key => $value) {
-            return $key;
-        }
+        return array_key_first($credentials);
     }
 
     /**


### PR DESCRIPTION
Starting from PHP 7.3, there is a new built-in function called array_key_first() which will retrieve the first key from the given array without resetting the internal pointer. Check out the [documentation](https://www.php.net/manual/en/function.array-key-first.php) for more info.

I checked [composer.json](https://github.com/laravel/framework/blob/8.x/src/Illuminate/Auth/composer.json#L17) and see that we can use this function.

![image](https://user-images.githubusercontent.com/5250117/98454584-a4e2ba80-2198-11eb-91ef-f931e05f72ec.png)
