### PR TITLE
[8.x] Support value callback arguments

### DIFF
--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -179,8 +179,8 @@ if (! function_exists('value')) {
      * @param  mixed  $value
      * @return mixed
      */
-    function value($value)
+    function value($value, ...$args)
     {
-        return $value instanceof Closure ? $value() : $value;
+        return $value instanceof Closure ? $value(...$args) : $value;
     }
 }

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -40,6 +40,9 @@ class SupportHelpersTest extends TestCase
         $this->assertSame('foo', value(function () {
             return 'foo';
         }));
+        $this->assertSame('foo', value(function ($arg) {
+            return $arg;
+        }, 'foo'));
     }
 
     public function testObjectGet()


### PR DESCRIPTION
This addition allows the developer to pass arguments to a `value()` helper callback.

```php
$callback = fn ($arg) => $arg;

value($callback, 'foo'); // `foo`
```