### PR TITLE
[8.x] Adjust Fluent Assertions

### DIFF
--- a/src/Illuminate/Testing/Fluent/AssertableJson.php
+++ b/src/Illuminate/Testing/Fluent/AssertableJson.php
@@ -52,13 +52,13 @@ class AssertableJson implements Arrayable
      * @param  string  $key
      * @return string
      */
-    protected function dotPath(string $key): string
+    protected function dotPath(string $key = ''): string
     {
         if (is_null($this->path)) {
             return $key;
         }
 
-        return implode('.', [$this->path, $key]);
+        return rtrim(implode('.', [$this->path, $key]), '.');
     }
 
     /**
@@ -91,6 +91,30 @@ class AssertableJson implements Arrayable
         $scope->interacted();
 
         return $this;
+    }
+
+    /**
+     * Instantiate a new "scope" on the first child element.
+     *
+     * @param  \Closure  $callback
+     * @return $this
+     */
+    public function first(Closure $callback): self
+    {
+        $props = $this->prop();
+
+        $path = $this->dotPath();
+
+        PHPUnit::assertNotEmpty($props, $path === ''
+            ? 'Cannot scope directly onto the first element of the root level because it is empty.'
+            : sprintf('Cannot scope directly onto the first element of property [%s] because it is empty.', $path)
+        );
+
+        $key = array_keys($props)[0];
+
+        $this->interactsWith($key);
+
+        return $this->scope($key, $callback);
     }
 
     /**

--- a/src/Illuminate/Testing/Fluent/Concerns/Has.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Has.php
@@ -24,7 +24,7 @@ trait Has
                 $key,
                 $this->prop(),
                 $path
-                    ? sprintf('Scope [%s] does not have the expected size.', $path)
+                    ? sprintf('Property [%s] does not have the expected size.', $path)
                     : sprintf('Root level does not have the expected size.')
             );
 

--- a/src/Illuminate/Testing/Fluent/Concerns/Has.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Has.php
@@ -11,12 +11,26 @@ trait Has
     /**
      * Assert that the prop is of the expected size.
      *
-     * @param  string  $key
-     * @param  int  $length
+     * @param  string|int  $key
+     * @param  int|null  $length
      * @return $this
      */
