### PR TITLE
[9.x] Validates the route domain (host) that contains port

### DIFF
--- a/src/Illuminate/Routing/Matching/HostValidator.php
+++ b/src/Illuminate/Routing/Matching/HostValidator.php
@@ -22,6 +22,6 @@ class HostValidator implements ValidatorInterface
             return true;
         }
 
-        return preg_match($hostRegex, $request->getHost());
+        return preg_match($hostRegex, $request->getHttpHost());
     }
 }

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -695,6 +695,16 @@ class Route
     }
 
     /**
+     * Determine if the route allows wildcard port.
+     *
+     * @return bool
+     */
+    public function wildcardPort()
+    {
+        return $this->action['wildcard_port'] ?? true;
+    }
+
+    /**
      * Get or set the domain for the route.
      *
      * @param  string|null  $domain

--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -130,9 +130,7 @@ class RouteUrlGenerator
      */
     protected function formatDomain($route, &$parameters)
     {
-        return $this->addPortToDomain(
-            $this->getRouteScheme($route).$route->getDomain()
-        );
+        return $this->getRouteScheme($route).$route->getDomain();
     }
 
     /**
@@ -150,22 +148,6 @@ class RouteUrlGenerator
         }
 
         return $this->url->formatScheme();
-    }
-
-    /**
-     * Add the port to the domain if necessary.
-     *
-     * @param  string  $domain
-     * @return string
-     */
-    protected function addPortToDomain($domain)
-    {
-        $secure = $this->request->isSecure();
-
-        $port = (int) $this->request->getPort();
-
-        return ($secure && $port === 443) || (! $secure && $port === 80)
-                    ? $domain : $domain.':'.$port;
     }
 
     /**

--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -130,7 +130,10 @@ class RouteUrlGenerator
      */
     protected function formatDomain($route, &$parameters)
     {
-        return $this->getRouteScheme($route).$route->getDomain();
+        return $this->addPortToDomain(
+            $this->getRouteScheme($route).$route->getDomain(),
+            $route->wildcardPort()
+        );
     }
 
     /**
@@ -148,6 +151,27 @@ class RouteUrlGenerator
         }
 
         return $this->url->formatScheme();
+    }
+
+    /**
+     * Add the port to the domain if necessary.
+     *
+     * @param  string  $domain
+     * @param  bool  $wildcardPort
+     * @return string
+     */
+    protected function addPortToDomain($domain, $wildcardPort)
+    {
+        if (! $wildcardPort) {
+            return $domain;
+        }
+
+        $secure = $this->request->isSecure();
+
+        $port = (int) $this->request->getPort();
+
+        return ($secure && $port === 443) || (! $secure && $port === 80)
+                    ? $domain : $domain.':'.$port;
     }
 
     /**

--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -130,10 +130,11 @@ class RouteUrlGenerator
      */
     protected function formatDomain($route, &$parameters)
     {
-        return $this->addPortToDomain(
-            $this->getRouteScheme($route).$route->getDomain(),
-            $route->wildcardPort()
-        );
+        $domain = $this->getRouteScheme($route).$route->getDomain();
+
+        return $route->wildcardPort()
+            ? $this->addPortToDomain($domain)
+            : $domain;
     }
 
     /**
@@ -157,15 +158,10 @@ class RouteUrlGenerator
      * Add the port to the domain if necessary.
      *
      * @param  string  $domain
-     * @param  bool  $wildcardPort
      * @return string
      */
-    protected function addPortToDomain($domain, $wildcardPort)
+    protected function addPortToDomain($domain)
     {
-        if (! $wildcardPort) {
-            return $domain;
-        }
-
         $secure = $this->request->isSecure();
 
         $port = (int) $this->request->getPort();

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -685,6 +685,11 @@ class RoutingRouteTest extends TestCase
             return 'hello';
         });
         $this->assertSame('hello', $router->dispatch(Request::create('http://api.foo.bar/foo/bar', 'GET'))->getContent());
+
+        $router->get('/foo/baz')->domain('localhost:8000')->uses(function () {
+            return 'hi';
+        });
+        $this->assertSame('hi', $router->dispatch(Request::create('http://localhost:8000/foo/baz', 'GET'))->getContent());
     }
 
     public function testMatchesMethodAgainstRequests()

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -678,6 +678,28 @@ class RoutingRouteTest extends TestCase
         $this->assertSame('hello', $router->dispatch(Request::create('http://api.baz.boom/foo/bar', 'GET'))->getContent());
     }
 
