### PR TITLE
[8.x] Compatibility between EnumeratesValues and BuildsQueries on when() method

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -468,9 +468,9 @@ trait EnumeratesValues
         }
 
         if ($value) {
-            return $callback($this, $value);
+            return $callback($this, $value) ?: $this;
         } elseif ($default) {
-            return $default($this, $value);
+            return $default($this, $value) ?: $this;
         }
 
         return $this;


### PR DESCRIPTION
This simple PR aims to ensure compatibility between `src/Illuminate/Collections/Traits/EnumeratesValues.php` and `src/Illuminate/Database/Concerns/BuildsQueries.php` on `when()` method. 

Before, using `when()` method on collection **without** returning value, lead to collection being null (user must always return the same collection to chain further methods). This is understandable, but when we're doing the same thing inside query builder, we may return nothing (null) and Laravel corrects us returning builder again:
https://github.com/laravel/framework/blob/a6680d98f9dadaa363aa7d5218517a08706cee64/src/Illuminate/Database/Concerns/BuildsQueries.php#L208-L210

This leads to confusion in my opinion.
Thank you for reading.