### PR TITLE
[9.x] Allow binding facade classes to implementations on IOC

### DIFF
--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -191,6 +191,10 @@ abstract class Facade
      */
     protected static function getFacadeAccessor()
     {
+        if (static::$app->bound(static::class)) {
+            return static::class;
+        }
+
         throw new RuntimeException('Facade does not implement getFacadeAccessor method.');
     }
 


### PR DESCRIPTION
This change allows us **to have a proper default for getFacadeAccessor method for facade subclasses**, so that users do not have to implement it.
All they have to do is to bind the facade class itself to the implementation class, just like they do for interfaces.


**Before**:

Technically, we can use the namespaced-class name of the subclass as the default value returned by the getFacadeAccessor, which can act like any other arbitrary string.

Suppose we use 'App\\Facades\\MyFacade' as our **unique arbitrary string** on the contianer.
```php

public function register()
{
    app()->bind('App\\Facades\\MyFacade', SomeClass1::class);
}

```

```php
namespace App\Facades;

class MyFacade extends Facade 
{
    protected static function getFacadeAccessor()
    {
        return 'App\\Facades\\MyFacade';
    }
}
```

**After:**


```php

use App\Facades\MyFacade;
...

public function register()
{
    // We used MyFacade::class as the unique key on IOC.
    app()->bind(MyFacade::class, SomeClass1::class);
}
```
and we do not need to implement the `getFacadeAccessor` method anymore.

```php
namespace App\Facades;

class MyFacade extends Facade 
{
    // can remain empty
}
```

**Benefits for end-users**:
- A problem with facades is that it is somewhat tricky to find their implementation, which is addressed in this approach.
Because when we look at the registration phase it would be clear to which class the facade is proxying to.
- Using Facades instead of interfaces can be more flexible when the signatures of methods are not very stable yet.

**Backward compatibility:**
- it seems that it is fully backward compatible since all the current facades of older laravel apps implement and override the parent method by force without calling the `parent`, so it can be considered fully safe and even can be merged on laravel 8.x

**Note**:
Changing the namespace of facades classes when refactoring does not break the application when this approach is used. (for example, moving the facade to some other folder)