### PR TITLE
[8.x] Wrap page numbers in number_format() so large numbers have commas

### DIFF
--- a/src/Illuminate/Pagination/resources/views/bootstrap-4.blade.php
+++ b/src/Illuminate/Pagination/resources/views/bootstrap-4.blade.php
@@ -23,9 +23,9 @@
                 @if (is_array($element))
                     @foreach ($element as $page => $url)
                         @if ($page == $paginator->currentPage())
-                            <li class="page-item active" aria-current="page"><span class="page-link">{{ $page }}</span></li>
+                            <li class="page-item active" aria-current="page"><span class="page-link">{{ number_format($page) }}</span></li>
                         @else
-                            <li class="page-item"><a class="page-link" href="{{ $url }}">{{ $page }}</a></li>
+                            <li class="page-item"><a class="page-link" href="{{ $url }}">{{ number_format($page) }}</a></li>
                         @endif
                     @endforeach
                 @endif

--- a/src/Illuminate/Pagination/resources/views/default.blade.php
+++ b/src/Illuminate/Pagination/resources/views/default.blade.php
@@ -23,9 +23,9 @@
                 @if (is_array($element))
                     @foreach ($element as $page => $url)
                         @if ($page == $paginator->currentPage())
-                            <li class="active" aria-current="page"><span>{{ $page }}</span></li>
+                            <li class="active" aria-current="page"><span>{{ number_format($page) }}</span></li>
                         @else
-                            <li><a href="{{ $url }}">{{ $page }}</a></li>
+                            <li><a href="{{ $url }}">{{ number_format($page) }}</a></li>
                         @endif
                     @endforeach
                 @endif

--- a/src/Illuminate/Pagination/resources/views/semantic-ui.blade.php
+++ b/src/Illuminate/Pagination/resources/views/semantic-ui.blade.php
@@ -18,9 +18,9 @@
             @if (is_array($element))
                 @foreach ($element as $page => $url)
                     @if ($page == $paginator->currentPage())
-                        <a class="item active" href="{{ $url }}" aria-current="page">{{ $page }}</a>
+                        <a class="item active" href="{{ $url }}" aria-current="page">{{ number_format($page) }}</a>
                     @else
-                        <a class="item" href="{{ $url }}">{{ $page }}</a>
+                        <a class="item" href="{{ $url }}">{{ number_format($page) }}</a>
                     @endif
                 @endforeach
             @endif

--- a/src/Illuminate/Pagination/resources/views/tailwind.blade.php
+++ b/src/Illuminate/Pagination/resources/views/tailwind.blade.php
@@ -68,11 +68,11 @@
                             @foreach ($element as $page => $url)
                                 @if ($page == $paginator->currentPage())
                                     <span aria-current="page">
-                                        <span class="relative inline-flex items-center px-4 py-2 -ml-px text-sm font-medium text-gray-500 bg-white border border-gray-300 cursor-default leading-5">{{ $page }}</span>
+                                        <span class="relative inline-flex items-center px-4 py-2 -ml-px text-sm font-medium text-gray-500 bg-white border border-gray-300 cursor-default leading-5">{{ number_format($page) }}</span>
                                     </span>
                                 @else
                                     <a href="{{ $url }}" class="relative inline-flex items-center px-4 py-2 -ml-px text-sm font-medium text-gray-700 bg-white border border-gray-300 leading-5 hover:text-gray-500 focus:z-10 focus:outline-none focus:ring ring-gray-300 focus:border-blue-300 active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150" aria-label="{{ __('Go to page :page', ['page' => $page]) }}">
-                                        {{ $page }}
+                                        {{ number_format($page) }}
                                     </a>
                                 @endif
                             @endforeach


### PR DESCRIPTION
Minor change to pagination views to improve readability of large page numbers.
### Before
<img width="553" alt="Screen Shot 2020-12-18 at 7 56 03 PM" src="https://user-images.githubusercontent.com/376199/102680224-2d2a8700-416b-11eb-9609-cb26a4f4a116.png">

### After
<img width="559" alt="Screen Shot 2020-12-18 at 7 55 41 PM" src="https://user-images.githubusercontent.com/376199/102680218-28fe6980-416b-11eb-8a28-9d0b388dbbd6.png">

