### PR TITLE
[8.x] Fix bug with RetryCommand

### DIFF
--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Queue\Console;
 
+use DateTimeInterface;
 use Illuminate\Console\Command;
 use Illuminate\Support\Arr;
 
@@ -133,7 +134,11 @@ class RetryCommand extends Command
         $instance = unserialize($payload['data']['command']);
 
         if (is_object($instance) && method_exists($instance, 'retryUntil')) {
-            $payload['retryUntil'] = $instance->retryUntil()->timestamp;
+            $retryUntil = $instance->retryUntil();
+
+            $payload['retryUntil'] = $retryUntil instanceof DateTimeInterface
+                                        ? $retryUntil->getTimestamp()
+                                        : $retryUntil;
         }
 
         return json_encode($payload);


### PR DESCRIPTION
This fixes an issue where a bug can happen if `retryUntil` doesn't returns a `DateTimeInterface` object but rather an integer timestamp or `null`.

Fixes https://github.com/laravel/framework/issues/35825