### PR TITLE
[8.x] Is dirty giving false negative when null value changed to false

### DIFF
--- a/tests/Integration/Database/EloquentModelJsonCastingTest.php
+++ b/tests/Integration/Database/EloquentModelJsonCastingTest.php
@@ -74,6 +74,23 @@ class EloquentModelJsonCastingTest extends DatabaseTestCase
         $this->assertInstanceOf(Collection::class, $user->collection_as_json_field);
         $this->assertSame('value1', $user->collection_as_json_field->get('key1'));
     }
+
+    public function testObjectsChangedIsDirty()
+    {
+        $object = new stdClass();
+        $object->key1 = null;
+
+        /** @var \Illuminate\Tests\Integration\Database\EloquentModelJsonCastingTest\JsonCast $user */
+        $user = JsonCast::create([
+            'object_as_json_field' => $object,
+        ]);
+
+        $changedObject = new stdClass();
+        $changedObject->key1 = false;
+        $user->object_as_json_field = $changedObject;
+
+        $this->assertTrue($user->isDirty());
+    }
 }
 
 /**


### PR DESCRIPTION
I stumbled into this today and created a test to make sure I was not going crazy... 

So basically it looks like Laravel does a loose comparison when checking if objects are equal each other, meaning if you change a json object from having a null value to a false value, it will not save it, because `isDirty` is not detecting any changes.


If anyone else have this issue, then the new `AsArrayObject` cast seems to fix it as it uses strict comparison. 