### PR TITLE
[6.x] Fix Str@contains for PHP 8.0.1

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -154,8 +154,6 @@ class Str
      */
     public static function contains($haystack, $needles)
     {
-        $haystack = (string) $haystack;
-
         foreach ((array) $needles as $needle) {
             if ($needle !== '' && mb_strpos($haystack, $needle) !== false) {
                 return true;

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -154,6 +154,8 @@ class Str
      */
     public static function contains($haystack, $needles)
     {
+        $haystack = (string) $haystack;
+
         foreach ((array) $needles as $needle) {
             if ($needle !== '' && mb_strpos($haystack, $needle) !== false) {
                 return true;

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -151,11 +151,11 @@ class SupportStrTest extends TestCase
         $this->assertTrue(Str::contains('taylor', 'taylor'));
         $this->assertTrue(Str::contains('taylor', ['ylo']));
         $this->assertTrue(Str::contains('taylor', ['xxx', 'ylo']));
+        $this->assertTrue(Str::contains(123, '1'));
         $this->assertFalse(Str::contains('taylor', 'xxx'));
         $this->assertFalse(Str::contains('taylor', ['xxx']));
         $this->assertFalse(Str::contains('taylor', ''));
-        $this->assertFalse(Str::contains(null, 'null'));
-        $this->assertFalse(Str::contains(1, '123'));
+        $this->assertFalse(Str::contains(null, ''));
     }
 
     public function testStrContainsAll()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -151,11 +151,10 @@ class SupportStrTest extends TestCase
         $this->assertTrue(Str::contains('taylor', 'taylor'));
         $this->assertTrue(Str::contains('taylor', ['ylo']));
         $this->assertTrue(Str::contains('taylor', ['xxx', 'ylo']));
-        $this->assertTrue(Str::contains(123, '1'));
+        $this->assertTrue(Str::contains(new StringableObjectStub('123'), '1'));
         $this->assertFalse(Str::contains('taylor', 'xxx'));
         $this->assertFalse(Str::contains('taylor', ['xxx']));
         $this->assertFalse(Str::contains('taylor', ''));
-        $this->assertFalse(Str::contains(null, ''));
     }
 
     public function testStrContainsAll()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -154,6 +154,8 @@ class SupportStrTest extends TestCase
         $this->assertFalse(Str::contains('taylor', 'xxx'));
         $this->assertFalse(Str::contains('taylor', ['xxx']));
         $this->assertFalse(Str::contains('taylor', ''));
+        $this->assertFalse(Str::contains(null, 'null'));
+        $this->assertFalse(Str::contains(1, '123'));
     }
 
     public function testStrContainsAll()


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Fix issue described in #35891.

The issue only happens when running PHP >= 8.0.1. if the `$haystack` parameter when calling `mb_strpos` is not a string, PHP will throw and error. 

After fixing it one test started failing. I then fixed `Illuminate\Database\Query\Builder@where` to explicitly cast the `$haystack` parameter to a string when calling `Str@contains`.

It was failing on the last assertion of the `Illuminate\Tests\Database\DatabaseQueryBuilderTest@testMySqlWrappingJsonWithBoolean` test.

Issue was, besides the `Builder@where` docblock accept `\Closure|string|array` the assertion was passing a `Illuminate\Database\Query\Expression` object as the column name on `->where()` call.

I didn't fix the docblock for the `Builder@where` on this PR, as I think it should be fixed in a separate PR.

One alternative approach is to always cast the `$haystack` to a string inside the `Str@contains` implementation.

I prefer the implementation I sent in this PR (return `false` if not a string) instead, as it conforms with the method current dockblock and with the "Principle of least astonishment". 

But I can update the PR if you prefer the alternative implementation.