### PR TITLE
[8.x] Support dot notation in request query method

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -334,7 +334,9 @@ trait InteractsWithInput
      */
     public function query($key = null, $default = null)
     {
-        return $this->retrieveItem('query', $key, $default);
+        return data_get(
+            $this->query->all(), $key, $default
+        );
     }
 
     /**


### PR DESCRIPTION
Hey,

This is a follow up to https://github.com/laravel/framework/issues/34021#issuecomment-749497945, a conversation to better understand if there was specific reason why dot notation for the `request()->query` method isn't supported?

Like mentioned in the issue I like to be explicit with where my data is coming from, and in this instance I'm unable to do so as the query method doesn't support dot notation. I'm currently using the input method but this doesn't accurately represent where I'm retrieving the data from.

Thanks for your time,
Sam