### PR TITLE
[8.x] Make `ResponseSequence` macroable

### DIFF
--- a/src/Illuminate/Http/Client/ResponseSequence.php
+++ b/src/Illuminate/Http/Client/ResponseSequence.php
@@ -2,10 +2,13 @@
 
 namespace Illuminate\Http\Client;
 
+use Illuminate\Support\Traits\Macroable;
 use OutOfBoundsException;
 
 class ResponseSequence
 {
+    use Macroable;
+
     /**
      * The responses in the sequence.
      *

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -7,7 +7,9 @@ use Illuminate\Http\Client\Factory;
 use Illuminate\Http\Client\Request;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\Client\Response;
+use Illuminate\Http\Client\ResponseSequence;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
 use OutOfBoundsException;
 use PHPUnit\Framework\AssertionFailedError;
@@ -801,5 +803,14 @@ class HttpClientTest extends TestCase
         $this->assertSame(1000, $dumped[4]['delay']);
 
         VarDumper::setHandler(null);
+    }
+
+    public function testResponseSequenceIsMacroable()
+    {
+        ResponseSequence::macro('customMethod', function () {
+            return 'yes!';
+        });
+
+        $this->assertSame('yes!', $this->factory->fakeSequence()->customMethod());
     }
 }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -9,7 +9,6 @@ use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\Client\Response;
 use Illuminate\Http\Client\ResponseSequence;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
 use OutOfBoundsException;
 use PHPUnit\Framework\AssertionFailedError;


### PR DESCRIPTION
This PR makes the `ResponseSequence` class macroable. This class is used by `Http::fakeSequence()`.

My first use-case is that some APIs always need to retrieve an access token before any calls can be made. Currently I always push a fixture of the access token response every time I call `Http::fakeSequence()`. Custom macros can clean this up:
```php
Http::fakeSequence()
    ->pushFile($this->fixtures.'dhl/access-token-01.json')
    ->pushFile($this->fixtures.'dhl/tracking-01.json');

// After this PR

Http::fakeSequence()
    ->pushDhlAccessTokenResponse()
    ->pushFile($this->fixtures.'dhl/tracking-01.json');
```

Macros can also be used to craft custom responses. This is a use-case from another project of mine:

```php
$checkoutUrl = 'http://example.com/'.Str::random();

Http::fakeSequence()
    ->pushMollieCheckoutResponse($checkoutUrl);

$this->postCheckout()
    ->assertRedirect($checkoutUrl);
```
