### PR TITLE
[8.x] Improve functionality of queued listeners

### DIFF
--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -504,14 +504,14 @@ class Dispatcher implements DispatcherContract
     /**
      * Queue the handler class.
      *
-     * @param  object  $instance
+     * @param  object  $listener
      * @param  string  $method
      * @param  array  $arguments
      * @return void
      */
-    protected function queueHandler($instance, $method, $arguments)
+    protected function queueHandler($listener, $method, $arguments)
     {
-        [$listener, $job] = $this->createJob($instance, $method, $arguments);
+        $job = $this->createJob($listener, $method, $arguments);
 
         $connection = $this->resolveQueue()->connection(
             $listener->connection ?? null
@@ -532,13 +532,13 @@ class Dispatcher implements DispatcherContract
      * @param  object  $listener
      * @param  string  $method
      * @param  array  $arguments
-     * @return array
+     * @return mixed
      */
     protected function createJob($listener, $method, $arguments)
     {
-        return [$listener, $this->propagateListenerOptions(
+        return $this->propagateListenerOptions(
             $listener, new CallQueuedListener(get_class($listener), $method, $arguments)
-        )];
+        );
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -21,6 +21,20 @@ class QueueFake extends QueueManager implements Queue
     protected $jobs = [];
 
     /**
+     * Connection name which was taken from the queued listener.
+     *
+     * @var string|null
+     */
+    protected $selectedQueuedListenerConnection = null;
+
+    /**
+     * Delay value which was taken from the queued listener.
+     *
+     * @var int|null
+     */
+    protected $selectedQueuedListenerDelay = null;
+
+    /**
      * Assert if a job was pushed based on a truth-test callback.
      *
      * @param  string|\Closure  $job
@@ -203,6 +217,30 @@ class QueueFake extends QueueManager implements Queue
     }
 
     /**
+     * @param string $expectedConnection
+     */
+    public function assertQueuedListenerConnectionWas(string $expectedConnection): void
+    {
+        PHPUnit::assertEquals(
+            $expectedConnection,
+            $this->selectedQueuedListenerConnection,
+            "The last queued listener expected connection was [{$this->selectedQueuedListenerConnection}]"
+        );
+    }
+
+    /**
+     * @param int $expectedDelay
+     */
+    public function assertQueuedListenerDelayWas(int $expectedDelay): void
+    {
+        PHPUnit::assertEquals(
+            $expectedDelay,
+            $this->selectedQueuedListenerDelay,
+            "The last queued listener expected delay was [{$this->selectedQueuedListenerDelay}]"
+        );
+    }
+
+    /**
      * Assert that no jobs were pushed.
      *
      * @return void
@@ -253,6 +291,8 @@ class QueueFake extends QueueManager implements Queue
      */
     public function connection($value = null)
     {
+        $this->selectedQueuedListenerConnection = $value;
+
         return $this;
     }
 
@@ -336,6 +376,8 @@ class QueueFake extends QueueManager implements Queue
      */
     public function laterOn($queue, $delay, $job, $data = '')
     {
+        $this->selectedQueuedListenerDelay = $delay;
+
         return $this->push($job, $data, $queue);
     }
 

--- a/tests/Events/QueuedEventsTest.php
+++ b/tests/Events/QueuedEventsTest.php
@@ -66,6 +66,31 @@ class QueuedEventsTest extends TestCase
 
         $fakeQueue->assertPushedOn('some_other_queue', CallQueuedListener::class);
     }
+
+    public function testQueueOptionsWereTakenFromConstructor()
+    {
+        $dispatcher = new Dispatcher();
+
+        $fakeQueue = new QueueFake(new Container());
+
+        $dispatcher->setQueueResolver(function () use ($fakeQueue): QueueFake {
+            return $fakeQueue;
+        });
+
+        $dispatcher->listen('some.event', TestEventListenerWithQueueOptionsDeclaredInTheConstructor::class);
+        $dispatcher->dispatch('some.event', ['foo', 'bar']);
+
+        $fakeQueue->assertPushedOn('constructor_queue', CallQueuedListener::class);
+        $fakeQueue->assertQueuedListenerConnectionWas('constructor_connection');
+        $fakeQueue->assertQueuedListenerDelayWas(3600 * 200);
+
+        $dispatcher->listen('some.event', TestEventListenerWithQueueOptionsDeclaredWithinProperties::class);
+        $dispatcher->dispatch('some.event', ['foo', 'bar']);
+
+        $fakeQueue->assertPushedOn('property_queue', CallQueuedListener::class);
+        $fakeQueue->assertQueuedListenerConnectionWas('property_connection');
+        $fakeQueue->assertQueuedListenerDelayWas(3600 * 80);
+    }
 }
 
 class TestDispatcherQueuedHandler implements ShouldQueue
@@ -102,5 +127,36 @@ class TestDispatcherGetQueue implements ShouldQueue
     public function viaQueue()
     {
         return 'some_other_queue';
+    }
+}
+
+class TestEventListenerWithQueueOptionsDeclaredInTheConstructor implements ShouldQueue
+{
+    public $queue = 'property_queue';
+    public $connection = 'property_connection';
+    public $delay = 3600 * 80;
+
+    public function __construct()
+    {
+        $this->queue = 'constructor_queue';
+        $this->connection = 'constructor_connection';
+        $this->delay = 3600 * 200;
+    }
+
+    public function handle()
+    {
+        //
+    }
+}
+
+class TestEventListenerWithQueueOptionsDeclaredWithinProperties implements ShouldQueue
+{
+    public $queue = 'property_queue';
+    public $connection = 'property_connection';
+    public $delay = 3600 * 80;
+
+    public function handle()
+    {
+        //
     }
 }


