### PR TITLE
[8.x] Fix issue with dumping schema from a postgres database using no default schema

### DIFF
--- a/src/Illuminate/Database/Schema/PostgresSchemaState.php
+++ b/src/Illuminate/Database/Schema/PostgresSchemaState.php
@@ -16,9 +16,7 @@ class PostgresSchemaState extends SchemaState
      */
     public function dump(Connection $connection, $path)
     {
-        $schemaBuilder = $connection->getSchemaBuilder();
-        $schema = $schemaBuilder->getConnection()->getConfig('schema');
-
+        $schema = $connection->getConfig('schema');
         $excludedTables = collect($connection->getSchemaBuilder()->getAllTables())
                         ->map->tablename
                         ->reject(function ($table) {

--- a/src/Illuminate/Database/Schema/PostgresSchemaState.php
+++ b/src/Illuminate/Database/Schema/PostgresSchemaState.php
@@ -42,7 +42,7 @@ class PostgresSchemaState extends SchemaState
      */
     public function load($path)
     {
-        $command = 'PGPASSWORD=$LARAVEL_LOAD_PASSWORD pg_restore --no-owner --no-acl --host=$LARAVEL_LOAD_HOST --port=$LARAVEL_LOAD_PORT --username=$LARAVEL_LOAD_USER --dbname=$LARAVEL_LOAD_DATABASE $LARAVEL_LOAD_PATH';
+        $command = 'PGPASSWORD=$LARAVEL_LOAD_PASSWORD pg_restore --no-owner --no-acl --clean --if-exists --host=$LARAVEL_LOAD_HOST --port=$LARAVEL_LOAD_PORT --username=$LARAVEL_LOAD_USER --dbname=$LARAVEL_LOAD_DATABASE $LARAVEL_LOAD_PATH';
 
         if (Str::endsWith($path, '.sql')) {
             $command = 'PGPASSWORD=$LARAVEL_LOAD_PASSWORD psql --file=$LARAVEL_LOAD_PATH --host=$LARAVEL_LOAD_HOST --port=$LARAVEL_LOAD_PORT --username=$LARAVEL_LOAD_USER --dbname=$LARAVEL_LOAD_DATABASE';

--- a/src/Illuminate/Database/Schema/PostgresSchemaState.php
+++ b/src/Illuminate/Database/Schema/PostgresSchemaState.php
@@ -16,12 +16,15 @@ class PostgresSchemaState extends SchemaState
      */
     public function dump(Connection $connection, $path)
     {
+        $schemaBuilder = $connection->getSchemaBuilder();
+        $schema = $schemaBuilder->getConnection()->getConfig('schema');
+
         $excludedTables = collect($connection->getSchemaBuilder()->getAllTables())
                         ->map->tablename
                         ->reject(function ($table) {
                             return $table === $this->migrationTable;
-                        })->map(function ($table) {
-                            return '--exclude-table-data='.$table;
+                        })->map(function ($table) use ($schema) {
+                            return '--exclude-table-data='.$schema.'.'.$table;
                         })->implode(' ');
 
         $this->makeProcess(


### PR DESCRIPTION
This PR solves the issue #35965 by adding the schema of the table to be ignored in the `--exclude-table-data` option when performing a dump.

When loading generated dump it outputs some warnings saying that it cannot create the schema because it already exists, either way the rest of the load works successfully. Looking into the [Postgresql documentation](https://www.postgresql.org/docs/9.6/app-pgrestore.html) it is possible tho suppress such warnings ugins the option `--clean` and `--if-exists` when executing a `pg_restore`. As the load will only occur when the database is empty anyway the addition of those options seems harmless.

Fixes #35965