### PR TITLE
[8.x] Add implicit binding test

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -84,7 +84,7 @@
         "guzzlehttp/guzzle": "^6.5.5|^7.0.1",
         "league/flysystem-cached-adapter": "^1.0",
         "mockery/mockery": "^1.4.2",
-        "orchestra/testbench-core": "^6.5",
+        "orchestra/testbench-core": "^6.8",
         "pda/pheanstalk": "^4.0",
         "phpunit/phpunit": "^8.5.8|^9.3.3",
         "predis/predis": "^1.1.1",

--- a/tests/Integration/Routing/ImplicitBindingTest.php
+++ b/tests/Integration/Routing/ImplicitBindingTest.php
@@ -5,10 +5,27 @@ namespace Illuminate\Tests\Integration\Routing;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Orchestra\Testbench\Concerns\InteractsWithPublishedFiles;
 use Orchestra\Testbench\TestCase;
 
 class ImplicitBindingTest extends TestCase
 {
+    use InteractsWithPublishedFiles;
+
+    protected $files = [
+        'routes/testbench.php',
+    ];
+
+    /**
+     * Teardown the test environment.
+     */
+    protected function tearDown(): void
+    {
+        $this->tearDownInteractsWithPublishedFiles();
+
+        parent::tearDown();
+    }
+
     protected function defineEnvironment($app)
     {
         $app['config']->set('app.debug', 'true');
@@ -50,7 +67,11 @@ PHP;
 
         $this->artisan('route:cache')->run();
 
-        $this->reloadApplicationWithCachedRoutes();
+        $this->reloadApplication();
+
+        $this->assertFilenameExists('bootstrap/cache/routes-v7.php');
+
+        $this->requireApplicationCachedRoutes();
 
         $user = ImplicitBindingModel::create(['name' => 'Dries']);
 

--- a/tests/Integration/Routing/ImplicitBindingTest.php
+++ b/tests/Integration/Routing/ImplicitBindingTest.php
@@ -4,7 +4,6 @@ namespace Illuminate\Tests\Integration\Routing;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Schema;
 use Orchestra\Testbench\TestCase;
@@ -43,15 +42,15 @@ class ImplicitBindingTest extends TestCase
             dd($user);
 
             return $user;
-        });
+        })->middleware('web');
 
-        // Artisan::call('route:cache');
+        $this->artisan('route:cache')->run();
 
         $response = $this->post("/user/{$user->id}");
 
         $this->assertSame($user->toJson(), $response->content());
 
-        Artisan::call('route:clear');
+        $this->artisan('route:clear')->run();
     }
 }
 

--- a/tests/Integration/Routing/ImplicitBindingTest.php
+++ b/tests/Integration/Routing/ImplicitBindingTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Routing;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\Schema;
+use Orchestra\Testbench\TestCase;
+
+class ImplicitBindingTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('app.debug', 'true');
+
+        $app['config']->set('database.default', 'testbench');
+
+        $app['config']->set('database.connections.testbench', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+
+    public function testPreviousUrlWithoutSession()
+    {
+        $user = ImplicitBindingModel::create(['name' => 'Dries']);
+
+        Route::post('/user/{user}', function (ImplicitBindingModel $user) {
+            dd($user);
+
+            return $user;
+        });
+
+        // Artisan::call('route:cache');
+
+        $response = $this->post("/user/{$user->id}");
+
+        $this->assertSame($user->toJson(), $response->content());
+
+        Artisan::call('route:clear');
+    }
+}
+
+class ImplicitBindingModel extends Model
+{
+    public $table = 'users';
+
+    protected $fillable = ['name'];
+}

--- a/tests/Integration/Routing/ImplicitBindingTest.php
+++ b/tests/Integration/Routing/ImplicitBindingTest.php
@@ -4,7 +4,6 @@ namespace Illuminate\Tests\Integration\Routing;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Schema;
 use Orchestra\Testbench\TestCase;
 
@@ -38,7 +37,7 @@ class ImplicitBindingTest extends TestCase
 
     public function testPreviousUrlWithoutSession()
     {
-            $route = <<<PHP
+        $route = <<<PHP
 <?php
 
 use Illuminate\Tests\Integration\Routing\ImplicitBindingModel;

--- a/tests/Integration/Routing/ImplicitBindingTest.php
+++ b/tests/Integration/Routing/ImplicitBindingTest.php
@@ -52,7 +52,7 @@ class ImplicitBindingTest extends TestCase
         });
     }
 
-    public function testPreviousUrlWithoutSession()
+    public function testImplicitModelBindingWithRouteCachingEnabled()
     {
         $route = <<<PHP
 <?php

--- a/tests/Integration/Routing/ImplicitRouteBindingTest.php
+++ b/tests/Integration/Routing/ImplicitRouteBindingTest.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Facades\Schema;
 use Orchestra\Testbench\Concerns\InteractsWithPublishedFiles;
 use Orchestra\Testbench\TestCase;
 
-class ImplicitBindingTest extends TestCase
+class ImplicitRouteBindingTest extends TestCase
 {
     use InteractsWithPublishedFiles;
 
@@ -52,7 +52,7 @@ class ImplicitBindingTest extends TestCase
         });
     }
 
-    public function testImplicitModelBindingWithRouteCachingEnabled()
+    public function testWithRouteCachingEnabled()
     {
         $route = <<<PHP
 <?php
@@ -63,6 +63,7 @@ Route::post('/user/{user}', function (ImplicitBindingModel \$user) {
     return \$user;
 })->middleware('web');
 PHP;
+
         file_put_contents(base_path('routes/testbench.php'), $route);
 
         $this->artisan('route:cache')->run();


### PR DESCRIPTION
This PR adds an integration test for https://github.com/laravel/framework/commit/eb3e262c870739a6e9705b851e0066b3473eed2b

Thanks to @crynobone we can now cache routes in tests through Orchestra. There's plan to improving the syntax for this in the near future but for now this is fine for this test.