### PR TITLE
Fix last item calculation for LengthAwarePaginator

### DIFF
--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -183,6 +183,19 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
     {
         return $this->lastPage;
     }
+    
+    /**
+     * Get the number of the last item in the slice.
+     *
+     * @return int
+     */
+    public function lastItem()
+    {
+        $total = count($this->items);
+        $to = $this->firstItem() + $this->perPage() - 1;
+
+        return $total > 0 ? ($to > $total ? $total : $to) : null;
+    }
 
     /**
      * Get the instance as an array.


### PR DESCRIPTION
Currently, the last number is showing as the actual total amount instead of the last item in a given page.
This fixes the calculation for it, to show actual last item number in a given page.
Previous PR failed tests because this is actually needed only for LengthAwarePaginator