### PR TITLE
[8.x] Add Clean and Mask to String Helper

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -784,9 +784,7 @@ class Str
      * Clean a string with easy to remember options.
      *
      * @param $target
-     * @param array $options
-     *
-     * options include letters, numbers, space, comma, period, dash
+     * @param array|null $options
      *
      * @return string
      */

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -858,6 +858,7 @@ class Str
                 $new_value = array_slice($new_value, 0, $i);
             }
         }
+
         return implode('', $new_value);
     }
 }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -781,7 +781,7 @@ class Str
     }
 
     /**
-     * Clean a string with easy to remember options
+     * Clean a string with easy to remember options.
      *
      * @param $target
      * @param array $options
@@ -821,7 +821,7 @@ class Str
             $needles[] = ' ';
         }
 
-        return preg_replace(sprintf("/[^%s]/", implode('', $needles)), '', $target);
+        return preg_replace(sprintf('/[^%s]/', implode('', $needles)), '', $target);
     }
 
     /**
@@ -847,7 +847,7 @@ class Str
                         $new_value[$i] = substr($cleaned_target, $string_position_of_next_number, 1);
                     }
                     $cleaned_target = substr($cleaned_target, $string_position_of_next_number + 1);
-                } else if ($new_value[$i] == '$') {
+                } elseif ($new_value[$i] == '$') {
                     $string_position_of_next_alpha = strcspn(strtolower($cleaned_target), 'abcdefghijklmnopqrstuvwxyz');
                     if ($string_position_of_next_alpha < strlen($cleaned_target)) {
                         $new_value[$i] = substr($cleaned_target, $string_position_of_next_alpha, 1);

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -779,4 +779,85 @@ class Str
     {
         static::$uuidFactory = null;
     }
+
+    /**
+     * Clean a string with easy to remember options
+     *
+     * @param $target
+     * @param array $options
+     *
+     * options include letters, numbers, space, comma, period, dash
+     *
+     * @return string
+     */
+    public static function clean($target, $options = null)
+    {
+        if (is_null($options)) {
+            $options = ['letters', 'numbers', 'space', 'comma', 'period', 'dash'];
+        }
+
+        $needles = [];
+
+        if (in_array('letters', $options) || in_array('alpha', $options)) {
+            $needles[] = 'a-zA-Z';
+        }
+
+        if (in_array('numbers', $options) || in_array('nums', $options)) {
+            $needles[] = '0-9';
+        }
+        if (in_array('comma', $options) || in_array(',', $options)) {
+            $needles[] = ',';
+        }
+        if (in_array('dash', $options) || in_array('-', $options) || in_array('hyphen', $options)) {
+            $needles[] = "\-";
+        }
+        if (in_array('dot', $options) || in_array('.', $options) || in_array('period', $options)) {
+            $needles[] = "\.";
+        }
+        if (in_array('colon', $options) || in_array(':', $options)) {
+            $needles[] = ':';
+        }
+        if (in_array('space', $options) || in_array(' ', $options)) {
+            $needles[] = ' ';
+        }
+
+        return preg_replace(sprintf("/[^%s]/", implode('', $needles)), '', $target);
+    }
+
+    /**
+     * Mask a string to a specific format, eg. Phone numbers, postal codes etc.
+     *
+     * @param string $target
+     * @param string $pattern
+     *
+     *  pattern should use the # character for numbers, and the $ character for letters
+     *
+     * @return string
+     */
+    public static function mask($target, $pattern)
+    {
+        $cleaned_target = preg_replace('/[^0-9a-zA-Z]/', '', $target);
+
+        $new_value = str_split($pattern);
+        for ($i = 0; $i < count($new_value); $i++) {
+            if (strlen($cleaned_target) > 0) {
+                if ($new_value[$i] == '#') {
+                    $string_position_of_next_number = strcspn($cleaned_target, '0123456789');
+                    if ($string_position_of_next_number < strlen($cleaned_target)) {
+                        $new_value[$i] = substr($cleaned_target, $string_position_of_next_number, 1);
+                    }
+                    $cleaned_target = substr($cleaned_target, $string_position_of_next_number + 1);
+                } else if ($new_value[$i] == '$') {
+                    $string_position_of_next_alpha = strcspn(strtolower($cleaned_target), 'abcdefghijklmnopqrstuvwxyz');
+                    if ($string_position_of_next_alpha < strlen($cleaned_target)) {
+                        $new_value[$i] = substr($cleaned_target, $string_position_of_next_alpha, 1);
+                    }
+                    $cleaned_target = substr($cleaned_target, $string_position_of_next_alpha + 1);
+                }
+            } else {
+                $new_value = array_slice($new_value, 0, $i);
+            }
+        }
+        return implode('', $new_value);
+    }
 }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -783,7 +783,7 @@ class Str
     /**
      * Clean a string with easy to remember options.
      *
-     * @param $target
+     * @param string $target
      * @param array|null $options
      *
      * @return string

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -828,8 +828,6 @@ class Str
      * @param string $target
      * @param string $pattern
      *
-     *  pattern should use the # character for numbers, and the $ character for letters
-     *
      * @return string
      */
     public static function mask($target, $pattern)

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -521,8 +521,8 @@ class SupportStrTest extends TestCase
 
     public function testMask()
     {
-        $this->assertSame('800-800-8000', Str::mask('phone number: (800)!800.8000', "###-###-####"));
-        $this->assertSame('m1b 2c3', Str::mask('my postal code is a1b2c3', "$#$ #$#"));
+        $this->assertSame('800-800-8000', Str::mask('phone number: (800)!800.8000', '###-###-####'));
+        $this->assertSame('m1b 2c3', Str::mask('my postal code is a1b2c3', '$#$ #$#'));
     }
 }
 

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -511,6 +511,19 @@ class SupportStrTest extends TestCase
             ['ff6f8cb0-c57da-51e1-9b21-0800200c9a66'],
         ];
     }
