### PR TITLE
[8.x] creating pivot tables by model classes

### DIFF
--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -203,9 +203,9 @@ class Builder
     /**
      * Create a new pivot table for a many-to-many relation on the schema.
      *
-     * @param  \Illuminate\Database\Eloquent\Model|string $firstModel
-     * @param  \Illuminate\Database\Eloquent\Model|string $secondModel
-     * @param  \Closure|null $callback
+     * @param  \Illuminate\Database\Eloquent\Model|string  $firstModel
+     * @param  \Illuminate\Database\Eloquent\Model|string  $secondModel
+     * @param  \Closure|null  $callback
      * @return void
      */
     public function createPivotTable($firstModel, $secondModel, Closure $callback = null)

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -203,9 +203,9 @@ class Builder
     /**
      * Create a new pivot table for a many-to-many relation on the schema.
      *
-     * @param \Illuminate\Database\Eloquent\Model|string $firstModel
-     * @param \Illuminate\Database\Eloquent\Model|string $secondModel
-     * @param Closure|null $callback
+     * @param  \Illuminate\Database\Eloquent\Model|string $firstModel
+     * @param  \Illuminate\Database\Eloquent\Model|string $secondModel
+     * @param  \Closure|null $callback
      * @return void
      */
     public function createPivotTable($firstModel, $secondModel, Closure $callback = null)
@@ -223,7 +223,7 @@ class Builder
             $blueprint->create();
             $blueprint->foreignIdFor($firstModel);
             $blueprint->foreignIdFor($secondModel);
-            if($callback) {
+            if ($callback) {
                 $callback($blueprint);
             }
         }));

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -201,6 +201,35 @@ class Builder
     }
 
     /**
+     * Create a new pivot table for a many-to-many relation on the schema.
+     *
+     * @param \Illuminate\Database\Eloquent\Model|string $firstModel
+     * @param \Illuminate\Database\Eloquent\Model|string $secondModel
+     * @param Closure|null $callback
+     * @return void
+     */
+    public function createPivotTable($firstModel, $secondModel, Closure $callback = null)
+    {
+        if (is_string($firstModel)) {
+            $firstModel = new $firstModel;
+        }
+        if (is_string($secondModel)) {
+            $secondModel = new $secondModel;
+        }
+
+        $table = $firstModel->joiningTable($secondModel);
+
+        $this->build(tap($this->createBlueprint($table), function ($blueprint) use ($callback, $firstModel, $secondModel) {
+            $blueprint->create();
+            $blueprint->foreignIdFor($firstModel);
+            $blueprint->foreignIdFor($secondModel);
+            if($callback) {
+                $callback($blueprint);
+            }
+        }));
+    }
+
+    /**
      * Drop a table from the schema.
      *
      * @param  string  $table

--- a/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
@@ -76,11 +76,11 @@ class DatabaseSchemaBuilderIntegrationTest extends TestCase
 
     public function testCreatePivotTable()
     {
-        $this->db->connection()->getSchemaBuilder()->createPivotTable(Test::class, Example::class,function (Blueprint $table){
+        $this->db->connection()->getSchemaBuilder()->createPivotTable(Test::class, Example::class, function (Blueprint $table) {
             $table->integer('id');
         });
         $this->assertTrue($this->db->connection()->getSchemaBuilder()->hasTable('example_test'));
-        $this->assertTrue($this->db->connection()->getSchemaBuilder()->hasColumns('example_test',['id', 'example_id','test_id']));
+        $this->assertTrue($this->db->connection()->getSchemaBuilder()->hasColumns('example_test',['id', 'example_id', 'test_id']));
     }
 
 
@@ -148,5 +148,11 @@ class DatabaseSchemaBuilderIntegrationTest extends TestCase
 }
 
 
-class Test extends Model {}
-class Example extends Model {}
+class Test extends Model
+{
+
+}
+class Example extends Model
+{
+
+}

--- a/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
@@ -83,7 +83,6 @@ class DatabaseSchemaBuilderIntegrationTest extends TestCase
         $this->assertTrue($this->db->connection()->getSchemaBuilder()->hasColumns('example_test', ['id', 'example_id', 'test_id']));
     }
 
-
     public function testHasColumnAndIndexWithPrefixIndexDisabled()
     {
         $this->db->addConnection([

--- a/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Database;
 
 use Illuminate\Container\Container;
 use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Facade;
 use PHPUnit\Framework\TestCase;
@@ -73,6 +74,16 @@ class DatabaseSchemaBuilderIntegrationTest extends TestCase
         $this->assertTrue($this->db->connection()->getSchemaBuilder()->hasColumn('table1', 'name'));
     }
 
+    public function testCreatePivotTable()
+    {
+        $this->db->connection()->getSchemaBuilder()->createPivotTable(Test::class, Example::class,function (Blueprint $table){
+            $table->integer('id');
+        });
+        $this->assertTrue($this->db->connection()->getSchemaBuilder()->hasTable('example_test'));
+        $this->assertTrue($this->db->connection()->getSchemaBuilder()->hasColumns('example_test',['id', 'example_id','test_id']));
+    }
+
+
     public function testHasColumnAndIndexWithPrefixIndexDisabled()
     {
         $this->db->addConnection([
@@ -135,3 +146,7 @@ class DatabaseSchemaBuilderIntegrationTest extends TestCase
         return $this->db->connection()->getSchemaBuilder();
     }
 }
+
+
+class Test extends Model {}
+class Example extends Model {}

--- a/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
@@ -80,7 +80,7 @@ class DatabaseSchemaBuilderIntegrationTest extends TestCase
             $table->integer('id');
         });
         $this->assertTrue($this->db->connection()->getSchemaBuilder()->hasTable('example_test'));
-        $this->assertTrue($this->db->connection()->getSchemaBuilder()->hasColumns('example_test',['id', 'example_id', 'test_id']));
+        $this->assertTrue($this->db->connection()->getSchemaBuilder()->hasColumns('example_test', ['id', 'example_id', 'test_id']));
     }
 
 
@@ -147,12 +147,9 @@ class DatabaseSchemaBuilderIntegrationTest extends TestCase
     }
 }
 
-
 class Test extends Model
 {
-
 }
 class Example extends Model
 {
-
 }


### PR DESCRIPTION
This PR adds `createPivotTable` to the Schema builder class.

it creates `role_user` table with `role_id` and `user_id` columns by default. it also accepts a Closure as the third parameter that allows users to add their additional columns to the table.

### Usage 

```php
/**
 * Run the migrations.
 *
 * @return void
 */
public function up()
{
    Schema::createPivotTable('App\Models\User','App\Models\Role');
}
```

It's handy for users and allows them to create pivot tables quickly, and prevents them from writing similar codes to create tables like this.

