### PR TITLE
[8.x] Add support for asterisks for unique validator

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -749,7 +749,7 @@ trait ValidatesAttributes
     {
         $idColumn = $idColumn ?? $parameters[3] ?? 'id';
 
-        return [$idColumn, $this->prepareUniqueId($parameters[2])];
+        return [$idColumn, $this->getValue($this->prepareUniqueId($parameters[2]))];
     }
 
     /**
@@ -853,7 +853,7 @@ trait ValidatesAttributes
         $count = count($segments);
 
         for ($i = 0; $i < $count; $i += 2) {
-            $extra[$segments[$i]] = $segments[$i + 1];
+            $extra[$segments[$i]] = $this->getValue($segments[$i + 1]);
         }
 
         return $extra;


### PR DESCRIPTION
When validating array that accept other fields as parameters, like `unique`. It should be able to validate from the array 

`'*.title' => 'unique:Category,title,*.id,id,parent,*.parent'`

This rule wouldn't check if the `Category` model has row with with `parent`  and `id` which exist in the same array. It is working with single object but not for array. How it work now is it except value directly  while defining rule. like

`'title' => 'unique:Category,title,'.$request->id.',id,parent,'$request->parent` 