### PR TITLE
Enhance prunes command

### DIFF
--- a/src/Illuminate/Bus/DatabaseBatchRepository.php
+++ b/src/Illuminate/Bus/DatabaseBatchRepository.php
@@ -239,19 +239,16 @@ class DatabaseBatchRepository implements PrunableBatchRepository
      */
     public function prune(DateTimeInterface $before)
     {
-        $query = $this->connection->table($this->table)
+        $items = $this->connection->table($this->table)
             ->whereNotNull('finished_at')
-            ->where('finished_at', '<', $before->getTimestamp());
+            ->where('finished_at', '<', $before->getTimestamp())
+            ->cursor();
 
-        $totalDeleted = 0;
+        foreach ($items as $item) {
+            $item->delete();
+        }
 
-        do {
-            $deleted = $query->take(1000)->delete();
-
-            $totalDeleted += $deleted;
-        } while ($deleted !== 0);
-
-        return $totalDeleted;
+        return $items->count();
     }
 
     /**

--- a/src/Illuminate/Queue/Console/PruneBatchesCommand.php
+++ b/src/Illuminate/Queue/Console/PruneBatchesCommand.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Queue\Console;
 
 use Carbon\Carbon;
-use Illuminate\Bus\BatchRepository;
 use Illuminate\Bus\PrunableBatchRepository;
 use Illuminate\Console\Command;
 
@@ -26,17 +25,14 @@ class PruneBatchesCommand extends Command
     /**
      * Execute the console command.
      *
+     * @param  PrunableBatchRepository $repository
      * @return void
      */
-    public function handle()
+    public function handle(PrunableBatchRepository $repository)
     {
-        $count = 0;
-
-        $repository = $this->laravel[BatchRepository::class];
-
-        if ($repository instanceof PrunableBatchRepository) {
-            $count = $repository->prune(Carbon::now()->subHours($this->option('hours')));
-        }
+        $count = $repository->prune(
+            Carbon::now()->subHours($this->option('hours'))
+        );
 
         $this->info("{$count} entries deleted!");
     }


### PR DESCRIPTION
This PR introduces small tweaks to enhance the feature introduced in https://github.com/laravel/framework/pull/35694

- Work with `cursor` to avoid memory issues reading from tables with a bunch of records.
- Inject the `prune` interface instead to avoid checking for types to decide paths.

I will be happy to add the missing tests for it (couldn't find them) if the proposed changes are accepted.

Merry Christmas 🤞🏻 