### PR TITLE
[8.x] Rename rules to rule in ValidationRuleParser::parse()

### DIFF
--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -186,57 +186,57 @@ class ValidationRuleParser
     /**
      * Extract the rule name and parameters from a rule.
      *
-     * @param  array|string  $rules
+     * @param  array|string  $rule
      * @return array
      */
-    public static function parse($rules)
+    public static function parse($rule)
     {
-        if ($rules instanceof RuleContract) {
-            return [$rules, []];
+        if ($rule instanceof RuleContract) {
+            return [$rule, []];
         }
 
-        if (is_array($rules)) {
-            $rules = static::parseArrayRule($rules);
+        if (is_array($rule)) {
+            $rule = static::parseArrayRule($rule);
         } else {
-            $rules = static::parseStringRule($rules);
+            $rule = static::parseStringRule($rule);
         }
 
-        $rules[0] = static::normalizeRule($rules[0]);
+        $rule[0] = static::normalizeRule($rule[0]);
 
-        return $rules;
+        return $rule;
     }
 
     /**
      * Parse an array based rule.
      *
-     * @param  array  $rules
+     * @param  array  $rule
      * @return array
      */
-    protected static function parseArrayRule(array $rules)
+    protected static function parseArrayRule(array $rule)
     {
-        return [Str::studly(trim(Arr::get($rules, 0))), array_slice($rules, 1)];
+        return [Str::studly(trim(Arr::get($rule, 0))), array_slice($rule, 1)];
     }
 
     /**
      * Parse a string based rule.
      *
-     * @param  string  $rules
+     * @param  string  $rule
      * @return array
      */
-    protected static function parseStringRule($rules)
+    protected static function parseStringRule($rule)
     {
         $parameters = [];
 
         // The format for specifying validation rules and parameters follows an
         // easy {rule}:{parameters} formatting convention. For instance the
         // rule "Max:3" states that the value may only be three letters.
-        if (strpos($rules, ':') !== false) {
-            [$rules, $parameter] = explode(':', $rules, 2);
+        if (strpos($rule, ':') !== false) {
+            [$rule, $parameter] = explode(':', $rule, 2);
 
-            $parameters = static::parseParameters($rules, $parameter);
+            $parameters = static::parseParameters($rule, $parameter);
         }
 
-        return [Str::studly(trim($rules)), $parameters];
+        return [Str::studly(trim($rule)), $parameters];
     }
 
     /**


### PR DESCRIPTION
This matches the two callsites as well as the description. I also made the same change in functions that were called from within it.

