### PR TITLE
[8.x] Add 'check' column modifier 

### DIFF
--- a/src/Illuminate/Database/Schema/ColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ColumnDefinition.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Fluent;
  * @method $this autoIncrement() Set INTEGER columns as auto-increment (primary key)
  * @method $this change() Change the column
  * @method $this charset(string $charset) Specify a character set for the column (MySQL)
+ * @method $this check(string $check) Specify a column check (MySQL/PostgreSQL)
  * @method $this collation(string $collation) Specify a collation for the column (MySQL/PostgreSQL/SQL Server)
  * @method $this comment(string $comment) Add a comment to the column (MySQL)
  * @method $this default(mixed $value) Specify a "default" value for the column

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -1034,7 +1034,7 @@ class MySqlGrammar extends Grammar
     protected function modifyCheck(Blueprint $blueprint, Fluent $column)
     {
         if (! is_null($column->check)) {
-            return ' check ('.$this->wrap($column->name).' '.$column->check.' ) ';
+            return ' check ('.$this->wrap($column->name).' '.$column->check.')';
         }
     }
 

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -16,7 +16,7 @@ class MySqlGrammar extends Grammar
      */
     protected $modifiers = [
         'Unsigned', 'Charset', 'Collate', 'VirtualAs', 'StoredAs', 'Nullable',
-        'Srid', 'Default', 'Increment', 'Comment', 'After', 'First',
+        'Srid', 'Default', 'Increment', 'Comment', 'After', 'First', 'Check',
     ];
 
     /**
@@ -1021,6 +1021,20 @@ class MySqlGrammar extends Grammar
     {
         if (! is_null($column->after)) {
             return ' after '.$this->wrap($column->after);
+        }
+    }
+
+    /**
+     * Get the SQL for a "check" column modifier.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string|null
+     */
+    protected function modifyCheck(Blueprint $blueprint, Fluent $column)
+    {
+        if (! is_null($column->check)) {
+            return ' check ('.$this->wrap($column->name).' '.$column->check.' ) ';
         }
     }
 

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -19,7 +19,7 @@ class PostgresGrammar extends Grammar
      *
      * @var string[]
      */
-    protected $modifiers = ['Collate', 'Increment', 'Nullable', 'Default', 'VirtualAs', 'StoredAs'];
+    protected $modifiers = ['Collate', 'Increment', 'Nullable', 'Default', 'VirtualAs', 'StoredAs', 'Check'];
 
     /**
      * The columns available as serials.
@@ -991,6 +991,20 @@ class PostgresGrammar extends Grammar
     {
         if ($column->storedAs !== null) {
             return " generated always as ({$column->storedAs}) stored";
+        }
+    }
+
+    /**
+     * Get the SQL for a generated stored column modifier.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string|null
+     */
+    protected function modifyCheck(Blueprint $blueprint, Fluent $column)
+    {
+        if ($column->check !== null) {
+            return sprintf(' check ("%s" %s)', $column->name, $column->check);
         }
     }
 }

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -536,6 +536,16 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `links` add `url` varchar(2083) character set ascii not null, add `url_hash_virtual` varchar(64) character set ascii as (sha2(url, 256)), add `url_hash_stored` varchar(64) character set ascii as (sha2(url, 256)) stored', $statements[0]);
     }
+    
+    public function testAddingColumnCheck()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->string('foo')->nullable()->check("<> 'hejsan'");
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `foo` varchar(255) null check (`foo` <> \'hejsan\')', $statements[0]);
+    }
 
     public function testAddingString()
     {

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -536,13 +536,13 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `links` add `url` varchar(2083) character set ascii not null, add `url_hash_virtual` varchar(64) character set ascii as (sha2(url, 256)), add `url_hash_stored` varchar(64) character set ascii as (sha2(url, 256)) stored', $statements[0]);
     }
-    
+
     public function testAddingColumnCheck()
     {
         $blueprint = new Blueprint('users');
         $blueprint->string('foo')->nullable()->check("<> 'hejsan'");
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-        
+
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` varchar(255) null check (`foo` <> \'hejsan\')', $statements[0]);
     }

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -64,6 +64,16 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertSame('comment on column "users"."email" is \'my first comment\'', $statements[1]);
     }
 
+    public function testAddingColumnCheck()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->string('foo')->nullable()->check("<> 'hejsan'");
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add column "foo" varchar(255) null check ("foo" <> \'hejsan\')', $statements[0]);
+    }
+    
     public function testCreateTemporaryTable()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -69,11 +69,11 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $blueprint = new Blueprint('users');
         $blueprint->string('foo')->nullable()->check("<> 'hejsan'");
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-        
+
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" varchar(255) null check ("foo" <> \'hejsan\')', $statements[0]);
     }
-    
+
     public function testCreateTemporaryTable()
     {
         $blueprint = new Blueprint('users');


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This request add a check modifier for columns to be used in migrations. Use:
`$table->integer('weight')->check('> 0');` 

Implemented for MySQL and PostgreSQL.

Basic tests are included.