### PR TITLE
[8.x] Add SetupTestDatabase Method Doc Block

### DIFF
--- a/src/Illuminate/Support/Facades/ParallelTesting.php
+++ b/src/Illuminate/Support/Facades/ParallelTesting.php
@@ -5,6 +5,7 @@ namespace Illuminate\Support\Facades;
 /**
  * @method static void setUpProcess(callable $callback)
  * @method static void setUpTestCase(callable $callback)
+ * @method static void setupTestDatabase(callable $callback)
  * @method static void tearDownProcess(callable $callback)
  * @method static void tearDownTestCase(callable $callback)
  * @method static int|false token()


### PR DESCRIPTION
Adds the missing `setupTestDatabase` method doc block for parallel testing.