### PR TITLE
[9.x] Change EncryptCookies serialized method behaviour

### DIFF
--- a/src/Illuminate/Cookie/Middleware/EncryptCookies.php
+++ b/src/Illuminate/Cookie/Middleware/EncryptCookies.php
@@ -27,11 +27,11 @@ class EncryptCookies
     protected $except = [];
 
     /**
-     * Indicates if cookies should be serialized.
+     * The names of the cookies that should be serialized.
      *
-     * @var bool
+     * @var array
      */
-    protected static $serialize = false;
+    protected static $serialize = [];
 
     /**
      * Create a new CookieGuard instance.
@@ -221,6 +221,6 @@ class EncryptCookies
      */
     public static function serialized($name)
     {
-        return static::$serialize;
+        return in_array($name, static::$serialize);
     }
 }


### PR DESCRIPTION
Currently, the serialize method returns a bool value no matter what is in the `$name` parameter. I changed it to work as `in_array` check just like the `isDisabled` method for the encryption.
Now you can add the cookie's names to the `$serialize` static property which you want to serialize.
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
