### PR TITLE
[8.x] Update CallQueuedClosure to catch Throwable/Error

### DIFF
--- a/src/Illuminate/Queue/CallQueuedClosure.php
+++ b/src/Illuminate/Queue/CallQueuedClosure.php
@@ -3,13 +3,13 @@
 namespace Illuminate\Queue;
 
 use Closure;
-use Throwable;
 use Illuminate\Bus\Batchable;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use ReflectionFunction;
+use Throwable;
 
 class CallQueuedClosure implements ShouldQueue
 {

--- a/src/Illuminate/Queue/CallQueuedClosure.php
+++ b/src/Illuminate/Queue/CallQueuedClosure.php
@@ -9,7 +9,6 @@ use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use ReflectionFunction;
-use Throwable;
 
 class CallQueuedClosure implements ShouldQueue
 {
@@ -87,10 +86,10 @@ class CallQueuedClosure implements ShouldQueue
     /**
      * Handle a job failure.
      *
-     * @param  \Exception  $e
+     * @param  \Throwable  $e
      * @return void
      */
-    public function failed(Throwable $e)
+    public function failed($e)
     {
         foreach ($this->failureCallbacks as $callback) {
             call_user_func($callback instanceof SerializableClosure ? $callback->getClosure() : $callback, $e);

--- a/src/Illuminate/Queue/CallQueuedClosure.php
+++ b/src/Illuminate/Queue/CallQueuedClosure.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Queue;
 
 use Closure;
-use Exception;
+use Throwable;
 use Illuminate\Bus\Batchable;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Container\Container;
@@ -90,7 +90,7 @@ class CallQueuedClosure implements ShouldQueue
      * @param  \Exception  $e
      * @return void
      */
-    public function failed(Exception $e)
+    public function failed(Throwable $e)
     {
         foreach ($this->failureCallbacks as $callback) {
             call_user_func($callback instanceof SerializableClosure ? $callback->getClosure() : $callback, $e);


### PR DESCRIPTION
- Laravel Version: 8.26.1
- PHP Version: 8.0.0

### Description:
Queued closures that throw an Error will throw again when handled by CallQueuedClosure@failed, as its currently type-hinted for Exceptions only.

### Steps To Reproduce:
```php
Bus::chain([
    function () {
        SomeClassThatDoesntExist::foo();
    }
])->dispatch();
```

The above will first throw `Error Class "SomeClassThatDoesntExist" not found`. The queue will attempt to handle it and throw again: `TypeError
Illuminate\Queue\CallQueuedClosure::failed(): Argument #1 ($e) must be of type Exception, Error given, called in /var/task/vendor/laravel/framework/src/Illuminate/Queue/CallQueuedHandler.php on line 261`

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
