### PR TITLE
[8.x] Add missing `sortByMany` method to `Arr` helper

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -688,22 +688,19 @@ class Arr
      */
     public static function sortByMany($array, $comparisons = [])
     {
-        usort($array, function($a, $b) use($comparisons) {
-
-            foreach($comparisons as $cmp)
-            {
+        usort($array, function ($a, $b) use ($comparisons) {
+            foreach ($comparisons as $cmp) {
                 // destruct comparison array to variables
                 // with order set by default to 1
                 [$prop, $ascending] = static::wrap($cmp) + [1 => true];
                 $result = 0;
 
-                if(is_callable($prop)) {
+                if (is_callable($prop)) {
                     $result = $prop($a, $b);
-                }
-                else {
+                } else {
                     $values = [static::get($a, $prop), static::get($b, $prop)];
 
-                    if(!$ascending) {
+                    if (! $ascending) {
                         $values = array_reverse($values);
                     }
 
@@ -712,7 +709,7 @@ class Arr
 
                 // if result is 0, values are equal
                 // so we have to order items by next comparison
-                if($result === 0) {
+                if ($result === 0) {
                     continue;
                 }
 

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -707,7 +707,7 @@ class Arr
                         $values = array_reverse($values);
                     }
 
-                    $result = static::compareValues(...$values);
+                    $result = $values[0] <=> $values[1];
                 }
 
                 // if result is 0, values are equal
@@ -721,17 +721,5 @@ class Arr
         });
 
         return $array;
-    }
-
-    /**
-     * Compare two values
-     *
-     * @param  mixed    $a
-     * @param  mixed    $b
-     * @return int
-     */
-    protected static function compareValues($a, $b)
-    {
-        return $a <=> $b;
     }
 }

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -678,4 +678,60 @@ class Arr
 
         return is_array($value) ? $value : [$value];
     }
+
+    /**
+     * Sort giiven array by many properties.
+     *
+     * @param  array  $array
+     * @param  array  $comparisons
+     * @return array
+     */
+    public static function sortByMany($array, $comparisons = [])
+    {
+        usort($array, function($a, $b) use($comparisons) {
+
+            foreach($comparisons as $cmp)
+            {
+                // destruct comparison array to variables
+                // with order set by default to 1
+                [$prop, $ascending] = static::wrap($cmp) + [1 => true];
+                $result = 0;
+
+                if(is_callable($prop)) {
+                    $result = $prop($a, $b);
+                }
+                else {
+                    $values = [static::get($a, $prop), static::get($b, $prop)];
+
+                    if(!$ascending) {
+                        $values = array_reverse($values);
+                    }
+
+                    $result = static::compareValues(...$values);
+                }
+
+                // if result is 0, values are equal
+                // so we have to order items by next comparison
+                if($result === 0) {
+                    continue;
+                }
+
+                return $result;
+            }
+        });
+
+        return $array;
+    }
+
+    /**
+     * Compare two values
+     *
+     * @param  mixed    $a
+     * @param  mixed    $b
+     * @return int
+     */
+    protected static function compareValues($a, $b)
+    {
+        return $a <=> $b;
+    }
 }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -941,10 +941,10 @@ class SupportArrTest extends TestCase
 
         // sort using callable
         $sortedWithCallable = array_values(Arr::sortByMany($unsorted, [
-            function($a, $b) {
+            function ($a, $b) {
                 return $a['name'] <=> $b['name'];
             },
-            function($a, $b) {
+            function ($a, $b) {
                 return $b['age'] <=> $a['age'];
             },
             ['meta.key', true],

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -903,4 +903,57 @@ class SupportArrTest extends TestCase
         $this->assertEquals([$obj], Arr::wrap($obj));
         $this->assertSame($obj, Arr::wrap($obj)[0]);
     }
+
+    public function testSortByMany()
+    {
+        $unsorted = [
+            ['name' => 'John', 'age' => 8,  'meta' => ['key' => 3]],
+            ['name' => 'John', 'age' => 10, 'meta' => ['key' => 5]],
+            ['name' => 'Dave', 'age' => 10, 'meta' => ['key' => 3]],
+            ['name' => 'John', 'age' => 8,  'meta' => ['key' => 2]],
+        ];
+
+        // sort using keys
+        $sorted = array_values(Arr::sortByMany($unsorted, [
+            'name',
+            'age',
+            'meta.key',
+        ]));
+        $this->assertEquals([
+            ['name' => 'Dave', 'age' => 10, 'meta' => ['key' => 3]],
+            ['name' => 'John', 'age' => 8,  'meta' => ['key' => 2]],
+            ['name' => 'John', 'age' => 8,  'meta' => ['key' => 3]],
+            ['name' => 'John', 'age' => 10, 'meta' => ['key' => 5]],
+        ], $sorted);
+
+        // sort with order
+        $sortedWithOrder = array_values(Arr::sortByMany($unsorted, [
+            'name',
+            ['age', false],
+            ['meta.key', true],
+        ]));
+        $this->assertEquals([
+            ['name' => 'Dave', 'age' => 10, 'meta' => ['key' => 3]],
+            ['name' => 'John', 'age' => 10, 'meta' => ['key' => 5]],
+            ['name' => 'John', 'age' => 8,  'meta' => ['key' => 2]],
+            ['name' => 'John', 'age' => 8,  'meta' => ['key' => 3]],
+        ], $sortedWithOrder);
+
+        // sort using callable
+        $sortedWithCallable = array_values(Arr::sortByMany($unsorted, [
+            function($a, $b) {
+                return $a['name'] <=> $b['name'];
+            },
+            function($a, $b) {
+                return $b['age'] <=> $a['age'];
+            },
+            ['meta.key', true],
+        ]));
+        $this->assertEquals([
+            ['name' => 'Dave', 'age' => 10, 'meta' => ['key' => 3]],
+            ['name' => 'John', 'age' => 10, 'meta' => ['key' => 5]],
+            ['name' => 'John', 'age' => 8,  'meta' => ['key' => 2]],
+            ['name' => 'John', 'age' => 8,  'meta' => ['key' => 3]],
+        ], $sortedWithCallable);
+    }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

The need to sort array with multiple columns is the problem I faced so many times. Incuding today.
`Arr` and `Str` helpers are really powerfull and cover so many common use cases. But not this one.
This PR fills this gap, empowering helpers functionality.

Sorting may be done by array of strings:

```php
$sorted = Arr::sortByMany($unsorted, [
    'name', 'age'
];
``` 
These props will be sorted in ascending order by default. 

Order may be changed, using array instead of property name:
```php
$sorted = Arr::sortByMany($unsorted, [
    ['name', false], // will be ordered by `name` descending  
    ['age', true] // then by age ascending, if there are items with same `name` value
];
``` 

Sometimes more complicated logic or calling object methods is needed, this may be achieved using anonymous functions: 
```php
$sorted = Arr::sortByMany($unsorted, [
    // order by childrens count asc
    function($a, $b) {
        return $a->childrens()->count() <=> $b->childrens()->count();
    },
    // then by grandchildrens by descending order if needed
    function($a, $b) {
        return $b->grandchildrens()->count() <=> $a->grandchildrens()->count();
    }
];
``` 
When using anonymous functions, order boolean parameter won't be respected. 
