### PR TITLE
[9.x] Fix postgres reference parsing

### DIFF
--- a/src/Illuminate/Database/Connectors/PostgresConnector.php
+++ b/src/Illuminate/Database/Connectors/PostgresConnector.php
@@ -116,7 +116,7 @@ class PostgresConnector extends Connector implements ConnectorInterface
             $searchPath = $matches[0];
         }
 
-        array_walk($searchPath, function(&$schema) {
+        array_walk($searchPath, function (&$schema) {
             $schema = trim($schema, '\'"');
         });
 
@@ -131,7 +131,7 @@ class PostgresConnector extends Connector implements ConnectorInterface
      */
     protected function formatSearchPath($searchPath)
     {
-        return count($searchPath) === 1 ? '"' . $searchPath[0] . '"' : '"'.implode('", "', $searchPath).'"';
+        return count($searchPath) === 1 ? '"'.$searchPath[0].'"' : '"'.implode('", "', $searchPath).'"';
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -42,7 +42,7 @@ class PostgresGrammar extends Grammar
      */
     public function compileTableExists()
     {
-        return "select * from information_schema.tables where table_schema = ? and table_name = ? and table_type = 'BASE TABLE'";
+        return "select * from information_schema.tables where table_catalog = ? and table_schema = ? and table_name = ? and table_type = 'BASE TABLE'";
     }
 
     /**
@@ -52,7 +52,7 @@ class PostgresGrammar extends Grammar
      */
     public function compileColumnListing()
     {
-        return 'select column_name from information_schema.columns where table_schema = ? and table_name = ?';
+        return 'select column_name from information_schema.columns where table_catalog = ? and table_schema = ? and table_name = ?';
     }
 
     /**

--- a/src/Illuminate/Database/Schema/PostgresBuilder.php
+++ b/src/Illuminate/Database/Schema/PostgresBuilder.php
@@ -168,7 +168,7 @@ class PostgresBuilder extends Builder
             $searchPath = $matches[0];
         }
 
-        array_walk($searchPath, function(&$schema) {
+        array_walk($searchPath, function (&$schema) {
             $schema = trim($schema, '\'"');
         });
 

--- a/tests/Database/DatabasePostgresBuilderTest.php
+++ b/tests/Database/DatabasePostgresBuilderTest.php
@@ -1,0 +1,209 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Connection;
+use Illuminate\Database\Query\Processors\PostgresProcessor;
+use Illuminate\Database\Schema\Grammars\PostgresGrammar;
+use Illuminate\Database\Schema\PostgresBuilder;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class DatabasePostgresBuilderTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    /**
+     * Ensure that when the reference is unqualified (i.e., does not contain a
+     * database name or a schema), and the search_path is empty, the database
+     * specified on the connection is used, and the default schema ('public')
+     * is used.
+     */
+    public function testWhenSearchPathEmptyHasTableWithUnqualifiedReferenceIsCorrect()
+    {
+        $connection = $this->getConnection();
+        $connection->shouldReceive('getConfig')->with('search_path')->andReturn(null);
+        $grammar = m::mock(PostgresGrammar::class);
+        $connection->shouldReceive('getSchemaGrammar')->once()->andReturn($grammar);
+        $grammar->shouldReceive('compileTableExists')->andReturn("select * from information_schema.tables where table_catalog = ? and table_schema = ? and table_name = ? and table_type = 'BASE TABLE'");
+        $connection->shouldReceive('select')->with("select * from information_schema.tables where table_catalog = ? and table_schema = ? and table_name = ? and table_type = 'BASE TABLE'", ['laravel', 'public', 'foo'])->andReturn(['countable_result']);
+        $connection->shouldReceive('getTablePrefix');
+        $connection->shouldReceive('getConfig')->with('database')->andReturn('laravel');
+        $builder = $this->getBuilder($connection);
+
+        $builder->hasTable('foo');
+    }
+
+    /**
+     * Ensure that when the reference is unqualified (i.e., does not contain a
+     * database name or a schema), and the first schema in the search_path is
+     * NOT the default ('public'), the database specified on the connection is
+     * used, and the first schema in the search_path is used.
+     */
+    public function testWhenSearchPathNotEmptyHasTableWithUnqualifiedSchemaReferenceIsCorrect()
+    {
+        $connection = $this->getConnection();
+        $connection->shouldReceive('getConfig')->with('search_path')->andReturn('myapp,public');
+        $grammar = m::mock(PostgresGrammar::class);
+        $connection->shouldReceive('getSchemaGrammar')->once()->andReturn($grammar);
+        $grammar->shouldReceive('compileTableExists')->andReturn("select * from information_schema.tables where table_catalog = ? and table_schema = ? and table_name = ? and table_type = 'BASE TABLE'");
+        $connection->shouldReceive('select')->with("select * from information_schema.tables where table_catalog = ? and table_schema = ? and table_name = ? and table_type = 'BASE TABLE'", ['laravel', 'myapp', 'foo'])->andReturn(['countable_result']);
+        $connection->shouldReceive('getTablePrefix');
+        $connection->shouldReceive('getConfig')->with('database')->andReturn('laravel');
+        $builder = $this->getBuilder($connection);
+
+        $builder->hasTable('foo');
+    }
+
+    /**
+     * Ensure that when the reference is qualified only with a schema, that
+     * the database specified on the connection is used, and the specified
+     * schema is used, even if it is not within the search_path.
+     */
+    public function testWhenSchemaNotInSearchPathHasTableWithQualifiedSchemaReferenceIsCorrect()
+    {
+        $connection = $this->getConnection();
+        $connection->shouldReceive('getConfig')->with('search_path')->andReturn('public');
+        $grammar = m::mock(PostgresGrammar::class);
+        $connection->shouldReceive('getSchemaGrammar')->once()->andReturn($grammar);
+        $grammar->shouldReceive('compileTableExists')->andReturn("select * from information_schema.tables where table_catalog = ? and table_schema = ? and table_name = ? and table_type = 'BASE TABLE'");
+        $connection->shouldReceive('select')->with("select * from information_schema.tables where table_catalog = ? and table_schema = ? and table_name = ? and table_type = 'BASE TABLE'", ['laravel', 'myapp', 'foo'])->andReturn(['countable_result']);
+        $connection->shouldReceive('getTablePrefix');
+        $connection->shouldReceive('getConfig')->with('database')->andReturn('laravel');
+        $builder = $this->getBuilder($connection);
+
+        $builder->hasTable('myapp.foo');
+    }
+
+    /**
+     * Ensure that when the reference is qualified with a database AND a schema,
+     * and the database is NOT the database configured for the connection, the
+     * specified database is used instead.
+     */
+    public function testWhenDatabaseNotDefaultHasTableWithFullyQualifiedReferenceIsCorrect()
+    {
+        $connection = $this->getConnection();
+        $connection->shouldReceive('getConfig')->with('search_path')->andReturn('public');
+        $grammar = m::mock(PostgresGrammar::class);
+        $connection->shouldReceive('getSchemaGrammar')->once()->andReturn($grammar);
+        $grammar->shouldReceive('compileTableExists')->andReturn("select * from information_schema.tables where table_catalog = ? and table_schema = ? and table_name = ? and table_type = 'BASE TABLE'");
+        $connection->shouldReceive('select')->with("select * from information_schema.tables where table_catalog = ? and table_schema = ? and table_name = ? and table_type = 'BASE TABLE'", ['mydatabase', 'myapp', 'foo'])->andReturn(['countable_result']);
+        $connection->shouldReceive('getTablePrefix');
+        $connection->shouldReceive('getConfig')->with('database')->andReturn('laravel');
+        $builder = $this->getBuilder($connection);
+
+        $builder->hasTable('mydatabase.myapp.foo');
+    }
+
+    /**
+     * Ensure that when the reference is unqualified (i.e., does not contain a
+     * database name or a schema), and the search_path is empty, the database
+     * specified on the connection is used, and the default schema ('public')
+     * is used.
+     */
+    public function testWhenSearchPathEmptyGetColumnListingWithUnqualifiedReferenceIsCorrect()
+    {
+        $connection = $this->getConnection();
+        $connection->shouldReceive('getConfig')->with('search_path')->andReturn(null);
+        $grammar = m::mock(PostgresGrammar::class);
+        $connection->shouldReceive('getSchemaGrammar')->once()->andReturn($grammar);
+        $grammar->shouldReceive('compileColumnListing')->andReturn('select column_name from information_schema.columns where table_catalog = ? and table_schema = ? and table_name = ?');
+        $connection->shouldReceive('select')->with('select column_name from information_schema.columns where table_catalog = ? and table_schema = ? and table_name = ?', ['laravel', 'public', 'foo'])->andReturn(['countable_result']);
+        $connection->shouldReceive('getTablePrefix');
+        $connection->shouldReceive('getConfig')->with('database')->andReturn('laravel');
+        $processor = m::mock(PostgresProcessor::class);
+        $connection->shouldReceive('getPostProcessor')->andReturn($processor);
+        $processor->shouldReceive('processColumnListing')->andReturn(['some_column']);
+        $builder = $this->getBuilder($connection);
+
+        $builder->getColumnListing('foo');
+    }
+
+    /**
+     * Ensure that when the reference is unqualified (i.e., does not contain a
+     * database name or a schema), and the first schema in the search_path is
+     * NOT the default ('public'), the database specified on the connection is
+     * used, and the first schema in the search_path is used.
+     */
+    public function testWhenSearchPathNotEmptyGetColumnListingWithUnqualifiedSchemaReferenceIsCorrect()
+    {
+        $connection = $this->getConnection();
+        $connection->shouldReceive('getConfig')->with('search_path')->andReturn('myapp,public');
+        $grammar = m::mock(PostgresGrammar::class);
+        $connection->shouldReceive('getSchemaGrammar')->once()->andReturn($grammar);
+        $grammar->shouldReceive('compileColumnListing')->andReturn('select column_name from information_schema.columns where table_catalog = ? and table_schema = ? and table_name = ?');
+        $connection->shouldReceive('select')->with('select column_name from information_schema.columns where table_catalog = ? and table_schema = ? and table_name = ?', ['laravel', 'myapp', 'foo'])->andReturn(['countable_result']);
+        $connection->shouldReceive('getTablePrefix');
+        $connection->shouldReceive('getConfig')->with('database')->andReturn('laravel');
+        $processor = m::mock(PostgresProcessor::class);
+        $connection->shouldReceive('getPostProcessor')->andReturn($processor);
+        $processor->shouldReceive('processColumnListing')->andReturn(['some_column']);
+        $builder = $this->getBuilder($connection);
+
+        $builder->getColumnListing('foo');
+    }
+
+    /**
+     * Ensure that when the reference is qualified only with a schema, that
+     * the database specified on the connection is used, and the specified
+     * schema is used, even if it is not within the search_path.
+     */
+    public function testWhenSchemaNotInSearchPathGetColumnListingWithQualifiedSchemaReferenceIsCorrect()
+    {
+        $connection = $this->getConnection();
+        $connection->shouldReceive('getConfig')->with('search_path')->andReturn('public');
+        $grammar = m::mock(PostgresGrammar::class);
+        $connection->shouldReceive('getSchemaGrammar')->once()->andReturn($grammar);
+        $grammar->shouldReceive('compileColumnListing')->andReturn('select column_name from information_schema.columns where table_catalog = ? and table_schema = ? and table_name = ?');
+        $connection->shouldReceive('select')->with('select column_name from information_schema.columns where table_catalog = ? and table_schema = ? and table_name = ?', ['laravel', 'myapp', 'foo'])->andReturn(['countable_result']);
+        $connection->shouldReceive('getTablePrefix');
+        $connection->shouldReceive('getConfig')->with('database')->andReturn('laravel');
+        $processor = m::mock(PostgresProcessor::class);
+        $connection->shouldReceive('getPostProcessor')->andReturn($processor);
+        $processor->shouldReceive('processColumnListing')->andReturn(['some_column']);
+        $builder = $this->getBuilder($connection);
+
+        $builder->getColumnListing('myapp.foo');
+    }
+
+    /**
+     * Ensure that when the reference is qualified with a database AND a schema,
+     * and the database is NOT the database configured for the connection, the
+     * specified database is used instead.
+     */
+    public function testWhenDatabaseNotDefaultGetColumnListingWithFullyQualifiedReferenceIsCorrect()
+    {
+        $connection = $this->getConnection();
+        $connection->shouldReceive('getConfig')->with('search_path')->andReturn('public');
+        $grammar = m::mock(PostgresGrammar::class);
+        $connection->shouldReceive('getSchemaGrammar')->once()->andReturn($grammar);
+        $grammar->shouldReceive('compileColumnListing')->andReturn('select column_name from information_schema.columns where table_catalog = ? and table_schema = ? and table_name = ?');
+        $connection->shouldReceive('select')->with('select column_name from information_schema.columns where table_catalog = ? and table_schema = ? and table_name = ?', ['mydatabase', 'myapp', 'foo'])->andReturn(['countable_result']);
+        $connection->shouldReceive('getTablePrefix');
+        $connection->shouldReceive('getConfig')->with('database')->andReturn('laravel');
+        $processor = m::mock(PostgresProcessor::class);
+        $connection->shouldReceive('getPostProcessor')->andReturn($processor);
+        $processor->shouldReceive('processColumnListing')->andReturn(['some_column']);
+        $builder = $this->getBuilder($connection);
+
+        $builder->getColumnListing('mydatabase.myapp.foo');
+    }
+
+    protected function getConnection()
+    {
+        return m::mock(Connection::class);
+    }
+
+    protected function getBuilder($connection)
+    {
+        return new PostgresBuilder($connection);
+    }
+
+    protected function getGrammar()
+    {
+        return new PostgresGrammar;
+    }
+}

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -998,6 +998,20 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertSame('drop type "alpha","beta","gamma" cascade', $statement);
     }
 
+    public function testCompileTableExists()
+    {
+        $statement = $this->getGrammar()->compileTableExists();
+
+        $this->assertSame('select * from information_schema.tables where table_catalog = ? and table_schema = ? and table_name = ? and table_type = \'BASE TABLE\'', $statement);
+    }
+
+    public function testCompileColumnListing()
+    {
+        $statement = $this->getGrammar()->compileColumnListing();
+
+        $this->assertSame('select column_name from information_schema.columns where table_catalog = ? and table_schema = ? and table_name = ?', $statement);
+    }
+
     protected function getConnection()
     {
         return m::mock(Connection::class);


### PR DESCRIPTION
## Preface

I'm submitting this to `master` because it relies on https://github.com/laravel/framework/pull/35463 , which was also sent to `master` due to breaking changes.

~~Regarding tests, there are no existing tests that cover this functionality. While I can write tests to cover what I changed and added, it'll take me a while, and given the significance of these issues for the small number of users that they affect, my recommendation is to merge this, even without new tests, because the current implementation should be fixed with urgency. I'm willing to commit to writing the tests when I have more time, and propose them in a separate PR.~~

(UPDATE: I added tests.)

I should mention also that I inadvertently introduced a slight regression (undefined variable warning) on https://github.com/laravel/framework/blob/a974ad6191523addf2755aebdf94ce3c14eb958f/src/Illuminate/Database/Schema/PostgresBuilder.php#L167 in the part 1 of 2 PR, which I fixed properly in this PR. (Rolling back that method wouldn't be a "fix", either, because its logic is not quite correct to begin with.)

## Substance

This PR is essentially "part 2 of 2" relative to the above-mentioned PR, in that it "normalizes" the search_path parsing behavior such that the new `parseSearchPath()` method returns the same result whether the `search_path` input is an array (with one or more schemas), a string with one schema, or a string of comma-separated schemas. This method's presence makes it much simpler to retrieve the `search_path` as configured on the connection and use it for more complex schema-related grammar construction.

This PR also fixes several issues with the `parseSchemaAndTable()` method.

If the database object reference is unqualified (i.e., the `$table` string does not contain a schema + `.` prefix), the existing logic is reasonably sound. But if the reference is qualified, there are a few issues that arise.

Assuming the input `$table` is `'public.users'`:

1. If the `search_path` is the default, `'public'` (or if it is `null`, in which case `'public'` is used), the following query is executed, which will never return a result, because the `public.` portion is never removed from the table name:

```sql
select * from information_schema.tables where table_schema = 'public' and table_name = 'public.users' and table_type = 'BASE TABLE'
```

For this logic to be sound, if the schema is found in the table reference, it should be removed, e.g.:

```sql
select * from information_schema.tables where table_schema = 'public' and table_name = 'users' and table_type = 'BASE TABLE'
```

And furthermore, PostgreSQL table names cannot contain periods, so there's just no reason for a period ever to be included in the table name binding here.

But there's still another issue, which is that the database name is not considered, neither in this method nor in the SQL grammar that is used to construct the queries for `hasTable($table)` and `getColumnListing($table)`.

This omission is problematic because it causes these methods to return inaccurate results in some cases. For example, failing to qualify these queries with a database name (in the `table_catalog` column on the `WHERE` clause) could cause `hasTable($table)` to return `true` just because another/different database has a schema and table combination with the same names.

## Seeking Feedback...

I don't like the fact that I added identical `parseSearchPath($searchPath)` methods to both the `PostgresConnetor` and the `PostgresBuilder` classes. Is there a better location for this method that both of these classes can leverage without adding new dependencies? This method is essentially a "utility function" that ingests any reasonably-formatted `search_path` (list of schemas) from the connection's configuration and returns a neatly-formatted array of schemas that can be queried or `implode()`d, for example.

Also, are the comments in the `parseSchemaAndTable()` method helpful? Sure, they seem self-evident, but the underlying logic here is deceptively complicated, due to the complexities inherent to PostgreSQL's `search_path` related nuances, so I thought some explicit commentary might be warranted.

Finally, that method should perhaps be renamed to `parseDatabaseSchemaAndTable()` or `parseDatabaseObjectReference()`, or something that better reflects what it actually does. I say this specifically because the method now supports a database part. For example, if the `$table` input is `homestead.laravel.users`, the `homestead` portion is actually used and passed to the underlying `information_schema` query (and if it's not passed, the `database` configuration parameter on the connection is used). So, technically, the method is parsing a full database object reference, and not a "schema and a table", _per se_.