### PR TITLE
[6.x] Fixed broken hash config

### DIFF
--- a/src/Illuminate/Hashing/ArgonHasher.php
+++ b/src/Illuminate/Hashing/ArgonHasher.php
@@ -19,14 +19,14 @@ class ArgonHasher extends AbstractHasher implements HasherContract
      *
      * @var int
      */
-    protected $time = 2;
+    protected $time = 3;
 
     /**
      * The default threads factor.
      *
      * @var int
      */
-    protected $threads = 2;
+    protected $threads = 1;
 
     /**
      * Indicates whether to perform an algorithm check.

--- a/tests/Hashing/HasherTest.php
+++ b/tests/Hashing/HasherTest.php
@@ -32,7 +32,7 @@ class HasherTest extends TestCase
         $this->assertNotSame('password', $value);
         $this->assertTrue($hasher->check('password', $value));
         $this->assertFalse($hasher->needsRehash($value));
-        $this->assertTrue($hasher->needsRehash($value, ['threads' => 1]));
+        $this->assertTrue($hasher->needsRehash($value, ['time' => 4]));
         $this->assertSame('argon2i', password_get_info($value)['algoName']);
     }
 
@@ -47,7 +47,7 @@ class HasherTest extends TestCase
         $this->assertNotSame('password', $value);
         $this->assertTrue($hasher->check('password', $value));
         $this->assertFalse($hasher->needsRehash($value));
-        $this->assertTrue($hasher->needsRehash($value, ['threads' => 1]));
+        $this->assertTrue($hasher->needsRehash($value, ['time' => 4]));
         $this->assertSame('argon2id', password_get_info($value)['algoName']);
     }
 


### PR DESCRIPTION
The minimum value supported for time is 3, and the only supported number of threads is 1. It's a bug that PHP is silently allowing our bad config, and PHP 8.1 is stricter. See https://github.com/shivammathur/php-builder/issues/8. We should additionally deprecate the threads config, since it's essentially useless from what I can see?

I think this needs a review from someone on the PHP core team who knows more about this stuff.