### PR TITLE
[8.x] Allow custom validation rules to use prepareValuesAndOthers()

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1493,7 +1493,7 @@ trait ValidatesAttributes
      * @param  array  $parameters
      * @return array
      */
-    protected function prepareValuesAndOther($parameters)
+    public function prepareValuesAndOther($parameters)
     {
         $other = Arr::get($this->data, $parameters[0]);
 


### PR DESCRIPTION
Similar to #35183, I've needed to re-implement `ValidatesAttributes::prepareValuesAndOthers()` (and the two other methods it calls) on a few projects when implementing custom validation rules with true/false/null parameters.

So, I was wondering whether this method could be made public?

Alternatively, I could PR my `prohibited_if` custom validation rule that is basically the opposite of `required_if` and similar to `exclude_if` except that it fails validation instead of excluding the field. Not sure how common the use case is though.

No hard feelings if you prefer to keep this method private - totally understandable.