### PR TITLE
[8.x] Adds If method for Collections

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -293,7 +293,7 @@ trait EnumeratesValues
     }
 
     /**
-     * Apply the callback if the evaluated check is truthy.
+     * Apply the callback if the evaluated check for the collection is truthy.
      *
      * @param  callable  $check
      * @param  callable|null  $callback

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -293,6 +293,19 @@ trait EnumeratesValues
     }
 
     /**
+     * Apply the callback if the evaluated check is truthy.
+     *
+     * @param  callable  $check
+     * @param  callable|null  $callback
+     * @param  callable|null  $default
+     * @return static|mixed
+     */
+    public function if(callable $check, callable $callback = null, callable $default = null)
+    {
+        return $this->when($check(clone $this), $callback, $default);
+    }
+
+    /**
      * Determine if the collection is not empty.
      *
      * @return bool

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -4489,6 +4489,72 @@ class SupportCollectionTest extends TestCase
     }
 
     /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testIf($collection)
+    {
+        $data = new $collection(['michael', 'tom']);
+
+        $data = $data->if(function ($data) {
+            return $data->contains('michael');
+        }, function ($data) {
+            return $data->concat(['adam']);
+        });
+
+        $this->assertSame(['michael', 'tom', 'adam'], $data->toArray());
+
+        $data = new $collection(['michael', 'tom']);
+
+        $data = $data->if(function ($data) {
+            return $data->contains('adam');
+        }, function ($data) {
+            return $data->concat(['adam']);
+        });
+
+        $this->assertSame(['michael', 'tom'], $data->toArray());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testIfDefault($collection)
+    {
+        $data = new $collection(['michael', 'tom']);
+
+        $data = $data->if(function ($data) {
+            return $data->contains('poppy');
+        }, function ($data) {
+            return $data->concat(['adam']);
+        }, function ($data) {
+            return $data->concat(['taylor']);
+        });
+
+        $this->assertSame(['michael', 'tom', 'taylor'], $data->toArray());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testIfHigherOrder($collection)
+    {
+        $data = new $collection(['michael', 'tom']);
+
+        $data = $data->if(function ($data) {
+            return $data->contains('tom');
+        })->concat(['taylor']);
+
+        $this->assertSame(['michael', 'tom', 'taylor'], $data->toArray());
+
+        $data = new $collection(['michael', 'tom']);
+
+        $data = $data->if(function ($data) {
+            return $data->contains('poppy');
+        })->concat(['taylor']);
+
+        $this->assertSame(['michael', 'tom'], $data->toArray());
+    }
+
+    /**
      * Provides each collection class, respectively.
      *
      * @return array

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -4530,6 +4530,18 @@ class SupportCollectionTest extends TestCase
         });
 
         $this->assertSame(['michael', 'tom', 'taylor'], $data->toArray());
+
+        $data = new $collection(['michael', 'tom']);
+
+        $data = $data->if(function ($data) {
+            return $data->contains('tom');
+        }, function ($data) {
+            return $data->concat(['adam']);
+        }, function ($data) {
+            return $data->concat(['taylor']);
+        });
+
+        $this->assertSame(['michael', 'tom', 'adam'], $data->toArray());
     }
 
     /**


### PR DESCRIPTION
## Overview
> This is a successor to [PR #35570](https://github.com/laravel/framework/pull/35570), which would have been a breaking change. 

This adds an `if` method to `Collection`. This is essentially the same as `when` and `unless`, just that the parameter to be passed is always a `callable`. The `check` is passed the current `Collection` to evaluate:

```php
collect(['taylor', 'adam'])->if(fn($names) => $names->contains('taylor'))->concat('poppy')

// ['taylor', 'adam', 'poppy']
```
### Benefits/Usage
Often when working with a `Collection`, it would be useful to inspect the current state of the data and then act accordingly. Otherwise, a temporary variable is required, the `pipe` method is required, or some other solution. This is especially so when the inspection is desired before the interaction with the `Collection` is finished.

Say we want to report a low quote count for an Api response before mapping over them. Currently, it might look like this:

```php
$quotes = Api::getQuotes()->reject(fn($quote) => $quote->isExpired())

if ($quotes->count() < 3) {
    $this->reportLowCount($quotes)
}

$quotes = $quotes->map('...')
```
With a `callable` that can inspect the current state of the `Collection`, it can become:

```php
$quotes = Api::getQuotes()
               ->reject(fn($quote) => $quote->isExpired())
               ->if(fn($quotes) => $quotes->count() < 3, fn($quotes) => $this->reportLowCount($quotes))
               ->map('...')
```
Granted, this is a simplistic example, but I hope it illustrates the usages possible.

### Testing/Compatibility
Tests have been added to `SupportCollectionTest`. These imitate the existing `when` and `unless` tests for functionality.

Unlike the [previous PR](https://github.com/laravel/framework/pull/35570), this should not be a breaking change.

### Pros/Cons of a new method
As seen in the [previous PR](https://github.com/laravel/framework/pull/35570), updating `when` and/or `unless` for this functionality is a breaking change. As the use case of this functionality is perhaps limited, it seems the break might not justify the update?

Which is why this PR targets 8.x with a new method that utilises `when`:
```php
public function if(callable $check, callable $callback = null, callable $default = null)
{
    return $this->when($check(clone $this), $callback, $default);
}
```
Which means it can even be used as a higher order function.

But, it is just a wrapper around `when`, which could just be macroed in projects that desire this functionality. Therefore, it might be deemed that adding a new method is not justified. Plus, I appreciate the name `if` might be somewhat ambiguous.

### Summary 
I think it would be a really useful addition to have this option to inspect the `Collection`. When combined with the higher order function available for the underlying implementation of `when`, it should make for clean and expressive code.

p.s. This will be the last PR on this topic unless requested otherwise!