### PR TITLE
[8.x] Allow transaction retries when savepoints disabled

### DIFF
--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -78,6 +78,7 @@ trait ManagesTransactions
         // retry the query. We have to throw this exception all the way out and
         // let the developer handle it in another way. We will decrement too.
         if ($this->causedByConcurrencyError($e) &&
+            $this->queryGrammar->supportsSavepoints() &&
             $this->transactions > 1) {
             $this->transactions--;
 


### PR DESCRIPTION
In my use case, I disabled MySQL savepoints to allow DB::transaction() to retry in deadlock scenarios. However, the current logic throws the exception even though it's seemingly not necessary when savepoints are disabled. Since there is only one transaction open in MySQL, the entire transaction can be rolled back and replayed. So we check to see if the query grammar supports savepoints before throwing.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
