### PR TITLE
[8.x] Fix Mailer contract returns

### DIFF
--- a/src/Illuminate/Contracts/Mail/Factory.php
+++ b/src/Illuminate/Contracts/Mail/Factory.php
@@ -8,7 +8,7 @@ interface Factory
      * Get a mailer instance by name.
      *
      * @param  string|null  $name
-     * @return \Illuminate\Mail\Mailer
+     * @return \Illuminate\Contracts\Mail\Mailer
      */
     public function mailer($name = null);
 }

--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -63,7 +63,7 @@ class MailManager implements FactoryContract
      * Get a mailer instance by name.
      *
      * @param  string|null  $name
-     * @return \Illuminate\Mail\Mailer
+     * @return \Illuminate\Contracts\Mail\Mailer
      */
     public function mailer($name = null)
     {

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -276,7 +276,7 @@ class MailFake implements Factory, Mailer, MailQueue
      * Get a mailer instance by name.
      *
      * @param  string|null  $name
-     * @return \Illuminate\Mail\Mailer
+     * @return \Illuminate\Contracts\Mail\Mailer
      */
     public function mailer($name = null)
     {


### PR DESCRIPTION
All other factory contracts return an implementation of a contract. I think the original reason why this was a concrete is because the `MailManager`'s `resolve` method always returns a concrete implementation of `Illuminate\Mail\Mailer`. This is fine and while this technically means that the `MailManager` will always return an instance of `Illuminate\Mail\Mailer` it's probably best to loosen the implementation on the `Factory` contract to allow any implementation of a `Mailer` type. The `Mail` component should function perfectly fine with any mailer implementing this contract type.

No breaking change because only DocBlocks were edited and existing code will continue to work as is.