### PR TITLE
[8.x] Add array support on route actions

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -210,7 +210,9 @@ class Route
      */
     protected function isControllerAction()
     {
-        return is_string($this->action['uses']) && ! $this->isSerializedClosure();
+        $uses = $this->action['uses'];
+
+        return (is_string($uses) || is_array($uses)) && ! $this->isSerializedClosure();
     }
 
     /**
@@ -285,10 +287,22 @@ class Route
      * Parse the controller.
      *
      * @return array
+     *
+     * @throws \LogicException
      */
     protected function parseControllerCallback()
     {
-        return Str::parseCallback($this->action['uses']);
+        $uses = $this->action['uses'];
+
+        if (is_string($uses)) {
+            return Str::parseCallback($uses);
+        }
+
+        if (is_array($uses) && count($uses) === 2) {
+            return $uses;
+        }
+
+        throw new LogicException('Invalid route definition.');
     }
 
     /**

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1729,6 +1729,39 @@ class RoutingRouteTest extends TestCase
         $this->assertSame('hello', $router->dispatch(Request::create('foo/bar2', 'GET'))->getContent());
     }
 
+    public function testDispatchingAction()
+    {
+        $router = $this->getRouter();
+
+        $router->get('foo/bar', [
+            'as' => 'foo.bar',
+            'uses' => [ActionStub::class, '__invoke'],
+        ]);
+
+        $this->assertSame('hello', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
+
+        $router->get('foo/bar', [
+            'as' => 'foo.bar',
+            'uses' => [ActionStub::class, 'foo'],
+        ]);
+
+        $this->assertSame('bar', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
+    }
+
+    public function testDispatchingInvalidAction()
+    {
+        $this->expectException(LogicException::class);
+
+        $router = $this->getRouter();
+
+        $router->get('foo/bar', [
+            'as' => 'foo.bar',
+            'uses' => [ActionStub::class],
+        ]);
+
+        $this->assertSame('hello', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
+    }
+
     public function testResponseIsReturned()
     {
         $router = $this->getRouter();
@@ -2261,6 +2294,11 @@ class ActionStub
     public function __invoke()
     {
         return 'hello';
+    }
+
+    public function foo()
+    {
+        return 'bar';
     }
 }
 


### PR DESCRIPTION
Currently, the "uses" of the action definition only accepts strings:

```php
$router->get('/', [
    'as' => 'my_route',
    'uses' => 'App/Controllers/MyController@method',
]);

// Or

$router->get('/', [
    'as' => 'my_route',
    'uses' => MyController::class . '@method',
]);
```

This change brings the ability to do the same but using an array.

```php
$router->get('/', [
    'as' => 'my_route',
    'uses' => [MyController::class, 'method'],
]);
```

Personally, I find this a way better to read. I use a lot this style of definition in my projects.

What do you guys think?