### PR TITLE
[8.x] Fixes parallel testing when a database is configured using URLs

### DIFF
--- a/src/Illuminate/Testing/Concerns/TestDatabases.php
+++ b/src/Illuminate/Testing/Concerns/TestDatabases.php
@@ -142,10 +142,19 @@ trait TestDatabases
 
         $default = config('database.default');
 
-        config()->set(
-            "database.connections.{$default}.database",
-            $database,
-        );
+        $url = config("database.connections.{$default}.url");
+
+        if ($url) {
+            config()->set(
+                "database.connections.{$default}.url",
+                preg_replace('/^(.*)(\/[\w-]*)(\??.*)$/', "$1/{$database}$3", $url),
+            );
+        } else {
+            config()->set(
+                "database.connections.{$default}.database",
+                $database,
+            );
+        }
     }
 
     /**

--- a/tests/Testing/Concerns/TestDatabasesTest.php
+++ b/tests/Testing/Concerns/TestDatabasesTest.php
@@ -29,7 +29,7 @@ class TestDatabasesTest extends TestCase
         $_SERVER['LARAVEL_PARALLEL_TESTING'] = 1;
     }
 
-    public function testSwitchToDatabaseWithoutUrls()
+    public function testSwitchToDatabaseWithoutUrl()
     {
         DB::shouldReceive('purge')->once();
 
@@ -46,9 +46,9 @@ class TestDatabasesTest extends TestCase
     }
 
     /**
-     * @dataProvider urlConnections
+     * @dataProvider databaseUrls
      */
-    public function testSwitchToDatabaseWithUrls($testDatabase, $url, $testUrl)
+    public function testSwitchToDatabaseWithUrl($testDatabase, $url, $testUrl)
     {
         DB::shouldReceive('purge')->once();
 
@@ -74,7 +74,7 @@ class TestDatabasesTest extends TestCase
         tap($method)->setAccessible(true)->invoke($instance, $database);
     }
 
-    public function urlConnections()
+    public function databaseUrls()
     {
         return [
             [

--- a/tests/Testing/Concerns/TestDatabasesTest.php
+++ b/tests/Testing/Concerns/TestDatabasesTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Illuminate\Tests\Testing\Concerns;
+
+use Illuminate\Container\Container;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Testing\Concerns\TestDatabases;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+class TestDatabasesTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Container::setInstance($container = new Container);
+
+        $container->singleton('config', function () {
+            return m::mock(Config::class)
+                ->shouldReceive('get')
+                ->once()
+                ->with('database.default', null)
+                ->andReturn('mysql')
+                ->getMock();
+        });
+
+        $_SERVER['LARAVEL_PARALLEL_TESTING'] = 1;
+    }
+
+    public function testSwitchToDatabaseWithoutUrls()
+    {
+        DB::shouldReceive('purge')->once();
+
+        config()->shouldReceive('get')
+            ->once()
+            ->with('database.connections.mysql.url', false)
+            ->andReturn(false);
+
+        config()->shouldReceive('set')
+            ->once()
+            ->with('database.connections.mysql.database', 'my_database_test_1');
+
+        $this->switchToDatabase('my_database_test_1');
+    }
+
+    /**
+     * @dataProvider urlConnections
+     */
+    public function testSwitchToDatabaseWithUrls($testDatabase, $url, $testUrl)
+    {
+        DB::shouldReceive('purge')->once();
+
+        config()->shouldReceive('get')
+            ->once()
+            ->with('database.connections.mysql.url', false)
+            ->andReturn($url);
+
+        config()->shouldReceive('set')
+            ->once()
+            ->with('database.connections.mysql.url', $testUrl);
+
+        $this->switchToDatabase($testDatabase);
+    }
+
+    public function switchToDatabase($database)
+    {
+        $instance = new class {
+            use TestDatabases;
+        };
+
+        $method = new ReflectionMethod($instance, 'switchToDatabase');
+        tap($method)->setAccessible(true)->invoke($instance, $database);
+    }
+
+    public function urlConnections()
+    {
+        return [
+            [
+                'my_database_test_1',
+                'mysql://root:@127.0.0.1/my_database?charset=utf8mb4',
+                'mysql://root:@127.0.0.1/my_database_test_1?charset=utf8mb4',
+            ],
+            [
+                'my_database_test_1',
+                'mysql://my-user:@localhost/my_database',
+                'mysql://my-user:@localhost/my_database_test_1',
+            ],
+            [
+                'my-database_test_1',
+                'postgresql://my_database_user:@127.0.0.1/my-database?charset=utf8',
+                'postgresql://my_database_user:@127.0.0.1/my-database_test_1?charset=utf8',
+            ],
+        ];
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+
+        Container::setInstance(null);
+
+        unset($_SERVER['LARAVEL_PARALLEL_TESTING']);
+
+        m::close();
+    }
+}

--- a/tests/Testing/ParallelConsoleOutputTest.php
+++ b/tests/Testing/ParallelConsoleOutputTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Foundation;
+namespace Illuminate\Tests\Testing;
 
 use Illuminate\Testing\ParallelConsoleOutput;
 use PHPUnit\Framework\TestCase;

--- a/tests/Testing/ParallelTestingTest.php
+++ b/tests/Testing/ParallelTestingTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Foundation;
+namespace Illuminate\Tests\Testing;
 
 use Illuminate\Container\Container;
 use Illuminate\Testing\ParallelTesting;

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Foundation;
+namespace Illuminate\Tests\Testing;
 
 use Illuminate\Container\Container;
 use Illuminate\Contracts\View\View;


### PR DESCRIPTION
This pull requests fixes running tests in parallel when a [database is configured using URLs](https://laravel.com/docs/8.x/database#configuration-using-urls). The regular expression was expired by @ekateiva's pull request https://github.com/laravel/framework/pull/36199. @ekateiva Fell free to propose some more use cases for the [databaseUrls](https://github.com/laravel/framework/compare/8.x...fix/parallel-testing-with-db-urls#diff-7cda6947391e68e90925c18879934d9f49a461f452709704e9745c24d22eec43R77) data provider.

Closes #36199 #36189