### PR TITLE
[8.x] Include validation errors in ValidationException::$message

### DIFF
--- a/src/Illuminate/Validation/ValidationException.php
+++ b/src/Illuminate/Validation/ValidationException.php
@@ -5,7 +5,6 @@ namespace Illuminate\Validation;
 use Exception;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Validator as ValidatorFacade;
-use Illuminate\Support\Str;
 
 class ValidationException extends Exception
 {

--- a/src/Illuminate/Validation/ValidationException.php
+++ b/src/Illuminate/Validation/ValidationException.php
@@ -77,7 +77,6 @@ class ValidationException extends Exception
         }));
     }
 
-
     /**
      * Create a summary error message from the validation errors.
      *
@@ -89,7 +88,7 @@ class ValidationException extends Exception
     {
         $messages = $validator->errors()->all();
 
-        if (!count($messages)) {
+        if (! count($messages)) {
             return 'The given data was invalid.';
         }
 

--- a/src/Illuminate/Validation/ValidationException.php
+++ b/src/Illuminate/Validation/ValidationException.php
@@ -5,6 +5,7 @@ namespace Illuminate\Validation;
 use Exception;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Validator as ValidatorFacade;
+use Illuminate\Support\Str;
 
 class ValidationException extends Exception
 {
@@ -53,7 +54,7 @@ class ValidationException extends Exception
      */
     public function __construct($validator, $response = null, $errorBag = 'default')
     {
-        parent::__construct('The given data was invalid.');
+        parent::__construct(static::summarize($validator));
 
         $this->response = $response;
         $this->errorBag = $errorBag;
@@ -75,6 +76,32 @@ class ValidationException extends Exception
                 }
             }
         }));
+    }
+
+
+    /**
+     * Create a summary error message from the validation errors.
+     *
+     * @param \Illuminate\Contracts\Validation\Validator      $validator
+     *
+     * @return string
+     */
+    protected static function summarize($validator)
+    {
+        $messages = $validator->errors()->all();
+
+        if (!count($messages)) {
+            return 'The given data was invalid.';
+        }
+
+        $message = array_shift($messages);
+
+        if ($additional = count($messages)) {
+            $pluralized = 1 === $additional ? 'error' : 'errors';
+            $message .= " (and $additional more $pluralized)";
+        }
+
+        return $message;
     }
 
     /**

--- a/tests/Validation/ValidationExceptionTest.php
+++ b/tests/Validation/ValidationExceptionTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
+use Illuminate\Validation\ValidationException;
+use Illuminate\Validation\Validator;
+use PHPUnit\Framework\TestCase;
+
+class ValidationExceptionTest extends TestCase
+{
+    public function testExceptionSummarizesZeroErrors()
+    {
+        $exception = $this->getException([], []);
+
+        $this->assertEquals('The given data was invalid.', $exception->getMessage());
+    }
+
+
+    public function testExceptionSummarizesOneError()
+    {
+        $exception = $this->getException([], ['foo' => 'required']);
+
+        $this->assertEquals('validation.required', $exception->getMessage());
+    }
+
+
+    public function testExceptionSummarizesTwoErrors()
+    {
+        $exception = $this->getException([], [ 'foo' => 'required', 'bar' => 'required' ]);
+
+        $this->assertEquals('validation.required (and 1 more error)', $exception->getMessage());
+    }
+
+    public function testExceptionSummarizesThreeOrMoreErrors()
+    {
+        $exception = $this->getException([], [
+            'foo' => 'required',
+            'bar' => 'required',
+            'baz' => 'required',
+        ]);
+
+        $this->assertEquals('validation.required (and 2 more errors)', $exception->getMessage());
+    }
+
+    protected function getException($data = [], $rules = [])
+    {
+        $translator = new Translator(new ArrayLoader, 'en');
+        $validator = new Validator($translator, $data, $rules);
+
+        return new ValidationException($validator);
+    }
+}

--- a/tests/Validation/ValidationExceptionTest.php
+++ b/tests/Validation/ValidationExceptionTest.php
@@ -17,7 +17,6 @@ class ValidationExceptionTest extends TestCase
         $this->assertEquals('The given data was invalid.', $exception->getMessage());
     }
 
-
     public function testExceptionSummarizesOneError()
     {
         $exception = $this->getException([], ['foo' => 'required']);
@@ -25,10 +24,9 @@ class ValidationExceptionTest extends TestCase
         $this->assertEquals('validation.required', $exception->getMessage());
     }
 
-
     public function testExceptionSummarizesTwoErrors()
     {
-        $exception = $this->getException([], [ 'foo' => 'required', 'bar' => 'required' ]);
+        $exception = $this->getException([], ['foo' => 'required', 'bar' => 'required']);
 
         $this->assertEquals('validation.required (and 1 more error)', $exception->getMessage());
     }


### PR DESCRIPTION
The default exception message for validation exceptions is "The given data was invalid." which is not particularly descriptive. There are lots of times when I'm running tests with exception handling turned off and I find I need to either `dd()` the validation messages or turn on exception handling and add a call to `assertSessionHasNoErrors()` to find the issue.

This PR adds a `summarize()` static method to the validation exception that includes the first error message, and if there are more than one, a count of the additional errors. That way, instead of "The given data was invalid." the message will look something like:

"The first name field is required (and 2 more errors)"