### PR TITLE
[8.x] Adding NullableMorphMany relation

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
+use Illuminate\Database\Eloquent\Relations\NullableMorphMany;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
@@ -458,6 +459,47 @@ trait HasRelationships
     protected function newMorphMany(Builder $query, Model $parent, $type, $id, $localKey)
     {
         return new MorphMany($query, $parent, $type, $id, $localKey);
+    }
+
+    /**
+     * Define a polymorphic one-to-many relationship.
+     *
+     * @param  string  $related
+     * @param  string  $name
+     * @param  string|null  $type
+     * @param  string|null  $id
+     * @param  string|null  $localKey
+     * @return \Illuminate\Database\Eloquent\Relations\NullableMorphMany
+     */
+    public function nullableMorphMany($related, $name, $type = null, $id = null, $localKey = null)
+    {
+        $instance = $this->newRelatedInstance($related);
+
+        // Here we will gather up the morph type and ID for the relationship so that we
+        // can properly query the intermediate table of a relation. Finally, we will
+        // get the table and create the relationship instances for the developers.
+        [$type, $id] = $this->getMorphs($name, $type, $id);
+
+        $table = $instance->getTable();
+
+        $localKey = $localKey ?: $this->getKeyName();
+
+        return $this->newNullableMorphMany($instance->newQuery(), $this, $table.'.'.$type, $table.'.'.$id, $localKey);
+    }
+
+    /**
+     * Instantiate a new NullableMorphMany relationship.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  \Illuminate\Database\Eloquent\Model  $parent
+     * @param  string  $type
+     * @param  string  $id
+     * @param  string  $localKey
+     * @return \Illuminate\Database\Eloquent\Relations\NullableMorphMany
+     */
+    protected function newNullableMorphMany(Builder $query, Model $parent, $type, $id, $localKey)
+    {
+        return new NullableMorphMany($query, $parent, $type, $id, $localKey);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/NullableMorphMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/NullableMorphMany.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Relations;
+
+use Illuminate\Database\Eloquent\Collection;
+
+class NullableMorphMany extends MorphMany
+{
+    /**
+     * Set the base constraints on the relation query.
+     *
+     * @return void
+     */
+    public function addConstraints()
+    {
+        if (static::$constraints) {
+            $this->query->where($this->foreignKey, '=', $this->getParentKey());
+
+            if (! is_null($this->getParentKey())) {
+                $this->query->whereNotNull($this->foreignKey);
+            }
+
+            $this->query->where($this->morphType, $this->morphClass);
+        }
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Relations/NullableMorphMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/NullableMorphMany.php
@@ -2,8 +2,6 @@
 
 namespace Illuminate\Database\Eloquent\Relations;
 
-use Illuminate\Database\Eloquent\Collection;
-
 class NullableMorphMany extends MorphMany
 {
     /**

--- a/tests/Integration/Database/EloquentNullableMorphManyTest.php
+++ b/tests/Integration/Database/EloquentNullableMorphManyTest.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentNullableMorphManyTest;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+/**
+ * @group integration
+ */
+class EloquentNullableMorphManyTest extends DatabaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('posts', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('title');
+            $table->timestamps();
+        });
+
+        Schema::create('articles', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('title');
+            $table->timestamps();
+        });
+
+        Schema::create('comments', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            // $table->nullableMorphs('commentable');
+            $table->integer('commentable_id')->nullable();
+            $table->string('commentable_type');
+            $table->timestamps();
+        });
+
+        Carbon::setTestNow(null);
+    }
+
+    public function testUpdateModelWithDefaultWithCount()
+    {
+        $post = Post::create(['title' => Str::random()]);
+
+        $post->update(['title' => 'new name']);
+
+        $this->assertSame('new name', $post->title);
+    }
+
+    public function test_self_referencing_existence_query()
+    {
+        $post = Post::create(['title' => 'foo']);
+
+        $comment = tap((new Comment(['name' => 'foo']))->commentable()->associate($post))->save();
+
+        (new Comment(['name' => 'bar']))->commentable()->associate($comment)->save();
+
+        $comments = Comment::has('replies')->get();
+
+        $this->assertEquals([1], $comments->pluck('id')->all());
+    }
+
+    public function testQueryIsNotCheckingForeignKeyWhenNull()
+    {
+        $post = new Post();
+        $comment = $post->comments()->save(new Comment(['name' => 'bar']));
+        $expectedSql = 'select * from "comments" where "comments"."commentable_id" is null and "comments"."commentable_type" = ?';
+
+        $this->assertEquals($comment->id, Comment::first()->id);
+        $this->assertEquals($expectedSql, $post->comments()->toSql());
+    }
+
+    public function testQueryIsCheckingForeignKeyWhenNotNull()
+    {
+        $post = Post::create(['title' => 'foo']);
+        $comment = $post->comments()->save(new Comment(['name' => 'bar']));
+        $expectedSql = 'select * from "comments" where "comments"."commentable_id" = ? and "comments"."commentable_id" is not null and "comments"."commentable_type" = ?';
+
+        $this->assertEquals($post->id, Post::first()->id);
+        $this->assertEquals($comment->id, Comment::first()->id);
+        $this->assertEquals($comment->commentable->id, $post->id);
+        $this->assertEquals($expectedSql, $post->comments()->toSql());
+    }
+
+    public function testMorphManyQueryIsAlwaysCheckingForeignKeyIsNotNull()
+    {
+        $article = new Article();
+        $comment = $article->comments()->save(new Comment(['name' => 'bar']));
+        $badSql = 'select * from "comments" where "comments"."commentable_id" is null and "comments"."commentable_id" is not null and "comments"."commentable_type" = ?';
+
+        $this->assertEquals($comment->id, Comment::first()->id);
+        $this->assertEquals($badSql, $article->comments()->toSql());
+    }
+}
+
+class Post extends Model
+{
+    public $table = 'posts';
+    public $timestamps = true;
+    protected $guarded = [];
+    protected $withCount = ['comments'];
+
+    public function comments()
+    {
+        return $this->nullableMorphMany(Comment::class, 'commentable');
+    }
+}
+
+class Article extends Model
+{
+    public $table = 'articles';
+    public $timestamps = true;
+    protected $guarded = [];
+
+    public function comments()
+    {
+        return $this->morphMany(Comment::class, 'commentable');
+    }
+}
+
+class Comment extends Model
+{
+    public $table = 'comments';
+    public $timestamps = true;
+    protected $guarded = [];
+
+    public function commentable()
+    {
+        return $this->morphTo();
+    }
+
+    public function replies()
+    {
+        return $this->morphMany(self::class, 'commentable');
+    }
+}


