### PR TITLE
[8.x] Expose the view component stack and keep full components on stack

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
@@ -66,7 +66,7 @@ trait CompilesComponents
             '<?php $component = $__env->getContainer()->make('.Str::finish($component, '::class').', '.($data ?: '[]').'); ?>',
             '<?php $component->withName('.$alias.'); ?>',
             '<?php if ($component->shouldRender()): ?>',
-            '<?php $__env->startComponent($component->resolveView(), $component->data()); ?>',
+            '<?php $__env->startComponent($component, $component->data()); ?>',
         ]);
     }
 

--- a/src/Illuminate/View/Concerns/ManagesComponents.php
+++ b/src/Illuminate/View/Concerns/ManagesComponents.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Arr;
 use Illuminate\Support\HtmlString;
+use Illuminate\View\Component;
 use InvalidArgumentException;
 
 trait ManagesComponents
@@ -42,7 +43,7 @@ trait ManagesComponents
     /**
      * Start a component rendering process.
      *
-     * @param  \Illuminate\Contracts\View\View|\Illuminate\Contracts\Support\Htmlable|\Closure|string  $view
+     * @param  \Illuminate\Contracts\View\View|\Illuminate\Contracts\Support\Htmlable|\Illuminate\View\Component|\Closure|string  $view
      * @param  array  $data
      * @return void
      */
@@ -84,6 +85,10 @@ trait ManagesComponents
 
         $data = $this->componentData();
 
+        if ($view instanceof Component) {
+            $view = $view->resolveView();
+        }
+
         if ($view instanceof Closure) {
             $view = $view($data);
         }
@@ -95,6 +100,17 @@ trait ManagesComponents
         } else {
             return $this->make($view, $data)->render();
         }
