### PR TITLE
[9.x] Was recently updated and was recently deleted

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -103,6 +103,13 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     public $wasRecentlyCreated = false;
 
     /**
+     * Indicates if the model was updated during the current request lifecycle.
+     *
+     * @var bool
+     */
+    public $wasRecentlyUpdated = false;
+
+    /**
      * The connection resolver instance.
      *
      * @var \Illuminate\Database\ConnectionResolverInterface
@@ -936,6 +943,8 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
             $this->setKeysForSaveQuery($query)->update($dirty);
 
             $this->syncChanges();
+
+            $this->wasRecentlyUpdated = true;
 
             $this->fireModelEvent('updated', false);
         }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -110,6 +110,13 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     public $wasRecentlyUpdated = false;
 
     /**
+     * Indicates if the model was deleted during the current request lifecycle.
+     *
+     * @var bool
+     */
+    public $wasRecentlyDeleted = false;
+
+    /**
      * The connection resolver instance.
      *
      * @var \Illuminate\Database\ConnectionResolverInterface
@@ -1133,6 +1140,8 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
         $this->touchOwners();
 
         $this->performDeleteOnModel();
+
+        $this->wasRecentlyDeleted = true;
 
         // Once the model has been deleted, we will fire off the deleted event so that
         // the developers may hook into post-delete operations. We will then return

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -449,6 +449,18 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertFalse($fresh->wasRecentlyUpdated);
     }
 
+    public function testWasRecentlyDeleted()
+    {
+        $user = EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
+
+        $this->assertTrue($user->wasRecentlyCreated);
+        $this->assertFalse($user->wasRecentlyDeleted);
+
+        $user->delete();
+
+        $this->assertTrue($user->wasRecentlyDeleted);
+    }
+
     public function testChunkByIdWithNonIncrementingKey()
     {
         EloquentTestNonIncrementingSecond::create(['name' => ' First']);

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -431,6 +431,24 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertFalse($user->fresh()->wasRecentlyCreated);
     }
 
+    public function testWasRecentlyUpdated()
+    {
+        $user = EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
+
+        $this->assertTrue($user->wasRecentlyCreated);
+        $this->assertFalse($user->wasRecentlyUpdated);
+
+        $user->update(['email' => 'taylor@laravel.com']);
+
+        $this->assertTrue($user->wasRecentlyUpdated);
+
+        $fresh = $user->fresh();
+
+        // Note: new instances fetched from the database will not be marked.
+        $this->assertFalse($fresh->wasRecentlyCreated);
+        $this->assertFalse($fresh->wasRecentlyUpdated);
+    }
+
     public function testChunkByIdWithNonIncrementingKey()
     {
         EloquentTestNonIncrementingSecond::create(['name' => ' First']);

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -422,6 +422,15 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertFalse($model->wasRecentlyCreated);
     }
 
+    public function testWasRecentlyCreated()
+    {
+        $user = EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
+
+        $this->assertTrue($user->wasRecentlyCreated);
+        // Note: new instances fetched from the database will not be marked.
+        $this->assertFalse($user->fresh()->wasRecentlyCreated);
+    }
+
     public function testChunkByIdWithNonIncrementingKey()
     {
         EloquentTestNonIncrementingSecond::create(['name' => ' First']);

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -269,8 +269,14 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         /** @var \Illuminate\Tests\Database\SoftDeletesTestUser $userModel */
         $userModel = SoftDeletesTestUser::find(2);
         $userModel->delete();
+
         $this->assertEquals($now->toDateTimeString(), $userModel->getOriginal('deleted_at'));
         $this->assertNull(SoftDeletesTestUser::find(2));
+
+        // Comparing a model that was recently deleted with a fresh instance of itself,
+        // even though it's a trashed instance, would not work due to the different
+        // values for the $wasRecentlyDeleted property on these model instances.
+        $userModel->wasRecentlyDeleted = false;
         $this->assertEquals($userModel, SoftDeletesTestUser::withTrashed()->find(2));
     }
 

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -273,6 +273,8 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $this->assertEquals($now->toDateTimeString(), $userModel->getOriginal('deleted_at'));
         $this->assertNull(SoftDeletesTestUser::find(2));
 
+        $this->assertTrue($userModel->is(SoftDeletesTestUser::withTrashed()->find(2)));
+
         // Comparing a model that was recently deleted with a fresh instance of itself,
         // even though it's a trashed instance, would not work due to the different
         // values for the $wasRecentlyDeleted property on these model instances.


### PR DESCRIPTION
Hey, folks

For the [Turbo Laravel](https://github.com/tonysm/turbo-laravel) package, there is a convention in place that can use the same Turbo Stream view to send Turbo Streams responses to the user making the form submission and later broadcast it to all other users. So the partial needs to "know" when the model was recently created, recently updated or recently deleted.

Here's an example of a Turbo Stream view that is used to generate HTTP responses and broadcasting to all users:

**Before:**

```blade
<turbo-stream target="@domid($message)" action="replace">
    <template>
        @include ('messages._message', ['message' => $message])
    </template>
</turbo-stream>

@unless (app()->runningInConsole())
    <turbo-stream target="notices" action="append">
        <template>
            @include ('flash.message', ['message' => __('Message was suggessfully updated!')])
        </template>
    </turbo-stream>
@endunless
```

**After:**

```blade
<turbo-stream target="@domid($message)" action="replace">
    <template>
        @include ('messages._message', ['message' => $message])
    </template>
</turbo-stream>

@if ($message->wasRecentlyUpdated)
    <turbo-stream target="notices" action="append">
        <template>
            @include ('flash.message', ['message' => __('Message was suggessfully updated!')])
        </template>
    </turbo-stream>
@endif
```

---

I *think* there are two breaking changes here (although I would say low impact, but you folks would know more about this):

- Adding new properties to the base model would, in itself, a breaking change
- The loose comparison of the recently deleted model against a fresh, trashed instance of the model would not be possible because the `$wasRecentlyDeleted` property is only set to true for the recently deleted instance, making the loose comparison fail. Should work when comparing them like `$recentlyDeleted->is($fresh)`

That's why the PR aims to `master`.