### PR TITLE
[8.x] Fix custom and fallback validation messages for size rules

### DIFF
--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -596,6 +596,19 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
         $this->assertSame('really required!', $v->messages()->first('name'));
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->getLoader()->addMessages('en', 'validation', [
+            'custom' => [
+                '*' => [
+                    'max.string' => 'max :max chars!',
+                ],
+            ],
+        ]);
+        $v = new Validator($trans, ['name' => 'taylor'], ['name' => 'max:2']);
+        $this->assertFalse($v->passes());
+        $v->messages()->setFormat(':message');
+        $this->assertSame('max 2 chars!', $v->messages()->first('name'));
     }
 
     public function testCustomValidationLinesAreRespectedWithAsterisks()
@@ -3752,6 +3765,30 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
         $this->assertSame('foo!', $v->messages()->first('name'));
+    }
+
+    public function testFallbackMessages()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['name' => 'taylor'], ['name' => 'max:2']);
+        $v->setFallbackMessages(['*' => 'fallback']);
+        $this->assertFalse($v->passes());
+        $v->messages()->setFormat(':message');
+        $this->assertSame('fallback', $v->messages()->first('name'));
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['name' => 'taylor'], ['name' => 'max:2']);
+        $v->setFallbackMessages(['max' => 'fallback']);
+        $this->assertFalse($v->passes());
+        $v->messages()->setFormat(':message');
+        $this->assertSame('fallback', $v->messages()->first('name'));
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['name' => 'taylor'], ['name' => 'max:2']);
+        $v->setFallbackMessages(['max.string' => 'fallback']);
+        $this->assertFalse($v->passes());
+        $v->messages()->setFormat(':message');
+        $this->assertSame('fallback', $v->messages()->first('name'));
     }
 
     public function testClassBasedCustomValidators()


### PR DESCRIPTION
This fixes a premature return of validation translations for size rules (e.g. 'max', 'between', etc.), which causes custom messages and fallbacks for these rules not to be applied.

### Problem description:

1) Asterisk fallback messages set via `Illuminate\Validation\Validator::setFallbackMessages()` are not respected if a size rule (e.g. `max`, `between`, etc.) exists. If you set a `['*' => 'fallback']` message, it will apply to all non-size rules, but the validator will return `'validation.max.string'` instead of `'fallback'` for the size rules only.

2) Fallback messages for size rules that explicitly include the type (e.g. `max.string`, `between.integer`, etc.)  are not respected. As in (1), the `validation.{sizerule}.{type}` will be returned instead.

3) Custom validation messages from translator for size rules that explicitly include the type (e.g. keys like 'validation.custom.attr1.max.integer' or 'validation.custom.*.max.integer') are not respected. As in (1), the `validation.{sizerule}.{type}` will be returned instead.

All three of these problems are due to the premature return of [translator output](https://github.com/laravel/framework/blob/8.x/src/Illuminate/Validation/Concerns/FormatsMessages.php#L179) in [FormatsMessages.php:L49](https://github.com/laravel/framework/blob/8.x/src/Illuminate/Validation/Concerns/FormatsMessages.php#L49), which prevents fallback and custom messages from being reached if the translator was not able to supply a message.

### To reproduce:

Please see test code included, which shows specific inputs and outputs that are currently failing. All the tests added in this pull request will fail without the fixes applied here.

Problems (1) and (2) are tested in [`testFallbackMessages()`](https://github.com/laravel/framework/pull/35306/files#diff-eb2d4924c4dc2a5eed5cebe577dd7a6694c6222b681440c20aad2c92c222ac6fR3770), which produce the following errors before the changes:
``` 
Illuminate\Tests\Validation\ValidationValidatorTest::testFallbackMessages
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'fallback'
+'validation.max.string'
```

Problem (3) is tested in  [`testCustomValidationLinesAreRespected()`](https://github.com/laravel/framework/pull/35306/files#diff-eb2d4924c4dc2a5eed5cebe577dd7a6694c6222b681440c20aad2c92c222ac6fR600),  which produces the following errors before the changes:
```
Illuminate\Tests\Validation\ValidationValidatorTest::testCustomValidationLinesAreRespected
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'max 2 chars!'
+'validation.max.string'
```
