### PR TITLE
[8.x] Unexpected behaviour when sending the same mailable object multiple times using Mail

### DIFF
--- a/src/Illuminate/Mail/PendingMail.php
+++ b/src/Illuminate/Mail/PendingMail.php
@@ -152,6 +152,13 @@ class PendingMail
      */
     protected function fill(MailableContract $mailable)
     {
+        // Before populating mailable with the addresses
+        // remove any previous addresses and reset locale.
+        $mailable->to = [];
+        $mailable->cc = [];
+        $mailable->bcc = [];
+        $mailable->locale = null;
+
         return tap($mailable->to($this->to)
             ->cc($this->cc)
             ->bcc($this->bcc), function (MailableContract $mailable) {


### PR DESCRIPTION
$mailable = new OrderMailable($order);

Mail::to($user)->send($mailable);  // Will send email to user
Mail::to('sales@company.com')->send($mailable); // Will send email to sales and the user again

The user will get 2 emails and sales department will get one. You can imagine what would happen if you call Mail::to->send() in for loop with hundreds of emails.