### PR TITLE
[9.x] Add before resolving callbacks to contract

### DIFF
--- a/src/Illuminate/Contracts/Container/Container.php
+++ b/src/Illuminate/Contracts/Container/Container.php
@@ -164,7 +164,7 @@ interface Container extends ContainerInterface
     public function resolved($abstract);
 
     /**
-     * Register a new before resolving callback for all types.
+     * Register a new before resolving callback.
      *
      * @param  \Closure|string  $abstract
      * @param  \Closure|null  $callback

--- a/src/Illuminate/Contracts/Container/Container.php
+++ b/src/Illuminate/Contracts/Container/Container.php
@@ -164,6 +164,15 @@ interface Container extends ContainerInterface
     public function resolved($abstract);
 
     /**
+     * Register a new before resolving callback for all types.
+     *
+     * @param  \Closure|string  $abstract
+     * @param  \Closure|null  $callback
+     * @return void
+     */
+    public function beforeResolving($abstract, Closure $callback = null);
+
+    /**
      * Register a new resolving callback.
      *
      * @param  \Closure|string  $abstract


### PR DESCRIPTION
Following the addition of **before resolving callbacks** on the Container (See https://github.com/laravel/framework/pull/35228), this PR ensures the `Container` contract is up-to-date with it's implementation and adds consistency with the other resolving callbacks (namely `resolving` and `afterResolving`).

I could not add this to the previous PR since it would have been a potential breaking change which is why I made a separate PR to `9.x` instead of `8.x`.