### PR TITLE
[8.x] Use different config key for overriding temporary url host in AwsTemporaryUrl method

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -601,7 +601,7 @@ class FilesystemAdapter implements CloudFilesystemContract
         // If an explicit base URL has been set on the disk configuration then we will use
         // it as the base URL instead of the default path. This allows the developer to
         // have full control over the base path for this filesystem's generated URLs.
-        if (! is_null($url = $this->driver->getConfig()->get('url_temporary'))) {
+        if (! is_null($url = $this->driver->getConfig()->get('temporary_url'))) {
             $uri = $this->replaceBaseUrl($uri, $url);
         }
 

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -601,7 +601,7 @@ class FilesystemAdapter implements CloudFilesystemContract
         // If an explicit base URL has been set on the disk configuration then we will use
         // it as the base URL instead of the default path. This allows the developer to
         // have full control over the base path for this filesystem's generated URLs.
-        if (! is_null($url = $this->driver->getConfig()->get('url'))) {
+        if (! is_null($url = $this->driver->getConfig()->get('url_temporary'))) {
             $uri = $this->replaceBaseUrl($uri, $url);
         }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

In https://github.com/laravel/framework/pull/36480 an option was introduced to override the host for AWS temporary URLs. This works with DO Spaces (as suggested in their documentation, see [their docs](https://www.digitalocean.com/docs/spaces/resources/s3-sdk-examples/#generate-a-pre-signed-url-to-download-a-private-file)).

However this breaks things on default AWS S3 implementations with custom subdomains, therefore I suggest to use a different config key here so existing setups are no longer affected.