### PR TITLE
[8.x] Per route parameter binding

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -143,6 +143,13 @@ class Route
     protected $bindingFields = [];
 
     /**
+     * The bindings for the url parameters.
+     *
+     * @var array
+     */
+    protected $parameterBindings = [];
+
+    /**
      * The validators used by the routes.
      *
      * @var array
@@ -479,6 +486,44 @@ class Route
         }
 
         return $this->parameterNames = $this->compileParameterNames();
+    }
+
+    /**
+     * Get all of the parameter bindings for the route.
+     *
+     * @return array
+     */
+    public function parameterBindings()
+    {
+        return $this->parameterBindings;
+    }
+
+    /**
+     * Get all of the parameter bindings for the route.
+     *
+     * @param  string $name
+     * @return callable|null
+     */
+    public function parameterBinding($name)
+    {
+        return $this->parameterBindings[$name] ?? null;
+    }
+
+    /**
+     * Add a new route parameter binder.
+     *
+     * @param  string  $key
+     * @param  string|callable  $binder
+     * @return void
+     */
+    public function bindParameter($key, $binder)
+    {
+        $this->parameterBindings[str_replace('-', '_', $key)] = RouteBinding::forCallback(
+            $this->container,
+            $binder
+        );
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -807,7 +807,9 @@ class Router implements BindingRegistrar, RegistrarContract
     public function substituteBindings($route)
     {
         foreach ($route->parameters() as $key => $value) {
-            if (isset($this->binders[$key])) {
+            if ($binding = $route->parameterBinding($key)) {
+                $route->setParameter($key, call_user_func($binding, $value, $route));
+            } else if (isset($this->binders[$key])) {
                 $route->setParameter($key, $this->performBinding($key, $value, $route));
             }
         }

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -670,6 +670,19 @@ class RouteRegistrarTest extends TestCase
         $this->assertSame('users.index', $this->getRoute()->getName());
     }
 
+    public function testCanSetParameterBindings()
+    {
+        $closure = fn ($value) => "resolved-value-$value";
+
+        $this->router->get('users/{user}', function ($resolved) {
+            return $resolved;
+        })->bindParameter('user', $closure);
+
+        $this->assertSame($closure, $this->getRoute()->parameterBinding('user'));
+        $this->assertSame(['user' => $closure], $this->getRoute()->parameterBindings());
+        $this->assertSame('resolved-value-1', $this->getRoute()->parameterBinding('user')(1));
+    }
+
     /**
      * Get the last route registered with the router.
      *

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -879,6 +879,19 @@ class RoutingRouteTest extends TestCase
         $this->assertSame('TAYLOR', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
     }
 
+    public function testSingleRouteBinding()
+    {
+        $router = $this->getRouter();
+
+        $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => function ($name) {
+            return $name;
+        }])->bindParameter('bar', function ($value) {
+            return strtoupper($value);
+        });
+
+        $this->assertSame('TAYLOR', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
+    }
+
     public function testRouteClassBinding()
     {
         $router = $this->getRouter();
@@ -889,6 +902,16 @@ class RoutingRouteTest extends TestCase
         $this->assertSame('TAYLOR', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
     }
 
+    public function testSingleRouteClassBinding()
+    {
+        $router = $this->getRouter();
+        $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => function ($name) {
+            return $name;
+        }])->bindParameter('bar', RouteBindingStub::class);
+
+        $this->assertSame('TAYLOR', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
+    }
+
     public function testRouteClassMethodBinding()
     {
         $router = $this->getRouter();
@@ -896,6 +919,16 @@ class RoutingRouteTest extends TestCase
             return $name;
         }]);
         $router->bind('bar', RouteBindingStub::class.'@find');
+        $this->assertSame('dragon', $router->dispatch(Request::create('foo/Dragon', 'GET'))->getContent());
+    }
+
+    public function testSingleRouteClassMethodBinding()
+    {
+        $router = $this->getRouter();
+        $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => function ($name) {
+            return $name;
+        }])->bindParameter('bar', RouteBindingStub::class.'@find');
+
         $this->assertSame('dragon', $router->dispatch(Request::create('foo/Dragon', 'GET'))->getContent());
     }
 


### PR DESCRIPTION
This PR adds the ability to define per route parameter binding definitions, overriding global bindings defined at the router level.

Example:

```php
$router
    ->delete('{user}', function (User $user) {
        dd($user);
    })
    ->bindParameter('training', fn ($value) => User::withTrashed()->findOrFail($value));
```

This binding is evaluated before implicit bindings or global bindings defined via `Route::bind()`, allowing you to customize your routes even more.

I think this is very util when working with soft deletes.

Function naming can be changed if needed. I'd like to use the word `bind`, but it is already used to bind the request to the route.
