### PR TITLE
[8.x] Update Route Facade docblock to fix namespace method definition

### DIFF
--- a/src/Illuminate/Support/Facades/Route.php
+++ b/src/Illuminate/Support/Facades/Route.php
@@ -25,7 +25,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Routing\RouteRegistrar domain(string $value)
  * @method static \Illuminate\Routing\RouteRegistrar middleware(array|string|null $middleware)
  * @method static \Illuminate\Routing\RouteRegistrar name(string $value)
- * @method static \Illuminate\Routing\RouteRegistrar namespace(string $value)
+ * @method static \Illuminate\Routing\RouteRegistrar namespace(string|null $value)
  * @method static \Illuminate\Routing\RouteRegistrar prefix(string  $prefix)
  * @method static \Illuminate\Routing\RouteRegistrar where(array  $where)
  * @method static \Illuminate\Routing\Router|\Illuminate\Routing\RouteRegistrar group(\Closure|string|array $attributes, \Closure|string $routes)


### PR DESCRIPTION
Should match https://github.com/laravel/framework/blob/8.x/src/Illuminate/Routing/RouteRegistrar.php#L23

Psalms raises a warning about it when it checks RouteServiceProvider in our app.