### PR TITLE
[8.x] MorphTo relationship eager loading constraints

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -52,6 +52,13 @@ class MorphTo extends BelongsTo
     protected $morphableEagerLoadCounts = [];
 
     /**
+     * A map of constraints to apply for each individual morph type.
+     *
+     * @var array
+     */
+    protected $morphableConstraints = [];
+
+    /**
      * Create a new morph to relationship instance.
      *
      * @param  \Illuminate\Database\Eloquent\Builder  $query
@@ -132,6 +139,10 @@ class MorphTo extends BelongsTo
                             ->withCount(
                                 (array) ($this->morphableEagerLoadCounts[get_class($instance)] ?? [])
                             );
+
+        if ($callback = $this->morphableConstraints[get_class($instance)] ?? null) {
+            $callback($query);
+        }
 
         $whereIn = $this->whereInMethod($instance, $ownerKey);
 
@@ -307,6 +318,21 @@ class MorphTo extends BelongsTo
     {
         $this->morphableEagerLoadCounts = array_merge(
             $this->morphableEagerLoadCounts, $withCount
+        );
+
+        return $this;
+    }
+
+    /**
+     * Specify constraints on the query for a given morph type.
+     *
+     * @param  array  $with
+     * @return \Illuminate\Database\Eloquent\Relations\MorphTo
+     */
+    public function constrain(array $callbacks)
+    {
+        $this->morphableConstraints = array_merge(
+            $this->morphableConstraints, $callbacks
         );
 
         return $this;

--- a/tests/Integration/Database/EloquentMorphConstrainTest.php
+++ b/tests/Integration/Database/EloquentMorphConstrainTest.php
@@ -56,7 +56,7 @@ class EloquentMorphConstrainTest extends DatabaseTestCase
                     },
                     Video::class => function ($query) {
                         $query->where('video_visible', true);
-                    }
+                    },
                 ]);
             }])
             ->get();

--- a/tests/Integration/Database/EloquentMorphConstrainTest.php
+++ b/tests/Integration/Database/EloquentMorphConstrainTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentMorphConstrainTest;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+/**
+ * @group integration
+ */
+class EloquentMorphConstrainTest extends DatabaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('posts', function (Blueprint $table) {
+            $table->increments('id');
+            $table->boolean('post_visible');
+        });
+
+        Schema::create('videos', function (Blueprint $table) {
+            $table->increments('id');
+            $table->boolean('video_visible');
+        });
+
+        Schema::create('comments', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('commentable_type');
+            $table->integer('commentable_id');
+        });
+
+        $post1 = Post::create(['post_visible' => true]);
+        (new Comment)->commentable()->associate($post1)->save();
+
+        $post2 = Post::create(['post_visible' => false]);
+        (new Comment)->commentable()->associate($post2)->save();
+
+        $video1 = Video::create(['video_visible' => true]);
+        (new Comment)->commentable()->associate($video1)->save();
+
+        $video2 = Video::create(['video_visible' => false]);
+        (new Comment)->commentable()->associate($video2)->save();
+    }
+
+    public function testMorphConstraints()
+    {
+        $comments = Comment::query()
+            ->with(['commentable' => function (MorphTo $morphTo) {
+                $morphTo->constrain([
+                    Post::class => function ($query) {
+                        $query->where('post_visible', true);
+                    },
+                    Video::class => function ($query) {
+                        $query->where('video_visible', true);
+                    }
+                ]);
+            }])
+            ->get();
+
+        $this->assertTrue($comments[0]->commentable->post_visible);
+        $this->assertNull($comments[1]->commentable);
+        $this->assertTrue($comments[2]->commentable->video_visible);
+        $this->assertNull($comments[3]->commentable);
+    }
+}
+
+class Comment extends Model
+{
+    public $timestamps = false;
+
+    public function commentable()
+    {
+        return $this->morphTo();
+    }
+}
+
+class Post extends Model
+{
+    public $timestamps = false;
+    protected $fillable = ['post_visible'];
+    protected $casts = ['post_visible' => 'boolean'];
+}
+
+class Video extends Model
+{
+    public $timestamps = false;
+    protected $fillable = ['video_visible'];
+    protected $casts = ['video_visible' => 'boolean'];
+}


### PR DESCRIPTION
Currently it is not possible to apply different constraints to the queries that eager load each different type in a morph-to relation. You can apply constraints directly to the `MorphTo` relation object:

```php
use Illuminate\Database\Eloquent\Builder;
use Illuminate\Database\Eloquent\Relations\MorphTo;

$activities = ActivityFeed::query()
    ->with(['parentable' => function (MorphTo $query) {
        $query->where('foo', 'bar');
    }])->get();
```

However these constraints will be applied uniformly to the queries for each morph type, so it is only useful if constraining by a column which is present on all types – otherwise, it will fail.

In a similar vein to the `morphWith` method introduced in #28647, **this PR introduces the ability to apply different constraints to the queries for each type:**

```php
use Illuminate\Database\Eloquent\Builder;
use Illuminate\Database\Eloquent\Relations\MorphTo;

$activities = ActivityFeed::query()
    ->with(['parentable' => function (MorphTo $morphTo) {
        $morphTo->constrain([
            Event::class => function (Builder $query) {
                $query->where('event_foo', 'bar');
            },
            Photo::class => function (Builder $query) {
                $query->where('photo_foo', 'bar');
            },
        ]);
    }])->get();
```