### PR TITLE
[9.x] Allow for accessing cookies via TestResponse

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -347,7 +347,7 @@ class TestResponse implements ArrayAccess
         $expiresAt = Carbon::createFromTimestamp($cookie->getExpiresTime());
 
         PHPUnit::assertTrue(
-            $expiresAt->greaterThan(Carbon::now()),
+            0 === $cookie->getExpiresTime() || $expiresAt->greaterThan(Carbon::now()),
             "Cookie [{$cookieName}] is expired, it expired at [{$expiresAt}]."
         );
 

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -15,6 +15,7 @@ use Illuminate\Support\Traits\Tappable;
 use Illuminate\Testing\Assert as PHPUnit;
 use Illuminate\Testing\Constraints\SeeInOrder;
 use LogicException;
+use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 /**
@@ -289,7 +290,7 @@ class TestResponse implements ArrayAccess
     public function assertCookie($cookieName, $value = null, $encrypted = true, $unserialize = false)
     {
         PHPUnit::assertNotNull(
-            $cookie = $this->getCookie($cookieName),
+            $cookie = $this->getCookie($cookieName, $encrypted, $unserialize),
             "Cookie [{$cookieName}] not present on response."
         );
 
@@ -299,13 +300,9 @@ class TestResponse implements ArrayAccess
 
         $cookieValue = $cookie->getValue();
 
-        $actual = $encrypted
-            ? CookieValuePrefix::remove(app('encrypter')->decrypt($cookieValue, $unserialize))
-            : $cookieValue;
-
         PHPUnit::assertEquals(
-            $value, $actual,
-            "Cookie [{$cookieName}] was found, but value [{$actual}] does not match [{$value}]."
+            $value, $cookieValue,
+            "Cookie [{$cookieName}] was found, but value [{$cookieValue}] does not match [{$value}]."
         );
 
         return $this;
@@ -377,12 +374,23 @@ class TestResponse implements ArrayAccess
      * Get the given cookie from the response.
      *
      * @param  string  $cookieName
+     * @param  bool  $decrypt
+     * @param  bool  $unserialize
      * @return \Symfony\Component\HttpFoundation\Cookie|null
      */
