### PR TITLE
[6.x] Backport for fix issue with polymorphic morphMaps with literal 0 (#35364)

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -233,7 +233,7 @@ trait HasRelationships
         // If the type value is null it is probably safe to assume we're eager loading
         // the relationship. In this case we'll just pass in a dummy query where we
         // need to remove any eager loads that may already be defined on a model.
-        return empty($class = $this->{$type})
+        return is_null($class = $this->{$type})
                     ? $this->morphEagerTo($name, $type, $id, $ownerKey)
                     : $this->morphInstanceTo($class, $name, $type, $id, $ownerKey);
     }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -233,7 +233,7 @@ trait HasRelationships
         // If the type value is null it is probably safe to assume we're eager loading
         // the relationship. In this case we'll just pass in a dummy query where we
         // need to remove any eager loads that may already be defined on a model.
-        return is_null($class = $this->{$type})
+        return is_null($class = $this->{$type}) || $class === ''
                     ? $this->morphEagerTo($name, $type, $id, $ownerKey)
                     : $this->morphInstanceTo($class, $name, $type, $id, $ownerKey);
     }

--- a/tests/Database/DatabaseEloquentMorphToTest.php
+++ b/tests/Database/DatabaseEloquentMorphToTest.php
@@ -90,6 +90,16 @@ class DatabaseEloquentMorphToTest extends TestCase
         $this->assertSame('taylor', $result->username);
     }
 
+    public function testMorphToWithZeroMorphType()
+    {
+        $parent = $this->getMockBuilder(EloquentMorphToModelStub::class)->onlyMethods(['getAttribute', 'morphEagerTo', 'morphInstanceTo'])->getMock();
+        $parent->method('getAttribute')->with('relation_type')->willReturn(0);
+        $parent->expects($this->once())->method('morphInstanceTo');
+        $parent->expects($this->never())->method('morphEagerTo');
+
+        $parent->relation();
+    }
+
     public function testMorphToWithSpecifiedClassDefault()
     {
         $parent = new EloquentMorphToModelStub;

--- a/tests/Database/DatabaseEloquentMorphToTest.php
+++ b/tests/Database/DatabaseEloquentMorphToTest.php
@@ -92,7 +92,7 @@ class DatabaseEloquentMorphToTest extends TestCase
 
     public function testMorphToWithZeroMorphType()
     {
-        $parent = $this->getMockBuilder(EloquentMorphToModelStub::class)->onlyMethods(['getAttribute', 'morphEagerTo', 'morphInstanceTo'])->getMock();
+        $parent = $this->getMockBuilder(EloquentMorphToModelStub::class)->setMethods(['getAttribute', 'morphEagerTo', 'morphInstanceTo'])->getMock();
         $parent->method('getAttribute')->with('relation_type')->willReturn(0);
         $parent->expects($this->once())->method('morphInstanceTo');
         $parent->expects($this->never())->method('morphEagerTo');


### PR DESCRIPTION
This is a backport of https://github.com/laravel/framework/pull/35364 to Laravel 6 LTS.