### PR TITLE
[6.x] Fixed type error

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php
@@ -31,7 +31,7 @@ trait InteractsWithContentTypes
      */
     public function isJson()
     {
-        return Str::contains($this->header('CONTENT_TYPE'), ['/json', '+json']);
+        return Str::contains($this->header('CONTENT_TYPE') ?? '', ['/json', '+json']);
     }
 
     /**


### PR DESCRIPTION
`Str::contains` expects a string for the first param, not `?string`. Passing `null` to this function will cause a crash if the Symfony mbstring polyfill is used, or if PHP 8.1+ is used.

---

Related: https://github.com/laravel/framework/issues/35891, https://github.com/laravel/framework/pull/35915, https://github.com/symfony/polyfill/issues/329, https://bugs.php.net/bug.php?id=80649, https://wiki.php.net/rfc/deprecate_null_to_scalar_internal_arg.