### PR TITLE
[6.x] Delete existing links that are broken

### DIFF
--- a/src/Illuminate/Foundation/Console/StorageLinkCommand.php
+++ b/src/Illuminate/Foundation/Console/StorageLinkCommand.php
@@ -31,6 +31,10 @@ class StorageLinkCommand extends Command
             return $this->error('The "public/storage" directory already exists.');
         }
 
+        if (is_link(public_path('storage'))) {
+            $this->laravel->make('files')->delete(public_path('storage'));
+        }
+
         $this->laravel->make('files')->link(
             storage_path('app/public'), public_path('storage')
         );


### PR DESCRIPTION
This PR attempt to fix an issue that occur when the storage link already exists but is somehow broken. By "broken", I mean link that point to a non-existing target.

When running the `storage:link` command, we get an error message and the link is not updated.

```
$ php artisan storage:link

In Filesystem.php line 263:
                                        
  symlink(): No such file or directory  
                                        
```

To fix this issue, we add an additional check to detect and delete broken links when running the `storage:link` command.

### Implementation details

When a link exists but is broken, `file_exists($link)` return _false_. And when `symlink($link, $target)` is called on a broken link, a **PHP Warning** is returned and the link is not updated. To fix this, we add an additional check using `is_link($link)` (which return _true_, even if the link is broken) to detect and delete broken links.
