### PR TITLE
[9.x] Make ValidatesWhenResolvedTrait::getValidatorInstance abstract

### DIFF
--- a/src/Illuminate/Validation/ValidatesWhenResolvedTrait.php
+++ b/src/Illuminate/Validation/ValidatesWhenResolvedTrait.php
@@ -44,10 +44,7 @@ trait ValidatesWhenResolvedTrait
      *
      * @return \Illuminate\Validation\Validator
      */
-    protected function getValidatorInstance()
-    {
-        return $this->validator();
-    }
+    abstract protected function getValidatorInstance();
 
     /**
      * Handle a passed validation attempt.

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -12,6 +12,7 @@ use Illuminate\Contracts\Hashing\Hasher;
 use Illuminate\Contracts\Translation\Translator as TranslatorContract;
 use Illuminate\Contracts\Validation\ImplicitRule;
 use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Contracts\Validation\ValidatesWhenResolved;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
@@ -20,6 +21,7 @@ use Illuminate\Translation\Translator;
 use Illuminate\Validation\DatabasePresenceVerifierInterface;
 use Illuminate\Validation\Rules\Exists;
 use Illuminate\Validation\Rules\Unique;
+use Illuminate\Validation\ValidatesWhenResolvedTrait;
 use Illuminate\Validation\ValidationData;
 use Illuminate\Validation\ValidationException;
 use Illuminate\Validation\Validator;
@@ -5719,6 +5721,14 @@ class ValidationValidatorTest extends TestCase
         $this->assertSame(['data.1.date' => ['validation.date'], 'data.*.date' => ['validation.date']], $validator->messages()->toArray());
     }
 
+    public function testThatCustomValidatedInstanceWork()
+    {
+        $validatedInstance = new CustomValidatedInstance();
+
+        // See that no errors are thrown
+        self::assertNull($validatedInstance->validateResolved());
+    }
+
     protected function getTranslator()
     {
         return m::mock(TranslatorContract::class);
@@ -5755,4 +5765,14 @@ class ExplicitTableAndConnectionModel extends Model
 
 class NonEloquentModel
 {
+}
+
+class CustomValidatedInstance implements ValidatesWhenResolved
+{
+    use ValidatesWhenResolvedTrait;
+
+    protected function getValidatorInstance()
+    {
+        return new Validator(new Translator(new ArrayLoader(), 'en'), [], []);
+    }
 }


### PR DESCRIPTION
We in our project use custom validator that make our work more easy and faster. It also use `ValidatesWhenResolved` interface that help laravel validate instance automatically. But trait `ValidatesWhenResolvedTrait` has bug in `getValidatorInstance()` method that use an undefined method `validator()`. This method no present nor in trait, nor in interface (that it is normal), even nor in FormRequest. Why is it needed? This method (`getValidatorInstance()`) **must** be abstract because trait does not know about validated object rules, attributes, data and cannot create right validator instance. And so we expect that trait tell us to give validator instance, but it doesn't. It's not right behavior. This PR make `getValidatorInstance()` abstract. Yes, i know that this change is more about right architecture than code but architecture is one of more important requirements for frameworks. 
