### PR TITLE
check if AsPivot trait is used instead of Pivot Model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Database\Eloquent\Relations\Concerns\AsPivot;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 
@@ -177,7 +178,7 @@ class BelongsToMany extends Relation
             return $table;
         }
 
-        if ($model instanceof Pivot) {
+        if (in_array(AsPivot::class, class_uses_recursive($model))) {
             $this->using($table);
         }
 


### PR DESCRIPTION
Right now the logic that allows using a class name of a pivot model as `$table` argument and resolves its table and also uses it as pivot model only checks for the default `\Illuminate\Database\Eloquent\Relations\Pivot` model class.

The problem with this is that the real thing that makes a pivot model is the `\Illuminate\Database\Eloquent\Relations\Concerns\AsPivot` trait.

This PR changes this condition to check for the trait instead of an instance check for the base class.

The benefit is that the user is able to create his own pivot base model that doesn't have to be based on the default pivot model.

As an example - that's our custom pivot model in one app that's based on our custom base model.

```php
namespace App\Eloquent;

use Illuminate\Database\Eloquent\Relations\Concerns\AsPivot;
use Illuminate\Support\Str;

abstract class Pivot extends Model
{
    use AsPivot;

    public $incrementing = true;

    public function getTable(): string
    {
        return $this->table ?? Str::snake(Str::singular(Str::replaceLast('Pivot', '', class_basename($this))));
    }
}
```