### PR TITLE
[8.x] Ability to slow the workers down

### DIFF
--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -33,6 +33,7 @@ class WorkCommand extends Command
                             {--force : Force the worker to run even in maintenance mode}
                             {--memory=128 : The memory limit in megabytes}
                             {--sleep=3 : Number of seconds to sleep when no job is available}
+                            {--rest=0 : Number of seconds to rest between jobs}
                             {--timeout=60 : The number of seconds a child process can run}
                             {--tries=1 : Number of times to attempt a job before logging it failed}';
 
@@ -134,7 +135,8 @@ class WorkCommand extends Command
             $this->option('force'),
             $this->option('stop-when-empty'),
             $this->option('max-jobs'),
-            $this->option('max-time')
+            $this->option('max-time'),
+            $this->option('rest')
         );
     }
 

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -156,6 +156,8 @@ class Worker
                 $jobsProcessed++;
 
                 $this->runJob($job, $connectionName, $options);
+
+                $this->sleep($options->rest);
             } else {
                 $this->sleep($options->sleep);
             }

--- a/src/Illuminate/Queue/WorkerOptions.php
+++ b/src/Illuminate/Queue/WorkerOptions.php
@@ -75,6 +75,13 @@ class WorkerOptions
     public $maxTime;
 
     /**
+     * The number of seconds to rest between jobs.
+     *
+     * @var int
+     */
+    public $rest;
+
+    /**
      * Create a new worker options instance.
      *
      * @param  string  $name
@@ -87,10 +94,11 @@ class WorkerOptions
      * @param  bool  $stopWhenEmpty
      * @param  int  $maxJobs
      * @param  int  $maxTime
+     * @param  int  $rest
      * @return void
      */
     public function __construct($name = 'default', $backoff = 0, $memory = 128, $timeout = 60, $sleep = 3, $maxTries = 1,
-                                $force = false, $stopWhenEmpty = false, $maxJobs = 0, $maxTime = 0)
+                                $force = false, $stopWhenEmpty = false, $maxJobs = 0, $maxTime = 0, $rest = 0)
     {
         $this->name = $name;
         $this->backoff = $backoff;
@@ -102,5 +110,6 @@ class WorkerOptions
         $this->stopWhenEmpty = $stopWhenEmpty;
         $this->maxJobs = $maxJobs;
         $this->maxTime = $maxTime;
+        $this->rest = $rest;
     }
 }


### PR DESCRIPTION
```
php artisan queue:work --rest=0.5
```

Using the `rest` option, the worker will sleep after processing each job. This will slow down job processing.

This was requested by @fideloper a few months back and I kept getting similar requests regarding it for several people so I thought I'd propose it.