### PR TITLE
[9.x] Add timezone group configurable on timezone validation rule

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -5,6 +5,7 @@ namespace Illuminate\Validation\Concerns;
 use Countable;
 use DateTime;
 use DateTimeInterface;
+use DateTimeZone;
 use Egulias\EmailValidator\EmailValidator;
 use Egulias\EmailValidator\Validation\DNSCheckValidation;
 use Egulias\EmailValidator\Validation\MultipleValidationWithAnd;
@@ -1750,11 +1751,18 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
+     * @param  array  $parameters
      * @return bool
      */
-    public function validateTimezone($attribute, $value)
+    public function validateTimezone($attribute, $value, $parameters)
     {
-        return in_array($value, timezone_identifiers_list(), true);
+        $timezoneGroup = DateTimeZone::class.'::'.Str::upper(Arr::get($parameters, '0', 'ALL'));
+
+        if (! defined($timezoneGroup)) {
+            throw new InvalidArgumentException("Invalid timezone group: '{$parameters[0]}' provided.");
+        }
+
+        return in_array($value, timezone_identifiers_list(constant($timezoneGroup)), true);
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3232,6 +3232,20 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['foo' => ['this_is_not_a_timezone']], ['foo' => 'Timezone']);
         $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Etc/UTC'], ['foo' => 'Timezone:all_with_bc']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Africa/Windhoek'], ['foo' => 'Timezone:asia']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'Asia/Dhaka'], ['foo' => 'Timezone:asia']);
+        $this->assertTrue($v->passes());
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Invalid timezone group: 'invalid_group' provided.");
+        $v = new Validator($trans, ['foo' => 'Asia/Dhaka'], ['foo' => 'Timezone:invalid_group']);
+        $this->assertFalse($v->passes());
     }
 
     public function testValidateRegex()


### PR DESCRIPTION
Right now users can't control `timezone group` by using [`timezone`](https://laravel.com/docs/8.x/validation#rule-timezone) validation rule.
By default `timezone_identifiers_list` function use `DateTimeZone::ALL` timezone group. If a user wants to use different timezone group such as: `DateTimeZone::ALL_WITH_BC`, `DateTimeZone::ASIA` or [something else](https://www.php.net/manual/en/class.datetimezone.php#datetimezone.constants) then they can't.

So, In this PR users can now provide timezone group explicitly. 

```php
$this->validate([
    'deliver_timezone' => 'timezone:asia'
])
```

If users, is not passed any timezone group then by default `DateTimeZone::ALL` will be used.
