### PR TITLE
[8.x] The label for page number in pagination links should always be a string

### DIFF
--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -109,7 +109,7 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
             return collect($item)->map(function ($url, $page) {
                 return [
                     'url' => $url,
-                    'label' => $page,
+                    'label' => (string) $page,
                     'active' => $this->currentPage() === $page,
                 ];
             });


### PR DESCRIPTION
For the consistency, the label for page number in pagination links generated by `LengthAwarePaginator` class should always be a string instead of mix of string and number.