### PR TITLE
[8.x] Change argument order of perMinues() rate limit method

### DIFF
--- a/src/Illuminate/Cache/RateLimiting/Limit.php
+++ b/src/Illuminate/Cache/RateLimiting/Limit.php
@@ -61,11 +61,11 @@ class Limit
     /**
      * Create a new rate limit using minutes as decay time.
      *
-     * @param  int  $decayMinutes
      * @param  int  $maxAttempts
+     * @param  int  $decayMinutes
      * @return static
      */
-    public static function perMinutes($decayMinutes, $maxAttempts)
+    public static function perMinutes($maxAttempts, $decayMinutes)
     {
         return new static('', $maxAttempts, $decayMinutes);
     }


### PR DESCRIPTION
I created the pull request (#36352) that introduced the `perMinutes()` rate limit method, to allow greater specificity than the existing rate limit methods allowed. Somehow, during the merge process, it seems like a commit (86d0a5c733b3f22ae2353df538e07605963c3052) was introduced that swapped the order of the arguments.

As a result, the behavior of `perMinutes()` differs from that of the previously existing methods, `perMinute()`, `perDay()` and `perHour()`. Perhaps I'm missing something obvious here but it seems like the argument order for `perMinutes()` should match that of the other rate limit methods. This PR changes the order of the arguments so that they match.

As a matter of example, my application had the following code to rate limiting a job to run a maximum of once every 30 minutes:

```
return Limit::perHour(1, 0.50);
```

After the `perMinutes()` method was introduced, I expected to be able to change my code as such:

```
return Limit::perMinutes(1, 30);
```