### PR TITLE
MultipleSpaceClean method was added into str.

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -723,6 +723,17 @@ class Str
     }
 
     /**
+     * Make a string's multiple space characters clean.
+     *
+     * @param  string  $string
+     * @return string
+     */
+    public static function multipleSpaceClean($string)
+    {
+        return preg_replace('!\s+!', ' ', $string);
+    }
+
+    /**
      * Generate a UUID (version 4).
      *
      * @return \Ramsey\Uuid\UuidInterface

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -449,6 +449,14 @@ class SupportStrTest extends TestCase
         $this->assertSame('Мама мыла раму', Str::ucfirst('мама мыла раму'));
     }
 
+    public function testMultipleSpaceClean()
+    {
+        $this->assertSame('a b  c   d    e', Str::ucfirst('a b c d e'));
+        $this->assertSame('a b  c   d    e   ', Str::ucfirst('a b c d e '));
+        $this->assertSame('  a b  c   d    e', Str::ucfirst(' a b c d e'));
+        $this->assertSame('  a b  c   d    e   ', Str::ucfirst(' a b c d e '));
+    }
+
     public function testUuid()
     {
         $this->assertInstanceOf(UuidInterface::class, Str::uuid());


### PR DESCRIPTION
MultipleSpaceClean method was added.
The inserted method clears multiple whitespace characters in a string.

Example:
$input = 'a b  c   d';
$output = Str:multipleSpaceClean($input);
echo $output;    // Result: a b c d