### PR TITLE
[8.x] Add hasVerifiedEmail scope

### DIFF
--- a/src/Illuminate/Auth/MustVerifyEmail.php
+++ b/src/Illuminate/Auth/MustVerifyEmail.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Auth;
 
 use Illuminate\Auth\Notifications\VerifyEmail;
+use Illuminate\Database\Eloquent\Builder;
 
 trait MustVerifyEmail
 {
@@ -46,5 +47,16 @@ trait MustVerifyEmail
     public function getEmailForVerification()
     {
         return $this->email;
+    }
+
+    /**
+     * Scope a query to only include users with verified email.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeHasVerifiedEmail(Builder $query)
+    {
+        return $query->whereNotNull('email_verified_at');
     }
 }

--- a/src/Illuminate/Contracts/Auth/MustVerifyEmail.php
+++ b/src/Illuminate/Contracts/Auth/MustVerifyEmail.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Contracts\Auth;
 
+use Illuminate\Database\Eloquent\Builder;
+
 interface MustVerifyEmail
 {
     /**
@@ -31,4 +33,12 @@ interface MustVerifyEmail
      * @return string
      */
     public function getEmailForVerification();
+
+    /**
+     * Scope a query to only include users with verified email.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeHasVerifiedEmail(Builder $query);
 }

--- a/src/Illuminate/Contracts/Auth/MustVerifyEmail.php
+++ b/src/Illuminate/Contracts/Auth/MustVerifyEmail.php
@@ -2,8 +2,6 @@
 
 namespace Illuminate\Contracts\Auth;
 
-use Illuminate\Database\Eloquent\Builder;
-
 interface MustVerifyEmail
 {
     /**
@@ -33,12 +31,4 @@ interface MustVerifyEmail
      * @return string
      */
     public function getEmailForVerification();
-
-    /**
-     * Scope a query to only include users with verified email.
-     *
-     * @param  \Illuminate\Database\Eloquent\Builder  $query
-     * @return \Illuminate\Database\Eloquent\Builder
-     */
-    public function scopeHasVerifiedEmail(Builder $query);
 }


### PR DESCRIPTION
Just like in #35215, this scope provides a more convinient way of scoping users with a verified email.

I know we have more flexibility here than in the case of `DatabaseNotification` – so anyone can easily implement a custom scope – but in my experience, often this is one of the first things to do in a project so I thought it might be a good idea adding a scope by default.