### PR TITLE
[8.x] Add optional arguments to value() for the closure

### DIFF
--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -177,10 +177,11 @@ if (! function_exists('value')) {
      * Return the default value of the given value.
      *
      * @param  mixed  $value
+     * @param  mixed $args
      * @return mixed
      */
-    function value($value)
+    function value($value, ...$args)
     {
-        return $value instanceof Closure ? $value() : $value;
+        return $value instanceof Closure ? call_user_func($value, ...$args) : $value;
     }
 }

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -40,6 +40,13 @@ class SupportHelpersTest extends TestCase
         $this->assertSame('foo', value(function () {
             return 'foo';
         }));
+
+        $this->assertSame('Hello John Doe', value(function ($firstName, $lastName) {
+            return sprintf('Hello %s %s', $firstName, $lastName);
+        }, 'John', 'Doe'));
+        $this->assertSame('Hello John Doe', value(function ($firstName, $lastName) {
+            return sprintf('Hello %s %s', $firstName, $lastName);
+        }, ...['John', 'Doe']));
     }
 
     public function testObjectGet()


### PR DESCRIPTION
This PR aims to add arguments to `value()` helper that will be passed to the closure.

**Examples**

```php
// Single value
$test = fn ($name) => 'Hello ' . $name;

echo value($test, 'John'); // Hello John

// Multiple values
$test = fn ($firstName, $lastName) => sprintf('Hello %s %s', $firstName, $lastName);

echo value($test, 'John', 'Doe'); // Hello John Doe

// Same result but with splat operator if working with an array
echo value($test, ...['John', 'Doe']); // Hello John Doe
```