### PR TITLE
[8.x] Adds "setUpTestDatabase" support to Parallel Testing

### DIFF
--- a/src/Illuminate/Testing/Concerns/TestDatabases.php
+++ b/src/Illuminate/Testing/Concerns/TestDatabases.php
@@ -47,12 +47,16 @@ trait TestDatabases
 
             if (Arr::hasAny($uses, $databaseTraits)) {
                 $this->whenNotUsingInMemoryDatabase(function ($database) use ($uses) {
-                    $testDatabase = $this->ensureTestDatabaseExists($database);
+                    [$testDatabase, $created] = $this->ensureTestDatabaseExists($database);
 
                     $this->switchToDatabase($testDatabase);
 
                     if (isset($uses[Testing\DatabaseTransactions::class])) {
                         $this->ensureSchemaIsUpToDate();
+                    }
+
+                    if ($created) {
+                        ParallelTesting::callSetUpTestDatabaseCallbacks($testDatabase);
                     }
                 });
             }
@@ -64,22 +68,26 @@ trait TestDatabases
      *
      * @param  string  $database
      *
-     * @return string
+     * @return array
      */
     protected function ensureTestDatabaseExists($database)
     {
-        return tap($this->testDatabase($database), function ($testDatabase) use ($database) {
-            try {
-                $this->usingDatabase($testDatabase, function () {
-                    Schema::hasTable('dummy');
-                });
-            } catch (QueryException $e) {
-                $this->usingDatabase($database, function () use ($testDatabase) {
-                    Schema::dropDatabaseIfExists($testDatabase);
-                    Schema::createDatabase($testDatabase);
-                });
-            }
-        });
+        $testDatabase = $this->testDatabase($database);
+
+        try {
+            $this->usingDatabase($testDatabase, function () {
+                Schema::hasTable('dummy');
+            });
+        } catch (QueryException $e) {
+            $this->usingDatabase($database, function () use ($testDatabase) {
+                Schema::dropDatabaseIfExists($testDatabase);
+                Schema::createDatabase($testDatabase);
+            });
+
+            return [$testDatabase, true];
+        }
+
+        return [$testDatabase, false];
     }
 
     /**

--- a/src/Illuminate/Testing/ParallelTesting.php
+++ b/src/Illuminate/Testing/ParallelTesting.php
@@ -43,6 +43,13 @@ class ParallelTesting
     protected $setUpTestCaseCallbacks = [];
 
     /**
+     * All of the registered "setUp" test database callbacks.
+     *
+     * @var array
+     */
+    protected $setUpTestDatabaseCallbacks = [];
+
+    /**
      * All of the registered "tearDown" process callbacks.
      *
      * @var array
@@ -112,6 +119,17 @@ class ParallelTesting
     }
 
     /**
+     * Register a "setUp" test database callback.
+     *
+     * @param  callable  $callback
+     * @return void
+     */
+    public function setUpTestDatabase($callback)
+    {
+        $this->setUpTestDatabaseCallbacks[] = $callback;
+    }
+
+    /**
      * Register a "tearDown" process callback.
      *
      * @param  callable  $callback
@@ -161,6 +179,24 @@ class ParallelTesting
             foreach ($this->setUpTestCaseCallbacks as $callback) {
                 $this->container->call($callback, [
                     'testCase' => $testCase,
+                    'token' => $this->token(),
+                ]);
+            }
+        });
+    }
+
+    /**
+     * Call all of the "setUp" test database callbacks.
+     *
+     * @param  string  $database
+     * @return void
+     */
+    public function callSetUpTestDatabaseCallbacks($database)
+    {
+        $this->whenRunningInParallel(function () use ($database) {
+            foreach ($this->setUpTestDatabaseCallbacks as $callback) {
+                $this->container->call($callback, [
+                    'database' => $database,
                     'token' => $this->token(),
                 ]);
             }

--- a/tests/Testing/ParallelTestingTest.php
+++ b/tests/Testing/ParallelTestingTest.php
@@ -83,6 +83,7 @@ class ParallelTestingTest extends TestCase
         return [
             ['setUpProcess'],
             ['setUpTestCase'],
+            ['setUpTestDatabase'],
             ['tearDownTestCase'],
             ['tearDownProcess'],
         ];


### PR DESCRIPTION
This pull request adds `setUpTestDatabase` support to Parallel Testing. Since we have added Parallel Testing to Laravel, some people have reported that there is no easy way to seed test databases. With this pull request, people can `seed` their test databases like so:

```php
<?php

namespace App\Providers;

use Illuminate\Support\Facades\ParallelTesting;
use Illuminate\Support\ServiceProvider;

class AppServiceProvider extends ServiceProvider
{
    /**
     * Bootstrap any application services.
     *
     * @return void
     */
    public function boot()
    {
        ParallelTesting::setUpTestDatabase(function () {
            Artisan::call('db:seed');
        });
    }
}
```

Of course, this hook only gets executed when the test database is created. So, if people want to re-seed their test databases they will need to call `art test --parallel --recreate-databases`.

@introwit @daniloesser @johanvanhelden Please let me know what do you think.