### PR TITLE
[8.x] Update MySqlSchemaState.php to support MariaDB dump

### DIFF
--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -85,7 +85,7 @@ class MySqlSchemaState extends SchemaState
     {
         $command = 'mysqldump '.$this->connectionString().' --skip-add-locks --skip-comments --skip-set-charset --tz-utc';
 
-        if ($this->connection->isMaria()) {
+        if (!$this->connection->isMaria()) {
             $command .= ' --column-statistics=0 --set-gtid-purged=OFF';
         }
 

--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -85,7 +85,7 @@ class MySqlSchemaState extends SchemaState
     {
         $command = 'mysqldump '.$this->connectionString().' --skip-add-locks --skip-comments --skip-set-charset --tz-utc';
 
-        if (!$this->connection->isMaria()) {
+        if (! $this->connection->isMaria()) {
             $command .= ' --column-statistics=0 --set-gtid-purged=OFF';
         }
 


### PR DESCRIPTION
isMaria db logic was incorrect, because those params not work in MariaDB so it should only append those when it's not MariaDB.