### PR TITLE
[8.x] Add commonmark as recommended package for Illuminate\Support

### DIFF
--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -42,6 +42,7 @@
     },
     "suggest": {
         "illuminate/filesystem": "Required to use the composer class (^8.0).",
+        "league/commonmark": "Required to use Str::markdown() and Stringable::markdown() (^1.3).",
         "ramsey/uuid": "Required to use Str::uuid() (^4.0).",
         "symfony/process": "Required to use the composer class (^5.1.4).",
         "symfony/var-dumper": "Required to use the dd function (^5.1.4).",


### PR DESCRIPTION
`league/commonmark` is a required package when using the `Str::markdown()` and `$stringable->markdown()` methods.

`illuminate/support` when used outside of `laravel/framework` does not require `league/commonmark` in it's `composer.json`. 

Added as a suggested package, which seems to be the home for others like this, such as `ramsey/uuid`.

PR that introduced of these methods: https://github.com/laravel/framework/pull/36071