### PR TITLE
[6.x] Fixes the issue using cache:clear with PhpRedis and a clustered Redis instance.

### DIFF
--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -484,14 +484,8 @@ class PhpRedisConnection extends Connection implements ConnectionContract
             return $this->command('flushdb');
         }
 
-        foreach ($this->client->_masters() as [$host, $port]) {
-            $redis = tap(new Redis)->connect($host, $port);
-
-            if (isset($this->config['password']) && ! empty($this->config['password'])) {
-                $redis->auth($this->config['password']);
-            }
-
-            $redis->flushDb();
+        foreach ($this->client->_masters() as $master) {
+            $this->client->flushDb($master);
         }
     }
 


### PR DESCRIPTION
This is simply a replication of the fix  by @willbrowningme in MR #36281 which was already merged to the 8.x release branch.

The issue is however still unfixed within the 6.x LTS release, so this PR is a simple replication of the work previously undertaken to allow for the fix to be merged into the 6.x branch.

I have tested that as with the other branch, these changes not only work, but also have no adverse affects. In addition to replicating the tests undertaken by @willbrowningme I have also tested this within a Kubernetes environment running both php-fpm 7.3 & 7.4 tests alongside a clustered Redis instance.