### PR TITLE
[8.x] Adds a `collect` method to the HTTP Client response

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -83,9 +83,9 @@ class Response implements ArrayAccess
      *
      * @return Collection
      */
-    public function collect()
+    public function collect($key = null)
     {
-        return Collection::make($this->json());
+        return Collection::make($this->json($key));
     }
 
     /**

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -79,9 +79,9 @@ class Response implements ArrayAccess
     }
 
     /**
-     * Get the JSON decoded body of the response as a Collection.
+     * Get the JSON decoded body of the response as a collection.
      *
-     * @return Collection
+     * @return \Illuminate\Support\Collection
      */
     public function collect($key = null)
     {

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -81,6 +81,7 @@ class Response implements ArrayAccess
     /**
      * Get the JSON decoded body of the response as a collection.
      *
+     * @param  string|null  $key
      * @return \Illuminate\Support\Collection
      */
     public function collect($key = null)

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Http\Client;
 
 use ArrayAccess;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Traits\Macroable;
 use LogicException;
 
@@ -75,6 +76,16 @@ class Response implements ArrayAccess
     public function object()
     {
         return json_decode($this->body(), false);
+    }
+
+    /**
+     * Get the JSON decoded body of the response as a Collection.
+     *
+     * @return Collection
+     */
+    public function collect()
+    {
+        return Collection::make($this->json());
     }
 
     /**

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -65,6 +65,9 @@ class HttpClientTest extends TestCase
 
         $this->assertInstanceOf(Collection::class, $response->collect());
         $this->assertEquals(collect(['result' => ['foo' => 'bar']]), $response->collect());
+        $this->assertEquals(collect(['foo' => 'bar']), $response->collect('result'));
+        $this->assertEquals(collect(['bar']), $response->collect('result.foo'));
+        $this->assertEquals(collect(), $response->collect('missing_key'));
     }
 
     public function testUrlsCanBeStubbedByPath()

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -19,6 +19,13 @@ class HttpClientTest extends TestCase
      */
     protected $factory;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->factory = new Factory;
+    }
+
     public function testStubbedResponsesAreReturnedAfterFaking()
     {
         $this->factory->fake();
@@ -30,16 +37,14 @@ class HttpClientTest extends TestCase
 
     public function testResponseBodyCasting()
     {
-        $this->factory->fake(
-            [
-                '*' => ['result' => ['foo' => 'bar']],
-            ]
-        );
+        $this->factory->fake([
+            '*' => ['result' => ['foo' => 'bar']],
+        ]);
 
         $response = $this->factory->get('http://foo.com/api');
 
         $this->assertSame('{"result":{"foo":"bar"}}', $response->body());
-        $this->assertSame('{"result":{"foo":"bar"}}', (string)$response);
+        $this->assertSame('{"result":{"foo":"bar"}}', (string) $response);
         $this->assertIsArray($response->json());
         $this->assertSame(['foo' => 'bar'], $response->json()['result']);
         $this->assertSame(['foo' => 'bar'], $response->json('result'));
@@ -52,11 +57,9 @@ class HttpClientTest extends TestCase
 
     public function testResponseCanBeReturnedAsCollection()
     {
-        $this->factory->fake(
-            [
-                '*' => ['result' => ['foo' => 'bar']],
-            ]
-        );
+        $this->factory->fake([
+            '*' => ['result' => ['foo' => 'bar']],
+        ]);
 
         $response = $this->factory->get('http://foo.com/api');
 
@@ -66,13 +69,11 @@ class HttpClientTest extends TestCase
 
     public function testUrlsCanBeStubbedByPath()
     {
-        $this->factory->fake(
-            [
-                'foo.com/*' => ['page' => 'foo'],
-                'bar.com/*' => ['page' => 'bar'],
-                '*' => ['page' => 'fallback'],
-            ]
-        );
+        $this->factory->fake([
+            'foo.com/*' => ['page' => 'foo'],
+            'bar.com/*' => ['page' => 'bar'],
+            '*' => ['page' => 'fallback'],
+        ]);
 
         $fooResponse = $this->factory->post('http://foo.com/test');
         $barResponse = $this->factory->post('http://bar.com/test');
@@ -82,79 +83,60 @@ class HttpClientTest extends TestCase
         $this->assertSame('bar', $barResponse['page']);
         $this->assertSame('fallback', $fallbackResponse['page']);
 
-        $this->factory->assertSent(
-            function (Request $request) {
-                return $request->url() === 'http://foo.com/test' &&
-                    $request->hasHeader('Content-Type', 'application/json');
-            }
-        );
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/test' &&
+                   $request->hasHeader('Content-Type', 'application/json');
+        });
     }
 
     public function testCanSendJsonData()
     {
         $this->factory->fake();
 
-        $this->factory->withHeaders(
-            [
-                'X-Test-Header' => 'foo',
-                'X-Test-ArrayHeader' => ['bar', 'baz'],
-            ]
-        )->post(
-            'http://foo.com/json',
-            [
-                'name' => 'Taylor',
-            ]
-        );
+        $this->factory->withHeaders([
+            'X-Test-Header' => 'foo',
+            'X-Test-ArrayHeader' => ['bar', 'baz'],
+        ])->post('http://foo.com/json', [
+            'name' => 'Taylor',
+        ]);
 
-        $this->factory->assertSent(
-            function (Request $request) {
-                return $request->url() === 'http://foo.com/json' &&
-                    $request->hasHeader('Content-Type', 'application/json') &&
-                    $request->hasHeader('X-Test-Header', 'foo') &&
-                    $request->hasHeader('X-Test-ArrayHeader', ['bar', 'baz']) &&
-                    $request['name'] === 'Taylor';
-            }
-        );
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/json' &&
+                   $request->hasHeader('Content-Type', 'application/json') &&
+                   $request->hasHeader('X-Test-Header', 'foo') &&
+                   $request->hasHeader('X-Test-ArrayHeader', ['bar', 'baz']) &&
+                   $request['name'] === 'Taylor';
+        });
     }
 
     public function testCanSendFormData()
     {
         $this->factory->fake();
 
-        $this->factory->asForm()->post(
-            'http://foo.com/form',
-            [
-                'name' => 'Taylor',
-                'title' => 'Laravel Developer',
-            ]
-        );
+        $this->factory->asForm()->post('http://foo.com/form', [
+            'name' => 'Taylor',
+            'title' => 'Laravel Developer',
+        ]);
 
-        $this->factory->assertSent(
-            function (Request $request) {
-                return $request->url() === 'http://foo.com/form' &&
-                    $request->hasHeader('Content-Type', 'application/x-www-form-urlencoded') &&
-                    $request['name'] === 'Taylor';
-            }
-        );
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/form' &&
+                   $request->hasHeader('Content-Type', 'application/x-www-form-urlencoded') &&
+                   $request['name'] === 'Taylor';
+        });
     }
 
     public function testSpecificRequestIsNotBeingSent()
     {
         $this->factory->fake();
 
-        $this->factory->post(
-            'http://foo.com/form',
-            [
-                'name' => 'Taylor',
-            ]
-        );
+        $this->factory->post('http://foo.com/form', [
+            'name' => 'Taylor',
+        ]);
 
-        $this->factory->assertNotSent(
-            function (Request $request) {
-                return $request->url() === 'http://foo.com/form' &&
-                    $request['name'] === 'Peter';
-            }
-        );
+        $this->factory->assertNotSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/form' &&
+                $request['name'] === 'Peter';
+        });
     }
 
     public function testNoRequestIsNotBeingSent()
