### PR TITLE
[6.x] Backport Redis context option

### DIFF
--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -128,6 +128,10 @@ class PhpRedisConnector implements Connector
             $parameters[] = Arr::get($config, 'read_timeout', 0.0);
         }
 
+        if (version_compare(phpversion('redis'), '5.3.0', '>=')) {
+            $parameters[] = Arr::get($config, 'context');
+        }
+
         $client->{($persistent ? 'pconnect' : 'connect')}(...$parameters);
     }
 
@@ -150,6 +154,10 @@ class PhpRedisConnector implements Connector
 
         if (version_compare(phpversion('redis'), '4.3.0', '>=')) {
             $parameters[] = $options['password'] ?? null;
+        }
+
+        if (version_compare(phpversion('redis'), '5.3.2', '>=')) {
+            $parameters[] = Arr::get($options, 'context');
         }
 
         return tap(new RedisCluster(...$parameters), function ($client) use ($options) {


### PR DESCRIPTION
This backports https://github.com/laravel/framework/pull/33799 & https://github.com/laravel/framework/pull/34935 into Laravel 6.

While technically it supports a new Redis v5.3.2 feature I believe it would be good if we supported this in Laravel 6 LTS. This can also be considered as a bug fix because technically we provide support for Redis v5 in Laravel 6.

Fixes https://github.com/laravel/framework/issues/35368
