### PR TITLE
[8.x] Allow to encrypt json with fillJsonAttribute

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -779,9 +779,15 @@ trait HasAttributes
     {
         [$key, $path] = explode('->', $key, 2);
 
-        $this->attributes[$key] = $this->asJson($this->getArrayAttributeWithValue(
+        $value = $this->asJson($this->getArrayAttributeWithValue(
             $path, $key, $value
         ));
+
+        if ($this->isEncryptedCastable($key)) {
+            $value = $this->castAttributeAsEncryptedString($key, $value);
+        }
+
+        $this->attributes[$key] = $value;
 
         return $this;
     }

--- a/tests/Integration/Database/EloquentModelEncryptedCastingTest.php
+++ b/tests/Integration/Database/EloquentModelEncryptedCastingTest.php
@@ -108,7 +108,7 @@ class EloquentModelEncryptedCastingTest extends DatabaseTestCase
             ->andReturn('{"key1":"value1"}');
 
         $subject = new EncryptedCast;
-        $subject->setAttribute('secret_json->key1','value1');
+        $subject->setAttribute('secret_json->key1', 'value1');
         $subject->save();
 
         $this->assertSame(['key1' => 'value1'], $subject->secret_json);

--- a/tests/Integration/Database/EloquentModelEncryptedCastingTest.php
+++ b/tests/Integration/Database/EloquentModelEncryptedCastingTest.php
@@ -98,6 +98,26 @@ class EloquentModelEncryptedCastingTest extends DatabaseTestCase
         ]);
     }
 
+    public function testJsonAttributeIsCastable()
+    {
+        $this->encrypter->expects('encrypt')
+            ->with('{"key1":"value1"}', false)
+            ->andReturn('encrypted-secret-json-string');
+        $this->encrypter->expects('decrypt')
+            ->with('encrypted-secret-json-string', false)
+            ->andReturn('{"key1":"value1"}');
+
+        $subject = new EncryptedCast;
+        $subject->setAttribute('secret_json->key1','value1');
+        $subject->save();
+
+        $this->assertSame(['key1' => 'value1'], $subject->secret_json);
+        $this->assertDatabaseHas('encrypted_casts', [
+            'id' => $subject->id,
+            'secret_json' => 'encrypted-secret-json-string',
+        ]);
+    }
+
     public function testObjectIsCastable()
     {
         $object = new \stdClass();


### PR DESCRIPTION
This PR allow to use fillJsonAttribute with encrypted json/array.

```php
public $casts = [
        'secret_json' => 'encrypted:json',
];

$model->setAttribute('secret_json->key', 'value');
```