### PR TITLE
[8.x] Helper methods to dump requests of the Laravel HTTP client

### DIFF
--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -32,6 +32,8 @@ use PHPUnit\Framework\Assert as PHPUnit;
  * @method \Illuminate\Http\Client\PendingRequest withToken(string $token, string $type = 'Bearer')
  * @method \Illuminate\Http\Client\PendingRequest withoutRedirecting()
  * @method \Illuminate\Http\Client\PendingRequest withoutVerifying()
+ * @method \Illuminate\Http\Client\PendingRequest dump()
+ * @method \Illuminate\Http\Client\PendingRequest dd()
  * @method \Illuminate\Http\Client\Response delete(string $url, array $data = [])
  * @method \Illuminate\Http\Client\Response get(string $url, array $query = [])
  * @method \Illuminate\Http\Client\Response head(string $url, array $query = [])

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -9,6 +9,7 @@ use GuzzleHttp\HandlerStack;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
+use Symfony\Component\VarDumper\VarDumper;
 
 class PendingRequest
 {
@@ -449,6 +450,40 @@ class PendingRequest
     {
         return tap($this, function () use ($callback) {
             $this->beforeSendingCallbacks[] = $callback;
+        });
+    }
+
+    /**
+     * Dump the request.
+     *
+     * @return $this
+     */
+    public function dump()
+    {
+        $values = func_get_args();
+
+        return $this->beforeSending(function (Request $request, array $options) use ($values) {
+            foreach (array_merge($values, [$request, $options]) as $value) {
+                VarDumper::dump($value);
+            }
+        });
+    }
+
+    /**
+     * Dump the request and end the script.
+     *
+     * @return $this
+     */
+    public function dd()
+    {
+        $values = func_get_args();
+
+        return $this->beforeSending(function (Request $request, array $options) use ($values) {
+            foreach (array_merge($values, [$request, $options]) as $value) {
+                VarDumper::dump($value);
+            }
+
+            exit(1);
         });
     }
 

--- a/src/Illuminate/Support/Facades/Http.php
+++ b/src/Illuminate/Support/Facades/Http.php
@@ -30,6 +30,8 @@ use Illuminate\Http\Client\Factory;
  * @method static \Illuminate\Http\Client\PendingRequest withToken(string $token, string $type = 'Bearer')
  * @method static \Illuminate\Http\Client\PendingRequest withoutRedirecting()
  * @method static \Illuminate\Http\Client\PendingRequest withoutVerifying()
+ * @method static \Illuminate\Http\Client\PendingRequest dump()
+ * @method static \Illuminate\Http\Client\PendingRequest dd()
  * @method static \Illuminate\Http\Client\Response delete(string $url, array $data = [])
  * @method static \Illuminate\Http\Client\Response get(string $url, array $query = [])
  * @method static \Illuminate\Http\Client\Response head(string $url, array $query = [])

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use OutOfBoundsException;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\VarDumper\VarDumper;
 
 class HttpClientTest extends TestCase
 {
@@ -780,5 +781,24 @@ class HttpClientTest extends TestCase
         $this->expectException(\PHPUnit\Framework\AssertionFailedError::class);
 
         $this->factory->assertSentInOrder($executionOrder);
+    }
+
+    public function testCanDump()
+    {
+        $dumped = [];
+
+        VarDumper::setHandler(function ($value) use (&$dumped) {
+            $dumped[] = $value;
+        });
+
+        $this->factory->fake()->dump(1, 2, 3)->withOptions(['delay' => 1000])->get('http://foo.com');
+
+        $this->assertSame(1, $dumped[0]);
+        $this->assertSame(2, $dumped[1]);
+        $this->assertSame(3, $dumped[2]);
+        $this->assertInstanceOf(Request::class, $dumped[3]);
+        $this->assertSame(1000, $dumped[4]['delay']);
+
+        VarDumper::setHandler(null);
     }
 }


### PR DESCRIPTION
Sometimes developers may need to inspect requests sent via the Laravel HTTP client. This PR aims to introduce the popular `dump()` and `dd()` helpers in the client so that this syntax is possible:

```php
Http::dump()->get($url);
Http::dd()->post($url);
```

The helpers will dump both the instance of `Illuminate\Http\Client\Request` and the client options used to perform the request:

```
Illuminate\Http\Client\Request {#685 ▼
  #request: GuzzleHttp\Psr7\Request {#480 ▶}
  #data: []
}

array:10 [▼
  "http_errors" => false
  "laravel_data" => []
  "on_stats" => Closure($transferStats) {#504 ▶}
  "synchronous" => true
  "handler" => GuzzleHttp\HandlerStack {#724 ▶}
  "cookies" => GuzzleHttp\Cookie\CookieJar {#853 ▶}
  "allow_redirects" => array:5 [▶]
  "decode_content" => true
  "verify" => true
  "idn_conversion" => false
]
```

To keep the same behavior of the homonym methods in Collections, it is also possible to pass extra variables to dump:

```php
Http::dump($var1, $var2)->get($url);
Http::dd($var3)->post($url);
```
