### PR TITLE
[8.x] Add doc blocks for dispatchAfterResponse and batch assertions

### DIFF
--- a/src/Illuminate/Support/Facades/Bus.php
+++ b/src/Illuminate/Support/Facades/Bus.php
@@ -18,7 +18,11 @@ use Illuminate\Support\Testing\Fakes\BusFake;
  * @method static mixed dispatchNow($command, $handler = null)
  * @method static void assertDispatched(string $command, callable|int $callback = null)
  * @method static void assertDispatchedTimes(string $command, int $times = 1)
- * @method static void assertNotDispatched(string $command, callable|int $callback = null)
+ * @method static void assertNotDispatched(string $command, callable $callback = null)
+ * @method static void assertDispatchedAfterResponse(string $command, callable|int $callback = null)
+ * @method static void assertDispatchedAfterResponseTimes(string $command, int $times = 1)
+ * @method static void assertNotDispatchedAfterResponse(string $command, callable $callback = null)
+ * @method static void assertBatched(callable $callback)
  *
  * @see \Illuminate\Contracts\Bus\Dispatcher
  */


### PR DESCRIPTION
Added doc blocks for `BusFake` dispatchAfterResponse and batch assertions
