### PR TITLE
[8.x] Adds the possibility of testing file upload content

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -52,9 +52,10 @@ class FilesystemAdapter implements CloudFilesystemContract
      * Assert that the given file exists.
      *
      * @param  string|array  $path
+     * @param  string|null  $content
      * @return $this
      */
-    public function assertExists($path)
+    public function assertExists($path, $content = null)
     {
         $paths = Arr::wrap($path);
 
@@ -62,6 +63,16 @@ class FilesystemAdapter implements CloudFilesystemContract
             PHPUnit::assertTrue(
                 $this->exists($path), "Unable to find a file at path [{$path}]."
             );
+
+            if (! is_null($content)) {
+                $actual = $this->get($path);
+
+                PHPUnit::assertSame(
+                    $content,
+                    $actual,
+                    "File [{$path}] was found, but content [{$actual}] does not match [{$content}]."
+                );
+            }
         }
 
         return $this;

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -262,6 +262,11 @@ class FilesystemAdapterTest extends TestCase
         $filesystemAdapter->assertExists($storagePath);
 
         $this->assertSame('uploaded file content', $filesystemAdapter->read($storagePath));
+
+        $filesystemAdapter->assertExists(
+            $storagePath,
+            'uploaded file content'
+        );
     }
 
     public function testPutFileAsWithAbsoluteFilePath()
@@ -290,6 +295,11 @@ class FilesystemAdapterTest extends TestCase
         $this->assertFileExists($filePath);
 
         $filesystemAdapter->assertExists($storagePath);
+
+        $filesystemAdapter->assertExists(
+            $storagePath,
+            'uploaded file content'
+        );
     }
 
     public function testPutFileWithAbsoluteFilePath()
@@ -303,5 +313,10 @@ class FilesystemAdapterTest extends TestCase
         $this->assertSame(44, strlen($storagePath)); // random 40 characters + ".txt"
 
         $filesystemAdapter->assertExists($storagePath);
+
+        $filesystemAdapter->assertExists(
+            $storagePath,
+            'uploaded file content'
+        );
     }
 }


### PR DESCRIPTION
This pull request adds the possibility of **testing the file upload content** while checking if the file exist:

Before:
 ```php
Storage::disk('reports')->assertExists('foo.csv');
$this->assertSame('my;csv;content', Storage::disk('reports')->read('foo.csv'));
```

After:
```php
Storage::disk('reports')->assertExists('foo.csv', 'my;csv;content');
```