### PR TITLE
[8.x] Clear a cached user in RequestGuard if a request is changed

### DIFF
--- a/src/Illuminate/Auth/RequestGuard.php
+++ b/src/Illuminate/Auth/RequestGuard.php
@@ -81,6 +81,8 @@ class RequestGuard implements Guard
     public function setRequest(Request $request)
     {
         $this->request = $request;
+        
+        $this->user = null;
 
         return $this;
     }

--- a/src/Illuminate/Auth/RequestGuard.php
+++ b/src/Illuminate/Auth/RequestGuard.php
@@ -81,7 +81,7 @@ class RequestGuard implements Guard
     public function setRequest(Request $request)
     {
         $this->request = $request;
-        
+
         $this->user = null;
 
         return $this;


### PR DESCRIPTION
This guard retrieves a user based on a request data, so a cached user should be cleared on a request change.

Personally, I've faced a problem with it while creating a test for my API with a help of default Laravel testing methods (`postJson`, `getJson` etc). Requests with different API tokens got the same user (from the first request) because it is cached which is counter-intuitive.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
