### PR TITLE
[8.x] Pipe through render and report exception methods

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -21,7 +21,6 @@ use Illuminate\Routing\Router;
 use Illuminate\Session\TokenMismatchException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\View;
 use Illuminate\Support\Reflector;
 use Illuminate\Support\Traits\ReflectsClosures;
 use Illuminate\Support\ViewErrorBag;

--- a/src/Illuminate/View/Engines/CompilerEngine.php
+++ b/src/Illuminate/View/Engines/CompilerEngine.php
@@ -2,9 +2,9 @@
 
 namespace Illuminate\View\Engines;
 
-use ErrorException;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\View\Compilers\CompilerInterface;
+use Illuminate\View\ViewException;
 use Throwable;
 
 class CompilerEngine extends PhpEngine
@@ -76,7 +76,7 @@ class CompilerEngine extends PhpEngine
      */
     protected function handleViewException(Throwable $e, $obLevel)
     {
-        $e = new ErrorException($this->getMessage($e), 0, 1, $e->getFile(), $e->getLine(), $e);
+        $e = new ViewException($this->getMessage($e), 0, 1, $e->getFile(), $e->getLine(), $e);
 
         parent::handleViewException($e, $obLevel);
     }

--- a/src/Illuminate/View/ViewException.php
+++ b/src/Illuminate/View/ViewException.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Illuminate\View;
+
+use ErrorException;
+
+class ViewException extends ErrorException
+{
+    /**
+     * Report the exception.
+     *
+     * @return void
+     */
+    public function report()
+    {
+        $exception = $this->getPrevious();
+
+        if ($exception && method_exists('report', $exception)) {
+            $exception->report();
+        }
+    }
+
+    /**
+     * Render the exception into an HTTP response.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function render($request)
+    {
+        $exception = $this->getPrevious();
+
+        if ($exception && method_exists($exception, 'render')) {
+            return $exception->render($request);
+        }
+    }
+}

--- a/tests/Integration/View/RenderableViewExceptionTest.php
+++ b/tests/Integration/View/RenderableViewExceptionTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Illuminate\Tests\Integration\View;
+
+use Exception;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\View;
+use Orchestra\Testbench\TestCase;
+
+class RenderableViewExceptionTest extends TestCase
+{
+    public function testRenderMethodOfExceptionThrownInViewGetsHandled()
+    {
+        Route::get('/', function () {
+            return View::make('renderable-exception');
+        });
+
+        $response = $this->get('/');
+
+        $response->assertSee('This is a renderable exception.');
+    }
+
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('view.paths', [__DIR__.'/templates']);
+    }
+}
+
+class RenderableException extends Exception
+{
+    public function render($request)
+    {
+        return new Response('This is a renderable exception.');
+    }
+}

--- a/tests/Integration/View/templates/renderable-exception.blade.php
+++ b/tests/Integration/View/templates/renderable-exception.blade.php
@@ -1,0 +1,3 @@
+@php
+    throw new Illuminate\Tests\Integration\View\RenderableException;
+@endphp

--- a/tests/View/fixtures/nested/basic.php
+++ b/tests/View/fixtures/nested/basic.php
@@ -1,1 +1,0 @@
-Hello World


### PR DESCRIPTION
This PR fixes a bug where the `report` or `render` methods of an exception that were thrown in a view aren't being called by Laravel's exception handler. The reason for this is that these kind of view exceptions are wrapped in an `ErrorException` instance by Laravel here: https://github.com/laravel/framework/blob/3ab9f7ad8704bd3ae38306e741308de774d8aa61/src/Illuminate/View/Engines/CompilerEngine.php#L79

Because there's no `render` or `report` method on an `ErrorException` instance the original ones aren't executed. I've solved this by introducing a new `ViewException` class that extends `ErrorException` and pipes through any `render` or `report` calls that are present on the previous exception instance. This should be non-breaking.

Fixes https://github.com/laravel/framework/issues/35493