### PR TITLE
[8.x] phpredis lock serialization and compression support

### DIFF
--- a/src/Illuminate/Cache/PhpRedisLock.php
+++ b/src/Illuminate/Cache/PhpRedisLock.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Illuminate\Cache;
+
+use Illuminate\Redis\Connections\PhpRedisConnection;
+use Redis;
+use UnexpectedValueException;
+
+class PhpRedisLock extends RedisLock
+{
+    public function __construct(PhpRedisConnection $redis, string $name, int $seconds, ?string $owner = null)
+    {
+        parent::__construct($redis, $name, $seconds, $owner);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function release()
+    {
+        return (bool) $this->redis->eval(
+            LuaScripts::releaseLock(),
+            1,
+            $this->name,
+            $this->serializedAndCompressedOwner()
+        );
+    }
+
+    protected function serializedAndCompressedOwner(): string
+    {
+        $client = $this->redis->client();
+
+        /* If a serialization mode such as "php" or "igbinary" and/or a
+         * compression mode such as "lzf" or "zstd" is enabled, the owner
+         * must be serialized and/or compressed by us, because phpredis does
+         * not do this for the eval command.
+         *
+         * Name must not be modified!
+         */
+        $owner = $client->_serialize($this->owner);
+
+        /* Once the phpredis extension exposes a compress function like the
+         * above `_serialize()` function, we should switch to it to guarantee
+         * consistency in the way the extension serializes and compresses to
+         * avoid the need to check each compression option ourselves.
+         *
+         * @see https://github.com/phpredis/phpredis/issues/1938
+         */
+        if ($this->compressed()) {
+            if ($this->lzfCompressed()) {
+                $owner = \lzf_compress($owner);
+            } elseif ($this->zstdCompressed()) {
+                $owner = \zstd_compress($owner, $client->getOption(Redis::OPT_COMPRESSION_LEVEL));
+            } elseif ($this->lz4Compressed()) {
+                $owner = \lz4_compress($owner, $client->getOption(Redis::OPT_COMPRESSION_LEVEL));
+            } else {
+                throw new UnexpectedValueException(sprintf(
+                    'Unknown phpredis compression in use (%d). Unable to release lock.',
+                    $client->getOption(Redis::OPT_COMPRESSION)
+                ));
+            }
+        }
+
+        return $owner;
+    }
+
+    protected function compressed(): bool
+    {
+        return $this->redis->client()->getOption(Redis::OPT_COMPRESSION) !== Redis::COMPRESSION_NONE;
+    }
+
+    protected function lzfCompressed(): bool
+    {
+        return defined('Redis::COMPRESSION_LZF') &&
+            $this->redis->client()->getOption(Redis::OPT_COMPRESSION) === Redis::COMPRESSION_LZF;
+    }
+
+    protected function zstdCompressed(): bool
+    {
+        return defined('Redis::COMPRESSION_ZSTD') &&
+            $this->redis->client()->getOption(Redis::OPT_COMPRESSION) === Redis::COMPRESSION_ZSTD;
+    }
+
+    protected function lz4Compressed(): bool
+    {
+        return defined('Redis::COMPRESSION_LZ4') &&
+            $this->redis->client()->getOption(Redis::OPT_COMPRESSION) === Redis::COMPRESSION_LZ4;
+    }
+}

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -4,6 +4,7 @@ namespace Illuminate\Cache;
 
 use Illuminate\Contracts\Cache\LockProvider;
 use Illuminate\Contracts\Redis\Factory as Redis;
+use Illuminate\Redis\Connections\PhpRedisConnection;
 
 class RedisStore extends TaggableStore implements LockProvider
 {
@@ -188,7 +189,14 @@ class RedisStore extends TaggableStore implements LockProvider
      */
     public function lock($name, $seconds = 0, $owner = null)
     {
-        return new RedisLock($this->lockConnection(), $this->prefix.$name, $seconds, $owner);
+        $lockName = $this->prefix.$name;
+        $lockConnection = $this->lockConnection();
+
+        if ($lockConnection instanceof PhpRedisConnection) {
+            return new PhpRedisLock($lockConnection, $lockName, $seconds, $owner);
+        }
+
+        return new RedisLock($lockConnection, $lockName, $seconds, $owner);
     }
 
     /**

--- a/tests/Integration/Cache/PhpRedisCacheLockTest.php
+++ b/tests/Integration/Cache/PhpRedisCacheLockTest.php
@@ -1,0 +1,306 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Cache;
+
+use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
+use Illuminate\Support\Facades\Cache;
+use Orchestra\Testbench\TestCase;
+use Redis;
+
+/**
+ * @group integration
+ */
+class PhpRedisCacheLockTest extends TestCase
+{
+    use InteractsWithRedis;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->setUpRedis();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        $this->tearDownRedis();
+    }
+
+    public function testRedisLockCanBeAcquiredAndReleasedWithoutSerializationAndCompression()
+    {
+        $this->app['config']->set('database.redis.client', 'phpredis');
+        $this->app['config']->set('cache.stores.redis.connection', 'default');
+        $this->app['config']->set('cache.stores.redis.lock_connection', 'default');
+
+        /** @var \Illuminate\Cache\RedisStore $store */
+        $store = Cache::store('redis');
+        /** @var \Redis $client */
+        $client = $store->lockConnection()->client();
+
+        $client->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_NONE);
+        $store->lock('foo')->forceRelease();
+        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
+        $lock = $store->lock('foo', 10);
+        $this->assertTrue($lock->get());
+        $this->assertFalse($store->lock('foo', 10)->get());
+        $lock->release();
+        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
+    }
+
+    public function testRedisLockCanBeAcquiredAndReleasedWithPhpSerialization()
+    {
+        $this->app['config']->set('database.redis.client', 'phpredis');
+        $this->app['config']->set('cache.stores.redis.connection', 'default');
+        $this->app['config']->set('cache.stores.redis.lock_connection', 'default');
+
+        /** @var \Illuminate\Cache\RedisStore $store */
+        $store = Cache::store('redis');
+        /** @var \Redis $client */
+        $client = $store->lockConnection()->client();
+
+        $client->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_PHP);
+        $store->lock('foo')->forceRelease();
+        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
+        $lock = $store->lock('foo', 10);
+        $this->assertTrue($lock->get());
+        $this->assertFalse($store->lock('foo', 10)->get());
+        $lock->release();
+        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
+    }
+
+    public function testRedisLockCanBeAcquiredAndReleasedWithJsonSerialization()
+    {
+        $this->app['config']->set('database.redis.client', 'phpredis');
+        $this->app['config']->set('cache.stores.redis.connection', 'default');
+        $this->app['config']->set('cache.stores.redis.lock_connection', 'default');
+
+        /** @var \Illuminate\Cache\RedisStore $store */
+        $store = Cache::store('redis');
+        /** @var \Redis $client */
+        $client = $store->lockConnection()->client();
+
+        $client->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_JSON);
+        $store->lock('foo')->forceRelease();
+        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
+        $lock = $store->lock('foo', 10);
+        $this->assertTrue($lock->get());
+        $this->assertFalse($store->lock('foo', 10)->get());
+        $lock->release();
+        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
+    }
+
+    public function testRedisLockCanBeAcquiredAndReleasedWithIgbinarySerialization()
+    {
+        if (! defined('Redis::SERIALIZER_IGBINARY')) {
+            $this->markTestSkipped('Redis extension is not configured to support the igbinary serializer.');
+        }
+
+        $this->app['config']->set('database.redis.client', 'phpredis');
+        $this->app['config']->set('cache.stores.redis.connection', 'default');
+        $this->app['config']->set('cache.stores.redis.lock_connection', 'default');
+
+        /** @var \Illuminate\Cache\RedisStore $store */
+        $store = Cache::store('redis');
+        /** @var \Redis $client */
+        $client = $store->lockConnection()->client();
+
+        $client->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_IGBINARY);
+        $store->lock('foo')->forceRelease();
+        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
+        $lock = $store->lock('foo', 10);
+        $this->assertTrue($lock->get());
+        $this->assertFalse($store->lock('foo', 10)->get());
+        $lock->release();
+        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
+    }
+
+    public function testRedisLockCanBeAcquiredAndReleasedWithMsgpackSerialization()
+    {
+        if (! defined('Redis::SERIALIZER_MSGPACK')) {
+            $this->markTestSkipped('Redis extension is not configured to support the msgpack serializer.');
+        }
+
+        $this->app['config']->set('database.redis.client', 'phpredis');
+        $this->app['config']->set('cache.stores.redis.connection', 'default');
+        $this->app['config']->set('cache.stores.redis.lock_connection', 'default');
+
+        /** @var \Illuminate\Cache\RedisStore $store */
+        $store = Cache::store('redis');
+        /** @var \Redis $client */
+        $client = $store->lockConnection()->client();
+
+        $client->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_MSGPACK);
+        $store->lock('foo')->forceRelease();
+        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
+        $lock = $store->lock('foo', 10);
+        $this->assertTrue($lock->get());
+        $this->assertFalse($store->lock('foo', 10)->get());
+        $lock->release();
+        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
+    }
+
+    public function testRedisLockCanBeAcquiredAndReleasedWithLzfCompression()
+    {
+        if (! defined('Redis::COMPRESSION_LZF')) {
+            $this->markTestSkipped('Redis extension is not configured to support the lzf compression.');
+        }
+
+        if (! extension_loaded('lzf')) {
+            $this->markTestSkipped('Lzf extension is not installed.');
+        }
+
+        $this->app['config']->set('database.redis.client', 'phpredis');
+        $this->app['config']->set('cache.stores.redis.connection', 'default');
+        $this->app['config']->set('cache.stores.redis.lock_connection', 'default');
+
+        /** @var \Illuminate\Cache\RedisStore $store */
+        $store = Cache::store('redis');
+        /** @var \Redis $client */
+        $client = $store->lockConnection()->client();
+
+        $client->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_NONE);
+        $client->setOption(Redis::OPT_COMPRESSION, Redis::COMPRESSION_LZF);
+        $store->lock('foo')->forceRelease();
+        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
+        $lock = $store->lock('foo', 10);
+        $this->assertTrue($lock->get());
+        $this->assertFalse($store->lock('foo', 10)->get());
+        $lock->release();
+        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
+    }
+
+    public function testRedisLockCanBeAcquiredAndReleasedWithZstdCompression()
+    {
+        if (! defined('Redis::COMPRESSION_ZSTD')) {
+            $this->markTestSkipped('Redis extension is not configured to support the zstd compression.');
+        }
+
+        if (! extension_loaded('zstd')) {
+            $this->markTestSkipped('Zstd extension is not installed.');
+        }
+
+        $this->app['config']->set('database.redis.client', 'phpredis');
+        $this->app['config']->set('cache.stores.redis.connection', 'default');
+        $this->app['config']->set('cache.stores.redis.lock_connection', 'default');
+
+        /** @var \Illuminate\Cache\RedisStore $store */
+        $store = Cache::store('redis');
+        /** @var \Redis $client */
+        $client = $store->lockConnection()->client();
+
+        $client->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_NONE);
+        $client->setOption(Redis::OPT_COMPRESSION, Redis::COMPRESSION_ZSTD);
+        $client->setOption(Redis::OPT_COMPRESSION_LEVEL, Redis::COMPRESSION_ZSTD_DEFAULT);
+        $store->lock('foo')->forceRelease();
+        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
+        $lock = $store->lock('foo', 10);
+        $this->assertTrue($lock->get());
+        $this->assertFalse($store->lock('foo', 10)->get());
+        $lock->release();
+        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
+
+        $client->setOption(Redis::OPT_COMPRESSION_LEVEL, Redis::COMPRESSION_ZSTD_MIN);
+        $store->lock('foo')->forceRelease();
+        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
+        $lock = $store->lock('foo', 10);
+        $this->assertTrue($lock->get());
+        $this->assertFalse($store->lock('foo', 10)->get());
+        $lock->release();
+        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
+
+        $client->setOption(Redis::OPT_COMPRESSION_LEVEL, Redis::COMPRESSION_ZSTD_MAX);
+        $store->lock('foo')->forceRelease();
+        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
+        $lock = $store->lock('foo', 10);
+        $this->assertTrue($lock->get());
+        $this->assertFalse($store->lock('foo', 10)->get());
+        $lock->release();
+        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
+    }
+
+    public function testRedisLockCanBeAcquiredAndReleasedWithLz4Compression()
+    {
+        if (! defined('Redis::COMPRESSION_LZ4')) {
+            $this->markTestSkipped('Redis extension is not configured to support the lz4 compression.');
+        }
+
+        if (! extension_loaded('lz4')) {
+            $this->markTestSkipped('Lz4 extension is not installed.');
+        }
+
+        $this->markTestIncomplete(
+            'phpredis extension does not compress consistently with the php '.
+            'extension lz4. See: https://github.com/phpredis/phpredis/issues/1939'
+        );
+
+        $this->app['config']->set('database.redis.client', 'phpredis');
+        $this->app['config']->set('cache.stores.redis.connection', 'default');
+        $this->app['config']->set('cache.stores.redis.lock_connection', 'default');
+
+        /** @var \Illuminate\Cache\RedisStore $store */
+        $store = Cache::store('redis');
+        /** @var \Redis $client */
+        $client = $store->lockConnection()->client();
+
+        $client->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_NONE);
+        $client->setOption(Redis::OPT_COMPRESSION, Redis::COMPRESSION_LZ4);
+        $client->setOption(Redis::OPT_COMPRESSION_LEVEL, 1);
+        $store->lock('foo')->forceRelease();
+        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
+        $lock = $store->lock('foo', 10);
+        $this->assertTrue($lock->get());
+        $this->assertFalse($store->lock('foo', 10)->get());
+        $lock->release();
+        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
+
+        $client->setOption(Redis::OPT_COMPRESSION_LEVEL, 3);
+        $store->lock('foo')->forceRelease();
+        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
+        $lock = $store->lock('foo', 10);
+        $this->assertTrue($lock->get());
+        $this->assertFalse($store->lock('foo', 10)->get());
+        $lock->release();
+        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
+
+        $client->setOption(Redis::OPT_COMPRESSION_LEVEL, 12);
+        $store->lock('foo')->forceRelease();
+        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
+        $lock = $store->lock('foo', 10);
+        $this->assertTrue($lock->get());
+        $this->assertFalse($store->lock('foo', 10)->get());
+        $lock->release();
+        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
+    }
+
+    public function testRedisLockCanBeAcquiredAndReleasedWithSerializationAndCompression()
+    {
+        if (! defined('Redis::COMPRESSION_LZF')) {
+            $this->markTestSkipped('Redis extension is not configured to support the lzf compression.');
+        }
+
+        if (! extension_loaded('lzf')) {
+            $this->markTestSkipped('Lzf extension is not installed.');
+        }
+
+        $this->app['config']->set('database.redis.client', 'phpredis');
+        $this->app['config']->set('cache.stores.redis.connection', 'default');
+        $this->app['config']->set('cache.stores.redis.lock_connection', 'default');
+
+        /** @var \Illuminate\Cache\RedisStore $store */
+        $store = Cache::store('redis');
+        /** @var \Redis $client */
+        $client = $store->lockConnection()->client();
+
+        $client->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_PHP);
+        $client->setOption(Redis::OPT_COMPRESSION, Redis::COMPRESSION_LZF);
+        $store->lock('foo')->forceRelease();
+        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
+        $lock = $store->lock('foo', 10);
+        $this->assertTrue($lock->get());
+        $this->assertFalse($store->lock('foo', 10)->get());
+        $lock->release();
+        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
+    }
+}


### PR DESCRIPTION
laravel/framework#36337: Respect serialization and compression settings of the phpredis extension when using it for locking via the cache service.

- Support phpredis serialization when locking (none, php, json, igbinary, msgpack).
- Support phpredis compression when locking (none, lzf, zstd, lz4).

This is a bug that will cause locking to not release the lock if the redis connection is configured to use serialization and/or compression of data. LZ4 code support was added, but is not working yet as phpredis implemented it not consistent to the lz4 php extension. Waiting for this issue on phpredis to be resolved: https://github.com/phpredis/phpredis/issues/1939. All other compression options resolve this bug.

Also once the phpredis issue https://github.com/phpredis/phpredis/issues/1938 is resolved, we might have a consistent way to call the same compression logic that the extension is using without the need to check for each implementation.

Tested locally with all extensions enabled/configured (lzf, zstd, lz4, igbinary, msgpack).

Solves #36337 