### PR TITLE
[8.x] Fix setUpTestDatabase method signature in the ParallelTesting facade

### DIFF
--- a/src/Illuminate/Support/Facades/ParallelTesting.php
+++ b/src/Illuminate/Support/Facades/ParallelTesting.php
@@ -5,7 +5,7 @@ namespace Illuminate\Support\Facades;
 /**
  * @method static void setUpProcess(callable $callback)
  * @method static void setUpTestCase(callable $callback)
- * @method static void setupTestDatabase(callable $callback)
+ * @method static void setUpTestDatabase(callable $callback)
  * @method static void tearDownProcess(callable $callback)
  * @method static void tearDownTestCase(callable $callback)
  * @method static int|false token()


### PR DESCRIPTION
This PR fixes the facade method description for the newly introduced `setUpTestDatabase` method.

IDE's will now be able to provide more information to the developer.

This PR is an alternative to https://github.com/laravel/framework/pull/36385, so feel free to choose one of the solutions and close the other one.