### PR TITLE
[8.x] Allow overriding the MySQL server version for database queue driver

### DIFF
--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -233,7 +233,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
     protected function getLockForPopping()
     {
         $databaseEngine = $this->database->getPdo()->getAttribute(PDO::ATTR_DRIVER_NAME);
-        $databaseVersion = $this->database->getPdo()->getAttribute(PDO::ATTR_SERVER_VERSION);
+        $databaseVersion = $this->database->getConfig('version') ?? $this->database->getPdo()->getAttribute(PDO::ATTR_SERVER_VERSION);
 
         if ($databaseEngine == 'mysql' && ! strpos($databaseVersion, 'MariaDB') && version_compare($databaseVersion, '8.0.1', '>=') ||
             $databaseEngine == 'pgsql' && version_compare($databaseVersion, '9.5', '>=')) {


### PR DESCRIPTION
Azure managed MySQL comes with the problem that PDO::ATTR_SERVER_VERSION will always return 5.6.42 even if the actual version is 8.0.x.

This is a [known limitation](https://docs.microsoft.com/en-us/azure/mysql/concepts-limits#current-known-issues) [since 2017](https://social.msdn.microsoft.com/Forums/en-US/795cb2be-dce7-4805-b324-a67e83697580/azure-database-for-mysql-reports-incorrect-version?forum=AzureDatabaseforMySQL) and it appears Microsoft has no intention of fixing the problem. 

Therefore the fixes to deadlocks in the queues is not applied.

This PR incorporates the principle from [PR 32708](https://github.com/laravel/framework/pull/32708) in the database queue driver to support manually overrinding the database version.

As a side note, [Drupal seems to be moving towards](https://www.drupal.org/project/drupal/issues/3089902) using `SELECT version()` instead of `PDO::ATTR_SERVER_VERSION`, but that's out of scope for this PR.
