### PR TITLE
[8.x] Add support for get relationship value from parent model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -589,13 +589,16 @@ class Builder
 
         $constraints($relation);
 
+        $models = $relation->initRelation($models, $name);
+        $results = $relation->getParent()->eagerLoadRelationFromModel($relation, $name, $models);
+        if (is_null($results)) {
+            $results = $relation->getEager();
+        }
+
         // Once we have the results, we just match those back up to their parent models
         // using the relationship instance. Then we just return the finished arrays
         // of models which have been eagerly hydrated and are readied for return.
-        return $relation->match(
-            $relation->initRelation($models, $name),
-            $relation->getEager(), $name
-        );
+        return $relation->match($models, $results, $name);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -485,7 +485,7 @@ trait HasAttributes
      *
      * @return mixed
      */
-    public function eagerLoadRelationFromModel(Relation $relation, $name, array $models = null)
+    public function eagerLoadRelationFromModel($relation, $name, array $models = null)
     {
         $results = null;
         $parent = $relation->getParent();

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -493,7 +493,7 @@ trait HasAttributes
 
         if (method_exists($parent, $method)) {
             $query = $relation->getQuery()->getQuery();
-            $where = array_reduce($query->wheres ?: [], function($dat, $v) use ($query) {
+            $where = array_reduce($query->wheres ?: [], function ($dat, $v) use ($query) {
                 if (isset($v['values']) || isset($v['value'])) {
                     $key = Arr::get($v, 'column');
                     if (Str::startsWith($key, "{$query->from}.")) {
@@ -503,7 +503,7 @@ trait HasAttributes
                 }
 
                 return $dat;
-            },[]);
+            }, []);
             $results = $parent->$method($relation, isset($models) ? $models : [$this], $where);
         }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -466,9 +466,48 @@ trait HasAttributes
             ));
         }
 
-        return tap($relation->getResults(), function ($results) use ($method) {
+        $results = $this->eagerLoadRelationFromModel($relation, $method, [$this]);
+        if (is_null($results)) {
+            $results = $relation->getResults();
+        }
+
+        return tap($results, function ($results) use ($method) {
             $this->setRelation($method, $results);
         });
+    }
+
+    /**
+     * Get a relationship value from parent model.
+     *
+     * @param  Relation    $relation
+     * @param  string      $name  relationship name
+     * @param  array|null  $models
+     *
+     * @return mixed
+     */
+    public function eagerLoadRelationFromModel(Relation $relation, $name, array $models = null)
+    {
+        $results = null;
+        $parent = $relation->getParent();
+        $method = 'eagerLoad'.Str::studly($name);
+
+        if (method_exists($parent, $method)) {
+            $query = $relation->getQuery()->getQuery();
+            $where = array_reduce($query->wheres ?: [], function($dat, $v) use ($query) {
+                if (isset($v['values']) || isset($v['value'])) {
+                    $key = Arr::get($v, 'column');
+                    if (Str::startsWith($key, "{$query->from}.")) {
+                        $key = substr($key, strlen($query->from) + 1);
+                    }
+                    $dat[$key] = $v['values'] ?? [$v['value']];
+                }
+
+                return $dat;
+            },[]);
+            $results = $parent->$method($relation, isset($models) ? $models : [$this], $where);
+        }
+
+        return $results;
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -517,11 +517,13 @@ class DatabaseEloquentBuilderTest extends TestCase
             $_SERVER['__eloquent.constrain'] = $query;
         }]);
         $relation = m::mock(stdClass::class);
+        $relation->shouldReceive('getParent')->once()->andReturn($builder);
         $relation->shouldReceive('addEagerConstraints')->once()->with(['models']);
         $relation->shouldReceive('initRelation')->once()->with(['models'], 'orders')->andReturn(['models']);
         $relation->shouldReceive('getEager')->once()->andReturn(['results']);
         $relation->shouldReceive('match')->once()->with(['models'], ['results'], 'orders')->andReturn(['models.matched']);
         $builder->shouldReceive('getRelation')->once()->with('orders')->andReturn($relation);
+        $builder->shouldReceive('eagerLoadRelationFromModel')->once()->with($relation, 'orders', ['models'])->andReturn(null);
         $results = $builder->eagerLoadRelations(['models']);
 
         $this->assertEquals(['models.matched'], $results);


### PR DESCRIPTION
Eloquent relationships is very powerful, but it is helpless when it comes to getting the cached relationship value.
This PR can help users get the cached data from parent model first when obtaining relationship value.

### Example:
```php
use Illuminate\Database\Eloquent\Model;

class User extends Model
{

    public function profile()
    {
        return $this->hasOne('App\Profile', 'uid');
    }

    public function eagerLoadProfile($relation, $models = [], $where = [])
    {
        // Get cached data for relation
        if ( ! empty($where['uid'])) {
            return cache()->remember("user:profile:{$where['uid']}", 86400, function() use ($where) {
                return Profile::find($where['uid']);
            });
        }
        // return null for get from database
        return null;
    }

}
```