### PR TITLE
[8.x] Fix batch add method doc block

### DIFF
--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -156,7 +156,7 @@ class Batch implements Arrayable, JsonSerializable
     /**
      * Add additional jobs to the batch.
      *
-     * @param  \Illuminate\Support\Collection|array|mixed  $jobs
+     * @param  mixed  $jobs
      * @return self
      */
     public function add($jobs)

--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -156,7 +156,7 @@ class Batch implements Arrayable, JsonSerializable
     /**
      * Add additional jobs to the batch.
      *
-     * @param  \Illuminate\Support\Collection|array  $jobs
+     * @param  \Illuminate\Support\Collection|array|mixed  $jobs
      * @return self
      */
     public function add($jobs)


### PR DESCRIPTION
Add `mixed` parameter type to the batch add method for `Batchable` jobs, allowing singlular jobs to be passed. This already works (because the method wraps the given jobs in a `Collection`) but this change fixes warnings in IDEs and static analyzers

Before:

```php
    public function handle()
    {
        $this->batch()->add([
            new ProcessPodcast()
        ]);
    }
```

After:
```php
    public function handle()
    {
        $this->batch()->add(new ProcessPodcast());
    }
```