### PR TITLE
[8.x] Queue:forget command support for array of ids and range argument

### DIFF
--- a/src/Illuminate/Queue/Console/ForgetFailedCommand.php
+++ b/src/Illuminate/Queue/Console/ForgetFailedCommand.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Queue\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\Arr;
 
 class ForgetFailedCommand extends Command
 {
@@ -11,7 +12,9 @@ class ForgetFailedCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'queue:forget {id : The ID of the failed job}';
+    protected $signature = 'queue:forget 
+                            {id?* : The ID of the failed job or "all" to delete all failed jobs}
+                            {--range=* : Range of job IDs (numeric) to be deleted}';
 
     /**
      * The console command description.
@@ -27,10 +30,55 @@ class ForgetFailedCommand extends Command
      */
     public function handle()
     {
-        if ($this->laravel['queue.failer']->forget($this->argument('id'))) {
-            $this->info('Failed job deleted successfully!');
-        } else {
-            $this->error('No failed job matches the given ID.');
+        foreach ($this->getJobIds() as $id) {
+            $job = $this->laravel['queue.failer']->find($id);
+
+            if (is_null($job)) {
+                $this->error("Unable to find failed job with ID [{$id}].");
+            } else {
+                $this->info("The failed job [{$id}] has been deleted successfully!");
+
+                $this->laravel['queue.failer']->forget($id);
+            }
         }
+    }
+
+    /**
+     * Get the job IDs to be deleted.
+     *
+     * @return array
+     */
+    protected function getJobIds()
+    {
+        $ids = (array) $this->argument('id');
+
+        if (count($ids) === 1 && $ids[0] === 'all') {
+            return Arr::pluck($this->laravel['queue.failer']->all(), 'id');
+        }
+
+        if ($ranges = (array) $this->option('range')) {
+            $ids = array_merge($ids, $this->getJobIdsByRanges($ranges));
+        }
+
+        return array_values(array_filter(array_unique($ids)));
+    }
+
+    /**
+     * Get the job IDs ranges, if applicable.
+     *
+     * @param  array  $ranges
+     * @return array
+     */
+    protected function getJobIdsByRanges(array $ranges)
+    {
+        $ids = [];
+
+        foreach ($ranges as $range) {
+            if (preg_match('/^[0-9]+\-[0-9]+$/', $range)) {
+                $ids = array_merge($ids, range(...explode('-', $range)));
+            }
+        }
+
+        return $ids;
     }
 }


### PR DESCRIPTION
This PR brings support for (array) {id} argument for `php artisan queue:forget` command, along with 'all' value and a {range?} argument, like in the `php artisan queue:retry` command.