### PR TITLE
[8.x] No need to call unset many times

### DIFF
--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -184,10 +184,12 @@ class AuthAccessGateTest extends TestCase
         $this->assertTrue($_SERVER['__laravel.gateAfter']);
         $this->assertFalse($_SERVER['__laravel.gateAfter2']);
 
-        unset($_SERVER['__laravel.gateBefore']);
-        unset($_SERVER['__laravel.gateBefore2']);
-        unset($_SERVER['__laravel.gateAfter']);
-        unset($_SERVER['__laravel.gateAfter2']);
+        unset(
+            $_SERVER['__laravel.gateBefore'],
+            $_SERVER['__laravel.gateBefore2'],
+            $_SERVER['__laravel.gateAfter'],
+            $_SERVER['__laravel.gateAfter2']
+        );
     }
 
     public function testResourceGatesCanBeDefined()

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -70,10 +70,7 @@ class BusBatchTest extends TestCase
      */
     protected function tearDown(): void
     {
-        unset($_SERVER['__finally.batch']);
-        unset($_SERVER['__then.batch']);
-        unset($_SERVER['__catch.batch']);
-        unset($_SERVER['__catch.exception']);
+        unset($_SERVER['__finally.batch'], $_SERVER['__then.batch'], $_SERVER['__catch.batch'], $_SERVER['__catch.exception']);
 
         $this->schema()->drop('job_batches');
 

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -200,8 +200,7 @@ class DatabaseEloquentFactoryTest extends TestCase
         $this->assertSame($user, $_SERVER['__test.user.making']);
         $this->assertSame($user, $_SERVER['__test.user.creating']);
 
-        unset($_SERVER['__test.user.making']);
-        unset($_SERVER['__test.user.creating']);
+        unset($_SERVER['__test.user.making'], $_SERVER['__test.user.creating']);
     }
 
     public function test_has_many_relationship()
@@ -232,9 +231,7 @@ class DatabaseEloquentFactoryTest extends TestCase
         $this->assertInstanceOf(Eloquent::class, $_SERVER['__test.post.creating-user']);
         $this->assertInstanceOf(Eloquent::class, $_SERVER['__test.post.state-user']);
 
-        unset($_SERVER['__test.post.creating-post']);
-        unset($_SERVER['__test.post.creating-user']);
-        unset($_SERVER['__test.post.state-user']);
+        unset($_SERVER['__test.post.creating-post'], $_SERVER['__test.post.creating-user'], $_SERVER['__test.post.state-user']);
     }
 
     public function test_belongs_to_relationship()
@@ -331,8 +328,7 @@ class DatabaseEloquentFactoryTest extends TestCase
         $this->assertInstanceOf(Eloquent::class, $_SERVER['__test.role.creating-role']);
         $this->assertInstanceOf(Eloquent::class, $_SERVER['__test.role.creating-user']);
 
-        unset($_SERVER['__test.role.creating-role']);
-        unset($_SERVER['__test.role.creating-user']);
+        unset($_SERVER['__test.role.creating-role'], $_SERVER['__test.role.creating-user']);
     }
 
     public function test_belongs_to_many_relationship_with_existing_model_instances()

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -388,8 +388,7 @@ class EventsDispatcherTest extends TestCase
         $this->assertSame('fooo', $_SERVER['__event.test1']);
         $this->assertSame('baar', $_SERVER['__event.test2']);
 
-        unset($_SERVER['__event.test1']);
-        unset($_SERVER['__event.test2']);
+        unset($_SERVER['__event.test1'], $_SERVER['__event.test2']);
     }
 
     public function testNestedEvent()

--- a/tests/Foundation/Bootstrap/LoadEnvironmentVariablesTest.php
+++ b/tests/Foundation/Bootstrap/LoadEnvironmentVariablesTest.php
@@ -11,8 +11,7 @@ class LoadEnvironmentVariablesTest extends TestCase
 {
     protected function tearDown(): void
     {
-        unset($_ENV['FOO']);
-        unset($_SERVER['FOO']);
+        unset($_ENV['FOO'], $_SERVER['FOO']);
         putenv('FOO');
         m::close();
     }

--- a/tests/Integration/Routing/CompiledRouteCollectionTest.php
+++ b/tests/Integration/Routing/CompiledRouteCollectionTest.php
@@ -39,8 +39,7 @@ class CompiledRouteCollectionTest extends TestCase
     {
         parent::tearDown();
 
-        unset($this->routeCollection);
-        unset($this->router);
+        unset($this->routeCollection, $this->router);
     }
 
     /**

--- a/tests/Pipeline/PipelineTest.php
+++ b/tests/Pipeline/PipelineTest.php
@@ -28,8 +28,7 @@ class PipelineTest extends TestCase
         $this->assertSame('foo', $_SERVER['__test.pipe.one']);
         $this->assertSame('foo', $_SERVER['__test.pipe.two']);
 
-        unset($_SERVER['__test.pipe.one']);
-        unset($_SERVER['__test.pipe.two']);
+        unset($_SERVER['__test.pipe.one'], $_SERVER['__test.pipe.two']);
     }
 
     public function testPipelineUsageWithObjects()


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR ensures that `unset` is not called many times instead than once
