### PR TITLE
[8.x] Fix typo in broadcast channel constructor docblock

### DIFF
--- a/src/Illuminate/Notifications/Channels/BroadcastChannel.php
+++ b/src/Illuminate/Notifications/Channels/BroadcastChannel.php
@@ -18,7 +18,7 @@ class BroadcastChannel
     protected $events;
 
     /**
-     * Create a new database channel.
+     * Create a new broadcast channel.
      *
      * @param  \Illuminate\Contracts\Events\Dispatcher  $events
      * @return void


### PR DESCRIPTION
This PR contain a simple typo fix. It can be merged or absolutely ignored. 