### PR TITLE
[8.x] Mock with constructor arguments

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
@@ -45,10 +45,10 @@ trait InteractsWithContainer
      * Mock an instance of an object in the container.
      *
      * @param  string  $abstract
-     * @param  \Closure|null  $mock
+     * @param  array  ...$args
      * @return \Mockery\MockInterface
      */
-    protected function mock($abstract, Closure $mock = null)
+    protected function mock($abstract, ...$args)
     {
         return $this->instance($abstract, Mockery::mock(...array_filter(func_get_args())));
     }
@@ -57,23 +57,10 @@ trait InteractsWithContainer
      * Mock a partial instance of an object in the container.
      *
      * @param  string  $abstract
-     * @param  \Closure|null  $mock
+     * @param  array  ...$args
      * @return \Mockery\MockInterface
      */
-    protected function partialMock($abstract, Closure $mock = null)
-    {
-        return $this->instance($abstract, Mockery::mock(...array_filter(func_get_args()))->makePartial());
-    }
-
-    /**
-     * Mock a partial instance of an object with arguments in the container.
-     *
-     * @param  string  $abstract
-     * @param  array  $arguments
-     * @param  Closure|null  $mock
-     * @return \Mockery\MockInterface
-     */
-    protected function partialMockWithArguments($abstract, $arguments = [], Closure $mock = null)
+    protected function partialMock($abstract, ...$args)
     {
         return $this->instance($abstract, Mockery::mock(...array_filter(func_get_args()))->makePartial());
     }

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
@@ -66,6 +66,19 @@ trait InteractsWithContainer
     }
 
     /**
+     * Mock a partial instance of an object with arguments in the container.
+     *
+     * @param  string  $abstract
+     * @param  array  $arguments
+     * @param  Closure|null  $mock
+     * @return \Mockery\MockInterface
+     */
+    protected function partialMockWithArguments($abstract, $arguments = [], Closure $mock = null)
+    {
+        return $this->instance($abstract, Mockery::mock(...array_filter(func_get_args()))->makePartial());
+    }
+
+    /**
      * Spy an instance of an object in the container.
      *
      * @param  string  $abstract


### PR DESCRIPTION
Use splat operator to support constructor arguments as suggested from the mockery docs.
http://docs.mockery.io/en/latest/reference/creating_test_doubles.html#creating-test-doubles-constructor-arguments

Instead of
```
$this->instance(
    Service::class,
    Mockery::mock(Service::class, ['arg1', 'arg2'], function (MockInterface $mock) {
        $mock->shouldReceive('process')->once();
    })
);
```

We could now
```
$mock = $this->mock(Service::class, ['arg1', 'arg2'], function (MockInterface $mock) {
    $mock->shouldReceive('process')->once();
});
```