### PR TITLE
[8.x] Pass component children to Blade components

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
@@ -66,7 +66,7 @@ trait CompilesComponents
             '<?php $component = $__env->getContainer()->make('.Str::finish($component, '::class').', '.($data ?: '[]').'); ?>',
             '<?php $component->withName('.$alias.'); ?>',
             '<?php if ($component->shouldRender()): ?>',
-            '<?php $__env->startComponent($component->resolveView(), $component->data()); ?>',
+            '<?php $__env->startComponentClass($component); ?>',
         ]);
     }
 

--- a/tests/View/Blade/BladeComponentsTest.php
+++ b/tests/View/Blade/BladeComponentsTest.php
@@ -16,7 +16,7 @@ class BladeComponentsTest extends AbstractBladeTestCase
 <?php $component = $__env->getContainer()->make(Test::class, ["foo" => "bar"]); ?>
 <?php $component->withName(\'test\'); ?>
 <?php if ($component->shouldRender()): ?>
-<?php $__env->startComponent($component->resolveView(), $component->data()); ?>', $this->compiler->compileString('@component(\'Test::class\', \'test\', ["foo" => "bar"])'));
+<?php $__env->startComponentClass($component); ?>', $this->compiler->compileString('@component(\'Test::class\', \'test\', ["foo" => "bar"])'));
     }
 
     public function testEndComponentsAreCompiled()


### PR DESCRIPTION
This PR allows Blade components to access their own child elements. This can be extremely useful if you want to build more complex components, or if you want to use components as structured meta-data.
The child components will be accessible in a `__children` variable within your Blade components.

For example, you could create a `table` component, that accepts `table-columns` components, which will be used to determine the columns that should be rendered:

```blade
<x-table :data="[['id' => 1, 'name' => 'Marcel'], ['id' => 2, 'name' => 'Adam']]">
    <x-table-column name="ID" attribute="id" />
    <x-table-column name="Name" attribute="name" />
</x-table>
```

The (simplified) components could look like this:

```blade
{{-- table.blade.php --}}
<table>
    <thead>
        <tr>
            @foreach($__children as $tableColumn)
                <th>{{ $tableColumn->data()['name'] }}</th>
            @endforeach
        </tr>
    </thead>
    <tbody>
    @foreach($data as $row)
        <tr>
            @foreach($__children as $tableColumn)
                <td>{{ $row[$tableColumn->data()['attribute']] }}</td>
            @endforeach
        </tr>
    @endforeach
    </tbody>
</table>
```


```blade
{{-- table-column.blade.php --}}
@props([
    'name' => '',
    'attribute' => ''
]);
```

The `table-column` component does not require any actual view content, as it is only used to hold the meta information.

In order to pass the actual child component instances to the view, this new feature only works with class-based components (either AnonymousComponent or a custom component class). This means, that it won't work when using the `@component` syntax, which is no longer documented anyway.

I'm having a hard time figuring out whats the best way to properly test this, that's why this PR does not include automated tests yet. 