### PR TITLE
[8.x] Increase min version of http-foundation to fix ConvertEmptyStringsToNull middleware on PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "symfony/console": "^5.1",
         "symfony/error-handler": "^5.1",
         "symfony/finder": "^5.1",
-        "symfony/http-foundation": "^5.1",
+        "symfony/http-foundation": "^5.1.3",
         "symfony/http-kernel": "^5.1",
         "symfony/mime": "^5.1",
         "symfony/process": "^5.1",

--- a/tests/Foundation/Http/Middleware/ConvertEmptyStringsToNullTest.php
+++ b/tests/Foundation/Http/Middleware/ConvertEmptyStringsToNullTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Http\Middleware;
+
+use Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull;
+use Illuminate\Http\Request;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
+
+class ConvertEmptyStringsToNullTest extends TestCase
+{
+    public function testConvertsEmptyStringsToNull()
+    {
+        $middleware = new ConvertEmptyStringsToNull();
+        $symfonyRequest = new SymfonyRequest([
+            'foo' => 'bar',
+            'baz' => '',
+        ]);
+        $symfonyRequest->server->set('REQUEST_METHOD', 'GET');
+        $request = Request::createFromBase($symfonyRequest);
+
+        $middleware->handle($request, function (Request $request) {
+            $this->assertSame('bar', $request->get('foo'));
+            $this->assertNull($request->get('bar'));
+        });
+    }
+}


### PR DESCRIPTION
Excuse the wordy title.

The `ConvertEmptyStringsToNull` middleware fails within `symfony/http-foundation` on PHP 8. It didn't have a test, so I've added one. It's been fixed in 5.1.3.

This PR only contains the test at the moment so I can see the suite fail. I'll push the fix in a moment.