### PR TITLE
[8.x] Add assertDatabaseHasCount assertion

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Testing\Constraints\CountInDatabase;
+use Illuminate\Testing\Constraints\HasCountInDatabase;
 use Illuminate\Testing\Constraints\HasInDatabase;
 use Illuminate\Testing\Constraints\SoftDeletedInDatabase;
 use PHPUnit\Framework\Constraint\LogicalNot as ReverseConstraint;
@@ -26,6 +27,24 @@ trait InteractsWithDatabase
     {
         $this->assertThat(
             $table, new HasInDatabase($this->getConnection($connection), $data)
+        );
+
+        return $this;
+    }
+
+    /**
+     * Assert that a given where condition has the expected count.
+     *
+     * @param  string  $table
+     * @param  array  $data
+     * @param  int  $count
+     * @param  string|null  $connection
+     * @return $this
+     */
+    protected function assertDatabaseHasCount($table, array $data, int $count, $connection = null)
+    {
+        $this->assertThat(
+            $table, new HasCountInDatabase($this->getConnection($connection), $data, $count)
         );
 
         return $this;

--- a/src/Illuminate/Testing/Constraints/HasCountInDatabase.php
+++ b/src/Illuminate/Testing/Constraints/HasCountInDatabase.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Illuminate\Testing\Constraints;
+
+use Illuminate\Database\Connection;
+use Illuminate\Database\Query\Expression;
+use PHPUnit\Framework\Constraint\Constraint;
+
+class HasCountInDatabase extends Constraint
+{
+    /**
+     * Number of records that will be shown in the console in case of failure.
+     *
+     * @var int
+     */
+    protected $show = 3;
+
+    /**
+     * The database connection.
+     *
+     * @var \Illuminate\Database\Connection
+     */
+    protected $database;
+
+    /**
+     * The data that will be used to narrow the search in the database table.
+     *
+     * @var array
+     */
+    protected $data;
+
+    /**
+     * The expected table entries count that will be checked against the actual count.
+     *
+     * @var int
+     */
+    protected $expectedCount;
+
+    /**
+     * The actual table entries count that will be checked against the expected count.
+     *
+     * @var int
+     */
+    protected $actualCount;
+
+    /**
+     * Create a new constraint instance.
+     *
+     * @param  \Illuminate\Database\Connection  $database
+     * @param  array  $data
+     * @param  int  $expectedCount
+     * @return void
+     */
+    public function __construct(Connection $database, array $data, int $expectedCount)
+    {
+        $this->data = $data;
+
+        $this->expectedCount = $expectedCount;
+
+        $this->database = $database;
+    }
+
+    /**
+     * Check if the expected and actual count are equal.
+     *
+     * @param  string  $table
+     * @return bool
+     */
+    public function matches($table): bool
+    {
+        $this->actualCount = $this->database->table($table)->where($this->data)->count();
+
+        return $this->actualCount === $this->expectedCount;
+    }
+
+    /**
+     * Get the description of the failure.
+     *
+     * @param  string  $table
+     * @return string
+     */
+    public function failureDescription($table): string
+    {
+        return sprintf(
+            "table [%s] with attributes\n%s\nmatches expected entries count of %s. Matching entries found: %s.\n",
+            $table, $this->toString(JSON_PRETTY_PRINT), $this->expectedCount, $this->actualCount
+        );
+    }
+
+    /**
+     * Get a string representation of the object.
+     *
+     * @param  int  $options
+     * @return string
+     */
+    public function toString($options = 0): string
+    {
+        foreach ($this->data as $key => $data) {
+            $output[$key] = $data instanceof Expression ? (string) $data : $data;
+        }
+
+        return json_encode($output ?? [], $options);
+    }
+}

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -119,6 +119,35 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertDatabaseCount($this->table, 3);
     }
 
+    public function testSeeInDatabaseAndAssertTableEntriesCountFindsResults()
+    {
+        $this->mockCountBuilder(1);
+
+        $this->assertDatabaseHasCount($this->table, $this->data, 1);
+    }
+
+    public function testSeeInDatabaseAndAssertTableEntriesCountDoesNotFindResults()
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage("Failed asserting that table [products] with attributes\n".json_encode($this->data, JSON_PRETTY_PRINT)."\nmatches expected entries count of 1. Matching entries found: 0.");
+
+        $builder = $this->mockCountBuilder(0);
+
+        $builder->shouldReceive('get')->andReturn(collect());
+
+        $this->assertDatabaseHasCount($this->table, $this->data, 1);
+    }
+
+    public function testSeeInDatabaseAndAssertTableEntriesCountWrong()
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage("Failed asserting that table [products] with attributes\n".json_encode($this->data, JSON_PRETTY_PRINT)."\nmatches expected entries count of 3. Matching entries found: 1.");
+
+        $this->mockCountBuilder(1);
+
+        $this->assertDatabaseHasCount($this->table, $this->data, 3);
+    }
+
     public function testAssertDeletedPassesWhenDoesNotFindResults()
     {
         $this->mockCountBuilder(0);


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
PR for laravel/ideas#2538.

Adds a new database assertion `assertDatabaseHasCount` for counting database records that match given criteria.

The current assertions only allow for asserting the existence of a database match, or for counting total records on a given table.  

This PR combines the functionality of both assertions into a single call.  This is especially helpful if the test database comes pre-seeded and `RefreshDatabase` is not able to be used.

```php
$data = ['name' => 'Taylor'];

$result = User::where($data)->get();

$this->assertCount(1, $result);
```
becomes
```php
$this->assertDatabaseHasCount('users', $data, 1);
```