### PR TITLE
[8.x] Prevents double trailing slash in storage path

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -274,7 +274,7 @@ class FilesystemAdapter implements CloudFilesystemContract
         // they provide better performance than alternatives. Once we write the file this
         // stream will get closed automatically by us so the developer doesn't have to.
         $result = $this->put(
-            $path = trim($path.'/'.$name, '/'), $stream, $options
+            $path = trim(rtrim($path, '/').'/'.$name, '/'), $stream, $options
         );
 
         if (is_resource($stream)) {

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -280,6 +280,17 @@ class FilesystemAdapterTest extends TestCase
         $this->assertSame('normal file content', $filesystemAdapter->read($storagePath));
     }
 
+    public function testPutFileAsGivenPathWithTrailingSlash()
+    {
+        file_put_contents($filePath = $this->tempDir.'/foo.txt', 'normal file content');
+
+        $filesystemAdapter = new FilesystemAdapter($this->filesystem);
+
+        $storagePath = $filesystemAdapter->putFileAs('directory/', $filePath, 'new.txt');
+
+        $this->assertSame('directory/new.text', $storagePath);
+    }
+
     public function testPutFile()
     {
         file_put_contents($filePath = $this->tempDir.'/foo.txt', 'uploaded file content');
@@ -318,5 +329,16 @@ class FilesystemAdapterTest extends TestCase
             $storagePath,
             'uploaded file content'
         );
+    }
+
+    public function testPutFileGivenPathWithTrailingSlash()
+    {
+        file_put_contents($filePath = $this->tempDir.'/foo.txt', 'normal file content');
+
+        $filesystemAdapter = new FilesystemAdapter($this->filesystem);
+
+        $storagePath = $filesystemAdapter->putFile('directory/', $filePath);
+
+        $this->assertStringStartsNotWith('directory//', $storagePath);
     }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
A pull request to [resolve the issue](https://github.com/laravel/framework/issues/35245) I opened. 