### PR TITLE
[8.x] Consolidate empty function bodies

### DIFF
--- a/src/Illuminate/Events/NullDispatcher.php
+++ b/src/Illuminate/Events/NullDispatcher.php
@@ -37,6 +37,7 @@ class NullDispatcher implements DispatcherContract
      */
     public function dispatch($event, $payload = [], $halt = false)
     {
+        //
     }
 
     /**
@@ -48,6 +49,7 @@ class NullDispatcher implements DispatcherContract
      */
     public function push($event, $payload = [])
     {
+        //
     }
 
     /**
@@ -59,6 +61,7 @@ class NullDispatcher implements DispatcherContract
      */
     public function until($event, $payload = [])
     {
+        //
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/BatchRepositoryFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BatchRepositoryFake.php
@@ -33,6 +33,7 @@ class BatchRepositoryFake implements BatchRepository
      */
     public function find(string $batchId)
     {
+        //
     }
 
     /**
@@ -68,6 +69,7 @@ class BatchRepositoryFake implements BatchRepository
      */
     public function incrementTotalJobs(string $batchId, int $amount)
     {
+        //
     }
 
     /**
@@ -102,6 +104,7 @@ class BatchRepositoryFake implements BatchRepository
      */
     public function markAsFinished(string $batchId)
     {
+        //
     }
 
     /**
@@ -112,6 +115,7 @@ class BatchRepositoryFake implements BatchRepository
      */
     public function cancel(string $batchId)
     {
+        //
     }
 
     /**
@@ -122,6 +126,7 @@ class BatchRepositoryFake implements BatchRepository
      */
     public function delete(string $batchId)
     {
+        //
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -517,6 +517,7 @@ class BusFake implements QueueingDispatcher
      */
     public function findBatch(string $batchId)
     {
+        //
     }
 
     /**

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -577,6 +577,7 @@ class CircularAStub
 {
     public function __construct(CircularBStub $b)
     {
+        //
     }
 }
 
@@ -584,6 +585,7 @@ class CircularBStub
 {
     public function __construct(CircularCStub $c)
     {
+        //
     }
 }
 
@@ -591,6 +593,7 @@ class CircularCStub
 {
     public function __construct(CircularAStub $a)
     {
+        //
     }
 }
 

--- a/tests/Integration/Queue/CustomPayloadTest.php
+++ b/tests/Integration/Queue/CustomPayloadTest.php
@@ -60,5 +60,6 @@ class MyJob implements ShouldQueue
 
     public function handle()
     {
+        //
     }
 }

--- a/tests/Support/SupportReflectorTest.php
+++ b/tests/Support/SupportReflectorTest.php
@@ -81,6 +81,7 @@ class B extends A
 {
     public function f(parent $x)
     {
+        //
     }
 }
 
@@ -92,6 +93,7 @@ class C
 {
     public function f(A|Model $x)
     {
+        //
     }
 }'
     );
@@ -101,6 +103,7 @@ class TestClassWithCall
 {
     public function __call($method, $parameters)
     {
+        //
     }
 }
 
@@ -108,5 +111,6 @@ class TestClassWithCallStatic
 {
     public static function __callStatic($method, $parameters)
     {
+        //
     }
 }


### PR DESCRIPTION
This consolidates empty function bodies in the way they're defined in the rest of the framework.