### PR TITLE
[8.x] Added findOr eloquent function to Builder, HasOneThrough, BelongsToMany

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -422,6 +422,28 @@ class Builder
     }
 
     /**
+     * Find multiple models by their primary keys or call a callback.
+     *
+     * @param  int|array  $ids
+     * @param  \Closure|array  $columns
+     * @param  \Closure|null  $callback
+     * @return \Illuminate\Database\Eloquent\Model|static|mixed
+     */
+    public function findOr($ids, $columns = ['*'], Closure $callback = null)
+    {
+        if ($columns instanceof Closure) {
+            $callback = $columns;
+            $columns = ['*'];
+        }
+
+        if (! is_null($model = $this->find($ids, $columns))) {
+            return $model;
+        }
+
+        return $callback();
+    }
+
+    /**
      * Get the first record matching the attributes or instantiate it.
      *
      * @param  array  $attributes

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -274,7 +274,9 @@ class Builder
     public function orWhere($column, $operator = null, $value = null)
     {
         [$value, $operator] = $this->query->prepareValueAndOperator(
-            $value, $operator, func_num_args() === 2
+            $value,
+            $operator,
+            func_num_args() === 2
         );
 
         return $this->where($column, $operator, $value, 'or');
@@ -401,7 +403,8 @@ class Builder
         }
 
         throw (new ModelNotFoundException)->setModel(
-            get_class($this->model), $id
+            get_class($this->model),
+            $id
         );
     }
 
@@ -436,7 +439,9 @@ class Builder
             $columns = ['*'];
         }
 
-        if (! is_null($model = $this->find($ids, $columns))) {
+        $model = $this->find($ids, $columns);
+
+        if (! is_null($model) || count($model)) {
             return $model;
         }
 
@@ -638,7 +643,8 @@ class Builder
         // of models which have been eagerly hydrated and are readied for return.
         return $relation->match(
             $relation->initRelation($models, $name),
-            $relation->getEager(), $name
+            $relation->getEager(),
+            $name
         );
     }
 
@@ -886,7 +892,9 @@ class Builder
     public function increment($column, $amount = 1, array $extra = [])
     {
         return $this->toBase()->increment(
-            $column, $amount, $this->addUpdatedAtColumn($extra)
+            $column,
+            $amount,
+            $this->addUpdatedAtColumn($extra)
         );
     }
 
@@ -901,7 +909,9 @@ class Builder
     public function decrement($column, $amount = 1, array $extra = [])
     {
         return $this->toBase()->decrement(
-            $column, $amount, $this->addUpdatedAtColumn($extra)
+            $column,
+            $amount,
+            $this->addUpdatedAtColumn($extra)
         );
     }
 
@@ -1159,11 +1169,13 @@ class Builder
         $query->wheres = [];
 
         $this->groupWhereSliceForScope(
-            $query, array_slice($allWheres, 0, $originalWhereCount)
+            $query,
+            array_slice($allWheres, 0, $originalWhereCount)
         );
 
         $this->groupWhereSliceForScope(
-            $query, array_slice($allWheres, $originalWhereCount)
+            $query,
+            array_slice($allWheres, $originalWhereCount)
         );
     }
 
@@ -1183,7 +1195,8 @@ class Builder
         // we don't add any unnecessary nesting thus keeping the query clean.
         if ($whereBooleans->contains('or')) {
             $query->wheres[] = $this->createNestedWhere(
-                $whereSlice, $whereBooleans->first()
+                $whereSlice,
+                $whereBooleans->first()
             );
         } else {
             $query->wheres = array_merge($query->wheres, $whereSlice);
@@ -1601,8 +1614,8 @@ class Builder
     protected static function registerMixin($mixin, $replace)
     {
         $methods = (new ReflectionClass($mixin))->getMethods(
-                ReflectionMethod::IS_PUBLIC | ReflectionMethod::IS_PROTECTED
-            );
+            ReflectionMethod::IS_PUBLIC | ReflectionMethod::IS_PROTECTED
+        );
 
         foreach ($methods as $method) {
             if ($replace || ! static::hasGlobalMacro($method->name)) {

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -441,7 +441,7 @@ class Builder
 
         $model = $this->find($ids, $columns);
 
-        if (! is_null($model) || ($model instanceof Collection && $model->count())) {
+        if (! is_null($model) || ! ($model instanceof Collection && $model->isEmpty())) {
             return $model;
         }
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -441,7 +441,7 @@ class Builder
 
         $model = $this->find($ids, $columns);
 
-        if (! is_null($model) || count($model)) {
+        if (! empty($model)) {
             return $model;
         }
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database\Eloquent;
 
 use BadMethodCallException;
 use Closure;
+use Countable;
 use Exception;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Concerns\BuildsQueries;
@@ -441,7 +442,7 @@ class Builder
 
         $model = $this->find($ids, $columns);
 
-        if (! empty($model)) {
+        if (! is_null($model) || ($model instanceof Countable && count($model))) {
             return $model;
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -14,6 +14,7 @@ use InvalidArgumentException;
 class BelongsToMany extends Relation
 {
     use Concerns\InteractsWithPivotTable;
+    use Concerns\FindOr;
 
     /**
      * The intermediate table for the relation.

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/FindOr.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/FindOr.php
@@ -21,7 +21,9 @@ trait FindOr
             $columns = ['*'];
         }
 
-        if (! is_null($model = $this->find($ids, $columns))) {
+        $model = $this->find($ids, $columns);
+
+        if (! is_null($model) || count($model)) {
             return $model;
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/FindOr.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/FindOr.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Eloquent\Relations\Concerns;
 
 use Closure;
+use Countable;
 
 trait FindOr
 {
@@ -23,7 +24,7 @@ trait FindOr
 
         $model = $this->find($ids, $columns);
 
-        if (! empty($model)) {
+        if (! is_null($model) || ($model instanceof Countable && count($model))) {
             return $model;
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/FindOr.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/FindOr.php
@@ -23,7 +23,7 @@ trait FindOr
 
         $model = $this->find($ids, $columns);
 
-        if (! is_null($model) || count($model)) {
+        if (! empty($model)) {
             return $model;
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/FindOr.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/FindOr.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Relations\Concerns;
+
+use Closure;
+
+trait FindOr
+{
+    /**
+     * Find a related model by its primary key or call a callback.
+     *
+     * @param  int|array  $ids
+     * @param  \Closure|array  $columns
+     * @param  \Closure|null  $callback
+     * @return \Illuminate\Database\Eloquent\Model|static|mixed
+     */
+    public function findOr($ids, $columns = ['*'], Closure $callback = null)
+    {
+        if ($columns instanceof Closure) {
+            $callback = $columns;
+            $columns = ['*'];
+        }
+
+        if (! is_null($model = $this->find($ids, $columns))) {
+            return $model;
+        }
+
+        return $callback();
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/FindOr.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/FindOr.php
@@ -24,7 +24,7 @@ trait FindOr
 
         $model = $this->find($ids, $columns);
 
-        if (! is_null($model) || ($model instanceof Collection && $model->count())) {
+        if (! is_null($model) || ! ($model instanceof Collection && $model->isEmpty())) {
             return $model;
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -11,6 +11,8 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 
 class HasManyThrough extends Relation
 {
+    use Concerns\FindOr;
+
     /**
      * The "through" parent model instance.
      *

--- a/tests/Database/DatabaseEloquentHasOneThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasOneThroughIntegrationTest.php
@@ -137,6 +137,18 @@ class DatabaseEloquentHasOneThroughIntegrationTest extends TestCase
         HasOneThroughTestPosition::first()->contract()->findOrFail(1);
     }
 
+    public function testFindOrCallsACallback()
+    {
+        HasOneThroughTestPosition::create(['id' => 1, 'name' => 'President', 'shortname' => 'ps'])
+            ->user()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'position_short' => 'ps']);
+
+        $contract = HasOneThroughTestPosition::first()->contract()->findOr(0, function () {
+            return 'foo';
+        });
+
+        $this->assertSame('foo', $contract);
+    }
+
     public function testFirstRetrievesFirstRecord()
     {
         $this->seedData();

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -531,8 +531,8 @@ class DatabaseEloquentIntegrationTest extends TestCase
         });
 
         $this->assertNotInstanceOf(EloquentTestUser::class, $single);
-        $this->assertSame('foo', $single);
-        $this->assertSame('bar', $multiple);
+        $this->assertEquals('foo', $single);
+        $this->assertEquals('bar', $multiple);
         $this->assertNotInstanceOf(Collection::class, $multiple);
         $this->assertNotInstanceOf(EloquentTestUser::class, $multiple[0]);
         $this->assertNotInstanceOf(EloquentTestUser::class, $multiple[1]);

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -531,8 +531,8 @@ class DatabaseEloquentIntegrationTest extends TestCase
         });
 
         $this->assertNotInstanceOf(EloquentTestUser::class, $single);
-        $this->assertEquals('foo', $single);
-        $this->assertEquals('bar', $multiple);
+        $this->assertSame('foo', $single);
+        $this->assertSame('bar', $multiple);
         $this->assertNotInstanceOf(Collection::class, $multiple);
         $this->assertNotInstanceOf(EloquentTestUser::class, $multiple[0]);
         $this->assertNotInstanceOf(EloquentTestUser::class, $multiple[1]);

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -526,7 +526,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
             return 'foo';
         });
 
-        $multiple = EloquentTestUser::findOr([3, 4], function () {
+        $multiple = EloquentTestUser::findOr([0, -1], function () {
             return 'bar';
         });
 

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -451,7 +451,10 @@ class DatabaseEloquentIntegrationTest extends TestCase
         EloquentTestNonIncrementingSecond::query()->eachById(
             function (EloquentTestNonIncrementingSecond $user, $i) use (&$users) {
                 $users[] = [$user->name, $i];
-            }, 2, 'name');
+            },
+            2,
+            'name'
+        );
         $this->assertSame([[' First', 0], [' Second', 1], [' Third', 2]], $users);
     }
 
@@ -492,6 +495,47 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         $this->assertEquals(['taylorotwell@gmail.com', 'abigailotwell@gmail.com'], $simple);
         $this->assertEquals([1 => 'taylorotwell@gmail.com', 2 => 'abigailotwell@gmail.com'], $keyed);
+    }
+
+    public function testFindOr()
+    {
+        EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
+        EloquentTestUser::create(['id' => 2, 'email' => 'abigailotwell@gmail.com']);
+
+        $single = EloquentTestUser::findOr(1, function () {
+            return 'foo';
+        });
+
+        $multiple = EloquentTestUser::findOr([1, 2], function () {
+            return 'bar';
+        });
+
+        $this->assertInstanceOf(EloquentTestUser::class, $single);
+        $this->assertSame('taylorotwell@gmail.com', $single->email);
+        $this->assertInstanceOf(Collection::class, $multiple);
+        $this->assertInstanceOf(EloquentTestUser::class, $multiple[0]);
+        $this->assertInstanceOf(EloquentTestUser::class, $multiple[1]);
+    }
+
+    public function testFindOrCallsACallback()
+    {
+        EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
+        EloquentTestUser::create(['id' => 2, 'email' => 'abigailotwell@gmail.com']);
+
+        $single = EloquentTestUser::findOr(3, function () {
+            return 'foo';
+        });
+
+        $multiple = EloquentTestUser::findOr([3, 4], function () {
+            return 'bar';
+        });
+
+        $this->assertNotInstanceOf(EloquentTestUser::class, $single);
+        $this->assertSame('foo', $single);
+        $this->assertSame('bar', $multiple);
+        $this->assertNotInstanceOf(Collection::class, $multiple);
+        $this->assertNotInstanceOf(EloquentTestUser::class, $multiple[0]);
+        $this->assertNotInstanceOf(EloquentTestUser::class, $multiple[1]);
     }
 
     public function testFindOrFail()

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -392,7 +392,7 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
             return 'foo';
         }));
 
-        $this->assertEquals('foo', $post->tags()->findOr([0, 10], function () {
+        $this->assertEquals('foo', $post->tags()->findOr([0, -1], function () {
             return 'foo';
         }));
     }

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -353,6 +353,50 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $this->assertCount(2, $post->tags()->findMany(new Collection([$tag->id, $tag2->id])));
     }
 
+    public function testFindOr()
+    {
+        $post = Post::create(['title' => Str::random()]);
+
+        $tag = Tag::create(['name' => Str::random()]);
+
+        $tag2 = Tag::create(['name' => Str::random()]);
+
+        $post->tags()->attach(Tag::all());
+
+        $this->assertEquals($tag2->name, $post->tags()->findOr($tag2->id, function () {
+            return 'foo';
+        })->name);
+
+        $this->assertCount(0, $post->tags()->findOr([]));
+
+        $this->assertCount(2, $post->tags()->findOr([$tag->id, $tag2->id], function () {
+            return [];
+        }));
+
+        $this->assertCount(0, $post->tags()->findOr(new Collection(), function () {
+            return [];
+        }));
+
+        $this->assertCount(2, $post->tags()->findOr(new Collection([$tag->id, $tag2->id]), function () {
+            return [];
+        }));
+    }
+
+    public function testFindOrCallsACallback()
+    {
+        $post = Post::create(['title' => Str::random()]);
+
+        $post->tags()->attach(Tag::all());
+
+        $this->assertEquals('foo', $post->tags()->findOr(0, function () {
+            return 'foo';
+        }));
+
+        $this->assertEquals('foo', $post->tags()->findOr([0, 10], function () {
+            return 'foo';
+        }));
+    }
+
     public function testFindOrFailMethod()
     {
         $this->expectException(ModelNotFoundException::class);

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -392,8 +392,8 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
             return 'foo';
         }));
 
-        $this->assertEquals('foo', $post->tags()->findOr([0, -1], function () {
-            return 'foo';
+        $this->assertEquals('bar', $post->tags()->findOr([0, -1], function () {
+            return 'bar';
         }));
     }
 


### PR DESCRIPTION
Added eloquent function `findOr` which executes a callback if the result is null, It reuses the `find` function with additional check that decides to return the result or call the callback if passed.

Example: 
```php
$user = User::findOr(100, function () {
    return 'Not Found';
    // or do some other staff here. ex: call some function
})

// in this case if the user is not found will return 'Not Found'
```