### PR TITLE
[8.x] Add column comment() support for SQL Server

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -57,6 +57,7 @@ class SqlServerGrammar extends Grammar
         $isChange = $command->get('column')->get('change');
         $column = $command->get('column')->get('name');
         $sp_cmd = $isChange ? 'sp_updateextendedproperty' : 'sp_addextendedproperty';
+
         return sprintf("exec %s 'MS_Description', N'%s', 'Schema', 'dbo', 'Table', '%s', 'Column', '%s'",
             $sp_cmd, $command->get('value'), $blueprint->getTable(), $column
         );


### PR DESCRIPTION
Use example:

```
Schema::create('test', function (Blueprint $table) {
    $table->id();
    $table->string('new_column')->comment('this is column comment');
    $table->timestamps();
});
```
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
