### PR TITLE
Handle "Array to string conversion" when binding is not a scalar value.

### DIFF
--- a/src/Illuminate/Database/QueryException.php
+++ b/src/Illuminate/Database/QueryException.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use PDOException;
 use Throwable;

--- a/src/Illuminate/Database/QueryException.php
+++ b/src/Illuminate/Database/QueryException.php
@@ -58,6 +58,7 @@ class QueryException extends PDOException
         // This handles error when binding is not a scalar value
         if (Arr::where($bindings, function ($item) {
             return !is_scalar($item);
+            return ! is_scalar($item);
         })) {
             $bindings = array_map(function ($item) {
                 return is_scalar($item) ? $item : json_encode($item);

--- a/src/Illuminate/Database/QueryException.php
+++ b/src/Illuminate/Database/QueryException.php
@@ -54,6 +54,17 @@ class QueryException extends PDOException
      */
     protected function formatMessage($sql, $bindings, Throwable $previous)
     {
+        // This handles error when binding is not a scalar value
+        if (Arr::where($bindings, function ($item) {
+            return !is_scalar($item);
+        })) {
+            $bindings = array_map(function ($item) {
+                return is_scalar($item) ? $item : json_encode($item);
+            }, $bindings);
+
+            return $previous->getMessage().' (Bindings not scalar - SQL: '.Str::replaceArray('?', $bindings, $sql).')';
+        }
+
         return $previous->getMessage().' (SQL: '.Str::replaceArray('?', $bindings, $sql).')';
     }
 


### PR DESCRIPTION
I've seen that PRs go through quick reviews, so I didn't put too much time into details in case it gets rejected, but I can improve it if there is interest.

This fixes an error when query binding is not a scalar value. It causes PDO to throw an error which is caught by the framework.
Framework then tries to generate a nicer message, but it fails again with a same error - "Array to string conversion"

This error happened to me many times so I thought it should be handled.

Now the message gives a hint what the problem is, and it prevents original exception.


