### PR TITLE
[8.x] Allow using dot syntax for $responseKey

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -693,7 +693,7 @@ class TestResponse implements ArrayAccess
         $json = $this->json();
 
         if (! Arr::has($json, $responseKey)) {
-            PHPUnit::assertFalse(Arr::has($json, $responseKey), 'Response has unexpected ' .$responseKey.' key.');
+            PHPUnit::assertFalse(Arr::has($json, $responseKey), 'Response has unexpected '.$responseKey.' key.');
 
             return $this;
         }

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -692,13 +692,13 @@ class TestResponse implements ArrayAccess
 
         $json = $this->json();
 
-        if (! array_key_exists($responseKey, $json)) {
-            PHPUnit::assertArrayNotHasKey($responseKey, $json);
+        if (! Arr::has($json, $responseKey)) {
+            PHPUnit::assertFalse(Arr::has($json, $responseKey));
 
             return $this;
         }
 
-        $errors = $json[$responseKey];
+        $errors = Arr::get($json, $responseKey, []);
 
         if (is_null($keys) && count($errors) > 0) {
             PHPUnit::fail(

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -693,7 +693,7 @@ class TestResponse implements ArrayAccess
         $json = $this->json();
 
         if (! Arr::has($json, $responseKey)) {
-            PHPUnit::assertFalse(Arr::has($json, $responseKey));
+            PHPUnit::assertFalse(Arr::has($json, $responseKey), 'Response has unexpected ' .$responseKey.' key.');
 
             return $this;
         }

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -693,7 +693,7 @@ class TestResponse implements ArrayAccess
         $json = $this->json();
 
         if (! Arr::has($json, $responseKey)) {
-            PHPUnit::assertFalse(Arr::has($json, $responseKey), 'Response has unexpected '.$responseKey.' key.');
+            PHPUnit::assertTrue(true);
 
             return $this;
         }

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -1048,6 +1048,27 @@ class TestResponseTest extends TestCase
         $response->assertJsonMissingValidationErrors('bar');
     }
 
+    public function testAssertJsonMissingValidationErrorsCanFail3()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $baseResponse = tap(new Response, function ($response) {
+            $response->setContent(
+                json_encode([
+                    'data' => [
+                        'errors' => [
+                            'foo' => ['one'],
+                        ],
+                    ],
+                ]),
+            );
+        });
+
+        $response = TestResponse::fromBaseResponse($baseResponse);
+
+        $response->assertJsonMissingValidationErrors('foo', 'data.errors');
+    }
+
     public function testAssertJsonMissingValidationErrorsWithoutArgument()
     {
         $data = ['status' => 'ok'];
@@ -1107,6 +1128,31 @@ class TestResponseTest extends TestCase
         );
 
         $testResponse->assertJsonMissingValidationErrors('bar', 'data');
+    }
+
+    public function testAssertJsonMissingValidationErrorsNestedCustomErrorsName1()
+    {
+        $data = [
+            'status' => 'ok',
+            'data' => [
+                'errors' => ['foo' => 'oops'],
+            ],
+        ];
+
+        $testResponse = TestResponse::fromBaseResponse(
+            (new Response)->setContent(json_encode($data))
+        );
+
+        $testResponse->assertJsonMissingValidationErrors('bar', 'data.errors');
+    }
+
+    public function testAssertJsonMissingValidationErrorsNestedCustomErrorsName2()
+    {
+        $testResponse = TestResponse::fromBaseResponse(
+            (new Response)->setContent(json_encode([]))
+        );
+
+        $testResponse->assertJsonMissingValidationErrors('bar', 'data.errors');
     }
 
     public function testMacroable()


### PR DESCRIPTION
I just noticed that the `assertJsonMissingValidationErrors()` assertion [does not appreciate the dot syntax](https://github.com/illuminate/testing/blob/59fdeca0cf1b5f7e010c7e9600cacffead5a3c35/TestResponse.php#L718) of the `$responseKey` parameter. However, the `assertJsonValidationErrors()` assertion [appreciates that](https://github.com/laravel/framework/blob/79b804ee6ef3f6344b22b5fd334e4af1ae052021/tests/Testing/TestResponseTest.php#L810).

So if we had a Laravel project with a customised way of exposing JSON validation errors as something like this:
```php
// customised
'message' => $exception->getMessage(),
'data' => [
  'errors' => $exception->errors(),
],

// default
'message' => $exception->getMessage(),
'errors' => $exception->errors(),
```
the following test would pass:
```php
$this->postJson('/api/users')
    ->assertJsonValidationErrors(
        ['email' => 'The email field is required.'], 
        $responseKey = 'data.errors',
    )

    // This one will pass as the assertion does not appreciate the dot syntax of the $responseKey parameter
    // as it will try to get this: `$jsonResponse['validation.errors']` rather than `$jsonResponse['validation']['errors']`.
    ->assertJsonMissingValidationErrors(
        ['email'],
        $responseKey = 'data.errors',
    );
```

So, this PR makes it so it appreciates the dot syntax for the `$responseKey` parameter on the `assertJsonMissingValidationErrors()` assertion as it's partially related assertion `assertJsonValidationErrors()` [appreciates that](https://github.com/laravel/framework/blob/79b804ee6ef3f6344b22b5fd334e4af1ae052021/tests/Testing/TestResponseTest.php#L810).