### PR TITLE
[8.x] Align PHP 8.1 behavior of e()

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -101,7 +101,7 @@ if (! function_exists('e')) {
     /**
      * Encode HTML special characters in a string.
      *
-     * @param  \Illuminate\Contracts\Support\DeferringDisplayableValue|\Illuminate\Contracts\Support\Htmlable|string  $value
+     * @param  \Illuminate\Contracts\Support\DeferringDisplayableValue|\Illuminate\Contracts\Support\Htmlable|string|null  $value
      * @param  bool  $doubleEncode
      * @return string
      */
@@ -115,7 +115,7 @@ if (! function_exists('e')) {
             return $value->toHtml();
         }
 
-        return htmlspecialchars($value, ENT_QUOTES, 'UTF-8', $doubleEncode);
+        return htmlspecialchars($value ?? '', ENT_QUOTES, 'UTF-8', $doubleEncode);
     }
 }
 


### PR DESCRIPTION
While not explicitly allowed in the PHPDoc, `e(null)` returns `""` with PHP < 8.1
On PHP >= 8.1, an error is thrown if `null` is passed to `htmlspecialchars`.

As `e(null)` is still a common case (for instance via Blade in view templates) I think it's safest to just default the `null` value to an empty string to get the same behavior with the next PHP minor version.