### PR TITLE
[8.x] Add support for custom separator in Arr::dot()

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -104,15 +104,16 @@ class Arr
      *
      * @param  iterable  $array
      * @param  string  $prepend
+     * @param  string  $separator
      * @return array
      */
-    public static function dot($array, $prepend = '')
+    public static function dot($array, $prepend = '', $separator = '.')
     {
         $results = [];
 
         foreach ($array as $key => $value) {
             if (is_array($value) && ! empty($value)) {
-                $results = array_merge($results, static::dot($value, $prepend.$key.'.'));
+                $results = array_merge($results, static::dot($value, $prepend.$key.$separator, $separator));
             } else {
                 $results[$prepend.$key] = $value;
             }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -111,6 +111,10 @@ class SupportArrTest extends TestCase
 
         $array = Arr::dot(['name' => 'taylor', 'languages' => ['php' => true]]);
         $this->assertEquals(['name' => 'taylor', 'languages.php' => true], $array);
+
+        // Custom separator
+        $array = Arr::dot(['resources' => ['views' => ['index.blade.php' => '<h1>Hello world</h1>']]], '', '/');
+        $this->assertEquals(['resources/views/index.blade.php' => '<h1>Hello world</h1>'], $array);
     }
 
     public function testExcept()


### PR DESCRIPTION
This PR adds support for passing a new third parameter to `Arr::dot()` to specify a custom separator instead of using `.`:

```php
$nginx = [
    'etc' => [
        'nginx' => [
            'conf.d' => [
                'uploads.conf' => '...',
            ],
            'nginx.conf' => '...',
        ],
    ],
];

// With just Arr::dot($nginx), the keys will look like 'etc.nginx.conf.d.uploads.conf'

// With this PR, we can make them valid file paths:

Arr::dot($nginx, '/', '/');

// [
//     '/etc/nginx/conf.d/uploads.conf' => '...',
//     '/etc/nginx/nginx.conf' => '...',
// ]

// PHP 8 named arguments are nice too:
Arr::dot(['app' => ['resources' => ['views' => ['index.blade.php' => 'Hello, world.']]]], separator: '/');
// ['app/resources/views/index.blade.php' => 'Hello, world.']
```

I imagine there are other use cases besides file trees where this would come in handy too. Docs PR is ready to go if this is accepted.