### PR TITLE
[8.x] Support for WHERE in Postgres' and SQLite's INSERT ON CONFLICT UPDATE clause

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database\Query\Grammars;
 
 use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Str;
+use RuntimeException;
 
 class MySqlGrammar extends Grammar
 {
@@ -170,6 +171,11 @@ class MySqlGrammar extends Grammar
                 ? $this->wrap($value).' = values('.$this->wrap($value).')'
                 : $this->wrap($key).' = '.$this->parameter($value);
         })->implode(', ');
+
+        $where = $this->compileWheres($query);
+        if (!empty($where)) {
+          throw new RuntimeException('MySQL does not support filtering when doing ON DUPLICATE KEY UPDATE.');
+        }
 
         return $sql.$columns;
     }

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -239,7 +239,10 @@ class PostgresGrammar extends Grammar
                 : $this->wrap($key).' = '.$this->parameter($value);
         })->implode(', ');
 
-        return $sql.$columns;
+        $where = $this->compileWheres($query);
+        $where = (empty($where) ? '' : ' ') . $where;
+
+        return $sql.$columns.$where;
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -203,7 +203,10 @@ class SQLiteGrammar extends Grammar
                 : $this->wrap($key).' = '.$this->parameter($value);
         })->implode(', ');
 
-        return $sql.$columns;
+        $where = $this->compileWheres($query);
+        $where = (empty($where) ? '' : ' ') . $where;
+
+        return $sql.$columns.$where;
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2234,6 +2234,11 @@ class DatabaseQueryBuilderTest extends TestCase
         $result = $builder->from('users')->upsert([['email' => 'foo', 'name' => 'bar'], ['name' => 'bar2', 'email' => 'foo2']], 'email');
         $this->assertEquals(2, $result);
 
+        $builder = $this->getSQLiteBuilder();
+        $builder->getConnection()->shouldReceive('affectingStatement')->once()->with('insert into "users" ("email", "name") values (?, ?), (?, ?) on conflict ("email") do update set "email" = "excluded"."email", "name" = "excluded"."name" where "users"."email" < "excluded"."email"', ['foo', 'bar', 'foo2', 'bar2'])->andReturn(2);
+        $result = $builder->from('users')->whereRaw('"users"."email" < "excluded"."email"')->upsert([['email' => 'foo', 'name' => 'bar'], ['name' => 'bar2', 'email' => 'foo2']], 'email');
+        $this->assertEquals(2, $result);
+
         $builder = $this->getSqlServerBuilder();
         $builder->getConnection()->shouldReceive('affectingStatement')->once()->with('merge [users] using (values (?, ?), (?, ?)) [laravel_source] ([email], [name]) on [laravel_source].[email] = [users].[email] when matched then update set [email] = [laravel_source].[email], [name] = [laravel_source].[name] when not matched then insert ([email], [name]) values ([email], [name]);', ['foo', 'bar', 'foo2', 'bar2'])->andReturn(2);
         $result = $builder->from('users')->upsert([['email' => 'foo', 'name' => 'bar'], ['name' => 'bar2', 'email' => 'foo2']], 'email');

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2219,6 +2219,13 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->from('users')->where('"users"."email" < "excluded"."email"')->upsert([['email' => 'foo', 'name' => 'bar'], ['name' => 'bar2', 'email' => 'foo2']], 'email');
     }
 
+    public function testSqlServerInvalidUpsertMethod()
+    {
+        $this->expectException(RuntimeException::class);
+        $builder = $this->getSqlServerBuilder();
+        $builder->from('users')->where('"users"."email" < "excluded"."email"')->upsert([['email' => 'foo', 'name' => 'bar'], ['name' => 'bar2', 'email' => 'foo2']], 'email');
+    }
+
     public function testUpsertMethod()
     {
         $builder = $this->getMySqlBuilder();

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2212,6 +2212,13 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(1, $result);
     }
 
