### PR TITLE
[8.x] Require the correct password to rehash it when logging out other devices

### DIFF
--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -574,7 +574,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     }
 
     /**
-     * Rehash the user's password.
+     * Rehash the current user's password.
      *
      * @param  string  $password
      * @param  string  $attribute

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -580,7 +580,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      * @param  string  $attribute
      * @return bool|null
      *
-     * @throws AuthenticationException If the password is invalid.
+     * @throws \Illuminate\Auth\AuthenticationException
      */
     protected function rehashUserPassword($password, $attribute)
     {
@@ -602,7 +602,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      * @param  string  $attribute
      * @return bool|null
      *
-     * @throws AuthenticationException If the password is invalid.
+     * @throws \Illuminate\Auth\AuthenticationException
      */
     public function logoutOtherDevices($password, $attribute = 'password')
     {

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -601,6 +601,8 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      * @param  string  $password
      * @param  string  $attribute
      * @return bool|null
+     *
+     * @throws AuthenticationException If the password is invalid.
      */
     public function logoutOtherDevices($password, $attribute = 'password')
     {

--- a/tests/Integration/Auth/AuthenticationTest.php
+++ b/tests/Integration/Auth/AuthenticationTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Auth;
 
+use Illuminate\Auth\AuthenticationException;
 use Illuminate\Auth\EloquentUserProvider;
 use Illuminate\Auth\Events\Attempting;
 use Illuminate\Auth\Events\Authenticated;
@@ -211,7 +212,7 @@ class AuthenticationTest extends TestCase
 
         $this->assertEquals(1, $user->id);
 
-        $this->app['auth']->logoutOtherDevices('adifferentpassword');
+        $this->app['auth']->logoutOtherDevices('password');
         $this->assertEquals(1, $user->id);
 
         Event::assertDispatched(OtherDeviceLogout::class, function ($event) {
@@ -220,6 +221,20 @@ class AuthenticationTest extends TestCase
 
             return true;
         });
+    }
+
+    public function testPasswordMustBeValidToLogOutOtherDevices()
+    {
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Password mismatch.');
+
+        $this->app['auth']->loginUsingId(1);
+
+        $user = $this->app['auth']->user();
+
+        $this->assertEquals(1, $user->id);
+
+        $this->app['auth']->logoutOtherDevices('adifferentpassword');
     }
 
     public function testLoggingInOutViaAttemptRemembering()


### PR DESCRIPTION
`SessionGuard::logoutOtherDevices()` doesn't presently check the password it rehashes, and could therefore inadvertently change the user's password. In fact, the existing unit test demonstrates this possibility. This updates `SessionGuard` to check the password prior to rehashing it to ensure that would never happen.

---

Editor's note: I wasn't certain of which `Exception` to throw and opted for `AuthenticationException`, but I would appreciate a second opinion on that choice. I also considered `ValidationException`, `RuntimeException`, `AuthorizationException`... all apply in their own way, none seem the obvious choice to me.
