### PR TITLE
[8.x] Use contract encrypt and decrypt methods

### DIFF
--- a/src/Illuminate/Database/Eloquent/Casts/AsEncryptedArrayObject.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEncryptedArrayObject.php
@@ -19,12 +19,12 @@ class AsEncryptedArrayObject implements Castable
         return new class implements CastsAttributes {
             public function get($model, $key, $value, $attributes)
             {
-                return new ArrayObject(json_decode(Crypt::decryptString($attributes[$key]), true));
+                return new ArrayObject(json_decode(Crypt::decrypt($attributes[$key], false), true));
             }
 
             public function set($model, $key, $value, $attributes)
             {
-                return [$key => Crypt::encryptString(json_encode($value))];
+                return [$key => Crypt::encrypt(json_encode($value), false)];
             }
 
             public function serialize($model, string $key, $value, array $attributes)

--- a/src/Illuminate/Database/Eloquent/Casts/AsEncryptedCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEncryptedCollection.php
@@ -20,12 +20,12 @@ class AsEncryptedCollection implements Castable
         return new class implements CastsAttributes {
             public function get($model, $key, $value, $attributes)
             {
-                return new Collection(json_decode(Crypt::decryptString($attributes[$key]), true));
+                return new Collection(json_decode(Crypt::decrypt($attributes[$key], false), true));
             }
 
             public function set($model, $key, $value, $attributes)
             {
-                return [$key => Crypt::encryptString(json_encode($value))];
+                return [$key => Crypt::encrypt(json_encode($value), false)];
             }
         };
     }


### PR DESCRIPTION
Alternative to https://github.com/laravel/framework/pull/36566

These changes will make use of the `Illuminate\Contracts\Encryption\Encrypter` contract's methods so people can still roll their own implementations without running into problems with some framework usages of a concrete implementation. This prevents us from having to widen the contract for no real reason. 