### PR TITLE
[8.x] Fix prune batches command interface check

### DIFF
--- a/src/Illuminate/Queue/Console/PruneBatchesCommand.php
+++ b/src/Illuminate/Queue/Console/PruneBatchesCommand.php
@@ -4,7 +4,7 @@ namespace Illuminate\Queue\Console;
 
 use Carbon\Carbon;
 use Illuminate\Bus\BatchRepository;
-use Illuminate\Bus\Prunable;
+use Illuminate\Bus\PrunableBatchRepository;
 use Illuminate\Console\Command;
 
 class PruneBatchesCommand extends Command
@@ -34,7 +34,7 @@ class PruneBatchesCommand extends Command
 
         $repository = $this->laravel[BatchRepository::class];
 
-        if ($repository instanceof Prunable) {
+        if ($repository instanceof PrunableBatchRepository) {
             $count = $repository->prune(Carbon::now()->subHours($this->option('hours')));
         }
 


### PR DESCRIPTION
The `Prunable` interface I added in PR #35694 was renamed to `PrunableBatchRepository` post merge in commit https://github.com/laravel/framework/commit/33f5ac695a55d6cdbadcfe1b46e3409e4a66df16 but the command should have also been changed to use the renamed interface.