### PR TITLE
[8.x] Add uri option to artisan route:list to evaluate a URI against routing rules

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -191,7 +191,9 @@ class RouteListCommand extends Command
             ($this->option('name') && ! Str::contains($route['name'], $this->option('name'))) ||
             ($this->option('path') && ! Str::contains($route['uri'], $this->option('path'))) ||
             ($this->option('method') && ! Str::contains($route['method'], strtoupper($this->option('method')))) ||
-            ($this->option('uri') && ! $route['route']->matches(Request::create($this->option('uri'))))
+            ($this->option('uri') && ! $route['route']->matches(
+                Request::create($this->option('uri'), $this->option('method') ?: 'GET'))
+            )
         ) {
             return;
         }

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Console;
 
 use Closure;
 use Illuminate\Console\Command;
+use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Arr;
@@ -117,6 +118,7 @@ class RouteListCommand extends Command
             'name'   => $route->getName(),
             'action' => ltrim($route->getActionName(), '\\'),
             'middleware' => $this->getMiddleware($route),
+            'route'  => $route,
         ]);
     }
 
@@ -181,13 +183,16 @@ class RouteListCommand extends Command
      * Filter the route by URI and / or name.
      *
      * @param  array  $route
-     * @return array|null
+     * @return array|void
      */
     protected function filterRoute(array $route)
     {
-        if (($this->option('name') && ! Str::contains($route['name'], $this->option('name'))) ||
-             $this->option('path') && ! Str::contains($route['uri'], $this->option('path')) ||
-             $this->option('method') && ! Str::contains($route['method'], strtoupper($this->option('method')))) {
+        if (
+            ($this->option('name') && ! Str::contains($route['name'], $this->option('name'))) ||
+            ($this->option('path') && ! Str::contains($route['uri'], $this->option('path'))) ||
+            ($this->option('method') && ! Str::contains($route['method'], strtoupper($this->option('method')))) ||
+            ($this->option('uri') && ! $route['route']->matches(Request::create($this->option('uri'))))
+        ) {
             return;
         }
 
@@ -259,6 +264,7 @@ class RouteListCommand extends Command
             ['method', null, InputOption::VALUE_OPTIONAL, 'Filter the routes by method'],
             ['name', null, InputOption::VALUE_OPTIONAL, 'Filter the routes by name'],
             ['path', null, InputOption::VALUE_OPTIONAL, 'Filter the routes by path'],
+            ['uri', null, InputOption::VALUE_OPTIONAL, 'Evaluate a URI against routing rules'],
             ['reverse', 'r', InputOption::VALUE_NONE, 'Reverse the ordering of the routes'],
             ['sort', null, InputOption::VALUE_OPTIONAL, 'The column (domain, method, uri, name, action, middleware) to sort by', 'uri'],
         ];


### PR DESCRIPTION
I was having trouble figuring out why a controller action was not triggering, and it turned out to be a route ordering problem. What I needed was to be able to see easily which route a given URI matches, and that's what this PR provides. Note that this is different to the `path` option, which only does simple string matching against the rule pattern itself and doesn't evaluate the rule.

Usage:

```sh
./artisan route:list --uri=/users/123 -c
+----------+--------------+----------------------------------------------+
| Method   | URI          | Action                                       |
+----------+--------------+----------------------------------------------+
| GET|HEAD | users/{user} | App\Http\Controllers\API\UserController@show |
+----------+--------------+----------------------------------------------+
```

I added the `$route` property itself to the array returned from `getRouteInformation` so it's easier to get a handle on the route itself; future extensions might find this useful too. It's implemented as a filter, so it cooperates with all the other filtering and output options, and I put it last as it's the slowest to evaluate. That's slightly academic as a URI should only ever match a single route, or none, but I guess it may help spot ambiguous routing definitions too.

I also cleaned up the layout of the `filterRoute` function to make it easier to read.