### PR TITLE
[8.x] Give a more meaningul message when route parameters are missing

### DIFF
--- a/src/Illuminate/Routing/Exceptions/UrlGenerationException.php
+++ b/src/Illuminate/Routing/Exceptions/UrlGenerationException.php
@@ -3,6 +3,8 @@
 namespace Illuminate\Routing\Exceptions;
 
 use Exception;
+use Illuminate\Routing\Route;
+use Illuminate\Support\Str;
 
 class UrlGenerationException extends Exception
 {
@@ -10,10 +12,26 @@ class UrlGenerationException extends Exception
      * Create a new exception for missing route parameters.
      *
      * @param  \Illuminate\Routing\Route  $route
+     * @param array $parameters
      * @return static
      */
-    public static function forMissingParameters($route)
+    public static function forMissingParameters(Route $route, array $parameters = [])
     {
-        return new static("Missing required parameters for [Route: {$route->getName()}] [URI: {$route->uri()}].");
+        $paramterLabel = Str::plural('parameter', count($parameters));
+
+        $message = sprintf(
+            'Missing required %s for [Route: %s] [URI: %s]',
+            $paramterLabel,
+            $route->getName(),
+            $route->uri()
+        );
+
+        if (count($parameters) > 0) {
+            $message .= sprintf(' [Missing %s: %s]', $paramterLabel, implode(', ', $parameters));
+        }
+
+        $message .= '.';
+
+        return new static($message);
     }
 }

--- a/src/Illuminate/Routing/Exceptions/UrlGenerationException.php
+++ b/src/Illuminate/Routing/Exceptions/UrlGenerationException.php
@@ -17,17 +17,17 @@ class UrlGenerationException extends Exception
      */
     public static function forMissingParameters(Route $route, array $parameters = [])
     {
-        $paramterLabel = Str::plural('parameter', count($parameters));
+        $parameterLabel = Str::plural('parameter', count($parameters));
 
         $message = sprintf(
             'Missing required %s for [Route: %s] [URI: %s]',
-            $paramterLabel,
+            $parameterLabel,
             $route->getName(),
             $route->uri()
         );
 
         if (count($parameters) > 0) {
-            $message .= sprintf(' [Missing %s: %s]', $paramterLabel, implode(', ', $parameters));
+            $message .= sprintf(' [Missing %s: %s]', $parameterLabel, implode(', ', $parameters));
         }
 
         $message .= '.';

--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -87,8 +87,8 @@ class RouteUrlGenerator
             $route
         ), $parameters);
 
