### PR TITLE
[8.x] Refresh the retryUntil time on job retry

### DIFF
--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -98,7 +98,7 @@ class RetryCommand extends Command
     }
 
     /**
-     * Possibly refresh job attempts and retryUntil value
+     * Possibly refresh job attempts and retryUntil value.
      *
      * @param  string  $payload
      * @return string
@@ -132,7 +132,7 @@ class RetryCommand extends Command
     }
 
     /**
-     * Refreshes a jobs retryUntil time with it's own retryUntil method
+     * Refreshes a jobs retryUntil time with it's own retryUntil method.
      *
      * @param  string  $payload
      * @return string

--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -143,9 +143,11 @@ class RetryCommand extends Command
 
         $jobInstance = unserialize($payload['data']['command']);
 
-        $newRetryUntil = $jobInstance->retryUntil()->timestamp;
+        if (method_exists($jobInstance, 'retryUntil')) {
+            $newRetryUntil = $jobInstance->retryUntil()->timestamp;
 
-        $payload['retryUntil'] = $newRetryUntil;
+            $payload['retryUntil'] = $newRetryUntil;
+        }
 
         return json_encode($payload);
     }


### PR DESCRIPTION
Much like how `attempts` is reset when a job is retried using the with the `queue:retry` command, this will now make it so the `retryUntil` time is refreshed before being put back onto the queue. Using the jobs own `retryUntil` method of course!

Without this, jobs that use a custom `retryUntil` method will always fail with a `MaxAttemptsExceededException` if put back onto the queue with the `queue:retry` command AFTER the first time the job is run and `retryUntil` is set in the job payload.

This will provide a benefit to users who want to retry jobs sitting in `failed_jobs` with a custom `retryUntil` and don't want to have to update that value manually in the DB