### PR TITLE
[8.x] Add ::assertNothingDispatched() to Events::fake

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -107,6 +107,21 @@ class EventFake implements Dispatcher
     }
 
     /**
+     * Assert if no event was dispatched.
+     *
+     * @return void
+     */
+    public function assertNothingDispatched()
+    {
+        $count = count(Arr::flatten($this->events));
+
+        PHPUnit::assertSame(
+            0, $count,
+            "Unexpected {$count} events were dispatched."
+        );
+    }
+
+    /**
      * Get all of the events matching a truth-test callback.
      *
      * @param  string  $event

--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -107,7 +107,7 @@ class EventFake implements Dispatcher
     }
 
     /**
-     * Assert if no event was dispatched.
+     * Assert that no events were dispatched.
      *
      * @return void
      */
@@ -117,7 +117,7 @@ class EventFake implements Dispatcher
 
         PHPUnit::assertSame(
             0, $count,
-            "Unexpected {$count} events were dispatched."
+            "{$count} unexpected events were dispatched."
         );
     }
 

--- a/tests/Support/SupportTestingEventFakeTest.php
+++ b/tests/Support/SupportTestingEventFakeTest.php
@@ -130,7 +130,7 @@ class SupportTestingEventFakeTest extends TestCase
             $this->fake->assertNothingDispatched();
             $this->fail();
         } catch (ExpectationFailedException $e) {
-            $this->assertThat($e, new ExceptionMessage('Unexpected 2 events were dispatched.'));
+            $this->assertThat($e, new ExceptionMessage('2 unexpected events were dispatched.'));
         }
     }
 }

--- a/tests/Support/SupportTestingEventFakeTest.php
+++ b/tests/Support/SupportTestingEventFakeTest.php
@@ -118,6 +118,21 @@ class SupportTestingEventFakeTest extends TestCase
         $fake->assertDispatched('Bar');
         $fake->assertNotDispatched('Baz');
     }
+
+    public function testAssertNothingDispatched()
+    {
+        $this->fake->assertNothingDispatched();
+
+        $this->fake->dispatch(EventStub::class);
+        $this->fake->dispatch(EventStub::class);
+
+        try {
+            $this->fake->assertNothingDispatched();
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('Unexpected 2 events were dispatched.'));
+        }
+    }
 }
 
 class EventStub


### PR DESCRIPTION
Add a new assertion `assertNothingDispatched()` to `Event::fake()` mock. Currently all the assertion for Events require a specific event to be provided, this will catch "any" event.

Example:

```php
Event::fake();

// Function that should NOT dispatch any event

Event::assertNothingDispatched();
```