### PR TITLE
[8.x] Use table property for migration stubs

### DIFF
--- a/src/Illuminate/Database/Migrations/stubs/migration.create.stub
+++ b/src/Illuminate/Database/Migrations/stubs/migration.create.stub
@@ -8,6 +8,7 @@ class {{ class }} extends Migration
 {
     /**
      * The name of the database table to use.
+     *
      * @var string
      */
     protected $table = '{{ table }}';

--- a/src/Illuminate/Database/Migrations/stubs/migration.create.stub
+++ b/src/Illuminate/Database/Migrations/stubs/migration.create.stub
@@ -7,13 +7,19 @@ use Illuminate\Support\Facades\Schema;
 class {{ class }} extends Migration
 {
     /**
+     * The name of the database table to use.
+     * @var string
+     */
+    protected $table = '{{ table }}';
+
+    /**
      * Run the migrations.
      *
      * @return void
      */
     public function up()
     {
-        Schema::create('{{ table }}', function (Blueprint $table) {
+        Schema::create($this->table, function (Blueprint $table) {
             $table->id();
             $table->timestamps();
         });
@@ -26,6 +32,6 @@ class {{ class }} extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('{{ table }}');
+        Schema::dropIfExists($this->table);
     }
 }

--- a/src/Illuminate/Database/Migrations/stubs/migration.update.stub
+++ b/src/Illuminate/Database/Migrations/stubs/migration.update.stub
@@ -8,6 +8,7 @@ class {{ class }} extends Migration
 {
     /**
      * The name of the database table to use.
+     *
      * @var string
      */
     protected $table = '{{ table }}';

--- a/src/Illuminate/Database/Migrations/stubs/migration.update.stub
+++ b/src/Illuminate/Database/Migrations/stubs/migration.update.stub
@@ -7,13 +7,19 @@ use Illuminate\Support\Facades\Schema;
 class {{ class }} extends Migration
 {
     /**
+     * The name of the database table to use.
+     * @var string
+     */
+    protected $table = '{{ table }}';
+
+    /**
      * Run the migrations.
      *
      * @return void
      */
     public function up()
     {
-        Schema::table('{{ table }}', function (Blueprint $table) {
+        Schema::table($this->table, function (Blueprint $table) {
             //
         });
     }
@@ -25,7 +31,7 @@ class {{ class }} extends Migration
      */
     public function down()
     {
-        Schema::table('{{ table }}', function (Blueprint $table) {
+        Schema::table($this->table, function (Blueprint $table) {
             //
         });
     }


### PR DESCRIPTION
### Description
Migration stubs will now generate a property for the table, instead of repeating the table as a string in both the `up()` and `down()` methods.

This change introduces a less error prone migration since from my experience, most migrations only act on 1 table.

If a migration happens to change/insert multiple tables (which from experience is the less common case), you are free to remove the property and use strings where needed.

### Backwards compatibility
No issues, completely backwards compatible.