### PR TITLE
[8.x] Add query builder map method

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -7,6 +7,7 @@ use Illuminate\Database\MultipleRecordsFoundException;
 use Illuminate\Database\RecordsNotFoundException;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Pagination\Paginator;
+use Illuminate\Support\Collection;
 
 trait BuildsQueries
 {
@@ -147,6 +148,26 @@ trait BuildsQueries
     public function first($columns = ['*'])
     {
         return $this->take(1)->get($columns)->first();
+    }
+
+    /**
+     * Run a map over each item while chunking.
+     *
+     * @param  callable  $callback
+     * @param  int  $count
+     * @return \Illuminate\Support\Collection
+     */
+    public function map(callable $callback, $count = 1000)
+    {
+        $collection = Collection::make();
+
+        $this->chunk($count, function ($items) use ($collection, $callback) {
+            $items->each(function ($item) use ($collection, $callback) {
+                $collection->push($callback($item));
+            });
+        });
+
+        return $collection;
     }
 
     /**

--- a/tests/Integration/Database/EloquentWhereTest.php
+++ b/tests/Integration/Database/EloquentWhereTest.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\MultipleRecordsFoundException;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 /**
@@ -133,6 +134,32 @@ class EloquentWhereTest extends DatabaseTestCase
         }
 
         $this->assertSame(UserWhereTest::class, $exception->getModel());
+    }
+
+    public function testMap()
+    {
+        UserWhereTest::create([
+            'name' => 'first-name',
+            'email' => 'first-email',
+            'address' => 'first-address',
+        ]);
+
+        UserWhereTest::create([
+            'name' => 'second-name',
+            'email' => 'second-email',
+            'address' => 'second-address',
+        ]);
+
+        DB::enableQueryLog();
+
+        $results = UserWhereTest::orderBy('id')->map(function ($user) {
+            return $user->name;
+        }, 1);
+
+        $this->assertCount(2, $results);
+        $this->assertSame('first-name', $results[0]);
+        $this->assertSame('second-name', $results[1]);
+        $this->assertCount(3, DB::getQueryLog());
     }
 }
 

--- a/tests/Integration/Database/QueryBuilderTest.php
+++ b/tests/Integration/Database/QueryBuilderTest.php
@@ -213,4 +213,18 @@ class QueryBuilderTest extends DatabaseTestCase
             (object) ['title' => 'Bar Post', 'content' => 'Lorem Ipsum.'],
         ]);
     }
+
+    public function testMap()
+    {
+        DB::enableQueryLog();
+
+        $results = DB::table('posts')->orderBy('id')->map(function ($post) {
+            return $post->title;
+        }, 1);
+
+        $this->assertCount(2, $results);
+        $this->assertSame('Foo Post', $results[0]);
+        $this->assertSame('Bar Post', $results[1]);
+        $this->assertCount(3, DB::getQueryLog());
+    }
 }


### PR DESCRIPTION
This PR adds a new `map()` method to the `Query/Builder` and `Eloquent/Builder` classes (via the `BuildsQueries` trait). This method is similar to the `each()` query builder method, where it automatically chunks over the results. Here's how to use it:

```php
return User::orderBy('name')->map(fn ($user) => [
    'id' => $user->id,
    'name' => $user->name,
]), 25);
```

The primary motivation here is to make it easier to chunk through query results while also performing a map. Previously, this was quite verbose to do (and required a temporary variable):

```php
use Illuminate\Support\Collection;

$users = Collection::make();

User::orderBy('name')->each(function ($user) use ($users) {
    $users->push([
        'id' => $user->id,
        'name' => $user->name,
    ]);
}, 25);

return $users;
```

For what it's worth, I probably would have preferred the `$count` argument first (before the `$callback`), like the `chunk()` method, but I did it this way to match the `each()` method.