### PR TITLE
[8.x] Transaction aware code execution

### DIFF
--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -324,11 +324,11 @@ trait ManagesTransactions
     }
 
     /**
-     * Execute the callback within a transaction context.
+     * Execute the callback after a transaction commits.
      *
      * @return void
      */
-    public function withinTransaction($callback)
+    public function afterCommit($callback)
     {
         if ($this->transactionsManager) {
             return $this->transactionsManager->addCallback($callback);

--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Concerns;
 
 use Closure;
+use RuntimeException;
 use Throwable;
 
 trait ManagesTransactions
@@ -320,5 +321,19 @@ trait ManagesTransactions
     public function transactionLevel()
     {
         return $this->transactions;
+    }
+
+    /**
+     * Execute the callback within a transaction context.
+     *
+     * @return void
+     */
+    public function withinTransaction($callback)
+    {
+        if ($this->transactionsManager) {
+            return $this->transactionsManager->addCallback($callback);
+        }
+
+        throw new RuntimeException('Transactions Manager has not been set.');
     }
 }

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -113,6 +113,13 @@ class Connection implements ConnectionInterface
     protected $transactions = 0;
 
     /**
+     * The transaction manager instance.
+     *
+     * @var \Illuminate\Database\DatabaseTransactionsManager
+     */
+    protected $transactionsManager;
+
+    /**
      * Indicates if changes have been made to the database.
      *
      * @var int
@@ -1149,6 +1156,29 @@ class Connection implements ConnectionInterface
     public function unsetEventDispatcher()
     {
         $this->events = null;
+    }
+
+    /**
+     * Set the transaction manager instance on the connection.
+     *
+     * @param  \Illuminate\Database\DatabaseTransactionsManager  $manager
+     * @return $this
+     */
+    public function setTransactionManager($manager)
+    {
+        $this->transactionsManager = $manager;
+
+        return $this;
+    }
+
+    /**
+     * Unset the event transaction manager for this connection.
+     *
+     * @return void
+     */
+    public function unsetTransactionManager()
+    {
+        $this->transactionsManager = null;
     }
 
     /**

--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -174,6 +174,10 @@ class DatabaseManager implements ConnectionResolverInterface
             $connection->setEventDispatcher($this->app['events']);
         }
 
+        if ($this->app->bound('db.transactions')) {
+            $connection->setTransactionManager($this->app['db.transactions']);
+        }
+
         // Here we'll set a reconnector callback. This reconnector can be any callable
         // so we will set a Closure to reconnect from this manager with the name of
         // the connection, which will allow us to reconnect from the connections.

--- a/src/Illuminate/Database/DatabaseServiceProvider.php
+++ b/src/Illuminate/Database/DatabaseServiceProvider.php
@@ -71,6 +71,10 @@ class DatabaseServiceProvider extends ServiceProvider
         $this->app->bind('db.connection', function ($app) {
             return $app['db']->connection();
         });
+
+        $this->app->singleton('db.transactions', function ($app) {
+            return new DatabaseTransactionsManager();
+        });
     }
 
     /**

--- a/src/Illuminate/Database/DatabaseTransactionRecord.php
+++ b/src/Illuminate/Database/DatabaseTransactionRecord.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Illuminate\Database;
+
+class DatabaseTransactionRecord
+{
+    /**
+     * The name of the database connection.
+     *
+     * @var string
+     */
+    public $connection;
+
+    /**
+     * The transaction level.
+     *
+     * @var int
+     */
+    public $level;
+
+    /**
+     * The callbacks that should be executed after committing.
+     *
+     * @var array
+     */
+    protected $callbacks = [];
+
+    /**
+     * Create a new database transaction record instance.
+     *
+     * @param  string  $connection
+     * @param  int  $level
+     * @retunr void
+     */
+    public function __construct($connection, $level)
+    {
+        $this->connection = $connection;
+        $this->level = $level;
+    }
+
+    /**
+     * Register a callback to be executed after committing.
+     *
+     * @param  callable  $callback
+     * @return void
+     */
+    public function addCallback($callback)
+    {
+        $this->callbacks[] = $callback;
+    }
+
+    /**
+     * Execute all of the callbacks.
+     *
+     * @return void
+     */
+    public function executeCallbacks()
+    {
+        foreach ($this->callbacks as $callback) {
+            call_user_func($callback);
+        }
+    }
+
+    /**
+     * Get all of the callbacks.
+     *
+     * @return array
+     */
+    public function getCallbacks()
+    {
+        return $this->callbacks;
+    }
+}

