### PR TITLE
[8.x] Added cover string helper

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -824,7 +824,7 @@ class Str
                 $replacementCharacter,
                 static::substr($string, $charsToKeep, 0 - $charsToKeep)
             ),
-            static::substr($string, 0 - $charsToKeep)
+            static::substr($string, 0 - $charsToKeep),
         ]);
     }
 }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -816,7 +816,7 @@ class Str
             $charsToKeep = 2;
         }
 
-        return join( [
+        return join([
             static::substr( $string, 0, $charsToKeep ),
             preg_replace(
                 '/./',
@@ -824,6 +824,6 @@ class Str
                 static::substr( $string, $charsToKeep, 0 - $charsToKeep )
             ),
             static::substr( $string, 0 - $charsToKeep )
-        ] );
+        ]);
     }
 }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -803,7 +803,8 @@ class Str
      * @param  string|null  $replacementCharacter
      * @return string
      */
-    public static function cover($string, $replacementCharacter = '*') {
+    public static function cover($string, $replacementCharacter = '*')
+    {
         $stringLength = static::length($string);
 
         if ($stringLength < 4) {

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -803,27 +803,27 @@ class Str
      * @param  string|null  $replacementCharacter
      * @return string
      */
-    public static function cover( $string, $replacementCharacter = '*' ) {
-        $stringLength = static::length( $string );
+    public static function cover($string, $replacementCharacter = '*') {
+        $stringLength = static::length($string);
 
-        if ( $stringLength < 4 ) {
-            return preg_replace( '/./', $replacementCharacter, $string );
+        if ($stringLength < 4) {
+            return preg_replace('/./', $replacementCharacter, $string);
         }
 
-        if ( $stringLength < 8 ) {
+        if ($stringLength < 8) {
             $charsToKeep = 1;
         } else {
             $charsToKeep = 2;
         }
 
         return join([
-            static::substr( $string, 0, $charsToKeep ),
+            static::substr($string, 0, $charsToKeep),
             preg_replace(
                 '/./',
                 $replacementCharacter,
-                static::substr( $string, $charsToKeep, 0 - $charsToKeep )
+                static::substr($string, $charsToKeep, 0 - $charsToKeep)
             ),
-            static::substr( $string, 0 - $charsToKeep )
+            static::substr($string, 0 - $charsToKeep)
         ]);
     }
 }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -794,4 +794,36 @@ class Str
     {
         static::$uuidFactory = null;
     }
+
+    /**
+     * Hides a part of the string. It keeps none, one or two characters at
+     * both sides of the given string. Depending on the length of it.
+     *
+     * @param  string  $string
+     * @param  string|null  $replacementCharacter
+     * @return string
+     */
+    public static function cover( $string, $replacementCharacter = '*' ) {
+        $stringLength = static::length( $string );
+
+        if ( $stringLength < 4 ) {
+            return preg_replace( '/./', $replacementCharacter, $string );
+        }
+
+        if ( $stringLength < 8 ) {
+            $charsToKeep = 1;
+        } else {
+            $charsToKeep = 2;
+        }
+
+        return join( [
+            static::substr( $string, 0, $charsToKeep ),
+            preg_replace(
+                '/./',
+                $replacementCharacter,
+                static::substr( $string, $charsToKeep, 0 - $charsToKeep )
+            ),
+            static::substr( $string, 0 - $charsToKeep )
+        ] );
+    }
 }

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -517,6 +517,18 @@ class SupportStrTest extends TestCase
         $this->assertEquals("<p><em>hello world</em></p>\n", Str::markdown('*hello world*'));
         $this->assertEquals("<h1>hello world</h1>\n", Str::markdown('# hello world'));
     }
+
+    public function testCover(){
+        $this->assertEquals('**',Str::cover('ab'));
+        $this->assertEquals('***',Str::cover('abc'));
+        $this->assertEquals('a**d',Str::cover('abcd'));
+        $this->assertEquals('a***e',Str::cover('abcde'));
+        $this->assertEquals('a****f',Str::cover('abcdef'));
+        $this->assertEquals('a*****g',Str::cover('abcdefg'));
+        $this->assertEquals('ab****gh',Str::cover('abcdefgh'));
+        $this->assertEquals('ab*****hi',Str::cover('abcdefghi'));
+        $this->assertEquals('ab?????hi',Str::cover('abcdefghi','?'));
+    }
 }
 
 class StringableObjectStub

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -518,13 +518,14 @@ class SupportStrTest extends TestCase
         $this->assertEquals("<h1>hello world</h1>\n", Str::markdown('# hello world'));
     }
 
-    public function testCover() {
-        $this->assertEquals( '**', Str::cover( 'ab' ) );
-        $this->assertEquals( '***', Str::cover( 'abc' ) );
-        $this->assertEquals( 'a**d', Str::cover( 'abcd' ) );
-        $this->assertEquals( 'a*****g', Str::cover( 'abcdefg' ) );
-        $this->assertEquals( 'ab****gh', Str::cover( 'abcdefgh' ) );
-        $this->assertEquals( 'ab????gh', Str::cover( 'abcdefgh', '?' ) );
+    public function testCover()
+    {
+        $this->assertEquals('**', Str::cover('ab'));
+        $this->assertEquals('***', Str::cover('abc'));
+        $this->assertEquals('a**d', Str::cover('abcd'));
+        $this->assertEquals('a*****g', Str::cover('abcdefg'));
+        $this->assertEquals('ab****gh', Str::cover('abcdefgh'));
+        $this->assertEquals('ab????gh', Str::cover('abcdefgh', '?'));
     }
 }
 

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -522,12 +522,9 @@ class SupportStrTest extends TestCase
         $this->assertEquals('**',Str::cover('ab'));
         $this->assertEquals('***',Str::cover('abc'));
         $this->assertEquals('a**d',Str::cover('abcd'));
-        $this->assertEquals('a***e',Str::cover('abcde'));
-        $this->assertEquals('a****f',Str::cover('abcdef'));
         $this->assertEquals('a*****g',Str::cover('abcdefg'));
         $this->assertEquals('ab****gh',Str::cover('abcdefgh'));
-        $this->assertEquals('ab*****hi',Str::cover('abcdefghi'));
-        $this->assertEquals('ab?????hi',Str::cover('abcdefghi','?'));
+        $this->assertEquals('ab????gh',Str::cover('abcdefgh','?'));
     }
 }
 

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -518,13 +518,13 @@ class SupportStrTest extends TestCase
         $this->assertEquals("<h1>hello world</h1>\n", Str::markdown('# hello world'));
     }
 
