### PR TITLE
[8.x] Update egulias/email-validator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "ext-openssl": "*",
         "doctrine/inflector": "^1.4|^2.0",
         "dragonmantank/cron-expression": "^3.0.2",
-        "egulias/email-validator": "^2.1.10",
+        "egulias/email-validator": "^3.1.0",
         "league/commonmark": "^1.3",
         "league/flysystem": "^1.1",
         "monolog/monolog": "^2.0",


### PR DESCRIPTION
Update egulias/email-validator. 

Check (between 2.1.10 and 3.1.0) https://github.com/egulias/EmailValidator/releases for bug fixes in this PR