### PR TITLE
[8.x] Use dynamic app namespace in Eloquent Factory instead of App\ string

### DIFF
--- a/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
+++ b/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
@@ -68,8 +68,8 @@ class FactoryMakeCommand extends GeneratorCommand
 
         $model = class_basename($namespaceModel);
 
-        if (Str::startsWith($namespaceModel, 'App\\Models')) {
-            $namespace = Str::beforeLast('Database\\Factories\\'.Str::after($namespaceModel, 'App\\Models\\'), '\\');
+        if (Str::startsWith($namespaceModel, $this->rootNamespace().'Models')) {
+            $namespace = Str::beforeLast('Database\\Factories\\'.Str::after($namespaceModel, $this->rootNamespace().'Models\\'), '\\');
         } else {
             $namespace = 'Database\\Factories';
         }
@@ -99,7 +99,7 @@ class FactoryMakeCommand extends GeneratorCommand
      */
     protected function getPath($name)
     {
-        $name = (string) Str::of($name)->replaceFirst('App\\', '')->finish('Factory');
+        $name = (string) Str::of($name)->replaceFirst($this->rootNamespace(), '')->finish('Factory');
 
         return $this->laravel->databasePath().'/factories/'.str_replace('\\', '/', $name).'.php';
     }
@@ -116,17 +116,17 @@ class FactoryMakeCommand extends GeneratorCommand
             $name = substr($name, 0, -7);
         }
 
-        $modelName = $this->qualifyModel(Str::after($name, 'App\\'));
+        $modelName = $this->qualifyModel(Str::after($name, $this->rootNamespace()));
 
         if (class_exists($modelName)) {
             return $modelName;
         }
 
         if (is_dir(app_path('Models/'))) {
-            return 'App\Models\Model';
+            return $this->rootNamespace().'Models\Model';
         }
 
-        return 'App\Model';
+        return $this->rootNamespace().'Model';
     }
 
     /**


### PR DESCRIPTION
Currently, Eloquent Factory does not handle model namespaces other than the ones with `App\` prefix.

_(This is the only place in the framework where `App\` string is used, all the other parts are using `getNamespace()` from `Application`.)_

This PR eliminates the use of `App\` namespace string and adds a dynamic way to determine the actual root namespace.
Test is included.