### PR TITLE
Make error handling a bit more friendly

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -38,7 +38,9 @@ class HandleExceptions
 
         $this->app = $app;
 
-        error_reporting(-1);
+        if (! $app->environment('production')) {
+            error_reporting(-1);
+        }
 
         set_error_handler([$this, 'handleError']);
 

--- a/tests/Foundation/Bootstrap/HandleExceptionsTest.php
+++ b/tests/Foundation/Bootstrap/HandleExceptionsTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Bootstrap;
+
+use const E_ALL;
+use function error_reporting;
+use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Bootstrap\HandleExceptions;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * This test is set to run in isolation to avoid messing up with the test environment and affecting other tests.
+ *
+ * @runInSeparateProcess
+ */
+class HandleExceptionsTest extends TestCase
+{
+    /** @var Application */
+    private $app;
+
+    /** @before */
+    public function configureApp(): void
+    {
+        $this->app = m::mock(Application::class);
+        $this->app->allows()->environment('testing')->andReturns(false);
+    }
+
+    /** @test */
+    public function errorReportingShouldNotBeAffectedOnProduction(): void
+    {
+        error_reporting(E_ALL);
+
+        $this->app->allows()->environment('production')->andReturns(true);
+
+        (new HandleExceptions())->bootstrap($this->app);
+
+        self::assertSame(E_ALL, error_reporting());
+    }
+
+    /** @test */
+    public function errorReportingShouldBeOverriddenForOtherEnvironmentSoPeopleCanFindBugsEarlier(): void
+    {
+        error_reporting(E_ALL);
+
+        $this->app->allows()->environment('production')->andReturns(false);
+
+        (new HandleExceptions())->bootstrap($this->app);
+
+        self::assertSame(-1, error_reporting());
+    }
+}

--- a/tests/Foundation/Bootstrap/HandleExceptionsTest.php
+++ b/tests/Foundation/Bootstrap/HandleExceptionsTest.php
@@ -3,11 +3,14 @@
 namespace Illuminate\Tests\Foundation\Bootstrap;
 
 use const E_ALL;
+use const E_USER_DEPRECATED;
 use function error_reporting;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Bootstrap\HandleExceptions;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use function trigger_error;
 
 /**
  * This test is set to run in isolation to avoid messing up with the test environment and affecting other tests.
@@ -48,5 +51,22 @@ class HandleExceptionsTest extends TestCase
         (new HandleExceptions())->bootstrap($this->app);
 
         self::assertSame(-1, error_reporting());
+    }
+
+    /** @test */
+    public function deprecationMessagesShouldJustBeLogged(): void
+    {
+        $logger = m::mock(LoggerInterface::class);
+
+        $this->app->allows()->environment('production')->andReturns(false);
+        $this->app->allows()->make(LoggerInterface::class)->andReturns($logger);
+
+        (new HandleExceptions())->bootstrap($this->app);
+
+        $logger->shouldReceive('warning')->withArgs(['Deprecation one', m::hasKey('exception')])->once();
+        $logger->shouldReceive('warning')->withArgs(['Deprecation two', m::hasKey('exception')])->once();
+
+        trigger_error('Deprecation one', E_USER_DEPRECATED);
+        @trigger_error('Deprecation two', E_USER_DEPRECATED);
     }
 }


### PR DESCRIPTION
Hello :wave: 

After releasing a new version of one of my libs I received several messages from Laravel users saying that their apps were broken due to deprecation messages:

* https://github.com/lcobucci/jwt/issues/550
* https://github.com/lcobucci/jwt/issues/551
* https://github.com/lcobucci/jwt/issues/553
* https://github.com/lcobucci/jwt/issues/557

This is then an attempt to help other library authors/maintainers not to break end user's apps.