### PR TITLE
[8.x] [POC] Pushing retries and secondary queue

### DIFF
--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -65,6 +65,7 @@ use Illuminate\Queue\Console\FlushFailedCommand as FlushFailedQueueCommand;
 use Illuminate\Queue\Console\ForgetFailedCommand as ForgetFailedQueueCommand;
 use Illuminate\Queue\Console\ListenCommand as QueueListenCommand;
 use Illuminate\Queue\Console\ListFailedCommand as ListFailedQueueCommand;
+use Illuminate\Queue\Console\PushCommand as QueuePushCommand;
 use Illuminate\Queue\Console\RestartCommand as QueueRestartCommand;
 use Illuminate\Queue\Console\RetryBatchCommand as QueueRetryBatchCommand;
 use Illuminate\Queue\Console\RetryCommand as QueueRetryCommand;
@@ -108,6 +109,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'QueueListen' => 'command.queue.listen',
         'QueueRestart' => 'command.queue.restart',
         'QueueRetry' => 'command.queue.retry',
+        'QueuePush' => 'command.queue.push',
         'QueueRetryBatch' => 'command.queue.retry-batch',
         'QueueWork' => 'command.queue.work',
         'RouteCache' => 'command.route.cache',
@@ -703,6 +705,18 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
     {
         $this->app->singleton('command.queue.retry', function () {
             return new QueueRetryCommand;
+        });
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerQueuePushCommand()
+    {
+        $this->app->singleton('command.queue.push', function () {
+            return new QueuePushCommand();
         });
     }
 

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -68,6 +68,7 @@ use Illuminate\Queue\Console\ListFailedCommand as ListFailedQueueCommand;
 use Illuminate\Queue\Console\RestartCommand as QueueRestartCommand;
 use Illuminate\Queue\Console\RetryBatchCommand as QueueRetryBatchCommand;
 use Illuminate\Queue\Console\RetryCommand as QueueRetryCommand;
+use Illuminate\Queue\Console\SecondaryQueueTableCommand;
 use Illuminate\Queue\Console\TableCommand;
 use Illuminate\Queue\Console\WorkCommand as QueueWorkCommand;
 use Illuminate\Routing\Console\ControllerMakeCommand;
@@ -150,6 +151,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'PolicyMake' => 'command.policy.make',
         'ProviderMake' => 'command.provider.make',
         'QueueFailedTable' => 'command.queue.failed-table',
+        'QueueSecondaryTable' => 'command.queue.secondary-table',
         'QueueTable' => 'command.queue.table',
         'QueueBatchesTable' => 'command.queue.batches-table',
         'RequestMake' => 'command.request.make',
@@ -761,6 +763,18 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
     {
         $this->app->singleton('command.queue.table', function ($app) {
             return new TableCommand($app['files'], $app['composer']);
+        });
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerQueueSecondaryTableCommand()
+    {
+        $this->app->singleton('command.queue.secondary-table', function ($app) {
+            return new SecondaryQueueTableCommand($app['files'], $app['composer']);
         });
     }
 

--- a/src/Illuminate/Queue/Console/PushCommand.php
+++ b/src/Illuminate/Queue/Console/PushCommand.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Queue\Console;
 
 use Illuminate\Console\Command;
-use Illuminate\Support\Arr;
 
 class PushCommand extends Command
 {

--- a/src/Illuminate/Queue/Console/PushCommand.php
+++ b/src/Illuminate/Queue/Console/PushCommand.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Illuminate\Queue\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Arr;
+
+class PushCommand extends Command
+{
+    /**
+     * The console command signature.
+     *
+     * @var string
+     */
+    protected $signature = 'queue:push';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Push jobs from the secondary queue';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        foreach ($this->laravel['queue.secondary']->all() as $job) {
+            $this->retryJob($job);
+
+            $this->info("Job [#{$job->id}] has been pushed back onto the queue!");
+
+            $this->laravel['queue.secondary']->forget($job->id);
+        }
+    }
+
+    /**
+     * Retry the queue job.
+     *
+     * @param  \stdClass  $job
+     * @return void
+     */
+    protected function retryJob($job)
+    {
+        $this->laravel['queue']->connection($job->connection)->push(
+            unserialize($job->job), '', $job->queue
+        );
+    }
+}

--- a/src/Illuminate/Queue/Console/SecondaryQueueTableCommand.php
+++ b/src/Illuminate/Queue/Console/SecondaryQueueTableCommand.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Illuminate\Queue\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Composer;
+use Illuminate\Support\Str;
+
+class SecondaryQueueTableCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'queue:secondary-table';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a migration for the secondary queue database table';
+
+    /**
+     * The filesystem instance.
+     *
+     * @var \Illuminate\Filesystem\Filesystem
+     */
+    protected $files;
+
+    /**
+     * @var \Illuminate\Support\Composer
+     */
+    protected $composer;
+
+    /**
+     * Create a new failed queue jobs table command instance.
+     *
+     * @param  \Illuminate\Filesystem\Filesystem  $files
+     * @param  \Illuminate\Support\Composer  $composer
+     * @return void
+     */
+    public function __construct(Filesystem $files, Composer $composer)
+    {
+        parent::__construct();
+
+        $this->files = $files;
+        $this->composer = $composer;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $table = $this->laravel['config']['queue.secondary.table'];
+
+        $this->replaceMigration(
+            $this->createBaseMigration($table), $table, Str::studly($table)
+        );
+
+        $this->info('Migration created successfully!');
+
+        $this->composer->dumpAutoloads();
+    }
+
+    /**
+     * Create a base migration file for the table.
+     *
+     * @param  string  $table
+     * @return string
+     */
+    protected function createBaseMigration($table = 'failed_jobs')
+    {
+        return $this->laravel['migration.creator']->create(
+            'create_'.$table.'_table', $this->laravel->databasePath().'/migrations'
+        );
+    }
+
+    /**
+     * Replace the generated migration with the failed job table stub.
+     *
+     * @param  string  $path
+     * @param  string  $table
+     * @param  string  $tableClassName
+     * @return void
+     */
+    protected function replaceMigration($path, $table, $tableClassName)
+    {
+        $stub = str_replace(
+            ['{{table}}', '{{tableClassName}}'],
+            [$table, $tableClassName],
+            $this->files->get(__DIR__.'/stubs/secondary_queue.stub')
+        );
+
+        $this->files->put($path, $stub);
+    }
+}

