### PR TITLE
add passwordTimeout to RequirePassword middleware as a parameter

### DIFF
--- a/src/Illuminate/Auth/Middleware/RequirePassword.php
+++ b/src/Illuminate/Auth/Middleware/RequirePassword.php
@@ -50,11 +50,12 @@ class RequirePassword
      * @param  \Illuminate\Http\Request  $request
      * @param  \Closure  $next
      * @param  string|null  $redirectToRoute
+     * @param  int|null  $passwordTimeoutSeconds
      * @return mixed
      */
-    public function handle($request, Closure $next, $redirectToRoute = null)
+    public function handle($request, Closure $next, $redirectToRoute = null, int $passwordTimeoutSeconds = null)
     {
-        if ($this->shouldConfirmPassword($request)) {
+        if ($this->shouldConfirmPassword($request, $passwordTimeoutSeconds)) {
             if ($request->expectsJson()) {
                 return $this->responseFactory->json([
                     'message' => 'Password confirmation required.',
@@ -73,12 +74,13 @@ class RequirePassword
      * Determine if the confirmation timeout has expired.
      *
      * @param  \Illuminate\Http\Request  $request
+     * @param  int|null  $passwordTimeoutSeconds
      * @return bool
      */
-    protected function shouldConfirmPassword($request)
+    protected function shouldConfirmPassword($request, int $passwordTimeoutSeconds = null)
     {
         $confirmedAt = time() - $request->session()->get('auth.password_confirmed_at', 0);
 
-        return $confirmedAt > $this->passwordTimeout;
+        return $confirmedAt > ($passwordTimeoutSeconds ?? $this->passwordTimeout);
     }
 }


### PR DESCRIPTION
This PR add the possibility to customize the RequirePassword middleware passwordTimeout duration, witch is retrieved from config default value at `config('auth.password_timeout')`.

Example:

`Route::get('/foo}', 'FooController@foo')->middleware(['password.confirm:password.confirm,60']);`

1. 'password.confirm' value parameter keeps the current possibility to customize desired redirect route.
2. '60' value parameter allow developers to customize passwordTimeout in seconds for each route as desired.

The PR is fully backwards compatible, it just add a new parameter to the middleware.

PS: This is my first PR to Laravel, soo please don't be to harsh, I'm learning to.
PS2: Initially I was thinking to preserve this logic with only one parameter (the current 'redirectToRoute') and check if is numeric, but I decided to keep it as simple as possible, and avoid conflicts with possible routes named as numeric.