### PR TITLE
[8.x] Remove unnecessary fallback

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -125,7 +125,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
                 if (! is_null($line = $this->getLine(
                     $namespace, $group, $locale, $item, $replace
                 ))) {
-                    return $line ?? $key;
+                    return $line;
                 }
             }
         }


### PR DESCRIPTION
Since there's a `! is_null()` check, there's no need to have a fallback for when `$line` is null.