### PR TITLE
[8.x] Use alias to 'rowid' when using SQLite

### DIFF
--- a/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
+++ b/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
@@ -147,11 +147,17 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
     {
         $schema = $this->getConnection()->getSchemaBuilder();
 
-        $schema->create($this->table, function ($table) {
+        $schema->create($this->table, function ($table) use ($schema) {
             // The migrations table is responsible for keeping track of which of the
             // migrations have actually run for the application. We'll create the
             // table to hold the migration file's path as well as the batch ID.
-            $table->increments('id');
+
+            // In case of sqlite, we use the alias to 'rowid' column
+            if ($schema->getConnection()->getDriverName() === 'sqlite') {
+                $table->integer('id')->primary();
+            } else {
+                $table->increments('id');
+            }
             $table->string('migration');
             $table->integer('batch');
         });


### PR DESCRIPTION
See #35792

Using this syntax removes the unnecessary `sqlite_sequence` table created by `sqlite` to keep track of `AUTOINCREMENT` values.

This PR makes me wonder if it wouldn't be a better idea to change the way `$table->…Increments()` are compiled with `sqlite` instead.