+
+    public function testClean()
+    {
+        $this->assertSame('invoice:AQ12345', Str::clean('invoice: AQ&*(*&(* 12345', ['letters', 'numbers', 'colon']));
+        $this->assertSame('103', Str::clean('Spend 10 hours working on a function to save you 3 minutes per project!', ['numbers']));
+        $this->assertSame('txjNOBlJQD8dVn5M9DM0BpPVksEc', Str::clean('t"xj+N#;OBlJ*QD8dVn5M9>;+-DM0BpP;V:k#sEc', ['letters', 'numbers']));
+    }
+
+    public function testMask()
+    {
+        $this->assertSame('800-800-8000', Str::mask('phone number: (800)!800.8000', "###-###-####"));
+        $this->assertSame('m1b 2c3', Str::mask('my postal code is a1b2c3', "$#$ #$#"));
+    }
 }
 
 class StringableObjectStub


### PR DESCRIPTION
Ok - This one I think doesn't have the formatting changes - hopefully this one checks out better!

## Intro
First pull request so if I'm missing anything just let me know and I will totally understand if it's not approved.  I believe I've read all the important details in the contribution guide, but I feel like I heard/read somewhere that you weren't looking to add to the string/array helper functions anymore, but I couldn't find where I read that - so hopefully this is a welcome PR, and not an annoyance.

This is a minor feature - and should be backwards compatible to versions prior to php 5.6.

At the moment there weren't any function definitions for `mask` or `clean` in the string helper so I don't think it should break any existing features.

It should also have good longevity/stability, the code itself uses pretty base level php functions like `strpos`, `preg_replace`, `substr` etc. 

### The problem I am trying to solve
I build primarily B2B software, usually a lot of forms, and profile pages etc. 
There are always a few things that need to happen when I work on these forms
- When you store data, you want to store it in a standardized format so it's easily searchable/filterable
- When displaying data, you want to appear it in an easy-to-read format

Common use cases that I have are 
- Phone numbers
- Zip/postal codes
- Employee IDs, or any other formatted identification numbers

So these 2 functions help developers do this. Their use-cases are 
- the clean function strips away all the formatting characters eg. `(800) 800-8000` turns into `8008008000`
- the mask function adds the formatting to the string eg `8008008000` turns into `(800) 800-8000`

As a side note, these functions also work great with Livewire - so you can make real-time masks.


### Str::clean - a wrapper around `preg_replace` with easy to remember options
this takes a target string, and an array of options - the options include `numbers`, `letters`, `space`, `comma`,`period`, `colon`, and has a few aliases as well (eg. `' '` = `'space'`)

```
Str::clean('y7Av58R/NW/Qep6vP@W/vvn;2ucp)KMzt6<D', ['numbers','letters']);
//Returns: 'y7Av58RNWQep6vPWvvn2ucpKMzt6D';

Str::clean('y7Av58R/NW/Qep6vP@W/vvn;2ucp)KMzt6<D', ['numbers']);
//Returns: '758626';
```

### Str::mask - takes a string and forces it into an easily definable format

```
//US Social Security Number
Str::mask('987654321', '###-##-####'); //returns "987-65-4321"

//US & Canada Phone Numbers
Str::mask('(800) 800.8000', '###-###-####'); //returns '800-800-8000'
Str::mask('8008008000 x 123', '###-###-#### ext. ######'); //returns '800-800-8000 ext. 123'
Str::mask('8008008000', '###-###-#### ext. ######'); //returns '800-800-8000'

//US Zip-code
Str::mask("The zip code for the whitehouse is: 20500", "#####"); //returns "20500"

//Canada Postal Code
Str::mask("A1B2C3", "$#$ #$#");  // returns 'A1B 2C3'
```