### PR TITLE
[9.x] Rule object as string validation rule

### DIFF
--- a/src/Illuminate/Validation/Factory.php
+++ b/src/Illuminate/Validation/Factory.php
@@ -190,7 +190,7 @@ class Factory implements FactoryContract
     {
         if ($extension instanceof RuleContract) {
             $this->extensions[$rule] = function ($attribute, $value) use ($extension) {
-                return $extension->passes(...func_get_args());
+                return $extension->passes($attribute, $value);
             };
 
             if (! $message) {
@@ -217,7 +217,7 @@ class Factory implements FactoryContract
     {
         if ($extension instanceof ImplicitRuleContract) {
             $this->implicitExtensions[$rule] = function ($attribute, $value) use ($extension) {
-                return $extension->passes(...func_get_args());
+                return $extension->passes($attribute, $value);
             };
 
             if (! $message) {


### PR DESCRIPTION
This PR makes it easier and cleaner to 'alias' a custom Rule object to a validation rule-string.

**_Usage_** (typically in a serviceprovider boot):
```php
Validator::extend('myrule', app(MyRule::class));
```

**_without_** this PR:
```php
$myRule = app(MyRule::class);
Validator::extend('myrule', fn ($attribute, $value) => $myRule->passes($attribute, $value), $myRule->message());
```

While I am aware that the idea behind a Rule-object is more or less meant to be replacing - or at least be a successor - of Validator::extend(), I do encounter situations where this PR makes sense: when validation-rules are stored elsewhere (CMS / db) preventing me from using the Rule-object directly in my validators.

For example, on most occasions I'd prefer to validate within my controllers as:
```php
$this->validate($request, [
    'field' => ['required', new MyRule],
]);
```

...but on other parts of the codebase I would need to use it as:
```php
$this->validate($request, [
    'field' => $validationrulesStringFromMyDatabase, // e.g. 'required|myrule'
]);
```

This PR makes it easy to use both scenario's without duplicating the code from the custom Rule.


If you like (the concept of) this PR too, I'm more than happy to elaborate with tests, docs, etc.
