### PR TITLE
Add dd() and dump() helper functions to the request object

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -5,6 +5,7 @@ namespace Illuminate\Http\Concerns;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Symfony\Component\VarDumper\VarDumper;
 use SplFileInfo;
 use stdClass;
 
@@ -264,7 +265,9 @@ trait InteractsWithInput
     public function input($key = null, $default = null)
     {
         return data_get(
-            $this->getInputSource()->all() + $this->query->all(), $key, $default
+            $this->getInputSource()->all() + $this->query->all(),
+            $key,
+            $default
         );
     }
 
@@ -461,5 +464,40 @@ trait InteractsWithInput
         }
 
         return $this->$source->get($key, $default);
+    }
+
+    /**
+     * Dump the items and end the script.
+     *
+     * @param  array|mixed $keys
+     * @return void
+     */
+    public function dd(...$keys)
+    {
+        $keys = is_array($keys) ? $keys : func_get_args();
+
+        call_user_func_array([$this, 'dump'], $keys);
+
+        die(1);
+    }
+
+    /**
+     * Dump the items.
+     *
+     * @return $this
+     */
+    public function dump($keys = [])
+    {
+        $keys = is_array($keys) ? $keys : func_get_args();
+
+        if (count($keys) > 0) {
+            $data = $this->only($keys);
+        } else {
+            $data = $this->all();
+        }
+
+        VarDumper::dump($data);
+
+        return $this;
     }
 }

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -5,9 +5,9 @@ namespace Illuminate\Http\Concerns;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
-use Symfony\Component\VarDumper\VarDumper;
 use SplFileInfo;
 use stdClass;
+use Symfony\Component\VarDumper\VarDumper;
 
 trait InteractsWithInput
 {
@@ -478,7 +478,7 @@ trait InteractsWithInput
 
         call_user_func_array([$this, 'dump'], $keys);
 
-        die(1);
+        exit(1);
     }
 
     /**


### PR DESCRIPTION
This PR adds dump() and dd() to the Request class.

# Usage
```php
// use Illuminate\Http\Request;
public function index(Request $request)
{
    // instead of
    dd($request->all());

    // we can use
    $request->dd();

    $request->dd(['name', 'age']); // print only the keys from the array

    $request->dd('name', 'age'); // pass them as separate arguments
}
```

`dump()` can be used the same way, and it will be useful for debugging AJAX requests.

# Real world example
```php
// use Illuminate\Http\Request;
public function index(Request $request)
{
    $request->dd()->validate([
        'name' => 'required'
    ]);
}
```

Quickly inspect the request params before passing them to the validator.

When using `dd()` or `dump()` without params the `all()` method is used, and when there are params passed in, the `only()` method is used.