### PR TITLE
[9.x] Fixes restrictive type declaration in InteractsWithViews testing concern

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithViews.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithViews.php
@@ -18,7 +18,7 @@ trait InteractsWithViews
      * @param  \Illuminate\Contracts\Support\Arrayable|array  $data
      * @return \Illuminate\Testing\TestView
      */
-    protected function view(string $view, array $data = [])
+    protected function view(string $view, $data = [])
     {
         return new TestView(view($view, $data));
     }
@@ -30,7 +30,7 @@ trait InteractsWithViews
      * @param  \Illuminate\Contracts\Support\Arrayable|array  $data
      * @return \Illuminate\Testing\TestView
      */
-    protected function blade(string $template, array $data = [])
+    protected function blade(string $template, $data = [])
     {
         $tempDirectory = sys_get_temp_dir();
 
@@ -52,7 +52,7 @@ trait InteractsWithViews
      * @param  \Illuminate\Contracts\Support\Arrayable|array  $data
      * @return \Illuminate\Testing\TestView
      */
-    protected function component(string $componentClass, array $data = [])
+    protected function component(string $componentClass, $data = [])
     {
         $component = $this->app->make($componentClass, $data);
 


### PR DESCRIPTION
New PR to master for #36567 

This PR removes the array type declaration on the `InteractsWithViews` concern used in testing. These methods should ultimately have the type declaration of `Arrayable|array`, but until the framework's minimum PHP version is increased to 8, the type declaration should be removed.

With this array type declaration, one must explicitly call `->toArray()` on any `Arrayable` they are using, otherwise a TypeError is thrown: `TypeError : Illuminate\Foundation\Testing\TestCase::view(): Argument #2 ($data) must be of type array, ...`

```
public function test_view()
{
    $arrayable = new SomeArrayable();
    $this->view('post.form', $arrayable->toArray());
}
```
```
public function test_view()
{
    $arrayable = new SomeArrayable();
    $this->view('post.form', $arrayable);
}
```