### PR TITLE
Update Str.php

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -179,12 +179,13 @@ class Str
      */
     public static function contains($haystack, $needles)
     {
-        foreach ((array) $needles as $needle) {
-            if ($needle !== '' && mb_strpos($haystack, $needle) !== false) {
-                return true;
+        if($haystack !== null && is_string($haystack)){
+            foreach ((array) $needles as $needle) {
+                if ($needle !== '' && mb_strpos($haystack, $needle) !== false) {
+                    return true;
+                }
             }
         }
-
         return false;
     }
 


### PR DESCRIPTION
When $haystack is null or is not a string, mb_strpos throws a 500 PHP error. I'm not sure how I got the 500 error, but have three environments in the same server sharing the same database, all running the same app with different subdomains. Session is managed with the files drive, but cache uses the database driver. Two sites run as expected, and the other one wasn't able to handle the request. After checking the PHP error log:

[proxy_fcgi:error] [pid 256670] [client 190.104.120.178:59913] AH01071: Got error 'PHP message: PHP Fatal error:  Uncaught TypeError: mb_strpos(): Argument #1 ($haystack) must be of type string, null given, called in /var/www/test2.readforall.com/vendor/laravel/framework/src/Illuminate/Support/Str.php on line 177 and defined in /var/www/test2.readforall.com/vendor/symfony/polyfill-mbstring/bootstrap80.php:60\nStack trace:\n#0 /var/www/test2.readforall.com/vendor/laravel/framework/src/Illuminate/Support/Str.php(177): mb_strpos()\n#1 /var/www/test2.readforall.com/vendor/laravel/framework/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php(34): Illuminate\\Support\\Str::contains()\n#2 /var/www/test2.readforall.com/vendor/laravel/framework/src/Illuminate/Http/Request.php(371): Illuminate\\Http\\Request->isJson()\n#3 /var/www/test2.readforall.com/vendor/laravel/framework/src/Illuminate/Http/Request.php(435): Illuminate\\Http\\Request->getInputSource()\n#4 /var/www/test2.readforall.com/vendor/laravel/framework/src/Illuminate/Http/Request.php(64): Illuminate\\Http\\Request::createFromBase()\n#...'

And adding the propose change, I was able to run the application as expected.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
