### PR TITLE
[8.x] Fix Event Dispatcher listen phpdoc: add array to $listener

### DIFF
--- a/src/Illuminate/Contracts/Events/Dispatcher.php
+++ b/src/Illuminate/Contracts/Events/Dispatcher.php
@@ -8,7 +8,7 @@ interface Dispatcher
      * Register an event listener with the dispatcher.
      *
      * @param  \Closure|string|array  $events
-     * @param  \Closure|string|null  $listener
+     * @param  \Closure|string|array|null  $listener
      * @return void
      */
     public function listen($events, $listener = null);

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -71,7 +71,7 @@ class Dispatcher implements DispatcherContract
      * Register an event listener with the dispatcher.
      *
      * @param  \Closure|string|array  $events
-     * @param  \Closure|string|null  $listener
+     * @param  \Closure|string|array|null  $listener
      * @return void
      */
     public function listen($events, $listener = null)

--- a/src/Illuminate/Events/NullDispatcher.php
+++ b/src/Illuminate/Events/NullDispatcher.php
@@ -65,7 +65,7 @@ class NullDispatcher implements DispatcherContract
      * Register an event listener with the dispatcher.
      *
      * @param  \Closure|string|array  $events
-     * @param  \Closure|string|null  $listener
+     * @param  \Closure|string|array|null  $listener
      * @return void
      */
     public function listen($events, $listener = null)


### PR DESCRIPTION
Hi!

`array` type is missed for param `$listener` of `Dispatcher::listen()` method. 

Example (from docs):
```php
$events->listen(
    'Illuminate\Auth\Events\Login',
    [UserEventSubscriber::class, 'handleUserLogin']
);
```