### PR TITLE
[8.x] Add array to URL action method argument

### DIFF
--- a/src/Illuminate/Support/Facades/URL.php
+++ b/src/Illuminate/Support/Facades/URL.php
@@ -5,7 +5,7 @@ namespace Illuminate\Support\Facades;
 /**
  * @method static \Illuminate\Contracts\Routing\UrlGenerator setRootControllerNamespace(string $rootNamespace)
  * @method static bool hasValidSignature(\Illuminate\Http\Request $request, bool $absolute = true)
- * @method static string action(string $action, $parameters = [], bool $absolute = true)
+ * @method static string action(string|array $action, $parameters = [], bool $absolute = true)
  * @method static string asset(string $path, bool $secure = null)
  * @method static string secureAsset(string $path)
  * @method static string current()


### PR DESCRIPTION
This PR add an array type to URL action method first argument.
Mainly to prevent IDE "Expected parameter of type 'string', 'array' provided" error.