### PR TITLE
[8.x] Account for a numerical array of views in Mailable::renderForAssertions()

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -937,11 +937,18 @@ class Mailable implements MailableContract, Renderable
                 $view = $this->buildView(), $this->buildViewData()
             );
 
-            $text = $view['text'] ?? '';
+            // If the given view is an array with numeric keys, we will just assume that
+            // both a "pretty" and "plain" view were provided, so we will use the
+            // plain index since it should contain both views with numerical keys.
+            if (is_array($view) && isset($view[1])) {
+                $text = $view[1];
+            }
+
+            $text = $text ?? $view['text'] ?? '';
 
             if (! empty($text) && ! $text instanceof Htmlable) {
                 $text = Container::getInstance()->make('mailer')->render(
-                    $view['text'], $this->buildViewData()
+                    $text, $this->buildViewData()
                 );
             }
 


### PR DESCRIPTION
This attempts to account for a numerical array returned from `Mailable::buildView()` within the new `renderForAssertions()` method introduced in afb858ad9c944bd3f9ad56c3e4485527d77a7327. The update isn't elegant, but `buildView` can return a string so this checks if the `$view` is an array and if the numeric index is set.

I did not see any existing tests and realized it'd take more work to add template fixtures, container support, etc. to existing tests so please review carefully in case I missed something.

## Steps to reproduce

```php
// in a mailable
public function build()
{
    return $this->view('emails.my-email')
                ->text('emails.my-email-plain');
}
```

In the `Mailable::renderForAssertions()` method:

```php
$html = Container::getInstance()->make('mailer')->render(
    $view = $this->buildView(), $this->buildViewData()
);

dd($view);
/*
array:2 [
  0 => "emails.my-email"
  1 => "emails.my-email-plain"
]
*/
```

The current logic (before this fix) works as expected when you use markdown or HTML in which `Mailable::buildView()` returns an associative array:

```php
    return $this->html('Hello World')
                ->text('emails.my-email-plain');

/*
array:2 [
  "html" => Illuminate\Support\HtmlString^ {#114
    #html: "Hello World"
  }
  "text" => "emails.my-email-plain"
]
*/
```

Similar logic can be found in [Mailer::parseView](https://github.com/laravel/framework/blob/001d39b592780aa6abdc4ca7d7d952a05be7c328/src/Illuminate/Mail/Mailer.php#L321-L326).