### PR TITLE
[6.x] Fix mime validation for jpeg files

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1206,6 +1206,11 @@ trait ValidatesAttributes
             return false;
         }
 
+        // Make sure both JPG & JPEG validate true for each other.
+        if (in_array('jpg', $parameters) || in_array('jpeg', $parameters)) {
+            $parameters = array_unique(array_merge($parameters, ['jpg', 'jpeg']));
+        }
+
         return $value->getPath() !== '' && in_array($value->guessExtension(), $parameters);
     }
 

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1206,7 +1206,6 @@ trait ValidatesAttributes
             return false;
         }
 
-        // Make sure both JPG & JPEG validate true for each other.
         if (in_array('jpg', $parameters) || in_array('jpeg', $parameters)) {
             $parameters = array_unique(array_merge($parameters, ['jpg', 'jpeg']));
         }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2665,49 +2665,49 @@ class ValidationValidatorTest extends TestCase
         $file = $this->getMockBuilder(UploadedFile::class)->setMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
         $file->expects($this->any())->method('guessExtension')->willReturn('php');
         $file->expects($this->any())->method('getClientOriginalExtension')->willReturn('php');
-        $v = new Validator($trans, ['x' => $file], ['x' => 'Image']);
+        $v = new Validator($trans, ['x' => $file], ['x' => 'image']);
         $this->assertFalse($v->passes());
 
         $file2 = $this->getMockBuilder(UploadedFile::class)->setMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
-        $file2->expects($this->any())->method('guessExtension')->willReturn('jpeg');
+        $file2->expects($this->any())->method('guessExtension')->willReturn('jpg');
         $file2->expects($this->any())->method('getClientOriginalExtension')->willReturn('jpeg');
-        $v = new Validator($trans, ['x' => $file2], ['x' => 'Image']);
-        $this->assertTrue($v->passes());
-
-        $file3 = $this->getMockBuilder(UploadedFile::class)->setMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
-        $file3->expects($this->any())->method('guessExtension')->willReturn('gif');
-        $file3->expects($this->any())->method('getClientOriginalExtension')->willReturn('gif');
-        $v = new Validator($trans, ['x' => $file3], ['x' => 'Image']);
-        $this->assertTrue($v->passes());
-
-        $file4 = $this->getMockBuilder(UploadedFile::class)->setMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
-        $file4->expects($this->any())->method('guessExtension')->willReturn('bmp');
-        $file4->expects($this->any())->method('getClientOriginalExtension')->willReturn('bmp');
-        $v = new Validator($trans, ['x' => $file4], ['x' => 'Image']);
-        $this->assertTrue($v->passes());
-
-        $file5 = $this->getMockBuilder(UploadedFile::class)->setMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
-        $file5->expects($this->any())->method('guessExtension')->willReturn('png');
-        $file5->expects($this->any())->method('getClientOriginalExtension')->willReturn('png');
-        $v = new Validator($trans, ['x' => $file5], ['x' => 'Image']);
-        $this->assertTrue($v->passes());
-
-        $file6 = $this->getMockBuilder(UploadedFile::class)->setMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
-        $file6->expects($this->any())->method('guessExtension')->willReturn('svg');
-        $file6->expects($this->any())->method('getClientOriginalExtension')->willReturn('svg');
-        $v = new Validator($trans, ['x' => $file6], ['x' => 'Image']);
-        $this->assertTrue($v->passes());
-
-        $file7 = $this->getMockBuilder(UploadedFile::class)->setMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
-        $file7->expects($this->any())->method('guessExtension')->willReturn('webp');
-        $file7->expects($this->any())->method('getClientOriginalExtension')->willReturn('webp');
-        $v = new Validator($trans, ['x' => $file7], ['x' => 'Image']);
+        $v = new Validator($trans, ['x' => $file2], ['x' => 'image']);
         $this->assertTrue($v->passes());
 
         $file2 = $this->getMockBuilder(UploadedFile::class)->setMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
         $file2->expects($this->any())->method('guessExtension')->willReturn('jpg');
         $file2->expects($this->any())->method('getClientOriginalExtension')->willReturn('jpg');
-        $v = new Validator($trans, ['x' => $file2], ['x' => 'Image']);
+        $v = new Validator($trans, ['x' => $file2], ['x' => 'image']);
+        $this->assertTrue($v->passes());
+
+        $file3 = $this->getMockBuilder(UploadedFile::class)->setMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
+        $file3->expects($this->any())->method('guessExtension')->willReturn('gif');
+        $file3->expects($this->any())->method('getClientOriginalExtension')->willReturn('gif');
+        $v = new Validator($trans, ['x' => $file3], ['x' => 'image']);
+        $this->assertTrue($v->passes());
+
+        $file4 = $this->getMockBuilder(UploadedFile::class)->setMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
+        $file4->expects($this->any())->method('guessExtension')->willReturn('bmp');
+        $file4->expects($this->any())->method('getClientOriginalExtension')->willReturn('bmp');
+        $v = new Validator($trans, ['x' => $file4], ['x' => 'image']);
+        $this->assertTrue($v->passes());
+
+        $file5 = $this->getMockBuilder(UploadedFile::class)->setMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
+        $file5->expects($this->any())->method('guessExtension')->willReturn('png');
+        $file5->expects($this->any())->method('getClientOriginalExtension')->willReturn('png');
+        $v = new Validator($trans, ['x' => $file5], ['x' => 'image']);
+        $this->assertTrue($v->passes());
+
+        $file6 = $this->getMockBuilder(UploadedFile::class)->setMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
+        $file6->expects($this->any())->method('guessExtension')->willReturn('svg');
+        $file6->expects($this->any())->method('getClientOriginalExtension')->willReturn('svg');
+        $v = new Validator($trans, ['x' => $file6], ['x' => 'image']);
+        $this->assertTrue($v->passes());
+
+        $file7 = $this->getMockBuilder(UploadedFile::class)->setMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
+        $file7->expects($this->any())->method('guessExtension')->willReturn('webp');
+        $file7->expects($this->any())->method('getClientOriginalExtension')->willReturn('webp');
+        $v = new Validator($trans, ['x' => $file7], ['x' => 'image']);
         $this->assertTrue($v->passes());
     }
 
