### PR TITLE
[8.x] updateOrInsert optional merge

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2919,12 +2919,13 @@ class Builder
      *
      * @param  array  $attributes
      * @param  array  $values
+     * @param  bool   $merge
      * @return bool
      */
-    public function updateOrInsert(array $attributes, array $values = [])
+    public function updateOrInsert(array $attributes, array $values = [], bool $merge = true)
     {
         if (! $this->where($attributes)->exists()) {
-            return $this->insert(array_merge($attributes, $values));
+            return ($merge) ? $this->insert(array_merge($attributes, $values)) : $this->insert($values);
         }
 
         if (empty($values)) {


### PR DESCRIPTION
Added third argument in updateOrInsert method to have merge optional.

I just overwritten in one of my projects due to this use case:

```
Schema::create('xxx', function (Blueprint $table) {
            $table->id();
            $table->string('name');
            $table->string('email');
            $table->timestamps();
        });
```
When I tried to updateOrInsert on this model, I needed to check the ID because either name and email could be changed.
All I needed was to have the possibility to decide which column to update without merging with the first argument column, useful in my case only to check a matching.

So calling the method updateOrInsert could be done in this way:

```
DB::table('users')
    ->updateOrInsert(
        ['email' => 'john@example.com', 'name' => 'John'],
        ['votes' => '2'],
        false
    );
```
the third argument is optional and is true by default (i.e. it will merge the two first two arguments as it currently does)

In my case I used it as following:

```
MyModel::updateOrInsert(
                [
                    'id' => $request->id,
                    'shop_id' => $shop_id
                ],
                [
                    'name' => $request->name,
                    'email' => $request->email,
                    'shop_id' => $shop_id
                ],
                false
                );
```

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
