### PR TITLE
[8.x] Add QueryBuilder::last method

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -150,6 +150,17 @@ trait BuildsQueries
     }
 
     /**
+     * Execute the query and get the last result.
+     *
+     * @param  array|string  $columns
+     * @return \Illuminate\Database\Eloquent\Model|object|static|null
+     */
+    public function last($columns = ['*'])
+    {
+        return $this->get($columns)->last();
+    }
+
+    /**
      * Execute the query and get the first result if it's the sole matching record.
      *
      * @param  array|string  $columns

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -180,10 +180,20 @@ class DatabaseEloquentBuilderTest extends TestCase
     {
         $builder = m::mock(Builder::class.'[get,take]', [$this->getMockQueryBuilder()]);
         $builder->shouldReceive('take')->with(1)->andReturnSelf();
-        $builder->shouldReceive('get')->with(['*'])->andReturn(new Collection(['bar']));
+        $builder->shouldReceive('get')->with(['*'])->andReturn(new Collection(['bar', 'foo']));
 
         $result = $builder->first();
         $this->assertSame('bar', $result);
+    }
+
+    public function testLastMethod()
+    {
+        $builder = m::mock(Builder::class.'[get,take]', [$this->getMockQueryBuilder()]);
+        $builder->shouldReceive('take')->with(1)->andReturnSelf();
+        $builder->shouldReceive('get')->with(['*'])->andReturn(new Collection(['bar', 'foo']));
+
+        $result = $builder->last();
+        $this->assertSame('foo', $result);
     }
 
     public function testQualifyColumn()


### PR DESCRIPTION
This PR adds a `last()` method to the QueryBuilder for logical consistency. Currently, `first()` can be used to run the query and return the first entry from the `Collection`. This PR aims to add a `last()` method to add the same functionality but with the difference that it returns the last element from the `Collection` that is the result of a query.

This should be a logical addition to add more consistency (e.g. `Collection`s also have first&last methods).

A test has been added as well and the `first()` test has been extended to make more sense, as the current `first()` test only checks on an array with only one entry (hence it will always be true, no matter if the actual first entry is returned or not).
