### PR TITLE
[8.x] Check $user instead of $this->user

### DIFF
--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -498,7 +498,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
 
         $this->clearUserDataFromStorage();
 
-        if (! is_null($this->user) && ! empty($user->getRememberToken())) {
+        if (! is_null($user) && ! empty($user->getRememberToken())) {
             $this->cycleRememberToken($user);
         }
 


### PR DESCRIPTION
We assigned the variable earlier.
![image](https://user-images.githubusercontent.com/5250117/98454843-a6fa4880-219b-11eb-9396-4696d9b2fe1a.png)

And it has value of `$this->user`.
![image](https://user-images.githubusercontent.com/5250117/98454855-d741e700-219b-11eb-991c-6645a0ffad87.png)

So I think this condition should check `$user` instead of `$this->user`. This will prevent the error "Null pointer exception may occur here." from occurring at line 502.