### PR TITLE
[8.x] Allow to override discover events base path

### DIFF
--- a/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
@@ -119,7 +119,7 @@ class EventServiceProvider extends ServiceProvider
                     ->reduce(function ($discovered, $directory) {
                         return array_merge_recursive(
                             $discovered,
-                            DiscoverEvents::within($directory, $this->discoverEventsBasePath())
+                            DiscoverEvents::within($directory, $this->eventDiscoveryBasePath())
                         );
                     }, []);
     }
@@ -136,7 +136,12 @@ class EventServiceProvider extends ServiceProvider
         ];
     }
 
-    protected function discoverEventsBasePath()
+    /**
+     * Get the base path to be used during event discovery.
+     *
+     * @return string
+     */
+    protected function eventDiscoveryBasePath()
     {
         return base_path();
     }

--- a/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
@@ -119,7 +119,7 @@ class EventServiceProvider extends ServiceProvider
                     ->reduce(function ($discovered, $directory) {
                         return array_merge_recursive(
                             $discovered,
-                            DiscoverEvents::within($directory, base_path())
+                            DiscoverEvents::within($directory, $this->discoverEventsBasePath())
                         );
                     }, []);
     }
@@ -134,5 +134,10 @@ class EventServiceProvider extends ServiceProvider
         return [
             $this->app->path('Listeners'),
         ];
+    }
+
+    protected function discoverEventsBasePath()
+    {
+        return base_path();
     }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

When customizing the app's directory structure event discovery fails as it uses `base_path()` to remove the "real path" part from a class file and tries to guess the class name from the remaining path.

For example, if one is following "Laravel Beyond Crud" book, from Spatie, proposed file structure, and have an event placed at `./src/App/Events/UserCreated.php`, the `DiscoverEvents` class will guess the namespace of that class as `Src\App\Events\UserCreated`, which PHP won't find as a class.

This PR allows a developer to override in their local `EventServiceProvider` the base path used for event discovery by adding a protected method they can override and provide a custom base path to be used by the `DiscoverEvents` class.

**EDIT** no tests were added as the test for `DiscoverEvents` is already agnostic about the base path used.

reference: 

https://github.com/laravel/framework/blob/0798479b95fd241c829b0e36a1d6f8573a586738/tests/Integration/Foundation/DiscoverEventsTest.php#L15-L32



