### PR TITLE
[8.x] Detect "Temporary failure in name resolution" on DigitalOcean's PostgreSQL

### DIFF
--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -49,6 +49,7 @@ trait DetectsLostConnections
             'SQLSTATE[HY000] [2002] Connection timed out',
             'SSL: Connection timed out',
             'SQLSTATE[HY000]: General error: 1105 The last transaction was aborted due to Seamless Scaling. Please retry.',
+            'Temporary failure in name resolution',
         ]);
     }
 }


### PR DESCRIPTION
When using managed PostgreSQL instances on DigitalOcean every now and then this pops out. After seeing #35744, #35790 and others decided to fix this.

PDOException: ```SQLSTATE[08006] [7] could not translate host name "private-xxx-do-user-0.a.db.ondigitalocean.com" to address: Temporary failure in name resolution```