### PR TITLE
[9.x] Bump DBAL to 2.12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -79,7 +79,7 @@
     },
     "require-dev": {
         "aws/aws-sdk-php": "^3.155",
-        "doctrine/dbal": "^2.6|^3.0",
+        "doctrine/dbal": "^2.12|^3.0",
         "filp/whoops": "^2.8",
         "guzzlehttp/guzzle": "^7.2",
         "league/flysystem-aws-s3-v3": "^2.0",
@@ -96,6 +96,7 @@
         "psr/container-implementation": "1.0"
     },
     "conflict": {
+        "doctrine/dbal": "<2.12",
         "tightenco/collect": "<5.5.33"
     },
     "autoload": {
@@ -132,7 +133,7 @@
         "ext-redis": "Required to use the Redis cache and queue drivers (^4.0|^5.0).",
         "aws/aws-sdk-php": "Required to use the SQS queue driver, DynamoDb failed job storage and SES mail driver (^3.155).",
         "brianium/paratest": "Required to run tests in parallel (^6.0).",
-        "doctrine/dbal": "Required to rename columns and drop SQLite columns (^2.6|^3.0).",
+        "doctrine/dbal": "Required to rename columns and drop SQLite columns (^2.12|^3.0).",
         "filp/whoops": "Required for friendly error pages in development (^2.8).",
         "fakerphp/faker": "Required to use the eloquent factory builder (^1.9.1).",
         "guzzlehttp/guzzle": "Required to use the HTTP Client, Mailgun mail driver and the ping methods on schedules (^7.2).",

--- a/composer.json
+++ b/composer.json
@@ -96,7 +96,6 @@
         "psr/container-implementation": "1.0"
     },
     "conflict": {
-        "doctrine/dbal": "<2.12",
         "tightenco/collect": "<5.5.33"
     },
     "autoload": {

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -920,7 +920,7 @@ class Connection implements ConnectionInterface
             $this->doctrineConnection = new DoctrineConnection(array_filter([
                 'pdo' => $this->getPdo(),
                 'dbname' => $this->getDatabaseName(),
-                'driver' => method_exists($driver, 'getName') ? $driver->getName() : null,
+                'driver' => $driver->getName(),
                 'serverVersion' => $this->getConfig('server_version'),
             ]), $driver);
         }

--- a/src/Illuminate/Database/DBAL/TimestampType.php
+++ b/src/Illuminate/Database/DBAL/TimestampType.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Database\DBAL;
 
-use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
 

--- a/src/Illuminate/Database/MySqlConnection.php
+++ b/src/Illuminate/Database/MySqlConnection.php
@@ -2,8 +2,6 @@
 
 namespace Illuminate\Database;
 
-use Doctrine\DBAL\Driver\PDOMySql\Driver as DoctrineDriver;
-use Doctrine\DBAL\Version;
 use Illuminate\Database\PDO\MySqlDriver;
 use Illuminate\Database\Query\Grammars\MySqlGrammar as QueryGrammar;
 use Illuminate\Database\Query\Processors\MySqlProcessor;
@@ -84,10 +82,10 @@ class MySqlConnection extends Connection
     /**
      * Get the Doctrine DBAL driver.
      *
-     * @return \Doctrine\DBAL\Driver\PDOMySql\Driver|\Illuminate\Database\PDO\MySqlDriver
+     * @return \Illuminate\Database\PDO\MySqlDriver
      */
     protected function getDoctrineDriver()
     {
-        return class_exists(Version::class) ? new DoctrineDriver : new MySqlDriver;
+        return new MySqlDriver;
     }
 }

--- a/src/Illuminate/Database/PDO/Concerns/ConnectsToDatabase.php
+++ b/src/Illuminate/Database/PDO/Concerns/ConnectsToDatabase.php
@@ -13,7 +13,7 @@ trait ConnectsToDatabase
      * @param  array  $params
      * @return \Illuminate\Database\PDO\Connection
      */
