### PR TITLE
[8.x] Accept attribute to touch

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
@@ -16,10 +16,17 @@ trait HasTimestamps
     /**
      * Update the model's update timestamp.
      *
+     * @param  string  $attribute
      * @return bool
      */
-    public function touch()
+    public function touch($attribute = null)
     {
+        if ($attribute) {
+            $this->$attribute = $this->freshTimestamp();
+
+            return $this->save();
+        }
+
         if (! $this->usesTimestamps()) {
             return false;
         }


### PR DESCRIPTION
With the changes in this PR you can replace this code...

```php
$this->update(['attribute' => now()]);
```

... with ...

```php
$this->touch('attribute');
```

Which feels a tad nicer.

I didn't find any test around the normal behaviour of `touch` so I didn't add any. 

If you want to accept this PR, but want tests, point me where these should be created.

