### PR TITLE
[8.x] Prevent superfluent attribute casts when comparing old and new

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1558,7 +1558,7 @@ trait HasAttributes
 
         if ($attribute === $original) {
             return true;
-        } elseif (is_null($attribute)) {
+        } elseif (is_null($attribute) || is_null($original)) {
             return false;
         } elseif ($this->isDateAttribute($key)) {
             return $this->fromDateTime($attribute) ===
@@ -1567,10 +1567,6 @@ trait HasAttributes
             return $this->castAttribute($key, $attribute) ==
                 $this->castAttribute($key, $original);
         } elseif ($this->hasCast($key, ['real', 'float', 'double'])) {
-            if (($attribute === null && $original !== null) || ($attribute !== null && $original === null)) {
-                return false;
-            }
-
             return abs($this->castAttribute($key, $attribute) - $this->castAttribute($key, $original)) < PHP_FLOAT_EPSILON * 4;
         } elseif ($this->hasCast($key, static::$primitiveCastTypes)) {
             return $this->castAttribute($key, $attribute) ===


### PR DESCRIPTION
When either is null and the other is not, they're not the same.

Check this early so fromDateTime() and/or castAttribute() are not called unnecessary. I saw 8 casts for a single attribute update from null to another value in a single save() call.

The only situation i can come up with this is not desired is if there is a cast that transforms a null to another value. But as the current is_null check is only done for the dirty value, not the original, this seems unlikely. Anyway, tests pass, so this situation is probably not anticipated.