### PR TITLE
Add missing flushFinderCache method to ViewFactory contract

### DIFF
--- a/src/Illuminate/Contracts/View/Factory.php
+++ b/src/Illuminate/Contracts/View/Factory.php
@@ -76,4 +76,11 @@ interface Factory
      * @return $this
      */
     public function replaceNamespace($namespace, $hints);
+    
+     /**
+     * Flush the cache of views located by the finder.
+     *
+     * @return void
+     */
+    public function flushFinderCache();
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Add missing `flushFinderCache()` method to `Illuminate\Contracts\View\Factory` interface causing red squiggle as shown in screenshot below in `Markdown.php`.
<img width="595" alt="image" src="https://user-images.githubusercontent.com/29105478/111468095-028aa300-8747-11eb-936f-6613dd7b7b32.png">
 