### PR TITLE
[8.x] Create Collection `chunkInto` method

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1063,6 +1063,17 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
+     * Chunk the collection into a set number of chunks.
+     *
+     * @param  int  $chunks
+     * @return static
+     */
+    public function chunkInto($chunks)
+    {
+        return $this->chunk(ceil($this->count() / $chunks));
+    }
+
+    /**
      * Chunk the collection into chunks with a callback.
      *
      * @param  callable  $callback

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1042,6 +1042,17 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
+     * Split a collection into a certain number of groups, and fill the first groups completely.
+     *
+     * @param  int  $numberOfGroups
+     * @return static
+     */
+    public function splitIn($numberOfGroups)
+    {
+        return $this->chunk(ceil($this->count() / $numberOfGroups));
+    }
+
+    /**
      * Chunk the collection into chunks of the given size.
      *
      * @param  int  $size
@@ -1060,17 +1071,6 @@ class Collection implements ArrayAccess, Enumerable
         }
 
         return new static($chunks);
-    }
-
-    /**
-     * Chunk the collection into a set number of chunks.
-     *
-     * @param  int  $chunks
-     * @return static
-     */
-    public function chunkInto($chunks)
-    {
-        return $this->chunk(ceil($this->count() / $chunks));
     }
 
     /**

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1058,14 +1058,14 @@ class LazyCollection implements Enumerable
     }
 
     /**
-     * Chunk the collection into a set number of chunks.
+     * Split a collection into a certain number of groups, and fill the first groups completely.
      *
-     * @param  int  $chunks
+     * @param  int  $numberOfGroups
      * @return static
      */
-    public function chunkInto($chunks)
+    public function splitIn($numberOfGroups)
     {
-        return $this->chunk(ceil($this->count() / $chunks));
+        return $this->chunk(ceil($this->count() / $numberOfGroups));
     }
 
     /**

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1058,6 +1058,17 @@ class LazyCollection implements Enumerable
     }
 
     /**
+     * Chunk the collection into a set number of chunks.
+     *
+     * @param  int  $chunks
+     * @return static
+     */
+    public function chunkInto($chunks)
+    {
+        return $this->chunk(ceil($this->count() / $chunks));
+    }
+
+    /**
      * Chunk the collection into chunks with a callback.
      *
      * @param  callable  $callback

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1648,10 +1648,10 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
-    public function testChunkInto($collection)
+    public function testSplitIn($collection)
     {
         $data = new $collection([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-        $data = $data->chunkInto(3);
+        $data = $data->splitIn(3);
 
         $this->assertInstanceOf($collection, $data);
         $this->assertInstanceOf($collection, $data->first());

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1648,6 +1648,22 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testChunkInto($collection)
+    {
+        $data = new $collection([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        $data = $data->chunkInto(3);
+
+        $this->assertInstanceOf($collection, $data);
+        $this->assertInstanceOf($collection, $data->first());
+        $this->assertCount(3, $data);
+        $this->assertEquals([1, 2, 3, 4], $data->get(0)->values()->toArray());
+        $this->assertEquals([5, 6, 7, 8], $data->get(1)->values()->toArray());
+        $this->assertEquals([9, 10], $data->get(2)->values()->toArray());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testChunkWhileOnEqualElements($collection)
     {
         $data = (new $collection(['A', 'A', 'B', 'B', 'C', 'C', 'C']))


### PR DESCRIPTION
This methods defines the number of chunks we would like to end up with. It fills all non-last chunks first, before placing the remainder in the final chunk.

This method is similar to, but different than, `split()`.

Given the following Collection:

```php
$array = collect([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
```

`$array->split(3)` will return 3 chunks of sizes 4, 3, and 3.

`$array->chunkInto(3)` will return 3 chunks of sizes 4, 4, and 2.