### PR TITLE
[8.x] Added errorBag to json validation errors

### DIFF
--- a/src/Illuminate/Validation/ValidationException.php
+++ b/src/Illuminate/Validation/ValidationException.php
@@ -87,7 +87,7 @@ class ValidationException extends Exception
         if ($this->errorBag) {
             return [$this->errorBag => $this->validator->errors()->messages()];
         }
-        
+
         return $this->validator->errors()->messages();
     }
 

--- a/src/Illuminate/Validation/ValidationException.php
+++ b/src/Illuminate/Validation/ValidationException.php
@@ -84,6 +84,10 @@ class ValidationException extends Exception
      */
     public function errors()
     {
+        if ($this->errorBag) {
+            return [$this->errorBag => $this->validator->errors()->messages()];
+        }
+        
         return $this->validator->errors()->messages();
     }
 


### PR DESCRIPTION
When using multiple forms on the page via api, there is no way to distinguish which form the errors belong to.

`Validator::make($data, $rules)->validateWithBag('truck');` 
 
Before: 
`errors: {plate: ["The plate field is required."]}`

After: 
`errors: {truck: {plate: ["The plate field is required."]}}`
