### PR TITLE
Update .editorconfig to support Makefile

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,3 +13,5 @@ trim_trailing_whitespace = false
 
 [*.{yml,yaml}]
 indent_size = 2
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
Makefile needs us to use tabs instead of spaces.

With present .editorconfig, Makefile would be written with spaces even when we type tab,  which will give error while running the make command

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
