### PR TITLE
[8.x] Add query builder toSqlWithBindings method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -75,8 +75,9 @@ class Builder
      * @var string[]
      */
     protected $passthru = [
-        'insert', 'insertOrIgnore', 'insertGetId', 'insertUsing', 'getBindings', 'toSql', 'dump', 'dd',
-        'exists', 'doesntExist', 'count', 'min', 'max', 'avg', 'average', 'sum', 'getConnection', 'raw', 'getGrammar',
+        'insert', 'insertOrIgnore', 'insertGetId', 'insertUsing', 'getBindings', 'toSql', 'toSqlWithBindings',
+        'dump', 'dd', 'exists', 'doesntExist', 'count', 'min', 'max', 'avg', 'average', 'sum', 'getConnection', 'raw',
+        'getGrammar',
     ];
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2265,6 +2265,21 @@ class Builder
     }
 
     /**
+     * Get the SQL representation of the query with bindings.
+     *
+     * @return string
+     */
+    public function toSqlWithBindings()
+    {
+        $bindings = array_map(
+            function ($value) {
+                return is_numeric($value) ? $value : "{$value}";
+            }, $this->getBindings()
+        );
+        return Str::replaceArray('?', $bindings, $this->toSql());
+    }
+
+    /**
      * Execute a query for a single record by ID.
      *
      * @param  int|string  $id

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2276,6 +2276,7 @@ class Builder
                 return is_numeric($value) ? $value : "{$value}";
             }, $this->getBindings()
         );
+
         return Str::replaceArray('?', $bindings, $this->toSql());
     }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Sometimes we need to view SQL query with its bindings, so this toSqlWithBindings method will help without effecting exist methods in query builder.