### PR TITLE
[8.x] Allow components to use custom attribute bag

### DIFF
--- a/src/Illuminate/View/AnonymousComponent.php
+++ b/src/Illuminate/View/AnonymousComponent.php
@@ -48,7 +48,7 @@ class AnonymousComponent extends Component
      */
     public function data()
     {
-        $this->attributes = $this->attributes ?: new ComponentAttributeBag;
+        $this->attributes = $this->attributes ?: $this->newAttributeBag();
 
         return $this->data + ['attributes' => $this->attributes];
     }

--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -121,7 +121,7 @@ abstract class Component
      */
     public function data()
     {
-        $this->attributes = $this->attributes ?: new ComponentAttributeBag;
+        $this->attributes = $this->attributes ?: $this->newAttributeBag();
 
         return array_merge($this->extractPublicProperties(), $this->extractPublicMethods());
     }
@@ -266,11 +266,22 @@ abstract class Component
      */
     public function withAttributes(array $attributes)
     {
-        $this->attributes = $this->attributes ?: new ComponentAttributeBag;
+        $this->attributes = $this->attributes ?: $this->newAttributeBag();
 
         $this->attributes->setAttributes($attributes);
 
         return $this;
+    }
+
+    /**
+     * Get a new attribute bag.
+     *
+     * @param  array  $attributes
+     * @return \Illuminate\View\ComponentAttributeBag
+     */
+    protected function newAttributeBag(array $attributes = [])
+    {
+        return new ComponentAttributeBag($attributes);
     }
 
     /**

--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -274,7 +274,7 @@ abstract class Component
     }
 
     /**
-     * Get a new attribute bag.
+     * Get a new attribute bag instance.
      *
      * @param  array  $attributes
      * @return \Illuminate\View\ComponentAttributeBag


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR allows a developer to provide a custom `ComponentAttributeBag` instance for their view's components.

I really liked the idea on PR #36148 , but I totally get that merging it would expand the maintenance work for a feature not all users would use.

By allowing the developer to override the  `ComponentAttributeBag` instantiation, a third-party package could provide the features from PR #36148 .

Also it is similar to how an Eloquent Model allows a custom Collection or Query Builder instantiation.



