### PR TITLE
[8.x] Adjust event facade comment for ide hint

### DIFF
--- a/src/Illuminate/Support/Facades/Event.php
+++ b/src/Illuminate/Support/Facades/Event.php
@@ -19,7 +19,7 @@ use Illuminate\Support\Testing\Fakes\EventFake;
  * @method static void flush(string $event)
  * @method static void forget(string $event)
  * @method static void forgetPushed()
- * @method static void listen(string|array $events, \Closure|string $listener = null)
+ * @method static void listen(\Closure|string|array $events, \Closure|string $listener = null)
  * @method static void push(string $event, array $payload = [])
  * @method static void subscribe(object|string $subscriber)
  *


### PR DESCRIPTION
While reading https://laravel.com/docs/8.x/events#manually-registering-events, I found that my IDE hint didn't say that I can use closure.
Is this change ok? It's my first time sending a pull request.