### PR TITLE
[8.x] Using withoutMiddleware() and a closure-based middleware on PHP8 throws an exception

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -712,7 +712,13 @@ class Router implements BindingRegistrar, RegistrarContract
         })->flatten()->reject(function ($name) use ($excluded) {
             if (empty($excluded)) {
                 return false;
-            } elseif (in_array($name, $excluded, true)) {
+            }
+
+            if ($name instanceof Closure) {
+                return false;
+            }
+
+            if (in_array($name, $excluded, true)) {
                 return true;
             }
 


### PR DESCRIPTION
PHP8 throws a `TypeError` when `class_exists()` is used on anything but a string.

```
Psy Shell v0.10.5 (PHP 7.4.13 — cli) by Justin Hileman
>>> class_exists(fn () => []);
<warning>PHP Warning:  class_exists() expects parameter 1 to be string, object given in Psy Shell code on line 1</warning>

Psy Shell v0.10.5 (PHP 8.0.1 — cli) by Justin Hileman
>>> class_exists(fn () => []);
TypeError: class_exists(): Argument #1 ($class) must be of type string, Closure given
```

This can be replicated by using a closure-based middleware in a controller and removing a class-based middleware from a route.

```php
// app/Http/Kernel.php
class Kernel extends HttpKernel
{
    protected $middleware = [
        \App\Http\Middleware\ContentSecurityPolicy::class,
    ];
}

// app/Http/Controllers/UsersController.php
class UserController extends Controller
{
    /**
     * Instantiate a new controller instance.
     *
     * @return void
     */
    public function __construct()
    {
        $this->middleware(function ($request, $next) {
            return $next($request);
        });
    }
}

// routes/web.php
Route::get('/users', [UsersController::class, 'list'])
    ->withoutMiddleware(ContentSecurityPolicy::class);
```