### PR TITLE
[9.x] Added functionality to check if used states of a factory collide

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -39,16 +39,16 @@ abstract class Factory
     protected $states;
 
     /**
-     * The states that were called
+     * The states that were called.
      *
      * @var array|null
      */
     protected $calledStates;
 
     /**
-     * The states that will collide
+     * The states that will collide.
      *
-     * @var array|null $collidingStates
+     * @var array|null
      */
     protected $collidingStates;
 
@@ -146,13 +146,11 @@ abstract class Factory
         $this->connection = $connection;
         $this->faker = $this->withFaker();
 
-        if($calledStates)
-        {
+        if ($calledStates) {
             $this->calledStates = $calledStates;
         }
 
-        if($collidingStates)
-        {
+        if ($collidingStates) {
             $this->collidingStates = $collidingStates;
         }
     }
@@ -481,7 +479,7 @@ abstract class Factory
      */
     private function checkStateCollides($newState): void
     {
-        if (is_array($this->calledStates) && count($this->calledStates) > 0) {
+        if (is_array($this->collidingStates) && count($this->collidingStates) > 0 && is_array($this->calledStates) && count($this->calledStates) > 0) {
             foreach ($this->calledStates as $calledState) {
                 if (in_array($newState, $this->collidingStates[$calledState])) {
                     throw new \Exception('State '.$newState.' can not be combined with '.$calledState);

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -472,12 +472,12 @@ abstract class Factory
     }
 
     /**
-     * @param $newState
+     * @param string $newState
      *
      * @return void
      * @throws \Exception
      */
-    private function checkStateCollides($newState): void
+    private function checkStateCollides(string $newState)
     {
         if (is_array($this->collidingStates) && count($this->collidingStates) > 0 && is_array($this->calledStates) && count($this->calledStates) > 0) {
             foreach ($this->calledStates as $calledState) {

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -243,10 +243,20 @@ class DatabaseEloquentFactoryTest extends TestCase
     public function test_states_can_collide()
     {
         $this->expectExceptionMessage('State password can not be combined with email');
-        $user = FactoryTestUserFactory::new()->email()->password()->create();
+        FactoryTestUserFactory::new()->email()->password()->create();
+        $this->assertCount(0, FactoryTestUser::count());
 
         $this->expectExceptionMessage('State email can not be combined with password');
-        $user = FactoryTestUserFactory::new()->password()->email()->create();
+        FactoryTestUserFactory::new()->password()->email()->create();
+        $this->assertCount(0, FactoryTestUser::count());
+
+        $this->expectExceptionMessage('State password can not be combined with email');
+        FactoryTestUserFactory::new()->email()->password()->make();
+        $this->assertCount(0, FactoryTestUser::count());
+
+        $this->expectExceptionMessage('State email can not be combined with password');
+        FactoryTestUserFactory::new()->password()->email()->make();
+        $this->assertCount(0, FactoryTestUser::count());
     }
 
     public function test_belongs_to_relationship()

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Tests\Database;
 
 use Illuminate\Container\Container;
-use Illuminate\Support\Facades\Hash;
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\Factory;
@@ -11,6 +10,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Factories\Sequence;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use Illuminate\Foundation\Application;
+use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
 use Mockery;
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Added functionality to prevent used states of a factory from colliding. This can be useful for factories with many states and newcomers to the codebase.

https://github.com/laravel/framework/discussions/34494
https://github.com/laravel/ideas/issues/2363
