### PR TITLE
[8.x] Add --tags option to the migrate command

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/FreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/FreshCommand.php
@@ -53,6 +53,7 @@ class FreshCommand extends Command
             '--schema-path' => $this->input->getOption('schema-path'),
             '--force' => true,
             '--step' => $this->option('step'),
+            '--tags' => $this->option('tags'),
         ]));
 
         if ($this->laravel->bound(Dispatcher::class)) {
@@ -101,6 +102,7 @@ class FreshCommand extends Command
     protected function getOptions()
     {
         return [
+            ['tags', null, InputOption::VALUE_OPTIONAL, 'Indicates the tagged migrations to be run'],
             ['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use'],
             ['drop-views', null, InputOption::VALUE_NONE, 'Drop all tables and views'],
             ['drop-types', null, InputOption::VALUE_NONE, 'Drop all tables and types (Postgres only)'],

--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -20,6 +20,7 @@ class MigrateCommand extends BaseCommand
     protected $signature = 'migrate {--database= : The database connection to use}
                 {--force : Force the operation to run when in production}
                 {--path=* : The path(s) to the migrations files to be executed}
+                {--tags= : Indicates the tagged migrations to be run}
                 {--realpath : Indicate any provided migration file paths are pre-resolved absolute paths}
                 {--schema-path= : The path to a schema dump file}
                 {--pretend : Dump the SQL queries that would be run}
@@ -83,6 +84,7 @@ class MigrateCommand extends BaseCommand
                     ->run($this->getMigrationPaths(), [
                         'pretend' => $this->option('pretend'),
                         'step' => $this->option('step'),
+                        'tags' => $this->option('tags'),
                     ]);
 
             // Finally, if the "seed" option has been given, we will re-run the database

--- a/src/Illuminate/Database/Migrations/Migration.php
+++ b/src/Illuminate/Database/Migrations/Migration.php
@@ -12,6 +12,13 @@ abstract class Migration
     protected $connection;
 
     /**
+     * The Tag titles of migration file.
+     *
+     * @var string|array
+     */
+    public $tags = [];
+
+    /**
      * Enables, if supported, wrapping the migration within a transaction.
      *
      * @var bool

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -162,7 +162,7 @@ class Migrator
         // migrations "up" so the changes are made to the databases. We'll then log
         // that the migration was run so we don't repeat it next time we execute.
         foreach ($migrations as $file) {
-            $this->runUp($file, $batch, $pretend);
+            $this->runUp($file, $batch, $pretend, $options['tags'] ?? null);
 
             if ($step) {
                 $batch++;
@@ -178,9 +178,10 @@ class Migrator
      * @param  string  $file
      * @param  int  $batch
      * @param  bool  $pretend
+     * @param  string|null  $tags
      * @return void
      */
-    protected function runUp($file, $batch, $pretend)
+    protected function runUp($file, $batch, $pretend, $tags)
     {
         // First we will resolve a "real" instance of the migration class from this
         // migration file name. Once we have the instances we can run the actual
@@ -191,6 +192,10 @@ class Migrator
 
         if ($pretend) {
             return $this->pretendToRun($migration, 'up');
+        }
+
+        if ($tags && ! array_intersect((array) $migration->tags, explode(',', $tags))) {
+            return;
         }
 
         $this->note("<comment>Migrating:</comment> {$name}");

--- a/tests/Database/DatabaseMigrationMigrateCommandTest.php
+++ b/tests/Database/DatabaseMigrationMigrateCommandTest.php
@@ -31,7 +31,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
             return $callback();
         });
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
-        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => false]);
+        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => false, 'tags' => null]);
         $migrator->shouldReceive('getNotes')->andReturn([]);
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
 
@@ -57,7 +57,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
         $schemaState->shouldReceive('load')->once()->with(__DIR__.'/stubs/schema.sql');
         $dispatcher->shouldReceive('dispatch')->once()->with(m::type(SchemaLoaded::class));
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
-        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => false]);
+        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => false, 'tags' => null]);
         $migrator->shouldReceive('getNotes')->andReturn([]);
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
 
@@ -77,7 +77,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
             return $callback();
         });
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
-        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => false]);
+        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => false, 'tags' => null]);
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(false);
         $command->expects($this->once())->method('call')->with($this->equalTo('migrate:install'), $this->equalTo([]));
 
@@ -96,7 +96,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
             return $callback();
         });
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
-        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => true, 'step' => false]);
+        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => true, 'step' => false, 'tags' => null]);
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
 
         $this->runCommand($command, ['--pretend' => true]);
@@ -114,7 +114,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
             return $callback();
         });
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
-        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => false]);
+        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => false, 'tags' => null]);
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
 
         $this->runCommand($command, ['--database' => 'foo']);
@@ -132,7 +132,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
             return $callback();
         });
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
-        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => true]);
+        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => true, 'tags' => null]);
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
 
         $this->runCommand($command, ['--step' => true]);


### PR DESCRIPTION
Currently, the migrate command has an "all or nothing" approach. but when testing features of the applications (for example "Contact us" form) we usually need a subset of tables and columns which are really involved with that feature
And running the entire migrations can get really slow (using the in memory sqlite is not always an option since there are tricky implementations detail differences which ruin the whole purpose of testing).

This PR allows us to be selective on which migration should be run by sort of tagging the classes.
```
php artisan migrate --tag=contact,users
```
The command above runs only the migrations with "contact" or "users" tag.

- The change seems to be fully-backward compatible, to me.
- I do not exactly know if the `migrate:fresh` also needs the tag option or not but I added the support for that.

Sample tagging:
```php
class CreateDiscussionsTable extends Migration
{
    public $tags = ['discussions'];

    public function up()
    {
         //...
```

This PR reopens https://github.com/laravel/framework/pull/35274
Why re-opened? As time passed the need of "being selective about the migration run in the tests"  just always repeated for me.

I really needed to run only a subset of the migrations for a single test suite.

So if this implementation is not a perfect one, at least we need something along the lines of that.
Maybe a lot better implementation is still possible but let's go for the feature.

Currently, I have to put a lot of fluffy code in my migrations to accomplish this.

Thanks for your attention.