### PR TITLE
[8.x] Update view-component.stub docblock 

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/view-component.stub
+++ b/src/Illuminate/Foundation/Console/stubs/view-component.stub
@@ -19,7 +19,7 @@ class DummyClass extends Component
     /**
      * Get the view / contents that represent the component.
      *
-     * @return \Illuminate\Contracts\View\View|string
+     * @return \Illuminate\Contracts\View\View|\Closure|string
      */
     public function render()
     {


### PR DESCRIPTION
Add the return type `\Closure` to the component's `render` method.