### PR TITLE
[8.x] Add global extenders

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -395,6 +395,7 @@ class Container implements ArrayAccess, ContainerContract
     {
         if ($abstract instanceof Closure) {
             $this->addGlobalExtender($abstract);
+
             return;
         }
 
@@ -412,6 +413,7 @@ class Container implements ArrayAccess, ContainerContract
             }
         }
     }
+
     /**
      * Add a global extender callback to the container.
      *

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -391,10 +391,10 @@ class Container implements ArrayAccess, ContainerContract
      *
      * @throws \InvalidArgumentException
      */
-    public function extend($abstract, $closure = null)
+    public function extend($abstract, Closure $closure = null)
     {
         if ($abstract instanceof Closure) {
-            $this->addGlobalExtender($abstract);
+            $this->globalExtenders[] = $abstract;
 
             return;
         }
@@ -412,28 +412,6 @@ class Container implements ArrayAccess, ContainerContract
                 $this->rebound($abstract);
             }
         }
-    }
-
-    /**
-     * Add a global extender callback to the container.
-     *
-     * @param  \Closure  $closure
-     * @return void
-     *
-     * @throws \InvalidArgumentException
-     */
-    protected function addGlobalExtender(Closure $closure)
-    {
-        foreach ($this->instances as $abstract => $instance) {
-            $this->instances[$abstract] = $closure($instance, $this);
-            $this->rebound($abstract);
-        }
-
-        foreach (array_keys($this->resolved) as $abstract) {
-            $this->rebound($abstract);
-        }
-
-        $this->globalExtenders[] = $closure;
     }
 
     /**

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1219,7 +1219,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function forgetGlobalExtenders()
     {
-        $this->extenders = [];
+        $this->globalExtenders = [];
     }
 
     /**

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -394,14 +394,7 @@ class Container implements ArrayAccess, ContainerContract
     public function extend($abstract, $closure = null)
     {
         if ($abstract instanceof Closure) {
-            $closure = $abstract;
-
-            foreach ($this->instances as $abstract => $instance) {
-                $this->instances[$abstract] = $closure($instance, $this);
-                $this->rebound($abstract);
-            }
-
-            $this->globalExtenders[] = $closure;
+            $this->addGlobalExtender($abstract);
             return;
         }
 
@@ -418,6 +411,27 @@ class Container implements ArrayAccess, ContainerContract
                 $this->rebound($abstract);
             }
         }
+    }
+    /**
+     * Add a global extender callback to the container.
+     *
+     * @param  \Closure  $closure
+     * @return void
+     *
+     * @throws \InvalidArgumentException
+     */
+    protected function addGlobalExtender(Closure $closure)
+    {
+        foreach ($this->instances as $abstract => $instance) {
+            $this->instances[$abstract] = $closure($instance, $this);
+            $this->rebound($abstract);
+        }
+
+        foreach (array_keys($this->resolved) as $abstract) {
+            $this->rebound($abstract);
+        }
+
+        $this->globalExtenders[] = $closure;
     }
 
     /**

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -64,18 +64,18 @@ class Container implements ArrayAccess, ContainerContract
     protected $abstractAliases = [];
 
     /**
-     * The extension closures for services.
-     *
-     * @var array[]
-     */
-    protected $extenders = [];
-
-    /**
      * The global extension closures for services.
      *
      * @var array[]
      */
     protected $globalExtenders = [];
+
+    /**
+     * The extension closures for services.
+     *
+     * @var array[]
+     */
+    protected $extenders = [];
 
     /**
      * All of the registered tags.
@@ -1192,7 +1192,20 @@ class Container implements ArrayAccess, ContainerContract
      */
     protected function getExtenders($abstract)
     {
-        return $this->extenders[$this->getAlias($abstract)] ?? [];
+        return array_merge(
+            $this->globalExtenders,
+            $this->extenders[$this->getAlias($abstract)] ?? []
+        );
+    }
+
+    /**
+     * Remove all of the global extender callbacks.
+     *
+     * @return void
+     */
+    public function forgetGlobalExtenders()
+    {
+        $this->extenders = [];
     }
 
     /**

--- a/tests/Container/ContainerExtendTest.php
+++ b/tests/Container/ContainerExtendTest.php
@@ -196,7 +196,7 @@ class ContainerExtendTest extends TestCase
 
         // When we append "bar" to all bindings.
         $container->extend(function ($old, $container) {
-            return $old . 'bar';
+            return $old.'bar';
         });
 
         // Then we resolve "foobar".
@@ -394,7 +394,7 @@ class ContainerExtendTest extends TestCase
 
         // And a global extender that appends "bar" to all bindings.
         $container->extend(function ($obj, $container) {
-            return $obj . 'bar';
+            return $obj.'bar';
         });
 
         // When we forget all global extenders.


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

## Current limitations

It is currently impossible to hook some logic into the container resolution unless we know in advance the exact class that will be resolved.

This makes it impossible to extend classes that:
- Implement a certain interface;
- Use a certain trait;
- Extend a certain super-class;
- Or, more generally, follow any custom logic we might have.

The container offer four types of resolution callbacks, namely:
- `globalResolvingCallbacks`
- `globalAfterResolvingCallbacks`
- `resolvingCallbacks`
- `afterResolvingCallbacks`

However, none of the callbacks can affect what is being returned by the `resolve` method and, therefore, cannot be used to extend a class that follows some custom logic.

## Solution

The solution I offer in this PR is to support **global extenders** in addition to the existing extenders (following the same convention as `resolvingCallbacks` and `globalResolvingCallbacks`).

## Usage

The `Illuminate\Container\Container@extend` method has been extended to support both specific and global extenders.

```php
// Current usage (still supported).
$this->app->extend(SomeSpecificThirdPartyService::class, function ($instance, $app) {
    return FakeServiceDecorator($instance);
});

// New (more flexible) usage.
$this->app->extend(function ($instance, $app) {
    if (! $app->isProduction() && $instance instanceof CanBeFaked) {
        return FakeServiceDecorator($instance);
    }

    return $instance;
});
```

As you can see, this enables us to properly hook some custom logic at the core of the container resolution. This offers a new set of possibilities for both Laravel user and package developers.

For example, we could use this mechanism to dynamically catch certain classes that are being used as controllers and swap them for a more appropriate decorator. As such, this would allow packages like [Laravel Actions](https://github.com/lorisleiva/laravel-actions) to decorate their own sub-classes dynamically without having to extend core Laravel components that might conflict with other packages.

## Backward compatibility

This PR does not add any breaking changes.

It adjusts the current signature of `extend` in a way that does not break the current usage of this method.

## Other notes

- Since we currently have the ability to forget specific extenders using `forgetExtenders($abstract)`, a `forgetGlobalExtenders()` method has been added for consistency.
- Similarly to the current behaviour of the `extend` method, when registering a new global extender:
    - The provided callback is applied to all previously resolved instances;
    - The rebinding callbacks are triggered for all `$resolved` and `$instances` elements.
- Many tests have been added following the existing tests for specific extenders.
- Please let me know if there is anything I can do to help improve this PR.