### PR TITLE
[8.x] Container - Detect circular dependencies

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -671,12 +671,13 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * Resolve the given type from the container.
      *
-     * @param  string|callable  $abstract
-     * @param  array  $parameters
-     * @param  bool  $raiseEvents
+     * @param string|callable $abstract
+     * @param array $parameters
+     * @param bool $raiseEvents
      * @return mixed
      *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     * @throws \Illuminate\Contracts\Container\CircularDependencyFoundException
      */
     protected function resolve($abstract, $parameters = [], $raiseEvents = true)
     {
@@ -813,10 +814,11 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * Instantiate a concrete instance of the given type.
      *
-     * @param  \Closure|string  $concrete
+     * @param \Closure|string $concrete
      * @return mixed
      *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     * @throws \Illuminate\Contracts\Container\CircularDependencyFoundException
      */
     public function build($concrete)
     {

--- a/src/Illuminate/Contracts/Container/CircularDependencyFoundException.php
+++ b/src/Illuminate/Contracts/Container/CircularDependencyFoundException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Illuminate\Contracts\Container;
+
+use Exception;
+use Psr\Container\ContainerExceptionInterface;
+
+class CircularDependencyFoundException extends Exception implements ContainerExceptionInterface
+{
+    //
+}

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Container;
 use Illuminate\Container\Container;
 use Illuminate\Container\EntryNotFoundException;
 use Illuminate\Contracts\Container\BindingResolutionException;
+use Illuminate\Contracts\Container\CircularDependencyFoundException;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerExceptionInterface;
 use stdClass;
@@ -561,6 +562,31 @@ class ContainerTest extends TestCase
         $class = $container->get(ContainerConcreteStub::class);
 
         $this->assertInstanceOf(ContainerConcreteStub::class, $class);
+    }
+
+    public function testContainerCanCatchCircularDependency() {
+        $this->expectException(CircularDependencyFoundException::class);
+
+        $container = new Container;
+        $container->get(CircularAStub::class);
+    }
+}
+
+class CircularAStub {
+    public function __construct(CircularBStub $b) {
+
+    }
+}
+
+class CircularBStub {
+    public function __construct(CircularCStub $c) {
+
+    }
+}
+
+class CircularCStub {
+    public function __construct(CircularAStub $a) {
+
     }
 }
 


### PR DESCRIPTION
Hello, 

This PR adds support to detect circular dependencies when the container resolves a dependency. 

The case is, during the development, if we have classes A, B, and C. and:
- **ClassA** constructor has ClassB
- ClassB constructor has ClassC
- ClassC constructor has **ClassA**

The error you would see before this PR is:
```
Maximum function nesting level of '256' reached, aborting!
```

and it's really hard to know which piece of code is causing this error. in this PR the error would be like:
```
Circular dependency when initiating [App\Http\Controllers\ClassA]
```

This way it's much easier to detect and tell the user which class is causing this error.