### PR TITLE
[8.x] Create MigrateAutoCommand.php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "ext-openssl": "*",
-        "doctrine/dbal": "^3.0",
+        "doctrine/dbal": "^2.0|^3.0",
         "doctrine/inflector": "^1.4|^2.0",
         "dragonmantank/cron-expression": "^3.0.2",
         "egulias/email-validator": "^2.1.10",

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "ext-openssl": "*",
+        "doctrine/dbal": "^3.0",
         "doctrine/inflector": "^1.4|^2.0",
         "dragonmantank/cron-expression": "^3.0.2",
         "egulias/email-validator": "^2.1.10",

--- a/src/Illuminate/Foundation/Console/MigrateAutoCommand.php
+++ b/src/Illuminate/Foundation/Console/MigrateAutoCommand.php
@@ -15,20 +15,20 @@ class MigrateAutoCommand extends Command
 
     public function handle()
     {
-        Artisan::call('migrate' . ($this->option('fresh') ? ':fresh' : null) . ($this->option('force') ? ' --force' : null));
+        Artisan::call('migrate'.($this->option('fresh') ? ':fresh' : null).($this->option('force') ? ' --force' : null));
 
         $filesystem = new Filesystem;
         $dir = base_path(config('database.model_path'));
 
         if ($filesystem->exists($dir)) {
-            $namespace = str_replace(['app', '/'], ['App', '\\'], rtrim(config('database.model_path'), '/')) . '\\';
+            $namespace = str_replace(['app', '/'], ['App', '\\'], rtrim(config('database.model_path'), '/')).'\\';
 
             foreach ($filesystem->allFiles($dir) as $file) {
-                $class = app($namespace . str_replace(['/', '.php'], ['\\', null], $file->getRelativePathname()));
+                $class = app($namespace.str_replace(['/', '.php'], ['\\', null], $file->getRelativePathname()));
 
                 if (method_exists($class, 'migration')) {
                     if (Schema::hasTable($class->getTable())) {
-                        $tempTable = 'temp_' . $class->getTable();
+                        $tempTable = 'temp_'.$class->getTable();
 
                         Schema::dropIfExists($tempTable);
                         Schema::create($tempTable, function (Blueprint $table) use ($class) {
@@ -57,7 +57,7 @@ class MigrateAutoCommand extends Command
         $this->info('Migration complete!');
 
         if ($this->option('seed')) {
-            Artisan::call('db:seed' . ($this->option('force') ? ' --force' : null));
+            Artisan::call('db:seed'.($this->option('force') ? ' --force' : null));
 
             $this->info('Seeding complete!');
         }

--- a/src/Illuminate/Foundation/Console/MigrateAutoCommand.php
+++ b/src/Illuminate/Foundation/Console/MigrateAutoCommand.php
@@ -19,6 +19,7 @@ class MigrateAutoCommand extends Command
 
         if (! $modelNamespace) {
             $this->warn('model_namespace not found in database config file! Aborting...');
+            
             return;
         }
 

--- a/src/Illuminate/Foundation/Console/MigrateAutoCommand.php
+++ b/src/Illuminate/Foundation/Console/MigrateAutoCommand.php
@@ -17,7 +17,7 @@ class MigrateAutoCommand extends Command
     {
         $modelNamespace = config('database.model_namespace');
 
-        if (!$modelNamespace) {
+        if (! $modelNamespace) {
             $this->warn('model_namespace not found in database config file! Aborting...');
             return;
         }

--- a/src/Illuminate/Foundation/Console/MigrateAutoCommand.php
+++ b/src/Illuminate/Foundation/Console/MigrateAutoCommand.php
@@ -15,6 +15,11 @@ class MigrateAutoCommand extends Command
 
     public function handle()
     {
+        if (!config('database.model_path')) {
+            $this->error('model_path not found in database config file! Aborting...');
+            return;
+        }
+        
         Artisan::call('migrate'.($this->option('fresh') ? ':fresh' : null).($this->option('force') ? ' --force' : null));
 
         $filesystem = new Filesystem;

--- a/src/Illuminate/Foundation/Console/MigrateAutoCommand.php
+++ b/src/Illuminate/Foundation/Console/MigrateAutoCommand.php
@@ -19,7 +19,7 @@ class MigrateAutoCommand extends Command
 
         if (! $modelNamespace) {
             $this->warn('model_namespace not found in database config file! Aborting...');
-            
+
             return;
         }
 

--- a/src/Illuminate/Foundation/Console/MigrateAutoCommand.php
+++ b/src/Illuminate/Foundation/Console/MigrateAutoCommand.php
@@ -18,11 +18,13 @@ class MigrateAutoCommand extends Command
         Artisan::call('migrate' . ($this->option('fresh') ? ':fresh' : null) . ($this->option('force') ? ' --force' : null));
 
         $filesystem = new Filesystem;
-        $dir = base_path('app/Models');
+        $dir = base_path(config('database.model_path'));
 
         if ($filesystem->exists($dir)) {
+            $namespace = str_replace(['app', '/'], ['App', '\\'], rtrim(config('database.model_path'), '/')) . '\\';
+
             foreach ($filesystem->allFiles($dir) as $file) {
-                $class = app('App\\Models\\' . str_replace(['/', '.php'], ['\\', ''], $file->getRelativePathname()));
+                $class = app($namespace . str_replace(['/', '.php'], ['\\', null], $file->getRelativePathname()));
 
                 if (method_exists($class, 'migration')) {
                     if (Schema::hasTable($class->getTable())) {

--- a/src/Illuminate/Foundation/Console/MigrateAutoCommand.php
+++ b/src/Illuminate/Foundation/Console/MigrateAutoCommand.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Doctrine\DBAL\Schema\Comparator;
+use Illuminate\Console\Command;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Schema;
+
+class MigrateAutoCommand extends Command
+{
+    protected $signature = 'migrate:auto {--fresh} {--seed} {--force}';
+
+    public function handle()
+    {
+        Artisan::call('migrate' . ($this->option('fresh') ? ':fresh' : null) . ($this->option('force') ? ' --force' : null);
+
+        $filesystem = new Filesystem;
+        $dir = base_path('App/Models');
+
+        if ($filesystem->exists($dir)) {
+            foreach ($filesystem->allFiles($dir) as $file) {
+                $class = app('App\\Models\\' . str_replace(['/', '.php'], ['\\', ''], $file->getRelativePathname()));
+
+                if (method_exists($class, 'migration')) {
+                    if (Schema::hasTable($class->getTable())) {
+                        $tempTable = 'temp_' . $class->getTable();
+
+                        Schema::dropIfExists($tempTable);
+                        Schema::create($tempTable, function (Blueprint $table) use ($class) {
+                            $class->migration($table);
+                        });
+
+                        $schemaManager = $class->getConnection()->getDoctrineSchemaManager();
+                        $classTableDetails = $schemaManager->listTableDetails($class->getTable());
+                        $tempTableDetails = $schemaManager->listTableDetails($tempTable);
+                        $tableDiff = (new Comparator)->diffTable($classTableDetails, $tempTableDetails);
+
+                        if ($tableDiff) {
+                            $schemaManager->alterTable($tableDiff);
+                        }
+
+                        Schema::drop($tempTable);
+                    } else {
+                        Schema::create($class->getTable(), function (Blueprint $table) use ($class) {
+                            $class->migration($table);
+                        });
+                    }
+                }
+            }
+        }
+
+        $this->info('Migration complete!');
+
+        if ($this->option('seed')) {
+            Artisan::call('db:seed' . ($this->option('force') ? ' --force' : null));
+
+            $this->info('Seeding complete!');
+        }
+    }
+}

--- a/src/Illuminate/Foundation/Console/MigrateAutoCommand.php
+++ b/src/Illuminate/Foundation/Console/MigrateAutoCommand.php
@@ -15,10 +15,10 @@ class MigrateAutoCommand extends Command
 
     public function handle()
     {
-        Artisan::call('migrate' . ($this->option('fresh') ? ':fresh' : null) . ($this->option('force') ? ' --force' : null);
+        Artisan::call('migrate' . ($this->option('fresh') ? ':fresh' : null) . ($this->option('force') ? ' --force' : null));
 
         $filesystem = new Filesystem;
-        $dir = base_path('App/Models');
+        $dir = base_path('app/Models');
 
         if ($filesystem->exists($dir)) {
             foreach ($filesystem->allFiles($dir) as $file) {


### PR DESCRIPTION
# How It Works

The `migrate:auto` command will automatically diff the database and apply the necessary changes via Doctrine each time it is executed.

## Usage

Specify a `migration` method in your Laravel models:

    class Vehicle extends Model
    {
        use HasFactory;
    
        public function migration(Blueprint $table)
        {
            $table->id();
            $table->string('name');
            $table->timestamps();
        }
    }

Run the `migrate:auto` command:

    php artisan migrate:auto --fresh --seed --force

Note that `--fresh`, `--seed`, and `--force` are optional.

## Traditional Migrations

The `migrate:auto` command will run the traditional migration files before the automatic migration methods.

## Model Namespace

This would require a change to `laravel/laravel`, adding a `model_namespace` value to the `database` config file:

    /*
    |--------------------------------------------------------------------------
    | Model Namespace
    |--------------------------------------------------------------------------
    |
    | Here you may specify the namespace where your model classes reside. 
    | This is what will be used when resolving the automatic migration methods 
    | within your application when running the migrate:auto command.
    |
    */

    'model_namespace' => 'App\\Models',