### PR TITLE
[8.X] Add json method to Requests to retrieve encoded input as array/object 

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -286,11 +286,10 @@ trait InteractsWithInput
     /**
      * Decode input from JSON to array/object. Useful when only parts are json encoded.
      *
-     * Returns decoded JSON as array or object
-     *
-     * @param string $key
-     * @param bool $assoc
-     * @param int $options
+     * @param  string  $key
+     * @param  bool  $assoc
+     * @param  int  $options
+     * @return mixed
      */
     public function json($key, $assoc = false, $options = 0)
     {

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -64,7 +64,7 @@ trait InteractsWithInput
      * Determine if the request contains a given input item key.
      *
      * @param  string|array  $key
-     * @return bool
+     * @return boo
      */
     public function exists($key)
     {
@@ -283,6 +283,19 @@ trait InteractsWithInput
         return filter_var($this->input($key, $default), FILTER_VALIDATE_BOOLEAN);
     }
 
+    /**
+     * Decode input from JSON to array/object. Useful when only parts are json encoded.
+     * 
+     * Returns decoded JSON as array or object
+     *
+     * @param string $key
+     * @param bool $assoc
+     * @param int $options
+     */
+    public function json($key, $assoc = false, $options = 0) {
+        return json_decode($this->input($key), $assoc, $options);
+    }
+    
     /**
      * Get a subset containing the provided keys with values from the input data.
      *

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -64,7 +64,7 @@ trait InteractsWithInput
      * Determine if the request contains a given input item key.
      *
      * @param  string|array  $key
-     * @return boo
+     * @return bool
      */
     public function exists($key)
     {

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -285,17 +285,18 @@ trait InteractsWithInput
 
     /**
      * Decode input from JSON to array/object. Useful when only parts are json encoded.
-     * 
+     *
      * Returns decoded JSON as array or object
      *
      * @param string $key
      * @param bool $assoc
      * @param int $options
      */
-    public function json($key, $assoc = false, $options = 0) {
+    public function json($key, $assoc = false, $options = 0)
+    {
         return json_decode($this->input($key), $assoc, $options);
     }
-    
+
     /**
      * Get a subset containing the provided keys with values from the input data.
      *


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This method is useful when only parts of the request are json encoded. For example, this happens when sending multipart/form-data encoded requests where files are present alongside json.

Before:
`json_decode($request->input("key"))->json_property;`

After:
`$request->json("key")->json_property;`

it is my first pull request, would be nice to get some feedback on improving the functionality/code. If necessary I can also include a test for this function.
