### PR TITLE
[8.x] Add variables for controller stubs

### DIFF
--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -156,7 +156,21 @@ class ControllerMakeCommand extends GeneratorCommand
             }
         }
 
+        $plain = Str::of(class_basename($modelClass))->snake()->replace('_', ' ');
+
         return array_merge($replace, [
+            '{{ lower }}' => $plain,
+            '{{ title }}' => Str::of($plain)->title(),
+            '{{ studly }}' => Str::of($plain)->studly(),
+            '{{ camel }}' => Str::of($plain)->camel(),
+            '{{ slug }}' => Str::of($plain)->slug(),
+            '{{ snake }}' => Str::of($plain)->snake(),
+            '{{ plural }}' => Str::of($plain)->plural(),
+            '{{ titlePlural }}' => Str::of($plain)->plural()->title(),
+            '{{ studlyPlural }}' => Str::of($plain)->plural()->studly(),
+            '{{ camelPlural }}' => Str::of($plain)->plural()->camel(),
+            '{{ slugPlural }}' => Str::of($plain)->plural()->slug(),
+            '{{ snakePlural }}' => Str::of($plain)->plural()->snake(),
             'DummyFullModelClass' => $modelClass,
             '{{ namespacedModel }}' => $modelClass,
             '{{namespacedModel}}' => $modelClass,

--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -127,7 +127,21 @@ class ControllerMakeCommand extends GeneratorCommand
             }
         }
 
+        $plain = Str::of(class_basename($parentModelClass))->snake()->replace('_', ' ');
+
         return [
+            '{{ parentLower }}' => $plain,
+            '{{ parentTitle }}' => Str::of($plain)->title(),
+            '{{ parentStudly }}' => Str::of($plain)->studly(),
+            '{{ parentCamel }}' => Str::of($plain)->camel(),
+            '{{ parentSlug }}' => Str::of($plain)->slug(),
+            '{{ parentSnake }}' => Str::of($plain)->snake(),
+            '{{ parentPlural }}' => Str::of($plain)->plural(),
+            '{{ parentTitlePlural }}' => Str::of($plain)->plural()->title(),
+            '{{ parentStudlyPlural }}' => Str::of($plain)->plural()->studly(),
+            '{{ parentCamelPlural }}' => Str::of($plain)->plural()->camel(),
+            '{{ parentSlugPlural }}' => Str::of($plain)->plural()->slug(),
+            '{{ parentSnakePlural }}' => Str::of($plain)->plural()->snake(),
             'ParentDummyFullModelClass' => $parentModelClass,
             '{{ namespacedParentModel }}' => $parentModelClass,
             '{{namespacedParentModel}}' => $parentModelClass,

--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Routing\Console;
 
 use Illuminate\Console\GeneratorCommand;
+use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Symfony\Component\Console\Input\InputOption;
 
@@ -105,6 +106,10 @@ class ControllerMakeCommand extends GeneratorCommand
             $replace = $this->buildModelReplacements($replace);
         }
 
+        foreach($replace as $variable => $value) {
+            $replace[str_replace(' ', '', $variable)] = $value;
+        }
+
         $replace["use {$controllerNamespace}\Controller;\n"] = '';
 
         return str_replace(
@@ -144,13 +149,10 @@ class ControllerMakeCommand extends GeneratorCommand
             '{{ parentSnakePlural }}' => Str::of($plain)->plural()->snake(),
             'ParentDummyFullModelClass' => $parentModelClass,
             '{{ namespacedParentModel }}' => $parentModelClass,
-            '{{namespacedParentModel}}' => $parentModelClass,
             'ParentDummyModelClass' => class_basename($parentModelClass),
             '{{ parentModel }}' => class_basename($parentModelClass),
-            '{{parentModel}}' => class_basename($parentModelClass),
             'ParentDummyModelVariable' => lcfirst(class_basename($parentModelClass)),
             '{{ parentModelVariable }}' => lcfirst(class_basename($parentModelClass)),
-            '{{parentModelVariable}}' => lcfirst(class_basename($parentModelClass)),
         ];
     }
 
@@ -187,13 +189,10 @@ class ControllerMakeCommand extends GeneratorCommand
             '{{ snakePlural }}' => Str::of($plain)->plural()->snake(),
             'DummyFullModelClass' => $modelClass,
             '{{ namespacedModel }}' => $modelClass,
-            '{{namespacedModel}}' => $modelClass,
             'DummyModelClass' => class_basename($modelClass),
             '{{ model }}' => class_basename($modelClass),
-            '{{model}}' => class_basename($modelClass),
             'DummyModelVariable' => lcfirst(class_basename($modelClass)),
             '{{ modelVariable }}' => lcfirst(class_basename($modelClass)),
-            '{{modelVariable}}' => lcfirst(class_basename($modelClass)),
         ]);
     }
 


### PR DESCRIPTION
When publishing stubs, we have a nice starting place for our own code styles.

But what if we could include some common repetitive logic for controllers? 🤩

The addition of these common string variations within controllers stubs would allow this.

And could introduce additional code sharing in the Laravel ecosystem.

### Examples

```
php artisan make:controller PostController --model=Post
```
```php
class PostController extends Controller
{
    public function index()
    {
        $posts = Post::all();

        return view('posts.index')->with([
            'posts' => $posts
        ]);
    }
}
```
```
controller.model.stub
```
```php
class {{ class }} extends Controller
{
    public function index()
    {
        ${{ camelPlural }} = {{studly}}::all();

        return view('{{ slugPlural }}.index')->with([
            '{{ snakePlural }}' => ${{ camelPlural }}
        ]);
    }
}
```

```
php artisan make:controller UserPostsController --model=Post --parent=User --api
```
```php
class UserPostsController extends Controller
{
    public function index(User $user)
    {
        $posts = $user->posts()->get();

        return new PostCollection($posts);
    }
}
```
```
controller.nested.api.stub
```
```php
class {{ class }} extends Controller
{
    public function index({{ parentModel }} ${{ parentModelVariable }})
    {
        ${{ camelPlural }} = ${{ parentCamel }}->{{ camelPlural }}()->get();

        return new {{studly}}Collection(${{ camelPlural }});
    }
}
```

### Variables: `AccountUser`

| Variable | Output |
| - | - |
| lower | account user |
| title | Account User |
| studly | AccountUser |
| camel | accountUser |
| slug | account-user |
| snake | account_user |
| plural | account users |
| titlePlural | Account Users |
| studlyPlural | AccountUsers |
| camelPlural | accountUsers |
| slugPlural | account-users |
| snakePlural | account_users |

### Variables: `User`
| Variable | Output |
| - | - |
| parentLower | user |
| parentTitle | User |
| parentStudly | User |
| parentCamel | user |
| parentSlug | user |
| parentSnake | user |
| parentPlural | users |
| parentTitlePlural | Users |
| parentStudlyPlural | Users |
| parentCamelPlural | users |
| parentSlugPlural | users |
| parentSnakePlural | users |

> Note:` user` may look redundant.. but thats because its not a compound word like AccountUser