### PR TITLE
[8.x] Add Buffered Console Output

### DIFF
--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -19,7 +19,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\BufferedOutput;
-use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\PhpExecutableFinder;
 

--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -86,7 +86,7 @@ class Application extends SymfonyApplication implements ApplicationContract
 
         $this->events->dispatch(
             new CommandStarting(
-                $commandName, $input, $output = $output ?: new ConsoleOutput
+                $commandName, $input, $output = $output ?: new BufferedConsoleOutput
             )
         );
 

--- a/src/Illuminate/Console/BufferedConsoleOutput.php
+++ b/src/Illuminate/Console/BufferedConsoleOutput.php
@@ -11,7 +11,7 @@ class BufferedConsoleOutput extends ConsoleOutput
      *
      * @var string
      */
-    private $buffer = '';
+    protected $buffer = '';
 
     /**
      * Empties the buffer and returns its content.

--- a/src/Illuminate/Console/BufferedConsoleOutput.php
+++ b/src/Illuminate/Console/BufferedConsoleOutput.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Illuminate\Console;
+
+use Symfony\Component\Console\Output\ConsoleOutput;
+
+class BufferedConsoleOutput extends ConsoleOutput
+{
+    /**
+     * The current buffer.
+     *
+     * @var string
+     */
+    private $buffer = '';
+
+    /**
+     * Empties the buffer and returns its content.
+     *
+     * @return string
+     */
+    public function fetch()
+    {
+        return tap($this->buffer, function () {
+            $this->buffer = '';
+        });
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doWrite(string $message, bool $newline)
+    {
+        $this->buffer .= $message;
+
+        if ($newline) {
+            $this->buffer .= \PHP_EOL;
+        }
+
+        return parent::doWrite($message, $newline);
+    }
+}


### PR DESCRIPTION
This change will allow the `CommandFinished` event output property to be fetched as a string.