### PR TITLE
[8.x] Stringable::match - remove null return from phpdoc

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -335,7 +335,7 @@ class Stringable implements JsonSerializable
      * Get the string matching the given pattern.
      *
      * @param  string  $pattern
-     * @return static|null
+     * @return static
      */
     public function match($pattern)
     {


### PR DESCRIPTION
The PHPDoc for `Stringable::match` includes `null` even though it never returns a null value. It returns a new empty instance if there are no matches found, and a new instance with the match if one is found.

As a result, php inspections warns that the variable may be null even though that's not the case.

![image](https://user-images.githubusercontent.com/4411748/111070410-e7632d80-84d1-11eb-817d-9006709b974f.png)
