### PR TITLE
[8.x] Ensure $prefix is a string

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -746,6 +746,8 @@ class Route
      */
     public function prefix($prefix)
     {
+        $prefix = $prefix ?? '';
+
         $this->updatePrefixOnAction($prefix);
 
         $uri = rtrim($prefix, '/').'/'.ltrim($this->uri, '/');

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -741,7 +741,7 @@ class Route
     /**
      * Add a prefix to the route URI.
      *
-     * @param  string  $prefix
+     * @param  string|null  $prefix
      * @return $this
      */
     public function prefix($prefix)

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -741,7 +741,7 @@ class Route
     /**
      * Add a prefix to the route URI.
      *
-     * @param  string|null  $prefix
+     * @param  string  $prefix
      * @return $this
      */
     public function prefix($prefix)


### PR DESCRIPTION
Because PHP 8.1 will no longer allow it and throw:
`rtrim(): Passing null to parameter #1 ($string) of type string is deprecated`