### PR TITLE
[8.x] Use Application::storagePath() instead of global function in artisan cache:clear

### DIFF
--- a/src/Illuminate/Cache/Console/ClearCommand.php
+++ b/src/Illuminate/Cache/Console/ClearCommand.php
@@ -86,7 +86,7 @@ class ClearCommand extends Command
      */
     public function flushFacades()
     {
-        if (! $this->files->exists($storagePath = storage_path('framework/cache'))) {
+        if (! $this->files->exists($storagePath = $this->laravel->storagePath().'framework/cache')) {
             return;
         }
 


### PR DESCRIPTION
Since `illuminate/cache` is distributed as a separate package, it should probably not rely on the existence of global function `storage_path()`. Instead, it should rely on `Application::storagePath()` since that method is part of the `Application` contract.

This is consistent with the use of [`Application::databasePath()` in `CacheTableCommand`](https://github.com/laravel/framework/blob/8.x/src/Illuminate/Cache/Console/CacheTableCommand.php#L77)