### PR TITLE
[8.x] Fix Application flush method

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1311,8 +1311,11 @@ class Application extends Container implements ApplicationContract, CachesConfig
         $this->serviceProviders = [];
         $this->resolvingCallbacks = [];
         $this->terminatingCallbacks = [];
+        $this->beforeResolvingCallbacks = [];
         $this->afterResolvingCallbacks = [];
+        $this->globalBeforeResolvingCallbacks = [];
         $this->globalResolvingCallbacks = [];
+        $this->globalAfterResolvingCallbacks = [];
     }
 
     /**


### PR DESCRIPTION
Following a recent PR https://github.com/laravel/framework/pull/35228 on Container class which adds a couple of new properties,
it seems that these properties are forgotten to be included in the flush method on the subclass  (Application),

**Note**: Obviously, the application object should get reset completely after the flush is called, 
so this is actually a "bug fix", not a performance improvement like in https://github.com/laravel/framework/pull/30065
