### PR TITLE
[8.x] Add 'comment' property for db table creation

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -64,6 +64,14 @@ class Blueprint
      */
     public $collation;
 
+    
+    /**
+     * The comment that should be used for the table.
+     *
+     * @var string
+     */
+    public $comment;
+
     /**
      * Whether to make the table temporary.
      *

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -64,7 +64,6 @@ class Blueprint
      */
     public $collation;
 
-    
     /**
      * The comment that should be used for the table.
      *

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -66,7 +66,7 @@ class MySqlGrammar extends Grammar
         $sql = $this->compileCreateEncoding(
             $sql, $connection, $blueprint
         );
-        
+
         // If present, add the table comment
         $sql = $this->compileTableComment($sql, $blueprint);
 
@@ -138,9 +138,9 @@ class MySqlGrammar extends Grammar
         if (isset($blueprint->comment)) {
             $sql .= " comment '".addslashes($blueprint->comment)."'";
         }
+
         return $sql;
     }
-    
 
     /**
      * Append the engine specifications to a command.

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -66,6 +66,9 @@ class MySqlGrammar extends Grammar
         $sql = $this->compileCreateEncoding(
             $sql, $connection, $blueprint
         );
+        
+        // If present, add the table comment
+        $sql = $this->compileTableComment($sql, $blueprint);
 
         // Finally, we will append the engine configuration onto this SQL statement as
         // the final thing we do before returning this finished SQL. Once this gets
@@ -122,6 +125,22 @@ class MySqlGrammar extends Grammar
 
         return $sql;
     }
+
+    /**
+     * Append the comment to a command.
+     *
+     * @param  string  $sql
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @return string
+     */
+    protected function compileTableComment($sql, Blueprint $blueprint)
+    {
+        if (isset($blueprint->comment)) {
+            $sql .= " comment '".addslashes($blueprint->comment)."'";
+        }
+        return $sql;
+    }
+    
 
     /**
      * Append the engine specifications to a command.

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -66,6 +66,9 @@ class MySqlGrammar extends Grammar
         $sql = $this->compileCreateEncoding(
             $sql, $connection, $blueprint
         );
+        
+        // If present, add the table comment
+        $sql = $this->compileTableComment($sql, $blueprint);
 
         // Finally, we will append the engine configuration onto this SQL statement as
         // the final thing we do before returning this finished SQL. Once this gets
@@ -122,6 +125,22 @@ class MySqlGrammar extends Grammar
 
         return $sql;
     }
+
+    /**
+     * Append the comment to a command.
+     *
+     * @param  string  $sql
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @return string
+     */
+    protected function compileTableComment($sql, Blueprint $blueprint)
+    {
+        if (isset($blueprint->comment)) {
+            $sql .= " comment '".addslashes($blueprint>comment)."'";
+        }
+        return $sql;
+    }
+    
 
     /**
      * Append the engine specifications to a command.

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -109,9 +109,8 @@ class PostgresGrammar extends Grammar
     public function compileTableComment(Blueprint $blueprint)
     {
         if (isset($blueprint->comment)) {
-            return sprintf('comment on table %s is %s', $this->wrapTable($blueprint), "'" . str_replace("'", "''", $blueprint->comment) . "'");
+            return sprintf('comment on table %s is %s', $this->wrapTable($blueprint), "'".str_replace("'", "''", $blueprint->comment)."'");
         }
-        return;
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -68,7 +68,8 @@ class PostgresGrammar extends Grammar
             $blueprint->temporary ? 'create temporary' : 'create',
             $this->wrapTable($blueprint),
             implode(', ', $this->getColumns($blueprint))
-        )], $this->compileAutoIncrementStartingValues($blueprint))));
+        )], $this->compileAutoIncrementStartingValues($blueprint),
+            $this->compileTableComment($blueprint))));
     }
 
     /**
@@ -97,6 +98,20 @@ class PostgresGrammar extends Grammar
         return collect($blueprint->autoIncrementingStartingValues())->map(function ($value, $column) use ($blueprint) {
             return 'alter sequence '.$blueprint->getTable().'_'.$column.'_seq restart with '.$value;
         })->all();
+    }
+
+    /**
+     * Compile table comment.
+     *
+     * @param \Illuminate\Database\Schema\Blueprint $blueprint
+     * @return array
+     */
+    public function compileTableComment(Blueprint $blueprint)
+    {
+        if (isset($blueprint->comment)) {
+            return sprintf('comment on table %s is %s', $this->wrapTable($blueprint), "'" . str_replace("'", "''", $blueprint->comment) . "'");
+        }
+        return;
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -69,7 +69,7 @@ class PostgresGrammar extends Grammar
             $this->wrapTable($blueprint),
             implode(', ', $this->getColumns($blueprint))
         )], $this->compileAutoIncrementStartingValues($blueprint),
