### PR TITLE
[8.x] Correct return type on View facade's first()

### DIFF
--- a/src/Illuminate/Support/Facades/View.php
+++ b/src/Illuminate/Support/Facades/View.php
@@ -4,7 +4,7 @@ namespace Illuminate\Support\Facades;
 
 /**
  * @method static \Illuminate\Contracts\View\Factory addNamespace(string $namespace, string|array $hints)
- * @method static \Illuminate\Contracts\View\Factory first(array $views, \Illuminate\Contracts\Support\Arrayable|array $data = [], array $mergeData = [])
+ * @method static \Illuminate\Contracts\View\View first(array $views, \Illuminate\Contracts\Support\Arrayable|array $data = [], array $mergeData = [])
  * @method static \Illuminate\Contracts\View\Factory replaceNamespace(string $namespace, string|array $hints)
  * @method static \Illuminate\Contracts\View\View file(string $path, array $data = [], array $mergeData = [])
  * @method static \Illuminate\Contracts\View\View make(string $view, array $data = [], array $mergeData = [])

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -7,6 +7,7 @@ use ErrorException;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
 use Illuminate\Contracts\View\Engine;
+use Illuminate\Contracts\View\View as ViewContract;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\HtmlString;
@@ -87,6 +88,7 @@ class ViewFactoryTest extends TestCase
         $factory->addExtension('php', 'php');
         $view = $factory->first(['bar', 'view'], ['foo' => 'bar'], ['baz' => 'boom']);
 
+        $this->assertInstanceOf(ViewContract::class, $view);
         $this->assertSame($engine, $view->getEngine());
         $this->assertSame($_SERVER['__test.view'], $view);
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

I noticed my IDE (VS Code) was making a fuss about `View::first()` not returning a `View` instance, but a `Factory` (which it doesn't seem to return, since `Illuminate\View\Factory` returns a `View` instance (as noted in the factory docblock)

I added the correct return type to the `View` facade and added a small test assertion to ensure this type is returned (which might be useless, but I added it for good measure).