### PR TITLE
[8.x] Ability to set should discover events via property

### DIFF
--- a/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
@@ -23,6 +23,13 @@ class EventServiceProvider extends ServiceProvider
     protected $subscribe = [];
 
     /**
+     * Determine if events and listeners should be automatically discovered.
+     *
+     * @var boolean
+     */
+    protected $shouldDiscoverEvents = false;
+
+    /**
      * Register the application's event listeners.
      *
      * @return void
@@ -102,7 +109,7 @@ class EventServiceProvider extends ServiceProvider
      */
     public function shouldDiscoverEvents()
     {
-        return false;
+        return $this->shouldDiscoverEvents;
     }
 
     /**


### PR DESCRIPTION
Before:
```
public function shouldDiscoverEvents()
{
   return trye
}
```
After:
`protected $shouldDiscoverEvents = true`