### PR TITLE
[8.x] Allow test assertions to be made about email contents - option #2

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -13,12 +13,13 @@ use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\ForwardsCalls;
 use Illuminate\Support\Traits\Localizable;
+use Illuminate\Support\Traits\Macroable;
 use ReflectionClass;
 use ReflectionProperty;
 
 class Mailable implements MailableContract, Renderable
 {
-    use ForwardsCalls, Localizable;
+    use ForwardsCalls, Localizable, Macroable;
 
     /**
      * The locale of the message.

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -13,13 +13,12 @@ use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\ForwardsCalls;
 use Illuminate\Support\Traits\Localizable;
-use Illuminate\Support\Traits\Macroable;
 use ReflectionClass;
 use ReflectionProperty;
 
 class Mailable implements MailableContract, Renderable
 {
-    use ForwardsCalls, Localizable, Macroable;
+    use ForwardsCalls, Localizable;
 
     /**
      * The locale of the message.

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -11,8 +11,8 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\ReflectsClosures;
 use Illuminate\Testing\TestMailable;
-use PHPUnit\Framework\Assert as PHPUnit;
 use Mockery as m;
+use PHPUnit\Framework\Assert as PHPUnit;
 
 class MailFake implements Factory, Mailer, MailQueue
 {
@@ -253,7 +253,9 @@ class MailFake implements Factory, Mailer, MailQueue
         $renderer = new TestMailable($mailable);
 
         foreach (get_class_methods($renderer) as $method) {
-            if (Str::startsWith($method, '__')) continue;
+            if (Str::startsWith($method, '__')) {
+                continue;
+            }
             $mock->shouldReceive($method)->andReturnUsing($renderer->{$method}());
         }
 

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -119,7 +119,7 @@ class MailFake implements Factory, Mailer, MailQueue
         return [
             'html' => $this->renderView($html, $data),
             'text' => $this->renderView($plain, $data),
-            'raw' => $raw
+            'raw' => $raw,
         ];
     }
 

--- a/src/Illuminate/Testing/TestMailable.php
+++ b/src/Illuminate/Testing/TestMailable.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Illuminate\Testing;
+
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Testing\Assert as PHPUnit;
+use \Illuminate\Contracts\View\Factory;
+
+class TestMailable {
+    /**
+     * The mailable to delegate to.
+     *
+     * @var Mailable
+     */
+    public $baseMailable;
+
+    public $html;
+
+    public $text;
+
+    public function __construct(Mailable $mailable)
+    {
+        $this->baseMailable = $mailable;
+
+        if (Container::getInstance()->has('mailer')) {
+            $this->render();
+        }
+    }
+
+    public function seeInHtml()
+    {
+        return function ($needle) {
+            PHPUnit::assertStringContainsString(
+                $needle,
+                $this->html
+            );
+
+            return true;
+        };
+    }
+
+    public function dontSeeInHtml()
+    {
+        return function ($needle) {
+            PHPUnit::assertStringNotContainsString(
+                $needle,
+                $this->html
+            );
+
+            return true;
+        };
+    }
+
+    public function seeInText()
+    {
+        return function ($needle) {
+            PHPUnit::assertStringContainsString(
+                $needle,
+                $this->text
+            );
+
+            return true;
+        };
+    }
+
+    public function dontSeeInText()
+    {
+        return function ($needle) {
+            PHPUnit::assertStringNotContainsString(
+                $needle,
+                $this->text
+            );
+
+            return true;
+        };
+    }
+
+    protected function render()
+    {
+        [$view, $data] = $this->baseMailable->render();
+
+        if (! is_array($view)) {
+            $view = [$view];
+        }
+
+        // This array key preference logic is borrowed from Mailer class
+        $this->html = $this->renderView($view[0] ?? $view['html'] ?? null, $data);
+        $this->text = $this->renderView($view[1] ?? $view['text'] ?? null, $data);
+
+        return $this;
+    }
+
+    /**
+     * Render the given view.
+     *
+     * @param  string  $view
+     * @param  array  $data
+     * @return string
+     */
+    protected function renderView($view, $data)
+    {
+        return $view instanceof Htmlable
+            ? $view->toHtml()
+            : Container::getInstance()->make(Factory::class)->make($view, $data)->render();
+    }
+}

