### PR TITLE
[8.x] Clear OPCache when clear-compiled or dump-autoload

### DIFF
--- a/src/Illuminate/Foundation/ComposerScripts.php
+++ b/src/Illuminate/Foundation/ComposerScripts.php
@@ -17,6 +17,7 @@ class ComposerScripts
         require_once $event->getComposer()->getConfig()->get('vendor-dir').'/autoload.php';
 
         static::clearCompiled();
+        static::clearOpcache();
     }
 
     /**
@@ -30,6 +31,7 @@ class ComposerScripts
         require_once $event->getComposer()->getConfig()->get('vendor-dir').'/autoload.php';
 
         static::clearCompiled();
+        static::clearOpcache();
     }
 
     /**
@@ -43,6 +45,7 @@ class ComposerScripts
         require_once $event->getComposer()->getConfig()->get('vendor-dir').'/autoload.php';
 
         static::clearCompiled();
+        static::clearOpcache();
     }
 
     /**
@@ -60,6 +63,18 @@ class ComposerScripts
 
         if (is_file($packagesPath = $laravel->getCachedPackagesPath())) {
             @unlink($packagesPath);
+        }
+    }
+
+    /**
+     * Resets the contents of the opcode cache.
+     *
+     * @return void
+     */
+    protected static function clearOpcache()
+    {
+        if (function_exists('opcache_reset')) {
+            @opcache_reset();
         }
     }
 }

--- a/src/Illuminate/Foundation/Console/ClearCompiledCommand.php
+++ b/src/Illuminate/Foundation/Console/ClearCompiledCommand.php
@@ -21,6 +21,29 @@ class ClearCompiledCommand extends Command
     protected $description = 'Remove the compiled class file';
 
     /**
+     * Has OPCache extension.
+     *
+     * @var bool
+     */
+    protected $hasOpcache;
+
+    /**
+     * Create a new console command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->hasOpcache = function_exists('opcache_reset');
+
+        if ($this->hasOpcache) {
+            $this->description = 'Remove the compiled class file and clear OPCache';
+        }
+
+        parent::__construct();
+    }
+
+    /**
      * Execute the console command.
      *
      * @return void
@@ -35,6 +58,14 @@ class ClearCompiledCommand extends Command
             @unlink($packagesPath);
         }
 
-        $this->info('Compiled services and packages files removed!');
+        if ($this->hasOpcache) {
+            @opcache_reset();
+        }
+
+        $message = $this->hasOpcache
+            ? 'OPCache and compiled services and packages files removed!'
+            : 'Compiled services and packages files removed!';
+
+        $this->info($message);
     }
 }


### PR DESCRIPTION
Sometimes models or other code saved in OPCache and stays there even after `composer dump-autoload` and `php artisan clear-compiled`. For a better experience I propose clearing the OPCache.