### PR TITLE
[6.x] Set minimum Guzzle version for PHP 8 CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           timeout_minutes: 5
           max_attempts: 5
-          command: composer require guzzle/guzzle:^7.2 --no-interaction --no-update
+          command: composer require guzzlehttp/guzzle:^7.2 --no-interaction --no-update
         if: matrix.php >= 8
 
       - name: Install dependencies
@@ -107,7 +107,7 @@ jobs:
         with:
           timeout_minutes: 5
           max_attempts: 5
-          command: composer require guzzle/guzzle:^7.2 --no-interaction --no-update
+          command: composer require guzzlehttp/guzzle:^7.2 --no-interaction --no-update
         if: matrix.php >= 8
 
       - name: Install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,6 +50,14 @@ jobs:
       - name: Setup problem matchers
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
+      - name: Set Minimum Guzzle Version
+        uses: nick-invision/retry@v1
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          command: composer require guzzle/guzzle:^7.2 --no-interaction --no-update
+        if: matrix.php >= 8
+
       - name: Install dependencies
         uses: nick-invision/retry@v1
         with:
@@ -93,6 +101,14 @@ jobs:
 
       - name: Setup problem matchers
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+      - name: Set Minimum Guzzle Version
+        uses: nick-invision/retry@v1
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          command: composer require guzzle/guzzle:^7.2 --no-interaction --no-update
+        if: matrix.php >= 8
 
       - name: Install dependencies
         uses: nick-invision/retry@v1

--- a/composer.json
+++ b/composer.json
@@ -77,7 +77,7 @@
         "tightenco/collect": "<5.5.33"
     },
     "require-dev": {
-        "aws/aws-sdk-php": "^3.0",
+        "aws/aws-sdk-php": "^3.155",
         "doctrine/dbal": "^2.6",
         "filp/whoops": "^2.8",
         "guzzlehttp/guzzle": "^6.3.1|^7.0.1",
@@ -119,7 +119,7 @@
         "ext-pcntl": "Required to use all features of the queue worker.",
         "ext-posix": "Required to use all features of the queue worker.",
         "ext-redis": "Required to use the Redis cache and queue drivers (^4.0|^5.0).",
-        "aws/aws-sdk-php": "Required to use the SQS queue driver, DynamoDb failed job storage and SES mail driver (^3.0).",
+        "aws/aws-sdk-php": "Required to use the SQS queue driver, DynamoDb failed job storage and SES mail driver (^3.155).",
         "doctrine/dbal": "Required to rename columns and drop SQLite columns (^2.6).",
         "filp/whoops": "Required for friendly error pages in development (^2.8).",
         "fakerphp/faker": "Required to use the eloquent factory builder (^1.9.1).",

--- a/src/Illuminate/Mail/composer.json
+++ b/src/Illuminate/Mail/composer.json
@@ -35,7 +35,7 @@
         }
     },
     "suggest": {
-        "aws/aws-sdk-php": "Required to use the SES mail driver (^3.0).",
+        "aws/aws-sdk-php": "Required to use the SES mail driver (^3.155).",
         "guzzlehttp/guzzle": "Required to use the Mailgun mail driver (^6.3.1|^7.0.1).",
         "wildbit/swiftmailer-postmark": "Required to use Postmark mail driver (^3.0)."
     },

--- a/src/Illuminate/Queue/composer.json
+++ b/src/Illuminate/Queue/composer.json
@@ -40,7 +40,7 @@
     "suggest": {
         "ext-pcntl": "Required to use all features of the queue worker.",
         "ext-posix": "Required to use all features of the queue worker.",
-        "aws/aws-sdk-php": "Required to use the SQS queue driver and DynamoDb failed job storage (^3.0).",
+        "aws/aws-sdk-php": "Required to use the SQS queue driver and DynamoDb failed job storage (^3.155).",
         "illuminate/redis": "Required to use the Redis queue driver (^6.0).",
         "pda/pheanstalk": "Required to use the Beanstalk queue driver (^4.0)."
     },


### PR DESCRIPTION
This will fix the recent test failures (such as in https://github.com/laravel/framework/pull/35266). The reason for this work around is Guzzle 6 does not have an upper bound on it's required PHP version, and only Guzzle 7.2.0 or higher will run on PHP 8.0.

I've also corrected the AWS SDK minimum version to be the first that will support S3 on PHP 8 (ish... their tests are actually failing on PHP 8 **still**) and also work with Guzzle 7.