@@ -169,21 +151,15 @@ class HttpClientTest extends TestCase
         $this->factory->fake();
         $this->factory->assertSentCount(0);
 
-        $this->factory->post(
-            'http://foo.com/form',
-            [
-                'name' => 'Taylor',
-            ]
-        );
+        $this->factory->post('http://foo.com/form', [
+            'name' => 'Taylor',
+        ]);
 
         $this->factory->assertSentCount(1);
 
-        $this->factory->post(
-            'http://foo.com/form',
-            [
-                'name' => 'Jim',
-            ]
-        );
+        $this->factory->post('http://foo.com/form', [
+            'name' => 'Jim',
+        ]);
 
         $this->factory->assertSentCount(2);
     }
@@ -192,24 +168,19 @@ class HttpClientTest extends TestCase
     {
         $this->factory->fake();
 
-        $this->factory->asMultipart()->post(
-            'http://foo.com/multipart',
+        $this->factory->asMultipart()->post('http://foo.com/multipart', [
             [
-                [
-                    'name' => 'foo',
-                    'contents' => 'data',
-                    'headers' => ['X-Test-Header' => 'foo'],
-                ],
-            ]
-        );
+                'name' => 'foo',
+                'contents' => 'data',
+                'headers' => ['X-Test-Header' => 'foo'],
+            ],
+        ]);
 
