### PR TITLE
[8.x] Revert table name as morph type

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -731,10 +731,6 @@ trait HasRelationships
             return array_search(static::class, $morphMap, true);
         }
 
-        if (Relation::$tableNameAsMorphType) {
-            return $this->getTable();
-        }
-
         return static::class;
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -56,13 +56,6 @@ abstract class Relation
     public static $morphMap = [];
 
     /**
-     * Indicates if the morph relation type should default to table name.
-     *
-     * @var bool
-     */
-    public static $tableNameAsMorphType = false;
-
-    /**
      * The count of self joins.
      *
      * @var int
@@ -364,16 +357,6 @@ abstract class Relation
         }
 
         return static::$morphMap;
-    }
-
-    /**
-     * Specifies that the morph types should be table names.
-     *
-     * @return void
-     */
-    public static function tableNameAsMorphType()
-    {
-        self::$tableNameAsMorphType = true;
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1211,23 +1211,6 @@ class DatabaseEloquentModelTest extends TestCase
         }
     }
 
-    public function testCorrectMorphClassIsReturnedOnChangingDefault()
-    {
-        Relation::tableNameAsMorphType();
-        Relation::morphMap(['alias' => EloquentModelCamelStub::class]);
-        Relation::morphMap(['alias2' => 'AnotherModel']);
-        $model = new EloquentModelStub;
-        $model2 = new EloquentModelCamelStub;
-
-        try {
-            $this->assertEquals('stub', $model->getMorphClass());
-            $this->assertEquals('alias', $model2->getMorphClass());
-        } finally {
-            Relation::morphMap([], false);
-            Relation::$tableNameAsMorphType = false;
-        }
-    }
-
     public function testHasManyCreatesProperRelation()
     {
         $model = new EloquentModelStub;


### PR DESCRIPTION
This reverts https://github.com/laravel/framework/pull/35257 which broke the way `->morphTo()` works. 

Fixes https://github.com/laravel/framework/issues/35519