### PR TITLE
[8.x] Conditionally merge attributes into a Blade Component attribute bag

### DIFF
--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -546,7 +546,6 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
         $this->attributesBag[$key] = $mergeValues ? implode($mergeSeparator, $result) : $result;
 
         return $this;
-
     }
 
     /**

--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -168,7 +168,7 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
     protected $attributes = [];
 
     /**
-     * List of magic attribute methods
+     * List of magic attribute methods.
      *
      * @var array
      */
@@ -314,7 +314,7 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
         'usemap',
         'value',
         'width',
-        'wrap'
+        'wrap',
     ];
 
     /**
@@ -492,7 +492,7 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
         if (count($arguments) === 1) {
             $list = Arr::first($arguments);
         } else {
-            list($key, $list) = $arguments;
+            [$key, $list] = $arguments;
         }
 
         $list = Arr::wrap($list);
@@ -506,7 +506,7 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
                 $mergeValues = true;
                 break;
             case 'dataAttr':
-                $key = 'data-' . $key;
+                $key = 'data-'.$key;
                 $strKebab = false;
                 break;
             case 'style':
@@ -519,7 +519,7 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
             $key = Str::kebab($key);
         }
 
-        if (!$mergeValues && Arr::exists($this->attributesBag, $key)) {
+        if (! $mergeValues && Arr::exists($this->attributesBag, $key)) {
             return $this;
         }
 
@@ -771,7 +771,7 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
      */
     public function __call($method, $parameters)
     {
-        if (!in_array($method, $this->attributeMethods)) {
+        if (! in_array($method, $this->attributeMethods)) {
             throw new BadMethodCallException(sprintf(
                 'Method %s::%s does not exist.', static::class, $method
             ));

--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -4,6 +4,7 @@ namespace Illuminate\View;
 
 use ArrayAccess;
 use ArrayIterator;
+use BadMethodCallException;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\HtmlString;
@@ -11,6 +12,150 @@ use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use IteratorAggregate;
 
+/**
+ * @method static accept(mixed|array|string $value)
+ * @method static acceptCharset(mixed|array|string $value)
+ * @method static accesskey(mixed|array|string $value)
+ * @method static action(mixed|array|string $value)
+ * @method static alt(mixed|array|string $value)
+ * @method static autocomplete(mixed|array|string $value)
+ * @method static charset(mixed|array|string $value)
+ * @method static class(mixed|array|string $classList)
+ * @method static cite(mixed|array|string $value)
+ * @method static cols(mixed|array|string $value)
+ * @method static colspan(mixed|array|string $value)
+ * @method static content(mixed|array|string $value)
+ * @method static contenteditable(mixed|array|string $value)
+ * @method static coords(mixed|array|string $value)
+ * @method static data(mixed|array|string $value)
+ * @method static dataAttr(string $key, mixed|array|string $values)
+ * @method static datetime(mixed|array|string $value)
+ * @method static dir(mixed|array|string $value)
+ * @method static dirname(mixed|array|string $value)
+ * @method static download(mixed|array|string $value)
+ * @method static draggable(mixed|array|string $value)
+ * @method static enctype(mixed|array|string $value)
+ * @method static for(mixed|array|string $value)
+ * @method static form(mixed|array|string $value)
+ * @method static formaction(mixed|array|string $value)
+ * @method static headers(mixed|array|string $value)
+ * @method static height(mixed|array|string $value)
+ * @method static high(mixed|array|string $value)
+ * @method static href(mixed|array|string $value)
+ * @method static hreflang(mixed|array|string $value)
+ * @method static httpEquiv(mixed|array|string $value)
+ * @method static id(mixed|array|string $value)
+ * @method static kind(mixed|array|string $value)
+ * @method static label(mixed|array|string $value)
+ * @method static list(mixed|array|string $value)
+ * @method static low(mixed|array|string $value)
+ * @method static max(mixed|array|string $value)
+ * @method static maxlength(mixed|array|string $value)
+ * @method static media(mixed|array|string $value)
+ * @method static method(mixed|array|string $value)
+ * @method static min(mixed|array|string $value)
+ * @method static name(mixed|array|string $value)
+ * @method static onabort(mixed|array|string $value)
+ * @method static onafterprint(mixed|array|string $value)
+ * @method static onbeforeprint(mixed|array|string $value)
+ * @method static onbeforeunload(mixed|array|string $value)
+ * @method static onblur(mixed|array|string $value)
+ * @method static oncanplay(mixed|array|string $value)
+ * @method static oncanplaythrough(mixed|array|string $value)
+ * @method static onchange(mixed|array|string $value)
+ * @method static onclick(mixed|array|string $value)
+ * @method static oncontextmenu(mixed|array|string $value)
+ * @method static oncopy(mixed|array|string $value)
+ * @method static oncuechange(mixed|array|string $value)
+ * @method static oncut(mixed|array|string $value)
+ * @method static ondblclick(mixed|array|string $value)
+ * @method static ondrag(mixed|array|string $value)
+ * @method static ondragend(mixed|array|string $value)
+ * @method static ondragenter(mixed|array|string $value)
+ * @method static ondragleave(mixed|array|string $value)
+ * @method static ondragover(mixed|array|string $value)
+ * @method static ondragstart(mixed|array|string $value)
+ * @method static ondrop(mixed|array|string $value)
+ * @method static ondurationchange(mixed|array|string $value)
+ * @method static onemptied(mixed|array|string $value)
+ * @method static onended(mixed|array|string $value)
+ * @method static onerror(mixed|array|string $value)
+ * @method static onfocus(mixed|array|string $value)
+ * @method static onhashchange(mixed|array|string $value)
+ * @method static oninput(mixed|array|string $value)
+ * @method static oninvalid(mixed|array|string $value)
+ * @method static onkeydown(mixed|array|string $value)
+ * @method static onkeypress(mixed|array|string $value)
+ * @method static onkeyup(mixed|array|string $value)
+ * @method static onload(mixed|array|string $value)
+ * @method static onloadeddata(mixed|array|string $value)
+ * @method static onloadedmetadata(mixed|array|string $value)
+ * @method static onloadstart(mixed|array|string $value)
+ * @method static onmousedown(mixed|array|string $value)
+ * @method static onmousemove(mixed|array|string $value)
+ * @method static onmouseout(mixed|array|string $value)
+ * @method static onmouseover(mixed|array|string $value)
+ * @method static onmouseup(mixed|array|string $value)
+ * @method static onmousewheel(mixed|array|string $value)
+ * @method static onoffline(mixed|array|string $value)
+ * @method static ononline(mixed|array|string $value)
+ * @method static onpagehide(mixed|array|string $value)
+ * @method static onpageshow(mixed|array|string $value)
+ * @method static onpaste(mixed|array|string $value)
+ * @method static onpause(mixed|array|string $value)
+ * @method static onplay(mixed|array|string $value)
+ * @method static onplaying(mixed|array|string $value)
+ * @method static onpopstate(mixed|array|string $value)
+ * @method static onprogress(mixed|array|string $value)
+ * @method static onratechange(mixed|array|string $value)
+ * @method static onreset(mixed|array|string $value)
+ * @method static onresize(mixed|array|string $value)
+ * @method static onscroll(mixed|array|string $value)
+ * @method static onsearch(mixed|array|string $value)
+ * @method static onseeked(mixed|array|string $value)
+ * @method static onseeking(mixed|array|string $value)
+ * @method static onselect(mixed|array|string $value)
+ * @method static onstalled(mixed|array|string $value)
+ * @method static onstorage(mixed|array|string $value)
+ * @method static onsubmit(mixed|array|string $value)
+ * @method static onsuspend(mixed|array|string $value)
+ * @method static ontimeupdate(mixed|array|string $value)
+ * @method static ontoggle(mixed|array|string $value)
+ * @method static onunload(mixed|array|string $value)
+ * @method static onvolumechange(mixed|array|string $value)
+ * @method static onwaiting(mixed|array|string $value)
+ * @method static onwheel(mixed|array|string $value)
+ * @method static optimum(mixed|array|string $value)
+ * @method static pattern(mixed|array|string $value)
+ * @method static placeholder(mixed|array|string $value)
+ * @method static poster(mixed|array|string $value)
+ * @method static preload(mixed|array|string $value)
+ * @method static rel(mixed|array|string $value)
+ * @method static rows(mixed|array|string $value)
+ * @method static rowspan(mixed|array|string $value)
+ * @method static scope(mixed|array|string $value)
+ * @method static shape(mixed|array|string $value)
+ * @method static size(mixed|array|string $value)
+ * @method static sizes(mixed|array|string $value)
+ * @method static span(mixed|array|string $value)
+ * @method static spellcheck(mixed|array|string $value)
+ * @method static src(mixed|array|string $value)
+ * @method static srcdoc(mixed|array|string $value)
+ * @method static srclang(mixed|array|string $value)
+ * @method static srcset(mixed|array|string $value)
+ * @method static start(mixed|array|string $value)
+ * @method static step(mixed|array|string $value)
+ * @method static style(mixed|array|string $styleList)
+ * @method static tabindex(mixed|array|string $value)
+ * @method static target(mixed|array|string $value)
+ * @method static title(mixed|array|string $value)
+ * @method static translate(mixed|array|string $value)
+ * @method static type(mixed|array|string $value)
+ * @method static usemap(mixed|array|string $value)
+ * @method static value(mixed|array|string $value)
+ * @method static width(mixed|array|string $value)
+ * @method static wrap(mixed|array|string $value)
+ */
 class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
 {
     use Macroable;
@@ -21,6 +166,163 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
      * @var array
      */
     protected $attributes = [];
+
+    /**
+     * List of magic attribute methods
+     *
+     * @var array
+     */
+    protected $attributeMethods = [
+        'accept',
+        'acceptCharset',
+        'accesskey',
+        'action',
+        'alt',
+        'autocomplete',
+        'charset',
+        'class',
+        'cite',
+        'cols',
+        'colspan',
+        'content',
+        'contenteditable',
+        'coords',
+        'data',
+        'dataAttr',
+        'datetime',
+        'dir',
+        'dirname',
+        'download',
+        'draggable',
+        'enctype',
+        'for',
+        'form',
+        'formaction',
+        'headers',
+        'height',
+        'high',
+        'href',
+        'hreflang',
+        'httpEquiv',
+        'id',
+        'kind',
+        'label',
+        'list',
+        'low',
+        'max',
+        'maxlength',
+        'media',
+        'method',
+        'min',
+        'name',
+        'onabort',
+        'onafterprint',
+        'onbeforeprint',
+        'onbeforeunload',
+        'onblur',
+        'oncanplay',
+        'oncanplaythrough',
+        'onchange',
+        'onclick',
+        'oncontextmenu',
+        'oncopy',
+        'oncuechange',
+        'oncut',
+        'ondblclick',
+        'ondrag',
+        'ondragend',
+        'ondragenter',
+        'ondragleave',
+        'ondragover',
+        'ondragstart',
+        'ondrop',
+        'ondurationchange',
+        'onemptied',
+        'onended',
+        'onerror',
+        'onfocus',
+        'onhashchange',
+        'oninput',
+        'oninvalid',
+        'onkeydown',
+        'onkeypress',
+        'onkeyup',
+        'onload',
+        'onloadeddata',
+        'onloadedmetadata',
+        'onloadstart',
+        'onmousedown',
+        'onmousemove',
+        'onmouseout',
+        'onmouseover',
+        'onmouseup',
+        'onmousewheel',
+        'onoffline',
+        'ononline',
+        'onpagehide',
+        'onpageshow',
+        'onpaste',
+        'onpause',
+        'onplay',
+        'onplaying',
+        'onpopstate',
+        'onprogress',
+        'onratechange',
+        'onreset',
+        'onresize',
+        'onscroll',
+        'onsearch',
+        'onseeked',
+        'onseeking',
+        'onselect',
+        'onstalled',
+        'onstorage',
+        'onsubmit',
+        'onsuspend',
+        'ontimeupdate',
+        'ontoggle',
+        'onunload',
+        'onvolumechange',
+        'onwaiting',
+        'onwheel',
+        'optimum',
+        'pattern',
+        'placeholder',
+        'poster',
+        'preload',
+        'rel',
+        'rows',
+        'rowspan',
+        'scope',
+        'shape',
+        'size',
+        'sizes',
+        'span',
+        'spellcheck',
+        'src',
+        'srcdoc',
+        'srclang',
+        'srcset',
+        'start',
+        'step',
+        'style',
+        'tabindex',
+        'target',
+        'title',
+        'translate',
+        'type',
+        'usemap',
+        'value',
+        'width',
+        'wrap'
+    ];
+
+    /**
+     * List of attributes that have not yet been processed.
+     *
+     * @var array
+     */
+    protected $attributesBag = [];
 
     /**
      * Create a new component attribute bag instance.
@@ -174,26 +476,77 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
     }
 
     /**
-     * Conditionally merge classes into the attribute bag.
+     * Conditionally set attributes into the attribute bag.
      *
-     * @param  mixed|array  $classList
+     * @param string $method
+     * @param array  $arguments
      * @return static
      */
-    public function class($classList)
+    public function makeAttribute($method, $arguments)
     {
-        $classList = Arr::wrap($classList);
+        $key = $method;
+        $mergeValues = false;
+        $mergeSeparator = ' ';
+        $strKebab = true;
 
-        $classes = [];
+        if (count($arguments) === 1) {
+            $list = Arr::first($arguments);
+        } else {
+            list($key, $list) = $arguments;
+        }
 
-        foreach ($classList as $class => $constraint) {
-            if (is_numeric($class)) {
-                $classes[] = $constraint;
+        $list = Arr::wrap($list);
+
+        switch ($method) {
+            case 'accept':
+                $mergeValues = true;
+                $mergeSeparator = '|';
+                break;
+            case 'class':
+                $mergeValues = true;
+                break;
+            case 'dataAttr':
+                $key = 'data-' . $key;
+                $strKebab = false;
+                break;
+            case 'style':
+                $mergeValues = true;
+                $mergeSeparator = ';';
+                break;
+        }
+
+        if ($strKebab) {
+            $key = Str::kebab($key);
+        }
+
+        if (!$mergeValues && Arr::exists($this->attributesBag, $key)) {
+            return $this;
+        }
+
+        $result = $mergeValues ? [] : null;
+
+        foreach ($list as $value => $constraint) {
+            if (is_numeric($value)) {
+                if ($mergeValues) {
+                    $result[] = $constraint;
+                } else {
+                    $result = $constraint;
+                    break;
+                }
             } elseif ($constraint) {
-                $classes[] = $class;
+                if ($mergeValues) {
+                    $result[] = $value;
+                } else {
+                    $result = $value;
+                    break;
+                }
             }
         }
 
-        return $this->merge(['class' => implode(' ', $classes)]);
+        $this->attributesBag[$key] = $mergeValues ? implode($mergeSeparator, $result) : $result;
+
+        return $this;
+
     }
 
     /**
@@ -205,6 +558,8 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
      */
     public function merge(array $attributeDefaults = [], $escape = true)
     {
+        $attributeDefaults = array_merge($this->attributesBag, $attributeDefaults);
+
         $attributeDefaults = array_map(function ($value) use ($escape) {
             return $this->shouldEscapeAttributeValue($escape, $value)
                         ? e($value)
@@ -403,5 +758,25 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
         }
 
         return trim($string);
+    }
+
+    /**
+     * Dynamically set attributes to the component.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return \Illuminate\View\ComponentAttributeBag
+     *
+     * @throws \BadMethodCallException
+     */
+    public function __call($method, $parameters)
+    {
+        if (!in_array($method, $this->attributeMethods)) {
+            throw new BadMethodCallException(sprintf(
+                'Method %s::%s does not exist.', static::class, $method
+            ));
+        } else {
+            return $this->makeAttribute($method, $parameters);
+        }
     }
 }

--- a/tests/View/ViewComponentAttributeBagTest.php
+++ b/tests/View/ViewComponentAttributeBagTest.php
@@ -27,9 +27,16 @@ class ViewComponentAttributeBagTest extends TestCase
         $this->assertSame('font-bold', $bag->get('class'));
         $this->assertSame('bar', $bag->get('foo', 'bar'));
         $this->assertSame('font-bold', $bag['class']);
-        $this->assertSame('class="mt-4 font-bold" name="test"', (string) $bag->class('mt-4'));
-        $this->assertSame('class="mt-4 font-bold" name="test"', (string) $bag->class(['mt-4']));
-        $this->assertSame('class="mt-4 ml-2 font-bold" name="test"', (string) $bag->class(['mt-4', 'ml-2' => true, 'mr-2' => false]));
+        $this->assertSame('href="/login" class="font-bold" name="test"', (string) $bag->href(['/login' => true, '/logout' => false])->merge());
+        $this->assertSame('href="/login" class="mt-4 font-bold" name="test"', (string) $bag->class('mt-4')->merge());
+        $this->assertSame('href="/login" class="mt-4 font-bold" name="test"', (string) $bag->class(['mt-4'])->merge());
+        $this->assertSame('href="/login" class="mt-4 font-bold" accept-charset="ISO-8859-1" name="test"', (string) $bag->acceptCharset('ISO-8859-1')->merge());
+        $this->assertSame('href="/login" class="mt-4 font-bold" accept-charset="ISO-8859-1" name="test"', (string) $bag->acceptCharset(['ISO-8859-1'])->merge());
+        $this->assertSame('href="/login" class="mt-4 font-bold" accept-charset="ISO-8859-1" name="test"', (string) $bag->acceptCharset(['ISO-8859-1' => true, 'UTF-8' => false])->merge());
+        $this->assertSame('href="/login" class="mt-4 ml-2 font-bold" accept-charset="ISO-8859-1" name="test"', (string) $bag->class(['mt-4', 'ml-2' => true, 'mr-2' => false])->merge());
+        $this->assertSame('href="/login" class="mt-4 font-bold" accept-charset="ISO-8859-1" style="display:block" name="test"', (string) $bag->class('mt-4')->style('display:block')->merge());
+        $this->assertSame('href="/login" class="mt-4 font-bold" accept-charset="ISO-8859-1" style="display:block;position:relative" name="test"', (string) $bag->class('mt-4')->style(['display:block', 'position:relative'])->merge());
+        $this->assertSame('href="/login" class="mt-4 font-bold" accept-charset="ISO-8859-1" style="display:block;position:relative" name="test"', (string) $bag->class('mt-4')->style(['display:block', 'position:relative' => true])->merge());
 
         $bag = new ComponentAttributeBag([]);
 


### PR DESCRIPTION
This is inspired by PR. #36131

A few examples:

```blade
<div {{ $attributes->class(['p-4', 'bg-red' => $hasError])->merge() }}>
```

```blade
<div {{ $attributes->class('p-4')->merge() }}>
```

```blade
<a {{ $attributes
               ->class('p-4')
               ->href([
                    '/login' => auth()->guest(),
                    '/logout' => !auth()->guest(),
               ])
              ->merge()
}}>
```

```blade
<a {{ $attributes
               ->class('p-4')
               ->href([
                    route('login') => auth()->guest(),
                    route('logout') => !auth()->guest(),
               ])
              ->merge()
}}>
```

```blade
<a {{ $attributes
               ->class('p-4')
               ->style([
                    'width: 100%',
                    'display:block' => !$isMobile,
                    'display:flex' => $isMobile
               ])
              ->merge()
}}>
```

Component:

```blade
<button {{ $attributes
              ->class('p-4')
               ->id([
                   'btndownload' => $isUser
               ])
               ->dataAttr('type', [
                    'none' => !$isUser,
                    'download' => $isUser
               ])
              ->merge()
}}>
{{ $slot }}
</button>
```

View:

```blade
<x-button class="hello">...</x-button>
```

Output:
```html
<button class="hello p-4" data-type="none">...</button>
<!-- or -->
<button class="hello p-4" id="btndownload" data-type="download">...</button>
```

Reference: [HTML Attribute Reference](https://www.w3schools.com/tags/ref_attributes.asp)