### PR TITLE
[9.x] Dont autodiscover require-dev packages in production

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -17,6 +17,7 @@ use Illuminate\Log\LogServiceProvider;
 use Illuminate\Routing\RoutingServiceProvider;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Composer;
 use Illuminate\Support\Env;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
@@ -197,7 +198,10 @@ class Application extends Container implements ApplicationContract, CachesConfig
 
         $this->singleton(PackageManifest::class, function () {
             return new PackageManifest(
-                new Filesystem, $this->basePath(), $this->getCachedPackagesPath()
+                new Filesystem,
+                new Composer(new Filesystem, $this->basePath()),
+                $this->basePath(),
+                $this->getCachedPackagesPath()
             );
         });
     }

--- a/src/Illuminate/Foundation/PackageManifest.php
+++ b/src/Illuminate/Foundation/PackageManifest.php
@@ -141,7 +141,7 @@ class PackageManifest
             $ignore = array_merge($ignore, $configuration['dont-discover'] ?? []);
         })->reject(function ($configuration, $package) use ($ignore, $ignoreAll) {
             return $ignoreAll || in_array($package, $ignore);
-        })->when(method_exists(app(), 'isProduction') && app()->isProduction(), function($packages) {
+        })->when(method_exists(app(), 'isProduction') && app()->isProduction(), function ($packages) {
             return $packages->intersectByKeys(array_flip($this->composer->getDependencies(false)));
         })->filter()->all());
     }

--- a/src/Illuminate/Support/Composer.php
+++ b/src/Illuminate/Support/Composer.php
@@ -75,6 +75,27 @@ class Composer
     }
 
     /**
+     * Get the package dependencies.
+     *
+     * @param  bool  $includeDev
+     * @return array
+     */
+    public function getDependencies($includeDev = true)
+    {
+        $command = array_merge($this->findComposer(), ['show', '-N']);
+
+        if (! $includeDev) {
+            $command[] = '--no-dev';
+        }
+
+        $process = $this->getProcess($command);
+
+        $process->run();
+
+        return array_map('trim', array_filter(explode("\n", $process->getOutput())));
+    }
+
+    /**
      * Get the PHP binary.
      *
      * @return string

--- a/tests/Foundation/FoundationPackageManifestTest.php
+++ b/tests/Foundation/FoundationPackageManifestTest.php
@@ -5,13 +5,19 @@ namespace Illuminate\Tests\Foundation;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Foundation\PackageManifest;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Support\Composer;
 
 class FoundationPackageManifestTest extends TestCase
 {
     public function testAssetLoading()
     {
         @unlink(__DIR__.'/fixtures/packages.php');
-        $manifest = new PackageManifest(new Filesystem, __DIR__.'/fixtures', __DIR__.'/fixtures/packages.php');
+        $manifest = new PackageManifest(
+            new Filesystem,
+            new Composer(new Filesystem),
+            __DIR__.'/fixtures',
+            __DIR__.'/fixtures/packages.php'
+        );
         $this->assertEquals(['foo', 'bar', 'baz'], $manifest->providers());
         $this->assertEquals(['Foo' => 'Foo\\Facade'], $manifest->aliases());
         unlink(__DIR__.'/fixtures/packages.php');

--- a/tests/Foundation/FoundationPackageManifestTest.php
+++ b/tests/Foundation/FoundationPackageManifestTest.php
@@ -5,7 +5,7 @@ namespace Illuminate\Tests\Foundation;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Foundation\PackageManifest;
 use Illuminate\Support\Composer;
-use PHPUnit\Framework\TestCase;
+use Orchestra\Testbench\TestCase;
 
 class FoundationPackageManifestTest extends TestCase
 {

--- a/tests/Foundation/FoundationPackageManifestTest.php
+++ b/tests/Foundation/FoundationPackageManifestTest.php
@@ -4,8 +4,8 @@ namespace Illuminate\Tests\Foundation;
 
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Foundation\PackageManifest;
-use PHPUnit\Framework\TestCase;
 use Illuminate\Support\Composer;
+use PHPUnit\Framework\TestCase;
 
 class FoundationPackageManifestTest extends TestCase
 {


### PR DESCRIPTION
## Motivation
Currently, the `package:discover` command auto-discovers all packages in the composer `installed.json` file, which means that even if the environment is set to production, the discover command would auto-load the service providers of the dev dependencies as well.

I think it may be useful to exclude `require-dev` dependencies if the config `app.env` is set to production. I know that the best practice would be to just run `composer install --no-dev` in production but I think it would be nice to provide an extra layer of checks / less error-prone defaults.

## Benefits
Dev packages such as ignition are known to have overhead and memory leaks (https://github.com/facade/ignition/issues/284). If we take this PR's approach, I think we can avoid these in production. Of course, if someone wants to include a specific dev dependency package in production, he/she could just pull it in `app.php` without having to auto-discover it or alternatively, place them in the `require` section instead of `require-dev`.

Since this is a breaking change, this PR targets 9x / master. Closes https://github.com/laravel/ideas/issues/2425