### PR TITLE
Added failOnFirstError property

### DIFF
--- a/src/Illuminate/Contracts/Validation/Factory.php
+++ b/src/Illuminate/Contracts/Validation/Factory.php
@@ -11,9 +11,10 @@ interface Factory
      * @param  array  $rules
      * @param  array  $messages
      * @param  array  $customAttributes
+     * @param  bool  $failOnFirstError
      * @return \Illuminate\Contracts\Validation\Validator
      */
-    public function make(array $data, array $rules, array $messages = [], array $customAttributes = []);
+    public function make(array $data, array $rules, array $messages = [], array $customAttributes = [], bool $failOnFirstError = false);
 
     /**
      * Register a custom validator extension.

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -66,6 +66,22 @@ class FormRequest extends Request implements ValidatesWhenResolved
     protected $validator;
 
     /**
+     * In case of first error, stop the validation process
+     *
+     * @var bool
+     */
+    protected $failOnFirstError;
+
+    public function __construct(array $query = [], array $request = [], array $attributes = [], array $cookies = [], array $files = [], array $server = [], $content = null)
+    {
+        parent::__construct($query, $request, $attributes, $cookies, $files, $server, $content);
+
+        if (!isset($this->failOnFirstError)) {
+            $this->failOnFirstError = config("validation.fail_on_first_error", false);
+        }
+    }
+
+    /**
      * Get the validator instance for the request.
      *
      * @return \Illuminate\Contracts\Validation\Validator
@@ -103,7 +119,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
     {
         return $factory->make(
             $this->validationData(), $this->container->call([$this, 'rules']),
-            $this->messages(), $this->attributes()
+            $this->messages(), $this->attributes(), $this->failOnFirstError
         );
     }
 

--- a/src/Illuminate/Validation/Factory.php
+++ b/src/Illuminate/Validation/Factory.php
@@ -93,12 +93,13 @@ class Factory implements FactoryContract
      * @param  array  $rules
      * @param  array  $messages
      * @param  array  $customAttributes
+     * @param  bool  $failOnFirstError
      * @return \Illuminate\Validation\Validator
      */
-    public function make(array $data, array $rules, array $messages = [], array $customAttributes = [])
+    public function make(array $data, array $rules, array $messages = [], array $customAttributes = [], bool $failOnFirstError = false)
     {
         $validator = $this->resolve(
-            $data, $rules, $messages, $customAttributes
+            $data, $rules, $messages, $customAttributes, $failOnFirstError
         );
 
         // The presence verifier is responsible for checking the unique and exists data
@@ -143,15 +144,16 @@ class Factory implements FactoryContract
      * @param  array  $rules
      * @param  array  $messages
      * @param  array  $customAttributes
+     * @param  bool  $failOnFirstError
      * @return \Illuminate\Validation\Validator
      */
-    protected function resolve(array $data, array $rules, array $messages, array $customAttributes)
+    protected function resolve(array $data, array $rules, array $messages, array $customAttributes, bool $failOnFirstError)
     {
         if (is_null($this->resolver)) {
-            return new Validator($this->translator, $data, $rules, $messages, $customAttributes);
+            return new Validator($this->translator, $data, $rules, $messages, $customAttributes, $failOnFirstError);
         }
 
-        return call_user_func($this->resolver, $this->translator, $data, $rules, $messages, $customAttributes);
+        return call_user_func($this->resolver, $this->translator, $data, $rules, $messages, $customAttributes, $failOnFirstError);
     }
 
     /**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -253,6 +253,13 @@ class Validator implements ValidatorContract
     protected $dotPlaceholder;
 
     /**
+     * In case of first error, stop the validation process
+     *
+     * @var bool
+     */
+    protected $failOnFirstError;
+
+    /**
      * Create a new Validator instance.
      *
      * @param  \Illuminate\Contracts\Translation\Translator  $translator
@@ -260,10 +267,11 @@ class Validator implements ValidatorContract
      * @param  array  $rules
      * @param  array  $messages
      * @param  array  $customAttributes
+     * @param  bool  $failOnFirstError
      * @return void
      */
     public function __construct(Translator $translator, array $data, array $rules,
-                                array $messages = [], array $customAttributes = [])
+                                array $messages = [], array $customAttributes = [], bool $failOnFirstError = false)
     {
         $this->dotPlaceholder = Str::random();
 
@@ -272,6 +280,7 @@ class Validator implements ValidatorContract
         $this->customMessages = $messages;
         $this->data = $this->parseData($data);
         $this->customAttributes = $customAttributes;
+        $this->failOnFirstError = $failOnFirstError;
 
         $this->setRules($rules);
     }
