### PR TITLE
[8.x] Add new `VendorTagPublished` event

### DIFF
--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Foundation\Events\VendorTagPublished;
 use Illuminate\Support\Arr;
 use Illuminate\Support\ServiceProvider;
 use League\Flysystem\Adapter\Local as LocalAdapter;
@@ -158,8 +159,9 @@ class VendorPublishCommand extends Command
     protected function publishTag($tag)
     {
         $published = false;
+        $pathsToPublish = $this->pathsToPublish($tag);
 
-        foreach ($this->pathsToPublish($tag) as $from => $to) {
+        foreach ($pathsToPublish as $from => $to) {
             $this->publishItem($from, $to);
 
             $published = true;
@@ -168,6 +170,8 @@ class VendorPublishCommand extends Command
         if ($published === false) {
             $this->error('Unable to locate publishable resources.');
         }
+
+        $this->laravel['events']->dispatch(new VendorTagPublished($tag, $pathsToPublish));
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -169,9 +169,9 @@ class VendorPublishCommand extends Command
 
         if ($published === false) {
             $this->error('Unable to locate publishable resources.');
+        } else {
+            $this->laravel['events']->dispatch(new VendorTagPublished($tag, $pathsToPublish));
         }
-
-        $this->laravel['events']->dispatch(new VendorTagPublished($tag, $pathsToPublish));
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -167,10 +167,10 @@ class VendorPublishCommand extends Command
             $published = true;
         }
 
+        $this->laravel['events']->dispatch(new VendorTagPublished($tag, $pathsToPublish));
+
         if ($published === false) {
             $this->error('Unable to locate publishable resources.');
-        } else {
-            $this->laravel['events']->dispatch(new VendorTagPublished($tag, $pathsToPublish));
         }
     }
 

--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -159,6 +159,7 @@ class VendorPublishCommand extends Command
     protected function publishTag($tag)
     {
         $published = false;
+
         $pathsToPublish = $this->pathsToPublish($tag);
 
         foreach ($pathsToPublish as $from => $to) {

--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -167,10 +167,10 @@ class VendorPublishCommand extends Command
             $published = true;
         }
 
-        $this->laravel['events']->dispatch(new VendorTagPublished($tag, $pathsToPublish));
-
         if ($published === false) {
             $this->error('Unable to locate publishable resources.');
+        } else {
+            $this->laravel['events']->dispatch(new VendorTagPublished($tag, $pathsToPublish));
         }
     }
 

--- a/src/Illuminate/Foundation/Events/VendorTagPublished.php
+++ b/src/Illuminate/Foundation/Events/VendorTagPublished.php
@@ -12,7 +12,7 @@ class VendorTagPublished
     public $tag;
 
     /**
-     * The publish paths registered by the tag.
+     * The publishable paths registered by the tag.
      *
      * @var array
      */

--- a/src/Illuminate/Foundation/Events/VendorTagPublished.php
+++ b/src/Illuminate/Foundation/Events/VendorTagPublished.php
@@ -5,7 +5,7 @@ namespace Illuminate\Foundation\Events;
 class VendorTagPublished
 {
     /**
-     * The vendor tag published.
+     * The vendor tag that was published.
      *
      * @var string
      */

--- a/src/Illuminate/Foundation/Events/VendorTagPublished.php
+++ b/src/Illuminate/Foundation/Events/VendorTagPublished.php
@@ -22,6 +22,7 @@ class VendorTagPublished
      * Create a new event instance.
      *
      * @param  string  $tag
+     * @param  array  $paths
      * @return void
      */
     public function __construct($tag, $paths)

--- a/src/Illuminate/Foundation/Events/VendorTagPublished.php
+++ b/src/Illuminate/Foundation/Events/VendorTagPublished.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Illuminate\Foundation\Events;
+
+class VendorTagPublished
+{
+    /**
+     * The vendor tag published.
+     *
+     * @var string
+     */
+    public $tag;
+
+    /**
+     * The paths that were published.
+     *
+     * @var array
+     */
+    public $paths;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  string  $tag
+     * @return void
+     */
+    public function __construct($tag, $paths)
+    {
+        $this->tag = $tag;
+        $this->paths = $paths;
+    }
+}

--- a/src/Illuminate/Foundation/Events/VendorTagPublished.php
+++ b/src/Illuminate/Foundation/Events/VendorTagPublished.php
@@ -12,7 +12,7 @@ class VendorTagPublished
     public $tag;
 
     /**
-     * The paths that were published.
+     * The publish paths registered by the tag.
      *
      * @var array
      */


### PR DESCRIPTION
This pull request introduces a new `VendorTagPublished` event that is dispatched after successfully running the `vendor:publish` command.

The event receives the `tag` that was published, as well as the array of paths that were published (source => location).

The main reasoning behind this new event is allowing third-party packages to run particular actions _after_ some of their publishable files have been actually been published.

E.g. you might set a file to be publishable using the tag `package-file` and wish to do something with that file _after_ is has been published. This would allow you listen for the `VendorTagPublished` event from your package and run whatever logic you need.

**Question for reviewer**: I'm firing the event regardless of whether any files were actually published. Is this okay, or should there be an `else` that wraps the event dispatch? Left it as is because if you run `vendor:publish` with an invalid tag, it shows the error _"Unable to locate publishable resources."_ but also has the success message _"Publishing complete."_.