### PR TITLE
[8.x] Make it possible to set Postmark Message Stream ID

### DIFF
--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -327,8 +327,13 @@ class MailManager implements FactoryContract
      */
     protected function createPostmarkTransport(array $config)
     {
+        $headers = isset($config['message_stream_id']) ? [
+            'X-PM-Message-Stream' => $config['message_stream_id'],
+        ] : [];
+
         return tap(new PostmarkTransport(
-            $config['token'] ?? $this->app['config']->get('services.postmark.token')
+            $config['token'] ?? $this->app['config']->get('services.postmark.token'),
+            $headers
         ), function ($transport) {
             $transport->registerPlugin(new ThrowExceptionOnFailurePlugin());
         });


### PR DESCRIPTION
This PR adds the possibility to set a Postmark `message stream id` when defining a Postmark mailer like:

```php
'postmark' => [
    'transport' => 'postmark',
    'message_stream_id' => env('POSTMARK_MESSAGE_STREAM_ID'), // this is new
],
```
(config/mail.php)

**Disclaimer:**
In Postmark you can define `servers` which are like accounts and they have a custom API token, which you can already set in Laravel when using the postmark mailer.

```php
'postmark' => [
    'token' => env('POSTMARK_TOKEN'),
],
```
(Example from Laravel docs https://laravel.com/docs/master/mail#postmark-driver)

But besides servers, you also have `message streams` with Postmark Servers. They can be used to separate `transactional` from `broadcast` emails for better deliverability. They do not have separated tokens, so you have to set a header in order to define the used stream. (https://github.com/wildbit/swiftmailer-postmark#5-setting-the-message-stream)

**Current working solutions:**

Currently, you can only set such a header on a `per mail base` in a mailable like:

```php
public function build()
{
    $this->view('emails.orders.shipped');

    $this->withSwiftMessage(function ($message) {
        $message->getHeaders()
                ->addTextHeader('Custom-Header', 'HeaderValue');
    });
}
```

With this PR you can also define a specific message stream on a `per mailer basis` which also lets you create different mailers which apps like Laravel Mailcoach supports.