### PR TITLE
[6.x] Fix the return type of spop for phpredis

### DIFF
--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -195,14 +195,10 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      * @param  int|null  $count
      * @return mixed|false
      */
-    public function spop($key, $count = null)
+    public function spop($key, $count = 1)
     {
-        $parameters = [$key];
-        if ($count !== null) {
-            $parameters[] = $count;
-        }
-
-        return $this->command('sPop', $parameters);
+        // use func_get_args() instead of [$key, $count] to fix the return type when called without the count argument.
+        return $this->command('spop', func_get_args());
     }
 
     /**

--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -197,7 +197,6 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      */
     public function spop($key, $count = 1)
     {
-        // use func_get_args() instead of [$key, $count] to fix the return type when called without the count argument.
         return $this->command('spop', func_get_args());
     }
 

--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -201,6 +201,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
         if ($count !== null) {
             $parameters[] = $count;
         }
+
         return $this->command('sPop', $parameters);
     }
 

--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -195,9 +195,13 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      * @param  int|null  $count
      * @return mixed|false
      */
-    public function spop($key, $count = 1)
+    public function spop($key, $count = null)
     {
-        return $this->command('spop', [$key, $count]);
+        $parameters = [$key];
+        if ($count !== null) {
+            $parameters[] = $count;
+        }
+        return $this->command('sPop', $parameters);
     }
 
     /**

--- a/tests/Redis/RedisConnectionTest.php
+++ b/tests/Redis/RedisConnectionTest.php
@@ -690,6 +690,33 @@ class RedisConnectionTest extends TestCase
         }
     }
 
+    public function testItSPopsForKeys()
+    {
+        foreach ($this->connections() as $redis) {
+            $members = ['test:spop:1', 'test:spop:2', 'test:spop:3', 'test:spop:4'];
+
+            foreach ($members as $member) {
+                $redis->sadd('set', $member);
+            }
+
+            $result = $redis->spop('set');
+            $this->assertIsNotArray($result);
+            $this->assertContains($result, $members);
+
+            $result = $redis->spop('set', 1);
+
+            $this->assertIsArray($result);
+            $this->assertCount(1, $result);
+
+            $result = $redis->spop('set', 2);
+
+            $this->assertIsArray($result);
+            $this->assertCount(2, $result);
+
+            $redis->flushAll();
+        }
+    }
+
     public function testPhpRedisScanOption()
     {
         foreach ($this->connections() as $redis) {


### PR DESCRIPTION
This PR fixes the return type of `spop` for phpredis and add missing `spop` test to redis connection.

## Current Behaviour

When called `spop` without the count argument, it returns array.

## Fixed Behaviour

When called `spop` without the count argument, it returns string.

## Reference
### [Return value of SPOP](https://redis.io/commands/spop#return-value)
When called without the count argument:
[Bulk string reply](https://redis.io/topics/protocol#bulk-string-reply): the removed member, or nil when key does not exist.

When called with the count argument:
[Array reply](https://redis.io/topics/protocol#array-reply): the removed members, or nil when key does not exist.
