### PR TITLE
[8.x] Typo fix in in docblock: Queue/LuaScripts fot->for

### DIFF
--- a/src/Illuminate/Queue/LuaScripts.php
+++ b/src/Illuminate/Queue/LuaScripts.php
@@ -24,7 +24,7 @@ LUA;
      * Get the Lua script for pushing jobs onto the queue.
      *
      * KEYS[1] - The queue to push the job onto, for example: queues:foo
-     * KEYS[2] - The notification list fot the queue we are pushing jobs onto, for example: queues:foo:notify
+     * KEYS[2] - The notification list for the queue we are pushing jobs onto, for example: queues:foo:notify
      * ARGV[1] - The job payload
      *
      * @return string


### PR DESCRIPTION
I wish I could explain more than what's already in the title.

Stumbled upon this while figuring out how to push a job on the queue from outside php code (probably a horrible idea, but I guess it's happening)

Have a nice . $this->calculateGreetingFromTimezone() . !
Cheers!