### PR TITLE
Removed the returning of void return types as per job contract

### DIFF
--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -230,10 +230,10 @@ class CallQueuedHandler
         }
 
         if ($shouldDelete) {
-            return $job->delete();
+            $job->delete();
         }
 
-        return $job->fail($e);
+        $job->fail($e);
     }
 
     /**

--- a/src/Illuminate/Queue/InteractsWithQueue.php
+++ b/src/Illuminate/Queue/InteractsWithQueue.php
@@ -31,7 +31,7 @@ trait InteractsWithQueue
     public function delete()
     {
         if ($this->job) {
-            return $this->job->delete();
+            $this->job->delete();
         }
     }
 
@@ -57,7 +57,7 @@ trait InteractsWithQueue
     public function release($delay = 0)
     {
         if ($this->job) {
-            return $this->job->release($delay);
+            $this->job->release($delay);
         }
     }
 

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Cache\Repository as CacheContract;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Queue\Factory as QueueManager;
+use Illuminate\Contracts\Queue\Job;
 use Illuminate\Database\DetectsLostConnections;
 use Illuminate\Queue\Events\JobExceptionOccurred;
 use Illuminate\Queue\Events\JobProcessed;
@@ -539,9 +540,9 @@ class Worker
      * @param  \Throwable  $e
      * @return void
      */
-    protected function failJob($job, Throwable $e)
+    protected function failJob(Job $job, Throwable $e)
     {
-        return $job->fail($e);
+        $job->fail($e);
     }
 
     /**


### PR DESCRIPTION
I've removed the return statements for methods within the queue ecosystem that should be void according to the job contract.