### PR TITLE
[8.x] Make sure the UrlGenerator does not create empty // on optional parameters

### DIFF
--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -202,8 +202,10 @@ class RouteUrlGenerator
 
             return (! isset($parameters[0]) && ! Str::endsWith($match[0], '?}'))
                         ? $match[0]
-                        : Arr::pull($parameters, 0);
+                        : Arr::pull($parameters, 0, '####NO_PARAMETER_FOUND####');
         }, $path);
+
+        $path = str_replace(['/####NO_PARAMETER_FOUND####/', '####NO_PARAMETER_FOUND####'], ['/', ''], $path);
 
         return trim(preg_replace('/\{.*?\?\}/', '', $path), '/');
     }


### PR DESCRIPTION
Hi,

This is just a follow up from the refused https://github.com/laravel/framework/pull/35967, this PR focus only on the UrlGenerator that generate empty `//` and so the code example from @driesvints : 

```
Route::get('home');
Route::group(['prefix' => '{locale?}'], function {
    Route::get('home')->name('home');
});
```

Would generate the right url on `route('home)` and `route('home', ['locale' => 'en'])` and those urls would work as expected.

Thanks for your time.