### PR TITLE
[8.x] Ignore max attempts if retryUntil is set

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -501,7 +501,7 @@ class Worker
             $this->failJob($job, $e);
         }
 
-        if ($maxTries > 0 && $job->attempts() >= $maxTries) {
+        if (! $job->retryUntil() && $maxTries > 0 && $job->attempts() >= $maxTries) {
             $this->failJob($job, $e);
         }
     }


### PR DESCRIPTION
Currently if a job fails due to an exception and `retryUntil` time has not passed yet, the worker will check for `maxAttempts`. However, if the job was released and `retryUntil` has not passed yet, the worker will not check for `maxAttempts`.

The PR unifies the behaviour. So with this PR, if a `retryUntil` is set the worker is going to ignore `maxAttempts` completely.

Solves #35199