### PR TITLE
[9.x] Model::offsetExists calls getAttribute and may result in double calls 

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -397,6 +397,33 @@ trait HasAttributes
     }
 
     /**
+     * Checks if an attribute exists. This mirrors getAttribute() but returns a bool,
+     * not calling the attribute method which might have side effects.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function hasAttribute($key)
+    {
+        if (! $key) {
+            return false;
+        }
+
+        if (array_key_exists($key, $this->attributes) ||
+            array_key_exists($key, $this->casts) ||
+            $this->hasGetMutator($key) ||
+            $this->isClassCastable($key)) {
+            return true;
+        }
+
+        if (method_exists(self::class, $key)) {
+            return false;
+        }
+
+        return $this->hasRelationValue($key);
+    }
+
+    /**
      * Get a plain attribute (not a relationship).
      *
      * @param  string  $key
@@ -440,6 +467,28 @@ trait HasAttributes
             (static::$relationResolvers[get_class($this)][$key] ?? null)) {
             return $this->getRelationshipFromMethod($key);
         }
+    }
+
+    /**
+     * Checks if a relationship has a value. This mirrors getRelationValue() but
+     * returns a bool, not actually fetching the relationship and therefore with
+     * no side effects.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function hasRelationValue($key)
+    {
+        if ($this->relationLoaded($key)) {
+            return true;
+        }
+
+        if (method_exists($this, $key) ||
+            (static::$relationResolvers[get_class($this)][$key] ?? null)) {
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1806,7 +1806,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
      */
     public function offsetExists($offset)
     {
-        return ! is_null($this->getAttribute($offset));
+        return $this->hasAttribute($offset);
     }
 
     /**


### PR DESCRIPTION
This patch adds `hasAttribute()` and `hasRelationValue()` to the `HasAttributes` trait. The reason, as outlined in https://github.com/laravel/framework/issues/36026, is that the current implementation of `offsetExists()` in the `Model` class calls `getAttributeValue()`, which can have side effects when calling accessors. This can include simple performance issues such as accessing the database twice, and worse actual non-pure effects such as creating repeated log entries etc. There's no guarantee that accessors are pure and Laravel does not require it anywhere.

While this can be solved by "caching the result" as suggested in the original issue, it requires a) that all developers are aware of this problem, which is not documented anywhere and b) that any accessor implements caching. It's much simpler to change `offsetExists` to not have side effects.

This patch is unlikely to change the behavior of any application. The only conceivable problem is if the application is expecting that `isset($model['something'])` actually calls an accessor which has a side effect, and does not call `$model['something']` after it. That is unlikely and really awkward code.

OTOH the current code is probably affecting negatively almost every existing Laravel application. 

The current test suite covers this change extensively, which is why there's no specific test added. The patch is an exact copy of the existing code without actually calling the accessors. 

I'm sending this PR to `master` as suggested by the reply on the issue, but IMHO it could be safely applied to the 8.x and 7.x branches.

I strongly urge you to consider this PR, please.