### PR TITLE
[8.x] Add sole to the query builder

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -3,6 +3,8 @@
 namespace Illuminate\Database\Concerns;
 
 use Illuminate\Container\Container;
+use Illuminate\Database\MultipleRecordsFoundException;
+use Illuminate\Database\NoRecordsFoundException;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Pagination\Paginator;
 
@@ -145,6 +147,30 @@ trait BuildsQueries
     public function first($columns = ['*'])
     {
         return $this->take(1)->get($columns)->first();
+    }
+
+    /**
+     * Execute the query and get the first result if it's the sole.
+     *
+     * @param  array|string  $columns
+     * @return \Illuminate\Database\Eloquent\Model|object|static|null
+     *
+     * @throws \Illuminate\Database\NoRecordsFoundException
+     * @throws \Illuminate\Database\MultipleRecordsFoundException
+     */
+    public function sole($columns = ['*'])
+    {
+        $result = $this->get($columns);
+
+        if ($result->isEmpty()) {
+            throw new NoRecordsFoundException();
+        }
+
+        if ($result->count() > 1) {
+            throw new MultipleRecordsFoundException();
+        }
+
+        return $result->first();
     }
 
     /**

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -160,7 +160,7 @@ trait BuildsQueries
      */
     public function sole($columns = ['*'])
     {
-        $result = $this->get($columns);
+        $result = $this->take(2)->get($columns);
 
         if ($result->isEmpty()) {
             throw new NoRecordsFoundException();

--- a/src/Illuminate/Database/MultipleRecordsFoundException.php
+++ b/src/Illuminate/Database/MultipleRecordsFoundException.php
@@ -6,5 +6,5 @@ use RuntimeException;
 
 class MultipleRecordsFoundException extends RuntimeException
 {
-
+    //
 }

--- a/src/Illuminate/Database/MultipleRecordsFoundException.php
+++ b/src/Illuminate/Database/MultipleRecordsFoundException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Database;
+
+use RuntimeException;
+
+class MultipleRecordsFoundException extends RuntimeException
+{
+
+}

--- a/src/Illuminate/Database/NoRecordsFoundException.php
+++ b/src/Illuminate/Database/NoRecordsFoundException.php
@@ -6,5 +6,5 @@ use RuntimeException;
 
 class NoRecordsFoundException extends RuntimeException
 {
-
+    //
 }

--- a/src/Illuminate/Database/NoRecordsFoundException.php
+++ b/src/Illuminate/Database/NoRecordsFoundException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Database;
+
+use RuntimeException;
+
+class NoRecordsFoundException extends RuntimeException
+{
+
+}

--- a/tests/Integration/Database/QueryBuilderTest.php
+++ b/tests/Integration/Database/QueryBuilderTest.php
@@ -3,6 +3,8 @@
 namespace Illuminate\Tests\Integration\Database;
 
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Database\MultipleRecordsFoundException;
+use Illuminate\Database\NoRecordsFoundException;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
@@ -28,6 +30,31 @@ class QueryBuilderTest extends DatabaseTestCase
             ['title' => 'Foo Post', 'content' => 'Lorem Ipsum.', 'created_at' => new Carbon('2017-11-12 13:14:15')],
             ['title' => 'Bar Post', 'content' => 'Lorem Ipsum.', 'created_at' => new Carbon('2018-01-02 03:04:05')],
         ]);
+    }
+
+    public function testSole()
+    {
+        $expected = ['id' => '1', 'title' => 'Foo Post'];
+
+        $this->assertEquals(1, DB::table('posts')->where('title', 'Foo Post')->sole()->id);
+    }
+
+    public function testSoleFailsForMultipleRecords()
+    {
+        DB::table('posts')->insert([
+            ['title' => 'Foo Post', 'content' => 'Lorem Ipsum.', 'created_at' => new Carbon('2017-11-12 13:14:15')],
+        ]);
+
+        $this->expectException(MultipleRecordsFoundException::class);
+
+        DB::table('posts')->where('title', 'Foo Post')->sole();
+    }
+
+    public function testSoleFailsIfNoRecords()
+    {
+        $this->expectException(NoRecordsFoundException::class);
+
+        DB::table('posts')->where('title', 'Baz Post')->sole();
     }
 
     public function testSelect()


### PR DESCRIPTION
Similar to Django's `get()` https://docs.djangoproject.com/en/3.1/topics/db/queries/#retrieving-a-single-object-with-get and Rails' `.sole` and `find_sole_by` https://github.com/rails/rails/blob/master/activerecord/CHANGELOG.md.

`DB::table('products')->where('ref', '#123')->sole()` will return the only record that matches the criteria, if no records found a `NoRecordsFoundException` will be thrown, and if multiple records were found a `MultipleRecordsFoundException` will be thrown.