### PR TITLE
[6.x] Fix validating image/jpeg images after Symfony/Mime update

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1054,7 +1054,7 @@ trait ValidatesAttributes
      */
     public function validateImage($attribute, $value)
     {
-        return $this->validateMimes($attribute, $value, ['jpeg', 'png', 'gif', 'bmp', 'svg', 'webp']);
+        return $this->validateMimes($attribute, $value, ['jpg', 'jpeg', 'png', 'gif', 'bmp', 'svg', 'webp']);
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2703,6 +2703,12 @@ class ValidationValidatorTest extends TestCase
         $file7->expects($this->any())->method('getClientOriginalExtension')->willReturn('webp');
         $v = new Validator($trans, ['x' => $file7], ['x' => 'Image']);
         $this->assertTrue($v->passes());
+
+        $file2 = $this->getMockBuilder(UploadedFile::class)->setMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
+        $file2->expects($this->any())->method('guessExtension')->willReturn('jpg');
+        $file2->expects($this->any())->method('getClientOriginalExtension')->willReturn('jpg');
+        $v = new Validator($trans, ['x' => $file2], ['x' => 'Image']);
+        $this->assertTrue($v->passes());
     }
 
     public function testValidateImageDoesNotAllowPhpExtensionsOnImageMime()


### PR DESCRIPTION
Symfony/Mime v5.20 changed the returned extension for an image with image/jpeg mime type: symfony/mime@aa1d922

This breaks laravel image validation, as it relied on a return value of .jpeg. This commit adds .jpg, which fixes the validation.

(see https://github.com/laravel/framework/pull/35416)