### PR TITLE
[6.x] Restore relations on serialized collections

### DIFF
--- a/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
+++ b/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
@@ -71,7 +71,7 @@ trait SerializesAndRestoresModelIdentifiers
 
         $collection = $this->getQueryForModelRestoration(
             (new $value->class)->setConnection($value->connection), $value->id
-        )->useWritePdo()->get();
+        )->useWritePdo()->get()->load($value->relations ?? []);
 
         if (is_a($value->class, Pivot::class, true) ||
             in_array(AsPivot::class, class_uses($value->class))) {


### PR DESCRIPTION
Currently its only possible to restore relations when a single model is restored from the queue. With this, collections also restore relations when pushed to the queue.

I'm sending this to 6.x as I think this is actually a bugfix.