### PR TITLE
[8.x] Multiple route URIs that point to a single action

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -446,12 +446,20 @@ class Router implements BindingRegistrar, RegistrarContract
      * Add a route to the underlying route collection.
      *
      * @param  array|string  $methods
-     * @param  string  $uri
+     * @param  array|string  $uri
      * @param  array|string|callable|null  $action
      * @return \Illuminate\Routing\Route
      */
     public function addRoute($methods, $uri, $action)
     {
+        if (is_array($uri)) {
+            foreach ($uri as $item) {
+                $this->addRoute($methods, $item, $action);
+            }
+
+            return;
+        }
+
         return $this->routes->add($this->createRoute($methods, $uri, $action));
     }
 


### PR DESCRIPTION
These changes add a functionality to attach multiple URIs to a single action. For example:

```php
Route::get(['/foo', '/bar', 'baz/path'], 'HomeController@index');
```
This is useful when an application uses SPA on front-end. So instead of writing multiple routes pointing to a single action:
```php
Route::get('/foo', 'HomeController@index');
Route::get('/bar', 'HomeController@index');
Route::get('baz/path', 'HomeController@index');
```
We can summarize them in a single line route.
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
