### PR TITLE
[8.x] Allow adding multiple columns after a column

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -72,6 +72,13 @@ class Blueprint
     public $temporary = false;
 
     /**
+     * The column to add new columns after.
+     *
+     * @var string
+     */
+    public $after;
+
+    /**
      * Create a new schema blueprint.
      *
      * @param  string  $table
@@ -836,14 +843,12 @@ class Blueprint
      */
     public function foreignId($column)
     {
-        $this->columns[] = $column = new ForeignIdColumnDefinition($this, [
+        return $this->addColumnDefinition(new ForeignIdColumnDefinition($this, [
             'type' => 'bigInteger',
             'name' => $column,
             'autoIncrement' => false,
             'unsigned' => true,
-        ]);
-
-        return $column;
+        ]));
     }
 
     /**
@@ -1189,10 +1194,10 @@ class Blueprint
      */
     public function foreignUuid($column)
     {
-        return $this->columns[] = new ForeignIdColumnDefinition($this, [
+        return $this->addColumnDefinition(new ForeignIdColumnDefinition($this, [
             'type' => 'uuid',
             'name' => $column,
-        ]);
+        ]));
     }
 
     /**
@@ -1436,6 +1441,39 @@ class Blueprint
     }
 
     /**
+     * @param  string  $column
+     * @param  \Closure  $callback
+     * @return void
+     */
+    public function after($column, Closure $callback )
+    {
+        $this->after = $column;
+
+        $callback($this);
+
+        $this->after = null;
+    }
+
+    /**
+     * Add a new column definition to the blueprint.
+     *
+     * @param  \Illuminate\Database\Schema\ColumnDefinition  $definition
+     * @return \Illuminate\Database\Schema\ColumnDefinition
+     */
+    protected function addColumnDefinition($definition)
+    {
+        $this->columns[] = $definition;
+
+        if ($this->after) {
+            $definition->after($this->after);
+
+            $this->after = $definition->name;
+        }
+
+        return $definition;
+    }
+
+    /**
      * Add a new index command to the blueprint.
      *
      * @param  string  $type
@@ -1504,11 +1542,9 @@ class Blueprint
      */
     public function addColumn($type, $name, array $parameters = [])
     {
-        $this->columns[] = $column = new ColumnDefinition(
+        return $this->addColumnDefinition(new ColumnDefinition(
             array_merge(compact('type', 'name'), $parameters)
-        );
-
-        return $column;
+        ));
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1441,11 +1441,13 @@ class Blueprint
     }
 
     /**
+     * Add the columns from the callback after the given column.
+     *
      * @param  string  $column
      * @param  \Closure  $callback
      * @return void
      */
-    public function after($column, Closure $callback )
+    public function after($column, Closure $callback)
     {
         $this->after = $column;
 

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -504,6 +504,19 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertSame('alter table `users` add `name` varchar(255) not null after `foo`', $statements[0]);
     }
 
+    public function testAddingMultipleColumnsAfterAnotherColumn()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->after('foo', function ($blueprint) {
+            $blueprint->string('one');
+            $blueprint->string('two');
+        });
+        $blueprint->string('three');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `one` varchar(255) not null after `foo`, add `two` varchar(255) not null after `one`, add `three` varchar(255) not null', $statements[0]);
+    }
+
     public function testAddingGeneratedColumn()
     {
         $blueprint = new Blueprint('products');


### PR DESCRIPTION
This PR allows:

```php
Schema::table('users', function (Blueprint $table) {
    $table->after('remember_token', function ($table){
        $table->string('card_brand')->nullable();
        $table->string('card_last_four', 4)->nullable();
    });
});
```

The order of the columns will be:

- remember_token
- card_brand
- card_last_four