### PR TITLE
[6.x] Retry connection if DNS lookup fails

### DIFF
--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -44,6 +44,7 @@ trait DetectsLostConnections
             'running with the --read-only option so it cannot execute this statement',
             'The connection is broken and recovery is not possible. The connection is marked by the client driver as unrecoverable. No attempt was made to restore the connection.',
             'SQLSTATE[HY000] [2002] php_network_getaddresses: getaddrinfo failed: Try again',
+            'SQLSTATE[HY000] [2002] php_network_getaddresses: getaddrinfo failed: Name or service not known',
             'SQLSTATE[HY000]: General error: 7 SSL SYSCALL error: EOF detected',
             'SQLSTATE[HY000] [2002] Connection timed out',
             'SSL: Connection timed out',


### PR DESCRIPTION
Resubmit of #35786 

----------

Recently I've been investigating some connection failures:

```
SQLSTATE[HY000] [2002] php_network_getaddresses: getaddrinfo failed: Name or service not known (SQL: select * from ...)
```

Upon investigation, I noticed that this happened about **36** times out of **130,396** requests in. Although extremely low (**0.02%**), it is still quite disruptive to have some requests throwing 500 Internal Server Error and writing database connection logs.
AWS Support has informed that due to transient network issues, it is possible that an extremely small number of connections to RDS or Elasticache might fail and that their engineers are always working on trying to reduce even further these errors. Since it's a rare event of connectivity issues, retrying the connection seem to be a viable option and doing this on my own project seems to be so much harder than using Laravel's built-in system for reconnection.