### PR TITLE
[8.x] Throw exception when unable to create LockableFile

### DIFF
--- a/src/Illuminate/Filesystem/LockableFile.php
+++ b/src/Illuminate/Filesystem/LockableFile.php
@@ -68,7 +68,7 @@ class LockableFile
         $this->handle = @fopen($path, $mode);
 
         if (!$this->handle) {
-            throw new Exception('Could not create file: ' . $path . '; please check your permissions.');
+            throw new Exception('Could not create file: '.$path.'; please check your permissions.');
         }
     }
 

--- a/src/Illuminate/Filesystem/LockableFile.php
+++ b/src/Illuminate/Filesystem/LockableFile.php
@@ -68,7 +68,7 @@ class LockableFile
         $this->handle = @fopen($path, $mode);
 
         if (! $this->handle) {
-            throw new Exception('Could not create file: '.$path.'; please check your permissions.');
+            throw new Exception('Unable to create lockable file: '.$path.'. Please ensure you have permission to create files in this location.');
         }
     }
 

--- a/src/Illuminate/Filesystem/LockableFile.php
+++ b/src/Illuminate/Filesystem/LockableFile.php
@@ -67,7 +67,7 @@ class LockableFile
     {
         $this->handle = @fopen($path, $mode);
 
-        if (!$this->handle) {
+        if (! $this->handle) {
             throw new Exception('Could not create file: '.$path.'; please check your permissions.');
         }
     }

--- a/src/Illuminate/Filesystem/LockableFile.php
+++ b/src/Illuminate/Filesystem/LockableFile.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Filesystem;
 
+use Exception;
 use Illuminate\Contracts\Filesystem\LockTimeoutException;
 
 class LockableFile
@@ -65,6 +66,10 @@ class LockableFile
     protected function createResource($path, $mode)
     {
         $this->handle = @fopen($path, $mode);
+
+        if (!$this->handle) {
+            throw new Exception('Could not create file: ' . $path . '; please check your permissions.');
+        }
     }
 
     /**


### PR DESCRIPTION
We run into this cryptic error in our production Laravel servers:
![image](https://user-images.githubusercontent.com/4450814/111848522-7607ee00-88c8-11eb-8fad-5bac6202bc71.png)

This is because `LockableFile` incorrectly presumes that the result of `fopen` (which is stored in `$this->handle`) is always a file pointer resource, when in fact it can be the boolean value `false` when the file failed to create properly - [relevant docs](https://www.php.net/manual/en/function.fopen.php). When the file fails to create, `$this->handle` silently gets set to false here:

https://github.com/laravel/framework/blob/72ea328b456ea570f8823c69f511583aa6234170/src/Illuminate/Filesystem/LockableFile.php#L65-L68

...such that subsequent references to `$this->handle` will fail with the above cryptic message, when in fact the real error happened much earlier when the file was supposed to be created.

If, instead, we throw an exception when `fopen` fails, the developer will see a helpful error showing the actual path of the file which failed to create, so that we can action upon that, whether it be updating the group permissions or umask of the `storage` folder or whatever is needed. This will be a much better developer experience then waiting for a subsequent usage of `$this->handle` to fail cryptically.

I'm not sure exactly what exception should be thrown here, please let me know how this can be improved.