### PR TITLE
[8.x] Add missing dispatchAfterCommit to DatabaseQueue

### DIFF
--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -49,12 +49,17 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
      * @param  int  $retryAfter
      * @return void
      */
-    public function __construct(Connection $database, $table, $default = 'default', $retryAfter = 60)
+    public function __construct(Connection $database,
+                                $table,
+                                $default = 'default',
+                                $retryAfter = 60,
+                                $dispatchAfterCommit = false)
     {
         $this->table = $table;
         $this->default = $default;
         $this->database = $database;
         $this->retryAfter = $retryAfter;
+        $this->dispatchAfterCommit = $dispatchAfterCommit;
     }
 
     /**

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -47,6 +47,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
      * @param  string  $table
      * @param  string  $default
      * @param  int  $retryAfter
+     * @param  bool  $dispatchAfterCommit
      * @return void
      */
     public function __construct(Connection $database,


### PR DESCRIPTION
The recent #35422 missed adding the new `$dispatchAfterCommit` parameter to the `DatabaseQueue`.
The new param is being passed in the [DatabaseConnector](https://github.com/laravel/framework/blob/344710f021c5b5b8fb32f6f66c5301829aa5758a/src/Illuminate/Queue/Connectors/DatabaseConnector.php#L41) but the queue class was not updated.

I also reformatted the `DatabaseQueue` constructor params (one arg per line) to match the changes in the previous PR.