--- a/src/Illuminate/Queue/Console/stubs/secondary_queue.stub
+++ b/src/Illuminate/Queue/Console/stubs/secondary_queue.stub
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class Create{{tableClassName}}Table extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('{{table}}', function (Blueprint $table) {
+            $table->id();
+            $table->text('connection');
+            $table->text('queue')->nullable();
+            $table->longText('job');
+            $table->longText('exception');
+            $table->unsignedInteger('failed_at')->useCurrent();
+            $table->unsignedInteger('due_at')->useCurrent();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('{{table}}');
+    }
+}

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -268,7 +268,17 @@ abstract class Queue
      */
     protected function enqueueUsing($job, $payload, $queue, $delay, $callback)
     {
-        return $callback($payload, $queue, $delay);
+        try {
+            return $callback($payload, $queue, $delay);
+        } catch (\Throwable $e) {
+            $this->container['queue.secondary']->push(
+                $this->getConnectionName(),
+                $queue,
+                serialize($job),
+                $delay,
+                $e
+            );
+        }
     }
 
     /**

--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -138,6 +138,15 @@ class QueueManager implements FactoryContract, MonitorContract
             $this->connections[$name] = $this->resolve($name);
 
             $this->connections[$name]->setContainer($this->app);
+
+            $this->connections[$name]->configurePushingRetries(
+                $this->app['config']['queue.retry_pushing.times'] ?? 0,
+                $this->app['config']['queue.retry_pushing.sleep'] ?? 0
+            );
+
+            if ($this->app['config']['queue.secondary.enabled'] ?? false) {
+                $this->connections[$name]->enableSecondaryQueue();
+            }
         }
 
         return $this->connections[$name];

--- a/src/Illuminate/Queue/QueueServiceProvider.php
+++ b/src/Illuminate/Queue/QueueServiceProvider.php
@@ -15,6 +15,8 @@ use Illuminate\Queue\Failed\DatabaseFailedJobProvider;
 use Illuminate\Queue\Failed\DatabaseUuidFailedJobProvider;
 use Illuminate\Queue\Failed\DynamoDbFailedJobProvider;
 use Illuminate\Queue\Failed\NullFailedJobProvider;
+use Illuminate\Queue\Secondary\DatabaseSecondaryQueueProvider;
+use Illuminate\Queue\Secondary\NullSecondaryQueueProvider;
 use Illuminate\Support\Arr;
 use Illuminate\Support\ServiceProvider;
 
@@ -32,6 +34,7 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
         $this->registerWorker();
         $this->registerListener();
         $this->registerFailedJobServices();
+        $this->registerSecondaryQueueServices();
     }
 
     /**
@@ -263,6 +266,26 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
     }
 
     /**
+     * Register the secondary queue services.
+     *
+     * @return void
+     */
+    protected function registerSecondaryQueueServices()
+    {
+        $this->app->singleton('queue.secondary', function ($app) {
+            $config = $app['config']['queue.secondary'];
+
+            if ($config['driver'] === 'database') {
+                return new DatabaseSecondaryQueueProvider(
+                    $this->app['db'], $config['database'], $config['table']
+                );
+            } else {
+                return new NullSecondaryQueueProvider();
+            }
+        });
+    }
+
+    /**
      * Get the services provided by the provider.
      *
      * @return array
@@ -273,6 +296,7 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
             'queue',
             'queue.connection',
             'queue.failer',
+            'queue.secondary',
             'queue.listener',
             'queue.worker',
         ];

--- a/src/Illuminate/Queue/Secondary/DatabaseSecondaryQueueProvider.php
+++ b/src/Illuminate/Queue/Secondary/DatabaseSecondaryQueueProvider.php
@@ -67,7 +67,7 @@ class DatabaseSecondaryQueueProvider implements SecondaryQueueProviderInterface
      */
     public function all()
     {
-        return $this->getTable()->orderBy('id', 'desc')->get()->all();
+        return $this->getTable()->orderBy('id', 'asc')->get()->all();
     }
 
     /**

--- a/src/Illuminate/Queue/Secondary/DatabaseSecondaryQueueProvider.php
+++ b/src/Illuminate/Queue/Secondary/DatabaseSecondaryQueueProvider.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Illuminate\Queue\Secondary;
+
+use Illuminate\Database\ConnectionResolverInterface;
+use Illuminate\Support\Facades\Date;
+use Illuminate\Support\InteractsWithTime;
+
+class DatabaseSecondaryQueueProvider implements SecondaryQueueProviderInterface
+{
+    use InteractsWithTime;
+
+    /**
+     * The connection resolver implementation.
+     *
+     * @var \Illuminate\Database\ConnectionResolverInterface
+     */
+    protected $resolver;
+
+    /**
+     * The database connection name.
+     *
+     * @var string
+     */
+    protected $database;
+
+    /**
+     * The database table.
+     *
+     * @var string
+     */
+    protected $table;
+
+    /**
+     * Create a new database failed job provider.
+     *
+     * @param  \Illuminate\Database\ConnectionResolverInterface  $resolver
+     * @param  string  $database
+     * @param  string  $table
+     * @return void
+     */
+    public function __construct(ConnectionResolverInterface $resolver, $database, $table)
+    {
+        $this->table = $table;
+        $this->resolver = $resolver;
+        $this->database = $database;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function push($connection, $queue, $job, $delay, $exception)
+    {
+        $failed_at = Date::now()->getTimestamp();
+
+        $due_at = $delay ? $this->availableAt($delay) : $failed_at;
+
+        $exception = (string) $exception;
+
+        return $this->getTable()->insertGetId(compact(
+            'connection', 'queue', 'job', 'exception', 'failed_at', 'due_at'
+        ));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function all()
+    {
+        return $this->getTable()->orderBy('id', 'desc')->get()->all();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function forget($id)
+    {
+        return $this->getTable()->where('id', $id)->delete() > 0;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function flush()
+    {
+        $this->getTable()->delete();
+    }
+
+    /**
+     * Get a new query builder instance for the table.
+     *
+     * @return \Illuminate\Database\Query\Builder
+     */
+    protected function getTable()
+    {
+        return $this->resolver->connection($this->database)->table($this->table);
+    }
+}

--- a/src/Illuminate/Queue/Secondary/NullSecondaryQueueProvider.php
+++ b/src/Illuminate/Queue/Secondary/NullSecondaryQueueProvider.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Illuminate\Queue\Secondary;
+
+class NullSecondaryQueueProvider implements SecondaryQueueProviderInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function push($connection, $queue, $job, $delay, $exception)
+    {
+        //
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function all()
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function forget($id)
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function flush()
+    {
+        //
+    }
+}

--- a/src/Illuminate/Queue/Secondary/SecondaryQueueProviderInterface.php
+++ b/src/Illuminate/Queue/Secondary/SecondaryQueueProviderInterface.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Illuminate\Queue\Secondary;
+
+interface SecondaryQueueProviderInterface
+{
+    /**
+     * Push a job into storage.
+     *
+     * @param  string  $connection
+     * @param  string  $queue
+     * @param  string  $job
+     * @param  \DateTimeInterface|\DateInterval|int|null  $delay
+     * @param  \Throwable  $exception
+     * @return string|int|null
+     */
+    public function push($connection, $queue, $job, $delay, $exception);
+
+    /**
+     * Get a list of all of the failed jobs.
+     *
+     * @return array
+     */
+    public function all();
+
+    /**
+     * Delete a single job from storage.
+     *
+     * @param  mixed  $id
+     * @return bool
+     */
+    public function forget($id);
+
+    /**
+     * Flush all of the failed jobs from storage.
+     *
+     * @return void
+     */
+    public function flush();
+}

--- a/tests/Queue/QueueManagerTest.php
+++ b/tests/Queue/QueueManagerTest.php
@@ -35,6 +35,7 @@ class QueueManagerTest extends TestCase
         });
 
         $queue->shouldReceive('setContainer')->once()->with($app);
+        $queue->shouldReceive('configurePushingRetries')->once()->with(0, 0);
         $this->assertSame($queue, $manager->connection('sync'));
     }
 
