### PR TITLE
[8.x] Exclude links from PaginatedResourceResponse

### DIFF
--- a/src/Illuminate/Http/Resources/Json/PaginatedResourceResponse.php
+++ b/src/Illuminate/Http/Resources/Json/PaginatedResourceResponse.php
@@ -79,6 +79,7 @@ class PaginatedResourceResponse extends ResourceResponse
             'last_page_url',
             'prev_page_url',
             'next_page_url',
+            'links',
         ]);
     }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

I've discovered a probably unintended schema change due to the addition of `links` to the paginator in https://github.com/laravel/framework/commit/13751a187834fabe515c14fb3ac1dc008fd23f37 for paginated resource responses.

For resource collection responses we get the following schema right now:
```
{
  "data": [],
  "links": {
    "first": "...",
    "last": "...",
    "prev": null,
    "next": null
  },
  "meta": {
    "current_page": 1,
    "from": 1,
    "last_page": 1,
    "links": [
      {
        "url": null,
        "label": "...",
        "active": false
      },
      {
        "url": "...",
        "label": 1,
        "active": true
      },
      {
        "url": null,
        "label": "...",
        "active": false
      }
    ],
    "path": "...",
    "per_page": 100,
    "to": 6,
    "total": 6
  }
}
```

Instead I think we expect `meta` not to contain the paginator links, as we already have them in `links`.
This PR adds `links` to the exclude list of `PaginatedResourceResponse`.