### PR TITLE
[9.] Update cron expression

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "ext-mbstring": "*",
         "ext-openssl": "*",
         "doctrine/inflector": "^1.4|^2.0",
-        "dragonmantank/cron-expression": "^3.0.2",
+        "dragonmantank/cron-expression": "^3.1",
         "egulias/email-validator": "^2.1.10",
         "league/commonmark": "^1.3",
         "league/flysystem": "^2.0",

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -328,7 +328,7 @@ class Event
             $date->setTimezone($this->timezone);
         }
 
-        return CronExpression::factory($this->expression)->isDue($date->toDateTimeString());
+        return (new CronExpression($this->expression))->isDue($date->toDateTimeString());
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Console\Scheduling;
 
 use Cron\CronExpression;
+use DateTimeZone;
 use Illuminate\Console\Command;
 use Illuminate\Support\Carbon;
 
@@ -47,7 +48,9 @@ class ScheduleListCommand extends Command
                 $event->description,
                 (new CronExpression($event->expression))
                             ->getNextRunDate(Carbon::now())
-                            ->setTimezone($this->option('timezone', config('app.timezone'))),
+                            ->setTimezone(
+                                new DateTimeZone($this->option('timezone') ?? config('app.timezone'))
+                            ),
             ];
         }
 

--- a/src/Illuminate/Console/composer.json
+++ b/src/Illuminate/Console/composer.json
@@ -33,7 +33,7 @@
         }
     },
     "suggest": {
-        "dragonmantank/cron-expression": "Required to use scheduler (^3.0.2).",
+        "dragonmantank/cron-expression": "Required to use scheduler (^3.1).",
         "guzzlehttp/guzzle": "Required to use the ping methods on schedules (^7.2).",
         "illuminate/bus": "Required to use the scheduled job dispatcher (^9.0).",
         "illuminate/container": "Required to use the scheduler (^9.0).",


### PR DESCRIPTION
Bumps cron expression to a higher minimum version and fixes a slight issue with the option call for timezone.