### PR TITLE
[8.x] If Symfony throws a Runtime exception, check if it's a 'Not enough arguments' error

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -123,12 +123,10 @@ class Command extends SymfonyCommand
                 $this->input = $input, $this->output
             );
         } catch (\Symfony\Component\Console\Exception\RuntimeException $e) {
-            $message = $e->getMessage();
-            if (Str::startsWith($message, 'Not enough arguments')) {
-                $this->output->writeln(sprintf('<comment>Usage:</comment>'));
-                $this->output->writeln(sprintf('  <info>%s</info>', sprintf($this->getSynopsis(), $this->getName())), OutputInterface::VERBOSITY_QUIET);
-                $this->output->writeln('', OutputInterface::VERBOSITY_QUIET);
-            }
+            $this->output->writeln(sprintf('<comment>Usage:</comment>'));
+            $this->output->writeln(sprintf('  <info>%s</info>', sprintf($this->getSynopsis(), $this->getName())), OutputInterface::VERBOSITY_QUIET);
+            $this->output->writeln('', OutputInterface::VERBOSITY_QUIET);
+
             throw $e;
         }
     }

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -121,14 +121,15 @@ class Command extends SymfonyCommand
             return parent::run(
                 $this->input = $input, $this->output
             );
-        } catch(\Symfony\Component\Console\Exception\RuntimeException $e) {
+        } catch (\Symfony\Component\Console\Exception\RuntimeException $e) {
             $message = $e->getMessage();
-            $notEnoughArgumentsMessage = "Not enough arguments";
+            $notEnoughArgumentsMessage = 'Not enough arguments';
             if (substr($message, 0, strlen($notEnoughArgumentsMessage)) == $notEnoughArgumentsMessage) {
                 $this->output->error(sprintf('%s', $e->getMessage()));
                 $this->output->writeln(sprintf('<comment>Usage:</comment>'));
                 $this->output->writeln(sprintf('  <info>%s</info>', sprintf($this->getSynopsis(), $this->getName())), OutputInterface::VERBOSITY_QUIET);
                 $this->output->writeln('', OutputInterface::VERBOSITY_QUIET);
+
                 return;
             }
             throw $e;

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -125,12 +125,9 @@ class Command extends SymfonyCommand
         } catch (\Symfony\Component\Console\Exception\RuntimeException $e) {
             $message = $e->getMessage();
             if (Str::startsWith($message, 'Not enough arguments')) {
-                $this->output->error(sprintf('%s', $e->getMessage()));
                 $this->output->writeln(sprintf('<comment>Usage:</comment>'));
                 $this->output->writeln(sprintf('  <info>%s</info>', sprintf($this->getSynopsis(), $this->getName())), OutputInterface::VERBOSITY_QUIET);
                 $this->output->writeln('', OutputInterface::VERBOSITY_QUIET);
-
-                return 1;
             }
             throw $e;
         }

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Console;
 
+use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
 use Symfony\Component\Console\Input\InputInterface;
@@ -123,14 +124,13 @@ class Command extends SymfonyCommand
             );
         } catch (\Symfony\Component\Console\Exception\RuntimeException $e) {
             $message = $e->getMessage();
-            $notEnoughArgumentsMessage = 'Not enough arguments';
-            if (substr($message, 0, strlen($notEnoughArgumentsMessage)) == $notEnoughArgumentsMessage) {
+            if (Str::startsWith($message, 'Not enough arguments')) {
                 $this->output->error(sprintf('%s', $e->getMessage()));
                 $this->output->writeln(sprintf('<comment>Usage:</comment>'));
                 $this->output->writeln(sprintf('  <info>%s</info>', sprintf($this->getSynopsis(), $this->getName())), OutputInterface::VERBOSITY_QUIET);
                 $this->output->writeln('', OutputInterface::VERBOSITY_QUIET);
 
-                return;
+                return 1;
             }
             throw $e;
         }

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -117,9 +117,22 @@ class Command extends SymfonyCommand
             OutputStyle::class, ['input' => $input, 'output' => $output]
         );
 
-        return parent::run(
-            $this->input = $input, $this->output
-        );
+        try {
+            return parent::run(
+                $this->input = $input, $this->output
+            );
+        } catch(\Symfony\Component\Console\Exception\RuntimeException $e) {
+            $message = $e->getMessage();
+            $notEnoughArgumentsMessage = "Not enough arguments";
+            if (substr($message, 0, strlen($notEnoughArgumentsMessage)) == $notEnoughArgumentsMessage) {
+                $this->output->error(sprintf('%s', $e->getMessage()));
+                $this->output->writeln(sprintf('<comment>Usage:</comment>'));
+                $this->output->writeln(sprintf('  <info>%s</info>', sprintf($this->getSynopsis(), $this->getName())), OutputInterface::VERBOSITY_QUIET);
+                $this->output->writeln('', OutputInterface::VERBOSITY_QUIET);
+                return;
+            }
+            throw $e;
+        }
     }
 
     /**

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Console;
 
-use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
 use Symfony\Component\Console\Input\InputInterface;


### PR DESCRIPTION
When running an artisan command, if you do not provide enough of the right arguments, artisan will dump a stack trace of the error and print a generic message. Why not instead suppress the exception trace (it's not helpful) and print the command usage (which is helpful).

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
