### PR TITLE
[9.x] Support for escaping bound attributes

### DIFF
--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -463,6 +463,10 @@ class ComponentTagCompiler
                 $value = "'".$this->compileAttributeEchos($value)."'";
             }
 
+            if (Str::startsWith($attribute, '::')) {
+                $attribute = substr($attribute, 1);
+            }
+
             return [$attribute => $value];
         })->toArray();
     }
@@ -493,7 +497,7 @@ class ComponentTagCompiler
     {
         $pattern = "/
             (?:^|\s+)     # start of the string or whitespace between attributes
-            :             # attribute needs to start with a semicolon
+            :(?!:)        # attribute needs to start with a single colon
             ([\w\-:.@]+)  # match the actual attribute name
             =             # only match attributes that have a value
         /xm";

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -463,8 +463,8 @@ class ComponentTagCompiler
                 $value = "'".$this->compileAttributeEchos($value)."'";
             }
 
-            if (Str::startsWith($attribute, '::')) {
-                $attribute = substr($attribute, 1);
+            if (Str::startsWith($attribute, ':::')) {
+                $attribute = substr($attribute, 2);
             }
 
             return [$attribute => $value];
@@ -497,7 +497,7 @@ class ComponentTagCompiler
     {
         $pattern = "/
             (?:^|\s+)     # start of the string or whitespace between attributes
-            :(?!:)        # attribute needs to start with a single colon
+            :(?!::)       # attribute needs to start with no more than two colons
             ([\w\-:.@]+)  # match the actual attribute name
             =             # only match attributes that have a value
         /xm";

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -463,8 +463,8 @@ class ComponentTagCompiler
                 $value = "'".$this->compileAttributeEchos($value)."'";
             }
 
-            if (Str::startsWith($attribute, ':::')) {
-                $attribute = substr($attribute, 2);
+            if (Str::startsWith($attribute, '::')) {
+                $attribute = substr($attribute, 1);
             }
 
             return [$attribute => $value];
@@ -497,7 +497,7 @@ class ComponentTagCompiler
     {
         $pattern = "/
             (?:^|\s+)     # start of the string or whitespace between attributes
-            :(?!::)       # attribute needs to start with no more than two colons
+            :(?!:)        # attribute needs to start with a single colon
             ([\w\-:.@]+)  # match the actual attribute name
             =             # only match attributes that have a value
         /xm";

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -90,13 +90,13 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
 
     public function testEscapedColonAttribute()
     {
-        $result = $this->compiler(['profile' => TestProfileComponent::class])->compileTags('<x-profile :user-id="1" ::aria-label="$ariaLabelExpression()" :::title="user.name"></x-profile>');
+        $result = $this->compiler(['profile' => TestProfileComponent::class])->compileTags('<x-profile :user-id="1" ::title="user.name"></x-profile>');
 
         $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\Tests\View\Blade\TestProfileComponent', 'profile', ['userId' => 1])
 <?php if (isset(\$attributes) && \$constructor = (new ReflectionClass(Illuminate\Tests\View\Blade\TestProfileComponent::class))->getConstructor()): ?>
 <?php \$attributes = \$attributes->except(collect(\$constructor->getParameters())->map->getName()->all()); ?>
 <?php endif; ?>
-<?php \$component->withAttributes([':aria-label' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute(\$ariaLabelExpression()),':title' => 'user.name']); ?> @endComponentClass##END-COMPONENT-CLASS##", trim($result));
+<?php \$component->withAttributes([':title' => 'user.name']); ?> @endComponentClass##END-COMPONENT-CLASS##", trim($result));
     }
 
     public function testColonAttributesIsEscapedIfStrings()

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -92,11 +92,11 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
     {
         $result = $this->compiler(['profile' => TestProfileComponent::class])->compileTags('<x-profile :user-id="1" ::aria-label="$ariaLabelExpression()" :::title="user.name"></x-profile>');
 
-        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestProfileComponent', 'profile', ['userId' => 1])
+        $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\Tests\View\Blade\TestProfileComponent', 'profile', ['userId' => 1])
 <?php if (isset(\$attributes) && \$constructor = (new ReflectionClass(Illuminate\Tests\View\Blade\TestProfileComponent::class))->getConstructor()): ?>
 <?php \$attributes = \$attributes->except(collect(\$constructor->getParameters())->map->getName()->all()); ?>
 <?php endif; ?>
-<?php \$component->withAttributes([':aria-label' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute(\$ariaLabelExpression()),':title' => 'user.name']); ?> @endcomponentClass", trim($result));
+<?php \$component->withAttributes([':aria-label' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute(\$ariaLabelExpression()),':title' => 'user.name']); ?> @endComponentClass##END-COMPONENT-CLASS##", trim($result));
     }
 
     public function testColonAttributesIsEscapedIfStrings()

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -88,6 +88,17 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
 <?php \$component->withAttributes([]); ?> @endComponentClass##END-COMPONENT-CLASS##", trim($result));
     }
 
+    public function testEscapedColonAttribute()
+    {
+        $result = $this->compiler([ 'profile' => TestProfileComponent::class ])->compileTags('<x-profile ::title="user.name"></x-profile>');
+
+        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestProfileComponent', 'profile', [])
+<?php if (isset(\$attributes) && \$constructor = (new ReflectionClass(Illuminate\Tests\View\Blade\TestProfileComponent::class))->getConstructor()): ?>
+<?php \$attributes = \$attributes->except(collect(\$constructor->getParameters())->map->getName()->all()); ?>
+<?php endif; ?>
+<?php \$component->withAttributes([':title' => 'user.name']); ?> @endcomponentClass", trim($result));
+    }
+
     public function testColonAttributesIsEscapedIfStrings()
     {
         $result = $this->compiler(['profile' => TestProfileComponent::class])->compileTags('<x-profile :src="\'foo\'"></x-profile>');

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -90,7 +90,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
 
     public function testEscapedColonAttribute()
     {
-        $result = $this->compiler([ 'profile' => TestProfileComponent::class ])->compileTags('<x-profile :user-id="1" ::aria-label="$ariaLabelExpression()" :::title="user.name"></x-profile>');
+        $result = $this->compiler(['profile' => TestProfileComponent::class])->compileTags('<x-profile :user-id="1" ::aria-label="$ariaLabelExpression()" :::title="user.name"></x-profile>');
 
         $this->assertSame("@component('Illuminate\Tests\View\Blade\TestProfileComponent', 'profile', ['userId' => 1])
 <?php if (isset(\$attributes) && \$constructor = (new ReflectionClass(Illuminate\Tests\View\Blade\TestProfileComponent::class))->getConstructor()): ?>

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -90,13 +90,13 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
 
     public function testEscapedColonAttribute()
     {
-        $result = $this->compiler([ 'profile' => TestProfileComponent::class ])->compileTags('<x-profile ::title="user.name"></x-profile>');
+        $result = $this->compiler([ 'profile' => TestProfileComponent::class ])->compileTags('<x-profile :user-id="1" ::aria-label="$ariaLabelExpression()" :::title="user.name"></x-profile>');
 
-        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestProfileComponent', 'profile', [])
+        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestProfileComponent', 'profile', ['userId' => 1])
 <?php if (isset(\$attributes) && \$constructor = (new ReflectionClass(Illuminate\Tests\View\Blade\TestProfileComponent::class))->getConstructor()): ?>
 <?php \$attributes = \$attributes->except(collect(\$constructor->getParameters())->map->getName()->all()); ?>
 <?php endif; ?>
-<?php \$component->withAttributes([':title' => 'user.name']); ?> @endcomponentClass", trim($result));
+<?php \$component->withAttributes([':aria-label' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute(\$ariaLabelExpression()),':title' => 'user.name']); ?> @endcomponentClass", trim($result));
     }
 
     public function testColonAttributesIsEscapedIfStrings()


### PR DESCRIPTION
This PR adds support for escaping bound component attributes with a triple colon (`:::`) in the same way you can escape blade directives with a double at (`@@`). I've opted for a triple colon rather than a double to allow support for bound attributes that also start with a colon.


### Sample Component Usage

```php
$buttonTitle = 'Button Title';
$getButtonTypeAlpineExpression = function() {
  return "inForm ? 'submit' : 'button'";
};
```

```html
<x-button
  :label="$buttonTitle"
  ::type="$getButtonTypeAlpineExpression()"
  :::class="{ hidden: !canSubmit }"
/>
```

### Sample Output
```html
<button :type="inForm ? 'submit' : 'button'" :class="{ hidden: !canSubmit }">
  Button Title
</button>
```

It also fixes a tiny typo in `ComponentTagCompiler` — swapping out "semicolon" with "colon"

I'm submitting this as a 9.x change because it could technically be considered breaking.  I think it's pretty safe to assume no one is using triple colons in their blade attributes, though, so I think it'd be OK to merge into 8.x instead. I'd be happy to re-submit if you agree.