### PR TITLE
[8.x] No need to check if clone->columns exists as it's just for pagination

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2393,7 +2393,7 @@ class Builder
         if ($this->groups || $this->havings) {
             $clone = $this->cloneForPaginationCount();
 
-            if (is_null($clone->columns) && ! empty($this->joins)) {
+            if (! empty($this->joins)) {
                 $clone->select($this->from.'.*');
             }
 


### PR DESCRIPTION
A part from that, there is no way to select null columns, always
receiving array(null) instead.

On the other hand, if we join tables and use select *, we could be using
diferent fields from each table but it always breaks when paginating because of
duplicate column name 'id'.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
