### PR TITLE
[8.x] Revert "[8.x] Make Validator::parseNamedParameters public"

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1875,7 +1875,7 @@ trait ValidatesAttributes
      * @param  array  $parameters
      * @return array
      */
-    public function parseNamedParameters($parameters)
+    protected function parseNamedParameters($parameters)
     {
         return array_reduce($parameters, function ($result, $item) {
             [$key, $value] = array_pad(explode('=', $item, 2), 2, null);


### PR DESCRIPTION
Reverts laravel/framework#35183. Should be made in 9.x only. It is likely some people are overriding this method, and changing its visibility is breaking.