### PR TITLE
[9.x] Improve event dispatcher capabilities

### DIFF
--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -494,8 +494,10 @@ class Dispatcher implements DispatcherContract
                 return is_object($a) ? clone $a : $a;
             }, func_get_args());
 
-            if ($this->handlerWantsToBeQueued($class, $arguments)) {
-                $this->queueHandler($class, $method, $arguments);
+            $instance = $this->container->make($class);
+
+            if ($this->handlerWantsToBeQueued($instance, $arguments)) {
+                $this->queueHandler($instance, $method, $arguments);
             }
         };
     }
@@ -503,14 +505,12 @@ class Dispatcher implements DispatcherContract
     /**
      * Determine if the event handler wants to be queued.
      *
-     * @param  string  $class
+     * @param  object $instance
      * @param  array  $arguments
      * @return bool
      */
-    protected function handlerWantsToBeQueued($class, $arguments)
+    protected function handlerWantsToBeQueued($instance, $arguments)
     {
-        $instance = $this->container->make($class);
-
         if (method_exists($instance, 'shouldQueue')) {
             return $instance->shouldQueue($arguments[0]);
         }
@@ -521,14 +521,14 @@ class Dispatcher implements DispatcherContract
     /**
      * Queue the handler class.
      *
-     * @param  string  $class
+     * @param  object  $listener
      * @param  string  $method
      * @param  array  $arguments
      * @return void
      */
-    protected function queueHandler($class, $method, $arguments)
+    protected function queueHandler($listener, $method, $arguments)
     {
-        [$listener, $job] = $this->createListenerAndJob($class, $method, $arguments);
+        $job = $this->createJob($listener, $method, $arguments);
 
         $connection = $this->resolveQueue()->connection(
             $listener->connection ?? null
@@ -544,20 +544,18 @@ class Dispatcher implements DispatcherContract
     }
 
     /**
-     * Create the listener and job for a queued listener.
+     * Create the job for a queued listener.
      *
-     * @param  string  $class
+     * @param  object  $listener
      * @param  string  $method
      * @param  array  $arguments
-     * @return array
+     * @return mixed
      */
-    protected function createListenerAndJob($class, $method, $arguments)
+    protected function createJob($listener, $method, $arguments)
     {
-        $listener = (new ReflectionClass($class))->newInstanceWithoutConstructor();
-
-        return [$listener, $this->propagateListenerOptions(
-            $listener, new CallQueuedListener($class, $method, $arguments)
-        )];
+        return $this->propagateListenerOptions(
+            $listener, new CallQueuedListener(get_class($listener), $method, $arguments)
+        );
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -21,6 +21,20 @@ class QueueFake extends QueueManager implements Queue
     protected $jobs = [];
 
     /**
+     * Connection name which was taken from the queued listener.
+     *
+     * @var string|null
+     */
+    protected $selectedQueuedListenerConnection = null;
+
+    /**
+     * Delay value which was taken from the queued listener.
+     *
+     * @var int|null
+     */
+    protected $selectedQueuedListenerDelay = null;
+
+    /**
      * Assert if a job was pushed based on a truth-test callback.
      *
      * @param  string|\Closure  $job
@@ -213,6 +227,30 @@ class QueueFake extends QueueManager implements Queue
     }
 
     /**
+     * @param string $expectedConnection
+     */
+    public function assertQueuedListenerConnectionWas(string $expectedConnection): void
+    {
+        PHPUnit::assertEquals(
+            $expectedConnection,
+            $this->selectedQueuedListenerConnection,
+            "The last queued listener expected connection was [{$this->selectedQueuedListenerConnection}]"
+        );
+    }
+
+    /**
+     * @param int $expectedDelay
+     */
+    public function assertQueuedListenerDelayWas(int $expectedDelay): void
+    {
+        PHPUnit::assertEquals(
+            $expectedDelay,
+            $this->selectedQueuedListenerDelay,
+            "The last queued listener expected delay was [{$this->selectedQueuedListenerDelay}]"
+        );
+    }
+
+    /**
      * Get all of the jobs matching a truth-test callback.
      *
      * @param  string  $job
@@ -253,6 +291,8 @@ class QueueFake extends QueueManager implements Queue
      */
     public function connection($value = null)
     {
+        $this->selectedQueuedListenerConnection = $value;
+
         return $this;
     }
 
@@ -336,6 +376,8 @@ class QueueFake extends QueueManager implements Queue
      */
     public function laterOn($queue, $delay, $job, $data = '')
     {
+        $this->selectedQueuedListenerDelay = $delay;
+
         return $this->push($job, $data, $queue);
     }
 

--- a/tests/Events/QueuedEventsTest.php
+++ b/tests/Events/QueuedEventsTest.php
@@ -31,7 +31,7 @@ class QueuedEventsTest extends TestCase
             return $queue;
         });
 
-        $d->listen('some.event', TestDispatcherQueuedHandler::class . '@someMethod');
+        $d->listen('some.event', TestDispatcherQueuedHandler::class.'@someMethod');
         $d->dispatch('some.event', ['foo', 'bar']);
     }
 


### PR DESCRIPTION
Now event dispatcher's behavior for queued listener looks a bit strange: when it creates the job for queued listener dispatcher looks just for properties which being set outside the constructor - connection, queue, delay, etc. Of course it work such because it creates a instance for listener without a constructor call (through reflection), but is incorrect, because listener's instance already has been created when `Dispatcher::handlerWantsToBeQueued` method was called:

```php
protected function createClassCallable($listener)
{
     [$class, $method] = $this->parseClassCallable($listener);

     if ($this->handlerShouldBeQueued($class)) {
         return $this->createQueuedHandlerCallable($class, $method);
     }

     return [$this->container->make($class), $method];
}
```

A listener should be queued, go further:

```php
protected function createQueuedHandlerCallable($class, $method)
{
     return function () use ($class, $method) {
            $arguments = array_map(function ($a) {
                return is_object($a) ? clone $a : $a;
            }, func_get_args());

            $instance = $this->container->make($class);

            if ($this->handlerWantsToBeQueued($instance, $arguments)) {
                $this->queueHandler($instance, $method, $arguments);
            }
        };
 }
```

And when dispatcher calls `handlerWantsToBeQueued` method it created a full fledged instance for listener:

```php
protected function handlerWantsToBeQueued($class, $arguments)
    {
        $instance = $this->container->make($class);

        if (method_exists($instance, 'shouldQueue')) {
            return $instance->shouldQueue($arguments[0]);
        }

        return true;
    }
``` 

But in `queueHandler` it also create an another instance but now without a constructor and without a container, thats why if we try to define connection, queue and other job options in constructor we will lose. 

```php
protected function createListenerAndJob($class, $method, $arguments)
    {
        $listener = (new ReflectionClass($class))->newInstanceWithoutConstructor();

        return [$listener, $this->propagateListenerOptions(
            $listener, new CallQueuedListener($class, $method, $arguments)
        )];
    }
```

But for me and, i guess, for many other developers it may be useful to choose job options depend on environment  and with constructor this work perfectly. I changed this behavior on PR.