### PR TITLE
[8.x] Add assertion to verify type of key in JSON

### DIFF
--- a/src/Illuminate/Testing/Fluent/Concerns/Matching.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Matching.php
@@ -4,7 +4,6 @@ namespace Illuminate\Testing\Fluent\Concerns;
 
 use Closure;
 use Illuminate\Contracts\Support\Arrayable;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use PHPUnit\Framework\Assert as PHPUnit;
 

--- a/src/Illuminate/Testing/Fluent/Concerns/Matching.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Matching.php
@@ -65,7 +65,7 @@ trait Matching
     /**
      * Asserts that the property is of the expected type.
      *
-     * @param  string       $key
+     * @param  string  $key
      * @param  string|array $expected
      * @return $this
      */

--- a/src/Illuminate/Testing/Fluent/Concerns/Matching.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Matching.php
@@ -63,6 +63,43 @@ trait Matching
     }
 
     /**
+     * Asserts that the property is of the expected type.
+     *
+     * @param  string $key
+     * @param  string $expected
+     * @return $this
+     */
+    public function whereType(string $key, string $expected): self
+    {
+        $this->has($key);
+
+        $actual = $this->prop($key);
+
+        PHPUnit::assertSame(
+            $expected,
+            strtolower(gettype($actual)),
+            sprintf('Property [%s] is not of expected type [%s].', $this->dotPath($key), $expected)
+        );
+
+        return $this;
+    }
+
+    /**
+     * Asserts that all properties are of their expected types.
+     *
+     * @param  array  $bindings
+     * @return $this
+     */
+    public function whereAllType(array $bindings): self
+    {
+        foreach ($bindings as $key => $value) {
+            $this->whereType($key, $value);
+        }
+
+        return $this;
+    }
+
+    /**
      * Ensures that all properties are sorted the same way, recursively.
      *
      * @param  mixed  $value

--- a/src/Illuminate/Testing/Fluent/Concerns/Matching.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Matching.php
@@ -4,6 +4,7 @@ namespace Illuminate\Testing\Fluent\Concerns;
 
 use Closure;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use PHPUnit\Framework\Assert as PHPUnit;
 
@@ -65,20 +66,24 @@ trait Matching
     /**
      * Asserts that the property is of the expected type.
      *
-     * @param  string $key
-     * @param  string $expected
+     * @param  string       $key
+     * @param  string|array $expected
      * @return $this
      */
-    public function whereType(string $key, string $expected): self
+    public function whereType(string $key, $expected): self
     {
         $this->has($key);
 
         $actual = $this->prop($key);
 
-        PHPUnit::assertSame(
-            $expected,
+        if (! is_array($expected)) {
+            $expected = explode('|', $expected);
+        }
+
+        PHPUnit::assertContains(
             strtolower(gettype($actual)),
-            sprintf('Property [%s] is not of expected type [%s].', $this->dotPath($key), $expected)
+            $expected,
+            sprintf('Property [%s] is not of expected type [%s].', $this->dotPath($key), implode('|', $expected))
         );
 
         return $this;

--- a/tests/Testing/Fluent/AssertTest.php
+++ b/tests/Testing/Fluent/AssertTest.php
@@ -783,6 +783,65 @@ class AssertTest extends TestCase
         ]);
     }
 
