### PR TITLE
[8.x] Add dd() and dump() to the request object

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use SplFileInfo;
 use stdClass;
+use Symfony\Component\VarDumper\VarDumper;
 
 trait InteractsWithInput
 {
@@ -461,5 +462,40 @@ trait InteractsWithInput
         }
 
         return $this->$source->get($key, $default);
+    }
+
+    /**
+     * Dump the items and end the script.
+     *
+     * @param  array|mixed $keys
+     * @return void
+     */
+    public function dd(...$keys)
+    {
+        $keys = is_array($keys) ? $keys : func_get_args();
+
+        call_user_func_array([$this, 'dump'], $keys);
+
+        exit(1);
+    }
+
+    /**
+     * Dump the items.
+     *
+     * @return $this
+     */
+    public function dump($keys = [])
+    {
+        $keys = is_array($keys) ? $keys : func_get_args();
+
+        if (count($keys) > 0) {
+            $data = $this->only($keys);
+        } else {
+            $data = $this->all();
+        }
+
+        VarDumper::dump($data);
+
+        return $this;
     }
 }


### PR DESCRIPTION
This PR adds dump() and dd() to the Request class.

# Usage
```php
// use Illuminate\Http\Request;
public function index(Request $request)
{
    // instead of
    dd($request->all());

    // we can use
    $request->dd();

    $request->dd(['name', 'age']); // print only the keys from the array

    $request->dd('name', 'age'); // pass them as separate arguments
}
```

`dump()` can be used the same way, and it will be useful for debugging AJAX requests.

# Real world example
```php
// use Illuminate\Http\Request;
public function index(Request $request)
{
    $request->dd()->validate([
        'name' => 'required'
    ]);
}
```

Quickly inspect the request params before passing them to the validator.

When using `dd()` or `dump()` without params the `all()` method is used, and when there are params passed in, the `only()` method is used.