### PR TITLE
[8.x] separate className and parameters before passing it to ReflectionClass

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -715,7 +715,9 @@ class Router implements BindingRegistrar, RegistrarContract
                 return true;
             }
 
-            $reflection = new ReflectionClass($name);
+            [$className] = explode(':', $name, 2);
+
+            $reflection = new ReflectionClass($className);
 
             return collect($excluded)->contains(function ($exclude) use ($reflection) {
                 return $reflection->isSubclassOf($exclude);

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -715,9 +715,7 @@ class Router implements BindingRegistrar, RegistrarContract
                 return true;
             }
 
-            [$className] = explode(':', $name, 2);
-
-            $reflection = new ReflectionClass($className);
+            $reflection = new ReflectionClass(Str::before($name, ':'));
 
             return collect($excluded)->contains(function ($exclude) use ($reflection) {
                 return $reflection->isSubclassOf($exclude);


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
fix #35358 and #35359 

Hi, <br>I try to fix those issues with extracting `$className` from `$name` before passing it to ReflectionClass using `explode()`. <br>
variable `$name` contains parameters such as `App\Http\Middleware\Authenticate:sanctum` or `Illuminate\Routing\Middleware\ThrottleRequests:api` it will made ReflectorClass cannot find the classes and throw ReflectionException, therefore
 variable `$className` will only contains `App\Http\Middleware\Authenticate` and `Illuminate\Routing\Middleware\ThrottleRequests` so ReflectionClass can get class name correctly.

<br>Hope this helps. 