### PR TITLE
[8.x] Add warning when running local migration aimed at non local database

### DIFF
--- a/src/Illuminate/Console/ConfirmableTrait.php
+++ b/src/Illuminate/Console/ConfirmableTrait.php
@@ -69,7 +69,7 @@ trait ConfirmableTrait
                 return 'Application In Production!';
             }
 
-            return;
+            return false;
         };
     }
 }

--- a/src/Illuminate/Console/ConfirmableTrait.php
+++ b/src/Illuminate/Console/ConfirmableTrait.php
@@ -13,17 +13,23 @@ trait ConfirmableTrait
      * @param  \Closure|bool|null  $callback
      * @return bool
      */
-    public function confirmToProceed($warning = null, $callback = null)
+    public function confirmToProceed($warning = 'Application In Production!', $callback = null)
     {
         $callback = is_null($callback) ? $this->getDefaultConfirmCallback() : $callback;
-        $warning = value($callback);
+        $shouldConfirm = value($callback);
 
-        if ($warning) {
+        if ($shouldConfirm) {
             if ($this->hasOption('force') && $this->option('force')) {
                 return true;
             }
 
-            $this->alert($warning);
+            if ($shouldConfirm === 'remote') {
+                $this->alert('You May Be Connected To A Remote Database!');
+            }
+
+            if ($shouldConfirm === 'production') {
+                $this->alert($warning);
+            }
 
             $confirmed = $this->confirm('Do you really wish to run this command?');
 
@@ -61,12 +67,12 @@ trait ConfirmableTrait
                 }
 
                 if ($remoteDatabase) {
-                    return 'You May Be Connected To A Remote Database!';
+                    return 'remote';
                 }
             }
 
             if ($this->getLaravel()->environment() === 'production') {
-                return 'Application In Production!';
+                return 'production';
             }
 
             return false;


### PR DESCRIPTION
I'd like to propose adding an additional confirmation when executing migrations locally that are not aimed at a local database.

There is currently a warning tied to the APP_ENV when it is set to production.  I'd like to suggest extending this warning in case a user changes their DB_HOST setting away from localhost or 127.0.0.1

I tried to write this in a way that wouldn't impact existing functionality and would account for any possible connection but ignore things like sqlite, etc.

TL;DR

I think there is an expectation that aiming at a remote database is a bad practice but developers who want to run a command against prod quickly, are newer developers that don't understand the consequences, or someone who just makes a configuration mistake could run into this problem where they forgot they changed the config and run migrate:fresh and wind up destroying their prod database with no warning what-so-ever.  I'm a reasonably experienced dev and I did this recently.  This is a real concern and I've done what I can to try to solve this here.  I really hope this is considered seriously and hopefully pulled in or at least thought about and some protection can be but in place.  Thanks!