### PR TITLE
[8.x] Delay pushing jobs to queue until database transactions are committed

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastEvent.php
+++ b/src/Illuminate/Broadcasting/BroadcastEvent.php
@@ -46,6 +46,7 @@ class BroadcastEvent implements ShouldQueue
         $this->event = $event;
         $this->tries = property_exists($event, 'tries') ? $event->tries : null;
         $this->timeout = property_exists($event, 'timeout') ? $event->timeout : null;
+        $this->dispatchAfterTransactions = property_exists($event, 'dispatchAfterTransactions') ? $event->dispatchAfterTransactions : null;
     }
 
     /**

--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -53,6 +53,13 @@ trait Queueable
     public $delay;
 
     /**
+     * Indicate the job should be dispatched after database transactions.
+     *
+     * @var bool|null
+     */
+    public $dispatchAfterTransactions;
+
+    /**
      * The middleware the job should be dispatched through.
      *
      * @var array
@@ -129,6 +136,19 @@ trait Queueable
     public function delay($delay)
     {
         $this->delay = $delay;
+
+        return $this;
+    }
+
+    /**
+     * Indicate that the job should be dispatched after database transactions.
+     *
+     * @param  bool|null  $value
+     * @return $this
+     */
+    public function afterTransactions($value = true)
+    {
+        $this->dispatchAfterTransactions = $value;
 
         return $this;
     }

--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -321,7 +321,7 @@ trait ManagesTransactions
     /**
      * Update the number of transactions.
      *
-     * @param  integer  $count
+     * @param  int  $count
      * @return void
      */
     protected function updateTransactionsCount($count)
@@ -346,6 +346,6 @@ trait ManagesTransactions
             call_user_func($callback);
         }
 
-        static::$afterTransactionCallbacks= [];
+        static::$afterTransactionCallbacks = [];
     }
 }

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -113,6 +113,20 @@ class Connection implements ConnectionInterface
     protected $transactions = 0;
 
     /**
+     * The total number of active transactions.
+     *
+     * @var int
+     */
+    public static $totalTransactions = 0;
+
+    /**
+     * The callbacks to invoke after transactions.
+     *
+     * @var callable[]
+     */
+    public static $afterTransactionCallbacks = [];
+
+    /**
      * Indicates if changes have been made to the database.
      *
      * @var int

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -559,6 +559,7 @@ class Dispatcher implements DispatcherContract
             $job->timeout = $listener->timeout ?? null;
             $job->retryUntil = method_exists($listener, 'retryUntil')
                                 ? $listener->retryUntil() : null;
+            $job->dispatchAfterTransactions = $listener->dispatchAfterTransactions ?? null;
         });
     }
 

--- a/src/Illuminate/Foundation/Bus/PendingDispatch.php
+++ b/src/Illuminate/Foundation/Bus/PendingDispatch.php
@@ -100,6 +100,19 @@ class PendingDispatch
     }
 
     /**
+     * Indicate that the job should be dispatched after database transactions.
+     *
+     * @param  bool|null  $value
+     * @return $this
+     */
+    public function afterTransactions($value = true)
+    {
+        $this->job->afterTransactions($value);
+
+        return $this;
+    }
+
+    /**
      * Set the jobs that should run if this job is successful.
      *
      * @param  array  $chain

--- a/src/Illuminate/Mail/SendQueuedMailable.php
+++ b/src/Illuminate/Mail/SendQueuedMailable.php
@@ -39,6 +39,7 @@ class SendQueuedMailable
         $this->mailable = $mailable;
         $this->tries = property_exists($mailable, 'tries') ? $mailable->tries : null;
         $this->timeout = property_exists($mailable, 'timeout') ? $mailable->timeout : null;
+        $this->dispatchAfterTransactions = property_exists($mailable, 'dispatchAfterTransactions') ? $mailable->dispatchAfterTransactions : null;
     }
 
     /**

--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -203,6 +203,7 @@ class NotificationSender
                             ->onConnection($notification->connection)
                             ->onQueue($queue)
                             ->delay($notification->delay)
+                            ->afterTransactions($notification->dispatchAfterTransactions)
                             ->through(
                                 array_merge(
                                     method_exists($notification, 'middleware') ? $notification->middleware() : [],

--- a/src/Illuminate/Queue/BeanstalkdQueue.php
+++ b/src/Illuminate/Queue/BeanstalkdQueue.php
@@ -42,7 +42,7 @@ class BeanstalkdQueue extends Queue implements QueueContract
      *
      * @var bool
      */
