### PR TITLE
[9.x] Null cache values

### DIFF
--- a/src/Illuminate/Cache/ApcStore.php
+++ b/src/Illuminate/Cache/ApcStore.php
@@ -34,6 +34,17 @@ class ApcStore extends TaggableStore
     }
 
     /**
+     * Determine if a key exists in the cache.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function has($key)
+    {
+        return $this->apc->exists($this->prefix.$key);
+    }
+
+    /**
      * Retrieve an item from the cache by key.
      *
      * @param  string|array  $key

--- a/src/Illuminate/Cache/ApcWrapper.php
+++ b/src/Illuminate/Cache/ApcWrapper.php
@@ -22,6 +22,17 @@ class ApcWrapper
     }
 
     /**
+     * Determine if a item exists in the cache.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function exists($key)
+    {
+        return $this->apcu ? apcu_exists($key) : apc_exists($key);
+    }
+
+    /**
      * Get an item from the cache.
      *
      * @param  string  $key

--- a/src/Illuminate/Cache/ArrayStore.php
+++ b/src/Illuminate/Cache/ArrayStore.php
@@ -42,6 +42,17 @@ class ArrayStore extends TaggableStore implements LockProvider
     }
 
     /**
+     * Determine if a key exists in the cache.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function has($key)
+    {
+        return isset($this->storage[$key]);
+    }
+
+    /**
      * Retrieve an item from the cache by key.
      *
      * @param  string|array  $key
@@ -49,7 +60,7 @@ class ArrayStore extends TaggableStore implements LockProvider
      */
     public function get($key)
     {
-        if (! isset($this->storage[$key])) {
+        if (!$this->has($key)) {
             return;
         }
 

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -82,6 +82,17 @@ class DatabaseStore implements LockProvider, Store
     }
 
     /**
+     * Determine if a key exists in the cache.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function has($key)
+    {
+        return $this->table()->where('key', '=', $this->prefix.$key)->exists();
+    }
+
+    /**
      * Retrieve an item from the cache by key.
      *
      * @param  string|array  $key

--- a/src/Illuminate/Cache/DynamoDbStore.php
+++ b/src/Illuminate/Cache/DynamoDbStore.php
@@ -85,6 +85,17 @@ class DynamoDbStore implements LockProvider, Store
     }
 
     /**
+     * Determine if a key exists in the cache.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function has($key)
+    {
+
+    }
+
+    /**
      * Retrieve an item from the cache by key.
      *
      * @param  string  $key

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -51,6 +51,17 @@ class FileStore implements Store, LockProvider
     }
 
     /**
+     * Determine if a key exists in the cache.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function has($key)
+    {
+        return $this->files->exists($this->path($key));
+    }
+
+    /**
      * Retrieve an item from the cache by key.
      *
      * @param  string|array  $key

--- a/src/Illuminate/Cache/MemcachedStore.php
+++ b/src/Illuminate/Cache/MemcachedStore.php
@@ -49,6 +49,17 @@ class MemcachedStore extends TaggableStore implements LockProvider
     }
 
     /**
+     * Determine if a key exists in the cache.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function has($key)
+    {
+
+    }
+
+    /**
      * Retrieve an item from the cache by key.
      *
      * @param  string  $key

--- a/src/Illuminate/Cache/NullStore.php
+++ b/src/Illuminate/Cache/NullStore.php
@@ -9,6 +9,17 @@ class NullStore extends TaggableStore implements LockProvider
     use RetrievesMultipleKeys;
 
     /**
+     * Check if a key exists in the cache.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function has($key)
+    {
+        return false;
+    }
+
+    /**
      * Retrieve an item from the cache by key.
      *
      * @param  string  $key

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -52,6 +52,17 @@ class RedisStore extends TaggableStore implements LockProvider
     }
 
     /**
+     * Determine if a key exists in the cache.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function has($key)
+    {
+        $this->connection()->exists($this->prefix.$key);
+    }
+
+    /**
      * Retrieve an item from the cache by key.
      *
      * @param  string|array  $key
@@ -59,9 +70,7 @@ class RedisStore extends TaggableStore implements LockProvider
      */
     public function get($key)
     {
-        $value = $this->connection()->get($this->prefix.$key);
-
-        return ! is_null($value) ? $this->unserialize($value) : null;
+        return $this->unserialize($this->connection()->get($this->prefix.$key));
     }
 
     /**

--- a/src/Illuminate/Contracts/Cache/Store.php
+++ b/src/Illuminate/Contracts/Cache/Store.php
@@ -5,6 +5,14 @@ namespace Illuminate\Contracts\Cache;
 interface Store
 {
     /**
+     * Determine if a key exists in the cache.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function has($key);
+
+    /**
      * Retrieve an item from the cache by key.
      *
      * @param  string|array  $key

--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -45,6 +45,17 @@ class PhpRedisConnection extends Connection implements ConnectionContract
     }
 
     /**
+     * Determine if a key exists in the cache.
+     *
+     * @param string $key
+     * @return bool
+     */
+    public function has($key)
+    {
+        return $this->command('exists', [$key]) === 1;
+    }
+
+    /**
      * Returns the value of the given key.
      *
      * @param  string  $key


### PR DESCRIPTION
Currently the cache system is unable to return `null` values.

```php
Cache::remember('cache-key', now()->addMinutes(5), function () {
    echo 'no hit';
    return null;
});
```

This will output "no hit" every single refresh. I believe this doesn't have to be the case if we implement checking if the key actually exists in the cache store, not based on what the returned value is.

I'm opening this as a draft PR to get some feedback and see if there's interest in this. This code is **not complete**, and tests are failing. Just more-so looking for a response from the team if I should continue pursuing this.

---

A real world example of where I ran into this. We have a multi-tenant application, and we have a middleware setup to determine if the current tenant has a redirect setup for the current page.

```php
public function handle(Request $request, Closure $next)
{
    //get url
    $source = trim($request->getPathInfo(), '/');

    //get domain
    $domain = $request->session()->get('domain');

    //check for local redirects
    if ($localRedirect = Cache::remember('middleware.handle-redirect.local.' . $domain->id . '.' . $source, now()->addMinutes(5), function () use ($domain, $source) {
        return $domain->redirects()->source($source)->first();
    })) {

        //register hit
        $localRedirect->increment('hits');

        //send to target
        return redirect()->to($localRedirect->target, $localRedirect->status_code ?? 302);
    }
```

If a redirect exists, this works fine, it caches correctly. But for the majority of our users, there is no redirect, so `return $domain->redirects()->source($source)->first();` returns `null`, and the cache fails to register.
