### PR TITLE
[9.x] Add default value in argument and option methods in Command class

### DIFF
--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -64,15 +64,16 @@ trait InteractsWithIO
      * Get the value of a command argument.
      *
      * @param  string|null  $key
+     * @param mixed $default
      * @return string|array|null
      */
-    public function argument($key = null)
+    public function argument($key = null, $default = null)
     {
         if (is_null($key)) {
             return $this->input->getArguments();
         }
 
-        return $this->input->getArgument($key);
+        return $this->input->getArgument($key) ?? $default;
     }
 
     /**
@@ -100,15 +101,16 @@ trait InteractsWithIO
      * Get the value of a command option.
      *
      * @param  string|null  $key
+     * @param mixed $default
      * @return string|array|bool|null
      */
-    public function option($key = null)
+    public function option($key = null, $default = null)
     {
         if (is_null($key)) {
             return $this->input->getOptions();
         }
 
-        return $this->input->getOption($key);
+        return $this->input->getOption($key) ?? $default;
     }
 
     /**

--- a/tests/Console/CommandTest.php
+++ b/tests/Console/CommandTest.php
@@ -63,6 +63,7 @@ class CommandTest extends TestCase
                 return [
                     new InputArgument('argument-one', InputArgument::REQUIRED, 'first test argument'),
                     ['argument-two', InputArgument::OPTIONAL, 'a second test argument'],
+                    ['argument-three', InputArgument::OPTIONAL, 'a third test argument'],
                 ];
             }
 
@@ -71,6 +72,7 @@ class CommandTest extends TestCase
                 return [
                     new InputOption('option-one', 'o', InputOption::VALUE_OPTIONAL, 'first test option'),
                     ['option-two', 't', InputOption::VALUE_REQUIRED, 'second test option'],
+                    ['option-three', 'tr', InputOption::VALUE_REQUIRED, 'third test option'],
                 ];
             }
         };
@@ -90,8 +92,10 @@ class CommandTest extends TestCase
 
         $this->assertSame('test-first-argument', $command->argument('argument-one'));
         $this->assertSame('test-second-argument', $command->argument('argument-two'));
+        $this->assertSame('test-default-argument', $command->argument('argument-three', 'test-default-argument'));
         $this->assertSame('test-first-option', $command->option('option-one'));
         $this->assertSame('test-second-option', $command->option('option-two'));
+        $this->assertSame('test-default-option', $command->option('option-three', 'test-default-option'));
     }
 
     public function testTheInputSetterOverwrite()


### PR DESCRIPTION
Add default value in argument and option methods in Command class.

```php
// $myArg will be 'null'
$myArg = $this->argument('foo');

// $myArg will be 'a default value'
$myArg = $this->argument('foo', 'a default value');          
```

```php
// $myOption will be 'null'
$myOption = $this->option('foo');

// $myOption will be 'a default value'
$myOption = $this->option('foo', 'a default value');
```

If there are any questions related to the changes, please let me know.