### PR TITLE
[8.x] Respect custom route key with explicit route model binding

### DIFF
--- a/src/Illuminate/Routing/RouteBinding.php
+++ b/src/Illuminate/Routing/RouteBinding.php
@@ -33,7 +33,7 @@ class RouteBinding
      */
     protected static function createClassBinding($container, $binding)
     {
-        return function ($value, $route) use ($container, $binding) {
+        return function ($value, $route, $key) use ($container, $binding) {
             // If the binding has an @ sign, we will assume it's being used to delimit
             // the class name from the bind method name. This allows for bindings
             // to run multiple bind methods in a single class for convenience.
@@ -41,7 +41,7 @@ class RouteBinding
 
             $callable = [$container->make($class), $method];
 
-            return $callable($value, $route);
+            return $callable($value, $route, $key);
         };
     }
 
@@ -57,7 +57,7 @@ class RouteBinding
      */
     public static function forModel($container, $class, $callback = null)
     {
-        return function ($value) use ($container, $class, $callback) {
+        return function ($value, $route, $key) use ($container, $class, $callback) {
             if (is_null($value)) {
                 return;
             }
@@ -67,7 +67,7 @@ class RouteBinding
             // throw a not found exception otherwise we will return the instance.
             $instance = $container->make($class);
 
-            if ($model = $instance->resolveRouteBinding($value)) {
+            if ($model = $instance->resolveRouteBinding($value, $route->bindingFieldFor($key))) {
                 return $model;
             }
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -840,7 +840,7 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     protected function performBinding($key, $value, $route)
     {
-        return call_user_func($this->binders[$key], $value, $route);
+        return call_user_func($this->binders[$key], $value, $route, $key);
     }
 
     /**

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -961,9 +961,12 @@ class RoutingRouteTest extends TestCase
 
         $mock->shouldReceive('resolveRouteBinding')
             ->with('taylor', 'custom')
+            ->once()
             ->andReturn('TAYLOR');
 
         $this->assertSame('TAYLOR', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
+
+        Mockery::close();
     }
 
     public function testModelBindingWithNullReturn()

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Tests\Routing;
 
 use Closure;
-use Mockery;
 use DateTime;
 use Exception;
 use Illuminate\Auth\Middleware\Authenticate;
@@ -30,6 +29,7 @@ use Illuminate\Routing\Router;
 use Illuminate\Routing\UrlGenerator;
 use Illuminate\Support\Str;
 use LogicException;
+use Mockery;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;


### PR DESCRIPTION
Hi there! 🚀

You can use explicit route model binding in a situation where implicit binding might not work. Implicit binding allows you to customize the binding field for each route.

```php
Route::get('/post/{post:slug}', fn (Post $post) => $post->content);
Route::get('/posts-by-id/{post}', fn (Post $post) => $post->content);
```

Unfortunately, this doesn't work when you're using explicit binding. It always uses the `$model->getRouteKeyName()`.

```php
Route::model('post', Post::class);
```

This PR makes sure that when explicitly binding models to route paramters, they respect any custom route fields being used.

Additionally, it passes the custom key to custom route binding.


```php
Route::bind('post', function ($value, $route, $key) {
    // do something
});
```