-    protected function getCookie($cookieName)
+    public function getCookie($cookieName, $decrypt = false, $unserialize = false)
     {
         foreach ($this->headers->getCookies() as $cookie) {
             if ($cookie->getName() === $cookieName) {
+                if ($decrypt) {
+                    $decryptedValue = CookieValuePrefix::remove(app('encrypter')->decrypt($cookie->getValue(), $unserialize));
+                    $cookie = new Cookie(
+                        $cookie->getName(), $decryptedValue, $cookie->getExpiresTime(), $cookie->getPath(),
+                        $cookie->getDomain(), $cookie->isSecure(), $cookie->isHttpOnly(),
+                        $cookie->isRaw(), $cookie->getSameSite()
+                    );
+                }
+
                 return $cookie;
             }
         }

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -4,6 +4,7 @@ namespace Illuminate\Testing;
 
 use ArrayAccess;
 use Closure;
+use Illuminate\Contracts\Encryption\Encrypter as EncrypterContract;
 use Illuminate\Contracts\View\View;
 use Illuminate\Cookie\CookieValuePrefix;
 use Illuminate\Database\Eloquent\Model;
@@ -317,7 +318,7 @@ class TestResponse implements ArrayAccess
     public function assertCookieExpired($cookieName)
     {
         PHPUnit::assertNotNull(
-            $cookie = $this->getCookie($cookieName),
+            $cookie = $this->getCookie($cookieName, false),
             "Cookie [{$cookieName}] not present on response."
         );
 
@@ -340,7 +341,7 @@ class TestResponse implements ArrayAccess
     public function assertCookieNotExpired($cookieName)
     {
         PHPUnit::assertNotNull(
-            $cookie = $this->getCookie($cookieName),
+            $cookie = $this->getCookie($cookieName, false),
             "Cookie [{$cookieName}] not present on response."
         );
 
@@ -363,7 +364,7 @@ class TestResponse implements ArrayAccess
     public function assertCookieMissing($cookieName)
     {
         PHPUnit::assertNull(
-            $this->getCookie($cookieName),
+            $this->getCookie($cookieName, false),
             "Cookie [{$cookieName}] is present on response."
         );
 
@@ -378,12 +379,12 @@ class TestResponse implements ArrayAccess
      * @param  bool  $unserialize
      * @return \Symfony\Component\HttpFoundation\Cookie|null
      */
-    public function getCookie($cookieName, $decrypt = false, $unserialize = false)
+    public function getCookie($cookieName, $decrypt = true, $unserialize = false)
     {
         foreach ($this->headers->getCookies() as $cookie) {
             if ($cookie->getName() === $cookieName) {
                 if ($decrypt) {
-                    $decryptedValue = CookieValuePrefix::remove(app('encrypter')->decrypt($cookie->getValue(), $unserialize));
+                    $decryptedValue = CookieValuePrefix::remove(app(EncrypterContract::class)->decrypt($cookie->getValue(), $unserialize));
                     $cookie = new Cookie(
                         $cookie->getName(), $decryptedValue, $cookie->getExpiresTime(), $cookie->getPath(),
                         $cookie->getDomain(), $cookie->isSecure(), $cookie->isHttpOnly(),

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -290,7 +290,7 @@ class TestResponse implements ArrayAccess
     public function assertCookie($cookieName, $value = null, $encrypted = true, $unserialize = false)
     {
         PHPUnit::assertNotNull(
-            $cookie = $this->getCookie($cookieName, $encrypted, $unserialize),
+            $cookie = $this->getCookie($cookieName, $encrypted && ! is_null($value), $unserialize),
             "Cookie [{$cookieName}] not present on response."
         );
 

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -324,7 +324,7 @@ class TestResponse implements ArrayAccess
         $expiresAt = Carbon::createFromTimestamp($cookie->getExpiresTime());
 
         PHPUnit::assertTrue(
-            $expiresAt->lessThan(Carbon::now()),
+            0 !== $cookie->getExpiresTime() && $expiresAt->lessThan(Carbon::now()),
             "Cookie [{$cookieName}] is not expired, it expires at [{$expiresAt}]."
         );
 

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -4,7 +4,6 @@ namespace Illuminate\Testing;
 
 use ArrayAccess;
 use Closure;
-use Illuminate\Contracts\Encryption\Encrypter as EncrypterContract;
 use Illuminate\Contracts\View\View;
 use Illuminate\Cookie\CookieValuePrefix;
 use Illuminate\Database\Eloquent\Model;
@@ -385,7 +384,7 @@ class TestResponse implements ArrayAccess
             if ($cookie->getName() === $cookieName) {
                 if ($decrypt) {
                     $decryptedValue = CookieValuePrefix::remove(
-                        app(EncrypterContract::class)->decrypt($cookie->getValue(), $unserialize)
+                        app('encrypter')->decrypt($cookie->getValue(), $unserialize)
                     );
                     $cookie = new Cookie(
                         $cookie->getName(), $decryptedValue, $cookie->getExpiresTime(), $cookie->getPath(),

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -384,7 +384,9 @@ class TestResponse implements ArrayAccess
         foreach ($this->headers->getCookies() as $cookie) {
             if ($cookie->getName() === $cookieName) {
                 if ($decrypt) {
-                    $decryptedValue = CookieValuePrefix::remove(app(EncrypterContract::class)->decrypt($cookie->getValue(), $unserialize));
+                    $decryptedValue = CookieValuePrefix::remove(
+                        app(EncrypterContract::class)->decrypt($cookie->getValue(), $unserialize)
+                    );
                     $cookie = new Cookie(
                         $cookie->getName(), $decryptedValue, $cookie->getExpiresTime(), $cookie->getPath(),
                         $cookie->getDomain(), $cookie->isSecure(), $cookie->isHttpOnly(),

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -1204,6 +1204,15 @@ class TestResponseTest extends TestCase
         $response->assertCookieNotExpired('cookie-name');
     }
 
+    public function testAssertSessionCookieNotExpired()
+    {
+        $response = TestResponse::fromBaseResponse(
+            (new Response())->withCookie(new Cookie('cookie-name', 'cookie-value', 0))
+        );
+
+        $response->assertCookieNotExpired('cookie-name');
+    }
+
     public function testAssertCookieMissing()
     {
         $response = TestResponse::fromBaseResponse(new Response());

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -1195,6 +1195,17 @@ class TestResponseTest extends TestCase
         $response->assertCookieExpired('cookie-name');
     }
 
+    public function testAssertSessionCookieExpiredDoesNotTriggerOnSessionCookies()
+    {
+        $response = TestResponse::fromBaseResponse(
+            (new Response())->withCookie(new Cookie('cookie-name', 'cookie-value', 0))
+        );
+
+        $this->expectException(ExpectationFailedException::class);
+
+        $response->assertCookieExpired('cookie-name');
+    }
+
     public function testAssertCookieNotExpired()
     {
         $response = TestResponse::fromBaseResponse(

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -1171,7 +1171,7 @@ class TestResponseTest extends TestCase
     {
         $container = Container::getInstance();
         $encrypter = new Encrypter(str_repeat('a', 16));
-        $container->singleton('encrypter', function() use ($encrypter) {
+        $container->singleton('encrypter', function () use ($encrypter) {
             return $encrypter;
         });
 
@@ -1195,7 +1195,6 @@ class TestResponseTest extends TestCase
         $response->assertCookieExpired('cookie-name');
     }
 
-
     public function testAssertCookieNotExpired()
     {
         $response = TestResponse::fromBaseResponse(
@@ -1204,7 +1203,6 @@ class TestResponseTest extends TestCase
 
         $response->assertCookieNotExpired('cookie-name');
     }
-
 
     public function testAssertCookieMissing()
     {
@@ -1226,12 +1224,11 @@ class TestResponseTest extends TestCase
         $this->assertEquals('cookie-value', $cookie->getValue());
     }
 
-
     public function testGetEncryptedCookie()
     {
         $container = Container::getInstance();
         $encrypter = new Encrypter(str_repeat('a', 16));
-        $container->singleton('encrypter', function() use ($encrypter) {
+        $container->singleton('encrypter', function () use ($encrypter) {
             return $encrypter;
         });
 

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Tests\Foundation;
 
 use Illuminate\Container\Container;
-use Illuminate\Contracts\Encryption\Encrypter as EncrypterContract;
 use Illuminate\Contracts\View\View;
 use Illuminate\Cookie\CookieValuePrefix;
 use Illuminate\Database\Eloquent\Model;
@@ -1172,7 +1171,7 @@ class TestResponseTest extends TestCase
     {
         $container = Container::getInstance();
         $encrypter = new Encrypter(str_repeat('a', 16));
-        $container->singleton(EncrypterContract::class, function() use ($encrypter) {
+        $container->singleton('encrypter', function() use ($encrypter) {
             return $encrypter;
         });
 
@@ -1232,7 +1231,7 @@ class TestResponseTest extends TestCase
     {
         $container = Container::getInstance();
         $encrypter = new Encrypter(str_repeat('a', 16));
-        $container->singleton(EncrypterContract::class, function() use ($encrypter) {
+        $container->singleton('encrypter', function() use ($encrypter) {
             return $encrypter;
         });
 

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -1172,7 +1172,7 @@ class TestResponseTest extends TestCase
     {
         $container = Container::getInstance();
         $encrypter = new Encrypter(str_repeat('a', 16));
-        $container->singleton('encrypter', function() use ($encrypter) {
+        $container->singleton(EncrypterContract::class, function() use ($encrypter) {
             return $encrypter;
         });
 
@@ -1220,7 +1220,7 @@ class TestResponseTest extends TestCase
             (new Response())->withCookie(new Cookie('cookie-name', 'cookie-value'))
         );
 
-        $cookie = $response->getCookie('cookie-name');
+        $cookie = $response->getCookie('cookie-name', false);
 
         $this->assertInstanceOf(Cookie::class, $cookie);
         $this->assertEquals('cookie-name', $cookie->getName());
@@ -1232,7 +1232,7 @@ class TestResponseTest extends TestCase
     {
         $container = Container::getInstance();
         $encrypter = new Encrypter(str_repeat('a', 16));
-        $container->singleton('encrypter', function() use ($encrypter) {
+        $container->singleton(EncrypterContract::class, function() use ($encrypter) {
             return $encrypter;
         });
 
@@ -1246,7 +1246,7 @@ class TestResponseTest extends TestCase
             (new Response())->withCookie(new Cookie($cookieName, $encryptedValue))
         );
 
-        $cookie = $response->getCookie($cookieName, true);
+        $cookie = $response->getCookie($cookieName);
 
         $this->assertInstanceOf(Cookie::class, $cookie);
         $this->assertEquals($cookieName, $cookie->getName());


### PR DESCRIPTION
`TestResponse::getCookie()` is currently protected, and is only used internally for cookie assertions. This PR exposes this method and handles the decryption of cookies.

This is particularly useful if a cookie has an unpredictable value which is needed later in your test.

Before:

```php
$cookie = collect($response->headers->getCookies());
  ->first(function(Cookie $cookie) {
    return 'my_cookie' === $cookie->getName();
  });

$value  = CookieValuePrefix::remove(Crypt::decrypt($cookie->getValue(), false));
```

After: 

```php
$value = $response->getCookie('my_cookie')->getValue();
```

It's worth noting that `TestResponse::getCookie()` already exists and is used almost exactly like the "Before" use-case. This simply makes that functionality available to application tests, and adds framework tests for it.

This also adds a bunch of test cases for cookie assertions, which were missing before.

In one test I discovered a bug which I can also submit as a separate PR to 8.x. Right now `assertCookieNotExpired()` doesn't properly handle "session" cookies (i.e. cookies where the expiration is `0`). This PR fixes that bug and adds a test for it.