### PR TITLE
[8.x] Allow nullable columns for AsArrayObject/AsCollection casts

### DIFF
--- a/src/Illuminate/Database/Eloquent/Casts/AsArrayObject.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsArrayObject.php
@@ -17,7 +17,7 @@ class AsArrayObject implements Castable
     {
         return new class implements CastsAttributes {
             public function get($model, $key, $value, $attributes)
-            {                  
+            {
                 return isset($attributes[$key]) ? new ArrayObject(json_decode($attributes[$key], true)) : null;
             }
 

--- a/src/Illuminate/Database/Eloquent/Casts/AsArrayObject.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsArrayObject.php
@@ -17,8 +17,8 @@ class AsArrayObject implements Castable
     {
         return new class implements CastsAttributes {
             public function get($model, $key, $value, $attributes)
-            {
-                return new ArrayObject(isset($attributes[$key]) ? json_decode($attributes[$key], true) : []);
+            {                  
+                return isset($attributes[$key]) ? new ArrayObject(json_decode($attributes[$key], true)) : null;
             }
 
             public function set($model, $key, $value, $attributes)

--- a/src/Illuminate/Database/Eloquent/Casts/AsArrayObject.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsArrayObject.php
@@ -18,7 +18,7 @@ class AsArrayObject implements Castable
         return new class implements CastsAttributes {
             public function get($model, $key, $value, $attributes)
             {
-                return new ArrayObject(json_decode($attributes[$key], true));
+                return new ArrayObject(isset($attributes[$key]) ? json_decode($attributes[$key], true) : []);
             }
 
             public function set($model, $key, $value, $attributes)

--- a/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
@@ -19,7 +19,7 @@ class AsCollection implements Castable
         return new class implements CastsAttributes {
             public function get($model, $key, $value, $attributes)
             {
-                return new Collection(json_decode($attributes[$key], true));
+                return new Collection(isset($attributes[$key]) ? json_decode($attributes[$key], true) : []);
             }
 
             public function set($model, $key, $value, $attributes)

--- a/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
@@ -19,7 +19,7 @@ class AsCollection implements Castable
         return new class implements CastsAttributes {
             public function get($model, $key, $value, $attributes)
             {
-                return new Collection(isset($attributes[$key]) ? json_decode($attributes[$key], true) : []);
+                return isset($attributes[$key]) ? new Collection(json_decode($attributes[$key], true)) : null;
             }
 
             public function set($model, $key, $value, $attributes)


### PR DESCRIPTION
When using either of these casts and allowing the column to be `null` it throws an undefined error whenever you access the attribute.

This fixes that issue.