### PR TITLE
[8.x] Update job batches migration to set options to mediumText

### DIFF
--- a/src/Illuminate/Queue/Console/stubs/batches.stub
+++ b/src/Illuminate/Queue/Console/stubs/batches.stub
@@ -20,7 +20,7 @@ class Create{{tableClassName}}Table extends Migration
             $table->integer('pending_jobs');
             $table->integer('failed_jobs');
             $table->text('failed_job_ids');
-            $table->text('options')->nullable();
+            $table->mediumText('options')->nullable();
             $table->integer('cancelled_at')->nullable();
             $table->integer('created_at');
             $table->integer('finished_at')->nullable();


### PR DESCRIPTION
When setting up job batches I came across an issue when trying to create a batch of 200 jobs.  When serializing the options the framework failed to retrieve the serialized data in the DatabaseBatchRepository after inserting it into the database as the text memory limited only allowed part of the data to be stored.  

This generated the following exception at the point of creation

Argument 8 passed to Illuminate\Bus\BatchFactory::make() must be of the type array, bool given, called in /vendor/laravel/framework/src/Illuminate/Bus/DatabaseBatchRepository.php on line 265

and this exception processing the queue:

Insufficient data for unserializing - 89419 required, 65459 present
Line 262 in file /vendor/laravel/framework/src/Illuminate/Bus/DatabaseBatchRepository.php

Amending the options field in the job_batches table to mediumText solved this issue and allows for a much greater number of jobs to be processed by a single batch.

This amend will not break any existing features as it is a very simple database amend which will also not affect testing.
