### PR TITLE
[8.x] Allow passing of Model instance on database rule.

### DIFF
--- a/src/Illuminate/Validation/Rules/DatabaseRule.php
+++ b/src/Illuminate/Validation/Rules/DatabaseRule.php
@@ -58,10 +58,6 @@ trait DatabaseRule
      */
     public function resolveTableName($table)
     {
-        if (! Str::contains($table, '\\') || ! class_exists($table)) {
-            return $table;
-        }
-
         if (is_subclass_of($table, Model::class)) {
             $model = new $table;
 

--- a/tests/Validation/ValidationUniqueRuleTest.php
+++ b/tests/Validation/ValidationUniqueRuleTest.php
@@ -67,6 +67,10 @@ class ValidationUniqueRuleTest extends TestCase
         $rule = new Unique('table');
         $rule->where('foo', '"bar"');
         $this->assertSame('unique:table,NULL,NULL,id,foo,"""bar"""', (string) $rule);
+
+        $rule = new Unique(new EloquentModelStub);
+        $rule->where('foo', '"bar"');
+        $this->assertSame('unique:table,NULL,NULL,id,foo,"""bar"""', (string) $rule);
     }
 }
 


### PR DESCRIPTION
No need to check if class exist since **"no error is generated if the class does not exist"** when using is_subclass_of.
https://www.php.net/manual/en/function.is-subclass-of.php

## Before PR

```php
$model = new Model;
Rule::unique($model->getTable())

$model = Model::first();
Rule::unique($model->getTable())->ignore($model->getKey())
```

## After PR

```php
Rule::unique(new Model)

$model = Model::first();
Rule::unique($model)->ignore($model->getKey())
```