### PR TITLE
[8.x] Use explicit flag as default sorting

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1086,7 +1086,7 @@ class Collection implements ArrayAccess, Enumerable
 
         $callback && is_callable($callback)
             ? uasort($items, $callback)
-            : asort($items, $callback);
+            : asort($items, $callback ?? SORT_REGULAR);
 
         return new static($items);
     }


### PR DESCRIPTION
PHP 8.1 will no longer support passing `null` as `asort()` flag.