### PR TITLE
[8.x] Support delaying notifications per channel

### DIFF
--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -202,7 +202,9 @@ class NotificationSender
                     (new SendQueuedNotifications($notifiable, $notification, [$channel]))
                             ->onConnection($notification->connection)
                             ->onQueue($queue)
-                            ->delay($notification->delay)
+                            ->delay(
+                                is_array($notification->delay) ? $notification->delay[$channel] ?? null : $notification->delay
+                            )
                             ->through(
                                 array_merge(
                                     method_exists($notification, 'middleware') ? $notification->middleware() : [],


### PR DESCRIPTION
Recently I faced the situation, I had to delay the same notification differently on database/email/sms channels.

Currently, there is no easy way to do that, however, we could solve this quite simply. This is a working, but rather conceptional PR, if you find this approach useful, we might polish it further, refactor a bit, update the docblocks, maybe extract the channel delay to its own method, adding tests and so on.

-----

```php
User::first()->notify(
    (new NewOrder(Order::first()))->delay([
        'mail' => now()->addDay(),
        'sms' => 300,
    ])
);
```

- This would not be a breaking change – as far as I know
- If a channel is not present in the delayed values it won't be delayed
- If the value is not an array, the given delay will be used by all channels (like now)