### PR TITLE
[8.x] Add lost connection messages for MySQL persistent connections

### DIFF
--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -45,6 +45,8 @@ trait DetectsLostConnections
             'The connection is broken and recovery is not possible. The connection is marked by the client driver as unrecoverable. No attempt was made to restore the connection.',
             'SQLSTATE[HY000] [2002] php_network_getaddresses: getaddrinfo failed: Try again',
             'SQLSTATE[HY000]: General error: 7 SSL SYSCALL error: EOF detected',
+            'SQLSTATE[HY000] [2002] Connection timed out',
+            'SSL: Connection timed out'
         ]);
     }
 }

--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -46,7 +46,7 @@ trait DetectsLostConnections
             'SQLSTATE[HY000] [2002] php_network_getaddresses: getaddrinfo failed: Try again',
             'SQLSTATE[HY000]: General error: 7 SSL SYSCALL error: EOF detected',
             'SQLSTATE[HY000] [2002] Connection timed out',
-            'SSL: Connection timed out'
+            'SSL: Connection timed out',
         ]);
     }
 }


### PR DESCRIPTION
MySQL persistent connections:

- PHP-FPM 7.4
- MySQL 8.0 (SSL)

Due to short network unavailabilities, we sometimes lose connection and a reconnection should be attempted.

**SQLSTATE[HY000] [2002] Connection timed out**

`````
[2020-11-15 11:00:19] production.ERROR: SQLSTATE[HY000] [2002] Connection timed out (SQL: select ...))) {"exception":"[object] (Illuminate\\Database\\QueryException(code: 2002): SQLSTATE[HY000] [2002] Connection timed out (SQL: select ...))) at /var/www/html/vendor/illuminate/database/Connection.php:671)
[stacktrace]
#0 /var/www/html/vendor/illuminate/database/Connection.php(631): Illuminate\\Database\\Connection->runQueryCallback('select count(*)...', Array, Object(Closure))
#1 /var/www/html/vendor/illuminate/database/Connection.php(339): Illuminate\\Database\\Connection->run('select count(*)...', Array, Object(Closure))
#2 /var/www/html/vendor/illuminate/database/Query/Builder.php(2303): Illuminate\\Database\\Connection->select('select count(*)...', Array, true)
#3 /var/www/html/vendor/illuminate/database/Query/Builder.php(2291): Illuminate\\Database\\Query\\Builder->runSelect()
#4 /var/www/html/vendor/illuminate/database/Query/Builder.php(2786): Illuminate\\Database\\Query\\Builder->Illuminate\\Database\\Query\\{closure}()
#5 /var/www/html/vendor/illuminate/database/Query/Builder.php(2292): Illuminate\\Database\\Query\\Builder->onceWithColumns(Array, Object(Closure))
#6 /var/www/html/vendor/illuminate/database/Query/Builder.php(2713): Illuminate\\Database\\Query\\Builder->get(Array)
#7 /var/www/html/vendor/illuminate/database/Query/Builder.php(2641): Illuminate\\Database\\Query\\Builder->aggregate('count', Array)
#8 /var/www/html/vendor/illuminate/database/Eloquent/Builder.php(1508): Illuminate\\Database\\Query\\Builder->count()
#9 /var/www/html/vendor/illuminate/support/Traits/ForwardsCalls.php(23): Illuminate\\Database\\Eloquent\\Builder->__call('count', Array)
#10 /var/www/html/vendor/illuminate/database/Eloquent/Model.php(1757): Illuminate\\Database\\Eloquent\\Model->forwardCallTo(Object(Illuminate\\Database\\Eloquent\\Builder), 'count', Array)
#11 /var/www/html/vendor/illuminate/database/Eloquent/Model.php(1769): Illuminate\\Database\\Eloquent\\Model->__call('count', Array)
``````

**SSL: Connection timed out**

`````
[2020-11-12 07:20:23] production.ERROR: PDO::__construct(): SSL: Connection timed out (SQL: select * ...) {"exception":"[object] (Illuminate\\Database\\QueryException(code: 0): PDO::__construct(): SSL: Connection timed out (SQL: select ...) at /var/www/html/vendor/illuminate/database/Connection.php:671)
[stacktrace]
#0 /var/www/html/vendor/illuminate/database/Connection.php(631): Illuminate\\Database\\Connection->runQueryCallback('select * from `...', Array, Object(Closure))
#1 /var/www/html/vendor/illuminate/database/Connection.php(339): Illuminate\\Database\\Connection->run('select * from `...', Array, Object(Closure))
#2 /var/www/html/vendor/illuminate/database/Query/Builder.php(2303): Illuminate\\Database\\Connection->select('select * from `...', Array, true)
#3 /var/www/html/vendor/illuminate/database/Query/Builder.php(2291): Illuminate\\Database\\Query\\Builder->runSelect()
#4 /var/www/html/vendor/illuminate/database/Query/Builder.php(2786): Illuminate\\Database\\Query\\Builder->Illuminate\\Database\\Query\\{closure}()
#5 /var/www/html/vendor/illuminate/database/Query/Builder.php(2292): Illuminate\\Database\\Query\\Builder->onceWithColumns(Array, Object(Closure))
#6 /var/www/html/vendor/illuminate/database/Eloquent/Builder.php(549): Illuminate\\Database\\Query\\Builder->get(Array)
#7 /var/www/html/vendor/illuminate/database/Eloquent/Builder.php(533): Illuminate\\Database\\Eloquent\\Builder->getModels(Array)
#8 /var/www/html/vendor/illuminate/database/Concerns/BuildsQueries.php(147): Illuminate\\Database\\Eloquent\\Builder->get(Array)
````

