### PR TITLE
[8.x] Add 'test' option to make model command

### DIFF
--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -46,6 +46,7 @@ class ModelMakeCommand extends GeneratorCommand
             $this->input->setOption('migration', true);
             $this->input->setOption('controller', true);
             $this->input->setOption('resource', true);
+            $this->input->setOption('test', true);
         }
 
         if ($this->option('factory')) {
@@ -62,6 +63,10 @@ class ModelMakeCommand extends GeneratorCommand
 
         if ($this->option('controller') || $this->option('resource') || $this->option('api')) {
             $this->createController();
+        }
+
+        if ($this->option('test')) {
+            $this->createFeatureTest();
         }
     }
 
@@ -132,6 +137,20 @@ class ModelMakeCommand extends GeneratorCommand
     }
 
     /**
+     * Create a feature test for the model.
+     *
+     * @return void
+     */
+    protected function createFeatureTest()
+    {
+        $testName = Str::studly(class_basename($this->argument('name')));
+
+        $this->call('make:test', array_filter([
+            'name'  => "{$testName}Test",
+        ]));
+    }
+
+    /**
      * Get the stub file for the generator.
      *
      * @return string
@@ -184,6 +203,7 @@ class ModelMakeCommand extends GeneratorCommand
             ['pivot', 'p', InputOption::VALUE_NONE, 'Indicates if the generated model should be a custom intermediate table model'],
             ['resource', 'r', InputOption::VALUE_NONE, 'Indicates if the generated controller should be a resource controller'],
             ['api', null, InputOption::VALUE_NONE, 'Indicates if the generated controller should be an API controller'],
+            ['test', 't', InputOption::VALUE_NONE, 'Create a new feature test'],
         ];
     }
 }


### PR DESCRIPTION
This PR adds a new `--test` or `-t` option to `make:model` command. Same as other options that create other classes (e.g. controllers, factories… etc). Here's how to use it:
```php
php artisan make:model Flight --test
```
This will create a feature test class with name `FlightTest`