### PR TITLE
[8.x] Add redirect assertions to TestResponse

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -41,6 +41,13 @@ class TestResponse implements ArrayAccess
     protected $streamedContent;
 
     /**
+     * The chain of URLs that were followed to get this response.
+     *
+     * @var array
+     */
+    protected $redirectChain = [];
+
+    /**
      * Create a new test response instance.
      *
      * @param  \Illuminate\Http\Response  $response
@@ -60,6 +67,20 @@ class TestResponse implements ArrayAccess
     public static function fromBaseResponse($response)
     {
         return new static($response);
+    }
+
+    /**
+     * Set the chain of URLs that were followed to get this response.
+     *
+     * @param array $redirectChain
+     *
+     * @return $this
+     */
+    public function fromRedirectChain($redirectChain)
+    {
+        $this->redirectChain = $redirectChain;
+
+        return $this;
     }
 
     /**
@@ -207,6 +228,36 @@ class TestResponse implements ArrayAccess
 
         return $this;
     }
+
+	/**
+	 * Assert that the response is the result of following redirects to a URI.
+	 *
+	 * @param string|null $uri
+	 * @return $this
+	 */
+	public function assertFollowedRedirect($uri = null)
+	{
+		PHPUnit::assertNotEmpty($this->redirectChain, 'Response is not part of a redirect chain.');
+
+		if (! is_null($uri)) {
+            PHPUnit::assertEquals(app('url')->to($uri), end($this->redirectChain));
+        }
+
+		return $this;
+	}
+
+	/**
+	 * Assert that the response is the result of following redirects that included a URI.
+	 *
+	 * @param string $uri
+	 * @return $this
+	 */
+	public function assertFollowedRedirectThrough($uri)
+	{
+		PHPUnit::assertContains(app('url')->to($uri), $this->redirectChain);
+
+		return $this;
+	}
 
     /**
      * Asserts that the response contains the given header and equals the optional value.

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -229,35 +229,35 @@ class TestResponse implements ArrayAccess
         return $this;
     }
 
-	/**
-	 * Assert that the response is the result of following redirects to a URI.
-	 *
-	 * @param string|null $uri
-	 * @return $this
-	 */
-	public function assertFollowedRedirect($uri = null)
-	{
-		PHPUnit::assertNotEmpty($this->redirectChain, 'Response is not part of a redirect chain.');
+    /**
+     * Assert that the response is the result of following redirects to a URI.
+     *
+     * @param string|null $uri
+     * @return $this
+     */
+    public function assertFollowedRedirect($uri = null)
+    {
+        PHPUnit::assertNotEmpty($this->redirectChain, 'Response is not part of a redirect chain.');
 
-		if (! is_null($uri)) {
+        if (! is_null($uri)) {
             PHPUnit::assertEquals(app('url')->to($uri), end($this->redirectChain));
         }
 
-		return $this;
-	}
+        return $this;
+    }
 
-	/**
-	 * Assert that the response is the result of following redirects that included a URI.
-	 *
-	 * @param string $uri
-	 * @return $this
-	 */
-	public function assertFollowedRedirectThrough($uri)
-	{
-		PHPUnit::assertContains(app('url')->to($uri), $this->redirectChain);
+    /**
+     * Assert that the response is the result of following redirects that included a URI.
+     *
+     * @param string $uri
+     * @return $this
+     */
+    public function assertFollowedRedirectThrough($uri)
+    {
+        PHPUnit::assertContains(app('url')->to($uri), $this->redirectChain);
 
-		return $this;
-	}
+        return $this;
+    }
 
     /**
      * Asserts that the response contains the given header and equals the optional value.

--- a/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
+++ b/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
@@ -128,7 +128,7 @@ class MakesHttpRequestsTest extends TestCase
             return new RedirectResponse($url->to('intermediate'));
         });
 
-        $router->get('intermediate', function() use ($url) {
+        $router->get('intermediate', function () use ($url) {
             return new RedirectResponse($url->to('to'));
         });
 
@@ -145,12 +145,11 @@ class MakesHttpRequestsTest extends TestCase
             ->assertSee('OK');
     }
 
-
     public function testAssertFollowedRedirectTriggersWithoutRedirectChain()
     {
         $router = $this->app->make(Registrar::class);
 
-        $router->get('to', function() {
+        $router->get('to', function () {
             return 'OK';
         });
 
@@ -163,7 +162,7 @@ class MakesHttpRequestsTest extends TestCase
     {
         $router = $this->app->make(Registrar::class);
 
-        $router->get('to', function() {
+        $router->get('to', function () {
             return 'OK';
         });
 
@@ -172,12 +171,11 @@ class MakesHttpRequestsTest extends TestCase
         $this->followingRedirects()->get('to')->assertFollowedRedirect('to');
     }
 
-
     public function testAssertFollowedRedirectThroughTriggersWithoutRedirectChain()
     {
         $router = $this->app->make(Registrar::class);
 
-        $router->get('to', function() {
+        $router->get('to', function () {
             return 'OK';
         });
 


### PR DESCRIPTION
Currently, when you use `followRedirects()`, Laravel will continue to follow the redirect chain until it returns a non-redirect response. This process does not track what URLs were followed, making it impossible to follow redirects *and* make assertions about the redirects.  This means that you have to test things like dynamic redirects as a multi-step process:

Before:

```php
// Get legacy affiliate link and ensure it redirects to new intermediate page
$this->get('tryfoo')->assertRedirect('affiliate?id=foo');

// Get intermediate page and ensure it redirects to purchase page
$this->get('affiliate?id=foo')->assertRedirect('purchase');

// Get purchase page and ensure that it has the affiliate ID on it
$this->get('purchase')->assertSee('value="foo"', false);
```

After:

```php
$this->followingRedirects()
     ->get('tryfoo')
     ->assertFollowedRedirect('purchase')
     ->assertSee('value="foo"', false);
```