### PR TITLE
[8.x] Add support for custom messages passed directly to validator when running custom rules

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -736,7 +736,7 @@ class Validator implements ValidatorContract
         if (! $rule->passes($attribute, $value)) {
             $this->failedRules[$attribute][get_class($rule)] = [];
 
-            $messages = $rule->message();
+            $messages = $this->customMessages[$attribute] ?? $rule->message();
 
             $messages = $messages ? (array) $messages : [get_class($rule)];
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -5719,6 +5719,26 @@ class ValidationValidatorTest extends TestCase
         $this->assertSame(['data.1.date' => ['validation.date'], 'data.*.date' => ['validation.date']], $validator->messages()->toArray());
     }
 
+    public function testCustomMessagesCanOverrideRuleMessages()
+    {
+        $data = ['foo' => true];
+        $validator = new Validator(
+            $this->getIlluminateArrayTranslator(),
+            $data,
+            ['foo' => [new FailRule()]],
+            ['foo' => 'bar']
+        );
+        $this->assertFalse($validator->passes());
+        $this->assertSame($validator->errors()->all(), ['bar']);
+        $validator = new Validator(
+            $this->getIlluminateArrayTranslator(),
+            $data,
+            ['foo' => [new FailRule()]]
+        );
+        $this->assertFalse($validator->passes());
+        $this->assertSame($validator->errors()->all(), ['foo']);
+    }
+
     protected function getTranslator()
     {
         return m::mock(TranslatorContract::class);
@@ -5755,4 +5775,18 @@ class ExplicitTableAndConnectionModel extends Model
 
 class NonEloquentModel
 {
+}
+
+class FailRule implements Rule
+{
+
+    public function passes($attribute, $value)
+    {
+        return false;
+    }
+
+    public function message()
+    {
+        return 'foo';
+    }
 }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -5779,7 +5779,6 @@ class NonEloquentModel
 
 class FailRule implements Rule
 {
-
     public function passes($attribute, $value)
     {
         return false;

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -5719,6 +5719,26 @@ class ValidationValidatorTest extends TestCase
         $this->assertSame(['data.1.date' => ['validation.date'], 'data.*.date' => ['validation.date']], $validator->messages()->toArray());
     }
 
+    public function testCustomMessagesCanOverrideRuleMessages()
+    {
+        $data = ['foo' => true];
+        $validator = new Validator(
+            $this->getIlluminateArrayTranslator(),
+            $data,
+            ['foo' => new FailRule()],
+            ['foo' => 'bar']
+        );
+        $this->assertFalse($validator->passes());
+        $this->assertSame($validator->errors()->all(), ['bar']);
+        $validator = new Validator(
+            $this->getIlluminateArrayTranslator(),
+            $data,
+            ['foo' => new FailRule()]
+        );
+        $this->assertFalse($validator->passes());
+        $this->assertSame($validator->errors()->all(), ['foo']);
+    }
+
     protected function getTranslator()
     {
         return m::mock(TranslatorContract::class);
@@ -5755,4 +5775,17 @@ class ExplicitTableAndConnectionModel extends Model
 
 class NonEloquentModel
 {
+}
+
+class FailRule implements Rule {
+
+    public function passes($attribute, $value)
+    {
+        return false;
+    }
+
+    public function message()
+    {
+        return 'foo';
+    }
 }


### PR DESCRIPTION
This change is to allow passing custom validation errors as an argument to the validator for custom rules.

I came across an instance this week where I needed to do exactly this and I had to create a wonky workaround to accomplish this.

This is a minimal example of what I was dealing with:

```
>>> class FailRule implements Rule {
... 
...     public function passes($attribute, $value)
...     {
...         return false;
...     }
... 
...     public function message()
...     {
...         return 'foo';
...     }
... }
>>> $v=Validator::make(['foo' => true],['foo' => [new FailRule()]],['foo'=>'bar'])
>>> $v->passes()
=> false
>>> $v->errors()->all()
=> [
     "foo",
   ]
```

What I expected was to be able to pass in a custom message like this case:

```
>>> $v=Validator::make([],['foo' => ['required']],['foo.required'=>'bar'])
>>> $v->passes()
=> false
>>> $v->errors()->all()
=> [
     "bar",
   ]
```