### PR TITLE
[8.x] Add reduce with keys to collections and lazy collections

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -885,6 +885,24 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
+     * Reduce an associative collection to a single value.
+     *
+     * @param  callable  $callback
+     * @param  mixed $initial
+     * @return mixed
+     */
+    public function reduceWithKeys(callable $callback, $initial = null)
+    {
+        $result = $initial;
+
+        foreach($this->items as $key => $value) {
+            $result = $callback($result, $value, $key);
+        }
+
+        return $result;
+    }
+
+    /**
      * Replace the collection items with the given items.
      *
      * @param  mixed  $items

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -895,7 +895,7 @@ class Collection implements ArrayAccess, Enumerable
     {
         $result = $initial;
 
-        foreach($this->items as $key => $value) {
+        foreach ($this->items as $key => $value) {
             $result = $callback($result, $value, $key);
         }
 

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -846,6 +846,24 @@ class LazyCollection implements Enumerable
     }
 
     /**
+     * Reduce an associative collection to a single value.
+     *
+     * @param  callable  $callback
+     * @param  mixed $initial
+     * @return mixed
+     */
+    public function reduceWithKeys(callable $callback, $initial = null)
+    {
+        $result = $initial;
+
+        foreach($this as $key => $value) {
+            $result = $callback($result, $value, $key);
+        }
+
+        return $result;
+    }
+
+    /**
      * Replace the collection items with the given items.
      *
      * @param  mixed  $items

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -856,7 +856,7 @@ class LazyCollection implements Enumerable
     {
         $result = $initial;
 
-        foreach($this as $key => $value) {
+        foreach ($this as $key => $value) {
             $result = $callback($result, $value, $key);
         }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3602,7 +3602,7 @@ class SupportCollectionTest extends TestCase
             'baz' => 'qux',
         ]);
         $this->assertEquals('foobarbazqux', $data->reduceWithKeys(function ($carry, $element, $key) {
-            return $carry .= $key . $element;
+            return $carry .= $key.$element;
         }));
     }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3595,6 +3595,20 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testReduceWithKeys($collection)
+    {
+        $data = new $collection([
+            'foo' => 'bar',
+            'baz' => 'qux',
+        ]);
+        $this->assertEquals('foobarbazqux', $data->reduceWithKeys(function ($carry, $element, $key) {
+            return $carry .= $key . $element;
+        }));
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testRandomThrowsAnExceptionUsingAmountBiggerThanCollectionSize($collection)
     {
         $this->expectException(InvalidArgumentException::class);


### PR DESCRIPTION
This adds the method `reduceWithKeys` to `Collection`s and `LazyCollection`s.
Similar to `map` and `mapWithKeys`, this augments `reduce` to pass associative arrays' keys to its callback. We can't do that currently because php's `array_reduce` doesn't pass array keys to its callback.

So, you can do this:
```php
$data = collect([
    'name' => 'Mo Khosh',
    'username' => 'mokhosh',
]);

return $data->reduceWithKeys(function($carry, $value, $key) {
    return $carry . $key . ': ' . $value . PHP_EOL;
});
```

I tried to mirror what's already been done with `map`, `mapWithKeys`, `reduce`, and respective tests.