### PR TITLE
[8.x] Throw ModelNotFoundException for sole in Eloquent

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Concerns\ExplainsQueries;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Builder as QueryBuilder;
+use Illuminate\Database\RecordsNotFoundException;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
@@ -25,7 +26,10 @@ use ReflectionMethod;
  */
 class Builder
 {
-    use BuildsQueries, Concerns\QueriesRelationships, ExplainsQueries, ForwardsCalls;
+    use Concerns\QueriesRelationships, ExplainsQueries, ForwardsCalls;
+    use BuildsQueries {
+        sole as baseSole;
+    }
 
     /**
      * The base query builder instance.
@@ -502,6 +506,24 @@ class Builder
         }
 
         return $callback();
+    }
+
+    /**
+     * Execute the query and get the first result if it's the sole matching record.
+     *
+     * @param  array|string  $columns
+     * @return \Illuminate\Database\Eloquent\Model
+     *
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
+     * @throws \Illuminate\Database\MultipleRecordsFoundException
+     */
+    public function sole($columns = ['*'])
+    {
+        try {
+            return $this->baseSole($columns);
+        } catch (RecordsNotFoundException $exception) {
+            throw new ModelNotFoundException($this->model);
+        }
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/ModelNotFoundException.php
+++ b/src/Illuminate/Database/Eloquent/ModelNotFoundException.php
@@ -2,10 +2,10 @@
 
 namespace Illuminate\Database\Eloquent;
 
+use Illuminate\Database\RecordsNotFoundException;
 use Illuminate\Support\Arr;
-use RuntimeException;
 
-class ModelNotFoundException extends RuntimeException
+class ModelNotFoundException extends RecordsNotFoundException
 {
     /**
      * Name of the affected Eloquent model.

--- a/tests/Integration/Database/EloquentWhereTest.php
+++ b/tests/Integration/Database/EloquentWhereTest.php
@@ -3,6 +3,8 @@
 namespace Illuminate\Tests\Integration\Database;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Database\MultipleRecordsFoundException;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
@@ -90,6 +92,43 @@ class EloquentWhereTest extends DatabaseTestCase
         $this->assertTrue($secondUser->is(
             UserWhereTest::firstWhere(['name' => 'wrong-name', 'email' => 'test-email1'], null, null, 'or'))
         );
+    }
+
+    public function testSole()
+    {
+        $expected = UserWhereTest::create([
+            'name' => 'test-name',
+            'email' => 'test-email',
+            'address' => 'test-address',
+        ]);
+
+        $this->assertTrue($expected->is(UserWhereTest::where('name', 'test-name')->sole()));
+    }
+
+    public function testSoleFailsForMultipleRecords()
+    {
+        UserWhereTest::create([
+            'name' => 'test-name',
+            'email' => 'test-email',
+            'address' => 'test-address',
+        ]);
+
+        UserWhereTest::create([
+            'name' => 'test-name',
+            'email' => 'other-email',
+            'address' => 'other-address',
+        ]);
+
+        $this->expectException(MultipleRecordsFoundException::class);
+
+        UserWhereTest::where('name', 'test-name')->sole();
+    }
+
+    public function testSoleFailsIfNoRecords()
+    {
+        $this->expectException(ModelNotFoundException::class);
+
+        UserWhereTest::where('name', 'test-name')->sole();
     }
 }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Follow up to #35869 

As suggested in comment https://github.com/laravel/framework/pull/35869#issuecomment-760482444 by @taylorotwell , this PR throws a `ModelNotFoundException` when `->sole()` is called from an Eloquent Query Builder and no records are found.

This is particularly useful as `ModelNotFoundException` exceptions are handled automatically in HTTP requests by returning a 404 response.

Maybe we should also add some kind of HTTP handling for the `MultipleRecordsFoundException` when called from an Eloquent Query Builder.

