### PR TITLE
[8.x] Fix error PDOException: There is no active transaction

### DIFF
--- a/src/Illuminate/Foundation/Testing/RefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/RefreshDatabase.php
@@ -104,7 +104,11 @@ trait RefreshDatabase
             $dispatcher = $connection->getEventDispatcher();
 
             $connection->unsetEventDispatcher();
-            $connection->beginTransaction();
+
+            if(!is_null($name)) {
+                $connection->beginTransaction();
+            }
+
             $connection->setEventDispatcher($dispatcher);
         }
 

--- a/src/Illuminate/Foundation/Testing/RefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/RefreshDatabase.php
@@ -105,7 +105,7 @@ trait RefreshDatabase
 
             $connection->unsetEventDispatcher();
 
-            if(!is_null($name)) {
+            if (! is_null($name)) {
                 $connection->beginTransaction();
             }
 


### PR DESCRIPTION
Got broken integration tests after an upgrade to Laravel 8.24.0 and PHP 8.0.1.

Tests are throwing error `PDOException: There is no active transaction` on DB refresh.

Tests are throwing error when the `Illuminate\Foundation\Testing\RefreshDatabase` trait used.

A condition added to the code in this pull request fixes the error described above.
