### PR TITLE
[8.x] Added a 'link()' method to the available console command methods

### DIFF
--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -377,7 +377,7 @@ trait InteractsWithIO
      * @param  int|string|null  $verbosity
      * @return void
      */
-    public function link(string $display, string $url, bool $urlHint = false, $verbosity = null): void
+    public function link(string $display, string $url, bool $urlHint = false, $verbosity = null)
     {
         $toDisplay = '<href='.$url.'>'.$display.'</>';
 

--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -369,6 +369,26 @@ trait InteractsWithIO
     }
 
     /**
+     * Write a clickable link to the console.
+     *
+     * @param  string  $display
+     * @param  string  $url
+     * @param  bool  $urlHint
+     * @param  int|string|null  $verbosity
+     * @return void
+     */
+    public function link(string $display, string $url, bool $urlHint = false, $verbosity = null): void
+    {
+        $toDisplay = '<href='.$url.'>'.$display.'</>';
+
+        if ($urlHint) {
+            $toDisplay .= ' ('.$url.')';
+        }
+
+        $this->line($toDisplay, null, $verbosity);
+    }
+
+    /**
      * Write a blank line.
      *
      * @param  int  $count


### PR DESCRIPTION
Hi guys!

This PR just adds a ` link() ` helper method that can be used in commands to add clickable links to the console output.

Using it, you can add a clickable link like this in your command:

```php
$this->link('Laravel Docs', 'https://laravel.com/docs/8.x');

// Output: Laravel Docs
```

I also added a boolean as the third parameter for this method so that the URL is displayed at the side of the link. This could be useful if someone is expecting another developer to be using the command with a terminal that doesn't fully support clickable links. For example:

```php
$this->link('Laravel Docs', 'https://laravel.com/docs/8.x', true);

// Output: Laravel Docs (https://laravel.com/docs/8.x)
```

Hopefully this is all okay. If anything needs changing on it to potentially get it ready for pulling in, please let me know and I'll get to it right away :smile: