### PR TITLE
[8.x] Fire pivot detach events when using custom class

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -199,10 +199,7 @@ trait InteractsWithPivotTable
      */
     public function updateExistingPivot($id, array $attributes, $touch = true)
     {
-        if ($this->using &&
-            empty($this->pivotWheres) &&
-            empty($this->pivotWhereIns) &&
-            empty($this->pivotWhereNulls)) {
+        if ($this->using) {
             return $this->updateExistingPivotUsingCustomClass($id, $attributes, $touch);
         }
 

--- a/tests/Database/DatabaseEloquentMorphToManyTest.php
+++ b/tests/Database/DatabaseEloquentMorphToManyTest.php
@@ -48,6 +48,7 @@ class DatabaseEloquentMorphToManyTest extends TestCase
         $relation = $this->getMockBuilder(MorphToMany::class)->onlyMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $query = m::mock(stdClass::class);
         $query->shouldReceive('from')->once()->with('taggables')->andReturn($query);
+        $query->shouldReceive('where')->once()->with(m::type('Closure'));
         $query->shouldReceive('where')->once()->with('taggable_id', 1)->andReturn($query);
         $query->shouldReceive('where')->once()->with('taggable_type', get_class($relation->getParent()))->andReturn($query);
         $query->shouldReceive('whereIn')->once()->with('tag_id', [1, 2, 3]);
@@ -64,6 +65,7 @@ class DatabaseEloquentMorphToManyTest extends TestCase
         $relation = $this->getMockBuilder(MorphToMany::class)->onlyMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $query = m::mock(stdClass::class);
         $query->shouldReceive('from')->once()->with('taggables')->andReturn($query);
+        $query->shouldReceive('where')->once()->with(m::type('Closure'));
         $query->shouldReceive('where')->once()->with('taggable_id', 1)->andReturn($query);
         $query->shouldReceive('where')->once()->with('taggable_type', get_class($relation->getParent()))->andReturn($query);
         $query->shouldReceive('whereIn')->never();

--- a/tests/Integration/Database/EloquentPivotEventsTest.php
+++ b/tests/Integration/Database/EloquentPivotEventsTest.php
@@ -61,18 +61,18 @@ class EloquentPivotEventsTest extends DatabaseTestCase
         $this->assertEquals(['deleting', 'deleted'], PivotEventsTestCollaborator::$eventsCalled);
     }
 
-    public function testPivotWithPivotCriteriaTriggerEventsToBeFiredOnCreateUpdateNoneOnDetach()
+    public function testPivotWithPivotCriteriaTriggerEventsToBeFiredOnCreateUpdateAndOnDetach()
     {
         $user = PivotEventsTestUser::forceCreate(['email' => 'taylor@laravel.com']);
         $user2 = PivotEventsTestUser::forceCreate(['email' => 'ralph@ralphschindler.com']);
         $project = PivotEventsTestProject::forceCreate(['name' => 'Test Project']);
 
-        $project->contributors()->sync([$user->id, $user2->id]);
+        $project->contributors()->sync([$user->id => ['role' => 'contributor'], $user2->id => ['role' => 'contributor']]);
         $this->assertEquals(['saving', 'creating', 'created', 'saved', 'saving', 'creating', 'created', 'saved'], PivotEventsTestCollaborator::$eventsCalled);
 
         PivotEventsTestCollaborator::$eventsCalled = [];
         $project->contributors()->detach($user->id);
-        $this->assertEquals([], PivotEventsTestCollaborator::$eventsCalled);
+        $this->assertEquals(['deleting', 'deleted'], PivotEventsTestCollaborator::$eventsCalled);
     }
 
     public function testCustomPivotUpdateEventHasExistingAttributes()


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/36291

This adjusts the detach logic when using custom classes such that the deleting and deleted events are fired for the pivot models. This also adjusts new pivot queries to wrap their conditions in a logical group for a lesser chance of unexpected query results.

The events are fired by retrieving the pivot models and then maintaining the same logic where we rehydrate new empty models. I tried to keep the logic as close as possible to the original implementation.

The decision to not fire these events was done here: https://github.com/laravel/framework/pull/27997 - but I believe that was more of a "quick fix" to stop a breakage when pivot events were added. The original implementation did not carry over any additional where clauses when using a custom pivot class and thus caused the bug where all pivot records were deleted. However, this PR fixes that by carrying over the where clauses.

Also, in the meantime since the original PR, @themsaid fixed an issue with updating existing pivots (https://github.com/laravel/framework/pull/28416) ... this also carries over where clauses. So, I don't think we need to check for empty where clauses before using `updateExistingPivotUsingCustomClass`.