### PR TITLE
Throw NotFoundHttpException with message Not Found

### DIFF
--- a/src/Illuminate/Routing/AbstractRouteCollection.php
+++ b/src/Illuminate/Routing/AbstractRouteCollection.php
@@ -40,7 +40,7 @@ abstract class AbstractRouteCollection implements Countable, IteratorAggregate, 
             return $this->getRouteForMethods($request, $others);
         }
 
-        throw new NotFoundHttpException;
+        throw new NotFoundHttpException("Not Found");
     }
 
     /**


### PR DESCRIPTION
When using invalid route with XHR/AJAX, the returned response contains "" as message while the raised response on server is NotFoundHttpException. It can be set to a simple text "Not Found" so that it doesn't take much size but acts like a valid placeholder.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
