### PR TITLE
[8.x] support nested arrays of encrypted cookies such as`a[b][c]`

### DIFF
--- a/src/Illuminate/Cookie/Middleware/EncryptCookies.php
+++ b/src/Illuminate/Cookie/Middleware/EncryptCookies.php
@@ -124,6 +124,9 @@ class EncryptCookies
             if (is_string($value)) {
                 $decrypted[$key] = $this->encrypter->decrypt($value, static::serialized($key));
             }
+            if (is_array($value)) {
+                $decrypted[$key] = $this->decryptArray($value);
+            }
         }
 
         return $decrypted;


### PR DESCRIPTION
The `EncryptCookies` middleware has support for cookie arrays i.e where there are cookies with names of the form `a[b]` and the values will be correctly decoded.
However if you nest one layer deeper i.e `a[b][c]` the result of the decryption is always empty.

This minor change allows for unlimited nesting by recursively calling the existing `decryptArray` function as required.

I can find no existing test coverage for array values so i have not added any but happy to add if desired.