### PR TITLE
[8.x] Add `sink` method docblock to HTTP facade

### DIFF
--- a/src/Illuminate/Support/Facades/Http.php
+++ b/src/Illuminate/Support/Facades/Http.php
@@ -18,6 +18,7 @@ use Illuminate\Http\Client\Factory;
  * @method static \Illuminate\Http\Client\PendingRequest bodyFormat(string $format)
  * @method static \Illuminate\Http\Client\PendingRequest contentType(string $contentType)
  * @method static \Illuminate\Http\Client\PendingRequest retry(int $times, int $sleep = 0)
+ * @method static \Illuminate\Http\Client\PendingRequest sink($to)
  * @method static \Illuminate\Http\Client\PendingRequest stub(callable $callback)
  * @method static \Illuminate\Http\Client\PendingRequest timeout(int $seconds)
  * @method static \Illuminate\Http\Client\PendingRequest withBasicAuth(string $username, string $password)


### PR DESCRIPTION
PR https://github.com/laravel/framework/pull/33720 added the `sink` method to the `HTTP` facade, but it didn't add the method to the facade's docblock.

Currently:
![image](https://user-images.githubusercontent.com/7202674/108875065-15550080-75fd-11eb-95d3-2c0a2fb598b2.png)

After this PR:
![image](https://user-images.githubusercontent.com/7202674/108875165-2b62c100-75fd-11eb-9858-91152a8c3544.png)

