### PR TITLE
[8.x] It makes possible resetting content of a stack

### DIFF
--- a/src/Illuminate/View/Concerns/ManagesStacks.php
+++ b/src/Illuminate/View/Concerns/ManagesStacks.php
@@ -84,6 +84,19 @@ trait ManagesStacks
     }
 
     /**
+     * Reset content to a given push section.
+     *
+     * @param  string  $section
+     * @return void
+     */
+    public function resetPush($section)
+    {
+        if (isset($this->pushes[$section][$this->renderCount])) {
+            $this->pushes[$section][$this->renderCount] = '';
+        }
+    }
+
+    /**
      * Start prepending content into a push section.
      *
      * @param  string  $section
@@ -136,6 +149,19 @@ trait ManagesStacks
             $this->prepends[$section][$this->renderCount] = $content;
         } else {
             $this->prepends[$section][$this->renderCount] = $content.$this->prepends[$section][$this->renderCount];
+        }
+    }
+
+    /**
+     * Reset content to a given stack.
+     *
+     * @param  string  $section
+     * @return void
+     */
+    public function resetPrepend($section)
+    {
+        if (isset($this->prepends[$section][$this->renderCount])) {
+            $this->prepends[$section][$this->renderCount] = '';
         }
     }
 

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -431,6 +431,16 @@ class ViewFactoryTest extends TestCase
         $this->assertSame('hi', $factory->yieldPushContent('foo'));
     }
 
+    public function testSingleStackPushReset()
+    {
+        $factory = $this->getFactory();
+        $factory->startPush('foo');
+        echo 'hi';
+        $factory->stopPush();
+        $factory->resetPush('foo');
+        $this->assertSame('', $factory->yieldPushContent('foo'));
+    }
+
     public function testMultipleStackPush()
     {
         $factory = $this->getFactory();
@@ -441,6 +451,19 @@ class ViewFactoryTest extends TestCase
         echo ', Hello!';
         $factory->stopPush();
         $this->assertSame('hi, Hello!', $factory->yieldPushContent('foo'));
+    }
+
+    public function testMultipleStackPushReset()
+    {
+        $factory = $this->getFactory();
+        $factory->startPush('foo');
+        echo 'hi';
+        $factory->stopPush();
+        $factory->resetPush('foo');
+        $factory->startPush('foo');
+        echo ', Hello!';
+        $factory->stopPush();
+        $this->assertSame(', Hello!', $factory->yieldPushContent('foo'));
     }
 
     public function testSessionAppending()


### PR DESCRIPTION
Users may want to change completely the content of a stack by the view composer. Extending content is possible with the methods of `ManagesStacks` at the moment. However, if the user would like to reset the content of a specific stack, they could make it with `resetPush` or `resetPrepend` methods.