### PR TITLE
[8.x] Add table name as default morph type

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -731,6 +731,10 @@ trait HasRelationships
             return array_search(static::class, $morphMap, true);
         }
 
+        if (Relation::$tableNameAsMorphType) {
+            return $this->getTable();
+        }
+
         return static::class;
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -56,6 +56,13 @@ abstract class Relation
     public static $morphMap = [];
 
     /**
+     * Indicates if the morph relation type should default to table name.
+     *
+     * @var bool
+     */
+    public static $tableNameAsMorphType = false;
+
+    /**
      * Create a new relation instance.
      *
      * @param  \Illuminate\Database\Eloquent\Builder  $query
@@ -339,6 +346,16 @@ abstract class Relation
         }
 
         return static::$morphMap;
+    }
+
+    /**
+     * Changes the default morph type to table name.
+     *
+     * @return void
+     */
+    public static function tableNameAsMorphType()
+    {
+        self::$tableNameAsMorphType = true;
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1200,6 +1200,23 @@ class DatabaseEloquentModelTest extends TestCase
         }
     }
 
+    public function testCorrectMorphClassIsReturnedOnChangingDefault()
+    {
+        Relation::tableNameAsMorphType();
+        Relation::morphMap(['alias' => EloquentModelCamelStub::class]);
+        Relation::morphMap(['alias2' => 'AnotherModel']);
+        $model = new EloquentModelStub;
+        $model2 = new EloquentModelCamelStub;
+
+        try {
+            $this->assertEquals('stub', $model->getMorphClass());
+            $this->assertEquals('alias', $model2->getMorphClass());
+        } finally {
+            Relation::morphMap([], false);
+            Relation::$tableNameAsMorphType = false;
+        }
+    }
+
     public function testHasManyCreatesProperRelation()
     {
         $model = new EloquentModelStub;


### PR DESCRIPTION
Currently, the default value for morph type is the "namespaced classpath" of the model and the user should define an alias for each new model.
The PR lets the user change the default morph values to the table names with a single method call which is good enough since the table names often do not change and are unique.

- Older projects can continue working unharmed as they were before. This is meant to be used for from-scratch projects.

- For laravel 9.x it is possible to make the table name as default values and enable the legacy mode with a method call, for upgrading projects.
