### PR TITLE
[8.x] Make Listeners, Mailables, and Notifications accept ShouldBeEncrypted

### DIFF
--- a/src/Illuminate/Events/CallQueuedListener.php
+++ b/src/Illuminate/Events/CallQueuedListener.php
@@ -62,6 +62,13 @@ class CallQueuedListener implements ShouldQueue
     public $timeout;
 
     /**
+     * Indicates if the job should be encrypted.
+     *
+     * @var bool
+     */
+    public $shouldBeEncrypted = false;
+
+    /**
      * Create a new job instance.
      *
      * @param  string  $class

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Broadcasting\Factory as BroadcastFactory;
 use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 use Illuminate\Contracts\Container\Container as ContainerContract;
 use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
+use Illuminate\Contracts\Queue\ShouldBeEncrypted;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
@@ -600,6 +601,8 @@ class Dispatcher implements DispatcherContract
 
             $job->retryUntil = method_exists($listener, 'retryUntil')
                                 ? $listener->retryUntil() : null;
+
+            $job->shouldBeEncrypted = $listener instanceof ShouldBeEncrypted;
         });
     }
 

--- a/src/Illuminate/Mail/SendQueuedMailable.php
+++ b/src/Illuminate/Mail/SendQueuedMailable.php
@@ -5,6 +5,7 @@ namespace Illuminate\Mail;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Mail\Factory as MailFactory;
 use Illuminate\Contracts\Mail\Mailable as MailableContract;
+use Illuminate\Contracts\Queue\ShouldBeEncrypted;
 
 class SendQueuedMailable
 {
@@ -32,6 +33,13 @@ class SendQueuedMailable
     public $timeout;
 
     /**
+     * Indicates if the job should be encrypted.
+     *
+     * @var bool
+     */
+    public $shouldBeEncrypted = false;
+
+    /**
      * Create a new job instance.
      *
      * @param  \Illuminate\Contracts\Mail\Mailable  $mailable
@@ -43,6 +51,7 @@ class SendQueuedMailable
         $this->tries = property_exists($mailable, 'tries') ? $mailable->tries : null;
         $this->timeout = property_exists($mailable, 'timeout') ? $mailable->timeout : null;
         $this->afterCommit = property_exists($mailable, 'afterCommit') ? $mailable->afterCommit : null;
+        $this->shouldBeEncrypted = $mailable instanceof ShouldBeEncrypted;
     }
 
     /**

--- a/src/Illuminate/Notifications/SendQueuedNotifications.php
+++ b/src/Illuminate/Notifications/SendQueuedNotifications.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Notifications;
 
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeEncrypted;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Model;
@@ -50,6 +51,13 @@ class SendQueuedNotifications implements ShouldQueue
     public $timeout;
 
     /**
+     * Indicates if the job should be encrypted.
+     *
+     * @var bool
+     */
+    public $shouldBeEncrypted = false;
+
+    /**
      * Create a new job instance.
      *
      * @param  \Illuminate\Notifications\Notifiable|\Illuminate\Support\Collection  $notifiables
@@ -65,6 +73,7 @@ class SendQueuedNotifications implements ShouldQueue
         $this->tries = property_exists($notification, 'tries') ? $notification->tries : null;
         $this->timeout = property_exists($notification, 'timeout') ? $notification->timeout : null;
         $this->afterCommit = property_exists($notification, 'afterCommit') ? $notification->afterCommit : null;
+        $this->shouldBeEncrypted = $notification instanceof ShouldBeEncrypted;
     }
 
     /**

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -177,21 +177,6 @@ abstract class Queue
     }
 
     /**
-     * Determine if the job should be encrypted.
-     *
-     * @param  object  $job
-     * @return bool
-     */
-    protected function jobShouldBeEncrypted($job)
-    {
-        if ($job instanceof ShouldBeEncrypted) {
-            return true;
-        }
-
-        return isset($job->shouldBeEncrypted) && $job->shouldBeEncrypted;
-    }
-
-    /**
      * Get the backoff for an object-based queue handler.
      *
      * @param  mixed  $job
@@ -226,6 +211,21 @@ abstract class Queue
 
         return $expiration instanceof DateTimeInterface
                         ? $expiration->getTimestamp() : $expiration;
+    }
+
+    /**
+     * Determine if the job should be encrypted.
+     *
+     * @param  object  $job
+     * @return bool
+     */
+    protected function jobShouldBeEncrypted($job)
+    {
+        if ($job instanceof ShouldBeEncrypted) {
+            return true;
+        }
+
+        return isset($job->shouldBeEncrypted) && $job->shouldBeEncrypted;
     }
 
     /**

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -152,7 +152,7 @@ abstract class Queue
             ],
         ]);
 
-        $command = $job instanceof ShouldBeEncrypted && $this->container->bound(Encrypter::class)
+        $command = $this->jobShouldBeEncrypted($job) && $this->container->bound(Encrypter::class)
                     ? $this->container[Encrypter::class]->encrypt(serialize(clone $job))
                     : serialize(clone $job);
 
@@ -174,6 +174,21 @@ abstract class Queue
     {
         return method_exists($job, 'displayName')
                         ? $job->displayName() : get_class($job);
+    }
+
+    /**
+     * Determine if the job should be encrypted.
+     *
+     * @param  object  $job
+     * @return bool
+     */
+    protected function jobShouldBeEncrypted($job)
+    {
+        if ($job instanceof ShouldBeEncrypted) {
+            return true;
+        }
+
+        return isset($job->shouldBeEncrypted) && $job->shouldBeEncrypted;
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -200,6 +200,8 @@ class BusFake implements QueueingDispatcher
 
         if ($command instanceof Closure) {
             [$command, $callback] = [$this->firstClosureParameterType($command), $command];
+        } elseif (! is_string($command)) {
+            $command = get_class($command);
         }
 
         PHPUnit::assertTrue(

--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -200,8 +200,6 @@ class BusFake implements QueueingDispatcher
 
         if ($command instanceof Closure) {
             [$command, $callback] = [$this->firstClosureParameterType($command), $command];
-        } elseif (! is_string($command)) {
-            $command = get_class($command);
         }
 
         PHPUnit::assertTrue(


### PR DESCRIPTION
I believe encrypting listeners can be useful to hide the event data but encrypting mailables and notifications isn't really useful. Let me know what you think.