### PR TITLE
Event when compiling views

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -5,6 +5,7 @@ namespace Illuminate\View\Compilers;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
+use Illuminate\View\Events\CompiledView;
 
 class BladeCompiler extends Compiler implements CompilerInterface
 {
@@ -156,6 +157,8 @@ class BladeCompiler extends Compiler implements CompilerInterface
             $this->files->put(
                 $this->getCompiledPath($this->getPath()), $contents
             );
+
+            event(new CompiledView($path, $contents));
         }
     }
 

--- a/src/Illuminate/View/Events/CompiledView.php
+++ b/src/Illuminate/View/Events/CompiledView.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Illuminate\View\Events;
+
+class CompiledView
+{
+    /**
+     * Path to the compiled version of a view.
+     *
+     * @var string
+     */
+    public $path;
+
+    /**
+     * Contents of the compiled view.
+     *
+     * @var string
+     */
+    public $contents;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  string  $path
+     * @param  string  $contents
+     * @return void
+     */
+    public function __construct($path, $contents)
+    {
+        $this->path = $path;
+        $this->contents = $contents;
+    }
+}


### PR DESCRIPTION
Sometimes you need to minify the HTML for better performance. In order not to add third party packages, I have added an event that fires when a view is compiled.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
