### PR TITLE
[8.x] Fix custom and fallback validation messages for size rules

### DIFF
--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -596,6 +596,19 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
         $this->assertSame('really required!', $v->messages()->first('name'));
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->getLoader()->addMessages('en', 'validation', [
+            'custom' => [
+                '*' => [
+                    'max.string' => 'max :max chars!',
+                ],
+            ],
+        ]);
+        $v = new Validator($trans, ['name' => 'taylor'], ['name' => 'max:2']);
+        $this->assertFalse($v->passes());
+        $v->messages()->setFormat(':message');
+        $this->assertSame('max 2 chars!', $v->messages()->first('name'));
     }
 
     public function testCustomValidationLinesAreRespectedWithAsterisks()
@@ -3752,6 +3765,30 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
         $this->assertSame('foo!', $v->messages()->first('name'));
+    }
+
+    public function testFallbackMessages()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['name' => 'taylor'], ['name' => 'max:2']);
+        $v->setFallbackMessages(['*' => 'fallback']);
+        $this->assertFalse($v->passes());
+        $v->messages()->setFormat(':message');
+        $this->assertSame('fallback', $v->messages()->first('name'));
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['name' => 'taylor'], ['name' => 'max:2']);
+        $v->setFallbackMessages(['max' => 'fallback']);
+        $this->assertFalse($v->passes());
+        $v->messages()->setFormat(':message');
+        $this->assertSame('fallback', $v->messages()->first('name'));
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['name' => 'taylor'], ['name' => 'max:2']);
+        $v->setFallbackMessages(['max.string' => 'fallback']);
+        $this->assertFalse($v->passes());
+        $v->messages()->setFormat(':message');
+        $this->assertSame('fallback', $v->messages()->first('name'));
     }
 
     public function testClassBasedCustomValidators()


### PR DESCRIPTION
Re-opening [this pull request](https://github.com/laravel/framework/pull/35306) with an expanded and (hopefully!) more clear demonstration of the bug in question — and that it actually is something worth fixing. We can of course extend the validation component on our end to fix this for our use cases, but it seems like it would be beneficial to the community to get this change in upstream. If you still decide this is a 'wontfix', no worries, I'll stop spamming you with PRs :)

### Summary 

This fixes a premature return of validation translations for size rules (e.g. 'max', 'between', etc.), which causes custom messages and fallbacks for these rules not to be applied. This means that the message precedence for size rules does not match the precedence of non-size rules. This behavior is unexpected and pretty clearly a bug, but on the off-chance that it is intentional, it should be documented at least with a comment.

Note that this PR does not contain breaking changes. By respecting precedence for size rule messages, the only behavior that can change is that instead of a Laravel-generated default message, a user-specified message will be returned instead, as is done for all other rules. 

### Bug description:

1) Asterisk fallback messages set via `Illuminate\Validation\Validator::setFallbackMessages()` are not respected if a size rule (e.g. `max`, `between`, etc.) exists. If you set a `['*' => 'fallback']` message, it will apply to all non-size rules, but the validator will return `'validation.max.string'` instead of `'fallback'` for the size rules only.

2) Fallback messages for size rules that explicitly include the type (e.g. `max.string`, `between.integer`, etc.)  are not respected. As in (1), the `validation.{sizerule}.{type}` will be returned instead.

3) Custom validation messages from translator for size rules that explicitly include the type (e.g. keys like 'validation.custom.attr1.max.integer' or 'validation.custom.*.max.integer') are not respected. As in (1), the `validation.{sizerule}.{type}` will be returned instead.

