### PR TITLE
[8.x] Add support for incrementing json column value

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1428,6 +1428,9 @@ trait HasAttributes
         $modelAttributes = $this->getAttributes();
 
         foreach ($attributes as $attribute) {
+            if (Str::contains($attribute, '->')) {
+                $attribute = explode('->', $attribute)[0];
+            }
             $this->original[$attribute] = $modelAttributes[$attribute];
         }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1431,6 +1431,7 @@ trait HasAttributes
             if (Str::contains($attribute, '->')) {
                 $attribute = explode('->', $attribute)[0];
             }
+
             $this->original[$attribute] = $modelAttributes[$attribute];
         }
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1946,6 +1946,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
         if (! Str::contains($column, '->')) {
             return $this->{$column};
         }
+
         [$column, $key] = $this->parseJsonColumnKey($column);
 
         return Arr::get($this->{$column}, $key);


### PR DESCRIPTION
Assuming this cast for json type column:
```php
protected $casts = [ 'my_json_col'  => 'json' ];
```

If we try this query, the age value in DB does increment up, but it also throws an error in php.

```php
Person::first()->increment('my_json_col->age');
```

This change helped me to remedy the error and now the json columns get incremented properly.

- It does not seem to be backward-incompatible.
- Works for nested keys (like the example below)
- In fact this feature facilitates this query (mysql example):
```php
Person::first()->increment('my_json_col->key2->key3');
```

```sql
"update `my_table` set `my_json_col` = json_set(`my_json_col`, '$."key2"."key3"', json_unquote(json_extract(`my_json_col`, '$."key2"."key3"')) + 1) where `id` = ?"
```

