### PR TITLE
[8.x] Respect ShouldQueue on mailables within notifications

### DIFF
--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -56,6 +56,10 @@ class MailChannel
         }
 
         if ($message instanceof Mailable) {
+            if ($message instanceof ShouldQueue) {
+                return $this->mailer->mailer($message->mailer ?? null)->queue($message);
+            }
+
             return $message->send($this->mailer);
         }
 


### PR DESCRIPTION
Mailables that implement `ShouldQueue` within notifications will not actually be queued unless the notification itself implements `ShouldQueue`. While possible, it may not always be desired. Consider this example: I want my notification to instantly write to the database, but delay (queue) the mail.

I'm unsure if this is a bugfix or a new feature, but I think it's a welcome change anyway. Please let me know otherwise.

Related to #27613