### PR TITLE
[8.x] Add strict comparison to distinct validation rule

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -556,7 +556,7 @@ trait ValidatesAttributes
             return empty(preg_grep('/^'.preg_quote($value, '/').'$/iu', $data));
         }
 
-        return ! in_array($value, array_values($data));
+        return ! in_array($value, array_values($data), in_array('strict', $parameters));
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2395,6 +2395,15 @@ class ValidationValidatorTest extends TestCase
         $v->messages()->setFormat(':message');
         $this->assertSame('There is a duplication!', $v->messages()->first('foo.0'));
         $this->assertSame('There is a duplication!', $v->messages()->first('foo.1'));
+
+        $v = new Validator($trans, ['foo' => ['0100', '100']], ['foo.*' => 'distinct'], ['foo.*.distinct' => 'There is a duplication!']);
+        $this->assertFalse($v->passes());
+        $v->messages()->setFormat(':message');
+        $this->assertSame('There is a duplication!', $v->messages()->first('foo.0'));
+        $this->assertSame('There is a duplication!', $v->messages()->first('foo.1'));
+
+        $v = new Validator($trans, ['foo' => ['0100', '100']], ['foo.*' => 'distinct:strict']);
+        $this->assertTrue($v->passes());
     }
 
     public function testValidateDistinctForTopLevelArrays()


### PR DESCRIPTION
Adds the ability to add the parameter `strict` to the `distinct` validation rule.

```php
$v = new Validator($trans, ['foo' => ['0100', '100']], ['foo.*' => 'distinct'], ['foo.*.distinct' => 'There is a duplication!']);
$this->assertFalse($v->passes());
$v->messages()->setFormat(':message');
$this->assertSame('There is a duplication!', $v->messages()->first('foo.0'));
$this->assertSame('There is a duplication!', $v->messages()->first('foo.1'));

$v = new Validator($trans, ['foo' => ['0100', '100']], ['foo.*' => 'distinct:strict']);
$this->assertTrue($v->passes());
```

The default behaviour was not changed.