### PR TITLE
[8.x] Storage::download() chunked streaming

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -34,7 +34,7 @@ class FilesystemAdapter implements CloudFilesystemContract
     /**
      * Streaming chunked output size.
      *
-     * @var string
+     * @var int Bytes
      */
     private const DOWNLOAD_CHUNK_SIZE = 1024 * 128;
 
@@ -188,7 +188,7 @@ class FilesystemAdapter implements CloudFilesystemContract
 
         $response->setCallback(function () use ($path) {
             $stream = $this->readStream($path);
-            while (feof($stream) === true) {
+            while (feof($stream) === false) {
                 echo fread($stream, static::DOWNLOAD_CHUNK_SIZE);
             }
 

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -32,9 +32,9 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
 class FilesystemAdapter implements CloudFilesystemContract
 {
     /**
-     * Streaming chunked output size.
+     * Streaming output chunk size.
      *
-     * @var int Bytes
+     * @var int
      */
     private const DOWNLOAD_CHUNK_SIZE = 1024 * 128;
 

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -32,6 +32,13 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
 class FilesystemAdapter implements CloudFilesystemContract
 {
     /**
+     * Streaming chunked output size.
+     *
+     * @var string
+     */
+    private const DOWNLOAD_CHUNK_SIZE = 1024 * 128;
+
+    /**
      * The Flysystem filesystem implementation.
      *
      * @var \League\Flysystem\FilesystemInterface
@@ -181,7 +188,10 @@ class FilesystemAdapter implements CloudFilesystemContract
 
         $response->setCallback(function () use ($path) {
             $stream = $this->readStream($path);
-            fpassthru($stream);
+            while (feof($stream) === true) {
+                echo fread($stream, static::DOWNLOAD_CHUNK_SIZE);
+            }
+
             fclose($stream);
         });
 


### PR DESCRIPTION
Resolves issue https://github.com/laravel/framework/issues/36249 (thanks @uberbrady)

This is a non-breaking change, could also goto 7.x branch too_

`FilesystemAdapter::response()` has not been streaming responses for files in an effective way.
Formerly this code used `fpassthru`, which resulted in the resource stream being allocated entirely to memory, before the buffer is output which obviously is not great for large files.

This PR changes ensures file responses are streamed in chunks, avoiding large memory allocation 

P.S. There's a bug in core PHP, which flysystem v1 depends on, which will also be a contributing factor to the memory hunger - but that is a separate issue solved at the runtime & upstream PHP.

References
- https://bugs.php.net/bug.php?id=78987
- https://bugs.astron.com/view.php?id=234
- https://bugs.php.net/bug.php?id=79263