### PR TITLE
[8.x] Allow Blade's service injection to inject services typed using class name resolution

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesInjections.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesInjections.php
@@ -12,12 +12,12 @@ trait CompilesInjections
      */
     protected function compileInject($expression)
     {
-        $segments = explode(',', preg_replace("/[\(\)\\\"\']/", '', $expression));
+        $segments = explode(',', preg_replace("/[\(\)]/", '', $expression));
 
-        $variable = trim($segments[0]);
+        $variable = trim($segments[0], " '\"");
 
         $service = trim($segments[1]);
 
-        return "<?php \${$variable} = app('{$service}'); ?>";
+        return "<?php \${$variable} = app({$service}); ?>";
     }
 }

--- a/tests/View/Blade/BladeInjectTest.php
+++ b/tests/View/Blade/BladeInjectTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Illuminate\Tests\View\Blade;
+
+class BladeInjectTest extends AbstractBladeTestCase
+{
+    public function testDependenciesInjectedAsStringsAreCompiled()
+    {
+        $string = "Foo @inject('baz', 'SomeNamespace\SomeClass') bar";
+        $expected = "Foo <?php \$baz = app('SomeNamespace\SomeClass'); ?> bar";
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testDependenciesInjectedAsStringsAreCompiledWhenInjectedWithDoubleQuotes()
+    {
+        $string = 'Foo @inject("baz", "SomeNamespace\SomeClass") bar';
+        $expected = 'Foo <?php $baz = app("SomeNamespace\SomeClass"); ?> bar';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testDependenciesAreCompiled()
+    {
+        $string = "Foo @inject('baz', SomeNamespace\SomeClass::class) bar";
+        $expected = "Foo <?php \$baz = app(SomeNamespace\SomeClass::class); ?> bar";
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testDependenciesAreCompiledWithDoubleQuotes()
+    {
+        $string = 'Foo @inject("baz", SomeNamespace\SomeClass::class) bar';
+        $expected = "Foo <?php \$baz = app(SomeNamespace\SomeClass::class); ?> bar";
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+}


### PR DESCRIPTION
Right now, Blade supports [service injection](https://laravel.com/docs/8.x/blade#service-injection) via `@inject` directive. Example:

```
@inject ('service', 'App\SomeService')
```

Due to the fact that the contents of the expression were parsed/segmented then passed into the `app()` helper but wrapped into quotes, doing something like:

```
@inject ('service', App\SomeService::class)
```

Was not possible as the compiled output would be: `$service = app('App\SomeService::class')` resulting in an error. This PR adds the ability to inject services using this syntax, as well as keeping the old syntax. The way it's solved is that, instead of preg_replacing quotes, we'd pass the exact expression into the `app()` helper without wrapping into quotes, while the variable part (`$service`) is trimmed of all whitespace as well as quotes.

## Any breaking changes

The only potentially breaking change I can think of would be if someone accidentally added a whitespace after opening quotation mark:

```
@inject ('service', ' App\SomeService')
```

This would result in calling `app(' App\SomeService')`, while previously this would call `app('App\SomeService')`, but I guess that could be fixed by preg_replacing all whitespace. Let me know.