### PR TITLE
[8.x] Ensure that perPage method of the paginator returns an integer

### DIFF
--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -355,7 +355,7 @@ abstract class AbstractPaginator implements Htmlable
      */
     public function perPage()
     {
-        return $this->perPage;
+        return (int) $this->perPage;
     }
 
     /**


### PR DESCRIPTION
This PR allows `perPage` method of the paginator to return an integer. At the moment it returns a string when you pass a string parameter to the paginate function and it returns an integer by default which is confusing.

This can be extremely useful for example if you use a strongly typed language!
