### PR TITLE
[8.x] Adds global eloquent type casters

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1261,7 +1261,7 @@ trait HasAttributes
      * Resolve the custom caster class for a given key.
      *
      * @param  string  $key
-     * @return mixed
+     * @return object
      */
     protected function resolveCasterClass($key)
     {

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1239,7 +1239,7 @@ trait HasAttributes
     protected function isClassDeviable($key)
     {
         return $this->isClassCastable($key) &&
-            method_exists($castType = $this->parseCasterClass($this->getCasts()[$key]), 'increment') &&
+            method_exists($castType = $this->resolveCasterClass($key), 'increment') &&
             method_exists($castType, 'decrement');
     }
 
@@ -1254,7 +1254,7 @@ trait HasAttributes
     protected function isClassSerializable($key)
     {
         return $this->isClassCastable($key) &&
-               method_exists($this->parseCasterClass($this->getCasts()[$key]), 'serialize');
+               method_exists($this->resolveCasterClass($key), 'serialize');
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1221,6 +1221,10 @@ trait HasAttributes
             return false;
         }
 
+        if (array_key_exists($castType, self::$casterResolvers)) {
+            return true;
+        }
+
         if (class_exists($castType)) {
             return true;
         }

--- a/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
@@ -279,7 +279,7 @@ class TestEloquentModelWithCustomCast extends Model
      */
     protected $casts = [
         'address' => AddressCaster::class,
-        'price' => DecimalCaster::class,
+        'price' => Decimal::class,
         'password' => HashCaster::class,
         'other_password' => HashCaster::class.':md5',
         'uppercase' => UppercaseCaster::class,
@@ -463,7 +463,7 @@ class Address
     }
 }
 
-final class Decimal
+final class Decimal implements Castable
 {
     private $value;
     private $scale;
@@ -484,6 +484,11 @@ final class Decimal
     public function __toString()
     {
         return substr_replace($this->value, '.', -$this->scale, 0);
+    }
+
+    public static function castUsing(array $arguments)
+    {
+        return new DecimalCaster();
     }
 }
 

--- a/tests/Integration/Database/EloquentModelCustomCastingTest.php
+++ b/tests/Integration/Database/EloquentModelCustomCastingTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentModelDateCastingTest;
+
+use ArrayObject;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Database\Eloquent\Casts\AsArrayObject;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
+
+/**
+ * @group integration
+ */
+class EloquentModelCustomCastingTest extends DatabaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('test_model1', function (Blueprint $table) {
+            $table->increments('id');
+            $table->uuid('uuid')->nullable();
+            $table->json('data')->nullable();
+        });
+
+        Model::castUsing(Uuid::class, new class() implements CastsAttributes {
+            public function get($model, string $key, $value, array $attributes)
+            {
+                return $value === null ? null : Uuid::fromString((string) $value);
+            }
+
+            public function set($model, string $key, $value, array $attributes)
+            {
+                return $value === null ? null : (string) $value;
+            }
+        });
+
+        Model::castUsing(ArrayObject::class, function ($arguments) {
+            return AsArrayObject::castUsing($arguments);
+        });
+    }
+
+    public function testCustomUuidCaster()
+    {
+        $uuid = Uuid::uuid4();
+        $model = TestCastModel::query()->create([
+            'uuid' => $uuid,
+        ]);
+
+        $this->assertInstanceOf(UuidInterface::class, $model->uuid);
+        $this->assertSame((string) $uuid, (string) $model->uuid);
+    }
+
+    public function testCustomArrayObjectCaster()
+    {
+        $model = TestCastModel::query()->create([
+            'data' => new ArrayObject(['a' => 'b']),
+        ]);
+
+        $this->assertInstanceOf(ArrayObject::class, $model->data);
+        $this->assertSame(['a' => 'b'], $model->data->getArrayCopy());
+    }
+}
+
+class TestCastModel extends Model
+{
+    public $table = 'test_model1';
+    public $timestamps = false;
+    protected $guarded = [];
+
+    public $casts = [
+        'uuid' => Uuid::class,
+        'data' => ArrayObject::class,
+    ];
+}

--- a/tests/Integration/Database/EloquentModelGlobalCustomCastingTest.php
+++ b/tests/Integration/Database/EloquentModelGlobalCustomCastingTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Integration\Database\EloquentModelDateCastingTest;
+namespace Illuminate\Tests\Integration\Database;
 
 use ArrayObject;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
@@ -8,14 +8,13 @@ use Illuminate\Database\Eloquent\Casts\AsArrayObject;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidInterface;
 
 /**
  * @group integration
  */
-class EloquentModelCustomCastingTest extends DatabaseTestCase
+class EloquentModelGlobalCustomCastingTest extends DatabaseTestCase
 {
     protected function setUp(): void
     {
@@ -27,7 +26,7 @@ class EloquentModelCustomCastingTest extends DatabaseTestCase
             $table->json('data')->nullable();
         });
 
-        Model::castUsing(Uuid::class, new class() implements CastsAttributes {
+        Model::castUsing('uuid', new class() implements CastsAttributes {
             public function get($model, string $key, $value, array $attributes)
             {
                 return $value === null ? null : Uuid::fromString((string) $value);
@@ -73,7 +72,7 @@ class TestCastModel extends Model
     protected $guarded = [];
 
     public $casts = [
-        'uuid' => Uuid::class,
+        'uuid' => 'uuid',
         'data' => ArrayObject::class,
     ];
 }


### PR DESCRIPTION
This PR adds feature for declaring type caster in global space.

```php
Model::castUsing(Uuid::class, new class() implements CastsAttributes {
    //...
});

class MyModel extends Model {
    public $casts = [
        'uuid' => Uuid::class,
    ];
}
```

In this case no need to make caster class or modify(extending) vendor classes like Uuid or Enums.

Also can add autobinding internal casting types
```php
Model::castUsing(ArrayObject::class, function ($arguments) {
    return AsArrayObject::castUsing($arguments);
});
```