### PR TITLE
[6.x] Catch DecryptException with invalid X-XSRF-TOKEN

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Http\Middleware;
 
 use Closure;
+use Illuminate\Contracts\Encryption\DecryptException;
 use Illuminate\Contracts\Encryption\Encrypter;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\Support\Responsable;
@@ -152,7 +153,11 @@ class VerifyCsrfToken
         $token = $request->input('_token') ?: $request->header('X-CSRF-TOKEN');
 
         if (! $token && $header = $request->header('X-XSRF-TOKEN')) {
-            $token = CookieValuePrefix::remove($this->encrypter->decrypt($header, static::serialized()));
+            try {
+                $token = CookieValuePrefix::remove($this->encrypter->decrypt($header, static::serialized()));
+            } catch (DecryptException $e) {
+                $token = '';
+            }
         }
 
         return $token;


### PR DESCRIPTION
It fixes #33127.

For any `POST`, `PUT`, `PATCH` or `DELETE`  request, anyone can change the `X-XSRF-TOKEN` value in the headers and cause a server error (500 response).

With this fix, if a user changes the value, the server will return a `419 – CSRF token mismatch` response instead.