### PR TITLE
[8.x] Add default parameter to throw_if / throw_unless (attempt 2)

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -277,10 +277,14 @@ if (! function_exists('throw_if')) {
      *
      * @throws \Throwable
      */
-    function throw_if($condition, $exception, ...$parameters)
+    function throw_if($condition, $exception = 'RuntimeException', ...$parameters)
     {
         if ($condition) {
-            throw (is_string($exception) ? new $exception(...$parameters) : $exception);
+            if (is_string($exception) && class_exists($exception)) {
+                $exception = new $exception(...$parameters);
+            }
+
+            throw is_string($exception) ? new RuntimeException($exception) : $exception;
         }
 
         return $condition;
@@ -298,10 +302,14 @@ if (! function_exists('throw_unless')) {
      *
      * @throws \Throwable
      */
-    function throw_unless($condition, $exception, ...$parameters)
+    function throw_unless($condition, $exception = 'RuntimeException', ...$parameters)
     {
         if (! $condition) {
-            throw (is_string($exception) ? new $exception(...$parameters) : $exception);
+            if (is_string($exception) && class_exists($exception)) {
+                $exception = new $exception(...$parameters);
+            }
+
+            throw is_string($exception) ? new RuntimeException($exception) : $exception;
         }
 
         return $condition;

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -6,6 +6,7 @@ use ArrayAccess;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Env;
 use Illuminate\Support\Optional;
+use LogicException;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
@@ -363,9 +364,62 @@ class SupportHelpersTest extends TestCase
 
     public function testThrow()
     {
+        $this->expectException(LogicException::class);
+
+        throw_if(true, new LogicException);
+    }
+
+    public function testThrowDefaultException()
+    {
         $this->expectException(RuntimeException::class);
 
-        throw_if(true, new RuntimeException);
+        throw_if(true);
+    }
+
+    public function testThrowExceptionWithMessage()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('test');
+
+        throw_if(true, 'test');
+    }
+
+    public function testThrowExceptionAsStringWithMessage()
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('test');
+
+        throw_if(true, LogicException::class, 'test');
+    }
+
+    public function testThrowUnless()
+    {
+        $this->expectException(LogicException::class);
+
+        throw_unless(false, new LogicException);
+    }
+
+    public function testThrowUnlessDefaultException()
+    {
+        $this->expectException(RuntimeException::class);
+
+        throw_unless(false);
+    }
+
+    public function testThrowUnlessExceptionWithMessage()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('test');
+
+        throw_unless(false, 'test');
+    }
+
+    public function testThrowUnlessExceptionAsStringWithMessage()
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('test');
+
+        throw_unless(false, LogicException::class, 'test');
     }
 
     public function testThrowReturnIfNotThrown()


### PR DESCRIPTION
This is a follow-up on https://github.com/laravel/framework/pull/35888

You can now pass `throw_if` and `throw_unless` a message as the second parameter, similar to the `report` function (which was changed in https://github.com/laravel/framework/pull/35803):

```php
// Currently:
throw_if($sometingIsWrong, new RuntimeException('something wrong with user '.$user->id));

// With this PR:
throw_if($sometingIsWrong, 'something wrong with user '.$user->id);
```

If the message passed is an existing class, that will be used as the exception instead:
```php
throw_if($somethingIsWrong, LogicException::class);
```

And the newly added default parameter allows you to also do this, if you're not interested in a custom message:
```php
throw_if($somethingIsWrong);
```
