### PR TITLE
[8.x] Add key/index/iteration placeholders to validation attributes

### DIFF
--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -212,10 +212,15 @@ trait FormatsMessages
      */
     public function makeReplacements($message, $attribute, $rule, $parameters)
     {
+        $explicitKeys = $this->getExplicitKeys($attribute);
+
         $message = $this->replaceAttributePlaceholder(
             $message, $this->getDisplayableAttribute($attribute)
         );
 
+        $message = $this->replaceKeyPlaceholder($message, $explicitKeys);
+        $message = $this->replaceIndexPlaceholder($message, $explicitKeys);
+        $message = $this->replaceIterationPlaceholder($message, $explicitKeys);
         $message = $this->replaceInputPlaceholder($message, $attribute);
 
         if (isset($this->replacers[Str::snake($rule)])) {
@@ -293,6 +298,82 @@ trait FormatsMessages
             [$value, Str::upper($value), Str::ucfirst($value)],
             $message
         );
+    }
+
+    /**
+     * Replace the :key{n} placeholders in the given message.
+     *
+     * @param  string  $message
+     * @param  array  $explicitKeys
+     * @return string
+     */
+    protected function replaceKeyPlaceholder($message, $explicitKeys)
+    {
+        if (count($explicitKeys) > 0) {
+            foreach ($explicitKeys as $explicitKeyIndex => $explicitKey) {
+                $message = str_replace(
+                    [":key$explicitKeyIndex", ":KEY$explicitKeyIndex", ":Key$explicitKeyIndex"],
+                    [$explicitKey, Str::upper($explicitKey), Str::ucfirst($explicitKey)],
+                    $message
+                );
+            }
+            $firstKey = $explicitKeys[0];
+            $message = str_replace(
+                [':key', ':KEY', ':Key'],
+                [$firstKey, Str::upper($firstKey), Str::ucfirst($firstKey)],
+                $message
+            );
+        }
+
+        return $message;
+    }
+
+    /**
+     * Replace the :index{n} placeholders in the given message.
+     *
+     * @param  string  $message
+     * @param  array  $explicitKeys
+     * @return string
+     */
+    protected function replaceIndexPlaceholder($message, $explicitKeys)
+    {
+        if (count($explicitKeys) > 0) {
+            foreach ($explicitKeys as $explicitKeyIndex => $explicitKey) {
+                if (is_numeric($explicitKey)) {
+                    $message = str_replace(":index$explicitKeyIndex", $explicitKey, $message);
+                }
+            }
+            $firstKey = $explicitKeys[0];
+            if (is_numeric($firstKey)) {
+                $message = str_replace(':index', $firstKey, $message);
+            }
+        }
+
+        return $message;
+    }
+
+    /**
+     * Replace the :iteration{n} placeholders in the given message.
+     *
+     * @param  string  $message
+     * @param  array  $explicitKeys
+     * @return string
+     */
+    protected function replaceIterationPlaceholder($message, $explicitKeys)
+    {
+        if (count($explicitKeys) > 0) {
+            foreach ($explicitKeys as $explicitKeyIndex => $explicitKey) {
+                if (is_numeric($explicitKey)) {
+                    $message = str_replace(":iteration$explicitKeyIndex", intval($explicitKey) + 1, $message);
+                }
+            }
+            $firstKey = $explicitKeys[0];
+            if (is_numeric($firstKey)) {
+                $message = str_replace(':iteration', intval($firstKey) + 1, $message);
+            }
+        }
+
+        return $message;
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -415,6 +415,70 @@ class ValidationValidatorTest extends TestCase
         $this->assertSame('First name is required!', $v->messages()->first('names.0'));
     }
 
