### PR TITLE
Fix Route@uses called with already callable action

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -12,6 +12,7 @@ use Illuminate\Routing\Matching\MethodValidator;
 use Illuminate\Routing\Matching\SchemeValidator;
 use Illuminate\Routing\Matching\UriValidator;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Reflector;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use LogicException;
@@ -857,7 +858,11 @@ class Route
      * @return $this
      */
     public function uses($action)
-    {
+    {        
+        if (Reflector::isCallable($action, true)) {
+            return $this->setAction(array_merge($this->action, $this->parseAction($action)));
+        }
+
         if (is_array($action)) {
             $action = $action[0].'@'.$action[1];
         }


### PR DESCRIPTION
Currently when defining a route eg. `$router->get('/companies/{company}/users')->uses([UsersController::class, 'index']) within a group with a specified namespace eg. `->namespace('Company')` the action is altered when `addGroupNamespaceToStringUses` is called resulting in `Controllers\Company\Controllers\Company\UsersController`. (Which most likely does not exist)

This patch fixes it by checking if the action isn't already callable.