### PR TITLE
[8.x] fix SQL Server command generation

### DIFF
--- a/src/Illuminate/Database/Console/DbCommand.php
+++ b/src/Illuminate/Database/Console/DbCommand.php
@@ -160,7 +160,7 @@ class DbCommand extends Command
             'username' => ['-U', $connection['username']],
             'password' => ['-P', $connection['password']],
             'host' => ['-S', 'tcp:'.$connection['host']
-                        .($connection['port'] ? ','.$connection['port'] : '')],
+                        .($connection['port'] ? ','.$connection['port'] : ''), ],
         ], $connection));
     }
 

--- a/src/Illuminate/Database/Console/DbCommand.php
+++ b/src/Illuminate/Database/Console/DbCommand.php
@@ -155,13 +155,13 @@ class DbCommand extends Command
      */
     protected function getSqlsrvArguments(array $connection)
     {
-        return $this->getOptionalArguments([
-            'database' => '-d '.$connection['database'],
-            'username' => '-U '.$connection['username'],
-            'password' => '-P '.$connection['password'],
-            'host' => '-S tcp:'.$connection['host']
-                        .($connection['port'] ? ','.$connection['port'] : ''),
-        ], $connection);
+        return array_merge(...$this->getOptionalArguments([
+            'database' => ['-d', $connection['database']],
+            'username' => ['-U', $connection['username']],
+            'password' => ['-P', $connection['password']],
+            'host' => ['-S', 'tcp:'.$connection['host']
+                        .($connection['port'] ? ','.$connection['port'] : '')],
+        ], $connection));
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

The new `php artisan db` command introduced in PR #35304 adds a very nice feature that allows the developer to easily connect to the DBMS CLI using the connection parameters already configured in the application.

But as noted by that PR author, he didn't have SQL Server available, then he couldn't test the generated command against it.

I tested locally the new command and the command-line generated by the original PR fails when executed. This PR fixes the command for SQL Server.

Sample command generated before this PR:

~~~bash
'sqlcmd' '-d database' '-U sa' '-P Password123456' '-S tcp:127.0.0.1,1433'
~~~

Note command options and their values are quoted together.

Sample command generated after this PR:

~~~bash
'sqlcmd' '-d' 'database' '-U' 'sa' '-P' 'Password123456' '-S' 'tcp:127.0.0.1,1433'
~~~
