### PR TITLE
delete additional back slash before implode action

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -480,7 +480,7 @@ class UrlGenerator implements UrlGeneratorContract
     protected function formatAction($action)
     {
         if (is_array($action)) {
-            $action = '\\'.implode('@', $action);
+            $action = implode('@', $action);
         }
 
         if ($this->rootNamespace && strpos($action, '\\') !== 0) {


### PR DESCRIPTION
this error `Action \App\Http\Controllers\HomeController@index not defined.` appears with me when I use action method, so when I delete the back slash this error disappeared

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
