### PR TITLE
[8.x] Don't overwrite minute and hour when specifying a time with twiceMonthly()

### DIFF
--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -425,9 +425,7 @@ trait ManagesFrequencies
 
         $this->dailyAt($time);
 
-        return $this->spliceIntoPosition(1, 0)
-            ->spliceIntoPosition(2, 0)
-            ->spliceIntoPosition(3, $daysOfMonth);
+        return $this->spliceIntoPosition(3, $daysOfMonth);
     }
 
     /**

--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -103,10 +103,10 @@ class FrequencyTest extends TestCase
     {
         $this->assertSame('0 0 1,16 * *', $this->event->twiceMonthly(1, 16)->getExpression());
     }
-    
+
     public function testTwiceMonthlyAtTime()
     {
-        $this->assertSame('30 1 1,16 * *', $this->event->twiceMonthly(1, 16, "1:30")->getExpression());
+        $this->assertSame('30 1 1,16 * *', $this->event->twiceMonthly(1, 16, '1:30')->getExpression());
     }
 
     public function testMonthlyOnWithMinutes()

--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -103,6 +103,11 @@ class FrequencyTest extends TestCase
     {
         $this->assertSame('0 0 1,16 * *', $this->event->twiceMonthly(1, 16)->getExpression());
     }
+    
+    public function testTwiceMonthlyAtTime()
+    {
+        $this->assertSame('30 1 1,16 * *', $this->event->twiceMonthly(1, 16, "1:30")->getExpression());
+    }
 
     public function testMonthlyOnWithMinutes()
     {


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/35429