### PR TITLE
[8.x] Allow strings to be passed to the `report` function

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -586,11 +586,15 @@ if (! function_exists('report')) {
     /**
      * Report an exception.
      *
-     * @param  \Throwable  $exception
+     * @param  \Throwable|string  $exception
      * @return void
      */
-    function report(Throwable $exception)
+    function report($exception)
     {
+        if (is_string($exception)) {
+            $exception = new Exception($exception);
+        }
+
         app(ExceptionHandler::class)->report($exception);
     }
 }


### PR DESCRIPTION
Right now, if you want to report something without your code throwing an exception, you have to manually create an exception and pass that to `report`.

```php
$exception = new \Exception('Something weird occurred, that I want to report, but no exception was thrown'); 

report($exception);
```

With the change in this PR, that can be simplified, you can just pass a string to `report`.

```php
report('something weird occurred');
```

I didn't find any tests for the `report` function, so I didn't add any. I will gladly add tests if you point where they should be added.
