### PR TITLE
[8.x] Add missing import

### DIFF
--- a/src/Illuminate/Testing/Constraints/HasInDatabase.php
+++ b/src/Illuminate/Testing/Constraints/HasInDatabase.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Testing\Constraints;
 
 use Illuminate\Database\Connection;
+use Illuminate\Database\Query\Expression;
 use PHPUnit\Framework\Constraint\Constraint;
 
 class HasInDatabase extends Constraint


### PR DESCRIPTION
This is a bug fix to #34569.

Apparently I completely forgot to import this class, which means it wasn't working at all.