### PR TITLE
[8.x] Fix assertCookieExpired and assertCookieNotExpired checks for session cookies

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -327,7 +327,7 @@ class TestResponse implements ArrayAccess
         $expiresAt = Carbon::createFromTimestamp($cookie->getExpiresTime());
 
         PHPUnit::assertTrue(
-            $expiresAt->lessThan(Carbon::now()),
+            0 !== $cookie->getExpiresTime() && $expiresAt->lessThan(Carbon::now()),
             "Cookie [{$cookieName}] is not expired, it expires at [{$expiresAt}]."
         );
 
@@ -350,7 +350,7 @@ class TestResponse implements ArrayAccess
         $expiresAt = Carbon::createFromTimestamp($cookie->getExpiresTime());
 
         PHPUnit::assertTrue(
-            $expiresAt->greaterThan(Carbon::now()),
+            0 === $cookie->getExpiresTime() || $expiresAt->greaterThan(Carbon::now()),
             "Cookie [{$cookieName}] is expired, it expired at [{$expiresAt}]."
         );
 

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -2,8 +2,11 @@
 
 namespace Illuminate\Tests\Foundation;
 
+use Illuminate\Container\Container;
 use Illuminate\Contracts\View\View;
+use Illuminate\Cookie\CookieValuePrefix;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Encryption\Encrypter;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Http\Response;
 use Illuminate\Testing\TestResponse;
@@ -13,6 +16,7 @@ use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\Cookie;
 
 class TestResponseTest extends TestCase
 {
@@ -1152,6 +1156,79 @@ class TestResponseTest extends TestCase
         $response->tap(function ($response) {
             $this->assertInstanceOf(TestResponse::class, $response);
         })->assertStatus(418);
+    }
+
+    public function testAssertPlainCookie()
+    {
+        $response = TestResponse::fromBaseResponse(
+            (new Response())->withCookie(new Cookie('cookie-name', 'cookie-value'))
+        );
+
+        $response->assertPlainCookie('cookie-name', 'cookie-value');
+    }
+
+    public function testAssertCookie()
+    {
+        $container = Container::getInstance();
+        $encrypter = new Encrypter(str_repeat('a', 16));
+        $container->singleton('encrypter', function () use ($encrypter) {
+            return $encrypter;
+        });
+
+        $cookieName = 'cookie-name';
+        $cookieValue = 'cookie-value';
+        $encryptedValue = $encrypter->encrypt(CookieValuePrefix::create($cookieName, $encrypter->getKey()).$cookieValue, false);
+
+        $response = TestResponse::fromBaseResponse(
+            (new Response())->withCookie(new Cookie($cookieName, $encryptedValue))
+        );
+
+        $response->assertCookie($cookieName, $cookieValue);
+    }
+
+    public function testAssertCookieExpired()
+    {
+        $response = TestResponse::fromBaseResponse(
+            (new Response())->withCookie(new Cookie('cookie-name', 'cookie-value', time() - 5000))
+        );
+
+        $response->assertCookieExpired('cookie-name');
+    }
+
+    public function testAssertSessionCookieExpiredDoesNotTriggerOnSessionCookies()
+    {
+        $response = TestResponse::fromBaseResponse(
+            (new Response())->withCookie(new Cookie('cookie-name', 'cookie-value', 0))
+        );
+
+        $this->expectException(ExpectationFailedException::class);
+
+        $response->assertCookieExpired('cookie-name');
+    }
+
+    public function testAssertCookieNotExpired()
+    {
+        $response = TestResponse::fromBaseResponse(
+            (new Response())->withCookie(new Cookie('cookie-name', 'cookie-value', time() + 5000))
+        );
+
+        $response->assertCookieNotExpired('cookie-name');
+    }
+
+    public function testAssertSessionCookieNotExpired()
+    {
+        $response = TestResponse::fromBaseResponse(
+            (new Response())->withCookie(new Cookie('cookie-name', 'cookie-value', 0))
+        );
+
+        $response->assertCookieNotExpired('cookie-name');
+    }
+
+    public function testAssertCookieMissing()
+    {
+        $response = TestResponse::fromBaseResponse(new Response());
+
+        $response->assertCookieMissing('cookie-name');
     }
 
     private function makeMockResponse($content)


### PR DESCRIPTION
This PR brings the backwards-compatible bugfixes from #35611 into the `8.x` branch.

Currently both `assertCookieExpired()` and `assertCookieNotExpired()` do not handle session cookies (where they don't have an expires timestamp, and thus will be removed at the end of the browser session).

For example:

```php
$response = TestResponse::fromBaseResponse(
  (new Response())->withCookie(new Cookie('cookie-name', 'cookie-value'))
);

$response->assertCookieExpired('cookie-name'); // Will pass
$response->assertCookieNotExpired('cookie-name'); // Will fail
```

I've also pulled in the other backwards-compatible cookie tests into this PR so they exist in the `8.x` branch as well.