### PR TITLE
[8.x] Add console generated event

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -157,6 +157,8 @@ abstract class GeneratorCommand extends Command
         $this->makeDirectory($path);
 
         $this->files->put($path, $this->sortImports($this->buildClass($name)));
+        
+        event("console.generated: {$this->type}", compact('name', 'path'));
 
         $this->info($this->type.' created successfully.');
     }


### PR DESCRIPTION
In efforts to make a package for https://github.com/laravel/framework/pull/35922
```php
Event::listen('console.generated: *', function($event, $asset) {
      dd($event, $asset);
});
```
```php
"console.generated: Controller"
array:2 [
  "name" => "App\Http\Controllers\AdminController"
  "path" => "/Users/brian/Sites/laravel/app/Http/Controllers/AdminController.php"
]
```

Which lends itself to extending the output of generated files:
```php
Event::listen('console.generated: Controller', function($asset) {
    $content = file_get_contents($asset['path']);
    $content = str_replace('{{ custom }}', 'hello world', $content);
    file_put_contents($asset['path'], $content);
});
```

I tried to keep it inline with `eloquent.created:` convention