### PR TITLE
[6.x] Add missing PHPDoc methods to Request facade

### DIFF
--- a/src/Illuminate/Support/Facades/Request.php
+++ b/src/Illuminate/Support/Facades/Request.php
@@ -83,6 +83,9 @@ namespace Illuminate\Support\Facades;
  * @method static mixed offsetGet(string $offset)
  * @method static void offsetSet(string $offset, mixed $value)
  * @method static void offsetUnset(string $offset)
+ * @method static array validate(array $rules, ...$params)
+ * @method static array validateWithBag(string $errorBag, array $rules, ...$params)
+ * @method static bool hasValidSignature(bool $absolute = true)
  *
  * @see \Illuminate\Http\Request
  */


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Adds missing PHPDoc method annotations to the Request facade. 

I have simply copied their definition from https://github.com/laravel/framework/blob/6.x/src/Illuminate/Http/Request.php#L16

These methods are defined as macro's on the Request class in [the FoundationServiceProvider](https://github.com/laravel/framework/blob/6.x/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php).