### PR TITLE
[8.x] When following redirects, terminate each test request in proper order

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -508,11 +508,11 @@ trait MakesHttpRequests
             $request = Request::createFromBase($symfonyRequest)
         );
 
+        $kernel->terminate($request, $response);
+
         if ($this->followRedirects) {
             $response = $this->followRedirects($response);
         }
-
-        $kernel->terminate($request, $response);
 
         return $this->createTestResponse($response);
     }
@@ -623,11 +623,11 @@ trait MakesHttpRequests
      */
     protected function followRedirects($response)
     {
+        $this->followRedirects = false;
+
         while ($response->isRedirect()) {
             $response = $this->get($response->headers->get('Location'));
         }
-
-        $this->followRedirects = false;
 
         return $response;
     }

--- a/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
+++ b/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
@@ -2,6 +2,9 @@
 
 namespace Illuminate\Tests\Foundation\Testing\Concerns;
 
+use Illuminate\Contracts\Routing\Registrar;
+use Illuminate\Contracts\Routing\UrlGenerator;
+use Illuminate\Http\RedirectResponse;
 use Orchestra\Testbench\TestCase;
 
 class MakesHttpRequestsTest extends TestCase
@@ -114,6 +117,50 @@ class MakesHttpRequestsTest extends TestCase
         $this->defaultCookies = ['foo' => 'bar'];
         $this->assertSame(['foo' => 'bar'], $this->prepareCookiesForJsonRequest());
     }
+
+
+    public function testFollowingRedirects()
+    {
+        $router = $this->app->make(Registrar::class);
+        $url = $this->app->make(UrlGenerator::class);
+
+        $router->get('from', function() use ($url) {
+            return new RedirectResponse($url->to('to'));
+        });
+
+        $router->get('to', function() {
+            return 'OK';
+        });
+
+        $this->followingRedirects()
+            ->get('from')
+            ->assertOk()
+            ->assertSee('OK');
+    }
+
+
+    public function testFollowingRedirectsTerminatesInExpectedOrder()
+    {
+        $router = $this->app->make(Registrar::class);
+        $url = $this->app->make(UrlGenerator::class);
+
+        $callOrder = [];
+        TerminatingMiddleware::$callback = function($request) use (&$callOrder) {
+            $callOrder[] = $request->path();
+        };
+
+        $router->get('from', function() use ($url) {
+            return new RedirectResponse($url->to('to'));
+        })->middleware(TerminatingMiddleware::class);
+
+        $router->get('to', function() {
+            return 'OK';
+        })->middleware(TerminatingMiddleware::class);
+
+        $this->followingRedirects()->get('from');
+
+        $this->assertEquals([ 'from', 'to' ], $callOrder);
+    }
 }
 
 class MyMiddleware
@@ -121,5 +168,20 @@ class MyMiddleware
     public function handle($request, $next)
     {
         return $next($request.'WithMiddleware');
+    }
+}
+
+class TerminatingMiddleware
+{
+    public static $callback;
+
+    public function handle($request, $next)
+    {
+        return $next($request);
+    }
+
+    public function terminate($request, $response)
+    {
+        call_user_func(static::$callback, $request, $response);
     }
 }

--- a/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
+++ b/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
@@ -118,17 +118,16 @@ class MakesHttpRequestsTest extends TestCase
         $this->assertSame(['foo' => 'bar'], $this->prepareCookiesForJsonRequest());
     }
 
-
     public function testFollowingRedirects()
     {
         $router = $this->app->make(Registrar::class);
         $url = $this->app->make(UrlGenerator::class);
 
-        $router->get('from', function() use ($url) {
+        $router->get('from', function () use ($url) {
             return new RedirectResponse($url->to('to'));
         });
 
-        $router->get('to', function() {
+        $router->get('to', function () {
             return 'OK';
         });
 
@@ -138,28 +137,27 @@ class MakesHttpRequestsTest extends TestCase
             ->assertSee('OK');
     }
 
-
     public function testFollowingRedirectsTerminatesInExpectedOrder()
     {
         $router = $this->app->make(Registrar::class);
         $url = $this->app->make(UrlGenerator::class);
 
         $callOrder = [];
-        TerminatingMiddleware::$callback = function($request) use (&$callOrder) {
+        TerminatingMiddleware::$callback = function ($request) use (&$callOrder) {
             $callOrder[] = $request->path();
         };
 
-        $router->get('from', function() use ($url) {
+        $router->get('from', function () use ($url) {
             return new RedirectResponse($url->to('to'));
         })->middleware(TerminatingMiddleware::class);
 
-        $router->get('to', function() {
+        $router->get('to', function () {
             return 'OK';
         })->middleware(TerminatingMiddleware::class);
 
         $this->followingRedirects()->get('from');
 
-        $this->assertEquals([ 'from', 'to' ], $callOrder);
+        $this->assertEquals(['from', 'to'], $callOrder);
     }
 }
 
@@ -168,6 +166,7 @@ class MyMiddleware
     public function handle($request, $next)
     {
         return $next($request.'WithMiddleware');
+
     }
 }
 

--- a/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
+++ b/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
@@ -166,7 +166,6 @@ class MyMiddleware
     public function handle($request, $next)
     {
         return $next($request.'WithMiddleware');
-
     }
 }
 


### PR DESCRIPTION
The current `followRedirects()` implementation applies both a `while` loop and recursion, causing `Kernel::terminate()` to be called in the incorrect order. 99% of the time this is not an issue, but in the case of terminating middleware or callbacks set up with `App::terminating()`, the termination callbacks will be executed in reverse order.

For example, with two routes:

| Route   | Middleware             | Response        |
|----------|-----------------------|-----------------|
| /from    | LogRequest | Redirect to /to |
| /to      | LogRequest | return "OK"     |

And the following middleware:

```php
class LogRequest
{
    public function handle($request, $next)
    {
        return $next($request);
    }

    public function terminate($request, $response)
    {
        // Log request path and response status code
    }
}
```

Given the following pseudo-test:

```php
$this->followingRedirects()->get('from');
$this->assertEquals(['from', 'to'], get_logged_request_paths()); // <-- This fails before the PR
```