### PR TITLE
[8.x] Per route explicit model binding definition

### DIFF
--- a/src/Illuminate/Routing/AbstractRouteCollection.php
+++ b/src/Illuminate/Routing/AbstractRouteCollection.php
@@ -144,6 +144,7 @@ abstract class AbstractRouteCollection implements Countable, IteratorAggregate, 
                 'defaults' => $route->defaults,
                 'wheres' => $route->wheres,
                 'bindingFields' => $route->bindingFields(),
+                'parameterBindings' => $route->parameterBindings(),
                 'lockSeconds' => $route->locksFor(),
                 'waitSeconds' => $route->waitsFor(),
             ];

--- a/src/Illuminate/Routing/CompiledRouteCollection.php
+++ b/src/Illuminate/Routing/CompiledRouteCollection.php
@@ -302,7 +302,7 @@ class CompiledRouteCollection extends AbstractRouteCollection
             ->setDefaults($attributes['defaults'])
             ->setWheres($attributes['wheres'])
             ->setBindingFields($attributes['bindingFields'])
-            ->bindParameters($attributes['parameterBindings'])
+            ->bindParameter($attributes['parameterBindings'])
             ->block($attributes['lockSeconds'] ?? null, $attributes['waitSeconds'] ?? null);
     }
 

--- a/src/Illuminate/Routing/CompiledRouteCollection.php
+++ b/src/Illuminate/Routing/CompiledRouteCollection.php
@@ -302,7 +302,7 @@ class CompiledRouteCollection extends AbstractRouteCollection
             ->setDefaults($attributes['defaults'])
             ->setWheres($attributes['wheres'])
             ->setBindingFields($attributes['bindingFields'])
-            ->setParameterBindings($attributes['parameterBindings'])
+            ->bindParameters($attributes['parameterBindings'])
             ->block($attributes['lockSeconds'] ?? null, $attributes['waitSeconds'] ?? null);
     }
 

--- a/src/Illuminate/Routing/CompiledRouteCollection.php
+++ b/src/Illuminate/Routing/CompiledRouteCollection.php
@@ -302,6 +302,7 @@ class CompiledRouteCollection extends AbstractRouteCollection
             ->setDefaults($attributes['defaults'])
             ->setWheres($attributes['wheres'])
             ->setBindingFields($attributes['bindingFields'])
+            ->setParameterBindings($attributes['parameterBindings'])
             ->block($attributes['lockSeconds'] ?? null, $attributes['waitSeconds'] ?? null);
     }
 

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -510,36 +510,27 @@ class Route
     }
 
     /**
-     * Add a new route parameter binding.
+     * Set the bound parameters for the route.
      *
-     * @param  string|array  $key
+     * @param  string|array  $bindings
      * @param  string|callable|null  $binder
      * @return $this
      */
