### PR TITLE
[8.x] Add morph type to attributes when making new pivot

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
@@ -151,6 +151,8 @@ class MorphToMany extends BelongsToMany
     {
         $using = $this->using;
 
+        $attributes = Arr::add($attributes, $this->morphType, $this->morphClass);
+
         $pivot = $using ? $using::fromRawAttributes($this->parent, $attributes, $this->table, $exists)
                         : MorphPivot::fromAttributes($this->parent, $attributes, $this->table, $exists);
 


### PR DESCRIPTION
Currently when attaching a morph pivot the `type` will be set on the new pivot record as it's done within the overloaded `baseAttachRecord` method.

When making a new pivot it's handy to set the morph type as the pivot is ambiguous without it. My main use case is a `deleting` event on my custom morph pivot model. This event at the moment will only get the IDs for the pivot but not the morph type, so I don't exactly know *what* is being deleted.

If there's potentially problems elsewhere with setting this here then that's fine, it can be worked around for my cases, I just figured it'd be nice to get this in upstream.

Cheers.