### PR TITLE
[8.x] Move the getRelationCountHash method to parent class (Relation)

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -41,13 +41,6 @@ class BelongsTo extends Relation
     protected $relationName;
 
     /**
-     * The count of self joins.
-     *
-     * @var int
-     */
-    protected static $selfJoinCount = 0;
-
-    /**
      * Create a new belongs to relationship instance.
      *
      * @param  \Illuminate\Database\Eloquent\Builder  $query
@@ -277,17 +270,6 @@ class BelongsTo extends Relation
         return $query->whereColumn(
             $hash.'.'.$this->ownerKey, '=', $this->getQualifiedForeignKeyName()
         );
-    }
-
-    /**
-     * Get a relationship join table hash.
-     *
-     * @param  bool $lockCount
-     * @return string
-     */
-    public function getRelationCountHash($lockCount = false)
-    {
-        return 'laravel_reserved_'.($lockCount ? static::$selfJoinCount : static::$selfJoinCount++);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -128,13 +128,6 @@ class BelongsToMany extends Relation
     protected $accessor = 'pivot';
 
     /**
-     * The count of self joins.
-     *
-     * @var int
-     */
-    protected static $selfJoinCount = 0;
-
-    /**
      * Create a new belongs to many relationship instance.
      *
      * @param  \Illuminate\Database\Eloquent\Builder  $query
@@ -1165,17 +1158,6 @@ class BelongsToMany extends Relation
     public function getExistenceCompareKey()
     {
         return $this->getQualifiedForeignPivotKeyName();
-    }
-
-    /**
-     * Get a relationship join table hash.
-     *
-     * @param  bool $lockCount
-     * @return string
-     */
-    public function getRelationCountHash($lockCount = false)
-    {
-        return 'laravel_reserved_'.($lockCount ? static::$selfJoinCount : static::$selfJoinCount++);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -54,13 +54,6 @@ class HasManyThrough extends Relation
     protected $secondLocalKey;
 
     /**
-     * The count of self joins.
-     *
-     * @var int
-     */
-    protected static $selfJoinCount = 0;
-
-    /**
      * Create a new has many through relationship instance.
      *
      * @param  \Illuminate\Database\Eloquent\Builder  $query
@@ -594,17 +587,6 @@ class HasManyThrough extends Relation
         return $query->select($columns)->whereColumn(
             $parentQuery->getQuery()->from.'.'.$this->localKey, '=', $hash.'.'.$this->firstKey
         );
-    }
-
-    /**
-     * Get a relationship join table hash.
-     *
-     * @param  bool $lockCount
-     * @return string
-     */
-    public function getRelationCountHash($lockCount = false)
-    {
-        return 'laravel_reserved_'.($lockCount ? static::$selfJoinCount : static::$selfJoinCount++);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -23,13 +23,6 @@ abstract class HasOneOrMany extends Relation
     protected $localKey;
 
     /**
-     * The count of self joins.
-     *
-     * @var int
-     */
-    protected static $selfJoinCount = 0;
-
-    /**
      * Create a new has one or many relationship instance.
      *
      * @param  \Illuminate\Database\Eloquent\Builder  $query
@@ -361,17 +354,6 @@ abstract class HasOneOrMany extends Relation
         return $query->select($columns)->whereColumn(
             $this->getQualifiedParentKeyName(), '=', $hash.'.'.$this->getForeignKeyName()
         );
-    }
-
-    /**
-     * Get a relationship join table hash.
-     *
-     * @param  bool $lockCount
-     * @return string
-     */
-    public function getRelationCountHash($lockCount = false)
-    {
-        return 'laravel_reserved_'.($lockCount ? static::$selfJoinCount : static::$selfJoinCount++);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -230,12 +230,12 @@ abstract class Relation
     /**
      * Get a relationship join table hash.
      *
-     * @param  bool $lockCount
+     * @param  bool $incrementJoinCount
      * @return string
      */
-    public function getRelationCountHash($lockCount = false)
+    public function getRelationCountHash($incrementJoinCount = true)
     {
-        return 'laravel_reserved_'.($lockCount ? static::$selfJoinCount : static::$selfJoinCount++);
+        return 'laravel_reserved_'.($incrementJoinCount ? static::$selfJoinCount++ : static::$selfJoinCount);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -63,6 +63,13 @@ abstract class Relation
     public static $tableNameAsMorphType = false;
 
     /**
+     * The count of self joins.
+     *
+     * @var int
+     */
+    protected static $selfJoinCount = 0;
+
+    /**
      * Create a new relation instance.
      *
      * @param  \Illuminate\Database\Eloquent\Builder  $query
@@ -218,6 +225,17 @@ abstract class Relation
         return $query->select($columns)->whereColumn(
             $this->getQualifiedParentKeyName(), '=', $this->getExistenceCompareKey()
         );
+    }
+
+    /**
+     * Get a relationship join table hash.
+     *
+     * @param  bool $lockCount
+     * @return string
+     */
+    public function getRelationCountHash($lockCount = false)
+    {
+        return 'laravel_reserved_'.($lockCount ? static::$selfJoinCount : static::$selfJoinCount++);
     }
 
     /**


### PR DESCRIPTION
The `getRelationCountHash` was duplicted on 4 places and all of them inherit from 'Relation'.
I have just moved the above method and `$selfJoinCount` to parent `Relation` class.