### PR TITLE
[8.x] Adds an ability for the Wormhole class to take us back to the present.

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTime.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTime.php
@@ -44,8 +44,6 @@ trait InteractsWithTime
      */
     public function travelBack()
     {
-        Carbon::setTestNow();
-
-        return Carbon::now();
+        return Wormhole::back();
     }
 }

--- a/src/Illuminate/Foundation/Testing/Wormhole.php
+++ b/src/Illuminate/Foundation/Testing/Wormhole.php
@@ -116,6 +116,18 @@ class Wormhole
     }
 
     /**
+     * Travel back to the current time.
+     *
+     * @return \DateTimeInterface
+     */
+    public static function back()
+    {
+        Carbon::setTestNow();
+
+        return Carbon::now();
+    }
+
+    /**
      * Handle the given optional execution callback.
      *
      * @param  callable|null  $callback

--- a/tests/Foundation/Testing/WormholeTest.php
+++ b/tests/Foundation/Testing/WormholeTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Testing;
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Foundation\Testing\Wormhole;
+
+class WormholeTest extends TestCase
+{
+    public function testCanTravelBackToPresent()
+    {
+        // Preserve the timelines we want to compare the reality with..
+        $present = now();
+        $future = now()->addDays(10);
+
+        // Travel in time..
+        (new Wormhole(10))->days();
+
+        // Assert we are now in the future..
+        $this->assertEquals($future->format('Y-m-d'), now()->format('Y-m-d'));
+
+        // Assert we can go back to the present..
+        $this->assertEquals($present->format('Y-m-d'), Wormhole::back()->format('Y-m-d'));
+    }
+}

--- a/tests/Foundation/Testing/WormholeTest.php
+++ b/tests/Foundation/Testing/WormholeTest.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Tests\Foundation\Testing;
 
-use PHPUnit\Framework\TestCase;
 use Illuminate\Foundation\Testing\Wormhole;
+use PHPUnit\Framework\TestCase;
 
 class WormholeTest extends TestCase
 {


### PR DESCRIPTION
This PR upgrades the Wormhole to take us back to the present with its API 

```
use Illuminate\Foundation\Testing\Wormhole;
use Illuminate\Support\Carbon;

(new Wormhole(10))->days();

// Currently, to go back to the present we we'll need to reach out for Carbon class like so..
Carbon::setTestNow();

// This PR upgrades the Wormhole to take us back to the present..
Wormhole::back();
```