### PR TITLE
Update GuardsAttributes.php

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
@@ -203,9 +203,11 @@ trait GuardsAttributes
             return false;
         }
 
-        return $this->getGuarded() == ['*'] ||
-               ! empty(preg_grep('/^'.preg_quote($key).'$/i', $this->getGuarded())) ||
-               ! $this->isGuardableColumn($key);
+        return (
+            $this->getGuarded() == ['*'] ||
+            ! empty(preg_grep('/^'.preg_quote($key).'$/i', $this->getGuarded()))
+        ) &&
+            $this->isGuardableColumn($key);
     }
 
     /**


### PR DESCRIPTION
The isGuarded function behaves incorrectly, see this line: 
`return $this->getGuarded() == ['*'] ||
               ! empty(preg_grep('/^'.preg_quote($key).'$/i', $this->getGuarded())) ||
               ! $this->isGuardableColumn($key)`

The last line should not contain "NOT" operator. If a column is not guardable, it should not return that it is guarded.

The current logic is: If we do have defined custom guarded columns and the one in question is not in the list, but it could be guarded, mark it as guarded.

I suppose the correct logic would be: If we do have defined custom guarded columns and the one in question is not in the list, it most not be guarded. Also, if we did not define custom guarded columns, but the one in question cannot be guarded, it must not be guarded.

See the following discussion where this already came up: https://github.com/illuminate/database/commit/f650a93014204cdd138de4aca17ce5e5713f6d91#diff-d47879edea9ea3b4f5995692d0fd94ff7e7164001503ff3ec2516eac712b5e44