### PR TITLE
[8.x] Nested array encrypted cookies

### DIFF
--- a/src/Illuminate/Cookie/CookieValuePrefix.php
+++ b/src/Illuminate/Cookie/CookieValuePrefix.php
@@ -26,4 +26,19 @@ class CookieValuePrefix
     {
         return substr($cookieValue, 41);
     }
+
+    /**
+     * Validate a cookie value contains a valid prefix and return it without or null.
+     *
+     * @param  string  $cookieName
+     * @param  string  $cookieValue
+     * @param  string  $key
+     * @return string|null
+     */
+    public static function validate($cookieName, $cookieValue, $key)
+    {
+        $hasValidPrefix = strpos($cookieValue, static::create($cookieName, $key)) === 0;
+
+        return $hasValidPrefix ? static::remove($cookieValue) : null;
+    }
 }

--- a/src/Illuminate/Cookie/Middleware/EncryptCookies.php
+++ b/src/Illuminate/Cookie/Middleware/EncryptCookies.php
@@ -124,6 +124,9 @@ class EncryptCookies
             if (is_string($value)) {
                 $decrypted[$key] = $this->encrypter->decrypt($value, static::serialized($key));
             }
+            if (is_array($value)) {
+                $decrypted[$key] = $this->decryptArray($value);
+            }
         }
 
         return $decrypted;

--- a/src/Illuminate/Cookie/Middleware/EncryptCookies.php
+++ b/src/Illuminate/Cookie/Middleware/EncryptCookies.php
@@ -95,7 +95,7 @@ class EncryptCookies
     }
 
     /**
-     * Validate and remove the cookie value prefix from the value
+     * Validate and remove the cookie value prefix from the value.
      *
      * @param  string  $key
      * @param  string  $value
@@ -108,7 +108,8 @@ class EncryptCookies
     }
 
     /**
-     * Strip a valid value prefix from the value
+     * Strip a valid value prefix from the value.
+     *
      * @param  string  $key
      * @param  array  $value
      * @return array

--- a/src/Illuminate/Cookie/Middleware/EncryptCookies.php
+++ b/src/Illuminate/Cookie/Middleware/EncryptCookies.php
@@ -76,17 +76,15 @@ class EncryptCookies
     protected function decrypt(Request $request)
     {
         foreach ($request->cookies as $key => $cookie) {
-            if ($this->isDisabled($key) || is_array($cookie)) {
+            if ($this->isDisabled($key)) {
                 continue;
             }
 
             try {
                 $value = $this->decryptCookie($key, $cookie);
 
-                $hasValidPrefix = strpos($value, CookieValuePrefix::create($key, $this->encrypter->getKey())) === 0;
-
                 $request->cookies->set(
-                    $key, $hasValidPrefix ? CookieValuePrefix::remove($value) : null
+                    $key, $this->validateValue($key, $value)
                 );
             } catch (DecryptException $e) {
                 $request->cookies->set($key, null);
@@ -94,6 +92,35 @@ class EncryptCookies
         }
 
         return $request;
+    }
+
+    /**
+     * Validate and remove the cookie value prefix from the value
+     *
+     * @param  string  $key
+     * @param  string  $value
+     * @return string|array|null
+     */
+    protected function validateValue(string $key, $value)
+    {
+        return is_array($value) ? $this->validateArray($key, $value) :
+            CookieValuePrefix::validate($key, $value, $this->encrypter->getKey());
+    }
+
+    /**
+     * Strip a valid value prefix from the value
+     * @param  string  $key
+     * @param  array  $value
+     * @return array
+     */
+    protected function validateArray(string $key, array $value)
+    {
+        $stripped = [];
+        foreach ($value as $subKey => $subValue) {
+            $stripped[$subKey] = $this->validateValue("${key}[${subKey}]", $subValue);
+        }
+
+        return $stripped;
     }
 
     /**

--- a/tests/Cookie/Middleware/EncryptCookiesTest.php
+++ b/tests/Cookie/Middleware/EncryptCookiesTest.php
@@ -97,7 +97,6 @@ class EncryptCookiesTest extends TestCase
 
     public function testCookieDecryption()
     {
-
         $cookies = [
             'encrypted_cookie' => $this->getEncryptedCookieValue('encrypted_cookie', 'value'),
             'encrypted' => [
@@ -124,6 +123,7 @@ class EncryptCookiesTest extends TestCase
                 $this->assertSame('value', $cookies['encrypted']['nested']['array_cookie']);
                 $this->assertArrayHasKey('unencrypted_cookie', $cookies);
                 $this->assertSame('value', $cookies['unencrypted_cookie']);
+
                 return new Response;
             }
         );

--- a/tests/Cookie/Middleware/EncryptCookiesTest.php
+++ b/tests/Cookie/Middleware/EncryptCookiesTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Cookie\Middleware;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Encryption\Encrypter as EncrypterContract;
 use Illuminate\Cookie\CookieJar;
+use Illuminate\Cookie\CookieValuePrefix;
 use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
 use Illuminate\Cookie\Middleware\EncryptCookies;
 use Illuminate\Encryption\Encrypter;
@@ -19,6 +20,11 @@ use Symfony\Component\HttpFoundation\Cookie;
 class EncryptCookiesTest extends TestCase
 {
     /**
+     * @var \Illuminate\Container\Container
+     */
+    protected $container;
+
+    /**
      * @var \Illuminate\Routing\Router
      */
     protected $router;
