### PR TITLE
[8.x] Allow Macroable::mixin to accept FQCN's and arrays

### DIFF
--- a/src/Illuminate/Macroable/Traits/Macroable.php
+++ b/src/Illuminate/Macroable/Traits/Macroable.php
@@ -39,6 +39,14 @@ trait Macroable
      */
     public static function mixin($mixin, $replace = true)
     {
+        if (is_iterable($mixin)) {
+            foreach ($mixin as $macro) {
+                static::mixin($macro, $replace);
+            }
+
+            return;
+        }
+
         $methods = (new ReflectionClass($mixin))->getMethods(
             ReflectionMethod::IS_PUBLIC | ReflectionMethod::IS_PROTECTED
         );

--- a/src/Illuminate/Macroable/Traits/Macroable.php
+++ b/src/Illuminate/Macroable/Traits/Macroable.php
@@ -31,7 +31,7 @@ trait Macroable
     /**
      * Mix another object into the class.
      *
-     * @param  mixed  $mixin
+     * @param  object|iterable  $mixin
      * @param  bool  $replace
      * @return void
      *

--- a/src/Illuminate/Macroable/Traits/Macroable.php
+++ b/src/Illuminate/Macroable/Traits/Macroable.php
@@ -31,7 +31,7 @@ trait Macroable
     /**
      * Mix another object into the class.
      *
-     * @param  object  $mixin
+     * @param  mixed  $mixin
      * @param  bool  $replace
      * @return void
      *
@@ -42,6 +42,8 @@ trait Macroable
         $methods = (new ReflectionClass($mixin))->getMethods(
             ReflectionMethod::IS_PUBLIC | ReflectionMethod::IS_PROTECTED
         );
+
+        $mixin = (new ReflectionClass($mixin))->newInstance();
 
         foreach ($methods as $method) {
             if ($replace || ! static::hasMacro($method->name)) {

--- a/tests/Support/SupportMacroableTest.php
+++ b/tests/Support/SupportMacroableTest.php
@@ -61,6 +61,13 @@ class SupportMacroableTest extends TestCase
         $this->assertSame('instance-Adam', $instance->methodOne('Adam'));
     }
 
+    public function testQualifiedNameBasedMacros()
+    {
+        TestMacroable::mixin(TestMixin::class);
+        $instance = new TestMacroable;
+        $this->assertSame('instance-Adam', $instance->methodOne('Adam'));
+    }
+
     public function testClassBasedMacrosNoReplace()
     {
         TestMacroable::macro('methodThree', function () {
@@ -71,6 +78,19 @@ class SupportMacroableTest extends TestCase
         $this->assertSame('bar', $instance->methodThree());
 
         TestMacroable::mixin(new TestMixin);
+        $this->assertSame('foo', $instance->methodThree());
+    }
+
+    public function testQualifiedNameBasedMacrosNoReplace()
+    {
+        TestMacroable::macro('methodThree', function () {
+            return 'bar';
+        });
+        TestMacroable::mixin(TestMixin::class, false);
+        $instance = new TestMacroable;
+        $this->assertSame('bar', $instance->methodThree());
+
+        TestMacroable::mixin(TestMixin::class);
         $this->assertSame('foo', $instance->methodThree());
     }
 }

--- a/tests/Support/SupportMacroableTest.php
+++ b/tests/Support/SupportMacroableTest.php
@@ -157,7 +157,6 @@ class TestMixin
     }
 }
 
-
 class TestMixinTwo
 {
     public function methodFour()

--- a/tests/Support/SupportMacroableTest.php
+++ b/tests/Support/SupportMacroableTest.php
@@ -68,6 +68,14 @@ class SupportMacroableTest extends TestCase
         $this->assertSame('instance-Adam', $instance->methodOne('Adam'));
     }
 
+    public function testArrayBasedMacros()
+    {
+        TestMacroable::mixin([new TestMixin, TestMixinTwo::class]);
+        $instance = new TestMacroable;
+        $this->assertSame('instance-Adam', $instance->methodOne('Adam'));
+        $this->assertSame('bar', $instance->methodFour());
+    }
+
     public function testClassBasedMacrosNoReplace()
     {
         TestMacroable::macro('methodThree', function () {
@@ -91,6 +99,19 @@ class SupportMacroableTest extends TestCase
         $this->assertSame('bar', $instance->methodThree());
 
         TestMacroable::mixin(TestMixin::class);
+        $this->assertSame('foo', $instance->methodThree());
+    }
+
+    public function testArrayBasedMacrosNoReplace()
+    {
+        TestMacroable::macro('methodThree', function () {
+            return 'bar';
+        });
+        TestMacroable::mixin([new TestMixin], false);
+        $instance = new TestMacroable;
+        $this->assertSame('bar', $instance->methodThree());
+
+        TestMacroable::mixin([new TestMixin]);
         $this->assertSame('foo', $instance->methodThree());
     }
 }
@@ -132,6 +153,17 @@ class TestMixin
     {
         return function () {
             return 'foo';
+        };
+    }
+}
+
+
+class TestMixinTwo
+{
+    public function methodFour()
+    {
+        return function () {
+            return 'bar';
         };
     }
 }


### PR DESCRIPTION
This PR adds support for `Macroable::mixin` to use FQCN's, arrays, or even `Collections` to load mixins. I've been experimenting with `mixin` and thought FQCN's would be supported already but I guess it wasn't. Taking the query builder as an example we could with this PR now do the following.

```php
use Illuminate\Database\Query\Builder;

Builder::mixin(\App\Macros\QueryBuilderMacros::class);
```

Or if you want to load multiple mixins into one `Macroable` class that's now also supported.

```php
use Illuminate\Database\Query\Builder;

Builder::mixin([
    \App\Macros\QueryBuilderMacros::class
]);
```

Any feedback on this would be much appreciated. 🙂