### PR TITLE
[8.x] Rename setUp to setup in ParallelTesting classes

### DIFF
--- a/src/Illuminate/Support/Facades/ParallelTesting.php
+++ b/src/Illuminate/Support/Facades/ParallelTesting.php
@@ -3,8 +3,8 @@
 namespace Illuminate\Support\Facades;
 
 /**
- * @method static void setUpProcess(callable $callback)
- * @method static void setUpTestCase(callable $callback)
+ * @method static void setupProcess(callable $callback)
+ * @method static void setupTestCase(callable $callback)
  * @method static void setupTestDatabase(callable $callback)
  * @method static void tearDownProcess(callable $callback)
  * @method static void tearDownTestCase(callable $callback)

--- a/src/Illuminate/Testing/Concerns/TestDatabases.php
+++ b/src/Illuminate/Testing/Concerns/TestDatabases.php
@@ -26,7 +26,7 @@ trait TestDatabases
      */
     protected function bootTestDatabase()
     {
-        ParallelTesting::setUpProcess(function () {
+        ParallelTesting::setupProcess(function () {
             $this->whenNotUsingInMemoryDatabase(function ($database) {
                 if (ParallelTesting::option('recreate_databases')) {
                     Schema::dropDatabaseIfExists(
@@ -36,7 +36,7 @@ trait TestDatabases
             });
         });
 
-        ParallelTesting::setUpTestCase(function ($testCase) {
+        ParallelTesting::setupTestCase(function ($testCase) {
             $uses = array_flip(class_uses_recursive(get_class($testCase)));
 
             $databaseTraits = [
@@ -56,7 +56,7 @@ trait TestDatabases
                     }
 
                     if ($created) {
-                        ParallelTesting::callSetUpTestDatabaseCallbacks($testDatabase);
+                        ParallelTesting::callSetupTestDatabaseCallbacks($testDatabase);
                     }
                 });
             }

--- a/src/Illuminate/Testing/ParallelRunner.php
+++ b/src/Illuminate/Testing/ParallelRunner.php
@@ -81,7 +81,7 @@ class ParallelRunner implements RunnerInterface
         (new PhpHandler)->handle($this->options->configuration()->php());
 
         $this->forEachProcess(function () {
-            ParallelTesting::callSetUpProcessCallbacks();
+            ParallelTesting::callSetupProcessCallbacks();
         });
 
         try {

--- a/src/Illuminate/Testing/ParallelTesting.php
+++ b/src/Illuminate/Testing/ParallelTesting.php
@@ -29,25 +29,25 @@ class ParallelTesting
     protected $tokenResolver;
 
     /**
-     * All of the registered "setUp" process callbacks.
+     * All of the registered "setup" process callbacks.
      *
      * @var array
      */
-    protected $setUpProcessCallbacks = [];
+    protected $setupProcessCallbacks = [];
 
     /**
-     * All of the registered "setUp" test case callbacks.
+     * All of the registered "setup" test case callbacks.
      *
      * @var array
      */
-    protected $setUpTestCaseCallbacks = [];
+    protected $setupTestCaseCallbacks = [];
 
     /**
-     * All of the registered "setUp" test database callbacks.
+     * All of the registered "setup" test database callbacks.
      *
      * @var array
      */
-    protected $setUpTestDatabaseCallbacks = [];
+    protected $setupTestDatabaseCallbacks = [];
 
     /**
      * All of the registered "tearDown" process callbacks.
@@ -97,36 +97,36 @@ class ParallelTesting
     }
 
     /**
-     * Register a "setUp" process callback.
+     * Register a "setup" process callback.
      *
      * @param  callable  $callback
      * @return void
      */
-    public function setUpProcess($callback)
+    public function setupProcess($callback)
     {
-        $this->setUpProcessCallbacks[] = $callback;
+        $this->setupProcessCallbacks[] = $callback;
     }
 
     /**
-     * Register a "setUp" test case callback.
+     * Register a "setup" test case callback.
      *
      * @param  callable  $callback
      * @return void
      */
-    public function setUpTestCase($callback)
+    public function setupTestCase($callback)
     {
-        $this->setUpTestCaseCallbacks[] = $callback;
+        $this->setupTestCaseCallbacks[] = $callback;
     }
 
     /**
-     * Register a "setUp" test database callback.
+     * Register a "setup" test database callback.
      *
      * @param  callable  $callback
      * @return void
      */
-    public function setUpTestDatabase($callback)
+    public function setupTestDatabase($callback)
     {
-        $this->setUpTestDatabaseCallbacks[] = $callback;
+        $this->setupTestDatabaseCallbacks[] = $callback;
     }
 
     /**
@@ -152,14 +152,14 @@ class ParallelTesting
     }
 
     /**
-     * Call all of the "setUp" process callbacks.
+     * Call all of the "setup" process callbacks.
      *
      * @return void
      */
     public function callSetUpProcessCallbacks()
     {
         $this->whenRunningInParallel(function () {
-            foreach ($this->setUpProcessCallbacks as $callback) {
+            foreach ($this->setupProcessCallbacks as $callback) {
                 $this->container->call($callback, [
                     'token' => $this->token(),
                 ]);
@@ -168,7 +168,7 @@ class ParallelTesting
     }
 
     /**
-     * Call all of the "setUp" test case callbacks.
+     * Call all of the "setup" test case callbacks.
      *
      * @param  \Illuminate\Foundation\Testing\TestCase  $testCase
      * @return void
@@ -176,7 +176,7 @@ class ParallelTesting
     public function callSetUpTestCaseCallbacks($testCase)
     {
         $this->whenRunningInParallel(function () use ($testCase) {
-            foreach ($this->setUpTestCaseCallbacks as $callback) {
+            foreach ($this->setupTestCaseCallbacks as $callback) {
                 $this->container->call($callback, [
                     'testCase' => $testCase,
                     'token' => $this->token(),
@@ -186,7 +186,7 @@ class ParallelTesting
     }
 
     /**
-     * Call all of the "setUp" test database callbacks.
+     * Call all of the "setup" test database callbacks.
      *
      * @param  string  $database
      * @return void
@@ -194,7 +194,7 @@ class ParallelTesting
     public function callSetUpTestDatabaseCallbacks($database)
     {
         $this->whenRunningInParallel(function () use ($database) {
-            foreach ($this->setUpTestDatabaseCallbacks as $callback) {
+            foreach ($this->setupTestDatabaseCallbacks as $callback) {
                 $this->container->call($callback, [
                     'database' => $database,
                     'token' => $this->token(),

--- a/tests/Testing/ParallelTestingTest.php
+++ b/tests/Testing/ParallelTestingTest.php
@@ -30,7 +30,7 @@ class ParallelTestingTest extends TestCase
         $this->assertFalse($state);
 
         $parallelTesting->{$callback}(function ($token, $testCase = null) use ($callback, &$state) {
-            if (in_array($callback, ['setUpTestCase', 'tearDownTestCase'])) {
+            if (in_array($callback, ['setupTestCase', 'tearDownTestCase'])) {
                 $this->assertSame($this, $testCase);
             } else {
                 $this->assertNull($testCase);
@@ -81,9 +81,9 @@ class ParallelTestingTest extends TestCase
     public function callbacks()
     {
         return [
-            ['setUpProcess'],
-            ['setUpTestCase'],
-            ['setUpTestDatabase'],
+            ['setupProcess'],
+            ['setupTestCase'],
+            ['setupTestDatabase'],
             ['tearDownTestCase'],
             ['tearDownProcess'],
         ];


### PR DESCRIPTION
As suggested by @GrahamCampbell in https://github.com/laravel/framework/pull/36383#issuecomment-785733395

Renames all instances of `setUp` to `setup` in the ParallelTesting classes to make the code consistent.

This PR is an alternative to https://github.com/laravel/framework/pull/36383, so feel free to choose one of the solutions and close the other one.

If this PR will be merged, I will also prepare a PR for the docs.