### PR TITLE
[8.x] Load collection relations on serialisation restore

### DIFF
--- a/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
+++ b/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
@@ -82,11 +82,11 @@ trait SerializesAndRestoresModelIdentifiers
 
         $collectionClass = get_class($collection);
 
-        return new $collectionClass(
+        return (new $collectionClass(
             collect($value->id)->map(function ($id) use ($collection) {
                 return $collection[$id] ?? null;
             })->filter()
-        );
+        ))->load($value->relations ?? []);
     }
 
     /**


### PR DESCRIPTION
This PR ensures collection relations are restored after an eloquent collection has been serialised.

This feature was introduced in PR #21191 for single models, and merged in PR #21229, with this feature to be added to collections in a later PR (as noted on the original PR). But I couldn't find any follow up PR that added this.

The use-case I have for this, is for Livewire.

Livewire uses this feature to serialise and restore model properties and eloquent collection properties. Currently model properties restore correctly, but eloquent collections do not, causing an n+1 problem when blade templates iterate through any relations. See this issue on Livewire repo as an example livewire/livewire#2010.

Hope this helps!
