### PR TITLE
[6.x] Add broken pipe exception as lost connection error

### DIFF
--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -50,6 +50,7 @@ trait DetectsLostConnections
             'SSL: Connection timed out',
             'SQLSTATE[HY000]: General error: 1105 The last transaction was aborted due to Seamless Scaling. Please retry.',
             'Temporary failure in name resolution',
+            'SSL: Broken pipe',
         ]);
     }
 }


### PR DESCRIPTION
On Google Cloud SQL instances it may happen that the connection to the DB is lost with horizon.

This occasionally happens when there are no jobs for a few hours but the connection is still alive.

<details><summary>Log</summary>
<p>

```
ErrorException: PDO::prepare(): SSL: Broken pipe
#40 /vendor/laravel/framework/src/Illuminate/Database/Connection.php(338): Illuminate\Foundation\Bootstrap\HandleExceptions::handleError
#39 [internal](0): PDO::prepare
#38 /vendor/laravel/framework/src/Illuminate/Database/Connection.php(338): Illuminate\Database\Connection::Illuminate\Database\{closure}
#37 /vendor/laravel/framework/src/Illuminate/Database/Connection.php(671): Illuminate\Database\Connection::runQueryCallback
#36 /vendor/laravel/framework/src/Illuminate/Database/Connection.php(638): Illuminate\Database\Connection::run
#35 /vendor/laravel/framework/src/Illuminate/Database/Connection.php(346): Illuminate\Database\Connection::select
#34 /vendor/laravel/framework/src/Illuminate/Database/Query/Builder.php(2313): Illuminate\Database\Query\Builder::runSelect
#33 /vendor/laravel/framework/src/Illuminate/Database/Query/Builder.php(2301): Illuminate\Database\Query\Builder::Illuminate\Database\Query\{closure}
#32 /vendor/laravel/framework/src/Illuminate/Database/Query/Builder.php(2796): Illuminate\Database\Query\Builder::onceWithColumns
#31 /vendor/laravel/framework/src/Illuminate/Database/Query/Builder.php(2302): Illuminate\Database\Query\Builder::get
#30 /vendor/laravel/framework/src/Illuminate/Database/Eloquent/Builder.php(588): Illuminate\Database\Eloquent\Builder::getModels
#29 /vendor/laravel/framework/src/Illuminate/Database/Eloquent/Builder.php(572): Illuminate\Database\Eloquent\Builder::get
#28 /vendor/laravel/framework/src/Illuminate/Database/Concerns/BuildsQueries.php(170): Illuminate\Database\Eloquent\Builder::first
#27 /vendor/laravel/framework/src/Illuminate/Database/Eloquent/Builder.php(499): Illuminate\Database\Eloquent\Builder::firstOrFail
#26 /vendor/laravel/framework/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php(102): App\Events\Updated::restoreModel
#25 /vendor/laravel/framework/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php(57): App\Events\Updated::getRestoredPropertyValue
#24 /vendor/laravel/framework/src/Illuminate/Queue/SerializesModels.php(122): App\Events\Updated::__unserialize
#23 [internal](0): unserialize
#22 /vendor/laravel/framework/src/Illuminate/Queue/CallQueuedHandler.php(95): Illuminate\Queue\CallQueuedHandler::getCommand
#21 /vendor/laravel/framework/src/Illuminate/Queue/CallQueuedHandler.php(60): Illuminate\Queue\CallQueuedHandler::call
#20 /vendor/laravel/framework/src/Illuminate/Queue/Jobs/Job.php(98): Illuminate\Queue\Jobs\Job::fire
#19 /vendor/laravel/framework/src/Illuminate/Queue/Worker.php(406): Illuminate\Queue\Worker::process
#18 /vendor/laravel/framework/src/Illuminate/Queue/Worker.php(356): Illuminate\Queue\Worker::runJob
#17 /vendor/laravel/framework/src/Illuminate/Queue/Worker.php(158): Illuminate\Queue\Worker::daemon
#16 /vendor/laravel/framework/src/Illuminate/Queue/Console/WorkCommand.php(116): Illuminate\Queue\Console\WorkCommand::runWorker
#15 /vendor/laravel/framework/src/Illuminate/Queue/Console/WorkCommand.php(100): Illuminate\Queue\Console\WorkCommand::handle
#14 /vendor/laravel/horizon/src/Console/WorkCommand.php(50): Laravel\Horizon\Console\WorkCommand::handle
#13 /vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(36): Illuminate\Container\BoundMethod::Illuminate\Container\{closure}
#12 /vendor/laravel/framework/src/Illuminate/Container/Util.php(40): Illuminate\Container\Util::unwrapIfClosure
#11 /vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(93): Illuminate\Container\BoundMethod::callBoundMethod
#10 /vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(37): Illuminate\Container\BoundMethod::call
#9 /vendor/laravel/framework/src/Illuminate/Container/Container.php(610): Illuminate\Container\Container::call
#8 /vendor/laravel/framework/src/Illuminate/Console/Command.php(136): Illuminate\Console\Command::execute
#7 /vendor/symfony/console/Command/Command.php(256): Symfony\Component\Console\Command\Command::run
#6 /vendor/laravel/framework/src/Illuminate/Console/Command.php(121): Illuminate\Console\Command::run
#5 /vendor/symfony/console/Application.php(971): Symfony\Component\Console\Application::doRunCommand
#4 /vendor/symfony/console/Application.php(290): Symfony\Component\Console\Application::doRun
#3 /vendor/symfony/console/Application.php(166): Symfony\Component\Console\Application::run
#2 /vendor/laravel/framework/src/Illuminate/Console/Application.php(92): Illuminate\Console\Application::run
#1 /vendor/laravel/framework/src/Illuminate/Foundation/Console/Kernel.php(129): Illuminate\Foundation\Console\Kernel::handle
#0 /artisan(37): null

Illuminate\Database\QueryException: PDO::prepare(): SSL: Broken pipe (SQL: select * from ?????????? limit 1)
#37 /vendor/laravel/framework/src/Illuminate/Database/Connection.php(678): Illuminate\Database\Connection::runQueryCallback
#36 /vendor/laravel/framework/src/Illuminate/Database/Connection.php(638): Illuminate\Database\Connection::run
#35 /vendor/laravel/framework/src/Illuminate/Database/Connection.php(346): Illuminate\Database\Connection::select
#34 /vendor/laravel/framework/src/Illuminate/Database/Query/Builder.php(2313): Illuminate\Database\Query\Builder::runSelect
#33 /vendor/laravel/framework/src/Illuminate/Database/Query/Builder.php(2301): Illuminate\Database\Query\Builder::Illuminate\Database\Query\{closure}
#32 /vendor/laravel/framework/src/Illuminate/Database/Query/Builder.php(2796): Illuminate\Database\Query\Builder::onceWithColumns
#31 /vendor/laravel/framework/src/Illuminate/Database/Query/Builder.php(2302): Illuminate\Database\Query\Builder::get
#30 /vendor/laravel/framework/src/Illuminate/Database/Eloquent/Builder.php(588): Illuminate\Database\Eloquent\Builder::getModels
#29 /vendor/laravel/framework/src/Illuminate/Database/Eloquent/Builder.php(572): Illuminate\Database\Eloquent\Builder::get
#28 /vendor/laravel/framework/src/Illuminate/Database/Concerns/BuildsQueries.php(170): Illuminate\Database\Eloquent\Builder::first
#27 /vendor/laravel/framework/src/Illuminate/Database/Eloquent/Builder.php(499): Illuminate\Database\Eloquent\Builder::firstOrFail
#26 /vendor/laravel/framework/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php(102): App\Events\Updated::restoreModel
#25 /vendor/laravel/framework/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php(57): App\Events\Updated::getRestoredPropertyValue
#24 /vendor/laravel/framework/src/Illuminate/Queue/SerializesModels.php(122): App\Events\Updated::__unserialize
#23 [internal](0): unserialize
#22 /vendor/laravel/framework/src/Illuminate/Queue/CallQueuedHandler.php(95): Illuminate\Queue\CallQueuedHandler::getCommand
#21 /vendor/laravel/framework/src/Illuminate/Queue/CallQueuedHandler.php(60): Illuminate\Queue\CallQueuedHandler::call
#20 /vendor/laravel/framework/src/Illuminate/Queue/Jobs/Job.php(98): Illuminate\Queue\Jobs\Job::fire
#19 /vendor/laravel/framework/src/Illuminate/Queue/Worker.php(406): Illuminate\Queue\Worker::process
#18 /vendor/laravel/framework/src/Illuminate/Queue/Worker.php(356): Illuminate\Queue\Worker::runJob
#17 /vendor/laravel/framework/src/Illuminate/Queue/Worker.php(158): Illuminate\Queue\Worker::daemon
#16 /vendor/laravel/framework/src/Illuminate/Queue/Console/WorkCommand.php(116): Illuminate\Queue\Console\WorkCommand::runWorker
#15 /vendor/laravel/framework/src/Illuminate/Queue/Console/WorkCommand.php(100): Illuminate\Queue\Console\WorkCommand::handle
#14 /vendor/laravel/horizon/src/Console/WorkCommand.php(50): Laravel\Horizon\Console\WorkCommand::handle
#13 /vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(36): Illuminate\Container\BoundMethod::Illuminate\Container\{closure}
#12 /vendor/laravel/framework/src/Illuminate/Container/Util.php(40): Illuminate\Container\Util::unwrapIfClosure
#11 /vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(93): Illuminate\Container\BoundMethod::callBoundMethod
#10 /vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(37): Illuminate\Container\BoundMethod::call
#9 /vendor/laravel/framework/src/Illuminate/Container/Container.php(610): Illuminate\Container\Container::call
#8 /vendor/laravel/framework/src/Illuminate/Console/Command.php(136): Illuminate\Console\Command::execute
#7 /vendor/symfony/console/Command/Command.php(256): Symfony\Component\Console\Command\Command::run
#6 /vendor/laravel/framework/src/Illuminate/Console/Command.php(121): Illuminate\Console\Command::run
#5 /vendor/symfony/console/Application.php(971): Symfony\Component\Console\Application::doRunCommand
#4 /vendor/symfony/console/Application.php(290): Symfony\Component\Console\Application::doRun
#3 /vendor/symfony/console/Application.php(166): Symfony\Component\Console\Application::run
#2 /vendor/laravel/framework/src/Illuminate/Console/Application.php(92): Illuminate\Console\Application::run
#1 /vendor/laravel/framework/src/Illuminate/Foundation/Console/Kernel.php(129): Illuminate\Foundation\Console\Kernel::handle
#0 /artisan(37): null
```

</p>
</details>