### PR TITLE
[8.x] Adds FormRequest::getValidated() to take jus a specific validated key

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -188,11 +188,13 @@ class FormRequest extends Request implements ValidatesWhenResolved
     /**
      * Get the validated data from the request.
      *
+     * @param  string|null  $key
+     * @param  mixed  $default
      * @return array
      */
-    public function validated()
+    public function validated(string $key = null, $default = null)
     {
-        return $this->validator->validated();
+        return data_get($this->validator->validated(), $key, $default);
     }
 
     /**

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -190,7 +190,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
      *
      * @param  string|null  $key
      * @param  mixed  $default
-     * @return array
+     * @return mixed
      */
     public function validated(string $key = null, $default = null)
     {

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -188,13 +188,23 @@ class FormRequest extends Request implements ValidatesWhenResolved
     /**
      * Get the validated data from the request.
      *
+     * @return array
+     */
+    public function validated()
+    {
+        return $this->validator->validated();
+    }
+
+    /**
+     * Get a specific field from validated data.
+     *
      * @param  string|null  $key
      * @param  mixed  $default
      * @return mixed
      */
-    public function validated(string $key = null, $default = null)
+    public function getValidated(string $key = null, $default = null)
     {
-        return data_get($this->validator->validated(), $key, $default);
+        return data_get($this->validated(), $key, $default);
     }
 
     /**

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -115,16 +115,16 @@ class FoundationFormRequestTest extends TestCase
         $this->assertEquals(['name' => 'Adam'], $request->all());
     }
 
-    public function testValidatedMethodReturnsASpecificValidatedData()
+    public function testGetValidatedMethodReturnsASpecificValidatedData()
     {
         $request = $this->createRequest(['name' => 'specified', 'with' => 'extras']);
 
         $request->validateResolved();
 
-        $this->assertEquals('specified', $request->validated('name', 'default'));
+        $this->assertEquals('specified', $request->getValidated('name', 'default'));
     }
 
-    public function testValidatedMethodReturnsASpecificNestedValidatedData()
+    public function testGetValidatedMethodReturnsASpecificNestedValidatedData()
     {
         $request = $this->createRequest([
             'name' => ['nested' => 'values'],
@@ -133,10 +133,10 @@ class FoundationFormRequestTest extends TestCase
 
         $request->validateResolved();
 
-        $this->assertEquals('values', $request->validated('name.nested', 'default'));
+        $this->assertEquals('values', $request->getValidated('name.nested', 'default'));
     }
 
-    public function testValidatedMethodReturnsASpecificNestedValidatedArray()
+    public function testGetValidatedMethodReturnsASpecificNestedValidatedArray()
     {
         $request = $this->createRequest([
             'name' => ['nested' => ['key' => 'value']],
@@ -145,16 +145,16 @@ class FoundationFormRequestTest extends TestCase
 
         $request->validateResolved();
 
-        $this->assertEquals(['key' => 'value'], $request->validated('name.nested', 'default'));
+        $this->assertEquals(['key' => 'value'], $request->getValidated('name.nested', 'default'));
     }
 
-    public function testValidatedMethodReturnsDefaultValueIfMissingSpecificValidatedData()
+    public function testGetValidatedMethodReturnsDefaultValueIfMissingSpecificValidatedData()
     {
         $request = $this->createRequest(['name' => 'specified', 'with' => 'extras']);
 
         $request->validateResolved();
 
-        $this->assertEquals('default', $request->validated('missing_key', 'default'));
+        $this->assertEquals('default', $request->getValidated('missing_key', 'default'));
     }
 
     /**

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -124,6 +124,30 @@ class FoundationFormRequestTest extends TestCase
         $this->assertEquals('specified', $request->validated('name', 'default'));
     }
 
+    public function testValidatedMethodReturnsASpecificNestedValidatedData()
+    {
+        $request = $this->createRequest([
+            'name' => ['nested' => 'values'],
+            'with' => 'extras',
+        ]);
+
+        $request->validateResolved();
+
+        $this->assertEquals('values', $request->validated('name.nested', 'default'));
+    }
+
+    public function testValidatedMethodReturnsASpecificNestedValidatedArray()
+    {
+        $request = $this->createRequest([
+            'name' => ['nested' => ['key' => 'value']],
+            'with' => 'extras',
+        ]);
+
+        $request->validateResolved();
+
+        $this->assertEquals(['key' => 'value'], $request->validated('name.nested', 'default'));
+    }
+
     public function testValidatedMethodReturnsDefaultValueIfMissingSpecificValidatedData()
     {
         $request = $this->createRequest(['name' => 'specified', 'with' => 'extras']);

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -115,6 +115,24 @@ class FoundationFormRequestTest extends TestCase
         $this->assertEquals(['name' => 'Adam'], $request->all());
     }
 
+    public function testValidatedMethodReturnsASpecificValidatedData()
+    {
+        $request = $this->createRequest(['name' => 'specified', 'with' => 'extras']);
+
+        $request->validateResolved();
+
+        $this->assertEquals('specified', $request->validated('name', 'default'));
+    }
+
+    public function testValidatedMethodReturnsDefaultValueIfMissingSpecificValidatedData()
+    {
+        $request = $this->createRequest(['name' => 'specified', 'with' => 'extras']);
+
+        $request->validateResolved();
+
+        $this->assertEquals('default', $request->validated('missing_key', 'default'));
+    }
+
     /**
      * Catch the given exception thrown from the executor, and return it.
      *


### PR DESCRIPTION
This PR allows to ask a FormRequest instance to get a single specific key from the validated pool.  This can be useful to avoid creating an additional variable to store the validated values in order to extract the one you need:


With the current codebase I should do:

```php
public function store(MyFormRequest $request)
{
    /* other stuff */

    $data = $request->validated();

    $foo = MyModel::create($data);

    $foo->handleMoreData(data_get($data, 'bar', 'default'));

    /* more other stuff */
}
```


With this PR it would be fine to write:

```php
public function store(MyFormRequest $request)
{
    /* other stuff */

    $foo = MyModel::create($request->validated());

    $foo->handleMoreData($request->getValidated('bar', 'default'));

    /* more other stuff */
}
```


EDIT: moved to a dedicated `getValidated()` method to avoid breaking changes. 