### PR TITLE
[8.x] Eloquent Factories: Allow access to $faker from inline state

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -375,7 +375,7 @@ abstract class Factory
             }], $states->all()));
         })->reduce(function ($carry, $state) use ($parent) {
             if ($state instanceof Closure) {
-                $state = $state->bindTo($this);
+                $state = $state->bindTo($this, $this);
             }
 
             return array_merge($carry, $state($carry, $parent));

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -211,6 +211,7 @@ class DatabaseEloquentFactoryTest extends TestCase
                                     ->state(function ($attributes, $user) {
                                         // Test parent is passed to child state mutations...
                                         $_SERVER['__test.post.state-user'] = $user;
+                                        $_SERVER['__test.post.state-faker'] = $this->faker;
 
                                         return [];
                                     })
@@ -230,10 +231,12 @@ class DatabaseEloquentFactoryTest extends TestCase
         $this->assertInstanceOf(Eloquent::class, $_SERVER['__test.post.creating-post']);
         $this->assertInstanceOf(Eloquent::class, $_SERVER['__test.post.creating-user']);
         $this->assertInstanceOf(Eloquent::class, $_SERVER['__test.post.state-user']);
+        $this->assertInstanceOf(\Faker\Generator::class, $_SERVER['__test.post.state-faker']);
 
         unset($_SERVER['__test.post.creating-post']);
         unset($_SERVER['__test.post.creating-user']);
         unset($_SERVER['__test.post.state-user']);
+        unset($_SERVER['__test.post.state-faker']);
     }
 
     public function test_belongs_to_relationship()


### PR DESCRIPTION
It is currently possible to access `$faker` from factory state defined in the factory class itself. This was discussed in #34069 and implemented in #34074.

However, Eloquent Factories also support passing inline state when using the factory:
```php
$user = User::factory()->state([
    'name' => 'Abigail Otwell',
])->make();
```

The current implementation does not allow accessing `$faker` from this inline state closure:
```php
$user = User::factory()->state(fn () => [
    // The following line throws the error "Cannot access protected property UserFactory::$faker"
    'name' => $this->faker,
])->make();
```
I demonstrate this with a failing test in the first commit in this PR.

I understand from the documentation that using inline state should be as similar as possible to using a state defined on the factory itself. To fix it, we simply need to also pass `$this` as the second argument to `bindTo`, in order to also re-bind the scope of the closure. This is implemented in the second commit.