### PR TITLE
[8.x] The request helper might return null, update docblock to reflect this

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -605,7 +605,7 @@ if (! function_exists('request')) {
      *
      * @param  array|string|null  $key
      * @param  mixed  $default
-     * @return \Illuminate\Http\Request|string|array
+     * @return \Illuminate\Http\Request|string|array|null
      */
     function request($key = null, $default = null)
     {


### PR DESCRIPTION
## Problem

Let's say a request has the following properties:
```
id: int
foo: string
```

And I use `request()` helper in the following way:

```php
$value = request('bar');
```

In this case, the request helper gets a closure from the __get function on the Request class. It resolves the value in the closure (which in this case checks the Router for values), it finally returns `null`.

So in this case, the `request()` function returns `null`, while the defined return type (docblock) is `\Illuminate\Http\Request|string|array`.

## Solution

I have updated the docblock to also include `null` as a possible return value.

---

As for testing, I have not been able to find a test for the request helper. So I'm not sure if it is expected to update a test in this case.

Also, stuff like this seems preventable with static analysis, is there a reason why there is no PHPStan or Psalm in this project?