### PR TITLE
[8.x] Change Wormhole to use the Date Factory

### DIFF
--- a/src/Illuminate/Foundation/Testing/Wormhole.php
+++ b/src/Illuminate/Foundation/Testing/Wormhole.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Foundation\Testing;
 
-use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Date;
 
 class Wormhole
 {
@@ -32,7 +32,7 @@ class Wormhole
      */
     public function milliseconds($callback = null)
     {
-        Carbon::setTestNow(Carbon::now()->addMilliseconds($this->value));
+        Date::setTestNow(Date::now()->addMilliseconds($this->value));
 
         return $this->handleCallback($callback);
     }
@@ -45,7 +45,7 @@ class Wormhole
      */
     public function seconds($callback = null)
     {
-        Carbon::setTestNow(Carbon::now()->addSeconds($this->value));
+        Date::setTestNow(Date::now()->addSeconds($this->value));
 
         return $this->handleCallback($callback);
     }
@@ -58,7 +58,7 @@ class Wormhole
      */
     public function minutes($callback = null)
     {
-        Carbon::setTestNow(Carbon::now()->addMinutes($this->value));
+        Date::setTestNow(Date::now()->addMinutes($this->value));
 
         return $this->handleCallback($callback);
     }
@@ -71,7 +71,7 @@ class Wormhole
      */
     public function hours($callback = null)
     {
-        Carbon::setTestNow(Carbon::now()->addHours($this->value));
+        Date::setTestNow(Date::now()->addHours($this->value));
 
         return $this->handleCallback($callback);
     }
@@ -84,7 +84,7 @@ class Wormhole
      */
     public function days($callback = null)
     {
-        Carbon::setTestNow(Carbon::now()->addDays($this->value));
+        Date::setTestNow(Date::now()->addDays($this->value));
 
         return $this->handleCallback($callback);
     }
@@ -97,7 +97,7 @@ class Wormhole
      */
     public function weeks($callback = null)
     {
-        Carbon::setTestNow(Carbon::now()->addWeeks($this->value));
+        Date::setTestNow(Date::now()->addWeeks($this->value));
 
         return $this->handleCallback($callback);
     }
@@ -110,7 +110,7 @@ class Wormhole
      */
     public function years($callback = null)
     {
-        Carbon::setTestNow(Carbon::now()->addYears($this->value));
+        Date::setTestNow(Date::now()->addYears($this->value));
 
         return $this->handleCallback($callback);
     }
@@ -122,9 +122,9 @@ class Wormhole
      */
     public static function back()
     {
-        Carbon::setTestNow();
+        Date::setTestNow();
 
-        return Carbon::now();
+        return Date::now();
     }
 
     /**
@@ -137,7 +137,7 @@ class Wormhole
     {
         if ($callback) {
             return tap($callback(), function () {
-                Carbon::setTestNow();
+                Date::setTestNow();
             });
         }
     }

--- a/tests/Foundation/Testing/WormholeTest.php
+++ b/tests/Foundation/Testing/WormholeTest.php
@@ -42,5 +42,8 @@ class WormholeTest extends TestCase
 
         // Assert the time travel was successful...
         $this->assertEquals($future->format('Y-m-d'), now()->format('Y-m-d'));
+
+        // Restore the default Date Factory...
+        Date::useDefault();
     }
 }

--- a/tests/Foundation/Testing/WormholeTest.php
+++ b/tests/Foundation/Testing/WormholeTest.php
@@ -2,7 +2,9 @@
 
 namespace Illuminate\Tests\Foundation\Testing;
 
+use Carbon\CarbonImmutable;
 use Illuminate\Foundation\Testing\Wormhole;
+use Illuminate\Support\Facades\Date;
 use PHPUnit\Framework\TestCase;
 
 class WormholeTest extends TestCase
@@ -21,5 +23,24 @@ class WormholeTest extends TestCase
 
         // Assert we can go back to the present..
         $this->assertEquals($present->format('Y-m-d'), Wormhole::back()->format('Y-m-d'));
+    }
+
+    public function testCarbonImmutableCompatibility()
+    {
+        // Tell the Date Factory to use CarbonImmutable...
+        Date::use(CarbonImmutable::class);
+
+        // Record what time it is in 10 days...
+        $present = now();
+        $future = $present->addDays(10);
+
+        // Travel in time...
+        (new Wormhole(10))->days();
+
+        // Assert that the present time didn't get mutated...
+        $this->assertNotEquals($future->format('Y-m-d'), $present->format('Y-m-d'));
+
+        // Assert the time travel was successful...
+        $this->assertEquals($future->format('Y-m-d'), now()->format('Y-m-d'));
     }
 }


### PR DESCRIPTION
I wanted to use `CarbonImmutable` by default in an app I'm building, and got caught up in a wormhole issue when trying to travel into the future.

Basically, this example currently doesn't work as expected:

``` php
<?php

namespace Tests\Feature;

use Carbon\CarbonImmutable;
use Illuminate\Support\Facades\Date;
use Tests\TestCase;

class ExampleTest extends TestCase
{
    public function testItTravelsInTime()
    {
        Date::use(CarbonImmutable::class);

        $this->travel(10)->days();

        dump(now()); // Incorrectly dumps the current time
    }
}
```

This PR fixes the issue by making sure the `Wormhole` class references `Illuminate\Support\Facades\Date` facade instead of `Illuminate\Support\Carbon`.

Also added a test to make sure it works as expected.

