### PR TITLE
[8.x] Allow custom stub replacement values

### DIFF
--- a/src/Illuminate/Database/Migrations/MigrationCreator.php
+++ b/src/Illuminate/Database/Migrations/MigrationCreator.php
@@ -167,7 +167,7 @@ class MigrationCreator
         // within the custom stubs. In case the 'create' method was called
         // manually it allows to local custom stubs to be replaced.
         $customPopulator = array_merge($this->customStubPopulator, $customPopulate);
-        foreach($customPopulator as $key => $values) {
+        foreach ($customPopulator as $key => $values) {
             $stub = str_replace(
                 ['{{ '.$key.' }}', '{{'.$key.'}}'],
                 $values, $stub


### PR DESCRIPTION
When using custom stubs it would be awesome to have custom replacement values that can be set within the AppServiceProvider or somewhere else.

This will also allow CRUD panels to easily add migrations programmicly by generating the migration code and place it within their own custom migration stub.
Example Stub:
```php
<?php

use Illuminate\Database\Migrations\Migration;
use Illuminate\Database\Schema\Blueprint;
use Illuminate\Support\Facades\Schema;

class {{ class }} extends Migration
{
    /**
     * Run the migrations.
     *
     * @return void
     */
    public function up()
    {
        /**
         * Some very awesome code block for your company:
         * ========================================================
         * .____                                    .__
         * |    |   _____ ____________ ___  __ ____ |  |
         * |    |   \__  \\_  __ \__  \\  \/ // __ \|  |
         * |    |___ / __ \|  | \// __ \\   /\  ___/|  |__
         * |_______ (____  /__|  (____  /\_/  \___  >____/ /\
         *         \/    \/           \/          \/       \/
         * ========================================================
         */
        Schema::create('{{ table }}', function (Blueprint $table) {
            $table->id();
            {{ code }}
            $table->timestamps();
        });
    }

    /**
     * Reverse the migrations.
     *
     * @return void
     */
    public function down()
    {
        Schema::dropIfExists('{{ table }}');
    }
}
```
Within the AppServiceProvider for example we can set the default replacement value for `{{ code }}` and when calling programmicly the `create` method it can be replaced. 
```php
$migrator = app('migration.creator');
// set default replacement value for 'code'.
$migrator->addCustomPopulator('code', '//');
```
Within your custom command or somewhere else:
```php
$path = $this->laravel->databasePath().'/migrations';
$codes = '{custom migration code}';

// creator
$migrator = app('migration.creator');
$migrator->create('create_'.$table.'_table', $path, $table, true, ['code' => $codes]);
```

Option: Auto find `{{ code }}` or `{{code}}` values from within the stubs and replace them with empty strings?
