### PR TITLE
[8.x] Add support for attaching existing model instances in factories

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/BelongsToManyRelationship.php
+++ b/src/Illuminate/Database/Eloquent/Factories/BelongsToManyRelationship.php
@@ -10,7 +10,7 @@ class BelongsToManyRelationship
     /**
      * The related factory instance.
      *
-     * @var \Illuminate\Database\Eloquent\Factories\Factory
+     * @var \Illuminate\Database\Eloquent\Factories\Factory|\Illuminate\Database\Eloquent\Model
      */
     protected $factory;
 
@@ -31,12 +31,12 @@ class BelongsToManyRelationship
     /**
      * Create a new attached relationship definition.
      *
-     * @param  \Illuminate\Database\Eloquent\Factories\Factory  $factory
+     * @param  \Illuminate\Database\Eloquent\Factories\Factory|\Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Model  $factory
      * @param  callable|array  $pivot
      * @param  string  $relationship
      * @return void
      */
-    public function __construct(Factory $factory, $pivot, $relationship)
+    public function __construct($factory, $pivot, $relationship)
     {
         $this->factory = $factory;
         $this->pivot = $pivot;
@@ -51,7 +51,7 @@ class BelongsToManyRelationship
      */
     public function createFor(Model $model)
     {
-        Collection::wrap($this->factory->create([], $model))->each(function ($attachable) use ($model) {
+        Collection::wrap($this->factory instanceof Factory ? $this->factory->create([], $model) : $this->factory)->each(function ($attachable) use ($model) {
             $model->{$this->relationship}()->attach(
                 $attachable,
                 is_callable($this->pivot) ? call_user_func($this->pivot, $model) : $this->pivot

--- a/src/Illuminate/Database/Eloquent/Factories/BelongsToManyRelationship.php
+++ b/src/Illuminate/Database/Eloquent/Factories/BelongsToManyRelationship.php
@@ -10,7 +10,7 @@ class BelongsToManyRelationship
     /**
      * The related factory instance.
      *
-     * @var \Illuminate\Database\Eloquent\Factories\Factory|\Illuminate\Database\Eloquent\Model
+     * @var \Illuminate\Database\Eloquent\Factories\Factory|\Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Model
      */
     protected $factory;
 

--- a/src/Illuminate/Database/Eloquent/Factories/BelongsToRelationship.php
+++ b/src/Illuminate/Database/Eloquent/Factories/BelongsToRelationship.php
@@ -31,11 +31,11 @@ class BelongsToRelationship
     /**
      * Create a new "belongs to" relationship definition.
      *
-     * @param  \Illuminate\Database\Eloquent\Factories\Factory  $factory
+     * @param  \Illuminate\Database\Eloquent\Factories\Factory|\Illuminate\Database\Eloquent\Model  $factory
      * @param  string  $relationship
      * @return void
      */
-    public function __construct(Factory $factory, $relationship)
+    public function __construct($factory, $relationship)
     {
         $this->factory = $factory;
         $this->relationship = $relationship;
@@ -52,7 +52,7 @@ class BelongsToRelationship
         $relationship = $model->{$this->relationship}();
 
         return $relationship instanceof MorphTo ? [
-            $relationship->getMorphType() => $this->factory->newModel()->getMorphClass(),
+            $relationship->getMorphType() => $this->factory instanceof Model ? $this->factory->getMorphClass() : $this->factory->newModel()->getMorphClass(),
             $relationship->getForeignKeyName() => $this->resolver($relationship->getOwnerKeyName()),
         ] : [
             $relationship->getForeignKeyName() => $this->resolver($relationship->getOwnerKeyName()),
@@ -69,7 +69,7 @@ class BelongsToRelationship
     {
         return function () use ($key) {
             if (! $this->resolved) {
-                $instance = $this->factory->create();
+                $instance = $this->factory instanceof Model ? $this->factory : $this->factory->create();
 
                 return $this->resolved = $key ? $instance->{$key} : $instance->getKey();
             }

--- a/src/Illuminate/Database/Eloquent/Factories/BelongsToRelationship.php
+++ b/src/Illuminate/Database/Eloquent/Factories/BelongsToRelationship.php
@@ -10,7 +10,7 @@ class BelongsToRelationship
     /**
      * The related factory instance.
      *
-     * @var \Illuminate\Database\Eloquent\Factories\Factory
+     * @var \Illuminate\Database\Eloquent\Factories\Factory|\Illuminate\Database\Eloquent\Model
      */
     protected $factory;
 
@@ -52,7 +52,7 @@ class BelongsToRelationship
         $relationship = $model->{$this->relationship}();
 
         return $relationship instanceof MorphTo ? [
-            $relationship->getMorphType() => $this->factory instanceof Model ? $this->factory->getMorphClass() : $this->factory->newModel()->getMorphClass(),
+            $relationship->getMorphType() => $this->factory instanceof Factory ? $this->factory->newModel()->getMorphClass() : $this->factory->getMorphClass(),
             $relationship->getForeignKeyName() => $this->resolver($relationship->getOwnerKeyName()),
         ] : [
             $relationship->getForeignKeyName() => $this->resolver($relationship->getOwnerKeyName()),
@@ -69,7 +69,7 @@ class BelongsToRelationship
     {
         return function () use ($key) {
             if (! $this->resolved) {
-                $instance = $this->factory instanceof Model ? $this->factory : $this->factory->create();
+                $instance = $this->factory instanceof Factory ? $this->factory->create() : $this->factory;
 
                 return $this->resolved = $key ? $instance->{$key} : $instance->getKey();
             }

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -506,7 +506,6 @@ abstract class Factory
      */
     public function for($factory, $relationship = null)
     {
-
         return $this->newInstance(['for' => $this->for->concat([new BelongsToRelationship(
             $factory,
             $relationship ?: Str::camel(class_basename($factory->modelName()))

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -481,13 +481,21 @@ abstract class Factory
     /**
      * Define an attached relationship for the model.
      *
-     * @param  \Illuminate\Database\Eloquent\Factories\Factory  $factory
+     * @param  \Illuminate\Database\Eloquent\Factories\Factory|\Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Model  $factory
      * @param  callable|array  $pivot
      * @param  string|null  $relationship
      * @return static
      */
-    public function hasAttached(self $factory, $pivot = [], $relationship = null)
+    public function hasAttached($factory, $pivot = [], $relationship = null)
     {
+        if ($factory instanceof Collection || $factory instanceof Model) {
+            $factory = Collection::wrap($factory);
+
+            return $this->afterCreating(function ($model) use ($factory, $pivot, $relationship) {
+                $model->{$relationship ?: Str::camel(Str::plural(class_basename($factory->first())))}()->attach($factory, $pivot);
+            });
+        }
+
         return $this->newInstance([
             'has' => $this->has->concat([new BelongsToManyRelationship(
                 $factory,

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -514,11 +514,6 @@ abstract class Factory
      */
     public function for($factory, $relationship = null)
     {
-        if ($factory instanceof Model) {
-            return $this->afterMaking(function ($model) use ($factory, $relationship) {
-                $model->{$relationship ?: Str::camel(class_basename($factory))}()->associate($factory);
-            });
-        }
 
         return $this->newInstance(['for' => $this->for->concat([new BelongsToRelationship(
             $factory,

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -488,14 +488,6 @@ abstract class Factory
      */
     public function hasAttached($factory, $pivot = [], $relationship = null)
     {
-        if ($factory instanceof Collection || $factory instanceof Model) {
-            $factory = Collection::wrap($factory);
-
-            return $this->afterCreating(function ($model) use ($factory, $pivot, $relationship) {
-                $model->{$relationship ?: Str::camel(Str::plural(class_basename($factory->first())))}()->attach($factory, $pivot);
-            });
-        }
-
         return $this->newInstance([
             'has' => $this->has->concat([new BelongsToManyRelationship(
                 $factory,

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -500,12 +500,18 @@ abstract class Factory
     /**
      * Define a parent relationship for the model.
      *
-     * @param  \Illuminate\Database\Eloquent\Factories\Factory  $factory
+     * @param  \Illuminate\Database\Eloquent\Factories\Factory|\Illuminate\Database\Eloquent\Model  $factory
      * @param  string|null  $relationship
      * @return static
      */
-    public function for(self $factory, $relationship = null)
+    public function for($factory, $relationship = null)
     {
+        if ($factory instanceof Model) {
+            return $this->afterMaking(function ($model) use ($factory, $relationship) {
+                $model->{$relationship ?: Str::camel(class_basename($factory))}()->associate($factory);
+            });
+        }
+
         return $this->newInstance(['for' => $this->for->concat([new BelongsToRelationship(
             $factory,
             $relationship ?: Str::camel(class_basename($factory->modelName()))

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -321,7 +321,8 @@ class DatabaseEloquentFactoryTest extends TestCase
 
     public function test_belongs_to_many_relationship_with_existing_model_instances()
     {
-        $roles = FactoryTestRoleFactory::times(3)->afterCreating(function ($role) {
+        $roles = FactoryTestRoleFactory::times(3)
+                        ->afterCreating(function ($role) {
                             $_SERVER['__test.role.creating-role'] = $role;
                         })
                         ->create();

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -305,6 +305,28 @@ class DatabaseEloquentFactoryTest extends TestCase
         unset($_SERVER['__test.role.creating-user']);
     }
 
+    public function test_belongs_to_many_relationship_with_existing_model_instances()
+    {
+        $roles = FactoryTestRoleFactory::times(3)->afterCreating(function ($role) {
+                            $_SERVER['__test.role.creating-role'] = $role;
+                        })
+                        ->create();
+        $users = FactoryTestUserFactory::times(3)
+                        ->hasAttached($roles, ['admin' => 'Y'], 'roles')
+                        ->create();
+
+        $this->assertCount(3, FactoryTestRole::all());
+
+        $user = FactoryTestUser::latest()->first();
+
+        $this->assertCount(3, $user->roles);
+        $this->assertSame('Y', $user->roles->first()->pivot->admin);
+
+        $this->assertInstanceOf(Eloquent::class, $_SERVER['__test.role.creating-role']);
+
+        unset($_SERVER['__test.role.creating-role']);
+    }
+
     public function test_sequences()
     {
         $users = FactoryTestUserFactory::times(2)->sequence(

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -278,6 +278,20 @@ class DatabaseEloquentFactoryTest extends TestCase
         $this->assertCount(3, FactoryTestComment::all());
     }
 
+    public function test_morph_to_relationship_with_existing_model_instance()
+    {
+        $post = FactoryTestPostFactory::new(['title' => 'Test Title'])->create();
+        $posts = FactoryTestCommentFactory::times(3)
+                        ->for($post, 'commentable')
+                        ->create();
+
+        $this->assertSame('Test Title', FactoryTestPost::first()->title);
+        $this->assertCount(3, FactoryTestPost::first()->comments);
+
+        $this->assertCount(1, FactoryTestPost::all());
+        $this->assertCount(3, FactoryTestComment::all());
+    }
+
     public function test_belongs_to_many_relationship()
     {
         $users = FactoryTestUserFactory::times(3)
@@ -311,7 +325,7 @@ class DatabaseEloquentFactoryTest extends TestCase
                             $_SERVER['__test.role.creating-role'] = $role;
                         })
                         ->create();
-        $users = FactoryTestUserFactory::times(3)
+        FactoryTestUserFactory::times(3)
                         ->hasAttached($roles, ['admin' => 'Y'], 'roles')
                         ->create();
 

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -250,6 +250,21 @@ class DatabaseEloquentFactoryTest extends TestCase
         $this->assertCount(3, FactoryTestPost::all());
     }
 
+    public function test_belongs_to_relationship_with_existing_model_instance()
+    {
+        $user = FactoryTestUserFactory::new(['name' => 'Taylor Otwell'])->create();
+        $posts = FactoryTestPostFactory::times(3)
+                        ->for($user, 'user')
+                        ->create();
+
+        $this->assertCount(3, $posts->filter(function ($post) use ($user) {
+            return $post->user->is($user);
+        }));
+
+        $this->assertCount(1, FactoryTestUser::all());
+        $this->assertCount(3, FactoryTestPost::all());
+    }
+
     public function test_morph_to_relationship()
     {
         $posts = FactoryTestCommentFactory::times(3)


### PR DESCRIPTION
**TL;DR:** adds support for passing Eloquent model instances, or collections of model instances, into the `for()` and `hasAttached()` factory methods.

Sometimes when creating models in a test, we need to be able to attach existing model instances to them instead of relying on the relation's factory. Currently the way to do this is to create all the models separately and then relate them manually, or to pass the column name and ID of the existing models into a factory's state or `create()` method.

This PR makes attaching existing models more straightforward. It's similar to #34539, but focuses on making the `for()` and `hasAttached()` methods more flexible and doesn't add any new methods.

### BelongsTo / MorphTo

**Before**

```php
$posts = Post::factory(10)
    ->for(User::factory()->state(['admin' => true]))
    ->create();

// Now we have to retrieve the user through a specific Post

$user = $posts->first()->user;

$this->be($user)->get(/*...*/);
```

**After**

```php
$posts = Post::factory(10)
    ->for($user = User::factory()->create())
    ->create();

// Now the user is available in $user

$this->be($user)->get(/*...*/);
```

### BelongsToMany / MorphToMany

**Before**

```php
$users = User::factory(3)
    ->hasAttached(Role::factory(3), ['admin' => 'Y'])
    ->create();

// Now there are 9 roles, and we have to retrieve them via specific Users
```

The alternative to this, right now, is to create the users and roles separately and then attach them manually:

```php
$roles = Role::factory(3)->create();
$users = User::factory(3)->create();
$users->each->roles()->attach($roles);
```

**After**

```php
$users = User::factory(3)
    ->hasAttached($roles = Role::factory(3)->create(), ['admin' => 'Y'])
    ->create();

// Now there are three roles, three users, each user has the same three roles, and they're available in $users and $roles
```