### PR TITLE
Added argument transformNullToEmptyString to the functions old() and …

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -526,11 +526,12 @@ if (! function_exists('old')) {
      *
      * @param  string|null  $key
      * @param  mixed  $default
+     * @param  bool  $transformNullToEmptyString
      * @return mixed
      */
-    function old($key = null, $default = null)
+    function old($key = null, $default = null, $transformNullToEmptyString = false)
     {
-        return app('request')->old($key, $default);
+        return app('request')->old($key, $default, $transformNullToEmptyString);
     }
 }
 

--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -248,11 +248,18 @@ class Store implements Session
      *
      * @param  string|null  $key
      * @param  mixed  $default
+     * @param  bool  $transformNullToEmptyString
      * @return mixed
      */
-    public function getOldInput($key = null, $default = null)
+    public function getOldInput($key = null, $default = null, $transformNullToEmptyString = false)
     {
-        return Arr::get($this->get('_old_input', []), $key, $default);
+        $oldInputs = $this->get('_old_input', []);
+        $result = Arr::get($oldInputs, $key, $default);
+
+        if ($transformNullToEmptyString && is_null($result) && Arr::has($oldInputs, $key)) {
+            return '';
+        }
+        return $result;
     }
 
     /**

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -226,7 +226,7 @@ class SessionStoreTest extends TestCase
     {
         $session = $this->getSession();
         $session->put('boom', 'baz');
-        $session->flashInput(['foo' => 'bar', 'bar' => 0]);
+        $session->flashInput(['foo' => 'bar', 'bar' => 0, 'name' => null]);
 
         $this->assertTrue($session->hasOldInput('foo'));
         $this->assertSame('bar', $session->getOldInput('foo'));
@@ -239,6 +239,11 @@ class SessionStoreTest extends TestCase
         $this->assertSame('bar', $session->getOldInput('foo'));
         $this->assertEquals(0, $session->getOldInput('bar'));
         $this->assertFalse($session->hasOldInput('boom'));
+
+        $this->assertSame('default', $session->getOldInput('input', 'default'));
+        $this->assertSame('default', $session->getOldInput('input', 'default', true));
+        $this->assertSame('', $session->getOldInput('name', 'default', true));
+        $this->assertSame(null, $session->getOldInput('name', 'default'));
     }
 
     public function testDataFlashing()


### PR DESCRIPTION
…getOldInput() and added tests

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

I implemented this feature: https://github.com/laravel/ideas/issues/1826

Basically I modified the old() and getOldInput() functions to work nicely with the ConvertEmptyStringsToNull middleware. At the moment when you are making an update form (or a create form with a default non empty value) you can't use the old() helper function. Because if a specific field already has a value and the user removes this value in the form, the empty value is overridden with the existing value (or the default value). Which is not the intended behavior and makes the old() function rather useless at the moment. The only way to properly use the old() function at the moment is by not using the ConvertEmptyStringsToNull middleware. But this is a default middleware so in my opinion it makes sense that the old() function can handle this properly.

This shouldn't break anything. I added a default value of false and the tests are all working. I also added some extra tests (asserts) cases that weren't covered yet and added tests for the new feature itself.

Personally I think it would make sense to make the default value equal true. But this would be a breaking change, that's why I used false.