### PR TITLE
[8.x] Add ::destructure() to Support/Arr

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -89,6 +89,31 @@ class Arr
     }
 
     /**
+     * Deconstruct an array from the given keys.
+     *
+     * @param  array  $array
+     * @param  array|string  $keys
+     * @return array
+     */
+    public static function deconstruct($array, $keys)
+    {
+        $keys = self::wrap($keys);
+        $results = [];
+
+        foreach ($keys as $key) {
+            if (is_array($key)) {
+                $results[] = self::only($array, $key);
+            } else {
+                $results[] = array_key_exists($key, $array) ? $array[$key] : null;
+            }
+        }
+
+        $results[] = self::except($array, self::flatten($keys));
+
+        return $results;
+    }
+
+    /**
      * Divide an array into two arrays. One with keys and the other with values.
      *
      * @param  array  $array

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -88,6 +88,43 @@ class SupportArrTest extends TestCase
         $this->assertSame([[]], Arr::crossJoin());
     }
 
+    public function testDeconstruct()
+    {
+        $post = [
+            'title' => 'Article 1',
+            'slug' => 'article-1',
+            'description' => 'Lorem ipsum',
+            'tags' => ['foo', 'bar'],
+            'gallery' => [
+                ['image' => 'image.jpg'],
+                ['image' => 'image2.jpg'],
+            ],
+        ];
+
+        [$tags, $article] = Arr::deconstruct($post, 'tags');
+        $this->assertEquals(['foo', 'bar'], $tags);
+        $this->assertEquals(Arr::except($post, 'tags'), $article);
+
+        [$notFoundKey, $article] = Arr::deconstruct($post, 'notFoundKey');
+        $this->assertNull($notFoundKey);
+        $this->assertEquals($post, $article);
+
+        [$tags, $gallery, $article] = Arr::deconstruct($post, ['tags', 'gallery']);
+        $this->assertEquals(['foo', 'bar'], $tags);
+        $this->assertEquals([['image' => 'image.jpg'], ['image' => 'image2.jpg']], $gallery);
+        $this->assertEquals(Arr::except($post, ['tags', 'gallery']), $article);
+
+        [$slug, $meta, $article] = Arr::deconstruct($post, ['slug', ['tags', 'gallery']]);
+        $this->assertEquals('article-1', $slug);
+        $this->assertEquals(Arr::only($post, ['tags', 'gallery']), $meta);
+        $this->assertEquals(Arr::except($post, ['slug', 'tags', 'gallery']), $article);
+
+        [$slug, $notFoundMeta, $article] = Arr::deconstruct($post, ['slug', ['notFoundKey', 'notFoundKey2']]);
+        $this->assertEquals('article-1', $slug);
+        $this->assertEquals([], $notFoundMeta);
+        $this->assertEquals(Arr::except($post, 'slug'), $article);
+    }
+
     public function testDivide()
     {
         [$keys, $values] = Arr::divide(['name' => 'Desk']);


### PR DESCRIPTION
This PR aims to add a `Arr::destructure()` helper.  

The function acts can be described as a _"JS object destructuring"_ + _"Advanced ::only() + ::expect()"_.  Currently in PHP we have a deconstruction but it's kinda awful and not complete as the one of JS.

It basically extract the keys a user provided, returning them + the remaining of the given array to destructure them into variables.
I hope the examples are self-explanatory and they give a clear use case.

> **Note on keys not found**: if a key is not found, the helper will return `null` for single keys and an empty array `[]` for grouped keys as described in the tests.

**Examples**:

1. Basic destructuring

```php
$post = [
	'title' => 'Article 1',
	'slug' => 'article-1',
	'description' => 'Lorem ipsum',
	'tags' => ['foo', 'bar'],
	'gallery' => [
	    ['image' => 'image.jpg'],
	    ['image' => 'image2.jpg'],
	],
];

[$tags, $article] = Arr::destructure($post, 'tags');

dump($tags); // ['foo', 'bar']
dump($article) // ['title' => 'Article 1', 'slug' => 'article-1', ...] without tags
```


2. Destructuring with multiple keys

```php
$post = [
	'title' => 'Article 1',
	'slug' => 'article-1',
	'description' => 'Lorem ipsum',
	'tags' => ['foo', 'bar'],
	'gallery' => [
	    ['image' => 'image.jpg'],
	    ['image' => 'image2.jpg'],
	],
];

[$tags, $gallery, $article] = Arr::destructure($post, ['tags', 'gallery']);

dump($tags); // ['foo', 'bar']
dump($gallery); // [['image' => 'image.jpg'], ['image' => 'image2.jpg']]
dump($article) // ['title' => 'Article 1', 'slug' => 'article-1', ...] without tags and gallery
```

3. Destructuring with grouped keys and single keys

```php
$post = [
	'title' => 'Article 1',
	'slug' => 'article-1',
	'description' => 'Lorem ipsum',
	'tags' => ['foo', 'bar'],
	'gallery' => [
	    ['image' => 'image.jpg'],
	    ['image' => 'image2.jpg'],
	],
];

[$slug, $meta, $article] = Arr::destructure($post, ['slug', ['tags', 'gallery']]);

dump($slug); // article-1
dump($meta); // ['tags' => ['foo', 'bar'], 'gallery' => ['image' => 'image.jpg'], ['image' => 'image2.jpg']]
dump($article) // ['title' => 'Article 1', 'slug' => 'article-1', ...] without slug, tags and gallery
```
