### PR TITLE
[8.x] Add Route::missing()

### DIFF
--- a/src/Illuminate/Routing/Middleware/SubstituteBindings.php
+++ b/src/Illuminate/Routing/Middleware/SubstituteBindings.php
@@ -4,6 +4,7 @@ namespace Illuminate\Routing\Middleware;
 
 use Closure;
 use Illuminate\Contracts\Routing\Registrar;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 class SubstituteBindings
 {
@@ -34,9 +35,17 @@ class SubstituteBindings
      */
     public function handle($request, Closure $next)
     {
-        $this->router->substituteBindings($route = $request->route());
+        try {
+            $this->router->substituteBindings($route = $request->route());
 
-        $this->router->substituteImplicitBindings($route);
+            $this->router->substituteImplicitBindings($route);
+        } catch (ModelNotFoundException $exception) {
+            if($route->getMissing()) {
+                return $route->getMissing()($request);
+            }
+
+            throw $exception;
+        }
 
         return $next($request);
     }

--- a/src/Illuminate/Routing/Middleware/SubstituteBindings.php
+++ b/src/Illuminate/Routing/Middleware/SubstituteBindings.php
@@ -40,7 +40,7 @@ class SubstituteBindings
 
             $this->router->substituteImplicitBindings($route);
         } catch (ModelNotFoundException $exception) {
-            if($route->getMissing()) {
+            if ($route->getMissing()) {
                 return $route->getMissing()($request);
             }
 

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -934,6 +934,29 @@ class Route
     }
 
     /**
+     * Get the value of the else redirect.
+     *
+     * @return \Illuminate\Http\RedirectResponse|null
+     */
+    public function getElse()
+    {
+        return $this->action['else'] ?? null;
+    }
+
+    /**
+     * Add or change the else redirect.
+     *
+     * @param  \Illuminate\Http\RedirectResponse  $else
+     * @return $this
+     */
+    public function else($else)
+    {
+        $this->action['else'] = $else;
+
+        return $this;
+    }
+
+    /**
      * Get all middleware, including the ones from the controller.
      *
      * @return array

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -940,7 +940,12 @@ class Route
      */
     public function getMissing()
     {
-        return $this->action['missing'] ?? null;
+        $missing = $this->action['missing'] ?? null;
+
+        return is_string($missing) &&
+            Str::startsWith($missing, 'C:32:"Opis\\Closure\\SerializableClosure')
+                ? unserialize($missing)
+                : $missing;
     }
 
     /**
@@ -1192,6 +1197,10 @@ class Route
             $this->action['uses'] = serialize(new SerializableClosure($this->action['uses']));
 
             // throw new LogicException("Unable to prepare route [{$this->uri}] for serialization. Uses Closure.");
+        }
+
+        if (isset($this->action['missing']) && $this->action['missing'] instanceof Closure) {
+            $this->action['missing'] = serialize(new SerializableClosure($this->action['missing']));
         }
 
         $this->compileRoute();

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -934,24 +934,24 @@ class Route
     }
 
     /**
-     * Get the value of the else redirect.
+     * Get the value of the missing redirect.
      *
-     * @return \Illuminate\Http\RedirectResponse|null
+     * @return \Closure|null
      */
-    public function getElse()
+    public function getMissing()
     {
-        return $this->action['else'] ?? null;
+        return $this->action['missing'] ?? null;
     }
 
     /**
-     * Add or change the else redirect.
+     * Add or change the missing redirect.
      *
-     * @param  \Illuminate\Http\RedirectResponse  $else
+     * @param  \Closure  $missing
      * @return $this
      */
-    public function else($else)
+    public function missing($missing)
     {
-        $this->action['else'] = $else;
+        $this->action['missing'] = $missing;
 
         return $this;
     }

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -12,7 +12,6 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -671,8 +671,8 @@ class Router implements BindingRegistrar, RegistrarContract
                 $this->runRouteWithinStack($route, $request)
             );
         } catch (ModelNotFoundException $exception) {
-            if ($route->getElse()) {
-                return $route->getElse();
+            if ($route->getMissing()) {
+                return $route->getMissing()($request);
             }
 
             throw $exception;

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -666,17 +666,9 @@ class Router implements BindingRegistrar, RegistrarContract
 
         $this->events->dispatch(new RouteMatched($route, $request));
 
-        try {
-            return $this->prepareResponse($request,
-                $this->runRouteWithinStack($route, $request)
-            );
-        } catch (ModelNotFoundException $exception) {
-            if ($route->getMissing()) {
-                return $route->getMissing()($request);
-            }
-
-            throw $exception;
-        }
+        return $this->prepareResponse($request,
+            $this->runRouteWithinStack($route, $request)
+        );
     }
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -12,6 +12,7 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
@@ -665,9 +666,17 @@ class Router implements BindingRegistrar, RegistrarContract
 
         $this->events->dispatch(new RouteMatched($route, $request));
 
-        return $this->prepareResponse($request,
-            $this->runRouteWithinStack($route, $request)
-        );
+        try {
+            return $this->prepareResponse($request,
+                $this->runRouteWithinStack($route, $request)
+            );
+        } catch (ModelNotFoundException $exception) {
+            if($route->getElse()) {
+                return $route->getElse();
+            }
+
+            throw $exception;
+        }
     }
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -671,7 +671,7 @@ class Router implements BindingRegistrar, RegistrarContract
                 $this->runRouteWithinStack($route, $request)
             );
         } catch (ModelNotFoundException $exception) {
-            if($route->getElse()) {
+            if ($route->getElse()) {
                 return $route->getElse();
             }
 

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1672,10 +1672,8 @@ class RoutingRouteTest extends TestCase
         $this->assertSame('taylor', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
     }
 
-    public function testImplicitBindingsWithMissingModelHandledByElse()
+    public function testImplicitBindingsWithMissingModelHandledByMissing()
     {
-        $redirect = new RedirectResponse('/', 302);
-
         $router = $this->getRouter();
         $router->get('foo/{bar}', [
             'middleware' => SubstituteBindings::class,
@@ -1684,7 +1682,9 @@ class RoutingRouteTest extends TestCase
 
                 return $bar->first();
             },
-        ])->else($redirect);
+        ])->missing(function() {
+            return new RedirectResponse('/', 302);
+        });
 
         $request = Request::create('foo/taylor', 'GET');
 

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1682,7 +1682,7 @@ class RoutingRouteTest extends TestCase
 
                 return $bar->first();
             },
