### PR TITLE
[8.x] Create assertSentInOrder to test against the order of Http Requests

### DIFF
--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -271,7 +271,7 @@ class Factory
     public function assertSentInOrder($requestSequence)
     {
         $this->assertSentCount(count($requestSequence));
-        
+
         foreach ($requestSequence as $orderPosition => $url) {
             PHPUnit::assertEquals($url, $this->recorded[$orderPosition][0]->url());
         }

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -263,6 +263,23 @@ class Factory
     }
 
     /**
+     * Assert that requests were sent in the order specified.
+     * 
+     * @param  array  $requestSequence
+     * @return void
+     */
+    public function assertSentInOrder($requestSequence)
+    {
+        
+        $this->assertSentCount(count($requestSequence));
+        
+        foreach($requestSequence as $orderPosition => $url){
+            PHPUnit::assertEquals($url, $this->recorded[$orderPosition][0]->url());
+        }    
+
+    }
+
+    /**
      * Assert that every created response sequence is empty.
      *
      * @return void

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -264,19 +264,17 @@ class Factory
 
     /**
      * Assert that requests were sent in the order specified.
-     * 
+     *
      * @param  array  $requestSequence
      * @return void
      */
     public function assertSentInOrder($requestSequence)
     {
-        
         $this->assertSentCount(count($requestSequence));
         
-        foreach($requestSequence as $orderPosition => $url){
+        foreach ($requestSequence as $orderPosition => $url) {
             PHPUnit::assertEquals($url, $this->recorded[$orderPosition][0]->url());
-        }    
-
+        }
     }
 
     /**

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -610,4 +610,40 @@ class HttpClientTest extends TestCase
 
         $this->assertSame(json_encode(['page' => 'foo']), stream_get_contents($resource));
     }
+
+    public function testCanAssertAgainstOrderOfHttpRequests()
+    {
+        $this->factory->fake();
+
+        $exampleUrls = [
+            'http://example.com/1',
+            'http://example.com/2',
+            'http://example.com/3',
+        ];
+
+        foreach($exampleUrls as $url){
+            $this->factory->get($url);
+        }
+
+        $this->factory->assertSentInOrder($exampleUrls);
+    }
+
+    public function testAssertionsSentOutOfOrderThrowAssertionFailed()
+    {
+        $this->factory->fake();
+
+        $exampleUrls = [
+            'http://example.com/1',
+            'http://example.com/2',
+            'http://example.com/3',
+        ];
+
+        $this->factory->get($exampleUrls[0]);
+        $this->factory->get($exampleUrls[2]);
+        $this->factory->get($exampleUrls[1]);
+
+        $this->expectException(\PHPUnit\Framework\AssertionFailedError::class);
+
+        $this->factory->assertSentInOrder($exampleUrls);
+    }
 }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -621,7 +621,7 @@ class HttpClientTest extends TestCase
             'http://example.com/3',
         ];
 
-        foreach($exampleUrls as $url){
+        foreach ($exampleUrls as $url) {
             $this->factory->get($url);
         }
 

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -646,4 +646,22 @@ class HttpClientTest extends TestCase
 
         $this->factory->assertSentInOrder($exampleUrls);
     }
+
+    public function testWrongNumberOfRequestsThrowAssertionFailed()
+    {
+        $this->factory->fake();
+
+        $exampleUrls = [
+            'http://example.com/1',
+            'http://example.com/2',
+            'http://example.com/3',
+        ];
+
+        $this->factory->get($exampleUrls[0]);
+        $this->factory->get($exampleUrls[1]);
+
+        $this->expectException(\PHPUnit\Framework\AssertionFailedError::class);
+
+        $this->factory->assertSentInOrder($exampleUrls);
+    }
 }


### PR DESCRIPTION
This adds a new assertion to the Http client: `Http::assertSentInOrder` which allows you to assert not only that the URLs were sent, but which order they were sent in.

Backstory: I was testing a class today that sends a series of API calls in a specific order when things are performing in one way (user doesn't exist, user is created, user is granted access to a resource). I needed to verify that these were being called in a very specific order, and it was a struggle.

I was eventually able to do it like this: https://gist.github.com/anubisthejackle/7388cca61d86c51b759eece64eb7540f

This assertion would have allowed me to simplify my test.