### PR TITLE
[8.x] Allow a specific seeder to be used in tests

### DIFF
--- a/src/Illuminate/Foundation/Testing/RefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/RefreshDatabase.php
@@ -79,11 +79,15 @@ trait RefreshDatabase
      */
     protected function migrateFreshUsing()
     {
-        return [
-            '--drop-views' => $this->shouldDropViews(),
-            '--drop-types' => $this->shouldDropTypes(),
-            '--seed' => $this->shouldSeed(),
-        ];
+        $seeder = $this->seeder();
+
+        return array_merge(
+            [
+                '--drop-views' => $this->shouldDropViews(),
+                '--drop-types' => $this->shouldDropTypes(),
+            ],
+            $seeder ? ['--seeder' => $seeder] : ['--seed' => $this->shouldSeed()]
+        );
     }
 
     /**
@@ -156,5 +160,15 @@ trait RefreshDatabase
     protected function shouldSeed()
     {
         return property_exists($this, 'seed') ? $this->seed : false;
+    }
+
+    /**
+     * Determine if a specific seeder should be used.
+     *
+     * @return mixed
+     */
+    protected function seeder()
+    {
+        return property_exists($this, 'seeder') ? $this->seeder : false;
     }
 }

--- a/src/Illuminate/Foundation/Testing/RefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/RefreshDatabase.php
@@ -163,7 +163,7 @@ trait RefreshDatabase
     }
 
     /**
-     * Determine if a specific seeder should be used.
+     * Determine the specific seeder class that should be used when refreshing the database.
      *
      * @return mixed
      */


### PR DESCRIPTION
It is quite common to have a seeder filled with dummy data that makes the developer experience closer to the production app, and a separate test suite seeder that provides the basics needed to get the app started; languages, permissions levels, oauth apps etc.

This PR enables the developer to specify a seeder to be used in the `RefreshDatabase` trait. 

```php
class TasksApiTest extends TestCase 
{
    use RefreshDatabase;

    protected $seeder = TestSuiteSeeder::class;

    // ...
}
```

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
