### PR TITLE
[8.x] Add item to list of causedByLostConnection errors

### DIFF
--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -47,6 +47,7 @@ trait DetectsLostConnections
             'SQLSTATE[HY000]: General error: 7 SSL SYSCALL error: EOF detected',
             'SQLSTATE[HY000] [2002] Connection timed out',
             'SSL: Connection timed out',
+            'SQLSTATE[HY000]: General error: 1105 The last transaction was aborted due to Seamless Scaling. Please retry.',
         ]);
     }
 }


### PR DESCRIPTION
AWS Aurora serverless MySQL DB sometimes aborts queries while performing scaling. The error returned is:

"SQLSTATE[HY000]: General error: 1105 The last transaction was aborted due to Seamless Scaling. Please retry."
