### PR TITLE
[8.x] Add insensitive mode to contains method

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -175,12 +175,15 @@ class Str
      *
      * @param  string  $haystack
      * @param  string|string[]  $needles
+     * @param  bool $insensitive
      * @return bool
      */
-    public static function contains($haystack, $needles)
+    public static function contains($haystack, $needles, $insensitive = false)
     {
+        $method = $insensitive ? 'mb_stripos' : 'mb_strpos';
+
         foreach ((array) $needles as $needle) {
-            if ($needle !== '' && mb_strpos($haystack, $needle) !== false) {
+            if ($needle !== '' && $method($haystack, $needle) !== false) {
                 return true;
             }
         }

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -178,10 +178,15 @@ class SupportStrTest extends TestCase
 
     public function testStrContains()
     {
+        $this->assertTrue(Str::contains('taylor', 'Tay', true));
+        $this->assertTrue(Str::contains('Taylor', 'Tay', true));
+        $this->assertTrue(Str::contains('Taylor', 'tay', true));
+        $this->assertFalse(Str::contains('taylor', 'Tay', false));
         $this->assertTrue(Str::contains('taylor', 'ylo'));
         $this->assertTrue(Str::contains('taylor', 'taylor'));
         $this->assertTrue(Str::contains('taylor', ['ylo']));
         $this->assertTrue(Str::contains('taylor', ['xxx', 'ylo']));
+        $this->assertTrue(Str::contains('taylor', ['xx', 'Ylo'], true));
         $this->assertFalse(Str::contains('taylor', 'xxx'));
         $this->assertFalse(Str::contains('taylor', ['xxx']));
         $this->assertFalse(Str::contains('taylor', ''));


### PR DESCRIPTION
Somebody just needs to check there is a needle in a haystack with insensitive mode and there was no way before that.