-        if (preg_match('/\{.*?\}/', $uri)) {
-            throw UrlGenerationException::forMissingParameters($route);
+        if (preg_match_all('/{(.*?)}/', $uri, $matchedMissingParameters)) {
+            throw UrlGenerationException::forMissingParameters($route, $matchedMissingParameters[1]);
         }
 
         // Once we have ensured that there are no missing parameters in the URI we will encode

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1831,7 +1831,7 @@ class RoutingRouteTest extends TestCase
     public function testRouteRedirectExceptionWhenMissingExpectedParameters()
     {
         $this->expectException(UrlGenerationException::class);
-        $this->expectExceptionMessage('Missing required parameters for [Route: laravel_route_redirect_destination] [URI: users/{user}].');
+        $this->expectExceptionMessage('Missing required parameter for [Route: laravel_route_redirect_destination] [URI: users/{user}] [Missing parameter: user].');
 
         $container = new Container;
         $router = new Router(new Dispatcher, $container);

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -550,6 +550,61 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertSame('http://www.foo.com:8080/foo?test=123', $url->route('foo', $parameters));
     }
 
+    public function provideParametersAndExpectedMeaningfulExceptionMessages()
+    {
+        return [
+            'Missing parameters "one", "two" and "three"' => [
+                [],
+                'Missing required parameters for [Route: foo] [URI: foo/{one}/{two}/{three}/{four?}] [Missing parameters: one, two, three].',
+            ],
+            'Missing parameters "two" and "three"' => [
+                ['one' => '123'],
+                'Missing required parameters for [Route: foo] [URI: foo/{one}/{two}/{three}/{four?}] [Missing parameters: two, three].',
+            ],
+            'Missing parameters "one" and "three"' => [
+                ['two' => '123'],
+                'Missing required parameters for [Route: foo] [URI: foo/{one}/{two}/{three}/{four?}] [Missing parameters: one, three].',
+            ],
+            'Missing parameters "one" and "two"' => [
+                ['three' => '123'],
+                'Missing required parameters for [Route: foo] [URI: foo/{one}/{two}/{three}/{four?}] [Missing parameters: one, two].',
+            ],
+            'Missing parameter "three"' => [
+                ['one' => '123', 'two' => '123'],
+                'Missing required parameter for [Route: foo] [URI: foo/{one}/{two}/{three}/{four?}] [Missing parameter: three].',
+            ],
+            'Missing parameter "two"' => [
+                ['one' => '123', 'three' => '123'],
+                'Missing required parameter for [Route: foo] [URI: foo/{one}/{two}/{three}/{four?}] [Missing parameter: two].',
+            ],
+            'Missing parameter "one"' => [
+                ['two' => '123', 'three' => '123'],
+                'Missing required parameter for [Route: foo] [URI: foo/{one}/{two}/{three}/{four?}] [Missing parameter: one].',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideParametersAndExpectedMeaningfulExceptionMessages
+     */
+    public function testUrlGenerationThrowsExceptionForMissingParametersWithMeaningfulMessage($parameters, $expectedMeaningfulExceptionMessage)
+    {
+        $this->expectException(UrlGenerationException::class);
+        $this->expectExceptionMessage($expectedMeaningfulExceptionMessage);
+
+        $url = new UrlGenerator(
+            $routes = new RouteCollection,
+            Request::create('http://www.foo.com:8080/')
+        );
+
+        $route = new Route(['GET'], 'foo/{one}/{two}/{three}/{four?}', ['as' => 'foo', function () {
+            //
+        }]);
+        $routes->add($route);
+
+        $url->route('foo', $parameters);
+    }
+
     public function testForceRootUrl()
     {
         $url = new UrlGenerator(


### PR DESCRIPTION
The message for `UrlGenerationException` when parameters are missing is a nice start, but knowing *which* parameters are missing can be a huge help in figuring out where something is broken. Especially if a route has multiple possible parameters. Which parameter is actually missing? Are more than one missing? Now we'll know!

For example, say a developer is presented with the following exception message:

> Missing required parameters [Route: admin.client.form.show] [URI: admin/client/{client}/form/{webform}]

It would lead them to their controller which might look something like this:

```
$connectionRequest->serviceUrl = route('admin.client.form.show', [
    'client' => $connectionRequest->client,
    'webform' => $serviceIntake,
]);
```

... it is not immediately obvious where to start. Is it that the `$connectionRequest` doesn't have a `client`? Or is the `$serviceIntake` set to `null` for some reason? Or are they both having issues?

With this PR, the exception message would change to one of the following:

 * > Missing required parameters [Route: admin.client.form.show] [URI: admin/client/{client}/form/{webform}] [Missing Parameters: client, webform].
 * > Missing required parameter [Route: admin.client.form.show] [URI: admin/client/{client}/form/{webform}] [Missing Parameter: client].
 * > Missing required parameter [Route: admin.client.form.show] [URI: admin/client/{client}/form/{webform}] [Missing Parameter: webform].

This feedback will save the developer a lot of time trying to figure out which parameters are missing so they can get right to fixing the issue instead of digging more to figure out which parameter is actually causing the problem.

----

Originally targeted `8.x` with this PR, but realized it can go all the way back to `6.x`, too. Let me know if you'd like me to retarget another branch or if there is anything I can do to help ensure this makes it into the most versions possible if it is accepted. :)