### PR TITLE
[8.x] Added timestamp reference to schedule:work artisan command output

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
@@ -51,7 +51,7 @@ class ScheduleWorkCommand extends Command
 
                 if (! empty($output)) {
                     if ($key !== $keyOfLastExecutionWithOutput) {
-                        $this->info(PHP_EOL.'Execution #'.($key + 1).' output:');
+                        $this->info(PHP_EOL.'['.date('c').'] Execution #'.($key + 1).' output:');
 
                         $keyOfLastExecutionWithOutput = $key;
                     }


### PR DESCRIPTION
This is a very small update on schedule:work artisan command to print timestamp reference on every execution.