### PR TITLE
[6.x] Avoid deprecated response create method

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -322,7 +322,7 @@ class Handler implements ExceptionHandlerContract
      */
     protected function convertExceptionToResponse(Exception $e)
     {
-        return SymfonyResponse::create(
+        return new SymfonyResponse(
             $this->renderExceptionContent($e),
             $this->isHttpException($e) ? $e->getStatusCode() : 500,
             $this->isHttpException($e) ? $e->getHeaders() : []


### PR DESCRIPTION
The create method just calls the constructor in all versions of Symfony 4/5. It was deprecated in 5.1.0. Fixes https://github.com/laravel/framework/issues/35288. 