-    protected $dispatchAfterTransaction = false;
+    protected $dispatchAfterTransactions = false;
 
     /**
      * Create a new Beanstalkd queue instance.
@@ -51,19 +51,20 @@ class BeanstalkdQueue extends Queue implements QueueContract
      * @param  string  $default
      * @param  int  $timeToRun
      * @param  int  $blockFor
+     * @param  bool $dispatchAfterTransactions
      * @return void
      */
     public function __construct(Pheanstalk $pheanstalk,
                                 $default,
                                 $timeToRun,
                                 $blockFor = 0,
-                                $dispatchAfterTransaction = false)
+                                $dispatchAfterTransactions = false)
     {
         $this->default = $default;
         $this->blockFor = $blockFor;
         $this->timeToRun = $timeToRun;
         $this->pheanstalk = $pheanstalk;
-        $this->dispatchAfterTransaction = $dispatchAfterTransaction;
+        $this->dispatchAfterTransactions = $dispatchAfterTransactions;
     }
 
     /**

--- a/src/Illuminate/Queue/BeanstalkdQueue.php
+++ b/src/Illuminate/Queue/BeanstalkdQueue.php
@@ -90,7 +90,7 @@ class BeanstalkdQueue extends Queue implements QueueContract
      */
     public function pushRaw($payload, $queue = null, array $options = [])
     {
-        return $this->afterTransactions(function () use ($payload, $queue) {
+        return $this->enqueueUsing($this, function () use ($payload, $queue) {
             return $this->pheanstalk->useTube($this->getQueue($queue))->put(
                 $payload, Pheanstalk::DEFAULT_PRIORITY, Pheanstalk::DEFAULT_DELAY, $this->timeToRun
             );
@@ -108,7 +108,7 @@ class BeanstalkdQueue extends Queue implements QueueContract
      */
     public function later($delay, $job, $data = '', $queue = null)
     {
-        return $this->afterTransactions(function () use ($delay, $job, $data, $queue) {
+        return $this->enqueueUsing($this, function () use ($delay, $job, $data, $queue) {
             $pheanstalk = $this->pheanstalk->useTube($this->getQueue($queue));
 
             return $pheanstalk->put(

--- a/src/Illuminate/Queue/BeanstalkdQueue.php
+++ b/src/Illuminate/Queue/BeanstalkdQueue.php
@@ -90,7 +90,7 @@ class BeanstalkdQueue extends Queue implements QueueContract
      */
     public function pushRaw($payload, $queue = null, array $options = [])
     {
-        return $this->afterTransactions(function () use ($payload, $queue, $options) {
+        return $this->afterTransactions(function () use ($payload, $queue) {
             return $this->pheanstalk->useTube($this->getQueue($queue))->put(
                 $payload, Pheanstalk::DEFAULT_PRIORITY, Pheanstalk::DEFAULT_DELAY, $this->timeToRun
             );

--- a/src/Illuminate/Queue/BeanstalkdQueue.php
+++ b/src/Illuminate/Queue/BeanstalkdQueue.php
@@ -89,7 +89,11 @@ class BeanstalkdQueue extends Queue implements QueueContract
      */
     public function push($job, $data = '', $queue = null)
     {
-        return $this->pushRaw($this->createPayload($job, $this->getQueue($queue), $data), $queue);
+        $payload = $this->createPayload($job, $this->getQueue($queue), $data);
+
+        return $this->enqueueUsing($this, function () use ($payload, $queue) {
+            return $this->pushRaw($payload, $queue);
+        });
     }
 
     /**
@@ -102,11 +106,9 @@ class BeanstalkdQueue extends Queue implements QueueContract
      */
     public function pushRaw($payload, $queue = null, array $options = [])
     {
-        return $this->enqueueUsing($this, function () use ($payload, $queue) {
-            return $this->pheanstalk->useTube($this->getQueue($queue))->put(
-                $payload, Pheanstalk::DEFAULT_PRIORITY, Pheanstalk::DEFAULT_DELAY, $this->timeToRun
-            );
-        });
+        return $this->pheanstalk->useTube($this->getQueue($queue))->put(
+            $payload, Pheanstalk::DEFAULT_PRIORITY, Pheanstalk::DEFAULT_DELAY, $this->timeToRun
+        );
     }
 
     /**

--- a/src/Illuminate/Queue/BeanstalkdQueue.php
+++ b/src/Illuminate/Queue/BeanstalkdQueue.php
@@ -38,6 +38,13 @@ class BeanstalkdQueue extends Queue implements QueueContract
     protected $blockFor;
 
     /**
+     * Indicate that pushes should be delayed till after database transactions commit.
+     *
+     * @var bool
+     */
+    protected $pushAfterCommits = false;
+
+    /**
      * Create a new Beanstalkd queue instance.
      *
      * @param  \Pheanstalk\Pheanstalk  $pheanstalk
@@ -46,12 +53,17 @@ class BeanstalkdQueue extends Queue implements QueueContract
      * @param  int  $blockFor
      * @return void
      */
-    public function __construct(Pheanstalk $pheanstalk, $default, $timeToRun, $blockFor = 0)
+    public function __construct(Pheanstalk $pheanstalk,
+                                $default,
+                                $timeToRun,
+                                $blockFor = 0,
+                                $pushAfterCommits = false)
     {
         $this->default = $default;
         $this->blockFor = $blockFor;
         $this->timeToRun = $timeToRun;
         $this->pheanstalk = $pheanstalk;
+        $this->pushAfterCommits = $pushAfterCommits;
     }
 
     /**

--- a/src/Illuminate/Queue/BeanstalkdQueue.php
+++ b/src/Illuminate/Queue/BeanstalkdQueue.php
@@ -42,7 +42,7 @@ class BeanstalkdQueue extends Queue implements QueueContract
      *
      * @var bool
      */
-    protected $pushAfterCommits = false;
+    protected $dispatchAfterTransaction = false;
 
     /**
      * Create a new Beanstalkd queue instance.
@@ -57,13 +57,13 @@ class BeanstalkdQueue extends Queue implements QueueContract
                                 $default,
                                 $timeToRun,
                                 $blockFor = 0,
-                                $pushAfterCommits = false)
+                                $dispatchAfterTransaction = false)
     {
         $this->default = $default;
         $this->blockFor = $blockFor;
         $this->timeToRun = $timeToRun;
         $this->pheanstalk = $pheanstalk;
-        $this->pushAfterCommits = $pushAfterCommits;
+        $this->dispatchAfterTransaction = $dispatchAfterTransaction;
     }
 
     /**
@@ -91,7 +91,7 @@ class BeanstalkdQueue extends Queue implements QueueContract
     {
         $payload = $this->createPayload($job, $this->getQueue($queue), $data);
 
-        return $this->enqueueUsing($this, function () use ($payload, $queue) {
+        return $this->enqueueUsing($this, $job, function () use ($payload, $queue) {
             return $this->pushRaw($payload, $queue);
         });
     }
@@ -122,7 +122,7 @@ class BeanstalkdQueue extends Queue implements QueueContract
      */
     public function later($delay, $job, $data = '', $queue = null)
     {
-        return $this->enqueueUsing($this, function () use ($delay, $job, $data, $queue) {
+        return $this->enqueueUsing($this, $job, function () use ($delay, $job, $data, $queue) {
             $pheanstalk = $this->pheanstalk->useTube($this->getQueue($queue));
 
             return $pheanstalk->put(

--- a/src/Illuminate/Queue/Connectors/BeanstalkdConnector.php
+++ b/src/Illuminate/Queue/Connectors/BeanstalkdConnector.php
@@ -20,7 +20,8 @@ class BeanstalkdConnector implements ConnectorInterface
             $this->pheanstalk($config),
             $config['queue'],
             $config['retry_after'] ?? Pheanstalk::DEFAULT_TTR,
-            $config['block_for'] ?? 0
+            $config['block_for'] ?? 0,
+            $config['after_commits'] ?? false
         );
     }
 

--- a/src/Illuminate/Queue/Connectors/DatabaseConnector.php
+++ b/src/Illuminate/Queue/Connectors/DatabaseConnector.php
@@ -37,7 +37,8 @@ class DatabaseConnector implements ConnectorInterface
             $this->connections->connection($config['connection'] ?? null),
             $config['table'],
             $config['queue'],
-            $config['retry_after'] ?? 60
+            $config['retry_after'] ?? 60,
+            $config['after_commits'] ?? false
         );
     }
 }

--- a/src/Illuminate/Queue/Connectors/RedisConnector.php
+++ b/src/Illuminate/Queue/Connectors/RedisConnector.php
@@ -46,7 +46,8 @@ class RedisConnector implements ConnectorInterface
             $this->redis, $config['queue'],
             $config['connection'] ?? $this->connection,
             $config['retry_after'] ?? 60,
-            $config['block_for'] ?? null
+            $config['block_for'] ?? null,
+            $config['after_commits'] ?? false
         );
     }
 }

--- a/src/Illuminate/Queue/Connectors/SqsConnector.php
+++ b/src/Illuminate/Queue/Connectors/SqsConnector.php
@@ -23,7 +23,11 @@ class SqsConnector implements ConnectorInterface
         }
 
         return new SqsQueue(
-            new SqsClient($config), $config['queue'], $config['prefix'] ?? '', $config['suffix'] ?? ''
+            new SqsClient($config),
+            $config['queue'],
+            $config['prefix'] ?? '',
+            $config['suffix'] ?? '',
+            $config['after_commits'] ?? false
         );
     }
 

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -45,7 +45,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
      *
      * @var bool
      */
-    protected $pushAfterCommits = false;
+    protected $dispatchAfterTransaction = false;
 
     /**
      * Create a new database queue instance.
@@ -60,13 +60,13 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
                                 $table,
                                 $default = 'default',
                                 $retryAfter = 60,
-                                $pushAfterCommits = false)
+                                $dispatchAfterTransaction = false)
     {
         $this->table = $table;
         $this->default = $default;
         $this->database = $database;
         $this->retryAfter = $retryAfter;
-        $this->pushAfterCommits = $pushAfterCommits;
+        $this->dispatchAfterTransaction = $dispatchAfterTransaction;
     }
 
     /**
@@ -94,7 +94,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
     {
         $payload = $this->createPayload($job, $this->getQueue($queue), $data);
 
-        return $this->enqueueUsing($this, function () use ($queue, $payload) {
+        return $this->enqueueUsing($this, $job, function () use ($queue, $payload) {
             return $this->pushToDatabase($queue, $payload);
         });
     }
@@ -125,7 +125,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
     {
         $payload = $this->createPayload($job, $this->getQueue($queue), $data);
 
-        return $this->enqueueUsing($this, function () use ($queue, $delay, $payload) {
+        return $this->enqueueUsing($this, $job, function () use ($queue, $delay, $payload) {
             return $this->pushToDatabase($queue, $payload, $delay);
         });
     }

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -159,9 +159,11 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
      */
     protected function pushToDatabase($queue, $payload, $delay = 0, $attempts = 0)
     {
-        return $this->database->table($this->table)->insertGetId($this->buildDatabaseRecord(
-            $this->getQueue($queue), $payload, $this->availableAt($delay), $attempts
-        ));
+        return $this->enqueueUsing($this, function () use ($queue, $payload, $delay, $attempts) {
+            return $this->database->table($this->table)->insertGetId($this->buildDatabaseRecord(
+                $this->getQueue($queue), $payload, $this->availableAt($delay), $attempts
+            ));
+        });
     }
 
     /**

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -41,6 +41,13 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
     protected $retryAfter = 60;
 
     /**
+     * Indicate that pushes should be delayed till after database transactions commit.
+     *
+     * @var bool
+     */
+    protected $pushAfterCommits = false;
+
+    /**
      * Create a new database queue instance.
      *
      * @param  \Illuminate\Database\Connection  $database
@@ -49,12 +56,17 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
      * @param  int  $retryAfter
      * @return void
      */
-    public function __construct(Connection $database, $table, $default = 'default', $retryAfter = 60)
+    public function __construct(Connection $database,
+                                $table,
+                                $default = 'default',
+                                $retryAfter = 60,
+                                $pushAfterCommits = false)
     {
         $this->table = $table;
         $this->default = $default;
         $this->database = $database;
         $this->retryAfter = $retryAfter;
+        $this->pushAfterCommits = $pushAfterCommits;
     }
 
     /**

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -45,7 +45,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
      *
      * @var bool
      */
-    protected $dispatchAfterTransaction = false;
+    protected $dispatchAfterTransactions = false;
 
     /**
      * Create a new database queue instance.
@@ -54,19 +54,20 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
      * @param  string  $table
      * @param  string  $default
      * @param  int  $retryAfter
+     * @param  bool  $dispatchAfterTransactions
      * @return void
      */
     public function __construct(Connection $database,
                                 $table,
                                 $default = 'default',
                                 $retryAfter = 60,
-                                $dispatchAfterTransaction = false)
+                                $dispatchAfterTransactions = false)
     {
         $this->table = $table;
         $this->default = $default;
         $this->database = $database;
         $this->retryAfter = $retryAfter;
-        $this->dispatchAfterTransaction = $dispatchAfterTransaction;
+        $this->dispatchAfterTransactions = $dispatchAfterTransactions;
     }
 
     /**

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -321,12 +321,12 @@ abstract class Queue
      */
     protected function shouldDispatchAfterTransactions($connection, $job)
     {
-        if (is_object($job) && isset($job->dispatchAfterTransaction)) {
-            return $job->dispatchAfterTransaction;
+        if (is_object($job) && isset($job->dispatchAfterTransactions)) {
+            return $job->dispatchAfterTransactions;
         }
 
-        if (isset($connection->dispatchAfterTransaction)) {
-            return $connection->dispatchAfterTransaction;
+        if (isset($connection->dispatchAfterTransactions)) {
+            return $connection->dispatchAfterTransactions;
         }
 
         return false;

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -259,12 +259,13 @@ abstract class Queue
     /**
      * Run the given callback after database transactions.
      *
+     * @param  \Illuminate\Contracts\Queue\Queue  $connection
      * @param  callable  $callback
      * @return mixed
      */
-    protected function afterTransactions($callback)
+    protected function enqueueUsing($connection, $callback)
     {
-        if (Connection::$totalTransactions > 0) {
+        if (! $connection instanceof DatabaseQueue && Connection::$totalTransactions > 0) {
             Connection::$afterTransactionCallbacks[] = function () use ($callback) {
                 $callback();
             };

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -257,7 +257,7 @@ abstract class Queue
     }
 
     /**
-     * Run the given callback after database transactions.
+     * Enqueue a jobs using the given callback.
      *
      * @param  \Illuminate\Contracts\Queue\Queue  $connection
      * @param  callable  $callback

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -265,7 +265,7 @@ abstract class Queue
      */
     protected function enqueueUsing($connection, $callback)
     {
-        if (! $connection instanceof DatabaseQueue && Connection::$totalTransactions > 0) {
+        if ($connection->pushAfterCommits ?? false && Connection::$totalTransactions > 0) {
             Connection::$afterTransactionCallbacks[] = function () use ($callback) {
                 $callback();
             };

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -5,6 +5,7 @@ namespace Illuminate\Queue;
 use Closure;
 use DateTimeInterface;
 use Illuminate\Container\Container;
+use Illuminate\Database\Connection;
 use Illuminate\Support\InteractsWithTime;
 use Illuminate\Support\Str;
 
@@ -253,6 +254,25 @@ abstract class Queue
         }
 
         return $payload;
+    }
+
+    /**
+     * Run the given callback after database transactions.
+     *
+     * @param  callable  $callback
+     * @return mixed
+     */
+    protected function afterTransactions($callback)
+    {
+        if (Connection::$totalTransactions > 0) {
+            Connection::$afterTransactionCallbacks[] = function () use ($callback) {
+                $callback();
+            };
+
+            return;
+        }
+
+        return $callback();
     }
 
     /**

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -122,7 +122,7 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
      */
     public function pushRaw($payload, $queue = null, array $options = [])
     {
-        return $this->afterTransactions(function () use ($payload, $queue, $options) {
+        return $this->afterTransactions(function () use ($payload, $queue) {
             $this->getConnection()->eval(
                 LuaScripts::push(), 2, $this->getQueue($queue),
                 $this->getQueue($queue).':notify', $payload

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -51,7 +51,7 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
      *
      * @var bool
      */
-    protected $pushAfterCommits = false;
+    protected $dispatchAfterTransaction = false;
 
     /**
      * Create a new Redis queue instance.
@@ -68,14 +68,14 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
                                 $connection = null,
                                 $retryAfter = 60,
                                 $blockFor = null,
-                                $pushAfterCommits = false)
+                                $dispatchAfterTransaction = false)
     {
         $this->redis = $redis;
         $this->default = $default;
         $this->blockFor = $blockFor;
         $this->connection = $connection;
         $this->retryAfter = $retryAfter;
-        $this->pushAfterCommits = $pushAfterCommits;
+        $this->dispatchAfterTransaction = $dispatchAfterTransaction;
     }
 
     /**
@@ -124,7 +124,7 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
     {
         $payload = $this->createPayload($job, $this->getQueue($queue), $data);
 
-        return $this->enqueueUsing($this, function () use ($payload, $queue) {
+        return $this->enqueueUsing($this, $job, function () use ($payload, $queue) {
             return $this->pushRaw($payload, $queue);
         });
     }
@@ -160,7 +160,7 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
     {
         $payload = $this->createPayload($job, $this->getQueue($queue), $data);
 
-        return $this->enqueueUsing($this, function () use ($payload, $delay, $queue) {
+        return $this->enqueueUsing($this, $job, function () use ($payload, $delay, $queue) {
             return $this->laterRaw($delay, $payload, $queue);
         });
     }

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -51,7 +51,7 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
      *
      * @var bool
      */
-    protected $dispatchAfterTransaction = false;
+    protected $dispatchAfterTransactions = false;
 
     /**
      * Create a new Redis queue instance.
@@ -61,6 +61,7 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
      * @param  string|null  $connection
      * @param  int  $retryAfter
      * @param  int|null  $blockFor
+     * @param  bool  $dispatchAfterTransactions
      * @return void
      */
     public function __construct(Redis $redis,
@@ -68,14 +69,14 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
                                 $connection = null,
                                 $retryAfter = 60,
                                 $blockFor = null,
-                                $dispatchAfterTransaction = false)
+                                $dispatchAfterTransactions = false)
     {
         $this->redis = $redis;
         $this->default = $default;
         $this->blockFor = $blockFor;
         $this->connection = $connection;
         $this->retryAfter = $retryAfter;
-        $this->dispatchAfterTransaction = $dispatchAfterTransaction;
+        $this->dispatchAfterTransactions = $dispatchAfterTransactions;
     }
 
     /**

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -122,7 +122,7 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
      */
     public function pushRaw($payload, $queue = null, array $options = [])
     {
-        return $this->afterTransactions(function () use ($payload, $queue) {
+        return $this->enqueueUsing($this, function () use ($payload, $queue) {
             $this->getConnection()->eval(
                 LuaScripts::push(), 2, $this->getQueue($queue),
                 $this->getQueue($queue).':notify', $payload
@@ -156,7 +156,7 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
      */
     protected function laterRaw($delay, $payload, $queue = null)
     {
-        return $this->afterTransactions(function () use ($delay, $payload, $queue) {
+        return $this->enqueueUsing($this, function () use ($delay, $payload, $queue) {
             $this->getConnection()->zadd(
                 $this->getQueue($queue).':delayed', $this->availableAt($delay), $payload
             );

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -47,6 +47,13 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
     protected $blockFor = null;
 
     /**
+     * Indicate that pushes should be delayed till after database transactions commit.
+     *
+     * @var bool
+     */
+    protected $pushAfterCommits = false;
+
+    /**
      * Create a new Redis queue instance.
      *
      * @param  \Illuminate\Contracts\Redis\Factory  $redis
@@ -56,13 +63,19 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
      * @param  int|null  $blockFor
      * @return void
      */
-    public function __construct(Redis $redis, $default = 'default', $connection = null, $retryAfter = 60, $blockFor = null)
+    public function __construct(Redis $redis,
+                                $default = 'default',
+                                $connection = null,
+                                $retryAfter = 60,
+                                $blockFor = null,
+                                $pushAfterCommits = false)
     {
         $this->redis = $redis;
         $this->default = $default;
         $this->blockFor = $blockFor;
         $this->connection = $connection;
         $this->retryAfter = $retryAfter;
+        $this->pushAfterCommits = $pushAfterCommits;
     }
 
     /**

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -96,7 +96,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
      */
     public function pushRaw($payload, $queue = null, array $options = [])
     {
-        return $this->afterTransactions(function () use ($payload, $queue, $options) {
+        return $this->afterTransactions(function () use ($payload, $queue) {
             return $this->sqs->sendMessage([
                 'QueueUrl' => $this->getQueue($queue), 'MessageBody' => $payload,
             ])->get('MessageId');

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -43,7 +43,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
      *
      * @var bool
      */
-    protected $dispatchAfterTransaction = false;
+    protected $dispatchAfterTransactions = false;
 
     /**
      * Create a new Amazon SQS queue instance.
@@ -52,19 +52,20 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
      * @param  string  $default
      * @param  string  $prefix
      * @param  string  $suffix
+     * @param  bool  $dispatchAfterTransactions
      * @return void
      */
     public function __construct(SqsClient $sqs,
                                 $default,
                                 $prefix = '',
                                 $suffix = '',
-                                $dispatchAfterTransaction = false)
+                                $dispatchAfterTransactions = false)
     {
         $this->sqs = $sqs;
         $this->prefix = $prefix;
         $this->default = $default;
         $this->suffix = $suffix;
-        $this->dispatchAfterTransaction = $dispatchAfterTransaction;
+        $this->dispatchAfterTransactions = $dispatchAfterTransactions;
     }
 
     /**

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -39,6 +39,13 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     private $suffix;
 
     /**
+     * Indicate that pushes should be delayed till after database transactions commit.
+     *
+     * @var bool
+     */
+    protected $pushAfterCommits = false;
+
+    /**
      * Create a new Amazon SQS queue instance.
      *
      * @param  \Aws\Sqs\SqsClient  $sqs
@@ -47,12 +54,17 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
      * @param  string  $suffix
      * @return void
      */
-    public function __construct(SqsClient $sqs, $default, $prefix = '', $suffix = '')
+    public function __construct(SqsClient $sqs,
+                                $default,
+                                $prefix = '',
+                                $suffix = '',
+                                $pushAfterCommits = false)
     {
         $this->sqs = $sqs;
         $this->prefix = $prefix;
         $this->default = $default;
         $this->suffix = $suffix;
+        $this->pushAfterCommits = $pushAfterCommits;
     }
 
     /**

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -96,7 +96,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
      */
     public function pushRaw($payload, $queue = null, array $options = [])
     {
-        return $this->afterTransactions(function () use ($payload, $queue) {
+        return $this->enqueueUsing($this, function () use ($payload, $queue) {
             return $this->sqs->sendMessage([
                 'QueueUrl' => $this->getQueue($queue), 'MessageBody' => $payload,
             ])->get('MessageId');
@@ -114,7 +114,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
      */
     public function later($delay, $job, $data = '', $queue = null)
     {
-        return $this->afterTransactions(function () use ($data, $delay, $job, $queue) {
+        return $this->enqueueUsing($this, function () use ($data, $delay, $job, $queue) {
             return $this->sqs->sendMessage([
                 'QueueUrl' => $this->getQueue($queue),
                 'MessageBody' => $this->createPayload($job, $queue ?: $this->default, $data),

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -425,6 +425,38 @@ class DatabaseConnectionTest extends TestCase
         $this->assertSame($connection, $schema->getConnection());
     }
 
+    public function testTotalTransactionsIsUpdated()
+    {
+        $pdo = $this->createMock(DatabaseConnectionTestMockPDO::class);
+        $connection = $this->getMockConnection([], $pdo);
+
+        $connection->beginTransaction();
+        $this->assertEquals(1, $connection::$totalTransactions);
+
+        $connection->commit();
+        $this->assertEquals(0, $connection::$totalTransactions);
+    }
+
+    public function testAfterTransactionCallbacksAreCalled()
+    {
+        $pdo = $this->createMock(DatabaseConnectionTestMockPDO::class);
+        $connection = $this->getMockConnection([], $pdo);
+
+        $name = 'mohamed';
+
+        $connection->beginTransaction();
+
+        Connection::$afterTransactionCallbacks[] = function () use (&$name) {
+            $name = 'zain';
+        };
+
+        $this->assertEquals('mohamed', $name);
+
+        $connection->commit();
+
+        $this->assertEquals('zain', $name);
+    }
+
     protected function getMockConnection($methods = [], $pdo = null)
     {
         $pdo = $pdo ?: new DatabaseConnectionTestMockPDO;

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -29,6 +29,8 @@ class DatabaseConnectionTest extends TestCase
     protected function tearDown(): void
     {
         m::close();
+
+        Connection::$afterTransactionCallbacks = [];
     }
 
     public function testSettingDefaultCallsGetDefaultGrammar()
@@ -430,6 +432,8 @@ class DatabaseConnectionTest extends TestCase
         $pdo = $this->createMock(DatabaseConnectionTestMockPDO::class);
         $connection = $this->getMockConnection([], $pdo);
 
+        $connection::$totalTransactions = 0;
+
         $connection->beginTransaction();
         $this->assertEquals(1, $connection::$totalTransactions);
 
@@ -441,6 +445,8 @@ class DatabaseConnectionTest extends TestCase
     {
         $pdo = $this->createMock(DatabaseConnectionTestMockPDO::class);
         $connection = $this->getMockConnection([], $pdo);
+
+        $connection::$totalTransactions = 0;
 
         $name = 'mohamed';
 

--- a/tests/Integration/Queue/QueueConnectionTest.php
+++ b/tests/Integration/Queue/QueueConnectionTest.php
@@ -18,6 +18,7 @@ class QueueConnectionTest extends TestCase
     {
         $app['config']->set('app.debug', 'true');
         $app['config']->set('queue.default', 'sqs');
+        $app['config']->set('queue.connections.sqs.after_commits', true);
     }
 
     protected function tearDown(): void

--- a/tests/Integration/Queue/QueueConnectionTest.php
+++ b/tests/Integration/Queue/QueueConnectionTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Queue;
+
+use Illuminate\Bus\Dispatcher;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\Connection;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\DB;
+use Orchestra\Testbench\TestCase;
+
+/**
+ * @group integration
+ */
+class QueueConnectionTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('app.debug', 'true');
+        $app['config']->set('queue.default', 'sqs');
+    }
+
+    protected function tearDown(): void
+    {
+        QueueConnectionTestJob::$ran = false;
+    }
+
+    public function testJobWontGetDispatchedInsideATransaction()
+    {
+        Connection::$totalTransactions = 1;
+
+        Bus::dispatch(new QueueConnectionTestJob);
+        Bus::dispatch(new QueueConnectionTestJob);
+
+        $this->assertFalse(QueueConnectionTestJob::$ran);
+        $this->assertCount(2, Connection::$afterTransactionCallbacks);
+    }
+}
+
+class QueueConnectionTestJob implements ShouldQueue
+{
+    use Dispatchable, Queueable;
+
+    public static $ran = false;
+
+    public function handle()
+    {
+        static::$ran = true;
+    }
+}

--- a/tests/Integration/Queue/QueueConnectionTest.php
+++ b/tests/Integration/Queue/QueueConnectionTest.php
@@ -25,6 +25,8 @@ class QueueConnectionTest extends TestCase
     protected function tearDown(): void
     {
         QueueConnectionTestJob::$ran = false;
+        Connection::$totalTransactions;
+        Connection::$afterTransactionCallbacks = [];
     }
 
     public function testJobWontGetDispatchedInsideATransaction()

--- a/tests/Integration/Queue/QueueConnectionTest.php
+++ b/tests/Integration/Queue/QueueConnectionTest.php
@@ -2,13 +2,11 @@
 
 namespace Illuminate\Tests\Integration\Queue;
 
-use Illuminate\Bus\Dispatcher;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Database\Connection;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Support\Facades\Bus;
-use Illuminate\Support\Facades\DB;
 use Orchestra\Testbench\TestCase;
 
 /**

--- a/tests/Queue/QueueBeanstalkdQueueTest.php
+++ b/tests/Queue/QueueBeanstalkdQueueTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Queue;
 
 use Illuminate\Container\Container;
+use Illuminate\Database\Connection;
 use Illuminate\Queue\BeanstalkdQueue;
 use Illuminate\Queue\Jobs\BeanstalkdJob;
 use Illuminate\Support\Str;
@@ -13,6 +14,13 @@ use PHPUnit\Framework\TestCase;
 
 class QueueBeanstalkdQueueTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        Connection::$totalTransactions = 0;
+
+        parent::setUp();
+    }
+
     protected function tearDown(): void
     {
         m::close();

--- a/tests/Queue/QueueRedisQueueTest.php
+++ b/tests/Queue/QueueRedisQueueTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Queue;
 
 use Illuminate\Contracts\Redis\Factory;
+use Illuminate\Database\Connection;
 use Illuminate\Queue\LuaScripts;
 use Illuminate\Queue\Queue;
 use Illuminate\Queue\RedisQueue;
@@ -13,6 +14,13 @@ use PHPUnit\Framework\TestCase;
 
 class QueueRedisQueueTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        Connection::$totalTransactions = 0;
+
+        parent::setUp();
+    }
+
     protected function tearDown(): void
     {
         m::close();


### PR DESCRIPTION
```php
DB::transaction(function(){
    $user = User::create(...);

    SendWelcomeEmail::dispatch($user);
});
```

When running the code above, the `SendWelcomeEmail` job may get dispatched and picked by a worker before the transaction is committed. This will lead to errors since the user model won't exist when the job runs.

This PR is an attempt to capture queue dispatches, store them in a local cache, and only perform the dispatch when all transactions has been committed. Given the example above, the `SendWelcomeEmail` won't get dispatched to the queue until the transaction is committed.

To enable this behaviour, you need to set the `after_commits` configuration value to `true` in the connection settings inside the `queue.php` config file. You can also use the `afterTransactions` method when dispatching the job:

```php
DB::transaction(function(){
    $user = User::create(...);

    SendWelcomeEmail::dispatch($user)->afterTransactions();
});
```

In the case of rollbacks, the jobs will *still* get pushed to the queue. But in that case the errors that will happen when the job runs will make sense. This PR's only purpose is to delay dispatching until the transactions are committed or rolledback.

You can add a `dispatchAfterTransactions` public property to mailables, notifications, listeners, and broadcastable events to achieve the same behaviour.