### PR TITLE
[8.x] Add finalCallback to Gate

### DIFF
--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -323,6 +323,23 @@ class AuthAccessGateTest extends TestCase
         $this->assertTrue($gate->denies('deny'));
     }
 
+    public function testFinallyIsExecutedLastly()
+    {
+        $gate = new Gate(new Container, function () {
+            //
+        });
+
+        $gate->after(function (?stdClass $user) {
+            //
+        });
+
+        $gate->finally(function (?stdClass $user) {
+            return true;
+        });
+
+        $this->assertTrue($gate->check('anything'));
+    }
+
     public function testCurrentUserThatIsOnGateAlwaysInjectedIntoClosureCallbacks()
     {
         $gate = $this->getBasicGate();


### PR DESCRIPTION
This callback will execute after all other checks have been made, including the ones defined by `afterCallbacks`. I specifically kept this as a single callback and not as an array one for a specific use case. This will be an internal feature that shouldn't be used in user land so I marked it as such. I didn't add the method to the contract because that would be a breaking change on 8.x and also because this isn't of interest to anyone outside Laravel.