### PR TITLE
[8.x]  Make the ConcurrencyLimiter methods public

### DIFF
--- a/src/Illuminate/Redis/Limiters/ConcurrencyLimiter.php
+++ b/src/Illuminate/Redis/Limiters/ConcurrencyLimiter.php
@@ -98,7 +98,7 @@ class ConcurrencyLimiter
      * @param  string  $id  A unique identifier for this lock
      * @return mixed
      */
-    protected function acquire($id)
+    public function acquire($id)
     {
         $slots = array_map(function ($i) {
             return $this->name.$i;
@@ -139,7 +139,7 @@ LUA;
      * @param  string  $id
      * @return void
      */
-    protected function release($key, $id)
+    public function release($key, $id)
     {
         $this->redis->eval($this->releaseScript(), 1, $key, $id);
     }

--- a/tests/Redis/ConcurrentLimiterTest.php
+++ b/tests/Redis/ConcurrentLimiterTest.php
@@ -170,7 +170,7 @@ class ConcurrentLimiterTest extends TestCase
 
 class ConcurrencyLimiterMockThatDoesntRelease extends ConcurrencyLimiter
 {
-    protected function release($key, $id)
+    public function release($key, $id)
     {
         //
     }


### PR DESCRIPTION
The `DurationLimiter` `acquire()` method is public. This PR makes the methods of the concurrency limiter also public.