### PR TITLE
[8.x] Add query log methods to the DB facade

### DIFF
--- a/src/Illuminate/Support/Facades/DB.php
+++ b/src/Illuminate/Support/Facades/DB.php
@@ -26,6 +26,11 @@ namespace Illuminate\Support\Facades;
  * @method static void listen(\Closure $callback)
  * @method static void rollBack(int $toLevel = null)
  * @method static void setDefaultConnection(string $name)
+ * @method static void enableQueryLog()
+ * @method static void disableQueryLog()
+ * @method static bool logging()
+ * @method static array getQueryLog()
+ * @method static void flushQueryLog()
  *
  * @see \Illuminate\Database\DatabaseManager
  * @see \Illuminate\Database\Connection


### PR DESCRIPTION
The DB facade is missing the methods for working with the query log.

This is basically a change to support a better developer experience.

No breaking change - if you agree I'll prepare PRs for other versions as well.