### PR TITLE
[8.x] Adds callables for Collection when method

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -137,7 +137,7 @@ trait EnumeratesValues
         }
 
         return static::range(1, $number)
-            ->when($callback)
+            ->when(isset($callback))
             ->map($callback);
     }
 

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -463,6 +463,8 @@ trait EnumeratesValues
      */
     public function when($value, callable $callback = null, callable $default = null)
     {
+        $value = is_callable($value) ? $value(clone $this) : $value;
+
         if (! $callback) {
             return new HigherOrderWhenProxy($this, $value);
         }

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -456,7 +456,7 @@ trait EnumeratesValues
     /**
      * Apply the callback if the value is truthy.
      *
-     * @param  bool|mixed  $value
+     * @param  bool|callable|mixed  $value
      * @param  callable|null  $callback
      * @param  callable|null  $default
      * @return static|mixed

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -4171,7 +4171,9 @@ class SupportCollectionTest extends TestCase
     {
         $data = new $collection(['michael', 'tom']);
 
-        $data = $data->when(fn($data) => $data->contains('michael'), function ($data) {
+        $data = $data->when(function ($data) {
+            return $data->contains('michael');
+        }, function ($data) {
             return $data->concat(['adam']);
         });
 
@@ -4179,7 +4181,9 @@ class SupportCollectionTest extends TestCase
 
         $data = new $collection(['michael', 'tom']);
 
-        $data = $data->when(fn($data) => $data->contains('poppy'), function ($data) {
+        $data = $data->when(function ($data) {
+            return $data->contains('poppy');
+         }, function ($data) {
             return $data->concat(['adam']);
         });
 
@@ -4193,7 +4197,9 @@ class SupportCollectionTest extends TestCase
     {
         $data = new $collection(['michael', 'tom']);
 
-        $data = $data->when(fn($data) => $data->contains('taylor'), function ($data) {
+        $data = $data->when(function ($data) {
+            return $data->contains('taylor');
+        }, function ($data) {
             return $data->concat(['adam']);
         }, function ($data) {
             return $data->concat(['taylor']);
@@ -4209,7 +4215,9 @@ class SupportCollectionTest extends TestCase
     {
         $data = new $collection(['michael', 'tom']);
 
-        $data = $data->when(fn($data) => $data->concat(['taylor']));
+        $data = $data->when(function ($data) {
+            return $data->concat(['taylor']);
+        });
 
         $this->assertSame(['michael', 'tom'], $data->toArray());
     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -4205,6 +4205,18 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testWhenWithCallableDoesNotAlterTheOriginalCollection($collection)
+    {
+        $data = new $collection(['michael', 'tom']);
+
+        $data = $data->when(fn($data) => $data->concat(['taylor']));
+
+        $this->assertSame(['michael', 'tom'], $data->toArray());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testWhenEmpty($collection)
     {
         $data = new $collection(['michael', 'tom']);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -4221,7 +4221,7 @@ class SupportCollectionTest extends TestCase
     {
         $data = new $collection(['michael', 'tom']);
 
-        $data = $data->whenEmpty(function ($collection) {
+        $data = $data->whenEmpty(function ($data) {
             return $data->concat(['adam']);
         });
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -4189,6 +4189,22 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testWhenWithCallableDefault($collection)
+    {
+        $data = new $collection(['michael', 'tom']);
+
+        $data = $data->when(fn($data) => $data->contains('taylor'), function ($data) {
+            return $data->concat(['adam']);
+        }, function ($data) {
+            return $data->concat(['taylor']);
+        });
+
+        $this->assertSame(['michael', 'tom', 'taylor'], $data->toArray());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testWhenEmpty($collection)
     {
         $data = new $collection(['michael', 'tom']);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -4167,6 +4167,28 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testWhenWithCallable($collection)
+    {
+        $data = new $collection(['michael', 'tom']);
+
+        $data = $data->when(fn($data) => $data->contains('michael'), function ($data) {
+            return $data->concat(['adam']);
+        });
+
+        $this->assertSame(['michael', 'tom', 'adam'], $data->toArray());
+
+        $data = new $collection(['michael', 'tom']);
+
+        $data = $data->when(fn($data) => $data->contains('poppy'), function ($data) {
+            return $data->concat(['adam']);
+        });
+
+        $this->assertSame(['michael', 'tom'], $data->toArray());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testWhenEmpty($collection)
     {
         $data = new $collection(['michael', 'tom']);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -4183,7 +4183,7 @@ class SupportCollectionTest extends TestCase
 
         $data = $data->when(function ($data) {
             return $data->contains('poppy');
-         }, function ($data) {
+        }, function ($data) {
             return $data->concat(['adam']);
         });
 


### PR DESCRIPTION
## Overview
This adds support for passing a `callable` to the `when` method of a `Collection`. This `callable` receives the current `Collection` to then return a `bool` result

```php
collect(['taylor', 'adam'])->when(fn($names) => $names->contains('taylor'))->concat('poppy')

// ['taylor', 'adam', 'poppy']
```
### Benefits/Usage
Often when working with a `Collection`, it would be useful to inspect the current state of the data and then act accordingly. Otherwise, a temporary variable is required, the `pipe` method is required, or some other solution. This is especially so when the inspection is desired before the interaction with the `Collection` is finished.

Say we want to report a low quote count for an Api response before mapping over them. Currently, it might look like this:

```php
$quotes = Api::getQuotes()->reject(fn($quote) => $quote->isExpired())

if ($quotes->count() < 3) {
    $this->reportLowCount($quotes)
}

$quotes = $quotes->map('...')
```
With a `callable` that can inspect the current state of the `Collection`, it can become:

```php
$quotes = Api::getQuotes()
               ->reject(fn($quote) => $quote->isExpired())
               ->when(fn($quotes) => $quotes->count() < 3, fn($quotes) => $this->reportLowCount($quotes))
               ->map('...')
```
Granted, this is a simplistic example, but I hope it illustrates the usages possible.

### Testing/Compatibility
Tests have been added to `SupportCollectionTest`. These imitate the existing `when` tests for functionality. I have also added a test to ensure the `Collection` is not open to transformation in the evaluation.

The code introduced is in `Illuminate/Collections/Traits/EnumeratesValues`, line `466`. This is now the first line in the method, to set up the value for the rest of the method:
```php
$value = is_callable($value) ? $value(clone $this) : $value;
```

### Summary 
I think it would be a really useful addition to have this option to inspect the `Collection`. When combined with the higher order function available for `when`, it should make for clean and expressive code. 

It'd be great to hear any and all feedback.

And, of course, thank you for everything!

### Edit
If acceptable and desired to be merged, should this be implemented for `unless` too?