### PR TITLE
[8.x] Clean up custom Queue payload between tests

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use Carbon\CarbonImmutable;
 use Illuminate\Console\Application as Artisan;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Queue\Queue;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\Facades\ParallelTesting;
 use Illuminate\Support\Str;
@@ -198,6 +199,8 @@ abstract class TestCase extends BaseTestCase
         $this->beforeApplicationDestroyedCallbacks = [];
 
         Artisan::forgetBootstrappers();
+
+        Queue::createPayloadUsing(null);
 
         if ($this->callbackException) {
             throw $this->callbackException;

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -6,7 +6,6 @@ use Carbon\Carbon;
 use Carbon\CarbonImmutable;
 use Illuminate\Console\Application as Artisan;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Queue\Queue;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\Facades\ParallelTesting;
 use Illuminate\Support\Str;
@@ -199,8 +198,6 @@ abstract class TestCase extends BaseTestCase
         $this->beforeApplicationDestroyedCallbacks = [];
 
         Artisan::forgetBootstrappers();
-
-        Queue::createPayloadUsing(null);
 
         if ($this->callbackException) {
             throw $this->callbackException;

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -253,7 +253,7 @@ abstract class Queue
     /**
      * Register a callback to be executed when creating job payloads.
      *
-     * @param  callable  $callback
+     * @param  callable|null  $callback
      * @return void
      */
     public static function createPayloadUsing($callback)

--- a/src/Illuminate/Queue/QueueServiceProvider.php
+++ b/src/Illuminate/Queue/QueueServiceProvider.php
@@ -27,6 +27,8 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
      */
     public function register()
     {
+        Queue::createPayloadUsing(null);
+
         $this->registerManager();
         $this->registerConnection();
         $this->registerWorker();

--- a/tests/Integration/Queue/CustomPayloadTest.php
+++ b/tests/Integration/Queue/CustomPayloadTest.php
@@ -5,7 +5,6 @@ namespace Illuminate\Tests\Integration\Queue;
 use Illuminate\Contracts\Bus\QueueingDispatcher;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Queue\Queue;
-use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\ServiceProvider;
 use Orchestra\Testbench\TestCase;
 
@@ -58,6 +57,5 @@ class MyJob implements ShouldQueue
 
     public function handle()
     {
-
     }
 }

--- a/tests/Integration/Queue/CustomPayloadTest.php
+++ b/tests/Integration/Queue/CustomPayloadTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Queue;
+
+use Illuminate\Contracts\Bus\QueueingDispatcher;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\Queue;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\ServiceProvider;
+use Orchestra\Testbench\TestCase;
+
+class CustomPayloadTest extends TestCase
+{
+    protected function getPackageProviders($app)
+    {
+        return [QueueServiceProvider::class];
+    }
+
+    public function websites()
+    {
+        yield ['laravel.com'];
+
+        yield ['blog.laravel.com'];
+    }
+
+    /**
+     * @dataProvider websites
+     */
+    public function test_custom_payload_gets_cleared_for_each_data_provider(string $websites)
+    {
+        $dispatcher = $this->app->make(QueueingDispatcher::class);
+
+        $dispatcher->dispatchToQueue(new MyJob);
+    }
+}
+
+class QueueServiceProvider extends ServiceProvider
+{
+    public function register()
+    {
+        $this->app->bind('one.time.password', function () {
+            return random_int(1, 10);
+        });
+
+        Queue::createPayloadUsing(function () {
+            $password = $this->app->make('one.time.password');
+
+            $this->app->offsetUnset('one.time.password');
+
+            return ['password' => $password];
+        });
+    }
+}
+
+class MyJob implements ShouldQueue
+{
+    public $connection = 'sync';
+
+    public function handle()
+    {
+
+    }
+}


### PR DESCRIPTION
When executing tests with Data Providers, `Queue::createPayloadUsing` leaks between tests and accumulates callbacks from different environments, leading to unexpected behaviors.

This pull request adds a clean up to the TearDown method so that callbacks are not kept between tests.
The test is likely to fail until https://github.com/orchestral/testbench-core/pull/54 is merged as it mimics the same behavior for tests executed from within the framework.