### PR TITLE
[8.x] Fix Model::create() when using guarded property.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
@@ -217,12 +217,11 @@ trait GuardsAttributes
     protected function isGuardableColumn($key)
     {
         if (! isset(static::$guardableColumns[get_class($this)])) {
-            static::$guardableColumns[get_class($this)] = $this->getConnection()
-                        ->getSchemaBuilder()
-                        ->getColumnListing($this->getTable());
+            $columnListing = $this->getConnection()->getSchemaBuilder()->getColumnListing($this->getTable());
+            static::$guardableColumns[get_class($this)] = array_map('strtolower', $columnListing);
         }
 
-        return in_array($key, static::$guardableColumns[get_class($this)]);
+        return in_array(strtolower($key), static::$guardableColumns[get_class($this)]);
     }
 
     /**


### PR DESCRIPTION
The PR fixes `Model::create()` when using a guarded property.

Fixes https://github.com/yajra/laravel-oci8/issues/596

## Snippets to reproduce the issue (checked using sqlite)

```php
class User extends Model
{
    protected $guarded = ['id'];
}

User::create([
  'NAME'  => 'Test',
  'email' => 'test@example.com',
]);
```

The code will throw:

```
Illuminate\Database\QueryException : SQLSTATE[23000]: Integrity constraint violation: 19 NOT NULL constraint failed: users.name (SQL: insert into "users" ("email", "updated_at", "created_at") values (test@example.com, 2020-12-06 11:08:50, 2020-12-06 11:08:50))
```


