### PR TITLE
[8.x] Add broker method to Password facade doc blocks

### DIFF
--- a/src/Illuminate/Support/Facades/Password.php
+++ b/src/Illuminate/Support/Facades/Password.php
@@ -12,6 +12,7 @@ use Illuminate\Contracts\Auth\PasswordBroker;
  * @method static void deleteToken(\Illuminate\Contracts\Auth\CanResetPassword $user)
  * @method static bool tokenExists(\Illuminate\Contracts\Auth\CanResetPassword $user, string $token)
  * @method static \Illuminate\Auth\Passwords\TokenRepositoryInterface getRepository()
+ * @method static \Illuminate\Contracts\Auth\PasswordBroker broker(string|null $name = null)
  *
  * @see \Illuminate\Auth\Passwords\PasswordBroker
  */


### PR DESCRIPTION
Allows IDEs to autocomplete `Password::broker()`