+    public function testKeyIsReplaced()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines([
+            'validation.required' => ':attribute is required!',
+            'validation.attributes.name.*' => 'Any name(:key)',
+            'validation.attributes.name_nested.*.*' => 'Any name(:key0)(:key1)',
+        ], 'en');
+        $v = new Validator($trans, ['name' => ['', 'Foo', '']], ['name.*' => 'required']);
+        $this->assertFalse($v->passes());
+        $v->messages()->setFormat(':message');
+        $this->assertSame('Any name(0) is required!', $v->messages()->first('name.0'));
+        $this->assertSame('Any name(2) is required!', $v->messages()->first('name.2'));
+
+        $v = new Validator($trans, ['name_nested' => [['en' => 'Foo', 'fa' => ''], ['en' => '', 'fa' => 'Bar']]], ['name_nested.*.*' => 'required']);
+        $this->assertFalse($v->passes());
+        $v->messages()->setFormat(':message');
+        $this->assertSame('Any name(0)(fa) is required!', $v->messages()->first('name_nested.0.fa'));
+        $this->assertSame('Any name(1)(en) is required!', $v->messages()->first('name_nested.1.en'));
+    }
+
+    public function testIndexIsReplaced()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines([
+            'validation.required' => ':attribute is required!',
+            'validation.attributes.name.*' => 'Any name(:index)',
+            'validation.attributes.name_nested.*.*' => 'Any name(:index0)(:index1)',
+        ], 'en');
+        $v = new Validator($trans, ['name' => ['', 'Foo', '']], ['name.*' => 'required']);
+        $this->assertFalse($v->passes());
+        $v->messages()->setFormat(':message');
+        $this->assertSame('Any name(0) is required!', $v->messages()->first('name.0'));
+        $this->assertSame('Any name(2) is required!', $v->messages()->first('name.2'));
+
+        $v = new Validator($trans, ['name_nested' => [['', 'Foo'], ['Bar', '']]], ['name_nested.*.*' => 'required']);
+        $this->assertFalse($v->passes());
+        $v->messages()->setFormat(':message');
+        $this->assertSame('Any name(0)(0) is required!', $v->messages()->first('name_nested.0.0'));
+        $this->assertSame('Any name(1)(1) is required!', $v->messages()->first('name_nested.1.1'));
+    }
+
+    public function testIterationIsReplaced()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines([
+            'validation.required' => ':attribute is required!',
+            'validation.attributes.name.*' => 'Any name(:iteration)',
+            'validation.attributes.name_nested.*.*' => 'Any name(:iteration0)(:iteration1)',
+        ], 'en');
+        $v = new Validator($trans, ['name' => ['', 'Foo', '']], ['name.*' => 'required']);
+        $this->assertFalse($v->passes());
+        $v->messages()->setFormat(':message');
+        $this->assertSame('Any name(1) is required!', $v->messages()->first('name.0'));
+        $this->assertSame('Any name(3) is required!', $v->messages()->first('name.2'));
+
+        $v = new Validator($trans, ['name_nested' => [['', 'Foo'], ['Bar', '', '']]], ['name_nested.*.*' => 'required']);
+        $this->assertFalse($v->passes());
+        $v->messages()->setFormat(':message');
+        $this->assertSame('Any name(1)(1) is required!', $v->messages()->first('name_nested.0.0'));
+        $this->assertSame('Any name(2)(2) is required!', $v->messages()->first('name_nested.1.1'));
+        $this->assertSame('Any name(2)(3) is required!', $v->messages()->first('name_nested.1.2'));
+    }
+
     public function testInputIsReplaced()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
This pull request provides 3 placeholders for validation attributes/messages when validating arrays
and replaces them for better validation messages.

`:key`: which is array key.
`:index`: which is the same key but replaces only numbers (not strings).
`:iteration`: which is the same index plus one (which more readable and useful for the final user).

An example code before this change:
```php
// Sample request ['items' => [4, 8, 'test', 3]]
public function test(Request $request)
{
	  $attributes = [];
      if(is_array($request->input('items'))) {
	      foreach ($request->input('items') as $key => $value) {
	          $attributes["items.$key"] = 'Item ('.(intval($key) + 1).')';
	      }
	  }
	  Validator::make($request->all(), 
          ['items.*' => 'required|numeric|min:1'],
          [],
          $attributes
      )->validate();
      // The Item (3) must be a number.
}
```

Same code after this change:
```php
// Sample request ['items' => [4, 8, 'test', 3]]
public function test(Request $request)
{
	  Validator::make($request->all(), 
          ['items.*' => 'required|numeric|min:1'],
          [],
          ['items.*' => 'Item (:iteration)']
      )->validate();
	  // The Item (3) must be a number.
}
```

---

There are placeholders for nested arrays too and can be handle by adding an index number at end of the placeholder.

```php
Validator::make(
    ['name' => [['', 'Foo'], ['', 'Bar']]],
    ['name.*.*' => 'required'],
    [],
    ['name.*.*' => 'Name (:iteration0)(:iteration1)']
)->validate();
// Error message 1: The Name (1)(1) field is required.
// Error message 2: The Name (2)(1) field is required.
```