### PR TITLE
Enable time travel with CarbonImmutable

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTime.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTime.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Testing\Concerns;
 use DateTimeInterface;
 use Illuminate\Foundation\Testing\Wormhole;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\CarbonImmutable;
 
 trait InteractsWithTime
 {
@@ -29,10 +30,12 @@ trait InteractsWithTime
     public function travelTo(DateTimeInterface $date, $callback = null)
     {
         Carbon::setTestNow($date);
+        CarbonImmutable::setTestNow($date);
 
         if ($callback) {
             return tap($callback(), function () {
                 Carbon::setTestNow();
+                CarbonImmutable::setTestNow();
             });
         }
     }
@@ -45,6 +48,7 @@ trait InteractsWithTime
     public function travelBack()
     {
         Carbon::setTestNow();
+        CarbonImmutable::setTestNow();
 
         return Carbon::now();
     }

--- a/src/Illuminate/Foundation/Testing/Wormhole.php
+++ b/src/Illuminate/Foundation/Testing/Wormhole.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Testing;
 
 use Illuminate\Support\Carbon;
+use Illuminate\Support\CarbonImmutable;
 
 class Wormhole
 {
@@ -32,7 +33,7 @@ class Wormhole
      */
     public function milliseconds($callback = null)
     {
-        Carbon::setTestNow(Carbon::now()->addMilliseconds($this->value));
+        $this->travelTo(Carbon::now()->addMilliseconds($this->value));
 
         return $this->handleCallback($callback);
     }
@@ -45,7 +46,7 @@ class Wormhole
      */
     public function seconds($callback = null)
     {
-        Carbon::setTestNow(Carbon::now()->addSeconds($this->value));
+        $this->travelTo(Carbon::now()->addSeconds($this->value));
 
         return $this->handleCallback($callback);
     }
@@ -58,7 +59,7 @@ class Wormhole
      */
     public function minutes($callback = null)
     {
-        Carbon::setTestNow(Carbon::now()->addMinutes($this->value));
+        $this->travelTo(Carbon::now()->addMinutes($this->value));
 
         return $this->handleCallback($callback);
     }
@@ -71,7 +72,7 @@ class Wormhole
      */
     public function hours($callback = null)
     {
-        Carbon::setTestNow(Carbon::now()->addHours($this->value));
+        $this->travelTo(Carbon::now()->addHours($this->value));
 
         return $this->handleCallback($callback);
     }
@@ -84,7 +85,7 @@ class Wormhole
      */
     public function days($callback = null)
     {
-        Carbon::setTestNow(Carbon::now()->addDays($this->value));
+        $this->travelTo(Carbon::now()->addDays($this->value));
 
         return $this->handleCallback($callback);
     }
@@ -97,7 +98,7 @@ class Wormhole
      */
     public function weeks($callback = null)
     {
-        Carbon::setTestNow(Carbon::now()->addWeeks($this->value));
+        $this->travelTo(Carbon::now()->addWeeks($this->value));
 
         return $this->handleCallback($callback);
     }
@@ -110,7 +111,7 @@ class Wormhole
      */
     public function years($callback = null)
     {
-        Carbon::setTestNow(Carbon::now()->addYears($this->value));
+        $this->travelTo(Carbon::now()->addYears($this->value));
 
         return $this->handleCallback($callback);
     }
@@ -126,7 +127,20 @@ class Wormhole
         if ($callback) {
             return tap($callback(), function () {
                 Carbon::setTestNow();
+                CarbonImmutable::setTestNow();
             });
         }
+    }
+
+    /**
+     * Travel to another time.
+     *
+     * @param  \DateTimeInterface  $date
+     * @return void
+     */
+    protected function travelTo(DateTimeInterface $date)
+    {
+        Carbon::setTestNow($date);
+        CarbonImmutable::setTestNow($date);
     }
 }


### PR DESCRIPTION
Hi,

With the current implementation, time travel with `travelTo` or `Wormhole` doesn't work with `CarbonImmutable` instances.
This can lead to unexpected test failures:

```php
$this->travelTo(Carbon::now()->addYears(2));
$this->assertFalse(Carbon::now()->subYear()->toImmutable()->isFuture()); // Returns true and fails
```

As the `Carbon::$testNow` property is static, it's not shared when generating immutable instances.
So, when CarbonImmutable creates a new `now()` instance, the real time is used.

Does this need some tests?

Thank you
