### PR TITLE
[8.x] Update firstOrNew method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -588,15 +588,16 @@ class BelongsToMany extends Relation
      * Get the first related model record matching the attributes or instantiate it.
      *
      * @param  array  $attributes
+     * @param  array  $values
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function firstOrNew(array $attributes)
+    public function firstOrNew(array $attributes = [], array $values = [])
     {
-        if (is_null($instance = $this->where($attributes)->first())) {
-            $instance = $this->related->newInstance($attributes);
+        if (! is_null($instance = $this->where($attributes)->first())) {
+            return $instance;
         }
 
-        return $instance;
+        return $this->related->newInstance($attributes + $values);
     }
 
     /**

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -417,10 +417,15 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
 
         $post->tags()->attach(Tag::all());
 
-        $this->assertEquals($tag->id, $post->tags()->firstOrNew(['id' => $tag->id])->id);
+        $newTag1 = $post->tags()->firstOrNew(['id' => $tag->id], ['name' => 'blablabla']);
+        $this->assertInstanceOf(Tag::class, $newTag1);
+        $this->assertEquals($tag->id, $newTag1->id);
+        $this->assertEquals($tag->name, $newTag1->name);
 
-        $this->assertNull($post->tags()->firstOrNew(['id' => 'asd'])->id);
-        $this->assertInstanceOf(Tag::class, $post->tags()->firstOrNew(['id' => 'asd']));
+        $newTag2 = $post->tags()->firstOrNew(['id' => 'asd'], ['name' => 'blablabla']);
+        $this->assertNull($newTag2->id);
+        $this->assertEquals('blablabla', $newTag2->name);
+        $this->assertInstanceOf(Tag::class, $newTag2);
     }
 
     public function testFirstOrCreateMethod()

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -423,9 +423,9 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $this->assertEquals($tag->name, $newTag1->name);
 
         $newTag2 = $post->tags()->firstOrNew(['id' => 'asd'], ['name' => 'blablabla']);
+        $this->assertInstanceOf(Tag::class, $newTag2);
         $this->assertNull($newTag2->id);
         $this->assertEquals('blablabla', $newTag2->name);
-        $this->assertInstanceOf(Tag::class, $newTag2);
     }
 
     public function testFirstOrCreateMethod()


### PR DESCRIPTION
Recently i've found that this code don't work with belongsToMany:

```
$tag = $post->tags()->firstOrNew(['id' => $tag->id], ['name' => 'blablabla']);
dd($tag->name); // null
```

Later, i've found this error in my IDE:

BelongsToMany.php:594
`Declaration should be compatible with Builder->firstOrNew([attributes: array = []], [values: array = []]) `