### PR TITLE
Respect default constructor parameters when mapping collections to class objects

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -351,8 +351,8 @@ trait EnumeratesValues
      */
     public function mapInto($class)
     {
-        return $this->map(function ($value, $key) use ($class) {
-            return new $class($value, $key);
+        return $this->map(function ($value) use ($class) {
+            return new $class($value);
         });
     }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2575,6 +2575,9 @@ class SupportCollectionTest extends TestCase
 
         $this->assertSame('first', $data->get(0)->value);
         $this->assertSame('second', $data->get(1)->value);
+
+        // Make sure that default values of other params are respected during mapping
+        $this->assertContainsEquals('default', $data->pluck('otherParam'));
     }
 
     /**
@@ -4647,10 +4650,12 @@ class TestJsonSerializeWithScalarValueObject implements JsonSerializable
 class TestCollectionMapIntoObject
 {
     public $value;
+    public $otherParam;
 
-    public function __construct($value)
+    public function __construct($value, $otherParam = 'default')
     {
         $this->value = $value;
+        $this->otherParam = $otherParam;
     }
 }
 


### PR DESCRIPTION
Currently, the Collection's `mapInto` function passes the element's key as the second parameter to the class constructor. This can cause unexpected errors for classes that have a default value for the second parameter and would expect it to be used when using the `mapInto`method. This use-case feels more likely than having the key passed as a second parameter to the class constructor. 

Also, because the JsonResource's `collection` method uses this function under the hood, it can't be used with resources that extended the constructor by adding additional parameters with default values. This pull request would allow us to do so. 