### PR TITLE
[8.x] Fix reset password url generation for reverse proxy

### DIFF
--- a/src/Illuminate/Auth/Notifications/ResetPassword.php
+++ b/src/Illuminate/Auth/Notifications/ResetPassword.php
@@ -66,10 +66,10 @@ class ResetPassword extends Notification
         if (static::$createUrlCallback) {
             $url = call_user_func(static::$createUrlCallback, $notifiable, $this->token);
         } else {
-            $url = url(route('password.reset', [
+            $url = route('password.reset', [
                 'token' => $this->token,
                 'email' => $notifiable->getEmailForPasswordReset(),
-            ], false));
+            ]);
         }
 
         return $this->buildMailMessage($url);


### PR DESCRIPTION
url(route()) 
This is redundant and should be changed to "route()" only.

And besides that, there are problems with reverse proxies.
It looks fine in artisan tinker, but that's because he doesn't understand about Reverse Proxy. Try to build it in real.

For reverse proxy site, we can use forRootUrl to force it to env APP_URL to operate properly.
This is especially correct working too when you place it under a subdirectory.

However, url(route()) breaks this.

x https://example.com/mysite/mysite/password/reset
o https://example.com/mysite/password/reset

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
