### PR TITLE
[8.x] Pass $key to closure in Collection and LazyCollection's reduce method as well

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -885,6 +885,24 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
+     * Reduce an associative collection to a single value.
+     *
+     * @param  callable  $callback
+     * @param  mixed $initial
+     * @return mixed
+     */
+    public function reduceWithKeys(callable $callback, $initial = null)
+    {
+        $result = $initial;
+
+        foreach($this->items as $key => $value) {
+            $result = $callback($result, $value, $key);
+        }
+
+        return $result;
+    }
+
+    /**
      * Replace the collection items with the given items.
      *
      * @param  mixed  $items

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -873,42 +873,6 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
-     * Reduce the collection to a single value.
-     *
-     * @param  callable  $callback
-     * @param  mixed  $initial
-     * @return mixed
-     */
-    public function reduce(callable $callback, $initial = null)
-    {
-        $result = $initial;
-
-        foreach ($this->items as $key => $value) {
-            $result = $callback($result, $value, $key);
-        }
-
-        return $result;
-    }
-
-    /**
-     * Reduce an associative collection to a single value.
-     *
-     * @param  callable  $callback
-     * @param  mixed $initial
-     * @return mixed
-     */
-    public function reduceWithKeys(callable $callback, $initial = null)
-    {
-        $result = $initial;
-
-        foreach ($this->items as $key => $value) {
-            $result = $callback($result, $value, $key);
-        }
-
-        return $result;
-    }
-
-    /**
      * Replace the collection items with the given items.
      *
      * @param  mixed  $items

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -895,7 +895,7 @@ class Collection implements ArrayAccess, Enumerable
     {
         $result = $initial;
 
-        foreach($this->items as $key => $value) {
+        foreach ($this->items as $key => $value) {
             $result = $callback($result, $value, $key);
         }
 

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -881,18 +881,6 @@ class Collection implements ArrayAccess, Enumerable
      */
     public function reduce(callable $callback, $initial = null)
     {
-        return array_reduce($this->items, $callback, $initial);
-    }
-
-    /**
-     * Reduce an associative collection to a single value.
-     *
-     * @param  callable  $callback
-     * @param  mixed $initial
-     * @return mixed
-     */
-    public function reduceWithKeys(callable $callback, $initial = null)
-    {
         $result = $initial;
 
         foreach ($this->items as $key => $value) {

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -846,6 +846,24 @@ class LazyCollection implements Enumerable
     }
 
     /**
+     * Reduce an associative collection to a single value.
+     *
+     * @param  callable  $callback
+     * @param  mixed $initial
+     * @return mixed
+     */
+    public function reduceWithKeys(callable $callback, $initial = null)
+    {
+        $result = $initial;
+
+        foreach($this as $key => $value) {
+            $result = $callback($result, $value, $key);
+        }
+
+        return $result;
+    }
+
+    /**
      * Replace the collection items with the given items.
      *
      * @param  mixed  $items

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -838,24 +838,6 @@ class LazyCollection implements Enumerable
     {
         $result = $initial;
 
-        foreach ($this as $value) {
-            $result = $callback($result, $value);
-        }
-
-        return $result;
-    }
-
-    /**
-     * Reduce an associative collection to a single value.
-     *
-     * @param  callable  $callback
-     * @param  mixed $initial
-     * @return mixed
-     */
-    public function reduceWithKeys(callable $callback, $initial = null)
-    {
-        $result = $initial;
-
         foreach ($this as $key => $value) {
             $result = $callback($result, $value, $key);
         }

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -856,7 +856,7 @@ class LazyCollection implements Enumerable
     {
         $result = $initial;
 
-        foreach($this as $key => $value) {
+        foreach ($this as $key => $value) {
             $result = $callback($result, $value, $key);
         }
 

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -828,42 +828,6 @@ class LazyCollection implements Enumerable
     }
 
     /**
-     * Reduce the collection to a single value.
-     *
-     * @param  callable  $callback
-     * @param  mixed  $initial
-     * @return mixed
-     */
-    public function reduce(callable $callback, $initial = null)
-    {
-        $result = $initial;
-
-        foreach ($this as $key => $value) {
-            $result = $callback($result, $value, $key);
-        }
-
-        return $result;
-    }
-
-    /**
-     * Reduce an associative collection to a single value.
-     *
-     * @param  callable  $callback
-     * @param  mixed $initial
-     * @return mixed
-     */
-    public function reduceWithKeys(callable $callback, $initial = null)
-    {
-        $result = $initial;
-
-        foreach ($this as $key => $value) {
-            $result = $callback($result, $value, $key);
-        }
-
-        return $result;
-    }
-
-    /**
      * Replace the collection items with the given items.
      *
      * @param  mixed  $items

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -717,6 +717,42 @@ trait EnumeratesValues
     }
 
     /**
+     * Reduce the collection to a single value.
+     *
+     * @param  callable  $callback
+     * @param  mixed $initial
+     * @return mixed
+     */
+    public function reduce(callable $callback, $initial = null)
+    {
+        $result = $initial;
+
+        foreach ($this as $key => $value) {
+            $result = $callback($result, $value, $key);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Reduce an associative collection to a single value.
+     *
+     * @param  callable  $callback
+     * @param  mixed $initial
+     * @return mixed
+     */
+    public function reduceWithKeys(callable $callback, $initial = null)
+    {
+        $result = $initial;
+
+        foreach ($this as $key => $value) {
+            $result = $callback($result, $value, $key);
+        }
+
+        return $result;
+    }
+
+    /**
      * Create a collection of all elements that do not pass a given truth test.
      *
      * @param  callable|mixed  $callback

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3602,7 +3602,7 @@ class SupportCollectionTest extends TestCase
             'baz' => 'qux',
         ]);
         $this->assertEquals('foobarbazqux', $data->reduceWithKeys(function ($carry, $element, $key) {
-            return $carry .= $key . $element;
+            return $carry .= $key.$element;
         }));
     }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3590,6 +3590,14 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(6, $data->reduce(function ($carry, $element) {
             return $carry += $element;
         }));
+        
+        $data = new $collection([
+            'foo' => 'bar',
+            'baz' => 'qux',
+        ]);
+        $this->assertEquals('foobarbazqux', $data->reduce(function ($carry, $element, $key) {
+            return $carry .= $key.$element;
+        }));
     }
 
     /**
@@ -3601,7 +3609,7 @@ class SupportCollectionTest extends TestCase
             'foo' => 'bar',
             'baz' => 'qux',
         ]);
-        $this->assertEquals('foobarbazqux', $data->reduce(function ($carry, $element, $key) {
+        $this->assertEquals('foobarbazqux', $data->reduceWithKeys(function ($carry, $element, $key) {
             return $carry .= $key.$element;
         }));
     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3595,6 +3595,20 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testReduceWithKeys($collection)
+    {
+        $data = new $collection([
+            'foo' => 'bar',
+            'baz' => 'qux',
+        ]);
+        $this->assertEquals('foobarbazqux', $data->reduceWithKeys(function ($carry, $element, $key) {
+            return $carry .= $key . $element;
+        }));
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testRandomThrowsAnExceptionUsingAmountBiggerThanCollectionSize($collection)
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3601,7 +3601,7 @@ class SupportCollectionTest extends TestCase
             'foo' => 'bar',
             'baz' => 'qux',
         ]);
-        $this->assertEquals('foobarbazqux', $data->reduceWithKeys(function ($carry, $element, $key) {
+        $this->assertEquals('foobarbazqux', $data->reduce(function ($carry, $element, $key) {
             return $carry .= $key.$element;
         }));
     }


### PR DESCRIPTION
Following the discussion we had here https://github.com/laravel/framework/pull/35839 I've removed `reduceWithKeys` and changed the `reduce` method to pass `$key` to its closure as well as  `$value`.

The previous test is there. I've just added another test for closures that accept the key, since I thought you might want to have one assertion per test. If you prefer to have one test per method and you don't care how many assertions are in one test, we can merge the two tests.