### PR TITLE
[8.x] Bumped minimum Symfony version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,15 +31,15 @@
         "psr/simple-cache": "^1.0",
         "ramsey/uuid": "^4.0",
         "swiftmailer/swiftmailer": "^6.0",
-        "symfony/console": "^5.1",
-        "symfony/error-handler": "^5.1",
-        "symfony/finder": "^5.1",
-        "symfony/http-foundation": "^5.1",
-        "symfony/http-kernel": "^5.1",
-        "symfony/mime": "^5.1",
-        "symfony/process": "^5.1",
-        "symfony/routing": "^5.1",
-        "symfony/var-dumper": "^5.1",
+        "symfony/console": "^5.1.4",
+        "symfony/error-handler": "^5.1.4",
+        "symfony/finder": "^5.1.4",
+        "symfony/http-foundation": "^5.1.4",
+        "symfony/http-kernel": "^5.1.4",
+        "symfony/mime": "^5.1.4",
+        "symfony/process": "^5.1.4",
+        "symfony/routing": "^5.1.4",
+        "symfony/var-dumper": "^5.1.4",
         "tijsverkoyen/css-to-inline-styles": "^2.2.2",
         "vlucas/phpdotenv": "^5.2",
         "voku/portable-ascii": "^1.4.8"
@@ -88,7 +88,7 @@
         "pda/pheanstalk": "^4.0",
         "phpunit/phpunit": "^8.5.8|^9.3.3",
         "predis/predis": "^1.1.1",
-        "symfony/cache": "^5.1"
+        "symfony/cache": "^5.1.4"
     },
     "provide": {
         "psr/container-implementation": "1.0"
@@ -144,8 +144,8 @@
         "predis/predis": "Required to use the predis connector (^1.1.2).",
         "psr/http-message": "Required to allow Storage::put to accept a StreamInterface (^1.0).",
         "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (^4.0).",
-        "symfony/cache": "Required to PSR-6 cache bridge (^5.1).",
-        "symfony/filesystem": "Required to enable support for relative symbolic links (^5.1).",
+        "symfony/cache": "Required to PSR-6 cache bridge (^5.1.4).",
+        "symfony/filesystem": "Required to enable support for relative symbolic links (^5.1.4).",
         "symfony/psr-http-message-bridge": "Required to use PSR-7 bridging features (^2.0).",
         "wildbit/swiftmailer-postmark": "Required to use Postmark mail driver (^3.0)."
     },

--- a/src/Illuminate/Cache/composer.json
+++ b/src/Illuminate/Cache/composer.json
@@ -35,7 +35,7 @@
         "illuminate/database": "Required to use the database cache driver (^8.0).",
         "illuminate/filesystem": "Required to use the file cache driver (^8.0).",
         "illuminate/redis": "Required to use the redis cache driver (^8.0).",