--- a/src/Illuminate/Testing/TestMailable.php
+++ b/src/Illuminate/Testing/TestMailable.php
@@ -4,11 +4,12 @@ namespace Illuminate\Testing;
 
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Contracts\View\Factory;
 use Illuminate\Mail\Mailable;
 use Illuminate\Testing\Assert as PHPUnit;
-use \Illuminate\Contracts\View\Factory;
 
-class TestMailable {
+class TestMailable
+{
     /**
      * The mailable to delegate to.
      *

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -204,11 +204,11 @@ class SupportTestingMailFakeTest extends TestCase
     {
         $viewFactory = m::mock(Factory::class);
         $view = m::mock(View::class);
-        $viewFactory->shouldReceive('make')->once()->andReturn($view);
-        $viewFactory->shouldReceive('flushFinderCache')->once();
-        $viewFactory->shouldReceive('replaceNamespace')->once()->andReturn($viewFactory);
+        $viewFactory->shouldReceive('make')->times(3)->andReturn($view);
+        $viewFactory->shouldReceive('flushFinderCache')->twice();
+        $viewFactory->shouldReceive('replaceNamespace')->twice()->andReturn($viewFactory);
         $viewFactory->shouldReceive('exists')->once()->andReturn(false);
-        $view->shouldReceive('render')->once()->andReturn('Hello Taylor');
+        $view->shouldReceive('render')->times(3)->andReturn('Hello Taylor');
 
         $this->fake->to('taylor@laravel.com')->send(new MarkdownMailableStub);
 
@@ -223,6 +223,11 @@ class SupportTestingMailFakeTest extends TestCase
 
             return true;
         });
+    }
+
+    protected function tearDown(): void
+    {
+        m::close();
     }
 }
 

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -178,7 +178,7 @@ class SupportTestingMailFakeTest extends TestCase
         });
     }
 
-    public function testRender()
+    public function testSeeInHtml()
     {
         $viewFactory = m::mock(Factory::class);
         $view = m::mock(View::class);
@@ -192,15 +192,11 @@ class SupportTestingMailFakeTest extends TestCase
         Container::getInstance()->instance(FactoryContract::class, $viewFactory);
 
         $this->fake->assertSent(function (MailableWithContentsStub $mail) {
-            $rendered = $mail->render();
-            $this->assertStringContainsString('Taylor HTML', $rendered['html']);
-            $this->assertStringContainsString('Taylor TEXT', $rendered['text']);
-
-            return true;
+            return $mail->seeInHtml('Taylor HTML') && $mail->seeInText('Taylor TEXT') && $mail->seeInHtml('Taylor HTML');
         });
     }
 
-    public function testRenderMarkdown()
+    public function testSeeInHtmlMarkdown()
     {
         $viewFactory = m::mock(Factory::class);
         $view = m::mock(View::class);
@@ -216,10 +212,7 @@ class SupportTestingMailFakeTest extends TestCase
         Container::getInstance()->instance(FactoryContract::class, $viewFactory);
 
         $this->fake->assertSent(function (MarkdownMailableStub $mail) {
-            $rendered = $mail->render();
-            $this->assertStringContainsString('Taylor</p>', $rendered['html']);
-            $this->assertStringContainsString('Taylor', $rendered['text']);
-            $this->assertStringNotContainsString('Taylor</p>', $rendered['text']);
+            return $mail->seeInHtml('Taylor</p>') && $mail->seeInText('Taylor') && $mail->dontSeeInText('Taylor</p>');
 
             return true;
         });

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -6,15 +6,15 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\Mail\Mailable as MailableContract;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Contracts\Translation\HasLocalePreference;
+use Illuminate\Contracts\View\Factory as FactoryContract;
 use Illuminate\Mail\Mailable;
 use Illuminate\Support\Testing\Fakes\MailFake;
-use Illuminate\Contracts\View\Factory as FactoryContract;
 use Illuminate\View\Factory;
 use Illuminate\View\View;
+use Mockery as m;
 use PHPUnit\Framework\Constraint\ExceptionMessage;
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
-use Mockery as m;
 
 class SupportTestingMailFakeTest extends TestCase
 {
@@ -195,6 +195,7 @@ class SupportTestingMailFakeTest extends TestCase
             $rendered = $mail->render();
             $this->assertStringContainsString('Taylor HTML', $rendered['html']);
             $this->assertStringContainsString('Taylor TEXT', $rendered['text']);
+
             return true;
         });
     }
@@ -219,6 +220,7 @@ class SupportTestingMailFakeTest extends TestCase
             $this->assertStringContainsString('Taylor</p>', $rendered['html']);
             $this->assertStringContainsString('Taylor', $rendered['text']);
             $this->assertStringNotContainsString('Taylor</p>', $rendered['text']);
+
             return true;
         });
     }


### PR DESCRIPTION
Another implementation of a previously submitted PR: https://github.com/laravel/framework/pull/35354

Currently, Laravel allows to make assertions about response contents, eg:

```php
    /**
     * @test
     */
    public function homepage_welcomes_users()
    {
        $this->get('/')->assertSee('Welcome');
    }
```

You can make assertions about API (JSON) output as well. However, there is no easy way to test email contents as a part of integration testing - MailFake is not equipped for it. Developers have several options:

* Extending Mailable class to "hijack" render() method
* Extending Mailer class to extend render() or send() methods
* Making assertions about data variables, rather than rendered output
* Testing views - writing test units that render specific views

With this pull request, I'm proposing that MailFake class decorates Mailables to allow developers to test their outgoing emails:

```php
    /**
     * @test
     */
    public function email_confirmation_is_correct()
    {
        Mail::fake();

        event(new TestEvent());
        config(['app.name' => 'Test App']);

        Mail::assertSent(TestMail::class, function (TestMail $mail) {
            return $mail->hasTo('test@test.com') && $mail->seeInHtml('shipped')
                && $mail->dontSeeInHtml('failed') && $mail->seeInText('Test App');
        });
    }
```

The job wasn't trivial - I tried to find a solution that has full backward compatibility, therefore `MailFake` still had to return user's own Mailable classes in closures - to account for developers who have type hints in there (just like the example above). Therefore, the only three options left were:

* Extend Mailable class to make it suitable for testing. Not ideal since we don't want any test-related logic in framework code
* Add Macroable trait to Mailable class so that it can be extended dynamically during testing. Mailable has a magic handler for methods starting with "with" and Macroable trait doesn't support masks/regular expressions at the moment
* Create a proxy class that extends given Mailable class, it should forward all function calls and pass all public properties in case the user is testing these, plus add a handful of testing-related methods on top: `seeInHtml()`, `seeInText()` and so on. This is the option that I chose as the least intrusive.

How it works in short:
```php
    // Before we return a Mailable from Mailfake as a part of a closure, we decorate that Mailable first
    protected function decorateMailable($mailable)
    {
        // We use Mockery to create a so-called proxy mock
        // This object will proxy all method calls to the original Mailable object
        $mock = m::mock($mailable);

        // It doesn't proxy properties, so we have to copy them over
        // We know that some developers make assertions about these
        foreach (get_object_vars($mailable) as $property => $value) {
            $mock->{$property} = $value;
        }

        // TestMailable is the class that implements assertions, it's designed after existing TestResponse class
        $renderer = new TestMailable($mailable);

        // Now we use Mockery again to dynamically add new methods - we copy them over from TestMailable
        // These methods will still be bound to TestMailable, even though launched from custom Mailable
        foreach (get_class_methods($renderer) as $method) {
            if (Str::startsWith($method, '__')) continue;
            $mock->shouldReceive($method)->andReturnUsing($renderer->{$method}());
        }

        return $mock;
    }
```


Extra remarks:

* There is a small amount of code repetition between TestMailable and Mailer classes, namely renderView method. I couldn't find a reasonable way to share that piece of code between the two

Would love to hear more opinions, I'm sure there must be more developers out there in the wild who wanted to test their email contents at some stage!