### PR TITLE
[8.x] Modify `mergeCasts` to return `$this`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -514,11 +514,13 @@ trait HasAttributes
      * Merge new casts with existing casts on the model.
      *
      * @param  array  $casts
-     * @return void
+     * @return $this
      */
     public function mergeCasts($casts)
     {
         $this->casts = array_merge($this->casts, $casts);
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
RP #35677 for 8.x branch

This change helpful to use the method in pipeline like this:
```php
    public function initializeUsesUuid()
    {
        $this
            ->setKeyName('uuid')
            ->setKeyType('string')
            ->setIncrementing(false)
            ->mergeCasts([$this->getKeyName() => $this->getKeyType()])
            ->mergeGuarded([$this->getKeyName()]);
    }
```
P.S.
> @GrahamCampbell this isn't a breaking change
https://github.com/laravel/framework/pull/35676#issuecomment-748901658