### PR TITLE
[8.x] Reduce complexity of model factories

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -425,17 +425,17 @@ abstract class Factory
      * Add a new state transformation to the model definition.
      *
      * @param  callable|array  $state
-     * @return static
+     * @return $this
      */
     public function state($state)
     {
-        return $this->newInstance([
-            'states' => $this->states->concat([
-                is_callable($state) ? $state : function () use ($state) {
-                    return $state;
-                },
-            ]),
+        $this->states = $this->states->concat([
+            is_callable($state) ? $state : function () use ($state) {
+                return $state;
+            },
         ]);
+
+        return $this;
     }
 
     /**
@@ -454,15 +454,17 @@ abstract class Factory
      *
      * @param  \Illuminate\Database\Eloquent\Factories\Factory  $factory
      * @param  string|null  $relationship
-     * @return static
+     * @return $this
      */
     public function has(self $factory, $relationship = null)
     {
-        return $this->newInstance([
-            'has' => $this->has->concat([new Relationship(
+        $this->has = $this->has->concat([
+            new Relationship(
                 $factory, $relationship ?: $this->guessRelationship($factory->modelName())
-            )]),
+            ),
         ]);
+
+        return $this;
     }
 
     /**
@@ -484,12 +486,12 @@ abstract class Factory
      * @param  \Illuminate\Database\Eloquent\Factories\Factory|\Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Model  $factory
      * @param  callable|array  $pivot
      * @param  string|null  $relationship
-     * @return static
+     * @return $this
      */
     public function hasAttached($factory, $pivot = [], $relationship = null)
     {
-        return $this->newInstance([
-            'has' => $this->has->concat([new BelongsToManyRelationship(
+        $this->has = $this->has->concat([
+            new BelongsToManyRelationship(
                 $factory,
                 $pivot,
                 $relationship ?: Str::camel(Str::plural(class_basename(
@@ -497,8 +499,10 @@ abstract class Factory
                         ? $factory->modelName()
                         : Collection::wrap($factory)->first()
                 )))
-            )]),
+            ),
         ]);
+
+        return $this;
     }
 
     /**
@@ -506,38 +510,46 @@ abstract class Factory
      *
      * @param  \Illuminate\Database\Eloquent\Factories\Factory|\Illuminate\Database\Eloquent\Model  $factory
      * @param  string|null  $relationship
-     * @return static
+     * @return $this
      */
     public function for($factory, $relationship = null)
     {
-        return $this->newInstance(['for' => $this->for->concat([new BelongsToRelationship(
-            $factory,
-            $relationship ?: Str::camel(class_basename(
-                $factory instanceof Factory ? $factory->modelName() : $factory
-            ))
-        )])]);
+        $this->for = $this->for->concat([
+            new BelongsToRelationship(
+                $factory,
+                $relationship ?: Str::camel(class_basename(
+                    $factory instanceof Factory ? $factory->modelName() : $factory
+                ))
+            ),
+        ]);
+
+        return $this;
     }
 
     /**
      * Add a new "after making" callback to the model definition.
      *
      * @param  \Closure  $callback
-     * @return static
+     * @return $this
      */
     public function afterMaking(Closure $callback)
     {
-        return $this->newInstance(['afterMaking' => $this->afterMaking->concat([$callback])]);
+        $this->afterMaking = $this->afterMaking->concat([$callback]);
+
+        return $this;
     }
 
     /**
      * Add a new "after creating" callback to the model definition.
      *
      * @param  \Closure  $callback
-     * @return static
+     * @return $this
      */
     public function afterCreating(Closure $callback)
     {
-        return $this->newInstance(['afterCreating' => $this->afterCreating->concat([$callback])]);
+        $this->afterCreating = $this->afterCreating->concat([$callback]);
+
+        return $this;
     }
 
     /**
@@ -575,22 +587,26 @@ abstract class Factory
      * Specify how many models should be generated.
      *
      * @param  int|null  $count
-     * @return static
+     * @return $this
      */
     public function count(?int $count)
     {
-        return $this->newInstance(['count' => $count]);
+        $this->count = $count;
+
+        return $this;
     }
 
     /**
      * Specify the database connection that should be used to generate models.
      *
      * @param  string  $connection
-     * @return static
+     * @return $this
      */
     public function connection(string $connection)
     {
-        return $this->newInstance(['connection' => $connection]);
+        $this->connection = $connection;
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
I've been looking at the model factories for a couple days now, and I'll be honest, I'm really confused.

A lot of the methods 

- `state`
- `has`
- `hasAttached`
- `for`
- `afterMaking`
- `afterCreating`
- `count`
- `connection`

delegate to the `newInstance()` method to create a new object with some updated properties.

To me, this seems like an over-complicated "setter", and the process of creating a whole new object each time seems unnecessary.

I'm trying to figure out if this is intentional, an oversight, or maybe some carry-over from when factories were not class based, and may have required this.

If this is intentional, it'd be great if someone could explain to me the benefit of it.  If not, this PR updates all these methods to behave as traditional getters, by updating the properties on the current instance, and returning the current instance.