@@ -30,12 +36,12 @@ class EncryptCookiesTest extends TestCase
     {
         parent::setUp();
 
-        $container = new Container;
-        $container->singleton(EncrypterContract::class, function () {
+        $this->container = new Container;
+        $this->container->singleton(EncrypterContract::class, function () {
             return new Encrypter(str_repeat('a', 16));
         });
 
-        $this->router = new Router(new Dispatcher, $container);
+        $this->router = new Router(new Dispatcher, $this->container);
     }
 
     public function testSetCookieEncryption()
@@ -48,11 +54,14 @@ class EncryptCookiesTest extends TestCase
         $response = $this->router->dispatch(Request::create($this->setCookiePath, 'GET'));
 
         $cookies = $response->headers->getCookies();
-        $this->assertCount(2, $cookies);
+        $this->assertCount(4, $cookies);
         $this->assertSame('encrypted_cookie', $cookies[0]->getName());
         $this->assertNotSame('value', $cookies[0]->getValue());
-        $this->assertSame('unencrypted_cookie', $cookies[1]->getName());
-        $this->assertSame('value', $cookies[1]->getValue());
+        $this->assertSame('encrypted[array_cookie]', $cookies[1]->getName());
+        $this->assertNotSame('value', $cookies[1]->getValue());
+        $this->assertSame('encrypted[nested][array_cookie]', $cookies[2]->getName());
+        $this->assertSame('unencrypted_cookie', $cookies[3]->getName());
+        $this->assertSame('value', $cookies[3]->getValue());
     }
 
     public function testQueuedCookieEncryption()
@@ -65,11 +74,59 @@ class EncryptCookiesTest extends TestCase
         $response = $this->router->dispatch(Request::create($this->queueCookiePath, 'GET'));
 
         $cookies = $response->headers->getCookies();
-        $this->assertCount(2, $cookies);
+        $this->assertCount(4, $cookies);
         $this->assertSame('encrypted_cookie', $cookies[0]->getName());
         $this->assertNotSame('value', $cookies[0]->getValue());
-        $this->assertSame('unencrypted_cookie', $cookies[1]->getName());
-        $this->assertSame('value', $cookies[1]->getValue());
+        $this->assertSame('encrypted[array_cookie]', $cookies[1]->getName());
+        $this->assertNotSame('value', $cookies[1]->getValue());
+        $this->assertSame('encrypted[nested][array_cookie]', $cookies[2]->getName());
+        $this->assertNotSame('value', $cookies[2]->getValue());
+        $this->assertSame('unencrypted_cookie', $cookies[3]->getName());
+        $this->assertSame('value', $cookies[3]->getValue());
+    }
+
+    protected function getEncryptedCookieValue($key, $value)
+    {
+        $encrypter = $this->container->make(EncrypterContract::class);
+
+        return $encrypter->encrypt(
+            CookieValuePrefix::create($key, $encrypter->getKey()) . $value,
+            false
+        );
+    }
+
+    public function testCookieDecryption()
+    {
+
+        $cookies = [
+            'encrypted_cookie' => $this->getEncryptedCookieValue('encrypted_cookie', 'value'),
+            'encrypted' => [
+                'array_cookie' => $this->getEncryptedCookieValue('encrypted[array_cookie]', 'value'),
+                'nested' => [
+                    'array_cookie' => $this->getEncryptedCookieValue('encrypted[nested][array_cookie]', 'value')
+                ]
+            ],
+            'unencrypted_cookie' => 'value'
+        ];
+
+        $this->container->make(EncryptCookiesTestMiddleware::class)->handle(
+            Request::create('/cookie/read', 'GET', [], $cookies),
+            function ($request) {
+                $cookies = $request->cookies->all();
+                $this->assertCount(3, $cookies);
+                $this->assertArrayHasKey('encrypted_cookie', $cookies);
+                $this->assertSame('value', $cookies['encrypted_cookie']);
+                $this->assertArrayHasKey('encrypted', $cookies);
+                $this->assertArrayHasKey('array_cookie', $cookies['encrypted']);
+                $this->assertSame('value', $cookies['encrypted']['array_cookie']);
+                $this->assertArrayHasKey('nested', $cookies['encrypted']);
+                $this->assertArrayHasKey('array_cookie', $cookies['encrypted']['nested']);
+                $this->assertSame('value', $cookies['encrypted']['nested']['array_cookie']);
+                $this->assertArrayHasKey('unencrypted_cookie', $cookies);
+                $this->assertSame('value', $cookies['unencrypted_cookie']);
+                return new Response;
+            }
+        );
     }
 }
 
