### PR TITLE
[8.x] Add PHPDoc 'afterCommit' on DB Facade

### DIFF
--- a/src/Illuminate/Support/Facades/DB.php
+++ b/src/Illuminate/Support/Facades/DB.php
@@ -22,6 +22,7 @@ namespace Illuminate\Support\Facades;
  * @method static string getDefaultConnection()
  * @method static void beginTransaction()
  * @method static void commit()
+ * @method static void afterCommit(\Closure $callback)
  * @method static void listen(\Closure $callback)
  * @method static void rollBack(int $toLevel = null)
  * @method static void setDefaultConnection(string $name)


### PR DESCRIPTION
## Added

- PHPDoc for `afterCommit` on DB Facade.