### PR TITLE
Fix syntax error in TestDatabases (#36074)

### DIFF
--- a/src/Illuminate/Testing/Concerns/TestDatabases.php
+++ b/src/Illuminate/Testing/Concerns/TestDatabases.php
@@ -144,7 +144,7 @@ trait TestDatabases
 
         config()->set(
             "database.connections.{$default}.database",
-            $database,
+            $database
         );
     }
 


### PR DESCRIPTION
Fixes the below fatal error when loading a page after updating to Laravel 8.25.0.

`production.ERROR: syntax error, unexpected ')' {"exception":"[object] (ParseError(code: 0): syntax error, unexpected ')' at /.../vendor/laravel/framework/src/Illuminate/Testing/Concerns/TestDatabases.php:148)`

Fixes #36074
