### PR TITLE
[8.x] Fixes job batch serialization for PostgreSQL (#36061)

### DIFF
--- a/src/Illuminate/Bus/DatabaseBatchRepository.php
+++ b/src/Illuminate/Bus/DatabaseBatchRepository.php
@@ -314,7 +314,7 @@ class DatabaseBatchRepository implements PrunableBatchRepository
      */
     protected function unserialize($serialized)
     {
-        $serialized = $this->connection instanceof PostgresConnection
+        $serialized = $this->connection instanceof PostgresConnection && ! Str::contains($serialized, [':', ';'])
             ? base64_decode($serialized)
             : $serialized;
 

--- a/src/Illuminate/Bus/DatabaseBatchRepository.php
+++ b/src/Illuminate/Bus/DatabaseBatchRepository.php
@@ -314,9 +314,9 @@ class DatabaseBatchRepository implements PrunableBatchRepository
      */
     protected function unserialize($serialized)
     {
-        $serialized = $this->connection instanceof PostgresConnection && ! Str::contains($serialized, [':', ';'])
-            ? base64_decode($serialized)
-            : $serialized;
+        if ($this->connection instanceof PostgresConnection) {
+            $serialized = base64_decode($serialized, true) ?: $serialized;
+        }
 
         return unserialize($serialized);
     }

--- a/src/Illuminate/Bus/DatabaseBatchRepository.php
+++ b/src/Illuminate/Bus/DatabaseBatchRepository.php
@@ -314,8 +314,8 @@ class DatabaseBatchRepository implements PrunableBatchRepository
      */
     protected function unserialize($serialized)
     {
-        if ($this->connection instanceof PostgresConnection) {
-            $serialized = base64_decode($serialized, true) ?: $serialized;
+        if ($this->connection instanceof PostgresConnection && ! Str::contains($serialized, [':', ';'])) {
+            $serialized = base64_decode($serialized);
         }
 
         return unserialize($serialized);

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -379,7 +379,7 @@ class BusBatchTest extends TestCase
                 'failed_jobs' => '',
                 'failed_job_ids' => '[]',
                 'options' => base64_encode(serialize($options)),
-                'created_at' => now(),
+                'created_at' => null,
                 'cancelled_at' => null,
                 'finished_at' => null,
             ]);
@@ -387,7 +387,7 @@ class BusBatchTest extends TestCase
         $batch = (new DatabaseBatchRepository($factory, $connection, 'job_batches'));
 
         $factory->shouldReceive('make')
-            ->withSomeOfArgs($batch, '', '', '', '', '', '', [1, 2]);
+            ->withSomeOfArgs($batch, '', '', '', '', '', '', $options);
 
         $batch->find(1);
     }

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -362,13 +362,14 @@ class BusBatchTest extends TestCase
             });
     }
 
-    public function test_options_unserialize_on_postgres()
+    /**
+     * @dataProvider serializedOptions
+     */
+    public function test_options_unserialize_on_postgres($serialize, $options)
     {
         $factory = m::mock(BatchFactory::class);
 
         $connection = m::spy(PostgresConnection::class);
-
-        $options = [1, 2];
 
         $connection->shouldReceive('table->where->first')
             ->andReturn($m = (object) [
@@ -378,7 +379,7 @@ class BusBatchTest extends TestCase
                 'pending_jobs' => '',
                 'failed_jobs' => '',
                 'failed_job_ids' => '[]',
-                'options' => base64_encode(serialize($options)),
+                'options' => $serialize,
                 'created_at' => null,
                 'cancelled_at' => null,
                 'finished_at' => null,
@@ -390,6 +391,19 @@ class BusBatchTest extends TestCase
             ->withSomeOfArgs($batch, '', '', '', '', '', '', $options);
 
         $batch->find(1);
+    }
+
+    /**
+     * @return array
+     */
+    public function serializedOptions()
+    {
+        $options = [1, 2];
+
+        return [
+            [serialize($options), $options],
+            [base64_encode(serialize($options)), $options],
+        ];
     }
 
     protected function createTestBatch($queue, $allowFailures = false)


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This pull request resolves #36061, by using base64 encoding in `DatabaseBatchRepository` for PostgreSQL.