### PR TITLE
[8.x] Fix extra attributes in loadAggregate

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -84,9 +84,9 @@ class Collection extends BaseCollection implements QueueableCollection
             ->get()
             ->keyBy($this->first()->getKeyName());
 
-        $attributes = Arr::except(
+        $attributes = array_diff(
             array_keys($models->first()->getAttributes()),
-            $models->first()->getKeyName()
+            [$models->first()->getKeyName()]
         );
 
         $this->each(function ($model) use ($models, $attributes) {


### PR DESCRIPTION
`Arr::except` does not filter out the model key, because the given array is not an associative array. Using `array_diff` works.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
