### PR TITLE
Bugfix ModelFactory not found

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -719,6 +719,10 @@ abstract class Factory
                 ? Str::after($modelName, $appNamespace.'Models\\')
                 : Str::after($modelName, $appNamespace);
 
+            if (Str::endsWith($modelName, 'Model')) {
+                $modelName = Str::beforeLast($modelName, 'Model');
+            }
+
             return static::$namespace.$modelName.'Factory';
         };
 

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -415,9 +415,13 @@ class DatabaseEloquentFactoryTest extends TestCase
 
         $resolves = [
             'App\\Foo' => 'Factories\\FooFactory',
+            'App\\FooModel' => 'Factories\\FooFactory',
             'App\\Models\\Foo' => 'Factories\\FooFactory',
+            'App\\Models\\FooModel' => 'Factories\\FooFactory',
             'App\\Models\\Nested\\Foo' => 'Factories\\Nested\\FooFactory',
+            'App\\Models\\Nested\\FooModel' => 'Factories\\Nested\\FooFactory',
             'App\\Models\\Really\\Nested\\Foo' => 'Factories\\Really\\Nested\\FooFactory',
+            'App\\Models\\Really\\Nested\\FooModel' => 'Factories\\Really\\Nested\\FooFactory',
         ];
 
         foreach ($resolves as $model => $factory) {
@@ -434,9 +438,13 @@ class DatabaseEloquentFactoryTest extends TestCase
 
         $resolves = [
             'Foo\\Bar' => 'Factories\\BarFactory',
+            'Foo\\BarModel' => 'Factories\\BarFactory',
             'Foo\\Models\\Bar' => 'Factories\\BarFactory',
+            'Foo\\Models\\BarModel' => 'Factories\\BarFactory',
             'Foo\\Models\\Nested\\Bar' => 'Factories\\Nested\\BarFactory',
+            'Foo\\Models\\Nested\\BarModel' => 'Factories\\Nested\\BarFactory',
             'Foo\\Models\\Really\\Nested\\Bar' => 'Factories\\Really\\Nested\\BarFactory',
+            'Foo\\Models\\Really\\Nested\\BarModel' => 'Factories\\Really\\Nested\\BarFactory',
         ];
 
         foreach ($resolves as $model => $factory) {


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Closes: #36482 

With this PR, it is possible to give models the `Model` a suffix, for example `ArticleModel`, without breaking the resolving of the factory name.