### PR TITLE
Grammarly corrections

### DIFF
--- a/src/Illuminate/Auth/DatabaseUserProvider.php
+++ b/src/Illuminate/Auth/DatabaseUserProvider.php
@@ -122,7 +122,7 @@ class DatabaseUserProvider implements UserProvider
             }
         }
 
-        // Now we are ready to execute the query to see if we have an user matching
+        // Now we are ready to execute the query to see if we have a user matching
         // the given credentials. If not, we will just return nulls and indicate
         // that there are no matching users for these given credential arrays.
         $user = $query->first();

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -134,7 +134,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
         $id = $this->session->get($this->getName());
 
         // First we will try to load the user using the identifier in the session if
-        // one exists. Otherwise we will check for a "remember me" cookie in this
+        // one exists. Otherwise, we will check for a "remember me" cookie in this
         // request, and if one exists, attempt to retrieve the user using that.
         if (! is_null($id) && $this->user = $this->provider->retrieveById($id)) {
             $this->fireAuthenticatedEvent($this->user);

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -423,7 +423,7 @@ class Arr
             $itemValue = data_get($item, $value);
 
             // If the key is "null", we will just append the value to the array and keep
-            // looping. Otherwise we will key the array using the value of the key we
+            // looping. Otherwise, we will key the array using the value of the key we
             // received from the developer. Then we'll return the final array form.
             if (is_null($key)) {
                 $results[] = $itemValue;

--- a/src/Illuminate/Contracts/Queue/Monitor.php
+++ b/src/Illuminate/Contracts/Queue/Monitor.php
@@ -13,7 +13,7 @@ interface Monitor
     public function looping($callback);
 
     /**
-     * Register a callback to be executed when a job fails after the maximum amount of retries.
+     * Register a callback to be executed when a job fails after the maximum number of retries.
      *
      * @param  mixed  $callback
      * @return void

--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -31,7 +31,7 @@ trait ManagesTransactions
 
             // If we catch an exception we'll rollback this transaction and try again if we
             // are not out of attempts. If we are out of attempts we will just throw the
-            // exception back out and let the developer handle an uncaught exceptions.
+            // exception back out and let the developer handle an uncaught exception.
             catch (Throwable $e) {
                 $this->handleTransactionException(
                     $e, $currentAttempt, $attempts

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -333,7 +333,7 @@ class Connection implements ConnectionInterface
 
             // For select statements, we'll simply execute the query and return an array
             // of the database result set. Each element in the array will be a single
-            // row from the database table, and will either be an array or objects.
+            // row from the database table, and will either be an array or object.
             $statement = $this->prepared(
                 $this->getPdoForSelect($useReadPdo)->prepare($query)
             );
@@ -633,7 +633,7 @@ class Connection implements ConnectionInterface
 
         // Here we will run this query. If an exception occurs we'll determine if it was
         // caused by a connection that has been lost. If that is the cause, we'll try
-        // to re-establish connection and re-run the query with a fresh connection.
+        // to re-establish a connection and re-run the query with a fresh connection.
         try {
             $result = $this->runQueryCallback($query, $bindings, $callback);
         } catch (QueryException $e) {

--- a/src/Illuminate/Database/Connectors/SQLiteConnector.php
+++ b/src/Illuminate/Database/Connectors/SQLiteConnector.php
@@ -19,7 +19,7 @@ class SQLiteConnector extends Connector implements ConnectorInterface
         $options = $this->getOptions($config);
 
         // SQLite supports "in-memory" databases that only last as long as the owning
-        // connection does. These are useful for tests or for short lifetime store
+        // connection does. These are useful for tests or short lifetime store
         // querying. In-memory databases may only have a single open connection.
         if ($config['database'] === ':memory:') {
             return $this->createConnection('sqlite::memory:', $config, $options);

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1156,7 +1156,7 @@ class Builder
     {
         $whereBooleans = collect($whereSlice)->pluck('boolean');
 
-        // Here we'll check if the given subset of where clauses contains any "or"
+        // Here we'll check if the given subset of where clauses contain any "or"
         // booleans and in this case create a nested where expression. That way
         // we don't add any unnecessary nesting thus keeping the query clean.
         if ($whereBooleans->contains('or')) {

--- a/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
@@ -172,7 +172,7 @@ trait GuardsAttributes
             return true;
         }
 
-        // If the key is in the "fillable" array, we can of course assume that it's
+        // If the key is in the "fillable" array, we can, of course, assume that it's
         // a fillable attribute. Otherwise, we will check the guarded array when
         // we need to determine if the attribute is black-listed on the model.
         if (in_array($key, $this->getFillable())) {

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -301,7 +301,7 @@ trait HasAttributes
         $attributes = [];
 
         foreach ($this->getArrayableRelations() as $key => $value) {
-            // If the values implements the Arrayable interface we can just call this
+            // If the values implement the Arrayable interface we can just call this
             // toArray method on the instances which will convert both models and
             // collections to their proper array form and we'll set the values.
             if ($value instanceof Arrayable) {
@@ -695,7 +695,7 @@ trait HasAttributes
     {
         // First we will check for the presence of a mutator for the set operation
         // which simply lets the developers tweak the attribute as it is set on
-        // the model, such as "json_encoding" an listing of data for storage.
+        // the model, such as "json_encoding" a listing of data for storage.
         if ($this->hasSetMutator($key)) {
             return $this->setMutatedAttributeValue($key, $value);
         }
@@ -1514,7 +1514,7 @@ trait HasAttributes
 
         // Here we will spin through every attribute and see if this is in the array of
         // dirty attributes. If it is, we will return true and if we make it through
-        // all of the attributes for the entire array we will return false at end.
+        // all of the attributes for the entire array we will return false at the end.
         foreach (Arr::wrap($attributes) as $attribute) {
             if (array_key_exists($attribute, $changes)) {
                 return true;

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -210,7 +210,7 @@ trait HasRelationships
 
         // Once we have the foreign key names, we'll just create a new Eloquent query
         // for the related models and returns the relationship instance which will
-        // actually be responsible for retrieving and hydrating every relations.
+        // actually be responsible for retrieving and hydrating every relation.
         $ownerKey = $ownerKey ?: $instance->getKeyName();
 
         return $this->newBelongsTo(
@@ -254,7 +254,7 @@ trait HasRelationships
         );
 
         // If the type value is null it is probably safe to assume we're eager loading
-        // the relationship. In this case we'll just pass in a dummy query where we
+        // the relationship. In this case, we'll just pass in a dummy query where we
         // need to remove any eager loads that may already be defined on a model.
         return is_null($class = $this->getAttributeFromArray($type)) || $class === ''
                     ? $this->morphEagerTo($name, $type, $id, $ownerKey)
@@ -553,8 +553,8 @@ trait HasRelationships
         $relatedPivotKey = $relatedPivotKey ?: $instance->getForeignKey();
 
         // Now we're ready to create a new query builder for this related model and
-        // the relationship instances for this relation. This relations will set
-        // appropriate query constraints then entirely manages the hydrations.
+        // the relationship instances for this relation. These relations will set
+        // appropriate query constraints then entirely manage the hydrations.
         if (! $table) {
             $words = preg_split('/(_)/u', $name, -1, PREG_SPLIT_DELIM_CAPTURE);
 

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -297,7 +297,7 @@ class BelongsToMany extends Relation
     {
         // First we will build a dictionary of child models keyed by the foreign key
         // of the relation so that we will easily and quickly match them to their
-        // parents without having a possibly slow inner loops for every models.
+        // parents without having a possibly slow inner loop for every model.
         $dictionary = [];
 
         foreach ($results as $result) {
@@ -767,7 +767,7 @@ class BelongsToMany extends Relation
     public function get($columns = ['*'])
     {
         // First we'll add the proper select columns onto the query so it is run with
-        // the proper columns. Then, we will get the results and hydrate out pivot
+        // the proper columns. Then, we will get the results and hydrate out the pivot
         // models with the result of those columns as a separate model relation.
         $builder = $this->query->applyScopes();
 
@@ -1092,9 +1092,9 @@ class BelongsToMany extends Relation
     {
         $instance = $this->related->newInstance($attributes);
 
-        // Once we save the related model, we need to attach it to the base model via
-        // through intermediate table so we'll use the existing "attach" method to
-        // accomplish this which will insert the record and any more attributes.
+        // Once we save the related model, we need to attach it to the base model
+        // through the intermediate table so we'll use the existing "attach" method
+        // to accomplish this which will insert the record and any more attributes.
         $instance->save(['touch' => false]);
 
         $this->attach($instance, $joining, $touch);

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
@@ -45,8 +45,8 @@ trait AsPivot
         $instance->timestamps = $instance->hasTimestampAttributes($attributes);
 
         // The pivot model is a "dynamic" model since we will set the tables dynamically
-        // for the instance. This allows it work for any intermediate tables for the
-        // many to many relationship that are defined by this developer's classes.
+        // for the instance. This allows it to work for any intermediate tables for the
+        // many to many relationships that are defined by this developer's classes.
         $instance->setConnection($parent->getConnectionName())
             ->setTable($table)
             ->forceFill($attributes)

--- a/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
+++ b/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
@@ -54,7 +54,7 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
     }
 
     /**
-     * Get list of migrations.
+     * Get the list of migrations.
      *
      * @param  int  $steps
      * @return array

--- a/src/Illuminate/Database/Migrations/MigrationCreator.php
+++ b/src/Illuminate/Database/Migrations/MigrationCreator.php
@@ -145,7 +145,7 @@ class MigrationCreator
         );
 
         // Here we will replace the table place-holders with the table specified by
-        // the developer, which is useful for quickly creating a tables creation
+        // the developer, which is useful for quickly creating a table creation
         // or update migration from the console instead of typing it manually.
         if (! is_null($table)) {
             $stub = str_replace(

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -195,7 +195,7 @@ class Builder
     ];
 
     /**
-     * Whether to use write pdo for the select.
+     * Whether to use the write connection for the PDO select.
      *
      * @var bool
      */
@@ -3230,7 +3230,7 @@ class Builder
     }
 
     /**
-     * Use the write pdo for query.
+     * Use the write connection for the PDO query.
      *
      * @return $this
      */

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -693,7 +693,7 @@ class Builder
             $value, $operator, func_num_args() === 2
         );
 
