### PR TITLE
[8.x] Add DB stubs function return types

### DIFF
--- a/src/Illuminate/Cache/Console/stubs/cache.stub
+++ b/src/Illuminate/Cache/Console/stubs/cache.stub
@@ -11,7 +11,7 @@ class CreateCacheTable extends Migration
      *
      * @return void
      */
-    public function up()
+    public function up(): void
     {
         Schema::create('cache', function (Blueprint $table) {
             $table->string('key')->unique();
@@ -25,7 +25,7 @@ class CreateCacheTable extends Migration
      *
      * @return void
      */
-    public function down()
+    public function down(): void
     {
         Schema::dropIfExists('cache');
     }

--- a/src/Illuminate/Database/Migrations/stubs/migration.create.stub
+++ b/src/Illuminate/Database/Migrations/stubs/migration.create.stub
@@ -11,7 +11,7 @@ class {{ class }} extends Migration
      *
      * @return void
      */
-    public function up()
+    public function up(): void
     {
         Schema::create('{{ table }}', function (Blueprint $table) {
             $table->id();
@@ -24,7 +24,7 @@ class {{ class }} extends Migration
      *
      * @return void
      */
-    public function down()
+    public function down(): void
     {
         Schema::dropIfExists('{{ table }}');
     }

--- a/src/Illuminate/Database/Migrations/stubs/migration.stub
+++ b/src/Illuminate/Database/Migrations/stubs/migration.stub
@@ -11,7 +11,7 @@ class {{ class }} extends Migration
      *
      * @return void
      */
-    public function up()
+    public function up(): void
     {
         //
     }
@@ -21,7 +21,7 @@ class {{ class }} extends Migration
      *
      * @return void
      */
-    public function down()
+    public function down(): void
     {
         //
     }

--- a/src/Illuminate/Database/Migrations/stubs/migration.update.stub
+++ b/src/Illuminate/Database/Migrations/stubs/migration.update.stub
@@ -11,7 +11,7 @@ class {{ class }} extends Migration
      *
      * @return void
      */
-    public function up()
+    public function up(): void
     {
         Schema::table('{{ table }}', function (Blueprint $table) {
             //
@@ -23,7 +23,7 @@ class {{ class }} extends Migration
      *
      * @return void
      */
-    public function down()
+    public function down(): void
     {
         Schema::table('{{ table }}', function (Blueprint $table) {
             //

--- a/src/Illuminate/Notifications/Console/stubs/notifications.stub
+++ b/src/Illuminate/Notifications/Console/stubs/notifications.stub
@@ -11,7 +11,7 @@ class CreateNotificationsTable extends Migration
      *
      * @return void
      */
-    public function up()
+    public function up(): void
     {
         Schema::create('notifications', function (Blueprint $table) {
             $table->uuid('id')->primary();
@@ -28,7 +28,7 @@ class CreateNotificationsTable extends Migration
      *
      * @return void
      */
-    public function down()
+    public function down(): void
     {
         Schema::dropIfExists('notifications');
     }

--- a/src/Illuminate/Queue/Console/stubs/batches.stub
+++ b/src/Illuminate/Queue/Console/stubs/batches.stub
@@ -11,7 +11,7 @@ class Create{{tableClassName}}Table extends Migration
      *
      * @return void
      */
-    public function up()
+    public function up(): void
     {
         Schema::create('{{table}}', function (Blueprint $table) {
             $table->string('id')->primary();
@@ -32,7 +32,7 @@ class Create{{tableClassName}}Table extends Migration
      *
      * @return void
      */
-    public function down()
+    public function down(): void
     {
         Schema::dropIfExists('{{table}}');
     }

--- a/src/Illuminate/Queue/Console/stubs/failed_jobs.stub
+++ b/src/Illuminate/Queue/Console/stubs/failed_jobs.stub
@@ -11,7 +11,7 @@ class Create{{tableClassName}}Table extends Migration
      *
      * @return void
      */
-    public function up()
+    public function up(): void
     {
         Schema::create('{{table}}', function (Blueprint $table) {
             $table->id();
@@ -29,7 +29,7 @@ class Create{{tableClassName}}Table extends Migration
      *
      * @return void
      */
-    public function down()
+    public function down(): void
     {
         Schema::dropIfExists('{{table}}');
     }

--- a/src/Illuminate/Queue/Console/stubs/jobs.stub
+++ b/src/Illuminate/Queue/Console/stubs/jobs.stub
@@ -11,7 +11,7 @@ class Create{{tableClassName}}Table extends Migration
      *
      * @return void
      */
-    public function up()
+    public function up(): void
     {
         Schema::create('{{table}}', function (Blueprint $table) {
             $table->bigIncrements('id');
@@ -29,7 +29,7 @@ class Create{{tableClassName}}Table extends Migration
      *
      * @return void
      */
-    public function down()
+    public function down(): void
     {
         Schema::dropIfExists('{{table}}');
     }

--- a/src/Illuminate/Session/Console/stubs/database.stub
+++ b/src/Illuminate/Session/Console/stubs/database.stub
@@ -11,7 +11,7 @@ class CreateSessionsTable extends Migration
      *
      * @return void
      */
-    public function up()
+    public function up(): void
     {
         Schema::create('sessions', function (Blueprint $table) {
             $table->string('id')->primary();
@@ -28,7 +28,7 @@ class CreateSessionsTable extends Migration
      *
      * @return void
      */
-    public function down()
+    public function down(): void
     {
         Schema::dropIfExists('sessions');
     }

--- a/tests/Database/migrations/one/2016_01_01_000000_create_users_table.php
+++ b/tests/Database/migrations/one/2016_01_01_000000_create_users_table.php
@@ -11,7 +11,7 @@ class CreateUsersTable extends Migration
      *
      * @return void
      */
-    public function up()
+    public function up(): void
     {
         Schema::create('users', function (Blueprint $table) {
             $table->increments('id');
@@ -28,7 +28,7 @@ class CreateUsersTable extends Migration
      *
      * @return void
      */
-    public function down()
+    public function down(): void
     {
         Schema::dropIfExists('users');
     }

--- a/tests/Database/migrations/one/2016_01_01_100000_create_password_resets_table.php
+++ b/tests/Database/migrations/one/2016_01_01_100000_create_password_resets_table.php
@@ -11,7 +11,7 @@ class CreatePasswordResetsTable extends Migration
      *
      * @return void
      */
-    public function up()
+    public function up(): void
     {
         Schema::create('password_resets', function (Blueprint $table) {
             $table->string('email')->index();
@@ -25,7 +25,7 @@ class CreatePasswordResetsTable extends Migration
      *
      * @return void
      */
-    public function down()
+    public function down(): void
     {
         Schema::dropIfExists('password_resets');
     }

--- a/tests/Database/migrations/two/2016_01_01_200000_create_flights_table.php
+++ b/tests/Database/migrations/two/2016_01_01_200000_create_flights_table.php
@@ -11,7 +11,7 @@ class CreateFlightsTable extends Migration
      *
      * @return void
      */
-    public function up()
+    public function up(): void
     {
         Schema::create('flights', function (Blueprint $table) {
             $table->increments('id');
@@ -24,7 +24,7 @@ class CreateFlightsTable extends Migration
      *
      * @return void
      */
-    public function down()
+    public function down(): void
     {
         Schema::dropIfExists('flights');
     }

--- a/tests/Integration/Database/stubs/2014_10_12_000000_create_members_table.php
+++ b/tests/Integration/Database/stubs/2014_10_12_000000_create_members_table.php
@@ -11,7 +11,7 @@ class CreateMembersTable extends Migration
      *
      * @return void
      */
-    public function up()
+    public function up(): void
     {
         Schema::create('members', function (Blueprint $table) {
             $table->increments('id');
@@ -28,7 +28,7 @@ class CreateMembersTable extends Migration
      *
      * @return void
      */
-    public function down()
+    public function down(): void
     {
         Schema::drop('members');
     }

--- a/tests/Integration/Migration/fixtures/2014_10_12_000000_create_people_table.php
+++ b/tests/Integration/Migration/fixtures/2014_10_12_000000_create_people_table.php
@@ -11,7 +11,7 @@ class CreatePeopleTable extends Migration
      *
      * @return void
      */
-    public function up()
+    public function up(): void
     {
         Schema::create('people', function (Blueprint $table) {
             $table->increments('id');
@@ -28,7 +28,7 @@ class CreatePeopleTable extends Migration
      *
      * @return void
      */
-    public function down()
+    public function down(): void
     {
         Schema::drop('people');
     }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Hey guys,

Since Laravel 8.x requires `PHP >= 7.3`, stubs can declare void return types (PHP >= 7.1 - [more info](https://wiki.php.net/rfc/void_return_type))

It's basic enhancement but end-users will save a few keyboard clicks, also static analysis tools like PHPStan, PHP inspections will stop squeaking 🐷 