### PR TITLE
[8.x] Refactor cookie tests

### DIFF
--- a/tests/Cookie/CookieTest.php
+++ b/tests/Cookie/CookieTest.php
@@ -2,202 +2,306 @@
 
 namespace Illuminate\Tests\Cookie;
 
-use Illuminate\Cookie\CookieJar;
-use Mockery as m;
 use PHPUnit\Framework\TestCase;
-use ReflectionObject;
-use Symfony\Component\HttpFoundation\Cookie;
+use Illuminate\Cookie\CookieJar;
+use Illuminate\Support\Traits\Macroable;
 
 class CookieTest extends TestCase
 {
-    protected function tearDown(): void
-    {
-        m::close();
-    }
-
-    public function testCookiesAreCreatedWithProperOptions()
-    {
-        $cookie = $this->getCreator();
-        $cookie->setDefaultPathAndDomain('foo', 'bar');
-        $c = $cookie->make('color', 'blue', 10, '/path', '/domain', true, false, false, 'lax');
-        $this->assertSame('blue', $c->getValue());
-        $this->assertFalse($c->isHttpOnly());
-        $this->assertTrue($c->isSecure());
-        $this->assertSame('/domain', $c->getDomain());
-        $this->assertSame('/path', $c->getPath());
-        $this->assertSame('lax', $c->getSameSite());
-
-        $c2 = $cookie->forever('color', 'blue', '/path', '/domain', true, false, false, 'strict');
-        $this->assertSame('blue', $c2->getValue());
-        $this->assertFalse($c2->isHttpOnly());
-        $this->assertTrue($c2->isSecure());
-        $this->assertSame('/domain', $c2->getDomain());
-        $this->assertSame('/path', $c2->getPath());
-        $this->assertSame('strict', $c2->getSameSite());
-
-        $c3 = $cookie->forget('color');
-        $this->assertNull($c3->getValue());
-        $this->assertTrue($c3->getExpiresTime() < time());
-    }
-
-    public function testCookiesAreCreatedWithProperOptionsUsingDefaultPathAndDomain()
-    {
-        $cookie = $this->getCreator();
-        $cookie->setDefaultPathAndDomain('/path', '/domain', true, 'lax');
-        $c = $cookie->make('color', 'blue');
-        $this->assertSame('blue', $c->getValue());
-        $this->assertTrue($c->isSecure());
-        $this->assertSame('/domain', $c->getDomain());
-        $this->assertSame('/path', $c->getPath());
-        $this->assertSame('lax', $c->getSameSite());
-    }
-
-    public function testCookiesCanSetSecureOptionUsingDefaultPathAndDomain()
-    {
-        $cookie = $this->getCreator();
-        $cookie->setDefaultPathAndDomain('/path', '/domain', true, 'lax');
-        $c = $cookie->make('color', 'blue', 10, null, null, false);
-        $this->assertSame('blue', $c->getValue());
-        $this->assertFalse($c->isSecure());
-        $this->assertSame('/domain', $c->getDomain());
-        $this->assertSame('/path', $c->getPath());
-        $this->assertSame('lax', $c->getSameSite());
-    }
-
-    public function testQueuedCookies()
-    {
-        $cookie = $this->getCreator();
-        $this->assertEmpty($cookie->getQueuedCookies());
-        $this->assertFalse($cookie->hasQueued('foo'));
-        $cookie->queue($cookie->make('foo', 'bar'));
-        $this->assertTrue($cookie->hasQueued('foo'));
-        $this->assertInstanceOf(Cookie::class, $cookie->queued('foo'));
-        $cookie->queue('qu', 'ux');
-        $this->assertTrue($cookie->hasQueued('qu'));
-        $this->assertInstanceOf(Cookie::class, $cookie->queued('qu'));
-    }
-
-    public function testQueuedWithPath(): void
-    {
-        $cookieJar = $this->getCreator();
-        $cookieOne = $cookieJar->make('foo', 'bar', 0, '/path');
-        $cookieTwo = $cookieJar->make('foo', 'rab', 0, '/');
-        $cookieJar->queue($cookieOne);
-        $cookieJar->queue($cookieTwo);
-        $this->assertEquals($cookieOne, $cookieJar->queued('foo', null, '/path'));
-        $this->assertEquals($cookieTwo, $cookieJar->queued('foo', null, '/'));
-    }
-
-    public function testQueuedWithoutPath(): void
-    {
-        $cookieJar = $this->getCreator();
-        $cookieOne = $cookieJar->make('foo', 'bar', 0, '/path');
-        $cookieTwo = $cookieJar->make('foo', 'rab', 0, '/');
-        $cookieJar->queue($cookieOne);
-        $cookieJar->queue($cookieTwo);
-        $this->assertEquals($cookieTwo, $cookieJar->queued('foo'));
-    }
-
-    public function testHasQueued(): void
-    {
-        $cookieJar = $this->getCreator();
-        $cookie = $cookieJar->make('foo', 'bar');
-        $cookieJar->queue($cookie);
-        $this->assertTrue($cookieJar->hasQueued('foo'));
-    }
-
-    public function testHasQueuedWithPath(): void
-    {
-        $cookieJar = $this->getCreator();
-        $cookieOne = $cookieJar->make('foo', 'bar', 0, '/path');
-        $cookieTwo = $cookieJar->make('foo', 'rab', 0, '/');
-        $cookieJar->queue($cookieOne);
-        $cookieJar->queue($cookieTwo);
-        $this->assertTrue($cookieJar->hasQueued('foo', '/path'));
-        $this->assertTrue($cookieJar->hasQueued('foo', '/'));
-        $this->assertFalse($cookieJar->hasQueued('foo', '/wrongPath'));
-    }
-
-    public function testUnqueue()
-    {
-        $cookie = $this->getCreator();
-        $cookie->queue($cookie->make('foo', 'bar'));
-        $cookie->unqueue('foo');
-        $this->assertEmpty($cookie->getQueuedCookies());
-    }
-
-    public function testUnqueueWithPath(): void
-    {
-        $cookieJar = $this->getCreator();
-        $cookieOne = $cookieJar->make('foo', 'bar', 0, '/path');
-        $cookieTwo = $cookieJar->make('foo', 'rab', 0, '/');
-        $cookieJar->queue($cookieOne);
-        $cookieJar->queue($cookieTwo);
-        $cookieJar->unqueue('foo', '/path');
-        $this->assertEquals(['foo' => ['/' => $cookieTwo]], $this->getQueuedPropertyValue($cookieJar));
-    }
-
-    public function testUnqueueOnlyCookieForName(): void
-    {
-        $cookieJar = $this->getCreator();
-        $cookie = $cookieJar->make('foo', 'bar', 0, '/path');
-        $cookieJar->queue($cookie);
-        $cookieJar->unqueue('foo', '/path');
-        $this->assertEmpty($this->getQueuedPropertyValue($cookieJar));
-    }
-
-    public function testCookieJarIsMacroable()
-    {
-        $cookie = $this->getCreator();
-        $cookie->macro('foo', function () {
-            return 'bar';
-        });
-        $this->assertSame('bar', $cookie->foo());
-    }
-
-    public function testQueueCookie(): void
-    {
-        $cookieJar = $this->getCreator();
-        $cookie = $cookieJar->make('foo', 'bar', 0, '/path');
-        $cookieJar->queue($cookie);
-        $this->assertEquals(['foo' => ['/path' => $cookie]], $this->getQueuedPropertyValue($cookieJar));
-    }
-
-    public function testQueueWithCreatingNewCookie(): void
-    {
-        $cookieJar = $this->getCreator();
-        $cookieJar->queue('foo', 'bar', 0, '/path');
-        $this->assertEquals(
-            ['foo' => ['/path' => new Cookie('foo', 'bar', 0, '/path')]],
-            $this->getQueuedPropertyValue($cookieJar)
-        );
-    }
-
-    public function testGetQueuedCookies(): void
-    {
-        $cookieJar = $this->getCreator();
-        $cookieOne = $cookieJar->make('foo', 'bar', 0, '/path');
-        $cookieTwo = $cookieJar->make('foo', 'rab', 0, '/');
-        $cookieThree = $cookieJar->make('oof', 'bar', 0, '/path');
-        $cookieJar->queue($cookieOne);
-        $cookieJar->queue($cookieTwo);
-        $cookieJar->queue($cookieThree);
-        $this->assertEquals(
-            [$cookieOne, $cookieTwo, $cookieThree],
-            $cookieJar->getQueuedCookies()
-        );
-    }
-
-    public function getCreator()
+    public function getCookieJar(): CookieJar
     {
         return new CookieJar;
     }
 
-    private function getQueuedPropertyValue(CookieJar $cookieJar)
+    /**
+     * @test
+     */
+    public function create_cookie()
     {
-        $property = (new ReflectionObject($cookieJar))->getProperty('queued');
-        $property->setAccessible(true);
+        $sut = $this->getCookieJar();
 
-        return $property->getValue($cookieJar);
+        $actualCookie = $sut->make('color', 'blue', 10, '/path', '/domain', true, false, false, 'lax');
+
+        $this->assertSame('color', $actualCookie->getName());
+        $this->assertSame('blue', $actualCookie->getValue());
+        $this->assertFalse($actualCookie->isHttpOnly());
+        $this->assertTrue($actualCookie->isSecure());
+        $this->assertSame('/domain', $actualCookie->getDomain());
+        $this->assertSame('/path', $actualCookie->getPath());
+        $this->assertSame('lax', $actualCookie->getSameSite());
+    }
+
+    /**
+     * @test
+     */
+    public function create_cookies_with_defaults()
+    {
+        $sut = $this->getCookieJar()
+            ->setDefaultPathAndDomain('/path', '/domain', true, 'lax');
+
+        $actualCookie = $sut->make('color', 'blue');
+
+        $this->assertTrue($actualCookie->isSecure());
+        $this->assertSame('/domain', $actualCookie->getDomain());
+        $this->assertSame('/path', $actualCookie->getPath());
+        $this->assertSame('lax', $actualCookie->getSameSite());
+    }
+
+    /**
+     * @test
+     */
+    public function create_cookie_that_lasts_forever()
+    {
+        $sut = $this->getCookieJar()
+            ->setDefaultPathAndDomain('/path', '/domain', true, 'strict');
+
+        $actualCookie = $sut->forever('color', 'blue');
+
+        $this->assertSame('color', $actualCookie->getName());
+        $this->assertSame('blue', $actualCookie->getValue());
+        $this->assertTrue($actualCookie->isSecure());
+        $this->assertSame('/domain', $actualCookie->getDomain());
+        $this->assertSame('/path', $actualCookie->getPath());
+        $this->assertSame('strict', $actualCookie->getSameSite());
+    }
+
+    /**
+     * @test
+     */
+    public function create_cookie_that_lasts_forever_with_defaults()
+    {
+        $sut = $this->getCookieJar();
+
+        $actualCookie = $sut->forever('color', 'blue', '/path', '/domain', true, false, false, 'strict');
+
+        $this->assertSame('color', $actualCookie->getName());
+        $this->assertSame('blue', $actualCookie->getValue());
+        $this->assertFalse($actualCookie->isHttpOnly());
+        $this->assertTrue($actualCookie->isSecure());
+        $this->assertSame('/domain', $actualCookie->getDomain());
+        $this->assertSame('/path', $actualCookie->getPath());
+        $this->assertSame('strict', $actualCookie->getSameSite());
+    }
+
+    /**
+     * @test
+     */
+    public function forget_cookie()
+    {
+        $sut = $this->getCookieJar();
+
+        $actualCookie = $sut->forget('color', '/path', '/domain');
+
+        $this->assertNull($actualCookie->getValue());
+        $this->assertEquals('/path', $actualCookie->getPath());
+        $this->assertEquals('/domain', $actualCookie->getDomain());
+        $this->assertTrue($actualCookie->getExpiresTime() < time());
+    }
+
+    /**
+     * @test
+     */
+    public function forget_cookie_with_defaults()
+    {
+        $sut = $this->getCookieJar()
+            ->setDefaultPathAndDomain('/path', '/domain');
+
+
+        $actualCookie = $sut->forget('color');
+
+        $this->assertNull($actualCookie->getValue());
+        $this->assertEquals('/path', $actualCookie->getPath());
+        $this->assertEquals('/domain', $actualCookie->getDomain());
+        $this->assertTrue($actualCookie->getExpiresTime() < time());
+    }
+
+    /**
+     * @test
+     */
+    public function queue_cookie_by_cookie_instance()
+    {
+        $sut = $this->getCookieJar();
+        $cookie = $sut->make('foo', 'bar');
+
+        $sut->queue($cookie);
+
+        $this->assertTrue($sut->hasQueued('foo'));
+        $this->assertCount(1, $sut->getQueuedCookies());
+        $this->assertContains($cookie, $sut->getQueuedCookies());
+        $this->assertSame($cookie, $sut->queued('foo'));
+    }
+
+    /**
+     * @test
+     */
+    public function create_and_queue_cookie()
+    {
+        $sut = $this->getCookieJar();
+
+        $sut->queue('color', 'blue', 10, '/path', '/domain', true, false, false, 'lax');
+
+        $this->assertTrue($sut->hasQueued('color'));
+        $this->assertCount(1, $sut->getQueuedCookies());
+        $actualCookie = $sut->queued('color');
+        $this->assertSame('color', $actualCookie->getName());
+        $this->assertSame('blue', $actualCookie->getValue());
+        $this->assertFalse($actualCookie->isHttpOnly());
+        $this->assertTrue($actualCookie->isSecure());
+        $this->assertSame('/domain', $actualCookie->getDomain());
+        $this->assertSame('/path', $actualCookie->getPath());
+        $this->assertSame('lax', $actualCookie->getSameSite());
+    }
+
+    /**
+     * @test
+     */
+    public function create_and_queue_cookie_with_defaults()
+    {
+        $sut = $this->getCookieJar()
+            ->setDefaultPathAndDomain('/path', '/domain', true, 'strict');
+
+        $sut->queue('color', 'blue', 10);
+
+        $this->assertTrue($sut->hasQueued('color'));
+        $this->assertCount(1, $sut->getQueuedCookies());
+        $actualCookie = $sut->queued('color');
+        $this->assertSame('color', $actualCookie->getName());
+        $this->assertSame('blue', $actualCookie->getValue());
+        $this->assertTrue($actualCookie->isSecure());
+        $this->assertSame('/domain', $actualCookie->getDomain());
+        $this->assertSame('/path', $actualCookie->getPath());
+        $this->assertSame('strict', $actualCookie->getSameSite());
+    }
+
+    /**
+     * @test
+     */
+    public function get_queued_cookie_with_path()
+    {
+        $sut = $this->getCookieJar();
+        $sut->queue($sut->make('foo', 'bar', 0, '/another-path'));
+        $sut->queue($expectedCookie = $sut->make('foo', 'bar', 0, '/path'));
+
+        $actualQueue = $sut->queued('foo', null, '/path');
+
+        $this->assertEquals($expectedCookie, $actualQueue);
+    }
+
+    /**
+     * @test
+     */
+    public function get_last_queued_cookie_without_path()
+    {
+        $sut = $this->getCookieJar();
+        $sut->queue($sut->make('foo', 'laravel', 0, '/path'));
+        $sut->queue($expectedCookie = $sut->make('foo', 'bar', 0, '/path'));
+
+        $actualQueue = $sut->queued('foo');
+
+        $this->assertEquals($expectedCookie, $actualQueue);
+    }
+
+    /**
+     * @test
+     */
+    public function get_queued_cookies()
+    {
+        $sut = $this->getCookieJar();
+        $sut->queue($expectedCookie = $sut->make('foo', 'bar'));
+
+        $actualCookies = $sut->getQueuedCookies();
+
+        $this->assertContains($expectedCookie, $actualCookies);
+    }
+
+    /**
+     * @test
+     */
+    public function determine_if_cookie_is_queued()
+    {
+        $sut = $this->getCookieJar();
+        $cookie = $sut->make('foo', 'bar');
+        $sut->queue($cookie);
+
+        $result = $sut->hasQueued('foo');
+
+        $this->assertTrue($result);
+    }
+
+    /**
+     * @test
+     */
+    public function determine_if_cookie_is_not_queued_for_specific_path()
+    {
+        $sut = $this->getCookieJar();
+        $cookie = $sut->make('foo', 'bar', 0, '/path');
+        $sut->queue($cookie);
+
+        $result = $sut->hasQueued('foo', '/another-path');
+
+        $this->assertFalse($result);
+    }
+
+    /**
+     * @test
+     */
+    public function determine_if_cookie_is_not_queued()
+    {
+        $sut = $this->getCookieJar();
+
+        $result = $sut->hasQueued('foo');
+
+        $this->assertFalse($result);
+    }
+
+    /**
+     * @test
+     */
+    public function determine_if_cookie_is_queued_for_specific_path()
+    {
+        $sut = $this->getCookieJar();
+        $sut->queue($cookie = $sut->make('foo', 'bar', 0, '/path'));
+
+        $result = $sut->hasQueued('foo', '/path');
+
+        $this->assertTrue($result);
+    }
+
+    /**
+     * @test
+     */
+    public function unqueue_cookie()
+    {
+        $cookie = $this->getCookieJar();
+        $cookie->queue($cookie->make('foo', 'bar'));
+
+        $cookie->unqueue('foo');
+
+        $this->assertEmpty($cookie->getQueuedCookies());
+    }
+
+    /**
+     * @test
+     */
+    public function unqueue_cookie_for_a_specific_path()
+    {
+        $cookie = $this->getCookieJar();
+        $cookie->queue($cookie->make('foo', 'bar', 0, '/path'));
+
+        $cookie->unqueue('foo', '/path');
+
+        $this->assertEmpty($cookie->getQueuedCookies());
+    }
+
+    /**
+     * @test
+     */
+    public function cookie_jar_is_macroable()
+    {
+        $sut = $this->getCookieJar();
+
+        $isMacroable = in_array(Macroable::class, class_uses($sut), true);
+
+        $this->assertTrue($isMacroable);
     }
 }


### PR DESCRIPTION
Vladimir Khorikov states in his book _Unit Testing Principles, Practices, and Patterns_:

> A successful test suite provides maximum value with minimum maintenance costs.

There are lots of tests in the Laravel code base that are not well-designed and readable, holding test smells. some test methods don't provide any value but increase maintenance costs.
**So I tried to Refactor the CookieTest class for the beginning and improved the structure of the test methods using the [AAA pattern](https://freecontent.manning.com/making-better-unit-tests-part-1-the-aaa-pattern/).**

I've also removed useless tests that don't provide value (like the one that verifies private property using reflection) and enabled the test class to be used as Documentation by refactoring the following code smells:
- [Eager Test](http://xunitpatterns.com/Obscure%20Test.html#Eager%20Test)
- [Test Code Duplication](http://xunitpatterns.com/Test%20Code%20Duplication.html)
- [Multiple Test Conditions](http://xunitpatterns.com/Conditional%20Test%20Logic.html#Multiple%20Test%20Conditions)