### PR TITLE
[8.x] Make Database Factory macroable

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -11,11 +11,14 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\ForwardsCalls;
+use Illuminate\Support\Traits\Macroable;
 use Throwable;
 
 abstract class Factory
 {
-    use ForwardsCalls;
+    use ForwardsCalls, Macroable {
+        __call as macroCall;
+    }
 
     /**
      * The name of the factory's corresponding model.
@@ -747,6 +750,10 @@ abstract class Factory
      */
     public function __call($method, $parameters)
     {
+        if (static::hasMacro($method)) {
+            return $this->macroCall($method, $parameters);
+        }
+
         if (! Str::startsWith($method, ['for', 'has'])) {
             static::throwBadMethodCallException($method);
         }

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -473,6 +473,16 @@ class DatabaseEloquentFactoryTest extends TestCase
         $this->assertCount(2, $post->comments);
     }
 
+    public function test_can_be_macroable()
+    {
+        $factory = FactoryTestUserFactory::new();
+        $factory->macro('getFoo', function () {
+            return 'Hello World';
+        });
+
+        $this->assertEquals('Hello World', $factory->getFoo());
+    }
+
     /**
      * Get a database connection instance.
      *


### PR DESCRIPTION
My company is looking to upgrade to Laravel 8 soon, and while doing some due diligence, we noticed that we were going to have an issue with how we are currently using factory states and how they are handled in L8. While we're looking forward to using the new class-based factories, we have hundreds of states, thousands of tests, and a home-grown factory/state builder, which is used to create complex user stories. These references are using the string-based versions of states but accumulated over all of the builder calls and finally executed with the L7 `->states(...)` method call.

It would be a huge undertaking to make adjustments to the builder and delay the upgrade to L8. So, I'd like to add a macro to get the `states()` method back onto the database factory class. This way, we'd be able to temporarily leverage the macro and delete it when we're done with the changes we need to make to our builder. We might have to add some other macros as well, but this is to be determined.

The initial idea is to do something like this for the `states()` method.

```php
use Illuminate\Database\Eloquent\Factories\Factory;

Factory::macro('states', function (array $states = []) {
    $factory = $this;
    foreach ($states as $state) {
        $stateMethod = Str::camel($state);
        $factory = $factory->{$stateMethod}();
    }

    return $factory;
});
```