### PR TITLE
[6.x] Enable Redis in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,8 +8,8 @@ on:
 
 jobs:
   linux_tests:
-
     runs-on: ubuntu-latest
+
     services:
       mysql:
         image: mysql:5.7
@@ -40,7 +40,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, gd
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, gd, redis, memcached
           tools: composer:v2
           coverage: none
 
@@ -72,8 +72,8 @@ jobs:
           DB_USERNAME: root
 
   windows_tests:
-
     runs-on: windows-latest
+
     strategy:
       fail-fast: true
       matrix:
@@ -95,7 +95,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite, gd, pdo_mysql, fileinfo, ftp
+          extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite, gd, pdo_mysql, fileinfo, ftp, redis, memcached
           tools: composer:v2
           coverage: none
 

--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -129,7 +129,9 @@ class PhpRedisConnector implements Connector
         }
 
         if (version_compare(phpversion('redis'), '5.3.0', '>=')) {
-            $parameters[] = Arr::get($config, 'context');
+            if (! is_null($context = Arr::get($config, 'context'))) {
+                $parameters[] = $context;
+            }
         }
 
         $client->{($persistent ? 'pconnect' : 'connect')}(...$parameters);
@@ -157,7 +159,9 @@ class PhpRedisConnector implements Connector
         }
 
         if (version_compare(phpversion('redis'), '5.3.2', '>=')) {
-            $parameters[] = Arr::get($options, 'context');
+            if (! is_null($context = Arr::get($options, 'context'))) {
+                $parameters[] = $context;
+            }
         }
 
         return tap(new RedisCluster(...$parameters), function ($client) use ($options) {


### PR DESCRIPTION
This enables Redis in CI for testing PHP 8 and also fixes a small issue with it. I am not 100% if this will re-introduce https://github.com/laravel/framework/pull/34935 or not but I believe it won't since we're now relying on the `connect` method's default 7th param type if no context was set. It would be weird if it triggered SSL issues from its base behavior.

I tried enabling Memcached as well [but that's not yet available it seems](https://github.com/laravel/framework/runs/1464431057#step:5:27). As soon as it's available our builds will start testing it as well.