### PR TITLE
[8.x] Use `->toBase()` in `->cursor()`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -670,7 +670,7 @@ class Builder
      */
     public function cursor()
     {
-        return $this->applyScopes()->query->cursor()->map(function ($record) {
+        return $this->toBase()->cursor()->map(function ($record) {
             return $this->newModelInstance()->newFromBuilder($record);
         });
     }


### PR DESCRIPTION
This PR changes the `->cursor()` implementation to leverage the `->toBase()` method in order to increase consistency through `Eloquent\Builder` methods.

I noticed this was the only place that seemed inconsistent when I was preparing another PR I will send later.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