+    }
+
+
+    /**
+     * Get the current component stack.
+     *
+     * @return array
+     */
+    public function getComponentStack()
+    {
+        return $this->componentStack;
     }
 
     /**

--- a/src/Illuminate/View/Concerns/ManagesComponents.php
+++ b/src/Illuminate/View/Concerns/ManagesComponents.php
@@ -102,7 +102,6 @@ trait ManagesComponents
         }
     }
 
-
     /**
      * Get the current component stack.
      *

--- a/tests/View/Blade/BladeComponentStackTest.php
+++ b/tests/View/Blade/BladeComponentStackTest.php
@@ -23,7 +23,6 @@ class BladeComponentStackTest extends AbstractBladeTestCase
         Mockery::close();
     }
 
-
     public function testComponentStackOrder()
     {
         $factory = $this->getFactory();
@@ -48,7 +47,7 @@ class BladeComponentStackTest extends AbstractBladeTestCase
         $factory->startComponent($child, $child->data());
 
         $this->assertEquals($parent, $child->getParent());
-        
+
         $this->assertCount(3, $factory->getComponentStack());
         $this->assertEquals($parent, $factory->getComponentStack()[0]);
         $this->assertEquals($intermediate, $factory->getComponentStack()[1]);
@@ -70,10 +69,9 @@ class BladeComponentStackTest extends AbstractBladeTestCase
         $this->assertCount(0, $factory->getComponentStack());
     }
 
-
     protected function getFactory()
     {
-        if (!$this->factory) {
+        if (! $this->factory) {
             $this->factory = new Factory(
                 m::mock(EngineResolver::class),
                 m::mock(ViewFinderInterface::class),
@@ -98,7 +96,6 @@ class BladeComponentStackTest extends AbstractBladeTestCase
 
 class TestParentComponent extends Component
 {
-
     public function render()
     {
         return 'parent';
@@ -107,7 +104,6 @@ class TestParentComponent extends Component
 
 class TestIntermediateComponent extends Component
 {
-
     public function render()
     {
         return 'intermediate';
@@ -116,12 +112,11 @@ class TestIntermediateComponent extends Component
 
 class TestChildComponent extends Component
 {
-
     public function getParent()
     {
         return Collection::make(Container::getInstance()->make('view')->getComponentStack())
             ->reverse()
-            ->first(function($component) {
+            ->first(function ($component) {
                 return $component instanceof TestParentComponent;
             });
     }

--- a/tests/View/Blade/BladeComponentStackTest.php
+++ b/tests/View/Blade/BladeComponentStackTest.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Illuminate\Tests\View\Blade;
+
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Collection;
+use Illuminate\View\Component;
+use Illuminate\View\Engines\EngineResolver;
+use Illuminate\View\Engines\PhpEngine;
+use Illuminate\View\Factory;
+use Illuminate\View\ViewFinderInterface;
+use Mockery;
+use Mockery as m;
+
+class BladeComponentStackTest extends AbstractBladeTestCase
+{
+    protected $factory;
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+    }
+
+
+    public function testComponentStackOrder()
+    {
+        $factory = $this->getFactory();
+        $this->mockBasicComponent();
+
+        $this->assertCount(0, $factory->getComponentStack());
+
+        $parent = new TestParentComponent();
+        $factory->startComponent($parent, $parent->data());
+
+        $this->assertCount(1, $factory->getComponentStack());
+        $this->assertEquals($parent, $factory->getComponentStack()[0]);
+
+        $intermediate = new TestIntermediateComponent();
+        $factory->startComponent($intermediate, $intermediate->data());
+
+        $this->assertCount(2, $factory->getComponentStack());
+        $this->assertEquals($parent, $factory->getComponentStack()[0]);
+        $this->assertEquals($intermediate, $factory->getComponentStack()[1]);
+
+        $child = new TestChildComponent();
+        $factory->startComponent($child, $child->data());
+
+        $this->assertEquals($parent, $child->getParent());
+        
+        $this->assertCount(3, $factory->getComponentStack());
+        $this->assertEquals($parent, $factory->getComponentStack()[0]);
+        $this->assertEquals($intermediate, $factory->getComponentStack()[1]);
+        $this->assertEquals($child, $factory->getComponentStack()[2]);
+
+        $factory->renderComponent();
+
+        $this->assertCount(2, $factory->getComponentStack());
+        $this->assertEquals($parent, $factory->getComponentStack()[0]);
+        $this->assertEquals($intermediate, $factory->getComponentStack()[1]);
+
+        $factory->renderComponent();
+
+        $this->assertCount(1, $factory->getComponentStack());
+        $this->assertEquals($parent, $factory->getComponentStack()[0]);
+
+        $factory->renderComponent();
+
+        $this->assertCount(0, $factory->getComponentStack());
+    }
+
+
+    protected function getFactory()
+    {
+        if (!$this->factory) {
+            $this->factory = new Factory(
+                m::mock(EngineResolver::class),
+                m::mock(ViewFinderInterface::class),
+                m::mock(DispatcherContract::class)
+            );
+
+            Container::getInstance()->instance('view', $this->factory);
+        }
+
+        return $this->factory;
+    }
+
+    protected function mockBasicComponent()
+    {
+        $factory = $this->getFactory();
+
+        $factory->getFinder()->shouldReceive('find')->andReturn(__DIR__.'/../fixtures/basic.php');
+        $factory->getEngineResolver()->shouldReceive('resolve')->andReturn(new PhpEngine(new Filesystem));
+        $factory->getDispatcher()->shouldReceive('dispatch');
+    }
+}
+
+class TestParentComponent extends Component
+{
+
+    public function render()
+    {
+        return 'parent';
+    }
+}
+
+class TestIntermediateComponent extends Component
+{
+
+    public function render()
+    {
+        return 'intermediate';
+    }
+}
+
+class TestChildComponent extends Component
+{
+
+    public function getParent()
+    {
+        return Collection::make(Container::getInstance()->make('view')->getComponentStack())
+            ->reverse()
+            ->first(function($component) {
+                return $component instanceof TestParentComponent;
+            });
+    }
+
+    public function render()
+    {
+        return 'child';
+    }
+}

--- a/tests/View/Blade/BladeComponentsTest.php
+++ b/tests/View/Blade/BladeComponentsTest.php
@@ -16,7 +16,7 @@ class BladeComponentsTest extends AbstractBladeTestCase
 <?php $component = $__env->getContainer()->make(Test::class, ["foo" => "bar"]); ?>
 <?php $component->withName(\'test\'); ?>
 <?php if ($component->shouldRender()): ?>
-<?php $__env->startComponent($component->resolveView(), $component->data()); ?>', $this->compiler->compileString('@component(\'Test::class\', \'test\', ["foo" => "bar"])'));
+<?php $__env->startComponent($component, $component->data()); ?>', $this->compiler->compileString('@component(\'Test::class\', \'test\', ["foo" => "bar"])'));
     }
 
     public function testEndComponentsAreCompiled()


### PR DESCRIPTION
This is an alternative approach to #36472. This PR includes two changes:

1. It exposes `View::getComponentStack()` so that components can access the stack during render (for example, to find their parents)
2. It allows for passing the full Blade Component to the `startComponent()` so that when components are accessed from the stack you have access to more than just their resolved view

It turns out that `CompilesComponents::compileClassComponentOpening` will need to be changed for this to work, since right now we're only passing `$component->resolveView()` rather than the whole component. But this approach does mean that there's not a need to track child components, and adds support for accessing components that are not directly next to each other on the stack (like my instant search example).