### PR TITLE
[8.x] Nested AssertableJsonString

### DIFF
--- a/src/Illuminate/Testing/AssertableJsonString.php
+++ b/src/Illuminate/Testing/AssertableJsonString.php
@@ -358,7 +358,7 @@ class AssertableJsonString implements ArrayAccess, Countable
      */
     public function offsetGet($offset)
     {
-        return $this->decoded[$offset];
+        return new self($this->decoded[$offset]);
     }
 
     /**


### PR DESCRIPTION
This pr adds the ability to use the helpers provided by the `AssertableJsonString` class, in nested array or object elements within the json string.

The following example is a test for an api request that responses with an array of objects, where we want to test fragment of the first array element:

```php
$response->decodeResponseJson()[0]->assertFragment([
    'foo' => 'bar'
]);
```

Before we would have to write:
```php
$firstElement = new AssertableJsonString($response->decodeResponseJson()[0]);
$firstElement->assertFragment([
    'foo' => 'bar',
]);
```