### PR TITLE
[8.x] Add classBasename() method to Stringable

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -82,6 +82,16 @@ class Stringable
     {
         return new static(basename($this->value, $suffix));
     }
+    
+    /**
+     * Get the basename of the class path.
+     *
+     * @return static
+     */
+    public function classBasename()
+    {
+        return new static(class_basename($this->value));
+    }
 
     /**
      * Get the portion of a string before the first occurrence of a given value.

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -16,6 +16,14 @@ class SupportStringableTest extends TestCase
     {
         return new Stringable($string);
     }
+    
+    public function testClassBasename()
+    {
+        $this->assertEquals(
+            class_basename(static::class),
+            $this->stringable(static::class)->classBasename()
+        );
+    }
 
     public function testIsAscii()
     {


### PR DESCRIPTION
This PR adds a method for the `class_basename` function to the `Stringable` class.

```php
// This to me feels clear and concise
Str::of(static::class)
    ->classBasename()
    ->kebab();

// Instead of the verbose
Str::of(static::class)
    ->afterLast('\\')
    ->kebab();
```