### PR TITLE
[8.x] Fix issue with polymorphic morphMaps with literal 0

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -256,7 +256,7 @@ trait HasRelationships
         // If the type value is null it is probably safe to assume we're eager loading
         // the relationship. In this case we'll just pass in a dummy query where we
         // need to remove any eager loads that may already be defined on a model.
-        return empty($class = $this->{$type})
+        return is_null($class = $this->{$type})
                     ? $this->morphEagerTo($name, $type, $id, $ownerKey)
                     : $this->morphInstanceTo($class, $name, $type, $id, $ownerKey);
     }

--- a/tests/Database/DatabaseEloquentMorphToTest.php
+++ b/tests/Database/DatabaseEloquentMorphToTest.php
@@ -90,6 +90,16 @@ class DatabaseEloquentMorphToTest extends TestCase
         $this->assertSame('taylor', $result->username);
     }
 
+    public function testMorphToWithZeroMorphType()
+    {
+        $parent = $this->getMockBuilder(EloquentMorphToModelStub::class)->onlyMethods(['getAttribute', 'morphEagerTo', 'morphInstanceTo'])->getMock();
+        $parent->method('getAttribute')->with('relation_type')->willReturn(0);
+        $parent->expects($this->once())->method('morphInstanceTo');
+        $parent->expects($this->never())->method('morphEagerTo');
+
+        $parent->relation();
+    }
+
     public function testMorphToWithSpecifiedClassDefault()
     {
         $parent = new EloquentMorphToModelStub;


### PR DESCRIPTION
### Background

Ran into project where

```
Relation::morphMap([
 0 => Model::class
 1 => Model2::class
]);
```

During a legacy upgrade I noticed failures after completing the 5.8.x upgrade. At first I tracked it to this - https://github.com/laravel/framework/issues/27175, which then resulted in changing my `morphTo` parameters to `null, null, null, 'id'` so ownerKey would be set properly.

It still failed. It appeared that getting a 0 zero value back from `entity_type` (entity morph) was passing the `empty` check in the wrong way no longer resulting in getting the morphed instance back.

The comment above the code change even says "if value is null", so probably just a mistake.

### Test
Never wrote a test for the DB area before. Hope it works out. Open for feedback.