### PR TITLE
[8.x] syncWithPivotDefaults method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -128,7 +128,7 @@ trait InteractsWithPivotTable
      *
      * @param  \Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Model|array  $ids
      * @param  bool  $detaching
-     * @param  array $defaults
+     * @param  array  $defaults
      * @return array
      */
     public function syncWithPivotDefaults($ids, array $defaults, bool $detaching = true)

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -133,7 +133,7 @@ trait InteractsWithPivotTable
      */
     public function syncWithPivotDefaults($ids, array $defaults, bool $detaching = true)
     {
-        $idsWithDefaults = collect($this->parseIds($ids))->mapWithKeys(function($id) use ($defaults) {
+        $idsWithDefaults = collect($this->parseIds($ids))->mapWithKeys(function ($id) use ($defaults) {
             return [$id => $defaults];
         });
 

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -140,7 +140,6 @@ trait InteractsWithPivotTable
         return $this->sync($idsWithDefaults, $detaching);
     }
 
-
     /**
      * Format the sync / toggle record list so that it is keyed by ID.
      *

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -124,6 +124,24 @@ trait InteractsWithPivotTable
     }
 
     /**
+     * Sync the intermediate tables with a list of IDs or collection of models with default values.
+     *
+     * @param  \Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Model|array  $ids
+     * @param  bool  $detaching
+     * @param  array $defaults
+     * @return array
+     */
+    public function syncWithPivotDefaults($ids, array $defaults, bool $detaching = true)
+    {
+        $idsWithDefaults = collect($this->parseIds($ids))->mapWithKeys(function($id) use ($defaults) {
+            return [$id => $defaults];
+        });
+
+        return $this->sync($idsWithDefaults, $detaching);
+    }
+
+
+    /**
      * Format the sync / toggle record list so that it is keyed by ID.
      *
      * @param  array  $records

--- a/tests/Database/DatabaseEloquentBelongsToManySyncReturnValueTypeTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManySyncReturnValueTypeTest.php
@@ -47,6 +47,7 @@ class DatabaseEloquentBelongsToManySyncReturnValueTypeTest extends TestCase
             $table->foreign('article_id')->references('id')->on('articles');
             $table->integer('user_id')->unsigned();
             $table->foreign('user_id')->references('id')->on('users');
+            $table->boolean('visible')->default(false);
         });
     }
 
@@ -87,6 +88,28 @@ class DatabaseEloquentBelongsToManySyncReturnValueTypeTest extends TestCase
         collect($changes['attached'])->map(function ($id) {
             $this->assertSame(gettype($id), (new BelongsToManySyncTestTestArticle)->getKeyType());
         });
+
+        $user->articles->each(function (BelongsToManySyncTestTestArticle $article) {
+            $this->assertSame('0', $article->pivot->visible);
+        });
+    }
+
+    public function testSyncWithPivotDefaultsReturnValueType()
+    {
+        $this->seedData();
+
+        $user = BelongsToManySyncTestTestUser::query()->first();
+        $articleIDs = BelongsToManySyncTestTestArticle::all()->pluck('id')->toArray();
+
+        $changes = $user->articles()->syncWithPivotDefaults($articleIDs, ['visible' => true]);
+
+        collect($changes['attached'])->each(function ($id) {
+            $this->assertSame(gettype($id), (new BelongsToManySyncTestTestArticle)->getKeyType());
+        });
+
+        $user->articles->each(function (BelongsToManySyncTestTestArticle $article) {
+           $this->assertSame('1', $article->pivot->visible);
+        });
     }
 
     /**
@@ -118,7 +141,7 @@ class BelongsToManySyncTestTestUser extends Eloquent
 
     public function articles()
     {
-        return $this->belongsToMany(BelongsToManySyncTestTestArticle::class, 'article_user', 'user_id', 'article_id');
+        return $this->belongsToMany(BelongsToManySyncTestTestArticle::class, 'article_user', 'user_id', 'article_id')->withPivot('visible');
     }
 }
 

--- a/tests/Database/DatabaseEloquentBelongsToManySyncReturnValueTypeTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManySyncReturnValueTypeTest.php
@@ -108,7 +108,7 @@ class DatabaseEloquentBelongsToManySyncReturnValueTypeTest extends TestCase
         });
 
         $user->articles->each(function (BelongsToManySyncTestTestArticle $article) {
-           $this->assertSame('1', $article->pivot->visible);
+            $this->assertSame('1', $article->pivot->visible);
         });
     }
 


### PR DESCRIPTION
This PR introduces ability to sync records with default values in pivot tables

```
$server = Server::find(1);
$ips = Ip::findMany([1,2,3]);

$server->ips()->syncWithPivotDefaults($ips, ['vlan' => 1444]);
```