### PR TITLE
[8.x] Added extra dump flags for schema:dump command

### DIFF
--- a/src/Illuminate/Database/Console/DumpCommand.php
+++ b/src/Illuminate/Database/Console/DumpCommand.php
@@ -20,6 +20,7 @@ class DumpCommand extends Command
     protected $signature = 'schema:dump
                 {--database= : The database connection to use}
                 {--path= : The path where the schema dump file should be stored}
+                {--extra-dump-flags= : Extra dumper flags pushed to executed command}
                 {--prune : Delete all existing migration files}';
 
     /**
@@ -40,9 +41,11 @@ class DumpCommand extends Command
     {
         $connection = $connections->connection($database = $this->input->getOption('database'));
 
-        $this->schemaState($connection)->dump(
-            $connection, $path = $this->path($connection)
-        );
+        $this->schemaState($connection)
+            ->setExtraDumpCommandFlags($this->input->getOption('extra-dump-flags'))
+            ->dump(
+                $connection, $path = $this->path($connection)
+            );
 
         $dispatcher->dispatch(new SchemaDumped($connection, $path));
 

--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -86,7 +86,7 @@ class MySqlSchemaState extends SchemaState
         $command = 'mysqldump '.$this->connectionString().' --skip-add-locks --skip-comments --skip-set-charset --tz-utc';
 
         if ($extraFlags = $this->extraDumpCommandFlags()) {
-            $command .= ' ' . $extraFlags;
+            $command .= ' '.$extraFlags;
         }
 
         if (! $this->connection->isMaria()) {

--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -85,6 +85,10 @@ class MySqlSchemaState extends SchemaState
     {
         $command = 'mysqldump '.$this->connectionString().' --skip-add-locks --skip-comments --skip-set-charset --tz-utc';
 
+        if ($extraFlags = $this->extraDumpCommandFlags()) {
+            $command .= ' ' . $extraFlags;
+        }
+
         if (! $this->connection->isMaria()) {
             $command .= ' --column-statistics=0 --set-gtid-purged=OFF';
         }

--- a/src/Illuminate/Database/Schema/PostgresSchemaState.php
+++ b/src/Illuminate/Database/Schema/PostgresSchemaState.php
@@ -59,7 +59,13 @@ class PostgresSchemaState extends SchemaState
      */
     protected function baseDumpCommand()
     {
-        return 'PGPASSWORD=$LARAVEL_LOAD_PASSWORD pg_dump --no-owner --no-acl -Fc --host=$LARAVEL_LOAD_HOST --port=$LARAVEL_LOAD_PORT --username=$LARAVEL_LOAD_USER $LARAVEL_LOAD_DATABASE';
+        $command = 'PGPASSWORD=$LARAVEL_LOAD_PASSWORD pg_dump --no-owner --no-acl -Fc --host=$LARAVEL_LOAD_HOST --port=$LARAVEL_LOAD_PORT --username=$LARAVEL_LOAD_USER $LARAVEL_LOAD_DATABASE';
+
+        if ($extraFlags = $this->extraDumpCommandFlags()) {
+            $command .= ' ' . $extraFlags;
+        }
+
+        return $command;
     }
 
     /**

--- a/src/Illuminate/Database/Schema/PostgresSchemaState.php
+++ b/src/Illuminate/Database/Schema/PostgresSchemaState.php
@@ -62,7 +62,7 @@ class PostgresSchemaState extends SchemaState
         $command = 'PGPASSWORD=$LARAVEL_LOAD_PASSWORD pg_dump --no-owner --no-acl -Fc --host=$LARAVEL_LOAD_HOST --port=$LARAVEL_LOAD_PORT --username=$LARAVEL_LOAD_USER $LARAVEL_LOAD_DATABASE';
 
         if ($extraFlags = $this->extraDumpCommandFlags()) {
-            $command .= ' ' . $extraFlags;
+            $command .= ' '.$extraFlags;
         }
 
         return $command;

--- a/src/Illuminate/Database/Schema/SchemaState.php
+++ b/src/Illuminate/Database/Schema/SchemaState.php
@@ -37,6 +37,13 @@ abstract class SchemaState
     protected $processFactory;
 
     /**
+     * Extra flags added to be the dumper command.
+     *
+     * @var string
+     */
+    public $extraDumpCommandFlags = '';
+
+    /**
      * The output callable instance.
      *
      * @var callable
@@ -92,6 +99,29 @@ abstract class SchemaState
     public function makeProcess(...$arguments)
     {
         return call_user_func($this->processFactory, ...$arguments);
+    }
+
+    /**
+     * Set extra dump command flags.
+     *
+     * @param  string  $options
+     * @return $this
+     */
+    public function setExtraDumpCommandFlags($options = '')
+    {
+        $this->extraDumpCommandFlags = is_string($options) && !empty($options) ? $options : '';
+
+        return $this;
+    }
+
+    /**
+     * Get extra dump command flags.
+     *
+     * @return void
+     */
+    public function extraDumpCommandFlags()
+    {
+        return $this->extraDumpCommandFlags;
     }
 
     /**

--- a/src/Illuminate/Database/Schema/SchemaState.php
+++ b/src/Illuminate/Database/Schema/SchemaState.php
@@ -109,7 +109,7 @@ abstract class SchemaState
      */
     public function setExtraDumpCommandFlags($options = '')
     {
-        $this->extraDumpCommandFlags = is_string($options) && !empty($options) ? $options : '';
+        $this->extraDumpCommandFlags = is_string($options) && ! empty($options) ? $options : '';
 
         return $this;
     }

--- a/src/Illuminate/Database/Schema/SqliteSchemaState.php
+++ b/src/Illuminate/Database/Schema/SqliteSchemaState.php
@@ -75,7 +75,7 @@ class SqliteSchemaState extends SchemaState
      */
     protected function baseCommand()
     {
-        return 'sqlite3 "${:LARAVEL_LOAD_DATABASE}"';
+        return 'sqlite3 '.($this->extraDumpCommandFlags() ?? '').' "${:LARAVEL_LOAD_DATABASE}"';
     }
 
     /**


### PR DESCRIPTION
As end-user: I can easily add (flags or options) to the dump command which is
- `mysqldump` in case of using MySQL
- `pg_dump` in case of using PostgreSQL
- `sqlite3` in case of using SQLite database

This PR does not have any breaking changes with the base branch 8.x.

Now the users can easily add (flags or options) to the `schema:dump` command
For example
```bash
php artisan schema:dump --extra-dump-flags="--skip-lock-tables"
```
