### PR TITLE
Update asJson json_encoding defaults

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -874,7 +874,7 @@ trait HasAttributes
      */
     protected function asJson($value)
     {
-        return json_encode($value);
+        return json_encode($value, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
     }
 
     /**


### PR DESCRIPTION
Formatting "error" occurs when using mariadb or mysql and UTF-8 on "array" fields.

With defaults: 	
{"et":""Men\u00fc\u00fcd\/T\u00f5lked"}

With UNESCAPED options
{"et":"Menüüd/Tõlked"}

Tested this solution with MySQL and MariaDB using Homestead

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