--- a/src/Illuminate/Database/DatabaseTransactionsManager.php
+++ b/src/Illuminate/Database/DatabaseTransactionsManager.php
@@ -77,7 +77,11 @@ class DatabaseTransactionsManager
      */
     public function addCallback($callback)
     {
-        $this->transactions->last()->addCallback($callback);
+        if ($current = $this->transactions->last()) {
+            return $current->addCallback($callback);
+        }
+
+        call_user_func($callback);
     }
 
     /**

--- a/src/Illuminate/Database/DatabaseTransactionsManager.php
+++ b/src/Illuminate/Database/DatabaseTransactionsManager.php
@@ -46,7 +46,7 @@ class DatabaseTransactionsManager
     {
         $this->transactions = $this->transactions->reject(function ($transaction) use ($connection, $level) {
             return $transaction->connection == $connection &&
-                $transaction->level >= $level;
+                $transaction->level > $level;
         })->values();
     }
 

--- a/src/Illuminate/Database/DatabaseTransactionsManager.php
+++ b/src/Illuminate/Database/DatabaseTransactionsManager.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Illuminate\Database;
+
+class DatabaseTransactionsManager
+{
+    /**
+     * All the recorded transactions.
+     *
+     * @var \Illuminate\Support\Collection
+     */
+    protected $transactions;
+
+    /**
+     * Create a new database transactions manager instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->transactions = collect();
+    }
+
+    /**
+     * Start a new database transaction.
+     *
+     * @param  string  $connection
+     * @param  int  $level
+     * @return void
+     */
+    public function begin($connection, $level)
+    {
+        $this->transactions->push(
+            new DatabaseTransactionRecord($connection, $level)
+        );
+    }
+
+    /**
+     * Rollback the active database transaction.
+     *
+     * @param  string  $connection
+     * @param  int  $level
+     * @return void
+     */
+    public function rollback($connection, $level)
+    {
+        $this->transactions = $this->transactions->reject(function ($transaction) use ($connection, $level) {
+            return $transaction->connection == $connection &&
+                $transaction->level >= $level;
+        })->values();
+    }
+
+    /**
+     * Commit the active database transaction.
+     *
+     * @param  string  $connection
+     * @return void
+     */
+    public function commit($connection)
+    {
+        $this->transactions = $this->transactions->reject(function ($transaction) use ($connection) {
+            if ($transaction->connection == $connection) {
+                $transaction->executeCallbacks();
+
+                return true;
+            }
+
+            return false;
+        })->values();
+    }
+
+    /**
+     * Register a transaction callback.
+     *
+     * @param  callable $callback
+     * @return void.
+     */
+    public function addCallback($callback)
+    {
+        $this->transactions->last()->addCallback($callback);
+    }
+
+    /**
+     * Get all the transactions.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function getTransactions()
+    {
+        return $this->transactions;
+    }
+}

--- a/tests/Database/DatabaseTransactionsManagerTest.php
+++ b/tests/Database/DatabaseTransactionsManagerTest.php
@@ -171,4 +171,18 @@ class DatabaseTransactionsManagerTest extends TestCase
         $this->assertCount(1, $callbacks);
         $this->assertEquals(['default', 1], $callbacks[0]);
     }
+
+    public function testCallbackIsExecutedIfNoTransactions()
+    {
+        $callbacks = [];
+
+        $manager = (new DatabaseTransactionsManager());
+
+        $manager->addCallback(function () use (&$callbacks) {
+            $callbacks[] = ['default', 1];
+        });
+
+        $this->assertCount(1, $callbacks);
+        $this->assertEquals(['default', 1], $callbacks[0]);
+    }
 }

--- a/tests/Database/DatabaseTransactionsManagerTest.php
+++ b/tests/Database/DatabaseTransactionsManagerTest.php
@@ -52,7 +52,7 @@ class DatabaseTransactionsManagerTest extends TestCase
         $manager->begin('default', 2);
         $manager->begin('admin', 1);
 
-        $manager->rollback('default', 2);
+        $manager->rollback('default', 1);
 
         $this->assertCount(2, $manager->getTransactions());
 
@@ -71,7 +71,7 @@ class DatabaseTransactionsManagerTest extends TestCase
         $manager->begin('default', 2);
         $manager->begin('admin', 1);
 
-        $manager->rollback('default', 1);
+        $manager->rollback('default', 0);
 
         $this->assertCount(1, $manager->getTransactions());
 

--- a/tests/Database/DatabaseTransactionsManagerTest.php
+++ b/tests/Database/DatabaseTransactionsManagerTest.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use DateTime;
+use ErrorException;
+use Exception;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Database\Connection;
+use Illuminate\Database\DatabaseTransactionsManager;
+use Illuminate\Database\Events\QueryExecuted;
+use Illuminate\Database\Events\TransactionBeginning;
+use Illuminate\Database\Events\TransactionCommitted;
+use Illuminate\Database\Events\TransactionRolledBack;
+use Illuminate\Database\Query\Builder as BaseBuilder;
+use Illuminate\Database\Query\Grammars\Grammar;
+use Illuminate\Database\Query\Processors\Processor;
+use Illuminate\Database\QueryException;
+use Illuminate\Database\Schema\Builder;
+use Mockery as m;
+use PDO;
+use PDOException;
+use PDOStatement;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use stdClass;
+
+class DatabaseTransactionsManagerTest extends TestCase
+{
+    public function testBeginningTransactions()
+    {
+        $manager = (new DatabaseTransactionsManager());
+
+        $manager->begin('default', 1);
+        $manager->begin('default', 2);
+        $manager->begin('admin', 1);
+
+        $this->assertCount(3, $manager->getTransactions());
+        $this->assertEquals('default', $manager->getTransactions()[0]->connection);
+        $this->assertEquals(1, $manager->getTransactions()[0]->level);
+        $this->assertEquals('default', $manager->getTransactions()[1]->connection);
+        $this->assertEquals(2, $manager->getTransactions()[1]->level);
+        $this->assertEquals('admin', $manager->getTransactions()[2]->connection);
+        $this->assertEquals(1, $manager->getTransactions()[2]->level);
+    }
+
+    public function testRollingBackTransactions()
+    {
+        $manager = (new DatabaseTransactionsManager());
+
+        $manager->begin('default', 1);
+        $manager->begin('default', 2);
+        $manager->begin('admin', 1);
+
+        $manager->rollback('default', 2);
+
+        $this->assertCount(2, $manager->getTransactions());
+
+        $this->assertEquals('default', $manager->getTransactions()[0]->connection);
+        $this->assertEquals(1, $manager->getTransactions()[0]->level);
+
+        $this->assertEquals('admin', $manager->getTransactions()[1]->connection);
+        $this->assertEquals(1, $manager->getTransactions()[1]->level);
+    }
+
+    public function testRollingBackTransactionsAllTheWay()
+    {
+        $manager = (new DatabaseTransactionsManager());
+
+        $manager->begin('default', 1);
+        $manager->begin('default', 2);
+        $manager->begin('admin', 1);
+
+        $manager->rollback('default', 1);
+
+        $this->assertCount(1, $manager->getTransactions());
+
+        $this->assertEquals('admin', $manager->getTransactions()[0]->connection);
+        $this->assertEquals(1, $manager->getTransactions()[0]->level);
+    }
+
+    public function testCommittingTransactions()
+    {
+        $manager = (new DatabaseTransactionsManager());
+
+        $manager->begin('default', 1);
+        $manager->begin('default', 2);
+        $manager->begin('admin', 1);
+
+        $manager->commit('default');
+
+        $this->assertCount(1, $manager->getTransactions());
+
+        $this->assertEquals('admin', $manager->getTransactions()[0]->connection);
+        $this->assertEquals(1, $manager->getTransactions()[0]->level);
+    }
+
+    public function testCallbacksAreAddedToTheCurrentTransaction()
+    {
+        $callbacks = [];
+
+        $manager = (new DatabaseTransactionsManager());
+
+        $manager->begin('default', 1);
+
+        $manager->addCallback(function () use (&$callbacks) {
+
+        });
+
+        $manager->begin('default', 2);
+
+        $manager->begin('admin', 1);
+
+        $manager->addCallback(function () use (&$callbacks) {
+
+        });
+
+        $this->assertCount(1, $manager->getTransactions()[0]->getCallbacks());
+        $this->assertCount(0, $manager->getTransactions()[1]->getCallbacks());
+        $this->assertCount(1, $manager->getTransactions()[2]->getCallbacks());
+    }
+
+    public function testCommittingTransactionsExecutesCallbacks()
+    {
+        $callbacks = [];
+
+        $manager = (new DatabaseTransactionsManager());
+
+        $manager->begin('default', 1);
+
+        $manager->addCallback(function () use (&$callbacks) {
+            $callbacks[] = ['default', 1];
+        });
+
+        $manager->begin('default', 2);
+
+        $manager->addCallback(function () use (&$callbacks) {
+            $callbacks[] = ['default', 2];
+        });
+
+        $manager->begin('admin', 1);
+
+        $manager->commit('default');
+
+        $this->assertCount(2, $callbacks);
+        $this->assertEquals(['default', 1], $callbacks[0]);
+        $this->assertEquals(['default', 2], $callbacks[1]);
+    }
+
+    public function testCommittingExecutesOnlyCallbacksOfTheConnection()
+    {
+        $callbacks = [];
+
+        $manager = (new DatabaseTransactionsManager());
+
+        $manager->begin('default', 1);
+
+        $manager->addCallback(function () use (&$callbacks) {
+            $callbacks[] = ['default', 1];
+        });
+
+        $manager->begin('default', 2);
+        $manager->begin('admin', 1);
+
+        $manager->addCallback(function () use (&$callbacks) {
+            $callbacks[] = ['admin', 1];
+        });
+
+        $manager->commit('default');
+
+        $this->assertCount(1, $callbacks);
+        $this->assertEquals(['default', 1], $callbacks[0]);
+    }
+}

--- a/tests/Database/DatabaseTransactionsManagerTest.php
+++ b/tests/Database/DatabaseTransactionsManagerTest.php
@@ -2,28 +2,8 @@
 
 namespace Illuminate\Tests\Database;
 
-use DateTime;
-use ErrorException;
-use Exception;
-use Illuminate\Contracts\Events\Dispatcher;
-use Illuminate\Database\Connection;
 use Illuminate\Database\DatabaseTransactionsManager;
-use Illuminate\Database\Events\QueryExecuted;
-use Illuminate\Database\Events\TransactionBeginning;
-use Illuminate\Database\Events\TransactionCommitted;
-use Illuminate\Database\Events\TransactionRolledBack;
-use Illuminate\Database\Query\Builder as BaseBuilder;
-use Illuminate\Database\Query\Grammars\Grammar;
-use Illuminate\Database\Query\Processors\Processor;
-use Illuminate\Database\QueryException;
-use Illuminate\Database\Schema\Builder;
-use Mockery as m;
-use PDO;
-use PDOException;
-use PDOStatement;
 use PHPUnit\Framework\TestCase;
-use ReflectionClass;
-use stdClass;
 
 class DatabaseTransactionsManagerTest extends TestCase
 {
@@ -104,7 +84,6 @@ class DatabaseTransactionsManagerTest extends TestCase
         $manager->begin('default', 1);
 
         $manager->addCallback(function () use (&$callbacks) {
-
         });
 
         $manager->begin('default', 2);
@@ -112,7 +91,6 @@ class DatabaseTransactionsManagerTest extends TestCase
         $manager->begin('admin', 1);
 
         $manager->addCallback(function () use (&$callbacks) {
-
         });
 
         $this->assertCount(1, $manager->getTransactions()[0]->getCallbacks());

--- a/tests/Database/DatabaseTransactionsTest.php
+++ b/tests/Database/DatabaseTransactionsTest.php
@@ -1,0 +1,257 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\DatabaseTransactionsManager;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseTransactionsTest extends TestCase
+{
+    /**
+     * Setup the database schema.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $db = new DB;
+
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ], 'second_connection');
+
+        $db->setAsGlobal();
+
+        $this->createSchema();
+    }
+
+    protected function createSchema()
+    {
+        foreach (['default', 'second_connection'] as $connection) {
+            $this->schema($connection)->create('users', function ($table) {
+                $table->increments('id');
+                $table->string('name')->nullable();
+                $table->string('value')->nullable();
+            });
+        }
+    }
+
+    /**
+     * Tear down the database schema.
+     *
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        foreach (['default', 'second_connection'] as $connection) {
+            $this->schema($connection)->drop('users');
+        }
+
+        m::close();
+    }
+
+    public function testTransactionIsRecordedAndCommitted()
+    {
+        $transactionManager = m::mock(new DatabaseTransactionsManager());
+        $transactionManager->shouldReceive('begin')->once()->with('default', 1);
+        $transactionManager->shouldReceive('commit')->once()->with('default');
+
+        $this->connection()->setTransactionManager($transactionManager);
+
+        $this->connection()->table('users')->insert([
+            'name' => 'zain', 'value' => 1
+        ]);
+
+        $this->connection()->transaction(function() use ($transactionManager){
+            $this->connection()->table('users')->where(['name' => 'zain'])->update([
+                'value' => 2
+            ]);
+        });
+    }
+
+    public function testTransactionIsRecordedAndCommittedUsingTheSeparateMethods()
+    {
+        $transactionManager = m::mock(new DatabaseTransactionsManager());
+        $transactionManager->shouldReceive('begin')->once()->with('default', 1);
+        $transactionManager->shouldReceive('commit')->once()->with('default');
+
+        $this->connection()->setTransactionManager($transactionManager);
+
+        $this->connection()->table('users')->insert([
+            'name' => 'zain', 'value' => 1
+        ]);
+
+        $this->connection()->beginTransaction();
+        $this->connection()->table('users')->where(['name' => 'zain'])->update([
+            'value' => 2
+        ]);
+        $this->connection()->commit();
+    }
+
+    public function testNestedTransactionIsRecordedAndCommitted()
+    {
+        $transactionManager = m::mock(new DatabaseTransactionsManager());
+        $transactionManager->shouldReceive('begin')->once()->with('default', 1);
+        $transactionManager->shouldReceive('begin')->once()->with('default', 2);
+        $transactionManager->shouldReceive('commit')->once()->with('default');
+
+        $this->connection()->setTransactionManager($transactionManager);
+
+        $this->connection()->table('users')->insert([
+            'name' => 'zain', 'value' => 1
+        ]);
+
+        $this->connection()->transaction(function() use ($transactionManager){
+            $this->connection()->table('users')->where(['name' => 'zain'])->update([
+                'value' => 2
+            ]);
+
+            $this->connection()->transaction(function() use ($transactionManager){
+                $this->connection()->table('users')->where(['name' => 'zain'])->update([
+                    'value' => 2
+                ]);
+            });
+        });
+    }
+
+    public function testNestedTransactionIsRecordeForDifferentConnectionsdAndCommitted()
+    {
+        $transactionManager = m::mock(new DatabaseTransactionsManager());
+        $transactionManager->shouldReceive('begin')->once()->with('default', 1);
+        $transactionManager->shouldReceive('begin')->once()->with('second_connection', 1);
+        $transactionManager->shouldReceive('begin')->once()->with('second_connection', 2);
+        $transactionManager->shouldReceive('commit')->once()->with('default');
+        $transactionManager->shouldReceive('commit')->once()->with('second_connection');
+
+        $this->connection()->setTransactionManager($transactionManager);
+        $this->connection('second_connection')->setTransactionManager($transactionManager);
+
+        $this->connection()->table('users')->insert([
+            'name' => 'zain', 'value' => 1
+        ]);
+
+        $this->connection()->transaction(function() use ($transactionManager){
+            $this->connection()->table('users')->where(['name' => 'zain'])->update([
+                'value' => 2
+            ]);
+
+            $this->connection('second_connection')->transaction(function() use ($transactionManager){
+                $this->connection('second_connection')->table('users')->where(['name' => 'zain'])->update([
+                    'value' => 2
+                ]);
+
+                $this->connection('second_connection')->transaction(function() use ($transactionManager){
+                    $this->connection('second_connection')->table('users')->where(['name' => 'zain'])->update([
+                        'value' => 2
+                    ]);
+                });
+            });
+        });
+    }
+
+    public function testTransactionIsRolledBack()
+    {
+        $transactionManager = m::mock(new DatabaseTransactionsManager());
+        $transactionManager->shouldReceive('begin')->once()->with('default', 1);
+        $transactionManager->shouldReceive('rollback')->once()->with('default', 0);
+        $transactionManager->shouldNotReceive('commit');
+
+        $this->connection()->setTransactionManager($transactionManager);
+
+        $this->connection()->table('users')->insert([
+            'name' => 'zain', 'value' => 1
+        ]);
+
+        try {
+            $this->connection()->transaction(function () use ($transactionManager) {
+                $this->connection()->table('users')->where(['name' => 'zain'])->update([
+                    'value' => 2
+                ]);
+
+                throw new \Exception;
+            });
+        } catch (\Throwable $e) {
+
+        }
+    }
+
+    public function testTransactionIsRolledBackUsingSeparateMethods()
+    {
+        $transactionManager = m::mock(new DatabaseTransactionsManager());
+        $transactionManager->shouldReceive('begin')->once()->with('default', 1);
+        $transactionManager->shouldReceive('rollback')->once()->with('default', 0);
+        $transactionManager->shouldNotReceive('commit');
+
+        $this->connection()->setTransactionManager($transactionManager);
+
+        $this->connection()->table('users')->insert([
+            'name' => 'zain', 'value' => 1
+        ]);
+
+        $this->connection()->beginTransaction();
+
+        $this->connection()->table('users')->where(['name' => 'zain'])->update([
+            'value' => 2
+        ]);
+
+        $this->connection()->rollBack();
+    }
+
+    public function testNestedTransactionsAreRolledBack()
+    {
+        $transactionManager = m::mock(new DatabaseTransactionsManager());
+        $transactionManager->shouldReceive('begin')->once()->with('default', 1);
+        $transactionManager->shouldReceive('begin')->once()->with('default', 2);
+        $transactionManager->shouldReceive('rollback')->once()->with('default', 1);
+        $transactionManager->shouldReceive('rollback')->once()->with('default', 0);
+        $transactionManager->shouldNotReceive('commit');
+
+        $this->connection()->setTransactionManager($transactionManager);
+
+        $this->connection()->table('users')->insert([
+            'name' => 'zain', 'value' => 1
+        ]);
+
+        try {
+            $this->connection()->transaction(function () use ($transactionManager) {
+                $this->connection()->table('users')->where(['name' => 'zain'])->update([
+                    'value' => 2
+                ]);
+
+                $this->connection()->transaction(function () use ($transactionManager) {
+                    $this->connection()->table('users')->where(['name' => 'zain'])->update([
+                        'value' => 2
+                    ]);
+
+                    throw new \Exception;
+                });
+            });
+        } catch (\Throwable $e) {
+
+        }
+    }
+
+
+    /**
+     * Get a schema builder instance.
+     *
+     * @return \Illuminate\Database\Schema\Builder
+     */
+    protected function schema($connection = 'default')
+    {
+        return $this->connection($connection)->getSchemaBuilder();
+    }
+
+    public function connection($name = 'default')
+    {
+        return DB::connection($name);
+    }
+}

