### PR TITLE
[9.x] Make Redirector::setIntendedUrl fluent

### DIFF
--- a/src/Illuminate/Routing/Redirector.php
+++ b/src/Illuminate/Routing/Redirector.php
@@ -115,11 +115,13 @@ class Redirector
      * Set the intended url.
      *
      * @param  string  $url
-     * @return void
+     * @return $this
      */
     public function setIntendedUrl($url)
     {
         $this->session->put('url.intended', $url);
+
+        return $this;
     }
 
     /**

--- a/tests/Routing/RoutingRedirectorTest.php
+++ b/tests/Routing/RoutingRedirectorTest.php
@@ -182,6 +182,7 @@ class RoutingRedirectorTest extends TestCase
     {
         $this->session->shouldReceive('put')->once()->with('url.intended', 'http://foo.com/bar');
 
-        $this->redirect->setIntendedUrl('http://foo.com/bar');
+        $result = $this->redirect->setIntendedUrl('http://foo.com/bar');
+        $this->assertInstanceOf(Redirector::class, $result);
     }
 }


### PR DESCRIPTION
`Redirector::setIntendedUrl()` currently returns `void`. This simply makes `setIntendedUrl` a fluent method:

Before:

```php
redirect()->setIndendedUrl('foo')
return redirect()->to('bar');
```

After:

```php
return redirect()->setIndendedUrl('foo')->to('bar');
```