### PR TITLE
[8.x] Expect custom markdown mailable themes to be in mail subdirectory

### DIFF
--- a/src/Illuminate/Mail/Markdown.php
+++ b/src/Illuminate/Mail/Markdown.php
@@ -63,8 +63,8 @@ class Markdown
             'mail', $this->htmlComponentPaths()
         )->make($view, $data)->render();
 
-        if ($this->view->exists($this->theme)) {
-            $theme = $this->theme;
+        if ($this->view->exists($custom = Str::start($this->theme, 'mail.'))) {
+            $theme = $custom;
         } else {
             $theme = Str::contains($this->theme, '::')
                 ? $this->theme

--- a/tests/Mail/MailMarkdownTest.php
+++ b/tests/Mail/MailMarkdownTest.php
@@ -20,7 +20,7 @@ class MailMarkdownTest extends TestCase
         $markdown = new Markdown($viewFactory);
         $viewFactory->shouldReceive('flushFinderCache')->once();
         $viewFactory->shouldReceive('replaceNamespace')->once()->with('mail', $markdown->htmlComponentPaths())->andReturnSelf();
-        $viewFactory->shouldReceive('exists')->with('default')->andReturn(false);
+        $viewFactory->shouldReceive('exists')->with('mail.default')->andReturn(false);
         $viewFactory->shouldReceive('make')->with('view', [])->andReturnSelf();
         $viewFactory->shouldReceive('make')->with('mail::themes.default', [])->andReturnSelf();
         $viewFactory->shouldReceive('render')->twice()->andReturn('<html></html>', 'body {}');
@@ -37,9 +37,26 @@ class MailMarkdownTest extends TestCase
         $markdown->theme('yaz');
         $viewFactory->shouldReceive('flushFinderCache')->once();
         $viewFactory->shouldReceive('replaceNamespace')->once()->with('mail', $markdown->htmlComponentPaths())->andReturnSelf();
-        $viewFactory->shouldReceive('exists')->with('yaz')->andReturn(true);
+        $viewFactory->shouldReceive('exists')->with('mail.yaz')->andReturn(true);
         $viewFactory->shouldReceive('make')->with('view', [])->andReturnSelf();
-        $viewFactory->shouldReceive('make')->with('yaz', [])->andReturnSelf();
+        $viewFactory->shouldReceive('make')->with('mail.yaz', [])->andReturnSelf();
+        $viewFactory->shouldReceive('render')->twice()->andReturn('<html></html>', 'body {}');
+
+        $result = $markdown->render('view', []);
+
+        $this->assertNotFalse(strpos($result, '<html></html>'));
+    }
+
+    public function testRenderFunctionReturnsHtmlWithCustomThemeWithMailPrefix()
+    {
+        $viewFactory = m::mock(Factory::class);
+        $markdown = new Markdown($viewFactory);
+        $markdown->theme('mail.yaz');
+        $viewFactory->shouldReceive('flushFinderCache')->once();
+        $viewFactory->shouldReceive('replaceNamespace')->once()->with('mail', $markdown->htmlComponentPaths())->andReturnSelf();
+        $viewFactory->shouldReceive('exists')->with('mail.yaz')->andReturn(true);
+        $viewFactory->shouldReceive('make')->with('view', [])->andReturnSelf();
+        $viewFactory->shouldReceive('make')->with('mail.yaz', [])->andReturnSelf();
         $viewFactory->shouldReceive('render')->twice()->andReturn('<html></html>', 'body {}');
 
         $result = $markdown->render('view', []);


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

### Issue:

If you have a view named the same as your markdown theme, it will use _that_ as the CSS file and cause an unstyled mailable.

This was introduced in 5f78c90 in order to implement #34391

Related: https://github.com/statamic/cms/issues/2747

### Steps To Reproduce:

- Keep your `config/mail.php`'s `theme` as `default`
- Create a view named `default.blade.php`. (IMO a perfectly reasonable name for a view to have in an application)
- Send a mailable.
- See the mailable is unstyled.

The `default.css` won't be used because it'll try to use `default.blade.php`.


### PR Proposal:

This PR attempts to solve both the original request in #34391 and this issue by expecting any custom themes to be located in a `mail` subdirectory.

Mark's request there looked to be like he basically wanted to be able to define mail themes without needing a `vendor` directory.

If you set `theme` to `foo`, instead of just looking for a view named `foo` it'll look for `mail.foo`.

If you set `theme` to `mail.foo` (like Mark would have done), it'll still just look for `mail.foo` and will be a non-breaking change.

This change is only considered breaking if you had a custom css file in the root or a subdirectory that wasn't named `mail`. That feels unlikely. Also, this feature was never documented.






