### PR TITLE
[8.x] Stack driver fix: respect the defined processors

### DIFF
--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -244,12 +244,16 @@ class LogManager implements LoggerInterface
         $handlers = collect($config['channels'])->flatMap(function ($channel) {
             return $this->channel($channel)->getHandlers();
         })->all();
+        
+        $processors = collect($config['channels'])->flatMap(function ($channel) {
+            return $this->channel($channel)->getProcessors();
+        })->all();
 
         if ($config['ignore_exceptions'] ?? false) {
             $handlers = [new WhatFailureGroupHandler($handlers)];
         }
 
-        return new Monolog($this->parseChannel($config), $handlers);
+        return new Monolog($this->parseChannel($config), $handlers, $processors);
     }
 
     /**


### PR DESCRIPTION
This update fixes the issue: https://github.com/laravel/ideas/issues/1735
Before the change, if user defined **custom channel** using **custom driver** defined processor(s) were not triggered and useless.
After the fix, every defined **processor** is triggered, and `$record` array changes are reflected on all **stack channels**.
