### PR TITLE
[8.x] Use HTTP_ONLY config

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -190,7 +190,7 @@ class VerifyCsrfToken
 
         $response->headers->setCookie(
             new Cookie(
-                XSRF-TOKEN', $request->session()->token(), $this->availableAt(60 * $config['lifetime']),
+                'XSRF-TOKEN', $request->session()->token(), $this->availableAt(60 * $config['lifetime']),
                 $config['path'], $config['domain'], $config['secure'], $config['http_only'] ?? false, false,
                 $config['same_site'] ?? null
             )

--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -190,8 +190,9 @@ class VerifyCsrfToken
 
         $response->headers->setCookie(
             new Cookie(
-                'XSRF-TOKEN', $request->session()->token(), $this->availableAt(60 * $config['lifetime']),
-                $config['path'], $config['domain'], $config['secure'], false, false, $config['same_site'] ?? null
+                XSRF-TOKEN', $request->session()->token(), $this->availableAt(60 * $config['lifetime']),
+                $config['path'], $config['domain'], $config['secure'], $config['http_only'] ?? false, false,
+                $config['same_site'] ?? null
             )
         );
 


### PR DESCRIPTION
Use http_only config from config/session.php to add http_only cookie for XSRF-TOKEN if required.