### PR TITLE
[8.x] Adds `Str::remove` and `Str::of('foobar')->remove` methods

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -568,16 +568,13 @@ class Str
      */
     public static function remove($search, $subject, $caseSensitive = true)
     {
-        $regexSafeSearches = array_map(
-            function ($search) {
-                return preg_quote($search);
-            },
-            is_array($search) ? $search : [$search]
-        );
+        $regexSafeSearches = array_map(function ($search) {
+            return preg_quote($search);
+        }, is_array($search) ? $search : [$search]);
 
-        $regex = "/" . implode("|", $regexSafeSearches) . "/";
+        $regex = "/".implode("|", $regexSafeSearches)."/";
 
-        if (!$caseSensitive) {
+        if (! $caseSensitive) {
             $regex .= "i";
         }
 

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -494,13 +494,16 @@ class Str
     /**
      * Remove any occurrence of the given string in the subject.
      *
-     * @param string $search
+     * @param string|array<string> $search
      * @param string $subject
+     * @param bool $caseSensitive
      * @return string
      */
-    public static function remove($search, $subject)
+    public static function remove($search, $subject, $caseSensitive = true)
     {
-        return str_replace($search, "", $subject);
+        $search = is_array($search) ? implode("|", $search) : $search;
+        $regex = $caseSensitive ? "/$search/" : "/$search/i";
+        return preg_replace($regex, "", $subject);
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -492,6 +492,18 @@ class Str
     }
 
     /**
+     * Remove any occurrence of the given string in the subject.
+     *
+     * @param string $search
+     * @param string $subject
+     * @return string
+     */
+    public static function remove($search, $subject)
+    {
+        return str_replace($search, "", $subject);
+    }
+
+    /**
      * Replace a given value in the string sequentially with an array.
      *
      * @param  string  $search

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -45,7 +45,7 @@ class Str
     /**
      * Get a new stringable object from the given string.
      *
-     * @param  string  $string
+     * @param string $string
      * @return \Illuminate\Support\Stringable
      */
     public static function of($string)
@@ -54,22 +54,10 @@ class Str
     }
 
     /**
-     * Return the remainder of a string after the first occurrence of a given value.
-     *
-     * @param  string  $subject
-     * @param  string  $search
-     * @return string
-     */
-    public static function after($subject, $search)
-    {
-        return $search === '' ? $subject : array_reverse(explode($search, $subject, 2))[0];
-    }
-
-    /**
      * Return the remainder of a string after the last occurrence of a given value.
      *
-     * @param  string  $subject
-     * @param  string  $search
+     * @param string $subject
+     * @param string $search
      * @return string
      */
     public static function afterLast($subject, $search)
@@ -78,7 +66,7 @@ class Str
             return $subject;
         }
 
-        $position = strrpos($subject, (string) $search);
+        $position = strrpos($subject, (string)$search);
 
         if ($position === false) {
             return $subject;
@@ -88,22 +76,10 @@ class Str
     }
 
     /**
-     * Transliterate a UTF-8 value to ASCII.
-     *
-     * @param  string  $value
-     * @param  string  $language
-     * @return string
-     */
-    public static function ascii($value, $language = 'en')
-    {
-        return ASCII::to_ascii((string) $value, $language);
-    }
-
-    /**
      * Get the portion of a string before the first occurrence of a given value.
      *
-     * @param  string  $subject
-     * @param  string  $search
+     * @param string $subject
+     * @param string $search
      * @return string
      */
     public static function before($subject, $search)
@@ -112,16 +88,33 @@ class Str
             return $subject;
         }
 
-        $result = strstr($subject, (string) $search, true);
+        $result = strstr($subject, (string)$search, true);
 
         return $result === false ? $subject : $result;
     }
 
     /**
+     * Get the portion of a string between two given values.
+     *
+     * @param string $subject
+     * @param string $from
+     * @param string $to
+     * @return string
+     */
+    public static function between($subject, $from, $to)
+    {
+        if ($from === '' || $to === '') {
+            return $subject;
+        }
+
+        return static::beforeLast(static::after($subject, $from), $to);
+    }
+
+    /**
      * Get the portion of a string before the last occurrence of a given value.
      *
-     * @param  string  $subject
-     * @param  string  $search
+     * @param string $subject
+     * @param string $search
      * @return string
      */
     public static function beforeLast($subject, $search)
@@ -140,26 +133,34 @@ class Str
     }
 
     /**
-     * Get the portion of a string between two given values.
+     * Returns the portion of the string specified by the start and length parameters.
      *
-     * @param  string  $subject
-     * @param  string  $from
-     * @param  string  $to
+     * @param string $string
+     * @param int $start
+     * @param int|null $length
      * @return string
      */
-    public static function between($subject, $from, $to)
+    public static function substr($string, $start, $length = null)
     {
-        if ($from === '' || $to === '') {
-            return $subject;
-        }
+        return mb_substr($string, $start, $length, 'UTF-8');
+    }
 
-        return static::beforeLast(static::after($subject, $from), $to);
+    /**
+     * Return the remainder of a string after the first occurrence of a given value.
+     *
+     * @param string $subject
+     * @param string $search
+     * @return string
+     */
+    public static function after($subject, $search)
+    {
+        return $search === '' ? $subject : array_reverse(explode($search, $subject, 2))[0];
     }
 
     /**
      * Convert a value to camel case.
      *
-     * @param  string  $value
+     * @param string $value
      * @return string
      */
     public static function camel($value)
