### PR TITLE
[8.x] Handle `->sole()` exceptions

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -373,6 +373,10 @@ class Handler implements ExceptionHandlerContract
             $e = new HttpException(419, $e->getMessage(), $e);
         } elseif ($e instanceof SuspiciousOperationException) {
             $e = new NotFoundHttpException('Bad hostname provided.', $e);
+        } elseif ($e instanceof RecordsNotFoundException) {
+            $e = new NotFoundHttpException('Not found.', $e);
+        } elseif ($e instanceof MultipleRecordsFoundException) {
+            $e = new HttpException(400, 'Bad request.', $e);
         }
 
         return $e;

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -375,8 +375,6 @@ class Handler implements ExceptionHandlerContract
             $e = new NotFoundHttpException('Bad hostname provided.', $e);
         } elseif ($e instanceof RecordsNotFoundException) {
             $e = new NotFoundHttpException('Not found.', $e);
-        } elseif ($e instanceof MultipleRecordsFoundException) {
-            $e = new HttpException(400, 'Bad request.', $e);
         }
 
         return $e;

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -8,7 +8,6 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\Routing\ResponseFactory as ResponseFactoryContract;
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Contracts\View\Factory;
-use Illuminate\Database\MultipleRecordsFoundException;
 use Illuminate\Database\RecordsNotFoundException;
 use Illuminate\Foundation\Exceptions\Handler;
 use Illuminate\Http\RedirectResponse;
@@ -253,23 +252,6 @@ class FoundationExceptionsHandlerTest extends TestCase
         $logger->shouldNotReceive('error');
 
         $this->handler->report(new RecordsNotFoundException());
-    }
-
-    public function testMultipleRecordsFoundReturns400WithoutReporting()
-    {
-        $this->config->shouldReceive('get')->with('app.debug', null)->once()->andReturn(true);
-        $this->request->shouldReceive('expectsJson')->once()->andReturn(true);
-
-        $response = $this->handler->render($this->request, new MultipleRecordsFoundException());
-
-        $this->assertEquals(400, $response->getStatusCode());
-        $this->assertStringContainsString('"message": "Bad request."', $response->getContent());
-
-        $logger = m::mock(LoggerInterface::class);
-        $this->container->instance(LoggerInterface::class, $logger);
-        $logger->shouldNotReceive('error');
-
-        $this->handler->report(new MultipleRecordsFoundException());
     }
 }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR is a follow up of PRs #35902 and #35908

In addition on not reporting the exceptions thrown by calling `->sole()` (which is handled by PR #35908) this PR adds two `elseif` clauses to `\Illuminate\Foundation\Exceptions@prepareException` to handle both `RecordsNotFoundException` (when not called from an `Eloquent\Builder`) and `MultipleRecordsFoundException`.

Tests were added for both exceptions handling.

---

**EDIT**: After conversation with @GrahamCampbell , I just kept the `RecordsNotFoundException` handling. Leaving the `MultipleRecordsFoundException` to be handled as a regular exception which defaults to a 500.
