### PR TITLE
[8.x] Set chain queue when inside a batch

### DIFF
--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -170,7 +170,9 @@ class Batch implements Arrayable, JsonSerializable
                 $count += count($job);
 
                 return with($this->prepareBatchedChain($job), function ($chain) {
-                    return $chain->first()->chain($chain->slice(1)->values()->all());
+                    return $chain->first()
+                            ->allOnQueue($this->options['queue'] ?? null)
+                            ->chain($chain->slice(1)->values()->all());
                 });
             } else {
                 $job->withBatchId($this->id);

--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -172,6 +172,7 @@ class Batch implements Arrayable, JsonSerializable
                 return with($this->prepareBatchedChain($job), function ($chain) {
                     return $chain->first()
                             ->allOnQueue($this->options['queue'] ?? null)
+                            ->allOnConnection($this->options['connection'] ?? null)
                             ->chain($chain->slice(1)->values()->all());
                 });
             } else {

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -332,6 +332,7 @@ class BusBatchTest extends TestCase
 
         $this->assertEquals(3, $batch->totalJobs);
         $this->assertEquals(3, $batch->pendingJobs);
+        $this->assertEquals('test-queue', $chainHeadJob->chainQueue);
         $this->assertTrue(is_string($chainHeadJob->batchId));
         $this->assertTrue(is_string($secondJob->batchId));
         $this->assertTrue(is_string($thirdJob->batchId));


### PR DESCRIPTION
This fixes https://github.com/laravel/framework/issues/35739 by setting the chain queue and connection from the batch.