### PR TITLE
[8.x] Add new `Stringable::test` method

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -373,7 +373,7 @@ class Stringable implements JsonSerializable
      */
     public function matches($pattern)
     {
-        return $this->matchAll($pattern)->isNotEmpty();
+        return $this->match($pattern)->isNotEmpty();
     }
 
     /**

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -371,7 +371,7 @@ class Stringable implements JsonSerializable
      * @param  string  $pattern
      * @return bool
      */
-    public function matches($pattern)
+    public function test($pattern)
     {
         return $this->match($pattern)->isNotEmpty();
     }

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -366,6 +366,17 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Determine if the string matches the given pattern.
+     *
+     * @param  string  $pattern
+     * @return bool
+     */
+    public function matches($pattern)
+    {
+        return $this->matchAll($pattern)->isNotEmpty();
+    }
+
+    /**
      * Pad both sides of the string with another.
      *
      * @param  int  $length

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -60,11 +60,14 @@ class SupportStringableTest extends TestCase
 
         $this->assertEquals(['un', 'ly'], $stringable->matchAll('/f(\w*)/')->all());
         $this->assertTrue($stringable->matchAll('/nothing/')->isEmpty());
+    }
 
+    public function testTest()
+    {
         $stringable = $this->stringable('foo bar');
 
-        $this->assertTrue($stringable->matches('/bar/'));
-        $this->assertTrue($stringable->matches('/foo (.*)/'));
+        $this->assertTrue($stringable->test('/bar/'));
+        $this->assertTrue($stringable->test('/foo (.*)/'));
     }
 
     public function testTrim()

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -60,6 +60,11 @@ class SupportStringableTest extends TestCase
 
         $this->assertEquals(['un', 'ly'], $stringable->matchAll('/f(\w*)/')->all());
         $this->assertTrue($stringable->matchAll('/nothing/')->isEmpty());
+
+        $stringable = $this->stringable('foo bar');
+
+        $this->assertTrue($stringable->matches('/bar/'));
+        $this->assertTrue($stringable->matches('/foo (.*)/'));
     }
 
     public function testTrim()


### PR DESCRIPTION
This pull request introduces a new `Stringable::test` method that checks whether the string matches a particular pattern, but doesn't return the match(es).

This is essentially just a shortcut for `$stringable->match('//')->isNotEmpty()` but something that I do often enough, and also macro, that it warranted a pull request to the core.