### PR TITLE
[8.x] Refactor enqueueUsing calls

### DIFF
--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -80,11 +80,15 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
      */
     public function push($job, $data = '', $queue = null)
     {
-        return $this->enqueueUsing($job, function () use ($job, $data, $queue) {
-            return $this->pushToDatabase($queue, $this->createPayload(
-                $job, $this->getQueue($queue), $data
-            ));
-        });
+        return $this->enqueueUsing(
+            $job,
+            $this->createPayload($job, $this->getQueue($queue), $data),
+            $queue,
+            null,
+            function ($payload, $queue) {
+                return $this->pushToDatabase($queue, $payload);
+            }
+        );
     }
 
     /**
@@ -111,11 +115,15 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
      */
     public function later($delay, $job, $data = '', $queue = null)
     {
-        return $this->enqueueUsing($job, function () use ($delay, $job, $data, $queue) {
-            return $this->pushToDatabase($queue, $this->createPayload(
-                $job, $this->getQueue($queue), $data
-            ), $delay);
-        });
+        return $this->enqueueUsing(
+            $job,
+            $this->createPayload($job, $this->getQueue($queue), $data),
+            $queue,
+            null,
+            function ($payload, $queue, $delay) {
+                return $this->pushToDatabase($queue, $payload, $delay);
+            }
+        );
     }
 
     /**

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -259,13 +259,16 @@ abstract class Queue
     /**
      * Enqueue a job using the given callback.
      *
-     * @param  callable  $callback
      * @param  \Closure|string|object  $job
+     * @param  string  $payload
+     * @param  string  $queue
+     * @param  \DateTimeInterface|\DateInterval|int|null  $delay
+     * @param  callable  $callback
      * @return mixed
      */
-    protected function enqueueUsing($job, $callback)
+    protected function enqueueUsing($job, $payload, $queue, $delay, $callback)
     {
-        return $callback();
+        return $callback($payload, $queue, $delay);
     }
 
     /**

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -108,9 +108,15 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
      */
     public function push($job, $data = '', $queue = null)
     {
-        return $this->enqueueUsing($job, function () use ($job, $data, $queue) {
-            return $this->pushRaw($this->createPayload($job, $this->getQueue($queue), $data), $queue);
-        });
+        return $this->enqueueUsing(
+            $job,
+            $this->createPayload($job, $this->getQueue($queue), $data),
+            $queue,
+            null,
+            function ($payload, $queue) {
+                return $this->pushRaw($payload, $queue);
+            }
+        );
     }
 
     /**
@@ -142,9 +148,15 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
      */
     public function later($delay, $job, $data = '', $queue = null)
     {
-        return $this->enqueueUsing($job, function () use ($delay, $job, $data, $queue) {
-            return $this->laterRaw($delay, $this->createPayload($job, $this->getQueue($queue), $data), $queue);
-        });
+        return $this->enqueueUsing(
+            $job,
+            $this->createPayload($job, $this->getQueue($queue), $data),
+            $queue,
+            $delay,
+            function ($payload, $queue, $delay) {
+                return $this->laterRaw($delay, $payload, $queue);
+            }
+        );
     }
 
     /**


### PR DESCRIPTION
This PR is a followup on https://github.com/laravel/framework/pull/35415

Basically we're passing all available arguments to `enqueueUsing` so we can inspect those arguments inside the method when needed.