### PR TITLE
[8.x] Ensure DBAL custom type doesn't exists

### DIFF
--- a/src/Illuminate/Database/DatabaseServiceProvider.php
+++ b/src/Illuminate/Database/DatabaseServiceProvider.php
@@ -123,7 +123,9 @@ class DatabaseServiceProvider extends ServiceProvider
         $types = $this->app['config']->get('database.dbal.types', []);
 
         foreach ($types as $name => $class) {
-            Type::addType($name, $class);
+            if (! Type::hasType($name)) {
+                Type::addType($name, $class);
+            }
         }
     }
 }


### PR DESCRIPTION
Hi,

When a type is registered twice, an exception is thrown.
As the DBAL types registry is a static singleton, the same instance is used when running tests.

Does this need a test?
Should we overwrite a type that is already registered?

Thanks
