### PR TITLE
[8.x] Add nullable phpdoc to timestamp name's getters

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
@@ -110,7 +110,7 @@ trait HasTimestamps
     /**
      * Get the name of the "created at" column.
      *
-     * @return string
+     * @return string|null
      */
     public function getCreatedAtColumn()
     {
@@ -120,7 +120,7 @@ trait HasTimestamps
     /**
      * Get the name of the "updated at" column.
      *
-     * @return string
+     * @return string|null
      */
     public function getUpdatedAtColumn()
     {
@@ -130,7 +130,7 @@ trait HasTimestamps
     /**
      * Get the fully qualified "created at" column.
      *
-     * @return string
+     * @return string|null
      */
     public function getQualifiedCreatedAtColumn()
     {
@@ -140,7 +140,7 @@ trait HasTimestamps
     /**
      * Get the fully qualified "updated at" column.
      *
-     * @return string
+     * @return string|null
      */
     public function getQualifiedUpdatedAtColumn()
     {


### PR DESCRIPTION
Because methods getCreatedAtColumn and getUpdatedAtColumn can return null in some cases (Model doesn't have updated_at column, there are a lot of checks like `! is_null($updatedAtColumn)`), I added redundant `null` attribute to PHPDoc