### PR TITLE
[8.x] Allowing httpOnly from Session Config

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -186,7 +186,7 @@ class VerifyCsrfToken
         $response->headers->setCookie(
             new Cookie(
                 'XSRF-TOKEN', $request->session()->token(), $this->availableAt(60 * $config['lifetime']),
-                $config['path'], $config['domain'], $config['secure'], false, false, $config['same_site'] ?? null
+                $config['path'], $config['domain'], $config['secure'], $config['http_only'], false, $config['same_site'] ?? null
             )
         );
 


### PR DESCRIPTION
To allow `httpOnly` value to be use from `config('session.http_only')`. 

Currently it's been hardcoded as `false`. 

For some organisation like currently am working on, it's required to set it to true, unless there's necessity to have set to false.

Hence, the option for `httpOnly` need to be based on session config rather than hardcoded it.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
