### PR TITLE
[8.x] Added parameters for taking a part of validated data

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Validation\ValidatesWhenResolved;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Redirector;
+use Illuminate\Support\Arr;
 use Illuminate\Validation\ValidatesWhenResolvedTrait;
 use Illuminate\Validation\ValidationException;
 
@@ -181,11 +182,18 @@ class FormRequest extends Request implements ValidatesWhenResolved
     /**
      * Get the validated data from the request.
      *
+     * @param string|int|null  $key
+     * @param mixed  $default
+     *
      * @return array
      */
-    public function validated()
+    public function validated($key = null, $default = null)
     {
-        return $this->validator->validated();
+        $validated = $this->validator->validated();
+
+        return $key !== null
+            ? Arr::get($validated, $key, $default)
+            : $validated;
     }
 
     /**

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -115,6 +115,18 @@ class FoundationFormRequestTest extends TestCase
         $this->assertEquals(['name' => 'Adam'], $request->all());
     }
 
+    public function testValidatedMethodReturnsOfPartTheValidatedData()
+    {
+        $request = $this->createRequest([
+            'name'  => 'Taylor Otwell',
+        ]);
+
+        $request->validateResolved();
+
+        $this->assertEquals('Taylor Otwell', $request->validated('name'));
+        $this->assertEquals('default', $request->validated('default', 'default'));
+    }
+
     /**
      * Catch the given exception thrown from the executor, and return it.
      *


### PR DESCRIPTION
This request adds the ability to take part in the validated data from the request:

```php
$request->validate([
    'user.name'  => 'required|string',
    'user.email' => 'required|unique:users,email,' . $request->user()->id,
]);

$user->fill($request->validate('user'));
```
This can come in handy when you need to send multiple data. 
Otherwise, you have to specify the array explicitly:

```php
$user->fill($request->validate()['user']);
```

In addition, we can access the array inside: ( Just like `$reguest->get()` )

```php
$request->validate('user.email');
```

It will also help to avoid errors when the user uses a different method for convenience:


```php
// At the same time, someone will add role, permissions, or balance parameters to the array :)

$user->fill($request->get('user'));
```
