### PR TITLE
[8.x] ModelNotFoundException: ensure that the model class name is properly set

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -522,7 +522,7 @@ class Builder
         try {
             return $this->baseSole($columns);
         } catch (RecordsNotFoundException $exception) {
-            throw new ModelNotFoundException($this->model);
+            throw (new ModelNotFoundException)->setModel(get_class($this->model));
         }
     }
 

--- a/tests/Integration/Database/EloquentWhereTest.php
+++ b/tests/Integration/Database/EloquentWhereTest.php
@@ -126,9 +126,13 @@ class EloquentWhereTest extends DatabaseTestCase
 
     public function testSoleFailsIfNoRecords()
     {
-        $this->expectException(ModelNotFoundException::class);
+        try {
+            UserWhereTest::where('name', 'test-name')->sole();
+        } catch (ModelNotFoundException $exception) {
+            //
+        }
 
-        UserWhereTest::where('name', 'test-name')->sole();
+        $this->assertSame(UserWhereTest::class, $exception->getModel());
     }
 }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Previously the `ModelNotFoundException` exception was thrown passing the model object in the constructor.
This was surely not the expected intention.

This PR fixes that and ensurew that the model class name is properly set when raising the `ModelNotFoundException` exception.
 