### PR TITLE
[8.x] Avoid SwiftMailer forceReconnection when not running from a queue daemon

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -12,7 +12,7 @@ use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Mail\Events\MessageSending;
 use Illuminate\Mail\Events\MessageSent;
-use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
@@ -521,7 +521,7 @@ class Mailer implements MailerContract, MailQueueContract
         try {
             return $this->swift->send($message, $this->failedRecipients);
         } finally {
-            if (config('app.is_run_from_queue_daemon', false)) {
+            if (Config::get('app.is_run_from_queue_daemon', false)) {
                 $this->forceReconnection();
             }
         }

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -12,6 +12,7 @@ use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Mail\Events\MessageSending;
 use Illuminate\Mail\Events\MessageSent;
+use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
@@ -520,7 +521,9 @@ class Mailer implements MailerContract, MailQueueContract
         try {
             return $this->swift->send($message, $this->failedRecipients);
         } finally {
-            $this->forceReconnection();
+            if (config('app.is_run_from_queue_daemon', false)) {
+                $this->forceReconnection();
+            }
         }
     }
 

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -116,6 +116,10 @@ class Worker
      */
     public function daemon($connectionName, $queue, WorkerOptions $options)
     {
+        if ($connectionName !== 'sync') {
+            config()->set('app.is_run_from_queue_daemon', true);
+        }
+
         if ($this->supportsAsyncSignals()) {
             $this->listenForSignals();
         }

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -13,6 +13,7 @@ use Illuminate\Queue\Events\JobProcessing;
 use Illuminate\Queue\Events\Looping;
 use Illuminate\Queue\Events\WorkerStopping;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Config;
 use Throwable;
 
 class Worker
@@ -117,7 +118,7 @@ class Worker
     public function daemon($connectionName, $queue, WorkerOptions $options)
     {
         if ($connectionName !== 'sync') {
-            config()->set('app.is_run_from_queue_daemon', true);
+            Config::set('app.is_run_from_queue_daemon', true);
         }
 
         if ($this->supportsAsyncSignals()) {


### PR DESCRIPTION
I have noticed that emails that are sent in bulk all use separate connections (even though they are not simultaneous, there can be a limit of connections per minute per IP set for an SMTP server). As I've found in multiple pull requests (i.e., [https://github.com/laravel/framework/issues/4573](https://github.com/laravel/framework/issues/4573)), there has been a problem with long lasting SMTP connections due to some problems with SwiftMailer and a simple solution for it:

```
protected function sendSwiftMessage($message)
{
    $this->failedRecipients = [];

    try {
        return $this->swift->send($message, $this->failedRecipients);
    } finally {
        $this->forceReconnection();
    }
}
```

However, these problems are only encountered when a program is executed from a queue daemon (`php artisan queue:work` or `php artisan queue:listen`), so there can be a compromise between dealing with the SSL broken pipe error and sending multiple emails.

I propose setting a flag (or checking somehow else, if there's a better way for it) for when the script is executed from a queue daemon, then, when an email is sent via SMTP and the flag is not present, the SMTP connection will no longer be stopped. This would help in CRON jobs or in case of synchronous mail sending and wouldn't ruin queues a second time.