### PR TITLE
Failing: Allow to create migrations based on a provider.

### DIFF
--- a/tests/Database/DatabaseMigrationMakeCommandTest.php
+++ b/tests/Database/DatabaseMigrationMakeCommandTest.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Console\Migrations\MigrateMakeCommand;
 use Illuminate\Database\Migrations\MigrationCreator;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Composer;
+use Illuminate\Tests\Database\stubs\SpecificPackageServiceProvider;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -100,6 +101,21 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $app->setBasePath('/home/laravel');
         $creator->shouldReceive('create')->once()->with('create_foo', '/home/laravel/vendor/laravel-package/migrations', 'users', true);
         $this->runCommand($command, ['name' => 'create_foo', '--path' => 'vendor/laravel-package/migrations', '--create' => 'users']);
+    }
+
+    public function testCanSpecifyServiceProviderToCreateMigrationsFor()
+    {
+        $command = new MigrateMakeCommand(
+            $creator = m::mock(MigrationCreator::class),
+            m::mock(Composer::class)->shouldIgnoreMissing()
+        );
+        $app = new Application;
+        $app->register(SpecificPackageServiceProvider::class);
+        $app->useDatabasePath(__DIR__);
+        $command->setLaravel($app);
+        $creator->shouldReceive('create')->once()->with('create_users_table', SpecificPackageServiceProvider::expectedDirectory(), 'users', true);
+
+        $this->runCommand($command, ['name' => 'create_users_table', '--provider' => '\\Illuminate\\Tests\\Database\\stubs\\SpecificPackageServiceProvider']);
     }
 
     protected function runCommand($command, $input = [])

--- a/tests/Database/stubs/SpecificPackageServiceProvider.php
+++ b/tests/Database/stubs/SpecificPackageServiceProvider.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Tests\Database\stubs;
+
+use Illuminate\Support\ServiceProvider;
+
+class SpecificPackageServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        $this->loadMigrationsFrom(__DIR__ . '/database/migrations-test-dir');
+    }
+
+    public static function expectedDirectory(): string
+    {
+        return __DIR__ . '/database/migrations-test-dir';
+    }
+}


### PR DESCRIPTION
This pull request adds a failing test for a possible make improvement.

The idea is that, for some `make` commands, we can specify a `--provider` parameter.

Then based on for example `loadMigrationsFrom` in combination with `make:migration name --provider=DomainSpecificProvider` we can ensure the migration is created in the correct directory.

I have looked to implement it, but it seems that it would need some adjustments in the `loadMigrationsFrom` method so we can resolve this easier when we are resolving the path for the migration.

Before I would dive deeper, I first wanted to make sure this feature is to be considered to be part of the Laravel commands.

I believe this will be useful for package developers and Domain-based development.