### PR TITLE
[8.x] Change SQLite schema command environment variables to work on Windows

### DIFF
--- a/src/Illuminate/Database/Schema/SqliteSchemaState.php
+++ b/src/Illuminate/Database/Schema/SqliteSchemaState.php
@@ -60,7 +60,7 @@ class SqliteSchemaState extends SchemaState
      */
     public function load($path)
     {
-        $process = $this->makeProcess($this->baseCommand().' < $LARAVEL_LOAD_PATH');
+        $process = $this->makeProcess($this->baseCommand().' < "${:LARAVEL_LOAD_PATH}"');
 
         $process->mustRun(null, array_merge($this->baseVariables($this->connection->getConfig()), [
             'LARAVEL_LOAD_PATH' => $path,
@@ -74,7 +74,7 @@ class SqliteSchemaState extends SchemaState
      */
     protected function baseCommand()
     {
-        return 'sqlite3 $LARAVEL_LOAD_DATABASE';
+        return 'sqlite3 "${:LARAVEL_LOAD_DATABASE}"';
     }
 
     /**


### PR DESCRIPTION
As described in https://github.com/laravel/framework/issues/35162 the SQLite schema commands do not work on Windows as the environment variables are the Linux type. This update brings the environment variables in line with what is used in the *MySqlSchemaState.php* file