-        $this->factory->assertSent(
-            function (Request $request) {
-                return $request->url() === 'http://foo.com/multipart' &&
-                    Str::startsWith($request->header('Content-Type')[0], 'multipart') &&
-                    $request[0]['name'] === 'foo';
-            }
-        );
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/multipart' &&
+                   Str::startsWith($request->header('Content-Type')[0], 'multipart') &&
+                   $request[0]['name'] === 'foo';
+        });
     }
 
     public function testFilesCanBeAttached()
@@ -217,66 +188,54 @@ class HttpClientTest extends TestCase
         $this->factory->fake();
 
         $this->factory->attach('foo', 'data', 'file.txt', ['X-Test-Header' => 'foo'])
-            ->post('http://foo.com/file');
+                ->post('http://foo.com/file');
 
-        $this->factory->assertSent(
-            function (Request $request) {
-                return $request->url() === 'http://foo.com/file' &&
-                    Str::startsWith($request->header('Content-Type')[0], 'multipart') &&
-                    $request[0]['name'] === 'foo' &&
-                    $request->hasFile('foo', 'data', 'file.txt');
-            }
-        );
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/file' &&
+                   Str::startsWith($request->header('Content-Type')[0], 'multipart') &&
+                   $request[0]['name'] === 'foo' &&
+                   $request->hasFile('foo', 'data', 'file.txt');
+        });
     }
 
     public function testCanSendMultipartDataWithSimplifiedParameters()
     {
         $this->factory->fake();
 
-        $this->factory->asMultipart()->post(
-            'http://foo.com/multipart',
-            [
-                'foo' => 'bar',
-            ]
-        );
+        $this->factory->asMultipart()->post('http://foo.com/multipart', [
+            'foo' => 'bar',
+        ]);
 
-        $this->factory->assertSent(
-            function (Request $request) {
-                return $request->url() === 'http://foo.com/multipart' &&
-                    Str::startsWith($request->header('Content-Type')[0], 'multipart') &&
-                    $request[0]['name'] === 'foo' &&
-                    $request[0]['contents'] === 'bar';
-            }
-        );
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/multipart' &&
+                Str::startsWith($request->header('Content-Type')[0], 'multipart') &&
+                $request[0]['name'] === 'foo' &&
+                $request[0]['contents'] === 'bar';
+        });
     }
 
     public function testCanSendMultipartDataWithBothSimplifiedAndExtendedParameters()
     {
         $this->factory->fake();
 
-        $this->factory->asMultipart()->post(
-            'http://foo.com/multipart',
+        $this->factory->asMultipart()->post('http://foo.com/multipart', [
+            'foo' => 'bar',
             [
-                'foo' => 'bar',
-                [
-                    'name' => 'foobar',
-                    'contents' => 'data',
-                    'headers' => ['X-Test-Header' => 'foo'],
-                ],
-            ]
-        );
+                'name' => 'foobar',
+                'contents' => 'data',
+                'headers' => ['X-Test-Header' => 'foo'],
+            ],
+        ]);
 
