### PR TITLE
[8.x] [Proposal] Media types for content negotiation on Router

### DIFF
--- a/src/Illuminate/Routing/Matching/MediaTypeValidator.php
+++ b/src/Illuminate/Routing/Matching/MediaTypeValidator.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Illuminate\Routing\Matching;
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\Route;
+use Illuminate\Support\Str;
+use Symfony\Component\HttpFoundation\AcceptHeader;
+use Symfony\Component\HttpFoundation\AcceptHeaderItem;
+
+class MediaTypeValidator implements ValidatorInterface
+{
+    /**
+     * Validate a given rule against a route and request.
+     *
+     * @param \Illuminate\Routing\Route $route
+     * @param \Illuminate\Http\Request  $request
+     *
+     * @return bool
+     */
+    public function matches(Route $route, Request $request)
+    {
+        // just return true if we don't have any constraint
+        if (!$route->hasMediaTypeConstraint()) {
+            return true;
+        }
+
+        $acceptHeader = AcceptHeader::fromString($request->header('Accept'));
+
+        foreach ($acceptHeader->all() as $headerItem) {
+            if ($this->validate($route, $headerItem)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Validate an accept header item against content negotiation rules
+     *
+     * @param \Illuminate\Routing\Route                          $route
+     * @param \Symfony\Component\HttpFoundation\AcceptHeaderItem $headerItem
+     *
+     * @return bool
+     */
+    protected function validate(Route $route, AcceptHeaderItem $headerItem)
+    {
+        // we are only interested in application-specific media types
+        if (!Str::startsWith($headerItem->getValue(), 'application')) {
+            return false;
+        }
+
+        return $this->validateVersion($route, $headerItem) && $this->validateHeaderParts($route, $headerItem);
+    }
+
+    /**
+     * Validate version
+     *
+     * @param \Illuminate\Routing\Route                          $route
+     * @param \Symfony\Component\HttpFoundation\AcceptHeaderItem $headerItem
+     *
+     * @return bool
+     */
+    protected function validateVersion(Route $route, AcceptHeaderItem $headerItem)
+    {
+        if (!$version = $route->getAction('version')) {
+            return true;
+        }
+
+        if (!is_array($version)) {
+            $version = [$version];
+        }
+
+        return in_array($headerItem->getAttribute('version'), $version);
+    }
+
+    /**
+     * Validate header parts tree and subTypeSuffix
+     *
+     * @param \Illuminate\Routing\Route                          $route
+     * @param \Symfony\Component\HttpFoundation\AcceptHeaderItem $headerItem
+     *
+     * @return bool
+     */
+    protected function validateHeaderParts(Route $route, AcceptHeaderItem $headerItem)
+    {
+        if (!preg_match('#^application\/(?<tree>.+)\+(?<subtypeSuffix>.+)$#S', $headerItem->getValue(), $headerParts)) {
+            return false;
+        }
+
+        foreach (['tree', 'subtypeSuffix'] as $headerPart) {
+            // ignore if we don't have this constraint
+            if (!$actionValue = $route->getAction($headerPart)) {
+                continue;
+            }
+
+            if ($actionValue != $headerParts[$headerPart]) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -7,6 +7,7 @@ use Illuminate\Container\Container;
 use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Contracts\ControllerDispatcher as ControllerDispatcherContract;
+use Illuminate\Routing\Matching\MediaTypeValidator;
 use Illuminate\Routing\Matching\HostValidator;
 use Illuminate\Routing\Matching\MethodValidator;
 use Illuminate\Routing\Matching\SchemeValidator;
@@ -739,6 +740,65 @@ class Route
     }
 
     /**
+     * Sets the vendor, personal or x tree
+     *
+     * @param string $tree
+     *
+     * @return $this
+     */
+    public function tree($tree)
+    {
+        $this->action['tree'] = $tree;
+
+        return $this;
+    }
+
+    /**
+     * Sets version for content negotiation
+     *
+     * @param mixed $version
+     *
+     * @return $this
+     */
+    public function version($version)
+    {
+        $this->action['version'] = $version;
+
+        return $version;
+    }
+
+    /**
+     * Sets subtype suffix such as json, xml
+     * for content negotiation
+     *
+     * @param string $subtypeSuffix
+     *
+     * @return $this
+     */
+    public function subtypeSuffix($subtypeSuffix)
+    {
+        $this->action['subtypeSuffix'] = $subtypeSuffix;
+
+        return $this;
+    }
+
+    /**
+     * Returns true if the route has a content negotiation constraint
+     *
+     * @return bool
+     */
+    public function hasMediaTypeConstraint()
+    {
+        foreach (['tree', 'version', 'subtypeSuffix'] as $condition) {
+            if (array_key_exists($condition, $this->action)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Add a prefix to the route URI.
      *
      * @param  string  $prefix
@@ -1120,7 +1180,7 @@ class Route
         // passes and then we will know if the route as a whole matches request.
         return static::$validators = [
             new UriValidator, new MethodValidator,
-            new SchemeValidator, new HostValidator,
+            new SchemeValidator, new HostValidator, new MediaTypeValidator
         ];
     }
 


### PR DESCRIPTION
The idea is to have an ability to have content negotiation at Router level using `Accept` header.

# Problem 

Endpoint versioning using URIs such as `/v1/endpoint` or `/endpoint?version=1` tend to require changes in the actual api endpoint URIs in case of a version update which can be painful and confusing on client side and may also mean inconsistent API URIs as every different version has different URIs. Determining the API version at controller, resource or request level is also tricky and may require URI manipulation and interpretation. [Cool URIs don't change
](https://www.w3.org/Provider/Style/URI.html)

# Proposal

This PR proposes to have versioning feature at framework level by using media types (accept header) and content negotiation. This approach is also explained on [RFC-4288](https://www.ietf.org/rfc/rfc4288.html?number=4288)

# Usage

The PR introduces three methods for `Route`.

- `tree($tree)`: specifies a standard tree.
- `subtypeSuffix($subtypeSuffix)`: specifies subtype suffix which is to specify the response syntax.
- `version($version)`: specifies version of the endpoint. Multiple versions can be provided to this method

```php
Route::tree('vnd.foo.bar')->subtypeSuffix('json')->group(function (Route $route) {
    $route->version([1, 2])->group(...); # common endpoints for v1 and v2
    $route->version(1)->get(...); # v1 only endpoint
    $route->version(2)->post(...) # v2 only endpoint
})
```

And the endpoints should be called this way

```
GET /posts/1 HTTP/1.1
Accept: application/vnd.foo.bar+json; version=1
```

# Future and breaking changes

The further implementation would be to add helper methods on `Request` to easily determine the version, tree and subtypeSuffix of the API request such as:

```
Request::version()
Request::tree()
Request::subtypeSuffix()
```

So API request version can easily be determined and the response can be built accordingly not only at controller level but also at resource and request level.

Request methods above haven't been implemented yet as they may cause breaking changes may be a part of 9.x

# References

- [Rest versioning](https://www.baeldung.com/rest-versioning)
- [Using Media Type Parameters to Version an HTTP API](http://liddellj.com/2014/01/08/using-media-type-parameters-to-version-an-http-api)
- [Cool URIs don't change](https://www.w3.org/Provider/Style/URI.html)
- [How to architect a version-less API](http://urthen.github.io/2013/05/16/ways-to-version-your-api-part-2/)
- [Minting new Internet Media Type Identifiers](https://serialseb.com/blog/2011/02/01/minting-new-internet-media-type-identifiers/)
- [RFC-4288](https://www.ietf.org/rfc/rfc4288.html?number=4288)
- [Dingo API configurations](https://github.com/dingo/api/wiki/Configuration)
- [Dingo API creating endpoints](https://github.com/dingo/api/wiki/Creating-API-Endpoints)