### PR TITLE
[8.x] PHP 8: method_exists(): Argument #1 () must be of type object|string, array given

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1142,6 +1142,10 @@ trait ValidatesAttributes
      */
     public function validateJson($attribute, $value)
     {
+        if (is_array($value)) {
+            return false;
+        }
+
         if (! is_scalar($value) && ! method_exists($value, '__toString')) {
             return false;
         }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1553,6 +1553,10 @@ class ValidationValidatorTest extends TestCase
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => '{"name":"John","age":"34"}'], ['foo' => 'json']);
         $this->assertTrue($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => ['array']], ['foo' => 'json']);
+        $this->assertFalse($v->passes());
     }
 
     public function testValidateBoolean()


### PR DESCRIPTION
`array` is no longer allowed on `method_exist()` on PHP 8