### PR DESCRIPTION
Now event dispatcher's behavior for queued listener looks a bit strange: when it creates the job for queued listener dispatcher looks just for properties which being set outside the constructor - connection, queue, delay, etc. Of course it work such because it creates a instance for listener without a constructor call (through reflection), but is incorrect, because listener's instance already has been created when `Dispatcher::handlerWantsToBeQueued` method was called:

```php
protected function createClassCallable($listener)
{
     [$class, $method] = $this->parseClassCallable($listener);

     if ($this->handlerShouldBeQueued($class)) {
         return $this->createQueuedHandlerCallable($class, $method);
     }

     return [$this->container->make($class), $method];
}
```

A listener should be queued, go further:

```php
protected function createQueuedHandlerCallable($class, $method)
{
     return function () use ($class, $method) {
            $arguments = array_map(function ($a) {
                return is_object($a) ? clone $a : $a;
            }, func_get_args());

            $instance = $this->container->make($class);

            if ($this->handlerWantsToBeQueued($instance, $arguments)) {
                $this->queueHandler($instance, $method, $arguments);
            }
        };
 }
```

And when dispatcher calls `handlerWantsToBeQueued` method it created a full fledged instance for listener:

```php
protected function handlerWantsToBeQueued($class, $arguments)
    {
        $instance = $this->container->make($class);

        if (method_exists($instance, 'shouldQueue')) {
            return $instance->shouldQueue($arguments[0]);
        }

        return true;
    }
``` 

But in `queueHandler` it also create an another instance but now without a constructor and without a container, thats why if we try to define connection, queue and other job options in constructor we will lose. 

```php
protected function createListenerAndJob($class, $method, $arguments)
    {
        $listener = (new ReflectionClass($class))->newInstanceWithoutConstructor();

        return [$listener, $this->propagateListenerOptions(
            $listener, new CallQueuedListener($class, $method, $arguments)
        )];
    }
```

But for me and, i guess, for many other developers it may be useful to choose job options depend on environment  and with constructor this work perfectly. I changed this behavior on PR.