### PR TITLE
[8.x] Add tests for stack prepend

### DIFF
--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -443,6 +443,27 @@ class ViewFactoryTest extends TestCase
         $this->assertSame('hi, Hello!', $factory->yieldPushContent('foo'));
     }
 
+    public function testSingleStackPrepend()
+    {
+        $factory = $this->getFactory();
+        $factory->startPrepend('foo');
+        echo 'hi';
+        $factory->stopPrepend();
+        $this->assertSame('hi', $factory->yieldPushContent('foo'));
+    }
+
+    public function testMultipleStackPrepend()
+    {
+        $factory = $this->getFactory();
+        $factory->startPrepend('foo');
+        echo ', Hello!';
+        $factory->stopPrepend();
+        $factory->startPrepend('foo');
+        echo 'hi';
+        $factory->stopPrepend();
+        $this->assertSame('hi, Hello!', $factory->yieldPushContent('foo'));
+    }
+
     public function testSessionAppending()
     {
         $factory = $this->getFactory();


### PR DESCRIPTION
Tests added in order to check `prepend` functionality of [`ManagesStacks`](https://github.com/laravel/framework/blob/71265318358ee150fe8b13f68a03cb9f869fb483/src/Illuminate/View/Concerns/ManagesStacks.php#L93)