### PR TITLE
[8.x] Add optional parameter support in the middle of routes

### DIFF
--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -136,6 +136,19 @@ class RouteRegistrar
     }
 
     /**
+     * Create a route group with shared attributes.
+     *
+     * @param string $parameter
+     * @param string $pattern
+     * @param \Closure|string $routes
+     * @return void
+     */
+    public function groupWithOptionalParameter(string $parameter, string $pattern, $routes)
+    {
+        $this->router->groupWithOptionalParameter($parameter, $pattern, $this->attributes, $routes);
+    }
+
+    /**
      * Register a new route with the given verbs.
      *
      * @param  array|string  $methods

--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -202,8 +202,10 @@ class RouteUrlGenerator
 
             return (! isset($parameters[0]) && ! Str::endsWith($match[0], '?}'))
                         ? $match[0]
-                        : Arr::pull($parameters, 0);
+                        : Arr::pull($parameters, 0, '####NO_PARAMETER_FOUND####');
         }, $path);
+
+        $path = str_replace(['/####NO_PARAMETER_FOUND####/', '####NO_PARAMETER_FOUND####'], ['/', ''], $path);
 
         return trim(preg_replace('/\{.*?\?\}/', '', $path), '/');
     }

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -384,6 +384,26 @@ class Router implements BindingRegistrar, RegistrarContract
     }
 
     /**
+     * Create a route group with shared attributes.
+     *
+     * @param string $parameter
+     * @param string $pattern
+     * @param array $attributes
+     * @param $routes
+     * @return void
+     */
+    public function groupWithOptionalParameter(string $parameter, string $pattern, array $attributes, $routes)
+    {
+        $this->group($attributes, function ($router) use ($parameter, $pattern, $routes) {
+            $router->group([], $routes);
+            $router->group([
+                'prefix' => '{'.$parameter.'?}',
+                'where' => [$parameter => $pattern],
+            ], $routes);
+        });
+    }
+
+    /**
      * Update the group stack with the given attributes.
      *
      * @param  array  $attributes


### PR DESCRIPTION
This PR aims to give a way to handle optional parameters in the middle of routes.

The main use is for example the handling of languages/countries at the root of urls. 

This PR give the behavior for example: 
```
$router->name('Hreflang::')->groupWithOptionalParameter('hreflang', '^[a-z]{2}(?:\-[a-z]{2})?$', function () use ($router) {
    $router->get('home', ['as' => 'home', function () {
        return 'hello';
    }]);
});

$this->assertSame('http://www.foo.com:8080/home', $url->route('Hreflang::home'));

$this->assertSame('http://www.foo.com:8080/en-us/home', $url->route('Hreflang::home', [
    'hreflang'  =>  'en-us'
]));
```

Note: This feature is built on `group()` (ie the name `groupWithOptionalParameter`). One of the way I looked at it was to add a `optionalParameter($parameter, $pattern)` method to be chain as `name()`, `prefix()`, `namespace()`, etc... 
To me this would have been nicer but would involve potentially more code change.
 