### PR TITLE
[8.x] Create ScheduleTestCommand

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleTestCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleTestCommand.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Illuminate\Console\Scheduling;
+
+use Illuminate\Console\Command;
+
+class ScheduleTestCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'schedule:test';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Run a scheduled command';
+
+    /**
+     * Execute the console command.
+     *
+     * @param  \Illuminate\Console\Scheduling\Schedule  $schedule
+     * @return void
+     */
+    public function handle(Schedule $schedule)
+    {
+        $commands = $schedule->events();
+
+        $commandNames = [];
+
+        foreach ($commands as $command) {
+            $commandNames[] = $command->command;
+        }
+
+        $index = array_search($this->choice('Which command would you like to run?', $commandNames), $commandNames);
+
+        $event = $commands[$index];
+
+        $this->line('<info>Running scheduled command:</info> ' . $event->getSummaryForDisplay());
+
+        $event->run($this->laravel);
+    }
+}

--- a/src/Illuminate/Console/Scheduling/ScheduleTestCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleTestCommand.php
@@ -40,7 +40,7 @@ class ScheduleTestCommand extends Command
 
         $event = $commands[$index];
 
-        $this->line('<info>Running scheduled command:</info> ' . $event->getSummaryForDisplay());
+        $this->line('<info>Running scheduled command:</info> '.$event->getSummaryForDisplay());
 
         $event->run($this->laravel);
     }

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -8,6 +8,7 @@ use Illuminate\Cache\Console\ClearCommand as CacheClearCommand;
 use Illuminate\Cache\Console\ForgetCommand as CacheForgetCommand;
 use Illuminate\Console\Scheduling\ScheduleFinishCommand;
 use Illuminate\Console\Scheduling\ScheduleRunCommand;
+use Illuminate\Console\Scheduling\ScheduleTestCommand;
 use Illuminate\Console\Scheduling\ScheduleWorkCommand;
 use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Database\Console\DbCommand;
@@ -117,6 +118,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'ScheduleFinish' => ScheduleFinishCommand::class,
         'ScheduleRun' => ScheduleRunCommand::class,
         'ScheduleWork' => ScheduleWorkCommand::class,
+        'ScheduleTest' => ScheduleTestCommand::class,
         'StorageLink' => 'command.storage.link',
         'Up' => 'command.up',
         'ViewCache' => 'command.view.cache',
@@ -936,6 +938,16 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
     protected function registerScheduleWorkCommand()
     {
         $this->app->singleton(ScheduleWorkCommand::class);
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerScheduleTestCommand()
+    {
+        $this->app->singleton(ScheduleTestCommand::class);
     }
 
     /**


### PR DESCRIPTION
Currently, we have a couple ways to run scheduled jobs in our local environments.  In [Homestead](https://laravel.com/docs/8.x/homestead#configuring-cron-schedules) we can enable `schedule:run` to be enabled for a site. We also have the relatively new [`schedule:work`](https://github.com/laravel/framework/pull/34618) command that starts a long running worker in your terminal.

I've never turned on scheduling in Homestead, because I don't want the jobs running running around the clock on there.  And while `schedule:work` is nice, chances are you are going to need to manipulate when your commands are scheduled if you want to run some of them. You're not going to wait around for a command that runs at 1AM every morning.

As a (hopefully) simpler alternative, this PR introduces a new command that allows you to execute whichever scheduled task you'd like.

```sh
php artisan schedule:test
```

![Screen Shot 2020-12-10 at 10 55 51 PM](https://user-images.githubusercontent.com/5232313/101865116-051fa000-3b3b-11eb-9421-25661538e3b2.png)

Then make your selection, and the scheduled command will run.

![Screen Shot 2020-12-10 at 10 56 07 PM](https://user-images.githubusercontent.com/5232313/101865131-0e107180-3b3b-11eb-8f83-97b9f8ac1d25.png)

While we are no longer testing the timing aspect of the scheduled job, we are still able to see the side effects from things like `sendOutputTo()`, hooks, and pings, and we are able to test truth and environment constraints.