### PR TITLE
[8.x] Added oneOrFail() alias for sole()

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -174,6 +174,20 @@ trait BuildsQueries
     }
 
     /**
+     * Execute the query and get the first result if it's the sole matching record.
+     *
+     * @param  array|string  $columns
+     * @return \Illuminate\Database\Eloquent\Model|object|static|null
+     *
+     * @throws \Illuminate\Database\RecordsNotFoundException
+     * @throws \Illuminate\Database\MultipleRecordsFoundException
+     */
+    public function oneOrFail($columns = ['*'])
+    {
+        return $this->sole();
+    }
+
+    /**
      * Apply the callback's query changes if the given "value" is true.
      *
      * @param  mixed  $value

--- a/tests/Integration/Database/QueryBuilderTest.php
+++ b/tests/Integration/Database/QueryBuilderTest.php
@@ -39,6 +39,11 @@ class QueryBuilderTest extends DatabaseTestCase
         $this->assertEquals(1, DB::table('posts')->where('title', 'Foo Post')->sole()->id);
     }
 
+    public function testSoleAlias()
+    {
+        $this->assertEquals(1, DB::table('posts')->where('title', 'Foo Post')->oneOrFail()->id);
+    }
+
     public function testSoleFailsForMultipleRecords()
     {
         DB::table('posts')->insert([


### PR DESCRIPTION
I like the functionality of `sole()` but I also like consistency.

All other `QueryBuilder` methods that are able to `throw` an error end with `OrFail()`

If you prefer `singleOrFail` #35928