### PR TITLE
[8.x] Remove if-condition that always evaluates to false

### DIFF
--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -209,11 +209,7 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
     {
         $this->migrate($prefixed = $this->getQueue($queue));
 
-        if (empty($nextJob = $this->retrieveNextJob($prefixed))) {
-            return;
-        }
-
-        [$job, $reserved] = $nextJob;
+        [$job, $reserved] = $this->retrieveNextJob($prefixed);
 
         if ($reserved) {
             return new RedisJob(


### PR DESCRIPTION
The if-condition at src/Illuminate/Queue/RedisQueue.php:212 never evaluates to true and its early-return statement is never executed because $nextJob is never empty. $nextJob is never empty because \Illuminate\Queue\RedisQueue::retrieveNextJob can only return [null, null] or [$job, $reserved] which are both none-empty-arrays. Consequently we can remove the if-condition and its unreachable statement without causing any change to behaviour.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
