### PR TITLE
Fix Route uses method with callable

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -862,7 +862,7 @@ class Route
 
         $action = is_string($action) ? $this->addGroupNamespaceToStringUses($action) : $action;
 
-        return $this->setAction(array_merge($this->action, $this->parseAction([
+        return $this->setAction(array_merge($this->action, $this->parseAction(is_callable($action) ? $action : [
             'uses' => $action,
             'controller' => $action,
         ])));

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1904,6 +1904,17 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals(301, $response->getStatusCode());
     }
 
+    public function testUsesWithCallableActionNotSetAsController()
+    {
+        $router = $this->getRouter();
+        $route = $router->get('test')->uses(function () {
+            return 'Test';
+        });
+
+        $this->assertSame('Test', $router->dispatch(Request::create('test', 'GET'))->getContent());
+        $this->assertFalse(isset($route->action['controller']));
+    }
+
     protected function getRouter()
     {
         $container = new Container;


### PR DESCRIPTION
When using the `Illuminate\Routing\Route::uses` method with a Closure, an error is thrown in `Illuminate\Routing\RouteCollection::addToActionList`: 
> trim() expects parameter 1 to be string, object given 

For example if I use a route like
```php
$router->get('test')->uses(fn () => 'Test');
```
If I try to call the route I get the error.
This error only appears if the application is booted and the controller action dictionary is building. I tried to create Unit Tests by running the route, but everything works.

The problem is, that in `Illuminate\Routing\Route::uses` the Closure is inserted into an array with `uses` and `controller` keys.
```php
return $this->setAction(array_merge($this->action, $this->parseAction([
    'uses' => $action,
    'controller' => $action,
])));
```
Then the `Illuminate\Routing\RouteAction::parse` method doesn't recognize that the action is a callable and just merges the array with the route's action.
Because of that, the controller property of the action is a callable and on building the controller action dictionary the `RouteCollection` tries to trim a callable.
```php
protected function addToActionList($action, $route)
{
    $this->actionList[trim($action['controller'], '\\')] = $route;
}
```

Now the action is checked in `Route::uses` if it is a callable and pass it as one to the `parseAction` method.
