### PR TITLE
[8.x] Add support for dynamic 'for' methods on factories with existing model instances

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -762,7 +762,7 @@ abstract class Factory
         }
 
         if (Str::startsWith($method, 'for')) {
-            return $this->for($factory->state($parameters[0] ?? []), $relationship);
+            return $this->for($parameters[0] instanceof Factory ? $factory->state($parameters[0] ?? []) : $parameters[0], $relationship);
         } elseif (Str::startsWith($method, 'has')) {
             return $this->has(
                 $factory


### PR DESCRIPTION
Adds support for attaching existing model instances using dynamic `forModel()` syntax. Follow-up to #35494 and #35541.

For example, to attach a `User` model via an `author()` relationship that uses the `author_id` column:

```php
$posts = Post::factory(10)
    ->forAuthor($user = User::factory()->create())
    ->create();
```

See https://github.com/laravel/framework/pull/35494#issuecomment-742104351.