### PR TITLE
[6.x] Avoid using niden/actions-memcached

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,10 @@ jobs:
     runs-on: ubuntu-latest
 
     services:
+      memcached:
+        image: memcached:1.6-alpine
+        ports:
+          - 11211:11211
       mysql:
         image: mysql:5.7
         env:
@@ -43,9 +47,6 @@ jobs:
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, gd, redis, memcached
           tools: composer:v2
           coverage: none
-
-      - name: Setup Memcached
-        uses: niden/actions-memcached@v7
 
       - name: Setup problem matchers
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   memcached:
-    image: memcached:1.5-alpine
+    image: memcached:1.6-alpine
     ports:
       - "11211:11211"
     restart: always


### PR DESCRIPTION
Because it doesn't let us control the version (so stuff might start randomly breaking), and we don't need some special action for memcached anyway... we can load the docker image just like we do for mysql and redis. In fact, that is exactly what the old memcached action was doing anyway... but jut not letting us set the major.minor version.