### PR TITLE
[8.x] Add whenWhere clause to eloquent builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -292,6 +292,7 @@ class Builder
             if ($operator === null && $value === null) {
                 $operator = $condition;
             }
+
             $this->where($column, $operator, $value, $boolean);
         }
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -277,6 +277,28 @@ class Builder
     }
 
     /**
+     * Add an "when where" clause that runs "where" when condition is true.
+     *
+     * @param mixed $condition
+     * @param \Closure|array|string|\Illuminate\Database\Query\Expression $column
+     * @param mixed $operator
+     * @param mixed $value
+     * @param string $boolean
+     * @return $this
+     */
+    public function whenWhere($condition, $column, $operator = null, $value = null, $boolean = 'and')
+    {
+        if ($condition) {
+            if ($operator === null && $value === null) {
+                $operator = $condition;
+            }
+            $this->where($column, $operator, $value, $boolean);
+        }
+
+        return $this;
+    }
+
+    /**
      * Add an "order by" clause for a timestamp to the query.
      *
      * @param  string|\Illuminate\Database\Query\Expression  $column

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -279,11 +279,11 @@ class Builder
     /**
      * Add an "when where" clause that runs "where" when condition is true.
      *
-     * @param mixed $condition
-     * @param \Closure|array|string|\Illuminate\Database\Query\Expression $column
-     * @param mixed $operator
-     * @param mixed $value
-     * @param string $boolean
+     * @param  mixed  $condition
+     * @param  \Closure|array|string|\Illuminate\Database\Query\Expression  $column
+     * @param  mixed   $operator
+     * @param  mixed   $value
+     * @param  string   $boolean
      * @return $this
      */
     public function whenWhere($condition, $column, $operator = null, $value = null, $boolean = 'and')

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -845,6 +845,29 @@ class Builder
     }
 
     /**
+     * Add an "when where" clause that runs "where" when condition is true.
+     *
+     * @param  mixed  $condition
+     * @param  \Closure|array|string|\Illuminate\Database\Query\Expression  $column
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whenWhere($condition, $column, $operator = null, $value = null, $boolean = 'and')
+    {
+        if ($condition) {
+            if ($operator === null && $value === null) {
+                $operator = $condition;
+            }
+
+            $this->where($column, $operator, $value, $boolean);
+        }
+
+        return $this;
+    }
+
+    /**
      * Add a "where" clause comparing two columns to the query.
      *
      * @param  string|array  $first

--- a/tests/Database/DatabaseEloquentGlobalScopesTest.php
+++ b/tests/Database/DatabaseEloquentGlobalScopesTest.php
@@ -133,22 +133,22 @@ class DatabaseEloquentGlobalScopesTest extends TestCase
         $this->assertEquals(['taylor@gmail.com', 'someone@else.com', 1], $query->getBindings());
 
         // Where applied
-        $query = $model->newQuery()->where('col1', 'val1')->whenWhere(true,'col2', 'val2');
+        $query = $model->newQuery()->where('col1', 'val1')->whenWhere(true, 'col2', 'val2');
         $this->assertSame('select "email", "password" from "table" where "col1" = ? and "col2" = ? and ("email" = ? or "email" = ?) and "active" = ? order by "name" asc', $query->toSql());
         $this->assertEquals(['val1', 'val2', 'taylor@gmail.com', 'someone@else.com', 1], $query->getBindings());
 
         // Where is not applied
-        $query = $model->newQuery()->where('col1', 'val1')->whenWhere(false,'col2', 'val2');
+        $query = $model->newQuery()->where('col1', 'val1')->whenWhere(false, 'col2', 'val2');
         $this->assertSame('select "email", "password" from "table" where "col1" = ? and ("email" = ? or "email" = ?) and "active" = ? order by "name" asc', $query->toSql());
         $this->assertEquals(['val1', 'taylor@gmail.com', 'someone@else.com', 1], $query->getBindings());
 
         // Use condition as value
-        $query = $model->newQuery()->where('col1', 'val1')->whenWhere('val2','col2');
+        $query = $model->newQuery()->where('col1', 'val1')->whenWhere('val2', 'col2');
         $this->assertSame('select "email", "password" from "table" where "col1" = ? and "col2" = ? and ("email" = ? or "email" = ?) and "active" = ? order by "name" asc', $query->toSql());
         $this->assertEquals(['val1', 'val2', 'taylor@gmail.com', 'someone@else.com', 1], $query->getBindings());
 
         // With all whenWhere parameters passed
-        $query = $model->newQuery()->where('col1', 'val1')->whenWhere(true,'col2', '!=', 'val2', 'or');
+        $query = $model->newQuery()->where('col1', 'val1')->whenWhere(true, 'col2', '!=', 'val2', 'or');
         $this->assertSame('select "email", "password" from "table" where ("col1" = ? or "col2" != ?) and ("email" = ? or "email" = ?) and "active" = ? order by "name" asc', $query->toSql());
         $this->assertEquals(['val1', 'val2', 'taylor@gmail.com', 'someone@else.com', 1], $query->getBindings());
     }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -686,6 +686,24 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1, 1 => 'foo'], $builder->getBindings());
     }
 
+    public function testBasicWhenWheres()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('id', '=', 1)->whenWhere(true, 'email', '=', 'foo', 'or');
+        $this->assertSame('select * from "users" where "id" = ? or "email" = ?', $builder->toSql());
+        $this->assertEquals([0 => 1, 1 => 'foo'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('id', '=', 1)->whenWhere(false, 'email', '=', 'foo', 'or');
+        $this->assertSame('select * from "users" where "id" = ?', $builder->toSql());
+        $this->assertEquals([0 => 1], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('id', '=', 1)->whenWhere('foo', 'email');
+        $this->assertSame('select * from "users" where "id" = ? and "email" = ?', $builder->toSql());
+        $this->assertEquals([0 => 1, 1 => 'foo'], $builder->getBindings());
+    }
+
     public function testRawWheres()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
This will add whenWhere clause to Eloquent builder so this:
```php
$role = $request->input('role');

DB::table('users')
    ->when($role, function ($query, $role) {
        return $query->where('role_id', $role);
    })
```

Can become this:
```php
$role = $request->input('role');

DB::table('users')
    ->whenWhere($role, 'role_id')
```

Or:
```php
$role = $request->input('role');

DB::table('users')
    ->whenWhere($role, 'role_id', $role)


DB::table('users')
    ->whenWhere($role, 'role_id', '!=' , $role, 'or')
```