### PR TITLE
[8.x] Fixes restrictive type declaration in InteractsWithViews testing concern

### DIFF
--- a/src/Illuminate/Contracts/Mail/Factory.php
+++ b/src/Illuminate/Contracts/Mail/Factory.php
@@ -8,7 +8,7 @@ interface Factory
      * Get a mailer instance by name.
      *
      * @param  string|null  $name
-     * @return \Illuminate\Mail\Mailer
+     * @return \Illuminate\Contracts\Mail\Mailer
      */
     public function mailer($name = null);
 }

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithViews.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithViews.php
@@ -18,7 +18,7 @@ trait InteractsWithViews
      * @param  \Illuminate\Contracts\Support\Arrayable|array  $data
      * @return \Illuminate\Testing\TestView
      */
-    protected function view(string $view, array $data = [])
+    protected function view(string $view, $data = [])
     {
         return new TestView(view($view, $data));
     }
@@ -30,7 +30,7 @@ trait InteractsWithViews
      * @param  \Illuminate\Contracts\Support\Arrayable|array  $data
      * @return \Illuminate\Testing\TestView
      */
-    protected function blade(string $template, array $data = [])
+    protected function blade(string $template, $data = [])
     {
         $tempDirectory = sys_get_temp_dir();
 
@@ -52,7 +52,7 @@ trait InteractsWithViews
      * @param  \Illuminate\Contracts\Support\Arrayable|array  $data
      * @return \Illuminate\Testing\TestView
      */
-    protected function component(string $componentClass, array $data = [])
+    protected function component(string $componentClass, $data = [])
     {
         $component = $this->app->make($componentClass, $data);
 

--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -63,7 +63,7 @@ class MailManager implements FactoryContract
      * Get a mailer instance by name.
      *
      * @param  string|null  $name
-     * @return \Illuminate\Mail\Mailer
+     * @return \Illuminate\Contracts\Mail\Mailer
      */
     public function mailer($name = null)
     {

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -276,7 +276,7 @@ class MailFake implements Factory, Mailer, MailQueue
      * Get a mailer instance by name.
      *
      * @param  string|null  $name
-     * @return \Illuminate\Mail\Mailer
+     * @return \Illuminate\Contracts\Mail\Mailer
      */
     public function mailer($name = null)
     {


### PR DESCRIPTION
This PR removes the `array` type declaration on the InteractsWithViews concern used in testing. These methods should ultimately have the type declaration of `Arrayable|array`, but until the framework's minimum PHP version is increased to 8, the type declaration should be removed.

With this array type declaration, one must explicitly call `->toArray()` on any Arrayable they are using, otherwise a TypeError is thrown: `TypeError : Illuminate\Foundation\Testing\TestCase::view(): Argument #2 ($data) must be of type array, ...`

```
public function test_view()
{
    $arrayable = new SomeArrayable();
    $this->view('post.form', $arrayable->toArray());
}
```

```
public function test_view()
{
    $arrayable = new SomeArrayable();
    $this->view('post.form', $arrayable);
}
```