### PR TITLE
[8.x] Add method to sanitizing word

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -796,7 +796,7 @@ class Str
     }
 
     /**
-     * Sanitizing word to be only letter and space for word
+     * Sanitizing word to be only letter and space for word.
      *
      * @param  string  $word
      * @return string

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -794,4 +794,20 @@ class Str
     {
         static::$uuidFactory = null;
     }
+
+    /**
+     * Sanitizing word to be only letter and space for word
+     *
+     * @param  string  $word
+     * @return string
+     */
+    public static function sanitize($word)
+    {
+        if(!is_string($word)){
+            return $word;
+        }
+
+        $only_letter = preg_replace("/[^A-Za-z ]/", '', $word);
+        return preg_replace('/\s+/', ' ',$only_letter);
+    }
 }

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -517,6 +517,15 @@ class SupportStrTest extends TestCase
         $this->assertEquals("<p><em>hello world</em></p>\n", Str::markdown('*hello world*'));
         $this->assertEquals("<h1>hello world</h1>\n", Str::markdown('# hello world'));
     }
+
+    public function testSanitize()
+    {
+        $this->assertEquals("Foo Bar", Str::sanitize('Foo 1 Bar 1'));
+        $this->assertEquals("Foo Bar", Str::sanitize('Foo (Bar)'));
+        $this->assertEquals("Foo Bar Buz", Str::sanitize('Foo (Bar) /Buz'));
+        $this->assertEquals("Foo Bar Buz", Str::sanitize('Foo (Bar) __Buz__'));
+        $this->assertEquals("Foo Bar Buz", Str::sanitize('Foo      Bar     Buz'));
+    }
 }
 
 class StringableObjectStub


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Sometimes we need function to sanitizing our word to make it more clearly. like for example if user input as they want but we just need the original word without numbers/symbols we need to sanitize it first before we keep the data.

the example of usage already added to Test