### PR TITLE
Minior Issue: Including comma into translatable string

### DIFF
--- a/src/Illuminate/Notifications/resources/views/email.blade.php
+++ b/src/Illuminate/Notifications/resources/views/email.blade.php
@@ -43,7 +43,7 @@
 @if (! empty($salutation))
 {{ $salutation }}
 @else
-@lang('Regards'),<br>
+@lang('Regards,')<br>
 {{ config('app.name') }}
 @endif
 


### PR DESCRIPTION
`email.blade.php` included in the framework has a string that can't translate. This PR is just to include that little comma.