### PR TITLE
[8.x]Syntactic sugar for creating foreign keys.

### DIFF
--- a/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
@@ -48,7 +48,7 @@ class ForeignIdColumnDefinition extends ColumnDefinition
     public function constrainedByModel($class)
     {
         $model = with(new $class);
-        return $this->constrained($model->getTable(),$model->getKeyName());
+        return $this->constrained($model->getTable(), $model->getKeyName());
     }
     
     /**

--- a/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
@@ -40,6 +40,18 @@ class ForeignIdColumnDefinition extends ColumnDefinition
     }
 
     /**
+     * Create a foreign key constraint on this column referencing the "id" and "table" columns from Model.
+     *
+     * @param  string  $abstract
+     * @return \Illuminate\Support\Fluent|\Illuminate\Database\Schema\ForeignKeyDefinition
+     */
+    public function constrainedByModel($class)
+    {
+        $model = with(new $class);
+        return $this->constrained($model->getTable(),$model->getKeyName());
+    }
+    
+    /**
      * Specify which column this foreign ID references on another table.
      *
      * @param  string  $column

--- a/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
@@ -48,6 +48,7 @@ class ForeignIdColumnDefinition extends ColumnDefinition
     public function constrainedByModel($class)
     {
         $model = with(new $class);
+        
         return $this->constrained($model->getTable(), $model->getKeyName());
     }
     


### PR DESCRIPTION
A better way for creating foreign keys for legacy projects with Laravel. We don't need to use non-standard names for table or id in two files(migration and model), but only in model.