### PR TITLE
[9.x] Address confusion between PostgreSQL concepts "schema" and "search_path"

### DIFF
--- a/src/Illuminate/Database/Connectors/PostgresConnector.php
+++ b/src/Illuminate/Database/Connectors/PostgresConnector.php
@@ -40,7 +40,7 @@ class PostgresConnector extends Connector implements ConnectorInterface
         // database. Setting this DB timezone is an optional configuration item.
         $this->configureTimezone($connection, $config);
 
-        $this->configureSchema($connection, $config);
+        $this->configureSearchPath($connection, $config);
 
         // Postgres allows an application_name to be set by the user and this name is
         // used to when monitoring the application with pg_stat_activity. So we'll
@@ -85,34 +85,34 @@ class PostgresConnector extends Connector implements ConnectorInterface
     }
 
     /**
-     * Set the schema on the connection.
+     * Set the search_path on the connection.
      *
      * @param  \PDO  $connection
      * @param  array  $config
      * @return void
      */
-    protected function configureSchema($connection, $config)
+    protected function configureSearchPath($connection, $config)
     {
-        if (isset($config['schema'])) {
-            $schema = $this->formatSchema($config['schema']);
+        if (isset($config['search_path']) || isset($config['schema'])) {
+            $searchPath = $this->formatSearchPath($config['search_path'] ?? $config['schema']);
 
-            $connection->prepare("set search_path to {$schema}")->execute();
+            $connection->prepare("set search_path to {$searchPath}")->execute();
         }
     }
 
     /**
-     * Format the schema for the DSN.
+     * Format the search path for the DSN.
      *
-     * @param  array|string  $schema
+     * @param  array|string  $searchPath
      * @return string
      */
-    protected function formatSchema($schema)
+    protected function formatSearchPath($searchPath)
     {
-        if (is_array($schema)) {
-            return '"'.implode('", "', $schema).'"';
+        if (is_array($searchPath)) {
+            return '"'.implode('", "', $searchPath).'"';
         }
 
-        return '"'.$schema.'"';
+        return '"'.$searchPath.'"';
     }
 
     /**

--- a/src/Illuminate/Database/Connectors/PostgresConnector.php
+++ b/src/Illuminate/Database/Connectors/PostgresConnector.php
@@ -112,7 +112,8 @@ class PostgresConnector extends Connector implements ConnectorInterface
             return '"'.implode('", "', $searchPath).'"';
         }
 
-        return '"'.$searchPath.'"';
+        preg_match_all('/[a-zA-z0-9]{1,}/i', $searchPath, $matches);
+        return '"'.implode('", "', $matches[0]).'"';
     }
 
     /**

--- a/src/Illuminate/Database/Connectors/PostgresConnector.php
+++ b/src/Illuminate/Database/Connectors/PostgresConnector.php
@@ -112,7 +112,7 @@ class PostgresConnector extends Connector implements ConnectorInterface
             return '"'.implode('", "', $searchPath).'"';
         }
 
-        preg_match_all('/[a-zA-z0-9]{1,}/i', $searchPath, $matches);
+        preg_match_all('/[a-zA-z0-9$]{1,}/i', $searchPath, $matches);
         return '"'.implode('", "', $matches[0]).'"';
     }
 

--- a/src/Illuminate/Database/Connectors/PostgresConnector.php
+++ b/src/Illuminate/Database/Connectors/PostgresConnector.php
@@ -93,8 +93,8 @@ class PostgresConnector extends Connector implements ConnectorInterface
      */
     protected function configureSearchPath($connection, $config)
     {
-        if (isset($config['search_path']) || isset($config['schema'])) {
-            $searchPath = $this->formatSearchPath($config['search_path'] ?? $config['schema']);
+        if (isset($config['search_path'])) {
+            $searchPath = $this->formatSearchPath($config['search_path']);
 
             $connection->prepare("set search_path to {$searchPath}")->execute();
         }
@@ -109,15 +109,16 @@ class PostgresConnector extends Connector implements ConnectorInterface
     protected function formatSearchPath($searchPath)
     {
         if (is_array($searchPath)) {
-            return '"'.implode('", "', $searchPath).'"';
+            $searchPath = '"'.implode('", "', $searchPath).'"';
         }
 
         preg_match_all('/[a-zA-z0-9$]{1,}/i', $searchPath, $matches);
+
         return '"'.implode('", "', $matches[0]).'"';
     }
 
     /**
-     * Set the schema on the connection.
+     * Set the application name on the connection.
      *
      * @param  \PDO  $connection
      * @param  array  $config

--- a/src/Illuminate/Database/Schema/PostgresBuilder.php
+++ b/src/Illuminate/Database/Schema/PostgresBuilder.php
@@ -164,12 +164,12 @@ class PostgresBuilder extends Builder
     {
         $table = explode('.', $table);
 
-        if (is_array($schema = $this->connection->getConfig('schema'))) {
-            if (in_array($table[0], $schema)) {
+        if (is_array($searchPath = $this->connection->getConfig('search_path'))) {
+            if (in_array($table[0], $searchPath)) {
                 return [array_shift($table), implode('.', $table)];
             }
 
-            $schema = head($schema);
+            $schema = head($searchPath);
         }
 
         return [$schema ?: 'public', implode('.', $table)];

--- a/tests/Database/DatabaseConnectorTest.php
+++ b/tests/Database/DatabaseConnectorTest.php
@@ -133,6 +133,22 @@ class DatabaseConnectorTest extends TestCase
         $this->assertSame($result, $connection);
     }
 
+    public function testPostgresSearchPathVariablesSupported()
+    {
+        $dsn = 'pgsql:host=foo;dbname=bar';
+        $config = ['host' => 'foo', 'database' => 'bar', 'schema' => '$user, public, user', 'charset' => 'utf8'];
+        $connector = $this->getMockBuilder('Illuminate\Database\Connectors\PostgresConnector')->setMethods(['createConnection', 'getOptions'])->getMock();
+        $connection = m::mock('stdClass');
+        $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->will($this->returnValue(['options']));
+        $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->will($this->returnValue($connection));
+        $connection->shouldReceive('prepare')->once()->with('set names \'utf8\'')->andReturn($connection);
+        $connection->shouldReceive('prepare')->once()->with('set search_path to "$user", "public", "user"')->andReturn($connection);
+        $connection->shouldReceive('execute')->twice();
+        $result = $connector->connect($config);
+
+        $this->assertSame($result, $connection);
+    }
+
     public function testPostgresApplicationNameIsSet()
     {
         $dsn = 'pgsql:host=foo;dbname=bar';

--- a/tests/Database/DatabaseConnectorTest.php
+++ b/tests/Database/DatabaseConnectorTest.php
@@ -117,6 +117,22 @@ class DatabaseConnectorTest extends TestCase
         $this->assertSame($result, $connection);
     }
 
+    public function testPostgresSearchPathCommaSeparatedValueSupported()
+    {
+        $dsn = 'pgsql:host=foo;dbname=bar';
+        $config = ['host' => 'foo', 'database' => 'bar', 'schema' => 'public, user', 'charset' => 'utf8'];
+        $connector = $this->getMockBuilder('Illuminate\Database\Connectors\PostgresConnector')->setMethods(['createConnection', 'getOptions'])->getMock();
+        $connection = m::mock('stdClass');
+        $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->will($this->returnValue(['options']));
+        $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->will($this->returnValue($connection));
+        $connection->shouldReceive('prepare')->once()->with('set names \'utf8\'')->andReturn($connection);
+        $connection->shouldReceive('prepare')->once()->with('set search_path to "public", "user"')->andReturn($connection);
+        $connection->shouldReceive('execute')->twice();
+        $result = $connector->connect($config);
+
+        $this->assertSame($result, $connection);
+    }
+
     public function testPostgresApplicationNameIsSet()
     {
         $dsn = 'pgsql:host=foo;dbname=bar';

--- a/tests/Database/DatabaseConnectorTest.php
+++ b/tests/Database/DatabaseConnectorTest.php
@@ -88,7 +88,7 @@ class DatabaseConnectorTest extends TestCase
     public function testPostgresSearchPathIsSet()
     {
         $dsn = 'pgsql:host=foo;dbname=bar';
-        $config = ['host' => 'foo', 'database' => 'bar', 'schema' => 'public', 'charset' => 'utf8'];
+        $config = ['host' => 'foo', 'database' => 'bar', 'search_path' => 'public', 'charset' => 'utf8'];
         $connector = $this->getMockBuilder(PostgresConnector::class)->onlyMethods(['createConnection', 'getOptions'])->getMock();
         $connection = m::mock(stdClass::class);
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
@@ -104,7 +104,7 @@ class DatabaseConnectorTest extends TestCase
     public function testPostgresSearchPathArraySupported()
     {
         $dsn = 'pgsql:host=foo;dbname=bar';
-        $config = ['host' => 'foo', 'database' => 'bar', 'schema' => ['public', 'user'], 'charset' => 'utf8'];
+        $config = ['host' => 'foo', 'database' => 'bar', 'search_path' => ['public', '"user"'], 'charset' => 'utf8'];
         $connector = $this->getMockBuilder(PostgresConnector::class)->onlyMethods(['createConnection', 'getOptions'])->getMock();
         $connection = m::mock(stdClass::class);
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
@@ -120,7 +120,7 @@ class DatabaseConnectorTest extends TestCase
     public function testPostgresSearchPathCommaSeparatedValueSupported()
     {
         $dsn = 'pgsql:host=foo;dbname=bar';
-        $config = ['host' => 'foo', 'database' => 'bar', 'schema' => 'public, user', 'charset' => 'utf8'];
+        $config = ['host' => 'foo', 'database' => 'bar', 'search_path' => 'public, "user"', 'charset' => 'utf8'];
         $connector = $this->getMockBuilder('Illuminate\Database\Connectors\PostgresConnector')->setMethods(['createConnection', 'getOptions'])->getMock();
         $connection = m::mock('stdClass');
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->will($this->returnValue(['options']));
@@ -136,7 +136,7 @@ class DatabaseConnectorTest extends TestCase
     public function testPostgresSearchPathVariablesSupported()
     {
         $dsn = 'pgsql:host=foo;dbname=bar';
-        $config = ['host' => 'foo', 'database' => 'bar', 'schema' => '$user, public, user', 'charset' => 'utf8'];
+        $config = ['host' => 'foo', 'database' => 'bar', 'search_path' => '"$user", public, user', 'charset' => 'utf8'];
         $connector = $this->getMockBuilder('Illuminate\Database\Connectors\PostgresConnector')->setMethods(['createConnection', 'getOptions'])->getMock();
         $connection = m::mock('stdClass');
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->will($this->returnValue(['options']));


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This PR is intended to fulfill the objectives described in https://github.com/laravel/ideas/issues/918 , as they apply to this repository (related changes may be needed in `laravel/laravel`).

In short, this PR replaces the PostgreSQL term "schema" with "search_path". While related and conceptually similar, there is a crucial distinction to be made between the two, which I describe exhaustively in the above-cited post.

Beyond the terminology corrections, we have also sought to fix a significant limitation whereby a `search_path` that contains more than one schema cannot be specified as a string, e.g., via the effective environment (i.e., an `.env` file or similar) because the implementation does not parse and quote the specified value correctly.

Finally, we have added several new tests to ensure complete consistency in how the `search_path` value is passed on to PostgreSQL, regardless of whether the value is specified as:

- a string that contains only one schema (with or without double-quotes around the schema)
- a comma-separated string that contains more than one schema (with or without double-quotes around each schema)
- an array that contains any number of schemas (with or without double-quotes around each schema)
- any of the above variations, but with variable notation, e.g., the schema name begins with a `$` sign

At this juncture, I am unaware of any other valid `search_path` syntax that could possibly need to be supported.

~~Also, per https://github.com/laravel/ideas/issues/918 , @mfn had expressed an interest in completely expunging the term "schema" from Laravel's lexicon in relation to this issue, with which I more or less agree. However, I left the reference in the `configureSearchPath()` method so as to provide backwards compatibility, which makes sense only if this can be merged into the `8.x` branch. If the changes are already breaking, then I agree that we should completely expunge "schema" and target the next major release, at which time we should also update the default configuration array in https://github.com/laravel/laravel/blob/8.x/config/database.php (by replacing `schema` with `search_path`), and update any affected documentation, if any actually exists (I have yet to see any description of PostgreSQL's `schema`/`search_path` directive, or what format it should take when specified in Laravel's database configuration).~~

(UPDATE: This is breaking, so I expunged the incorrect terminology everywhere, with no concern for preserving BC with regard to the database connection configuration key name.)

~~I'm looking for some guidance from @taylorotwell or whomever else may be qualified in this regard.~~ (UPDATE: driesvints already addressed this.)

Finally, @mfn , you had noted one other method that may be affected, in https://github.com/laravel/framework/pull/22414#issuecomment-352210544 , and I'll take a look at that, as well as address any of your other lingering concerns from the previous PR, before taking this out of Draft mode.

Thank you!