### PR TITLE
[8.x] Adds more type freedom to schema builders foreignId and foreignIdFor methods

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -928,6 +928,7 @@ class Blueprint
         if ($model->getKeyType() === 'int' && $model->getIncrementing()) {
             try {
                 $foreignColumnType = resolve(Builder::class)->getColumnType($model->getTable(), $model->getKeyName());
+
                 return $this->typedForeignId($column ?: $model->getForeignKey(), $foreignColumnType);
             } catch (\Exception $ex) {
                 // PDO does not exist here or getting column type fails

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -891,14 +891,14 @@ class Blueprint
     }
 
     /**
-     * Create a new unsigned int integer (3-byte) column on the table.
+     * Create a new unsigned integer (4-byte) column on the table.
      *
      * @param  string  $column
      * @return \Illuminate\Database\Schema\ForeignIdColumnDefinition
      */
     public function intForeignId($column)
     {
-        return $this->typedForeignId($column, 'intInteger');
+        return $this->typedForeignId($column, 'integer');
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -925,7 +925,7 @@ class Blueprint
             $model = new $model;
         }
 
-        if($model->getKeyType() === 'int' && $model->getIncrementing()) {
+        if ($model->getKeyType() === 'int' && $model->getIncrementing()) {
             try {
                 $foreignColumnType = resolve(Builder::class)->getColumnType($model->getTable(), $model->getKeyName());
                 return $this->typedForeignId($column ?: $model->getForeignKey(), $foreignColumnType);

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -926,8 +926,13 @@ class Blueprint
         }
 
         if($model->getKeyType() === 'int' && $model->getIncrementing()) {
-            $foreignColumnType = resolve(Builder::class)->getColumnType($model->getTable(), $model->getKeyName());
-            return $this->typedForeignId($column ?: $model->getForeignKey(), $foreignColumnType);
+            try {
+                $foreignColumnType = resolve(Builder::class)->getColumnType($model->getTable(), $model->getKeyName());
+                return $this->typedForeignId($column ?: $model->getForeignKey(), $foreignColumnType);
+            } catch (\Exception $ex) {
+                // PDO does not exist here or getting column type fails
+                return $this->foreignId($column ?: $model->getForeignKey());
+            }
         }
 
         return $this->foreignUuid($column ?: $model->getForeignKey());

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -834,16 +834,82 @@ class Blueprint
      * @param  string  $column
      * @return \Illuminate\Database\Schema\ForeignIdColumnDefinition
      */
-    public function foreignId($column)
+    public function typedForeignId($column, $type = 'bigInteger')
     {
         $this->columns[] = $column = new ForeignIdColumnDefinition($this, [
-            'type' => 'bigInteger',
+            'type' => $type,
             'name' => $column,
             'autoIncrement' => false,
             'unsigned' => true,
         ]);
 
         return $column;
+    }
+
+    /**
+     * Create a new unsigned big integer (8-byte) column on the table.
+     *
+     * @param  string  $column
+     * @return \Illuminate\Database\Schema\ForeignIdColumnDefinition
+     */
+    public function foreignId($column)
+    {
+        return $this->typedForeignId($column);
+    }
+
+    /**
+     * Create a new unsigned tiny integer (1-byte) column on the table.
+     *
+     * @param  string  $column
+     * @return \Illuminate\Database\Schema\ForeignIdColumnDefinition
+     */
+    public function tinyForeignId($column)
+    {
+        return $this->typedForeignId($column, 'tinyInteger');
+    }
+
+    /**
+     * Create a new unsigned small integer (2-byte) column on the table.
+     *
+     * @param  string  $column
+     * @return \Illuminate\Database\Schema\ForeignIdColumnDefinition
+     */
+    public function smallForeignId($column)
+    {
+        return $this->typedForeignId($column, 'smallInteger');
+    }
+
+    /**
+     * Create a new unsigned medium integer (3-byte) column on the table.
+     *
+     * @param  string  $column
+     * @return \Illuminate\Database\Schema\ForeignIdColumnDefinition
+     */
+    public function mediumForeignId($column)
+    {
+        return $this->typedForeignId($column, 'mediumInteger');
+    }
+
+    /**
+     * Create a new unsigned int integer (3-byte) column on the table.
+     *
+     * @param  string  $column
+     * @return \Illuminate\Database\Schema\ForeignIdColumnDefinition
+     */
+    public function intForeignId($column)
+    {
+        return $this->typedForeignId($column, 'intInteger');
+    }
+
+    /**
+     * Create a new unsigned big integer (8-byte) column on the table.
+     *
+     * @param  string  $column
+     * @return \Illuminate\Database\Schema\ForeignIdColumnDefinition
+     */
+    public function bigForeignId($column)
+    {
+        return $this->typedForeignId($column);
     }
 
     /**
@@ -859,9 +925,12 @@ class Blueprint
             $model = new $model;
         }
 
-        return $model->getKeyType() === 'int' && $model->getIncrementing()
-                    ? $this->foreignId($column ?: $model->getForeignKey())
-                    : $this->foreignUuid($column ?: $model->getForeignKey());
+        if($model->getKeyType() === 'int' && $model->getIncrementing()) {
+            $foreignColumnType = resolve(Builder::class)->getColumnType($model->getTable(), $model->getKeyName());
+            return $this->typedForeignId($column ?: $model->getForeignKey(), $foreignColumnType);
+        }
+
+        return $this->foreignUuid($column ?: $model->getForeignKey());
     }
 
     /**

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -487,7 +487,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
-        foreach($foreignIds as $type => $foreignId) {
+        foreach ($foreignIds as $type => $foreignId) {
             $this->assertInstanceOf(ForeignIdColumnDefinition::class, $foreignId);
             $this->assertEquals($type, $foreignId->get('type'));
         }

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -474,6 +474,28 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         ], $statements);
     }
 
+    public function testAddingDifferentlyTypedForeignIDs()
+    {
+        $blueprint = new Blueprint('users');
+        $foreignIds = [
+            'tinyInteger' => $blueprint->tinyForeignId('foo1'),
+            'smallInteger' => $blueprint->smallForeignId('foo2'),
+            'mediumInteger' => $blueprint->mediumForeignId('foo3'),
+            'integer' => $blueprint->intForeignId('foo4'),
+            'bigInteger' => $blueprint->bigForeignId('foo5'),
+        ];
+
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        foreach($foreignIds as $type => $foreignId) {
+            $this->assertInstanceOf(ForeignIdColumnDefinition::class, $foreignId);
+            $this->assertEquals($type, $foreignId->get('type'));
+        }
+        $this->assertSame([
+            'alter table `users` add `foo1` tinyint unsigned not null, add `foo2` smallint unsigned not null, add `foo3` mediumint unsigned not null, add `foo4` int unsigned not null, add `foo5` bigint unsigned not null',
+        ], $statements);
+    }
+
     public function testAddingBigIncrementingID()
     {
         $blueprint = new Blueprint('users');


### PR DESCRIPTION
At this moment, id's and fk's are being defaulted to big ints. However, if you have a table that only needs a small or tiny int for the id having the id a bigint can have some memory implications. Having a bigint on a table that only uses ints within the smallint range will take up a lot more data than when just the smallint is used.

I've editted the methods to be non-breaking - added some more methods to have more type freedom within foreignId. 

I also made a small change top foreignIdFor - which here will automatically check the int type of the column the FK is for and create one in the same type. If this isn't done the column can't be constrained on non-bitInt foreign keys,

Please let me know how I can improve if I can. I'm new to open source contributing.