-        $this->factory->assertSent(
-            function (Request $request) {
-                return $request->url() === 'http://foo.com/multipart' &&
-                    Str::startsWith($request->header('Content-Type')[0], 'multipart') &&
-                    $request[0]['name'] === 'foo' &&
-                    $request[0]['contents'] === 'bar' &&
-                    $request[1]['name'] === 'foobar' &&
-                    $request[1]['contents'] === 'data' &&
-                    $request[1]['headers']['X-Test-Header'] === 'foo';
-            }
-        );
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/multipart' &&
+                Str::startsWith($request->header('Content-Type')[0], 'multipart') &&
+                $request[0]['name'] === 'foo' &&
+                $request[0]['contents'] === 'bar' &&
+                $request[1]['name'] === 'foobar' &&
+                $request[1]['contents'] === 'data' &&
+                $request[1]['headers']['X-Test-Header'] === 'foo';
+        });
     }
 
     public function testItCanSendToken()
@@ -285,12 +244,10 @@ class HttpClientTest extends TestCase
 
         $this->factory->withToken('token')->post('http://foo.com/json');
 
-        $this->factory->assertSent(
-            function (Request $request) {
-                return $request->url() === 'http://foo.com/json' &&
-                    $request->hasHeader('Authorization', 'Bearer token');
-            }
-        );
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/json' &&
+                $request->hasHeader('Authorization', 'Bearer token');
+        });
     }
 
     public function testItCanSendUserAgent()
@@ -299,25 +256,21 @@ class HttpClientTest extends TestCase
 
         $this->factory->withUserAgent('Laravel')->post('http://foo.com/json');
 
-        $this->factory->assertSent(
-            function (Request $request) {
-                return $request->url() === 'http://foo.com/json' &&
-                    $request->hasHeader('User-Agent', 'Laravel');
-            }
-        );
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/json' &&
+                $request->hasHeader('User-Agent', 'Laravel');
+        });
     }
 
     public function testSequenceBuilder()
     {
-        $this->factory->fake(
-            [
-                '*' => $this->factory->sequence()
-                    ->push('Ok', 201)
-                    ->push(['fact' => 'Cats are great!'])
-                    ->pushFile(__DIR__ . '/fixtures/test.txt')
-                    ->pushStatus(403),
-            ]
-        );
+        $this->factory->fake([
+            '*' => $this->factory->sequence()
+                ->push('Ok', 201)
+                ->push(['fact' => 'Cats are great!'])
+                ->pushFile(__DIR__.'/fixtures/test.txt')
+                ->pushStatus(403),
+        ]);
 
         $response = $this->factory->get('https://example.com');
         $this->assertSame('Ok', $response->body());
@@ -328,10 +281,7 @@ class HttpClientTest extends TestCase
         $this->assertSame(200, $response->status());
 
         $response = $this->factory->get('https://example.com');
-        $this->assertSame(
-            "This is a story about something that happened long ago when your grandfather was a child.\n",
-            $response->body()
-        );
+        $this->assertSame("This is a story about something that happened long ago when your grandfather was a child.\n", $response->body());
         $this->assertSame(200, $response->status());
 
         $response = $this->factory->get('https://example.com');
@@ -346,13 +296,11 @@ class HttpClientTest extends TestCase
 
     public function testSequenceBuilderCanKeepGoingWhenEmpty()
     {
-        $this->factory->fake(
-            [
-                '*' => $this->factory->sequence()
-                    ->dontFailWhenEmpty()
-                    ->push('Ok'),
-            ]
-        );
+        $this->factory->fake([
+            '*' => $this->factory->sequence()
+                ->dontFailWhenEmpty()
+                ->push('Ok'),
+        ]);
 
         $response = $this->factory->get('https://laravel.com');
         $this->assertSame('Ok', $response->body());
@@ -363,13 +311,11 @@ class HttpClientTest extends TestCase
 
     public function testAssertSequencesAreEmpty()
     {
-        $this->factory->fake(
-            [
-                '*' => $this->factory->sequence()
-                    ->push('1')
-                    ->push('2'),
-            ]
-        );
+        $this->factory->fake([
+            '*' => $this->factory->sequence()
+                ->push('1')
+                ->push('2'),
+        ]);
 
         $this->factory->get('https://example.com');
         $this->factory->get('https://example.com');
@@ -392,8 +338,7 @@ class HttpClientTest extends TestCase
         $this->factory->fakeSequence()->pushStatus(200);
 
         $response = $this->factory->withCookies(
-            ['foo' => 'bar'],
-            'https://laravel.com'
+            ['foo' => 'bar'], 'https://laravel.com'
         )->get('https://laravel.com');
 
         $this->assertCount(1, $response->cookies()->toArray());
@@ -412,12 +357,10 @@ class HttpClientTest extends TestCase
 
         $this->factory->get('http://foo.com/get', ['foo' => 'bar']);
 
-        $this->factory->assertSent(
-            function (Request $request) {
-                return $request->url() === 'http://foo.com/get?foo=bar'
-                    && $request['foo'] === 'bar';
-            }
-        );
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/get?foo=bar'
+                && $request['foo'] === 'bar';
+        });
     }
 
     public function testGetWithStringQueryParam()
