### PR TITLE
[8.x] Change exception's handler ignore method to public

### DIFF
--- a/CHANGELOG-8.x.md
+++ b/CHANGELOG-8.x.md
@@ -1,6 +1,12 @@
 # Release Notes for 8.x
 
-## [Unreleased](https://github.com/laravel/framework/compare/v8.32.0...8.x)
+## [Unreleased](https://github.com/laravel/framework/compare/v8.32.1...8.x)
+
+
+## [v8.32.1 (2021-03-09)](https://github.com/laravel/framework/compare/v8.32.0...v8.32.1)
+
+### Changed
+- Changed `Illuminate\Queue\Middleware\ThrottlesExceptions` ([b8a70e9](https://github.com/laravel/framework/commit/b8a70e9a3685871ed46a24fc03c0267849d2d7c8))
 
 
 ## [v8.32.0 (2021-03-09)](https://github.com/laravel/framework/compare/v8.31.0...v8.32.0)

--- a/CHANGELOG-8.x.md
+++ b/CHANGELOG-8.x.md
@@ -1,6 +1,19 @@
 # Release Notes for 8.x
 
-## [Unreleased](https://github.com/laravel/framework/compare/v8.30.1...8.x)
+## [Unreleased](https://github.com/laravel/framework/compare/v8.31.0...8.x)
+
+
+## [v8.31.0 (2021-03-04)](https://github.com/laravel/framework/compare/v8.30.1...v8.31.0)
+
+### Added
+- Added new `VendorTagPublished` event ([#36458](https://github.com/laravel/framework/pull/36458))
+- Added new `Stringable::test()` method ([#36462](https://github.com/laravel/framework/pull/36462))
+
+### Reverted
+- Reverted [Fixed `formatWheres()` methods in `DatabaseRule`](https://github.com/laravel/framework/pull/36441) ([#36452](https://github.com/laravel/framework/pull/36452))
+
+### Changed
+- Make user policy command fix (Windows) ([#36464](https://github.com/laravel/framework/pull/36464))
 
 
 ## [v8.30.1 (2021-03-03)](https://github.com/laravel/framework/compare/v8.30.0...v8.30.1)

--- a/CHANGELOG-8.x.md
+++ b/CHANGELOG-8.x.md
@@ -1,6 +1,27 @@
 # Release Notes for 8.x
 
-## [Unreleased](https://github.com/laravel/framework/compare/v8.31.0...8.x)
+## [Unreleased](https://github.com/laravel/framework/compare/v8.32.0...8.x)
+
+
+## [v8.32.0 (2021-03-09)](https://github.com/laravel/framework/compare/v8.31.0...v8.32.0)
+
+Added
+- Phpredis lock serialization and compression support ([#36412](https://github.com/laravel/framework/pull/36412), [10f1a93](https://github.com/laravel/framework/commit/10f1a935205340ba8954e7075c1d9b67943db27d))
+- Added Fluent JSON Assertions ([#36454](https://github.com/laravel/framework/pull/36454))
+- Added methods to dump requests of the Laravel HTTP client ([#36466](https://github.com/laravel/framework/pull/36466))
+- Added `ThrottlesExceptions` and `ThrottlesExceptionsWithRedis` job middlewares for unstable services ([#36473](https://github.com/laravel/framework/pull/36473), [21fee76](https://github.com/laravel/framework/commit/21fee7649e1b48a7701b8ba860218741c2c3bcef), [36518](https://github.com/laravel/framework/pull/36518), [37e48ba](https://github.com/laravel/framework/commit/37e48ba864e2f463517429d41cefd94e88136c1c))
+- Added support to Eloquent Collection on `Model::destroy()` ([#36497](https://github.com/laravel/framework/pull/36497))
+- Added `rest` option to `php artisan queue:work` command ([#36521](https://github.com/laravel/framework/pull/36521), [c6ea49c](https://github.com/laravel/framework/commit/c6ea49c80a2ac93aebb8fdf2360161b73cec26af))
+- Added `prohibited_if` and `prohibited_unless` validation rules ([#36516](https://github.com/laravel/framework/pull/36516))
+- Added class `argument` to `Illuminate\Database\Console\Seeds\SeedCommand` ([#36513](https://github.com/laravel/framework/pull/36513))
+
+### Fixed
+- Fix validator treating null as true for (required|exclude)_(if|unless) due to loose `in_array()` check ([#36504](https://github.com/laravel/framework/pull/36504))
+
+### Changed
+- Delete existing links that are broken in `Illuminate\Foundation\Console\StorageLinkCommand` ([#36470](https://github.com/laravel/framework/pull/36470))
+- Use user provided url in AwsTemporaryUrl method ([#36480](https://github.com/laravel/framework/pull/36480))
+- Allow to override discover events base path ([#36515](https://github.com/laravel/framework/pull/36515))
 
 
 ## [v8.31.0 (2021-03-04)](https://github.com/laravel/framework/compare/v8.30.1...v8.31.0)

--- a/src/Illuminate/Database/Eloquent/Casts/AsArrayObject.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsArrayObject.php
@@ -18,7 +18,7 @@ class AsArrayObject implements Castable
         return new class implements CastsAttributes {
             public function get($model, $key, $value, $attributes)
             {
-                return new ArrayObject(json_decode($attributes[$key], true));
+                return isset($attributes[$key]) ? new ArrayObject(json_decode($attributes[$key], true)) : null;
             }
 
             public function set($model, $key, $value, $attributes)

--- a/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
@@ -19,7 +19,7 @@ class AsCollection implements Castable
         return new class implements CastsAttributes {
             public function get($model, $key, $value, $attributes)
             {
-                return new Collection(json_decode($attributes[$key], true));
+                return isset($attributes[$key]) ? new Collection(json_decode($attributes[$key], true)) : null;
             }
 
             public function set($model, $key, $value, $attributes)

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -191,7 +191,7 @@ class Handler implements ExceptionHandlerContract
      * @param  string  $class
      * @return $this
      */
-    protected function ignore(string $class)
+    public function ignore(string $class)
     {
         $this->dontReport[] = $class;
 


### PR DESCRIPTION
Making this `ignore` method as public can helps when developing an app with sub-modules (package) as the main app will not always know what exception should be ignored from sub-modules.

For example, in a sub-module service provider:
```php
// Assume this will be resolved as App\Exceptions\Handler 
// which extends Illuminate\Foundation\Exceptions\Handler
$handler = $this->app->make(\Illuminate\Contracts\Debug\ExceptionHandler::class);
$handler->ignore(\Laravel\Passport\Exceptions\OAuthServerException::class);
```

This way will allow sub-modules add any exception (not only its own exception, but also any other exception) that considered should be ignored for reporting. If the sub-module is not used/included in main app, then the exception will not be added to `dontReport` list.

Another example of handy public method in Laravel's exception handler for a sub-module is `reportable` and `renderable`
```php
// Assume this will be resolved as App\Exceptions\Handler
// which extends Illuminate\Foundation\Exceptions\Handler
$handler = $this->app->make(\Illuminate\Contracts\Debug\ExceptionHandler::class);
$handler->reportable(function (\My\Module\Exception\InvalidUsernameException $e) {
    ...
});
```

Rather than creating this in `App\Exceptions\Handler` class:
```php
public function dontReport(string $class)
{
    $this->ignore($class);

    return $this;
}
```
It is better to call `ignore` directly than `dontReport` wrapper method.