### PR TITLE
[8.x] Fix passing model instances to factories

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -492,7 +492,11 @@ abstract class Factory
             'has' => $this->has->concat([new BelongsToManyRelationship(
                 $factory,
                 $pivot,
-                $relationship ?: Str::camel(Str::plural(class_basename($factory->modelName())))
+                $relationship ?: Str::camel(Str::plural(class_basename(
+                    $factory instanceof Factory
+                        ? $factory->modelName()
+                        : Collection::wrap($factory)->first()
+                )))
             )]),
         ]);
     }
@@ -508,7 +512,9 @@ abstract class Factory
     {
         return $this->newInstance(['for' => $this->for->concat([new BelongsToRelationship(
             $factory,
-            $relationship ?: Str::camel(class_basename($factory->modelName()))
+            $relationship ?: Str::camel(class_basename(
+                $factory instanceof Factory ? $factory->modelName() : $factory
+            ))
         )])]);
     }
 


### PR DESCRIPTION
This PR fixes the new feature introduced in #35494 which allows passing model instances to factories. We missed one place in each method where the model/factory instance needs to be treated differently depending on its type.