@@ -426,12 +369,10 @@ class HttpClientTest extends TestCase
 
         $this->factory->get('http://foo.com/get', 'foo=bar');
 
-        $this->factory->assertSent(
-            function (Request $request) {
-                return $request->url() === 'http://foo.com/get?foo=bar'
-                    && $request['foo'] === 'bar';
-            }
-        );
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/get?foo=bar'
+                && $request['foo'] === 'bar';
+        });
     }
 
     public function testGetWithQuery()
@@ -440,13 +381,11 @@ class HttpClientTest extends TestCase
 
         $this->factory->get('http://foo.com/get?foo=bar&page=1');
 
-        $this->factory->assertSent(
-            function (Request $request) {
-                return $request->url() === 'http://foo.com/get?foo=bar&page=1'
-                    && $request['foo'] === 'bar'
-                    && $request['page'] === '1';
-            }
-        );
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/get?foo=bar&page=1'
+                && $request['foo'] === 'bar'
+                && $request['page'] === '1';
+        });
     }
 
     public function testGetWithQueryWontEncode()
@@ -455,14 +394,12 @@ class HttpClientTest extends TestCase
 
         $this->factory->get('http://foo.com/get?foo;bar;1;5;10&page=1');
 
-        $this->factory->assertSent(
-            function (Request $request) {
-                return $request->url() === 'http://foo.com/get?foo;bar;1;5;10&page=1'
-                    && !isset($request['foo'])
-                    && !isset($request['bar'])
-                    && $request['page'] === '1';
-            }
-        );
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/get?foo;bar;1;5;10&page=1'
+                && ! isset($request['foo'])
+                && ! isset($request['bar'])
+                && $request['page'] === '1';
+        });
     }
 
     public function testGetWithArrayQueryParamOverwrites()
@@ -471,12 +408,10 @@ class HttpClientTest extends TestCase
 
         $this->factory->get('http://foo.com/get?foo=bar&page=1', ['hello' => 'world']);
 
-        $this->factory->assertSent(
-            function (Request $request) {
-                return $request->url() === 'http://foo.com/get?hello=world'
-                    && $request['hello'] === 'world';
-            }
-        );
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/get?hello=world'
+                && $request['hello'] === 'world';
+        });
     }
 
     public function testGetWithArrayQueryParamEncodes()
@@ -485,55 +420,43 @@ class HttpClientTest extends TestCase
 
         $this->factory->get('http://foo.com/get', ['foo;bar; space test' => 'laravel']);
 
