### PR TITLE
[8.x] Make height of image working with yahoo

### DIFF
--- a/src/Illuminate/Mail/resources/views/html/themes/default.css
+++ b/src/Illuminate/Mail/resources/views/html/themes/default.css
@@ -113,6 +113,7 @@ img {
 
 .logo {
     height: 75px;
+    max-height: 75px;
     width: 75px;
 }
 


### PR DESCRIPTION
In yahoo it not show `height` but shows `max-height`.
I tested remove `height` and show the result on yahoo, google and outlook, it's perfect, but i would prefer use `height` too with it for anything would happen.