### PR TITLE
[8.x] Added "exclude-path" option

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -187,6 +187,7 @@ class RouteListCommand extends Command
     {
         if (($this->option('name') && ! Str::contains($route['name'], $this->option('name'))) ||
              $this->option('path') && ! Str::contains($route['uri'], $this->option('path')) ||
+             $this->option('exclude-path') && Str::contains($route['uri'], $this->option('exclude-path')) ||
              $this->option('method') && ! Str::contains($route['method'], strtoupper($this->option('method')))) {
             return;
         }
@@ -259,6 +260,7 @@ class RouteListCommand extends Command
             ['method', null, InputOption::VALUE_OPTIONAL, 'Filter the routes by method'],
             ['name', null, InputOption::VALUE_OPTIONAL, 'Filter the routes by name'],
             ['path', null, InputOption::VALUE_OPTIONAL, 'Filter the routes by path'],
+            ['exclude-path', null, InputOption::VALUE_OPTIONAL, 'Filter the routes by exclude path'],
             ['reverse', 'r', InputOption::VALUE_NONE, 'Reverse the ordering of the routes'],
             ['sort', null, InputOption::VALUE_OPTIONAL, 'The column (domain, method, uri, name, action, middleware) to sort by', 'uri'],
         ];


### PR DESCRIPTION
The development team at my company has just installed Telescope and found that the route:list command now will show all Telescope's routes. This is a little annoying.

After searching on Google, I found this issue was [mentioned](https://github.com/laravel/ideas/issues/1982) by @shahvirag. Screenshot:

### Before laravel/telescope installed.
![image](https://user-images.githubusercontent.com/5250117/111362306-3327f980-86c1-11eb-8258-24a331149cf0.png)

### After laravel/telescope installed.
![image](https://user-images.githubusercontent.com/5250117/111362342-3e7b2500-86c1-11eb-8288-40baa78e4fac.png)

So in this PR, I added an option to be able to remove unwanted routes from the list.

### Usage
```
php artisan route:list --exclude-path=<path>
```

For example, in our case, we would run this command to remove all Telescope's routes from the list:

```
php artisan route:list --exclude-path=telescope
```

You can use a different value for other cases.