### PR TITLE
[8.x] Create assertSentInOrder to test against the order of Http Requests using Strings or Closures

### DIFF
--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -273,7 +273,16 @@ class Factory
         $this->assertSentCount(count($requestSequence));
 
         foreach ($requestSequence as $orderPosition => $url) {
-            PHPUnit::assertEquals($url, $this->recorded[$orderPosition][0]->url());
+
+            $callback = $url;
+            if(!is_callable($url)){
+                $callback = function($request) use ($url) {
+                    return $request->url() == $url;
+                };
+            }
+
+            PHPUnit::assertTrue( $callback( $this->recorded[ $orderPosition ][0], $this->recorded[ $orderPosition ][1] ) );
+
         }
     }
 

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -271,7 +271,7 @@ class Factory
     public function assertSentInOrder($requestSequence)
     {
         $this->assertSentCount(count($requestSequence));
-        
+
         foreach ($requestSequence as $orderPosition => $url) {
             PHPUnit::assertEquals($url, $this->recorded[$orderPosition][0]->url());
         }

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -263,6 +263,23 @@ class Factory
     }
 
     /**
+     * Assert that requests were sent in the order specified.
+     * 
+     * @param  array  $requestSequence
+     * @return void
+     */
+    public function assertSentInOrder($requestSequence)
+    {
+        
+        $this->assertSentCount(count($requestSequence));
+        
+        foreach($requestSequence as $orderPosition => $url){
+            PHPUnit::assertEquals($url, $this->recorded[$orderPosition][0]->url());
+        }    
+
+    }
+
+    /**
      * Assert that every created response sequence is empty.
      *
      * @return void

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -264,19 +264,17 @@ class Factory
 
     /**
      * Assert that requests were sent in the order specified.
-     * 
+     *
      * @param  array  $requestSequence
      * @return void
      */
     public function assertSentInOrder($requestSequence)
     {
-        
         $this->assertSentCount(count($requestSequence));
         
-        foreach($requestSequence as $orderPosition => $url){
+        foreach ($requestSequence as $orderPosition => $url) {
             PHPUnit::assertEquals($url, $this->recorded[$orderPosition][0]->url());
-        }    
-
+        }
     }
 
     /**

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -610,4 +610,40 @@ class HttpClientTest extends TestCase
 
         $this->assertSame(json_encode(['page' => 'foo']), stream_get_contents($resource));
     }
+
+    public function testCanAssertAgainstOrderOfHttpRequests()
+    {
+        $this->factory->fake();
+
+        $exampleUrls = [
+            'http://example.com/1',
+            'http://example.com/2',
+            'http://example.com/3',
+        ];
+
+        foreach($exampleUrls as $url){
+            $this->factory->get($url);
+        }
+
+        $this->factory->assertSentInOrder($exampleUrls);
+    }
+
+    public function testAssertionsSentOutOfOrderThrowAssertionFailed()
+    {
+        $this->factory->fake();
+
+        $exampleUrls = [
+            'http://example.com/1',
+            'http://example.com/2',
+            'http://example.com/3',
+        ];
+
+        $this->factory->get($exampleUrls[0]);
+        $this->factory->get($exampleUrls[2]);
+        $this->factory->get($exampleUrls[1]);
+
+        $this->expectException(\PHPUnit\Framework\AssertionFailedError::class);
+
+        $this->factory->assertSentInOrder($exampleUrls);
+    }
 }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -621,7 +621,7 @@ class HttpClientTest extends TestCase
             'http://example.com/3',
         ];
 
-        foreach($exampleUrls as $url){
+        foreach ($exampleUrls as $url) {
             $this->factory->get($url);
         }
 

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -646,4 +646,22 @@ class HttpClientTest extends TestCase
 
         $this->factory->assertSentInOrder($exampleUrls);
     }
+
+    public function testWrongNumberOfRequestsThrowAssertionFailed()
+    {
+        $this->factory->fake();
+
+        $exampleUrls = [
+            'http://example.com/1',
+            'http://example.com/2',
+            'http://example.com/3',
+        ];
+
+        $this->factory->get($exampleUrls[0]);
+        $this->factory->get($exampleUrls[1]);
+
+        $this->expectException(\PHPUnit\Framework\AssertionFailedError::class);
+
+        $this->factory->assertSentInOrder($exampleUrls);
+    }
 }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -611,7 +611,7 @@ class HttpClientTest extends TestCase
         $this->assertSame(json_encode(['page' => 'foo']), stream_get_contents($resource));
     }
 
-    public function testCanAssertAgainstOrderOfHttpRequests()
+    public function testCanAssertAgainstOrderOfHttpRequestsWithUrlStrings()
     {
         $this->factory->fake();
 
@@ -663,5 +663,103 @@ class HttpClientTest extends TestCase
         $this->expectException(\PHPUnit\Framework\AssertionFailedError::class);
 
         $this->factory->assertSentInOrder($exampleUrls);
+    }
+
+    public function testCanAssertAgainstOrderOfHttpRequestsWithCallables() {
+        $this->factory->fake();
+
+        $exampleUrls = [
+            function($request) {
+                return $request->url() == 'http://example.com/1';
+            },
+            function($request) {
+                return $request->url() == 'http://example.com/2';
+            },
+            function($request) {
+                return $request->url() == 'http://example.com/3';
+            },
+        ];
+            
+        $this->factory->get('http://example.com/1');
+        $this->factory->get('http://example.com/2');
+        $this->factory->get('http://example.com/3');
+
+        $this->factory->assertSentInOrder($exampleUrls);
+    }
+
+    public function testCanAssertAgainstOrderOfHttpRequestsWithCallablesAndHeaders() {
+        $this->factory->fake();
+
+        $executionOrder = [
+            function (Request $request) {
+                return $request->url() === 'http://foo.com/json' &&
+                       $request->hasHeader('Content-Type', 'application/json') &&
+                       $request->hasHeader('X-Test-Header', 'foo') &&
+                       $request->hasHeader('X-Test-ArrayHeader', ['bar', 'baz']) &&
+                       $request['name'] === 'Taylor';
+            },
+            function (Request $request) {
+                return $request->url() === 'http://bar.com/json' &&
+                       $request->hasHeader('Content-Type', 'application/json') &&
+                       $request->hasHeader('X-Test-Header', 'bar') &&
+                       $request->hasHeader('X-Test-ArrayHeader', ['bar', 'baz']) &&
+                       $request['name'] === 'Taylor';
+            }
+        ];
+
+        $this->factory->withHeaders([
+            'X-Test-Header' => 'foo',
+            'X-Test-ArrayHeader' => ['bar', 'baz'],
+        ])->post('http://foo.com/json', [
+            'name' => 'Taylor',
+        ]);
+
+        $this->factory->withHeaders([
+            'X-Test-Header' => 'bar',
+            'X-Test-ArrayHeader' => ['bar', 'baz'],
+        ])->post('http://bar.com/json', [
+            'name' => 'Taylor',
+        ]);
+
+        $this->factory->assertSentInOrder($executionOrder);
+    }
+
+    public function testCanAssertAgainstOrderOfHttpRequestsWithCallablesAndHeadersFailsCorrectly() {
+        $this->factory->fake();
+
+        $executionOrder = [
+            function (Request $request) {
+                return $request->url() === 'http://bar.com/json' &&
+                       $request->hasHeader('Content-Type', 'application/json') &&
+                       $request->hasHeader('X-Test-Header', 'bar') &&
+                       $request->hasHeader('X-Test-ArrayHeader', ['bar', 'baz']) &&
+                       $request['name'] === 'Taylor';
+            },
+            function (Request $request) {
+                return $request->url() === 'http://foo.com/json' &&
+                       $request->hasHeader('Content-Type', 'application/json') &&
+                       $request->hasHeader('X-Test-Header', 'foo') &&
+                       $request->hasHeader('X-Test-ArrayHeader', ['bar', 'baz']) &&
+                       $request['name'] === 'Taylor';
+            },
+        ];
+
+        $this->factory->withHeaders([
+            'X-Test-Header' => 'foo',
+            'X-Test-ArrayHeader' => ['bar', 'baz'],
+        ])->post('http://foo.com/json', [
+            'name' => 'Taylor',
+        ]);
+
+        $this->factory->withHeaders([
+            'X-Test-Header' => 'bar',
+            'X-Test-ArrayHeader' => ['bar', 'baz'],
+        ])->post('http://bar.com/json', [
+            'name' => 'Taylor',
+        ]);
+
+        $this->expectException(\PHPUnit\Framework\AssertionFailedError::class);
+
+        $this->factory->assertSentInOrder($executionOrder);
     }
 }


### PR DESCRIPTION
I've updated the assertSentInOrder method to take an array of callables, or an array of URLs. Original PR #35497