### PR TITLE
[8.x] Add regex registration method to check alphanumeric route parameters.

### DIFF
--- a/src/Illuminate/Routing/CreatesRegularExpressionRouteConstraints.php
+++ b/src/Illuminate/Routing/CreatesRegularExpressionRouteConstraints.php
@@ -18,6 +18,17 @@ trait CreatesRegularExpressionRouteConstraints
     }
 
     /**
+     * Specify that the given route parameters must be alphanumeric.
+     *
+     * @param  array|string  $parameters
+     * @return $this
+     */
+    public function whereAlphaNumeric($parameters)
+    {
+        return $this->assignExpressionToParameters($parameters, '[a-zA-Z0-9]+');
+    }
+
+    /**
      * Specify that the given route parameters must be numeric.
      *
      * @param  array|string  $parameters

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -620,6 +620,18 @@ class RouteRegistrarTest extends TestCase
         }
     }
 
+    public function testWhereAlphaNumericRegistration()
+    {
+        $wheres = ['1a2b3c' => '[a-zA-Z0-9]+'];
+
+        $this->router->get('/{foo}')->whereAlphaNumeric(['1a2b3c']);
+
+        /** @var \Illuminate\Routing\Route $route */
+        foreach ($this->router->getRoutes() as $route) {
+            $this->assertEquals($wheres, $route->wheres);
+        }
+    }
+
     public function testCanSetRouteName()
     {
         $this->router->as('users.index')->get('users', function () {


### PR DESCRIPTION
Inspired by #34997, This PR adds a (supposedly) missing `whereAlphaNumeric` regex registration method to check alphanumeric route parameters.
