### PR TITLE
[8.x] Update test stubs to snake_case

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/test.stub
+++ b/src/Illuminate/Foundation/Console/stubs/test.stub
@@ -13,7 +13,7 @@ class {{ class }} extends TestCase
      *
      * @return void
      */
-    public function testExample()
+    public function test_example()
     {
         $response = $this->get('/');
 

--- a/src/Illuminate/Foundation/Console/stubs/test.unit.stub
+++ b/src/Illuminate/Foundation/Console/stubs/test.unit.stub
@@ -11,7 +11,7 @@ class {{ class }} extends TestCase
      *
      * @return void
      */
-    public function testExample()
+    public function test_example()
     {
         $this->assertTrue(true);
     }


### PR DESCRIPTION
During the big documentation overhaul test case naming convention has changed to `snake_case`. I guess it makes sense to update test stubs for new projects too.