### PR TITLE
[8.x] Use PHP_EOL in PendingCommand

### DIFF
--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -351,7 +351,7 @@ class PendingCommand
             $table->render();
 
             $lines = array_filter(
-                explode("\n", $output->fetch())
+                explode(PHP_EOL, $output->fetch())
             );
 
             foreach ($lines as $line) {


### PR DESCRIPTION
Use PHP_EOL in PendingCommand@applyTableOutputExpectations
This gave me a headache while working on Windows :joy:

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
