### PR TITLE
[8.x] Added the whereInstanceOfAny() method for collections

### DIFF
--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -423,6 +423,15 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function whereInstanceOf($type);
 
     /**
+     * Filter the items, removing any items that don't match any of the
+     * given types.
+     *
+     * @param  string[]  $types
+     * @return static
+     */
+    public function whereInstanceOfAny(array $types);
+
+    /**
      * Get the first item from the enumerable passing the given truth test.
      *
      * @param  callable|null  $callback

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -415,21 +415,12 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function whereNotInStrict($key, $values);
 
     /**
-     * Filter the items, removing any items that don't match the given type.
+     * Filter the items, removing any items that don't match the given type(s).
      *
-     * @param  string  $type
+     * @param  string|string[]  $type
      * @return static
      */
     public function whereInstanceOf($type);
-
-    /**
-     * Filter the items, removing any items that don't match any of the
-     * given types.
-     *
-     * @param  string[]  $types
-     * @return static
-     */
-    public function whereInstanceOfAny(array $types);
 
     /**
      * Get the first item from the enumerable passing the given truth test.

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -669,35 +669,25 @@ trait EnumeratesValues
     }
 
     /**
-     * Filter the items, removing any items that don't match the given type.
+     * Filter the items, removing any items that don't match the given type(s).
      *
-     * @param  string  $type
+     * @param  string|string[]  $type
      * @return static
      */
     public function whereInstanceOf($type)
     {
         return $this->filter(function ($value) use ($type) {
-            return $value instanceof $type;
-        });
-    }
-
-    /**
-     * Filter the items, removing any items that don't match any of the
-     * given types.
-     *
-     * @param  string[]  $types
-     * @return static
-     */
-    public function whereInstanceOfAny(array $types)
-    {
-        return $this->filter(function ($value) use ($types) {
-            foreach ($types as $type) {
-                if ($value instanceof $type) {
-                    return true;
+            if (is_array($type)) {
+                foreach ($type as $classType) {
+                    if ($value instanceof $classType) {
+                        return true;
+                    }
                 }
+
+                return false;
             }
 
-            return false;
+            return $value instanceof $type;
         });
     }
 

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -682,6 +682,26 @@ trait EnumeratesValues
     }
 
     /**
+     * Filter the items, removing any items that don't match any of the
+     * given types.
+     *
+     * @param  string[]  $types
+     * @return static
+     */
+    public function whereInstanceOfAny(array $types)
+    {
+        return $this->filter(function ($value) use ($types) {
+            foreach ($types as $type) {
+                if ($value instanceof $type) {
+                    return true;
+                }
+            }
+
+            return false;
+        });
+    }
+
+    /**
      * Pass the collection to the given callback and return the result.
      *
      * @param  callable  $callback

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -766,8 +766,10 @@ class SupportCollectionTest extends TestCase
      */
     public function testWhereInstanceOf($collection)
     {
-        $c = new $collection([new stdClass, new stdClass, new $collection, new stdClass]);
+        $c = new $collection([new stdClass, new stdClass, new $collection, new stdClass, new Str]);
         $this->assertCount(3, $c->whereInstanceOf(stdClass::class));
+
+        $this->assertCount(4, $c->whereInstanceOf([stdClass::class, Str::class]));
     }
 
     /**


### PR DESCRIPTION
Hi guys!

This PR hopefully adds a new ` whereInstanceOfAny() ` method that we can on ` Collection `s. It works pretty much the same as the existing ` whereInstanceOf() ` method but can be used for checking multiple classes at once instead. I was thinking of maybe adding the code into the existing method so that it could accept a string or an array, but I couldn't decide which approach would be better (I'm happy to move it if needed).

I couldn't find any existing tests for anything like this, but I'm happy to write some for this functionality if you'd like.

Here's a really basic example of how it could be used.

```php
$posts = Post::all();
$images = Image::all();
$videos = Video::all();

$merged = collect()->merge($posts)->merge($images)->merge($videos);

$filtered = $merged->whereInstanceOfAny([Image::class, VideoClass]);

// $filtered will now only contain Image and Video classes. All of the Post classes will have been removed.
```