### PR TITLE
[9.x] Add Faker as dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -80,6 +80,7 @@
     "require-dev": {
         "aws/aws-sdk-php": "^3.155",
         "doctrine/dbal": "^2.12|^3.0",
+        "fakerphp/faker": "^1.9.2",
         "filp/whoops": "^2.8",
         "guzzlehttp/guzzle": "^7.2",
         "league/flysystem-aws-s3-v3": "^2.0",


### PR DESCRIPTION
Brings in Faker as a dev dependency as it was removed from testbench.

/cc @crynobone @GrahamCampbell 