### PR TITLE
[8.x] Add ability to rate limit jobs per second

### DIFF
--- a/src/Illuminate/Cache/RateLimiting/Limit.php
+++ b/src/Illuminate/Cache/RateLimiting/Limit.php
@@ -40,11 +40,34 @@ class Limit
      * @param  int  $decayMinutes
      * @return void
      */
-    public function __construct($key = '', int $maxAttempts = 60, int $decayMinutes = 1)
+    public function __construct($key = '', int $maxAttempts = 60, float $decayMinutes = 1)
     {
         $this->key = $key;
         $this->maxAttempts = $maxAttempts;
         $this->decayMinutes = $decayMinutes;
+    }
+
+    /**
+     * Create a new rate limit using a second.
+     *
+     * @param  int  $maxAttempts
+     * @return static
+     */
+    public static function perSecond($maxAttempts)
+    {
+        return new static('', $maxAttempts, 1 / 60);
+    }
+
+    /**
+     * Create a new rate limit using seconds as decay time.
+     *
+     * @param  int  $decaySeconds
+     * @param  int  $maxAttempts
+     * @return static
+     */
+    public static function perSeconds($decaySeconds, $maxAttempts)
+    {
+        return new static('', $maxAttempts, $decaySeconds / 60);
     }
 
     /**

--- a/tests/Integration/Queue/RateLimitedWithRedisTest.php
+++ b/tests/Integration/Queue/RateLimitedWithRedisTest.php
@@ -67,6 +67,20 @@ class RateLimitedWithRedisTest extends TestCase
         $this->assertJobWasReleased($testJob);
     }
 
+    public function testRateLimitedJobsAcceptFractionalMinutes()
+    {
+        $rateLimiter = $this->app->make(RateLimiter::class);
+
+        $testJob = new RedisRateLimitedTestJob;
+
+        $rateLimiter->for($testJob->key, function ($job) {
+            return Limit::perSecond(1);
+        });
+
+        $this->assertJobRanSuccessfully($testJob);
+        $this->assertJobWasReleased($testJob);
+    }
+
     public function testRateLimitedJobsCanBeSkippedOnLimitReached()
     {
         $rateLimiter = $this->app->make(RateLimiter::class);


### PR DESCRIPTION
Sometimes, when interacting with 3rd party API's, you are restricted to a rate limit of X requests per second. The throttle job middleware is a great way to queue up API requests and dispatch them at an allowed rate limit.

However, the lowest time denominator for the queue rate limit middleware is on a per-minute basis.

The pull request lowers the minimum time denominator to a per-second basis.

I would be happy to also lower the HTTP rate limit middleware to a per-second basis too.