### PR TITLE
[8.x] Accept callable class for reportable and renderable in exception handler

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -139,6 +139,10 @@ class Handler implements ExceptionHandlerContract
      */
     public function reportable(callable $reportUsing)
     {
+        if (! $reportUsing instanceof Closure) {
+            $reportUsing = Closure::fromCallable($reportUsing);
+        }
+
         return tap(new ReportableHandler($reportUsing), function ($callback) {
             $this->reportCallbacks[] = $callback;
         });
@@ -152,6 +156,10 @@ class Handler implements ExceptionHandlerContract
      */
     public function renderable(callable $renderUsing)
     {
+        if (! $renderUsing instanceof Closure) {
+            $renderUsing = Closure::fromCallable($renderUsing);
+        }
+
         $this->renderCallbacks[] = $renderUsing;
 
         return $this;


### PR DESCRIPTION
In its current implementation, as the `reportable` and `renderable` callbacks are handled by depending on `ReflectClosure`'s `firstClosureParameterType` call, the `callable` parameter type in both method can not accept a callable class such as:

```php
use My\CustomException;

class CustomReporter
{
    public function __invoke(CustomException $e)
    {
        // Do whatever here
    }
}

class CustomRenderer
{
    public function __invoke(CustomException $e, $request)
    {
        return response()->json(['message' => 'The CustomRenderer response']);
    }
}
```

and in exception handler:

```php
public function register()
{
    $this->reportable(new CustomReporter());
    $this->renderable(new CustomRenderer());
}
```

This PR will allow this to happen as any class with `__invoke()` implemented can be passed into both `reportable` and `renderable`, and probably any other callable as long as it accepted by `Closure::fromCallable()`.