### PR TITLE
[9.x] Removed action from SymfonyRoute options

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1103,7 +1103,7 @@ class Route
     {
         return new SymfonyRoute(
             preg_replace('/\{(\w+?)\?\}/', '{$1}', $this->uri()), $this->getOptionalParameterNames(),
-            $this->wheres, ['utf8' => true, 'action' => $this->action],
+            $this->wheres, ['utf8' => true],
             $this->getDomain() ?: '', [], $this->methods
         );
     }


### PR DESCRIPTION
This is a `master` PR of this original PR: https://github.com/laravel/framework/pull/35451
The text below is copied from that original PR.

## Description

`Illuminate\Routing\Route::toSymfonyRoute()` included two options: `utf8` and `action`.  The options do not include a `compiler_class` option so the default `Symfony\Component\Routing\RouteCompiler` will always be used.  This compiler does not utilize an `action` parameter and, because you cannot override the `RouteCompiler`, I have removed that option from the `toSymfonyRoute()` options array.

## Unit Tests

This PR removes unused code so no new unit tests would be useful. Removing the ephemera and testing with the current unit tests shows this does not affect the framework.

## Discussion

Removing this unused (in Symfony) code from the Route simplifies the `toSymfonyRoute()` method and prevents developers from going on a wild goose chase to figure out why this code is there in the first place.  There is no direct benefit to the end consumer.

The extraneous option was sent to Symfony classes so there are no Laravel unit tests which could apply to the call to the constructor of the Symfony Route class.

This change benefits the developer community around Laravel by only including code which has a purpose.

## External Resources

This change is directed against the constructor of https://github.com/symfony/symfony/blob/5.x/src/Symfony/Component/Routing/Route.php#L53
and involves the route compiler https://github.com/symfony/symfony/blob/5.x/src/Symfony/Component/Routing/RouteCompiler.php
Additionally the valid options are listed in the comments of the constructor: https://github.com/symfony/symfony/blob/5.x/src/Symfony/Component/Routing/Route.php#L41