### PR TITLE
[8.x] Add withLocale method on Application

### DIFF
--- a/src/Illuminate/Contracts/Foundation/Application.php
+++ b/src/Illuminate/Contracts/Foundation/Application.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Contracts\Foundation;
 
+use Closure;
 use Illuminate\Contracts\Container\Container;
 
 interface Application extends Container
@@ -198,6 +199,16 @@ interface Application extends Container
      * @return void
      */
     public function setLocale($locale);
+
+    /**
+     * Set the current application locale temporarily, execute the given closure,
+     * then reset the locale.
+     *
+     * @param  string  $locale
+     * @param  \Closure  $withDifferentLocale
+     * @return void
+     */
+    public function withLocale($locale, Closure $withDifferentLocale);
 
     /**
      * Determine if middleware has been disabled for the application.

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1257,7 +1257,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
     public function withLocale($locale, Closure $withDifferentLocale)
     {
         $currentLocale = $this->getLocale();
-        
+
         $this->setLocale($locale);
 
         $withDifferentLocale();

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1247,6 +1247,25 @@ class Application extends Container implements ApplicationContract, CachesConfig
     }
 
     /**
+     * Set the current application locale temporarily, execute the given closure,
+     * then reset the locale.
+     *
+     * @param  string  $locale
+     * @param  \Closure  $withDifferentLocale
+     * @return void
+     */
+    public function withLocale($locale, Closure $withDifferentLocale)
+    {
+        $currentLocale = $this->getLocale();
+        
+        $this->setLocale($locale);
+
+        $withDifferentLocale();
+
+        $this->setLocale($currentLocale);
+    }
+
+    /**
      * Set the current application fallback locale.
      *
      * @param  string  $fallbackLocale

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -31,6 +31,41 @@ class FoundationApplicationTest extends TestCase
         $app->setLocale('foo');
     }
 
+    public function testWithLocaleTemporarilySetsLocale()
+    {
+        $app = new Application;
+        $app['translator'] = $trans = m::mock(stdClass::class);
+        $trans->shouldReceive('setLocale')->times(3);
+
+        $app['config'] = new class
+        {
+            private $values = [];
+            
+            public function set($name, $value)
+            {
+                $this->values[$name] = $value;
+            }
+            
+            public function get($name)
+            {
+                return $this->values[$name];
+            }
+        };
+
+        $called = m::mock(stdClass::class);
+        $called->shouldReceive('testLocaleCalled')->once();
+
+        $app->setLocale('foo');
+
+        $app->withLocale('bar', function () use ($called, $app) {
+            $called->testLocaleCalled();
+
+            $this->assertEquals('bar', $app->getLocale());
+        });
+
+        $this->assertEquals('foo', $app->getLocale());
+    }
+
     public function testServiceProvidersAreCorrectlyRegistered()
     {
         $provider = m::mock(ApplicationBasicServiceProviderStub::class);

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -37,15 +37,14 @@ class FoundationApplicationTest extends TestCase
         $app['translator'] = $trans = m::mock(stdClass::class);
         $trans->shouldReceive('setLocale')->times(3);
 
-        $app['config'] = new class
-        {
+        $app['config'] = new class {
             private $values = [];
-            
+
             public function set($name, $value)
             {
                 $this->values[$name] = $value;
             }
-            
+
             public function get($name)
             {
                 return $this->values[$name];


### PR DESCRIPTION
Sometimes you need to generate assets like emails or PDFs in one specific locale that is not the user's / application's general locale.

This method helps in that it does so temporarily for the duration of the provided closure.
