### PR TITLE
[8.x] Add console output to migrations

### DIFF
--- a/src/Illuminate/Database/Migrations/Migration.php
+++ b/src/Illuminate/Database/Migrations/Migration.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Database\Migrations;
 
+use Symfony\Component\Console\Output\OutputInterface;
+
 abstract class Migration
 {
     /**
@@ -19,6 +21,13 @@ abstract class Migration
     public $withinTransaction = true;
 
     /**
+     * The output interface implementation.
+     *
+     * @var \Symfony\Component\Console\Output\OutputInterface|null
+     */
+    protected $output;
+
+    /**
      * Get the migration connection name.
      *
      * @return string|null
@@ -26,5 +35,16 @@ abstract class Migration
     public function getConnection()
     {
         return $this->connection;
+    }
+
+    /**
+     * Set the output implementation that should be used by the console.
+     *
+     * @param  \Symfony\Component\Console\Output\OutputInterface  $output
+     * @return void
+     */
+    public function setOutput(OutputInterface $output)
+    {
+        $this->output = $output;
     }
 }

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -193,6 +193,10 @@ class Migrator
             return $this->pretendToRun($migration, 'up');
         }
 
+        if ($this->output && method_exists($migration, 'setOutput')) {
+            $migration->setOutput($this->output);
+        }
+
         $this->note("<comment>Migrating:</comment> {$name}");
 
         $startTime = microtime(true);
@@ -356,6 +360,10 @@ class Migrator
 
         if ($pretend) {
             return $this->pretendToRun($instance, 'down');
+        }
+
+        if ($this->output && method_exists($instance, 'setOutput')) {
+            $instance->setOutput($this->output);
         }
 
         $startTime = microtime(true);

--- a/tests/Database/DatabaseMigratorIntegrationTest.php
+++ b/tests/Database/DatabaseMigratorIntegrationTest.php
@@ -240,6 +240,7 @@ class DatabaseMigratorIntegrationTest extends TestCase
         foreach ($messages as $i => $message) {
             $output->shouldReceive('writeln')->once()->ordered()->withArgs(function ($line) use ($message) {
                 $this->assertStringStartsWith($message, $line);
+
                 return true;
             });
         }

--- a/tests/Database/DatabaseMigratorIntegrationTest.php
+++ b/tests/Database/DatabaseMigratorIntegrationTest.php
@@ -223,4 +223,30 @@ class DatabaseMigratorIntegrationTest extends TestCase
         $this->migrator->reset([__DIR__.'/migrations/one'], ['database' => 'sqlite2']);
         $this->assertSame('default', $this->migrator->getConnection());
     }
+
+    public function testMigrationsCanWriteToTheOutput()
+    {
+        $output = m::mock(OutputStyle::class);
+
+        $messages = [
+            '<comment>Migrating:</comment>',
+            '<comment>Created table</comment>',
+            '<info>Migrated:</info>',
+            '<comment>Rolling back:</comment>',
+            '<error>Dropped table</error>',
+            '<info>Rolled back:</info>',
+        ];
+
+        foreach ($messages as $i => $message) {
+            $output->shouldReceive('writeln')->once()->ordered()->withArgs(function ($line) use ($message) {
+                $this->assertStringStartsWith($message, $line);
+                return true;
+            });
+        }
+
+        $this->migrator->setOutput($output);
+
+        $this->migrator->run([__DIR__.'/migrations/output']);
+        $this->migrator->rollback([__DIR__.'/migrations/output']);
+    }
 }

--- a/tests/Database/migrations/output/2016_01_01_200000_create_airports_table.php
+++ b/tests/Database/migrations/output/2016_01_01_200000_create_airports_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateAirportsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('airports', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+        });
+
+        $this->output->writeln('<comment>Created table</comment>');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('airports');
+
+        $this->output->writeln('<error>Dropped table</error>');
+    }
+}


### PR DESCRIPTION
This PR allows migrations to write to the console output.

The `Migrator` itself already has access to the output and writes messages before and after running or reverting migrations.
But there is no way for developers to write additional messages or stream the output of other artisan commands that might run during migrations.

A common case is running seeders after a table has been created or modified. While the seeder has access to the console output and can write messages, during migrations nothing is output.

Currently, in order to achieve this, a new instance of the console output must be instantiated:

```php
public function up()
{
    Schema::create('users', function (Blueprint $table) {
        // ...
    });
    
    Artisan::call(
        'db:seed',
        ['--class' => UserSeeder::class],
        new \Symfony\Component\Console\Output\ConsoleOutput
    );
}
```

After this PR, we can use the existing output like this:

```php
Artisan::call('db:seed', ['--class' => UserSeeder::class], $this->output);
```

This feature does not make many assumptions about the state of the output or the migration:
- It checks that the console output is set to the `Migrator`, since it might be `null`
- It checks that the migration class has as `setOutput` method, since developers can use custom stubs or migration classes
- Even if the developer tries to access an output that is `null`, `Artisan::call()` would accept that and create a  new `BufferedOutput`.