### PR TITLE
[8.x] Fix Self-Relation issue in withAggregate method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -383,8 +383,10 @@ trait QueriesRelationships
             $relation = $this->getRelationWithoutConstraints($name);
 
             if ($function) {
+                $predictedColumn = $this->getQuery()->from === $relation->getQuery()->getQuery()->from ? "{$relation->getRelationCountHash(true)}.$column" : $column;
+
                 $expression = sprintf('%s(%s)', $function, $this->getQuery()->getGrammar()->wrap(
-                    $column === '*' ? $column : $relation->getRelated()->qualifyColumn($column)
+                    $column === '*' ? $column : $relation->getRelated()->qualifyColumn($predictedColumn)
                 ));
             } else {
                 $expression = $column;

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -282,11 +282,12 @@ class BelongsTo extends Relation
     /**
      * Get a relationship join table hash.
      *
+     * @param  bool $lockCount
      * @return string
      */
-    public function getRelationCountHash()
+    public function getRelationCountHash($lockCount = false)
     {
-        return 'laravel_reserved_'.static::$selfJoinCount++;
+        return 'laravel_reserved_'.($lockCount ? static::$selfJoinCount : static::$selfJoinCount++);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -1170,11 +1170,12 @@ class BelongsToMany extends Relation
     /**
      * Get a relationship join table hash.
      *
+     * @param  bool $lockCount
      * @return string
      */
-    public function getRelationCountHash()
+    public function getRelationCountHash($lockCount = false)
     {
-        return 'laravel_reserved_'.static::$selfJoinCount++;
+        return 'laravel_reserved_'.($lockCount ? static::$selfJoinCount : static::$selfJoinCount++);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -599,11 +599,12 @@ class HasManyThrough extends Relation
     /**
      * Get a relationship join table hash.
      *
+     * @param  bool $lockCount
      * @return string
      */
-    public function getRelationCountHash()
+    public function getRelationCountHash($lockCount = false)
     {
-        return 'laravel_reserved_'.static::$selfJoinCount++;
+        return 'laravel_reserved_'.($lockCount ? static::$selfJoinCount : static::$selfJoinCount++);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -366,11 +366,12 @@ abstract class HasOneOrMany extends Relation
     /**
      * Get a relationship join table hash.
      *
+     * @param  bool $lockCount
      * @return string
      */
-    public function getRelationCountHash()
+    public function getRelationCountHash($lockCount = false)
     {
-        return 'laravel_reserved_'.static::$selfJoinCount++;
+        return 'laravel_reserved_'.($lockCount ? static::$selfJoinCount : static::$selfJoinCount++);
     }
 
     /**


### PR DESCRIPTION
This PR is created in following of the PR #35389 .

It modifies the `getRelationCountHash` to provide a way to predict the hash.
It prevents increasing `$selfJoinCount`, if called like this:

```php
$relation->getRelationCountHash(true)
```
