### PR TITLE
[8.x] Make getMorphClass method statically accessible

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -723,7 +723,7 @@ trait HasRelationships
      *
      * @return string
      */
-    public function getMorphClass()
+    public static function getMorphClass()
     {
         $morphMap = Relation::morphMap();
 


### PR DESCRIPTION
This PR makes the `getMorphClass` method statically accessible. There doesn't seem to be a reason within the method why this cannot be called statically, and making it static would simplify code where you might do the following:

```php
// Before...
Foo::create([
    'model_type' => (new Bar)->getMorphClass(),
]);

// After
Foo::create([
    'model_type' => Bar::getMorphClass(),
]);
```