### PR TITLE
validateNotArray function

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -306,6 +306,23 @@ trait ValidatesAttributes
     }
 
     /**
+    * Validate an attribute is not array.
+    * @param  string  $attribute
+    * @param  mixed  $value
+    * @return bool
+    */
+    public function validateNotArray($attribute, $value)
+    {
+        if(is_array($value))
+           {
+               return false;
+           }
+        if(!is_array($value))
+        {
+            return true;
+        }
+    } 
+    /**
      * Validate the size of an attribute is between a set of values.
      *
      * @param  string  $attribute


### PR DESCRIPTION
Sometimes we need to prevent to arrays from input.For examles it creates weakness in hash usage.
Example:
$secret = 'secure_random_secret_value';
$hmac = md5($secret . $_POST['message']);
if($hmac == $_POST['hmac'])
shell_exec($_POST['message']);

Code:
var_dump("0e123" == "0e51217526859264863");
Output:
bool(true)
This is also a problem in databases with lots of users. Using this format, an attacker can try to log into every single user account with a password that will result in a hash of the mentioned format. If there is a hash with the same format in the database, he will be logged in as the user that the hash belongs to, without needing to know the password.


