### PR TITLE
[8.x] Deprecate `Session::remove($key)` in favor of `Session::pull($key, $default = null)`

### DIFF
--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -437,6 +437,8 @@ class Store implements Session
     /**
      * Remove an item from the session, returning its value.
      *
+     * @deprecated Will be removed in a future Laravel version.
+     *
      * @param  string  $key
      * @return mixed
      */


### PR DESCRIPTION
Just a suggestion that [`Session::remove($key)`](https://github.com/laravel/framework/blob/8.x/src/Illuminate/Session/Store.php#L443-L446) (which is undocumented) could be deprecated in favor of [`Session::pull($key, $default = null)`](https://github.com/laravel/framework/blob/8.x/src/Illuminate/Session/Store.php#L228-L231) ([which is documented](https://laravel.com/docs/8.x/session#retrieving-deleting-an-item)) and therefore removed in Laravel 9.x.

https://github.com/laravel/framework/blob/19f338e841983939fc41ad847c7188af59e5e268/src/Illuminate/Session/Store.php#L228-L231

https://github.com/laravel/framework/blob/19f338e841983939fc41ad847c7188af59e5e268/src/Illuminate/Session/Store.php#L443-L446

Unless you want to keep things as is and document `Session::remove`? Just thought it was worth bringing to your attention.

---

**Note:** `Session::remove` also appears in the [contract](https://github.com/laravel/framework/blob/8.x/src/Illuminate/Contracts/Session/Session.php#L121), the [facade](https://github.com/laravel/framework/blob/8.x/src/Illuminate/Support/Facades/Session.php#L18) and the [SessionGuard](https://github.com/laravel/framework/blob/8.x/src/Illuminate/Auth/SessionGuard.php#L555).