### PR TITLE
[8.x] Added orderPivotBy for BelongsToMany relation

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -557,6 +557,18 @@ class BelongsToMany extends Relation
     }
 
     /**
+     * Add an "order by" clause for a pivot table column.
+     *
+     * @param  string  $column
+     * @param  string  $direction
+     * @return $this
+     */
+    public function orderPivotBy($column, $direction = 'asc')
+    {
+        return $this->orderBy($this->qualifyPivotColumn($column), $direction);
+    }
+
+    /**
      * Find a related model by its primary key or return new instance of the related model.
      *
      * @param  mixed  $id

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -905,6 +905,28 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $user->postsWithCustomPivot()->updateExistingPivot($post2->uuid, ['is_draft' => 0]);
         $this->assertEquals(0, $user->postsWithCustomPivot()->first()->pivot->is_draft);
     }
+
+    public function testOrderPivotByMethod()
+    {
+        $tag1 = Tag::create(['name' => Str::random()]);
+        $tag2 = Tag::create(['name' => Str::random()]);
+        $tag3 = Tag::create(['name' => Str::random()]);
+        $tag4 = Tag::create(['name' => Str::random()]);
+        $post = Post::create(['title' => Str::random()]);
+
+        DB::table('posts_tags')->insert([
+            ['post_id' => $post->id, 'tag_id' => $tag1->id, 'flag' => 'foo3'],
+            ['post_id' => $post->id, 'tag_id' => $tag2->id, 'flag' => 'foo1'],
+            ['post_id' => $post->id, 'tag_id' => $tag3->id, 'flag' => 'foo4'],
+            ['post_id' => $post->id, 'tag_id' => $tag4->id, 'flag' => 'foo2'],
+        ]);
+
+        $relationTag1 = $post->tagsWithCustomExtraPivot()->orderPivotBy('flag', 'asc')->first();
+        $this->assertEquals($relationTag1->getAttributes(), $tag2->getAttributes());
+
+        $relationTag2 = $post->tagsWithCustomExtraPivot()->orderPivotBy('flag', 'desc')->first();
+        $this->assertEquals($relationTag2->getAttributes(), $tag3->getAttributes());
+    }
 }
 
 class User extends Model


### PR DESCRIPTION
This PR will allow us to directly order the query results of BelongsToMany relation such as:
```php
class Tag extends Model
{
    public $table = 'tags';
}

class Post extends Model
{
    public $table = 'posts';

    public function tags()
    {
        return $this->belongsToMany(Tag::class, 'posts_tags', 'post_id', 'tag_id')
            ->using(PostTagPivot::class)
            ->withTimestamps()
            ->withPivot('flag');
    }
}

class PostTagPivot extends Pivot
{
    protected $table = 'posts_tags';
}

// Somewhere in a controller
public function getPostTags($id)
{
    return Post::findOrFail($id)->tags()->orderPivotBy('flag', 'desc')->get();
}
```
Using `orderPivotBy` will allow us to not having to append the `Tag` class table name explicitly in case the `flag` attribute exists in both `Tag` and `PostTagPivot`. The results will be ordered based on `flag` value.

Note: I will also make a PR for [7.x] branch