### PR TITLE
[8.x] Easily set a null cache driver

### DIFF
--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -314,7 +314,11 @@ class CacheManager implements FactoryContract
      */
     protected function getConfig($name)
     {
-        return $this->app['config']["cache.stores.{$name}"];
+        if (! is_null($name) && $name !== 'null') {
+            return $this->app['config']["cache.stores.{$name}"];
+        }
+
+        return ['driver' => 'null'];
     }
 
     /**


### PR DESCRIPTION
if the passed `$name` is `null` or `'null'`, we'll build up a config with a null driver, so the user does not have to define it in the config file.

this is identical to how other Managers handle this.

https://github.com/laravel/framework/blob/8.x/src/Illuminate/Queue/QueueManager.php#L208

apologies for not adding a test. I tried to find similar examples in some of the other Manager tests to copy, but could not.