### PR TITLE
[8.x] Allow ignore an exception report or render method

### DIFF
--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -113,6 +113,7 @@ class FoundationExceptionsHandlerTest extends TestCase
         $this->handler->reportable(function (ReportableException $e) {
             $reportingService = $this->container->make(ReportingService::class);
             $reportingService->send('Called from reportable');
+
             return false;
         });
 


### PR DESCRIPTION
Since the addition of report and render callbacks, we can easily add custom renderer for an exception, such as:

```php
$this->renderable(function (OAuthServerException $e, $request) {
    return response()->json(['message' => 'Authentication error']);
});
```

But, for this case, because `Laravel\Passport\Exceptions\OAuthServerException` class has a `render` method defined,
the above render callback for `OAuthServerException` will not be called because of this:

```php
public function render($request, Throwable $e)
{
    if (method_exists($e, 'render') && $response = $e->render($request)) {
        return Router::toResponse($request, $response);
    } elseif ($e instanceof Responsable) {
        return $e->toResponse($request);
    }

    $e = $this->prepareException($this->mapException($e));

    foreach ($this->renderCallbacks as $renderCallback) {
        if (is_a($e, $this->firstClosureParameterType($renderCallback))) {
            $response = $renderCallback($e, $request);

            if (! is_null($response)) {
                return $response;
            }
        }
    }
}
```

The rendered response for this exception will always come from its own custom response defined by its `render` method. So, the defined render callbacks for this exception will become unusable. Then, there is no point in using render callbacks for such exception.

This PR allows us to ignore the `render` or `report` method of an exception. An example case for this is when we want to override renderer for Passport's `OAuthServerException`. Instead of being forced to use the exception's renderer, we can instead ignore it and override it with our own renderer.

```php
$this->ignoreRenderMethod(OAuthServerException::class);

$this->renderable(function (OAuthServerException $e, $request) {
    return response()->json(['message' => 'Authentication error']);
});
```