### PR TITLE
[9.x] Remove extra code from event list command

### DIFF
--- a/src/Illuminate/Foundation/Console/EventListCommand.php
+++ b/src/Illuminate/Foundation/Console/EventListCommand.php
@@ -4,7 +4,6 @@ namespace Illuminate\Foundation\Console;
 
 use Closure;
 use Illuminate\Console\Command;
-use Illuminate\Foundation\Support\Providers\EventServiceProvider;
 use Illuminate\Support\Str;
 use ReflectionFunction;
 
@@ -57,12 +56,6 @@ class EventListCommand extends Command
     protected function getEvents()
     {
         $events = [];
-
-        foreach ($this->laravel->getProviders(EventServiceProvider::class) as $provider) {
-            $providerEvents = array_merge_recursive($provider->shouldDiscoverEvents() ? $provider->discoverEvents() : [], $provider->listens());
-
-            $events = array_merge_recursive($events, $providerEvents);
-        }
 
         $events = $this->addListenersOnDispatcher($events);
 


### PR DESCRIPTION
While reviewing my previous work I realized that the old way of finding event/listeners mapping now redundant and the new way will find all of them anyway.
Currently, those which are registered in the event service providers are overridden by the new way. I mean they do not show up twice on the list.
