### PR TITLE
[8.x] Fix fail to morph with custom casting to objects

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -256,7 +256,7 @@ trait HasRelationships
         // If the type value is null it is probably safe to assume we're eager loading
         // the relationship. In this case we'll just pass in a dummy query where we
         // need to remove any eager loads that may already be defined on a model.
-        return is_null($class = $this->{$type})
+        return is_null($class = $this->getAttributeFromArray($type))
                     ? $this->morphEagerTo($name, $type, $id, $ownerKey)
                     : $this->morphInstanceTo($class, $name, $type, $id, $ownerKey);
     }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1275,6 +1275,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->addMockConnection($model);
 
         // $this->morphTo();
+        $model->setAttribute('morph_to_stub_type', EloquentModelSaveStub::class);
         $relation = $model->morphToStub();
         $this->assertSame('morph_to_stub_id', $relation->getForeignKeyName());
         $this->assertSame('morph_to_stub_type', $relation->getMorphType());
@@ -2229,7 +2230,6 @@ class EloquentModelStub extends Model
     public $scopesCalled = [];
     protected $table = 'stub';
     protected $guarded = [];
-    protected $morph_to_stub_type = EloquentModelSaveStub::class;
     protected $casts = ['castedFloat' => 'float'];
 
     public function getListItemsAttribute($value)

--- a/tests/Database/DatabaseEloquentMorphToTest.php
+++ b/tests/Database/DatabaseEloquentMorphToTest.php
@@ -92,8 +92,8 @@ class DatabaseEloquentMorphToTest extends TestCase
 
     public function testMorphToWithZeroMorphType()
     {
-        $parent = $this->getMockBuilder(EloquentMorphToModelStub::class)->onlyMethods(['getAttribute', 'morphEagerTo', 'morphInstanceTo'])->getMock();
-        $parent->method('getAttribute')->with('relation_type')->willReturn(0);
+        $parent = $this->getMockBuilder(EloquentMorphToModelStub::class)->onlyMethods(['getAttributeFromArray', 'morphEagerTo', 'morphInstanceTo'])->getMock();
+        $parent->method('getAttributeFromArray')->with('relation_type')->willReturn(0);
         $parent->expects($this->once())->method('morphInstanceTo');
         $parent->expects($this->never())->method('morphEagerTo');
 


### PR DESCRIPTION
While Laravel introduce [custom cast](https://laravel.com/docs/8.x/eloquent-mutators#custom-casts) in 7.x, it's not really that compatible with [morph map](https://laravel.com/docs/8.x/eloquent-relationships#custom-polymorphic-types).

For a `morphTo` relation to work, it relies on accessing the actual data with the `__get()` method of the model to assume whether we're or not eager loading the relationship. [See code here.](https://github.com/laravel/framework/blob/ff1baa1eca5ac64dfc1abca60c82e00145e84a14/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php#L259)

By using the `__get()` method of the model, we'll be applying the cast to the attribute we're asking for. This works great before custom cast are introduced.

However if a custom cast is applied on the attribute, the attribute might be casted to any object, which is incompatible with `Relation::morphMap()` (returning an array with the key as `int/string`).

Here's an example setup:
```php
class Logs extends Model
{
    protected $table = 'logs';

    protected $fillable = ['role_type', 'role_user_id'];

    protected $casts = [
        'role' => CastToRoleTypeEnum::class,
    ];

    public function roleUser()
    {
        return $this->morphTo(__FUNCTION__, 'role_type', 'role_user_id', 'id');
    }
}

class Admins extends Model
{
    protected $table = 'admins';
}

class Users extends Model
{
    protected $table = 'users';
}

class CastToRoleTypeEnum implements CastsAttributes
{
    public function get($model, $key, $value, $attributes)
    {
        return new RoleTypeEnum($value);
    }

    public function set($model, $key, $value, $attributes)
    {
        return $value->getValue();
    }
}

class RoleTypeEnum
{
    public function __construct($value)
    {
        $this->value = $value;
    }

    public function getValue()
    {
        return $this->value;
    }
}

// In AppServiceProvider.php, define the morph map
// Also remember to define Admin/User model which I will not demonstrate here to save space
Relation::morphMap([
    'admin' => 'App\Models\Admins',
    'user' => 'App\Models\Users',
]);
```

The `morphMap` above uses the keys of an array as the custom polymorphic types to map to the correspond models, which is impossible to map while the magic `__get` method in `Model.php` will be always casting it to a `LogRole` object in `morphTo`.

Sorry this is my first pull request to Laravel, I've tried my best to understand the [contribution guide](https://laravel.com/docs/8.x/contributions) and explain my problem, please feel free to ask any question and I'll try my best to reply as soon as possible.