### PR TITLE
[8.x] Update supported versions in security policy

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -6,6 +6,8 @@
 
 Version | Security Fixes Until
 --- | ---
+8 | September 8th, 2021
+7 | March 3rd, 2021
 6 (LTS) | September 3rd, 2022
 5.8	| February 26th, 2020
 5.7	| September 4th, 2019


### PR DESCRIPTION
Adds Laravel 7 and 8 to the supported versions table.