### PR TITLE
[8.x] Route group for same controller

### DIFF
--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -55,7 +55,7 @@ class RouteRegistrar
      * @var string[]
      */
     protected $allowedAttributes = [
-        'as', 'domain', 'middleware', 'name', 'namespace', 'prefix', 'where',
+        'as', 'domain', 'middleware', 'name', 'namespace', 'prefix', 'where', 'controller',
     ];
 
     /**
@@ -65,6 +65,7 @@ class RouteRegistrar
      */
     protected $aliases = [
         'name' => 'as',
+        'controller' => 'controller_class',
     ];
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -470,7 +470,7 @@ class Router implements BindingRegistrar, RegistrarContract
         // controller_class in group and action.
         $group = end($this->groupStack);
         if (isset($group['controller_class']) && is_string($action)) {
-            $action = [ $this->prependGroupNamespace($group['controller_class']), $action ];
+            $action = [$this->prependGroupNamespace($group['controller_class']), $action];
         }
 
         // If the route is routing to a controller we will parse the route action into

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -465,6 +465,14 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     protected function createRoute($methods, $uri, $action)
     {
+        // If we declared controller_class group before, then we parse action in
+        // specific way: if it is a method name, then create a callback using the
+        // controller_class in group and action.
+        $group = end($this->groupStack);
+        if (isset($group['controller_class']) && is_string($action)) {
+            $action = [ $this->prependGroupNamespace($group['controller_class']), $action ];
+        }
+
         // If the route is routing to a controller we will parse the route action into
         // an acceptable array format before registering it and creating this route
         // instance itself. We need to build the Closure that will call this out.

--- a/src/Illuminate/Support/Facades/Route.php
+++ b/src/Illuminate/Support/Facades/Route.php
@@ -28,6 +28,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Routing\RouteRegistrar namespace(string|null $value)
  * @method static \Illuminate\Routing\RouteRegistrar prefix(string  $prefix)
  * @method static \Illuminate\Routing\RouteRegistrar where(array  $where)
+ * @method static \Illuminate\Routing\RouteRegistrar controller(string $value)
  * @method static \Illuminate\Routing\Router|\Illuminate\Routing\RouteRegistrar group(\Closure|string|array $attributes, \Closure|string $routes)
  * @method static \Illuminate\Routing\ResourceRegistrar resourceVerbs(array $verbs = [])
  * @method static string|null currentRouteAction()

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1084,7 +1084,7 @@ class RoutingRouteTest extends TestCase
 
         $router->group(
             ['namespace' => 'App\Http\Controllers',
-            'controller_class' => 'UsersController'],
+                'controller_class' => 'UsersController'],
             function ($router) {
                 $router->get('users', 'index');
             });
@@ -1134,8 +1134,8 @@ class RoutingRouteTest extends TestCase
         $router = $this->getRouter();
         $router->group(['prefix' => 'foo', 'as' => 'Foo::'], function () use ($router) {
             $router->get('bar', ['as' => 'bar', function () {
-                return 'hello';
-            }]);
+            return 'hello';
+        }]);
         });
         $routes = $router->getRoutes();
         $route = $routes->getByName('Foo::bar');
@@ -1151,8 +1151,8 @@ class RoutingRouteTest extends TestCase
         $router->group(['prefix' => 'foo', 'as' => 'Foo::'], function () use ($router) {
             $router->group(['prefix' => 'bar', 'as' => 'Bar::'], function () use ($router) {
                 $router->get('baz', ['as' => 'baz', function () {
-                    return 'hello';
-                }]);
+                return 'hello';
+            }]);
             });
         });
         $routes = $router->getRoutes();
@@ -1166,8 +1166,8 @@ class RoutingRouteTest extends TestCase
         $router->group(['prefix' => 'foo', 'as' => 'Foo::'], function () use ($router) {
             $router->group(['prefix' => 'bar'], function () use ($router) {
                 $router->prefix('foz')->get('baz', ['as' => 'baz', function () {
-                    return 'hello';
-                }]);
+                return 'hello';
+            }]);
             });
         });
         $routes = $router->getRoutes();
@@ -1183,8 +1183,8 @@ class RoutingRouteTest extends TestCase
         $router = $this->getRouter();
         $router->group(['prefix' => 'foo', 'as' => 'Foo::'], function () use ($router) {
             $router->prefix('bar')->get('baz', ['as' => 'baz', function () {
-                return 'hello';
-            }]);
+            return 'hello';
+        }]);
         });
         $routes = $router->getRoutes();
         $route = $routes->getByName('Foo::baz');

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1062,6 +1062,42 @@ class RoutingRouteTest extends TestCase
         );
     }
 
