### PR TITLE
[8.x] Use --no-owner and --no-acl with pg_restore

### DIFF
--- a/src/Illuminate/Database/Schema/PostgresSchemaState.php
+++ b/src/Illuminate/Database/Schema/PostgresSchemaState.php
@@ -25,7 +25,7 @@ class PostgresSchemaState extends SchemaState
                         })->implode(' ');
 
         $this->makeProcess(
-            $this->baseDumpCommand().' --no-owner --file=$LARAVEL_LOAD_PATH '.$excludedTables
+            $this->baseDumpCommand().' --file=$LARAVEL_LOAD_PATH '.$excludedTables
         )->mustRun($this->output, array_merge($this->baseVariables($this->connection->getConfig()), [
             'LARAVEL_LOAD_PATH' => $path,
         ]));
@@ -39,7 +39,7 @@ class PostgresSchemaState extends SchemaState
      */
     public function load($path)
     {
-        $command = 'PGPASSWORD=$LARAVEL_LOAD_PASSWORD pg_restore --host=$LARAVEL_LOAD_HOST --port=$LARAVEL_LOAD_PORT --username=$LARAVEL_LOAD_USER --dbname=$LARAVEL_LOAD_DATABASE $LARAVEL_LOAD_PATH';
+        $command = 'PGPASSWORD=$LARAVEL_LOAD_PASSWORD pg_restore --no-owner --no-acl --host=$LARAVEL_LOAD_HOST --port=$LARAVEL_LOAD_PORT --username=$LARAVEL_LOAD_USER --dbname=$LARAVEL_LOAD_DATABASE $LARAVEL_LOAD_PATH';
 
         if (Str::endsWith($path, '.sql')) {
             $command = 'PGPASSWORD=$LARAVEL_LOAD_PASSWORD psql --file=$LARAVEL_LOAD_PATH --host=$LARAVEL_LOAD_HOST --port=$LARAVEL_LOAD_PORT --username=$LARAVEL_LOAD_USER --dbname=$LARAVEL_LOAD_DATABASE';


### PR DESCRIPTION
### Removed

- Removes the `--no-owner` from the `dump()` command, as it's a duplicate already set in the `baseDumpCommand` base command

### Changed

- Changes the `PostgresSchemaState::load()` to also use `--no-owner` and `--no-acl` flags in the `pg_restore` command (which are also used in the `schema:dump`, see comment above)

---

We were not able to run the migrate command on GitHub CI using the dump file without passing the `--no-owner` and `--no-acl` flags, as CI had a different DB user. [The Heroku](https://devcenter.heroku.com/articles/heroku-postgres-import-export#import) docs - for reference - also suggest using those flags with `pg_restore`.

Co-authored-by: @funkymonk91