### PR TITLE
fix(buildsqueries): Fix method when in BuildsQueries class

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -157,7 +157,7 @@ trait BuildsQueries
      */
     public function when($value, $callback, $default = null)
     {
-        if ($value) {
+        if ($value !== null) {
             return $callback($this, $value) ?: $this;
         } elseif ($default) {
             return $default($this, $value) ?: $this;


### PR DESCRIPTION
When the first parameter passes a Boolean variable or a number 0 or a string '0', the callback passed in the second parameter is not executed

for example
` Model::when($price, fn (Builder $q, int $price) => $q->where('price','>', $price))`
or
`Model::when($active, fn (Builder $q, bool $active) => $q->where('is_active', $active)))`

these examples will not work correctly