### PR TITLE
[8.x] Delay dispatching listeners until transaction commits

### DIFF
--- a/tests/Integration/Events/ListenerTest.php
+++ b/tests/Integration/Events/ListenerTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Events;
+
+use Illuminate\Events\CallQueuedListener;
+use Illuminate\Events\InvokeQueuedClosure;
+use function Illuminate\Events\queueable;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Event;
+use Mockery as m;
+use Orchestra\Testbench\TestCase;
+
+class ListenerTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        ListenerTestListener::$ran = false;
+        ListenerTestListenerAfterCommit::$ran = false;
+
+        m::close();
+    }
+
+    public function testClassListenerRunsNormallyIfNoTransactions()
+    {
+        $this->app->singleton('db.transactions', function () {
+            $transactionManager = m::mock(DatabaseTransactionsManager::class);
+            $transactionManager->shouldNotReceive('addCallback')->once()->andReturn(null);
+
+            return $transactionManager;
+        });
+
+        Event::listen(ListenerTestEvent::class, ListenerTestListener::class);
+
+        Event::dispatch(new ListenerTestEvent);
+
+        $this->assertTrue(ListenerTestListener::$ran);
+    }
+
+    public function testClassListenerDoesntRunInsideTransaction()
+    {
+        $this->app->singleton('db.transactions', function () {
+            $transactionManager = m::mock(DatabaseTransactionsManager::class);
+            $transactionManager->shouldReceive('addCallback')->once()->andReturn(null);
+
+            return $transactionManager;
+        });
+
+        Event::listen(ListenerTestEvent::class, ListenerTestListenerAfterCommit::class);
+
+        Event::dispatch(new ListenerTestEvent);
+
+        $this->assertFalse(ListenerTestListenerAfterCommit::$ran);
+    }
+}
+
+class ListenerTestEvent
+{
+    //
+}
+
+class ListenerTestListener
+{
+    public static $ran = false;
+
+    public function handle()
+    {
+        static::$ran = true;
+    }
+}
+
+class ListenerTestListenerAfterCommit
+{
+    public static $ran = false;
+
+    public $dispatchAfterCommit = true;
+
+    public function handle()
+    {
+        static::$ran = true;
+    }
+}
+

--- a/tests/Integration/Events/ListenerTest.php
+++ b/tests/Integration/Events/ListenerTest.php
@@ -2,10 +2,6 @@
 
 namespace Illuminate\Tests\Integration\Events;
 
-use Illuminate\Events\CallQueuedListener;
-use Illuminate\Events\InvokeQueuedClosure;
-use function Illuminate\Events\queueable;
-use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Event;
 use Mockery as m;
 use Orchestra\Testbench\TestCase;

--- a/tests/Integration/Events/ListenerTest.php
+++ b/tests/Integration/Events/ListenerTest.php
@@ -75,4 +75,3 @@ class ListenerTestListenerAfterCommit
         static::$ran = true;
     }
 }
-


### PR DESCRIPTION
This PR is similar to https://github.com/laravel/framework/pull/35422. It delays running listeners until transactions commit.

```php
DB::transaction(function(){
    $user = User::create(...);

   //...
});
```

Having a listener to the `UserCreated` event:

```php
class SendWelcomeEmail{
    public $disptachAfterCommit = true;

    public function handle(){
        // ...
    }
}
```

That listener will not run until after the transaction commits. If the transaction was rolledback, the listener will be discarded.