### PR TITLE
[8.x] Set process timeout to null for load mysql schema into database

### DIFF
--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -71,7 +71,9 @@ class MySqlSchemaState extends SchemaState
     {
         $command = 'mysql '.$this->connectionString().' --database="${:LARAVEL_LOAD_DATABASE}" < "${:LARAVEL_LOAD_PATH}"';
 
-        $this->makeProcess($command)->mustRun(null, array_merge($this->baseVariables($this->connection->getConfig()), [
+        $process = $this->makeProcess($command)->setTimeout(null);
+
+        $process->mustRun(null, array_merge($this->baseVariables($this->connection->getConfig()), [
             'LARAVEL_LOAD_PATH' => $path,
         ]));
     }


### PR DESCRIPTION
When we execute parallel testing and we have a huge schema to load, the process throws a timeout error:

```
$ php artisan test --recreate-databases --parallel 

Symfony\Component\Process\Exception\ProcessTimedOutException: The process "mysql  --user="${:LARAVEL_LOAD_USER}" --password="${:LARAVEL_LOAD_PASSWORD}" --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --database="${:LARAVEL_LOAD_DATABASE}" < "${:LARAVEL_LOAD_PATH}"" exceeded the timeout of 60 seconds.
```

With this change, we remove the timeout just like it was already in the dump method (protected function executeDumpProcess) allowing to load huge schemas or execute the parallel tests in computers with bad performance (like docker containers running in macOS) without any problems.