### PR TITLE
[6.x] Fix report method for ViewException

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/exception-render-report.stub
+++ b/src/Illuminate/Foundation/Console/stubs/exception-render-report.stub
@@ -9,7 +9,7 @@ class DummyClass extends Exception
     /**
      * Report the exception.
      *
-     * @return void
+     * @return bool|null
      */
     public function report()
     {

--- a/src/Illuminate/Foundation/Console/stubs/exception-report.stub
+++ b/src/Illuminate/Foundation/Console/stubs/exception-report.stub
@@ -9,7 +9,7 @@ class DummyClass extends Exception
     /**
      * Report the exception.
      *
-     * @return void
+     * @return bool|null
      */
     public function report()
     {

--- a/src/Illuminate/View/ViewException.php
+++ b/src/Illuminate/View/ViewException.php
@@ -20,6 +20,8 @@ class ViewException extends ErrorException
         if (Reflector::isCallable($reportCallable = [$exception, 'report'])) {
             return Container::getInstance()->call($reportCallable);
         }
+        
+        return false;
     }
 
     /**

--- a/src/Illuminate/View/ViewException.php
+++ b/src/Illuminate/View/ViewException.php
@@ -3,20 +3,22 @@
 namespace Illuminate\View;
 
 use ErrorException;
+use Illuminate\Container\Container;
+use Illuminate\Support\Reflector;
 
 class ViewException extends ErrorException
 {
     /**
      * Report the exception.
      *
-     * @return void
+     * @return bool|null
      */
     public function report()
     {
         $exception = $this->getPrevious();
 
-        if ($exception && method_exists($exception, 'report')) {
-            $exception->report();
+        if (Reflector::isCallable($reportCallable = [$exception, 'report'])) {
+            return Container::getInstance()->call($reportCallable);
         }
     }
 

--- a/src/Illuminate/View/ViewException.php
+++ b/src/Illuminate/View/ViewException.php
@@ -20,7 +20,7 @@ class ViewException extends ErrorException
         if (Reflector::isCallable($reportCallable = [$exception, 'report'])) {
             return Container::getInstance()->call($reportCallable);
         }
-        
+
         return false;
     }
 


### PR DESCRIPTION
I didn't take into account that the `report` method can resolve dependencies from the container. This PR fixes just that.

It also fixes the incorrect return types now present on the `report` method's DocBlock return annotations.

Fixes https://github.com/laravel/framework/issues/36108 https://github.com/laravel/framework/issues/36109