### PR TITLE
Translation with Validation failed message

### DIFF
--- a/src/Illuminate/Validation/ValidationException.php
+++ b/src/Illuminate/Validation/ValidationException.php
@@ -53,7 +53,7 @@ class ValidationException extends Exception
      */
     public function __construct($validator, $response = null, $errorBag = 'default')
     {
-        parent::__construct('The given data was invalid.');
+        parent::__construct(function_exists('__') ? __('validation.failed') : 'The given data was invalid.');
 
         $this->response = $response;
         $this->errorBag = $errorBag;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7767424/103472435-abb33580-4db5-11eb-96c3-0e20d0f37767.png)

As shown in the above picture, the validation failed message field was not being able to translate as it is hardcoded in source code. This pull request uses `validation.failed` key for that message which can be modified in Laravel's language file.