### PR TITLE
[9.x] Allow to fillJsonAttribute with encrypted fields

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -779,9 +779,12 @@ trait HasAttributes
     {
         [$key, $path] = explode('->', $key, 2);
 
-        $this->attributes[$key] = $this->asJson($this->getArrayAttributeWithValue(
+        $value = $this->asJson($this->getArrayAttributeWithValue(
             $path, $key, $value
         ));
+
+        $this->attributes[$key] = $this->isEncryptedCastable($key) ?
+            $this->castAttributeAsEncryptedString($key, $value) : $value;
 
         return $this;
     }
@@ -844,8 +847,13 @@ trait HasAttributes
      */
     protected function getArrayAttributeByKey($key)
     {
-        return isset($this->attributes[$key]) ?
-                    $this->fromJson($this->attributes[$key]) : [];
+        if (! isset($this->attributes[$key])) {
+            return [];
+        }
+
+        return $this->fromJson($this->isEncryptedCastable($key) ?
+            $this->fromEncryptedString($this->attributes[$key]) : $this->attributes[$key]
+        );
     }
 
     /**

--- a/tests/Integration/Database/EloquentModelEncryptedCastingTest.php
+++ b/tests/Integration/Database/EloquentModelEncryptedCastingTest.php
@@ -199,7 +199,7 @@ class EloquentModelEncryptedCastingTest extends DatabaseTestCase
             'secret_json' => ['key1' => 'value1'],
         ]);
         $subject->fill([
-            'secret_json->key2' => 'value2'
+            'secret_json->key2' => 'value2',
         ]);
         $subject->save();
 

--- a/tests/Integration/Database/EloquentModelEncryptedCastingTest.php
+++ b/tests/Integration/Database/EloquentModelEncryptedCastingTest.php
@@ -179,6 +179,36 @@ class EloquentModelEncryptedCastingTest extends DatabaseTestCase
             'secret' => 'encrypted-secret-string',
         ]);
     }
+
+    public function testJsonAttributeIsCastable()
+    {
+        $this->encrypter->expects('encrypt')
+            ->with('{"key1":"value1"}', false)
+            ->andReturn('encrypted-secret-json-string');
+        $this->encrypter->expects('decrypt')
+            ->with('encrypted-secret-json-string', false)
+            ->andReturn('{"key1":"value1"}');
+        $this->encrypter->expects('encrypt')
+            ->with('{"key1":"value1","key2":"value2"}', false)
+            ->andReturn('encrypted-secret-json-string2');
+        $this->encrypter->expects('decrypt')
+            ->with('encrypted-secret-json-string2', false)
+            ->andReturn('{"key1":"value1","key2":"value2"}');
+
+        $subject = new EncryptedCast([
+            'secret_json' => ['key1' => 'value1'],
+        ]);
+        $subject->fill([
+            'secret_json->key2' => 'value2'
+        ]);
+        $subject->save();
+
+        $this->assertSame(['key1' => 'value1', 'key2' => 'value2'], $subject->secret_json);
+        $this->assertDatabaseHas('encrypted_casts', [
+            'id' => $subject->id,
+            'secret_json' => 'encrypted-secret-json-string2',
+        ]);
+    }
 }
 
 /**


### PR DESCRIPTION

This PR allow to use fillJsonAttribute with encrypted fields.

```php
public $casts = [
        'secret_json' => 'encrypted:json',
        'secret' => 'encrypted',
];

$model->setAttribute('secret_json->key', 'value');
$model->fill([
  'secret->id' => 'id',
  'secret->key' => 'key'
]);
```