### PR TITLE
[8.x] Make DownCommand options available to prerendered view

### DIFF
--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -100,7 +100,7 @@ class DownCommand extends Command
     {
         (new RegisterErrorViewPaths)();
 
-        return view($this->option('render'), ['command' => $this])->render();
+        return view($this->option('render'), ['options' => $this->options()])->render();
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -100,7 +100,7 @@ class DownCommand extends Command
     {
         (new RegisterErrorViewPaths)();
 
-        return view($this->option('render'))->render();
+        return view($this->option('render'),['command' => $this])->render();
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -100,7 +100,7 @@ class DownCommand extends Command
     {
         (new RegisterErrorViewPaths)();
 
-        return view($this->option('render'),['command' => $this])->render();
+        return view($this->option('render'), ['command' => $this])->render();
     }
 
     /**


### PR DESCRIPTION
Having the command options available to the pre-rendered view gives the possibility to, eg. see if the retry option was set, so you can add a meta-refresh tag to your view.