### PR TITLE
[8.x] Add before resolving callbacks

### DIFF
--- a/tests/Container/ResolvingCallbackTest.php
+++ b/tests/Container/ResolvingCallbackTest.php
@@ -441,6 +441,45 @@ class ResolvingCallbackTest extends TestCase
         $container->make(ResolvingContractStub::class);
         $this->assertEquals(2, $callCounter);
     }
+
+    public function testBeforeResolvingCallbacksAreCalled()
+    {
+        // Given a call counter initialized to zero.
+        $container = new Container;
+        $callCounter = 0;
+
+        // And a contract/implementation stub binding.
+        $container->bind(ResolvingContractStub::class, ResolvingImplementationStub::class);
+
+        // When we add a before resolving callback that increment the counter by one.
+        $container->beforeResolving(ResolvingContractStub::class, function () use (&$callCounter) {
+            $callCounter++;
+        });
+
+        // Then resolving the implementation stub increases the counter by one.
+        $container->make(ResolvingImplementationStub::class);
+        $this->assertEquals(1, $callCounter);
+
+        // And resolving the contract stub increases the counter by one.
+        $container->make(ResolvingContractStub::class);
+        $this->assertEquals(2, $callCounter);
+    }
+
+    public function testGlobalBeforeResolvingCallbacksAreCalled()
+    {
+        // Given a call counter initialized to zero.
+        $container = new Container;
+        $callCounter = 0;
+
+        // When we add a global before resolving callback that increment that counter by one.
+        $container->beforeResolving(function () use (&$callCounter) {
+            $callCounter++;
+        });
+
+        // Then resolving anything increases the counter by one.
+        $container->make(ResolvingImplementationStub::class);
+        $this->assertEquals(1, $callCounter);
+    }
 }
 
 interface ResolvingContractStub


### PR DESCRIPTION
## Description

As mentioned in #35202, this PR enables us to hook some custom logic into the beginning of the container resolution — i.e. before an instance as been resolved from the provided abstract.

## Usage

It uses the same conventions as the `$(after)ResolvingCallbacks` and `$global(After)ResolvingCallbacks` to register and trigger the callbacks.

```php
// Adds a specific before resolving callback.
$this->app->beforeResolving(MyService::class, function ($abstract, $parameters, $app) {
    // ...
});

// Adds a global before resolving callback.
$this->app->beforeResolving(function ($abstract, $parameters, $app) {
    // ...
});
```

## Advanced usage

These before resolving callbacks can be used as a way to dynamically add specific extenders and, therefore, remove the need for #35202.

For example, this global extender...

```php
$this->app->extend(function ($instance, $app) {
    if (! $app->isProduction() && $instance instanceof CanBeFaked) {
        return FakeServiceDecorator($instance);
    }

    return $instance;
});
```

... could be achieve with the following before resolving callback:

```php
$this->app->beforeResolving(function ($abstract, $parameters, $app) {
    if ($app->isProduction() || ! is_subclass_of($abstract, CanBeFaked::class) || $app->resolved($abstract)) {
        return;
    }

    $app->extend($abstract, function ($instance) {
        return FakeServiceDecorator($instance);
    });
});
```

Since the specific before resolving callbacks already check for inheritance, this could be refactored to:


```php
$this->app->beforeResolving(CanBeFaked::class, function ($abstract, $parameters, $app) {
    if ($app->isProduction() || $app->resolved($abstract)) {
        return;
    }

    $app->extend($abstract, function ($instance) {
        return FakeServiceDecorator($instance);
    });
});
```

Note the use of `$app->resolved($abstract)`, to ensure we do not add the same extender multiple times.

## Backward compatibility

This PR does not add any breaking changes.

It triggers new types of callbacks that wouldn't have been registered before.