### PR TITLE
[9.x] Drop doctrine/inflector v1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "ext-openssl": "*",
-        "doctrine/inflector": "^1.4|^2.0",
+        "doctrine/inflector": "^2.0",
         "dragonmantank/cron-expression": "^3.0.2",
         "egulias/email-validator": "^2.1.10",
         "league/commonmark": "^1.3",

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -17,7 +17,7 @@
         "php": "^7.3|^8.0",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "doctrine/inflector": "^1.4|^2.0",
+        "doctrine/inflector": "^2.0",
         "illuminate/collections": "^9.0",
         "illuminate/contracts": "^9.0",
         "illuminate/macroable": "^9.0",


### PR DESCRIPTION
v1 is unmaintained and v2's constraints still allow for proper installs: https://www.doctrine-project.org/projects/inflector.html