### PR TITLE
[8.x] Add Fluent JSON Assertions

### DIFF
--- a/src/Illuminate/Testing/Fluent/Assert.php
+++ b/src/Illuminate/Testing/Fluent/Assert.php
@@ -19,19 +19,39 @@ class Assert implements Arrayable
         Macroable,
         Tappable;
 
-    /** @var array */
+    /**
+     * The properties in the current scope.
+     *
+     * @var array
+     */
     private $props;
 
-    /** @var string */
+    /**
+     * The "dot" path to the current scope.
+     *
+     * @var string|null
+     */
     private $path;
 
+    /**
+     * Create a new Assert instance.
+     *
+     * @param  array  $props
+     * @param  string|null  $path
+     */
     protected function __construct(array $props, string $path = null)
     {
         $this->path = $path;
         $this->props = $props;
     }
 
-    protected function dotPath($key): string
+    /**
+     * Compose the absolute "dot" path to the given key.
+     *
+     * @param  string  $key
+     * @return string
+     */
+    protected function dotPath(string $key): string
     {
         if (is_null($this->path)) {
             return $key;
@@ -40,12 +60,25 @@ class Assert implements Arrayable
         return implode('.', [$this->path, $key]);
     }
 
+    /**
+     * Retrieve a prop within the current scope using "dot" notation.
+     *
+     * @param  string|null  $key
+     * @return mixed
+     */
     protected function prop(string $key = null)
     {
         return Arr::get($this->props, $key);
     }
 
-    protected function scope($key, Closure $callback): self
+    /**
+     * Instantiate a new "scope" at the path of the given key.
+     *
+     * @param  string  $key
+     * @param  Closure  $callback
+     * @return $this
+     */
+    protected function scope(string $key, Closure $callback): self
     {
         $props = $this->prop($key);
         $path = $this->dotPath($key);
@@ -59,16 +92,33 @@ class Assert implements Arrayable
         return $this;
     }
 
+    /**
+     * Create a new instance from an array.
+     *
+     * @param  array  $data
+     * @return static
+     */
     public static function fromArray(array $data): self
     {
         return new self($data);
     }
 
+    /**
+     * Create a new instance from a AssertableJsonString.
+     *
+     * @param  AssertableJsonString  $json
+     * @return static
+     */
     public static function fromAssertableJsonString(AssertableJsonString $json): self
     {
         return self::fromArray($json->json());
     }
 
+    /**
+     * Get the instance as an array.
+     *
+     * @return array
+     */
     public function toArray()
     {
         return $this->props;

--- a/src/Illuminate/Testing/Fluent/Assert.php
+++ b/src/Illuminate/Testing/Fluent/Assert.php
@@ -75,7 +75,7 @@ class Assert implements Arrayable
      * Instantiate a new "scope" at the path of the given key.
      *
      * @param  string  $key
-     * @param  Closure  $callback
+     * @param  \Closure  $callback
      * @return $this
      */
     protected function scope(string $key, Closure $callback): self
@@ -106,7 +106,7 @@ class Assert implements Arrayable
     /**
      * Create a new instance from a AssertableJsonString.
      *
-     * @param  AssertableJsonString  $json
+     * @param  \Illuminate\Testing\AssertableJsonString  $json
      * @return static
      */
     public static function fromAssertableJsonString(AssertableJsonString $json): self

--- a/src/Illuminate/Testing/Fluent/Assert.php
+++ b/src/Illuminate/Testing/Fluent/Assert.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Illuminate\Testing\Fluent;
+
+use Closure;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Traits\Macroable;
+use Illuminate\Support\Traits\Tappable;
+use Illuminate\Testing\AssertableJsonString;
+use PHPUnit\Framework\Assert as PHPUnit;
+
+class Assert implements Arrayable
+{
+    use Concerns\Has,
+        Concerns\Matching,
+        Concerns\Debugging,
+        Concerns\Interaction,
+        Macroable,
+        Tappable;
+
+    /** @var array */
+    private $props;
+
+    /** @var string */
+    private $path;
+
+    protected function __construct(array $props, string $path = null)
+    {
+        $this->path = $path;
+        $this->props = $props;
+    }
+
+    protected function dotPath($key): string
+    {
+        if (is_null($this->path)) {
+            return $key;
+        }
+
+        return implode('.', [$this->path, $key]);
+    }
+
+    protected function prop(string $key = null)
+    {
+        return Arr::get($this->props, $key);
+    }
+
+    protected function scope($key, Closure $callback): self
+    {
+        $props = $this->prop($key);
+        $path = $this->dotPath($key);
+
+        PHPUnit::assertIsArray($props, sprintf('Property [%s] is not scopeable.', $path));
+
+        $scope = new self($props, $path);
+        $callback($scope);
+        $scope->interacted();
+
+        return $this;
+    }
+
+    public static function fromArray(array $data): self
+    {
+        return new self($data);
+    }
+
+    public static function fromAssertableJsonString(AssertableJsonString $json): self
+    {
+        return self::fromArray($json->json());
+    }
+
+    public function toArray()
+    {
+        return $this->props;
+    }
+}

--- a/src/Illuminate/Testing/Fluent/Concerns/Debugging.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Debugging.php
@@ -4,6 +4,12 @@ namespace Illuminate\Testing\Fluent\Concerns;
 
 trait Debugging
 {
+    /**
+     * Dumps the given props.
+     *
+     * @param  string|null  $prop
+     * @return $this
+     */
     public function dump(string $prop = null): self
     {
         dump($this->prop($prop));
@@ -11,10 +17,22 @@ trait Debugging
         return $this;
     }
 
+    /**
+     * Dumps the given props and exits.
+     *
+     * @param  string|null  $prop
+     * @return void
+     */
     public function dd(string $prop = null): void
     {
         dd($this->prop($prop));
     }
 
+    /**
+     * Retrieve a prop within the current scope using "dot" notation.
+     *
+     * @param  string|null  $key
+     * @return mixed
+     */
     abstract protected function prop(string $key = null);
 }

--- a/src/Illuminate/Testing/Fluent/Concerns/Debugging.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Debugging.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Illuminate\Testing\Fluent\Concerns;
+
+trait Debugging
+{
+    public function dump(string $prop = null): self
+    {
+        dump($this->prop($prop));
+
+        return $this;
+    }
+
+    public function dd(string $prop = null): void
+    {
+        dd($this->prop($prop));
+    }
+
+    abstract protected function prop(string $key = null);
+}

--- a/src/Illuminate/Testing/Fluent/Concerns/Has.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Has.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Illuminate\Testing\Fluent\Concerns;
+
+use Closure;
+use Illuminate\Support\Arr;
+use PHPUnit\Framework\Assert as PHPUnit;
+
+trait Has
+{
+    protected function count(string $key, $length): self
+    {
+        PHPUnit::assertCount(
+            $length,
+            $this->prop($key),
+            sprintf('Property [%s] does not have the expected size.', $this->dotPath($key))
+        );
+
+        return $this;
+    }
+
+    public function hasAll($key): self
+    {
+        $keys = is_array($key) ? $key : func_get_args();
+
+        foreach ($keys as $prop => $count) {
+            if (is_int($prop)) {
+                $this->has($count);
+            } else {
+                $this->has($prop, $count);
+            }
+        }
+
+        return $this;
+    }
+
+    public function has(string $key, $value = null, Closure $scope = null): self
+    {
+        $prop = $this->prop();
+
+        PHPUnit::assertTrue(
+            Arr::has($prop, $key),
+            sprintf('Property [%s] does not exist.', $this->dotPath($key))
+        );
+
+        $this->interactsWith($key);
+
+        // When all three arguments are provided, this indicates a short-hand
+        // expression that combines both a `count`-assertion, followed by
+        // directly creating a `scope` on the first element.
+        if (is_int($value) && ! is_null($scope)) {
+            $prop = $this->prop($key);
+            $path = $this->dotPath($key);
+
+            PHPUnit::assertTrue($value > 0, sprintf('Cannot scope directly onto the first entry of property [%s] when asserting that it has a size of 0.', $path));
+            PHPUnit::assertIsArray($prop, sprintf('Direct scoping is unsupported for non-array like properties such as [%s].', $path));
+
+            $this->count($key, $value);
+
+            return $this->scope($key.'.'.array_keys($prop)[0], $scope);
+        }
+
+        if (is_callable($value)) {
+            $this->scope($key, $value);
+        } elseif (! is_null($value)) {
+            $this->count($key, $value);
+        }
+
+        return $this;
+    }
+
+    public function missingAll($key): self
+    {
+        $keys = is_array($key) ? $key : func_get_args();
+
+        foreach ($keys as $prop) {
+            $this->missing($prop);
+        }
+
+        return $this;
+    }
+
+    public function missing(string $key): self
+    {
+        PHPUnit::assertNotTrue(
+            Arr::has($this->prop(), $key),
+            sprintf('Property [%s] was found while it was expected to be missing.', $this->dotPath($key))
+        );
+
+        return $this;
+    }
+
+    abstract protected function prop(string $key = null);
+
+    abstract protected function dotPath($key): string;
+
+    abstract protected function interactsWith(string $key): void;
+
+    abstract protected function scope($key, Closure $callback);
+}

--- a/src/Illuminate/Testing/Fluent/Concerns/Has.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Has.php
@@ -8,7 +8,14 @@ use PHPUnit\Framework\Assert as PHPUnit;
 
 trait Has
 {
-    protected function count(string $key, $length): self
+    /**
+     * Assert that the prop is of the expected size.
+     *
+     * @param  string  $key
+     * @param  int  $length
+     * @return $this
+     */
+    protected function count(string $key, int $length): self
     {
         PHPUnit::assertCount(
             $length,
@@ -19,21 +26,14 @@ trait Has
         return $this;
     }
 
-    public function hasAll($key): self
-    {
-        $keys = is_array($key) ? $key : func_get_args();
-
-        foreach ($keys as $prop => $count) {
-            if (is_int($prop)) {
-                $this->has($count);
-            } else {
-                $this->has($prop, $count);
-            }
-        }
-
-        return $this;
-    }
-
+    /**
+     * Ensure that the given prop exists.
+     *
+     * @param  string  $key
+     * @param  null  $value
+     * @param  Closure|null  $scope
+     * @return $this
+     */
     public function has(string $key, $value = null, Closure $scope = null): self
     {
         $prop = $this->prop();
@@ -69,6 +69,33 @@ trait Has
         return $this;
     }
 
+    /**
+     * Assert that all of the given props exist.
+     *
+     * @param  array|string $key
+     * @return $this
+     */
+    public function hasAll($key): self
+    {
+        $keys = is_array($key) ? $key : func_get_args();
+
+        foreach ($keys as $prop => $count) {
+            if (is_int($prop)) {
+                $this->has($count);
+            } else {
+                $this->has($prop, $count);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * Assert that none of the given props exist.
+     *
+     * @param  array|string $key
+     * @return $this
+     */
     public function missingAll($key): self
     {
         $keys = is_array($key) ? $key : func_get_args();
@@ -80,6 +107,12 @@ trait Has
         return $this;
     }
 
+    /**
+     * Assert that the given prop does not exist.
+     *
+     * @param  string  $key
+     * @return $this
+     */
     public function missing(string $key): self
     {
         PHPUnit::assertNotTrue(
@@ -90,11 +123,36 @@ trait Has
         return $this;
     }
 
-    abstract protected function prop(string $key = null);
+    /**
+     * Compose the absolute "dot" path to the given key.
+     *
+     * @param  string  $key
+     * @return string
+     */
+    abstract protected function dotPath(string $key): string;
 
-    abstract protected function dotPath($key): string;
-
+    /**
+     * Marks the property as interacted.
+     *
+     * @param  string  $key
+     * @return void
+     */
     abstract protected function interactsWith(string $key): void;
 
-    abstract protected function scope($key, Closure $callback);
+    /**
+     * Retrieve a prop within the current scope using "dot" notation.
+     *
+     * @param  string|null  $key
+     * @return mixed
+     */
+    abstract protected function prop(string $key = null);
+
+    /**
+     * Instantiate a new "scope" at the path of the given key.
+     *
+     * @param  string  $key
+     * @param  Closure  $callback
+     * @return $this
+     */
+    abstract protected function scope(string $key, Closure $callback);
 }

--- a/src/Illuminate/Testing/Fluent/Concerns/Has.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Has.php
@@ -31,7 +31,7 @@ trait Has
      *
      * @param  string  $key
      * @param  null  $value
-     * @param  Closure|null  $scope
+     * @param  \Closure|null  $scope
      * @return $this
      */
     public function has(string $key, $value = null, Closure $scope = null): self
@@ -151,7 +151,7 @@ trait Has
      * Instantiate a new "scope" at the path of the given key.
      *
      * @param  string  $key
-     * @param  Closure  $callback
+     * @param  \Closure  $callback
      * @return $this
      */
     abstract protected function scope(string $key, Closure $callback);

--- a/src/Illuminate/Testing/Fluent/Concerns/Interaction.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Interaction.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Illuminate\Testing\Fluent\Concerns;
+
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Assert as PHPUnit;
+
+trait Interaction
+{
+    /** @var array */
+    protected $interacted = [];
+
+    protected function interactsWith(string $key): void
+    {
+        $prop = Str::before($key, '.');
+
+        if (! in_array($prop, $this->interacted, true)) {
+            $this->interacted[] = $prop;
+        }
+    }
+
+    public function interacted(): void
+    {
+        PHPUnit::assertSame(
+            [],
+            array_diff(array_keys($this->prop()), $this->interacted),
+            $this->path
+                ? sprintf('Unexpected properties were found in scope [%s].', $this->path)
+                : 'Unexpected properties were found on the root level.'
+        );
+    }
+
+    public function etc(): self
+    {
+        $this->interacted = array_keys($this->prop());
+
+        return $this;
+    }
+
+    abstract protected function prop(string $key = null);
+}

--- a/src/Illuminate/Testing/Fluent/Concerns/Interaction.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Interaction.php
@@ -7,9 +7,19 @@ use PHPUnit\Framework\Assert as PHPUnit;
 
 trait Interaction
 {
-    /** @var array */
+    /**
+     * The list of interacted properties.
+     *
+     * @var array
+     */
     protected $interacted = [];
 
+    /**
+     * Marks the property as interacted.
+     *
+     * @param  string  $key
+     * @return void
+     */
     protected function interactsWith(string $key): void
     {
         $prop = Str::before($key, '.');
@@ -19,6 +29,11 @@ trait Interaction
         }
     }
 
+    /**
+     * Asserts that all properties have been interacted with.
+     *
+     * @return void
+     */
     public function interacted(): void
     {
         PHPUnit::assertSame(
@@ -30,6 +45,11 @@ trait Interaction
         );
     }
 
+    /**
+     * Disables the interaction check.
+     *
+     * @return $this
+     */
     public function etc(): self
     {
         $this->interacted = array_keys($this->prop());
@@ -37,5 +57,11 @@ trait Interaction
         return $this;
     }
 
+    /**
+     * Retrieve a prop within the current scope using "dot" notation.
+     *
+     * @param  string|null  $key
+     * @return mixed
+     */
     abstract protected function prop(string $key = null);
 }

--- a/src/Illuminate/Testing/Fluent/Concerns/Matching.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Matching.php
@@ -9,16 +9,14 @@ use PHPUnit\Framework\Assert as PHPUnit;
 
 trait Matching
 {
-    public function whereAll(array $bindings): self
-    {
-        foreach ($bindings as $key => $value) {
-            $this->where($key, $value);
-        }
-
-        return $this;
-    }
-
-    public function where($key, $expected): self
+    /**
+     * Asserts that the property matches the expected value.
+     *
+     * @param  string  $key
+     * @param  mixed|callable  $expected
+     * @return $this
+     */
+    public function where(string $key, $expected): self
     {
         $this->has($key);
 
@@ -49,6 +47,27 @@ trait Matching
         return $this;
     }
 
+    /**
+     * Asserts that all properties match their expected values.
+     *
+     * @param  array  $bindings
+     * @return $this
+     */
+    public function whereAll(array $bindings): self
+    {
+        foreach ($bindings as $key => $value) {
+            $this->where($key, $value);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Ensures that all properties are sorted the same way, recursively.
+     *
+     * @param  mixed  $value
+     * @return void
+     */
     protected function ensureSorted(&$value): void
     {
         if (! is_array($value)) {
@@ -62,9 +81,29 @@ trait Matching
         ksort($value);
     }
 
-    abstract protected function dotPath($key): string;
+    /**
+     * Compose the absolute "dot" path to the given key.
+     *
+     * @param  string  $key
+     * @return string
+     */
+    abstract protected function dotPath(string $key): string;
 
-    abstract protected function prop(string $key = null);
-
+    /**
+     * Ensure that the given prop exists.
+     *
+     * @param  string  $key
+     * @param  null  $value
+     * @param  Closure|null  $scope
+     * @return $this
+     */
     abstract public function has(string $key, $value = null, Closure $scope = null);
+
+    /**
+     * Retrieve a prop within the current scope using "dot" notation.
+     *
+     * @param  string|null  $key
+     * @return mixed
+     */
+    abstract protected function prop(string $key = null);
 }

--- a/src/Illuminate/Testing/Fluent/Concerns/Matching.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Matching.php
@@ -13,7 +13,7 @@ trait Matching
      * Asserts that the property matches the expected value.
      *
      * @param  string  $key
-     * @param  mixed|callable  $expected
+     * @param  mixed|\Closure  $expected
      * @return $this
      */
     public function where(string $key, $expected): self
@@ -94,7 +94,7 @@ trait Matching
      *
      * @param  string  $key
      * @param  null  $value
-     * @param  Closure|null  $scope
+     * @param  \Closure|null  $scope
      * @return $this
      */
     abstract public function has(string $key, $value = null, Closure $scope = null);

--- a/src/Illuminate/Testing/Fluent/Concerns/Matching.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Matching.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Illuminate\Testing\Fluent\Concerns;
+
+use Closure;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Collection;
+use PHPUnit\Framework\Assert as PHPUnit;
+
+trait Matching
+{
+    public function whereAll(array $bindings): self
+    {
+        foreach ($bindings as $key => $value) {
+            $this->where($key, $value);
+        }
+
+        return $this;
+    }
+
+    public function where($key, $expected): self
+    {
+        $this->has($key);
+
+        $actual = $this->prop($key);
+
+        if ($expected instanceof Closure) {
+            PHPUnit::assertTrue(
+                $expected(is_array($actual) ? Collection::make($actual) : $actual),
+                sprintf('Property [%s] was marked as invalid using a closure.', $this->dotPath($key))
+            );
+
+            return $this;
+        }
+
+        if ($expected instanceof Arrayable) {
+            $expected = $expected->toArray();
+        }
+
+        $this->ensureSorted($expected);
+        $this->ensureSorted($actual);
+
+        PHPUnit::assertSame(
+            $expected,
+            $actual,
+            sprintf('Property [%s] does not match the expected value.', $this->dotPath($key))
+        );
+
+        return $this;
+    }
+
+    protected function ensureSorted(&$value): void
+    {
+        if (! is_array($value)) {
+            return;
+        }
+
+        foreach ($value as &$arg) {
+            $this->ensureSorted($arg);
+        }
+
+        ksort($value);
+    }
+
+    abstract protected function dotPath($key): string;
+
+    abstract protected function prop(string $key = null);
+
+    abstract public function has(string $key, $value = null, Closure $scope = null);
+}

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -528,7 +528,6 @@ class TestResponse implements ArrayAccess
             }
         }
 
-
         return $this;
     }
 

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Traits\Macroable;
 use Illuminate\Support\Traits\Tappable;
 use Illuminate\Testing\Assert as PHPUnit;
 use Illuminate\Testing\Constraints\SeeInOrder;
+use Illuminate\Testing\Fluent\Assert as FluentAssert;
 use LogicException;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
@@ -507,13 +508,26 @@ class TestResponse implements ArrayAccess
     /**
      * Assert that the response is a superset of the given JSON.
      *
-     * @param  array  $data
+     * @param  array|callable  $value
      * @param  bool  $strict
      * @return $this
      */
-    public function assertJson(array $data, $strict = false)
+    public function assertJson($value, $strict = false)
     {
-        $this->decodeResponseJson()->assertSubset($data, $strict);
+        $json = $this->decodeResponseJson();
+
+        if (is_array($value)) {
+            $json->assertSubset($value, $strict);
+        } else {
+            $assert = FluentAssert::fromAssertableJsonString($json);
+
+            $value($assert);
+
+            if ($strict) {
+                $assert->interacted();
+            }
+        }
+
 
         return $this;
     }

--- a/tests/Testing/Fluent/AssertTest.php
+++ b/tests/Testing/Fluent/AssertTest.php
@@ -1,0 +1,688 @@
+<?php
+
+namespace Illuminate\Tests\Testing\Fluent;
+
+use Illuminate\Support\Collection;
+use Illuminate\Testing\Fluent\Assert;
+use Illuminate\Tests\Testing\Stubs\ArrayableStubObject;
+use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use TypeError;
+
+class AssertTest extends TestCase
+{
+    public function testAssertHas()
+    {
+        $assert = Assert::fromArray([
+            'prop' => 'value',
+        ]);
+
+        $assert->has('prop');
+    }
+
+    public function testAssertHasFailsWhenPropMissing()
+    {
+        $assert = Assert::fromArray([
+            'bar' => 'value',
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Property [prop] does not exist.');
+
+        $assert->has('prop');
+    }
+
+    public function testAssertHasNestedProp()
+    {
+        $assert = Assert::fromArray([
+            'example' => [
+                'nested' => 'nested-value',
+            ],
+        ]);
+
+        $assert->has('example.nested');
+    }
+
+    public function testAssertHasFailsWhenNestedPropMissing()
+    {
+        $assert = Assert::fromArray([
+            'example' => [
+                'nested' => 'nested-value',
+            ],
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Property [example.another] does not exist.');
+
+        $assert->has('example.another');
+    }
+
+    public function testAssertCountItemsInProp()
+    {
+        $assert = Assert::fromArray([
+            'bar' => [
+                'baz' => 'example',
+                'prop' => 'value',
+            ],
+        ]);
+
+        $assert->has('bar', 2);
+    }
+
+    public function testAssertCountFailsWhenAmountOfItemsDoesNotMatch()
+    {
+        $assert = Assert::fromArray([
+            'bar' => [
+                'baz' => 'example',
+                'prop' => 'value',
+            ],
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Property [bar] does not have the expected size.');
+
+        $assert->has('bar', 1);
+    }
+
+    public function testAssertCountFailsWhenPropMissing()
+    {
+        $assert = Assert::fromArray([
+            'bar' => [
+                'baz' => 'example',
+                'prop' => 'value',
+            ],
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Property [baz] does not exist.');
+
+        $assert->has('baz', 1);
+    }
+
+    public function testAssertHasFailsWhenSecondArgumentUnsupportedType()
+    {
+        $assert = Assert::fromArray([
+            'bar' => 'baz',
+        ]);
+
+        $this->expectException(TypeError::class);
+
+        $assert->has('bar', 'invalid');
+    }
+
+    public function testAssertMissing()
+    {
+        $assert = Assert::fromArray([
+            'foo' => [
+                'bar' => true,
+            ],
+        ]);
+
+        $assert->missing('foo.baz');
+    }
+
+    public function testAssertMissingFailsWhenPropExists()
+    {
+        $assert = Assert::fromArray([
+            'prop' => 'value',
+            'foo' => [
+                'bar' => true,
+            ],
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Property [foo.bar] was found while it was expected to be missing.');
+
+        $assert->missing('foo.bar');
+    }
+
+    public function testAssertMissingAll()
+    {
+        $assert = Assert::fromArray([
+            'baz' => 'foo',
+        ]);
+
+        $assert->missingAll([
+            'foo',
+            'bar',
+        ]);
+    }
+
+    public function testAssertMissingAllFailsWhenAtLeastOnePropExists()
+    {
+        $assert = Assert::fromArray([
+            'baz' => 'foo',
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Property [baz] was found while it was expected to be missing.');
+
+        $assert->missingAll([
+            'bar',
+            'baz',
+        ]);
+    }
+
+    public function testAssertMissingAllAcceptsMultipleArgumentsInsteadOfArray()
+    {
+        $assert = Assert::fromArray([
+            'baz' => 'foo',
+        ]);
+
+        $assert->missingAll('foo', 'bar');
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Property [baz] was found while it was expected to be missing.');
+
+        $assert->missingAll('bar', 'baz');
+    }
+
+    public function testAssertWhereMatchesValue()
+    {
+        $assert = Assert::fromArray([
+            'bar' => 'value',
+        ]);
+
+        $assert->where('bar', 'value');
+    }
+
+    public function testAssertWhereFailsWhenDoesNotMatchValue()
+    {
+        $assert = Assert::fromArray([
+            'bar' => 'value',
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Property [bar] does not match the expected value.');
+
+        $assert->where('bar', 'invalid');
+    }
+
+    public function testAssertWhereFailsWhenMissing()
+    {
+        $assert = Assert::fromArray([
+            'bar' => 'value',
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Property [baz] does not exist.');
+
+        $assert->where('baz', 'invalid');
+    }
+
+    public function testAssertWhereFailsWhenMachingLoosely()
+    {
+        $assert = Assert::fromArray([
+            'bar' => 1,
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Property [bar] does not match the expected value.');
+
+        $assert->where('bar', true);
+    }
+
+    public function testAssertWhereUsingClosure()
+    {
+        $assert = Assert::fromArray([
+            'bar' => 'baz',
+        ]);
+
+        $assert->where('bar', function ($value) {
+            return $value === 'baz';
+        });
+    }
+
+    public function testAssertWhereFailsWhenDoesNotMatchValueUsingClosure()
+    {
+        $assert = Assert::fromArray([
+            'bar' => 'baz',
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Property [bar] was marked as invalid using a closure.');
+
+        $assert->where('bar', function ($value) {
+            return $value === 'invalid';
+        });
+    }
+
+    public function testAssertWhereClosureArrayValuesAreAutomaticallyCastedToCollections()
+    {
+        $assert = Assert::fromArray([
+            'bar' => [
+                'baz' => 'foo',
+                'example' => 'value',
+            ],
+        ]);
+
+        $assert->where('bar', function ($value) {
+            $this->assertInstanceOf(Collection::class, $value);
+
+            return $value->count() === 2;
+        });
+    }
+
+    public function testAssertWhereMatchesValueUsingArrayable()
+    {
+        $stub = ArrayableStubObject::make(['foo' => 'bar']);
+
+        $assert = Assert::fromArray([
+            'bar' => $stub->toArray(),
+        ]);
+
+        $assert->where('bar', $stub);
+    }
+
+    public function testAssertWhereMatchesValueUsingArrayableWhenSortedDifferently()
+    {
+        $assert = Assert::fromArray([
+            'bar' => [
+                'baz' => 'foo',
+                'example' => 'value',
+            ],
+        ]);
+
+        $assert->where('bar', function ($value) {
+            $this->assertInstanceOf(Collection::class, $value);
+
+            return $value->count() === 2;
+        });
+    }
+
+    public function testAssertWhereFailsWhenDoesNotMatchValueUsingArrayable()
+    {
+        $assert = Assert::fromArray([
+            'bar' => ['id' => 1, 'name' => 'Example'],
+            'baz' => [
+                'id' => 1,
+                'name' => 'Taylor Otwell',
+                'email' => 'taylor@laravel.com',
+                'email_verified_at' => '2021-01-22T10:34:42.000000Z',
+                'created_at' => '2021-01-22T10:34:42.000000Z',
+                'updated_at' => '2021-01-22T10:34:42.000000Z',
+            ],
+        ]);
+
+        $assert
+            ->where('bar', ArrayableStubObject::make(['name' => 'Example', 'id' => 1]))
+            ->where('baz', [
+                'name' => 'Taylor Otwell',
+                'email' => 'taylor@laravel.com',
+                'id' => 1,
+                'email_verified_at' => '2021-01-22T10:34:42.000000Z',
+                'updated_at' => '2021-01-22T10:34:42.000000Z',
+                'created_at' => '2021-01-22T10:34:42.000000Z',
+            ]);
+    }
+
+    public function testAssertNestedWhereMatchesValue()
+    {
+        $assert = Assert::fromArray([
+            'example' => [
+                'nested' => 'nested-value',
+            ],
+        ]);
+
+        $assert->where('example.nested', 'nested-value');
+    }
+
+    public function testAssertNestedWhereFailsWhenDoesNotMatchValue()
+    {
+        $assert = Assert::fromArray([
+            'example' => [
+                'nested' => 'nested-value',
+            ],
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Property [example.nested] does not match the expected value.');
+
+        $assert->where('example.nested', 'another-value');
+    }
+
+    public function testScope()
+    {
+        $assert = Assert::fromArray([
+            'bar' => [
+                'baz' => 'example',
+                'prop' => 'value',
+            ],
+        ]);
+
+        $called = false;
+        $assert->has('bar', function (Assert $assert) use (&$called) {
+            $called = true;
+            $assert
+                ->where('baz', 'example')
+                ->where('prop', 'value');
+        });
+
+        $this->assertTrue($called, 'The scoped query was never actually called.');
+    }
+
+    public function testScopeFailsWhenPropMissing()
+    {
+        $assert = Assert::fromArray([
+            'bar' => [
+                'baz' => 'example',
+                'prop' => 'value',
+            ],
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Property [baz] does not exist.');
+
+        $assert->has('baz', function (Assert $item) {
+            $item->where('baz', 'example');
+        });
+    }
+
+    public function testScopeFailsWhenPropSingleValue()
+    {
+        $assert = Assert::fromArray([
+            'bar' => 'value',
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Property [bar] is not scopeable.');
+
+        $assert->has('bar', function (Assert $item) {
+            //
+        });
+    }
+
+    public function testScopeShorthand()
+    {
+        $assert = Assert::fromArray([
+            'bar' => [
+                ['key' => 'first'],
+                ['key' => 'second'],
+            ],
+        ]);
+
+        $called = false;
+        $assert->has('bar', 2, function (Assert $item) use (&$called) {
+            $item->where('key', 'first');
+            $called = true;
+        });
+
+        $this->assertTrue($called, 'The scoped query was never actually called.');
+    }
+
+    public function testScopeShorthandFailsWhenAssertingZeroItems()
+    {
+        $assert = Assert::fromArray([
+            'bar' => [
+                ['key' => 'first'],
+                ['key' => 'second'],
+            ],
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Cannot scope directly onto the first entry of property [bar] when asserting that it has a size of 0.');
+
+        $assert->has('bar', 0, function (Assert $item) {
+            $item->where('key', 'first');
+        });
+    }
+
+    public function testScopeShorthandFailsWhenAmountOfItemsDoesNotMatch()
+    {
+        $assert = Assert::fromArray([
+            'bar' => [
+                ['key' => 'first'],
+                ['key' => 'second'],
+            ],
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Property [bar] does not have the expected size.');
+
+        $assert->has('bar', 1, function (Assert $item) {
+            $item->where('key', 'first');
+        });
+    }
+
+    public function testFailsWhenNotInteractingWithAllPropsInScope()
+    {
+        $assert = Assert::fromArray([
+            'bar' => [
+                'baz' => 'example',
+                'prop' => 'value',
+            ],
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Unexpected properties were found in scope [bar].');
+
+        $assert->has('bar', function (Assert $item) {
+            $item->where('baz', 'example');
+        });
+    }
+
+    public function testDisableInteractionCheckForCurrentScope()
+    {
+        $assert = Assert::fromArray([
+            'bar' => [
+                'baz' => 'example',
+                'prop' => 'value',
+            ],
+        ]);
+
+        $assert->has('bar', function (Assert $item) {
+            $item->etc();
+        });
+    }
+
+    public function testCannotDisableInteractionCheckForDifferentScopes()
+    {
+        $assert = Assert::fromArray([
+            'bar' => [
+                'baz' => [
+                    'foo' => 'bar',
+                    'example' => 'value',
+                ],
+                'prop' => 'value',
+            ],
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Unexpected properties were found in scope [bar.baz].');
+
+        $assert->has('bar', function (Assert $item) {
+            $item
+                ->etc()
+                ->has('baz', function (Assert $item) {
+                    //
+                });
+        });
+    }
+
+    public function testTopLevelPropInteractionDisabledByDefault()
+    {
+        $assert = Assert::fromArray([
+            'foo' => 'bar',
+            'bar' => 'baz',
+        ]);
+
+        $assert->has('foo');
+    }
+
+    public function testTopLevelInteractionEnabledWhenInteractedFlagSet()
+    {
+        $assert = Assert::fromArray([
+            'foo' => 'bar',
+            'bar' => 'baz',
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Unexpected properties were found on the root level.');
+
+        $assert
+            ->has('foo')
+            ->interacted();
+    }
+
+    public function testAssertWhereAllMatchesValues()
+    {
+        $assert = Assert::fromArray([
+            'foo' => [
+                'bar' => 'value',
+                'example' => ['hello' => 'world'],
+            ],
+            'baz' => 'another',
+        ]);
+
+        $assert->whereAll([
+            'foo.bar' => 'value',
+            'foo.example' => ArrayableStubObject::make(['hello' => 'world']),
+            'baz' => function ($value) {
+                return $value === 'another';
+            },
+        ]);
+    }
+
+    public function testAssertWhereAllFailsWhenAtLeastOnePropDoesNotMatchValue()
+    {
+        $assert = Assert::fromArray([
+            'foo' => 'bar',
+            'baz' => 'example',
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Property [baz] was marked as invalid using a closure.');
+
+        $assert->whereAll([
+            'foo' => 'bar',
+            'baz' => function ($value) {
+                return $value === 'foo';
+            },
+        ]);
+    }
+
+    public function testAssertHasAll()
+    {
+        $assert = Assert::fromArray([
+            'foo' => [
+                'bar' => 'value',
+                'example' => ['hello' => 'world'],
+            ],
+            'baz' => 'another',
+        ]);
+
+        $assert->hasAll([
+            'foo.bar',
+            'foo.example',
+            'baz',
+        ]);
+    }
+
+    public function testAssertHasAllFailsWhenAtLeastOnePropMissing()
+    {
+        $assert = Assert::fromArray([
+            'foo' => [
+                'bar' => 'value',
+                'example' => ['hello' => 'world'],
+            ],
+            'baz' => 'another',
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Property [foo.baz] does not exist.');
+
+        $assert->hasAll([
+            'foo.bar',
+            'foo.baz',
+            'baz',
+        ]);
+    }
+
+    public function testAssertHasAllAcceptsMultipleArgumentsInsteadOfArray()
+    {
+        $assert = Assert::fromArray([
+            'foo' => [
+                'bar' => 'value',
+                'example' => ['hello' => 'world'],
+            ],
+            'baz' => 'another',
+        ]);
+
+        $assert->hasAll('foo.bar', 'foo.example', 'baz');
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Property [foo.baz] does not exist.');
+
+        $assert->hasAll('foo.bar', 'foo.baz', 'baz');
+    }
+
+    public function testAssertCountMultipleProps()
+    {
+        $assert = Assert::fromArray([
+            'bar' => [
+                'key' => 'value',
+                'prop' => 'example',
+            ],
+            'baz' => [
+                'another' => 'value',
+            ],
+        ]);
+
+        $assert->hasAll([
+            'bar' => 2,
+            'baz' => 1,
+        ]);
+    }
+
+    public function testAssertCountMultiplePropsFailsWhenPropMissing()
+    {
+        $assert = Assert::fromArray([
+            'bar' => [
+                'key' => 'value',
+                'prop' => 'example',
+            ],
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Property [baz] does not exist.');
+
+        $assert->hasAll([
+            'bar' => 2,
+            'baz' => 1,
+        ]);
+    }
+
+    public function testMacroable()
+    {
+        Assert::macro('myCustomMacro', function () {
+            throw new RuntimeException('My Custom Macro was called!');
+        });
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('My Custom Macro was called!');
+
+        $assert = Assert::fromArray(['foo' => 'bar']);
+        $assert->myCustomMacro();
+    }
+
+    public function testTappable()
+    {
+        $assert = Assert::fromArray([
+            'bar' => [
+                'baz' => 'example',
+                'prop' => 'value',
+            ],
+        ]);
+
+        $called = false;
+        $assert->has('bar', function (Assert $assert) use (&$called) {
+            $assert->etc();
+            $assert->tap(function (Assert $assert) use (&$called) {
+                $called = true;
+            });
+        });
+
+        $this->assertTrue($called, 'The scoped query was never actually called.');
+    }
+}

--- a/tests/Testing/Stubs/ArrayableStubObject.php
+++ b/tests/Testing/Stubs/ArrayableStubObject.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Illuminate\Tests\Testing\Stubs;
+
+use Illuminate\Contracts\Support\Arrayable;
+
+class ArrayableStubObject implements Arrayable
+{
+    protected $data;
+
+    public function __construct($data = [])
+    {
+        $this->data = $data;
+    }
+
+    public static function make($data = [])
+    {
+        return new self($data);
+    }
+
+    public function toArray()
+    {
+        return $this->data;
+    }
+}

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Encryption\Encrypter;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Http\Response;
+use Illuminate\Testing\Fluent\Assert;
 use Illuminate\Testing\TestResponse;
 use JsonSerializable;
 use Mockery as m;
@@ -575,6 +576,27 @@ class TestResponseTest extends TestCase
         $resource = new JsonSerializableSingleResourceStub;
 
         $response->assertJson($resource->jsonSerialize());
+    }
+
+    public function testAssertJsonWithFluent()
+    {
+        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceStub));
+
+        $response->assertJson(function (Assert $json) {
+            $json->where('0.foo', 'foo 0');
+        });
+    }
+
+    public function testAssertJsonWithFluentStrict()
+    {
+        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceStub));
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Unexpected properties were found on the root level.');
+
+        $response->assertJson(function (Assert $json) {
+            $json->where('0.foo', 'foo 0');
+        }, true);
     }
 
     public function testAssertSimilarJsonWithMixed()


### PR DESCRIPTION
This PR implements Inertia's Laravel Testing helpers as generic JSON helpers for Laravel.

While [I initially wrote this code for Inertia specifically](https://github.com/claudiodekker/inertia-laravel-testing), one of the first things @reinink mentioned was that these would be amazing to have as first-party tooling to test JSON API's in Laravel, as (_and we both share this opinion_) the current JSON testing helpers can be difficult to use sometimes. It goes without saying that all Inertia-specific code has been stripped out.

## Example
Here's an example of how this can be used, do note that while this shares the `assertJson` method, it is entirely backwards compatible:

```php
use Illuminate\Testing\Fluent\Assert;

class PodcastsControllerTest extends TestCase
{
    public function test_can_view_podcast()
    {
        $this->get('/podcasts/41')
            ->assertJson(fn (Assert $json) => $json
                ->has('podcast', fn (Assert $json) => $json
                    ->where('id', $podcast->id)
                    ->where('subject', 'The Laravel Podcast')
                    ->where('description', 'The Laravel Podcast brings you Laravel & PHP development news.')
                    ->has('seasons', 4)
                    ->has('seasons.4.episodes', 21)
                    ->has('host', fn (Assert $json) => $json
                        ->where('id', 1)
                        ->where('name', 'Matt Stauffer')
                    )
                    ->has('subscribers', 7, fn (Assert $json) => $json
                        ->where('id', 2)
                        ->where('name', 'Claudio Dekker')
                        ->where('platform', 'Apple Podcasts')
                        ->etc()
                        ->missing('email')
                        ->missing('password')
                    )
                )
            );
    }
}
```

## Basics

There's two ways to start using this, both of which rely on the 'Fluent Assert' class that this PR adds.
In the more-common scenario (testing a JSON API response), you would use it as already demonstrated above:

```php
$response->assertJson(fn (Assert $json) => $json
    ->has('expected-property')
);   
 
 ```
Alternatively, you may instantiate the object manually, even on non-JSON arrays if you wish:
```php
$assert = \Illuminate\Testing\Fluent\Assert::fromArray([/* ... */]);
$assert->has('expected-property');
```

Furthermore, while the scoping syntax above is by far the nicest to use with PHP 8's arrow functions, there's nothing preventing you from using standard functions.

## Available Assertions

- `has`
    - Count (Size / Length)
    - Scoping
- `where`
- `etc`
    - `missing`

Reducing verbosity (multiple assertions):
- `hasAll`
- `whereAll`
- `missingAll`

Helpers:
- Debugging (`dump` & `dd`)

Finally, the entire thing is Macroable and Tappable as well, so if someone really wants they can make use of those functionalities as well!

## `has`
### Basic Usage

To assert that your JSON response **has** a property, you may use the `has` method. 
You can think of `has` similar to PHP's `isset`:

```php
$response->assertJson(fn (Assert $json) => $json
    // Checking a root-level property
    ->has('podcast')

    // Checking that the podcast prop has a nested id property using "dot" notation
    ->has('podcast.id')
);
```

### Count / Size / Length
To assert that your JSON response **has a certain amount of items**, you may provide the expected size as the second argument:
```php
$response->assertJson(fn (Assert $json) => $json
    // Checking that the root-level podcasts property exists and has 7 items
    ->has('podcast', 7)

    // Checking that the podcast has 11 subscribers using "dot" notation
    ->has('podcast.subscribers', 11)
);
```

The above will first assert that the property exists, as well as that is the expected size.
This means that there is no need to manually ensure that the property exists using a separate `has` call.

### Scoping

The deeper your assertions go, the more complex and verbose they can become:
```php
$assert->where('message.comments.0.files.0.url', '/storage/attachments/example-attachment.pdf');
$assert->where('message.comments.0.files.0.name', 'example-attachment.pdf');
```

Fortunately, using scopes, we can remove this problem altogether through the `has` method:
```php
$response->assertJson(fn (Assert $json) => $json
    // Creating a single-level property scope
    ->has('message', fn (Assert $json) => $json
        // We can now continue chaining methods
        ->has('subject')
        ->has('comments', 5)

        // And can even create a deeper scope using "dot" notation
        ->has('comments.0', fn (Assert $json) => $json
            ->has('body')
            ->has('files', 1)
            ->has('files.0', fn (Assert $json) => $json
                ->has('url')
            )
        )
    )
);
```

While this is already a significant improvement, that's not all: As you can see in the example above, you'll often run 
into situations where you'll want to _check that a property has a certain length_, and then tap into one of the entries
to make sure that all the props there are as expected:

```php
    ->has('comments', 5)
    ->has('comments.0', fn (Assert $json) => $json
        // ...
```

To simplify this, you can simply combine the two calls, providing the scope as the third argument:
```php
$response->assertJson(fn (Assert $json) => $json
    // Assert that there are five comments, and automatically scope into the first comment.
    ->has('comments', 5, fn(Assert $json) => $json
        ->has('body')
        // ...
    )
);
```

## `where`
To assert that an property has an expected value, you may use the `where` assertion:

```php
$response->assertJson(fn (Assert $json) => $json
    ->has('message', fn (Assert $json) => $json
        // Assert that the subject prop matches the given message
        ->where('subject', 'This is an example message')

        // or, the exact same, but for deeply nested values
        ->where('comments.0.files.0.name', 'example-attachment.pdf')
    )
);
```

Under the hood, this first calls the `has` method to ensure that the property exists, and then uses an assertion to 
make sure that the values match. This means that there is no need to manually call `has` and `where` on the same exact prop.

#### Automatic Eloquent `Model` / `Arrayable` casting

For convenience, the `where` method doesn't just assert using basic JSON values, but also has the ability to
test directly against Eloquent Models and other classes that implement the `Arrayable` interface.

For example:
```php
$user = User::factory()->create(['name' => 'John Doe']);

// ... (Make your HTTP request etc.)

$response->assertJson(fn (Assert $json) => $json
    ->where('user', $user)
    ->where('deeply.nested.user', $user)
);
```

### Using a Closure

Finally, it's also possible to assert against a callback / closure. To do so, simply provide a callback as the value,
and make sure that the response is `true` in order to make the assertion pass, or anything else to fail the assertion:

```php
$response->assertJson(fn (Assert $json) => $json
    ->where('foo', fn ($value) => $value === 'bar')

    // or, as expected, for deeply nested values:
    ->where('deeply.nested.foo', function ($value) {
        return $value === 'bar';
    })
);
```

Because working with arrays directly isn't always a great experience, we'll automatically cast arrays to 
[Collections](https://laravel.com/docs/collections):
```php
$response->assertJson(fn (Assert $json) => $json
    ->where('foo', function (Collection $value) {
        return $value->median() === 1.5;
    })
);
```

## `etc`
This library will automatically fail your test when you haven't interacted with at least one of the props in a scope.
While this is generally useful, you might run into situations where you're working with unreliable data 
(such as from a feed), or with data that you really don't want interact with, in order to keep your test simple.
For those situations, the `etc` method exists:

```php
$response->assertJson(fn (Assert $json) => $json
    ->has('message', fn (Assert $json) => $json
        ->has('subject')
        ->has('comments')
        ->etc()
    )
);
```

> **IMPORTANT**: This automatic property check **DOES NOT APPLY TO TOP-LEVEL PROPS** and only works in scopes.

> **NOTE**: While `etc` reads fluently at the end of a query scope, placing it at the beginning or somewhere in the middle of your assertions does not change how it behaves: It will disable the automatic check that asserts that all properties in the current scope have been interacted with.

### `missing`
Because `missing` isn't necessary by default, it provides a great solution when using `etc`. 

In short, it does the exact opposite of the `has` method, ensuring that the property does _not exist_:
```php
$response->assertJson(fn (Assert $json) => $json
    ->has('message', fn (Assert $json) => $json
        ->has('subject')
        ->missing('published_at')
        ->etc()
    )
);
```

## Reducing verbosity
To reduce the amount of `where`, `has` or `missing` calls, there are a couple of convenience methods that allow you to
make these same assertions in a slightly less-verbose looking way. Do note that these methods do not make your assertions
any faster, and really only exist to help you reduce your test's visual complexity.

### `has`
Instead of making multiple `has` calls, you may use the `hasAll` assertion instead. Depending on how you provide 
arguments, this method will perform a series of slightly different but predictable assertion:

#### Basic `has` usage
```php
$response->assertJson(fn (Assert $json) => $json
    // Before
    ->has('messages')
    ->has('subscribers')

    // After
    ->hasAll([
        'messages',
        'subscribers',
    ])

    // Alternative
    ->hasAll('messages', 'subscribers')
);
```

#### Count / Size / Length
```php
$response->assertJson(fn (Assert $json) => $json
    // Before
    ->has('messages', 5)
    ->has('subscribers', 11)

    // After
    ->hasAll([
        'messages' => 5,
        'subscribers' => 11,
    ])
);
```

### `where`
To reduce the amount of `where` calls, the `whereAll` method exists.

Since this method checks properties against values by design, there isn't a lot of flexibility like with some of these
other methods, meaning that only the array-syntax exists for it right now:

```php
$response->assertJson(fn (Assert $json) => $json
    // Before
    ->where('subject', 'Hello World')
    ->has('user.name', 'Claudio')

    // After
    ->whereAll([
        'subject' => 'Hello World',
        'user.name' => fn ($value) => $value === 'Claudio',
    ])
);
```

### `missing`
Instead of making multiple `missing` call, you may use `missingAll` instead. 

Similar to basic `hasAll` usage, this assertion accepts both a single array or a list of arguments, at which point it 
will assert that the given props do not exist:

```php
$response->assertJson(fn (Assert $json) => $json
    // Before
    ->missing('subject')
    ->missing('user.name')

    // After
    ->missingAll([
        'subject',
        'user.name',
    ])

    // Alternative
    ->missingAll('subject', 'user.name')
);
```

## Debugging

While writing your tests, you might find yourself wanting to inspect some of the page's props using Laravel's 
`dump` or `dd` helpers. Luckily, this is really easy to do, and would work more or less how you'd expect it to:

```php
$response->assertJson(fn (Assert $json) => $json
    // Dumping all props in the current scope
    // while still running all other assertions
    ->dump()
    ->where('user.name', 'Claudio')

    // Dump-and-die all props in the current scope, preventing
    // all other (perhaps failing) assertions from running
    ->dd()
    ->where('user.name', 'Jonathan')

    // Dumping / Dump-and-die a specific prop
    ->dump('user')
    ->dd('user.name')
);
```