### PR TITLE
Add missing giveConfig method in ContextualBindingBuilder

### DIFF
--- a/src/Illuminate/Contracts/Container/ContextualBindingBuilder.php
+++ b/src/Illuminate/Contracts/Container/ContextualBindingBuilder.php
@@ -27,4 +27,13 @@ interface ContextualBindingBuilder
      * @return void
      */
     public function giveTagged($tag);
+
+    /**
+     * Specify the configuration item to bind as a primitive.
+     *
+     * @param  string  $tag
+     * @param  ?string  $default
+     * @return void
+     */
+    public function giveConfig($key, $default = null);
 }

--- a/src/Illuminate/Contracts/Container/ContextualBindingBuilder.php
+++ b/src/Illuminate/Contracts/Container/ContextualBindingBuilder.php
@@ -31,7 +31,7 @@ interface ContextualBindingBuilder
     /**
      * Specify the configuration item to bind as a primitive.
      *
-     * @param  string  $tag
+     * @param  string  $key
      * @param  ?string  $default
      * @return void
      */


### PR DESCRIPTION
Add missing `giveConfig` method in `ContextualBindingBuilder` interface.