### PR TITLE
[8.x] Allow users to specify configuration keys to be used for primitive binding

### DIFF
--- a/src/Illuminate/Container/ContextualBindingBuilder.php
+++ b/src/Illuminate/Container/ContextualBindingBuilder.php
@@ -81,4 +81,20 @@ class ContextualBindingBuilder implements ContextualBindingBuilderContract
             return is_array($taggedServices) ? $taggedServices : iterator_to_array($taggedServices);
         });
     }
+
+    /**
+     * Define configuration key to be used to look up in configuration to bind as a primitive.
+     *
+     * @param string  $key
+     * @param ?string $default
+     * @return void
+     */
+    public function giveConfig($key, $default = null)
+    {
+        $this->give(function ($container) use ($key, $default) {
+            $config = $container->get('config');
+
+            return $config->get($key, $default);
+        });
+    }
 }


### PR DESCRIPTION
Syntactic sugar around fancy calls to `->give()` related to getting primitives from configuration.

Most of the time when I'm doing primitive binding it is for the purpose of using configuration values as constructor arguments. A lot of function calls are used and feel pretty bulky compared to being able to just say, "hey, get the value from this config key."

This PR provides the ability to do just that. Need an API key? `->need('$apiKey')->giveConfig('awesome_api.key')` is all you'd need to set in a service provider now.

```
$container
    ->when(ContainerTestContextInjectFromConfigIndividualValues::class)
    ->needs('$username')
    ->giveConfig('test.username');
```

Is the same as:

```
$container
    ->when(ContainerTestContextInjectFromConfigIndividualValues::class)
    ->needs('$username')
    ->give(function () {
        return config('test.username');
    });
```

and

```
$container
    ->when(ContainerTestContextInjectFromConfigIndividualValues::class)
    ->needs('$username')
    ->give(fn() => config('test.username'));
```

----

I believe this may require additional work on the contract (?) that I'll do if this gets approved. Would just need to know which branch to target that change on. I can also do the docs on this if it looks like this will be able to be merged. :)