### PR TITLE
[6.x] miss dirty attributes updating when soft delete

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -81,7 +81,7 @@ trait SoftDeletes
 
         $time = $this->freshTimestamp();
 
-        $columns = [$this->getDeletedAtColumn() => $this->fromDateTime($time)];
+        $columns = $this->getDirty() + [$this->getDeletedAtColumn() => $this->fromDateTime($time)];
 
         $this->{$this->getDeletedAtColumn()} = $time;
 


### PR DESCRIPTION
```php
Class MyModel extends \Illuminate\Database\Eloquent\Model
{
    protected static function boot()
    {
        parent::boot();

        self::deleting(function (Model $model) {
            $model->deleted_by = 'system';
        });
    }
}
```
If we hook the deleting event with extra attributes changed, these changed attributes will not take effect. Because at the original line 84, the `$columns` only includes the **getDeletedAtColumn()** (e.g., `delated_at`) while the other changed attributes are missed. Thus, at the new line 84, we use `$columns = $this->getDirty() + ...` to prepend the changed attributes.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
