### PR TITLE
Builder paginate() with ResourceCollection

### DIFF
--- a/src/Illuminate/Http/Resources/Json/PaginatedResourceResponse.php
+++ b/src/Illuminate/Http/Resources/Json/PaginatedResourceResponse.php
@@ -29,7 +29,7 @@ class PaginatedResourceResponse extends ResourceResponse
                 if (is_array($item)) {
                     return Arr::get($item, 'resource');
                 } elseif ($item instanceof \stdClass) {
-                    return (array)$item;
+                    return (array) $item;
                 } else {
                     return $item->resource;
                 }

--- a/src/Illuminate/Http/Resources/Json/PaginatedResourceResponse.php
+++ b/src/Illuminate/Http/Resources/Json/PaginatedResourceResponse.php
@@ -26,7 +26,13 @@ class PaginatedResourceResponse extends ResourceResponse
             $this->calculateStatus()
         ), function ($response) use ($request) {
             $response->original = $this->resource->resource->map(function ($item) {
-                return is_array($item) ? Arr::get($item, 'resource') : $item->resource;
+                if (is_array($item)) {
+                    return Arr::get($item, 'resource');
+                } elseif ($item instanceof \stdClass) {
+                    return (array)$item;
+                } else {
+                    return $item->resource;
+                }
             });
 
             $this->resource->withResponse($request, $response);


### PR DESCRIPTION
Hello! Thank you for your work guys.
Sometimes I get data from the database using the Query Builder. It returns a sollection of stdClass objects. The paginate () method does not work with a resource file out of the box. Please consider adding this feature. For correct operation, I additionally change the resource file like this.  

I used: `return new MyResourceCollection($list->paginate());`
Resource class I can change locally:
```
public function toArray($request)
{
    $arr = [];
    foreach ($this->collection as $i) {
        $arr[] = (array)$i;
    }
    return $arr;
}
```
P.S.: If you approve, it will work for the 8.x branch.
Good luck!