### PR TITLE
[8.x] Introducing Job Encryption

### DIFF
--- a/src/Illuminate/Contracts/Queue/UsesEncryption.php
+++ b/src/Illuminate/Contracts/Queue/UsesEncryption.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Contracts\Queue;
+
+interface UsesEncryption
+{
+    //
+}

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -5,6 +5,7 @@ namespace Illuminate\Queue;
 use Closure;
 use DateTimeInterface;
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Queue\UsesEncryption;
 use Illuminate\Support\Arr;
 use Illuminate\Support\InteractsWithTime;
 use Illuminate\Support\Str;
@@ -142,10 +143,14 @@ abstract class Queue
             ],
         ]);
 
+        $command = $job instanceof UsesEncryption && $this->container->bound('encrypter')
+                    ? $this->container['encrypter']->encrypt(serialize(clone $job))
+                    : serialize(clone $job);
+
         return array_merge($payload, [
             'data' => [
                 'commandName' => get_class($job),
-                'command' => serialize(clone $job),
+                'command' => $command,
             ],
         ]);
     }

--- a/tests/Integration/Queue/JobEncryptionTest.php
+++ b/tests/Integration/Queue/JobEncryptionTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Queue;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Encryption\Encrypter;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Contracts\Queue\UsesEncryption;
+use Illuminate\Database\DatabaseTransactionsManager;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+use Illuminate\Tests\Integration\Database\EloquentCollectionLoadMissingTest\Comment;
+use Illuminate\Tests\Integration\Database\EloquentCollectionLoadMissingTest\Post;
+use Illuminate\Tests\Integration\Database\EloquentCollectionLoadMissingTest\Revision;
+use Illuminate\Tests\Integration\Database\EloquentCollectionLoadMissingTest\User;
+use Mockery as m;
+use Orchestra\Testbench\TestCase;
+
+/**
+ * @group integration
+ */
+class JobEncryptionTest extends DatabaseTestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('app.key', Str::random(32));
+        $app['config']->set('app.debug', 'true');
+        $app['config']->set('queue.default', 'database');
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('jobs', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('queue')->index();
+            $table->longText('payload');
+            $table->unsignedTinyInteger('attempts');
+            $table->unsignedInteger('reserved_at')->nullable();
+            $table->unsignedInteger('available_at');
+            $table->unsignedInteger('created_at');
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        JobEncryptionTestEncryptedJob::$ran = false;
+        JobEncryptionTestNonEncryptedJob::$ran = false;
+
+        m::close();
+    }
+
+    public function testEncryptedJobPayloadIsStoredEncrypted()
+    {
+        Bus::dispatch(new JobEncryptionTestEncryptedJob);
+
+        $this->assertNotEmpty(
+            decrypt(json_decode(DB::table('jobs')->first()->payload)->data->command)
+        );
+    }
+
+    public function testNonEncryptedJobPayloadIsStoredRaw()
+    {
+        Bus::dispatch(new JobEncryptionTestNonEncryptedJob);
+
+        $this->expectExceptionMessage('The payload is invalid');
+
+        $this->assertInstanceOf(JobEncryptionTestNonEncryptedJob::class,
+            unserialize(json_decode(DB::table('jobs')->first()->payload)->data->command)
+        );
+
+        decrypt(json_decode(DB::table('jobs')->first()->payload)->data->command);
+    }
+
+    public function testQueueCanProcessEncryptedJob()
+    {
+        Bus::dispatch(new JobEncryptionTestEncryptedJob);
+
+        Queue::pop()->fire();
+
+        $this->assertTrue(JobEncryptionTestEncryptedJob::$ran);
+    }
+
+    public function testQueueCanProcessUnEncryptedJob()
+    {
+        Bus::dispatch(new JobEncryptionTestNonEncryptedJob);
+
+        Queue::pop()->fire();
+
+        $this->assertTrue(JobEncryptionTestNonEncryptedJob::$ran);
+    }
+}
+
+class JobEncryptionTestEncryptedJob implements ShouldQueue, UsesEncryption
+{
+    use Dispatchable, Queueable;
+
+    public static $ran = false;
+
+    public function handle()
+    {
+        static::$ran = true;
+    }
+}
+
+
+class JobEncryptionTestNonEncryptedJob implements ShouldQueue
+{
+    use Dispatchable, Queueable;
+
+    public static $ran = false;
+
+    public function handle()
+    {
+        static::$ran = true;
+    }
+}

--- a/tests/Integration/Queue/JobEncryptionTest.php
+++ b/tests/Integration/Queue/JobEncryptionTest.php
@@ -3,10 +3,8 @@
 namespace Illuminate\Tests\Integration\Queue;
 
 use Illuminate\Bus\Queueable;
-use Illuminate\Contracts\Encryption\Encrypter;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Contracts\Queue\UsesEncryption;
-use Illuminate\Database\DatabaseTransactionsManager;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Support\Facades\Bus;
@@ -15,12 +13,7 @@ use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
-use Illuminate\Tests\Integration\Database\EloquentCollectionLoadMissingTest\Comment;
-use Illuminate\Tests\Integration\Database\EloquentCollectionLoadMissingTest\Post;
-use Illuminate\Tests\Integration\Database\EloquentCollectionLoadMissingTest\Revision;
-use Illuminate\Tests\Integration\Database\EloquentCollectionLoadMissingTest\User;
 use Mockery as m;
-use Orchestra\Testbench\TestCase;
 
 /**
  * @group integration


### PR DESCRIPTION
This PR adds a `UsesEncryption` interface. When the interface is used, laravel will encrypt the `command` inside the payload and decrypt it while running `CallQueuedHandler`.

Encrypting the command payload hides the job class properties which may hold sensitive information (API keys, passwords, personal information, etc...).