### PR TITLE
Index the "deleted_at" columns by default

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1138,7 +1138,7 @@ class Blueprint
      */
     public function softDeletes($column = 'deleted_at', $precision = 0)
     {
-        return $this->timestamp($column, $precision)->nullable();
+        return $this->timestamp($column, $precision)->nullable()->index();
     }
 
     /**
@@ -1150,7 +1150,7 @@ class Blueprint
      */
     public function softDeletesTz($column = 'deleted_at', $precision = 0)
     {
-        return $this->timestampTz($column, $precision)->nullable();
+        return $this->timestampTz($column, $precision)->nullable()->index();
     }
 
     /**


### PR DESCRIPTION
The column deleted_at added via softDeletes (or softDeletesTz) is included in the WHERE clause (by default) and checks if the value is NULL or not.

This adds a lot of load on queries that do not have any explicit index applied on the deleted_at column, and is usually skipped by new (and even some seasoned) developers.

The column must be indexed, if it is going to be included by default in the query as one of the WHERE condition.

Even though it is a small change, it has the potential to improve performance of a lot of applications by a significant factor (without doing anything else).

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
