### PR TITLE
[8.x] Modify `mergeCasts` to return `$this`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -519,7 +519,7 @@ trait HasAttributes
     public function mergeCasts($casts)
     {
         $this->casts = array_merge($this->casts, $casts);
-        
+
         return $this;
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -514,11 +514,13 @@ trait HasAttributes
      * Merge new casts with existing casts on the model.
      *
      * @param  array  $casts
-     * @return void
+     * @return $this
      */
     public function mergeCasts($casts)
     {
         $this->casts = array_merge($this->casts, $casts);
+        
+        return $this;
     }
 
     /**


### PR DESCRIPTION
This change helpful to use the method in pipeline like this:
```php
    public function initializeUsesUuid()
    {
        $this
            ->setKeyName('uuid')
            ->setKeyType('string')
            ->setIncrementing(false)
            ->mergeCasts([$this->getKeyName() => $this->getKeyType()])
            ->mergeGuarded([$this->getKeyName()]);
    }
```