-            $this->compileTableComment($blueprint))));
+            [$this->compileTableComment($blueprint)])));
     }
 
     /**

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -132,6 +132,25 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertSame("create table `users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) character set utf8mb4 collate 'utf8mb4_unicode_ci' not null) default character set utf8 collate 'utf8_unicode_ci'", $statements[0]);
     }
 
+    public function testCommentCreateTable()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->create();
+        $blueprint->increments('id');
+        $blueprint->string('email');
+        $blueprint->comment = "Test of comment's capability";
+        
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getConfig')->once()->with('engine')->andReturn(null);
+        $conn->shouldReceive('getConfig')->once()->with('charset')->andReturn('utf8');
+        $conn->shouldReceive('getConfig')->once()->with('collation')->andReturn('utf8_unicode_ci');
+        
+        $statements = $blueprint->toSql($conn, $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame("create table `users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) not null) default character set utf8 collate 'utf8_unicode_ci' comment 'Test of comment\'s capability'", $statements[0]);
+    }
+
     public function testBasicCreateTableWithPrefix()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -139,12 +139,12 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $blueprint->increments('id');
         $blueprint->string('email');
         $blueprint->comment = "Test of comment's capability";
-        
+
         $conn = $this->getConnection();
         $conn->shouldReceive('getConfig')->once()->with('engine')->andReturn(null);
         $conn->shouldReceive('getConfig')->once()->with('charset')->andReturn('utf8');
         $conn->shouldReceive('getConfig')->once()->with('collation')->andReturn('utf8_unicode_ci');
-        
+
         $statements = $blueprint->toSql($conn, $this->getGrammar());
 
         $this->assertCount(1, $statements);

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -63,6 +63,20 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertSame('create table "users" ("id" serial primary key not null, "email" varchar(255) not null)', $statements[0]);
         $this->assertSame('comment on column "users"."email" is \'my first comment\'', $statements[1]);
     }
+    
+    public function testCreateTableWithComment()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->create();
+        $blueprint->increments('id');
+        $blueprint->string('email');
+        $blueprint->comment = "Test of table comment";
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        
+        $this->assertCount(2, $statements);
+        $this->assertSame('create table "users" ("id" serial primary key not null, "email" varchar(255) not null)', $statements[0]);
+        $this->assertSame('comment on table "users" is \'Test of table comment\'', $statements[1]);
+    }
 
     public function testCreateTemporaryTable()
     {

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -63,16 +63,16 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertSame('create table "users" ("id" serial primary key not null, "email" varchar(255) not null)', $statements[0]);
         $this->assertSame('comment on column "users"."email" is \'my first comment\'', $statements[1]);
     }
-    
+
     public function testCreateTableWithComment()
     {
         $blueprint = new Blueprint('users');
         $blueprint->create();
         $blueprint->increments('id');
         $blueprint->string('email');
-        $blueprint->comment = "Test of table comment";
+        $blueprint->comment = 'Test of table comment';
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-        
+
         $this->assertCount(2, $statements);
         $this->assertSame('create table "users" ("id" serial primary key not null, "email" varchar(255) not null)', $statements[0]);
         $this->assertSame('comment on table "users" is \'Test of table comment\'', $statements[1]);


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This request add a comment property for use in migrations.  Usage:
`$table->comment = 'Some comment for this table';`

Implemented for MySQL and PostgreSQL.

Basic tests are included.