### PR TITLE
[8.x] Illegal offset type in some relations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -6,11 +6,12 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Concerns\ComparesRelatedModels;
+use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithDictionary;
 use Illuminate\Database\Eloquent\Relations\Concerns\SupportsDefaultModels;
 
 class BelongsTo extends Relation
 {
-    use ComparesRelatedModels, SupportsDefaultModels;
+    use ComparesRelatedModels, SupportsDefaultModels, InteractsWithDictionary;
 
     /**
      * The child model instance of the relation.
@@ -174,15 +175,17 @@ class BelongsTo extends Relation
         $dictionary = [];
 
         foreach ($results as $result) {
-            $dictionary[$result->getAttribute($owner)] = $result;
+            $attribute = $this->dictionaryKey($result->getAttribute($owner));
+            $dictionary[$attribute] = $result;
         }
 
         // Once we have the dictionary constructed, we can loop through all the parents
         // and match back onto their children using these keys of the dictionary and
         // the primary key of the children to map them onto the correct instances.
         foreach ($models as $model) {
-            if (isset($dictionary[$model->{$foreign}])) {
-                $model->setRelation($relation, $dictionary[$model->{$foreign}]);
+            $attribute = $this->dictionaryKey($model->{$foreign});
+            if (isset($dictionary[$attribute])) {
+                $model->setRelation($relation, $dictionary[$attribute]);
             }
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -175,7 +175,7 @@ class BelongsTo extends Relation
         $dictionary = [];
 
         foreach ($results as $result) {
-            $attribute = $this->dictionaryKey($result->getAttribute($owner));
+            $attribute = $this->getDictionaryKey($result->getAttribute($owner));
             $dictionary[$attribute] = $result;
         }
 
@@ -183,7 +183,7 @@ class BelongsTo extends Relation
         // and match back onto their children using these keys of the dictionary and
         // the primary key of the children to map them onto the correct instances.
         foreach ($models as $model) {
-            $attribute = $this->dictionaryKey($model->{$foreign});
+            $attribute = $this->getDictionaryKey($model->{$foreign});
             if (isset($dictionary[$attribute])) {
                 $model->setRelation($relation, $dictionary[$attribute]);
             }

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -279,7 +279,7 @@ class BelongsToMany extends Relation
         // children back to their parent using the dictionary and the keys on the
         // the parent models. Then we will return the hydrated models back out.
         foreach ($models as $model) {
-            $key = $this->dictionaryKey($model->{$this->parentKey});
+            $key = $this->getDictionaryKey($model->{$this->parentKey});
             if (isset($dictionary[$key])) {
                 $model->setRelation(
                     $relation, $this->related->newCollection($dictionary[$key])
@@ -304,7 +304,7 @@ class BelongsToMany extends Relation
         $dictionary = [];
 
         foreach ($results as $result) {
-            $value = $this->dictionaryKey($result->{$this->accessor}->{$this->foreignPivotKey});
+            $value = $this->getDictionaryKey($result->{$this->accessor}->{$this->foreignPivotKey});
             $dictionary[$value][] = $result;
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -8,12 +8,14 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\Eloquent\Relations\Concerns\AsPivot;
+use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithDictionary;
+use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithPivotTable;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 
 class BelongsToMany extends Relation
 {
-    use Concerns\InteractsWithPivotTable;
+    use InteractsWithPivotTable, InteractsWithDictionary;
 
     /**
      * The intermediate table for the relation.
@@ -277,7 +279,8 @@ class BelongsToMany extends Relation
         // children back to their parent using the dictionary and the keys on the
         // the parent models. Then we will return the hydrated models back out.
         foreach ($models as $model) {
-            if (isset($dictionary[$key = $model->{$this->parentKey}])) {
+            $key = $this->dictionaryKey($model->{$this->parentKey});
+            if (isset($dictionary[$key])) {
                 $model->setRelation(
                     $relation, $this->related->newCollection($dictionary[$key])
                 );
@@ -301,7 +304,8 @@ class BelongsToMany extends Relation
         $dictionary = [];
 
         foreach ($results as $result) {
-            $dictionary[$result->{$this->accessor}->{$this->foreignPivotKey}][] = $result;
+            $value = $this->dictionaryKey($result->{$this->accessor}->{$this->foreignPivotKey});
+            $dictionary[$value][] = $result;
         }
 
         return $dictionary;

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithDictionary.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithDictionary.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Relations\Concerns;
+
+use InvalidArgumentException;
+
+trait InteractsWithDictionary
+{
+    /**
+     * @param mixed $attribute
+     * @return mixed
+     */
+    protected function dictionaryKey($attribute)
+    {
+        if (is_object($attribute)) {
+            if (method_exists($attribute, '__toString')) {
+                return $attribute->__toString();
+            }
+            throw new InvalidArgumentException('Attribute value is an object without __toString method');
+        }
+
+        return $attribute;
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithDictionary.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithDictionary.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Database\Eloquent\Relations\Concerns;
 
-use InvalidArgumentException;
+use Doctrine\Instantiator\Exception\InvalidArgumentException;
 
 trait InteractsWithDictionary
 {
@@ -10,13 +10,13 @@ trait InteractsWithDictionary
      * @param mixed $attribute
      * @return mixed
      */
-    protected function dictionaryKey($attribute)
+    protected function getDictionaryKey($attribute)
     {
         if (is_object($attribute)) {
             if (method_exists($attribute, '__toString')) {
                 return $attribute->__toString();
             }
-            throw new InvalidArgumentException('Attribute value is an object without __toString method');
+            throw new InvalidArgumentException('Attribute value is an object without __toString method'); //I would prefer to throw an exception instead of "silent" and unintended behaviour
         }
 
         return $attribute;

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -7,10 +7,12 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithDictionary;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 class HasManyThrough extends Relation
 {
+    use InteractsWithDictionary;
     /**
      * The "through" parent model instance.
      *
@@ -193,7 +195,7 @@ class HasManyThrough extends Relation
         // link them up with their children using the keyed dictionary to make the
         // matching very convenient and easy work. Then we'll just return them.
         foreach ($models as $model) {
-            if (isset($dictionary[$key = $model->getAttribute($this->localKey)])) {
+            if (isset($dictionary[$key = $this->getDictionaryKey($model->getAttribute($this->localKey))])) {
                 $model->setRelation(
                     $relation, $this->related->newCollection($dictionary[$key])
                 );

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -5,9 +5,11 @@ namespace Illuminate\Database\Eloquent\Relations;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithDictionary;
 
 abstract class HasOneOrMany extends Relation
 {
+    use InteractsWithDictionary;
     /**
      * The foreign key of the parent model.
      *
@@ -141,7 +143,7 @@ abstract class HasOneOrMany extends Relation
         // link them up with their children using the keyed dictionary to make the
         // matching very convenient and easy work. Then we'll just return them.
         foreach ($models as $model) {
-            if (isset($dictionary[$key = $model->getAttribute($this->localKey)])) {
+            if (isset($dictionary[$key = $this->getDictionaryKey($model->getAttribute($this->localKey))])) {
                 $model->setRelation(
                     $relation, $this->getRelationValue($dictionary, $key, $type)
                 );
@@ -177,7 +179,8 @@ abstract class HasOneOrMany extends Relation
         $foreign = $this->getForeignKeyName();
 
         return $results->mapToDictionary(function ($result) use ($foreign) {
-            return [$result->{$foreign} => $result];
+            $dictionaryKey = $this->getDictionaryKey($result->{$foreign});
+            return [$dictionaryKey => $result];
         })->all();
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -180,6 +180,7 @@ abstract class HasOneOrMany extends Relation
 
         return $results->mapToDictionary(function ($result) use ($foreign) {
             $dictionaryKey = $this->getDictionaryKey($result->{$foreign});
+
             return [$dictionaryKey => $result];
         })->all();
     }

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneThrough.php
@@ -4,11 +4,12 @@ namespace Illuminate\Database\Eloquent\Relations;
 
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithDictionary;
 use Illuminate\Database\Eloquent\Relations\Concerns\SupportsDefaultModels;
 
 class HasOneThrough extends HasManyThrough
 {
-    use SupportsDefaultModels;
+    use SupportsDefaultModels, InteractsWithDictionary;
 
     /**
      * Get the results of the relationship.
@@ -52,7 +53,7 @@ class HasOneThrough extends HasManyThrough
         // link them up with their children using the keyed dictionary to make the
         // matching very convenient and easy work. Then we'll just return them.
         foreach ($models as $model) {
-            if (isset($dictionary[$key = $model->getAttribute($this->localKey)])) {
+            if (isset($dictionary[$key = $this->getDictionaryKey($model->getAttribute($this->localKey))])) {
                 $value = $dictionary[$key];
                 $model->setRelation(
                     $relation, reset($value)

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -6,9 +6,11 @@ use BadMethodCallException;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithDictionary;
 
 class MorphTo extends BelongsTo
 {
+    use InteractsWithDictionary;
     /**
      * The type of the polymorphic relation.
      *
@@ -97,7 +99,9 @@ class MorphTo extends BelongsTo
     {
         foreach ($models as $model) {
             if ($model->{$this->morphType}) {
-                $this->dictionary[$model->{$this->morphType}][$model->{$this->foreignKey}][] = $model;
+                $morphTypeKey = $this->getDictionaryKey($model->{$this->morphType});
+                $foreignKeyKey = $this->getDictionaryKey($model->{$this->foreignKey});
+                $this->dictionary[$morphTypeKey][$foreignKeyKey][] = $model;
             }
         }
     }
@@ -207,7 +211,7 @@ class MorphTo extends BelongsTo
     protected function matchToMorphParents($type, Collection $results)
     {
         foreach ($results as $result) {
-            $ownerKey = ! is_null($this->ownerKey) ? $result->{$this->ownerKey} : $result->getKey();
+            $ownerKey = ! is_null($this->ownerKey) ? $this->getDictionaryKey($result->{$this->ownerKey}) : $result->getKey();
 
             if (isset($this->dictionary[$type][$ownerKey])) {
                 foreach ($this->dictionary[$type][$ownerKey] as $model) {

--- a/tests/Database/DatabaseEloquentBelongsToManyWithCastedAttributesTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyWithCastedAttributesTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseEloquentBelongsToManyWithCastedAttributesTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    public function testModelsAreProperlyMatchedToParents()
+    {
+        $relation = $this->getRelation();
+        $model1 = m::mock(Model::class);
+        $model1->shouldReceive('getAttribute')->with('parent_key')->andReturn(1);
+        $model1->shouldReceive('getAttribute')->with('foo')->passthru();
+        $model1->shouldReceive('hasGetMutator')->andReturn(false);
+        $model1->shouldReceive('getCasts')->andReturn([]);
+        $model1->shouldReceive('getRelationValue', 'relationLoaded', 'setRelation')->passthru();
+
+        $model2 = m::mock(Model::class);
+        $model2->shouldReceive('getAttribute')->with('parent_key')->andReturn(2);
+        $model2->shouldReceive('getAttribute')->with('foo')->passthru();
+        $model2->shouldReceive('hasGetMutator')->andReturn(false);
+        $model2->shouldReceive('getCasts')->andReturn([]);
+        $model2->shouldReceive('getRelationValue', 'relationLoaded', 'setRelation')->passthru();
+
+        $result1 = (object) [
+            'pivot' => (object) [
+                'foreign_key' => new class {
+                    public function __toString()
+                    {
+                        return '1';
+                    }
+                },
+            ],
+        ];
+
+        $models = $relation->match([$model1, $model2], Collection::wrap($result1), 'foo');
+        self::assertNull($models[1]->foo);
+        self::assertEquals(1, $models[0]->foo->count());
+        self::assertContains($result1, $models[0]->foo);
+    }
+
+    protected function getRelation()
+    {
+        $builder = m::mock(Builder::class);
+        $related = m::mock(Model::class);
+        $related->shouldReceive('newCollection')->passthru();
+        $builder->shouldReceive('getModel')->andReturn($related);
+        $related->shouldReceive('qualifyColumn');
+        $builder->shouldReceive('join', 'where');
+
+        return new BelongsToMany(
+            $builder,
+            new EloquentBelongsToManyModelStub,
+            'relation',
+            'foreign_key',
+            'id',
+            'parent_key',
+            'related_key'
+        );
+    }
+}
+
+class EloquentBelongsToManyModelStub extends Model
+{
+    public $foreign_key = 'foreign.value';
+}

--- a/tests/Database/DatabaseEloquentBelongsToTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToTest.php
@@ -109,14 +109,29 @@ class DatabaseEloquentBelongsToTest extends TestCase
         $result1->shouldReceive('getAttribute')->with('id')->andReturn(1);
         $result2 = m::mock(stdClass::class);
         $result2->shouldReceive('getAttribute')->with('id')->andReturn(2);
+        $result3 = m::mock(stdClass::class);
+        $result3->shouldReceive('getAttribute')->with('id')->andReturn(new class {
+            public function __toString()
+            {
+                return '3';
+            }
+        });
         $model1 = new EloquentBelongsToModelStub;
         $model1->foreign_key = 1;
         $model2 = new EloquentBelongsToModelStub;
         $model2->foreign_key = 2;
-        $models = $relation->match([$model1, $model2], new Collection([$result1, $result2]), 'foo');
+        $model3 = new EloquentBelongsToModelStub;
+        $model3->foreign_key = new class {
+            public function __toString()
+            {
+                return '3';
+            }
+        };
+        $models = $relation->match([$model1, $model2, $model3], new Collection([$result1, $result2, $result3]), 'foo');
 
         $this->assertEquals(1, $models[0]->foo->getAttribute('id'));
         $this->assertEquals(2, $models[1]->foo->getAttribute('id'));
+        $this->assertEquals('3', $models[2]->foo->getAttribute('id'));
     }
 
     public function testAssociateMethodSetsForeignKeyOnModel()

--- a/tests/Database/DatabaseEloquentHasOneTest.php
+++ b/tests/Database/DatabaseEloquentHasOneTest.php
@@ -160,6 +160,13 @@ class DatabaseEloquentHasOneTest extends TestCase
         $result1->foreign_key = 1;
         $result2 = new EloquentHasOneModelStub;
         $result2->foreign_key = 2;
+        $result3 = new EloquentHasOneModelStub;
+        $result3->foreign_key = new class {
+            public function __toString()
+            {
+                return '4';
+            }
+        };
 
         $model1 = new EloquentHasOneModelStub;
         $model1->id = 1;
@@ -167,12 +174,15 @@ class DatabaseEloquentHasOneTest extends TestCase
         $model2->id = 2;
         $model3 = new EloquentHasOneModelStub;
         $model3->id = 3;
+        $model4 = new EloquentHasOneModelStub;
+        $model4->id = 4;
 
-        $models = $relation->match([$model1, $model2, $model3], new Collection([$result1, $result2]), 'foo');
+        $models = $relation->match([$model1, $model2, $model3, $model4], new Collection([$result1, $result2, $result3]), 'foo');
 
         $this->assertEquals(1, $models[0]->foo->foreign_key);
         $this->assertEquals(2, $models[1]->foo->foreign_key);
         $this->assertNull($models[2]->foo);
+        $this->assertEquals('4', $models[3]->foo->foreign_key);
     }
 
     public function testRelationCountQueryCanBeBuilt()

--- a/tests/Database/DatabaseEloquentMorphToTest.php
+++ b/tests/Database/DatabaseEloquentMorphToTest.php
@@ -26,6 +26,12 @@ class DatabaseEloquentMorphToTest extends TestCase
             $one = (object) ['morph_type' => 'morph_type_1', 'foreign_key' => 'foreign_key_1'],
             $two = (object) ['morph_type' => 'morph_type_1', 'foreign_key' => 'foreign_key_1'],
             $three = (object) ['morph_type' => 'morph_type_2', 'foreign_key' => 'foreign_key_2'],
+            $four = (object) ['morph_type' => 'morph_type_2', 'foreign_key' => new class {
+                public function __toString()
+                {
+                    return 'foreign_key_2';
+                }
+            }],
         ]);
 
         $dictionary = $relation->getDictionary();
@@ -40,6 +46,7 @@ class DatabaseEloquentMorphToTest extends TestCase
             'morph_type_2' => [
                 'foreign_key_2' => [
                     $three,
+                    $four,
                 ],
             ],
         ], $dictionary);


### PR DESCRIPTION
In case you have relations belongsTo or belongsToMany based on a casted to objects values and you are using `Model::with('belongsToRelationWithCasting')` you'll get `Illegal offset type`
Here is some example:
```php
class Video extends Model
{
    public function user_profile(): BelongsTo
    {
        return $this->belongsTo(UserProfile::class, 'user_profile_uuid', 'uuid');
    }
}
class UserProfile extends Model
{
    protected $casts = [
        'uuid' => UuidCast::class,
    ];
}
```
Without the patch
```php
>>> Video::with('user_profile')->first()
[!] Aliasing 'Video' to 'App\Models\Video' for this Tinker session.
<warning>PHP Warning:  Illegal offset type in /var/www/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php on line 179</warning>
=> App\Models\Video {#4604
     uuid: "f09ff84b-7ca8-4a57-acc2-f2fb88686ecd",
     user_profile: null,
   }

```
With applied patch:
```php
>>> Video::with('user_profile')->first()
[!] Aliasing 'Video' to 'App\Models\Video' for this Tinker session.
=> App\Models\Video {#4604
     id: 1,
     uuid: "f09ff84b-7ca8-4a57-acc2-f2fb88686ecd",
     user_profile: App\Models\UserProfile {#4837
       uuid: Ramsey\Uuid\Lazy\LazyUuidFromString {#4565
         uuid: "4c95d6cb-c3e9-455b-8789-40c8c90a1e25",
       },
     },
   }
```

