### PR TITLE
[8.x] Added reference to resourceVerbs method in docblock

### DIFF
--- a/src/Illuminate/Support/Facades/Route.php
+++ b/src/Illuminate/Support/Facades/Route.php
@@ -29,6 +29,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Routing\RouteRegistrar prefix(string  $prefix)
  * @method static \Illuminate\Routing\RouteRegistrar where(array  $where)
  * @method static \Illuminate\Routing\Router|\Illuminate\Routing\RouteRegistrar group(\Closure|string|array $attributes, \Closure|string $routes)
+ * @method static \Illuminate\Routing\ResourceRegistrar resourceVerbs(array $verbs = [])
  * @method static string|null currentRouteAction()
  * @method static string|null currentRouteName()
  * @method static void apiResources(array $resources, array $options = [])


### PR DESCRIPTION
Missing reference to resourceVerbs method in autocomplete
