### PR TITLE
[8.x] "null" constraint prevents aliasing SQLite ROWID

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -875,7 +875,7 @@ class SQLiteGrammar extends Grammar
     protected function modifyNullable(Blueprint $blueprint, Fluent $column)
     {
         if (is_null($column->virtualAs) && is_null($column->storedAs)) {
-            return $column->nullable ? ' null' : ' not null';
+            return $column->nullable ? '' : ' not null';
         }
 
         if ($column->nullable === false) {

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -361,7 +361,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "foo" varchar null default \'bar\'', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" varchar default \'bar\'', $statements[0]);
     }
 
     public function testAddingText()
@@ -663,8 +663,8 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(2, $statements);
         $this->assertEquals([
-            'alter table "users" add column "created_at" datetime null',
-            'alter table "users" add column "updated_at" datetime null',
+            'alter table "users" add column "created_at" datetime',
+            'alter table "users" add column "updated_at" datetime',
         ], $statements);
     }
 
@@ -675,8 +675,8 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(2, $statements);
         $this->assertEquals([
-            'alter table "users" add column "created_at" datetime null',
-            'alter table "users" add column "updated_at" datetime null',
+            'alter table "users" add column "created_at" datetime',
+            'alter table "users" add column "updated_at" datetime',
         ], $statements);
     }
 
@@ -687,7 +687,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "remember_token" varchar null', $statements[0]);
+        $this->assertSame('alter table "users" add column "remember_token" varchar', $statements[0]);
     }
 
     public function testAddingBinary()


### PR DESCRIPTION
On SQLite, columns are nullable by default. Adding `null` forcibly, prevents users aliasing `ROWID` and will create another (autoincrementing in some cases) column and it's overhead in calculation (see: [SQLite ROWID and the INTEGER PRIMARY KEY](https://sqlite.org/lang_createtable.html#rowid))

To summerize SQLite documentation: by default, every table has a `rowid` column, which already is an INTEGER (64bits), is autoincrementing (not always by 1) and is unique across the table. When a column type is *exactly* `INTEGER` and a `PRIMARY KEY`, then this column is an alias of `rowid`. When the column type is `INTEGER NULL`, `INT`, `BIGINT` or anything else, it's a totally different column.

This change should be backward compatible as columns are nullable by default anyway.