### PR TITLE
[8.x] Remove expectedTables after converting to expectedOutput in PendingCommand

### DIFF
--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -310,7 +310,7 @@ class PendingCommand
      */
     private function applyTableOutputExpectations($mock)
     {
-        foreach ($this->test->expectedTables as $consoleTable) {
+        foreach ($this->test->expectedTables as $index => $consoleTable) {
             $table = (new Table($output = new BufferedOutput))
                 ->setHeaders($consoleTable['headers'])
                 ->setRows($consoleTable['rows'])
@@ -329,6 +329,8 @@ class PendingCommand
             foreach ($lines as $line) {
                 $this->expectsOutput($line);
             }
+
+            unset($this->test->expectedTables[$index]);
         }
     }
 


### PR DESCRIPTION
Using the newly added method `expectsTable` in `Illuminate\Testing\PendingCommand` leads to errors if other commands, without the expected table output, run after the command with the expected table output within the same test.
For example:
```php
public function testCommandWithTableOutput()
{
    $this->artisan('command:table')
        ->expectsTable(['Header'], [['Value']])
        ->assertExitCode(0);

    $this->artisan('command:other')
        ->expectsOutput('Command Output')
        ->assertExitCode(0);
}
```
This leads to a failed test, because the table output of the first command is expected for the second command too.

The problem is, that for every command that runs in a test, the expected tables in the test get converted to expected output again.

I just removed the expected table after converting it so it will be used just once.