### PR TITLE
[8.x] Add default parameter to throw_if / throw_unless

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -277,7 +277,7 @@ if (! function_exists('throw_if')) {
      *
      * @throws \Throwable
      */
-    function throw_if($condition, $exception, ...$parameters)
+    function throw_if($condition, $exception = 'RuntimeException', ...$parameters)
     {
         if ($condition) {
             throw (is_string($exception) ? new $exception(...$parameters) : $exception);
@@ -298,7 +298,7 @@ if (! function_exists('throw_unless')) {
      *
      * @throws \Throwable
      */
-    function throw_unless($condition, $exception, ...$parameters)
+    function throw_unless($condition, $exception = 'RuntimeException', ...$parameters)
     {
         if (! $condition) {
             throw (is_string($exception) ? new $exception(...$parameters) : $exception);

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -6,6 +6,7 @@ use ArrayAccess;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Env;
 use Illuminate\Support\Optional;
+use LogicException;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
@@ -363,9 +364,30 @@ class SupportHelpersTest extends TestCase
 
     public function testThrow()
     {
+        $this->expectException(LogicException::class);
+
+        throw_if(true, new LogicException);
+    }
+
+    public function testThrowDefaultException()
+    {
         $this->expectException(RuntimeException::class);
 
-        throw_if(true, new RuntimeException);
+        throw_if(true);
+    }
+
+    public function testThrowUnless()
+    {
+        $this->expectException(LogicException::class);
+
+        throw_unless(false, new LogicException);
+    }
+
+    public function testThrowUnlessDefaultException()
+    {
+        $this->expectException(RuntimeException::class);
+
+        throw_unless(false);
     }
 
     public function testThrowReturnIfNotThrown()


### PR DESCRIPTION
This PR adds a default parameter to `throw_if` and `throw_unless`:
```php
// Currently:
throw_if($somethingIsWrong, new RuntimeException);

// With this PR:
throw_if($somethingIsWrong);
```

 

I use `throw_if` to guard against incorrect situations in non-user facing code. In my case. In most situations I don't care about the specific exception class, or about the exception message. I just want my code to stop running and write a stacktrace to the log file.

