### PR TITLE
[9.x] multipleSpaceClean and utrim method was added into Str helper

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -736,6 +736,18 @@ class Str
     }
 
     /**
+     * Trim that additionally removes slashes.
+     *
+     * @param string $string
+     *
+     * @return string
+     */
+    public static function utrim(string $string)
+    {
+        return trim($string, " \t\n\r\0\x0B/\\");
+    }
+
+    /**
      * Generate a UUID (version 4).
      *
      * @return \Ramsey\Uuid\UuidInterface

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -725,6 +725,17 @@ class Str
     }
 
     /**
+     * Make a string's multiple space characters clean.
+     *
+     * @param  string  $string
+     * @return string
+     */
+    public static function multipleSpaceClean($string)
+    {
+        return preg_replace('!\s+!', ' ', $string);
+    }
+
+    /**
      * Generate a UUID (version 4).
      *
      * @return \Ramsey\Uuid\UuidInterface

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -454,6 +454,19 @@ class SupportStrTest extends TestCase
         $this->assertSame('Мама мыла раму', Str::ucfirst('мама мыла раму'));
     }
 
+    public function testMultipleSpaceClean()
+    {
+        $this->assertSame('a b c d e', Str::multipleSpaceClean('a b  c   d    e'));
+        $this->assertSame('a b c d e ', Str::multipleSpaceClean('a b  c   d    e   '));
+        $this->assertSame(' a b c d e', Str::multipleSpaceClean('  a b  c   d    e'));
+        $this->assertSame(' a b c d e ', Str::multipleSpaceClean('  a b  c   d    e   '));
+
+        $this->assertSame('你 好 是 这 文', Str::multipleSpaceClean('你 好  是   这    文'));
+        $this->assertSame('你 好 是 这 文 ', Str::multipleSpaceClean('你 好  是   这    文   '));
+        $this->assertSame(' 你 好 是 这 文', Str::multipleSpaceClean('   你 好  是   这    文'));
+        $this->assertSame(' 你 好 是 这 文 ', Str::multipleSpaceClean('   你 好  是   这    文   '));
+    }
+
     public function testUuid()
     {
         $this->assertInstanceOf(UuidInterface::class, Str::uuid());

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -467,6 +467,12 @@ class SupportStrTest extends TestCase
         $this->assertSame(' 你 好 是 这 文 ', Str::multipleSpaceClean('   你 好  是   这    文   '));
     }
 
+    public function testUtrim()
+    {
+        $this->assertSame('hello world', Str::utrim("\hello world \n"));
+        $this->assertSame('你好', Str::utrim("\你好 \n"));
+    }
+
     public function testUuid()
     {
         $this->assertInstanceOf(UuidInterface::class, Str::uuid());


### PR DESCRIPTION
multipleSpaceClean method was added into Str helper.
The inserted method clears multiple whitespace characters in a string.

Example:
```php
$input = 'a b  c   d    e';
$output = Str:multipleSpaceClean($input);
echo $output; // Result: a b c d e
```


trim method was added into Str helper.
Trim that additionally removes slashes.

Example:
```php
$input = "\hello world \n";
$output = Str:utrim($input);
echo $output; // Result: hello world
```