### PR TITLE
[8.x] Do not use foundation helper on auth component

### DIFF
--- a/src/Illuminate/Auth/Middleware/EnsureEmailIsVerified.php
+++ b/src/Illuminate/Auth/Middleware/EnsureEmailIsVerified.php
@@ -6,6 +6,7 @@ use Closure;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Support\Facades\Redirect;
 use Illuminate\Support\Facades\URL;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class EnsureEmailIsVerified
 {
@@ -16,15 +17,19 @@ class EnsureEmailIsVerified
      * @param  \Closure  $next
      * @param  string|null  $redirectToRoute
      * @return \Illuminate\Http\Response|\Illuminate\Http\RedirectResponse|null
+     *
+     * @throws \Symfony\Component\HttpKernel\Exception\HttpException
      */
     public function handle($request, Closure $next, $redirectToRoute = null)
     {
         if (! $request->user() ||
             ($request->user() instanceof MustVerifyEmail &&
             ! $request->user()->hasVerifiedEmail())) {
-            return $request->expectsJson()
-                    ? abort(403, 'Your email address is not verified.')
-                    : Redirect::guest(URL::route($redirectToRoute ?: 'verification.notice'));
+            if ($request->expectsJson()) {
+                throw new HttpException(403, 'Your email address is not verified.');
+            }
+
+            return Redirect::guest(URL::route($redirectToRoute ?: 'verification.notice'));
         }
 
         return $next($request);


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

While skimming through closed issues, I saw that issue #35718 references PR #34808. From that PR code I noticed the `EnsureEmailIsVerified` uses the `abort` helper, but this class is from the `Illuminate\Auth` component which can be used outside of Laravel.

I searched for other places where the `abort` helper could be used and didn't found any.

I tried to replicate the same code from `Illuminate\Foundation\Application@abort`