### PR TITLE
[8.x] Fix preg_quote() add missing delimiter parameter

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
@@ -204,7 +204,7 @@ trait GuardsAttributes
         }
 
         return $this->getGuarded() == ['*'] ||
-               ! empty(preg_grep('/^'.preg_quote($key).'$/i', $this->getGuarded())) ||
+               ! empty(preg_grep('/^'.preg_quote($key, '/').'$/i', $this->getGuarded())) ||
                ! $this->isGuardableColumn($key);
     }
 


### PR DESCRIPTION
``` php
App\Models\User::query()->updateOrCreate(['email' => 'hldh214@gmail.com'], ['/some/evil/slashes/' => ''])
```
With above code will cause a `PHP Warning:  preg_grep(): Unknown modifier` warning.
Because `preg_quote()` needs a optional parameter `delimiter` to escape the slash.

ref: https://www.php.net/manual/en/function.preg-quote.php

