### PR TITLE
[8.x] Allow for automatically applying cookies across multiple test requests

### DIFF
--- a/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
+++ b/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
@@ -177,14 +177,14 @@ class MakesHttpRequestsTest extends TestCase
         // for our tests, and one that unsets them
         $router = $this->app->make(Registrar::class);
 
-        $router->get('set-cookies', function() {
+        $router->get('set-cookies', function () {
             return (new Response('OK'))
                 ->withCookie('unencrypted-cookie', 'unencrypted-value')
                 ->withCookie('expiring-cookie', 'expiring-value', 10)
                 ->withCookie('encrypted-cookie', 'encrypted-value');
         })->middleware(MyEncryptCookiesMiddleware::class);
 
-        $router->get('forget-cookies', function() {
+        $router->get('forget-cookies', function () {
             return (new Response('OK'))
                 ->withCookie('unencrypted-cookie', '', -2628000)
                 ->withCookie('expiring-cookie', '', -2628000)


### PR DESCRIPTION
This PR adds support for "browser-style" cookies inside a test, which automatically persist across multiple requests. Imagine a test that needs to check that cookie-based affiliate attribution works as expected:

Before:

```php
// Because calls to /affiliate generate a random attribution token,
// we need to mock our attribution manager to ensure that the token
// is predictable in our test.

$attributionToken = Str::random();

AffiliateManager::shouldReceive('startAttribution')
    ->once()
    ->with('foo')
    ->andReturn($attributionToken);

$response = $this->get('affiliate?id=foo');

// Now we'll confirm that our call to /affiliate set the expected
// cookie before we set up our next request to use the known cookie value.

$response->assertCookie('affiliate_attribution', "foo|$attributionToken");

// Now we get to the part of the test that we care about:
// When hitting the purchase page with the attribution payload, our affiliate
// is properly attributed to the conversion.

$this->withCookie('affiliate_attribution', "foo|$attributionToken")
     ->post('purchase', $this->purchasePayload());

$this->assertEquals('foo', Auth::user()->attribution->affiliate_id);
```

After:

```php
$this->withResponseCookies();

$this->get('affiliate?id=foo');
$this->post('purchase', $this->purchasePayload());

$this->assertEquals('foo', Auth::user()->attribution->affiliate_id);
```

`withResponseCookies()` respects cookie expiration and cookies set across multiple requests, so you can use `Date::setTestNow()` to ensure that time-limited cookie-based interactions work as expected.

In working on this PR, I had a very hard time with one of the [two hard things](https://martinfowler.com/bliki/TwoHardThings.html): naming things. Over the course of this work, I toyed with the following naming:

- `emulatingBrowserCookies()`
- `withCookieJar()`
- `applyingResponseCookies()`
- `persistingCookies()`

(Among others.) All-in-all I'm not 100% happy with any of them, and would happily take other suggestions or votes if someone has a better idea for the naming of these methods.