### PR TITLE
[9.x] Bumped symfony version to ^5.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,17 +31,17 @@
         "psr/simple-cache": "^1.0",
         "ramsey/uuid": "^4.0",
         "swiftmailer/swiftmailer": "^6.2.7",
-        "symfony/console": "^5.2",
-        "symfony/error-handler": "^5.2",
-        "symfony/finder": "^5.2",
-        "symfony/http-foundation": "^5.2",
-        "symfony/http-kernel": "^5.2",
-        "symfony/mime": "^5.2",
-        "symfony/process": "^5.2",
-        "symfony/routing": "^5.2",
-        "symfony/var-dumper": "^5.2",
+        "symfony/console": "^5.3",
+        "symfony/error-handler": "^5.3",
+        "symfony/finder": "^5.3",
+        "symfony/http-foundation": "^5.3",
+        "symfony/http-kernel": "^5.3",
+        "symfony/mime": "^5.3",
+        "symfony/process": "^5.3",
+        "symfony/routing": "^5.3",
+        "symfony/var-dumper": "^5.3",
         "tijsverkoyen/css-to-inline-styles": "^2.2.2",
-        "vlucas/phpdotenv": "^5.2",
+        "vlucas/phpdotenv": "^5.3",
         "voku/portable-ascii": "^1.4.8"
     },
     "replace": {
@@ -90,7 +90,7 @@
         "pda/pheanstalk": "^4.0",
         "phpunit/phpunit": "^9.4",
         "predis/predis": "^1.1.1",
-        "symfony/cache": "^5.2"
+        "symfony/cache": "^5.3"
     },
     "provide": {
         "psr/container-implementation": "1.0"
@@ -147,8 +147,8 @@
         "predis/predis": "Required to use the predis connector (^1.1.2).",
         "psr/http-message": "Required to allow Storage::put to accept a StreamInterface (^1.0).",
         "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (^4.0|^5.0).",
-        "symfony/cache": "Required to PSR-6 cache bridge (^5.2).",
-        "symfony/filesystem": "Required to enable support for relative symbolic links (^5.2).",
+        "symfony/cache": "Required to PSR-6 cache bridge (^5.3).",
+        "symfony/filesystem": "Required to enable support for relative symbolic links (^5.3).",
         "symfony/psr-http-message-bridge": "Required to use PSR-7 bridging features (^2.0).",
         "wildbit/swiftmailer-postmark": "Required to use Postmark mail driver (^3.0)."
     },

--- a/src/Illuminate/Cache/composer.json
+++ b/src/Illuminate/Cache/composer.json
@@ -35,7 +35,7 @@
         "illuminate/database": "Required to use the database cache driver (^9.0).",
         "illuminate/filesystem": "Required to use the file cache driver (^9.0).",
         "illuminate/redis": "Required to use the redis cache driver (^9.0).",
