### PR TITLE
[9.x] Add `untouched` method to the Collection

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -20,6 +20,13 @@ class Collection implements ArrayAccess, Enumerable
     protected $items = [];
 
     /**
+     * The untouched items in the collection
+     *
+     * @var array
+     */
+    protected $untouchedItems = [];
+
+    /**
      * Create a new collection.
      *
      * @param  mixed  $items
@@ -28,6 +35,8 @@ class Collection implements ArrayAccess, Enumerable
     public function __construct($items = [])
     {
         $this->items = $this->getArrayableItems($items);
+
+        $this->untouchedItems = $this->items;
     }
 
     /**
@@ -750,6 +759,16 @@ class Collection implements ArrayAccess, Enumerable
         }
 
         return new static($new);
+    }
+
+    /**
+     * Get untouched items from the collection
+     *
+     * @return self
+     */
+    public function untouched()
+    {
+        return new static($this->untouchedItems);
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3387,6 +3387,17 @@ class SupportCollectionTest extends TestCase
         $this->assertNull($c->min());
     }
 
+    public function testUntouched()
+    {
+        $c = new Collection([1, 2, 3]);
+
+        $c->transform(function ($item){
+            return $item * 2;
+        });
+
+        $this->assertEquals([1, 2, 3], $c->untouched()->all());
+    }
+
     /**
      * @dataProvider collectionClassProvider
      */


### PR DESCRIPTION
The `untouched` method retrieves original (untouched) items and allow to perform multiple operations in the chain:

```php
// before
$items = [
    'foo' => [1, 2, 3],
    'bar' => ['a', 'b', 'c'],
    // 10 anther key with different values
];

collect($items)->each(function ($items, $key) {
    if ($key == 'foo') {
        foreach ($items as $item) {
            //
        }
    }

    if ($key == 'bar') {
        foreach ($items as $item) {
            //
        }
    }
});

// after

collect($items)
    ->only('foo')
    ->each(/** operation for foo */)
    ->untouched()
    ->only('bar')
    ->each(/** operation for bar */);
```