### PR TITLE
[9.x] Update pusher-php-server to 5.x 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -146,7 +146,7 @@
         "phpunit/phpunit": "Required to use assertions and run tests (^9.4).",
         "predis/predis": "Required to use the predis connector (^1.1.2).",
         "psr/http-message": "Required to allow Storage::put to accept a StreamInterface (^1.0).",
-        "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (^4.0).",
+        "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (^5.0).",
         "symfony/cache": "Required to PSR-6 cache bridge (^5.2).",
         "symfony/filesystem": "Required to enable support for relative symbolic links (^5.2).",
         "symfony/psr-http-message-bridge": "Required to use PSR-7 bridging features (^2.0).",


### PR DESCRIPTION
This is my first PR for laravel, so I'm not sure if I did this right. This PR allows the usage of pusher PHP server 5.x. I don't think it's backwards compatible with 4.x

Made after issue: #36339