### PR TITLE
[8.x] Toggle between trashed and restored for soft deletes

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -137,7 +137,7 @@ trait SoftDeletes
     }
 
     /**
-     * Toggle between trashed and restored
+     * Toggle between trashed and restored.
      */
     public function toggleTrashed()
     {

--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -137,6 +137,18 @@ trait SoftDeletes
     }
 
     /**
+     * Toggle between trashed and restored
+     */
+    public function toggleTrashed()
+    {
+        if ($this->trashed()) {
+            $this->restore();
+        } else {
+            $this->delete();
+        }
+    }
+
+    /**
      * Register a "restoring" model event callback with the dispatcher.
      *
      * @param  \Closure|string  $callback

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -307,7 +307,6 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $this->assertEquals($userModel->getOriginal('deleted_at'), SoftDeletesTestUser::withTrashed()->find(1)->deleted_at);
     }
 
-
     public function testToggleTrashed()
     {
         $this->createUsers();

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -307,6 +307,19 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $this->assertEquals($userModel->getOriginal('deleted_at'), SoftDeletesTestUser::withTrashed()->find(1)->deleted_at);
     }
 
+
+    public function testToggleTrashed()
+    {
+        $this->createUsers();
+
+        /** @var \Illuminate\Tests\Database\SoftDeletesTestUser $userModel */
+        $userModel = SoftDeletesTestUser::withTrashed()->find(1);
+        $userModel->toggleTrashed();
+        $this->assertFalse($userModel->trashed());
+        $userModel->toggleTrashed();
+        $this->assertTrue($userModel->trashed());
+    }
+
     public function testModifyingBeforeSoftDeletingAndRestoring()
     {
         $this->createUsers();


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
When using soft deletes as a method to show and hide models, you have to check if the model is trashed first to know whether to delete() or restore() them. This method allows you to toggle the trashed state without the need to check first for convenience. 

```php
$user = User::withTrashed()->first();

$user->toggleTrashed(); 
```

An example usages of this would be a blog, where you want to easily show or hide a post by toggling the trashed state to publish or unpublish the post on your blog.