### PR TITLE
[9.x] Pass collection instance into `tap` directly, not a clone

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -764,7 +764,7 @@ trait EnumeratesValues
      */
     public function tap(callable $callback)
     {
-        $callback(clone $this);
+        $callback($this);
 
         return $this;
     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -4126,10 +4126,13 @@ class SupportCollectionTest extends TestCase
         $data = new $collection([1, 2, 3]);
 
         $fromTap = [];
-        $data = $data->tap(function ($data) use (&$fromTap) {
+        $tappedInstance = null;
+        $data = $data->tap(function ($data) use (&$fromTap, &$tappedInstance) {
             $fromTap = $data->slice(0, 1)->toArray();
+            $tappedInstance = $data;
         });
 
+        $this->assertSame($data, $tappedInstance);
         $this->assertSame([1], $fromTap);
         $this->assertSame([1, 2, 3], $data->toArray());
     }

--- a/tests/Support/SupportLazyCollectionTest.php
+++ b/tests/Support/SupportLazyCollectionTest.php
@@ -164,7 +164,7 @@ class SupportLazyCollectionTest extends TestCase
 
         $results = $mock
             ->times(10)
-            ->pipe(function ($collection) use ($mock, $timeout) {
+            ->tap(function ($collection) use ($mock, $timeout) {
                 tap($collection)
                     ->mockery_init($mock->mockery_getContainer())
                     ->shouldAllowMockingProtectedMethods()
@@ -175,8 +175,6 @@ class SupportLazyCollectionTest extends TestCase
                         (clone $timeout)->sub(1, 'minute')->getTimestamp(),
                         $timeout->getTimestamp()
                     );
-
-                return $collection;
             })
             ->takeUntilTimeout($timeout)
             ->all();


### PR DESCRIPTION
See here: https://github.com/laravel/framework/pull/17756#issuecomment-698711718