### PR TITLE
[8.x] Fix issues with dumping PostgreSQL databases that contain multiple schemata

### DIFF
--- a/src/Illuminate/Database/Schema/PostgresSchemaState.php
+++ b/src/Illuminate/Database/Schema/PostgresSchemaState.php
@@ -39,7 +39,7 @@ class PostgresSchemaState extends SchemaState
      */
     public function load($path)
     {
-        $command = 'PGPASSWORD=$LARAVEL_LOAD_PASSWORD pg_restore --no-owner --no-acl --host=$LARAVEL_LOAD_HOST --port=$LARAVEL_LOAD_PORT --username=$LARAVEL_LOAD_USER --dbname=$LARAVEL_LOAD_DATABASE $LARAVEL_LOAD_PATH';
+        $command = 'PGPASSWORD=$LARAVEL_LOAD_PASSWORD pg_restore --no-owner --no-acl --clean --if-exists --host=$LARAVEL_LOAD_HOST --port=$LARAVEL_LOAD_PORT --username=$LARAVEL_LOAD_USER --dbname=$LARAVEL_LOAD_DATABASE $LARAVEL_LOAD_PATH';
 
         if (Str::endsWith($path, '.sql')) {
             $command = 'PGPASSWORD=$LARAVEL_LOAD_PASSWORD psql --file=$LARAVEL_LOAD_PATH --host=$LARAVEL_LOAD_HOST --port=$LARAVEL_LOAD_PORT --username=$LARAVEL_LOAD_USER --dbname=$LARAVEL_LOAD_DATABASE';

--- a/src/Illuminate/Database/Schema/PostgresSchemaState.php
+++ b/src/Illuminate/Database/Schema/PostgresSchemaState.php
@@ -16,16 +16,12 @@ class PostgresSchemaState extends SchemaState
      */
     public function dump(Connection $connection, $path)
     {
-        $schema = $connection->getConfig('schema', 'public');
-
-        $schema = $schema === 'public' ? '' : $schema.'.';
-
         $excludedTables = collect($connection->getSchemaBuilder()->getAllTables())
                         ->map->tablename
                         ->reject(function ($table) {
                             return $table === $this->migrationTable;
-                        })->map(function ($table) use ($schema) {
-                            return '--exclude-table-data='.$schema.$table;
+                        })->map(function ($table) {
+                            return "--exclude-table-data=*.$table";
                         })->implode(' ');
 
         $this->makeProcess(

--- a/src/Illuminate/Database/Schema/PostgresSchemaState.php
+++ b/src/Illuminate/Database/Schema/PostgresSchemaState.php
@@ -21,7 +21,7 @@ class PostgresSchemaState extends SchemaState
                         ->reject(function ($table) {
                             return $table === $this->migrationTable;
                         })->map(function ($table) {
-                            return "--exclude-table-data=*.$table";
+                            return '--exclude-table-data="*.'.$table.'"';
                         })->implode(' ');
 
         $this->makeProcess(


### PR DESCRIPTION
To preface this post, it is intentionally long-winded (even though the punchline is succinct), because it articulates the complexities and nuances of this and similar situations concerning PostgreSQL's search_path.

Note also that this PR arises out of a continuing discussion regarding how the search_path is handled in various contexts throughout Laravel: https://github.com/laravel/framework/pull/35463#issuecomment-765730368 .

---

The `schema:dump` Artisan command is designed to dump structures only &mdash; not table data. To achieve this, a `--exclude-table-data` argument is appended to the `pg_dump` command for every table that `$connection->getSchemaBuilder()->getAllTables()` returns, excepting only the `$migrationTable`, as defined in the `SchemaState` class and configured via `config('database.migrations')`.

In the existing implementation, the underlying logic does not take into account the numerous different formats that the search_path can take (as defined in the connection's configuration properties). And while noble efforts were made to add support for Laravel installations using a non-default schema name (i.e., anything other than `public`), the table data dumping logic doesn't account for the possibility that the database has *more than one schema*, which causes tables to be dumped with data when they shouldn't be.

In a multi-schema environment, and when using a search_path that contains more than one schema, the aforementioned `getAllTables()` method returns a query like this, where `homestead` and `public` are schemas listed in the `search_path` that is set on the connection:

```sql
select tablename from pg_catalog.pg_tables where schemaname in ('homestead','public');
```

```
migrations
password_resets
users
products
failed_jobs
```

Of particular note is that the `products` table is in the `homestead` schema, and the other tables are in `public`. I mention this because it demonstrates why we cannot use only a single value from the `search_path` to prefix these references, as is done currently. Given this specific example, doing so would cause all but one of the tables to have the wrong schema qualifier, which would cause their data *not* to be excluded from the dump.

Because the `schemaname` column is not selected in the above query, we can't qualify these references fully when pairing them with `--exclude-table-data` switches. However, this is not a problem because `pg_dump`'s `--exclude-table-data` switch accepts a *pattern* (see: https://www.postgresql.org/docs/current/app-psql.html#APP-PSQL-PATTERNS ), and so is not limited to a static table reference, and more importantly, PostgreSQL will traverse the search_path while building reference qualifiers in this context.

What's this all mean? It means that the schema qualifier should actually be omitted entirely from the reference. So, the appended switches might look something like this:

```
.. --exclude-table-data=password_resets --exclude-table-data=users --exclude-table-data=products --exclude-table-data=failed_jobs
```

Now, PostgreSQL will do the "heavy lifting" and traverse the `search_path`, checking each schema therein, in the order specified, if and until it finds the specified table.

To demonstrate, PostgreSQL will, ultimately, build the following qualified references, which is exactly what we want:

```
public.migrations
public.password_resets
public.users
homestead.products
public.failed_jobs
```

*But*, what happens when we have tables with the same name in two different schemas, e.g., `homestead.foo` and `public.foo`? We'd end-up with two identical switches, like `--exclude-table-data=foo --exclude-table-data=foo`, and table data will be excluded only for the table that PostgreSQL finds first when traversing the `search_path`.

PostgreSQL's *pattern* capabilities to the rescue! The simple solution to this problem is to use a wildcard schema for each table, e.g., `--exclude-table-data="*.foo"`. This works because the only goal here is to *keep* the migration table data, but discard the data for every other table, and this accomplishes that objective.

In other words, we can eliminate all the logic around the `search_path`, and offload the complexity to PostgreSQL using a wildcard.

---

~~**IMPORTANT**: This PR fixes only the *dumping* behavior in a multi-schema database, and *not* the reloading behavior, which has never worked correctly in multi-schema databases, and, in my opinion, should be addressed in a separate PR.~~ Actually, it fixes both issues, now that it includes a previous fix that appears to have been reverted accidentally.