### PR TITLE
[8.x] Make user policy command fix (Windows)

### DIFF
--- a/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
@@ -131,8 +131,9 @@ class PolicyMakeCommand extends GeneratorCommand
             array_keys($replace), array_values($replace), $stub
         );
 
+        $eol = PHP_EOL;
         return str_replace(
-            "use {$namespacedModel};\nuse {$namespacedModel};", "use {$namespacedModel};", $stub
+            "use {$namespacedModel};{$eol}use {$namespacedModel};", "use {$namespacedModel};", $stub
         );
     }
 


### PR DESCRIPTION
When trying to run `php artisan make:policy UserPolicy --model=User` on Windows, the created file will contain:
```php
use App\Models\User;
use App\Models\User;
```