### PR TITLE
[8.x] Handle directive $value as a string

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -449,6 +449,8 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     protected function callCustomDirective($name, $value)
     {
+        $value = $value ?? '';
+
         if (Str::startsWith($value, '(') && Str::endsWith($value, ')')) {
             $value = Str::substr($value, 1, -1);
         }


### PR DESCRIPTION
- As per PHPDoc `Str::startsWith` and `Str::endsWith` are not supposed to handle `null` values
- `strncmp()` will no longer accept `null` in PHP 8.1
- It needs a `string` in the end (`trim`) so it would be relevant to cast it first.