### PR TITLE
[8.x] Fix setUp and tearDown methods visibility

### DIFF
--- a/tests/Cache/CacheMemcachedStoreTest.php
+++ b/tests/Cache/CacheMemcachedStoreTest.php
@@ -11,7 +11,7 @@ use stdClass;
 
 class CacheMemcachedStoreTest extends TestCase
 {
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         m::close();
 

--- a/tests/Integration/Foundation/MaintenanceModeTest.php
+++ b/tests/Integration/Foundation/MaintenanceModeTest.php
@@ -14,7 +14,7 @@ use Symfony\Component\HttpFoundation\Cookie;
  */
 class MaintenanceModeTest extends TestCase
 {
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         @unlink(storage_path('framework/down'));
     }

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -13,7 +13,7 @@ use Mockery;
 
 class BladeComponentTagCompilerTest extends AbstractBladeTestCase
 {
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         Mockery::close();
     }

--- a/tests/View/ComponentTest.php
+++ b/tests/View/ComponentTest.php
@@ -19,7 +19,7 @@ class ComponentTest extends TestCase
     protected $viewFactory;
     protected $config;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->config = m::mock(Config::class);
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR fix `setUp` and `tearDown` methods visibility, changing them from `public` to `protected`.