+    public function testAssertWhereTypeWhenWrongTypeIsGiven()
+    {
+        $assert = AssertableJson::fromArray([
+            'foo' => 'bar',
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Property [foo] is not of expected type [integer].');
+
+        $assert->whereType('foo', 'integer');
+    }
+
+    public function testAssertWhereTypeWithUnionTypes()
+    {
+        $firstAssert = AssertableJson::fromArray([
+            'foo' => 'bar',
+        ]);
+
+        $secondAssert = AssertableJson::fromArray([
+            'foo' => null,
+        ]);
+
+        $firstAssert->whereType('foo', ['string', 'null']);
+        $secondAssert->whereType('foo', ['string', 'null']);
+    }
+
+    public function testAssertWhereTypeWhenWrongUnionTypeIsGiven()
+    {
+        $assert = AssertableJson::fromArray([
+            'foo' => 123,
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Property [foo] is not of expected type [string|null].');
+
+        $assert->whereType('foo', ['string', 'null']);
+    }
+
+    public function testAssertWhereTypeWithPipeInUnionType()
+    {
+        $assert = AssertableJson::fromArray([
+             'foo' => 'bar',
+        ]);
+
+        $assert->whereType('foo', 'string|null');
+    }
+
+    public function testAssertWhereTypeWithPipeInWrongUnionType()
+    {
+        $assert = AssertableJson::fromArray([
+            'foo' => 'bar',
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Property [foo] is not of expected type [integer|null].');
+
+        $assert->whereType('foo', 'integer|null');
+    }
+
     public function testAssertHasAll()
     {
         $assert = AssertableJson::fromArray([

--- a/tests/Testing/Fluent/AssertTest.php
+++ b/tests/Testing/Fluent/AssertTest.php
@@ -824,7 +824,7 @@ class AssertTest extends TestCase
     public function testAssertWhereTypeWithPipeInUnionType()
     {
         $assert = AssertableJson::fromArray([
-             'foo' => 'bar',
+            'foo' => 'bar',
         ]);
 
         $assert->whereType('foo', 'string|null');

--- a/tests/Testing/Fluent/AssertTest.php
+++ b/tests/Testing/Fluent/AssertTest.php
@@ -704,6 +704,85 @@ class AssertTest extends TestCase
         ]);
     }
 
+    public function testAssertWhereTypeString()
+    {
+        $assert = AssertableJson::fromArray([
+            'foo' => 'bar',
+        ]);
+
+        $assert->whereType('foo', 'string');
+    }
+
+    public function testAssertWhereTypeInteger()
+    {
+        $assert = AssertableJson::fromArray([
+            'foo' => 123,
+        ]);
+
+        $assert->whereType('foo', 'integer');
+    }
+
+    public function testAssertWhereTypeBoolean()
+    {
+        $assert = AssertableJson::fromArray([
+            'foo' => true,
+        ]);
+
+        $assert->whereType('foo', 'boolean');
+    }
+
+    public function testAssertWhereTypeDouble()
+    {
+        $assert = AssertableJson::fromArray([
+            'foo' => 12.3,
+        ]);
+
+        $assert->whereType('foo', 'double');
+    }
+
+    public function testAssertWhereTypeArray()
+    {
+        $assert = AssertableJson::fromArray([
+            'foo' => ['bar', 'baz'],
+            'bar' => ['foo' => 'baz'],
+        ]);
+
+        $assert->whereType('foo', 'array');
+        $assert->whereType('bar', 'array');
+    }
+
+    public function testAssertWhereTypeNull()
+    {
+        $assert = AssertableJson::fromArray([
+            'foo' => null,
+        ]);
+
+        $assert->whereType('foo', 'null');
+    }
+
+    public function testAssertWhereAllType()
+    {
+        $assert = AssertableJson::fromArray([
+            'one' => 'foo',
+            'two' => 123,
+            'three' => true,
+            'four' => 12.3,
+            'five' => ['foo', 'bar'],
+            'six' => ['foo' => 'bar'],
+            'seven' => null,
+        ]);
+
+        $assert->whereAllType([
+            'one' => 'string',
+            'two' => 'integer',
+            'three' => 'boolean',
+            'four' => 'double',
+            'five' => 'array',
+            'six' => 'array',
+            'seven' => 'null',
+        ]);
+    }
+
     public function testAssertHasAll()
     {
         $assert = AssertableJson::fromArray([


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

As continuation on #36454 and #36620, this PR adds 2 new methods to `\Illuminate\Testing\Fluent\AssertableJson`:

- `whereType`
- `whereAllType`

These new methods can be used to verify that the keys in the JSON response are of the expected type(s), similar to the already existing `where` and `whereAll` methods on the same class:

```php
$response->assertJson(fn (Assert $json) => $json
    ->whereType('name', 'string')
    ->whereAllType(['name' => 'string', 'age' => 'integer'])
);
```

You can also use union types by passing either an array, or a pipe-delimited string as the second argument to `whereType`:

```php
$response->assertJson(fn (Assert $json) => $json
    ->whereType('name', 'string|null')
    ->whereType('age', ['integer', 'null'])
);
```

This currently uses [PHP's own `gettype()` function](https://www.php.net/manual/en/function.gettype.php), and only supports the following types:

- `string`
- `integer`
- `double`
- `boolean`
- `array`
- `null`

AKA the only types JSON supports 🙂 

I _did not_ add the possibility to pass a `\Closure` to `whereType`, because at that point you should just use the `where` 
method directly. I'm open to suggestions here though (how would passing a `\Closure` even work?).

Just wanted to say thanks to @claudiodekker for their amazing contribution this is building upon! ❤️ 