### PR TITLE
[8.x] Make use of new PHP8 string functions

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -179,9 +179,17 @@ class Str
      */
     public static function contains($haystack, $needles)
     {
-        foreach ((array) $needles as $needle) {
-            if ($needle !== '' && mb_strpos($haystack, $needle) !== false) {
-                return true;
+        if (version_compare(PHP_VERSION, '8.0', '>=')) {
+            foreach ((array) $needles as $needle) {
+                if (str_contains($haystack, $needle)) {
+                    return true;
+                }
+            }
+        } else {
+            foreach ((array) $needles as $needle) {
+                if ($needle !== '' && mb_strpos($haystack, $needle) !== false) {
+                    return true;
+                }
             }
         }
 
@@ -215,9 +223,17 @@ class Str
      */
     public static function endsWith($haystack, $needles)
     {
-        foreach ((array) $needles as $needle) {
-            if ($needle !== '' && substr($haystack, -strlen($needle)) === (string) $needle) {
-                return true;
+        if (function_exists('str_ends_with')) {
+            foreach ((array) $needles as $needle) {
+                if (str_ends_with($haystack, $needle)) {
+                    return true;
+                }
+            }
+        } else {
+            foreach ((array) $needles as $needle) {
+                if ($needle !== '' && substr($haystack, -strlen($needle)) === (string) $needle) {
+                    return true;
+                }
             }
         }
 
@@ -652,9 +668,17 @@ class Str
      */
     public static function startsWith($haystack, $needles)
     {
-        foreach ((array) $needles as $needle) {
-            if ((string) $needle !== '' && strncmp($haystack, $needle, strlen($needle)) === 0) {
-                return true;
+        if (function_exists('str_starts_with')) {
+            foreach ((array) $needles as $needle) {
+                if (str_starts_with($haystack, $needle)) {
+                    return true;
+                }
+            }
+        } else {
+            foreach ((array) $needles as $needle) {
+                if ((string) $needle !== '' && strncmp($haystack, $needle, strlen($needle)) === 0) {
+                    return true;
+                }
             }
         }
 


### PR DESCRIPTION
In PHP 8, functions `str_starts_with()`, `str_ends_with()` and `str_contains()` were introduced. These are [considered superior](https://wiki.php.net/rfc/add_str_starts_with_and_ends_with_functions) to userland implementations.

This PR reimplements `Str::startsWith`, `Str::endsWith`, and `Str::contains` using the new built-in functions, while keeping backwards compatibility.

Note: in [laravel/helpers](https://github.com/laravel/helpers), function `str_contains()` is already defined.To avoid infinite recursion for users using PHP 7 and the helpers package, in this PR for  `Str::contains` PHP version is checked rather than the existence of `str_contains()`. 