### PR TITLE
[8.x] create Collection `transformWithKeys` method

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1307,26 +1307,14 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
-     * Run an associative map over each of the items.
-     *
-     * The callback should return an associative array with a single key/value pair.
+     * Transform each item in the collection to key/value pairs using a callback.
      *
      * @param  callable  $callback
      * @return $this
      */
     public function transformWithKeys(callable $callback)
     {
-        $result = [];
-
-        foreach ($this->items as $key => $value) {
-            $assoc = $callback($value, $key);
-
-            foreach ($assoc as $mapKey => $mapValue) {
-                $result[$mapKey] = $mapValue;
-            }
-        }
-
-        $this->items = $result;
+        $this->items = $this->mapWithKeys($callback)->all();
 
         return $this;
     }

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1307,6 +1307,31 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
+     * Run an associative map over each of the items.
+     *
+     * The callback should return an associative array with a single key/value pair.
+     *
+     * @param  callable  $callback
+     * @return $this
+     */
+    public function transformWithKeys(callable $callback)
+    {
+        $result = [];
+
+        foreach ($this->items as $key => $value) {
+            $assoc = $callback($value, $key);
+
+            foreach ($assoc as $mapKey => $mapValue) {
+                $result[$mapKey] = $mapValue;
+            }
+        }
+
+        $this->items = $result;
+
+        return $this;
+    }
+
+    /**
      * Reset the keys on the underlying array.
      *
      * @return static

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2626,6 +2626,15 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['first' => 'first-rolyat', 'last' => 'last-llewto'], $data->all());
     }
 
+    public function testTransformWithKeys()
+    {
+        $data = new Collection(['first' => 'taylor', 'last' => 'otwell']);
+        $data->transformWithKeys(function ($item, $key) {
+            return [$item => $key];
+        });
+        $this->assertEquals(['taylor' => 'first', 'otwell' => 'last'], $data->all());
+    }
+
     /**
      * @dataProvider collectionClassProvider
      */


### PR DESCRIPTION
This method is a mix between the `mapWithKeys` and the `transform` method. It maps the items into key value pairs instantly on the collection itself, instead of creating a new collection instance.

This is a small addition to optionally make the code a little cleaner so instead of

`$data = collect(['first' => 'taylor', 'last' => 'otwell']);`

`$data = $data->mapWithKeys(function ($item, $key) {`
    `return [$item => $key];`
`});`

you can do this:

`$data = collect(['first' => 'taylor', 'last' => 'otwell']);`

`$data->transformWithKeys(function ($item, $key) {`
`    return [$item => $key];`
`});`
