### PR TITLE
[8.x] URL double port fix

### DIFF
--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -166,11 +166,11 @@ class RouteUrlGenerator
 
         $needsPort = ($secure && $port !== 443) || (!$secure && $port !== 80);
 
-		if (is_numeric(Str::afterLast($domain, ':'))) {
-			$needsPort = false;
-		}
+        if (is_numeric(Str::afterLast($domain, ':'))) {
+            $needsPort = false;
+        }
 
-		return $needsPort ? $domain . ':' . $port : $domain;
+        return $needsPort ? $domain . ':' . $port : $domain;
     }
 
     /**

--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -164,8 +164,13 @@ class RouteUrlGenerator
 
         $port = (int) $this->request->getPort();
 
-        return ($secure && $port === 443) || (! $secure && $port === 80)
-                    ? $domain : $domain.':'.$port;
+        $needsPort = ($secure && $port !== 443) || (!$secure && $port !== 80);
+
+		if (is_numeric(Str::afterLast($domain, ':'))) {
+			$needsPort = false;
+		}
+
+		return $needsPort ? $domain . ':' . $port : $domain;
     }
 
     /**

--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -164,13 +164,13 @@ class RouteUrlGenerator
 
         $port = (int) $this->request->getPort();
 
-        $needsPort = ($secure && $port !== 443) || (!$secure && $port !== 80);
+        $needsPort = ($secure && $port !== 443) || (! $secure && $port !== 80);
 
         if (is_numeric(Str::afterLast($domain, ':'))) {
             $needsPort = false;
         }
 
-        return $needsPort ? $domain . ':' . $port : $domain;
+        return $needsPort ? $domain.':'.$port : $domain;
     }
 
     /**

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -457,8 +457,15 @@ class RoutingUrlGeneratorTest extends TestCase
         $route = new Route(['GET'], 'foo/bar/{baz}', ['as' => 'bar', 'domain' => 'sub.{foo}.com']);
         $routes->add($route);
 
+        /*
+         * Domains with ports...
+         */
+        $route = new Route(['GET'], 'foo/bar', ['as' => 'baz', 'domain' => 'domain.foo.com:3000']);
+        $routes->add($route);
+
         $this->assertSame('http://sub.foo.com:8080/foo/bar', $url->route('foo'));
         $this->assertSame('http://sub.taylor.com:8080/foo/bar/otwell', $url->route('bar', ['taylor', 'otwell']));
+        $this->assertSame('http://domain.foo.com:3000/foo/bar', $url->route('baz'));
     }
 
     public function testRoutesWithDomainsStripsProtocols()


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

As detailed in #35731, if a specified domain for a route contains a port, and Laravel's server is also run under a non-standard port, Laravel's port will be added to that specified domain, resulting in an invalid URL.
