### PR TITLE
[8.x] Release concurrency lock for errors

### DIFF
--- a/src/Illuminate/Redis/Limiters/ConcurrencyLimiter.php
+++ b/src/Illuminate/Redis/Limiters/ConcurrencyLimiter.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Redis\Limiters;
 
-use Exception;
+use Throwable;
 use Illuminate\Contracts\Redis\LimiterTimeoutException;
 use Illuminate\Support\Str;
 
@@ -61,7 +61,7 @@ class ConcurrencyLimiter
      * @return bool
      *
      * @throws \Illuminate\Contracts\Redis\LimiterTimeoutException
-     * @throws \Exception
+     * @throws \Throwable
      */
     public function block($timeout, $callback = null)
     {
@@ -82,7 +82,7 @@ class ConcurrencyLimiter
                 return tap($callback(), function () use ($slot, $id) {
                     $this->release($slot, $id);
                 });
-            } catch (Exception $exception) {
+            } catch (Throwable $exception) {
                 $this->release($slot, $id);
 
                 throw $exception;

--- a/src/Illuminate/Redis/Limiters/ConcurrencyLimiter.php
+++ b/src/Illuminate/Redis/Limiters/ConcurrencyLimiter.php
@@ -2,9 +2,9 @@
 
 namespace Illuminate\Redis\Limiters;
 
-use Throwable;
 use Illuminate\Contracts\Redis\LimiterTimeoutException;
 use Illuminate\Support\Str;
+use Throwable;
 
 class ConcurrencyLimiter
 {

--- a/tests/Redis/ConcurrentLimiterTest.php
+++ b/tests/Redis/ConcurrentLimiterTest.php
@@ -152,7 +152,6 @@ class ConcurrentLimiterTest extends TestCase
                 throw new Error();
             });
         } catch (Error $e) {
-
         }
 
         $lock = new ConcurrencyLimiter($this->redis(), 'key', 1, 5);

--- a/tests/Redis/ConcurrentLimiterTest.php
+++ b/tests/Redis/ConcurrentLimiterTest.php
@@ -2,11 +2,11 @@
 
 namespace Illuminate\Tests\Redis;
 
+use Error;
 use Illuminate\Contracts\Redis\LimiterTimeoutException;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
 use Illuminate\Redis\Limiters\ConcurrencyLimiter;
 use PHPUnit\Framework\TestCase;
-use Error;
 use Throwable;
 
 /**

--- a/tests/Redis/ConcurrentLimiterTest.php
+++ b/tests/Redis/ConcurrentLimiterTest.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Redis\LimiterTimeoutException;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
 use Illuminate\Redis\Limiters\ConcurrencyLimiter;
 use PHPUnit\Framework\TestCase;
+use Error;
 use Throwable;
 
 /**
@@ -136,6 +137,28 @@ class ConcurrentLimiterTest extends TestCase
         } catch (Throwable $e) {
             $this->assertInstanceOf(LimiterTimeoutException::class, $e);
         }
+
+        $this->assertEquals([1], $store);
+    }
+
+    public function testItReleasesIfErrorIsThrown()
+    {
+        $store = [];
+
+        $lock = new ConcurrencyLimiter($this->redis(), 'key', 1, 5);
+
+        try {
+            $lock->block(1, function () {
+                throw new Error();
+            });
+        } catch (Error $e) {
+
+        }
+
+        $lock = new ConcurrencyLimiter($this->redis(), 'key', 1, 5);
+        $lock->block(1, function () use (&$store) {
+            $store[] = 1;
+        });
 
         $this->assertEquals([1], $store);
     }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Currently the concurrency limiter will only release the lock if an exception is thrown in the block request. This PR will catch `Throwable` instead to release the lock when an `Error` occurs