-    public function bindParameter($key, $binder = null)
+    public function bindParameter($bindings, $closure = null)
     {
-        if (is_string($binder) && RouteClosureSerializer::isSerializedClosure($binder)) {
-            $binder = unserialize($binder)->getClosure();
+        if (! is_array($bindings)) {
+            $bindings = [$bindings => $closure];
         }
 
-        $this->parameterBindings[str_replace('-', '_', $key)] = RouteBinding::forCallback(
-            $this->container,
-            $binder
-        );
+        foreach ($bindings as $key => $binder) {
+            if (is_string($binder) && RouteClosureSerializer::isSerializedClosure($binder)) {
+                $binder = unserialize($binder)->getClosure();
+            }
 
-        return $this;
-    }
-
-    /**
-     * Set all the parameter bindings fields for the route.
-     *
-     * @param  array  $bindings
-     * @return $this
-     */
-    public function bindParameters(array $bindings)
-    {
-        foreach ($bindings as $key => $value) {
-            $this->bindParameter($key, $value);
+            $this->parameterBindings[str_replace('-', '_', $key)] = RouteBinding::forCallback(
+                $this->container,
+                $binder
+            );
         }
 
         return $this;

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -527,6 +527,23 @@ class Route
     }
 
     /**
+     * Set the parameter bindings fields for the route.
+     *
+     * @param  array  $bindingFields
+     * @return $this
+     */
+    public function setParameterBindings(array $parameterBindings)
+    {
+        foreach ($parameterBindings as $key => $value) {
+            $this->parameterBindings[$key] = RouteClosureSerializer::isSerializedClosure($value)
+                ? unserialize($value)->getClosure()
+                : $value;
+        }
+
+        return $this;
+    }
+
+    /**
      * Get the parameter names for the route.
      *
      * @return array
@@ -990,7 +1007,7 @@ class Route
         $missing = $this->action['missing'] ?? null;
 
         return is_string($missing) &&
-            Str::startsWith($missing, 'C:32:"Opis\\Closure\\SerializableClosure')
+            RouteClosureSerializer::isSerializedClosure($missing)
                 ? unserialize($missing)
                 : $missing;
     }

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -143,6 +143,13 @@ class Route
     protected $bindingFields = [];
 
     /**
+     * The bindings for the url parameters.
+     *
+     * @var array
+     */
+    protected $parameterBindings = [];
+
+    /**
      * The validators used by the routes.
      *
      * @var array
@@ -479,6 +486,44 @@ class Route
         }
 
         return $this->parameterNames = $this->compileParameterNames();
+    }
+
+    /**
+     * Get all of the parameter bindings for the route.
+     *
+     * @return array
+     */
+    public function parameterBindings()
+    {
+        return $this->parameterBindings;
+    }
+
+    /**
+     * Get all of the parameter bindings for the route.
+     *
+     * @param  string $name
+     * @return callable|null
+     */
+    public function parameterBinding($name)
+    {
+        return $this->parameterBindings[$name] ?? null;
+    }
+
+    /**
+     * Add a new route parameter binder.
+     *
+     * @param  string  $key
+     * @param  string|callable  $binder
+     * @return void
+     */
+    public function bindParameter($key, $binder)
+    {
+        $this->parameterBindings[str_replace('-', '_', $key)] = RouteBinding::forCallback(
+            $this->container,
+            $binder
+        );
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Routing/RouteAction.php
+++ b/src/Illuminate/Routing/RouteAction.php
@@ -104,6 +104,6 @@ class RouteAction
     public static function containsSerializedClosure(array $action)
     {
         return is_string($action['uses']) &&
-               Str::startsWith($action['uses'], 'C:32:"Opis\\Closure\\SerializableClosure') !== false;
+               RouteClosureSerializer::isSerializedClosure($action['uses']);
     }
 }

--- a/src/Illuminate/Routing/RouteClosureSerializer.php
+++ b/src/Illuminate/Routing/RouteClosureSerializer.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\Routing;
+
+use Illuminate\Support\Str;
+
+class RouteClosureSerializer
+{
+    /**
+     * Determine if the given value is a serialized Closure.
+     *
+     * @param  string  $value
+     * @return bool
+     */
+    public static function isSerializedClosure($value)
+    {
+        return Str::startsWith($value, 'C:32:"Opis\\Closure\\SerializableClosure') !== false;
+    }
+}

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -809,7 +809,7 @@ class Router implements BindingRegistrar, RegistrarContract
         foreach ($route->parameters() as $key => $value) {
             if ($binding = $route->parameterBinding($key)) {
                 $route->setParameter($key, call_user_func($binding, $value, $route));
-            } else if (isset($this->binders[$key])) {
+            } elseif (isset($this->binders[$key])) {
                 $route->setParameter($key, $this->performBinding($key, $value, $route));
             }
         }

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -807,7 +807,9 @@ class Router implements BindingRegistrar, RegistrarContract
     public function substituteBindings($route)
     {
         foreach ($route->parameters() as $key => $value) {
-            if (isset($this->binders[$key])) {
+            if ($binding = $route->parameterBinding($key)) {
+                $route->setParameter($key, call_user_func($binding, $value, $route));
+            } else if (isset($this->binders[$key])) {
                 $route->setParameter($key, $this->performBinding($key, $value, $route));
             }
         }

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -670,6 +670,21 @@ class RouteRegistrarTest extends TestCase
         $this->assertSame('users.index', $this->getRoute()->getName());
     }
 
+    public function testCanSetParameterBindings()
+    {
+        $closure = function ($value) {
+            return "resolved-value-$value";
+        };
+
+        $this->router->get('users/{user}', function ($resolved) {
+            return $resolved;
+        })->bindParameter('user', $closure);
+
+        $this->assertSame($closure, $this->getRoute()->parameterBinding('user'));
+        $this->assertSame(['user' => $closure], $this->getRoute()->parameterBindings());
+        $this->assertSame('resolved-value-1', $this->getRoute()->parameterBinding('user')(1));
+    }
+
     /**
      * Get the last route registered with the router.
      *

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -879,6 +879,19 @@ class RoutingRouteTest extends TestCase
         $this->assertSame('TAYLOR', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
     }
 
+    public function testSingleRouteBinding()
+    {
+        $router = $this->getRouter();
+
+        $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => function ($name) {
+            return $name;
+        }])->bindParameter('bar', function ($value) {
+            return strtoupper($value);
+        });
+
+        $this->assertSame('TAYLOR', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
+    }
+
     public function testRouteClassBinding()
     {
         $router = $this->getRouter();
@@ -889,6 +902,16 @@ class RoutingRouteTest extends TestCase
         $this->assertSame('TAYLOR', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
     }
 
+    public function testSingleRouteClassBinding()
+    {
+        $router = $this->getRouter();
+        $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => function ($name) {
+            return $name;
+        }])->bindParameter('bar', RouteBindingStub::class);
+
+        $this->assertSame('TAYLOR', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
+    }
+
     public function testRouteClassMethodBinding()
     {
         $router = $this->getRouter();
@@ -896,6 +919,16 @@ class RoutingRouteTest extends TestCase
             return $name;
         }]);
         $router->bind('bar', RouteBindingStub::class.'@find');
+        $this->assertSame('dragon', $router->dispatch(Request::create('foo/Dragon', 'GET'))->getContent());
+    }
+
+    public function testSingleRouteClassMethodBinding()
+    {
+        $router = $this->getRouter();
+        $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => function ($name) {
+            return $name;
+        }])->bindParameter('bar', RouteBindingStub::class.'@find');
+
         $this->assertSame('dragon', $router->dispatch(Request::create('foo/Dragon', 'GET'))->getContent());
     }
 

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -913,13 +913,13 @@ class RoutingRouteTest extends TestCase
         $this->assertSame('TAYLOR', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
     }
 
-    public function testPerRouteBindings()
+    public function testPerRouteBindingsArray()
     {
         $router = $this->getRouter();
 
         $route = $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => function ($name) {
             return $name;
-        }])->bindParameters(['bar' => function ($value) {
+        }])->bindParameter(['bar' => function ($value) {
             return strtoupper($value);
         }]);
 
@@ -936,12 +936,12 @@ class RoutingRouteTest extends TestCase
         $this->assertSame('TAYLOR', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
     }
 
-    public function testPerRouteClassBindings()
+    public function testPerRouteClassBindingsArray()
     {
         $router = $this->getRouter();
         $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => function ($name) {
             return $name;
-        }])->bindParameters(['bar' => RouteBindingStub::class]);
+        }])->bindParameter(['bar' => RouteBindingStub::class]);
 
         $this->assertSame('TAYLOR', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
     }
@@ -956,12 +956,12 @@ class RoutingRouteTest extends TestCase
         $this->assertSame('dragon', $router->dispatch(Request::create('foo/Dragon', 'GET'))->getContent());
     }
 
-    public function testPerRouteClassMethodBindings()
+    public function testPerRouteClassMethodBindingsArray()
     {
         $router = $this->getRouter();
         $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => function ($name) {
             return $name;
-        }])->bindParameters(['bar' => RouteBindingStub::class.'@find']);
+        }])->bindParameter(['bar' => RouteBindingStub::class.'@find']);
 
         $this->assertSame('dragon', $router->dispatch(Request::create('foo/Dragon', 'GET'))->getContent());
     }
@@ -1658,9 +1658,15 @@ class RoutingRouteTest extends TestCase
     {
         $router = $this->getRouter();
 
-        $uses = function () { return 'uses'; };
-        $missing = function () { return 'missing'; };
-        $binding = function () { return 'binding'; };
+        $uses = function () {
+            return 'uses';
+        };
+        $missing = function () {
+            return 'missing';
+        };
+        $binding = function () {
+            return 'binding';
+        };
 
         $route = $router->get('foo/{bar}', ['uses' => $uses, 'missing' => $missing])
             ->bindParameter('bar', $binding);


### PR DESCRIPTION
Currently, there are two methods for defining route model binding:
- Implicit.
- Explicit.

While these options work great in most of the cases, the explicit bindings are directly attached to the router instance which means all the routes share the same logic resolution. This is good but sometimes is necessary a bit of customization for one or two routes. Currently, this can be achieved checking from which route our server is being called and act in consequence:

```php
Route::bind('user', function ($id) {
    if (request()->is('users/{user}/force')) {
        return User::withTrashed()->findOrFail($id);
    }

    return User::findOrFail($id);
});
```

I think we can do it better.

--- 

This PR adds the ability to define per route parameter binding definitions.

```php
// Single

$router->get('{one}/{two}', function (User $user) {
        //
})
->bindParameter('one', fn ($id) => 'one')
->bindParameter('two', MyCustomBindingsClass::class); // redirected to 'bind' method.


// Bulk

$router->get('{one}/{two}', function (User $user) {
    //
})
->bindParameter([
    'one' => fn ($id) => 'one',
    'two' => MyCustomBindingsClass::class . '@custom'
])
```

For the resolution, you can provide the same that is used for an explicit route model binding:
- A closure.
- A class name with a `bind` method.
- A `Class@method` string.

These bindings are evaluated before implicit or explicit global bindings.

---

Personally, I've found this very useful when working with soft deletes.

```php
$router->delete('users/{user}/force', function (User $user) {
    $user->forceDelete();
})->bindParameter('user', fn ($id) => fn () => User::withTrashed()->find($id));
```

--- 

**Note**: Naming can be changed if needed. I'd like to use the word `bind`, but it is already used to bind the request to the route.
