### PR TITLE
[9.x] Fixes `ParallelTesting::token()` return type in docs

### DIFF
--- a/src/Illuminate/Support/Facades/ParallelTesting.php
+++ b/src/Illuminate/Support/Facades/ParallelTesting.php
@@ -7,7 +7,7 @@ namespace Illuminate\Support\Facades;
  * @method static void setUpTestCase(callable $callback)
  * @method static void tearDownProcess(callable $callback)
  * @method static void tearDownTestCase(callable $callback)
- * @method static string token()
+ * @method static int|false token()
  *
  * @see \Illuminate\Testing\ParallelTesting
  */


### PR DESCRIPTION
This pull request fixes `ParallelTesting::token()` return type in facade docs.