### PR TITLE
[8.x] Add getCustomProviderCreators in AuthManager

### DIFF
--- a/src/Illuminate/Auth/CreatesUserProviders.php
+++ b/src/Illuminate/Auth/CreatesUserProviders.php
@@ -91,4 +91,14 @@ trait CreatesUserProviders
     {
         return $this->app['config']['auth.defaults.provider'];
     }
+
+    /**
+     * Get the custom providers name.
+     *
+     * @return array
+     */
+    public function getCustomProviderCreators()
+    {
+        return array_keys($this->customProviderCreators);
+    }
 }

--- a/src/Illuminate/Support/Facades/Auth.php
+++ b/src/Illuminate/Support/Facades/Auth.php
@@ -8,6 +8,7 @@ use RuntimeException;
 /**
  * @method static \Illuminate\Auth\AuthManager extend(string $driver, \Closure $callback)
  * @method static \Illuminate\Auth\AuthManager provider(string $name, \Closure $callback)
+ * @method static \Illuminate\Auth\AuthManager getCustomProviderCreators()
  * @method static \Illuminate\Contracts\Auth\Authenticatable loginUsingId(mixed $id, bool $remember = false)
  * @method static \Illuminate\Contracts\Auth\Authenticatable|null user()
  * @method static \Illuminate\Contracts\Auth\Guard|\Illuminate\Contracts\Auth\StatefulGuard guard(string|null $name = null)

--- a/tests/Auth/AuthenticatableTest.php
+++ b/tests/Auth/AuthenticatableTest.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Tests\Auth;
 
+use Illuminate\Auth\Authenticatable;
+use Illuminate\Auth\AuthManager;
 use Illuminate\Foundation\Auth\User;
 use PHPUnit\Framework\TestCase;
 
@@ -31,5 +33,16 @@ class AuthenticatableTest extends TestCase
         };
         $user->setRememberToken(true);
         $this->assertNull($user->getRememberToken());
+    }
+
+    public function testCustomDriverCreateList()
+    {
+        $authManager = new AuthManager(app());
+        $authManager->provider('test', function (){});
+        $authManager->provider('test2', function (){});
+
+        $this->assertContains('test', $authManager->getCustomProviderCreators());
+        $this->assertContains('test2', $authManager->getCustomProviderCreators());
+        $this->assertNotContains('test3', $authManager->getCustomProviderCreators());
     }
 }


### PR DESCRIPTION
There is no way to get custom providers which we create with `Auth::provider`
Whit this basic method You can get your custom providers name which you passed to `Auth::provider`
