### PR TITLE
[8.x] Conditionally merge classes into a Blade Component attribute bag

### DIFF
--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -236,6 +236,31 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
     }
 
     /**
+     * Conditionally merge classes into the attribute bag.
+     *
+     * @param  mixed|array  $classList
+     * @return static
+     */
+    public function class($classList)
+    {
+        $classList = Arr::wrap($classList);
+
+        $classes = [];
+
+        foreach ($classList as $class => $constraint) {
+            // If the "class" value is a numeric key, we can assume
+            // that no constraint has been specified.
+            if (is_numeric($class)) {
+                $classes[] = $constraint;
+            } elseif ($constraint) {
+                $classes[] = $class;
+            }
+        }
+
+        return $this->merge(['class' => implode(' ', $classes)]);
+    }
+
+    /**
      * Resolve an appendable attribute value default value.
      *
      * @param  array  $attributeDefaults

--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -70,7 +70,7 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
     /**
      * Only include the given attribute from the attribute array.
      *
-     * @param  mixed|array  $keys
+     * @param  mixed  $keys
      * @return static
      */
     public function only($keys)

--- a/tests/View/ViewComponentAttributeBagTest.php
+++ b/tests/View/ViewComponentAttributeBagTest.php
@@ -27,6 +27,9 @@ class ViewComponentAttributeBagTest extends TestCase
         $this->assertSame('font-bold', $bag->get('class'));
         $this->assertSame('bar', $bag->get('foo', 'bar'));
         $this->assertSame('font-bold', $bag['class']);
+        $this->assertSame('class="mt-4 font-bold" name="test"', (string) $bag->class('mt-4'));
+        $this->assertSame('class="mt-4 font-bold" name="test"', (string) $bag->class(['mt-4']));
+        $this->assertSame('class="mt-4 ml-2 font-bold" name="test"', (string) $bag->class(['mt-4', 'ml-2' => true, 'mr-2' => false]));
 
         $bag = new ComponentAttributeBag([]);
 


### PR DESCRIPTION
Inspired by Vue's `:class` syntax, this PR adds a `class()` method to the `ComponentAttributeBag` class. It merges the given classes into the attribute bag. 

It accepts an array of classes, and you can specify a constraint whether to merge the class or not:

```blade
<div {{ $attributes->class(['p-4', 'bg-red' => $hasError]) }}>
```

It also accepts a string:

```blade
<div {{ $attributes->class('p-4') }}>
```