### PR TITLE
[8.x] Allow validation error attribute names to fallback to a more generic translation

### DIFF
--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -276,7 +276,23 @@ trait FormatsMessages
      */
     protected function getAttributeFromTranslations($name)
     {
-        return Arr::get($this->translator->get('validation.attributes'), $name);
+        $attributes = $this->translator->get('validation.attributes');
+        $mostSpecific = Arr::get($attributes, $name);
+        if ($mostSpecific !== null) {
+            return $mostSpecific;
+        }
+
+        $tokens = array_reverse(explode('.', $name));
+        while (!empty($tokens)) {
+            $key = implode('.', array_reverse($tokens));
+            $translation = Arr::get($attributes, $key);
+            if ($translation !== null) {
+                return $translation;
+            }
+            array_pop($tokens);
+        }
+
+        return null;
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -283,7 +283,7 @@ trait FormatsMessages
         }
 
         $tokens = array_reverse(explode('.', $name));
-        while (!empty($tokens)) {
+        while (! empty($tokens)) {
             $key = implode('.', array_reverse($tokens));
             $translation = Arr::get($attributes, $key);
             if ($translation !== null) {

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -413,6 +413,13 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['names' => [null, 'name']], ['names.*' => 'Required']);
         $v->messages()->setFormat(':message');
         $this->assertSame('First name is required!', $v->messages()->first('names.0'));
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines(['validation.required' => ':attribute is required!'], 'en');
+        $trans->addLines(['validation.attributes' => ['name' => 'Name']], 'en');
+        $v = new Validator($trans, ['items' => [['name' => 'John'], []]], ['items.*.name' => 'Required']);
+        $v->messages()->setFormat(':message');
+        $this->assertSame('Name is required!', $v->messages()->first('items.1.name'));
     }
 
     public function testInputIsReplaced()


### PR DESCRIPTION
#### Use case

There is a complex form with similar fields present in different groups. For instance, within a network form, we want to define the name and IP of machines having some specific roles. The same field could in some cases have a specific translation but in most cases it would always be translated the same way.

#### Current

The validation attributes translation definition would look like that:

```php
'attributes'=> [
    'network.*.http.host_name' => 'HTTP server name',
    'network.*.db_master.host_name' => 'Server name',
    'network.*.db_slave.host_name' => 'Server name',
    'network.*.other.host_name' => 'Server name',
]
```

Notice that if the user add some more roles to the form, he will then have to define more translations: e.g. `'network.*.dns.host_name' => 'Server name'`. This becomes even more cumbersome as the number of fields grow per group.

Notice also that in the use case described in https://github.com/laravel/ideas/issues/2533 (dynamic validation rules per form item) we simply cannot get any translation.

#### Proposed fix

When a specific translation is missing, we could simply look if we find a more generic translation key. In the above example, we could simply the above translations to:

```php
'attributes'=> [
    'network.*.http.host_name' => 'HTTP server name',
    'host_name' => 'Server name',                                
]
```

When the `network.*.db_slave.host_name` is looked up, we will sequentially look for the following keys within the `validation.attributes` array:

1. `network.*.db_slave.host_name`
1. `*.db_slave.host_name`
1. `db_slave.host_name`
1. `host_name`

#### Gain from the user perspective

This allows the user to drastically lower the number of translations used, and to lower maintainance cost when new similar fields are added.

In the application we are working on, we currently have around 500 keys of attribute translations, with a lot of duplicate entries. The proposed fixe would allow to divide that number by around 3, leaving around 150 unique keys.

The gain is obvious when it comes to changing a translation (having to make sure we do not forget a key) and adding new groups of fields (not forgetting to define the specific duplicate for that particular group).

#### Further improvements

I think the same enhancement could be provided for the `validation.values` translations too.

fixes laravel/ideas#2533 and laravel/ideas#1771