### PR TITLE
[8.x] Allow factory relationships to override state

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -370,9 +370,9 @@ abstract class Factory
     protected function getRawAttributes(?Model $parent)
     {
         return $this->states->pipe(function ($states) {
-            return $this->for->isEmpty() ? $states : new Collection(array_merge([function () {
+            return $this->for->isEmpty() ? $states : new Collection(array_merge($states->all(), [function () {
                 return $this->parentResolvers();
-            }], $states->all()));
+            }]));
         })->reduce(function ($carry, $state) use ($parent) {
             if ($state instanceof Closure) {
                 $state = $state->bindTo($this);

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -265,6 +265,22 @@ class DatabaseEloquentFactoryTest extends TestCase
         $this->assertCount(3, FactoryTestPost::all());
     }
 
+    public function test_belongs_to_relationship_with_existing_model_instance_and_state()
+    {
+        $user = FactoryTestUserFactory::new(['name' => 'Taylor Otwell'])->create();
+        $posts = FactoryTestPostFactory::times(3)
+                        ->withUserState()
+                        ->for($user, 'user')
+                        ->create();
+
+        $this->assertCount(3, $posts->filter(function ($post) use ($user) {
+            return $post->user->is($user);
+        }));
+
+        $this->assertCount(1, FactoryTestUser::all());
+        $this->assertCount(3, FactoryTestPost::all());
+    }
+
     public function test_belongs_to_relationship_with_existing_model_instance_with_relationship_name_implied_from_model()
     {
         $user = FactoryTestUserFactory::new(['name' => 'Taylor Otwell'])->create();
@@ -539,6 +555,15 @@ class FactoryTestPostFactory extends Factory
             'user_id' => FactoryTestUserFactory::new(),
             'title' => $this->faker->name,
         ];
+    }
+
+    public function withUserState()
+    {
+        return $this->state(function () {
+            return [
+                'user_id' => FactoryTestUserFactory::new(),
+            ];
+        });
     }
 }
 

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -250,26 +250,25 @@ class DatabaseEloquentFactoryTest extends TestCase
         $this->assertCount(3, FactoryTestPost::all());
     }
 
-    public function test_belongs_to_relationship_with_existing_model_instance()
+    public function test_belongs_to_relationship_overriding_state()
     {
-        $user = FactoryTestUserFactory::new(['name' => 'Taylor Otwell'])->create();
         $posts = FactoryTestPostFactory::times(3)
-                        ->for($user, 'user')
+                        ->withUserState()
+                        ->for(FactoryTestUserFactory::new(['name' => 'Taylor Otwell']), 'user')
                         ->create();
 
-        $this->assertCount(3, $posts->filter(function ($post) use ($user) {
-            return $post->user->is($user);
+        $this->assertCount(3, $posts->filter(function ($post) {
+            return $post->user->name == 'Taylor Otwell';
         }));
 
         $this->assertCount(1, FactoryTestUser::all());
         $this->assertCount(3, FactoryTestPost::all());
     }
 
-    public function test_belongs_to_relationship_with_existing_model_instance_and_state()
+    public function test_belongs_to_relationship_with_existing_model_instance()
     {
         $user = FactoryTestUserFactory::new(['name' => 'Taylor Otwell'])->create();
         $posts = FactoryTestPostFactory::times(3)
-                        ->withUserState()
                         ->for($user, 'user')
                         ->create();
 


### PR DESCRIPTION
**TLDR:** This PR allows factory relationships (like `for`) to override relationships generated within state.

Imagine you have a `PostFactory` in Laravel with a state called `withTopic` that automatically generates a topic for the post as well as some other post-specific topic related data:

```php
// inside PostFactory

public function withTopic()
{
    return $this->state(function () {
        return [
            'topic_id' => Topic::factory(),
            'topic_text_color' => $this->faker->color,
            'topic_background_color' => $this->faker->color,
        ];
    });
}
```

Now imagine inside a test you want to use the `withTopic` state, but override the topic that is generated with your own:

```php
// inside a test

$topic = Topic::factory()->create();
$post = Post::factory()->withTopic()->for($topic)->create();
```

Currently, in Laravel 8, the result of the code above will be **1 post created, 2 topics created**, and the topic associated with the post will be the one generated inside the state, not the one passed in via `for`.

With the change in this PR, the above code will now **create 1 post and 1 topic** (the one created in the test, not the state).

I believe this is more in line with what developers will expect when using factories. If a relationship is specifically passed in, it should override what is happening inside state methods.

