### PR TITLE
[8.x] Add handlerStats method for Http Client

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -121,6 +121,16 @@ class Response implements ArrayAccess
     }
 
     /**
+     * Get the handler stats of the response.
+     *
+     * @return \Psr\Http\Message\UriInterface
+     */
+    public function handlerStats()
+    {
+        return $this->transferStats->getHandlerStats();
+    }
+
+    /**
      * Determine if the request was successful.
      *
      * @return bool


### PR DESCRIPTION
Third time lucky? Happy to submit on 8.x branch :)

Previous to this PR, retrieving handlerStats from the Http Client response was not intuitive or documented. The withOptions method fails with an error using Guzzle 'on_stats', and $response->transferStats->getHandlerStats() is not documented. To get handler stats required reverse engineering the Response.php class to some extent to figure out that getHandlerStats() can be called from the $response->transferStats property .

This PR addresses the issue, by mimicking behaviour of the 'effectiveUri()' method from the Response.php class, but the PR implements a new method calling the Guzzle getHandlerStats() method direct and returning handlerStats from the $this->transferStats property/object.