### PR TITLE
[8.x] Fix flushDb (cache:clear) for redis clusters

### DIFF
--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -501,14 +501,8 @@ class PhpRedisConnection extends Connection implements ConnectionContract
             return $this->command('flushdb');
         }
 
-        foreach ($this->client->_masters() as [$host, $port]) {
-            $redis = tap(new Redis)->connect($host, $port);
-
-            if (isset($this->config['password']) && ! empty($this->config['password'])) {
-                $redis->auth($this->config['password']);
-            }
-
-            $redis->flushDb();
+        foreach ($this->client->_masters() as $master) {
+            $this->client->flushDb($master);
         }
     }
 


### PR DESCRIPTION
When running `php artisan cache:clear` with a redis cluster as the cache driver, the flushDb() function is currently unable to run on each master if you are using a password or TLS scheme - https://github.com/laravel/framework/issues/35180

For redis clusters an empty `$config` array is passed through to the constructor of `vendor\laravel\framework\src\Illuminate\Redis\Connections\PhpRedisConnection.php` causing authentication to fail.

However, even if you update `vendor\laravel\framework\src\Illuminate\Redis\Connectors\PhpRedisConnector.php` to pass through the cluster password it still fails because the current `$redis = tap(new Redis)->connect($host, $port);` does not connect to each master node using the correct TLS scheme or any stream context such as `local_cert`, `local_pk`, `cafile` or `verify_peer_name`.

This pull request fixes the issue by using `directed node commands` as described here - https://github.com/phpredis/phpredis/blob/develop/cluster.markdown#directed-node-commands

It uses the already authenticated `RedisCluster` connection with correct scheme and context to direct the `flushdb` command to each master node to succesfully clear the entire cache.