### PR TITLE
[8.x] Redundant check in BoundMethod::addDependencyForCallParameter

### DIFF
--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -174,7 +174,7 @@ class BoundMethod
             }
         } elseif ($parameter->isDefaultValueAvailable()) {
             $dependencies[] = $parameter->getDefaultValue();
-        } elseif (! $parameter->isOptional() && ! array_key_exists($paramName, $parameters)) {
+        } elseif (! $parameter->isOptional()) {
             $message = "Unable to resolve dependency [{$parameter}] in class {$parameter->getDeclaringClass()->getName()}";
 
             throw new BindingResolutionException($message);


### PR DESCRIPTION
The only way to arrive to the last condition is when the parameter name is not available as a key in `$parameters` which is the first check performed in line https://github.com/laravel/framework/blob/ed3a8dbc826f49cf240d9db3f5e0a1ddb7ce35ef/src/Illuminate/Container/BoundMethod.php#L163. Thus the following check is redundant and could be removed.

```php
 && ! array_key_exists($paramName, $parameters)
```

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