+    public function testRoutesDontMatchNonMatchingDomainWithPort()
+    {
+        $this->expectException(NotFoundHttpException::class);
+
+        $router = $this->getRouter();
+        $router->get('foo/bar', ['domain' => 'localhost:8080', function () {
+            return 'hello';
+        }]);
+        $this->assertSame('hello', $router->dispatch(Request::create('http://localhost/foo/bar', 'GET'))->getContent());
+    }
+
+    public function testRoutesDontMatchNonMatchingDomainWhenWildcardPortDisabled()
+    {
+        $this->expectException(NotFoundHttpException::class);
+
+        $router = $this->getRouter();
+        $router->get('foo/bar', ['domain' => 'localhost', 'wildcard_port' => false, function () {
+            return 'hello';
+        }]);
+        $this->assertSame('hello', $router->dispatch(Request::create('http://localhost:8080/foo/bar', 'GET'))->getContent());
+    }
+
     public function testRouteDomainRegistration()
     {
         $router = $this->getRouter();

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -448,7 +448,7 @@ class RoutingUrlGeneratorTest extends TestCase
             Request::create('http://www.foo.com:8080/')
         );
 
-        $route = new Route(['GET'], 'foo/bar', ['as' => 'foo', 'domain' => 'sub.foo.com']);
+        $route = new Route(['GET'], 'foo/bar', ['as' => 'foo', 'domain' => 'sub.foo.com:8080']);
         $routes->add($route);
 
         /*

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -448,7 +448,7 @@ class RoutingUrlGeneratorTest extends TestCase
             Request::create('http://www.foo.com:8080/')
         );
 
-        $route = new Route(['GET'], 'foo/bar', ['as' => 'foo', 'domain' => 'sub.foo.com:8080']);
+        $route = new Route(['GET'], 'foo/bar', ['as' => 'foo', 'domain' => 'sub.foo.com']);
         $routes->add($route);
 
         /*
@@ -459,6 +459,23 @@ class RoutingUrlGeneratorTest extends TestCase
 
         $this->assertSame('http://sub.foo.com:8080/foo/bar', $url->route('foo'));
         $this->assertSame('http://sub.taylor.com:8080/foo/bar/otwell', $url->route('bar', ['taylor', 'otwell']));
+    }
+
+    public function testRoutesWithDomainsAndPortsWhenWildcardPortDisabled()
+    {
+        $url = new UrlGenerator(
+            $routes = new RouteCollection,
+            Request::create('http://www.foo.com:8080/')
+        );
+
+        $route = new Route(['GET'], 'foo', ['as' => 'foo', 'domain' => 'sub.foo.com', 'wildcard_port' => false]);
+        $routes->add($route);
+
+        $route = new Route(['GET'], 'foo/bar/{baz}', ['as' => 'bar', 'domain' => 'sub.{foo}.com', 'wildcard_port' => false]);
+        $routes->add($route);
+
+        $this->assertNotSame('http://sub.foo.com:8080/foo', $url->route('foo'));
+        $this->assertNotSame('http://sub.taylor.com:8080/foo/bar/otwell', $url->route('bar', ['taylor', 'otwell']));
     }
 
     public function testRoutesWithDomainsStripsProtocols()


### PR DESCRIPTION
Right now, if we have `port` in the domain, Laravel not correctly handle it.

```php
Route::get('/foo/bar')
    ->name('foo')
    ->domain('localhost:8000')
    ->uses(function () {
        return 'hi';
    });
```

1. If we try to access that route `http://localhost:8000/foo/bar`, it would fail.

2. If we try to generate named route from it, it will give you weird result `http://localhost:8000:8000/foo/bar`.

Proposed solution:

1. `HostValidator` must validate the domain against `$request->getHttpHost()`, not just `$request->getHost()`.

2. Add action route named `wildcard_port` (used only when we need to strict the port). If `wildcard_port` is `true` (default), it just same as before, if `false` the `RouteUrlGenerator` will not append `port` to the domain.

For me, I've found this use case when building multi tenant application, that using artisan serve in local.
Somehow, I need to separate the `tenant` route to the different domain (that uses port).