### PR TITLE
[8.x] Allow travelTo without passing parameters

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTime.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTime.php
@@ -22,11 +22,11 @@ trait InteractsWithTime
     /**
      * Travel to another time.
      *
-     * @param  \DateTimeInterface  $date
+     * @param  \DateTimeInterface|null  $date
      * @param  callable|null  $callback
      * @return mixed
      */
-    public function travelTo(DateTimeInterface $date, $callback = null)
+    public function travelTo(DateTimeInterface $date = null, $callback = null)
     {
         Carbon::setTestNow($date);
 


### PR DESCRIPTION
Carbon's `setTestNow()` method accepts the date parameter to be `null`.
This change will reflect that to the `travelTo` testing method.

Before:
```php
public function test_some_code()
{
    $this->travelTo($date = now());

    // perform action

    $this->assertDatabaseHas('table', [
        'created_at' => $date,
    ]);
}
```

After:
```php
public function test_some_code()
{
    $this->travelTo();

    // perform action

    $this->assertDatabaseHas('table', [
        'created_at' => now(),
    ]);
}
```