-        "symfony/cache": "Required to PSR-6 cache bridge (^5.2)."
+        "symfony/cache": "Required to PSR-6 cache bridge (^5.3)."
     },
     "config": {
         "sort-packages": true

--- a/src/Illuminate/Collections/composer.json
+++ b/src/Illuminate/Collections/composer.json
@@ -32,7 +32,7 @@
         }
     },
     "suggest": {
-        "symfony/var-dumper": "Required to use the dump method (^5.2)."
+        "symfony/var-dumper": "Required to use the dump method (^5.3)."
     },
     "config": {
         "sort-packages": true

--- a/src/Illuminate/Console/composer.json
+++ b/src/Illuminate/Console/composer.json
@@ -19,8 +19,8 @@
         "illuminate/contracts": "^9.0",
         "illuminate/macroable": "^9.0",
         "illuminate/support": "^9.0",
-        "symfony/console": "^5.2",
-        "symfony/process": "^5.2"
+        "symfony/console": "^5.3",
+        "symfony/process": "^5.3"
     },
     "autoload": {
         "psr-4": {

--- a/src/Illuminate/Cookie/composer.json
+++ b/src/Illuminate/Cookie/composer.json
@@ -19,8 +19,8 @@
         "illuminate/contracts": "^9.0",
         "illuminate/macroable": "^9.0",
         "illuminate/support": "^9.0",
-        "symfony/http-foundation": "^5.2",
-        "symfony/http-kernel": "^5.2"
+        "symfony/http-foundation": "^5.3",
+        "symfony/http-kernel": "^5.3"
     },
     "autoload": {
         "psr-4": {

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -22,7 +22,7 @@
         "illuminate/contracts": "^9.0",
         "illuminate/macroable": "^9.0",
         "illuminate/support": "^9.0",
-        "symfony/console": "^5.2"
+        "symfony/console": "^5.3"
     },
     "autoload": {
         "psr-4": {
@@ -41,7 +41,7 @@
         "illuminate/events": "Required to use the observers with Eloquent (^9.0).",
         "illuminate/filesystem": "Required to use the migrations (^9.0).",
         "illuminate/pagination": "Required to paginate the result set (^9.0).",
-        "symfony/finder": "Required to use Eloquent model factories (^5.2)."
+        "symfony/finder": "Required to use Eloquent model factories (^5.3)."
     },
     "config": {
         "sort-packages": true

--- a/src/Illuminate/Filesystem/composer.json
+++ b/src/Illuminate/Filesystem/composer.json
@@ -19,7 +19,7 @@
         "illuminate/contracts": "^9.0",
         "illuminate/macroable": "^9.0",
         "illuminate/support": "^9.0",
-        "symfony/finder": "^5.2"
+        "symfony/finder": "^5.3"
     },
     "autoload": {
         "psr-4": {
@@ -39,8 +39,8 @@
         "league/flysystem-ftp": "Required to use the Flysystem FTP driver (^2.0).",
         "league/flysystem-sftp": "Required to use the Flysystem SFTP driver (^2.0).",
         "psr/http-message": "Required to allow Storage::put to accept a StreamInterface (^1.0).",
-        "symfony/filesystem": "Required to enable support for relative symbolic links (^5.2).",
-        "symfony/mime": "Required to enable support for guessing extensions (^5.2)."
+        "symfony/filesystem": "Required to enable support for relative symbolic links (^5.3).",
+        "symfony/mime": "Required to enable support for guessing extensions (^5.3)."
     },
     "config": {
         "sort-packages": true

--- a/src/Illuminate/Http/composer.json
+++ b/src/Illuminate/Http/composer.json
@@ -20,9 +20,9 @@
         "illuminate/macroable": "^9.0",
         "illuminate/session": "^9.0",
         "illuminate/support": "^9.0",
-        "symfony/http-foundation": "^5.2",
-        "symfony/http-kernel": "^5.2",
-        "symfony/mime": "^5.2"
+        "symfony/http-foundation": "^5.3",
+        "symfony/http-kernel": "^5.3",
+        "symfony/mime": "^5.3"
     },
     "autoload": {
         "psr-4": {

--- a/src/Illuminate/Queue/composer.json
+++ b/src/Illuminate/Queue/composer.json
@@ -26,7 +26,7 @@
         "illuminate/support": "^9.0",
         "opis/closure": "^3.6",
         "ramsey/uuid": "^4.0",
-        "symfony/process": "^5.2"
+        "symfony/process": "^5.3"
     },
     "autoload": {
         "psr-4": {

--- a/src/Illuminate/Routing/composer.json
+++ b/src/Illuminate/Routing/composer.json
@@ -24,9 +24,9 @@
         "illuminate/pipeline": "^9.0",
         "illuminate/session": "^9.0",
         "illuminate/support": "^9.0",
-        "symfony/http-foundation": "^5.2",
-        "symfony/http-kernel": "^5.2",
-        "symfony/routing": "^5.2"
+        "symfony/http-foundation": "^5.3",
+        "symfony/http-kernel": "^5.3",
+        "symfony/routing": "^5.3"
     },
     "autoload": {
         "psr-4": {

--- a/src/Illuminate/Session/composer.json
+++ b/src/Illuminate/Session/composer.json
@@ -20,8 +20,8 @@
         "illuminate/contracts": "^9.0",
         "illuminate/filesystem": "^9.0",
         "illuminate/support": "^9.0",
-        "symfony/finder": "^5.2",
-        "symfony/http-foundation": "^5.2"
+        "symfony/finder": "^5.3",
+        "symfony/http-foundation": "^5.3"
     },
     "autoload": {
         "psr-4": {

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -44,9 +44,9 @@
         "illuminate/filesystem": "Required to use the composer class (^9.0).",
         "league/commonmark": "Required to use Str::markdown() and Stringable::markdown() (^1.3).",
         "ramsey/uuid": "Required to use Str::uuid() (^4.0).",
-        "symfony/process": "Required to use the composer class (^5.2).",
-        "symfony/var-dumper": "Required to use the dd function (^5.2).",
-        "vlucas/phpdotenv": "Required to use the Env class and env helper (^5.2)."
+        "symfony/process": "Required to use the composer class (^5.3).",
+        "symfony/var-dumper": "Required to use the dd function (^5.3).",
+        "vlucas/phpdotenv": "Required to use the Env class and env helper (^5.3)."
     },
     "config": {
         "sort-packages": true

--- a/src/Illuminate/Validation/composer.json
+++ b/src/Illuminate/Validation/composer.json
@@ -23,8 +23,8 @@
         "illuminate/macroable": "^9.0",
         "illuminate/support": "^9.0",
         "illuminate/translation": "^9.0",
-        "symfony/http-foundation": "^5.2",
-        "symfony/mime": "^5.2"
+        "symfony/http-foundation": "^5.3",
+        "symfony/mime": "^5.3"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
phpdotenv also got caught in my find and replace, but 5.3.0 is the newest version there right now anyway, so doesn't hurt, and contains some nice fixes we might as well enforce with the increased lower bound.