-    protected function count(string $key, int $length): self
+    public function count($key, int $length = null): self
     {
+        if (is_null($length)) {
+            $path = $this->dotPath();
+
+            PHPUnit::assertCount(
+                $key,
+                $this->prop(),
+                $path
+                    ? sprintf('Scope [%s] does not have the expected size.', $path)
+                    : sprintf('Root level does not have the expected size.')
+            );
+
+            return $this;
+        }
+
         PHPUnit::assertCount(
             $length,
             $this->prop($key),
@@ -29,14 +43,18 @@ trait Has
     /**
      * Ensure that the given prop exists.
      *
-     * @param  string  $key
-     * @param  null  $value
-     * @param  \Closure|null  $scope
+     * @param  string|int  $key
+     * @param  int|\Closure|null  $length
+     * @param  \Closure|null  $callback
      * @return $this
      */
-    public function has(string $key, $value = null, Closure $scope = null): self
+    public function has($key, $length = null, Closure $callback = null): self
     {
         $prop = $this->prop();
+
+        if (is_int($key) && is_null($length)) {
+            return $this->count($key);
+        }
 
         PHPUnit::assertTrue(
             Arr::has($prop, $key),
@@ -45,25 +63,20 @@ trait Has
 
         $this->interactsWith($key);
 
-        // When all three arguments are provided this indicates a short-hand expression
-        // that combines both a `count`-assertion, followed by directly creating the
-        // `scope` on the first element. We can simply handle this correctly here.
-        if (is_int($value) && ! is_null($scope)) {
-            $prop = $this->prop($key);
-            $path = $this->dotPath($key);
-
-            PHPUnit::assertTrue($value > 0, sprintf('Cannot scope directly onto the first entry of property [%s] when asserting that it has a size of 0.', $path));
-            PHPUnit::assertIsArray($prop, sprintf('Direct scoping is unsupported for non-array like properties such as [%s].', $path));
-
-            $this->count($key, $value);
-
-            return $this->scope($key.'.'.array_keys($prop)[0], $scope);
+        if (is_int($length) && ! is_null($callback)) {
+            return $this->has($key, function (self $scope) use ($length, $callback) {
+                return $scope->count($length)
+                    ->first($callback)
+                    ->etc();
+            });
         }
 
-        if (is_callable($value)) {
-            $this->scope($key, $value);
-        } elseif (! is_null($value)) {
-            $this->count($key, $value);
+        if (is_callable($length)) {
+            return $this->scope($key, $length);
+        }
+
+        if (! is_null($length)) {
+            return $this->count($key, $length);
         }
 
         return $this;
@@ -129,7 +142,7 @@ trait Has
      * @param  string  $key
      * @return string
      */
-    abstract protected function dotPath(string $key): string;
+    abstract protected function dotPath(string $key = ''): string;
 
     /**
      * Marks the property as interacted.
@@ -155,4 +168,19 @@ trait Has
      * @return $this
      */
     abstract protected function scope(string $key, Closure $callback);
+
+    /**
+     * Disables the interaction check.
+     *
+     * @return $this
+     */
+    abstract public function etc();
+
+    /**
+     * Instantiate a new "scope" on the first element.
+     *
+     * @param  \Closure  $callback
+     * @return $this
+     */
+    abstract public function first(Closure $callback);
 }

--- a/src/Illuminate/Testing/Fluent/Concerns/Matching.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Matching.php
@@ -87,7 +87,7 @@ trait Matching
      * @param  string  $key
      * @return string
      */
-    abstract protected function dotPath(string $key): string;
+    abstract protected function dotPath(string $key = ''): string;
 
     /**
      * Ensure that the given prop exists.

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -523,7 +523,9 @@ class TestResponse implements ArrayAccess
 
             $value($assert);
 
-            $assert->interacted();
+            if (Arr::isAssoc($assert->toArray())) {
+                $assert->interacted();
+            }
         }
 
         return $this;

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -523,9 +523,7 @@ class TestResponse implements ArrayAccess
 
             $value($assert);
 
-            if ($strict) {
-                $assert->interacted();
-            }
+            $assert->interacted();
         }
 
         return $this;

--- a/tests/Testing/Fluent/AssertTest.php
+++ b/tests/Testing/Fluent/AssertTest.php
@@ -146,7 +146,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Scope [bar] does not have the expected size.');
+        $this->expectExceptionMessage('Property [bar] does not have the expected size.');
 
         $assert->has('bar', function ($bar) {
             $bar->has(3);
@@ -188,7 +188,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Scope [bar] does not have the expected size.');
+        $this->expectExceptionMessage('Property [bar] does not have the expected size.');
 
         $assert->has('bar', function ($bar) {
             $bar->count(3);
@@ -505,7 +505,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Scope [bar] does not have the expected size.');
+        $this->expectExceptionMessage('Property [bar] does not have the expected size.');
 
         $assert->has('bar', 0, function (AssertableJson $item) {
             $item->where('key', 'first');
@@ -522,7 +522,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Scope [bar] does not have the expected size.');
+        $this->expectExceptionMessage('Property [bar] does not have the expected size.');
 
         $assert->has('bar', 1, function (AssertableJson $item) {
             $item->where('key', 'first');

--- a/tests/Testing/Fluent/AssertTest.php
+++ b/tests/Testing/Fluent/AssertTest.php
@@ -58,7 +58,7 @@ class AssertTest extends TestCase
         $assert->has('example.another');
     }
 
-    public function testAssertCountItemsInProp()
+    public function testAssertHasCountItemsInProp()
     {
         $assert = AssertableJson::fromArray([
             'bar' => [
@@ -70,7 +70,7 @@ class AssertTest extends TestCase
         $assert->has('bar', 2);
     }
 
-    public function testAssertCountFailsWhenAmountOfItemsDoesNotMatch()
+    public function testAssertHasCountFailsWhenAmountOfItemsDoesNotMatch()
     {
         $assert = AssertableJson::fromArray([
             'bar' => [
@@ -85,7 +85,7 @@ class AssertTest extends TestCase
         $assert->has('bar', 1);
     }
 
-    public function testAssertCountFailsWhenPropMissing()
+    public function testAssertHasCountFailsWhenPropMissing()
     {
         $assert = AssertableJson::fromArray([
             'bar' => [
@@ -109,6 +109,90 @@ class AssertTest extends TestCase
         $this->expectException(TypeError::class);
 
         $assert->has('bar', 'invalid');
+    }
+
+    public function testAssertHasOnlyCounts()
+    {
+        $assert = AssertableJson::fromArray([
+            'foo',
+            'bar',
+            'baz',
+        ]);
+
+        $assert->has(3);
+    }
+
+    public function testAssertHasOnlyCountFails()
+    {
+        $assert = AssertableJson::fromArray([
+            'foo',
+            'bar',
+            'baz',
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Root level does not have the expected size.');
+
+        $assert->has(2);
+    }
+
+    public function testAssertHasOnlyCountFailsScoped()
+    {
+        $assert = AssertableJson::fromArray([
+            'bar' => [
+                'baz' => 'example',
+                'prop' => 'value',
+            ],
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Scope [bar] does not have the expected size.');
+
+        $assert->has('bar', function ($bar) {
+            $bar->has(3);
+        });
+    }
+
+    public function testAssertCount()
+    {
+        $assert = AssertableJson::fromArray([
+            'foo',
+            'bar',
+            'baz',
+        ]);
+
+        $assert->count(3);
+    }
+
+    public function testAssertCountFails()
+    {
+        $assert = AssertableJson::fromArray([
+            'foo',
+            'bar',
+            'baz',
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Root level does not have the expected size.');
+
+        $assert->count(2);
+    }
+
+    public function testAssertCountFailsScoped()
+    {
+        $assert = AssertableJson::fromArray([
+            'bar' => [
+                'baz' => 'example',
+                'prop' => 'value',
+            ],
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Scope [bar] does not have the expected size.');
+
+        $assert->has('bar', function ($bar) {
+            $bar->count(3);
+        });
     }
 
     public function testAssertMissing()
@@ -421,7 +505,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Cannot scope directly onto the first entry of property [bar] when asserting that it has a size of 0.');
+        $this->expectExceptionMessage('Scope [bar] does not have the expected size.');
 
         $assert->has('bar', 0, function (AssertableJson $item) {
             $item->where('key', 'first');
@@ -438,10 +522,68 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [bar] does not have the expected size.');
+        $this->expectExceptionMessage('Scope [bar] does not have the expected size.');
 
         $assert->has('bar', 1, function (AssertableJson $item) {
             $item->where('key', 'first');
+        });
+    }
+
+    public function testFirstScope()
+    {
+        $assert = AssertableJson::fromArray([
+            'foo' => [
+                'key' => 'first',
+            ],
+            'bar' => [
+                'key' => 'second',
+            ],
+        ]);
+
+        $assert->first(function (AssertableJson $item) {
+            $item->where('key', 'first');
+        });
+    }
+
+    public function testFirstScopeFailsWhenNoProps()
+    {
+        $assert = AssertableJson::fromArray([]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Cannot scope directly onto the first element of the root level because it is empty.');
+
+        $assert->first(function (AssertableJson $item) {
+            //
+        });
+    }
+
+    public function testFirstNestedScopeFailsWhenNoProps()
+    {
+        $assert = AssertableJson::fromArray([
+            'foo' => [],
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Cannot scope directly onto the first element of property [foo] because it is empty.');
+
+        $assert->has('foo', function (AssertableJson $assert) {
+            $assert->first(function (AssertableJson $item) {
+                //
+            });
+        });
+    }
+
+    public function testFirstScopeFailsWhenPropSingleValue()
+    {
+        $assert = AssertableJson::fromArray([
+            'foo' => 'bar',
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Property [foo] is not scopeable.');
+
+        $assert->first(function (AssertableJson $item) {
+            //
         });
     }
 

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -583,11 +583,11 @@ class TestResponseTest extends TestCase
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceStub));
 
         $response->assertJson(function (AssertableJson $json) {
-            $json->where('0.foo', 'foo 0');
+            $json->where('0.foo', 'foo 0')->etc();
         });
     }
 
-    public function testAssertJsonWithFluentStrict()
+    public function testAssertJsonWithFluentFailsWhenNotInteractingWithAllProps()
     {
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceStub));
 
@@ -596,7 +596,7 @@ class TestResponseTest extends TestCase
 
         $response->assertJson(function (AssertableJson $json) {
             $json->where('0.foo', 'foo 0');
-        }, true);
+        });
     }
 
     public function testAssertSimilarJsonWithMixed()

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -583,7 +583,7 @@ class TestResponseTest extends TestCase
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceStub));
 
         $response->assertJson(function (AssertableJson $json) {
-            $json->where('0.foo', 'foo 0')->etc();
+            $json->where('0.foo', 'foo 0');
         });
     }
 

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -589,13 +589,13 @@ class TestResponseTest extends TestCase
 
     public function testAssertJsonWithFluentFailsWhenNotInteractingWithAllProps()
     {
-        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceStub));
+        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));
 
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Unexpected properties were found on the root level.');
 
         $response->assertJson(function (AssertableJson $json) {
-            $json->where('0.foo', 'foo 0');
+            $json->where('foo', 'bar');
         });
     }
 

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -599,6 +599,18 @@ class TestResponseTest extends TestCase
         });
     }
 
+    public function testAssertJsonWithFluentSkipsInteractionWhenTopLevelKeysNonAssociative()
+    {
+        $response = TestResponse::fromBaseResponse(new Response([
+            ['foo' => 'bar'],
+            ['foo' => 'baz'],
+        ]));
+
+        $response->assertJson(function (AssertableJson $json) {
+            //
+        });
+    }
+
     public function testAssertSimilarJsonWithMixed()
     {
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));


### PR DESCRIPTION
This PR expands upon #36454 

- Add `first` scoping method
- Allow `has(3)` to count the current scope
- Expose `count` method publicly