### PR TITLE
Add Clean and Mask functions to the String Helper

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -44,7 +44,8 @@ class Str
     /**
      * Get a new stringable object from the given string.
      *
-     * @param  string  $string
+     * @param string $string
+     *
      * @return \Illuminate\Support\Stringable
      */
     public static function of($string)
@@ -55,8 +56,9 @@ class Str
     /**
      * Return the remainder of a string after the first occurrence of a given value.
      *
-     * @param  string  $subject
-     * @param  string  $search
+     * @param string $subject
+     * @param string $search
+     *
      * @return string
      */
     public static function after($subject, $search)
@@ -67,8 +69,9 @@ class Str
     /**
      * Return the remainder of a string after the last occurrence of a given value.
      *
-     * @param  string  $subject
-     * @param  string  $search
+     * @param string $subject
+     * @param string $search
+     *
      * @return string
      */
     public static function afterLast($subject, $search)
@@ -77,7 +80,7 @@ class Str
             return $subject;
         }
 
-        $position = strrpos($subject, (string) $search);
+        $position = strrpos($subject, (string)$search);
 
         if ($position === false) {
             return $subject;
@@ -89,20 +92,22 @@ class Str
     /**
      * Transliterate a UTF-8 value to ASCII.
      *
-     * @param  string  $value
-     * @param  string  $language
+     * @param string $value
+     * @param string $language
+     *
      * @return string
      */
     public static function ascii($value, $language = 'en')
     {
-        return ASCII::to_ascii((string) $value, $language);
+        return ASCII::to_ascii((string)$value, $language);
     }
 
     /**
      * Get the portion of a string before the first occurrence of a given value.
      *
-     * @param  string  $subject
-     * @param  string  $search
+     * @param string $subject
+     * @param string $search
+     *
      * @return string
      */
     public static function before($subject, $search)
@@ -111,7 +116,7 @@ class Str
             return $subject;
         }
 
-        $result = strstr($subject, (string) $search, true);
+        $result = strstr($subject, (string)$search, true);
 
         return $result === false ? $subject : $result;
     }
@@ -119,8 +124,9 @@ class Str
     /**
      * Get the portion of a string before the last occurrence of a given value.
      *
-     * @param  string  $subject
-     * @param  string  $search
+     * @param string $subject
+     * @param string $search
+     *
      * @return string
      */
     public static function beforeLast($subject, $search)
@@ -141,9 +147,10 @@ class Str
     /**
      * Get the portion of a string between two given values.
      *
-     * @param  string  $subject
-     * @param  string  $from
-     * @param  string  $to
+     * @param string $subject
+     * @param string $from
+     * @param string $to
+     *
      * @return string
      */
     public static function between($subject, $from, $to)
@@ -158,7 +165,8 @@ class Str
     /**
      * Convert a value to camel case.
      *
-     * @param  string  $value
+     * @param string $value
+     *
      * @return string
      */
     public static function camel($value)
@@ -173,13 +181,14 @@ class Str
     /**
      * Determine if a given string contains a given substring.
      *
-     * @param  string  $haystack
-     * @param  string|string[]  $needles
+     * @param string $haystack
+     * @param string|string[] $needles
+     *
      * @return bool
      */
     public static function contains($haystack, $needles)
     {
-        foreach ((array) $needles as $needle) {
+        foreach ((array)$needles as $needle) {
             if ($needle !== '' && mb_strpos($haystack, $needle) !== false) {
                 return true;
             }
@@ -191,8 +200,9 @@ class Str
     /**
      * Determine if a given string contains all array values.
      *
-     * @param  string  $haystack
-     * @param  string[]  $needles
+     * @param string $haystack
+     * @param string[] $needles
+     *
      * @return bool
      */
     public static function containsAll($haystack, array $needles)
@@ -209,14 +219,15 @@ class Str
     /**
      * Determine if a given string ends with a given substring.
      *
-     * @param  string  $haystack
-     * @param  string|string[]  $needles
+     * @param string $haystack
+     * @param string|string[] $needles
+     *
      * @return bool
      */
     public static function endsWith($haystack, $needles)
     {
-        foreach ((array) $needles as $needle) {
-            if ($needle !== '' && substr($haystack, -strlen($needle)) === (string) $needle) {
+        foreach ((array)$needles as $needle) {
+            if ($needle !== '' && substr($haystack, -strlen($needle)) === (string)$needle) {
                 return true;
             }
         }
@@ -227,22 +238,24 @@ class Str
     /**
      * Cap a string with a single instance of a given value.
      *
-     * @param  string  $value
-     * @param  string  $cap
+     * @param string $value
+     * @param string $cap
+     *
      * @return string
      */
     public static function finish($value, $cap)
     {
         $quoted = preg_quote($cap, '/');
 
-        return preg_replace('/(?:'.$quoted.')+$/u', '', $value).$cap;
+        return preg_replace('/(?:' . $quoted . ')+$/u', '', $value) . $cap;
     }
 
     /**
      * Determine if a given string matches a given pattern.
      *
-     * @param  string|array  $pattern
-     * @param  string  $value
+     * @param string|array $pattern
+     * @param string $value
+     *
      * @return bool
      */
     public static function is($pattern, $value)
@@ -268,7 +281,7 @@ class Str
             // pattern such as "library/*", making any string check convenient.
             $pattern = str_replace('\*', '.*', $pattern);
 
-            if (preg_match('#^'.$pattern.'\z#u', $value) === 1) {
+            if (preg_match('#^' . $pattern . '\z#u', $value) === 1) {
                 return true;
             }
         }
@@ -279,18 +292,20 @@ class Str
     /**
      * Determine if a given string is 7 bit ASCII.
      *
-     * @param  string  $value
+     * @param string $value
+     *
      * @return bool
      */
     public static function isAscii($value)
     {
-        return ASCII::is_ascii((string) $value);
+        return ASCII::is_ascii((string)$value);
     }
 
     /**
      * Determine if a given string is a valid UUID.
      *
-     * @param  string  $value
+     * @param string $value
+     *
      * @return bool
      */
     public static function isUuid($value)
@@ -305,7 +320,8 @@ class Str
     /**
      * Convert a string to kebab case.
      *
-     * @param  string  $value
+     * @param string $value
+     *
      * @return string
      */
     public static function kebab($value)
@@ -316,8 +332,9 @@ class Str
     /**
      * Return the length of the given string.
      *
-     * @param  string  $value
-     * @param  string|null  $encoding
+     * @param string $value
+     * @param string|null $encoding
+     *
      * @return int
      */
     public static function length($value, $encoding = null)
@@ -332,9 +349,10 @@ class Str
     /**
      * Limit the number of characters in a string.
      *
-     * @param  string  $value
-     * @param  int  $limit
-     * @param  string  $end
+     * @param string $value
+     * @param int $limit
+     * @param string $end
+     *
      * @return string
      */
     public static function limit($value, $limit = 100, $end = '...')
@@ -343,13 +361,14 @@ class Str
             return $value;
         }
 
-        return rtrim(mb_strimwidth($value, 0, $limit, '', 'UTF-8')).$end;
+        return rtrim(mb_strimwidth($value, 0, $limit, '', 'UTF-8')) . $end;
     }
 
     /**
      * Convert the given string to lower-case.
      *
-     * @param  string  $value
+     * @param string $value
+     *
      * @return string
      */
     public static function lower($value)
@@ -360,28 +379,30 @@ class Str
     /**
      * Limit the number of words in a string.
      *
-     * @param  string  $value
-     * @param  int  $words
-     * @param  string  $end
+     * @param string $value
+     * @param int $words
+     * @param string $end
+     *
      * @return string
      */
     public static function words($value, $words = 100, $end = '...')
     {
-        preg_match('/^\s*+(?:\S++\s*+){1,'.$words.'}/u', $value, $matches);
+        preg_match('/^\s*+(?:\S++\s*+){1,' . $words . '}/u', $value, $matches);
 
         if (! isset($matches[0]) || static::length($value) === static::length($matches[0])) {
             return $value;
         }
 
-        return rtrim($matches[0]).$end;
+        return rtrim($matches[0]) . $end;
     }
 
     /**
      * Pad both sides of a string with another.
      *
-     * @param  string  $value
-     * @param  int  $length
-     * @param  string  $pad
+     * @param string $value
+     * @param int $length
+     * @param string $pad
+     *
      * @return string
      */
     public static function padBoth($value, $length, $pad = ' ')
@@ -392,9 +413,10 @@ class Str
     /**
      * Pad the left side of a string with another.
      *
-     * @param  string  $value
-     * @param  int  $length
-     * @param  string  $pad
+     * @param string $value
+     * @param int $length
+     * @param string $pad
+     *
      * @return string
      */
     public static function padLeft($value, $length, $pad = ' ')
@@ -405,9 +427,10 @@ class Str
     /**
      * Pad the right side of a string with another.
      *
-     * @param  string  $value
-     * @param  int  $length
-     * @param  string  $pad
+     * @param string $value
+     * @param int $length
+     * @param string $pad
+     *
      * @return string
      */
     public static function padRight($value, $length, $pad = ' ')
@@ -418,8 +441,9 @@ class Str
     /**
      * Parse a Class[@]method style callback into class and method.
      *
-     * @param  string  $callback
-     * @param  string|null  $default
+     * @param string $callback
+     * @param string|null $default
+     *
      * @return array<int, string|null>
      */
     public static function parseCallback($callback, $default = null)
@@ -430,8 +454,9 @@ class Str
     /**
      * Get the plural form of an English word.
      *
-     * @param  string  $value
-     * @param  int  $count
+     * @param string $value
+     * @param int $count
+     *
      * @return string
      */
     public static function plural($value, $count = 2)
@@ -442,8 +467,9 @@ class Str
     /**
      * Pluralize the last word of an English, studly caps case string.
      *
-     * @param  string  $value
-     * @param  int  $count
+     * @param string $value
+     * @param int $count
+     *
      * @return string
      */
     public static function pluralStudly($value, $count = 2)
@@ -452,13 +478,14 @@ class Str
 
         $lastWord = array_pop($parts);
 
-        return implode('', $parts).self::plural($lastWord, $count);
+        return implode('', $parts) . self::plural($lastWord, $count);
     }
 
     /**
      * Generate a more truly "random" alpha-numeric string.
      *
-     * @param  int  $length
+     * @param int $length
+     *
      * @return string
      */
     public static function random($length = 16)
@@ -479,9 +506,10 @@ class Str
     /**
      * Replace a given value in the string sequentially with an array.
      *
-     * @param  string  $search
-     * @param  array<int|string, string>  $replace
-     * @param  string  $subject
+     * @param string $search
+     * @param array<int|string, string> $replace
+     * @param string $subject
+     *
      * @return string
      */
     public static function replaceArray($search, array $replace, $subject)
@@ -491,7 +519,7 @@ class Str
         $result = array_shift($segments);
 
         foreach ($segments as $segment) {
-            $result .= (array_shift($replace) ?? $search).$segment;
+            $result .= (array_shift($replace) ?? $search) . $segment;
         }
 
         return $result;
@@ -500,9 +528,10 @@ class Str
     /**
      * Replace the first occurrence of a given value in the string.
      *
-     * @param  string  $search
-     * @param  string  $replace
-     * @param  string  $subject
+     * @param string $search
+     * @param string $replace
+     * @param string $subject
+     *
      * @return string
      */
     public static function replaceFirst($search, $replace, $subject)
@@ -523,9 +552,10 @@ class Str
     /**
      * Replace the last occurrence of a given value in the string.
      *
-     * @param  string  $search
-     * @param  string  $replace
-     * @param  string  $subject
+     * @param string $search
+     * @param string $replace
+     * @param string $subject
+     *
      * @return string
      */
     public static function replaceLast($search, $replace, $subject)
@@ -546,21 +576,23 @@ class Str
     /**
      * Begin a string with a single instance of a given value.
      *
-     * @param  string  $value
-     * @param  string  $prefix
+     * @param string $value
+     * @param string $prefix
+     *
      * @return string
      */
     public static function start($value, $prefix)
     {
         $quoted = preg_quote($prefix, '/');
 
-        return $prefix.preg_replace('/^(?:'.$quoted.')+/u', '', $value);
+        return $prefix . preg_replace('/^(?:' . $quoted . ')+/u', '', $value);
     }
 
     /**
      * Convert the given string to upper-case.
      *
-     * @param  string  $value
+     * @param string $value
+     *
      * @return string
      */
     public static function upper($value)
@@ -571,7 +603,8 @@ class Str
     /**
      * Convert the given string to title case.
      *
-     * @param  string  $value
+     * @param string $value
+     *
      * @return string
      */
     public static function title($value)
@@ -582,7 +615,8 @@ class Str
     /**
      * Get the singular form of an English word.
      *
-     * @param  string  $value
+     * @param string $value
+     *
      * @return string
      */
     public static function singular($value)
@@ -593,9 +627,10 @@ class Str
     /**
      * Generate a URL friendly "slug" from a given string.
      *
-     * @param  string  $title
-     * @param  string  $separator
-     * @param  string|null  $language
+     * @param string $title
+     * @param string $separator
+     * @param string|null $language
+     *
      * @return string
      */
     public static function slug($title, $separator = '-', $language = 'en')
@@ -605,16 +640,16 @@ class Str
         // Convert all dashes/underscores into separator
         $flip = $separator === '-' ? '_' : '-';
 
-        $title = preg_replace('!['.preg_quote($flip).']+!u', $separator, $title);
+        $title = preg_replace('![' . preg_quote($flip) . ']+!u', $separator, $title);
 
         // Replace @ with the word 'at'
-        $title = str_replace('@', $separator.'at'.$separator, $title);
+        $title = str_replace('@', $separator . 'at' . $separator, $title);
 
         // Remove all characters that are not the separator, letters, numbers, or whitespace.
-        $title = preg_replace('![^'.preg_quote($separator).'\pL\pN\s]+!u', '', static::lower($title));
+        $title = preg_replace('![^' . preg_quote($separator) . '\pL\pN\s]+!u', '', static::lower($title));
 
         // Replace all separator characters and whitespace by a single separator
-        $title = preg_replace('!['.preg_quote($separator).'\s]+!u', $separator, $title);
+        $title = preg_replace('![' . preg_quote($separator) . '\s]+!u', $separator, $title);
 
         return trim($title, $separator);
     }
@@ -622,8 +657,9 @@ class Str
     /**
      * Convert a string to snake case.
      *
-     * @param  string  $value
-     * @param  string  $delimiter
+     * @param string $value
+     * @param string $delimiter
+     *
      * @return string
      */
     public static function snake($value, $delimiter = '_')
@@ -637,7 +673,7 @@ class Str
         if (! ctype_lower($value)) {
             $value = preg_replace('/\s+/u', '', ucwords($value));
 
-            $value = static::lower(preg_replace('/(.)(?=[A-Z])/u', '$1'.$delimiter, $value));
+            $value = static::lower(preg_replace('/(.)(?=[A-Z])/u', '$1' . $delimiter, $value));
         }
 
         return static::$snakeCache[$key][$delimiter] = $value;
@@ -646,14 +682,15 @@ class Str
     /**
      * Determine if a given string starts with a given substring.
      *
-     * @param  string  $haystack
-     * @param  string|string[]  $needles
+     * @param string $haystack
+     * @param string|string[] $needles
+     *
      * @return bool
      */
     public static function startsWith($haystack, $needles)
     {
-        foreach ((array) $needles as $needle) {
-            if ((string) $needle !== '' && strncmp($haystack, $needle, strlen($needle)) === 0) {
+        foreach ((array)$needles as $needle) {
+            if ((string)$needle !== '' && strncmp($haystack, $needle, strlen($needle)) === 0) {
                 return true;
             }
         }
@@ -664,7 +701,8 @@ class Str
     /**
      * Convert a value to studly caps case.
      *
-     * @param  string  $value
+     * @param string $value
+     *
      * @return string
      */
     public static function studly($value)
@@ -683,9 +721,10 @@ class Str
     /**
      * Returns the portion of string specified by the start and length parameters.
      *
-     * @param  string  $string
-     * @param  int  $start
-     * @param  int|null  $length
+     * @param string $string
+     * @param int $start
+     * @param int|null $length
+     *
      * @return string
      */
     public static function substr($string, $start, $length = null)
@@ -696,10 +735,11 @@ class Str
     /**
      * Returns the number of substring occurrences.
      *
-     * @param  string  $haystack
-     * @param  string  $needle
-     * @param  int  $offset
-     * @param  int|null  $length
+     * @param string $haystack
+     * @param string $needle
+     * @param int $offset
+     * @param int|null $length
+     *
      * @return int
      */
     public static function substrCount($haystack, $needle, $offset = 0, $length = null)
@@ -714,12 +754,13 @@ class Str
     /**
      * Make a string's first character uppercase.
      *
-     * @param  string  $string
+     * @param string $string
+     *
      * @return string
      */
     public static function ucfirst($string)
     {
-        return static::upper(static::substr($string, 0, 1)).static::substr($string, 1);
+        return static::upper(static::substr($string, 0, 1)) . static::substr($string, 1);
     }
 
     /**
@@ -730,8 +771,8 @@ class Str
     public static function uuid()
     {
         return static::$uuidFactory
-                    ? call_user_func(static::$uuidFactory)
-                    : Uuid::uuid4();
+            ? call_user_func(static::$uuidFactory)
+            : Uuid::uuid4();
     }
 
     /**
@@ -762,7 +803,8 @@ class Str
     /**
      * Set the callable that will be used to generate UUIDs.
      *
-     * @param  callable|null  $factory
+     * @param callable|null $factory
+     *
      * @return void
      */
     public static function createUuidsUsing(callable $factory = null)
@@ -779,4 +821,86 @@ class Str
     {
         static::$uuidFactory = null;
     }
+
+    /**
+     * Clean a string with easy to remember options
+     *
+     * @param $target
+     * @param array $options
+     *
+     * options include letters, numbers, space, comma, period, dash
+     *
+     * @return string
+     */
+    public static function clean($target, $options = null)
+    {
+        if (is_null($options)) {
+            $options = ['letters', 'numbers', 'space', 'comma', 'period', 'dash'];
+        }
+
+        $needles = [];
+
+        if (in_array('letters', $options) || in_array('alpha', $options)) {
+            $needles[] = 'a-zA-Z';
+        }
+
+        if (in_array('numbers', $options) || in_array('nums', $options)) {
+            $needles[] = '0-9';
+        }
+        if (in_array('comma', $options) || in_array(',', $options)) {
+            $needles[] = ',';
+        }
+        if (in_array('dash', $options) || in_array('-', $options) || in_array('hyphen', $options)) {
+            $needles[] = "\-";
+        }
+        if (in_array('dot', $options) || in_array('.', $options) || in_array('period', $options)) {
+            $needles[] = "\.";
+        }
+        if (in_array('colon', $options) || in_array(':', $options)) {
+            $needles[] = ':';
+        }
+        if (in_array('space', $options) || in_array(' ', $options)) {
+            $needles[] = ' ';
+        }
+
+        return preg_replace(sprintf("/[^%s]/", implode('', $needles)), '', $target);
+    }
+
+    /**
+     * Mask a string to a specific format, eg. Phone numbers, postal codes etc.
+     *
+     * @param string $target
+     * @param string $pattern
+     *
+     *  pattern should use the # character for numbers, and the $ character for letters
+     *
+     * @return string
+     */
+    public static function mask($target, $pattern)
+    {
+        $cleaned_target = preg_replace('/[^0-9a-zA-Z]/', '', $target);
+
+        $new_value = str_split($pattern);
+        for ($i = 0; $i < count($new_value); $i++) {
+            if (strlen($cleaned_target) > 0) {
+                if ($new_value[$i] == '#') {
+                    $string_position_of_next_number = strcspn($cleaned_target, '0123456789');
+                    if ($string_position_of_next_number < strlen($cleaned_target)) {
+                        $new_value[$i] = substr($cleaned_target, $string_position_of_next_number, 1);
+                    }
+                    $cleaned_target = substr($cleaned_target, $string_position_of_next_number + 1);
+                } else if ($new_value[$i] == '$') {
+                    $string_position_of_next_alpha = strcspn(strtolower($cleaned_target), 'abcdefghijklmnopqrstuvwxyz');
+                    if ($string_position_of_next_alpha < strlen($cleaned_target)) {
+                        $new_value[$i] = substr($cleaned_target, $string_position_of_next_alpha, 1);
+                    }
+                    $cleaned_target = substr($cleaned_target, $string_position_of_next_alpha + 1);
+                }
+            } else {
+                $new_value = array_slice($new_value, 0, $i);
+            }
+        }
+        return implode('', $new_value);
+    }
+
 }

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -29,7 +29,7 @@ class SupportStrTest extends TestCase
 
     public function testStringWithoutWordsDoesntProduceError()
     {
-        $nbsp = chr(0xC2).chr(0xA0);
+        $nbsp = chr(0xC2) . chr(0xA0);
         $this->assertSame(' ', Str::words(' '));
         $this->assertEquals($nbsp, Str::words($nbsp));
     }
@@ -501,7 +501,7 @@ class SupportStrTest extends TestCase
         return [
             ['not a valid uuid so we can test this'],
             ['zf6f8cb0-c57d-11e1-9b21-0800200c9a66'],
-            ['145a1e72-d11d-11e8-a8d5-f2801f1b9fd1'.PHP_EOL],
+            ['145a1e72-d11d-11e8-a8d5-f2801f1b9fd1' . PHP_EOL],
             ['145a1e72-d11d-11e8-a8d5-f2801f1b9fd1 '],
             [' 145a1e72-d11d-11e8-a8d5-f2801f1b9fd1'],
             ['145a1e72-d11d-11e8-a8d5-f2z01f1b9fd1'],
@@ -510,6 +510,19 @@ class SupportStrTest extends TestCase
             ['af6f8cb0c57d11e19b210800200c9a66'],
             ['ff6f8cb0-c57da-51e1-9b21-0800200c9a66'],
         ];
+    }
+
+    public function testClean()
+    {
+        $this->assertSame('invoice:AQ12345', Str::clean('invoice: AQ&*(*&(* 12345', ['letters', 'numbers', 'colon']));
+        $this->assertSame('103', Str::clean('Spend 10 hours working on a function to save you 3 minutes per project!', ['numbers']));
+        $this->assertSame('txjNOBlJQD8dVn5M9DM0BpPVksEc', Str::clean('t"xj+N#;OBlJ*QD8dVn5M9>;+-DM0BpP;V:k#sEc', ['letters', 'numbers']));
+    }
+
+    public function testMask()
+    {
+        $this->assertSame('800-800-8000', Str::mask('phone number: (800)!800.8000', "###-###-####"));
+        $this->assertSame('m1b 2c3', Str::mask('my postal code is a1b2c3', "$#$ #$#"));
     }
 }
 


### PR DESCRIPTION
## Intro
First pull request so if I'm missing anything just let me know and I will totally understand if it's not approved.  I believe I've read all the important details in the contribution guide, but I feel like I heard/read somewhere that you weren't looking to add to the string/array helper functions anymore, but I couldn't find where I read that - so hopefully this is a welcome PR, and not an annoyance.

This is a minor feature - and should be backwards compatible to versions prior to php 5.6.

At the moment there weren't any function definitions for `mask` or `clean` in the string helper so I don't think it should break any existing features.

It should also have good longevity/stability, the code itself uses pretty base level php functions like `strpos`, `preg_replace`, `substr` etc. 

### The problem I am trying to solve
I build primarily B2B software, usually a lot of forms, and profile pages etc. 
There are always a few things that need to happen when I work on these forms
- When you store data, you want to store it in a standardized format so it's easily searchable/filterable
- When displaying data, you want to appear it in an easy-to-read format

Common use cases that I have are 
- Phone numbers
- Zip/postal codes
- Employee IDs, or any other formatted identification numbers

So these 2 functions help developers do this. Their use-cases are 
- the clean function strips away all the formatting characters eg. `(800) 800-8000` turns into `8008008000`
- the mask function adds the formatting to the string eg `8008008000` turns into `(800) 800-8000`

As a side note, these functions also work great with Livewire - so you can make real-time masks.


### Str::clean - a wrapper around `preg_replace` with easy to remember options
this takes a target string, and an array of options - the options include `numbers`, `letters`, `space`, `comma`,`period`, `colon`, and has a few aliases as well (eg. `' '` = `'space'`)

```
Str::clean('y7Av58R/NW/Qep6vP@W/vvn;2ucp)KMzt6<D', ['numbers','letters']);
//Returns: 'y7Av58RNWQep6vPWvvn2ucpKMzt6D';

Str::clean('y7Av58R/NW/Qep6vP@W/vvn;2ucp)KMzt6<D', ['numbers']);
//Returns: '758626';
```

### Str::mask - takes a string and forces it into an easily definable format

```
//US Social Security Number
Str::mask('987654321', '###-##-####'); //returns "987-65-4321"

//US & Canada Phone Numbers
Str::mask('(800) 800.8000', '###-###-####'); //returns '800-800-8000'
Str::mask('8008008000 x 123', '###-###-#### ext. ######'); //returns '800-800-8000 ext. 123'
Str::mask('8008008000', '###-###-#### ext. ######'); //returns '800-800-8000'

//US Zip-code
Str::mask("The zip code for the whitehouse is: 20500", "#####"); //returns "20500"

//Canada Postal Code
Str::mask("A1B2C3", "$#$ #$#");  // returns 'A1B 2C3'
```

### PS
Sorry about the formatting changes - my PHPStorm automatically changed the formatting and I didn't notice until creating this PR - I am pretty sure StyleCI will put them back anyways though?  If not, just let me know and I'm happy to run through and clean them up.