### PR TITLE
[8.x] Don't fire "saved" event if nothing has actually been saved

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -847,7 +847,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
         // clause to only update this model. Otherwise, we'll just insert them.
         if ($this->exists) {
             $saved = $this->isDirty() ?
-                        $this->performUpdate($query) : true;
+                        $this->performUpdate($query) : false;
         }
 
         // If the model is brand new, we'll insert it into our database and set the


### PR DESCRIPTION
The wording of the documentation suggest that when saving an existing model the events "updated" and "saved" are fired either both, or none at all. In the current code, when calling save() on an unchanged model, "saved" is fired, but "updated" is not. Expected would be that none would be fired. This PR makes the code follow the documentation.