### PR TITLE
[8.x] Fix test suite failing in CI, add suggestion for PHP extension "bcmath"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, gd, redis, memcached
+          extensions: bcmath, dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, gd, redis, memcached
           tools: composer:v2
           coverage: none
 
@@ -93,7 +93,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite, gd, pdo_mysql, fileinfo, ftp, redis, memcached
+          extensions: bcmath, dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite, gd, pdo_mysql, fileinfo, ftp, redis, memcached
           tools: composer:v2
           coverage: none
 

--- a/composer.json
+++ b/composer.json
@@ -122,6 +122,7 @@
         }
     },
     "suggest": {
+        "ext-bcmath": "Required to use the validation rule 'multiple_of'.",
         "ext-ftp": "Required to use the Flysystem FTP driver.",
         "ext-gd": "Required to use Illuminate\\Http\\Testing\\FileFactory::image().",
         "ext-memcached": "Required to use the memcache cache driver.",

--- a/src/Illuminate/Validation/composer.json
+++ b/src/Illuminate/Validation/composer.json
@@ -37,6 +37,7 @@
         }
     },
     "suggest": {
+        "ext-bcmath": "Required to use the validation rule 'multiple_of'.",
         "illuminate/database": "Required to use the database presence verifier (^8.0)."
     },
     "config": {

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1857,8 +1857,9 @@ class ValidationValidatorTest extends TestCase
      * @param bool $passes
      *
      * @dataProvider multipleOfDataProvider
+     * @requires extension bcmath
      */
-    public function testValidateMutlpleOf($input, $allowed, $passes)
+    public function testValidateMultipleOf($input, $allowed, $passes)
     {
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.multiple_of' => 'The :attribute must be a multiple of :value'], 'en');


### PR DESCRIPTION
In v8.12.0 the validation rule `multiple_of` started calling global function `bcmod()` (https://github.com/laravel/framework/pull/34971) which isn't part of the standard library. PHP extension "bcmath" must be installed which is typically included with distributions.

However the GitHub Actions environment setup for PHP 7.3 looks to no longer enable this extension by default so explicitly add it to the config.