### PR TITLE
[8.x] Added everyMinutes and everyHours schedule frequencies

### DIFF
--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -82,6 +82,17 @@ trait ManagesFrequencies
     }
 
     /**
+     * Schedule the event to run every custom minutes.
+     *
+     * @param  int  $minutes
+     * @return $this
+     */
+    public function everyMinutes($minutes)
+    {
+        return $this->spliceIntoPosition(1, '*/'.$minutes);
+    }
+
+    /**
      * Schedule the event to run every two minutes.
      *
      * @return $this

--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -186,6 +186,18 @@ trait ManagesFrequencies
     }
 
     /**
+     * Schedule the event to run every custom hours.
+     *
+     * @param  int  $hours
+     * @return $this
+     */
+    public function everyHours($hours)
+    {
+        return $this->spliceIntoPosition(1, 0)
+                    ->spliceIntoPosition(2, '*/'.$hours);
+    }
+
+    /**
      * Schedule the event to run every two hours.
      *
      * @return $this

--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -81,7 +81,14 @@ class FrequencyTest extends TestCase
         $this->assertSame('15,30,45 * * * *', $this->event->hourlyAt([15, 30, 45])->getExpression());
     }
 
-    public function testHourly()
+    public function testEveryHours()
+    {
+        $this->assertSame('0 */1 * * *', $this->event->everyHours(1)->getExpression());
+        $this->assertSame('0 */7 * * *', $this->event->everyHours(7)->getExpression());
+        $this->assertSame('0 */20 * * *', $this->event->everyHours(20)->getExpression());
+    }
+
+    public function testEveryXHours()
     {
         $this->assertSame('0 */2 * * *', $this->event->everyTwoHours()->getExpression());
         $this->assertSame('0 */3 * * *', $this->event->everyThreeHours()->getExpression());

--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -31,6 +31,13 @@ class FrequencyTest extends TestCase
         $this->assertSame('* * * * *', $this->event->everyMinute()->getExpression());
     }
 
+    public function testEveryMinutes()
+    {
+        $this->assertSame('*/1 * * * *', $this->event->everyMinutes(1)->getExpression());
+        $this->assertSame('*/7 * * * *', $this->event->everyMinutes(7)->getExpression());
+        $this->assertSame('*/20 * * * *', $this->event->everyMinutes(20)->getExpression());
+    }
+
     public function testEveryXMinutes()
     {
         $this->assertSame('*/2 * * * *', $this->event->everyTwoMinutes()->getExpression());


### PR DESCRIPTION
This PR add `everyMinutes` and `everyHours` as schedule frequencies to allow to set custom minutes and hours from an integer instead `everyXMinutes` or `everyXHours`.

On this way you can set cronjobs from external variables, for example:

```php
switch ($scheduleType) {
    case 'hours':
        return $schedule->everyHours($scheduleValue);

    case 'minutes':
        return $schedule->everyMinutes($scheduleValue);

    default:
        throw new Exception(sprintf('%s is not available at this time', $scheduleType));
}
```