### PR TITLE
[9.x] Add handlerStats method for Http Client

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -56,7 +56,7 @@ class Response implements ArrayAccess
      */
     public function json($key = null, $default = null)
     {
-        if (! $this->decoded) {
+        if (!$this->decoded) {
             $this->decoded = json_decode($this->body(), true);
         }
 
@@ -118,6 +118,16 @@ class Response implements ArrayAccess
     public function effectiveUri()
     {
         return $this->transferStats->getEffectiveUri();
+    }
+
+    /**
+     * Get the handler stats of the response.
+     *
+     * @return \Psr\Http\Message\UriInterface
+     */
+    public function handlerStats()
+    {
+        return $this->transferStats->getHandlerStats();
     }
 
     /**
@@ -223,8 +233,7 @@ class Response implements ArrayAccess
      *
      * @throws \Illuminate\Http\Client\RequestException
      */
-    public function throw()
-    {
+    function throw () {
         $callback = func_get_args()[0] ?? null;
 
         if ($this->failed()) {
@@ -307,7 +316,7 @@ class Response implements ArrayAccess
     public function __call($method, $parameters)
     {
         return static::hasMacro($method)
-                    ? $this->macroCall($method, $parameters)
-                    : $this->response->{$method}(...$parameters);
+        ? $this->macroCall($method, $parameters)
+        : $this->response->{$method}(...$parameters);
     }
 }


### PR DESCRIPTION
Previous to this PR, retrieving handlerStats from the Http Client response was not intuitive or documented. The withOptions method fails with an error using Guzzle 'on_stats', and $response->transferStats->getHandlerStats() is not documented. To get handler stats required reverse engineering the Response.php class to some extent to figure out that getHandlerStats()  can be called from the $response->transferStats property . 

This PR addresses the issue, by mimicking behaviour of the 'effectiveUri()' method from the Response.php class, but the PR implements a new method calling the Guzzle getHandlerStats() method direct and returning handlerStats from the $this->transferStats property/object.


