### PR TITLE
[6.x] Fix generic DetectsLostConnection string

### DIFF
--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -40,7 +40,7 @@ trait DetectsLostConnections
             'Communication link failure',
             'connection is no longer usable',
             'Login timeout expired',
-            'Connection refused',
+            'SQLSTATE[HY000] [2002] Connection refused',
             'running with the --read-only option so it cannot execute this statement',
             'The connection is broken and recovery is not possible. The connection is marked by the client driver as unrecoverable. No attempt was made to restore the connection.',
             'SQLSTATE[HY000] [2002] php_network_getaddresses: getaddrinfo failed: Try again',


### PR DESCRIPTION
This PR: https://github.com/laravel/framework/pull/31539 introduced a bug https://github.com/laravel/framework/issues/35321 and potentially more bugs that haven't been reported yet. The issue is that the `DetectsLostConnection` string added ("**connection refused**") is way too generic and may be caused by any TCP/IP service that's unable to connect (isn't limited to lost DB connections). Based on the original PR stack trace, I've narrowed it down to make it specific to lost database connections.

Closes https://github.com/laravel/framework/issues/35321.