### PR TITLE
Add new db console RunSqlCommand

### DIFF
--- a/src/Illuminate/Database/Console/RunSqlCommand.php
+++ b/src/Illuminate/Database/Console/RunSqlCommand.php
@@ -33,7 +33,7 @@ class RunSqlCommand extends Command
      */
     public function handle()
     {
-        if (!$this->confirmToProceed()) {
+        if (! $this->confirmToProceed()) {
             return 1;
         }
 

--- a/src/Illuminate/Database/Console/RunSqlCommand.php
+++ b/src/Illuminate/Database/Console/RunSqlCommand.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Illuminate\Database\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Console\ConfirmableTrait;
+use Illuminate\Database\ConnectionInterface;
+use Illuminate\Support\Str;
+use Symfony\Component\Console\Input\InputOption;
+
+class RunSqlCommand extends Command
+{
+    use ConfirmableTrait;
+
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'db:run-sql';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Executes arbitrary SQL directly from the command line';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        if (!$this->confirmToProceed()) {
+            return 1;
+        }
+
+        $database = $this->input->getOption('database');
+        $sql = $this->input->getOption('sql');
+        $forceFetch = $this->input->getOption('force-fetch');
+
+        assert(is_string($sql));
+
+        /** @var ConnectionInterface $connection */
+        $connection = $this->laravel['db']->connection($database);
+
+        if (Str::startsWith($sql, 'select') || $forceFetch) {
+            $items = $connection->select($sql);
+            $items = array_map(function ($item) {
+                return (array) $item;
+            }, $items);
+            $headers = empty($items) ? [] : array_keys($items[0]);
+            $this->output->table($headers, $items);
+        } else {
+            $this->output->write($connection->statement($sql));
+        }
+
+        return 0;
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use'],
+            ['sql', null, InputOption::VALUE_REQUIRED, 'The SQL statement to execute'],
+            ['force-fetch', null, InputOption::VALUE_NONE, 'Forces fetching the result'],
+            ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production'],
+        ];
+    }
+}


### PR DESCRIPTION
Add `RunSqlCommand` to execute arbitrary SQL directly from the command line

Example:
`artisan db:run-sql --database=test --sql="select 'world' as hello;"`
![image](https://user-images.githubusercontent.com/3595194/101621032-4e320000-3a26-11eb-9416-128b0a2bc4b3.png)

inspired by https://github.com/doctrine/dbal/blob/2.12.x/lib/Doctrine/DBAL/Tools/Console/Command/RunSqlCommand.php