### PR TITLE
[8.x] Fix `php artisan db` command for the Postgres CLI

### DIFF
--- a/src/Illuminate/Database/Console/DbCommand.php
+++ b/src/Illuminate/Database/Console/DbCommand.php
@@ -83,7 +83,7 @@ class DbCommand extends Command
     {
         $driver = ucfirst($connection['driver']);
 
-        if (method_exists($this, "get{$driver}Env")) {
+        if (method_exists($this, "get{$driver}Environment")) {
             return $this->{"get{$driver}Environment"}($connection);
         }
 


### PR DESCRIPTION
In case of PostgreSQL `php artisan db` uses `commandEnvironment` to set env variables for CLI auth. However it fails because it checks if `get{$driver}Env` method exists but the method is actually named `get{$driver}Environment`.