### PR TITLE
[9.x] Fix type hints

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTime.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTime.php
@@ -21,7 +21,7 @@ trait InteractsWithTime
     /**
      * Travel to another time.
      *
-     * @param  \DateTimeInterface|\Closure|\Illuminate\Support\Carbon|string|bool|null $date
+     * @param  \DateTimeInterface|\Closure|\Illuminate\Support\Carbon|string|bool|null  $date
      * @param  callable|null  $callback
      * @return mixed
      */

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTime.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTime.php
@@ -21,7 +21,7 @@ trait InteractsWithTime
     /**
      * Travel to another time.
      *
-     * @param  \DateTimeInterface|Closure|Carbon|string|false|null $date
+     * @param  \DateTimeInterface|\Closure|\Illuminate\Support\Carbon|string|bool|null $date
      * @param  callable|null  $callback
      * @return mixed
      */


### PR DESCRIPTION
https://github.com/laravel/framework/pull/35338 had some badly formatted type hints in the DocBlock.