### PR TITLE
[6.x] Detect "Temporary failure in name resolution" on DigitalOcean's PostgreSQL

### DIFF
--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -49,6 +49,7 @@ trait DetectsLostConnections
             'SQLSTATE[HY000] [2002] Connection timed out',
             'SSL: Connection timed out',
             'SQLSTATE[HY000]: General error: 1105 The last transaction was aborted due to Seamless Scaling. Please retry.',
+            'Temporary failure in name resolution',
         ]);
     }
 }


### PR DESCRIPTION
When using managed PostgreSQL instances on DigitalOcean every now and then this pops out. After seeing #35744, #35790 and others decided to fix this. Targeting this to 6.x as @GrahamCampbell [requested](https://github.com/laravel/framework/pull/36369#issuecomment-784989690).

PDOException: ```SQLSTATE[08006] [7] could not translate host name "private-xxx-do-user-0.a.db.ondigitalocean.com" to address: Temporary failure in name resolution```

_Side question:_
What do you think about adding `DetectsLostConnections` to Redis? Using managed Redis instance this also sometimes happens in `Redis::connect`.

RedisException: `php_network_getaddresses: getaddrinfo failed: Name or service not known`.