### PR TITLE
[Minor Feature] Adding recursion ability to the base Support\Collection

### DIFF
--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -7,12 +7,13 @@ if (! function_exists('collect')) {
     /**
      * Create a collection from the given value.
      *
-     * @param  mixed  $value
+     * @param mixed $value
+     * @param bool|null $recursive
      * @return \Illuminate\Support\Collection
      */
-    function collect($value = null)
+    function collect($value = null, $recursive = null)
     {
-        return new Collection($value);
+        return new Collection($value, $recursive);
     }
 }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2626,6 +2626,51 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['first' => 'first-rolyat', 'last' => 'last-llewto'], $data->all());
     }
 
+    public function testRecursiveNull()
+    {
+        $c = new Collection();
+        $c->recursive();
+        $this->assertEmpty($c);
+    }
+
+    public function testRecursiveArray()
+    {
+        $c = new Collection(['foo', 'bar', 'fruits' => 'banana']);
+        $c->recursive();
+        $this->assertSame($c->all(), ['foo', 'bar', 'fruits' => 'banana']);
+    }
+
+    public function testRecursiveMultiDimensionalArray()
+    {
+        $c = new Collection([
+            'foo' => 'bar',
+            'food' =>
+                ['fruits' => ['banana', 'orange'],
+                'vegetables' => 'tomato'
+            ]]);
+        $c->recursive();
+        $this->assertInstanceOf(Collection::class, $a = $c->get('food'));
+        $this->assertInstanceOf(Collection::class, $b = $a->get('fruits'));
+        $this->assertSame('bar', $c['foo']);
+        $this->assertSame('tomato', $a->get('vegetables'));
+        $this->assertSame(['banana', 'orange'], $b->all());
+    }
+
+    public function testRecursiveCollections()
+    {
+        $a = ['foo', 'bar'];
+        $b = new Collection(['fruits' => ['banana', 'orange']]);
+        $c = new Collection(['vegetables' => 'tomato']);
+        $d = new Collection(['food' => [$a ,$b, $c]]);
+        $d->recursive();
+        $aa = new Collection(['foo', 'bar']);
+        $bb = ['fruits' => ['banana', 'orange']];
+        $cc = ['vegetables' => 'tomato'];
+        $dd = new Collection(['food' => [$aa ,$bb, $cc]]);
+        $dd->recursive();
+        $this->assertEquals($d->all(), $dd->all());
+    }
+
     /**
      * @dataProvider collectionClassProvider
      */


### PR DESCRIPTION
This feature adds the ability for collections to be recursive (Items will be converted to collections in all children levels)
**How to make collection recursive:**
`collect($data, true) // using collect helper method`
`new Collection($data, true) // directly when creating the Collection`
`$existingCollection->recursive() // using recursive() method on the Collection`
By default all collections don't use recursive but you can do `Collection::setRecursive(true|false)` in any service provider or during runtime if needed to change the default behaviour.
even if the default is `true` you can still `collect($data, false) // or in constructor` to change it for that collection
all new instances created from inside the class have recursive to false (except in recursive() method) to avoid overwriting user data accidently. 
I have written some tests as well for this functionallity (not sure if i did it right, i don't often write tests)

This is extremely helpful when dealing with a lot of data.
I created this before on one of my projects where i needed to filter data retrieved from an api where I needed to filter **alot** of data and filtering using foreach and result[]= isn't very efficient so I decided to share this here in case somebody needs it.
_it doesn't break or interfere with any code_