### PR TITLE
[8.x] Add Str::pipe & make Stringable tappable

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -4,11 +4,12 @@ namespace Illuminate\Support;
 
 use Closure;
 use Illuminate\Support\Traits\Macroable;
+use Illuminate\Support\Traits\Tappable;
 use Symfony\Component\VarDumper\VarDumper;
 
 class Stringable
 {
-    use Macroable;
+    use Tappable, Macroable;
 
     /**
      * The underlying string value.

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -400,6 +400,17 @@ class Stringable
     }
 
     /**
+     * Call the given callback and return a new string.
+     *
+     * @param callable $callback
+     * @return static
+     */
+    public function pipe(callable $callback)
+    {
+        return new static(call_user_func($callback, $this));
+    }
+
+    /**
      * Get the plural form of an English word.
      *
      * @param  int  $count

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -545,4 +545,28 @@ class SupportStringableTest extends TestCase
         $this->assertInstanceOf(Collection::class, $chunks);
         $this->assertSame(['foo', 'bar', 'baz'], $chunks->all());
     }
+
+    public function testTap()
+    {
+        $stringable = $this->stringable('foobarbaz');
+
+        $fromTheTap = '';
+
+        $stringable = $stringable->tap(function (Stringable $string) use (&$fromTheTap) {
+            $fromTheTap = $string->substr(0, 3);
+        });
+
+        $this->assertSame('foo', (string) $fromTheTap);
+        $this->assertSame('foobarbaz', (string) $stringable);
+    }
+
+    public function testPipe()
+    {
+        $callback = function ($stringable) {
+            return 'bar';
+        };
+
+        $this->assertInstanceOf(Stringable::class, $this->stringable('foo')->pipe($callback));
+        $this->assertSame('bar', (string) $this->stringable('foo')->pipe($callback));
+    }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR add a simple `pipe` method (feel free to suggest other names) that similar to `Collection::transform`. 
I have considered to name it `transform`, but `transform` mutates itself.

Usage example:

```php
Str
  ::of('foo > bar')
  ->pipe('htmlentities') // callable
  ->pipe(fn ($str) => md5($str)); // closure
```

While `Stringable` is already macroable, often time we only need to run something once without need to register it into global.

I also made `Stringable` tappable:

```php
Str
  ::of('foo > bar')
  ->pipe('htmlentities')
  ->tap(fn ($str) => Log::info('Origin str: ' . $str))
  ->pipe('md5');
```