-    public function connect(array $params)
+    public function connect(array $params, $username = null, $password = null, array $driverOptions = [])
     {
         if (! isset($params['pdo']) || ! $params['pdo'] instanceof PDO) {
             throw new \InvalidArgumentException('Laravel requires the "pdo" property to be set and be a PDO instance.');

--- a/src/Illuminate/Database/PDO/Concerns/ConnectsToDatabase.php
+++ b/src/Illuminate/Database/PDO/Concerns/ConnectsToDatabase.php
@@ -10,7 +10,10 @@ trait ConnectsToDatabase
     /**
      * Create a new database connection.
      *
-     * @param  array  $params
+     * @param  mixed[]  $params
+     * @param  string|null  $username
+     * @param  string|null  $password
+     * @param  mixed[]  $driverOptions
      * @return \Illuminate\Database\PDO\Connection
      */
     public function connect(array $params, $username = null, $password = null, array $driverOptions = [])

--- a/src/Illuminate/Database/PDO/MySqlDriver.php
+++ b/src/Illuminate/Database/PDO/MySqlDriver.php
@@ -8,4 +8,16 @@ use Illuminate\Database\PDO\Concerns\ConnectsToDatabase;
 class MySqlDriver extends AbstractMySQLDriver
 {
     use ConnectsToDatabase;
+
+    /**
+     * Gets the name of the driver.
+     *
+     * @deprecated
+     *
+     * @return string The name of the driver.
+     */
+    public function getName()
+    {
+        return 'pdo_mysql';
+    }
 }

--- a/src/Illuminate/Database/PDO/MySqlDriver.php
+++ b/src/Illuminate/Database/PDO/MySqlDriver.php
@@ -10,11 +10,7 @@ class MySqlDriver extends AbstractMySQLDriver
     use ConnectsToDatabase;
 
     /**
-     * Gets the name of the driver.
-     *
-     * @deprecated
-     *
-     * @return string The name of the driver.
+     * {@inheritdoc}
      */
     public function getName()
     {

--- a/src/Illuminate/Database/PDO/PostgresDriver.php
+++ b/src/Illuminate/Database/PDO/PostgresDriver.php
@@ -8,4 +8,16 @@ use Illuminate\Database\PDO\Concerns\ConnectsToDatabase;
 class PostgresDriver extends AbstractPostgreSQLDriver
 {
     use ConnectsToDatabase;
+
+    /**
+     * Gets the name of the driver.
+     *
+     * @deprecated
+     *
+     * @return string The name of the driver.
+     */
+    public function getName()
+    {
+        return 'pdo_pgsql';
+    }
 }

--- a/src/Illuminate/Database/PDO/PostgresDriver.php
+++ b/src/Illuminate/Database/PDO/PostgresDriver.php
@@ -10,11 +10,7 @@ class PostgresDriver extends AbstractPostgreSQLDriver
     use ConnectsToDatabase;
 
     /**
-     * Gets the name of the driver.
-     *
-     * @deprecated
-     *
-     * @return string The name of the driver.
+     * {@inheritdoc}
      */
     public function getName()
     {

--- a/src/Illuminate/Database/PDO/SQLiteDriver.php
+++ b/src/Illuminate/Database/PDO/SQLiteDriver.php
@@ -8,4 +8,16 @@ use Illuminate\Database\PDO\Concerns\ConnectsToDatabase;
 class SQLiteDriver extends AbstractSQLiteDriver
 {
     use ConnectsToDatabase;
+
+    /**
+     * Gets the name of the driver.
+     *
+     * @deprecated
+     *
+     * @return string The name of the driver.
+     */
+    public function getName()
+    {
+        return 'pdo_sqlite';
+    }
 }

--- a/src/Illuminate/Database/PDO/SQLiteDriver.php
+++ b/src/Illuminate/Database/PDO/SQLiteDriver.php
@@ -10,11 +10,7 @@ class SQLiteDriver extends AbstractSQLiteDriver
     use ConnectsToDatabase;
 
     /**
-     * Gets the name of the driver.
-     *
-     * @deprecated
-     *
-     * @return string The name of the driver.
+     * {@inheritdoc}
      */
     public function getName()
     {

--- a/src/Illuminate/Database/PDO/SqlServerDriver.php
+++ b/src/Illuminate/Database/PDO/SqlServerDriver.php
@@ -14,11 +14,7 @@ class SqlServerDriver extends AbstractSQLServerDriver
     }
 
     /**
-     * Gets the name of the driver.
-     *
-     * @deprecated
-     *
-     * @return string The name of the driver.
+     * {@inheritdoc}
      */
     public function getName()
     {

--- a/src/Illuminate/Database/PDO/SqlServerDriver.php
+++ b/src/Illuminate/Database/PDO/SqlServerDriver.php
@@ -6,10 +6,22 @@ use Doctrine\DBAL\Driver\AbstractSQLServerDriver;
 
 class SqlServerDriver extends AbstractSQLServerDriver
 {
-    public function connect(array $params)
+    public function connect(array $params, $username = null, $password = null, array $driverOptions = [])
     {
         return new SqlServerConnection(
             new Connection($params['pdo'])
         );
+    }
+
+    /**
+     * Gets the name of the driver.
+     *
+     * @deprecated
+     *
+     * @return string The name of the driver.
+     */
+    public function getName()
+    {
+        return 'pdo_sqlsrv';
     }
 }

--- a/src/Illuminate/Database/PDO/SqlServerDriver.php
+++ b/src/Illuminate/Database/PDO/SqlServerDriver.php
@@ -6,6 +6,15 @@ use Doctrine\DBAL\Driver\AbstractSQLServerDriver;
 
 class SqlServerDriver extends AbstractSQLServerDriver
 {
+    /**
+     * Create a new database connection.
+     *
+     * @param  mixed[]  $params
+     * @param  string|null  $username
+     * @param  string|null  $password
+     * @param  mixed[]  $driverOptions
+     * @return \Illuminate\Database\PDO\Connection
+     */
     public function connect(array $params, $username = null, $password = null, array $driverOptions = [])
     {
         return new SqlServerConnection(

--- a/src/Illuminate/Database/PostgresConnection.php
+++ b/src/Illuminate/Database/PostgresConnection.php
@@ -2,8 +2,6 @@
 
 namespace Illuminate\Database;
 
-use Doctrine\DBAL\Driver\PDOPgSql\Driver as DoctrineDriver;
-use Doctrine\DBAL\Version;
 use Illuminate\Database\PDO\PostgresDriver;
 use Illuminate\Database\Query\Grammars\PostgresGrammar as QueryGrammar;
 use Illuminate\Database\Query\Processors\PostgresProcessor;
@@ -99,10 +97,10 @@ class PostgresConnection extends Connection
     /**
      * Get the Doctrine DBAL driver.
      *
-     * @return \Doctrine\DBAL\Driver\PDOPgSql\Driver|\Illuminate\Database\PDO\PostgresDriver
+     * @return \Illuminate\Database\PDO\PostgresDriver
      */
     protected function getDoctrineDriver()
     {
-        return class_exists(Version::class) ? new DoctrineDriver : new PostgresDriver;
+        return new PostgresDriver;
     }
 }

--- a/src/Illuminate/Database/SQLiteConnection.php
+++ b/src/Illuminate/Database/SQLiteConnection.php
@@ -2,8 +2,6 @@
 
 namespace Illuminate\Database;
 
-use Doctrine\DBAL\Driver\PDOSqlite\Driver as DoctrineDriver;
-use Doctrine\DBAL\Version;
 use Illuminate\Database\PDO\SQLiteDriver;
 use Illuminate\Database\Query\Grammars\SQLiteGrammar as QueryGrammar;
 use Illuminate\Database\Query\Processors\SQLiteProcessor;
@@ -98,11 +96,11 @@ class SQLiteConnection extends Connection
     /**
      * Get the Doctrine DBAL driver.
      *
-     * @return \Doctrine\DBAL\Driver\PDOSqlite\Driver|\Illuminate\Database\PDO\SQLiteDriver
+     * @return \Illuminate\Database\PDO\SQLiteDriver
      */
     protected function getDoctrineDriver()
     {
-        return class_exists(Version::class) ? new DoctrineDriver : new SQLiteDriver;
+        return new SQLiteDriver;
     }
 
     /**

--- a/src/Illuminate/Database/SqlServerConnection.php
+++ b/src/Illuminate/Database/SqlServerConnection.php
@@ -3,8 +3,6 @@
 namespace Illuminate\Database;
 
 use Closure;
-use Doctrine\DBAL\Driver\PDOSqlsrv\Driver as DoctrineDriver;
-use Doctrine\DBAL\Version;
 use Illuminate\Database\PDO\SqlServerDriver;
 use Illuminate\Database\Query\Grammars\SqlServerGrammar as QueryGrammar;
 use Illuminate\Database\Query\Processors\SqlServerProcessor;
@@ -116,10 +114,10 @@ class SqlServerConnection extends Connection
     /**
      * Get the Doctrine DBAL driver.
      *
-     * @return \Doctrine\DBAL\Driver\PDOSqlsrv\Driver|\Illuminate\Database\PDO\SqlServerDriver
+     * @return \Illuminate\Database\PDO\SqlServerDriver
      */
     protected function getDoctrineDriver()
     {
-        return class_exists(Version::class) ? new DoctrineDriver : new SqlServerDriver;
+        return new SqlServerDriver;
     }
 }

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -24,6 +24,9 @@
         "illuminate/support": "^9.0",
         "symfony/console": "^5.2"
     },
+    "conflict": {
+        "doctrine/dbal": "<2.12"
+    },
     "autoload": {
         "psr-4": {
             "Illuminate\\Database\\": ""
@@ -35,7 +38,7 @@
         }
     },
     "suggest": {
-        "doctrine/dbal": "Required to rename columns and drop SQLite columns (^2.6|^3.0).",
+        "doctrine/dbal": "Required to rename columns and drop SQLite columns (^2.12|^3.0).",
         "fakerphp/faker": "Required to use the eloquent factory builder (^1.9.1).",
         "illuminate/console": "Required to use the database commands (^9.0).",
         "illuminate/events": "Required to use the observers with Eloquent (^9.0).",

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -24,9 +24,6 @@
         "illuminate/support": "^9.0",
         "symfony/console": "^5.2"
     },
-    "conflict": {
-        "doctrine/dbal": "<2.12"
-    },
     "autoload": {
         "psr-4": {
             "Illuminate\\Database\\": ""


### PR DESCRIPTION
This bumps the minimum requirement for DBAL to 2.12 so we can remove some of the workarounds from when we introduced support for DBAL v3.0: https://github.com/laravel/framework/pull/35236

I've added an entry to `conflict` in `composer.json` so apps can't accidentally update and conflict with a lower version.

@taylorotwell appreciating a review from @GrahamCampbell before we merge this.

### Breaking Changes

This update of the minimum DBAL version needs to be documented in the upgrade guide for Laravel 9.