-    public function testCover(){
-        $this->assertEquals('**',Str::cover('ab'));
-        $this->assertEquals('***',Str::cover('abc'));
-        $this->assertEquals('a**d',Str::cover('abcd'));
-        $this->assertEquals('a*****g',Str::cover('abcdefg'));
-        $this->assertEquals('ab****gh',Str::cover('abcdefgh'));
-        $this->assertEquals('ab????gh',Str::cover('abcdefgh','?'));
+    public function testCover() {
+        $this->assertEquals( '**', Str::cover( 'ab' ) );
+        $this->assertEquals( '***', Str::cover( 'abc' ) );
+        $this->assertEquals( 'a**d', Str::cover( 'abcd' ) );
+        $this->assertEquals( 'a*****g', Str::cover( 'abcdefg' ) );
+        $this->assertEquals( 'ab****gh', Str::cover( 'abcdefgh' ) );
+        $this->assertEquals( 'ab????gh', Str::cover( 'abcdefgh', '?' ) );
     }
 }
 


### PR DESCRIPTION
Sometimes you need to display an word without displaying it. Like when your user is trying to remember the name of the second teacher of their high school. You don't want to display 'Gravenstein' as a hint, but 'Gr*******in' could help your user a lot.

The cover function helps you with that. Parse a name, secret word, phone number or anything else to hide the middle part.
Small strings will still be hidden. As a second parameter you're able to change the replacement character.

``` php
Str::cover('Foo')
// returns ***

Str::cover('FooBar')
// returns F****r

Str::cover('Gravenstein')
// returns Gr*******in

Str::cover('0612345678')
// returns 06******78

Str::cover('0612345678','x')
// returns 06xxxxxx78

```