### PR TITLE
[8.x] Adds functionality to skip specific eloquent events

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -340,9 +340,10 @@ trait HasEvents
     /**
      * Remove all of the event listeners for the model.
      *
+     * @param  string[]  $events
      * @return void
      */
-    public static function flushEventListeners()
+    public static function flushEventListeners(array $events = [])
     {
         if (! isset(static::$dispatcher)) {
             return;
@@ -350,11 +351,13 @@ trait HasEvents
 
         $instance = new static;
 
-        foreach ($instance->getObservableEvents() as $event) {
-            static::$dispatcher->forget("eloquent.{$event}: ".static::class);
-        }
+        $events = $events ?: array_merge(
+            $instance->getObservableEvents(),
+            array_values($instance->dispatchesEvents)
+        );
 
-        foreach (array_values($instance->dispatchesEvents) as $event) {
+        foreach ($events as $event) {
+            static::$dispatcher->forget("eloquent.{$event}: ".static::class);
             static::$dispatcher->forget($event);
         }
     }

--- a/tests/Integration/Database/EloquentModelCustomEventsTest.php
+++ b/tests/Integration/Database/EloquentModelCustomEventsTest.php
@@ -21,41 +21,76 @@ class EloquentModelCustomEventsTest extends DatabaseTestCase
             $table->increments('id');
         });
 
-        Event::listen(CustomEvent::class, function () {
-            $_SERVER['fired_event'] = true;
+        Event::listen(CustomCreatedEvent::class, function () {
+            $_SERVER['fired_created_event'] = true;
+        });
+
+        Event::listen(CustomUpdatedEvent::class, function () {
+            $_SERVER['fired_updated_event'] = true;
         });
     }
 
     public function testFlushListenersClearsCustomEvents()
     {
-        $_SERVER['fired_event'] = false;
+        $_SERVER['fired_created_event'] = false;
+        $_SERVER['fired_updated_event'] = false;
 
         TestModel1::flushEventListeners();
 
-        TestModel1::create();
+        $model = TestModel1::create();
+        $model->update();
 
-        $this->assertFalse($_SERVER['fired_event']);
+        $this->assertFalse($_SERVER['fired_created_event']);
+        $this->assertFalse($_SERVER['fired_updated_event']);
+    }
+
+
+    public function testFlushListenersClearsCustomEventsWithName()
+    {
+        $_SERVER['fired_created_event'] = false;
+        $_SERVER['fired_updated_event'] = false;
+
+        TestModel1::flushEventListeners([CustomCreatedEvent::class]);
+
+        $model = TestModel1::create();
+        $model->increment('id');
+
+        $this->assertFalse($_SERVER['fired_created_event']);
+        $this->assertTrue($_SERVER['fired_updated_event']);
     }
 
     public function testCustomEventListenersAreFired()
     {
-        $_SERVER['fired_event'] = false;
+        $_SERVER['fired_created_event'] = false;
+        $_SERVER['fired_updated_event'] = false;
 
-        TestModel1::create();
+        TestModel1::flushEventListeners([CustomUpdatedEvent::class]);
 
-        $this->assertTrue($_SERVER['fired_event']);
+        $model = TestModel1::create();
+        $model->increment('id');
+
+        $this->assertTrue($_SERVER['fired_created_event']);
+        $this->assertFalse($_SERVER['fired_updated_event']);
     }
 }
 
 class TestModel1 extends Model
 {
-    public $dispatchesEvents = ['created' => CustomEvent::class];
+    public $dispatchesEvents = [
+        'created' => CustomCreatedEvent::class,
+        'updated' => CustomUpdatedEvent::class,
+    ];
     public $table = 'test_model1';
     public $timestamps = false;
     protected $guarded = [];
 }
 
-class CustomEvent
+class CustomCreatedEvent
+{
+    //
+}
+
+class CustomUpdatedEvent
 {
     //
 }

--- a/tests/Integration/Database/EloquentModelWithoutEventsTest.php
+++ b/tests/Integration/Database/EloquentModelWithoutEventsTest.php
@@ -18,6 +18,7 @@ class EloquentModelWithoutEventsTest extends DatabaseTestCase
         Schema::create('auto_filled_models', function (Blueprint $table) {
             $table->increments('id');
             $table->text('project')->nullable();
+            $table->integer('stars')->default(0);
         });
     }
 
@@ -33,6 +34,30 @@ class EloquentModelWithoutEventsTest extends DatabaseTestCase
 
         $this->assertSame('Laravel', $model->project);
     }
+
+    public function testWithoutEventsRegistersBootedListenersForLaterWithName()
+    {
+        AutoFilledModel::flushEventListeners(['saving']);
+        $model = AutoFilledModel::create();
+        $this->assertNull($model->project);
+        $this->assertSame(1, $model->stars);
+    }
+
+    public function testWithoutEventsRegistersBootedListeners()
+    {
+        AutoFilledModel::flushEventListeners();
+        $model = AutoFilledModel::create();
+        $this->assertNull($model->project);
+        $this->assertNull($model->stars);
+    }
+
+    public function testWithoutEventsRegistersBootedListenersWithName()
+    {
+        AutoFilledModel::flushEventListeners(['created']);
+        $model = AutoFilledModel::create();
+        $this->assertSame('Laravel', $model->project);
+        $this->assertNull($model->stars);
+    }
 }
 
 class AutoFilledModel extends Model
@@ -47,6 +72,10 @@ class AutoFilledModel extends Model
 
         static::saving(function ($model) {
             $model->project = 'Laravel';
+        });
+
+        static::created(function ($model) {
+            $model->increment('stars');
         });
     }
 }


### PR DESCRIPTION
This PR adds an attribute of type `string []` to the `flushEventListeners` function and allows to omit custom events and eloquent events.

Usage:

```php

MyModel extends Model
{
    protected $dispatchesEvents = ['deleted' => MyCustomDeletedAction::class];

    protected static function  booted()
    {
        parent::booted();
        
        static::created(fn ($model) => /* do something.. */);

        static::updated(fn ($model) => /* do something.. */);
    }
}

MyModel::flushEventListeners(['created']); // Flush only created eloquent event.
MyModel::flushEventListeners([MyCustomDeletedAction::class]); // Flush custom event.
MyModel::flushEventListeners(); // Flush all

```

fix #35818 