### PR TITLE
[8.x] Add option to release unique job locks before processing

### DIFF
--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -59,6 +59,10 @@ class CallQueuedHandler
             return $this->handleModelNotFound($job, $e);
         }
 
+        if ($command->uniqueUntilStart ?? false) {
+            $this->ensureUniqueJobLockIsReleased($command);
+        }
+
         $this->dispatchThroughMiddleware($job, $command);
 
         if (! $job->isReleased()) {

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -30,6 +30,13 @@ class CallQueuedHandler
     protected $container;
 
     /**
+     * Indicates if the unique job lock has been released.
+     *
+     * @var bool
+     */
+    protected $uniqueLockReleased = false;
+
+    /**
      * Create a new handler instance.
      *
      * @param  \Illuminate\Contracts\Bus\Dispatcher  $dispatcher
@@ -171,7 +178,7 @@ class CallQueuedHandler
      */
     protected function ensureUniqueJobLockIsReleased($command)
     {
-        if (! $command instanceof ShouldBeUnique) {
+        if (! ($command instanceof ShouldBeUnique) || $this->uniqueLockReleased) {
             return;
         }
 
@@ -186,6 +193,8 @@ class CallQueuedHandler
         $cache->lock(
             'laravel_unique_job:'.get_class($command).$uniqueId
         )->forceRelease();
+
+        $this->uniqueLockReleased = true;
     }
 
     /**


### PR DESCRIPTION
Based on our discussion at https://github.com/laravel/framework/pull/35042, there may be use cases where it is desirable to release unique job locks before the job starts processing (to avoid race conditions between job completion and unlocking). This PR allows the option to release the unique job lock before processing if the `$uniqueUntilStart` is set to true like so:

```php
class ExampleJob implements ShouldQueue, ShouldBeUnique
{
    use InteractsWithQueue, Queueable, Dispatchable;

    public $uniqueUntilStart = true;
}
```

This is backwards-compatible. If the job raises an error, we don't attempt to re-acquire the lock and may be duplicate enqueued. This should be fine as anyone who wants to use this feature would need to make sure that the job is idempotent because a duplicate job dispatch can happen while the job is processing. This is similar to [Sidekiq's unique_until start feature](https://github.com/mperham/sidekiq/wiki/Ent-Unique-Jobs#unlock-policy).