### PR TITLE
[8.x] Support named arguments (PHP8)

### DIFF
--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -140,7 +140,7 @@ class Fluent implements Arrayable, ArrayAccess, Jsonable, JsonSerializable
      */
     public function __call($method, $parameters)
     {
-        $this->attributes[$method] = count($parameters) > 0 ? $parameters[0] : true;
+        $this->attributes[$method] = count($parameters) > 0 ? $parameters[array_key_first($parameters)] : true;
 
         return $this;
     }


### PR DESCRIPTION
When using named arguments (introduced in PHP 8) we get an error as the key is not ['0'] anymore...
This PR will support both calls with or without named arguments.

Reproduce the error:
```php
use Illuminate\Database\Schema\Blueprint;
use Illuminate\Support\Facades\Schema;

Schema::table('posts', function (Blueprint $table) {
    $table->unsignedBigInteger('user_id');

    $table->foreign(columns: 'user_id')->references(columns: 'id')->on(table: 'users');
});
```
Run: php artisan migrate:fresh