### PR TITLE
Added Pipeline 'afterEach()' method and 'MiddlewareFinished' event

### DIFF
--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -139,7 +139,7 @@ class Kernel implements KernelContract
         return (new Pipeline($this->app))
                     ->send($request)
                     ->through($this->app->shouldSkipMiddleware() ? [] : $this->middleware)
-                    ->afterEach(function($pipe) {
+                    ->afterEach(function ($pipe) {
                         $this->app['events']->dispatch(new MiddlewareFinished($pipe));
                     })
                     ->then($this->dispatchToRouter());

--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\Http\Kernel as KernelContract;
 use Illuminate\Foundation\Http\Events\RequestHandled;
+use Illuminate\Routing\Events\MiddlewareFinished;
 use Illuminate\Routing\Pipeline;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Facade;
@@ -138,6 +139,9 @@ class Kernel implements KernelContract
         return (new Pipeline($this->app))
                     ->send($request)
                     ->through($this->app->shouldSkipMiddleware() ? [] : $this->middleware)
+                    ->afterEach(function($pipe) {
+                        $this->app['events']->dispatch(new MiddlewareFinished($pipe));
+                    })
                     ->then($this->dispatchToRouter());
     }
 

--- a/src/Illuminate/Routing/Events/MiddlewareFinished.php
+++ b/src/Illuminate/Routing/Events/MiddlewareFinished.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Illuminate\Routing\Events;
+
+class MiddlewareFinished
+{
+    /**
+     * The middleware that has finished running.
+     *
+     * @var mixed
+     */
+    public $middleware;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param $middleware
+     */
+    public function __construct($middleware)
+    {
+        $this->middleware = $middleware;
+    }
+}

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -689,7 +689,7 @@ class Router implements BindingRegistrar, RegistrarContract
         return (new Pipeline($this->container))
                         ->send($request)
                         ->through($middleware)
-                        ->afterEach(function($pipe) {
+                        ->afterEach(function ($pipe) {
                             $this->container['events']->dispatch(new MiddlewareFinished($pipe));
                         })
                         ->then(function ($request) use ($route) {

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -15,6 +15,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Illuminate\Routing\Events\MiddlewareFinished;
 use Illuminate\Routing\Events\RouteMatched;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
@@ -688,6 +689,9 @@ class Router implements BindingRegistrar, RegistrarContract
         return (new Pipeline($this->container))
                         ->send($request)
                         ->through($middleware)
+                        ->afterEach(function($pipe) {
+                            $this->container['events']->dispatch(new MiddlewareFinished($pipe));
+                        })
                         ->then(function ($request) use ($route) {
                             return $this->prepareResponse(
                                 $request, $route->run()

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -690,7 +690,9 @@ class Router implements BindingRegistrar, RegistrarContract
                         ->send($request)
                         ->through($middleware)
                         ->afterEach(function ($pipe) {
-                            $this->container['events']->dispatch(new MiddlewareFinished($pipe));
+                            if ($this->container->bound('events')) {
+                                $this->container['events']->dispatch(new MiddlewareFinished($pipe));
+                            }
                         })
                         ->then(function ($request) use ($route) {
                             return $this->prepareResponse(


### PR DESCRIPTION
Hi guys!

This PR (hopefully) adds a new ` afterEach() ` method to the ` Pipeline ` and also dispatches an event each time any route middleware is run.

The ` afterEach() ` method is run after each pipe has been executed. This can useful for anyone who wants to run something between each pipe (like I've done in this PR to trigger the events).

There's then a new ` MiddlewareFinished ` event that is triggered each time the route middleware is run.

The idea behind maybe adding this new functionality is that we can hopefully add some new methods for the testing in the near future to assert that certain middleware has been run. We could do this in a similar way to how we check if certain jobs, events and notifications are sent. So, we could maybe add some new testing the methods down the line such as:

```php
public function test_that_middleware_is_used()
{
    $this->get('/')->assertMiddlewareUsed([MiddlewareNameHere::class]);
}
```
or
```php
public function test_that_middleware_is_used()
{
    Middleware::assertUsed('MiddlewareNameHere::class]);

    $this->get('/');
}
```

I've also not added any tests yet for this because I wasn't too sure if this will get approved. If it all looks okay though, I'd be happy to write tests for it :smile: