### PR TITLE
[8.x] Deprecate MocksApplicationServices trait

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
@@ -8,6 +8,9 @@ use Illuminate\Contracts\Notifications\Dispatcher as NotificationDispatcher;
 use Illuminate\Support\Facades\Event;
 use Mockery;
 
+/**
+ * @deprecated Will be removed in a future Laravel version.
+ */
 trait MocksApplicationServices
 {
     /**


### PR DESCRIPTION
The `MocksApplicationServices` has become redundant with the new Facade mocking functionality.