### PR TITLE
[9.x] Change class option to argument

### DIFF
--- a/src/Illuminate/Database/Console/Seeds/SeedCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeedCommand.php
@@ -6,6 +6,7 @@ use Illuminate\Console\Command;
 use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
 use Illuminate\Database\Eloquent\Model;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 
 class SeedCommand extends Command
@@ -90,7 +91,7 @@ class SeedCommand extends Command
      */
     protected function getSeeder()
     {
-        $class = $this->input->getOption('class');
+        $class = $this->input->getArgument('class');
 
         if (strpos($class, '\\') === false) {
             $class = 'Database\\Seeders\\'.$class;
@@ -119,6 +120,18 @@ class SeedCommand extends Command
     }
 
     /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return [
+            ['class', InputArgument::OPTIONAL, 'The class name of the root seeder', 'Database\\Seeders\\DatabaseSeeder'],
+        ];
+    }
+
+    /**
      * Get the console command options.
      *
      * @return array
@@ -126,7 +139,6 @@ class SeedCommand extends Command
     protected function getOptions()
     {
         return [
-            ['class', null, InputOption::VALUE_OPTIONAL, 'The class name of the root seeder', 'Database\\Seeders\\DatabaseSeeder'],
             ['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to seed'],
             ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production'],
         ];


### PR DESCRIPTION
A long standing paper-cut for me has been the `--class` option for the `db:seed` command. Most other artisan commands accept an argument for the _subject_.

This PR converts the `class` option to an argument. It has the same default (`Database\Seeders\DatabaseSeeder`). Just saves on typing to improve the developer experience.

**Before**
```sh
php artisan db:seed --class=UsersTableSeeder
```

**After**
```sh
php artisan db:seed UsersTableSeeder
```