### PR TITLE
[8.x] Fix SessionGuard::name property comment

### DIFF
--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -29,7 +29,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     use GuardHelpers, Macroable;
 
     /**
-     * The name of the Guard. Typically "web".
+     * The name of the guard. Typically "web".
      *
      * Corresponds to guard name in authentication configuration.
      *

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -29,7 +29,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     use GuardHelpers, Macroable;
 
     /**
-     * The name of the Guard. Typically "session".
+     * The name of the Guard. Typically "web".
      *
      * Corresponds to guard name in authentication configuration.
      *


### PR DESCRIPTION
Fix misleading comment on SessionGuard::name property.