@@ -371,6 +380,10 @@ class Validator implements ValidatorContract
                 $this->removeAttribute($attribute);
 
                 continue;
+            }
+
+            if ($this->failOnFirstError and $this->messages->isNotEmpty()) {
+                break;
             }
 
             foreach ($rules as $rule) {

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -141,6 +141,41 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals(['foo' => ['Same' => ['baz']]], $v->failed());
     }
 
+    public function testFailOnFirstError()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $data = [
+            "foo" => "bar",
+            "age" => 30
+        ];
+        $rules = [
+            "foo" => ["required", "string"],
+            "baz" => ["required"],
+            "age" => ["required", "min:31"]
+        ];
+
+        $expectedFailOnFirstErrorDisableResult = [
+            "baz" => [
+                "validation.required"
+            ],
+            "age" => [
+                "validation.min.string"
+            ]
+        ];
+        $failOnFirstErrorDisable = new Validator($trans, $data, $rules, [], [], false);
+        $this->assertFalse($failOnFirstErrorDisable->passes());
+        $this->assertEquals($expectedFailOnFirstErrorDisableResult, $failOnFirstErrorDisable->getMessageBag()->getMessages());
+
+        $expectedFailOnFirstErrorEnableResult = [
+            "baz" => [
+                "validation.required"
+            ]
+        ];
+        $failOnFirstErrorEnable = new Validator($trans, $data, $rules, [], [], true);
+        $this->assertFalse($failOnFirstErrorEnable->passes());
+        $this->assertEquals($expectedFailOnFirstErrorEnableResult, $failOnFirstErrorEnable->getMessageBag()->getMessages());
+    }
+
     public function testHasNotFailedValidationRules()
     {
         $trans = $this->getTranslator();


### PR DESCRIPTION
**Goal:**
During FormRequest validation, if a field fails, it will throw the validation error without checking the fields that come after it.

For example, we have defined rules as follows. In the present case; Even if the user_id field is missing, the post_id and comment_id fields are still being checked. If we want, we can stop the control process after the first error thanks to this PR.

```
$rules = [
    "user_id"    => ["required", "exists:users"],
    "post_id"    => ["required", "exists:posts"],
    "comment_id" => ["required", "exists:comments"],
];
```


**Use of:**
- We can create a config file. The value defined in the config file will be valid for all Request classes. This value can be overridden from the Request class. We can create a config file named ``config/validation.php`` and define a variable named ``fail_on_first_error`` inside it.

```
<?php
    return [
        "fail_on_first_error" => true,
    ];
?>
```

- We can define it by creating a property named $ failOnFirstError inside our FormRequest class. By defining variables like this in FormRequest, we override the value defined for all Request classes in ``config/validation.php``. Sample:
```
class FooBarStoreRequest extends FormRequest
{
    protected $failOnFirstError = false;

    /**
     * Determine if the user is authorized to make this request.
     *
     * @return bool
     */
    public function authorize()
    {
        return true;
    }

    /**
     * Get the validation rules that apply to the request.
     *
     * @return array
     */
    public function rules()
    {
        return [
            "foo" => ["required", "string"],
            "baz" => ["required"],
            "age" => ["required", "min:31"]
        ];
    }
}
```


If a value is not assigned for all Request classes by creating a config file, or if the property named ``$failOnFirstError`` is not overridden from the FormRequest class, this feature is disabled by default and its use is optional.

Config file and default value definition is made in __construct of ``src/Illuminate/Foundation/Http/FormRequest.php`` class. This class can be overridden to change the path of the config file.

Test processes were added to ``tests/Validation/ValidationValidatorTest.php`` and passed the test successfully.