### PR TITLE
Add erase option to key:generate command

### DIFF
--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -17,6 +17,7 @@ class KeyGenerateCommand extends Command
      */
     protected $signature = 'key:generate
                     {--show : Display the key instead of modifying files}
+                    {--erase : Erase the current key even if it is already defined}
                     {--force : Force the operation to run when in production}';
 
     /**
@@ -33,6 +34,10 @@ class KeyGenerateCommand extends Command
      */
     public function handle()
     {
+        if (! $this->confirmToProceed()) {
+            return;
+        }
+
         $key = $this->generateRandomKey();
 
         if ($this->option('show')) {
@@ -73,7 +78,8 @@ class KeyGenerateCommand extends Command
     {
         $currentKey = $this->laravel['config']['app.key'];
 
-        if (strlen($currentKey) !== 0 && (! $this->confirmToProceed())) {
+        if ((strlen($currentKey) !== 0) && (! $this->option('erase'))) {
+            $this->warn('Key already defined. Use the --erase option to replace the current key');
             return false;
         }
 


### PR DESCRIPTION
Hello 😃 

The current `key:generate` command will always erase the `APP_KEY` environment variable, even if it's already defined.

This pull request changes this behaviour, adding an `--erase` option to this command.

In my opinion, the application key should not be override when the command is ran, unless the user explicitly ask for it (with the --erase option in this case)

It's a pull request, but a question too : is this new behaviour correct ? We can imagine that the `key:generate` command is a part of a deployment script and should not affect an already deployed app... (except the first time)

Glad to read your comments.




