### PR TITLE
[8.x] Fluent add when()

### DIFF
--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -87,6 +87,25 @@ class Fluent implements Arrayable, ArrayAccess, Jsonable, JsonSerializable
     }
 
     /**
+     * Apply the callback's changes if the given "value" is true.
+     *
+     * @param  mixed  $value
+     * @param  callable  $callback
+     * @param  callable|null  $default
+     * @return mixed|$this
+     */
+    public function when($value, $callback, $default = null)
+    {
+        if ($value) {
+            return $callback($this, $value) ?: $this;
+        } elseif ($default) {
+            return $default($this, $value) ?: $this;
+        }
+
+        return $this;
+    }
+
+    /**
      * Determine if the given offset exists.
      *
      * @param  string  $offset

--- a/tests/Support/SupportFluentTest.php
+++ b/tests/Support/SupportFluentTest.php
@@ -113,6 +113,35 @@ class SupportFluentTest extends TestCase
 
         $this->assertJsonStringEqualsJsonString(json_encode('foo'), $results);
     }
+
+    public function testConditionalAttributeSetter()
+    {
+        $fluent = new Fluent;
+
+        $fluent->when(false, function (Fluent $values) {
+            $values->name('Taylor');
+        });
+        $this->assertFalse(isset($fluent->name));
+
+        $fluent->when(true, function (Fluent $values) {
+            $values->name('Taylor');
+        });
+        $this->assertTrue(isset($fluent->name));
+    }
+
+    public function testConditionalAttributeSetterWithDefault()
+    {
+        $fluent = new Fluent;
+
+        $fluent->when(false, function (Fluent $values) {
+            $values->name('Taylor');
+        }, function (Fluent $values) {
+            $values->age(25);
+        });
+
+        $this->assertFalse(isset($fluent->name));
+        $this->assertTrue(isset($fluent->age));
+    }
 }
 
 class FluentArrayIteratorStub implements IteratorAggregate


### PR DESCRIPTION
This PR adds when() to `Illuminate\Support\Fluent` class, known from QueryBuilder.

Usage
```php
$fluent = new Fluent;

$fluent->when(true, function (Fluent $values) {
    $values->name('test');
});

dump($fluent->toArray());
//  ["name" => "test"]
```
or
```php
$fluent = new Fluent;

$fluent->when(false, function (Fluent $values) {
    $values->name('test');
});

dump($fluent->toArray());
//  []
```
It works the same as the QueryBuilder method and has also an argument for a default closure.
```php
$fluent = new Fluent;

$fluent->when(true, function (Fluent $values) {
    $values->name('test');
}, function (Fluent $values) {
    $values->name('default');
});

dump($fluent->toArray());
//  ["name" => "default"]
```

I saw this Class at Laracon Online and thought lets use it in one of my projects but haven't used it then because of the missing `when` method.

As it is now it could only be used like this:
```php
$fluent = new Fluent;

$fluent->foo('test');

if (true) {
  $fluent->bar('baz');
}

dump($fluent->toArray());
//  ["foo" => "test", "bar" => "baz"]
```

The only downside with this solution is, that the key `when` can't be used anymore.
Hope you like my change :)