All three of these problems are due to the premature return of [translator output](https://github.com/laravel/framework/blob/8.x/src/Illuminate/Validation/Concerns/FormatsMessages.php#L179) in [FormatsMessages.php:L49](https://github.com/laravel/framework/blob/8.x/src/Illuminate/Validation/Concerns/FormatsMessages.php#L49), which prevents fallback and custom messages from being reached if the translator was not able to supply a message.

### Bug examples:
```php
// Case 1: This adds a fallback that should be applied if an inline message or custom message is lacking.
// Note that it works for 'age', but is not applied to 'name' due to the bug (fixed in this PR).

$validator = new \Illuminate\Validation\Validator(
    new \Illuminate\Translation\Translator(new \Illuminate\Translation\ArrayLoader(), 'en'),
    ['name' => 'taylor', 'age' => 'foo'],
    ['name' => 'string|max:5', 'age' => 'integer'],
    [] // Uh-oh! We're missing custom messages. But not to worry... the fallback has us covered, or does it?
);
$validator->setFallbackMessages(['*' => 'generic fallback']);
var_dump($validator->messages()->messages()['age'][0]); // output: "generic fallback"
var_dump($out_4 = $validator->messages()->messages()['name'][0]); // output: "validation.max.string" -- BUG!
```

```php
// Case 2: If a translator has custom messages but does not explicitly specify types for typed rules, 
// they are not applied to typed rules. Considering that typed rules are not even mentioned in the 
// documentation, messages for rules without type suffixes specified should take precedence (fixed in this PR). 

$translator = new \Illuminate\Translation\Translator(new \Illuminate\Translation\ArrayLoader(), 'en');
$translator->getLoader()->addMessages('en', 'validation', [
    'integer' => 'should be int!',
    'max' => 'max 5 chars!',
]);
$validator = new \Illuminate\Validation\Validator(
    $translator,
    ['name' => 'Taylor', 'age' => 'foo'],
    ['name' => 'string|max:5', 'age' => 'integer'],
);
var_dump($validator->messages()->messages()['age'][0]); // output: "should be int!"
var_dump($validator->messages()->messages()['name'][0]); // output: "validation.max.string" -- BUG!
// ^ (Should check for 'validation.max', which we specified, before checking for 'validation.max.string')
```

### Why not just use inline custom messages?

_Can't we just do this?_

```php
$validator = Validator::make(['name' => 'Taylor'], ['name' => 'string|max:5'], ['name.max' => 'Some custom message']);
```

Of course, but specifying custom messages inline as above requires means setting the (potentially same) custom message for similar fields every time they are validated, causing unnecessary repetition across potentially a large number of controllers. 

Luckily, `Validator` takes a `Translator` where you can set a custom message once and use it for all your validators. For example, we can set `['integer' => 'Must be an integer']` and then all failing integer rules will get that custom message without explicitly adding the message during validation. Likewise, we can set `['max:string'  => 'Max :max characters', 'max:numeric' => 'Max :max']` once in the Translator, and instantly have custom messages for all string and integer fields that have a 'max' rule, without having to specify them inline. 

_What happens if a Translator is missing a message for the failing rule, though?_ 

That's where fallbacks kick in. We can add a fallback like this:

```php
$validator->setFallbackMessages(['*' => 'This field has an invalid value']);
```

Now, if for any reason a message for the failing rule was not found, we can show our own default message.

### Typed rules:

In [an earlier version](https://github.com/laravel/framework/pull/35306#issuecomment-731602501) of this PR, @taylorotwell raised the question of whether custom messages formatted as `'max.string'` are supported. They actually aren't supported in inline messages, i.e. in the `$messages` argument to `Validator::make()` (though it wouldn't be a bad idea to support them there too). However, the snippet below demonstrates that they are indeed supported when a Translator is used. Given this, their precedence should match that of other non-typed rules.

```php
$translator = new \Illuminate\Translation\Translator(new \Illuminate\Translation\ArrayLoader(), 'en');
$translator->getLoader()->addMessages('en', 'validation', [
    'max.string' => 'max 5 chars', // This will apply to all strings
    'max.numeric' => 'max 35', // This will apply to all numeric values
]);
$validator = new \Illuminate\Validation\Validator($translator,
    ['name' => 'Taylor', 'age' => 36],
    ['name' => 'string|max:5', 'age' => 'integer|max:35'],
);
var_dump($validator->messages()->messages()['name'][0)]; // output: "max 5 chars"
var_dump($validator->messages()->messages()['age'][0]); // output: "max 35"
```

Note that this is currently documented [here](https://github.com/laravel/framework/blob/8.x/src/Illuminate/Validation/Concerns/FormatsMessages.php#L49):
```php
        // If the rule being validated is a "size" rule, we will need to gather the
        // specific error message for the type of attribute being validated such
        // as a number, file or string which all have different message types.
        elseif (in_array($rule, $this->sizeRules)) {
            return $this->getSizeMessage($attribute, $rule);
        }
```

The actual fetching of the custom messages currently occurs [here](https://github.com/laravel/framework/blob/8.x/src/Illuminate/Validation/Concerns/FormatsMessages.php#L172):
```php
        // There are three different types of size validations. The attribute may be
        // either a number, file, or string so we will check a few things to know
        // which type of value it is and return the correct line for that type.
        $type = $this->getAttributeType($attribute);

        $key = "validation.{$lowerRule}.{$type}";

        return $this->translator->get($key);
```

The web documentation on validation does not seem to mention these size suffixes at all. IMHO, it's a pretty handy feature. If desired, I'm happy to update those docs.