### PR TITLE
[8.x] Added extra dump flags for schema:dump command

### DIFF
--- a/src/Illuminate/Database/Console/DumpCommand.php
+++ b/src/Illuminate/Database/Console/DumpCommand.php
@@ -20,6 +20,7 @@ class DumpCommand extends Command
     protected $signature = 'schema:dump
                 {--database= : The database connection to use}
                 {--path= : The path where the schema dump file should be stored}
+                {--extra-dump-flags= : Extra flags added to the dumper command}
                 {--prune : Delete all existing migration files}';
 
     /**
@@ -41,10 +42,12 @@ class DumpCommand extends Command
         $connection = $connections->connection($database = $this->input->getOption('database'));
 
         $this->schemaState($connection)->dump(
-            $connection, $path = $this->path($connection)
+            $connection,
+            $path = $this->path($connection),
+            $extraDumpFlags = $this->input->getOption('extra-dump-flags')
         );
 
-        $dispatcher->dispatch(new SchemaDumped($connection, $path));
+        $dispatcher->dispatch(new SchemaDumped($connection, $path, $extraDumpFlags));
 
         $this->info('Database schema dumped successfully.');
 
@@ -79,7 +82,7 @@ class DumpCommand extends Command
      */
     protected function path(Connection $connection)
     {
-        return tap($this->option('path') ?: database_path('schema/'.$connection->getName().'-schema.dump'), function ($path) {
+        return tap($this->option('path') ?: database_path('schema/' . $connection->getName() . '-schema.dump'), function ($path) {
             (new Filesystem)->ensureDirectoryExists(dirname($path));
         });
     }

--- a/src/Illuminate/Database/Console/DumpCommand.php
+++ b/src/Illuminate/Database/Console/DumpCommand.php
@@ -82,7 +82,7 @@ class DumpCommand extends Command
      */
     protected function path(Connection $connection)
     {
-        return tap($this->option('path') ?: database_path('schema/' . $connection->getName() . '-schema.dump'), function ($path) {
+        return tap($this->option('path') ?: database_path('schema/'.$connection->getName().'-schema.dump'), function ($path) {
             (new Filesystem)->ensureDirectoryExists(dirname($path));
         });
     }

--- a/src/Illuminate/Database/Events/SchemaDumped.php
+++ b/src/Illuminate/Database/Events/SchemaDumped.php
@@ -26,16 +26,25 @@ class SchemaDumped
     public $path;
 
     /**
+     * Extra flags added to the dumper command.
+     *
+     * @var string|null
+     */
+    public $extraDumpFlags;
+
+    /**
      * Create a new event instance.
      *
      * @param  \Illuminate\Database\Connection  $connection
      * @param  string  $path
+     * @param  string|null  $extraDumpFlags
      * @return void
      */
-    public function __construct($connection, $path)
+    public function __construct($connection, $path, $extraDumpFlags = null)
     {
         $this->connection = $connection;
         $this->connectionName = $connection->getName();
         $this->path = $path;
+        $this->extraDumpFlags = $extraDumpFlags;
     }
 }

--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -20,7 +20,7 @@ class MySqlSchemaState extends SchemaState
     public function dump(Connection $connection, $path, $extraDumpFlags = null)
     {
         $this->executeDumpProcess($this->makeProcess(
-            $this->baseDumpCommand() . ' --routines --result-file="${:LARAVEL_LOAD_PATH}" ' . $extraDumpFlags ?? '' . '--no-data'
+            $this->baseDumpCommand().' --routines --result-file="${:LARAVEL_LOAD_PATH}" '.($extraDumpFlags ?? '').'--no-data'
         ), $this->output, array_merge($this->baseVariables($this->connection->getConfig()), [
             'LARAVEL_LOAD_PATH' => $path,
         ]));
@@ -54,7 +54,7 @@ class MySqlSchemaState extends SchemaState
     protected function appendMigrationData(string $path)
     {
         $process = $this->executeDumpProcess($this->makeProcess(
-            $this->baseDumpCommand() . ' ' . $this->migrationTable . ' --no-create-info --skip-extended-insert --skip-routines --compact'
+            $this->baseDumpCommand().' '.$this->migrationTable.' --no-create-info --skip-extended-insert --skip-routines --compact'
         ), null, array_merge($this->baseVariables($this->connection->getConfig()), [
             //
         ]));
@@ -70,7 +70,7 @@ class MySqlSchemaState extends SchemaState
      */
     public function load($path)
     {
-        $command = 'mysql ' . $this->connectionString() . ' --database="${:LARAVEL_LOAD_DATABASE}" < "${:LARAVEL_LOAD_PATH}"';
+        $command = 'mysql '.$this->connectionString().' --database="${:LARAVEL_LOAD_DATABASE}" < "${:LARAVEL_LOAD_PATH}"';
 
         $this->makeProcess($command)->mustRun(null, array_merge($this->baseVariables($this->connection->getConfig()), [
             'LARAVEL_LOAD_PATH' => $path,
@@ -84,13 +84,13 @@ class MySqlSchemaState extends SchemaState
      */
     protected function baseDumpCommand()
     {
-        $command = 'mysqldump ' . $this->connectionString() . ' --skip-add-locks --skip-comments --skip-set-charset --tz-utc';
+        $command = 'mysqldump '.$this->connectionString().' --skip-add-locks --skip-comments --skip-set-charset --tz-utc';
 
-        if (!$this->connection->isMaria()) {
+        if (! $this->connection->isMaria()) {
             $command .= ' --column-statistics=0 --set-gtid-purged=OFF';
         }
 
-        return $command . ' "${:LARAVEL_LOAD_DATABASE}"';
+        return $command.' "${:LARAVEL_LOAD_DATABASE}"';
     }
 
     /**
@@ -103,8 +103,8 @@ class MySqlSchemaState extends SchemaState
         $value = ' --user="${:LARAVEL_LOAD_USER}" --password="${:LARAVEL_LOAD_PASSWORD}"';
 
         $value .= $this->connection->getConfig()['unix_socket'] ?? false
-            ? ' --socket="${:LARAVEL_LOAD_SOCKET}"'
-            : ' --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}"';
+                        ? ' --socket="${:LARAVEL_LOAD_SOCKET}"'
+                        : ' --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}"';
 
         return $value;
     }

--- a/src/Illuminate/Database/Schema/PostgresSchemaState.php
+++ b/src/Illuminate/Database/Schema/PostgresSchemaState.php
@@ -12,20 +12,21 @@ class PostgresSchemaState extends SchemaState
      *
      * @param  \Illuminate\Database\Connection  $connection
      * @param  string  $path
+     * @param  string|null  $extraDumpFlags
      * @return void
      */
-    public function dump(Connection $connection, $path)
+    public function dump(Connection $connection, $path, $extraDumpFlags = null)
     {
         $excludedTables = collect($connection->getSchemaBuilder()->getAllTables())
                         ->map->tablename
                         ->reject(function ($table) {
                             return $table === $this->migrationTable;
                         })->map(function ($table) {
-                            return '--exclude-table-data='.$table;
+                            return '--exclude-table-data=' . $table;
                         })->implode(' ');
 
         $this->makeProcess(
-            $this->baseDumpCommand().' --file=$LARAVEL_LOAD_PATH '.$excludedTables
+            $this->baseDumpCommand() . ' --file=$LARAVEL_LOAD_PATH ' . $extraDumpFlags ?? '' . $excludedTables
         )->mustRun($this->output, array_merge($this->baseVariables($this->connection->getConfig()), [
             'LARAVEL_LOAD_PATH' => $path,
         ]));

--- a/src/Illuminate/Database/Schema/PostgresSchemaState.php
+++ b/src/Illuminate/Database/Schema/PostgresSchemaState.php
@@ -22,11 +22,11 @@ class PostgresSchemaState extends SchemaState
                         ->reject(function ($table) {
                             return $table === $this->migrationTable;
                         })->map(function ($table) {
-                            return '--exclude-table-data=' . $table;
+                            return '--exclude-table-data='.$table;
                         })->implode(' ');
 
         $this->makeProcess(
-            $this->baseDumpCommand() . ' --file=$LARAVEL_LOAD_PATH ' . $extraDumpFlags ?? '' . $excludedTables
+            $this->baseDumpCommand().' --file=$LARAVEL_LOAD_PATH '.($extraDumpFlags ?? '').$excludedTables
         )->mustRun($this->output, array_merge($this->baseVariables($this->connection->getConfig()), [
             'LARAVEL_LOAD_PATH' => $path,
         ]));

--- a/src/Illuminate/Database/Schema/SchemaState.php
+++ b/src/Illuminate/Database/Schema/SchemaState.php
@@ -71,9 +71,10 @@ abstract class SchemaState
      *
      * @param  \Illuminate\Database\Connection  $connection
      * @param  string  $path
+     * @param  string|null  $extraDumpFlags
      * @return void
      */
-    abstract public function dump(Connection $connection, $path);
+    abstract public function dump(Connection $connection, $path, $extraDumpFlags = null);
 
     /**
      * Load the given schema file into the database.

--- a/src/Illuminate/Database/Schema/SqliteSchemaState.php
+++ b/src/Illuminate/Database/Schema/SqliteSchemaState.php
@@ -9,14 +9,15 @@ class SqliteSchemaState extends SchemaState
     /**
      * Dump the database's schema into a file.
      *
-     * @param  \Illuminate\Database\Connection
+     * @param  \Illuminate\Database\Connection  $connection
      * @param  string  $path
+     * @param  string|null  $extraDumpFlags
      * @return void
      */
-    public function dump(Connection $connection, $path)
+    public function dump(Connection $connection, $path, $extraDumpFlags = null)
     {
         with($process = $this->makeProcess(
-            $this->baseCommand().' .schema'
+            $this->baseCommand(). $extraDumpFlags ?? '' .' .schema'
         ))->setTimeout(null)->mustRun(null, array_merge($this->baseVariables($this->connection->getConfig()), [
             //
         ]));

--- a/src/Illuminate/Database/Schema/SqliteSchemaState.php
+++ b/src/Illuminate/Database/Schema/SqliteSchemaState.php
@@ -17,17 +17,17 @@ class SqliteSchemaState extends SchemaState
     public function dump(Connection $connection, $path, $extraDumpFlags = null)
     {
         with($process = $this->makeProcess(
-            $this->baseCommand(). $extraDumpFlags ?? '' .' .schema'
+            $this->baseCommand().($extraDumpFlags ?? '').' .schema'
         ))->setTimeout(null)->mustRun(null, array_merge($this->baseVariables($this->connection->getConfig()), [
             //
         ]));
 
         $migrations = collect(preg_split("/\r\n|\n|\r/", $process->getOutput()))->filter(function ($line) {
             return stripos($line, 'sqlite_sequence') === false &&
-                   strlen($line) > 0;
+                strlen($line) > 0;
         })->all();
 
-        $this->files->put($path, implode(PHP_EOL, $migrations).PHP_EOL);
+        $this->files->put($path, implode(PHP_EOL, $migrations) . PHP_EOL);
 
         $this->appendMigrationData($path);
     }

--- a/src/Illuminate/Database/Schema/SqliteSchemaState.php
+++ b/src/Illuminate/Database/Schema/SqliteSchemaState.php
@@ -27,7 +27,7 @@ class SqliteSchemaState extends SchemaState
                 strlen($line) > 0;
         })->all();
 
-        $this->files->put($path, implode(PHP_EOL, $migrations) . PHP_EOL);
+        $this->files->put($path, implode(PHP_EOL, $migrations).PHP_EOL);
 
         $this->appendMigrationData($path);
     }


### PR DESCRIPTION
As end-user: I can easily add (flags or options) to the dump command which is
- `mysqldump` in case of using MySQL
- `pg_dump` in case of using PostgreSQL
- `sqlite3` in case of using SQLite database

This PR does not have any breaking changes with the base branch 8.x.

Now the users can easily add (flags or options) to the `schema:dump` command
For example
```bash
php artisan schema:dump --extra-dump-flags="--skip-lock-tables"
```
