### PR TITLE
[8.x] PHP 8.1 builds

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,6 +36,7 @@ jobs:
         include:
           - php: 8.1
             flags: "--ignore-platform-req=php"
+            stability: prefer-stable
 
 
     name: PHP ${{ matrix.php }} - ${{ matrix.stability }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
         php: ['7.3', '7.4', '8.0']
         stability: [prefer-lowest, prefer-stable]
         include:
-          - php: 8.1
+          - php: '8.1'
             flags: "--ignore-platform-req=php"
             stability: prefer-stable
 
@@ -84,7 +84,7 @@ jobs:
         php: ['7.3', '7.4', '8.0']
         stability: [prefer-lowest, prefer-stable]
         include:
-          - php: 8.1
+          - php: '8.1'
             flags: "--ignore-platform-req=php"
             stability: prefer-stable
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,8 +31,12 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: ['7.3', '7.4', '8.0']
+#        php: ['7.3', '7.4', '8.0']
         stability: [prefer-lowest, prefer-stable]
+        include:
+          - php: 8.1
+            flags: "--ignore-platform-req=php"
+
 
     name: PHP ${{ matrix.php }} - ${{ matrix.stability }}
 
@@ -61,7 +65,7 @@ jobs:
         with:
           timeout_minutes: 5
           max_attempts: 5
-          command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
+          command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress ${{ matrix.flags }}
 
       - name: Execute tests
         run: vendor/bin/phpunit --verbose
@@ -69,48 +73,48 @@ jobs:
           DB_PORT: ${{ job.services.mysql.ports[3306] }}
           DB_USERNAME: root
 
-  windows_tests:
-    runs-on: windows-latest
-
-    strategy:
-      fail-fast: true
-      matrix:
-        php: ['7.3', '7.4', '8.0']
-        stability: [prefer-lowest, prefer-stable]
-
-    name: PHP ${{ matrix.php }} - ${{ matrix.stability }} - Windows
-
-    steps:
-      - name: Set git to use LF
-        run: |
-          git config --global core.autocrlf false
-          git config --global core.eol lf
-
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite, gd, pdo_mysql, fileinfo, ftp, redis, memcached
-          tools: composer:v2
-          coverage: none
-
-      - name: Set Minimum Guzzle Version
-        uses: nick-invision/retry@v1
-        with:
-          timeout_minutes: 5
-          max_attempts: 5
-          command: composer require guzzlehttp/guzzle:^7.2 --no-interaction --no-update
-        if: matrix.php >= 8
-
-      - name: Install dependencies
-        uses: nick-invision/retry@v1
-        with:
-          timeout_minutes: 5
-          max_attempts: 5
-          command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
-
-      - name: Execute tests
-        run: vendor/bin/phpunit --verbose
+#  windows_tests:
+#    runs-on: windows-latest
+#
+#    strategy:
+#      fail-fast: true
+#      matrix:
+#        php: ['7.3', '7.4', '8.0']
+#        stability: [prefer-lowest, prefer-stable]
+#
+#    name: PHP ${{ matrix.php }} - ${{ matrix.stability }} - Windows
+#
+#    steps:
+#      - name: Set git to use LF
+#        run: |
+#          git config --global core.autocrlf false
+#          git config --global core.eol lf
+#
+#      - name: Checkout code
+#        uses: actions/checkout@v2
+#
+#      - name: Setup PHP
+#        uses: shivammathur/setup-php@v2
+#        with:
+#          php-version: ${{ matrix.php }}
+#          extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite, gd, pdo_mysql, fileinfo, ftp, redis, memcached
+#          tools: composer:v2
+#          coverage: none
+#
+#      - name: Set Minimum Guzzle Version
+#        uses: nick-invision/retry@v1
+#        with:
+#          timeout_minutes: 5
+#          max_attempts: 5
+#          command: composer require guzzlehttp/guzzle:^7.2 --no-interaction --no-update
+#        if: matrix.php >= 8
+#
+#      - name: Install dependencies
+#        uses: nick-invision/retry@v1
+#        with:
+#          timeout_minutes: 5
+#          max_attempts: 5
+#          command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
+#
+#      - name: Execute tests
+#        run: vendor/bin/phpunit --verbose

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-#        php: ['7.3', '7.4', '8.0']
+        php: ['7.3', '7.4', '8.0']
         stability: [prefer-lowest, prefer-stable]
         include:
           - php: 8.1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,53 +69,59 @@ jobs:
           command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress ${{ matrix.flags }}
 
       - name: Execute tests
+        continue-on-error: ${{ matrix.php > 8 }}
         run: vendor/bin/phpunit --verbose
         env:
           DB_PORT: ${{ job.services.mysql.ports[3306] }}
           DB_USERNAME: root
 
-#  windows_tests:
-#    runs-on: windows-latest
-#
-#    strategy:
-#      fail-fast: true
-#      matrix:
-#        php: ['7.3', '7.4', '8.0']
-#        stability: [prefer-lowest, prefer-stable]
-#
-#    name: PHP ${{ matrix.php }} - ${{ matrix.stability }} - Windows
-#
-#    steps:
-#      - name: Set git to use LF
-#        run: |
-#          git config --global core.autocrlf false
-#          git config --global core.eol lf
-#
-#      - name: Checkout code
-#        uses: actions/checkout@v2
-#
-#      - name: Setup PHP
-#        uses: shivammathur/setup-php@v2
-#        with:
-#          php-version: ${{ matrix.php }}
-#          extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite, gd, pdo_mysql, fileinfo, ftp, redis, memcached
-#          tools: composer:v2
-#          coverage: none
-#
-#      - name: Set Minimum Guzzle Version
-#        uses: nick-invision/retry@v1
-#        with:
-#          timeout_minutes: 5
-#          max_attempts: 5
-#          command: composer require guzzlehttp/guzzle:^7.2 --no-interaction --no-update
-#        if: matrix.php >= 8
-#
-#      - name: Install dependencies
-#        uses: nick-invision/retry@v1
-#        with:
-#          timeout_minutes: 5
-#          max_attempts: 5
-#          command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
-#
-#      - name: Execute tests
-#        run: vendor/bin/phpunit --verbose
+  windows_tests:
+    runs-on: windows-latest
+
+    strategy:
+      fail-fast: true
+      matrix:
+        php: ['7.3', '7.4', '8.0']
+        stability: [prefer-lowest, prefer-stable]
+        include:
+          - php: 8.1
+            flags: "--ignore-platform-req=php"
+            stability: prefer-stable
+
+    name: PHP ${{ matrix.php }} - ${{ matrix.stability }} - Windows
+
+    steps:
+      - name: Set git to use LF
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite, gd, pdo_mysql, fileinfo, ftp, redis, memcached
+          tools: composer:v2
+          coverage: none
+
+      - name: Set Minimum Guzzle Version
+        uses: nick-invision/retry@v1
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          command: composer require guzzlehttp/guzzle:^7.2 --no-interaction --no-update
+        if: matrix.php >= 8
+
+      - name: Install dependencies
+        uses: nick-invision/retry@v1
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress ${{ matrix.flags }}
+
+      - name: Execute tests
+        continue-on-error: ${{ matrix.php > 8 }}
+        run: vendor/bin/phpunit --verbose


### PR DESCRIPTION
This PR adds PHP 8.1 nightly builds. It applies the `continue-on-error` param to skip a failing build. This way we may gradually work towards PHP 8.1 stability in the framework. It'll also hopefully help the PHP core team and package maintainers to fix bugs early on. Atm the PHPUnit tests show the following results for the PHP 8.1 build on Ubuntu 20.04:

```
Tests: 5976, Assertions: 16054, Errors: 48, Failures: 28, Skipped: 16.
```

/cc @nikic

Closes https://github.com/laravel/framework/issues/36624