### PR TITLE
[8.x] Fix morphTo attempting to map an empty string morph type to an instance

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -256,7 +256,7 @@ trait HasRelationships
         // If the type value is null it is probably safe to assume we're eager loading
         // the relationship. In this case we'll just pass in a dummy query where we
         // need to remove any eager loads that may already be defined on a model.
-        return is_null($class = $this->getAttributeFromArray($type))
+        return is_null($class = $this->getAttributeFromArray($type)) || $class === ''
                     ? $this->morphEagerTo($name, $type, $id, $ownerKey)
                     : $this->morphInstanceTo($class, $name, $type, $id, $ownerKey);
     }

--- a/tests/Database/DatabaseEloquentMorphToTest.php
+++ b/tests/Database/DatabaseEloquentMorphToTest.php
@@ -100,6 +100,16 @@ class DatabaseEloquentMorphToTest extends TestCase
         $parent->relation();
     }
 
+    public function testMorphToWithEmptyStringMorphType()
+    {
+        $parent = $this->getMockBuilder(EloquentMorphToModelStub::class)->onlyMethods(['getAttributeFromArray', 'morphEagerTo', 'morphInstanceTo'])->getMock();
+        $parent->method('getAttributeFromArray')->with('relation_type')->willReturn('');
+        $parent->expects($this->once())->method('morphEagerTo');
+        $parent->expects($this->never())->method('morphInstanceTo');
+
+        $parent->relation();
+    }
+
     public function testMorphToWithSpecifiedClassDefault()
     {
         $parent = new EloquentMorphToModelStub;


### PR DESCRIPTION
After upgrading to 8 our morphTo relations started throwing exceptions.

#35364 allowed mapping literal 0 in morphType, this was backported to 6.x and 7.x with an additional check to not attempt to map an empty string to a type (#35487). This PR adds the empty string check into 8.x.