### PR TITLE
[8.x] Avoid no-op database query in Model::destroy() with empty ids

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1061,21 +1061,26 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
      */
     public static function destroy($ids)
     {
-        // We'll initialize a count here so we will return the total number of deletes
-        // for the operation. The developers can then check this number as a boolean
-        // type value or get this total count of records deleted for logging, etc.
-        $count = 0;
-
         if ($ids instanceof BaseCollection) {
             $ids = $ids->all();
         }
 
         $ids = is_array($ids) ? $ids : func_get_args();
 
+        // Avoid a no-op database query by bailing early
+        if (count($ids) === 0) {
+            return 0;
+        }
+
         // We will actually pull the models from the database table and call delete on
         // each of them individually so that their events get fired properly with a
         // correct set of attributes in case the developers wants to check these.
         $key = ($instance = new static)->getKeyName();
+
+        // We'll initialize a count here so we will return the total number of deletes
+        // for the operation. The developers can then check this number as a boolean
+        // type value or get this total count of records deleted for logging, etc.
+        $count = 0;
 
         foreach ($instance->whereIn($key, $ids)->get() as $model) {
             if ($model->delete()) {

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -300,7 +300,8 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testDestroyMethodCallsQueryBuilderCorrectlyWithEmptyIds()
     {
-        EloquentModelEmptyDestroyStub::destroy([]);
+        $count = EloquentModelEmptyDestroyStub::destroy([]);
+        $this->assertSame(0, $count);
     }
 
     public function testWithMethodCallsQueryBuilderCorrectly()

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -293,6 +293,16 @@ class DatabaseEloquentModelTest extends TestCase
         EloquentModelDestroyStub::destroy(new Collection([1, 2, 3]));
     }
 
+    public function testDestroyMethodCallsQueryBuilderCorrectlyWithMultipleArgs()
+    {
+        EloquentModelDestroyStub::destroy(1, 2, 3);
+    }
+
+    public function testDestroyMethodCallsQueryBuilderCorrectlyWithEmptyIds()
+    {
+        EloquentModelEmptyDestroyStub::destroy([]);
+    }
+
     public function testWithMethodCallsQueryBuilderCorrectly()
     {
         $result = EloquentModelWithStub::with('foo', 'bar');
@@ -2395,6 +2405,17 @@ class EloquentModelDestroyStub extends Model
         $mock->shouldReceive('whereIn')->once()->with('id', [1, 2, 3])->andReturn($mock);
         $mock->shouldReceive('get')->once()->andReturn([$model = m::mock(stdClass::class)]);
         $model->shouldReceive('delete')->once();
+
+        return $mock;
+    }
+}
+
+class EloquentModelEmptyDestroyStub extends Model
+{
+    public function newQuery()
+    {
+        $mock = m::mock(Builder::class);
+        $mock->shouldReceive('whereIn')->never();
 
         return $mock;
     }


### PR DESCRIPTION
I recently discovered that calling `Model::destroy()` with an empty array produces an unnecessary no-op database query.

```sql
select * from `tasks` where 0 = 1
```

This happens because the `destroy()` method calls `Builder::whereIn()`, which in turn turn an empty set of ids into the condition `0 = 1`: https://github.com/laravel/framework/blob/5ba7984e1d45ebecd0af245db96b03194281581f/src/Illuminate/Database/Query/Grammars/Grammar.php#L271

Since I do not know the reasons for adding the `0 = 1` condition, I went for a more cautious and minimal change. 

Now, `destroy()` checks for an empty input and bails early, saving a database roundtrip for a query that is guaranteed to have no effect.