### PR TITLE
Fix event:list command when more than one listner registered.

### DIFF
--- a/src/Illuminate/Foundation/Console/EventListCommand.php
+++ b/src/Illuminate/Foundation/Console/EventListCommand.php
@@ -58,7 +58,7 @@ class EventListCommand extends Command
         }
 
         return collect($events)->map(function ($listeners, $event) {
-            return ['Event' => $event, 'Listeners' => implode(PHP_EOL, $listeners)];
+            return ['Event' => $event, 'Listeners' => implode("\n", $listeners)];
         })->sortBy('Event')->values()->toArray();
     }
 


### PR DESCRIPTION
Preface
-----
When you run `event:list` command under bash in windows environment if you have some event with more than one listener registered table result will break.

Why?
----
The command use `PHP_EOL` to separate multiple listeners in the same table cell that under windows resolves as `\n\r` when the underlying symfony console component expects always `\n`.

Solution
----
Use always `\n` as glue to list listeners registered for events.

Proof
----

```php
    // in App\Providers\EventServiceProvider

    protected $listen = [
        'App\Events\LonelyEvent' => [
            'App\Notifications\LonelyNotification',
        ],
        Registered::class => [
            SendEmailVerificationNotification::class,
            'App\Notifications\AnotherVerificationNotification',
        ]
    ];
```

**Before** (8.x) - event cell is broken for events with more than one listener registered
```bash
$ php artisan event:list
+----------------------------------------------------+-----------------------------------------------------------------------------------------+
| Event                                              | Listeners                                                                               |
+----------------------------------------------------+-----------------------------------------------------------------------------------------+
| App\Events\LonelyEvent                             | App\Notifications\LonelyNotification                                                    |
                            |stered                  | Illuminate\Auth\Listeners\SendEmailVerificationNotification
|                                                    | App\Notifications\AnotherVerificationNotification                                       |
+----------------------------------------------------+-----------------------------------------------------------------------------------------+
```

**After** (PR) - event name correctly printed out
```bash
$ php artisan event:list
+----------------------------------------------------+-----------------------------------------------------------------------------------------+
| Event                                              | Listeners                                                                               |
+----------------------------------------------------+-----------------------------------------------------------------------------------------+
| App\Events\LonelyEvent                             | App\Notifications\LonelyNotification                                                    |
| Illuminate\Auth\Events\Registered                  | Illuminate\Auth\Listeners\SendEmailVerificationNotification                             |
|                                                    | App\Notifications\AnotherVerificationNotification                                       |
+----------------------------------------------------+-----------------------------------------------------------------------------------------+
```