### PR TITLE
[8.x] Add text string helper to convert back to text

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -729,7 +729,7 @@ class Str
     }
 
     /**
-     * Convert studly, camel or kebab case back to text
+     * Convert studly, camel, snake or kebab case back to text
      *
      * @param string $string
      * @return string

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -729,6 +729,17 @@ class Str
     }
 
     /**
+     * Convert studly, camel or kebab case back to text
+     *
+     * @param string $string
+     * @return string
+     */
+    public static function text($string)
+    {
+        return preg_replace('/[^a-z0-9 ]/i', ' ', static::snake($string));
+    }
+
+    /**
      * Make a string's first character uppercase.
      *
      * @param  string  $string

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -729,7 +729,7 @@ class Str
     }
 
     /**
-     * Convert studly, camel, snake or kebab case back to text
+     * Convert studly, camel, snake or kebab case back to text.
      *
      * @param string $string
      * @return string

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -526,7 +526,8 @@ class SupportStrTest extends TestCase
     public function testText()
     {
         $this->assertEquals('this is studly case', Str::text('ThisIsStudlyCase'));
-        $this->assertEquals('this is camel case', Str::text('this_is_camel_case'));
+        $this->assertEquals('this is camel case', Str::text('thisIsCamelCase'));
+        $this->assertEquals('this is snake case', Str::text('this_is_snake_case'));
         $this->assertEquals('this is kebab case', Str::text('this-is-kebab-case'));
         $this->assertEquals('this is mixed case', Str::text('thisIs-mixed_case'));
     }

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -522,6 +522,14 @@ class SupportStrTest extends TestCase
         $this->assertEquals("<p><em>hello world</em></p>\n", Str::markdown('*hello world*'));
         $this->assertEquals("<h1>hello world</h1>\n", Str::markdown('# hello world'));
     }
+
+    public function testText()
+    {
+        $this->assertEquals('this is studly case', Str::text('ThisIsStudlyCase'));
+        $this->assertEquals('this is camel case', Str::text('this_is_camel_case'));
+        $this->assertEquals('this is kebab case', Str::text('this-is-kebab-case'));
+        $this->assertEquals('this is mixed case', Str::text('thisIs-mixed_case'));
+    }
 }
 
 class StringableObjectStub


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
A string helper method that allows converting a string from studly, camel, snake or kebab case back into words. The `Str::words()` helper already exists so I called it text instead. 

```php
use Illuminate\Support\Str;

$text = Str::text('ThisIsStudlyCase');
// this is studly case

$text = Str::text('thisIsCamelCase');
// this is camel case

$text = Str::text('this_is_snake_case');
// this is snake case

$text = Str::text('this-is-kebab-case');
// this is kebab case
```
