### PR TITLE
[6.x] Add WSREP communication link failure for lost connection detection

### DIFF
--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -51,6 +51,7 @@ trait DetectsLostConnections
             'SQLSTATE[HY000]: General error: 1105 The last transaction was aborted due to Seamless Scaling. Please retry.',
             'Temporary failure in name resolution',
             'SSL: Broken pipe',
+            'SQLSTATE[08S01]: Communication link failure',
         ]);
     }
 }


### PR DESCRIPTION
We use Percona XtraDB Cluster for MySQL master-master replication. If the cluster goes into split brain mode and every node is non-Primary, the following error is triggered:

`SQLSTATE[08S01]: Communication link failure: 1047 WSREP has not yet prepared node for application use`

Most of the time this is resolved quickly, but using the database driver will get stuck as it doesn't retry the connection.

This PR adds that specific error to the retry connection logic.