### PR TITLE
[6.x] Fix pivot restoration

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
@@ -284,6 +284,8 @@ trait AsPivot
      */
     protected function newQueryForCollectionRestoration(array $ids)
     {
+        $ids = array_values($ids);
+
         if (! Str::contains($ids[0], ':')) {
             return parent::newQueryForRestoration($ids);
         }

--- a/src/Illuminate/Database/Eloquent/Relations/MorphPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphPivot.php
@@ -139,6 +139,8 @@ class MorphPivot extends Pivot
      */
     protected function newQueryForCollectionRestoration(array $ids)
     {
+        $ids = array_values($ids);
+
         if (! Str::contains($ids[0], ':')) {
             return parent::newQueryForRestoration($ids);
         }


### PR DESCRIPTION
This fixes an issue where it might be that an array with differently indexed records could be passed to any of the `newQueryForCollectionRestoration` methods which would conflict with the `[0]` retrieval for the first record. An alternative fix would be to use `Arr::first` instead without resetting the array keys.

Fixes https://github.com/laravel/framework/issues/35210