### PR TITLE
[8.x] Add missing ShouldBeUnique interface

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/job.queued.stub
+++ b/src/Illuminate/Foundation/Console/stubs/job.queued.stub
@@ -9,7 +9,7 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 
-class {{ class }} implements ShouldQueue
+class {{ class }} implements ShouldQueue, ShouldBeUnique
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 


### PR DESCRIPTION
`job.queue.stub` imports `ShouldBeUnique` which is not used.

This PR will add the missing interface to the generated class.