### PR TITLE
[8.x] Change cache lock block method return type to mixed

### DIFF
--- a/src/Illuminate/Cache/Lock.php
+++ b/src/Illuminate/Cache/Lock.php
@@ -105,7 +105,7 @@ abstract class Lock implements LockContract
      *
      * @param  int  $seconds
      * @param  callable|null  $callback
-     * @return bool
+     * @return mixed
      *
      * @throws \Illuminate\Contracts\Cache\LockTimeoutException
      */

--- a/src/Illuminate/Contracts/Cache/Lock.php
+++ b/src/Illuminate/Contracts/Cache/Lock.php
@@ -17,7 +17,7 @@ interface Lock
      *
      * @param  int  $seconds
      * @param  callable|null  $callback
-     * @return bool
+     * @return mixed
      */
     public function block($seconds, $callback = null);
 


### PR DESCRIPTION
When a callback is passed to the block method on a cache lock, the lock will return the return value of the callback instead of a boolean. Because of this it would make more sense if the method's return type is `mixed`.

E.g.:

```php
Cache::lock('myLock')->block(3, fn () => 10)); // Returns 10
```