### PR TITLE
[8.x] Fix for #34592 artisan schema:dump error

### DIFF
--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -146,6 +146,7 @@ class MySqlSchemaState extends SchemaState
                     str_replace(' --column-statistics=0', '', $process->getCommandLine())
                 ), $output, $variables);
             }
+
             if (Str::contains($e->getMessage(), ['set-gtid-purged'])) {
                 return $this->executeDumpProcess(Process::fromShellCommandLine(
                     str_replace(' --set-gtid-purged=OFF', '', $process->getCommandLine())

--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -146,6 +146,11 @@ class MySqlSchemaState extends SchemaState
                     str_replace(' --column-statistics=0', '', $process->getCommandLine())
                 ), $output, $variables);
             }
+            if (Str::contains($e->getMessage(), ['set-gtid-purged'])) {
+                return $this->executeDumpProcess(Process::fromShellCommandLine(
+                    str_replace(' --set-gtid-purged=OFF', '', $process->getCommandLine())
+                ), $output, $variables);
+            }
 
             throw $e;
         }


### PR DESCRIPTION
Fixes #34592

In Alpine Linux the mysql-client package (containing mysqldump and mysql CLI) is an alias for the MariaDB version of the CLI tools.  The MariaDB version of mysqldump doesn't support the set-gtid-purged parameter, so the command fails in cases where the MariaDB CLI tool is being used to access to MySQL database connection.  The current "isMaria" function only supports cases where the connection is to a MariaDB database.

This fix uses the same approach used for a similar issue with the column-statistics parameter: if there is an error related to the parameter it is removed and the command retried.