### PR TITLE
[8.x] Add perMinutes method for RateLimiting

### DIFF
--- a/src/Illuminate/Cache/RateLimiting/Limit.php
+++ b/src/Illuminate/Cache/RateLimiting/Limit.php
@@ -53,9 +53,9 @@ class Limit
      * @param  int  $maxAttempts
      * @return static
      */
-    public static function perMinute($maxAttempts)
+    public static function perMinute($maxAttempts, $decayMinutes = 1)
     {
-        return new static('', $maxAttempts);
+        return new static('', $maxAttempts, $decayMinutes);
     }
 
     /**

--- a/src/Illuminate/Cache/RateLimiting/Limit.php
+++ b/src/Illuminate/Cache/RateLimiting/Limit.php
@@ -51,10 +51,21 @@ class Limit
      * Create a new rate limit.
      *
      * @param  int  $maxAttempts
+     * @return static
+     */
+    public static function perMinute($maxAttempts)
+    {
+        return new static('', $maxAttempts);
+    }
+
+    /**
+     * Create a new rate limit using minutes as decay time.
+     *
+     * @param  int  $maxAttempts
      * @param  int  $decayMinutes
      * @return static
      */
-    public static function perMinute($maxAttempts, $decayMinutes = 1)
+    public static function perMinutes($maxAttempts, $decayMinutes = 1)
     {
         return new static('', $maxAttempts, $decayMinutes);
     }

--- a/src/Illuminate/Cache/RateLimiting/Limit.php
+++ b/src/Illuminate/Cache/RateLimiting/Limit.php
@@ -51,6 +51,7 @@ class Limit
      * Create a new rate limit.
      *
      * @param  int  $maxAttempts
+     * @param  int  $decayMinutes
      * @return static
      */
     public static function perMinute($maxAttempts, $decayMinutes = 1)


### PR DESCRIPTION
This PR allows the `perMinute` method to accept an optional argument for the number of decay minutes. This allows the `perMinute` method to function in the same way that the `perHour` and `perDay` methods function.