### PR TITLE
[8.x] Add DB::resetRecordsModifications

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -868,6 +868,16 @@ class Connection implements ConnectionInterface
     }
 
     /**
+     * Resets the records modifications property.
+     *
+     * @return void
+     */
+    public function resetRecordsModifications()
+    {
+        $this->recordsModified = false;
+    }
+
+    /**
      * Is Doctrine available?
      *
      * @return bool

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -868,11 +868,11 @@ class Connection implements ConnectionInterface
     }
 
     /**
-     * Resets the records modifications property.
+     * Reset the record modification state.
      *
      * @return void
      */
-    public function resetRecordsModifications()
+    public function forgetRecordModificationState()
     {
         $this->recordsModified = false;
     }


### PR DESCRIPTION
This method can be used to reset the modifications state before running queued jobs. This way if the app uses [the sticky](https://laravel.com/docs/8.x/database#the-sticky-option) option, the read connection can be used for read queries if there are no recent writes on the job level.