### PR TITLE
[6.x] fix doc blocks

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -371,7 +371,7 @@ class Mailer implements MailerContract, MailQueueContract
     /**
      * Queue a new e-mail message for sending.
      *
-     * @param  \Illuminate\Contracts\Mail\Mailable  $view
+     * @param  \Illuminate\Contracts\Mail\Mailable|string|array  $view
      * @param  string|null  $queue
      * @return mixed
      *

--- a/src/Illuminate/Mail/PendingMail.php
+++ b/src/Illuminate/Mail/PendingMail.php
@@ -114,7 +114,6 @@ class PendingMail
      * Send a new mailable message instance.
      *
      * @param  \Illuminate\Contracts\Mail\Mailable  $mailable
-     *
      * @return mixed
      */
     public function send(MailableContract $mailable)

--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -171,7 +171,7 @@ class NotificationSender
      * Queue the given notification instances.
      *
      * @param  mixed  $notifiables
-     * @param  array[\Illuminate\Notifications\Channels\Notification]  $notification
+     * @param  \Illuminate\Notifications\Notification  $notification
      * @return void
      */
     protected function queueNotification($notifiables, $notification)

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -306,7 +306,7 @@ class MailFake implements Mailer, MailQueue
     /**
      * Queue a new e-mail message for sending.
      *
-     * @param  string|array  $view
+     * @param  \Illuminate\Contracts\Mail\Mailable|string|array  $view
      * @param  string|null  $queue
      * @return mixed
      */

--- a/src/Illuminate/Support/Testing/Fakes/PendingMailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/PendingMailFake.php
@@ -21,7 +21,7 @@ class PendingMailFake extends PendingMail
     /**
      * Send a new mailable message instance.
      *
-     * @param  \Illuminate\Contracts\Mail\Mailable  $mailable;
+     * @param  \Illuminate\Contracts\Mail\Mailable  $mailable
      * @return mixed
      */
     public function send(Mailable $mailable)
@@ -32,7 +32,7 @@ class PendingMailFake extends PendingMail
     /**
      * Send a mailable message immediately.
      *
-     * @param  \Illuminate\Contracts\Mail\Mailable  $mailable;
+     * @param  \Illuminate\Contracts\Mail\Mailable  $mailable
      * @return mixed
      */
     public function sendNow(Mailable $mailable)
@@ -43,7 +43,7 @@ class PendingMailFake extends PendingMail
     /**
      * Push the given mailable onto the queue.
      *
-     * @param  \Illuminate\Contracts\Mail\Mailable  $mailable;
+     * @param  \Illuminate\Contracts\Mail\Mailable  $mailable
      * @return mixed
      */
     public function queue(Mailable $mailable)

--- a/src/Illuminate/Validation/Rules/Dimensions.php
+++ b/src/Illuminate/Validation/Rules/Dimensions.php
@@ -14,7 +14,7 @@ class Dimensions
     /**
      * Create a new dimensions rule instance.
      *
-     * @param  array  $constraints;
+     * @param  array  $constraints
      * @return void
      */
     public function __construct(array $constraints = [])


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Addresses errors for 6.x branch listed on #35673 .

This is a follow-up of PR #35675 . (changes suggested by Doctum in issue #35673)

As in that PR I avoid changing the `cache` and `event` helpers' doc blocks as to not be sure  on how to change it and keep their dynamic nature.

In addition I didn't change the `factory` helper which is not available anymore in Laravel 8 addressed by the previous PR.
