### PR TITLE
[8.x] Add prohibited validation rule

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1435,6 +1435,19 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate that an attribute does not exist.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  mixed  $parameters
+     * @return bool
+     */
+    public function validateProhibited($attribute, $value)
+    {
+        return false;
+    }
+
+    /**
      * Validate that an attribute does not exist when another attribute has a given value.
      *
      * @param  string  $attribute

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -227,6 +227,7 @@ class Validator implements ValidatorContract
         'RequiredWithAll',
         'RequiredWithout',
         'RequiredWithoutAll',
+        'Prohibited',
         'ProhibitedIf',
         'ProhibitedUnless',
         'Same',

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1190,6 +1190,36 @@ class ValidationValidatorTest extends TestCase
         $this->assertSame('The last field is required unless first is in taylor, sven.', $v->messages()->first('last'));
     }
 
+    public function testProhibited()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+
+        $v = new Validator($trans, [], ['name' => 'prohibited']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['last' => 'bar'], ['name' => 'prohibited']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['name' => 'foo'], ['name' => 'prohibited']);
+        $this->assertTrue($v->fails());
+
+        $file = new File('', false);
+        $v = new Validator($trans, ['name' => $file], ['name' => 'prohibited']);
+        $this->assertTrue($v->fails());
+
+        $file = new File(__FILE__, false);
+        $v = new Validator($trans, ['name' => $file], ['name' => 'prohibited']);
+        $this->assertTrue($v->fails());
+
+        $file = new File(__FILE__, false);
+        $file2 = new File(__FILE__, false);
+        $v = new Validator($trans, ['files' => [$file, $file2]], ['files.0' => 'prohibited', 'files.1' => 'prohibited']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['files' => [$file, $file2]], ['files' => 'prohibited']);
+        $this->assertTrue($v->fails());
+    }
+
     public function testProhibitedIf()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
In addition to the recently added `prohibited_if` and `prohibited_unless` validation rules (https://github.com/laravel/framework/pull/36516), I think a generic `prohibited` validation rule may be useful.

**Use case**
In my specific use case, the `prohibited` validation rule is useful when building API's while working with immutable attributes, for example:

```php
// Create a license key
$this->postJson(route('api.license'),['name' => 'foobar', 'key' => 'my-key']));

// Update given license key
$this->patchJson(route('api.license', '123-456'),['name' => 'hello-world', 'key' => 'random-key']));
```

The license key is immutable and for that reason it's not part of the validation rules, so the API responds with a successful status given it just ignores the `key` attribute:

```php
// PUT /api/licenses/123-456
// {"name":"hello-world", "key":"random-key"}

$validated = $request->validate([
    'name' => 'required|max:255',
]);

$license->update($validated);

// Response: OK
```

When working with API's this might be confusing. This might give the impression that the request was successful and both the name and key have been updated while in reality only the name has been changed. The `prohibited` validation rule will throw a validation error if a prohibited attribute is submitted.

```php
// PUT /api/licenses/123-456
// {"name":"hello-world", "key":"random-key"}

$validated = $request->validate([
    'name' => 'required|max:255',
    'key' => 'prohibited',
]);

// Response: 422
// The key field is prohibited
```

