### PR TITLE
[8.x] Allow to fillJsonAttribute with encrypted fields

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -779,9 +779,15 @@ trait HasAttributes
     {
         [$key, $path] = explode('->', $key, 2);
 
-        $this->attributes[$key] = $this->asJson($this->getArrayAttributeWithValue(
+        $value = $this->asJson($this->getArrayAttributeWithValue(
             $path, $key, $value
         ));
+
+        if ($this->isEncryptedCastable($key)) {
+            $value = $this->castAttributeAsEncryptedString($key, $value);
+        }
+
+        $this->attributes[$key] = $value;
 
         return $this;
     }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -850,8 +850,17 @@ trait HasAttributes
      */
     protected function getArrayAttributeByKey($key)
     {
-        return isset($this->attributes[$key]) ?
-                    $this->fromJson($this->attributes[$key]) : [];
+        if(!isset($this->attributes[$key])){
+            return [];
+        }
+
+        $value = $this->attributes[$key];
+
+        if ($this->isEncryptedCastable($key)) {
+            $value = $this->fromEncryptedString($value);
+        }
+
+        return $this->fromJson($value);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -783,11 +783,8 @@ trait HasAttributes
             $path, $key, $value
         ));
 
-        if ($this->isEncryptedCastable($key)) {
-            $value = $this->castAttributeAsEncryptedString($key, $value);
-        }
-
-        $this->attributes[$key] = $value;
+        $this->attributes[$key] = $this->isEncryptedCastable($key) ?
+            $this->castAttributeAsEncryptedString($key, $value) : $value;
 
         return $this;
     }
@@ -850,17 +847,13 @@ trait HasAttributes
      */
     protected function getArrayAttributeByKey($key)
     {
-        if(!isset($this->attributes[$key])){
+        if (! isset($this->attributes[$key])) {
             return [];
         }
 
-        $value = $this->attributes[$key];
-
-        if ($this->isEncryptedCastable($key)) {
-            $value = $this->fromEncryptedString($value);
-        }
-
-        return $this->fromJson($value);
+        return $this->fromJson($this->isEncryptedCastable($key) ?
+            $this->fromEncryptedString($this->attributes[$key]) : $this->attributes[$key]
+        );
     }
 
     /**

--- a/tests/Integration/Database/EloquentModelEncryptedCastingTest.php
+++ b/tests/Integration/Database/EloquentModelEncryptedCastingTest.php
@@ -106,15 +106,23 @@ class EloquentModelEncryptedCastingTest extends DatabaseTestCase
         $this->encrypter->expects('decrypt')
             ->with('encrypted-secret-json-string', false)
             ->andReturn('{"key1":"value1"}');
+        $this->encrypter->expects('encrypt')
+            ->with('{"key1":"value1","key2":"value2"}', false)
+            ->andReturn('encrypted-secret-json-string2');
+        $this->encrypter->expects('decrypt')
+            ->with('encrypted-secret-json-string2', false)
+            ->andReturn('{"key1":"value1","key2":"value2"}');
 
-        $subject = new EncryptedCast;
-        $subject->setAttribute('secret_json->key1', 'value1');
+        $subject = new EncryptedCast([
+            'secret_json' => ['key1' => 'value1'],
+        ]);
+        $subject->setAttribute('secret_json->key2', 'value2');
         $subject->save();
 
-        $this->assertSame(['key1' => 'value1'], $subject->secret_json);
+        $this->assertSame(['key1' => 'value1', 'key2' => 'value2'], $subject->secret_json);
         $this->assertDatabaseHas('encrypted_casts', [
             'id' => $subject->id,
-            'secret_json' => 'encrypted-secret-json-string',
+            'secret_json' => 'encrypted-secret-json-string2',
         ]);
     }
 

--- a/tests/Integration/Database/EloquentModelEncryptedCastingTest.php
+++ b/tests/Integration/Database/EloquentModelEncryptedCastingTest.php
@@ -116,7 +116,9 @@ class EloquentModelEncryptedCastingTest extends DatabaseTestCase
         $subject = new EncryptedCast([
             'secret_json' => ['key1' => 'value1'],
         ]);
-        $subject->setAttribute('secret_json->key2', 'value2');
+        $subject->fill([
+            'secret_json->key2' => 'value2',
+        ]);
         $subject->save();
 
         $this->assertSame(['key1' => 'value1', 'key2' => 'value2'], $subject->secret_json);

--- a/tests/Integration/Database/EloquentModelEncryptedCastingTest.php
+++ b/tests/Integration/Database/EloquentModelEncryptedCastingTest.php
@@ -108,7 +108,7 @@ class EloquentModelEncryptedCastingTest extends DatabaseTestCase
             ->andReturn('{"key1":"value1"}');
 
         $subject = new EncryptedCast;
-        $subject->setAttribute('secret_json->key1','value1');
+        $subject->setAttribute('secret_json->key1', 'value1');
         $subject->save();
 
         $this->assertSame(['key1' => 'value1'], $subject->secret_json);

--- a/tests/Integration/Database/EloquentModelEncryptedCastingTest.php
+++ b/tests/Integration/Database/EloquentModelEncryptedCastingTest.php
@@ -98,6 +98,26 @@ class EloquentModelEncryptedCastingTest extends DatabaseTestCase
         ]);
     }
 
+    public function testJsonAttributeIsCastable()
+    {
+        $this->encrypter->expects('encrypt')
+            ->with('{"key1":"value1"}', false)
+            ->andReturn('encrypted-secret-json-string');
+        $this->encrypter->expects('decrypt')
+            ->with('encrypted-secret-json-string', false)
+            ->andReturn('{"key1":"value1"}');
+
+        $subject = new EncryptedCast;
+        $subject->setAttribute('secret_json->key1','value1');
+        $subject->save();
+
+        $this->assertSame(['key1' => 'value1'], $subject->secret_json);
+        $this->assertDatabaseHas('encrypted_casts', [
+            'id' => $subject->id,
+            'secret_json' => 'encrypted-secret-json-string',
+        ]);
+    }
+
     public function testObjectIsCastable()
     {
         $object = new \stdClass();


### PR DESCRIPTION
This PR allow to use fillJsonAttribute with encrypted fields. (same as https://github.com/laravel/framework/pull/36056 for 9.x)

```php
public $casts = [
        'secret_json' => 'encrypted:json',
        'secret' => 'encrypted',
];

$model->setAttribute('secret_json->key', 'value');
$model->fill([
  'secret->id' => 'id',
  'secret->key' => 'key'
]);
```