### PR TITLE
Create validateNotArray function

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1937,4 +1937,18 @@ trait ValidatesAttributes
             $this->numericRules[] = $rule;
         }
     }
+    
+     /**
+     * Validate an attribute is not aray.
+     * @param  string  $attribute
+     * @param  mixed  $value
+     */
+    public function validateNotArray($attribute, $value)
+    {
+        if(is_array($value) && $this->hasRule($attribute, 'Array')
+           {
+               return false;
+           }    
+
+    }  
 }


### PR DESCRIPTION
Sometimes we need to prevent to arrays from input.For examles it creates weakness in hash usage.
Example:
$secret = 'secure_random_secret_value';
$hmac = md5($secret . $_POST['message']);
if($hmac == $_POST['hmac'])
shell_exec($_POST['message']);

Code:
var_dump("0e123" == "0e51217526859264863");
Output:
bool(true)
This is also a problem in databases with lots of users. Using this format, an attacker can try to log into every single user account with a password that will result in a hash of the mentioned format. If there is a hash with the same format in the database, he will be logged in as the user that the hash belongs to, without needing to know the password.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
