### PR TITLE
[8.x] Add resource missing option

### DIFF
--- a/src/Illuminate/Routing/PendingResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingResourceRegistration.php
@@ -196,6 +196,19 @@ class PendingResourceRegistration
     }
 
     /**
+     * Define the callable that should be invoked on a missing model exception.
+     *
+     * @param $callback
+     * @return $this
+     */
+    public function missing($callback)
+    {
+        $this->options['missing'] = $callback;
+
+        return $this;
+    }
+
+    /**
      * Indicate that the resource routes should be scoped using the given binding fields.
      *
      * @param  array  $fields

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -21,6 +21,13 @@ class ResourceRegistrar
     protected $resourceDefaults = ['index', 'create', 'store', 'show', 'edit', 'update', 'destroy'];
 
     /**
+     * Actions that use model binding.
+     *
+     * @var string[]
+     */
+    protected $modelBoundMethods = ['show', 'edit', 'update', 'destroy'];
+
+    /**
      * The parameters set for this resource instance.
      *
      * @var array|string
@@ -419,6 +426,10 @@ class ResourceRegistrar
 
         if (isset($options['wheres'])) {
             $action['where'] = $options['wheres'];
+        }
+
+        if (isset($options['missing']) && in_array($method, $this->modelBoundMethods)) {
+            $action['missing'] = $options['missing'];
         }
 
         return $action;

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -21,13 +21,6 @@ class ResourceRegistrar
     protected $resourceDefaults = ['index', 'create', 'store', 'show', 'edit', 'update', 'destroy'];
 
     /**
-     * Actions that use model binding.
-     *
-     * @var string[]
-     */
-    protected $modelBoundMethods = ['show', 'edit', 'update', 'destroy'];
-
-    /**
      * The parameters set for this resource instance.
      *
      * @var array|string
@@ -191,6 +184,8 @@ class ResourceRegistrar
     {
         $uri = $this->getResourceUri($name);
 
+        unset($options['missing']);
+
         $action = $this->getResourceAction($name, $controller, 'index', $options);
 
         return $this->router->get($uri, $action);
@@ -209,6 +204,8 @@ class ResourceRegistrar
     {
         $uri = $this->getResourceUri($name).'/'.static::$verbs['create'];
 
+        unset($options['missing']);
+
         $action = $this->getResourceAction($name, $controller, 'create', $options);
 
         return $this->router->get($uri, $action);
@@ -226,6 +223,8 @@ class ResourceRegistrar
     protected function addResourceStore($name, $base, $controller, $options)
     {
         $uri = $this->getResourceUri($name);
+
+        unset($options['missing']);
 
         $action = $this->getResourceAction($name, $controller, 'store', $options);
 
@@ -428,7 +427,7 @@ class ResourceRegistrar
             $action['where'] = $options['wheres'];
         }
 
-        if (isset($options['missing']) && in_array($method, $this->modelBoundMethods)) {
+        if (isset($options['missing'])) {
             $action['missing'] = $options['missing'];
         }
 

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -334,6 +334,22 @@ class RouteRegistrarTest extends TestCase
         }
     }
 
+    public function testCanRegisterResourceWithMissingOption()
+    {
+        $this->router->middleware('resource-middleware')
+            ->resource('users', RouteRegistrarControllerStub::class)
+            ->missing(function () { return 'missing'; });
+
+        $this->assertIsCallable($this->router->getRoutes()->getByName('users.show')->getMissing());
+        $this->assertIsCallable($this->router->getRoutes()->getByName('users.edit')->getMissing());
+        $this->assertIsCallable($this->router->getRoutes()->getByName('users.update')->getMissing());
+        $this->assertIsCallable($this->router->getRoutes()->getByName('users.destroy')->getMissing());
+
+        $this->assertNull($this->router->getRoutes()->getByName('users.index')->getMissing());
+        $this->assertNull($this->router->getRoutes()->getByName('users.create')->getMissing());
+        $this->assertNull($this->router->getRoutes()->getByName('users.store')->getMissing());
+    }
+
     public function testCanAccessRegisteredResourceRoutesAsRouteCollection()
     {
         $resource = $this->router->middleware('resource-middleware')


### PR DESCRIPTION
This PR adds an option for users to define a "missing" callback on resources:
```php
Route::resource('users', UsersController::class)
    ->missing(function () {
        return response('missing', 404);
    });
```
I think this will be useful, because when someone uses model bindings, they are usually registered via resources.