@@ -57,6 +58,7 @@ class QueueManagerTest extends TestCase
             return $connector;
         });
         $queue->shouldReceive('setContainer')->once()->with($app);
+        $queue->shouldReceive('configurePushingRetries')->once()->with(0, 0);
 
         $this->assertSame($queue, $manager->connection('foo'));
     }
@@ -79,6 +81,7 @@ class QueueManagerTest extends TestCase
             return $connector;
         });
         $queue->shouldReceive('setContainer')->once()->with($app);
+        $queue->shouldReceive('configurePushingRetries')->once()->with(0, 0);
 
         $this->assertSame($queue, $manager->connection('null'));
     }


### PR DESCRIPTION
This PR adds more reliability features to the queue system, 2 in particular:

1. Retrying pushes using the `retry()` helper.
2. Storing failed pushes in a secondary queue to be retried later.

Adding this to the `queue.php` configuration file:

```php
'retry_pushing' => [
    'times' => 2,
    'sleep' => 10000,
],
```

Will instruct the queue to retry pushing jobs 2 times, with 10 seconds sleep in between, if pushing fails. That way if SQS for example had a temporary outage, we will keep trying for 20 seconds.

And adding this to the config file:

```php
'secondary' => [
    'enabled' => true,
    'driver' => env('SECONDARY_QUEUE_DRIVER', 'database'),
    'database' => env('DB_CONNECTION', 'mysql'),
    'table' => 'secondary_queue',
],
```

Instructs the queue to store failed pushes in a secondary queue so the jobs are not lost. People can manually call `php artisan queue:push` to push all jobs in the secondary queue to the main queue. Or they can call this command via a cron job every x minutes to check for any failed pushes on regular basis.

---

This PR is a proof of concept, if the idea was found acceptable I still need to work on respecting any delay when pushing jobs from the secondary queue to the main queue and also write tests.