### PR TITLE
[6.x] Update changelog for v6.18.27 with upgrade info around cookies

### DIFF
--- a/CHANGELOG-6.x.md
+++ b/CHANGELOG-6.x.md
@@ -259,6 +259,8 @@
 ### Changed
 - Improve cookie encryption ([#33662](https://github.com/laravel/framework/pull/33662))
 
+**Important Note For Upgrading:** This change will invalidate all existing cookies (e.g. any users of your application will be logged out)
+
 
 ## [v6.18.26 (2020-07-21)](https://github.com/laravel/framework/compare/v6.18.25...v6.18.26)
 

--- a/CHANGELOG-6.x.md
+++ b/CHANGELOG-6.x.md
@@ -259,7 +259,7 @@
 ### Changed
 - Improve cookie encryption ([#33662](https://github.com/laravel/framework/pull/33662))
 
-**Important Note For Upgrading:** This change will invalidate all existing cookies (e.g. any users of your application will be logged out)
+**Important Note For Upgrading:** This change will invalidate all existing cookies (e.g. any users of your application will be logged out). Please see [this security bulletin](https://blog.laravel.com/laravel-cookie-security-releases) for more info.
 
 
 ## [v6.18.26 (2020-07-21)](https://github.com/laravel/framework/compare/v6.18.25...v6.18.26)

--- a/CHANGELOG-6.x.md
+++ b/CHANGELOG-6.x.md
@@ -259,7 +259,7 @@
 ### Changed
 - Improve cookie encryption ([#33662](https://github.com/laravel/framework/pull/33662))
 
-**Important Note For Upgrading:** This change will invalidate all existing cookies (e.g. any users of your application will be logged out). Please see [this security bulletin](https://blog.laravel.com/laravel-cookie-security-releases) for more info.
+This change will invalidate all existing cookies. Please see [this security bulletin](https://blog.laravel.com/laravel-cookie-security-releases) for more information.
 
 
 ## [v6.18.26 (2020-07-21)](https://github.com/laravel/framework/compare/v6.18.25...v6.18.26)


### PR DESCRIPTION
Anyone upgrading to >= v6.18.27 will have all their cookies invalidated.

This seems like an important point to highlight that I didn't see mentioned anywhere. I only found it after basically doing a binary search through upgrades to find out which version borked our cookies.

For some apps this means that all their users will be logged out at once - which could have a bunch of implications (not to mention an annoyance for the users)

I may have just completely missed the memo on this - but there was no info on the PR (#33662) and the discussion is currently locked.

Supercedes https://github.com/laravel/framework/pull/36489 (changed to target 6.x instead of 8.x)