### PR TITLE
[8.x] Remove @return from docs block

### DIFF
--- a/src/Illuminate/Cache/DynamoDbStore.php
+++ b/src/Illuminate/Cache/DynamoDbStore.php
@@ -442,8 +442,6 @@ class DynamoDbStore implements LockProvider, Store
     /**
      * Remove all items from the cache.
      *
-     * @return bool
-     *
      * @throws \RuntimeException
      */
     public function flush()


### PR DESCRIPTION
Because this function returns nothing.

![image](https://user-images.githubusercontent.com/5250117/98572944-cbb00680-22e8-11eb-965a-1f198dd724b4.png)
