### PR TITLE
[8.x] Update facade Docblock to match method signature

### DIFF
--- a/src/Illuminate/Support/Facades/View.php
+++ b/src/Illuminate/Support/Facades/View.php
@@ -4,7 +4,7 @@ namespace Illuminate\Support\Facades;
 
 /**
  * @method static \Illuminate\Contracts\View\Factory addNamespace(string $namespace, string|array $hints)
- * @method static \Illuminate\Contracts\View\Factory first(array $views, \Illuminate\Contracts\Support\Arrayable|array $data, array $mergeData)
+ * @method static \Illuminate\Contracts\View\Factory first(array $views, \Illuminate\Contracts\Support\Arrayable|array $data = [], array $mergeData = [])
  * @method static \Illuminate\Contracts\View\Factory replaceNamespace(string $namespace, string|array $hints)
  * @method static \Illuminate\Contracts\View\View file(string $path, array $data = [], array $mergeData = [])
  * @method static \Illuminate\Contracts\View\View make(string $view, array $data = [], array $mergeData = [])


### PR DESCRIPTION
I noticed when I used the example Code from the documentation, that phpstorm complains about missing a parameter ```$mergeData```, which is an optional paramter.

```php
View::first(['custom.admin', 'admin'], $data);
```

This PR updates the View Facade's Docblock for the first method to match its real signature in the View class.