### PR TITLE
[8.x] Fix undefined property with sole query

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -167,7 +167,7 @@ abstract class Relation
         $result = $this->take(2)->get($columns);
 
         if ($result->isEmpty()) {
-            throw (new ModelNotFoundException)->setModel(get_class($this->model));
+            throw (new ModelNotFoundException)->setModel(get_class($this->related));
         }
 
         if ($result->count() > 1) {

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -819,6 +819,13 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertTrue($soleFriend->pivot instanceof EloquentTestFriendPivot);
     }
 
+    public function testBelongsToManyRelationshipMissingModelExceptionWithSoleQueryWorks()
+    {
+        $this->expectException(ModelNotFoundException::class);
+        $user = EloquentTestUserWithCustomFriendPivot::create(['email' => 'taylorotwell@gmail.com']);
+        $user->friends()->where('email', 'abigailotwell@gmail.com')->sole();
+    }
+
     public function testBelongsToManyRelationshipModelsAreProperlyHydratedOverChunkedRequest()
     {
         $user = EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);


### PR DESCRIPTION
This is a followup to PR #36200 if no model exists on a e.g. `BelongsToMany` relation the `::$model` property doesn't exist.

The `findOrFail()` method on the `BelongsToMany::class` also uses the `::$related` property to set the model on the `ModelNotFoundException` https://github.com/laravel/framework/blob/8.x/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php#L702