### PR TITLE
[8.x] Add trait for models to detect their api resources and add some resource sugar

### DIFF
--- a/src/Illuminate/Http/Resources/HasResource.php
+++ b/src/Illuminate/Http/Resources/HasResource.php
@@ -7,7 +7,7 @@ use Illuminate\Http\Resources\Json\JsonResource;
 trait HasResource
 {
     /**
-     * Get a new resource instance for the given resource(s)
+     * Get a new resource instance for the given resource(s).
      *
      * @param mixed ...$parameters
      * @return \Illuminate\Http\Resources\Json\JsonResource
@@ -30,7 +30,7 @@ trait HasResource
     }
 
     /**
-     * Get the resource representation of the model
+     * Get the resource representation of the model.
      *
      * @return \Illuminate\Http\Resources\Json\JsonResource
      */

--- a/src/Illuminate/Http/Resources/HasResource.php
+++ b/src/Illuminate/Http/Resources/HasResource.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Illuminate\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+trait HasResource
+{
+    /**
+     * Get a new resource instance for the given resource(s)
+     *
+     * @param mixed ...$parameters
+     * @return JsonResource
+     */
+    public static function resource(...$parameters)
+    {
+        return static::newResource(...$parameters)
+            ?: JsonResource::resourceForModel(get_called_class(), ...$parameters);
+    }
+
+    /**
+     * Create a new resource instance for the model.
+     *
+     * @param static $model
+     * @return JsonResource
+     */
+    protected static function newResource($model = null)
+    {
+       //
+    }
+
+    /**
+     * Get the resource representation of the model
+     *
+     * @return JsonResource
+     */
+    public function toResource()
+    {
+        return static::resource($this);
+    }
+}

--- a/src/Illuminate/Http/Resources/HasResource.php
+++ b/src/Illuminate/Http/Resources/HasResource.php
@@ -10,7 +10,7 @@ trait HasResource
      * Get a new resource instance for the given resource(s)
      *
      * @param mixed ...$parameters
-     * @return JsonResource
+     * @return \Illuminate\Http\Resources\Json\JsonResource
      */
     public static function resource(...$parameters)
     {
@@ -21,8 +21,8 @@ trait HasResource
     /**
      * Create a new resource instance for the model.
      *
-     * @param static $model
-     * @return JsonResource
+     * @param static|null $model
+     * @return \Illuminate\Http\Resources\Json\JsonResource
      */
     protected static function newResource($model = null)
     {
@@ -32,7 +32,7 @@ trait HasResource
     /**
      * Get the resource representation of the model
      *
-     * @return JsonResource
+     * @return \Illuminate\Http\Resources\Json\JsonResource
      */
     public function toResource()
     {

--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -190,7 +190,7 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
      * Sets the resource for a model or collection of models
      *
      * @param mixed $resource
-     * @return $this|AnonymousResourceCollection
+     * @return $this|\Illuminate\Http\Resources\Json\AnonymousResourceCollection
      */
     public function for($resource)
     {

--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -287,10 +287,10 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     /**
      * Specify the callback that should be invoked to guess factory names based on dynamic relationship names.
      *
-     * @param  callable  $callback
+     * @param callable|null $callback
      * @return void
      */
-    public static function guessResourceNamesUsing(callable $callback)
+    public static function guessResourceNamesUsing(callable $callback = null)
     {
         static::$resourceNameResolver = $callback;
     }
@@ -298,10 +298,10 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     /**
      * Specify the callback that should be invoked to get the namespace of the API resources.
      *
-     * @param  callable  $callback
+     * @param callable|null $callback
      * @return void
      */
-    public static function resolveResourceNamespaceUsing(callable $callback)
+    public static function resolveResourceNamespaceUsing(callable $callback = null)
     {
         static::$resourceNamespaceResolver = $callback;
     }

--- a/tests/Integration/Http/Fixtures/Post.php
+++ b/tests/Integration/Http/Fixtures/Post.php
@@ -3,9 +3,12 @@
 namespace Illuminate\Tests\Integration\Http\Fixtures;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\Resources\HasResource;
 
 class Post extends Model
 {
+    use HasResource;
+
     /**
      * The attributes that aren't mass assignable.
      *

--- a/tests/Integration/Http/Fixtures/Resources/PostResource.php
+++ b/tests/Integration/Http/Fixtures/Resources/PostResource.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http\Fixtures\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class PostResource extends JsonResource
+{
+}

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -123,6 +123,7 @@ class ResourceTest extends TestCase
 
     public function testResourceClassCanBeDiscoveredBasedOnNamespaceResolution()
     {
+        JsonResource::guessResourceNamesUsing();
         JsonResource::resolveResourceNamespaceUsing(function () {
             return 'Illuminate\\Tests\\Integration\\Http\\Fixtures\\Resources\\';
         });
@@ -134,6 +135,7 @@ class ResourceTest extends TestCase
         ]));
 
         $this->assertInstanceOf(\Illuminate\Tests\Integration\Http\Fixtures\Resources\PostResource::class, $resource);
+        JsonResource::resolveResourceNamespaceUsing();
     }
 
     public function testResourcesMayBeConvertedToJsonWithToJsonMethod()

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -94,7 +94,7 @@ class ResourceTest extends TestCase
     {
         JsonResource::guessResourceNamesUsing(function ($modelName) {
             $namespace = 'Illuminate\\Tests\\Integration\\Http\\Fixtures\\';
-            $modelName = Str::after($modelName, $namespace);
+            $modelName = class_basename($modelName);
 
             return $namespace.$modelName.'Resource';
         });
@@ -119,6 +119,21 @@ class ResourceTest extends TestCase
                 'title' => 'Test Title',
             ],
         ]);
+    }
+
+    public function testResourceClassCanBeDiscoveredBasedOnNamespaceResolution()
+    {
+        JsonResource::resolveResourceNamespaceUsing(function () {
+            return 'Illuminate\\Tests\\Integration\\Http\\Fixtures\\Resources\\';
+        });
+
+        $resource = Post::resource(new Post([
+            'id' => 5,
+            'title' => 'Test Title',
+            'abstract' => 'Test abstract',
+        ]));
+
+        $this->assertInstanceOf(\Illuminate\Tests\Integration\Http\Fixtures\Resources\PostResource::class, $resource);
     }
 
     public function testResourcesMayBeConvertedToJsonWithToJsonMethod()

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Integration\Http;
 
 use Illuminate\Http\Resources\ConditionallyLoadsAttributes;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Http\Resources\MergeValue;
 use Illuminate\Http\Resources\MissingValue;
@@ -135,6 +136,30 @@ class ResourceTest extends TestCase
         ]));
 
         $this->assertInstanceOf(\Illuminate\Tests\Integration\Http\Fixtures\Resources\PostResource::class, $resource);
+        JsonResource::resolveResourceNamespaceUsing();
+    }
+
+    public function testResourceClassCanBeDiscoveredBasedOnNamespaceResolutionForACollection()
+    {
+        JsonResource::guessResourceNamesUsing();
+        JsonResource::resolveResourceNamespaceUsing(function () {
+            return 'Illuminate\\Tests\\Integration\\Http\\Fixtures\\Resources\\';
+        });
+
+        $resource = Post::resource(collect([
+            new Post([
+                'id' => 5,
+                'title' => 'Test Title',
+                'abstract' => 'Test abstract',
+            ]),
+            new Post([
+                'id' => 6,
+                'title' => 'Test Title 2',
+                'abstract' => 'Test abstract 2',
+            ]),
+        ]));
+
+        $this->assertInstanceOf(AnonymousResourceCollection::class, $resource);
         JsonResource::resolveResourceNamespaceUsing();
     }
 


### PR DESCRIPTION
Borrowing from the new factory syntax, this PR adds a trait which can be added to models to detect the model's api resource. It also adds sugar around generating resource objects, both for single model instances and a collection of models.

This is based on [an idea](https://github.com/laravel/ideas/issues/2434) I added last week. I haven't added all the features (basically just alternative resource "states") that I mention in the idea issue, but the sugar is achieve while not introducing any breaking changes to the current way of creating resources.

By adding the `Illuminate\Http\Resources\HasResource` to a model, the resource can be created by using a few different fluent syntaxes.

Say we have a `Post` model:

```php
use Illuminate\Database\Eloquent\Model;
use Illuminate\Http\Resources\HasResource;

class Post extends Model
{
    use HasResource;
    // 
}
```

And assume we have a `PostResource` object found in the typical `App\Http\Resources` namespace (this supports the naming convention of `App\Http\Resources\Post` or `App\Http\Resources\PostResource`, it looks for the existence of either):

```php
use Illuminate\Http\Resources\Json\JsonResource;

class PostResource extends JsonResource
{
    public function toArray($request)
    {
        return parent::toArray($request);
    }
}

```

We can now create the resource without referencing the resource class directly:

```php
$post = new Post();

// toResource
$post->toResource();

// Using static methods
Post::resource($post);

// or 
Post::resource()->for($post);
```

This supports collections of models:

```php
Post::resource($postCollection);
// or
Post::resource()->for($postCollection);
```

Some additional tests are needed before coverage is adequate.