### PR TITLE
[9.x] Add passthru methods to eloquent builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -77,6 +77,7 @@ class Builder
     protected $passthru = [
         'insert', 'insertOrIgnore', 'insertGetId', 'insertUsing', 'getBindings', 'toSql', 'dump', 'dd',
         'exists', 'doesntExist', 'count', 'min', 'max', 'avg', 'average', 'sum', 'getConnection', 'raw', 'getGrammar',
+        'newQuery', 'getProcessor', 'implode', 'aggregate', 'numericAggregate',
     ];
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

While working on  a project that used a `Scope` I noticed that the line marked below with `HERE`:

~~~php
<?php

namespace App;

use Illuminate\Database\Eloquent\Builder;
use Illuminate\Database\Eloquent\Model;
use Illuminate\Database\Eloquent\Scope;

class SampleScope implements Scope
{
    public function apply(Builder $builder, Model $model)
    {
        $query = $builder->newQuery(); // <<< HERE

        // ... add constraints to query

        $builder->whereIn('column', $query->pluck('id'));
    }
}
~~~

Did not return a clean query builder instance.

That is due to how the `Eloquent\Builder` handles non-existent methods on its magic `__call()` method. 

The return value for methods listed in its `$passthru` property are preserved, whereas the return value for other methods is the `Eloquent\Builder` itself as they are called using the `ForwardsCalls` trait, so any value returned is ignored. In this case the new base query instance I was expecting.

I searched the `Query\Builder` for all methods that return a value other than the builder instance **and** that were not ywet listed in the `$passthru` property or overriden. I found the following methods:

- **Group 1**: `newQuery`, `getProcessor`, `implode`, `aggregate`, `numericAggregate`
- **Group 2**: `prepareValueAndOperator`, `getCountForPagination`, `existsOr`, `doesntExistOr`, `truncate`, `getRawBindings`, `cleanBindings`, `updateOrInsert`
- **Group 3**: `clone`, `cloneWithout`, `cloneWithoutBindings`

*I grouped them like this to make the following discussion easier*

Methods listed in **Group 1** were already added to the `Eloquent\Builder`'s `$passtrhu` property in this PR as they seem harmless, or have similar methods already listed on that property (for example `aggregate`). As this is theoretically a breaking change, due to the return value from an `Eloquent\Builder` being changed I sent this PR to the master branch.

No tests were added as they are tested in the `Query\Builder` instance, and I didn't find direct tests for the other methods listed on the `$passthru` property from an `Eloquent\Builder` instance.

Methods listed in **Group 2** and **Group 3** were not added yet in this PR due to the following reasons:

### Group 2

Adding methods in **Group 2** seemed to me to not having any added benefit to the developer, or maybe they need to be overridden for better compatibility, or they looked like a bug fix.

Two methods I was tempted on adding were the `existsOr`, `doesntExistOr` as if a developer call them on an `Eloquent\Builder` instance they won't get a boolean or the callback result back, but the `Eloquent\Builder` instance which will evaluate to `true` in a `if` clause. You can test it in a plain Laravel app as this:

~~~php
Route::get('/', function () {
    dd(\App\Models\User::existsOr(fn() => false));
});
~~~

I can add those methods to the `$passthru` property in this PR if you think it is ok to do so.

### Group 3

I was afraid on adding methods in Group 3 as they would return a clone from the `Query\Builder` and not from the `Eloquent\Builder`, and that could cause confusion for developers.

Right now calling those as this: 

~~~php
Route::get('/', function () {
    $builder = \App\Models\User::query();

    dd($builder, $builder->clone());
});
~~~

Dumps the same instance, with the same underlying `Query\Builder` instance, as the `->clone()` call is not *"passed thru*", but called using the `ForwardsCalls` trait, thus its return value is never used.

It seems to me they need to be overridden on the `Eloquent\Builder`, but I let the decision to be discussed and maybe attempted on a new PR.