### PR TITLE
[8.x] Redis: allow to pass connection name

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithRedis.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithRedis.php
@@ -57,6 +57,7 @@ trait InteractsWithRedis
                     'port' => $port,
                     'database' => 5,
                     'timeout' => 0.5,
+                    'name' => 'default',
                 ],
             ]);
         }

--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -102,6 +102,10 @@ class PhpRedisConnector implements Connector
             if (! empty($config['scan'])) {
                 $client->setOption(Redis::OPT_SCAN, $config['scan']);
             }
+
+            if (! empty($config['name'])) {
+                $client->client('SETNAME', $config['name']);
+            }
         });
     }
 
@@ -175,6 +179,10 @@ class PhpRedisConnector implements Connector
 
             if (! empty($options['failover'])) {
                 $client->setOption(RedisCluster::OPT_SLAVE_FAILOVER, $options['failover']);
+            }
+
+            if (! empty($options['name'])) {
+                $client->client('SETNAME', $options['name']);
             }
         });
     }

--- a/tests/Redis/RedisConnectorTest.php
+++ b/tests/Redis/RedisConnectorTest.php
@@ -41,7 +41,7 @@ class RedisConnectorTest extends TestCase
         $phpRedisClient = $this->redis['phpredis']->connection()->client();
         $this->assertEquals($host, $phpRedisClient->getHost());
         $this->assertEquals($port, $phpRedisClient->getPort());
-        $this->assertEquals("default", $phpRedisClient->client('GETNAME'));
+        $this->assertEquals('default', $phpRedisClient->client('GETNAME'));
     }
 
     public function testUrl()

--- a/tests/Redis/RedisConnectorTest.php
+++ b/tests/Redis/RedisConnectorTest.php
@@ -41,6 +41,7 @@ class RedisConnectorTest extends TestCase
         $phpRedisClient = $this->redis['phpredis']->connection()->client();
         $this->assertEquals($host, $phpRedisClient->getHost());
         $this->assertEquals($port, $phpRedisClient->getPort());
+        $this->assertEquals("default", $phpRedisClient->client('GETNAME'));
     }
 
     public function testUrl()


### PR DESCRIPTION
When using PhpRedis persistent connections, it can become very tricky to monitor and debug connections when having a lot of apps/workers.

<img width="976" src="https://user-images.githubusercontent.com/12607242/100516717-08537d00-3186-11eb-8a64-3f0864819ef1.png">

Passing connection name allows to quickly identify Redis connections:

<img width="972" src="https://user-images.githubusercontent.com/12607242/100516683-d9d5a200-3185-11eb-99b5-eedab3d1d909.png">
