### PR TITLE
[9.x] Add path to post create hooks in MigrationCreator

### DIFF
--- a/src/Illuminate/Database/Migrations/MigrationCreator.php
+++ b/src/Illuminate/Database/Migrations/MigrationCreator.php
@@ -74,7 +74,7 @@ class MigrationCreator
         // Next, we will fire any hooks that are supposed to fire after a migration is
         // created. Once that is done we'll be ready to return the full path to the
         // migration file so it can be used however it's needed by the developer.
-        $this->firePostCreateHooks($table);
+        $this->firePostCreateHooks($table, $path);
 
         return $path;
     }
@@ -184,12 +184,13 @@ class MigrationCreator
      * Fire the registered post create hooks.
      *
      * @param  string|null  $table
+     * @param  string       $path
      * @return void
      */
-    protected function firePostCreateHooks($table)
+    protected function firePostCreateHooks($table, $path)
     {
         foreach ($this->postCreate as $callback) {
-            $callback($table);
+            $callback($table, $path);
         }
     }
 

--- a/src/Illuminate/Database/Migrations/MigrationCreator.php
+++ b/src/Illuminate/Database/Migrations/MigrationCreator.php
@@ -184,7 +184,7 @@ class MigrationCreator
      * Fire the registered post create hooks.
      *
      * @param  string|null  $table
-     * @param  string       $path
+     * @param  string  $path
      * @return void
      */
     protected function firePostCreateHooks($table, $path)

--- a/tests/Database/DatabaseMigrationCreatorTest.php
+++ b/tests/Database/DatabaseMigrationCreatorTest.php
@@ -35,9 +35,11 @@ class DatabaseMigrationCreatorTest extends TestCase
         $table = 'baz';
 
         $creator = $this->getCreator();
-        unset($_SERVER['__migration.creator']);
-        $creator->afterCreate(function ($table) {
-            $_SERVER['__migration.creator'] = $table;
+        unset($_SERVER['__migration.creator.table']);
+        unset($_SERVER['__migration.creator.path']);
+        $creator->afterCreate(function ($table, $path) {
+            $_SERVER['__migration.creator.table'] = $table;
+            $_SERVER['__migration.creator.path'] = $path;
         });
 
         $creator->expects($this->any())->method('getDatePrefix')->willReturn('foo');
@@ -50,9 +52,11 @@ class DatabaseMigrationCreatorTest extends TestCase
 
         $creator->create('create_bar', 'foo', $table);
 
-        $this->assertEquals($_SERVER['__migration.creator'], $table);
+        $this->assertEquals($_SERVER['__migration.creator.table'], $table);
+        $this->assertEquals($_SERVER['__migration.creator.path'], 'foo/foo_create_bar.php');
 
-        unset($_SERVER['__migration.creator']);
+        unset($_SERVER['__migration.creator.table']);
+        unset($_SERVER['__migration.creator.path']);
     }
 
     public function testTableUpdateMigrationStoresMigrationFile()


### PR DESCRIPTION
Add new argument to `firePostCreateHooks` in `MigrationCreator` which contains path of newly created file with migration. It provides ability to work with new files of migrations.