### PR TITLE
[6.x] Don't copy query parameters to Request.request

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -436,7 +436,9 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
 
         $newRequest->content = $request->content;
 
-        $newRequest->request = $newRequest->getInputSource();
+        if ($newRequest->isJson()) {
+            $newRequest->request = $newRequest->json();
+        }
 
         return $newRequest;
     }

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -938,6 +938,15 @@ class HttpRequestTest extends TestCase
         $this->assertEquals($request->request->all(), $body);
     }
 
+    public function testCreateFromBaseDoesNotUseQueryParametersForRequestBag()
+    {
+        $base = SymfonyRequest::create('/?foo=bar', 'GET');
+
+        $request = Request::createFromBase($base);
+
+        $this->assertEquals([], $request->request->all());
+    }
+
     /**
      * Tests for Http\Request magic methods `__get()` and `__isset()`.
      *


### PR DESCRIPTION
While creating a `Request` from the base `SymfonyRequest`, its query (GET) parameters are copied to the `request` field, but it shouldn't as the field's documentation clearly says it contains only body (POST) parameters:
```
/**
   * Request body parameters ($_POST).
   *
   * @var ParameterBag
   */
  public $request;
```

Due to this bug, PSR request created in `RoutingServiceProvider` via `PsrHttpFactory` returns query parameters with the `getParsedBody` method, but it obviously shoudn't.

The bug was introduced in https://github.com/laravel/framework/pull/7052, the reason for the changes was to copy the JSON body, but query parameters was copied as well.

The same issue in https://github.com/laravel/framework/issues/22805 and https://github.com/laravel/framework/pull/17087.

There might be misusing of this field due to the long presence of this bug (from 4.2), maybe it is better to fix it in master?