### PR TITLE
[8.x] Only dump migrations data if the table exists

### DIFF
--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -26,7 +26,9 @@ class MySqlSchemaState extends SchemaState
 
         $this->removeAutoIncrementingState($path);
 
-        $this->appendMigrationData($path);
+        if ($this->connection->getSchemaBuilder()->hasTable($this->migrationTable)) {
+            $this->appendMigrationData($path);
+        }
     }
 
     /**


### PR DESCRIPTION
This prevents `artisan schema:dump` crashing if the database doesn't contain a migrations table - e.g. when `artisan migrate` has never been run or when dumping a non-Laravel database (e.g. a secondary connection).

Currently it fails with this error:

```
   Symfony\Component\Process\Exception\ProcessFailedException

  The command "mysqldump  --user="${:LARAVEL_LOAD_USER}" --password="${:LARAVEL_LOAD_PASSWORD}" --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --skip-add-locks --skip-comments --skip-set-charset --t
z-utc "${:LARAVEL_LOAD_DATABASE}" migrations --no-create-info --skip-extended-insert --skip-routines --compact" failed.

Exit Code: 6(Unknown error)

Working directory: /home/www/test/repo

Output:
================


Error Output:
================
mysqldump: Couldn't find table: "migrations"
```