--- a/tests/Database/DatabaseTransactionsTest.php
+++ b/tests/Database/DatabaseTransactionsTest.php
@@ -70,7 +70,7 @@ class DatabaseTransactionsTest extends TestCase
             'name' => 'zain', 'value' => 1,
         ]);
 
-        $this->connection()->transaction(function() use ($transactionManager){
+        $this->connection()->transaction(function () {
             $this->connection()->table('users')->where(['name' => 'zain'])->update([
                 'value' => 2,
             ]);
@@ -109,12 +109,12 @@ class DatabaseTransactionsTest extends TestCase
             'name' => 'zain', 'value' => 1,
         ]);
 
-        $this->connection()->transaction(function() use ($transactionManager){
+        $this->connection()->transaction(function () {
             $this->connection()->table('users')->where(['name' => 'zain'])->update([
                 'value' => 2,
             ]);
 
-            $this->connection()->transaction(function() use ($transactionManager){
+            $this->connection()->transaction(function () {
                 $this->connection()->table('users')->where(['name' => 'zain'])->update([
                     'value' => 2,
                 ]);
@@ -138,17 +138,17 @@ class DatabaseTransactionsTest extends TestCase
             'name' => 'zain', 'value' => 1,
         ]);
 
-        $this->connection()->transaction(function() use ($transactionManager){
+        $this->connection()->transaction(function () {
             $this->connection()->table('users')->where(['name' => 'zain'])->update([
                 'value' => 2,
             ]);
 
-            $this->connection('second_connection')->transaction(function() use ($transactionManager){
+            $this->connection('second_connection')->transaction(function () {
                 $this->connection('second_connection')->table('users')->where(['name' => 'zain'])->update([
                     'value' => 2,
                 ]);
 
-                $this->connection('second_connection')->transaction(function() use ($transactionManager){
+                $this->connection('second_connection')->transaction(function () {
                     $this->connection('second_connection')->table('users')->where(['name' => 'zain'])->update([
                         'value' => 2,
                     ]);
@@ -171,7 +171,7 @@ class DatabaseTransactionsTest extends TestCase
         ]);
 
         try {
-            $this->connection()->transaction(function () use ($transactionManager) {
+            $this->connection()->transaction(function () {
                 $this->connection()->table('users')->where(['name' => 'zain'])->update([
                     'value' => 2,
                 ]);
@@ -220,12 +220,12 @@ class DatabaseTransactionsTest extends TestCase
         ]);
 
         try {
-            $this->connection()->transaction(function () use ($transactionManager) {
+            $this->connection()->transaction(function () {
                 $this->connection()->table('users')->where(['name' => 'zain'])->update([
                     'value' => 2,
                 ]);
 
-                $this->connection()->transaction(function () use ($transactionManager) {
+                $this->connection()->transaction(function () {
                     $this->connection()->table('users')->where(['name' => 'zain'])->update([
                         'value' => 2,
                     ]);

--- a/tests/Database/DatabaseTransactionsTest.php
+++ b/tests/Database/DatabaseTransactionsTest.php
@@ -67,12 +67,12 @@ class DatabaseTransactionsTest extends TestCase
         $this->connection()->setTransactionManager($transactionManager);
 
         $this->connection()->table('users')->insert([
-            'name' => 'zain', 'value' => 1
+            'name' => 'zain', 'value' => 1,
         ]);
 
         $this->connection()->transaction(function() use ($transactionManager){
             $this->connection()->table('users')->where(['name' => 'zain'])->update([
-                'value' => 2
+                'value' => 2,
             ]);
         });
     }
@@ -86,12 +86,12 @@ class DatabaseTransactionsTest extends TestCase
         $this->connection()->setTransactionManager($transactionManager);
 
         $this->connection()->table('users')->insert([
-            'name' => 'zain', 'value' => 1
+            'name' => 'zain', 'value' => 1,
         ]);
 
         $this->connection()->beginTransaction();
         $this->connection()->table('users')->where(['name' => 'zain'])->update([
-            'value' => 2
+            'value' => 2,
         ]);
         $this->connection()->commit();
     }
@@ -106,17 +106,17 @@ class DatabaseTransactionsTest extends TestCase
         $this->connection()->setTransactionManager($transactionManager);
 
         $this->connection()->table('users')->insert([
-            'name' => 'zain', 'value' => 1
+            'name' => 'zain', 'value' => 1,
         ]);
 
         $this->connection()->transaction(function() use ($transactionManager){
             $this->connection()->table('users')->where(['name' => 'zain'])->update([
-                'value' => 2
+                'value' => 2,
             ]);
 
             $this->connection()->transaction(function() use ($transactionManager){
                 $this->connection()->table('users')->where(['name' => 'zain'])->update([
-                    'value' => 2
+                    'value' => 2,
                 ]);
             });
         });
@@ -135,22 +135,22 @@ class DatabaseTransactionsTest extends TestCase
         $this->connection('second_connection')->setTransactionManager($transactionManager);
 
         $this->connection()->table('users')->insert([
-            'name' => 'zain', 'value' => 1
+            'name' => 'zain', 'value' => 1,
         ]);
 
         $this->connection()->transaction(function() use ($transactionManager){
             $this->connection()->table('users')->where(['name' => 'zain'])->update([
-                'value' => 2
+                'value' => 2,
             ]);
 
             $this->connection('second_connection')->transaction(function() use ($transactionManager){
                 $this->connection('second_connection')->table('users')->where(['name' => 'zain'])->update([
-                    'value' => 2
+                    'value' => 2,
                 ]);
 
                 $this->connection('second_connection')->transaction(function() use ($transactionManager){
                     $this->connection('second_connection')->table('users')->where(['name' => 'zain'])->update([
-                        'value' => 2
+                        'value' => 2,
                     ]);
                 });
             });
@@ -167,19 +167,18 @@ class DatabaseTransactionsTest extends TestCase
         $this->connection()->setTransactionManager($transactionManager);
 
         $this->connection()->table('users')->insert([
-            'name' => 'zain', 'value' => 1
+            'name' => 'zain', 'value' => 1,
         ]);
 
         try {
             $this->connection()->transaction(function () use ($transactionManager) {
                 $this->connection()->table('users')->where(['name' => 'zain'])->update([
-                    'value' => 2
+                    'value' => 2,
                 ]);
 
                 throw new \Exception;
             });
         } catch (\Throwable $e) {
-
         }
     }
 
@@ -193,13 +192,13 @@ class DatabaseTransactionsTest extends TestCase
         $this->connection()->setTransactionManager($transactionManager);
 
         $this->connection()->table('users')->insert([
-            'name' => 'zain', 'value' => 1
+            'name' => 'zain', 'value' => 1,
         ]);
 
         $this->connection()->beginTransaction();
 
         $this->connection()->table('users')->where(['name' => 'zain'])->update([
-            'value' => 2
+            'value' => 2,
         ]);
 
         $this->connection()->rollBack();
@@ -217,28 +216,26 @@ class DatabaseTransactionsTest extends TestCase
         $this->connection()->setTransactionManager($transactionManager);
 
         $this->connection()->table('users')->insert([
-            'name' => 'zain', 'value' => 1
+            'name' => 'zain', 'value' => 1,
         ]);
 
         try {
             $this->connection()->transaction(function () use ($transactionManager) {
                 $this->connection()->table('users')->where(['name' => 'zain'])->update([
-                    'value' => 2
+                    'value' => 2,
                 ]);
 
                 $this->connection()->transaction(function () use ($transactionManager) {
                     $this->connection()->table('users')->where(['name' => 'zain'])->update([
-                        'value' => 2
+                        'value' => 2,
                     ]);
 
                     throw new \Exception;
                 });
             });
         } catch (\Throwable $e) {
-
         }
     }
-
 
     /**
      * Get a schema builder instance.


### PR DESCRIPTION
This PR is a followup on https://github.com/laravel/framework/pull/35266 and the functionality introduced here, if merged, will be used in the other PR.

So, this PR introduces a transaction manager class that records transactions, commits, and rollbacks. It also records code execution that should be transaction aware. This code will only be executed after transactions are committed and will be discarded if transactions were rolled back.

```php
DB::transaction(function () {
    $user = User::create([...]);

    $user->teams()->create([...]);
});
```

Now imagine there's a listener registered on the `user.created` eloquent event that sends a welcome email. Inside the listener, you can do this:

```php
public function handle(){
    DB::afterCommit(function (){
        Mail::send(...);
    });
}
```

The callback passed to `afterCommit` will be stored in a local cache and will be executed once the transaction is committed. If the transaction was rolledback, the callback will be discarded.