### PR TITLE
[8.x] Check for context method

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -278,6 +278,10 @@ class Handler implements ExceptionHandlerContract
      */
     protected function exceptionContext(Throwable $e)
     {
+        if (method_exists($e, 'context')) {
+            return $e->context();
+        }
+
         return [];
     }
 

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -76,6 +76,15 @@ class FoundationExceptionsHandlerTest extends TestCase
         $this->handler->report(new RuntimeException('Exception message'));
     }
 
+    public function testHandlerCallsContextMethodIfPresent()
+    {
+        $logger = m::mock(LoggerInterface::class);
+        $this->container->instance(LoggerInterface::class, $logger);
+        $logger->shouldReceive('error')->withArgs(['Exception message', m::subset(['foo' => 'bar'])])->once();
+
+        $this->handler->report(new ContextProvidingException('Exception message'));
+    }
+
     public function testHandlerReportsExceptionWhenUnReportable()
     {
         $logger = m::mock(LoggerInterface::class);
@@ -280,6 +289,16 @@ class UnReportableException extends Exception
     public function report()
     {
         return false;
+    }
+}
+
+class ContextProvidingException extends Exception
+{
+    public function context()
+    {
+        return [
+            'foo' => 'bar',
+        ];
     }
 }
 


### PR DESCRIPTION
Currently, in order to send custom context to the logger on a per-exception basis, it is necessary to override the `exceptionContext` method in `App\Exceptions\Handler` and check the exception instance. This PR enables the base Handler to detect a `context` method defined on the exception class which would return an array, keeping the context logic within the exception class.


```php
class InvalidOrderException extends Exception
{
    /**
     * Provide exception context.
     *
     * @return array
     */
     public function context()
     {
         return ['id' => $this->order->id];
     }
}
```

Once this is merged, I can make a PR to the docs demonstrating this.