### PR TITLE
[8.x] Make use of specified ownerKey in MorphTo::associate() (attempt #2)

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -226,7 +226,7 @@ class MorphTo extends BelongsTo
     public function associate($model)
     {
         $this->parent->setAttribute(
-            $this->foreignKey, $model instanceof Model ? $model->getKey() : null
+            $this->foreignKey, $model instanceof Model ? $model->{$this->ownerKey ?: $model->getKeyName()} : null
         );
 
         $this->parent->setAttribute(

--- a/tests/Database/DatabaseEloquentMorphToTest.php
+++ b/tests/Database/DatabaseEloquentMorphToTest.php
@@ -132,7 +132,7 @@ class DatabaseEloquentMorphToTest extends TestCase
         $relation = $this->getRelationAssociate($parent);
 
         $associate = m::mock(Model::class);
-        $associate->shouldReceive('getKey')->once()->andReturn(1);
+        $associate->shouldReceive('getAttribute')->once()->andReturn(1);
         $associate->shouldReceive('getMorphClass')->once()->andReturn('Model');
 
         $parent->shouldReceive('setAttribute')->once()->with('foreign_key', 1);


### PR DESCRIPTION
Another attempt at creating a PR for https://github.com/laravel/framework/pull/36296, this time with the tests working.

I'm not that experienced with writing tests, so forgive me if my understanding here is incorrect; but I'm not 100% convinced the tests cover the change made. Should it not be split into two tests - one like what is contained in this PR, and another that _also_ checks for the execution of `getKeyName()`? I'm not sure how granular the tests should go.