### PR TITLE
[8.x] Make Validator::parseNamedParameters public

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1875,7 +1875,7 @@ trait ValidatesAttributes
      * @param  array  $parameters
      * @return array
      */
-    protected function parseNamedParameters($parameters)
+    public function parseNamedParameters($parameters)
     {
         return array_reduce($parameters, function ($result, $item) {
             [$key, $value] = array_pad(explode('=', $item, 2), 2, null);


### PR DESCRIPTION
This change will allow custom validation rules having access to the validator to parse named parameters.

Consider a custom validation rule using a closure or extension:

```php
Validator::extend('custom_rule', function($attribute, $value, $parameters, $validator) {
  // the parameters are something like ['country=US', 'level=pro'],
  // but we want ['country' => 'US', 'level' => 'pro'] instead
  dd($parameters);
  // this will give us what we want (but currently it fails, because the method is protected)
  dd($validator->parseNamedParameters($parameters));
});

Validator::make([
  'some_field' => 'custom_rule:country=US,level=pro'
], $data);
```

There are no breaking changes, it simply exposes a helpful method to custom validation rules.