### PR TITLE
[8.x] Update type defs for $abstract

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -626,7 +626,7 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * An alias function name for make().
      *
-     * @param  string  $abstract
+     * @param  string|callable  $abstract
      * @param  array  $parameters
      * @return mixed
      *
@@ -640,7 +640,7 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * Resolve the given type from the container.
      *
-     * @param  string  $abstract
+     * @param  string|callable $abstract
      * @param  array  $parameters
      * @return mixed
      *
@@ -670,7 +670,7 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * Resolve the given type from the container.
      *
-     * @param  string  $abstract
+     * @param  string|callable  $abstract
      * @param  array  $parameters
      * @param  bool  $raiseEvents
      * @return mixed
@@ -745,7 +745,7 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * Get the concrete type for a given abstract.
      *
-     * @param  string  $abstract
+     * @param  string|callable  $abstract
      * @return mixed
      */
     protected function getConcrete($abstract)
@@ -763,7 +763,7 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * Get the contextual concrete binding for the given abstract.
      *
-     * @param  string  $abstract
+     * @param  string|callable  $abstract
      * @return \Closure|string|array|null
      */
     protected function getContextualConcrete($abstract)
@@ -789,7 +789,7 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * Find the concrete binding for the given abstract in the contextual binding array.
      *
-     * @param  string  $abstract
+     * @param  string|callable  $abstract
      * @return \Closure|string|null
      */
     protected function findInContextualBindings($abstract)

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -640,7 +640,7 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * Resolve the given type from the container.
      *
-     * @param  string|callable $abstract
+     * @param  string|callable  $abstract
      * @param  array  $parameters
      * @return mixed
      *


### PR DESCRIPTION
`$abstract` can also be a Closure or invocable. This change will make PHPStan complain less.
