### PR TITLE
[8.x] Add read / unread scopes to database notifications

### DIFF
--- a/src/Illuminate/Notifications/DatabaseNotification.php
+++ b/src/Illuminate/Notifications/DatabaseNotification.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Notifications;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 
 class DatabaseNotification extends Model
@@ -96,6 +97,28 @@ class DatabaseNotification extends Model
     public function unread()
     {
         return $this->read_at === null;
+    }
+
+    /**
+     * Scope a query to only include read notifications.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeRead(Builder $query)
+    {
+        return $query->whereNotNull('read_at');
+    }
+
+    /**
+     * Scope a query to only include unread notifications.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeUnread(Builder $query)
+    {
+        return $query->whereNull('read_at');
     }
 
     /**

--- a/src/Illuminate/Notifications/HasDatabaseNotifications.php
+++ b/src/Illuminate/Notifications/HasDatabaseNotifications.php
@@ -21,7 +21,7 @@ trait HasDatabaseNotifications
      */
     public function readNotifications()
     {
-        return $this->notifications()->whereNotNull('read_at');
+        return $this->notifications()->read();
     }
 
     /**
@@ -31,6 +31,6 @@ trait HasDatabaseNotifications
      */
     public function unreadNotifications()
     {
-        return $this->notifications()->whereNull('read_at');
+        return $this->notifications()->unread();
     }
 }


### PR DESCRIPTION
This PR adds the `read()` / `unread()` scopes to the `DatabaseNotification` class.

This makes the notification queries a bit more cleaner / readable, which might be helpful when working a lot with the database channel.

I did not add tests, since (at least as I see) the tests for the `DatabaseNotification` are not present, so I didn't know where to add them.