### PR TITLE
[8.x] Added LockProvider to CacheFactory return type

### DIFF
--- a/src/Illuminate/Contracts/Cache/Factory.php
+++ b/src/Illuminate/Contracts/Cache/Factory.php
@@ -8,7 +8,7 @@ interface Factory
      * Get a cache store instance by name.
      *
      * @param  string|null  $name
-     * @return \Illuminate\Contracts\Cache\Repository
+     * @return \Illuminate\Contracts\Cache\Repository|\Illuminate\Contracts\Cache\LockProvider
      */
     public function store($name = null);
 }


### PR DESCRIPTION
When using DI instead of Cache-Facade, the IDE doesn't suggest `$cache->lock()` due the missing LockProvider return type. This should fix it, I think.