### PR TITLE
[8.x] Fix retry command for encrypted jobs

### DIFF
--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -136,7 +136,7 @@ class RetryCommand extends Command
 
         if (Str::startsWith($payload['data']['command'], 'O:')) {
             $instance = unserialize($payload['data']['command']);
-        } else if (app()->bound(Encrypter::class)) {
+        } elseif (app()->bound(Encrypter::class)) {
             $instance = unserialize(app()->make(Encrypter::class)->decrypt($payload['data']['command']));
         }
 

--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -136,9 +136,7 @@ class RetryCommand extends Command
 
         if (Str::startsWith($payload['data']['command'], 'O:')) {
             $instance = unserialize($payload['data']['command']);
-        }
-
-        if (app()->bound(Encrypter::class)) {
+        } else if (app()->bound(Encrypter::class)) {
             $instance = unserialize(app()->make(Encrypter::class)->decrypt($payload['data']['command']));
         }
 

--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -97,8 +97,7 @@ class RetryCommand extends Command
     protected function retryJob($job)
     {
         $this->laravel['queue']->connection($job->connection)->pushRaw(
-            $this->refreshRetryUntil($this->resetAttempts($job->payload)),
-            $job->queue
+            $this->refreshRetryUntil($this->resetAttempts($job->payload)), $job->queue
         );
     }
 


### PR DESCRIPTION
When using the new `Illuminate\Contracts\Queue\ShouldBeEncrypted` interface on a job if you run the `php aritsan queue:retry` command you get the following error:

`unserialize(): Error at offset 0 of x bytes`

This is because the job's command is not decrypted before being unserialized.

Steps to reproduce:

1. Create any queable job that implements the `ShouldBeEncrypted` interface
2. Call `$this->fail()` inside the job
3. Run `php artisan queue:retry <job-id>` 

This pull request fixes the issue by checking if the payload's command is encrypted before trying to unserialize it.

The code is taken from the `getCommand(array $data)` method in `Illuminate\Queue\CallQueuedHandler.php`
