### PR TITLE
[8.x] Don't pluralise string if string ends with none alphanumeric character

### DIFF
--- a/src/Illuminate/Support/Pluralizer.php
+++ b/src/Illuminate/Support/Pluralizer.php
@@ -69,7 +69,7 @@ class Pluralizer
      */
     public static function plural($value, $count = 2)
     {
-        if ((int) abs($count) === 1 || static::uncountable($value)) {
+        if ((int) abs($count) === 1 || static::uncountable($value) || preg_match('/^(.*)[A-Za-z0-9]$/', $value) == 0) {
             return $value;
         }
 

--- a/src/Illuminate/Support/Pluralizer.php
+++ b/src/Illuminate/Support/Pluralizer.php
@@ -69,7 +69,7 @@ class Pluralizer
      */
     public static function plural($value, $count = 2)
     {
-        if ((int) abs($count) === 1 || static::uncountable($value) || preg_match('/^(.*)[A-Za-z0-9]$/', $value) == 0) {
+        if ((int) abs($count) === 1 || static::uncountable($value) || preg_match('/^(.*)[A-Za-z0-9\x{0080}-\x{FFFF}]$/u', $value) == 0) {
             return $value;
         }
 

--- a/tests/Support/SupportPluralizerTest.php
+++ b/tests/Support/SupportPluralizerTest.php
@@ -68,6 +68,18 @@ class SupportPluralizerTest extends TestCase
         $this->assertPluralStudly('RealHumans', 'RealHuman', -2);
     }
 
+    public function testPluralNotAppliedForStringEndingWithNoneAlphanumericCharacter()
+    {
+        $this->assertSame('Alien.', Str::plural('Alien.'));
+        $this->assertSame('Alien!', Str::plural('Alien!'));
+        $this->assertSame('Alien ', Str::plural('Alien '));
+        $this->assertSame('50%', Str::plural('50%'));
+
+        $this->assertSame('User1s', Str::plural('User1'));
+        $this->assertSame('User2s', Str::plural('User2'));
+        $this->assertSame('User3s', Str::plural('User3'));
+    }
+
     private function assertPluralStudly($expected, $value, $count = 2)
     {
         $this->assertSame($expected, Str::pluralStudly($value, $count));

--- a/tests/Support/SupportPluralizerTest.php
+++ b/tests/Support/SupportPluralizerTest.php
@@ -68,7 +68,7 @@ class SupportPluralizerTest extends TestCase
         $this->assertPluralStudly('RealHumans', 'RealHuman', -2);
     }
 
-    public function testPluralNotAppliedForStringEndingWithNoneAlphanumericCharacter()
+    public function testPluralNotAppliedForStringEndingWithNonAlphanumericCharacter()
     {
         $this->assertSame('Alien.', Str::plural('Alien.'));
         $this->assertSame('Alien!', Str::plural('Alien!'));

--- a/tests/Support/SupportPluralizerTest.php
+++ b/tests/Support/SupportPluralizerTest.php
@@ -16,6 +16,8 @@ class SupportPluralizerTest extends TestCase
     {
         $this->assertSame('children', Str::plural('child'));
         $this->assertSame('cod', Str::plural('cod'));
+        $this->assertSame('The words', Str::plural('The word'));
+        $this->assertSame('Bouquetés', Str::plural('Bouqueté'));
     }
 
     public function testCaseSensitiveSingularUsage()
@@ -74,13 +76,13 @@ class SupportPluralizerTest extends TestCase
         $this->assertSame('Alien!', Str::plural('Alien!'));
         $this->assertSame('Alien ', Str::plural('Alien '));
         $this->assertSame('50%', Str::plural('50%'));
-
+    }
+    
+    public function testPluralAppliedForStringEndingWithNumericCharacter()
+    {
         $this->assertSame('User1s', Str::plural('User1'));
         $this->assertSame('User2s', Str::plural('User2'));
         $this->assertSame('User3s', Str::plural('User3'));
-
-        $this->assertSame('The words', Str::plural('The word'));
-        $this->assertSame('Bouquetés', Str::plural('Bouqueté'));
     }
 
     private function assertPluralStudly($expected, $value, $count = 2)

--- a/tests/Support/SupportPluralizerTest.php
+++ b/tests/Support/SupportPluralizerTest.php
@@ -78,6 +78,8 @@ class SupportPluralizerTest extends TestCase
         $this->assertSame('User1s', Str::plural('User1'));
         $this->assertSame('User2s', Str::plural('User2'));
         $this->assertSame('User3s', Str::plural('User3'));
+
+        $this->assertSame('Bouquetés', Str::plural('Bouqueté'));
     }
 
     private function assertPluralStudly($expected, $value, $count = 2)

--- a/tests/Support/SupportPluralizerTest.php
+++ b/tests/Support/SupportPluralizerTest.php
@@ -79,6 +79,7 @@ class SupportPluralizerTest extends TestCase
         $this->assertSame('User2s', Str::plural('User2'));
         $this->assertSame('User3s', Str::plural('User3'));
 
+        $this->assertSame('The words', Str::plural('The word'));
         $this->assertSame('Bouquetés', Str::plural('Bouqueté'));
     }
 


### PR DESCRIPTION
Avoid scenarios such as below.

![image](https://user-images.githubusercontent.com/172966/106872408-3ae19f00-670e-11eb-8b41-bad93a134960.png)

Right now we still enable adding `s` for string ending with numeric to avoid breaking change for `Model` to table name naming convention.


Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>