### PR TITLE
[8.x] Updated EmailVerificationRequest.php to check if user is not already verified

### DIFF
--- a/src/Illuminate/Foundation/Auth/EmailVerificationRequest.php
+++ b/src/Illuminate/Foundation/Auth/EmailVerificationRequest.php
@@ -46,9 +46,10 @@ class EmailVerificationRequest extends FormRequest
      */
     public function fulfill()
     {
-        $this->user()->markEmailAsVerified();
-
-        event(new Verified($this->user()));
+        if (! $this->user()->hasVerifiedEmail()) {
+            $this->user()->markEmailAsVerified();
+            event(new Verified($this->user()));
+        }
     }
 
     /**

--- a/src/Illuminate/Foundation/Auth/EmailVerificationRequest.php
+++ b/src/Illuminate/Foundation/Auth/EmailVerificationRequest.php
@@ -48,6 +48,7 @@ class EmailVerificationRequest extends FormRequest
     {
         if (! $this->user()->hasVerifiedEmail()) {
             $this->user()->markEmailAsVerified();
+
             event(new Verified($this->user()));
         }
     }


### PR DESCRIPTION
This PR solves issue #35168 It adds the condition to check if the user's email is not already verified before updating it in the database and does not fire the Verified event