### PR TITLE
[6.x] For Eloquent JSON cast saving, only check that key/value pairs are equal

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1184,6 +1184,9 @@ trait HasAttributes
             }
 
             return abs($this->castAttribute($key, $current) - $this->castAttribute($key, $original)) < PHP_FLOAT_EPSILON * 4;
+        } elseif ($this->hasCast($key, ['json'])) {
+            return $this->castAttribute($key, $current) ==
+                   $this->castAttribute($key, $original);
         } elseif ($this->hasCast($key)) {
             return $this->castAttribute($key, $current) ===
                    $this->castAttribute($key, $original);


### PR DESCRIPTION
When writing a data import using `SomeModel::updateOrCreate` I noticed via the MySQL query log that updates were being sent to the database even though no changes were present in the import file when a JSON type column was being used.  Normally when using `updateOrCreate` Eloquent will not send updates to the database when data hasn't changed.

Since JSON is an unordered data structure it should be compared with `==` instead of `===` because `===` also makes sure the order is the same between the two JSON arrays https://www.php.net/manual/en/language.operators.array.php

Here is an example with PHP

```
$ php artisan tinker
Psy Shell v0.10.5 (PHP 7.4.13 — cli) by Justin Hileman
>>> $string1 = '{"a": 1, "b": 2, "c": {"foo": "bar", "baz": "qux"}}';
=> "{"a": 1, "b": 2, "c": {"foo": "bar", "baz": "qux"}}"
>>> $string2 = '{"b": 2, "a": 1, "c": {"baz": "qux", "foo": "bar"}}';
=> "{"b": 2, "a": 1, "c": {"baz": "qux", "foo": "bar"}}"
>>> $json1 = json_decode($string1);
=> {#4548
     +"a": 1,
     +"b": 2,
     +"c": {#4546
       +"foo": "bar",
       +"baz": "qux",
     },
   }
>>> $json2 = json_decode($string2);
=> {#4549
     +"b": 2,
     +"a": 1,
     +"c": {#4539
       +"baz": "qux",
       +"foo": "bar",
     },
   }
>>> $json1 === $json2;
=> false
>>> $json1 == $json2;
=> true
```

This PR helps prevent Eloquent from thinking JSON types have changed causing an unnecessary trip to the database for an update during `updateOrCreate` for example.  The main benefit is speed for many thousands of `updateOrCreate`s

I'll be honest, I wasn't sure how I could write a test for this to make sure when `updateOrCreate` is called with the same data, only one select query is used instead of a select and update.
