### PR TITLE
[8.x] Add day constants to Scheduler

### DIFF
--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -18,7 +18,7 @@ use RuntimeException;
 class Schedule
 {
     use Macroable;
-    
+
     const SUNDAY = 0;
     const MONDAY = 1;
     const TUESDAY = 2;

--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -18,6 +18,14 @@ use RuntimeException;
 class Schedule
 {
     use Macroable;
+    
+    const SUNDAY = 0;
+    const MONDAY = 1;
+    const TUESDAY = 2;
+    const WEDNESDAY = 3;
+    const THURSDAY = 4;
+    const FRIDAY = 5;
+    const SATURDAY = 6;
 
     /**
      * All of the events on the schedule.


### PR DESCRIPTION
When you are adding a scheduled task to the console kernel, some of the code requires "magic numbers", which would be more readable with a constant for them.

```
$schedule->command('reminders:send')
                ->hourly()
                ->days([0, 3]);
```
becomes
```
$schedule->command('reminders:send')
                ->hourly()
                ->days([Schedule::SUNDAY, Schedule::WEDNESDAY]);
```