### PR TITLE
[8.x] Create ScheduleListCommand

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Illuminate\Console\Scheduling;
+
+use Cron\CronExpression;
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+
+class ScheduleListCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'schedule:list';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'List the scheduled commands';
+
+    /**
+     * Execute the console command.
+     *
+     * @param  \Illuminate\Console\Scheduling\Schedule  $schedule
+     * @return void
+     * @throws \Exception
+     */
+    public function handle(Schedule $schedule)
+    {
+        foreach ($schedule->events() as $event) {
+            $rows[] = [
+                $event->command,
+                $event->expression,
+                $event->description,
+                (new CronExpression($event->expression))->getPreviousRunDate(Carbon::now()),
+                (new CronExpression($event->expression))->getNextRunDate(Carbon::now()),
+            ];
+        }
+
+        $this->table([
+            'Command',
+            'Interval',
+            'Description',
+            'Last Run',
+            'Next Due',
+        ], $rows ?? []);
+    }
+}

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -7,6 +7,7 @@ use Illuminate\Cache\Console\CacheTableCommand;
 use Illuminate\Cache\Console\ClearCommand as CacheClearCommand;
 use Illuminate\Cache\Console\ForgetCommand as CacheForgetCommand;
 use Illuminate\Console\Scheduling\ScheduleFinishCommand;
+use Illuminate\Console\Scheduling\ScheduleListCommand;
 use Illuminate\Console\Scheduling\ScheduleRunCommand;
 use Illuminate\Console\Scheduling\ScheduleWorkCommand;
 use Illuminate\Contracts\Support\DeferrableProvider;
@@ -117,6 +118,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'ScheduleFinish' => ScheduleFinishCommand::class,
         'ScheduleRun' => ScheduleRunCommand::class,
         'ScheduleWork' => ScheduleWorkCommand::class,
+        'ScheduleList' => ScheduleListCommand::class,
         'StorageLink' => 'command.storage.link',
         'Up' => 'command.up',
         'ViewCache' => 'command.view.cache',
@@ -936,6 +938,16 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
     protected function registerScheduleWorkCommand()
     {
         $this->app->singleton(ScheduleWorkCommand::class);
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerScheduleListCommand()
+    {
+        $this->app->singleton(ScheduleListCommand::class);
     }
 
     /**


### PR DESCRIPTION
Display a table of all the scheduled commands, with some helpful information.

I hope I'm not stepping on any toes here, @JacobBennett and @michaeldyrynda.  Most of this code was taken from ThenPingMe's command, but I figured it'd be okay since this command is available to users even if they don't have a subscription.

Thought it would be useful in core too!