### PR TITLE
[8.x] Add dd() method to TestResponse class

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -718,6 +718,16 @@ class TestResponse implements ArrayAccess
     }
 
     /**
+     * Die and dump the HTTP response.
+     *
+     * @return void
+     */
+    public function dd()
+    {
+        dd($this);
+    }
+
+    /**
      * Validate and return the decoded response JSON.
      *
      * @return \Illuminate\Testing\AssertableJsonString


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR adds a new `dd` method to the fluent [`TestResponse`](https://github.com/laravel/framework/blob/8.x/src/Illuminate/Testing/TestResponse.php) class.

## Example

**Previously...** you'd have to comment out any assertions at the end of your chain, assign it to a variable and finally actually `dd` it.

```php
$response = $this
  ->get('/posts');
//  ->assertOk()
//  ->assertSee('foo');

dd($response);
```

**Now...** with this PR, you'll be able to simply add the `->dd()` method anywhere in your chain and the HTTP response will be die dumped. 

```php
$this
  ->get('/posts')
  ->dd()
  ->assertOk()
  ->assertSee('foo');
```

---

I've reviewed the `dd` methods available in other places in the codebase, like in the [`Builder`](https://github.com/laravel/framework/blob/8.x/src/Illuminate/Database/Query/Builder.php) class and the [`Stringable`](https://github.com/laravel/framework/blob/8.x/src/Illuminate/Support/Stringable.php) class and I couldn't find any tests that cover the `dd` method so I was unsure on how to actually add tests for this addition. Please let me know if I've missed anything.