### PR TITLE
[8.x] Add model correctly to ModelNotFoundException on sole query

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -522,7 +522,9 @@ class Builder
         try {
             return $this->baseSole($columns);
         } catch (RecordsNotFoundException $exception) {
-            throw new ModelNotFoundException($this->model);
+            throw (new ModelNotFoundException)->setModel(
+                get_class($this->model)
+            );
         }
     }
 

--- a/tests/Integration/Database/EloquentWhereTest.php
+++ b/tests/Integration/Database/EloquentWhereTest.php
@@ -127,6 +127,7 @@ class EloquentWhereTest extends DatabaseTestCase
     public function testSoleFailsIfNoRecords()
     {
         $this->expectException(ModelNotFoundException::class);
+        $this->expectExceptionMessageMatches('/.*UserWhereTest.*/');
 
         UserWhereTest::where('name', 'test-name')->sole();
     }


### PR DESCRIPTION
When using the sole query method and there were no results, you would get the following exception message (when used with eloquent builder)
```
Illuminate\Database\Eloquent\ModelNotFoundException : []
```

However this exception should include the model name.


This change makes the exception look like this instead
```
Illuminate\Database\Eloquent\ModelNotFoundException : No query results for model [App\User].
```


<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
