### PR TITLE
[9.x] Improve '$user' variable handling in PostgreSQL search_path

### DIFF
--- a/src/Illuminate/Database/Schema/PostgresBuilder.php
+++ b/src/Illuminate/Database/Schema/PostgresBuilder.php
@@ -181,7 +181,9 @@ class PostgresBuilder extends Builder
         // We will use the default schema unless the schema has been specified in the
         // query. If the schema has been specified in the query then we can use it
         // instead of a default schema configured in the connection search path.
-        $schema = $searchPath[0];
+        $schema = $searchPath[0] === '$user'
+            ? $this->connection->getConfig('username')
+            : $searchPath[0];
 
         if (count($parts) === 2) {
             $schema = $parts[0];


### PR DESCRIPTION
Upon closer scrutiny of PostgreSQL CVE-2018-1058 , which I first noted in https://github.com/laravel/ideas/issues/918#issuecomment-369705566 , a very slight tweak should be made to how the framework parses the `search_path`, as configured on the database connection.

**To be clear, the current implementation is not in itself vulnerable** to this CVE. However, the framework does not _yet_ fully-support the best-practice configuration described in the PostgreSQL documentation, in relation to aforementioned CVE.

It bears explaining that, in addition to literal schema names, the `search_path` accepts a special variable, `$user`, that PostgreSQL resolves to the effective username. So, if the `search_path` is defined as `"$user", public`, PostgreSQL resolves that to `foouser, public`, internally, when executing queries. All of this is completely transparent to Laravel, as of https://github.com/laravel/framework/pull/35463 (which, among other things, adds support for `$user` in the `search_path` configuration variable), with one exception, which is when querying PostgreSQL's `information_schema` to determine, e.g., whether a given table exists or which columns exist on a given table.

This PR modifies how the `search_path` is parsed when building queries to be executed against the `information_schema` to account for the possibility that the first schema listed in the `search_path` is the special `$user` variable.

I should underscore that including this variable in the `search_path` is not some exotic use-case that nobody would ever employ; _the default value_ in a PostgreSQL installation is `"$user", public`. Granted, Laravel overrides this default with the `search_path` value specified in the connection's configuration, but it's certainly conceivable that an end-user would want to configure Laravel to use the best-practice value, which is actually just `$user`.

In fact, I think consideration should be given to changing Laravel's default from `public` to `$user` (in `laravel/laravel`), because the latter is safer, for the [reason described in the PostgreSQL documentation](https://www.postgresql.org/docs/current/ddl-schemas.html#DDL-SCHEMAS-PATTERNS) (**emphasis mine**):

> Constrain ordinary users to user-private schemas. To implement this, issue REVOKE CREATE ON SCHEMA public FROM PUBLIC, and create a schema for each user with the same name as that user. **Recall that the default search path starts with $user, which resolves to the user name. Therefore, if each user has a separate schema, they access their own schemas by default.** After adopting this pattern in a database where untrusted users had already logged in, consider auditing the public schema for objects named like objects in schema pg_catalog. This pattern is a secure schema usage pattern unless an untrusted user is the database owner or holds the CREATEROLE privilege, in which case no secure schema usage pattern exists.

With the changes in this PR, if `$user` is the first schema in the `search_path`, the `PostgresBuilder` will resolve that schema name to the username defined on the database connection whenever appropriate, e.g., in the `hasTable()` and `getColumnListing()` methods.

With this change in place, Laravel's `search_path` handling should now be uniform, consistent, and capable of supporting the best-practices described in the PostgreSQL documentation; specifically, configuring the `search_path` to begin with `$user`.