### PR TITLE
[9.x] Remove view component from routing dependency

### DIFF
--- a/src/Illuminate/Routing/Exceptions/NotImplementedException.php
+++ b/src/Illuminate/Routing/Exceptions/NotImplementedException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Routing\Exceptions;
+
+use Exception;
+
+class NotImplementedException extends Exception
+{
+    public static function create()
+    {
+        return new static();
+    }
+}

--- a/src/Illuminate/Routing/ResponseFactory.php
+++ b/src/Illuminate/Routing/ResponseFactory.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Routing\ResponseFactory as FactoryContract;
 use Illuminate\Contracts\View\Factory as ViewFactory;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Response;
+use Illuminate\Routing\Exceptions\NotImplementedException;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
@@ -32,13 +33,13 @@ class ResponseFactory implements FactoryContract
     /**
      * Create a new response factory instance.
      *
-     * @param  \Illuminate\Contracts\View\Factory  $view
      * @param  \Illuminate\Routing\Redirector  $redirector
      * @return void
      */
-    public function __construct(ViewFactory $view, Redirector $redirector)
+    //public function __construct(ViewFactory $view, Redirector $redirector)
+    public function __construct(Redirector $redirector)
     {
-        $this->view = $view;
+        //$this->view = $view;
         $this->redirector = $redirector;
     }
 
@@ -68,6 +69,16 @@ class ResponseFactory implements FactoryContract
     }
 
     /**
+     * Set view factory to render blade errors
+     *
+     * @param ViewFactory $view
+     */
+    public function setView(ViewFactory $view)
+    {
+        $this->view = $view;
+    }
+
+    /**
      * Create a new response for a given view.
      *
      * @param  string|array  $view
@@ -78,6 +89,9 @@ class ResponseFactory implements FactoryContract
      */
     public function view($view, $data = [], $status = 200, array $headers = [])
     {
+        if (!isset($this->view)) {
+            throw NotImplementedException::create();
+        }
         if (is_array($view)) {
             return $this->make($this->view->first($view, $data), $status, $headers);
         }

--- a/src/Illuminate/Routing/RoutingServiceProvider.php
+++ b/src/Illuminate/Routing/RoutingServiceProvider.php
@@ -5,7 +5,6 @@ namespace Illuminate\Routing;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Routing\ResponseFactory as ResponseFactoryContract;
 use Illuminate\Contracts\Routing\UrlGenerator as UrlGeneratorContract;
-use Illuminate\Contracts\View\Factory as ViewFactoryContract;
 use Illuminate\Routing\Contracts\ControllerDispatcher as ControllerDispatcherContract;
 use Illuminate\Support\ServiceProvider;
 use Nyholm\Psr7\Factory\Psr17Factory;
@@ -165,7 +164,12 @@ class RoutingServiceProvider extends ServiceProvider
     protected function registerResponseFactory()
     {
         $this->app->singleton(ResponseFactoryContract::class, function ($app) {
-            return new ResponseFactory($app[ViewFactoryContract::class], $app['redirect']);
+            $responseFactory =  new ResponseFactory($app['redirect']);
+            if ($app->has('view')) {
+                $responseFactory->setView($app->get('view'));
+            }
+
+            return $responseFactory;
         });
     }
 

--- a/src/Illuminate/Routing/composer.json
+++ b/src/Illuminate/Routing/composer.json
@@ -40,6 +40,7 @@
     },
     "suggest": {
         "illuminate/console": "Required to use the make commands (^9.0).",
+        "illuminate/view": "Required to response with blade views",
         "nyholm/psr7": "Required to use PSR-7 bridging features (^1.2).",
         "symfony/psr-http-message-bridge": "Required to use PSR-7 bridging features (^2.0)."
     },

--- a/tests/Integration/Routing/WithoutViewComponentTest.php
+++ b/tests/Integration/Routing/WithoutViewComponentTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Routing;
+
+use Illuminate\Contracts\Routing\ResponseFactory;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\View;
+use Orchestra\Testbench\TestCase;
+
+class WithoutViewComponentTest extends TestCase
+{
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        if (
+            $this->app->hasBeenBootstrapped()
+            && $this->app->has(ResponseFactory::class)
+            && $this->app->has('view')
+        ) {
+            $this->app->forgetInstance('view');
+            $this->app->forgetInstance(ResponseFactory::class);
+            $this->app->forgetInstance('view');
+        }
+    }
+
+    public function testSignedMiddlewareWithInvalidUrl()
+    {
+        $url = '/foo/bar/baz';
+        Route::view($url, 'view', ['foo' => 'baz']);
+        View::addLocation(__DIR__.'/Fixtures');
+
+        $response = $this->get($url);
+
+        $this->assertStringContainsString('Test baz', $response->getContent());
+        $response->assertStatus(200);
+    }
+}


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->


Relates to https://github.com/laravel/framework/issues/31781 and https://github.com/laravel/ideas/issues/2112


The only thing, I don't know how to test when there is no view (`Illuminate\Contracts\View\Factory`).
Can you please help me recreate `Illuminate\Contracts\Routing\ResponseFactory` without view dependency?