### PR TITLE
[8.x] Add Collection@isSingle method

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -554,6 +554,16 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
+     * Determine if the collection contains a single element.
+     *
+     * @return bool
+     */
+    public function isSingle()
+    {
+        return $this->count() === 1;
+    }
+
+    /**
      * Join all items from the collection using a string. The final items can use a separate glue string.
      *
      * @param  string  $glue

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -557,6 +557,16 @@ class LazyCollection implements Enumerable
     }
 
     /**
+     * Determine if the collection contains a single element.
+     *
+     * @return bool
+     */
+    public function isSingle()
+    {
+        return $this->take(2)->count() === 1;
+    }
+
+    /**
      * Join all items from the collection using a string. The final items can use a separate glue string.
      *
      * @param  string  $glue

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -541,6 +541,16 @@ class SupportCollectionTest extends TestCase
         })->all());
     }
 
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testIsSingle($collection)
+    {
+        $this->assertFalse((new $collection([]))->isSingle());
+        $this->assertTrue((new $collection([1]))->isSingle());
+        $this->assertFalse((new $collection([1, 2]))->isSingle());
+    }
+
     public function testIterable()
     {
         $c = new Collection(['foo']);

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -484,6 +484,13 @@ class SupportLazyCollectionIsLazyTest extends TestCase
         });
     }
 
+    public function testIsSingleIsLazy()
+    {
+        $this->assertEnumerates(2, function ($collection) {
+            $collection->isSingle();
+        });
+    }
+
     public function testJoinIsLazy()
     {
         $this->assertEnumeratesOnce(function ($collection) {


### PR DESCRIPTION
Adds an `isSingle` method to the collections:

```php
collect([])->isSingle();     // false
collect([1])->isSingle();    // true
collect([1, 2])->isSingle(); // false
```

Calling `$collection->count() === 1` is so common, I believe it makes sense to have a separate expressive method for it (even more so for the lazy collection, which is a tad more tricky).