### PR TITLE
Fix validator treating null as true for (required|exclude)_(if|unless) due to loose in_array() check

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1465,7 +1465,7 @@ trait ValidatesAttributes
 
         [$values, $other] = $this->prepareValuesAndOther($parameters);
 
-        return in_array($other, $values);
+        return in_array($other, $values, is_bool($other));
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1448,7 +1448,7 @@ trait ValidatesAttributes
 
         [$values, $other] = $this->prepareValuesAndOther($parameters);
 
-        return ! in_array($other, $values);
+        return ! in_array($other, $values, is_bool($other));
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1554,7 +1554,7 @@ trait ValidatesAttributes
 
         [$values, $other] = $this->prepareValuesAndOther($parameters);
 
-        if (! in_array($other, $values)) {
+        if (! in_array($other, $values, is_bool($other))) {
             return $this->validateRequired($attribute, $value);
         }
 

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1427,7 +1427,7 @@ trait ValidatesAttributes
 
         [$values, $other] = $this->prepareValuesAndOther($parameters);
 
-        if (in_array($other, $values)) {
+        if (in_array($other, $values, is_bool($other))) {
             return $this->validateRequired($attribute, $value);
         }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -5726,6 +5726,14 @@ class ValidationValidatorTest extends TestCase
         );
         $this->assertTrue($validator->fails());
         $this->assertSame(['mouse' => ['validation.required']], $validator->messages()->toArray());
+
+        $validator = new Validator(
+            $this->getIlluminateArrayTranslator(),
+            ['foo' => true, 'bar' => 'baz'],
+            ['foo' => 'nullable', 'bar' => 'exclude_unless:foo,null']
+        );
+        $this->assertTrue($validator->passes());
+        $this->assertSame(['foo' => true], $validator->validated());
     }
 
     public function testExcludeWithout()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1097,7 +1097,31 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
 
         $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => true], ['bar' => 'required_if:foo,null']);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => 0], ['bar' => 'required_if:foo,0']);
+        $this->assertTrue($v->fails());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => '0'], ['bar' => 'required_if:foo,0']);
+        $this->assertTrue($v->fails());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => 1], ['bar' => 'required_if:foo,1']);
+        $this->assertTrue($v->fails());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => '1'], ['bar' => 'required_if:foo,1']);
+        $this->assertTrue($v->fails());
+
+        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => true], ['bar' => 'required_if:foo,true']);
+        $this->assertTrue($v->fails());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => false], ['bar' => 'required_if:foo,false']);
         $this->assertTrue($v->fails());
 
         // error message when passed multiple values (required_if:foo,bar,baz)

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -5380,6 +5380,20 @@ class ValidationValidatorTest extends TestCase
             ],
             [
                 [
+                    'has_appointment' => ['nullable', 'bool'],
+                    'appointment_date' => ['exclude_if:has_appointment,null', 'required', 'date'],
+                ],
+                [
+                    'has_appointment' => true,
+                    'appointment_date' => '2021-03-08',
+                ],
+                [
+                    'has_appointment' => true,
+                    'appointment_date' => '2021-03-08',
+                ],
+            ],
+            [
+                [
                     'has_appointment' => ['required', 'bool'],
                     'appointment_date' => ['exclude_if:has_appointment,false', 'required', 'date'],
                 ], [

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1162,6 +1162,26 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['foo' => false], ['bar' => 'required_unless:foo,true']);
         $this->assertTrue($v->fails());
 
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => true], ['bar' => 'required_unless:foo,null']);
+        $this->assertTrue($v->fails());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => '0'], ['bar' => 'required_unless:foo,0']);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => 0], ['bar' => 'required_unless:foo,0']);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => '1'], ['bar' => 'required_unless:foo,1']);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => 1], ['bar' => 'required_unless:foo,1']);
+        $this->assertTrue($v->passes());
+
         // error message when passed multiple values (required_unless:foo,bar,baz)
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.required_unless' => 'The :attribute field is required unless :other is in :values.'], 'en');


### PR DESCRIPTION
There's currently some unusual behavior with a number of validation rules that are using `in_array()` in the default loose mode.

For example, this currently fails:

```php
Validator::validate(['foo' => true], ['bar' => 'required_if:foo,null']);

// "bar": [
//   "The bar field is required when foo is true."
// ]
```

This is because the `null` parameter is converted to a string `'null'` and placed in an array, which is passed as the haystack to `in_array()`, with the dependent field value as the needle. e.g.

```php
in_array(true, ['null']); // true
```

We can pass `true` as the third parameter to use strict mode, however many people no doubt rely on it loosely comparing numeric strings and integers, so this PR instead **only enables strict mode when the value is a boolean**, which fixes the bug hopefully without breaking any expected behavior.

I'm not sure if this is considered a breaking change - I guess that depends on whether anyone is depending on the existing behavior. It does feel risky to tweak the behavior of such fundamental validation rules though.