### PR TITLE
[8.x] Added support of PHP 7.3 to RateLimiter middleware(queue) serialization

### DIFF
--- a/src/Illuminate/Queue/Middleware/RateLimited.php
+++ b/src/Illuminate/Queue/Middleware/RateLimited.php
@@ -126,25 +126,21 @@ class RateLimited
      *
      * @return array
      */
-    public function __serialize()
+    public function __sleep()
     {
         return [
-            'limiterName' => $this->limiterName,
-            'shouldRelease' => $this->shouldRelease,
+            'limiterName',
+            'shouldRelease',
         ];
     }
 
     /**
      * Prepare the object after unserialization.
      *
-     * @param  array  $data
      * @return void
      */
-    public function __unserialize(array $data)
+    public function __wakeup()
     {
         $this->limiter = Container::getInstance()->make(RateLimiter::class);
-
-        $this->limiterName = $data['limiterName'];
-        $this->shouldRelease = $data['shouldRelease'];
     }
 }

--- a/src/Illuminate/Queue/Middleware/RateLimitedWithRedis.php
+++ b/src/Illuminate/Queue/Middleware/RateLimitedWithRedis.php
@@ -92,12 +92,11 @@ class RateLimitedWithRedis extends RateLimited
     /**
      * Prepare the object after unserialization.
      *
-     * @param  array  $data
      * @return void
      */
-    public function __unserialize(array $data)
+    public function __wakeup()
     {
-        parent::__unserialize($data);
+        parent::__wakeup();
 
         $this->redis = Container::getInstance()->make(Redis::class);
     }

--- a/tests/Integration/Queue/RateLimitedTest.php
+++ b/tests/Integration/Queue/RateLimitedTest.php
@@ -80,6 +80,22 @@ class RateLimitedTest extends TestCase
         $this->assertJobWasReleased(NonAdminTestJob::class);
     }
 
+    public function testMiddlewareSerialization()
+    {
+        $rateLimited = new RateLimited('limiterName');
+        $rateLimited->shouldRelease = false;
+
+        $restoredRateLimited = unserialize(serialize($rateLimited));
+
+        $fetch = (function (string $name) {
+            return $this->{$name};
+        })->bindTo($restoredRateLimited, RateLimited::class);
+
+        $this->assertFalse($restoredRateLimited->shouldRelease);
+        $this->assertEquals('limiterName', $fetch('limiterName'));
+        $this->assertInstanceOf(RateLimiter::class, $fetch('limiter'));
+    }
+
     protected function assertJobRanSuccessfully($class)
     {
         $class::$handled = false;


### PR DESCRIPTION
PHP 7.3 does not support __serialize/__unserialize but Laravel 8 require php 7.3 and later.

Fixes https://github.com/laravel/framework/issues/35868 fro PHP 7.3+