### PR DESCRIPTION
When using  **nullableMorphs** and **morphMany** there is not a clean way to get the relations from an empty model. If you define the following:

```php
Schema::create('comments', function (Blueprint $table) {
    $table->increments('id');
    $table->string('name');
    $table->nullableMorphs('commentable');
    // $table->integer('commentable_id')->nullable();
    // $table->string('commentable_type');
    $table->timestamps();
});
```

```php
class Post extends Model
{
    public function comments()
    {
        return $this->morphMany(Comment::class, 'commentable');
    }
}
```
When you try to get every nullable **commentable_id** from the model the query is WRONG:
```php
$post = new Post();
// Get every comment where commentable_id is null and commentable_type = 'App\Model\Post'.
$comments = $post->comments()->get();
``` 
The query generated:
```sql
select * from "comments" where "comments"."commentable_id" is null and "comments"."commentable_id" is not null and "comments"."commentable_type" = "App\Model\Post"
```
MorphMany is expecting a not null **commentable_id**. As you can see: (**"comments"."commentable_id" is null and "comments"."commentable_id" is not null**).



**Proposed solution**
To use a **NullableMorphMany** relation. This relation extends **MorphMany** relation but is checking first if the foreignKey is not null to generate the query.

```php
class Post extends Model
{
    public function comments()
    {
        return $this->nullableMorphMany(Comment::class, 'commentable');
    }
}
```

```php
$post = new Post();
// Get every comment where commentable_id is null and commentable_type = 'App\Model\Post'.
$comments = $post->comments()->get();
``` 

The query generated:
```sql
select * from "comments" where "comments"."commentable_id" is null and "comments"."commentable_type" = "App\Model\Post"
```

**THERE IS NO BREAKING CHANGE.**