### PR TITLE
[9.x] More flexibility when time traveling in tests

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTime.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTime.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Foundation\Testing\Concerns;
 
-use DateTimeInterface;
 use Illuminate\Foundation\Testing\Wormhole;
 use Illuminate\Support\Carbon;
 
@@ -22,11 +21,11 @@ trait InteractsWithTime
     /**
      * Travel to another time.
      *
-     * @param  \DateTimeInterface  $date
+     * @param  \DateTimeInterface|Closure|Carbon|string|false|null $date
      * @param  callable|null  $callback
      * @return mixed
      */
-    public function travelTo(DateTimeInterface $date, $callback = null)
+    public function travelTo($date, $callback = null)
     {
         Carbon::setTestNow($date);
 


### PR DESCRIPTION
_Originally targeted 8.x #35326   , was informed it was a breaking change, so switched to 9.x_

The purpose of this PR is to bring parity to the `InteractsWithTime::travelTo` parameter type hint so it matches the `Carbon::setTestNow` type hint.

IMO this will allow for more flexibility when time traveling in tests. Here are some examples that would be supported if this PR were merged. 

### Currently, these all result in a type error.
```
$this->travelTo('Sunday'); 
$this->travelTo('tomorrow');
$this->travelTo('Monday +1 week');
$this->travelTo('+1 week 2 days 4 hours 2 seconds');
$this->travelTo('2020-11-23');
```

### Meanwhile, these all work fine.
```
Carbon::setTestNow('Sunday'); 
Carbon::setTestNow('tomorrow');
Carbon::setTestNow('Monday +1 week');
Carbon::setTestNow('+1 week 2 days 4 hours 2 seconds');
Carbon::setTestNow('2020-11-23');
```

Unless I'm missing something, the `DateTimeInterface` requirement seems like an arbitrary restriction when Carbon's implementation of `setTestNow` has no such restriction.
```
// InteractsWithTime.php
public function travelTo(DateTimeInterface $date, $callback = null)
{
    Carbon::setTestNow($date);
    ...
{

// CarbonInterface.php
@param Closure|static|string|false|null $testNow real or mock Carbon instance
public static function setTestNow($testNow = null);
```




