### PR TITLE
[9.x] Change exception's handler ignore method to public

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -191,7 +191,7 @@ class Handler implements ExceptionHandlerContract
      * @param  string  $class
      * @return $this
      */
-    protected function ignore(string $class)
+    public function ignore(string $class)
     {
         $this->dontReport[] = $class;
 


### PR DESCRIPTION
Following #36548 that should be PR'ed to 9.x instead as this is a breaking change.

With this we don't have to override `ignore` method just to make it public.