### PR TITLE
[6.x] Typecast page number as integer

### DIFF
--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -446,7 +446,7 @@ abstract class AbstractPaginator implements Htmlable
     public static function resolveCurrentPage($pageName = 'page', $default = 1)
     {
         if (isset(static::$currentPageResolver)) {
-            return call_user_func(static::$currentPageResolver, $pageName);
+            return (int) call_user_func(static::$currentPageResolver, $pageName);
         }
 
         return $default;


### PR DESCRIPTION
Atm when a custom page resolver is defined (like Livewire does) which doesn't always returns integers, a DB query for pagination could blow up (as I've experienced in Laravel.io). Since the return type hints that only an integer can be returned here it should be safe to typecast this.

See https://github.com/livewire/livewire/pull/2409