### PR TITLE
[6.x] Remove calls to TestCase::at

### DIFF
--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -153,9 +153,8 @@ class DatabaseConnectionTest extends TestCase
     public function testBeginTransactionMethodRetriesOnFailure()
     {
         $pdo = $this->createMock(DatabaseConnectionTestMockPDO::class);
-        $pdo->expects($this->at(0))
-            ->method('beginTransaction')
-            ->will($this->throwException(new ErrorException('server has gone away')));
+        $pdo->method('beginTransaction')
+            ->willReturnOnConsecutiveCalls($this->throwException(new ErrorException('server has gone away')));
         $connection = $this->getMockConnection(['reconnect'], $pdo);
         $connection->expects($this->once())->method('reconnect');
         $connection->beginTransaction();

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1787,14 +1787,14 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
 
         $file = $this->getMockBuilder(UploadedFile::class)->setMethods(['isValid', 'getSize'])->setConstructorArgs([__FILE__, basename(__FILE__)])->getMock();
-        $file->expects($this->any())->method('isValid')->willReturn(true);
-        $file->expects($this->at(1))->method('getSize')->willReturn(3072);
+        $file->method('isValid')->willReturn(true);
+        $file->method('getSize')->willReturn(3072);
         $v = new Validator($trans, ['photo' => $file], ['photo' => 'Max:10']);
         $this->assertTrue($v->passes());
 
         $file = $this->getMockBuilder(UploadedFile::class)->setMethods(['isValid', 'getSize'])->setConstructorArgs([__FILE__, basename(__FILE__)])->getMock();
-        $file->expects($this->at(0))->method('isValid')->willReturn(true);
-        $file->expects($this->at(1))->method('getSize')->willReturn(4072);
+        $file->method('isValid')->willReturn(true);
+        $file->method('getSize')->willReturn(4072);
         $v = new Validator($trans, ['photo' => $file], ['photo' => 'Max:2']);
         $this->assertFalse($v->passes());
 


### PR DESCRIPTION
`TestCase::at` is deprecated as of PHPUnit 9
So I refactor the test.

```
❯ ./vendor/bin/phpunit --stop-on-warning
PHPUnit 9.4.4 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.4.13
Configuration: /Users/dh/Projects/framework/phpunit.xml.dist

.............................................................   61 / 5729 (  1%)
.............................................................  122 / 5729 (  2%)
.............................................................  183 / 5729 (  3%)
.............................................................  244 / 5729 (  4%)
.............................................................  305 / 5729 (  5%)
.............................................................  366 / 5729 (  6%)
.............................................................  427 / 5729 (  7%)
.........SSSSSSSSSSSS........................................  488 / 5729 (  8%)
...................................SSSSSS....................  549 / 5729 (  9%)
...................................S.S.......................  610 / 5729 ( 10%)
.............................................................  671 / 5729 ( 11%)
.............................................................  732 / 5729 ( 12%)
....................................................W

Time: 00:00.662, Memory: 140.50 MB

There was 1 warning:

1) Illuminate\Tests\Database\DatabaseConnectionTest::testBeginTransactionMethodRetriesOnFailure
The at() matcher has been deprecated. It will be removed in PHPUnit 10. Please refactor your test to not rely on the order in which methods are invoked.

```

## Reference
sebastianbergmann/phpunit#4297