### PR TITLE
Fix paginator last item calculation from given slice

### DIFF
--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -332,7 +332,10 @@ abstract class AbstractPaginator implements Htmlable
      */
     public function lastItem()
     {
-        return count($this->items) > 0 ? $this->firstItem() + $this->count() - 1 : null;
+        $total = count($this->items);
+        $to = $this->firstItem() + $this->perPage() - 1;
+
+        return $total > 0 ? ($to > $total ? $total : $to) : null;
     }
 
     /**


### PR DESCRIPTION
Currently, the last number is showing as the actual total amount instead of the last item in a given page.
This fixes the calculation for it, to show actual last item number in a given page.