### PR TITLE
[9.x] Allow to discovering event listeners on packages

### DIFF
--- a/src/Illuminate/Foundation/Events/DiscoverEvents.php
+++ b/src/Illuminate/Foundation/Events/DiscoverEvents.php
@@ -22,7 +22,7 @@ class DiscoverEvents
     public static function within($listenerPath, $namespace)
     {
         return collect(static::getListenerEvents(
-            (new Finder)->files()->in($listenerPath), $listenerPath, $namespace
+            (new Finder)->files()->in($listenerPath), realpath($listenerPath), $namespace
         ))->mapToDictionary(function ($event, $listener) {
             return [$event => $listener];
         })->all();

--- a/src/Illuminate/Foundation/Events/DiscoverEvents.php
+++ b/src/Illuminate/Foundation/Events/DiscoverEvents.php
@@ -32,18 +32,18 @@ class DiscoverEvents
      * Get all of the listeners and their corresponding events.
      *
      * @param  iterable  $listeners
-     * @param  string  $path
+     * @param  string  $basePath
      * @param  string  $namespace
      * @return array
      */
-    protected static function getListenerEvents($listeners, $path, $namespace)
+    protected static function getListenerEvents($listeners, $basePath, $namespace)
     {
         $listenerEvents = [];
 
         foreach ($listeners as $listener) {
             try {
                 $listener = new ReflectionClass(
-                    static::classFromFile($listener, $path, $namespace)
+                    static::classFromFile($listener, $basePath, $namespace)
                 );
             } catch (ReflectionException $e) {
                 continue;
@@ -71,14 +71,14 @@ class DiscoverEvents
      * Extract the class name from the given file path.
      *
      * @param  \SplFileInfo  $file
-     * @param  string  $path
+     * @param  string  $basePath
      * @param  string  $namespace
      * @return string
      */
-    protected static function classFromFile(SplFileInfo $file, $path, $namespace)
+    protected static function classFromFile(SplFileInfo $file, $basePath, $namespace)
     {
         return str_replace(
-            [$path, DIRECTORY_SEPARATOR],
+            [$basePath, DIRECTORY_SEPARATOR],
             [$namespace, '\\'],
             ucfirst(Str::replaceLast('.php', '', $file->getRealPath()))
         );

--- a/src/Illuminate/Foundation/Events/DiscoverEvents.php
+++ b/src/Illuminate/Foundation/Events/DiscoverEvents.php
@@ -16,7 +16,6 @@ class DiscoverEvents
      * Get all of the events and listeners by searching the given listener directory.
      *
      * @param  string  $listenerPath
-     * @param  string  $path
      * @param  string  $namespace
      * @return array
      */

--- a/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
@@ -132,7 +132,7 @@ class EventServiceProvider extends ServiceProvider
     protected function discoverEventsWithin()
     {
         return [
-            $this->app->path('Listeners') => $this->app->getNamespace().'\Listeners',
+            $this->app->path('Listeners') => $this->app->getNamespace().'Listeners',
         ];
     }
 }

--- a/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
@@ -113,13 +113,13 @@ class EventServiceProvider extends ServiceProvider
     public function discoverEvents()
     {
         return collect($this->discoverEventsWithin())
-                    ->reject(function ($directory) {
+                    ->reject(function ($namespace, $directory) {
                         return ! is_dir($directory);
                     })
-                    ->reduce(function ($discovered, $directory) {
+                    ->reduce(function ($discovered, $namespace, $directory) {
                         return array_merge_recursive(
                             $discovered,
-                            DiscoverEvents::within($directory, base_path())
+                            DiscoverEvents::within($directory, $namespace)
                         );
                     }, []);
     }
@@ -132,7 +132,7 @@ class EventServiceProvider extends ServiceProvider
     protected function discoverEventsWithin()
     {
         return [
-            $this->app->path('Listeners'),
+            $this->app->path('Listeners') => $this->app->getNamespace().'\Listeners',
         ];
     }
 }

--- a/tests/Integration/Foundation/DiscoverEventsTest.php
+++ b/tests/Integration/Foundation/DiscoverEventsTest.php
@@ -18,7 +18,7 @@ class DiscoverEventsTest extends TestCase
         class_alias(AbstractListener::class, 'Tests\Integration\Foundation\Fixtures\EventDiscovery\Listeners\AbstractListener');
         class_alias(ListenerInterface::class, 'Tests\Integration\Foundation\Fixtures\EventDiscovery\Listeners\ListenerInterface');
 
-        $events = DiscoverEvents::within(__DIR__.'/Fixtures/EventDiscovery/Listeners', getcwd());
+        $events = DiscoverEvents::within(__DIR__.'/Fixtures/EventDiscovery/Listeners', 'Tests\Integration\Foundation\Fixtures\EventDiscovery\Listeners');
 
         $this->assertEquals([
             EventOne::class => [

--- a/tests/Integration/Foundation/DiscoverEventsTest.php
+++ b/tests/Integration/Foundation/DiscoverEventsTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Integration\Foundation;
 
 use Illuminate\Foundation\Events\DiscoverEvents;
+use Illuminate\Foundation\Support\Providers\EventServiceProvider;
 use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\Events\EventOne;
 use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\Events\EventTwo;
 use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\Listeners\AbstractListener;
@@ -29,5 +30,17 @@ class DiscoverEventsTest extends TestCase
                 Listener::class.'@handleEventTwo',
             ],
         ], $events);
+    }
+
+    public function testListenerNamespace()
+    {
+        $eventServiceProvider = new EventServiceProvider($this->app);
+        $listenerWithIn = tap(new \ReflectionMethod($eventServiceProvider, 'discoverEventsWithin'))
+            ->setAccessible(true)
+            ->invoke($eventServiceProvider);
+
+        $this->assertEquals([
+            $this->app->path('Listeners') => 'App\Listeners',
+        ], $listenerWithIn);
     }
 }


### PR DESCRIPTION
This PR allow to use discovering event listeners on other packages instead only application listeners.

```php
class PackageServiceProvider extends EventServiceProvider {

    public function shouldDiscoverEvents()
    {
        return true;
    }

    protected function discoverEventsWithin()
    {
        return [
            __DIR__.'/Listeners' =>  'Vendor\Package\Listeners'
        ];
    }
}
```

9.x because it has BC when developers override discoverEventsWithin. 

declaration path => namespace  selected because sometimes different paths may have same namespace

Fixed #36437