@@ -79,6 +136,8 @@ class EncryptCookiesTestController extends Controller
     {
         $response = new Response;
         $response->headers->setCookie(new Cookie('encrypted_cookie', 'value'));
+        $response->headers->setCookie(new Cookie('encrypted[array_cookie]', 'value'));
+        $response->headers->setCookie(new Cookie('encrypted[nested][array_cookie]', 'value'));
         $response->headers->setCookie(new Cookie('unencrypted_cookie', 'value'));
 
         return $response;
@@ -103,6 +162,8 @@ class AddQueuedCookiesToResponseTestMiddleware extends AddQueuedCookiesToRespons
     {
         $cookie = new CookieJar;
         $cookie->queue(new Cookie('encrypted_cookie', 'value'));
+        $cookie->queue(new Cookie('encrypted[array_cookie]', 'value'));
+        $cookie->queue(new Cookie('encrypted[nested][array_cookie]', 'value'));
         $cookie->queue(new Cookie('unencrypted_cookie', 'value'));
 
         $this->cookies = $cookie;

--- a/tests/Cookie/Middleware/EncryptCookiesTest.php
+++ b/tests/Cookie/Middleware/EncryptCookiesTest.php
@@ -90,7 +90,7 @@ class EncryptCookiesTest extends TestCase
         $encrypter = $this->container->make(EncrypterContract::class);
 
         return $encrypter->encrypt(
-            CookieValuePrefix::create($key, $encrypter->getKey()) . $value,
+            CookieValuePrefix::create($key, $encrypter->getKey()).$value,
             false
         );
     }
@@ -103,10 +103,10 @@ class EncryptCookiesTest extends TestCase
             'encrypted' => [
                 'array_cookie' => $this->getEncryptedCookieValue('encrypted[array_cookie]', 'value'),
                 'nested' => [
-                    'array_cookie' => $this->getEncryptedCookieValue('encrypted[nested][array_cookie]', 'value')
-                ]
+                    'array_cookie' => $this->getEncryptedCookieValue('encrypted[nested][array_cookie]', 'value'),
+                ],
             ],
-            'unencrypted_cookie' => 'value'
+            'unencrypted_cookie' => 'value',
         ];
 
         $this->container->make(EncryptCookiesTestMiddleware::class)->handle(


### PR DESCRIPTION
Follow up to: https://github.com/laravel/framework/pull/35601

This restores support for encrypted cookie arrays including setting and validating appropriate cookie prefix values which is the reason it was removed initially. 
