### PR TITLE
Simplify fetching custom attribute translations

### DIFF
--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -276,7 +276,7 @@ trait FormatsMessages
      */
     protected function getAttributeFromTranslations($name)
     {
-        return Arr::get($this->translator->get('validation.attributes'), $name);
+        return $this->translator->get("validation.attributes.$name");
     }
 
     /**


### PR DESCRIPTION
Use interpolated dot string to directly fetch attribute translations instead of retrieving all custom attribute translations, then fetching from them via Arr::get

This improves support for alternate translator implementations.

Fixes https://github.com/flarum/core/issues/2572