### PR TITLE
[8.x] Allow test assertions to be made about email contents (rendered Mailables)

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -119,7 +119,7 @@ class MailFake implements Factory, Mailer, MailQueue
         return [
             'html' => $this->renderView($html, $data),
             'text' => $this->renderView($plain, $data),
-            'raw' => $raw
+            'raw' => $raw,
         ];
     }
 

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -204,11 +204,11 @@ class SupportTestingMailFakeTest extends TestCase
     {
         $viewFactory = m::mock(Factory::class);
         $view = m::mock(View::class);
-        $viewFactory->shouldReceive('make')->once()->andReturn($view);
-        $viewFactory->shouldReceive('flushFinderCache')->once();
-        $viewFactory->shouldReceive('replaceNamespace')->once()->andReturn($viewFactory);
+        $viewFactory->shouldReceive('make')->times(3)->andReturn($view);
+        $viewFactory->shouldReceive('flushFinderCache')->twice();
+        $viewFactory->shouldReceive('replaceNamespace')->twice()->andReturn($viewFactory);
         $viewFactory->shouldReceive('exists')->once()->andReturn(false);
-        $view->shouldReceive('render')->once()->andReturn('Hello Taylor');
+        $view->shouldReceive('render')->times(3)->andReturn('Hello Taylor');
 
         $this->fake->to('taylor@laravel.com')->send(new MarkdownMailableStub);
 
@@ -223,6 +223,11 @@ class SupportTestingMailFakeTest extends TestCase
 
             return true;
         });
+    }
+
+    protected function tearDown(): void
+    {
+        m::close();
     }
 }
 

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -6,15 +6,15 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\Mail\Mailable as MailableContract;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Contracts\Translation\HasLocalePreference;
+use Illuminate\Contracts\View\Factory as FactoryContract;
 use Illuminate\Mail\Mailable;
 use Illuminate\Support\Testing\Fakes\MailFake;
-use Illuminate\Contracts\View\Factory as FactoryContract;
 use Illuminate\View\Factory;
 use Illuminate\View\View;
+use Mockery as m;
 use PHPUnit\Framework\Constraint\ExceptionMessage;
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
-use Mockery as m;
 
 class SupportTestingMailFakeTest extends TestCase
 {
@@ -195,6 +195,7 @@ class SupportTestingMailFakeTest extends TestCase
             $rendered = $mail->render();
             $this->assertStringContainsString('Taylor HTML', $rendered['html']);
             $this->assertStringContainsString('Taylor TEXT', $rendered['text']);
+
             return true;
         });
     }
@@ -219,6 +220,7 @@ class SupportTestingMailFakeTest extends TestCase
             $this->assertStringContainsString('Taylor</p>', $rendered['html']);
             $this->assertStringContainsString('Taylor', $rendered['text']);
             $this->assertStringNotContainsString('Taylor</p>', $rendered['text']);
+
             return true;
         });
     }


### PR DESCRIPTION
Currently, Laravel allows to make assertions about response contents, eg:
```php
    /**
     * @test
     */
    public function homepage_welcomes_users()
    {
        $this->get('/')->assertSee('Welcome');
    }
```

You can make assertions about API JSON output as well. However, there is no easy way to test email contents - MailFake is not equipped for it. Developers have several options:

* Extending Mailable class to "hijack" `render()` method
* Extending Mailer class to extend `render()` or `send()` methods
* Making assertions about data variables, rather than rendered output

With this pull request, I'm proposing that MailFake class is extended to allow developers to test their outgoing emails:

```php
    /**
     * @test
     */
    public function email_confirmation_is_correct()
    {
        Mail::fake();

        event(new TestEvent());

        Mail::assertSent(TestMail::class, function ($mail) {
            $this->assertStringContainsString('shipped', $mail->render()['html']);
            $this->assertStringContainsString('shipped', $mail->render()['text']);
            $this->assertEmpty($mail->render()['raw']);

            return true;
        });
    }
```

Extra remarks:
* Returning an array from MailFake's `render()` method is not ideal (Mailer class returns a string), but this is a path of least resistance, with minimum changes required to the existing classes or the API
* There is a small amount of code repetition between MailFake and Mailer classes, namely `parseView` and `renderView` methods. From what I understand MailFake class (as well as other fake facades) is supposed to be as stand-alone as possible, so sharing a trait with Mailer didn't feel like a very good idea

Would love to hear more opinions, I'm sure there must be more developers out there in the wild who wanted to test their email contents at some stage!