### PR TITLE
[8.x] Add class argument

### DIFF
--- a/src/Illuminate/Database/Console/Seeds/SeedCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeedCommand.php
@@ -6,6 +6,7 @@ use Illuminate\Console\Command;
 use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
 use Illuminate\Database\Eloquent\Model;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 
 class SeedCommand extends Command
@@ -81,7 +82,7 @@ class SeedCommand extends Command
      */
     protected function getSeeder()
     {
-        $class = $this->input->getOption('class');
+        $class = $this->input->getArgument('class') ?? $this->input->getOption('class');
 
         if (strpos($class, '\\') === false) {
             $class = 'Database\\Seeders\\'.$class;
@@ -107,6 +108,18 @@ class SeedCommand extends Command
         $database = $this->input->getOption('database');
 
         return $database ?: $this->laravel['config']['database.default'];
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return [
+            ['class', InputArgument::OPTIONAL, 'The class name of the root seeder', null],
+        ];
     }
 
     /**


### PR DESCRIPTION
This is a retry of #35536 after getting some [love on Twitter](https://twitter.com/gonedark/status/1366874923914977285). It avoids the breaking change by preserving the current `--class` option and adding a `class` argument which will be used if set. Otherwise, existing behavior ensues.

For example, all of the following may be used to run the `DatabaseSeeder`.

```sh
php artisan db:seed --class=DatabaseSeeder
php artisan db:seed DatabaseSeeder
php artisan db:seed
```

For a specific seeder, you may run:
```sh
php artisan db:seed --class=UsersTableSeeder
php artisan db:seed UsersTableSeeder
```