### PR TITLE
CHANGELOG-8.x.md Fixes

### DIFF
--- a/CHANGELOG-8.x.md
+++ b/CHANGELOG-8.x.md
@@ -3,7 +3,7 @@
 ## [Unreleased](https://github.com/laravel/framework/compare/v8.14.0...8.x)
 
 
-## [v8.13.0 (2020-11-10)](https://github.com/laravel/framework/compare/v8.13.0...v8.14.0)
+## [v8.14.0 (2020-11-10)](https://github.com/laravel/framework/compare/v8.13.0...v8.14.0)
 
 ### Added
 - Added ability to dispatch unique jobs ([#35042](https://github.com/laravel/framework/pull/35042), [2123e60](https://github.com/laravel/framework/commit/2123e603af027e7590974864715c028357ea4969))
@@ -29,7 +29,7 @@
 - Change SQLite schema command environment variables to work on Windows ([#35164](https://github.com/laravel/framework/pull/35164))
   
   
-## [v8.13.0 (2020-10-03)](https://github.com/laravel/framework/compare/v8.12.3...v8.13.0)
+## [v8.13.0 (2020-11-03)](https://github.com/laravel/framework/compare/v8.12.3...v8.13.0)
 
 ### Added
 - Added `loadMax()` | `loadMin()` | `loadSum()` | `loadAvg()` methods to `Illuminate\Database\Eloquent\Collection`. Added `loadMax()` | `loadMin()` | `loadSum()` | `loadAvg()` | `loadMorphMax()` | `loadMorphMin()` | `loadMorphSum()` | `loadMorphAvg()` methods to `Illuminate\Database\Eloquent\Model` ([#35029](https://github.com/laravel/framework/pull/35029))


### PR DESCRIPTION
- Fix release version for 8.14.0 (the [release page](https://github.com/laravel/framework/releases/tag/v8.14.0) is incorrect too)
- Fix release date for 8.13.0