### PR TITLE
[8.x] importing correct TestCase class when creating new unit test

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/test.unit.stub
+++ b/src/Illuminate/Foundation/Console/stubs/test.unit.stub
@@ -2,7 +2,7 @@
 
 namespace {{ namespace }};
 
-use PHPUnit\Framework\TestCase;
+use Tests\TestCase;
 
 class {{ class }} extends TestCase
 {


### PR DESCRIPTION
When creating a new unit test with `php artisan make:test FooTest --unit`, it imports `PHPUnit\Framework\TestCase` instead of `Tests\TestCase` and it's causing error in using Faker, like:

`Trying to get property numberBetween() of non-object`

Steps to reproduce:
1. Create a model with a migration: `php artisan make:model Foo -m`
2. Allow mass assignment to your model by adding the line: `protected $guarded = [];`
3. Create an unit test: `php artisan make:test FooTest --unit`
4. In the created test:
   1. Import your model: `use App\Models\Foo;`
   2. Import DatabaseMigrations trait: `use Illuminate\Foundation\Testing\DatabaseMigrations;`
   3. Import WithFaker trait: `use Illuminate\Foundation\Testing\WithFaker;`
   4. Use DatabaseMigrations in the class body: `use DatabaseMigrations;`
   5. Use WithFaker in the class body: `use WithFaker;`
   6. Create a simple test that uses faker:
`/** @test */`
`function can_create_foo()`
`{`
`Foo::create(['id' => $this->faker->numberBetween(1, 10)]);`
`$this->assertDatabaseCount('foos', 1);`
`}`
   7. Run the test: `vendor/phpunit/phpunit/phpunit --filter FooTest`

By changing the import of `PHPUnit\Framework\TestCase` to `Tests\TestCase` (as already happens with feature tests) solves the problem.