### PR TITLE
[9.x] Fix several lingering issues with PostgreSQL search_path handling

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -246,12 +246,12 @@ class PostgresGrammar extends Grammar
     /**
      * Compile the SQL needed to retrieve all table names.
      *
-     * @param  string|array  $schema
+     * @param  string|array  $searchPath
      * @return string
      */
-    public function compileGetAllTables($schema)
+    public function compileGetAllTables($searchPath)
     {
-        return "select tablename from pg_catalog.pg_tables where schemaname in ('".implode("','", (array) $schema)."')";
+        return "select tablename from pg_catalog.pg_tables where schemaname in ('".implode("','", (array) $searchPath)."')";
     }
 
     /**
@@ -260,9 +260,9 @@ class PostgresGrammar extends Grammar
      * @param  string|array  $schema
      * @return string
      */
-    public function compileGetAllViews($schema)
+    public function compileGetAllViews($searchPath)
     {
-        return "select viewname from pg_catalog.pg_views where schemaname in ('".implode("','", (array) $schema)."')";
+        return "select viewname from pg_catalog.pg_views where schemaname in ('".implode("','", (array) $searchPath)."')";
     }
 
     /**

--- a/src/Illuminate/Database/Schema/PostgresBuilder.php
+++ b/src/Illuminate/Database/Schema/PostgresBuilder.php
@@ -107,7 +107,9 @@ class PostgresBuilder extends Builder
     public function getAllTables()
     {
         return $this->connection->select(
-            $this->grammar->compileGetAllTables((array) $this->connection->getConfig('schema'))
+            $this->grammar->compileGetAllTables(
+                $this->parseSearchPath($this->connection->getConfig('search_path'))
+            )
         );
     }
 
@@ -119,7 +121,9 @@ class PostgresBuilder extends Builder
     public function getAllViews()
     {
         return $this->connection->select(
-            $this->grammar->compileGetAllViews((array) $this->connection->getConfig('schema'))
+            $this->grammar->compileGetAllViews(
+                $this->parseSearchPath($this->connection->getConfig('search_path'))
+            )
         );
     }
 
@@ -209,6 +213,10 @@ class PostgresBuilder extends Builder
 
         array_walk($searchPath, function (&$schema) {
             $schema = trim($schema, '\'"');
+
+            $schema = $schema === '$user'
+                ? $this->connection->getConfig('username')
+                : $schema;
         });
 
         return $searchPath;


### PR DESCRIPTION
In previous PRs I submitted, in relation to https://github.com/laravel/ideas/issues/918 , I spotted two other issues that should be fixed while we're at it. These issues shouldn't cause any further breaking changes.

1. Crucially, within the `parseSearchPath()` method, PostgreSQL's special `$user` variable wasn't being resolved to the username specified on the connection (just as is done in the `parseSchemaAndTable()` method).
2. The `getAllTables()` and `getAllViews()` methods, which are used when querying the list of tables/views to be dropped, were still referring to the `schema` configuration variable, which should be removed completely from the keys defined on the configuration by default, in favor of `search_path` (in the `laravel/laravel` repository). This PR updates that reference to `search_path` and wraps the value in the `parseSearchPath()` method.
3. I had overlooked a handful of `schema` references that should also have been updated to `search_path` or `searchPath`.

Also, while not _directly_ related to these changes, I added a couple of new tests to cover previously-uncovered code that is tangentially related to these changes.

Finally, it's worth cross-linking https://github.com/laravel/ideas/issues/2438 so that my reasoning is documented for posterity.

I swear that this is my last PR on this subject! Unless it's to add more tests for uncovered code! ;-)