-        // If the columns is actually a Closure instance, we will assume the developer
+        // If the columns are actually a Closure instance, we will assume the developer
         // wants to begin a nested where statement which is wrapped in parenthesis.
         // We'll add that Closure to the query then return back out immediately.
         if ($column instanceof Closure && is_null($operator)) {
@@ -937,7 +937,7 @@ class Builder
         $type = $not ? 'NotIn' : 'In';
 
         // If the value is a query builder instance we will assume the developer wants to
-        // look for any values that exists within this given query. So we will add the
+        // look for any values that exist within this given query. So we will add the
         // query accordingly so that this query is properly executed when it is run.
         if ($this->isQueryable($values)) {
             [$query, $bindings] = $this->createSub($values);
@@ -956,7 +956,7 @@ class Builder
 
         $this->wheres[] = compact('type', 'column', 'values', 'boolean');
 
-        // Finally we'll add a binding for each values unless that value is an expression
+        // Finally we'll add a binding for each value unless that value is an expression
         // in which case we will just skip over it since it will be the query as a raw
         // string and not as a parameterized place-holder to be replaced by the PDO.
         $this->addBinding($this->cleanBindings($values), 'where');
@@ -2596,8 +2596,8 @@ class Builder
             $this->grammar->compileExists($this), $this->getBindings(), ! $this->useWritePdo
         );
 
-        // If the results has rows, we will get the row and see if the exists column is a
-        // boolean true. If there is no results for this query we will return false as
+        // If the results have rows, we will get the row and see if the exists column is a
+        // boolean true. If there are no results for this query we will return false as
         // there are no rows for this query at all and we can return that info here.
         if (isset($results[0])) {
             $results = (array) $results[0];
@@ -2740,7 +2740,7 @@ class Builder
 
         // If there is no result, we can obviously just return 0 here. Next, we will check
         // if the result is an integer or float. If it is already one of these two data
-        // types we can just return the result as-is, otherwise we will convert this.
+        // types we can just return the result as-is, otherwise, we will convert this.
         if (! $result) {
             return 0;
         }

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -880,7 +880,7 @@ class Grammar extends BaseGrammar
         $columns = $this->columnize(array_keys(reset($values)));
 
         // We need to build a list of parameter place-holders of values that are bound
-        // to the query. Each insert should have the same amount of parameter bindings
+        // to the query. Each insert should have the same number of parameter bindings
         // so we will loop through the record and parameterize them all.
         $parameters = collect($values)->map(function ($record) {
             return '('.$this->parameterize($record).')';

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -183,7 +183,7 @@ class Grammar extends BaseGrammar
      */
     public function compileWheres(Builder $query)
     {
-        // Each type of where clauses has its own compiler function which is responsible
+        // Each type of where clause has its own compiler function which is responsible
         // for actually creating the where clauses SQL. This helps keep the code nice
         // and maintainable since each clause has a very small method that it uses.
         if (is_null($query->wheres)) {
@@ -866,7 +866,7 @@ class Grammar extends BaseGrammar
     {
         // Essentially we will force every insert to be treated as a batch insert which
         // simply makes creating the SQL easier for us since we can utilize the same
-        // basic routine regardless of an amount of records given to us to insert.
+        // basic routine regardless of the amount of records given to us to insert.
         $table = $this->wrapTable($query->from);
 
         if (empty($values)) {
@@ -880,8 +880,8 @@ class Grammar extends BaseGrammar
         $columns = $this->columnize(array_keys(reset($values)));
 
         // We need to build a list of parameter place-holders of values that are bound
-        // to the query. Each insert should have the exact same amount of parameter
-        // bindings so we will loop through the record and parameterize them all.
+        // to the query. Each insert should have the same amount of parameter bindings
+        // so we will loop through the record and parameterize them all.
         $parameters = collect($values)->map(function ($record) {
             return '('.$this->parameterize($record).')';
         })->implode(', ');

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -130,7 +130,7 @@ abstract class Grammar extends BaseGrammar
         $columns = [];
 
         foreach ($blueprint->getAddedColumns() as $column) {
-            // Each of the column types have their own compiler functions which are tasked
+            // Each of the column types has their own compiler functions which are tasked
             // with turning the column definition into its SQL format for this platform
             // used by the connection. The column's modifiers are compiled and added.
             $sql = $this->wrap($column).' '.$this->getType($column);

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -77,7 +77,7 @@ class SQLiteGrammar extends Grammar
         return collect($foreigns)->reduce(function ($sql, $foreign) {
             // Once we have all the foreign key commands for the table creation statement
             // we'll loop through each of them and add them to the create table SQL we
-            // are building, since SQLite needs foreign keys on the tables creation.
+            // are building, since SQLite needs foreign keys on the table's creation.
             $sql .= $this->getForeignKey($foreign);
 
             if (! is_null($foreign->onDelete)) {

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -238,7 +238,7 @@ class Dispatcher implements DispatcherContract
 
             // If a response is returned from the listener and event halting is enabled
             // we will just return this response, and not call the rest of the event
-            // listeners. Otherwise we will add the response on the response list.
+            // listeners. Otherwise, we will add the response on the response list.
             if ($halt && ! is_null($response)) {
                 return $response;
             }

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -149,7 +149,7 @@ class ServeCommand extends Command
     }
 
     /**
-     * Check if the command has reached its max amount of port tries.
+     * Check if the command has reached its maximum number of port tries.
      *
      * @return bool
      */

--- a/src/Illuminate/Pagination/UrlWindow.php
+++ b/src/Illuminate/Pagination/UrlWindow.php
@@ -100,7 +100,7 @@ class UrlWindow
     }
 
     /**
-     * Get the slider of URLs when too close to beginning of window.
+     * Get the slider of URLs when too close to the beginning of the window.
      *
      * @param  int  $window
      * @param  int  $onEachSide
@@ -116,7 +116,7 @@ class UrlWindow
     }
 
     /**
-     * Get the slider of URLs when too close to ending of window.
+     * Get the slider of URLs when too close to the ending of the window.
      *
      * @param  int  $window
      * @param  int  $onEachSide

--- a/src/Illuminate/Pagination/UrlWindow.php
+++ b/src/Illuminate/Pagination/UrlWindow.php
@@ -86,7 +86,7 @@ class UrlWindow
             return $this->getSliderTooCloseToBeginning($window, $onEachSide);
         }
 
-        // If the current page is close to the ending of the page range we will just get
+        // If the current page is close to the end of the page range we will just get
         // this first couple pages, followed by a larger window of these ending pages
         // since we're too close to the end of the list to create a full on slider.
         elseif ($this->currentPage() > ($this->lastPage() - $window)) {
@@ -116,7 +116,7 @@ class UrlWindow
     }
 
     /**
-     * Get the slider of URLs when too close to the ending of the window.
+     * Get the slider of URLs when too close to the end of the window.
      *
      * @param  int  $window
      * @param  int  $onEachSide

--- a/src/Illuminate/Queue/Capsule/Manager.php
+++ b/src/Illuminate/Queue/Capsule/Manager.php
@@ -34,7 +34,7 @@ class Manager
 
         // Once we have the container setup, we will setup the default configuration
         // options in the container "config" bindings. This just makes this queue
-        // manager behave correctly since all the correct binding are in place.
+        // manager behave correctly since all the correct bindings are in place.
         $this->setupDefaultConfiguration();
 
         $this->setupManager();

--- a/src/Illuminate/Queue/Listener.php
+++ b/src/Illuminate/Queue/Listener.php
@@ -30,7 +30,7 @@ class Listener
     protected $sleep = 3;
 
     /**
-     * The amount of times to try a job before logging it failed.
+     * The number of times to try a job before logging it failed.
      *
      * @var int
      */

--- a/src/Illuminate/Queue/Listener.php
+++ b/src/Illuminate/Queue/Listener.php
@@ -177,7 +177,7 @@ class Listener
 
         // Once we have run the job we'll go check if the memory limit has been exceeded
         // for the script. If it has, we will kill this script so the process manager
-        // will restart this with a clean slate of memory automatically on exiting.
+        // will restart this with a clean slate of memory automatically on exit.
         if ($this->memoryExceeded($memory)) {
             $this->stop();
         }

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -387,7 +387,7 @@ class Worker
     public function process($connectionName, $job, WorkerOptions $options)
     {
         try {
-            // First we will raise the before job event and determine if the job has already ran
+            // First we will raise the before job event and determine if the job has already run
             // over its maximum attempt limits, which could primarily happen when this job is
             // continually timing out and not actually throwing any exceptions from itself.
             $this->raiseBeforeJobEvent($connectionName, $job);
@@ -401,7 +401,7 @@ class Worker
             }
 
             // Here we will fire off the job and let it process. We will catch any exceptions so
-            // they can be reported to the developers logs, etc. Once the job is finished the
+            // they can be reported to the developer's logs, etc. Once the job is finished the
             // proper events will be fired to let any listeners know this job has finished.
             $job->fire();
 

--- a/src/Illuminate/Queue/WorkerOptions.php
+++ b/src/Illuminate/Queue/WorkerOptions.php
@@ -40,7 +40,7 @@ class WorkerOptions
     public $sleep;
 
     /**
-     * The maximum amount of times a job may be attempted.
+     * The maximum number of times a job may be attempted.
      *
      * @var int
      */

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -449,7 +449,7 @@ class ResourceRegistrar
 
         // If a global prefix has been assigned to all names for this resource, we will
         // grab that so we can prepend it onto the name when we create this name for
-        // the resource action. Otherwise we'll just use an empty string for here.
+        // the resource action. Otherwise, we'll just use an empty string for here.
         $prefix = isset($options['as']) ? $options['as'].'.' : '';
 
         return trim(sprintf('%s%s.%s', $prefix, $name, $method), '.');

--- a/src/Illuminate/Routing/RouteAction.php
+++ b/src/Illuminate/Routing/RouteAction.php
@@ -28,7 +28,7 @@ class RouteAction
 
         // If the action is already a Closure instance, we will just set that instance
         // as the "uses" property, because there is nothing else we need to do when
-        // it is available. Otherwise we will need to find it in the action list.
+        // it is available. Otherwise, we will need to find it in the action list.
         if (Reflector::isCallable($action, true)) {
             return ! is_array($action) ? ['uses' => $action] : [
                 'uses' => $action[0].'@'.$action[1],

--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -156,7 +156,7 @@ class RouteCollection extends AbstractRouteCollection
 
         // First, we will see if we can find a matching route for this current request
         // method. If we can, great, we can just return it so that it can be called
-        // by the consumer. Otherwise we will check for routes with another verb.
+        // by the consumer. Otherwise, we will check for routes with another verb.
         $route = $this->matchAgainstRoutes($routes, $request);
 
         return $this->handleMatchedRoute($request, $route);

--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -93,7 +93,7 @@ class RouteUrlGenerator
 
         // Once we have ensured that there are no missing parameters in the URI we will encode
         // the URI and prepare it for returning to the developer. If the URI is supposed to
-        // be absolute, we will return it as-is. Otherwise we will remove the URL's root.
+        // be absolute, we will return it as-is. Otherwise, we will remove the URL's root.
         $uri = strtr(rawurlencode($uri), $this->dontEncode);
 
         if (! $absolute) {

--- a/src/Illuminate/Support/DateFactory.php
+++ b/src/Illuminate/Support/DateFactory.php
@@ -211,7 +211,7 @@ class DateFactory
 
         $dateClass = static::$dateClass ?: $defaultClassName;
 
-        // Check if date can be created using public class method...
+        // Check if the date can be created using the public class method...
         if (method_exists($dateClass, $method) ||
             method_exists($dateClass, 'hasMacro') && $dateClass::hasMacro($method)) {
             return $dateClass::$method(...$parameters);

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -265,7 +265,7 @@ class Str
             $pattern = preg_quote($pattern, '#');
 
             // Asterisks are translated into zero-or-more regular expression wildcards
-            // to make it convenient to check if the strings starts with the given
+            // to make it convenient to check if the strings start with the given
             // pattern such as "library/*", making any string check convenient.
             $pattern = str_replace('\*', '.*', $pattern);
 

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -132,7 +132,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
 
         // If the line doesn't exist, we will return back the key which was requested as
         // that will be quick to spot in the UI if language keys are wrong or missing
-        // from the application's language files. Otherwise we can return the line.
+        // from the application's language files. Otherwise, we can return the line.
         return $this->makeReplacements($line ?: $key, $replace);
     }
 

--- a/src/Illuminate/Validation/Factory.php
+++ b/src/Illuminate/Validation/Factory.php
@@ -166,7 +166,7 @@ class Factory implements FactoryContract
 
         // Next, we will add the implicit extensions, which are similar to the required
         // and accepted rule in that they are run even if the attributes is not in a
-        // array of data that is given to a validator instances via instantiation.
+        // array of data that is given to a validator instance via instantiation.
         $validator->addImplicitExtensions($this->implicitExtensions);
 
         $validator->addDependentExtensions($this->dependentExtensions);

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -216,7 +216,7 @@ class ComponentTagCompiler
             return [Str::camel($key) => $value];
         });
 
-        // If the component doesn't exists as a class we'll assume it's a class-less
+        // If the component doesn't exist as a class we'll assume it's a class-less
         // component and pass the component as a view parameter to the data so it
         // can be accessed within the component and we can render out the view.
         if (! class_exists($class)) {
@@ -358,7 +358,7 @@ class ComponentTagCompiler
      */
     public function partitionDataAndAttributes($class, array $attributes)
     {
-        // If the class doesn't exists, we'll assume it's a class-less component and
+        // If the class doesn't exist, we'll assume it's a class-less component and
         // return all of the attributes as both data and attributes since we have
         // now way to partition them. The user can exclude attributes manually.
         if (! class_exists($class)) {

--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -112,7 +112,7 @@ class View implements ArrayAccess, Htmlable, ViewContract
      */
     protected function renderContents()
     {
-        // We will keep track of the amount of views being rendered so we can flush
+        // We will keep track of the number of views being rendered so we can flush
         // the section after the complete rendering operation is done. This will
         // clear out the sections for any separate views that may be rendered.
         $this->factory->incrementRender();
@@ -122,7 +122,7 @@ class View implements ArrayAccess, Htmlable, ViewContract
         $contents = $this->getContents();
 
         // Once we've finished rendering the view, we'll decrement the render count
-        // so that each sections get flushed out next time a view is created and
+        // so that each section gets flushed out next time a view is created and
         // no old sections are staying around in the memory of an environment.
         $this->factory->decrementRender();
 


### PR DESCRIPTION
- Grammarly corrections
- Use "number" rather than "amount" when discussing items that can be counted 🧮
  - [The difference between "number" and "amount"](http://crosstalk.cell.com/blog/the-difference-between-number-and-amount#:~:text=In%20other%20words%2C%20number%20refers,measure%20but%20not%20individually%20count.)