@@ -172,15 +173,52 @@ class Str
     }
 
     /**
+     * Convert a value to studly caps case.
+     *
+     * @param string $value
+     * @return string
+     */
+    public static function studly($value)
+    {
+        $key = $value;
+
+        if (isset(static::$studlyCache[$key])) {
+            return static::$studlyCache[$key];
+        }
+
+        $value = ucwords(str_replace(['-', '_'], ' ', $value));
+
+        return static::$studlyCache[$key] = str_replace(' ', '', $value);
+    }
+
+    /**
+     * Determine if a given string contains all array values.
+     *
+     * @param string $haystack
+     * @param string[] $needles
+     * @return bool
+     */
+    public static function containsAll($haystack, array $needles)
+    {
+        foreach ($needles as $needle) {
+            if (!static::contains($haystack, $needle)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * Determine if a given string contains a given substring.
      *
-     * @param  string  $haystack
-     * @param  string|string[]  $needles
+     * @param string $haystack
+     * @param string|string[] $needles
      * @return bool
      */
     public static function contains($haystack, $needles)
     {
-        foreach ((array) $needles as $needle) {
+        foreach ((array)$needles as $needle) {
             if ($needle !== '' && mb_strpos($haystack, $needle) !== false) {
                 return true;
             }
@@ -190,34 +228,16 @@ class Str
     }
 
     /**
-     * Determine if a given string contains all array values.
-     *
-     * @param  string  $haystack
-     * @param  string[]  $needles
-     * @return bool
-     */
-    public static function containsAll($haystack, array $needles)
-    {
-        foreach ($needles as $needle) {
-            if (! static::contains($haystack, $needle)) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    /**
      * Determine if a given string ends with a given substring.
      *
-     * @param  string  $haystack
-     * @param  string|string[]  $needles
+     * @param string $haystack
+     * @param string|string[] $needles
      * @return bool
      */
     public static function endsWith($haystack, $needles)
     {
-        foreach ((array) $needles as $needle) {
-            if ($needle !== '' && substr($haystack, -strlen($needle)) === (string) $needle) {
+        foreach ((array)$needles as $needle) {
+            if ($needle !== '' && substr($haystack, -strlen($needle)) === (string)$needle) {
                 return true;
             }
         }
@@ -228,22 +248,22 @@ class Str
     /**
      * Cap a string with a single instance of a given value.
      *
-     * @param  string  $value
-     * @param  string  $cap
+     * @param string $value
+     * @param string $cap
      * @return string
      */
     public static function finish($value, $cap)
     {
         $quoted = preg_quote($cap, '/');
 
-        return preg_replace('/(?:'.$quoted.')+$/u', '', $value).$cap;
+        return preg_replace('/(?:' . $quoted . ')+$/u', '', $value) . $cap;
     }
 
     /**
      * Determine if a given string matches a given pattern.
      *
-     * @param  string|array  $pattern
-     * @param  string  $value
+     * @param string|array $pattern
+     * @param string $value
      * @return bool
      */
     public static function is($pattern, $value)
@@ -269,7 +289,7 @@ class Str
             // pattern such as "library/*", making any string check convenient.
             $pattern = str_replace('\*', '.*', $pattern);
 
-            if (preg_match('#^'.$pattern.'\z#u', $value) === 1) {
+            if (preg_match('#^' . $pattern . '\z#u', $value) === 1) {
                 return true;
             }
         }
@@ -280,23 +300,23 @@ class Str
     /**
      * Determine if a given string is 7 bit ASCII.
      *
-     * @param  string  $value
+     * @param string $value
      * @return bool
      */
     public static function isAscii($value)
     {
-        return ASCII::is_ascii((string) $value);
+        return ASCII::is_ascii((string)$value);
     }
 
     /**
      * Determine if a given string is a valid UUID.
      *
-     * @param  string  $value
+     * @param string $value
      * @return bool
      */
     public static function isUuid($value)
     {
-        if (! is_string($value)) {
+        if (!is_string($value)) {
             return false;
         }
 
@@ -306,7 +326,7 @@ class Str
     /**
      * Convert a string to kebab case.
      *
-     * @param  string  $value
+     * @param string $value
      * @return string
      */
     public static function kebab($value)
@@ -315,10 +335,81 @@ class Str
     }
 
     /**
+     * Convert a string to snake case.
+     *
+     * @param string $value
+     * @param string $delimiter
+     * @return string
+     */
+    public static function snake($value, $delimiter = '_')
+    {
+        $key = $value;
+
+        if (isset(static::$snakeCache[$key][$delimiter])) {
+            return static::$snakeCache[$key][$delimiter];
+        }
+
+        if (!ctype_lower($value)) {
+            $value = preg_replace('/\s+/u', '', ucwords($value));
+
+            $value = static::lower(preg_replace('/(.)(?=[A-Z])/u', '$1' . $delimiter, $value));
+        }
+
+        return static::$snakeCache[$key][$delimiter] = $value;
+    }
+
+    /**
+     * Convert the given string to lower-case.
+     *
+     * @param string $value
+     * @return string
+     */
+    public static function lower($value)
+    {
+        return mb_strtolower($value, 'UTF-8');
+    }
+
+    /**
+     * Limit the number of characters in a string.
+     *
+     * @param string $value
+     * @param int $limit
+     * @param string $end
+     * @return string
+     */
+    public static function limit($value, $limit = 100, $end = '...')
+    {
+        if (mb_strwidth($value, 'UTF-8') <= $limit) {
+            return $value;
+        }
+
+        return rtrim(mb_strimwidth($value, 0, $limit, '', 'UTF-8')) . $end;
+    }
+
+    /**
+     * Limit the number of words in a string.
+     *
+     * @param string $value
+     * @param int $words
+     * @param string $end
+     * @return string
+     */
+    public static function words($value, $words = 100, $end = '...')
+    {
+        preg_match('/^\s*+(?:\S++\s*+){1,' . $words . '}/u', $value, $matches);
+
+        if (!isset($matches[0]) || static::length($value) === static::length($matches[0])) {
+            return $value;
+        }
+
+        return rtrim($matches[0]) . $end;
+    }
+
+    /**
      * Return the length of the given string.
      *
-     * @param  string  $value
-     * @param  string|null  $encoding
+     * @param string $value
+     * @param string|null $encoding
      * @return int
      */
     public static function length($value, $encoding = null)
@@ -331,57 +422,10 @@ class Str
     }
 
     /**
-     * Limit the number of characters in a string.
-     *
-     * @param  string  $value
-     * @param  int  $limit
-     * @param  string  $end
-     * @return string
-     */
-    public static function limit($value, $limit = 100, $end = '...')
-    {
-        if (mb_strwidth($value, 'UTF-8') <= $limit) {
-            return $value;
-        }
-
-        return rtrim(mb_strimwidth($value, 0, $limit, '', 'UTF-8')).$end;
-    }
-
-    /**
-     * Convert the given string to lower-case.
-     *
-     * @param  string  $value
-     * @return string
-     */
-    public static function lower($value)
-    {
-        return mb_strtolower($value, 'UTF-8');
-    }
-
-    /**
-     * Limit the number of words in a string.
-     *
-     * @param  string  $value
-     * @param  int  $words
-     * @param  string  $end
-     * @return string
-     */
-    public static function words($value, $words = 100, $end = '...')
-    {
-        preg_match('/^\s*+(?:\S++\s*+){1,'.$words.'}/u', $value, $matches);
-
-        if (! isset($matches[0]) || static::length($value) === static::length($matches[0])) {
-            return $value;
-        }
-
-        return rtrim($matches[0]).$end;
-    }
-
-    /**
      * Converts GitHub flavored Markdown into HTML.
      *
-     * @param  string  $string
-     * @param  array  $options
+     * @param string $string
+     * @param array $options
      * @return string
      */
     public static function markdown($string, array $options = [])
@@ -394,9 +438,9 @@ class Str
     /**
      * Pad both sides of a string with another.
      *
-     * @param  string  $value
-     * @param  int  $length
-     * @param  string  $pad
+     * @param string $value
+     * @param int $length
+     * @param string $pad
      * @return string
      */
     public static function padBoth($value, $length, $pad = ' ')
@@ -407,9 +451,9 @@ class Str
     /**
      * Pad the left side of a string with another.
      *
-     * @param  string  $value
-     * @param  int  $length
-     * @param  string  $pad
+     * @param string $value
+     * @param int $length
+     * @param string $pad
      * @return string
      */
     public static function padLeft($value, $length, $pad = ' ')
@@ -420,9 +464,9 @@ class Str
     /**
      * Pad the right side of a string with another.
      *
-     * @param  string  $value
-     * @param  int  $length
-     * @param  string  $pad
+     * @param string $value
+     * @param int $length
+     * @param string $pad
      * @return string
      */
     public static function padRight($value, $length, $pad = ' ')
@@ -433,8 +477,8 @@ class Str
     /**
      * Parse a Class[@]method style callback into class and method.
      *
-     * @param  string  $callback
-     * @param  string|null  $default
+     * @param string $callback
+     * @param string|null $default
      * @return array<int, string|null>
      */
     public static function parseCallback($callback, $default = null)
@@ -443,22 +487,10 @@ class Str
     }
 
     /**
-     * Get the plural form of an English word.
-     *
-     * @param  string  $value
-     * @param  int  $count
-     * @return string
-     */
-    public static function plural($value, $count = 2)
-    {
-        return Pluralizer::plural($value, $count);
-    }
-
-    /**
      * Pluralize the last word of an English, studly caps case string.
      *
-     * @param  string  $value
-     * @param  int  $count
+     * @param string $value
+     * @param int $count
      * @return string
      */
     public static function pluralStudly($value, $count = 2)
@@ -467,13 +499,25 @@ class Str
 
         $lastWord = array_pop($parts);
 
-        return implode('', $parts).self::plural($lastWord, $count);
+        return implode('', $parts) . self::plural($lastWord, $count);
+    }
+
+    /**
+     * Get the plural form of an English word.
+     *
+     * @param string $value
+     * @param int $count
+     * @return string
+     */
+    public static function plural($value, $count = 2)
+    {
+        return Pluralizer::plural($value, $count);
     }
 
     /**
      * Generate a more truly "random" alpha-numeric string.
      *
-     * @param  int  $length
+     * @param int $length
      * @return string
      */
     public static function random($length = 16)
@@ -501,17 +545,28 @@ class Str
      */
     public static function remove($search, $subject, $caseSensitive = true)
     {
-        $search = is_array($search) ? implode("|", $search) : $search;
-        $regex = $caseSensitive ? "/$search/" : "/$search/i";
+        $regexSafeSearches = array_map(
+            function ($search) {
+                return preg_quote($search);
+            },
+            is_array($search) ? $search : [$search]
+        );
+
+        $regex = "/" . implode("|", $regexSafeSearches) . "/";
+
+        if (!$caseSensitive) {
+            $regex .= "i";
+        }
+
         return preg_replace($regex, "", $subject);
     }
 
     /**
      * Replace a given value in the string sequentially with an array.
      *
-     * @param  string  $search
-     * @param  array<int|string, string>  $replace
-     * @param  string  $subject
+     * @param string $search
+     * @param array<int|string, string> $replace
+     * @param string $subject
      * @return string
      */
     public static function replaceArray($search, array $replace, $subject)
@@ -521,7 +576,7 @@ class Str
         $result = array_shift($segments);
 
         foreach ($segments as $segment) {
-            $result .= (array_shift($replace) ?? $search).$segment;
+            $result .= (array_shift($replace) ?? $search) . $segment;
         }
 
         return $result;
@@ -530,9 +585,9 @@ class Str
     /**
      * Replace the first occurrence of a given value in the string.
      *
-     * @param  string  $search
-     * @param  string  $replace
-     * @param  string  $subject
+     * @param string $search
+     * @param string $replace
+     * @param string $subject
      * @return string
      */
     public static function replaceFirst($search, $replace, $subject)
@@ -553,9 +608,9 @@ class Str
     /**
      * Replace the last occurrence of a given value in the string.
      *
-     * @param  string  $search
-     * @param  string  $replace
-     * @param  string  $subject
+     * @param string $search
+     * @param string $replace
+     * @param string $subject
      * @return string
      */
     public static function replaceLast($search, $replace, $subject)
@@ -576,32 +631,21 @@ class Str
     /**
      * Begin a string with a single instance of a given value.
      *
-     * @param  string  $value
-     * @param  string  $prefix
+     * @param string $value
+     * @param string $prefix
      * @return string
      */
     public static function start($value, $prefix)
     {
         $quoted = preg_quote($prefix, '/');
 
-        return $prefix.preg_replace('/^(?:'.$quoted.')+/u', '', $value);
-    }
-
-    /**
-     * Convert the given string to upper-case.
-     *
-     * @param  string  $value
-     * @return string
-     */
-    public static function upper($value)
-    {
-        return mb_strtoupper($value, 'UTF-8');
+        return $prefix . preg_replace('/^(?:' . $quoted . ')+/u', '', $value);
     }
 
     /**
      * Convert the given string to title case.
      *
-     * @param  string  $value
+     * @param string $value
      * @return string
      */
     public static function title($value)
@@ -612,7 +656,7 @@ class Str
     /**
      * Get the singular form of an English word.
      *
-     * @param  string  $value
+     * @param string $value
      * @return string
      */
     public static function singular($value)
@@ -623,9 +667,9 @@ class Str
     /**
      * Generate a URL friendly "slug" from a given string.
      *
-     * @param  string  $title
-     * @param  string  $separator
-     * @param  string|null  $language
+     * @param string $title
+     * @param string $separator
+     * @param string|null $language
      * @return string
      */
     public static function slug($title, $separator = '-', $language = 'en')
@@ -635,55 +679,43 @@ class Str
         // Convert all dashes/underscores into separator
         $flip = $separator === '-' ? '_' : '-';
 
-        $title = preg_replace('!['.preg_quote($flip).']+!u', $separator, $title);
+        $title = preg_replace('![' . preg_quote($flip) . ']+!u', $separator, $title);
 
         // Replace @ with the word 'at'
-        $title = str_replace('@', $separator.'at'.$separator, $title);
+        $title = str_replace('@', $separator . 'at' . $separator, $title);
 
         // Remove all characters that are not the separator, letters, numbers, or whitespace.
-        $title = preg_replace('![^'.preg_quote($separator).'\pL\pN\s]+!u', '', static::lower($title));
+        $title = preg_replace('![^' . preg_quote($separator) . '\pL\pN\s]+!u', '', static::lower($title));
 
         // Replace all separator characters and whitespace by a single separator
-        $title = preg_replace('!['.preg_quote($separator).'\s]+!u', $separator, $title);
+        $title = preg_replace('![' . preg_quote($separator) . '\s]+!u', $separator, $title);
 
         return trim($title, $separator);
     }
 
     /**
-     * Convert a string to snake case.
+     * Transliterate a UTF-8 value to ASCII.
      *
-     * @param  string  $value
-     * @param  string  $delimiter
+     * @param string $value
+     * @param string $language
      * @return string
      */
-    public static function snake($value, $delimiter = '_')
+    public static function ascii($value, $language = 'en')
     {
-        $key = $value;
-
-        if (isset(static::$snakeCache[$key][$delimiter])) {
-            return static::$snakeCache[$key][$delimiter];
-        }
-
-        if (! ctype_lower($value)) {
-            $value = preg_replace('/\s+/u', '', ucwords($value));
-
-            $value = static::lower(preg_replace('/(.)(?=[A-Z])/u', '$1'.$delimiter, $value));
-        }
-
-        return static::$snakeCache[$key][$delimiter] = $value;
+        return ASCII::to_ascii((string)$value, $language);
     }
 
     /**
      * Determine if a given string starts with a given substring.
      *
-     * @param  string  $haystack
-     * @param  string|string[]  $needles
+     * @param string $haystack
+     * @param string|string[] $needles
      * @return bool
      */
     public static function startsWith($haystack, $needles)
     {
-        foreach ((array) $needles as $needle) {
-            if ((string) $needle !== '' && strncmp($haystack, $needle, strlen($needle)) === 0) {
+        foreach ((array)$needles as $needle) {
+            if ((string)$needle !== '' && strncmp($haystack, $needle, strlen($needle)) === 0) {
                 return true;
             }
         }
@@ -692,49 +724,17 @@ class Str
     }
 
     /**
-     * Convert a value to studly caps case.
-     *
-     * @param  string  $value
-     * @return string
-     */
-    public static function studly($value)
-    {
-        $key = $value;
-
-        if (isset(static::$studlyCache[$key])) {
-            return static::$studlyCache[$key];
-        }
-
-        $value = ucwords(str_replace(['-', '_'], ' ', $value));
-
-        return static::$studlyCache[$key] = str_replace(' ', '', $value);
-    }
-
-    /**
-     * Returns the portion of the string specified by the start and length parameters.
-     *
-     * @param  string  $string
-     * @param  int  $start
-     * @param  int|null  $length
-     * @return string
-     */
-    public static function substr($string, $start, $length = null)
-    {
-        return mb_substr($string, $start, $length, 'UTF-8');
-    }
-
-    /**
      * Returns the number of substring occurrences.
      *
-     * @param  string  $haystack
-     * @param  string  $needle
-     * @param  int  $offset
-     * @param  int|null  $length
+     * @param string $haystack
+     * @param string $needle
+     * @param int $offset
+     * @param int|null $length
      * @return int
      */
     public static function substrCount($haystack, $needle, $offset = 0, $length = null)
     {
-        if (! is_null($length)) {
+        if (!is_null($length)) {
             return substr_count($haystack, $needle, $offset, $length);
         } else {
             return substr_count($haystack, $needle, $offset);
@@ -744,12 +744,23 @@ class Str
     /**
      * Make a string's first character uppercase.
      *
-     * @param  string  $string
+     * @param string $string
      * @return string
      */
     public static function ucfirst($string)
     {
-        return static::upper(static::substr($string, 0, 1)).static::substr($string, 1);
+        return static::upper(static::substr($string, 0, 1)) . static::substr($string, 1);
+    }
+
+    /**
+     * Convert the given string to upper-case.
+     *
+     * @param string $value
+     * @return string
+     */
+    public static function upper($value)
+    {
+        return mb_strtoupper($value, 'UTF-8');
     }
 
     /**
@@ -760,8 +771,8 @@ class Str
     public static function uuid()
     {
         return static::$uuidFactory
-                    ? call_user_func(static::$uuidFactory)
-                    : Uuid::uuid4();
+            ? call_user_func(static::$uuidFactory)
+            : Uuid::uuid4();
     }
 
     /**
@@ -777,14 +788,18 @@ class Str
 
         $factory = new UuidFactory();
 
-        $factory->setRandomGenerator(new CombGenerator(
-            $factory->getRandomGenerator(),
-            $factory->getNumberConverter()
-        ));
+        $factory->setRandomGenerator(
+            new CombGenerator(
+                $factory->getRandomGenerator(),
+                $factory->getNumberConverter()
+            )
+        );
 
-        $factory->setCodec(new TimestampFirstCombCodec(
-            $factory->getUuidBuilder()
-        ));
+        $factory->setCodec(
+            new TimestampFirstCombCodec(
+                $factory->getUuidBuilder()
+            )
+        );
 
         return $factory->uuid4();
     }
@@ -792,7 +807,7 @@ class Str
     /**
      * Set the callable that will be used to generate UUIDs.
      *
-     * @param  callable|null  $factory
+     * @param callable|null $factory
      * @return void
      */
     public static function createUuidsUsing(callable $factory = null)

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -45,7 +45,7 @@ class Str
     /**
      * Get a new stringable object from the given string.
      *
-     * @param string $string
+     * @param  string  $string
      * @return \Illuminate\Support\Stringable
      */
     public static function of($string)
@@ -54,10 +54,22 @@ class Str
     }
 
     /**
+     * Return the remainder of a string after the first occurrence of a given value.
+     *
+     * @param  string  $subject
+     * @param  string  $search
+     * @return string
+     */
+    public static function after($subject, $search)
+    {
+        return $search === '' ? $subject : array_reverse(explode($search, $subject, 2))[0];
+    }
+
+    /**
      * Return the remainder of a string after the last occurrence of a given value.
      *
-     * @param string $subject
-     * @param string $search
+     * @param  string  $subject
+     * @param  string  $search
      * @return string
      */
     public static function afterLast($subject, $search)
@@ -66,7 +78,7 @@ class Str
             return $subject;
         }
 
-        $position = strrpos($subject, (string)$search);
+        $position = strrpos($subject, (string) $search);
 
         if ($position === false) {
             return $subject;
@@ -76,10 +88,22 @@ class Str
     }
 
     /**
+     * Transliterate a UTF-8 value to ASCII.
+     *
+     * @param  string  $value
+     * @param  string  $language
+     * @return string
+     */
+    public static function ascii($value, $language = 'en')
+    {
+        return ASCII::to_ascii((string) $value, $language);
+    }
+
+    /**
      * Get the portion of a string before the first occurrence of a given value.
      *
-     * @param string $subject
-     * @param string $search
+     * @param  string  $subject
+     * @param  string  $search
      * @return string
      */
     public static function before($subject, $search)
@@ -88,33 +112,16 @@ class Str
             return $subject;
         }
 
-        $result = strstr($subject, (string)$search, true);
+        $result = strstr($subject, (string) $search, true);
 
         return $result === false ? $subject : $result;
     }
 
     /**
-     * Get the portion of a string between two given values.
-     *
-     * @param string $subject
-     * @param string $from
-     * @param string $to
-     * @return string
-     */
-    public static function between($subject, $from, $to)
-    {
-        if ($from === '' || $to === '') {
-            return $subject;
-        }
-
-        return static::beforeLast(static::after($subject, $from), $to);
-    }
-
-    /**
      * Get the portion of a string before the last occurrence of a given value.
      *
-     * @param string $subject
-     * @param string $search
+     * @param  string  $subject
+     * @param  string  $search
      * @return string
      */
     public static function beforeLast($subject, $search)
@@ -133,34 +140,26 @@ class Str
     }
 
     /**
-     * Returns the portion of the string specified by the start and length parameters.
+     * Get the portion of a string between two given values.
      *
-     * @param string $string
-     * @param int $start
-     * @param int|null $length
+     * @param  string  $subject
+     * @param  string  $from
+     * @param  string  $to
      * @return string
      */
-    public static function substr($string, $start, $length = null)
+    public static function between($subject, $from, $to)
     {
-        return mb_substr($string, $start, $length, 'UTF-8');
-    }
+        if ($from === '' || $to === '') {
+            return $subject;
+        }
 
-    /**
-     * Return the remainder of a string after the first occurrence of a given value.
-     *
-     * @param string $subject
-     * @param string $search
-     * @return string
-     */
-    public static function after($subject, $search)
-    {
-        return $search === '' ? $subject : array_reverse(explode($search, $subject, 2))[0];
+        return static::beforeLast(static::after($subject, $from), $to);
     }
 
     /**
      * Convert a value to camel case.
      *
-     * @param string $value
+     * @param  string  $value
      * @return string
      */
     public static function camel($value)
@@ -173,52 +172,15 @@ class Str
     }
 
     /**
-     * Convert a value to studly caps case.
-     *
-     * @param string $value
-     * @return string
-     */
-    public static function studly($value)
-    {
-        $key = $value;
-
-        if (isset(static::$studlyCache[$key])) {
-            return static::$studlyCache[$key];
-        }
-
-        $value = ucwords(str_replace(['-', '_'], ' ', $value));
-
-        return static::$studlyCache[$key] = str_replace(' ', '', $value);
-    }
-
-    /**
-     * Determine if a given string contains all array values.
-     *
-     * @param string $haystack
-     * @param string[] $needles
-     * @return bool
-     */
-    public static function containsAll($haystack, array $needles)
-    {
-        foreach ($needles as $needle) {
-            if (!static::contains($haystack, $needle)) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    /**
      * Determine if a given string contains a given substring.
      *
-     * @param string $haystack
-     * @param string|string[] $needles
+     * @param  string  $haystack
+     * @param  string|string[]  $needles
      * @return bool
      */
     public static function contains($haystack, $needles)
     {
-        foreach ((array)$needles as $needle) {
+        foreach ((array) $needles as $needle) {
             if ($needle !== '' && mb_strpos($haystack, $needle) !== false) {
                 return true;
             }
@@ -228,16 +190,34 @@ class Str
     }
 
     /**
+     * Determine if a given string contains all array values.
+     *
+     * @param  string  $haystack
+     * @param  string[]  $needles
+     * @return bool
+     */
+    public static function containsAll($haystack, array $needles)
+    {
+        foreach ($needles as $needle) {
+            if (! static::contains($haystack, $needle)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * Determine if a given string ends with a given substring.
      *
-     * @param string $haystack
-     * @param string|string[] $needles
+     * @param  string  $haystack
+     * @param  string|string[]  $needles
      * @return bool
      */
     public static function endsWith($haystack, $needles)
     {
-        foreach ((array)$needles as $needle) {
-            if ($needle !== '' && substr($haystack, -strlen($needle)) === (string)$needle) {
+        foreach ((array) $needles as $needle) {
+            if ($needle !== '' && substr($haystack, -strlen($needle)) === (string) $needle) {
                 return true;
             }
         }
@@ -248,22 +228,22 @@ class Str
     /**
      * Cap a string with a single instance of a given value.
      *
-     * @param string $value
-     * @param string $cap
+     * @param  string  $value
+     * @param  string  $cap
      * @return string
      */
     public static function finish($value, $cap)
     {
         $quoted = preg_quote($cap, '/');
 
-        return preg_replace('/(?:' . $quoted . ')+$/u', '', $value) . $cap;
+        return preg_replace('/(?:'.$quoted.')+$/u', '', $value).$cap;
     }
 
     /**
      * Determine if a given string matches a given pattern.
      *
-     * @param string|array $pattern
-     * @param string $value
+     * @param  string|array  $pattern
+     * @param  string  $value
      * @return bool
      */
     public static function is($pattern, $value)
@@ -289,7 +269,7 @@ class Str
             // pattern such as "library/*", making any string check convenient.
             $pattern = str_replace('\*', '.*', $pattern);
 
-            if (preg_match('#^' . $pattern . '\z#u', $value) === 1) {
+            if (preg_match('#^'.$pattern.'\z#u', $value) === 1) {
                 return true;
             }
         }
@@ -300,23 +280,23 @@ class Str
     /**
      * Determine if a given string is 7 bit ASCII.
      *
-     * @param string $value
+     * @param  string  $value
      * @return bool
      */
     public static function isAscii($value)
     {
-        return ASCII::is_ascii((string)$value);
+        return ASCII::is_ascii((string) $value);
     }
 
     /**
      * Determine if a given string is a valid UUID.
      *
-     * @param string $value
+     * @param  string  $value
      * @return bool
      */
     public static function isUuid($value)
     {
-        if (!is_string($value)) {
+        if (! is_string($value)) {
             return false;
         }
 
@@ -326,7 +306,7 @@ class Str
     /**
      * Convert a string to kebab case.
      *
-     * @param string $value
+     * @param  string  $value
      * @return string
      */
     public static function kebab($value)
@@ -335,81 +315,10 @@ class Str
     }
 
     /**
-     * Convert a string to snake case.
-     *
-     * @param string $value
-     * @param string $delimiter
-     * @return string
-     */
-    public static function snake($value, $delimiter = '_')
-    {
-        $key = $value;
-
-        if (isset(static::$snakeCache[$key][$delimiter])) {
-            return static::$snakeCache[$key][$delimiter];
-        }
-
-        if (!ctype_lower($value)) {
-            $value = preg_replace('/\s+/u', '', ucwords($value));
-
-            $value = static::lower(preg_replace('/(.)(?=[A-Z])/u', '$1' . $delimiter, $value));
-        }
-
-        return static::$snakeCache[$key][$delimiter] = $value;
-    }
-
-    /**
-     * Convert the given string to lower-case.
-     *
-     * @param string $value
-     * @return string
-     */
-    public static function lower($value)
-    {
-        return mb_strtolower($value, 'UTF-8');
-    }
-
-    /**
-     * Limit the number of characters in a string.
-     *
-     * @param string $value
-     * @param int $limit
-     * @param string $end
-     * @return string
-     */
-    public static function limit($value, $limit = 100, $end = '...')
-    {
-        if (mb_strwidth($value, 'UTF-8') <= $limit) {
-            return $value;
-        }
-
-        return rtrim(mb_strimwidth($value, 0, $limit, '', 'UTF-8')) . $end;
-    }
-
-    /**
-     * Limit the number of words in a string.
-     *
-     * @param string $value
-     * @param int $words
-     * @param string $end
-     * @return string
-     */
-    public static function words($value, $words = 100, $end = '...')
-    {
-        preg_match('/^\s*+(?:\S++\s*+){1,' . $words . '}/u', $value, $matches);
-
-        if (!isset($matches[0]) || static::length($value) === static::length($matches[0])) {
-            return $value;
-        }
-
-        return rtrim($matches[0]) . $end;
-    }
-
-    /**
      * Return the length of the given string.
      *
-     * @param string $value
-     * @param string|null $encoding
+     * @param  string  $value
+     * @param  string|null  $encoding
      * @return int
      */
     public static function length($value, $encoding = null)
@@ -422,10 +331,57 @@ class Str
     }
 
     /**
+     * Limit the number of characters in a string.
+     *
+     * @param  string  $value
+     * @param  int  $limit
+     * @param  string  $end
+     * @return string
+     */
+    public static function limit($value, $limit = 100, $end = '...')
+    {
+        if (mb_strwidth($value, 'UTF-8') <= $limit) {
+            return $value;
+        }
+
+        return rtrim(mb_strimwidth($value, 0, $limit, '', 'UTF-8')).$end;
+    }
+
+    /**
+     * Convert the given string to lower-case.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    public static function lower($value)
+    {
+        return mb_strtolower($value, 'UTF-8');
+    }
+
+    /**
+     * Limit the number of words in a string.
+     *
+     * @param  string  $value
+     * @param  int  $words
+     * @param  string  $end
+     * @return string
+     */
+    public static function words($value, $words = 100, $end = '...')
+    {
+        preg_match('/^\s*+(?:\S++\s*+){1,'.$words.'}/u', $value, $matches);
+
+        if (! isset($matches[0]) || static::length($value) === static::length($matches[0])) {
+            return $value;
+        }
+
+        return rtrim($matches[0]).$end;
+    }
+
+    /**
      * Converts GitHub flavored Markdown into HTML.
      *
-     * @param string $string
-     * @param array $options
+     * @param  string  $string
+     * @param  array  $options
      * @return string
      */
     public static function markdown($string, array $options = [])
@@ -438,9 +394,9 @@ class Str
     /**
      * Pad both sides of a string with another.
      *
-     * @param string $value
-     * @param int $length
-     * @param string $pad
+     * @param  string  $value
+     * @param  int  $length
+     * @param  string  $pad
      * @return string
      */
     public static function padBoth($value, $length, $pad = ' ')
@@ -451,9 +407,9 @@ class Str
     /**
      * Pad the left side of a string with another.
      *
-     * @param string $value
-     * @param int $length
-     * @param string $pad
+     * @param  string  $value
+     * @param  int  $length
+     * @param  string  $pad
      * @return string
      */
     public static function padLeft($value, $length, $pad = ' ')
@@ -464,9 +420,9 @@ class Str
     /**
      * Pad the right side of a string with another.
      *
-     * @param string $value
-     * @param int $length
-     * @param string $pad
+     * @param  string  $value
+     * @param  int  $length
+     * @param  string  $pad
      * @return string
      */
     public static function padRight($value, $length, $pad = ' ')
@@ -477,8 +433,8 @@ class Str
     /**
      * Parse a Class[@]method style callback into class and method.
      *
-     * @param string $callback
-     * @param string|null $default
+     * @param  string  $callback
+     * @param  string|null  $default
      * @return array<int, string|null>
      */
     public static function parseCallback($callback, $default = null)
@@ -487,26 +443,10 @@ class Str
     }
 
     /**
-     * Pluralize the last word of an English, studly caps case string.
-     *
-     * @param string $value
-     * @param int $count
-     * @return string
-     */
-    public static function pluralStudly($value, $count = 2)
-    {
-        $parts = preg_split('/(.)(?=[A-Z])/u', $value, -1, PREG_SPLIT_DELIM_CAPTURE);
-
-        $lastWord = array_pop($parts);
-
-        return implode('', $parts) . self::plural($lastWord, $count);
-    }
-
-    /**
      * Get the plural form of an English word.
      *
-     * @param string $value
-     * @param int $count
+     * @param  string  $value
+     * @param  int  $count
      * @return string
      */
     public static function plural($value, $count = 2)
@@ -515,9 +455,25 @@ class Str
     }
 
     /**
+     * Pluralize the last word of an English, studly caps case string.
+     *
+     * @param  string  $value
+     * @param  int  $count
+     * @return string
+     */
+    public static function pluralStudly($value, $count = 2)
+    {
+        $parts = preg_split('/(.)(?=[A-Z])/u', $value, -1, PREG_SPLIT_DELIM_CAPTURE);
+
+        $lastWord = array_pop($parts);
+
+        return implode('', $parts).self::plural($lastWord, $count);
+    }
+
+    /**
      * Generate a more truly "random" alpha-numeric string.
      *
-     * @param int $length
+     * @param  int  $length
      * @return string
      */
     public static function random($length = 16)
@@ -533,6 +489,73 @@ class Str
         }
 
         return $string;
+    }
+
+    /**
+     * Replace a given value in the string sequentially with an array.
+     *
+     * @param  string  $search
+     * @param  array<int|string, string>  $replace
+     * @param  string  $subject
+     * @return string
+     */
+    public static function replaceArray($search, array $replace, $subject)
+    {
+        $segments = explode($search, $subject);
+
+        $result = array_shift($segments);
+
+        foreach ($segments as $segment) {
+            $result .= (array_shift($replace) ?? $search).$segment;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Replace the first occurrence of a given value in the string.
+     *
+     * @param  string  $search
+     * @param  string  $replace
+     * @param  string  $subject
+     * @return string
+     */
+    public static function replaceFirst($search, $replace, $subject)
+    {
+        if ($search == '') {
+            return $subject;
+        }
+
+        $position = strpos($subject, $search);
+
+        if ($position !== false) {
+            return substr_replace($subject, $replace, $position, strlen($search));
+        }
+
+        return $subject;
+    }
+
+    /**
+     * Replace the last occurrence of a given value in the string.
+     *
+     * @param  string  $search
+     * @param  string  $replace
+     * @param  string  $subject
+     * @return string
+     */
+    public static function replaceLast($search, $replace, $subject)
+    {
+        if ($search === '') {
+            return $subject;
+        }
+
+        $position = strrpos($subject, $search);
+
+        if ($position !== false) {
+            return substr_replace($subject, $replace, $position, strlen($search));
+        }
+
+        return $subject;
     }
 
     /**
@@ -562,90 +585,34 @@ class Str
     }
 
     /**
-     * Replace a given value in the string sequentially with an array.
-     *
-     * @param string $search
-     * @param array<int|string, string> $replace
-     * @param string $subject
-     * @return string
-     */
-    public static function replaceArray($search, array $replace, $subject)
-    {
-        $segments = explode($search, $subject);
-
-        $result = array_shift($segments);
-
-        foreach ($segments as $segment) {
-            $result .= (array_shift($replace) ?? $search) . $segment;
-        }
-
-        return $result;
-    }
-
-    /**
-     * Replace the first occurrence of a given value in the string.
-     *
-     * @param string $search
-     * @param string $replace
-     * @param string $subject
-     * @return string
-     */
-    public static function replaceFirst($search, $replace, $subject)
-    {
-        if ($search == '') {
-            return $subject;
-        }
-
-        $position = strpos($subject, $search);
-
-        if ($position !== false) {
-            return substr_replace($subject, $replace, $position, strlen($search));
-        }
-
-        return $subject;
-    }
-
-    /**
-     * Replace the last occurrence of a given value in the string.
-     *
-     * @param string $search
-     * @param string $replace
-     * @param string $subject
-     * @return string
-     */
-    public static function replaceLast($search, $replace, $subject)
-    {
-        if ($search === '') {
-            return $subject;
-        }
-
-        $position = strrpos($subject, $search);
-
-        if ($position !== false) {
-            return substr_replace($subject, $replace, $position, strlen($search));
-        }
-
-        return $subject;
-    }
-
-    /**
      * Begin a string with a single instance of a given value.
      *
-     * @param string $value
-     * @param string $prefix
+     * @param  string  $value
+     * @param  string  $prefix
      * @return string
      */
     public static function start($value, $prefix)
     {
         $quoted = preg_quote($prefix, '/');
 
-        return $prefix . preg_replace('/^(?:' . $quoted . ')+/u', '', $value);
+        return $prefix.preg_replace('/^(?:'.$quoted.')+/u', '', $value);
+    }
+
+    /**
+     * Convert the given string to upper-case.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    public static function upper($value)
+    {
+        return mb_strtoupper($value, 'UTF-8');
     }
 
     /**
      * Convert the given string to title case.
      *
-     * @param string $value
+     * @param  string  $value
      * @return string
      */
     public static function title($value)
@@ -656,7 +623,7 @@ class Str
     /**
      * Get the singular form of an English word.
      *
-     * @param string $value
+     * @param  string  $value
      * @return string
      */
     public static function singular($value)
@@ -667,9 +634,9 @@ class Str
     /**
      * Generate a URL friendly "slug" from a given string.
      *
-     * @param string $title
-     * @param string $separator
-     * @param string|null $language
+     * @param  string  $title
+     * @param  string  $separator
+     * @param  string|null  $language
      * @return string
      */
     public static function slug($title, $separator = '-', $language = 'en')
@@ -679,43 +646,55 @@ class Str
         // Convert all dashes/underscores into separator
         $flip = $separator === '-' ? '_' : '-';
 
-        $title = preg_replace('![' . preg_quote($flip) . ']+!u', $separator, $title);
+        $title = preg_replace('!['.preg_quote($flip).']+!u', $separator, $title);
 
         // Replace @ with the word 'at'
-        $title = str_replace('@', $separator . 'at' . $separator, $title);
+        $title = str_replace('@', $separator.'at'.$separator, $title);
 
         // Remove all characters that are not the separator, letters, numbers, or whitespace.
-        $title = preg_replace('![^' . preg_quote($separator) . '\pL\pN\s]+!u', '', static::lower($title));
+        $title = preg_replace('![^'.preg_quote($separator).'\pL\pN\s]+!u', '', static::lower($title));
 
         // Replace all separator characters and whitespace by a single separator
-        $title = preg_replace('![' . preg_quote($separator) . '\s]+!u', $separator, $title);
+        $title = preg_replace('!['.preg_quote($separator).'\s]+!u', $separator, $title);
 
         return trim($title, $separator);
     }
 
     /**
-     * Transliterate a UTF-8 value to ASCII.
+     * Convert a string to snake case.
      *
-     * @param string $value
-     * @param string $language
+     * @param  string  $value
+     * @param  string  $delimiter
      * @return string
      */
-    public static function ascii($value, $language = 'en')
+    public static function snake($value, $delimiter = '_')
     {
-        return ASCII::to_ascii((string)$value, $language);
+        $key = $value;
+
+        if (isset(static::$snakeCache[$key][$delimiter])) {
+            return static::$snakeCache[$key][$delimiter];
+        }
+
+        if (! ctype_lower($value)) {
+            $value = preg_replace('/\s+/u', '', ucwords($value));
+
+            $value = static::lower(preg_replace('/(.)(?=[A-Z])/u', '$1'.$delimiter, $value));
+        }
+
+        return static::$snakeCache[$key][$delimiter] = $value;
     }
 
     /**
      * Determine if a given string starts with a given substring.
      *
-     * @param string $haystack
-     * @param string|string[] $needles
+     * @param  string  $haystack
+     * @param  string|string[]  $needles
      * @return bool
      */
     public static function startsWith($haystack, $needles)
     {
-        foreach ((array)$needles as $needle) {
-            if ((string)$needle !== '' && strncmp($haystack, $needle, strlen($needle)) === 0) {
+        foreach ((array) $needles as $needle) {
+            if ((string) $needle !== '' && strncmp($haystack, $needle, strlen($needle)) === 0) {
                 return true;
             }
         }
@@ -724,17 +703,49 @@ class Str
     }
 
     /**
+     * Convert a value to studly caps case.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    public static function studly($value)
+    {
+        $key = $value;
+
+        if (isset(static::$studlyCache[$key])) {
+            return static::$studlyCache[$key];
+        }
+
+        $value = ucwords(str_replace(['-', '_'], ' ', $value));
+
+        return static::$studlyCache[$key] = str_replace(' ', '', $value);
+    }
+
+    /**
+     * Returns the portion of the string specified by the start and length parameters.
+     *
+     * @param  string  $string
+     * @param  int  $start
+     * @param  int|null  $length
+     * @return string
+     */
+    public static function substr($string, $start, $length = null)
+    {
+        return mb_substr($string, $start, $length, 'UTF-8');
+    }
+
+    /**
      * Returns the number of substring occurrences.
      *
-     * @param string $haystack
-     * @param string $needle
-     * @param int $offset
-     * @param int|null $length
+     * @param  string  $haystack
+     * @param  string  $needle
+     * @param  int  $offset
+     * @param  int|null  $length
      * @return int
      */
     public static function substrCount($haystack, $needle, $offset = 0, $length = null)
     {
-        if (!is_null($length)) {
+        if (! is_null($length)) {
             return substr_count($haystack, $needle, $offset, $length);
         } else {
             return substr_count($haystack, $needle, $offset);
@@ -744,23 +755,12 @@ class Str
     /**
      * Make a string's first character uppercase.
      *
-     * @param string $string
+     * @param  string  $string
      * @return string
      */
     public static function ucfirst($string)
     {
-        return static::upper(static::substr($string, 0, 1)) . static::substr($string, 1);
-    }
-
-    /**
-     * Convert the given string to upper-case.
-     *
-     * @param string $value
-     * @return string
-     */
-    public static function upper($value)
-    {
-        return mb_strtoupper($value, 'UTF-8');
+        return static::upper(static::substr($string, 0, 1)).static::substr($string, 1);
     }
 
     /**
@@ -771,8 +771,8 @@ class Str
     public static function uuid()
     {
         return static::$uuidFactory
-            ? call_user_func(static::$uuidFactory)
-            : Uuid::uuid4();
+                    ? call_user_func(static::$uuidFactory)
+                    : Uuid::uuid4();
     }
 
     /**
@@ -788,18 +788,14 @@ class Str
 
         $factory = new UuidFactory();
 
-        $factory->setRandomGenerator(
-            new CombGenerator(
-                $factory->getRandomGenerator(),
-                $factory->getNumberConverter()
-            )
-        );
+        $factory->setRandomGenerator(new CombGenerator(
+            $factory->getRandomGenerator(),
+            $factory->getNumberConverter()
+        ));
 
-        $factory->setCodec(
-            new TimestampFirstCombCodec(
-                $factory->getUuidBuilder()
-            )
-        );
+        $factory->setCodec(new TimestampFirstCombCodec(
+            $factory->getUuidBuilder()
+        ));
 
         return $factory->uuid4();
     }
@@ -807,7 +803,7 @@ class Str
     /**
      * Set the callable that will be used to generate UUIDs.
      *
-     * @param callable|null $factory
+     * @param  callable|null  $factory
      * @return void
      */
     public static function createUuidsUsing(callable $factory = null)

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -468,6 +468,17 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Remove any occurrence of the given string in the subject.
+     *
+     * @param string $search
+     * @return static
+     */
+    public function remove($search)
+    {
+        return new static(Str::remove($search, $this->value));
+    }
+
+    /**
      * Replace the given value in the given string.
      *
      * @param  string|string[]  $search

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -470,12 +470,13 @@ class Stringable implements JsonSerializable
     /**
      * Remove any occurrence of the given string in the subject.
      *
-     * @param string $search
+     * @param string|array<string> $search
+     * @param bool $caseSensitive
      * @return static
      */
-    public function remove($search)
+    public function remove($search, $caseSensitive = true)
     {
-        return new static(Str::remove($search, $this->value));
+        return new static(Str::remove($search, $this->value, $caseSensitive));
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -376,6 +376,7 @@ class SupportStrTest extends TestCase
         $this->assertSame("Fbr", Str::remove(["o", "a"], 'Foobar'));
         $this->assertSame("Fooar", Str::remove(["f", "b"], 'Foobar'));
         $this->assertSame("ooar", Str::remove(["f", "b"], 'Foobar', false));
+        $this->assertSame("Foobar", Str::remove(["f", "|"], 'Foo|bar'));
     }
 
     public function testSnake()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -371,6 +371,11 @@ class SupportStrTest extends TestCase
         $this->assertSame("Foo", Str::remove('bar', 'Foobar'));
         $this->assertSame("oobar", Str::remove('F', 'Foobar'));
         $this->assertSame("Foobar", Str::remove('f', 'Foobar'));
+        $this->assertSame("oobar", Str::remove('f', 'Foobar', false));
+
+        $this->assertSame("Fbr", Str::remove(["o", "a"], 'Foobar'));
+        $this->assertSame("Fooar", Str::remove(["f", "b"], 'Foobar'));
+        $this->assertSame("ooar", Str::remove(["f", "b"], 'Foobar', false));
     }
 
     public function testSnake()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -365,6 +365,14 @@ class SupportStrTest extends TestCase
         $this->assertSame('Malmö Jönköping', Str::replaceLast('', 'yyy', 'Malmö Jönköping'));
     }
 
+    public function testRemove()
+    {
+        $this->assertSame("Fbar", Str::remove('o', 'Foobar'));
+        $this->assertSame("Foo", Str::remove('bar', 'Foobar'));
+        $this->assertSame("oobar", Str::remove('F', 'Foobar'));
+        $this->assertSame("Foobar", Str::remove('f', 'Foobar'));
+    }
+
     public function testSnake()
     {
         $this->assertSame('laravel_p_h_p_framework', Str::snake('LaravelPHPFramework'));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -464,6 +464,7 @@ class SupportStringableTest extends TestCase
         $this->assertSame("Fbr", (string) $this->stringable('Foobar')->remove(["o", "a"]));
         $this->assertSame("Fooar", (string) $this->stringable('Foobar')->remove(["f", "b"]));
         $this->assertSame("ooar", (string) $this->stringable('Foobar')->remove(["f", "b"], false));
+        $this->assertSame("Foobar", (string) $this->stringable('Foo|bar')->remove(["f", "|"]));
     }
 
     public function testSnake()

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -459,6 +459,11 @@ class SupportStringableTest extends TestCase
         $this->assertSame("Foo", (string) $this->stringable('Foobar')->remove('bar'));
         $this->assertSame("oobar", (string) $this->stringable('Foobar')->remove('F'));
         $this->assertSame("Foobar", (string) $this->stringable('Foobar')->remove('f'));
+        $this->assertSame("oobar", (string) $this->stringable('Foobar')->remove('f', false));
+
+        $this->assertSame("Fbr", (string) $this->stringable('Foobar')->remove(["o", "a"]));
+        $this->assertSame("Fooar", (string) $this->stringable('Foobar')->remove(["f", "b"]));
+        $this->assertSame("ooar", (string) $this->stringable('Foobar')->remove(["f", "b"], false));
     }
 
     public function testSnake()

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Support;
 
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
 use PHPUnit\Framework\TestCase;
 
@@ -450,6 +451,14 @@ class SupportStringableTest extends TestCase
         // Test for multibyte string support
         $this->assertSame('Malmö Jönkxxxping', (string) $this->stringable('Malmö Jönköping')->replaceLast('ö', 'xxx'));
         $this->assertSame('Malmö Jönköping', (string) $this->stringable('Malmö Jönköping')->replaceLast('', 'yyy'));
+    }
+
+    public function testRemove()
+    {
+        $this->assertSame("Fbar", (string) $this->stringable('Foobar')->remove('o'));
+        $this->assertSame("Foo", (string) $this->stringable('Foobar')->remove('bar'));
+        $this->assertSame("oobar", (string) $this->stringable('Foobar')->remove('F'));
+        $this->assertSame("Foobar", (string) $this->stringable('Foobar')->remove('f'));
     }
 
     public function testSnake()


### PR DESCRIPTION
It always annoyed me that there was no `str_remove` method in PHP. I know that you can do `str_replace` and pass '', but I think it makes the code a fair bit harder to parse visually.

This PR adds `remove($value)` to the `Str` and `Stringable` classes.

## Usage

```php
// Fbar
Str::remove('o', 'Foobar');
Str::of('Foobar')->remove('o');

// Fbr
Str::remove(['o', 'a'], 'Foobar');
Str::of('Foobar')->remove(['o', 'a']);
``` 

I think it makes it much easier when dealing with complex string manipulation to quickly get a sense of what's happening.

This PR also adds an extra layer of functionality by allowing the removal of items in a case insensitive manner by passing false as the last parameter:

```php
// oobar
Str::remove('f', 'Foobar', false);
Str::of('Foobar')->remove('f', false);
```