### PR TITLE
[8.x] Verify that SchemaState has the required utilities for restoring a database schema

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -131,6 +131,13 @@ class MigrateCommand extends BaseCommand
             return;
         }
 
+        /** @var \Illuminate\Database\Schema\SchemaState $schemaState */
+        $schemaState = $connection->getSchemaState();
+
+        if (! $schemaState->hasRequiredDependencies()) {
+            return;
+        }
+
         $this->line('<info>Loading stored database schema:</info> '.$path);
 
         $startTime = microtime(true);
@@ -140,7 +147,7 @@ class MigrateCommand extends BaseCommand
         // table already exists when the stored database schema file gets executed.
         $this->migrator->deleteRepository();
 
-        $connection->getSchemaState()->handleOutputUsing(function ($type, $buffer) {
+        $schemaState->handleOutputUsing(function ($type, $buffer) {
             $this->output->write($buffer);
         })->load($path);
 

--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -154,4 +154,12 @@ class MySqlSchemaState extends SchemaState
 
         return $process;
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function hasRequiredDependencies()
+    {
+        return $this->hasCommand('mysql');
+    }
 }

--- a/src/Illuminate/Database/Schema/PostgresSchemaState.php
+++ b/src/Illuminate/Database/Schema/PostgresSchemaState.php
@@ -78,4 +78,12 @@ class PostgresSchemaState extends SchemaState
             'LARAVEL_LOAD_DATABASE' => $config['database'],
         ];
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function hasRequiredDependencies()
+    {
+        return $this->hasCommand('pg_restore');
+    }
 }

--- a/src/Illuminate/Database/Schema/SchemaState.php
+++ b/src/Illuminate/Database/Schema/SchemaState.php
@@ -84,6 +84,12 @@ abstract class SchemaState
     abstract public function load($path);
 
     /**
+     * Verify that the environment has the required dependencies for restoring a schema.
+     * @return bool
+     */
+    abstract public function hasRequiredDependencies();
+
+    /**
      * Create a new process instance.
      *
      * @param  array  $arguments
@@ -118,5 +124,21 @@ abstract class SchemaState
         $this->output = $output;
 
         return $this;
+    }
+
+    /**
+     * Check if a command is available and executable in the user PATH.
+     * @param string $command
+     * @return bool
+     */
+    protected function hasCommand(string $command)
+    {
+        $isWindows = strpos(PHP_OS, 'WIN') === 0;
+        $process = $this->makeProcess(sprintf('%s %s',
+            $isWindows ? 'where' : 'command -v',
+            $command,
+        ));
+
+        return is_executable($process->getOutput());
     }
 }

--- a/src/Illuminate/Database/Schema/SqliteSchemaState.php
+++ b/src/Illuminate/Database/Schema/SqliteSchemaState.php
@@ -90,4 +90,9 @@ class SqliteSchemaState extends SchemaState
             'LARAVEL_LOAD_DATABASE' => $config['database'],
         ];
     }
+
+    public function hasRequiredDependencies()
+    {
+        return $this->hasCommand('sqlite3');
+    }
 }

--- a/tests/Database/DatabaseMigrationMigrateCommandTest.php
+++ b/tests/Database/DatabaseMigrationMigrateCommandTest.php
@@ -51,11 +51,35 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
         $migrator->shouldReceive('usingConnection')->once()->andReturnUsing(function ($name, $callback) {
             return $callback();
         });
-        $migrator->shouldReceive('deleteRepository')->once();
         $connection->shouldReceive('getSchemaState')->andReturn($schemaState = m::mock(stdClass::class));
+        $schemaState->shouldReceive('hasRequiredDependencies')->andReturn(true);
+        $migrator->shouldReceive('deleteRepository')->once();
         $schemaState->shouldReceive('handleOutputUsing')->andReturnSelf();
         $schemaState->shouldReceive('load')->once()->with(__DIR__.'/stubs/schema.sql');
         $dispatcher->shouldReceive('dispatch')->once()->with(m::type(SchemaLoaded::class));
+        $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
+        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => false]);
+        $migrator->shouldReceive('getNotes')->andReturn([]);
+        $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
+
+        $this->runCommand($command, ['--schema-path' => __DIR__.'/stubs/schema.sql']);
+    }
+
+    public function testMigrationsDontUseStoredSchemaWhenMissingDependencies()
+    {
+        $command = new MigrateCommand($migrator = m::mock(Migrator::class), $dispatcher = m::mock(Dispatcher::class));
+        $app = new ApplicationDatabaseMigrationStub(['path.database' => __DIR__]);
+        $app->useDatabasePath(__DIR__);
+        $command->setLaravel($app);
+        $migrator->shouldReceive('paths')->once()->andReturn([]);
+        $migrator->shouldReceive('hasRunAnyMigrations')->andReturn(false);
+        $migrator->shouldReceive('resolveConnection')->andReturn($connection = m::mock(stdClass::class));
+        $connection->shouldReceive('getName')->andReturn('mysql');
+        $migrator->shouldReceive('usingConnection')->once()->andReturnUsing(function ($name, $callback) {
+            return $callback();
+        });
+        $connection->shouldReceive('getSchemaState')->andReturn($schemaState = m::mock(stdClass::class));
+        $schemaState->shouldReceive('hasRequiredDependencies')->andReturn(false);
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
         $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => false]);
         $migrator->shouldReceive('getNotes')->andReturn([]);


### PR DESCRIPTION
I ran into the issue where my test environment did not have access to the mysql command. If the required command does not exist the Application will throw an Exception. 

What I added is that when we try to restore an existing schema we first check if the required command exists or else we just skip that part.
