### PR TITLE
[8.x] Add support to Eloquent Collection on Model::destroy()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\Routing\UrlRoutable;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\Concerns\AsPivot;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
@@ -1061,6 +1062,10 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
      */
     public static function destroy($ids)
     {
+        if ($ids instanceof EloquentCollection) {
+            $ids = $ids->modelKeys();
+        }
+
         if ($ids instanceof BaseCollection) {
             $ids = $ids->all();
         }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -290,7 +290,16 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testDestroyMethodCallsQueryBuilderCorrectlyWithCollection()
     {
-        EloquentModelDestroyStub::destroy(new Collection([1, 2, 3]));
+        EloquentModelDestroyStub::destroy(new BaseCollection([1, 2, 3]));
+    }
+
+    public function testDestroyMethodCallsQueryBuilderCorrectlyWithEloquentCollection()
+    {
+        EloquentModelDestroyStub::destroy(new Collection([
+            new EloquentModelDestroyStub(['id' => 1]),
+            new EloquentModelDestroyStub(['id' => 2]),
+            new EloquentModelDestroyStub(['id' => 3]),
+        ]));
     }
 
     public function testDestroyMethodCallsQueryBuilderCorrectlyWithMultipleArgs()
@@ -2383,6 +2392,10 @@ class EloquentModelFindWithWritePdoStub extends Model
 
 class EloquentModelDestroyStub extends Model
 {
+    protected $fillable = [
+        'id',
+    ];
+
     public function newQuery()
     {
         $mock = m::mock(Builder::class);


### PR DESCRIPTION
Hi,

Currently doing ```SomeModel::destroy(SomeModel::all())``` will do nothing which to me was unexpected.
This is due to the fact that ```destroy()``` takes any Collection as a list of ids which is fine if we do :

```SomeModel::destroy(SomeModel::all()->pluck('whatever_primary_key'))```
or 
```SomeModel::destroy(SomeModel::all()->modelKeys())```

This PR will apply the second solution if an EloquentCollection is passed and keep the current behavior for BaseCollection.