-        ])->missing(function() {
+        ])->missing(function () {
             return new RedirectResponse('/', 302);
         });
 

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -15,6 +15,7 @@ use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
@@ -1669,6 +1670,27 @@ class RoutingRouteTest extends TestCase
             },
         ]);
         $this->assertSame('taylor', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
+    }
+
+    public function testImplicitBindingsWithMissingModelHandledByElse()
+    {
+        $redirect = new RedirectResponse('/', 302);
+
+        $router = $this->getRouter();
+        $router->get('foo/{bar}', [
+            'middleware' => SubstituteBindings::class,
+            'uses' => function (RouteModelBindingNullStub $bar = null) {
+                $this->assertInstanceOf(RouteModelBindingNullStub::class, $bar);
+
+                return $bar->first();
+            },
+        ])->else($redirect);
+
+        $request = Request::create('foo/taylor', 'GET');
+
+        $response = $router->dispatch($request);
+        $this->assertTrue($response->isRedirect('/'));
+        $this->assertEquals(302, $response->getStatusCode());
     }
 
     public function testImplicitBindingsWithOptionalParameterWithNoKeyInUri()


### PR DESCRIPTION
This PR introduces a new `->missing()` method to `Route`.

Here's the intention...

Let's say you have a route that's using implicit route-model binding (in this case, bound to a particular attribute):
```php
Route::get('/locations/{location:slug}', [LocationsController::class, 'show'])
    ->name('locations.view');
```
Now, if that record doesn't exist, or has been removed, it'll throw a 404 if someone tries to access it. Currently to mitigate that you'd need to customize the controller method to check for it's existence and then handle it accordingly.

Instead, it would be great if there was an `->missing()` method that accepted a callback and handled the situation, ie:
```php
Route::get('/locations/{location:slug}', [LocationsController::class, 'show'])
    ->name('locations.view')
    ->missing(fn($request) => Redirect::route('locations.index', null, 301));
```

To do this we'd now be catching a `ModelNotFoundException` in the `SubstituteBindings` middleware, but this seems acceptable since it'll only be doing this if it detects an `missing` fallback.

Open to suggestions!

