### PR TITLE
[8.x] Added a 'expectedOutputNever' method for console command testing

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
@@ -23,6 +23,13 @@ trait InteractsWithConsole
     public $expectedOutput = [];
 
     /**
+     * All of the output lines that are expected to never be output.
+     *
+     * @var array
+     */
+    public $expectedOutputNever = [];
+
+    /**
      * All of the expected ouput tables.
      *
      * @var array

--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -134,6 +134,19 @@ class PendingCommand
     }
 
     /**
+     * Specify output that should never be printed when the command runs.
+     *
+     * @param  string  $output
+     * @return $this
+     */
+    public function expectsOutputNever($output)
+    {
+        $this->test->expectedOutputNever[$output] = false;
+
+        return $this;
+    }
+
+    /**
      * Specify a table that should be printed when the command runs.
      *
      * @param  array  $headers
@@ -238,6 +251,10 @@ class PendingCommand
         if (count($this->test->expectedOutput)) {
             $this->test->fail('Output "'.Arr::first($this->test->expectedOutput).'" was not printed.');
         }
+
+        if ($output = array_search(true, $this->test->expectedOutputNever)) {
+            $this->test->fail('Output "'.$output.'" was printed.');
+        }
     }
 
     /**
@@ -296,6 +313,16 @@ class PendingCommand
                 ->with($output, Mockery::any())
                 ->andReturnUsing(function () use ($i) {
                     unset($this->test->expectedOutput[$i]);
+                });
+        }
+
+        foreach ($this->test->expectedOutputNever as $output => $displayed) {
+            $mock->shouldReceive('doWrite')
+                ->once()
+                ->ordered()
+                ->with($output, Mockery::any())
+                ->andReturnUsing(function () use ($output) {
+                    $this->test->expectedOutputNever[$output] = true;
                 });
         }
 


### PR DESCRIPTION
Hi!

This pull request adds a new ` ->expectsOutputNever() ` method can be used for testing console commands. I think that this could be quite useful for helping to make the console tests a bit stricter.

This might not be the best example to show where it could be used, but it should hopefully give you a bit of an idea:

**Command:**
```php
public function handle()
{
    if ($this->something()) {
        $this->info('Something is truthy!');
    }

    // Continue the rest of the command...

    return 0;
}
```

**Test:**
```php
public function test_the_command_when_something_is_falsey()
{
    $this->artisan('signature')
        ->expectsOutputNever('Something is truthy!')
        ->assertExitCode(0);
}

public function test_the_command_when_something_is_truthy()
{
    $this->artisan('signature')
        ->expectsOutput('Something is truthy!')
        ->assertExitCode(0);
}
```

I'm hoping that you all think it could be valuable and would help with writing console tests. If I've targeted this to the wrong branch or if it needs any changes if you want to pull it in, please let me know and I'll update it straight away. :smile: