### PR TITLE
[8.x] Add console generated event

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -157,6 +157,13 @@ abstract class GeneratorCommand extends Command
         $this->makeDirectory($path);
 
         $this->files->put($path, $this->sortImports($this->buildClass($name)));
+        
+        event("console.generated: {$this->type}", [
+            'name' => $name,
+            'path' => $path,
+            'options' => $this->option(),
+            'arguments' => $this->argument(),
+        ]);
 
         $this->info($this->type.' created successfully.');
     }

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Console;
 
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Input\InputArgument;
@@ -157,13 +159,15 @@ abstract class GeneratorCommand extends Command
         $this->makeDirectory($path);
 
         $this->files->put($path, $this->sortImports($this->buildClass($name)));
-        
-        event("console.generated: {$this->type}", [
-            'name' => $name,
-            'path' => $path,
-            'options' => $this->option(),
-            'arguments' => $this->argument(),
-        ]);
+
+        Container::getInstance()
+            ->make(Dispatcher::class)
+            ->dispatch("console.generated: {$this->type}", [
+                'name' => $name,
+                'path' => $path,
+                'options' => $this->option(),
+                'arguments' => $this->argument(),
+            ]);
 
         $this->info($this->type.' created successfully.');
     }


### PR DESCRIPTION
In efforts to make a package for https://github.com/laravel/framework/pull/35922

An event to allow extending the output of generated files:
```php
Event::listen('console.generated: Controller', function($asset) {
    $content = file_get_contents($asset['path']);
    $content = str_replace('{{ custom }}', 'hello world', $content);
    file_put_contents($asset['path'], $content);
});
```

```php
Event::listen('console.generated: *', function($event, $asset) {
      dd($event, $asset);
});
```
```php
"console.generated: Controller"
array:4 [
  "name" => "App\Http\Controllers\UserController"
  "path" => "/Users/brian/Sites/laravel/app/Http/Controllers/UserController.php"
  "options" => array:14 [
    "api" => false
    "force" => false
    "invokable" => false
    "model" => null
    "parent" => null
    "resource" => false
    "help" => false
    "quiet" => false
    "verbose" => false
    "version" => false
    "ansi" => false
    "no-ansi" => false
    "no-interaction" => false
    "env" => null
  ]
  "arguments" => array:2 [
    "command" => "make:controller"
    "name" => "UserController"
  ]
]
```

I tried to keep it inline with `eloquent.created:` convention