### PR TITLE
[8.x] Ensure ValidateSignature middleware is high priority

### DIFF
--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -72,6 +72,7 @@ class Kernel implements KernelContract
      */
     protected $middlewarePriority = [
         \Illuminate\Cookie\Middleware\EncryptCookies::class,
+        \Illuminate\Routing\Middleware\ValidateSignature::class,
         \Illuminate\Session\Middleware\StartSession::class,
         \Illuminate\View\Middleware\ShareErrorsFromSession::class,
         \Illuminate\Contracts\Auth\Middleware\AuthenticatesRequests::class,


### PR DESCRIPTION
By default, the middleware `\Illuminate\Routing\Middleware\ValidateSignature::class` runs **after** most application middleware when using signed routes (i.e. routes assigned the `signed` middleware). This PR ensures the `ValidateSignature::class` middleware runs early on in the request to avoid the unnecessary execution of additional middleware if the route signature is invalid.

The rationale behind this is that if a signed route has been tampered with, execution should halt as soon as possible. For example, out of the box, route model bindings will be resolved **before** verifying the signature of a signed route, resulting in unnecessary queries. If a user modifies a URL parameter used by route model binding in a signed route, the application will throw `404 - Model Not Found` instead of the desired `403 - Invalid Signature`.

A user can always override the `protected $middlewarePriority` property themselves to achieve this, but this PR will make it the default behaviour. I believe this PR is fully backward-compatible with previous versions of Laravel.
