### PR TITLE
[8.x] Support for working with cookies from last response

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -244,7 +244,6 @@ trait MakesHttpRequests
         return $this;
     }
 
-
     /**
      * Use cookies that were set in last response during next request.
      *
@@ -256,7 +255,6 @@ trait MakesHttpRequests
 
         return $this;
     }
-
 
     /**
      * Do not use cookies that were set in last response during next request.
@@ -669,11 +667,11 @@ trait MakesHttpRequests
         }
 
         return collect($this->lastResponse->headers->getCookies())
-            ->reject(function(Cookie $cookie) {
+            ->reject(function (Cookie $cookie) {
                 return 0 !== $cookie->getExpiresTime()
                     && Date::createFromTimestamp($cookie->getExpiresTime())->isPast();
             })
-            ->mapWithKeys(function(Cookie $cookie) {
+            ->mapWithKeys(function (Cookie $cookie) {
                 return [$cookie->getName() => $cookie->getValue()];
             })
             ->all();

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -257,6 +257,19 @@ trait MakesHttpRequests
         return $this;
     }
 
+
+    /**
+     * Do not use cookies that were set in last response during next request.
+     *
+     * @return $this
+     */
+    public function ignoringCookiesFromLastResponse()
+    {
+        $this->useCookiesFromLastResponse = false;
+
+        return $this;
+    }
+
     /**
      * Automatically follow any redirects returned from the response.
      *

--- a/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
+++ b/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
@@ -116,20 +116,20 @@ class MakesHttpRequestsTest extends TestCase
         $now = Date::now();
 
         $encrypter = new Encrypter(str_repeat('a', 16));
-        $this->app->singleton(EncrypterContract::class, function() use ($encrypter) {
+        $this->app->singleton(EncrypterContract::class, function () use ($encrypter) {
             return $encrypter;
         });
 
         $router = $this->app->make(Registrar::class);
 
-        $router->get('set-cookies', function() {
+        $router->get('set-cookies', function () {
             return (new Response('OK'))
                 ->withCookie('unencrypted-cookie', 'unencrypted-value')
                 ->withCookie('expiring-cookie', 'expiring-value', 10)
                 ->withCookie('encrypted-cookie', 'encrypted-value');
         })->middleware(MyEncryptCookiesMiddleware::class);
 
-        $router->get('forget-cookies', function() {
+        $router->get('forget-cookies', function () {
             return (new Response('OK'))
                 ->withCookie('unencrypted-cookie', '', -2628000)
                 ->withCookie('expiring-cookie', '', -2628000)

--- a/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
+++ b/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
@@ -2,18 +2,12 @@
 
 namespace Illuminate\Tests\Foundation\Testing\Concerns;
 
-use Illuminate\Container\Container;
 use Illuminate\Contracts\Encryption\Encrypter as EncrypterContract;
 use Illuminate\Contracts\Routing\Registrar;
-use Illuminate\Contracts\Routing\UrlGenerator;
-use Illuminate\Cookie\CookieJar;
 use Illuminate\Cookie\CookieValuePrefix;
 use Illuminate\Cookie\Middleware\EncryptCookies;
 use Illuminate\Encryption\Encrypter;
-use Illuminate\Events\Dispatcher;
-use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Response;
-use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Date;
 use Orchestra\Testbench\TestCase;
 

--- a/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
+++ b/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
@@ -147,6 +147,12 @@ class MakesHttpRequestsTest extends TestCase
         $this->assertEquals('unencrypted-value', $cookies['unencrypted-cookie']);
         $this->assertEquals('expiring-value', $cookies['expiring-cookie']);
 
+        // Ensure that calling ignoringCookiesFromLastResponse() disables this
+        $this->ignoringCookiesFromLastResponse();
+        $this->assertEmpty($this->prepareCookiesForRequest());
+
+        $this->usingCookiesFromLastResponse();
+
         // Time-travel past the expiration of the "expiring-cookie"
         // and ensure it won't be used for the next request
         Date::setTestNow($now->copy()->addMinutes(11));


### PR DESCRIPTION
This PR adds `TestCase::usingCookiesFromLastResponse()` which enables automatically setting cookies from previous test responses on subsequent requests.

For example:

```php
$this->get('/set-a-cookie');
$this->usingCookiesFromLastResponse()->get('/depends-on-a-cookie');
```

This respects cookie expiration (and time travel) which allows you to do something like:

```php
$this->get('/set-a-short-lived-cookie');

$this->usingCookiesFromLastResponse()
  ->get('/requires-cookie-is-set')
  ->assertOk();

Date::setTestNow(now()->addHour());

$this->get('/requires-cookie-is-set')->assertForbidden();
```

This is particularly useful for integration tests where you want to match the real request lifecycle as much as possible. In these cases, calling `usingCookiesFromLastResponse()` lets you emulate a browser making multiple requests with cookies persisted across requests.