### PR TITLE
[8.x] Add default callback to whenHas and whenFilled methods in Request class

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -112,12 +112,17 @@ trait InteractsWithInput
      *
      * @param  string  $key
      * @param  callable  $callback
+     * @param  callable|null  $defaultCallback
      * @return $this|mixed
      */
-    public function whenHas($key, callable $callback)
+    public function whenHas($key, callable $callback, callable $defaultCallback = null)
     {
         if ($this->has($key)) {
             return $callback(data_get($this->all(), $key)) ?: $this;
+        }
+
+        if (is_callable($defaultCallback)) {
+            return $defaultCallback();
         }
 
         return $this;
@@ -185,12 +190,17 @@ trait InteractsWithInput
      *
      * @param  string  $key
      * @param  callable  $callback
+     * @param  callable|null  $defaultCallback
      * @return $this|mixed
      */
-    public function whenFilled($key, callable $callback)
+    public function whenFilled($key, callable $callback, callable $defaultCallback = null)
     {
         if ($this->filled($key)) {
             return $callback(data_get($this->all(), $key)) ?: $this;
+        }
+
+        if (is_callable($defaultCallback)) {
+            return $defaultCallback();
         }
 
         return $this;

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -12,6 +12,8 @@ use RuntimeException;
 use Symfony\Component\HttpFoundation\File\UploadedFile as SymfonyUploadedFile;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
+use function PHPUnit\Framework\assertEquals;
+
 class HttpRequestTest extends TestCase
 {
     protected function tearDown(): void
@@ -304,7 +306,7 @@ class HttpRequestTest extends TestCase
     {
         $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => '', 'city' => null]);
 
-        $name = $age = $city = $foo = false;
+        $name = $age = $city = $foo = $boo = false;
 
         $request->whenHas('name', function ($value) use (&$name) {
             $name = $value;
@@ -322,17 +324,24 @@ class HttpRequestTest extends TestCase
             $foo = 'test';
         });
 
+        $request->whenHas('boo', function() use (&$boo) {
+            $boo = 'test';
+        }, function() use (&$boo) {
+            $boo = 'default';
+        });
+
         $this->assertSame('Taylor', $name);
         $this->assertSame('', $age);
         $this->assertNull($city);
         $this->assertFalse($foo);
+        $this->assertSame('default', $boo);
     }
 
     public function testWhenFilledMethod()
     {
         $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => '', 'city' => null]);
 
-        $name = $age = $city = $foo = false;
+        $name = $age = $city = $foo = $boo = false;
 
         $request->whenFilled('name', function ($value) use (&$name) {
             $name = $value;
@@ -350,10 +359,17 @@ class HttpRequestTest extends TestCase
             $foo = 'test';
         });
 
+        $request->whenFilled('boo', function() use (&$boo) {
+            $boo = 'test';
+        }, function() use (&$boo) {
+            $boo = 'default';
+        });
+
         $this->assertSame('Taylor', $name);
         $this->assertFalse($age);
         $this->assertFalse($city);
         $this->assertFalse($foo);
+        $this->assertSame('default', $boo);
     }
 
     public function testMissingMethod()

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -12,8 +12,6 @@ use RuntimeException;
 use Symfony\Component\HttpFoundation\File\UploadedFile as SymfonyUploadedFile;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
-use function PHPUnit\Framework\assertEquals;
-
 class HttpRequestTest extends TestCase
 {
     protected function tearDown(): void
@@ -324,9 +322,9 @@ class HttpRequestTest extends TestCase
             $foo = 'test';
         });
 
-        $request->whenHas('boo', function() use (&$boo) {
+        $request->whenHas('boo', function () use (&$boo) {
             $boo = 'test';
-        }, function() use (&$boo) {
+        }, function () use (&$boo) {
             $boo = 'default';
         });
 
@@ -359,9 +357,9 @@ class HttpRequestTest extends TestCase
             $foo = 'test';
         });
 
-        $request->whenFilled('boo', function() use (&$boo) {
+        $request->whenFilled('boo', function () use (&$boo) {
             $boo = 'test';
-        }, function() use (&$boo) {
+        }, function () use (&$boo) {
             $boo = 'default';
         });
 


### PR DESCRIPTION
This PR allows adding a default callback for both whenHas and whenFilled methods in the Request class

In some cases, it's helpful to have a default callback that is called when the condition does not meet. 
And of course, the default callback in both methods is optional so it's backward compatible.

```php
$request->whenFilled('date', $callback, $defaultCallback = null)
$request->whenHas($attribute, $callback, $defaultCallback = null)
```