### PR TITLE
[8.x] Improve exception logging

### DIFF
--- a/src/Illuminate/Log/Logger.php
+++ b/src/Illuminate/Log/Logger.php
@@ -171,7 +171,9 @@ class Logger implements LoggerInterface
      */
     protected function writeLog($level, $message, $context)
     {
-        $this->logger->{$level}($message = $this->formatMessage($message), $context);
+        $message = $this->formatMessage($message);
+
+        $this->logger->{$level}($message, $context);
 
         $this->fireLogEvent($level, $message, $context);
     }

--- a/src/Illuminate/Log/Logger.php
+++ b/src/Illuminate/Log/Logger.php
@@ -250,7 +250,7 @@ class Logger implements LoggerInterface
     protected function formatContext($context, $message)
     {
         if ($message instanceof Throwable
-            && !isset($context['exception'])
+            && ! isset($context['exception'])
         ) {
             $context['exception'] = $message;
         }

--- a/tests/Log/LogLoggerTest.php
+++ b/tests/Log/LogLoggerTest.php
@@ -26,6 +26,27 @@ class LogLoggerTest extends TestCase
         $writer->error('foo');
     }
 
+    public function testMethodsPassExceptionAdditionsToMonolog()
+    {
+        $exception = new RuntimeException('Test error message.');
+
+        $writer = new Logger($monolog = m::mock(Monolog::class));
+        $monolog->shouldReceive('error')->once()->with('Test error message.', ['foo' => 'bar', 'exception' => $exception]);
+
+        $writer->error($exception, ['foo' => 'bar']);
+    }
+
+    public function testMethodsPassExceptionAdditionsToMonologWithoutOverwritingExplicitContext()
+    {
+        $exception1 = new RuntimeException('Test error message 1.');
+        $exception2 = new RuntimeException('Test error message 2.');
+
+        $writer = new Logger($monolog = m::mock(Monolog::class));
+        $monolog->shouldReceive('error')->once()->with('Test error message 1.', ['foo' => 'bar', 'exception' => $exception2]);
+
+        $writer->error($exception1, ['foo' => 'bar', 'exception' => $exception2]);
+    }
+
     public function testLoggerFiresEventsDispatcher()
     {
         $writer = new Logger($monolog = m::mock(Monolog::class), $events = new Dispatcher);


### PR DESCRIPTION
I'm not sure if this should go to `8.x` or `master`, let me know if I should switch the target branch.

Here's the commit message from the second commit (the first is just an aesthetic change to make the second commit more readable - feel free to squash if needed):

Add special handling when logging exceptions

- [`Illuminate\Foundation\Exceptions\Handler::report()`](https://github.com/laravel/framework/blob/08303c7cbaa0b3271060ce315160d0722b2a78f0/src/Illuminate/Foundation/Exceptions/Handler.php#L233-L240) already does this when logging caught exceptions
- This is well-defined behavior as per [PSR-3](https://www.php-fig.org/psr/psr-3/#13-context)

Previously, logged exceptions would be passed down to `Illuminate\Monolog\Logger` which forcibly casts them to strings, resulting in the `__toString()` method being called on them - which is inherited from [Exception](https://www.php.net/manual/en/exception.tostring.php), which prints a stack trace. This stack trace ends up being used as the log message itself.

This change makes it so that when an exception is logged, the log message becomes a shorter and usually more readable string, which is the return value of the `getMessage()` method on the exception object, and passes the exception object itself as the `exception` key of the log message context, but only if that key wasn't already manually set by the user when logging the exception.

Monolog's [`LineFormatter`](https://github.com/Seldaek/monolog/blob/78bd7bd33313c3a7ad1f2b0fc0c11a203d4e3826/src/Monolog/Formatter/LineFormatter.php#L168-L195) will already process exceptions found in the context to include a nice stack trace, if the `includeStacktraces` option is turned on (which it is by default in Laravel).

This means that no information should be lost, unless someone is explicitly relying on the current behavior and/or making uncommon logging configuration changes.

Furthermore, this enables userland code to attach additional processors to the wrapped Monolog instance and include additional custom processing on the logged exception objects if desired.

Ref https://github.com/laravel/ideas/issues/2449#issuecomment-749721377