### PR TITLE
[8.x] Database: SQLiteConnector: Create db file if not exists

### DIFF
--- a/src/Illuminate/Database/SQLiteConnection.php
+++ b/src/Illuminate/Database/SQLiteConnection.php
@@ -26,7 +26,7 @@ class SQLiteConnection extends Connection
     public function __construct($pdo, $database = '', $tablePrefix = '', array $config = [])
     {
         // check that if sqlite file currently not exists, create it
-        if (! is_file($database)) {
+        if (! is_file($database) && $database !== ':memory:') {
             touch($database);
         }
 

--- a/src/Illuminate/Database/SQLiteConnection.php
+++ b/src/Illuminate/Database/SQLiteConnection.php
@@ -28,6 +28,11 @@ class SQLiteConnection extends Connection
         // check that if sqlite file currently not exists, create it
         if (! is_file($database) && $database !== ':memory:') {
             touch($database);
+
+            // log
+            if (app()->runningInConsole()) {
+                echo "Sqlite file {$database} not found, creating it as an empty sqlite file..." . PHP_EOL;
+            }
         }
 
         parent::__construct($pdo, $database, $tablePrefix, $config);

--- a/src/Illuminate/Database/SQLiteConnection.php
+++ b/src/Illuminate/Database/SQLiteConnection.php
@@ -25,13 +25,8 @@ class SQLiteConnection extends Connection
      */
     public function __construct($pdo, $database = '', $tablePrefix = '', array $config = [])
     {
-        // check that if sqlite file currently not exists, create it
         if ($database !== ':memory:' && ! is_file($database)) {
             touch($database);
-            // log
-            // if (app()->runningInConsole()) {
-            //     echo "Sqlite file {$database} not found, creating it as an empty sqlite file..." . PHP_EOL;
-            // }
         }
 
         parent::__construct($pdo, $database, $tablePrefix, $config);

--- a/src/Illuminate/Database/SQLiteConnection.php
+++ b/src/Illuminate/Database/SQLiteConnection.php
@@ -26,7 +26,7 @@ class SQLiteConnection extends Connection
     public function __construct($pdo, $database = '', $tablePrefix = '', array $config = [])
     {
         // check that if sqlite file currently not exists, create it
-        if (! is_file($database) && $database !== ':memory:') {
+        if ($database !== ':memory:' && ! is_file($database)) {
             touch($database);
             // log
             // if (app()->runningInConsole()) {

--- a/src/Illuminate/Database/SQLiteConnection.php
+++ b/src/Illuminate/Database/SQLiteConnection.php
@@ -28,11 +28,10 @@ class SQLiteConnection extends Connection
         // check that if sqlite file currently not exists, create it
         if (! is_file($database) && $database !== ':memory:') {
             touch($database);
-
             // log
-            if (app()->runningInConsole()) {
-                echo "Sqlite file {$database} not found, creating it as an empty sqlite file..." . PHP_EOL;
-            }
+            // if (app()->runningInConsole()) {
+            //     echo "Sqlite file {$database} not found, creating it as an empty sqlite file..." . PHP_EOL;
+            // }
         }
 
         parent::__construct($pdo, $database, $tablePrefix, $config);

--- a/src/Illuminate/Database/SQLiteConnection.php
+++ b/src/Illuminate/Database/SQLiteConnection.php
@@ -25,6 +25,11 @@ class SQLiteConnection extends Connection
      */
     public function __construct($pdo, $database = '', $tablePrefix = '', array $config = [])
     {
+        // check that if sqlite file currently not exists, create it
+        if (! is_file($database)) {
+            touch($database);
+        }
+
         parent::__construct($pdo, $database, $tablePrefix, $config);
 
         $enableForeignKeyConstraints = $this->getForeignKeyConstraintsConfigurationValue();


### PR DESCRIPTION
When we using sqlite connection for database, while we are migrating or something else, if database file not exists, we will get error. But with this patch, connector checks the file and if not exists, creates it.
