### PR TITLE
[8.x] Ability to specify a separate lock connection

### DIFF
--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -199,7 +199,11 @@ class CacheManager implements FactoryContract
 
         $connection = $config['connection'] ?? 'default';
 
-        return $this->repository(new RedisStore($redis, $this->getPrefix($config), $connection));
+        $store = new RedisStore($redis, $this->getPrefix($config), $connection);
+
+        $store->setLockConnection($config['lock_connection'] ?? $connection);
+
+        return $this->repository($store);
     }
 
     /**
@@ -212,15 +216,19 @@ class CacheManager implements FactoryContract
     {
         $connection = $this->app['db']->connection($config['connection'] ?? null);
 
-        return $this->repository(
-            new DatabaseStore(
-                $connection,
-                $config['table'],
-                $this->getPrefix($config),
-                $config['lock_table'] ?? 'cache_locks',
-                $config['lock_lottery'] ?? [2, 100]
-            )
+        $store = new DatabaseStore(
+            $connection,
+            $config['table'],
+            $this->getPrefix($config),
+            $config['lock_table'] ?? 'cache_locks',
+            $config['lock_lottery'] ?? [2, 100]
         );
+
+        $store->setLockConnection(
+            $this->app['db']->connection($config['lock_connection'] ?? $config['connection'] ?? null)
+        );
+
+        return $this->repository($store);
     }
 
     /**

--- a/src/Illuminate/Cache/DatabaseLock.php
+++ b/src/Illuminate/Cache/DatabaseLock.php
@@ -128,6 +128,16 @@ class DatabaseLock extends Lock
     }
 
     /**
+     * Get the name of the database connection.
+     *
+     * @return string
+     */
+    public function getConnectionName()
+    {
+        return $this->connection->getName();
+    }
+
+    /**
      * Returns the owner value written into the driver for this lock.
      *
      * @return string

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -24,6 +24,13 @@ class DatabaseStore implements LockProvider, Store
     protected $connection;
 
     /**
+     * The database connection instance for the lock.
+     *
+     * @var \Illuminate\Database\ConnectionInterface
+     */
+    protected $lockConnection;
+
+    /**
      * The name of the cache table.
      *
      * @var string
@@ -265,7 +272,7 @@ class DatabaseStore implements LockProvider, Store
     public function lock($name, $seconds = 0, $owner = null)
     {
         return new DatabaseLock(
-            $this->connection,
+            $this->lockConnection ?? $this->connection,
             $this->lockTable,
             $this->prefix.$name,
             $seconds,
@@ -329,6 +336,17 @@ class DatabaseStore implements LockProvider, Store
     public function getConnection()
     {
         return $this->connection;
+    }
+
+    /**
+     * Set the lock connection to be used.
+     *
+     * @param  \Illuminate\Database\ConnectionInterface  $connection
+     * @return void
+     */
+    public function setLockConnection($connection)
+    {
+        $this->lockConnection = $connection;
     }
 
     /**

--- a/src/Illuminate/Cache/RedisLock.php
+++ b/src/Illuminate/Cache/RedisLock.php
@@ -62,6 +62,16 @@ class RedisLock extends Lock
     }
 
     /**
+     * Get the name of the Redis connection.
+     *
+     * @return string
+     */
+    public function getConnectionName()
+    {
+        return $this->redis->getName();
+    }
+
+    /**
      * Returns the owner value written into the driver for this lock.
      *
      * @return string

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -29,6 +29,13 @@ class RedisStore extends TaggableStore implements LockProvider
     protected $connection;
 
     /**
+     * The name of the connection that should be used for locks.
+     *
+     * @var string
+     */
+    protected $lockConnection;
+
+    /**
      * Create a new Redis store.
      *
      * @param  \Illuminate\Contracts\Redis\Factory  $redis
@@ -181,7 +188,7 @@ class RedisStore extends TaggableStore implements LockProvider
      */
     public function lock($name, $seconds = 0, $owner = null)
     {
-        return new RedisLock($this->connection(), $this->prefix.$name, $seconds, $owner);
+        return new RedisLock($this->lockConnection(), $this->prefix.$name, $seconds, $owner);
     }
 
     /**
@@ -243,6 +250,16 @@ class RedisStore extends TaggableStore implements LockProvider
     }
 
     /**
+     * Get the Redis connection instance for the lock.
+     *
+     * @return \Illuminate\Redis\Connections\Connection
+     */
+    public function lockConnection()
+    {
+        return $this->redis->connection($this->lockConnection ?? $this->connection);
+    }
+
+    /**
      * Set the connection name to be used.
      *
      * @param  string  $connection
@@ -251,6 +268,17 @@ class RedisStore extends TaggableStore implements LockProvider
     public function setConnection($connection)
     {
         $this->connection = $connection;
+    }
+
+    /**
+     * Set the lock connection name to be used.
+     *
+     * @param  string  $connection
+     * @return void
+     */
+    public function setLockConnection($connection)
+    {
+        $this->lockConnection = $connection;
     }
 
     /**

--- a/tests/Integration/Cache/RedisCacheLockTest.php
+++ b/tests/Integration/Cache/RedisCacheLockTest.php
@@ -44,6 +44,13 @@ class RedisCacheLockTest extends TestCase
         Cache::store('redis')->lock('foo')->release();
     }
 
+    public function testRedisLockCanHaveASeparateConnection()
+    {
+        $this->app['config']->set('cache.stores.redis.lock_connection', 'default');
+
+        $this->assertSame('default', Cache::store('redis')->lock('foo')->getConnectionName());
+    }
+
     public function testRedisLocksCanBlockForSeconds()
     {
         Carbon::setTestNow();

--- a/tests/Integration/Database/DatabaseLockTest.php
+++ b/tests/Integration/Database/DatabaseLockTest.php
@@ -23,6 +23,14 @@ class DatabaseLockTest extends DatabaseTestCase
         });
     }
 
+    public function testLockCanHaveASeparateConnection()
+    {
+        $this->app['config']->set('cache.stores.database.lock_connection', 'test');
+        $this->app['config']->set('database.connections.test', $this->app['config']->get('database.connections.mysql'));
+
+        $this->assertSame('test', Cache::driver('database')->lock('foo')->getConnectionName());
+    }
+
     public function testLockCanBeAcquired()
     {
         $lock = Cache::driver('database')->lock('foo');


### PR DESCRIPTION
## Motivation
This PR allows us to specify a separate lock connection for the Redis and Database cache stores. Related: https://github.com/laravel/ideas/issues/2404.

To use a separate lock connection, we may specify a `lock_connection` in our `config/cache.php` like so:

```php
    'stores' => [
        'database' => [
            'driver' => 'database',
            'table' => 'cache',
            'connection' => null,
            'lock_connection' => 'lock',
        ],
        'redis' => [
            'driver' => 'redis',
            'connection' => 'cache',
            'lock_connection' => 'lock',
        ],
    ]
```

## Benefits
The Laravel Framework currently uses locks for several things:

1. The `WithoutOverlapping` middleware to avoid overlapping jobs
2. Unique jobs
3. Session blocking

Plus of course, locks may also be used in userland for application specific use cases.

The current lock connection is always the same as the cache connection. So, a `php artisan cache:clear` will also clear your locks. It's absolutely fine to clear cache in production and in fact, even a common deployment step. But clearing locks could mean breaking your unique jobs or session blocking. This PR introduces the ability to have a separate lock connection to make it possible to clear the cache without clearing locks.

There are **no breaking changes** with this PR that's why it targets 8.x. 