### PR TITLE
[8.x] Use View contract when rendering Blade components

### DIFF
--- a/src/Illuminate/View/Concerns/ManagesComponents.php
+++ b/src/Illuminate/View/Concerns/ManagesComponents.php
@@ -4,9 +4,9 @@ namespace Illuminate\View\Concerns;
 
 use Closure;
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Contracts\View\View;
 use Illuminate\Support\Arr;
 use Illuminate\Support\HtmlString;
-use Illuminate\View\View;
 use InvalidArgumentException;
 
 trait ManagesComponents


### PR DESCRIPTION
Right now `ManagesComponents` uses `Illuminate\View\View` rather than `Illuminate\Contracts\View\View` which means that components that return a different implementation of the View contract break Blade components.

The only code that uses this import is:

```php
if ($view instanceof View) {
    return $view->with($data)->render();
}
```

Since `with()` and `render()` are both on the view contract, it should be completely safe to swap the implementation for the interface.