-        "symfony/cache": "Required to PSR-6 cache bridge (^5.1)."
+        "symfony/cache": "Required to PSR-6 cache bridge (^5.1.4)."
     },
     "config": {
         "sort-packages": true

--- a/src/Illuminate/Collections/composer.json
+++ b/src/Illuminate/Collections/composer.json
@@ -32,7 +32,7 @@
         }
     },
     "suggest": {
-        "symfony/var-dumper": "Required to use the dump method (^5.1)."
+        "symfony/var-dumper": "Required to use the dump method (^5.1.4)."
     },
     "config": {
         "sort-packages": true

--- a/src/Illuminate/Console/composer.json
+++ b/src/Illuminate/Console/composer.json
@@ -19,8 +19,8 @@
         "illuminate/contracts": "^8.0",
         "illuminate/macroable": "^8.0",
         "illuminate/support": "^8.0",
-        "symfony/console": "^5.1",
-        "symfony/process": "^5.1"
+        "symfony/console": "^5.1.4",
+        "symfony/process": "^5.1.4"
     },
     "autoload": {
         "psr-4": {

--- a/src/Illuminate/Cookie/composer.json
+++ b/src/Illuminate/Cookie/composer.json
@@ -19,8 +19,8 @@
         "illuminate/contracts": "^8.0",
         "illuminate/macroable": "^8.0",
         "illuminate/support": "^8.0",
-        "symfony/http-foundation": "^5.1",
-        "symfony/http-kernel": "^5.1"
+        "symfony/http-foundation": "^5.1.4",
+        "symfony/http-kernel": "^5.1.4"
     },
     "autoload": {
         "psr-4": {

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -22,7 +22,7 @@
         "illuminate/contracts": "^8.0",
         "illuminate/macroable": "^8.0",
         "illuminate/support": "^8.0",
-        "symfony/console": "^5.1"
+        "symfony/console": "^5.1.4"
     },
     "autoload": {
         "psr-4": {
@@ -41,7 +41,7 @@
         "illuminate/events": "Required to use the observers with Eloquent (^8.0).",
         "illuminate/filesystem": "Required to use the migrations (^8.0).",
         "illuminate/pagination": "Required to paginate the result set (^8.0).",
-        "symfony/finder": "Required to use Eloquent model factories (^5.1)."
+        "symfony/finder": "Required to use Eloquent model factories (^5.1.4)."
     },
     "config": {
         "sort-packages": true

--- a/src/Illuminate/Filesystem/composer.json
+++ b/src/Illuminate/Filesystem/composer.json
@@ -19,7 +19,7 @@
         "illuminate/contracts": "^8.0",
         "illuminate/macroable": "^8.0",
         "illuminate/support": "^8.0",
-        "symfony/finder": "^5.1"
+        "symfony/finder": "^5.1.4"
     },
     "autoload": {
         "psr-4": {
@@ -39,8 +39,8 @@
         "league/flysystem-cached-adapter": "Required to use the Flysystem cache (^1.0).",
         "league/flysystem-sftp": "Required to use the Flysystem SFTP driver (^1.0).",
         "psr/http-message": "Required to allow Storage::put to accept a StreamInterface (^1.0).",
-        "symfony/filesystem": "Required to enable support for relative symbolic links (^5.1).",
-        "symfony/mime": "Required to enable support for guessing extensions (^5.1)."
+        "symfony/filesystem": "Required to enable support for relative symbolic links (^5.1.4).",
+        "symfony/mime": "Required to enable support for guessing extensions (^5.1.4)."
     },
     "config": {
         "sort-packages": true

--- a/src/Illuminate/Http/composer.json
+++ b/src/Illuminate/Http/composer.json
@@ -20,9 +20,9 @@
         "illuminate/macroable": "^8.0",
         "illuminate/session": "^8.0",
         "illuminate/support": "^8.0",
-        "symfony/http-foundation": "^5.1",
-        "symfony/http-kernel": "^5.1",
-        "symfony/mime": "^5.1"
+        "symfony/http-foundation": "^5.1.4",
+        "symfony/http-kernel": "^5.1.4",
+        "symfony/mime": "^5.1.4"
     },
     "autoload": {
         "psr-4": {

--- a/src/Illuminate/Queue/composer.json
+++ b/src/Illuminate/Queue/composer.json
@@ -26,7 +26,7 @@
         "illuminate/support": "^8.0",
         "opis/closure": "^3.6",
         "ramsey/uuid": "^4.0",
-        "symfony/process": "^5.1"
+        "symfony/process": "^5.1.4"
     },
     "autoload": {
         "psr-4": {

--- a/src/Illuminate/Routing/composer.json
+++ b/src/Illuminate/Routing/composer.json
@@ -24,9 +24,9 @@
         "illuminate/pipeline": "^8.0",
         "illuminate/session": "^8.0",
         "illuminate/support": "^8.0",
-        "symfony/http-foundation": "^5.1",
-        "symfony/http-kernel": "^5.1",
-        "symfony/routing": "^5.1"
+        "symfony/http-foundation": "^5.1.4",
+        "symfony/http-kernel": "^5.1.4",
+        "symfony/routing": "^5.1.4"
     },
     "autoload": {
         "psr-4": {

--- a/src/Illuminate/Session/composer.json
+++ b/src/Illuminate/Session/composer.json
@@ -20,8 +20,8 @@
         "illuminate/contracts": "^8.0",
         "illuminate/filesystem": "^8.0",
         "illuminate/support": "^8.0",
-        "symfony/finder": "^5.1",
-        "symfony/http-foundation": "^5.1"
+        "symfony/finder": "^5.1.4",
+        "symfony/http-foundation": "^5.1.4"
     },
     "autoload": {
         "psr-4": {

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -43,8 +43,8 @@
     "suggest": {
         "illuminate/filesystem": "Required to use the composer class (^8.0).",
         "ramsey/uuid": "Required to use Str::uuid() (^4.0).",
-        "symfony/process": "Required to use the composer class (^5.1).",
-        "symfony/var-dumper": "Required to use the dd function (^5.1).",
+        "symfony/process": "Required to use the composer class (^5.1.4).",
+        "symfony/var-dumper": "Required to use the dd function (^5.1.4).",
         "vlucas/phpdotenv": "Required to use the Env class and env helper (^5.2)."
     },
     "config": {

--- a/src/Illuminate/Validation/composer.json
+++ b/src/Illuminate/Validation/composer.json
@@ -23,8 +23,8 @@
         "illuminate/macroable": "^8.0",
         "illuminate/support": "^8.0",
         "illuminate/translation": "^8.0",
-        "symfony/http-foundation": "^5.1",
-        "symfony/mime": "^5.1"
+        "symfony/http-foundation": "^5.1.4",
+        "symfony/mime": "^5.1.4"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Foundation/Http/Middleware/ConvertEmptyStringsToNullTest.php
+++ b/tests/Foundation/Http/Middleware/ConvertEmptyStringsToNullTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Http\Middleware;
+
+use Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull;
+use Illuminate\Http\Request;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
+
+class ConvertEmptyStringsToNullTest extends TestCase
+{
+    public function testConvertsEmptyStringsToNull()
+    {
+        $middleware = new ConvertEmptyStringsToNull();
+        $symfonyRequest = new SymfonyRequest([
+            'foo' => 'bar',
+            'baz' => '',
+        ]);
+        $symfonyRequest->server->set('REQUEST_METHOD', 'GET');
+        $request = Request::createFromBase($symfonyRequest);
+
+        $middleware->handle($request, function (Request $request) {
+            $this->assertSame('bar', $request->get('foo'));
+            $this->assertNull($request->get('bar'));
+        });
+    }
+}


### PR DESCRIPTION
Symfony version 5.1.3 and below are very broken on PHP 8. Nobody would want to use them, so we need not support them. Moreover, dropping them means we can add tests that don't work on the old broken versions (such as the test added in this PR for the empty string conversion middleware).