### PR TITLE
[8.x] Make layout in mail responsive in gmail app

### DIFF
--- a/src/Illuminate/Mail/resources/views/html/layout.blade.php
+++ b/src/Illuminate/Mail/resources/views/html/layout.blade.php
@@ -5,8 +5,6 @@
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 <meta name="color-scheme" content="light">
 <meta name="supported-color-schemes" content="light">
-</head>
-<body>
 <style>
 @media only screen and (max-width: 600px) {
 .inner-body {
@@ -24,6 +22,8 @@ width: 100% !important;
 }
 }
 </style>
+</head>
+<body>
 
 <table class="wrapper" width="100%" cellpadding="0" cellspacing="0" role="presentation">
 <tr>


### PR DESCRIPTION
The mail design in gmail app wasn't responsive, and I managed to solve the problem.

Tested in gmail app, i don't know about else, bu here https://templates.mailchimp.com/resources/email-client-css-support/ it's show it's compatible to all emails. 