+    public function testMySqlInvalidUpsertMethod()
+    {
+        $this->expectException(RuntimeException::class);
+        $builder = $this->getMySqlBuilder();
+        $builder->from('users')->where('"users"."email" < "excluded"."email"')->upsert([['email' => 'foo', 'name' => 'bar'], ['name' => 'bar2', 'email' => 'foo2']], 'email');
+    }
+
     public function testUpsertMethod()
     {
         $builder = $this->getMySqlBuilder();

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2224,6 +2224,11 @@ class DatabaseQueryBuilderTest extends TestCase
         $result = $builder->from('users')->upsert([['email' => 'foo', 'name' => 'bar'], ['name' => 'bar2', 'email' => 'foo2']], 'email');
         $this->assertEquals(2, $result);
 
+        $builder = $this->getPostgresBuilder();
+        $builder->getConnection()->shouldReceive('affectingStatement')->once()->with('insert into "users" ("email", "name") values (?, ?), (?, ?) on conflict ("email") do update set "email" = "excluded"."email", "name" = "excluded"."name" where "users"."email" < "excluded"."email"', ['foo', 'bar', 'foo2', 'bar2'])->andReturn(2);
+        $result = $builder->from('users')->whereRaw('"users"."email" < "excluded"."email"')->upsert([['email' => 'foo', 'name' => 'bar'], ['name' => 'bar2', 'email' => 'foo2']], 'email');
+        $this->assertEquals(2, $result);
+
         $builder = $this->getSQLiteBuilder();
         $builder->getConnection()->shouldReceive('affectingStatement')->once()->with('insert into "users" ("email", "name") values (?, ?), (?, ?) on conflict ("email") do update set "email" = "excluded"."email", "name" = "excluded"."name"', ['foo', 'bar', 'foo2', 'bar2'])->andReturn(2);
         $result = $builder->from('users')->upsert([['email' => 'foo', 'name' => 'bar'], ['name' => 'bar2', 'email' => 'foo2']], 'email');


### PR DESCRIPTION
> the reasons it does not break any existing features

PostgreSQL and SQLite supports using a `WHERE` clause to limit the rows updated when using its `INSERT ON CONFLICT` UPDATE support. 

PostgreSQL's support has been present from the introduction of the `ON CONFLICT` clause in [PostgreSQL 9.5](https://www.postgresql.org/docs/9.5/sql-insert.html) and continues to exist in the [current version (13)](https://www.postgresql.org/docs/13/sql-insert.html). 

SQLite's support has been present from the introduction of the `ON CONFLICT` clause in [3.24.0 (2018-06-04)]and continues to exist in the [current version(3.34.1)](https://www.sqlite.org/releaselog/3_24_0.html).

As such, for any user for whom the `upsert` function will work, the the `WHERE` will work and will not generate the "this version of this is compatible with that version of that" dance.

Additionally, since this functionality did not previously exist in Laravel, there is no conflict with anyone's existing code base.

MySQL, as of [version 8](https://dev.mysql.com/doc/refman/8.0/en/insert-on-duplicate.html) does not support filtering when using `ON DUPLICATE KEY UPDATE`.  I chose to throw an exception here in order to make it clear that the intended behavior isn't possible.

I do not have access to Microsoft's SQL Server, but it does appear to have support for filtering when updating as of (Version 15)[https://docs.microsoft.com/en-us/sql/t-sql/statements/merge-transact-sql?view=sql-server-ver15]. I chose to throw an exception here in order to make it clear that the intended behavior isn't possible with this version of the grammar.

While the exceptions could potentially break an existing application that calls `where` on the QueryBuilder that `upsert`is called on, I believe it more likely that this would call attention to code not behaving as intended and am unaware of a use-case that would require the `where` call on the QueryBuilder and `upsert` currently.

> please describe the benefit to end users
> how it makes building web applications easier

One use case for such a filter is when processing events which may come in the "wrong" order, which can happen frequently with Pub Sub systems or when having to replay an event stream to process some events that had been not processed due to an error.  For instance, and event comes in with a user's updated information with a timestamp of '2021-03-12 02:25:15', followed by one with a timestamp of '2021-03-12 02:24:32', in general, the incorrect behavior would be to apply the update with the older timestamp over top of the one with a newer timestamp. Being able to make such a check inside of a single query both reduced the load on the database but also makes it easier to write the correct logic.

Sample SQL to show the syntax works:
PostgreSQL:

```
% psql laraveltest
psql (13.2 (Ubuntu 13.2-1.pgdg20.04+1))
Type "help" for help.

laraveltest=# create table "users" ("email" text not null unique, "name" text);
CREATE TABLE
laraveltest=# insert into "users" ("email", "name") values ('foo', 'bar'), ('foo2', 'bar2') on conflict ("email") do update set "email" = "excluded"."email", "name" = "excluded"."name" where "users"."email" < "excluded"."email";
INSERT 0 2
laraveltest=# select * from users;
 email | name 
-------+------
 foo   | bar
 foo2  | bar2
(2 rows)

laraveltest=# insert into "users" ("email", "name") values ('foo', 'bar'), ('foo2', 'bar2') on conflict ("email") do update set "email" = "excluded"."email", "name" = "excluded"."name" where "users"."email" < "excluded"."email";
INSERT 0 0
laraveltest=# select * from users;
 email | name 
-------+------
 foo   | bar
 foo2  | bar2
(2 rows)
```

SQLite:

```
% sqlite3 test.db
SQLite version 3.31.1 2020-01-27 19:55:54
Enter ".help" for usage hints.
sqlite> create table "users" ("email" text not null unique, "name" text);
sqlite> insert into "users" ("email", "name") values ('foo', 'bar'), ('foo2', 'bar2') on conflict ("email") do update set "email" = "excluded"."email", "name" = "excluded"."name" where "users"."email" < "excluded"."email";
sqlite> select changes();
2
sqlite> select * from users;
foo|bar
foo2|bar2
sqlite> insert into "users" ("email", "name") values ('foo', 'bar'), ('foo2', 'bar2') on conflict ("email") do update set "email" = "excluded"."email", "name" = "excluded"."name" where "users"."email" < "excluded"."email";
sqlite> select changes();
0
sqlite> select * from users;
foo|bar
foo2|bar2
```