### PR TITLE
[9.x] Seed before argument

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/FreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/FreshCommand.php
@@ -61,11 +61,22 @@ class FreshCommand extends Command
             );
         }
 
+        $this->prepareBeforeSeeding();
+
         if ($this->needsSeeding()) {
             $this->runSeeder($database);
         }
 
         return 0;
+    }
+
+    protected function prepareBeforeSeeding()
+    {
+        if ($this->hasOption('seed-before')) {
+            $this->call('migrate:rollback', [
+                '--step' => $this->option('seed-before'),
+            ]);
+        }
     }
 
     /**


### PR DESCRIPTION
Ability to specify how many recent migrations to start seeding using the `--seed-before` argument for the `migrate:fresh` command

https://github.com/laravel/ideas/issues/2483