### PR TITLE
[8.x] Fix formatWheres in DatabaseRule

### DIFF
--- a/src/Illuminate/Validation/Rules/DatabaseRule.php
+++ b/src/Illuminate/Validation/Rules/DatabaseRule.php
@@ -197,7 +197,7 @@ trait DatabaseRule
     {
         return collect($this->wheres)->map(function ($where) {
             if (is_bool($where['value'])) {
-                return $where['column'].','.'true';
+                return $where['column'].','.($where['value']?'true':'false');
             } else {
                 return $where['column'].','.'"'.str_replace('"', '""', $where['value']).'"';
             }

--- a/src/Illuminate/Validation/Rules/DatabaseRule.php
+++ b/src/Illuminate/Validation/Rules/DatabaseRule.php
@@ -195,7 +195,7 @@ trait DatabaseRule
      */
     protected function formatWheres()
     {
-        return collect($this->wheres)->map( function ($where) {
+        return collect($this->wheres)->map(function ($where) {
             if (is_bool($where['value'])) {
                 return $where['column'].','.'true';
             } else {

--- a/src/Illuminate/Validation/Rules/DatabaseRule.php
+++ b/src/Illuminate/Validation/Rules/DatabaseRule.php
@@ -197,7 +197,7 @@ trait DatabaseRule
     {
         return collect($this->wheres)->map(function ($where) {
             if (is_bool($where['value'])) {
-                return $where['column'].','.($where['value']?'true':'false');
+                return $where['column'].','.($where['value'] ? 'true' : 'false');
             } else {
                 return $where['column'].','.'"'.str_replace('"', '""', $where['value']).'"';
             }

--- a/src/Illuminate/Validation/Rules/DatabaseRule.php
+++ b/src/Illuminate/Validation/Rules/DatabaseRule.php
@@ -195,8 +195,12 @@ trait DatabaseRule
      */
     protected function formatWheres()
     {
-        return collect($this->wheres)->map(function ($where) {
-            return $where['column'].','.'"'.str_replace('"', '""', $where['value']).'"';
+        return collect($this->wheres)->map( function ($where) {
+            if (is_bool($where['value'])) {
+                return $where['column'].','.'true';
+            } else {
+                return $where['column'].','.'"'.str_replace('"', '""', $where['value']).'"';
+            }
         })->implode(',');
     }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

When we try this, all validation will failed

```php
// controller level

$this->validate($request, [
    'some_field' => Rule::exists(ModelClass::class)->where('extra->field', true),
]);

```
Checking return of DatabaseRule `formatWheres` will return 
```
"extra->field,"1""
```

Now the PR fixes return is
```
"extra->field,true"
````


Thank you


