### PR TITLE
[9.x] Apply job backoff in seconds instead of minutes

### DIFF
--- a/src/Illuminate/Queue/Middleware/ThrottlesExceptions.php
+++ b/src/Illuminate/Queue/Middleware/ThrottlesExceptions.php
@@ -37,11 +37,11 @@ class ThrottlesExceptions
     protected $decayMinutes;
 
     /**
-     * The number of minutes to wait before retrying the job after an exception.
+     * The number of seconds to wait before retrying the job after an exception.
      *
      * @var int
      */
-    protected $retryAfterMinutes = 0;
+    protected $retryAfterSeconds = 0;
 
     /**
      * The callback that determines if rate limiting should apply.
@@ -104,7 +104,7 @@ class ThrottlesExceptions
 
             $this->limiter->hit($jobKey, $this->decayMinutes * 60);
 
-            return $job->release($this->retryAfterMinutes * 60);
+            return $job->release($this->retryAfterSeconds);
         }
     }
 
@@ -142,7 +142,7 @@ class ThrottlesExceptions
      */
     public function backoff($backoff)
     {
-        $this->retryAfterMinutes = $backoff;
+        $this->retryAfterSeconds = $backoff;
 
         return $this;
     }

--- a/src/Illuminate/Queue/Middleware/ThrottlesExceptionsWithRedis.php
+++ b/src/Illuminate/Queue/Middleware/ThrottlesExceptionsWithRedis.php
@@ -56,7 +56,7 @@ class ThrottlesExceptionsWithRedis extends ThrottlesExceptions
 
             $this->limiter->acquire();
 
-            return $job->release($this->retryAfterMinutes * 60);
+            return $job->release($this->retryAfterSeconds);
         }
     }
 }


### PR DESCRIPTION
Apply job backoff for ThrottlesExceptions and ThrottlesExceptionsWithRedis in seconds to be consistent with other backoff functions and official documentation.
