### PR TITLE
fix return type of Lock::release in PHPDoc

### DIFF
--- a/src/Illuminate/Contracts/Cache/Lock.php
+++ b/src/Illuminate/Contracts/Cache/Lock.php
@@ -24,7 +24,7 @@ interface Lock
     /**
      * Release the lock.
      *
-     * @return void
+     * @return bool
      */
     public function release();
 


### PR DESCRIPTION
A minor fix to make IDEs not complain anymore. As far as I've seen, all classes that implement the contract return a bool.