### PR TITLE
Add has() method to the ComponentAttributeBag

### DIFF
--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -57,6 +57,17 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
     }
 
     /**
+     * Determines if a given attribute exists in the attribute array.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function has($key)
+    {
+        return array_key_exists($key, $this->attributes);
+    }
+
+    /**
      * Only include the given attribute from the attribute array.
      *
      * @param  mixed|array  $keys


### PR DESCRIPTION
Allows to determine if a given attribute is present on a component.

While it's true that we can already guess if the property is present using `get()`, the `has()` method's job is only to check if it exists or not (returning a bool) allowing to build safer typed code that does not rely on type-casting attribute values.