### PR TITLE
[8.x] Use parallel testing when using database URL configuration

### DIFF
--- a/src/Illuminate/Testing/Concerns/TestDatabases.php
+++ b/src/Illuminate/Testing/Concerns/TestDatabases.php
@@ -146,6 +146,19 @@ trait TestDatabases
             "database.connections.{$default}.database",
             $database,
         );
+
+        if ($databaseConnectionUrl = config("database.connections.{$default}.url")) {
+            $testDatabaseConnectionUrl = preg_replace(
+                '/^(.*)(\/[\w-]*)(\??.*)$/',
+                "$1/{$database}$3",
+                $databaseConnectionUrl
+            );
+
+            config()->set(
+                "database.connections.{$default}.url",
+                $testDatabaseConnectionUrl
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
This PR fixes https://github.com/laravel/framework/issues/36189.

Right now when a database is [configured using URLs](https://laravel.com/docs/8.x/database#configuration-using-urls) (by using `DATABASE_URL`), [parallel testing](https://laravel.com/docs/8.x/testing#running-tests-in-parallel) is not working. If we have this option in configuration, I guess it would be good to support it in parallel testing as well.

The Regex used in this pull requests covers these cases for database connection URL:
![image](https://user-images.githubusercontent.com/12799259/107360979-53bbcd00-6adf-11eb-86b9-177bc3e64f4e.png)

Sorry, for not adding tests for this implementation, but it's kinda difficult to test this trait specifically.
