### PR TITLE
[8.x] Fix worker --delay option

### DIFF
--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -124,13 +124,9 @@ class WorkCommand extends Command
      */
     protected function gatherWorkerOptions()
     {
-        $backoff = $this->hasOption('backoff')
-                    ? $this->option('backoff')
-                    : $this->option('delay');
-
         return new WorkerOptions(
             $this->option('name'),
-            $backoff,
+            max($this->option('backoff'), $this->option('delay')),
             $this->option('memory'),
             $this->option('timeout'),
             $this->option('sleep'),


### PR DESCRIPTION
The `--delay` option was replaced with `--backoff`. However, the worker still accepts the `--delay` option to support old daemons running on servers.

The problem is that since we introduced `--backoff`, `--delay` stopped working because `$this->hasOption('backoff')` always returns true.

In this PR we fix that by using the highest value provided from the options. Since they both default to zero, the highest value will be the option provided.