-        $this->factory->assertSent(
-            function (Request $request) {
-                return $request->url() === 'http://foo.com/get?foo%3Bbar%3B%20space%20test=laravel'
-                    && $request['foo;bar; space test'] === 'laravel';
-            }
-        );
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/get?foo%3Bbar%3B%20space%20test=laravel'
+                && $request['foo;bar; space test'] === 'laravel';
+        });
     }
 
     public function testCanConfirmManyHeaders()
     {
         $this->factory->fake();
 
-        $this->factory->withHeaders(
-            [
-                'X-Test-Header' => 'foo',
-                'X-Test-ArrayHeader' => ['bar', 'baz'],
-            ]
-        )->post('http://foo.com/json');
+        $this->factory->withHeaders([
+            'X-Test-Header' => 'foo',
+            'X-Test-ArrayHeader' => ['bar', 'baz'],
+        ])->post('http://foo.com/json');
 
-        $this->factory->assertSent(
-            function (Request $request) {
-                return $request->url() === 'http://foo.com/json' &&
-                    $request->hasHeaders(
-                        [
-                            'X-Test-Header' => 'foo',
-                            'X-Test-ArrayHeader' => ['bar', 'baz'],
-                        ]
-                    );
-            }
-        );
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/json' &&
+                   $request->hasHeaders([
+                       'X-Test-Header' => 'foo',
+                       'X-Test-ArrayHeader' => ['bar', 'baz'],
+                   ]);
+        });
     }
 
     public function testCanConfirmManyHeadersUsingAString()
     {
         $this->factory->fake();
 
-        $this->factory->withHeaders(
-            [
-                'X-Test-Header' => 'foo',
-                'X-Test-ArrayHeader' => ['bar', 'baz'],
-            ]
-        )->post('http://foo.com/json');
+        $this->factory->withHeaders([
+            'X-Test-Header' => 'foo',
+            'X-Test-ArrayHeader' => ['bar', 'baz'],
+        ])->post('http://foo.com/json');
 
-        $this->factory->assertSent(
-            function (Request $request) {
-                return $request->url() === 'http://foo.com/json' &&
-                    $request->hasHeaders('X-Test-Header');
-            }
-        );
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/json' &&
+                   $request->hasHeaders('X-Test-Header');
+        });
     }
 
     public function testRequestExceptionSummary()
