### PR TITLE
[8.x] Ensure both Carbon and CarbonImmutable get the same test now

### DIFF
--- a/src/Illuminate/Foundation/Testing/Wormhole.php
+++ b/src/Illuminate/Foundation/Testing/Wormhole.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Foundation\Testing;
 
-use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Carbon;
 
 class Wormhole
 {
@@ -32,7 +32,7 @@ class Wormhole
      */
     public function milliseconds($callback = null)
     {
-        Date::setTestNow(Date::now()->addMilliseconds($this->value));
+        Carbon::setTestNow(Carbon::now()->addMilliseconds($this->value));
 
         return $this->handleCallback($callback);
     }
@@ -45,7 +45,7 @@ class Wormhole
      */
     public function seconds($callback = null)
     {
-        Date::setTestNow(Date::now()->addSeconds($this->value));
+        Carbon::setTestNow(Carbon::now()->addSeconds($this->value));
 
         return $this->handleCallback($callback);
     }
@@ -58,7 +58,7 @@ class Wormhole
      */
     public function minutes($callback = null)
     {
-        Date::setTestNow(Date::now()->addMinutes($this->value));
+        Carbon::setTestNow(Carbon::now()->addMinutes($this->value));
 
         return $this->handleCallback($callback);
     }
@@ -71,7 +71,7 @@ class Wormhole
      */
     public function hours($callback = null)
     {
-        Date::setTestNow(Date::now()->addHours($this->value));
+        Carbon::setTestNow(Carbon::now()->addHours($this->value));
 
         return $this->handleCallback($callback);
     }
@@ -84,7 +84,7 @@ class Wormhole
      */
     public function days($callback = null)
     {
-        Date::setTestNow(Date::now()->addDays($this->value));
+        Carbon::setTestNow(Carbon::now()->addDays($this->value));
 
         return $this->handleCallback($callback);
     }
@@ -97,7 +97,7 @@ class Wormhole
      */
     public function weeks($callback = null)
     {
-        Date::setTestNow(Date::now()->addWeeks($this->value));
+        Carbon::setTestNow(Carbon::now()->addWeeks($this->value));
 
         return $this->handleCallback($callback);
     }
@@ -110,7 +110,7 @@ class Wormhole
      */
     public function years($callback = null)
     {
-        Date::setTestNow(Date::now()->addYears($this->value));
+        Carbon::setTestNow(Carbon::now()->addYears($this->value));
 
         return $this->handleCallback($callback);
     }
@@ -122,9 +122,9 @@ class Wormhole
      */
     public static function back()
     {
-        Date::setTestNow();
+        Carbon::setTestNow();
 
-        return Date::now();
+        return Carbon::now();
     }
 
     /**
@@ -137,7 +137,7 @@ class Wormhole
     {
         if ($callback) {
             return tap($callback(), function () {
-                Date::setTestNow();
+                Carbon::setTestNow();
             });
         }
     }

--- a/src/Illuminate/Support/Carbon.php
+++ b/src/Illuminate/Support/Carbon.php
@@ -3,8 +3,16 @@
 namespace Illuminate\Support;
 
 use Carbon\Carbon as BaseCarbon;
+use Carbon\CarbonImmutable as BaseCarbonImmutable;
 
 class Carbon extends BaseCarbon
 {
-    //
+    /**
+     * {@inheritdoc}
+     */
+    public static function setTestNow($testNow = null)
+    {
+        BaseCarbon::setTestNow($testNow);
+        BaseCarbonImmutable::setTestNow($testNow);
+    }
 }

--- a/tests/Support/SupportCarbonTest.php
+++ b/tests/Support/SupportCarbonTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Support;
 
 use BadMethodCallException;
 use Carbon\Carbon as BaseCarbon;
+use Carbon\CarbonImmutable as BaseCarbonImmutable;
 use DateTime;
 use DateTimeInterface;
 use Illuminate\Support\Carbon;
@@ -107,5 +108,16 @@ class SupportCarbonTest extends TestCase
         $deserialized = eval($serialized);
 
         $this->assertInstanceOf(Carbon::class, $deserialized);
+    }
+
+    public function testSetTestNowWillPersistBetweenImmutableAndMutableInstance()
+    {
+        $now = new Carbon('2017-06-27 13:14:15.000000');
+
+        Carbon::setTestNow($now);
+
+        $this->assertSame('2017-06-27 13:14:15', Carbon::now()->toDateTimeString());
+        $this->assertSame('2017-06-27 13:14:15', BaseCarbon::now()->toDateTimeString());
+        $this->assertSame('2017-06-27 13:14:15', BaseCarbonImmutable::now()->toDateTimeString());
     }
 }

--- a/tests/Support/SupportCarbonTest.php
+++ b/tests/Support/SupportCarbonTest.php
@@ -112,9 +112,7 @@ class SupportCarbonTest extends TestCase
 
     public function testSetTestNowWillPersistBetweenImmutableAndMutableInstance()
     {
-        $now = new Carbon('2017-06-27 13:14:15.000000');
-
-        Carbon::setTestNow($now);
+        Carbon::setTestNow(new Carbon('2017-06-27 13:14:15.000000'));
 
         $this->assertSame('2017-06-27 13:14:15', Carbon::now()->toDateTimeString());
         $this->assertSame('2017-06-27 13:14:15', BaseCarbon::now()->toDateTimeString());


### PR DESCRIPTION
In a project where we might use mixes of `Carbon` and `CarbonImmutable` you need to remember to always `setTestNow()` for both scenarios. 

This PR solved it by ensuring both instances have the same date and time during tests.

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>