@@ -2719,7 +2719,7 @@ class ValidationValidatorTest extends TestCase
         $file = $this->getMockBuilder(UploadedFile::class)->setMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
         $file->expects($this->any())->method('guessExtension')->willReturn('jpeg');
         $file->expects($this->any())->method('getClientOriginalExtension')->willReturn('php');
-        $v = new Validator($trans, ['x' => $file], ['x' => 'Image']);
+        $v = new Validator($trans, ['x' => $file], ['x' => 'image']);
         $this->assertFalse($v->passes());
     }
 
@@ -2832,19 +2832,24 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
-    /**
-     * @requires extension fileinfo
-     */
-    public function testValidatePhpMimetypes()
+    public function testValidateMimetypes()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $uploadedFile = [__DIR__.'/ValidationRuleTest.php', '', null, null, null, true];
+        $uploadedFile = [__FILE__, '', null, null, null, true];
 
-        $file = $this->getMockBuilder(UploadedFile::class)->setMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
-        $file->expects($this->any())->method('guessExtension')->willReturn('rtf');
-        $file->expects($this->any())->method('getClientOriginalExtension')->willReturn('rtf');
-
+        $file = $this->getMockBuilder(UploadedFile::class)->setMethods(['getMimeType'])->setConstructorArgs($uploadedFile)->getMock();
+        $file->expects($this->any())->method('getMimeType')->willReturn('text/rtf');
         $v = new Validator($trans, ['x' => $file], ['x' => 'mimetypes:text/*']);
+        $this->assertTrue($v->passes());
+
+        $file = $this->getMockBuilder(UploadedFile::class)->setMethods(['getMimeType'])->setConstructorArgs($uploadedFile)->getMock();
+        $file->expects($this->any())->method('getMimeType')->willReturn('application/pdf');
+        $v = new Validator($trans, ['x' => $file], ['x' => 'mimetypes:text/rtf']);
+        $this->assertFalse($v->passes());
+
+        $file = $this->getMockBuilder(UploadedFile::class)->setMethods(['getMimeType'])->setConstructorArgs($uploadedFile)->getMock();
+        $file->expects($this->any())->method('getMimeType')->willReturn('image/jpeg');
+        $v = new Validator($trans, ['x' => $file], ['x' => 'mimetypes:image/jpeg']);
         $this->assertTrue($v->passes());
     }
 
@@ -2864,6 +2869,18 @@ class ValidationValidatorTest extends TestCase
         $file2->expects($this->any())->method('isValid')->willReturn(false);
         $v = new Validator($trans, ['x' => $file2], ['x' => 'mimes:pdf']);
         $this->assertFalse($v->passes());
+
+        $file = $this->getMockBuilder(UploadedFile::class)->setMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
+        $file->expects($this->any())->method('guessExtension')->willReturn('jpg');
+        $file->expects($this->any())->method('getClientOriginalExtension')->willReturn('jpg');
+        $v = new Validator($trans, ['x' => $file], ['x' => 'mimes:jpeg']);
+        $this->assertTrue($v->passes());
+
+        $file = $this->getMockBuilder(UploadedFile::class)->setMethods(['guessExtension', 'getClientOriginalExtension'])->setConstructorArgs($uploadedFile)->getMock();
+        $file->expects($this->any())->method('guessExtension')->willReturn('jpg');
+        $file->expects($this->any())->method('getClientOriginalExtension')->willReturn('jpeg');
+        $v = new Validator($trans, ['x' => $file], ['x' => 'mimes:jpg']);
+        $this->assertTrue($v->passes());
     }
 
     public function testValidateMimeEnforcesPhpCheck()


### PR DESCRIPTION
These changes fixes a regression introduced by recent changes in Symfony and is a follow up to https://github.com/laravel/framework/pull/35419. It makes sure that if either `mimes:jpeg` or `mimes:jpg` is used that it doesn't matter wether the file is a `.jpg` or `.jpeg` file. This was the previous behaviour. 

I've also cleaned up some incorrect casing for the `image` rule and cleaned up the tests for the `mimetypes` rule which were a bit out of date it seems.

As a side note it would be much better if these tests were integration tests against actual files but that's out of the scope for this PR.

See https://github.com/laravel/framework/pull/35419#issuecomment-739707706