@@ -555,9 +478,7 @@ class HttpClientTest extends TestCase
     public function testRequestExceptionTruncatedSummary()
     {
         $this->expectException(RequestException::class);
-        $this->expectExceptionMessage(
-            '{"error":{"code":403,"message":"The Request can not be completed because quota limit was exceeded. Please, check our sup (truncated...)'
-        );
+        $this->expectExceptionMessage('{"error":{"code":403,"message":"The Request can not be completed because quota limit was exceeded. Please, check our sup (truncated...)');
 
         $error = [
             'error' => [
@@ -583,18 +504,14 @@ class HttpClientTest extends TestCase
     public function testOnErrorDoesntCallClosureOnInformational()
     {
         $status = 0;
-        $client = $this->factory->fake(
-            [
-                'laravel.com' => $this->factory::response('', 101),
-            ]
-        );
+        $client = $this->factory->fake([
+            'laravel.com' => $this->factory::response('', 101),
+        ]);
 
         $response = $client->get('laravel.com')
-            ->onError(
-                function ($response) use (&$status) {
-                    $status = $response->status();
-                }
-            );
+            ->onError(function ($response) use (&$status) {
+                $status = $response->status();
+            });
 
         $this->assertSame(0, $status);
         $this->assertSame(101, $response->status());
@@ -603,18 +520,14 @@ class HttpClientTest extends TestCase
     public function testOnErrorDoesntCallClosureOnSuccess()
     {
         $status = 0;
-        $client = $this->factory->fake(
-            [
-                'laravel.com' => $this->factory::response('', 201),
-            ]
-        );
+        $client = $this->factory->fake([
+            'laravel.com' => $this->factory::response('', 201),
+        ]);
 
         $response = $client->get('laravel.com')
-            ->onError(
-                function ($response) use (&$status) {
-                    $status = $response->status();
-                }
-            );
+            ->onError(function ($response) use (&$status) {
+                $status = $response->status();
+            });
 
         $this->assertSame(0, $status);
         $this->assertSame(201, $response->status());
@@ -623,18 +536,14 @@ class HttpClientTest extends TestCase
     public function testOnErrorDoesntCallClosureOnRedirection()
     {
         $status = 0;
-        $client = $this->factory->fake(
-            [
-                'laravel.com' => $this->factory::response('', 301),
-            ]
-        );
+        $client = $this->factory->fake([
+            'laravel.com' => $this->factory::response('', 301),
+        ]);
 
         $response = $client->get('laravel.com')
-            ->onError(
-                function ($response) use (&$status) {
-                    $status = $response->status();
-                }
-            );
+            ->onError(function ($response) use (&$status) {
+                $status = $response->status();
+            });
 
         $this->assertSame(0, $status);
         $this->assertSame(301, $response->status());
@@ -643,18 +552,14 @@ class HttpClientTest extends TestCase
     public function testOnErrorCallsClosureOnClientError()
     {
         $status = 0;
-        $client = $this->factory->fake(
-            [
-                'laravel.com' => $this->factory::response('', 401),
-            ]
-        );
+        $client = $this->factory->fake([
+            'laravel.com' => $this->factory::response('', 401),
+        ]);
 
         $response = $client->get('laravel.com')
-            ->onError(
-                function ($response) use (&$status) {
-                    $status = $response->status();
-                }
-            );
+            ->onError(function ($response) use (&$status) {
+                $status = $response->status();
+            });
 
         $this->assertSame(401, $status);
         $this->assertSame(401, $response->status());
@@ -663,18 +568,14 @@ class HttpClientTest extends TestCase
     public function testOnErrorCallsClosureOnServerError()
     {
         $status = 0;
-        $client = $this->factory->fake(
-            [
-                'laravel.com' => $this->factory::response('', 501),
-            ]
-        );
+        $client = $this->factory->fake([
+            'laravel.com' => $this->factory::response('', 501),
+        ]);
 
         $response = $client->get('laravel.com')
-            ->onError(
-                function ($response) use (&$status) {
-                    $status = $response->status();
-                }
-            );
+            ->onError(function ($response) use (&$status) {
+                $status = $response->status();
+            });
 
         $this->assertSame(501, $status);
         $this->assertSame(501, $response->status());
@@ -684,7 +585,7 @@ class HttpClientTest extends TestCase
     {
         $this->factory->fakeSequence()->push('abc123');
 
-        $destination = __DIR__ . '/fixtures/sunk.txt';
+        $destination = __DIR__.'/fixtures/sunk.txt';
 
         if (file_exists($destination)) {
             unlink($destination);
@@ -712,11 +613,9 @@ class HttpClientTest extends TestCase
 
     public function testSinkWhenStubbedByPath()
     {
-        $this->factory->fake(
-            [
-                'foo.com/*' => ['page' => 'foo'],
-            ]
-        );
+        $this->factory->fake([
+            'foo.com/*' => ['page' => 'foo'],
+        ]);
 
         $resource = fopen('php://temp', 'w');
 
@@ -809,43 +708,33 @@ class HttpClientTest extends TestCase
         $executionOrder = [
             function (Request $request) {
                 return $request->url() === 'http://foo.com/json' &&
-                    $request->hasHeader('Content-Type', 'application/json') &&
-                    $request->hasHeader('X-Test-Header', 'foo') &&
-                    $request->hasHeader('X-Test-ArrayHeader', ['bar', 'baz']) &&
-                    $request['name'] === 'Taylor';
+                       $request->hasHeader('Content-Type', 'application/json') &&
+                       $request->hasHeader('X-Test-Header', 'foo') &&
+                       $request->hasHeader('X-Test-ArrayHeader', ['bar', 'baz']) &&
+                       $request['name'] === 'Taylor';
             },
             function (Request $request) {
                 return $request->url() === 'http://bar.com/json' &&
-                    $request->hasHeader('Content-Type', 'application/json') &&
-                    $request->hasHeader('X-Test-Header', 'bar') &&
-                    $request->hasHeader('X-Test-ArrayHeader', ['bar', 'baz']) &&
-                    $request['name'] === 'Taylor';
+                       $request->hasHeader('Content-Type', 'application/json') &&
+                       $request->hasHeader('X-Test-Header', 'bar') &&
+                       $request->hasHeader('X-Test-ArrayHeader', ['bar', 'baz']) &&
+                       $request['name'] === 'Taylor';
             },
         ];
 
-        $this->factory->withHeaders(
-            [
-                'X-Test-Header' => 'foo',
-                'X-Test-ArrayHeader' => ['bar', 'baz'],
-            ]
-        )->post(
-            'http://foo.com/json',
-            [
-                'name' => 'Taylor',
-            ]
-        );
+        $this->factory->withHeaders([
+            'X-Test-Header' => 'foo',
+            'X-Test-ArrayHeader' => ['bar', 'baz'],
+        ])->post('http://foo.com/json', [
+            'name' => 'Taylor',
+        ]);
 
-        $this->factory->withHeaders(
-            [
-                'X-Test-Header' => 'bar',
-                'X-Test-ArrayHeader' => ['bar', 'baz'],
-            ]
-        )->post(
-            'http://bar.com/json',
-            [
-                'name' => 'Taylor',
-            ]
-        );
+        $this->factory->withHeaders([
+            'X-Test-Header' => 'bar',
+            'X-Test-ArrayHeader' => ['bar', 'baz'],
+        ])->post('http://bar.com/json', [
+            'name' => 'Taylor',
+        ]);
 
         $this->factory->assertSentInOrder($executionOrder);
     }
@@ -857,53 +746,36 @@ class HttpClientTest extends TestCase
         $executionOrder = [
             function (Request $request) {
                 return $request->url() === 'http://bar.com/json' &&
-                    $request->hasHeader('Content-Type', 'application/json') &&
-                    $request->hasHeader('X-Test-Header', 'bar') &&
-                    $request->hasHeader('X-Test-ArrayHeader', ['bar', 'baz']) &&
-                    $request['name'] === 'Taylor';
+                       $request->hasHeader('Content-Type', 'application/json') &&
+                       $request->hasHeader('X-Test-Header', 'bar') &&
+                       $request->hasHeader('X-Test-ArrayHeader', ['bar', 'baz']) &&
+                       $request['name'] === 'Taylor';
             },
             function (Request $request) {
                 return $request->url() === 'http://foo.com/json' &&
-                    $request->hasHeader('Content-Type', 'application/json') &&
-                    $request->hasHeader('X-Test-Header', 'foo') &&
-                    $request->hasHeader('X-Test-ArrayHeader', ['bar', 'baz']) &&
-                    $request['name'] === 'Taylor';
+                       $request->hasHeader('Content-Type', 'application/json') &&
+                       $request->hasHeader('X-Test-Header', 'foo') &&
+                       $request->hasHeader('X-Test-ArrayHeader', ['bar', 'baz']) &&
+                       $request['name'] === 'Taylor';
             },
         ];
 
-        $this->factory->withHeaders(
-            [
-                'X-Test-Header' => 'foo',
-                'X-Test-ArrayHeader' => ['bar', 'baz'],
-            ]
-        )->post(
-            'http://foo.com/json',
-            [
-                'name' => 'Taylor',
-            ]
-        );
+        $this->factory->withHeaders([
+            'X-Test-Header' => 'foo',
+            'X-Test-ArrayHeader' => ['bar', 'baz'],
+        ])->post('http://foo.com/json', [
+            'name' => 'Taylor',
+        ]);
 
-        $this->factory->withHeaders(
-            [
-                'X-Test-Header' => 'bar',
-                'X-Test-ArrayHeader' => ['bar', 'baz'],
-            ]
-        )->post(
-            'http://bar.com/json',
-            [
-                'name' => 'Taylor',
-            ]
-        );
+        $this->factory->withHeaders([
+            'X-Test-Header' => 'bar',
+            'X-Test-ArrayHeader' => ['bar', 'baz'],
+        ])->post('http://bar.com/json', [
+            'name' => 'Taylor',
+        ]);
 
         $this->expectException(\PHPUnit\Framework\AssertionFailedError::class);
 
         $this->factory->assertSentInOrder($executionOrder);
-    }
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->factory = new Factory;
     }
 }


### PR DESCRIPTION
Hi all,

This PR is a DX improvement for retrieving HTTP REST responses as a `Collection` when using the HTTP Client.

Here's an example:

```php
Http::get("https://api.foo.bar/users")->collect();
```

This is syntactical sugar for:

```php
collect(Http::get("https://api.foo.bar/users")->json());
```

I feel that this allows for a more declarative experience, especially as more often than not the next step is to map the response into another object.

```php
return Http::get("https://api.foo.bar/users")
    ->collect()
    ->map(fn($data) => new DataObject($data['name'], $data['description']));
``` 

Would be glad to hear your thoughts!

Thanks for all the hard work,
Luke