### PR TITLE
[8.x] Pass lock instance into Lock get, block callbacks

### DIFF
--- a/src/Illuminate/Cache/Lock.php
+++ b/src/Illuminate/Cache/Lock.php
@@ -91,7 +91,7 @@ abstract class Lock implements LockContract
 
         if ($result && is_callable($callback)) {
             try {
-                return $callback();
+                return $callback($this);
             } finally {
                 $this->release();
             }
@@ -123,7 +123,7 @@ abstract class Lock implements LockContract
 
         if (is_callable($callback)) {
             try {
-                return $callback();
+                return $callback($this);
             } finally {
                 $this->release();
             }

--- a/tests/Integration/Cache/FileCacheLockTest.php
+++ b/tests/Integration/Cache/FileCacheLockTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Integration\Cache;
 
 use Exception;
+use Illuminate\Contracts\Cache\Lock;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
 use Orchestra\Testbench\TestCase;
@@ -43,7 +44,9 @@ class FileCacheLockTest extends TestCase
         Carbon::setTestNow();
 
         Cache::lock('foo')->forceRelease();
-        $this->assertSame('taylor', Cache::lock('foo', 10)->block(1, function () {
+        $this->assertSame('taylor', Cache::lock('foo', 10)->block(1, function ($lock) {
+            $this->assertInstanceOf(Lock::class, $lock);
+
             return 'taylor';
         }));
 
@@ -74,7 +77,9 @@ class FileCacheLockTest extends TestCase
         $firstLock = Cache::lock('foo', 10);
 
         try {
-            $firstLock->block(1, function () {
+            $firstLock->block(1, function ($lock) {
+                $this->assertInstanceOf(Lock::class, $lock);
+
                 throw new Exception('failed');
             });
         } catch (Exception $e) {

--- a/tests/Integration/Cache/MemcachedCacheLockTest.php
+++ b/tests/Integration/Cache/MemcachedCacheLockTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Cache;
 
+use Illuminate\Contracts\Cache\Lock;
 use Illuminate\Contracts\Cache\LockTimeoutException;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
@@ -27,7 +28,9 @@ class MemcachedCacheLockTest extends MemcachedIntegrationTest
         Carbon::setTestNow();
 
         Cache::store('memcached')->lock('foo')->forceRelease();
-        $this->assertSame('taylor', Cache::store('memcached')->lock('foo', 10)->block(1, function () {
+        $this->assertSame('taylor', Cache::store('memcached')->lock('foo', 10)->block(1, function ($lock) {
+            $this->assertInstanceOf(Lock::class, $lock);
+
             return 'taylor';
         }));
 
@@ -51,7 +54,9 @@ class MemcachedCacheLockTest extends MemcachedIntegrationTest
 
         Cache::store('memcached')->lock('foo')->release();
         Cache::store('memcached')->lock('foo', 5)->get();
-        $this->assertSame('taylor', Cache::store('memcached')->lock('foo', 10)->block(1, function () {
+        $this->assertSame('taylor', Cache::store('memcached')->lock('foo', 10)->block(1, function ($lock) {
+            $this->assertInstanceOf(Lock::class, $lock);
+
             return 'taylor';
         }));
     }

--- a/tests/Integration/Cache/NoLockTest.php
+++ b/tests/Integration/Cache/NoLockTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Cache;
 
+use Illuminate\Contracts\Cache\Lock;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
 use Orchestra\Testbench\TestCase;
@@ -44,7 +45,9 @@ class NoLockTest extends TestCase
         Carbon::setTestNow();
 
         Cache::lock('foo')->forceRelease();
-        $this->assertSame('taylor', Cache::lock('foo', 10)->block(1, function () {
+        $this->assertSame('taylor', Cache::lock('foo', 10)->block(1, function ($lock) {
+            $this->assertInstanceOf(Lock::class, $lock);
+
             return 'taylor';
         }));
 

--- a/tests/Integration/Cache/RedisCacheLockTest.php
+++ b/tests/Integration/Cache/RedisCacheLockTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Integration\Cache;
 
 use Exception;
+use Illuminate\Contracts\Cache\Lock;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
@@ -49,7 +50,9 @@ class RedisCacheLockTest extends TestCase
         Carbon::setTestNow();
 
         Cache::store('redis')->lock('foo')->forceRelease();
-        $this->assertSame('taylor', Cache::store('redis')->lock('foo', 10)->block(1, function () {
+        $this->assertSame('taylor', Cache::store('redis')->lock('foo', 10)->block(1, function ($lock) {
+            $this->assertInstanceOf(Lock::class, $lock);
+
             return 'taylor';
         }));
 
@@ -80,7 +83,9 @@ class RedisCacheLockTest extends TestCase
         $firstLock = Cache::store('redis')->lock('foo', 10);
 
         try {
-            $firstLock->block(1, function () {
+            $firstLock->block(1, function ($lock) {
+                $this->assertInstanceOf(Lock::class, $lock);
+
                 throw new Exception('failed');
             });
         } catch (Exception $e) {


### PR DESCRIPTION
Laravel currently provides callback variants for both the `Lock::get` and `Lock::block` methods, which simplifies the usage quite a bit.

Instead of 

```php
use Illuminate\Contracts\Cache\LockTimeoutException;

$lock = Cache::lock('foo', 10);

try {
    $lock->block(5);

    // Lock acquired after waiting maximum of 5 seconds...
} catch (LockTimeoutException $e) {
    // Unable to acquire lock...
} finally {
    optional($lock)->release();
}
```

You can simply use

```php
Cache::lock('foo', 10)->block(5, function () {
    // Lock acquired after waiting maximum of 5 seconds...
});
```

However, you're not currently able to use the closure method for cross-process locks, because you don't have access to the acquired lock instance within the callback.

```php
// Within Controller...
$podcast = Podcast::find($id);

$lock = Cache::lock('foo', 120);

if ($result = $lock->get()) {
    ProcessPodcast::dispatch($podcast, $lock->owner());
}

// Within ProcessPodcast Job...
Cache::restoreLock('foo', $this->owner)->release();
```

In order to shortcut the latter example, this PR passes the `Lock` instance (`$this`) into the callback, allowing you to use the closure syntax for cross-process locks, as well.

```php
use Illuminate\Contracts\Cache\Lock;

Cache::lock('foo', 120)->get(function (Lock $lock) {
    ProcessPodcast::dispatch($podcast, $lock->owner());
});
```

This makes use of the closure-method consistent with single-process locks, and streamlines usage.