### PR TITLE
[6.x] Revert "[6.x] Fix validator treating null as true for (required|exclude)_(if|unless) due to loose in_array() check"

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1422,7 +1422,7 @@ trait ValidatesAttributes
 
         [$values, $other] = $this->prepareValuesAndOther($parameters);
 
-        if (in_array($other, $values, is_bool($other))) {
+        if (in_array($other, $values)) {
             return $this->validateRequired($attribute, $value);
         }
 
@@ -1443,7 +1443,7 @@ trait ValidatesAttributes
 
         [$values, $other] = $this->prepareValuesAndOther($parameters);
 
-        return ! in_array($other, $values, is_bool($other));
+        return ! in_array($other, $values);
     }
 
     /**
@@ -1460,7 +1460,7 @@ trait ValidatesAttributes
 
         [$values, $other] = $this->prepareValuesAndOther($parameters);
 
-        return in_array($other, $values, is_bool($other));
+        return in_array($other, $values);
     }
 
     /**
@@ -1515,7 +1515,7 @@ trait ValidatesAttributes
 
         [$values, $other] = $this->prepareValuesAndOther($parameters);
 
-        if (! in_array($other, $values, is_bool($other))) {
+        if (! in_array($other, $values)) {
             return $this->validateRequired($attribute, $value);
         }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1057,31 +1057,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
 
         $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, ['foo' => true], ['bar' => 'required_if:foo,null']);
-        $this->assertTrue($v->passes());
-
-        $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, ['foo' => 0], ['bar' => 'required_if:foo,0']);
-        $this->assertTrue($v->fails());
-
-        $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, ['foo' => '0'], ['bar' => 'required_if:foo,0']);
-        $this->assertTrue($v->fails());
-
-        $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, ['foo' => 1], ['bar' => 'required_if:foo,1']);
-        $this->assertTrue($v->fails());
-
-        $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, ['foo' => '1'], ['bar' => 'required_if:foo,1']);
-        $this->assertTrue($v->fails());
-
-        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => true], ['bar' => 'required_if:foo,true']);
-        $this->assertTrue($v->fails());
-
-        $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, ['foo' => false], ['bar' => 'required_if:foo,false']);
         $this->assertTrue($v->fails());
 
         // error message when passed multiple values (required_if:foo,bar,baz)
@@ -1121,26 +1097,6 @@ class ValidationValidatorTest extends TestCase
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => false], ['bar' => 'required_unless:foo,true']);
         $this->assertTrue($v->fails());
-
-        $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, ['foo' => true], ['bar' => 'required_unless:foo,null']);
-        $this->assertTrue($v->fails());
-
-        $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, ['foo' => '0'], ['bar' => 'required_unless:foo,0']);
-        $this->assertTrue($v->passes());
-
-        $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, ['foo' => 0], ['bar' => 'required_unless:foo,0']);
-        $this->assertTrue($v->passes());
-
-        $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, ['foo' => '1'], ['bar' => 'required_unless:foo,1']);
-        $this->assertTrue($v->passes());
-
-        $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, ['foo' => 1], ['bar' => 'required_unless:foo,1']);
-        $this->assertTrue($v->passes());
 
         // error message when passed multiple values (required_unless:foo,bar,baz)
         $trans = $this->getIlluminateArrayTranslator();
@@ -5120,20 +5076,6 @@ class ValidationValidatorTest extends TestCase
             ],
             [
                 [
-                    'has_appointment' => ['nullable', 'bool'],
-                    'appointment_date' => ['exclude_if:has_appointment,null', 'required', 'date'],
-                ],
-                [
-                    'has_appointment' => true,
-                    'appointment_date' => '2021-03-08',
-                ],
-                [
-                    'has_appointment' => true,
-                    'appointment_date' => '2021-03-08',
-                ],
-            ],
-            [
-                [
                     'has_appointment' => ['required', 'bool'],
                     'appointment_date' => ['exclude_if:has_appointment,false', 'required', 'date'],
                 ], [
@@ -5466,14 +5408,6 @@ class ValidationValidatorTest extends TestCase
         );
         $this->assertTrue($validator->fails());
         $this->assertSame(['mouse' => ['validation.required']], $validator->messages()->toArray());
-
-        $validator = new Validator(
-            $this->getIlluminateArrayTranslator(),
-            ['foo' => true, 'bar' => 'baz'],
-            ['foo' => 'nullable', 'bar' => 'exclude_unless:foo,null']
-        );
-        $this->assertTrue($validator->passes());
-        $this->assertSame(['foo' => true], $validator->validated());
     }
 
     public function testExcludeValuesAreReallyRemoved()


### PR DESCRIPTION
Reverts laravel/framework#36504