+    public function testCanRegisterControllerGroupRouteWithAction()
+    {
+        $router = $this->getRouter();
+        $router->group(['controller_class' => 'App\Http\Controllers\UsersController'], function ($router) {
+            $router->get('users', 'index');
+        });
+
+        $routes = $router->getRoutes();
+        $routes = $routes->getRoutes();
+
+        $this->assertSame(
+            'App\Http\Controllers\UsersController@index',
+            $routes[0]->getAction()['uses']
+        );
+    }
+
+    public function testCanRegisterControllerAndNamespaceGroupWithAction()
+    {
+        $router = $this->getRouter();
+
+        $router->group([
+                'namespace' => 'App\Http\Controllers',
+                'controller_class' => 'UsersController'],
+            function ($router) {
+                $router->get('users', 'index');
+            });
+
+        $routes = $router->getRoutes();
+        $routes = $routes->getRoutes();
+
+        $this->assertSame(
+            'App\Http\Controllers\UsersController@index',
+            $routes[0]->getAction()['uses']
+        );
+    }
+
     public function testCurrentRouteUses()
     {
         $router = $this->getRouter();

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1084,7 +1084,7 @@ class RoutingRouteTest extends TestCase
 
         $router->group(
             ['namespace' => 'App\Http\Controllers',
-                'controller_class' => 'UsersController'],
+                'controller_class' => 'UsersController', ],
             function ($router) {
                 $router->get('users', 'index');
             });
@@ -1134,8 +1134,8 @@ class RoutingRouteTest extends TestCase
         $router = $this->getRouter();
         $router->group(['prefix' => 'foo', 'as' => 'Foo::'], function () use ($router) {
             $router->get('bar', ['as' => 'bar', function () {
-            return 'hello';
-        }]);
+                return 'hello';
+            }]);
         });
         $routes = $router->getRoutes();
         $route = $routes->getByName('Foo::bar');
@@ -1151,8 +1151,8 @@ class RoutingRouteTest extends TestCase
         $router->group(['prefix' => 'foo', 'as' => 'Foo::'], function () use ($router) {
             $router->group(['prefix' => 'bar', 'as' => 'Bar::'], function () use ($router) {
                 $router->get('baz', ['as' => 'baz', function () {
-                return 'hello';
-            }]);
+                    return 'hello';
+                }]);
             });
         });
         $routes = $router->getRoutes();
@@ -1166,8 +1166,8 @@ class RoutingRouteTest extends TestCase
         $router->group(['prefix' => 'foo', 'as' => 'Foo::'], function () use ($router) {
             $router->group(['prefix' => 'bar'], function () use ($router) {
                 $router->prefix('foz')->get('baz', ['as' => 'baz', function () {
-                return 'hello';
-            }]);
+                    return 'hello';
+                }]);
             });
         });
         $routes = $router->getRoutes();
@@ -1183,8 +1183,8 @@ class RoutingRouteTest extends TestCase
         $router = $this->getRouter();
         $router->group(['prefix' => 'foo', 'as' => 'Foo::'], function () use ($router) {
             $router->prefix('bar')->get('baz', ['as' => 'baz', function () {
-            return 'hello';
-        }]);
+                return 'hello';
+            }]);
         });
         $routes = $router->getRoutes();
         $route = $routes->getByName('Foo::baz');

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1082,9 +1082,9 @@ class RoutingRouteTest extends TestCase
     {
         $router = $this->getRouter();
 
-        $router->group([
-                'namespace' => 'App\Http\Controllers',
-                'controller_class' => 'UsersController'],
+        $router->group(
+            ['namespace' => 'App\Http\Controllers',
+            'controller_class' => 'UsersController'],
             function ($router) {
                 $router->get('users', 'index');
             });


### PR DESCRIPTION
Sometimes a controller that is responsible for a resource may use non-REST format, for example:
 - Deletion of user may be a GET request on /users/{id}/delete
 - Creation is a POST request on /users/{id}/store
 - The resource may have some additional actions. 

In this cases the current 'resource' method is not flexible enough, but it still would be intuitive to group them based on the controller that processes these requests. The grouping also would reduce number of controller's class name repetitions.
I noticed this kind of grouping is very handy after using similar 'controller' method in Ruby on Rails. 

Also, we already have a 'namespace' grouping option and controller grouping might work well in combination with it, or be an alternative in some places:
```php
use Illuminate\Support\Facades\Route;
use App\Http\Controllers\UsersController;

// grouping with fully qualified class name
Route::group([ 'controller_class' => UsersController::class ], function () {
    // defining custom CRUD operations
    Route::get('/users', 'index');
    Route::post('/user-create', 'store');
    Route::post('/users/{id}/delete', 'destroy');
    // maybe some additional actions
    Route::get('/users/{id}/permissions', 'getPermissions');
});

// grouping with namespaces
Route::group([ 'namespace' => 'App\Http\Controllers' ], function () {
    Route::group([ 'controller_class' => 'UsersController' ], function () {
        Route::get('/users', 'index');
    });
});

// this will not work
Route::group([ 'namespace' => 'App\Http\Controllers' ], function () {
    Route::group([ 'controller_class' => UsersController::class ], function () {
        Route::get('/users', 'index');
    });
});

// using registrar interface
Route::controller(UsersController::class)->group(function () {
    Route::get('/users', 'index');
});
```

I had to name the key 'controller_class', since name 'controller' was already occupied in Route parameters for 'controller@method' string.

This feature is small and should not change any of the current behaviors and just add another option to users, so I decided it should belong to 8.x release. If not, I am sorry for picking the wrong branch.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
