### PR TITLE
[8.x] Removed Dispatchable trait because it breaks Lumen apps

### DIFF
--- a/src/Illuminate/Queue/CallQueuedClosure.php
+++ b/src/Illuminate/Queue/CallQueuedClosure.php
@@ -8,12 +8,11 @@ use Illuminate\Bus\Batchable;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Foundation\Bus\Dispatchable;
 use ReflectionFunction;
 
 class CallQueuedClosure implements ShouldQueue
 {
-    use Batchable, Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+    use Batchable, InteractsWithQueue, Queueable, SerializesModels;
 
     /**
      * The serializable Closure instance.


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR relates to laravel/lumen-framework#1136 issue.

**Description**  
When initializing `vimeo/psalm` package for Lumen app, it complains that `Illuminate\Foundation\Bus\Dispatchable` Trait is missing. Hence it breaks in the initial run. 

I ran the test cases after this modification and tests are passing. But I doubt that test cases cover the particular piece of code. This bit of code has introduced 2 years back from this commit, https://github.com/laravel/framework/commit/556b948c41b273144e5f23f6b3b6167bf7e0c84e. So probably @taylorotwell can have a look to decide `Dispatachable` trait really needs for Lumen.

**Steps to reproduce issue**  
1. `composer create-project --prefer-dist laravel/lumen blog`
2. `cd blog`
3. `composer require --dev vimeo/psalm`
4. `./vendor/bin/psalm --init`

**Expected result**  
No errors to be thrown.

**Actual result**
Following error message throws
```bash
Calculating best config level based on project files
Calculating best config level based on project files
Scanning files...
PHP Fatal error:  Trait 'Illuminate\Foundation\Bus\Dispatchable' not found in /.../blog/vendor/illuminate/queue/CallQueuedClosure.php on line 14
Fatal error: Trait 'Illuminate\Foundation\Bus\Dispatchable' not found in /.../blog/vendor/illuminate/queue/CallQueuedClosure.php on line 14
```