### PR TITLE
[8.x] Incorrect FQCN for withAggregate() on self-relation

### DIFF
--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -834,6 +834,21 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertSame('select "eloquent_builder_test_model_parent_stubs".*, (select min("eloquent_builder_test_model_far_related_stubs"."id") from "eloquent_builder_test_model_far_related_stubs" inner join "user_role" on "eloquent_builder_test_model_far_related_stubs"."id" = "user_role"."related_id" where "eloquent_builder_test_model_parent_stubs"."id" = "user_role"."self_id") as "roles_min_id" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
     }
 
+    public function testWithMinOnSelfRelated()
+    {
+        $model = new EloquentBuilderTestModelSelfRelatedStub;
+
+        $sql = $model->withMin('childFoos', 'created_at')->toSql();
+
+        // alias has a dynamic hash, so replace with a static string for comparison
+        $alias = 'self_alias_hash';
+        $aliasRegex = '/\b(laravel_reserved_\d)(\b|$)/i';
+
+        $sql = preg_replace($aliasRegex, $alias, $sql);
+
+        $this->assertSame('select "self_related_stubs".*, (select min("self_alias_hash"."created_at") from "self_related_stubs" as "self_alias_hash" where "self_related_stubs"."id" = "self_alias_hash"."parent_id") as "child_foos_min_created_at" from "self_related_stubs"', $sql);
+    }
+
     public function testWithCountAndConstraintsAndHaving()
     {
         $model = new EloquentBuilderTestModelParentStub;


### PR DESCRIPTION
This PR provides a **failing test** case for when methods in the [`withAggregate()`](https://laravel.com/api/8.x/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.html#method_withAggregate)-family are used on an Eloquent "self-relation".

Aggregate queries on self-relations use a generated table alias, but the aggregate column will fail to be qualified to that alias, silently producing incorrect results, or an sql-error when `sql_mode=only_full_group_by`.

I not sure yet what the solution would be, but hopefully this failing-test PR can be a starting point to discuss a good approach!

## Background

Laravel `8.13` included https://github.com/laravel/framework/commit/b0dc0b2432d426349009a70775fa469d16ea1a14 that added `$relation->getRelated()->qualifyColumn($column)` to qualify the column name in the aggregate subquery. This seems reasonable as that column name used to end up unqualified, and that is of course a risk.

Unfortunately the introduced qualification is done *before* knowing what the actual table alias will be in the final query.
It will always qualify using the **table name from the relation** for the aggregate column.

This goes unnoticed for common relationships between two different models, each with their own table...

### What goes wrong?

For a relationship that references the same model (e.g. a student tutoring other students), the **table in the subquery is aliased** ([see example in `HasOneOrMany`](https://github.com/laravel/framework/blob/43bea00fd27c76c01fd009e46725a54885f4d2a5/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php#L338-L364) – variants are in other relationship types too).

So, the "child"-table of the subquery becomes aliased (a generated hash), while the selected aggregate column in the very same sub-query is still qualified to what at this point is actually the "parent" table. 😞 

### Example sql

This reflects current sql produced when `->withMin('created_at')` is used on a self-relationship:

```sql
select `self_related_stubs`.*,

(select
min(`self_related_stubs`.`created_at`) -- This FQCN is incorrect, it should reference the alias set below!
from `self_related_stubs` as `self_alias_hash`
where `self_related_stubs`.`id` = `self_alias_hash`.`parent_id`
) as `child_foos_min_created_at`

from `self_related_stubs`
```

Sql error looks something like this:
`In aggregated query without GROUP BY, expression #1 of SELECT list contains nonaggregated column 'test_db.self_related_stubs.id'; this is incompatible with sql_mode=only_full_group_by`

## Possible solutions

### Can we go back to not qualifying the aggregate column?

Between `8.12` (when the super-useful `withAggregate`-methods were introduced in https://github.com/laravel/framework/commit/95d0c9a19179dd1ceefb4d51bb04f7aecbd2fdcf, thanks @khalilst!) and `8.13`, aggregates on self-relations worked as expected (at least with mysql 8 that I've been running). The column name wasn't qualified at all and there was just a single from-table in the actual subquery part, so I guess it was unambiguous.

- Was the unqualified column ambiguous in other sql-dialects than mysql?
- Could there be cases where the aggregate subquery has joins or sub-sub-queries? 
- Perhaps contributor @dbakan has more information or examples as to why the FQCN was introduced?
- Is there a policy to always qualify columns throughout `illuminate/database`?

### What can we do if we want to keep the FQCN?

- Can the qualification wait and be applied inside [`getRelationExistenceQueryForSelfRelation`](https://github.com/laravel/framework/blob/43bea00fd27c76c01fd009e46725a54885f4d2a5/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php#L355-L364), where the final alias is in scope?
- Is it possible to create a general "deferred-FQCN" functionality to be used throughout `illuminate/database`? So that one can pass an object containing an unqualified column name, indicating that builder methods may qualify at the point they're actually used in queries... This may not make sense... 🤔 I just made it up! 😄 

Thanks for reading, and thanks for collaborating on this wonderful framework! Please share your thoughts on how we can solve this!