### PR TITLE
[8.x] Replace view facade with helper in RegisterErrorViewPaths

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/RegisterErrorViewPaths.php
+++ b/src/Illuminate/Foundation/Exceptions/RegisterErrorViewPaths.php
@@ -2,8 +2,6 @@
 
 namespace Illuminate\Foundation\Exceptions;
 
-use Illuminate\Support\Facades\View;
-
 class RegisterErrorViewPaths
 {
     /**
@@ -13,7 +11,7 @@ class RegisterErrorViewPaths
      */
     public function __invoke()
     {
-        View::replaceNamespace('errors', collect(config('view.paths'))->map(function ($path) {
+        view()->replaceNamespace('errors', collect(config('view.paths'))->map(function ($path) {
             return "{$path}/errors";
         })->push(__DIR__.'/views')->all());
     }


### PR DESCRIPTION
It is currently not possible to to use error views outside of Laravel today. By changing from the view facade to the helper when registering the view paths this allows us to use the views.

If this gets merged this would allow us to add a this as an example to [Torch](https://github.com/mattstauffer/Torch/).