### PR TITLE
[8.x] Add "array" type

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -84,7 +84,7 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Retrieve an item from the cache by key.
      *
-     * @param  string  $key
+     * @param  string|array  $key
      * @param  mixed  $default
      * @return mixed
      */


### PR DESCRIPTION
This condition makes no sense because it's always false according to resolved type. So, I added "array".

![image](https://user-images.githubusercontent.com/5250117/98575020-3f531300-22eb-11eb-984f-6915b0abcd85.png)