### PR TITLE
[8.x] Reflect object properties in view component

### DIFF
--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Contracts\View\View as ViewContract;
 use Illuminate\Support\Str;
 use ReflectionClass;
+use ReflectionObject;
 use ReflectionMethod;
 use ReflectionProperty;
 
@@ -136,7 +137,7 @@ abstract class Component
         $class = get_class($this);
 
         if (! isset(static::$propertyCache[$class])) {
-            $reflection = new ReflectionClass($this);
+            $reflection = new ReflectionObject($this);
 
             static::$propertyCache[$class] = collect($reflection->getProperties(ReflectionProperty::IS_PUBLIC))
                 ->reject(function (ReflectionProperty $property) {


### PR DESCRIPTION
With this change we'll be able create classes extensions of `Component::class` using dinamic properties 

```php
class ComponentTestable extends ComponentWrapper
{
    protected $props = [
        'id', 'items', 'total'
    ];

    public $test = 'test_string';

    protected $casts = [
        'items' => 'objects',
        'id' => 'int', 
        'total' => 'float:15,2'
    ];

    public $view = 'sale';
}
```