### PR TITLE
[8.x] Add foreignReferenceFor method to Blueprint class

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -873,18 +873,20 @@ class Blueprint
      * Creates a foreign ID column and key for the given model.
      *
      * @param \Illuminate\Database\Eloquent\Model|string $model
-     * @param string|null null $column
+     * @param string|null $column
+     * @param string|null $table
+     * @param string|null $keyName
      * @return ForeignKeyDefinition
      */
-    public function foreignReferenceFor($model, $column = null)
+    public function foreignReferenceFor($model, $column = null, $table = null, $keyName = null)
     {
         if (is_string($model)) {
             $model = new $model;
         }
 
         return $this->foreignIdFor($model, $column)
-            ->references($model->getKeyName())
-            ->on($model->getTable());
+            ->references($keyName ?: $model->getKeyName())
+            ->on($table ?: $model->getTable());
     }
 
 

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -889,7 +889,6 @@ class Blueprint
             ->on($table ?: $model->getTable());
     }
 
-
     /**
      * Create a new float column on the table.
      *

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -870,6 +870,25 @@ class Blueprint
     }
 
     /**
+     * Creates a foreign ID column and key for the given model.
+     *
+     * @param \Illuminate\Database\Eloquent\Model|string $model
+     * @param string|null null $column
+     * @return ForeignKeyDefinition
+     */
+    public function foreignReferenceFor($model, $column = null)
+    {
+        if (is_string($model)) {
+            $model = new $model;
+        }
+
+        return $this->foreignIdFor($model, $column)
+            ->references($model->getKeyName())
+            ->on($model->getTable());
+    }
+
+
+    /**
      * Create a new float column on the table.
      *
      * @param  string  $column

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -323,4 +323,19 @@ class DatabaseSchemaBlueprintTest extends TestCase
             'alter table `posts` add constraint `posts_eloquent_model_uuid_stub_id_foreign` foreign key (`eloquent_model_uuid_stub_id`) references `model` (`id`)'
         ], $blueprint->toSql($connection, new MySqlGrammar));
     }
+
+    public function testGenerateReferenceColumnWithOverrides()
+    {
+        $base = new Blueprint('posts', function($table) {
+            $table->foreignReferenceFor('Illuminate\Foundation\Auth\User', 'forum_user_id', 'forum_users', 'uid');
+        });
+
+        $connection = m::mock(Connection::class);
+        $blueprint = clone $base;
+
+        $this->assertEquals([
+            'alter table `posts` add `forum_user_id` bigint unsigned not null',
+            'alter table `posts` add constraint `posts_forum_user_id_foreign` foreign key (`forum_user_id`) references `forum_users` (`uid`)'
+        ], $blueprint->toSql($connection, new MySqlGrammar));
+    }
 }

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -294,7 +294,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
     public function testGenerateReferenceColumnWithIncrementalModel()
     {
-        $base = new Blueprint('posts', function($table) {
+        $base = new Blueprint('posts', function ($table) {
             $table->foreignReferenceFor('Illuminate\Foundation\Auth\User');
         });
 
@@ -303,15 +303,15 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
         $this->assertEquals([
             'alter table `posts` add `user_id` bigint unsigned not null',
-            'alter table `posts` add constraint `posts_user_id_foreign` foreign key (`user_id`) references `users` (`id`)'
+            'alter table `posts` add constraint `posts_user_id_foreign` foreign key (`user_id`) references `users` (`id`)',
         ], $blueprint->toSql($connection, new MySqlGrammar));
     }
 
     public function testGenerateReferenceColumnWithUuidModel()
     {
-        require_once __DIR__ . '/stubs/EloquentModelUuidStub.php';
+        require_once __DIR__.'/stubs/EloquentModelUuidStub.php';
 
-        $base = new Blueprint('posts', function($table) {
+        $base = new Blueprint('posts', function ($table) {
             $table->foreignReferenceFor('EloquentModelUuidStub');
         });
 
@@ -320,13 +320,13 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
         $this->assertEquals([
             'alter table `posts` add `eloquent_model_uuid_stub_id` char(36) not null',
-            'alter table `posts` add constraint `posts_eloquent_model_uuid_stub_id_foreign` foreign key (`eloquent_model_uuid_stub_id`) references `model` (`id`)'
+            'alter table `posts` add constraint `posts_eloquent_model_uuid_stub_id_foreign` foreign key (`eloquent_model_uuid_stub_id`) references `model` (`id`)',
         ], $blueprint->toSql($connection, new MySqlGrammar));
     }
 
     public function testGenerateReferenceColumnWithOverrides()
     {
-        $base = new Blueprint('posts', function($table) {
+        $base = new Blueprint('posts', function ($table) {
             $table->foreignReferenceFor('Illuminate\Foundation\Auth\User', 'forum_user_id', 'forum_users', 'uid');
         });
 
@@ -335,7 +335,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
         $this->assertEquals([
             'alter table `posts` add `forum_user_id` bigint unsigned not null',
-            'alter table `posts` add constraint `posts_forum_user_id_foreign` foreign key (`forum_user_id`) references `forum_users` (`uid`)'
+            'alter table `posts` add constraint `posts_forum_user_id_foreign` foreign key (`forum_user_id`) references `forum_users` (`uid`)',
         ], $blueprint->toSql($connection, new MySqlGrammar));
     }
 }

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -291,4 +291,36 @@ class DatabaseSchemaBlueprintTest extends TestCase
             'alter table `posts` add `eloquent_model_uuid_stub_id` char(36) not null',
         ], $blueprint->toSql($connection, new MySqlGrammar));
     }
+
+    public function testGenerateReferenceColumnWithIncrementalModel()
+    {
+        $base = new Blueprint('posts', function($table) {
+            $table->foreignReferenceFor('Illuminate\Foundation\Auth\User');
+        });
+
+        $connection = m::mock(Connection::class);
+        $blueprint = clone $base;
+
+        $this->assertEquals([
+            'alter table `posts` add `user_id` bigint unsigned not null',
+            'alter table `posts` add constraint `posts_user_id_foreign` foreign key (`user_id`) references `users` (`id`)'
+        ], $blueprint->toSql($connection, new MySqlGrammar));
+    }
+
+    public function testGenerateReferenceColumnWithUuidModel()
+    {
+        require_once __DIR__ . '/stubs/EloquentModelUuidStub.php';
+
+        $base = new Blueprint('posts', function($table) {
+            $table->foreignReferenceFor('EloquentModelUuidStub');
+        });
+
+        $connection = m::mock(Connection::class);
+        $blueprint = clone $base;
+
+        $this->assertEquals([
+            'alter table `posts` add `eloquent_model_uuid_stub_id` char(36) not null',
+            'alter table `posts` add constraint `posts_eloquent_model_uuid_stub_id_foreign` foreign key (`eloquent_model_uuid_stub_id`) references `model` (`id`)'
+        ], $blueprint->toSql($connection, new MySqlGrammar));
+    }
 }


### PR DESCRIPTION
# foreignReferenceFor
This method allows for a more convenient way to add a FK & column for a relation with just one line of code.

## Why?

### Before:
```php
$table->foreignIdFor(User::class)
    ->references('id')->on('users')->cascadeOnDelete();
```

This may not look like the biggest issue, but once your table contains more than 2 relations like this, your migration file will become messy. An example:

```php
// ...

class CreatePostsTable extends Migration
{
    public function up()
    {
        Schema::create('posts', function (Blueprint $table) {
            $table->increments('id');
            $table->foreignIdFor(User::class)
                ->references('id')->on('users')->cascadeOnDelete();
            $table->foreignIdFor(User::class, 'admin_id')
                ->references('id')->on('users')->cascadeOnDelete();
            $table->foreignIdFor(Board::class)
                ->references('id')->on('boards')->cascadeOnDelete();
            $table->string('title');
            $table->boolean('locked');
            $table->timestamps();
        });
    }

    /**
     * Reverse the migrations.
     *
     * @return void
     */
    public function down()
    {
        Schema::dropIfExists('posts');
    }
}
```

### After:
```php
$table->foreignReferenceFor(User::class)->cascadeOnDelete();
```
With this enhancement, you can do a one-liner to create the column definition and foreign key definition in one go.
And the example migration would look something like this

```php
Schema::create('posts', function (Blueprint $table) {
    $table->increments('id');
    $table->foreignReferenceFor(User::class)->cascadeOnDelete();
    $table->foreignReferenceFor(User::class, 'admin_id')->cascadeOnDelete();
    $table->foreignReferenceFor(Board::class)->cascadeOnDelete();
    $table->string('title');
    $table->boolean('locked');
    $table->timestamps();
});
```
Which looks a lot better.

## Misc
The method also takes in overrides for the FK table and key name through parameters.

This won't break any current applications since this is a new method on the Blueprint class.