### PR TITLE
[8.x] cleanup sole test A

### DIFF
--- a/tests/Integration/Database/QueryBuilderTest.php
+++ b/tests/Integration/Database/QueryBuilderTest.php
@@ -36,7 +36,7 @@ class QueryBuilderTest extends DatabaseTestCase
     {
         $expected = ['id' => '1', 'title' => 'Foo Post'];
 
-        $this->assertEquals(1, DB::table('posts')->where('title', 'Foo Post')->sole()->id);
+        $this->assertSame($expected, (array) DB::table('posts')->where('title', 'Foo Post')->select('id', 'title')->sole());
     }
 
     public function testSoleFailsForMultipleRecords()


### PR DESCRIPTION
Just a little service PR.

Use `$expected` like in other tests below.

Or remove it #35927