### PR TITLE
[8.x] ArrayObject + Collection Custom Casts

### DIFF
--- a/src/Illuminate/Database/Eloquent/Casts/ArrayObject.php
+++ b/src/Illuminate/Database/Eloquent/Casts/ArrayObject.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Casts;
+
+use ArrayObject as BaseArrayObject;
+use Illuminate\Contracts\Support\Arrayable;
+use JsonSerializable;
+
+class ArrayObject extends BaseArrayObject implements Arrayable, JsonSerializable
+{
+    /**
+     * Get a collection containing the underlying array.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function collect()
+    {
+        return collect($this->getArrayCopy());
+    }
+
+    /**
+     * Get the instance as an array.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return $this->getArrayCopy();
+    }
+
+    /**
+     * Get the array that should be JSON serialized.
+     *
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return $this->getArrayCopy();
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Casts/AsArrayObject.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsArrayObject.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\Castable;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+
+class AsArrayObject implements Castable
+{
+    /**
+     * Get the caster class to use when casting from / to this cast target.
+     *
+     * @param  array  $arguments
+     * @return object|string
+     */
+    public static function castUsing(array $arguments)
+    {
+        return new class implements CastsAttributes {
+            public function get($model, $key, $value, $attributes)
+            {
+                return new ArrayObject(json_decode($attributes[$key], true));
+            }
+
+            public function set($model, $key, $value, $attributes)
+            {
+                return [$key => json_encode($value)];
+            }
+
+            public function serialize($model, string $key, $value, array $attributes)
+            {
+                return $value->getArrayCopy();
+            }
+        };
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\Castable;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Support\Collection;
+
+class AsCollection implements Castable
+{
+    /**
+     * Get the caster class to use when casting from / to this cast target.
+     *
+     * @param  array  $arguments
+     * @return object|string
+     */
+    public static function castUsing(array $arguments)
+    {
+        return new class implements CastsAttributes {
+            public function get($model, $key, $value, $attributes)
+            {
+                return new Collection(json_decode($attributes[$key], true));
+            }
+
+            public function set($model, $key, $value, $attributes)
+            {
+                return [$key => json_encode($value)];
+            }
+        };
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Casts/AsEncryptedArrayObject.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEncryptedArrayObject.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\Castable;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Support\Facades\Crypt;
+
+class AsEncryptedArrayObject implements Castable
+{
+    /**
+     * Get the caster class to use when casting from / to this cast target.
+     *
+     * @param  array  $arguments
+     * @return object|string
+     */
+    public static function castUsing(array $arguments)
+    {
+        return new class implements CastsAttributes {
+            public function get($model, $key, $value, $attributes)
+            {
+                return new ArrayObject(json_decode(Crypt::decryptString($attributes[$key]), true));
+            }
+
+            public function set($model, $key, $value, $attributes)
+            {
+                return [$key => Crypt::encryptString(json_encode($value))];
+            }
+
+            public function serialize($model, string $key, $value, array $attributes)
+            {
+                return $value->getArrayCopy();
+            }
+        };
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Casts/AsEncryptedCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEncryptedCollection.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\Castable;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Crypt;
+
+class AsEncryptedCollection implements Castable
+{
+    /**
+     * Get the caster class to use when casting from / to this cast target.
+     *
+     * @param  array  $arguments
+     * @return object|string
+     */
+    public static function castUsing(array $arguments)
+    {
+        return new class implements CastsAttributes {
+            public function get($model, $key, $value, $attributes)
+            {
+                return new Collection(json_decode(Crypt::decryptString($attributes[$key]), true));
+            }
+
+            public function set($model, $key, $value, $attributes)
+            {
+                return [$key => Crypt::encryptString(json_encode($value))];
+            }
+        };
+    }
+}

--- a/tests/Integration/Database/DatabaseArrayObjectAndCollectionCustomCastTest.php
+++ b/tests/Integration/Database/DatabaseArrayObjectAndCollectionCustomCastTest.php
@@ -17,7 +17,7 @@ class DatabaseArrayObjectAndCollectionCustomCastTest extends DatabaseTestCase
     {
         parent::setUp();
 
-        Schema::create('test_eloquent_model_with_custom_casts', function (Blueprint $table) {
+        Schema::create('test_eloquent_model_with_custom_array_object_casts', function (Blueprint $table) {
             $table->increments('id');
             $table->text('array_object');
             $table->text('collection');
@@ -27,7 +27,7 @@ class DatabaseArrayObjectAndCollectionCustomCastTest extends DatabaseTestCase
 
     public function test_array_object_and_collection_casting()
     {
-        $model = new TestEloquentModelWithCustomCast;
+        $model = new TestEloquentModelWithCustomArrayObjectCast;
 
         $model->array_object = ['name' => 'Taylor'];
         $model->collection = collect(['name' => 'Taylor']);
@@ -54,7 +54,7 @@ class DatabaseArrayObjectAndCollectionCustomCastTest extends DatabaseTestCase
     }
 }
 
-class TestEloquentModelWithCustomCast extends Model
+class TestEloquentModelWithCustomArrayObjectCast extends Model
 {
     /**
      * The attributes that aren't mass assignable.

--- a/tests/Integration/Database/DatabaseArrayObjectAndCollectionCustomCastTest.php
+++ b/tests/Integration/Database/DatabaseArrayObjectAndCollectionCustomCastTest.php
@@ -49,7 +49,7 @@ class DatabaseArrayObjectAndCollectionCustomCastTest extends DatabaseTestCase
         $this->assertEquals([
             'name' => 'Taylor',
             'age' => 34,
-            'meta' => ['title' => 'Developer']
+            'meta' => ['title' => 'Developer'],
         ], $model->array_object->toArray());
     }
 }

--- a/tests/Integration/Database/DatabaseArrayObjectAndCollectionCustomCastTest.php
+++ b/tests/Integration/Database/DatabaseArrayObjectAndCollectionCustomCastTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Database\Eloquent\Casts\AsArrayObject;
+use Illuminate\Database\Eloquent\Casts\AsCollection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * @group integration
+ */
+class DatabaseArrayObjectAndCollectionCustomCastTest extends DatabaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('test_eloquent_model_with_custom_casts', function (Blueprint $table) {
+            $table->increments('id');
+            $table->text('array_object');
+            $table->text('collection');
+            $table->timestamps();
+        });
+    }
+
+    public function test_array_object_and_collection_casting()
+    {
+        $model = new TestEloquentModelWithCustomCast;
+
+        $model->array_object = ['name' => 'Taylor'];
+        $model->collection = collect(['name' => 'Taylor']);
+
+        $model->save();
+
+        $model = $model->fresh();
+
+        $this->assertEquals(['name' => 'Taylor'], $model->array_object->toArray());
+        $this->assertEquals(['name' => 'Taylor'], $model->collection->toArray());
+
+        $model->array_object['age'] = 34;
+        $model->array_object['meta']['title'] = 'Developer';
+
+        $model->save();
+
+        $model = $model->fresh();
+
+        $this->assertEquals([
+            'name' => 'Taylor',
+            'age' => 34,
+            'meta' => ['title' => 'Developer']
+        ], $model->array_object->toArray());
+    }
+}
+
+class TestEloquentModelWithCustomCast extends Model
+{
+    /**
+     * The attributes that aren't mass assignable.
+     *
+     * @var string[]
+     */
+    protected $guarded = [];
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'array_object' => AsArrayObject::class,
+        'collection' => AsCollection::class,
+    ];
+}


### PR DESCRIPTION
This PR implements an opt-in `AsArrayObject` and `AsCollection` custom cast.

### Background

Of course, Laravel already includes an ability to cast a JSON / TEXT column that contains JSON to an array or collection like so:

```php
$casts = ['options' => 'array'];
```

However, this does have some downsides. First, the following code is impossible using the simple `array` cast:

```php
$user = User::find(1);

$user->options['foo'] = 'bar';

$user->save();
```

Many developers probably expect this to work, but it doesn't. It is impossible to mutate a specific property of the primitive array returned by this cast. You must mutate the entire array:

```php
$user = User::find(1);

$user->options = ['foo' => 'bar'];

$user->save();
```

### AsArrayObject + AsCollection

However, these new casts utilize Eloquent's custom cast feature which implements more intelligent management and caching of objects. The `AsArrayObject` cast will cast the underlying JSON string to a PHP `ArrayObject` instance. This class is included in the standard library of PHP and allows an object to behave like an array. Such an approach makes the following possible:

```php
// Within model...
$casts = ['options' => AsArrayObject::class];

// Manipulating the options...
$user = User::find(1);

$user->options['foo']['bar'] = 'baz';

$user->save();
```

However, it should be noted that an `ArrayObject` can not be fed into array functions like `array_map`, so you must use `$user->options->toArray()` to access the raw underlying array if you wish to use the array in this way. You may also use `$user->options->collect()` to get a `Collection` instance from the `ArrayObject`.

Similar benefits are derived from the `AsCollection` cast - this cast is similar to the existing `collection` class, but because of the better object caching and management of custom casts, you are able to mutate singular properties on the collection or even push to the collection.

### Final Thoughts

The existing `array` and `collection` casts would not be removed from the framework. However, it may be wise to primarily document these new casts (if they are accepted) in the future as they are a bit more robust and developer friendly.