### PR TITLE
[8.x] Add MultiPluck Method To Collection

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -618,6 +618,23 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
+     * Get the values of given keys.
+     *
+     * @param  mixed  ...$values
+     * @return static
+     */
+    public function multiPluck(...$values)
+    {
+        if(func_num_args() > 1) {
+            return new static($this->map(function ($value) use ($values) {
+                return Arr::only($value, $values);
+            }));
+        }
+
+        return $this->pluck($values);
+    }
+
+    /**
      * Run a map over each of the items.
      *
      * @param  callable  $callback

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -633,6 +633,23 @@ class LazyCollection implements Enumerable
     }
 
     /**
+     * Get the values of given keys.
+     *
+     * @param  mixed  ...$values
+     * @return static
+     */
+    public function multiPluck(...$values)
+    {
+        if(func_num_args() > 1) {
+            return new static($this->map(function ($value) use ($values) {
+                return Arr::only($value, $values);
+            }));
+        }
+
+        return $this->pluck($values);
+    }
+
+    /**
      * Run a map over each of the items.
      *
      * @param  callable  $callback

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1780,6 +1780,16 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testMultiPluck($collection)
+    {
+        $data = new $collection([['name' => 'taylor', 'email' => 'foo', 'type' => 'superuser'], ['name' => 'dayle', 'email' => 'bar', 'type' => 'user']]);
+        $this->assertEquals([['name' => 'taylor', 'type' => 'superuser'], ['name' => 'dayle', 'type' => 'user']], $data->multiPluck('name', 'type')->all());
+        $this->assertEquals(['taylor', 'dayle'], $data->multiPluck('name')->all());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testHas($collection)
     {
         $data = new $collection(['id' => 1, 'first' => 'Hello', 'second' => 'World']);


### PR DESCRIPTION
With `pluck()` method we won't be able to get multi keys in a collection.
With `multiPluck()` we can get each key which we want!