### PR TITLE
[8.x] Fix sortBy with array-syntax callable

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1128,7 +1128,7 @@ class Collection implements ArrayAccess, Enumerable
      */
     public function sortBy($callback, $options = SORT_REGULAR, $descending = false)
     {
-        if (is_array($callback) && !is_callable($callback)) {
+        if (is_array($callback) && ! is_callable($callback)) {
             return $this->sortByMany($callback);
         }
 

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1128,7 +1128,7 @@ class Collection implements ArrayAccess, Enumerable
      */
     public function sortBy($callback, $options = SORT_REGULAR, $descending = false)
     {
-        if (is_array($callback)) {
+        if (is_array($callback) && !is_callable($callback)) {
             return $this->sortByMany($callback);
         }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1571,6 +1571,36 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testSortByMultipleCriteria($collection)
+    {
+        $data = new $collection([
+            ['name' => 'taylor', 'foo'=>'foo'], ['name' => 'taylor', 'foo'=>'bar'],
+            ['name' => 'dayle', 'foo'=>'foo'],  ['name' => 'dayle', 'foo'=>'bar']
+        ]);
+        $data = $data->sortBy(['name', 'foo'], SORT_STRING);
+
+        $this->assertEquals(
+            [
+                ['name' => 'dayle', 'foo'=>'bar'],  ['name' => 'dayle', 'foo'=>'foo'],
+                ['name' => 'taylor', 'foo'=>'bar'], ['name' => 'taylor', 'foo'=>'foo']
+            ], array_values($data->all()));
+
+        $data = new $collection([
+            ['name' => 'taylor', 'foo'=>'foo'], ['name' => 'taylor', 'foo'=>'bar'],
+            ['name' => 'dayle', 'foo'=>'foo'],  ['name' => 'dayle', 'foo'=>'bar']
+        ]);
+        $data = $data->sortBy(['foo', 'name'], SORT_STRING);
+
+        $this->assertEquals(
+            [
+                ['name' => 'dayle', 'foo'=>'bar'],  ['name' => 'taylor', 'foo'=>'bar'],
+                ['name' => 'dayle', 'foo'=>'foo'], ['name' => 'taylor', 'foo'=>'foo']
+            ], array_values($data->all()));
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testSortByAlwaysReturnsAssoc($collection)
     {
         $data = new $collection(['a' => 'taylor', 'b' => 'dayle']);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1533,7 +1533,7 @@ class SupportCollectionTest extends TestCase
 
         $this->assertEquals([['name' => 'dayle'], ['name' => 'taylor']], array_values($data->all()));
 
-        $data = new $collection([['name' => 'taylor'], ['name' => 'dayle']]);
+        $data = new $collection([['name' => 'dayle'], ['name' => 'taylor']]);
         $data = $data->sortBy('name', SORT_STRING);
 
         $this->assertEquals([['name' => 'dayle'], ['name' => 'taylor']], array_values($data->all()));

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1542,6 +1542,35 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testSortByCallable($collection)
+    {
+        $data = new $collection([['name' => 'taylor'], ['name' => 'dayle']]);
+        $data = $data->sortBy([$this, 'sortByName'], SORT_STRING);
+
+        $this->assertEquals([['name' => 'dayle'], ['name' => 'taylor']], array_values($data->all()));
+    }
+
+    public function sortByName(array $value)
+    {
+        return $value['name'];
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testSortByCallableClosure($collection)
+    {
+        $data = new $collection([['name' => 'taylor'], ['name' => 'dayle']]);
+        $data = $data->sortBy(function($value) {
+            return $value['name'];
+        }, SORT_STRING);
+
+        $this->assertEquals([['name' => 'dayle'], ['name' => 'taylor']], array_values($data->all()));
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testSortByAlwaysReturnsAssoc($collection)
     {
         $data = new $collection(['a' => 'taylor', 'b' => 'dayle']);


### PR DESCRIPTION
Commit https://github.com/laravel/framework/commit/53eb307fea077299d409adf3ba0307a8fda4c4d1 introduced multi-key sorting. It thereby broke support
for callables supplied in array form (i.e: [$obj, 'pubFunction']), which leads to the following exception;

array_key_exists(): Argument #1 ($key) must be a valid array offset type.

Thus, checking for a callable syntax might be advisable?

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
