### PR TITLE
[8.x] Change return type to "\Illuminate\Http\JsonResponse"

### DIFF
--- a/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
@@ -83,7 +83,7 @@ class PusherBroadcaster extends Broadcaster
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  mixed  $response
-     * @return array
+     * @return \Illuminate\Http\JsonResponse
      */
     protected function decodePusherResponse($request, $response)
     {

--- a/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
@@ -88,7 +88,7 @@ class PusherBroadcaster extends Broadcaster
     protected function decodePusherResponse($request, $response)
     {
         if (! $request->input('callback', false)) {
-            return json_decode($response, true);
+            return response()->json(json_decode($response, true));
         }
 
         return response()->json(json_decode($response, true))


### PR DESCRIPTION
Change return type from "array" to "\Illuminate\Http\JsonResponse". Based-on: https://github.com/laravel/framework/blob/8.x/src/Illuminate/Routing/ResponseFactory.php#L88-L100