### PR TITLE
[9.x] Pass custom values names for validation in FormRequest

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -111,7 +111,8 @@ class FormRequest extends Request implements ValidatesWhenResolved
         return $factory->make(
             $this->validationData(), $this->container->call([$this, 'rules']),
             $this->messages(), $this->attributes()
-        )->stopOnFirstFailure($this->stopOnFirstFailure);
+        )->stopOnFirstFailure($this->stopOnFirstFailure)
+            ->addCustomValues($this->valuesNames());
     }
 
     /**
@@ -211,6 +212,16 @@ class FormRequest extends Request implements ValidatesWhenResolved
      * @return array
      */
     public function attributes()
+    {
+        return [];
+    }
+
+    /**
+     * Get custom values for validator errors.
+     *
+     * @return array
+     */
+    public function valuesNames()
     {
         return [];
     }


### PR DESCRIPTION
## Overview
The validator allows you to specify **customValues** for replacement placeholder *:value* (thanks to this PR https://github.com/laravel/framework/pull/30878).

You can also specify transfers in: validation.php https://laravel.com/docs/8.x/validation#specifying-values-in-language-files

This PR adds the ability to register custom values in the FormRequest class. 

Perhaps the "valuesNames()" method should be named differently, for example "values()". But I think it will be misleading.

## Example of use

```php
class CreateUserRequest extends FormRequest
{
    /**
     * Get the validation rules that apply to the request.
     *
     * @return array
     */
    public function rules()
    {
        return [
           'company_name' => 'required_if:user_type,legal',
           'user_type' => 'in:legal,individual',
       ];
    }

    /**
     * Get custom values for validator errors.
     *
     * @return array
     */
    public function valuesNames()
    {
        return [
            'user_type' => [
                'legal' => 'Legal entity',
            ],
        ];
    }
}
 ```

Thanks for contributing
