### PR TITLE
[8.x] Remove useless loop

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -568,11 +568,9 @@ class Str
      */
     public static function remove($search, $subject, $caseSensitive = true)
     {
-        foreach (Arr::wrap($search) as $s) {
-            $subject = $caseSensitive
-                        ? str_replace($search, '', $subject)
-                        : str_ireplace($search, '', $subject);
-        }
+        $subject = $caseSensitive
+                    ? str_replace($search, '', $subject)
+                    : str_ireplace($search, '', $subject);
 
         return $subject;
     }


### PR DESCRIPTION
I was going to point out that `$search` was incorrectly used instead of `$s` in the original code, but then I realized that the code still works as-is, albeit with redundant calls to `str_(i)replace`. Realizing this, we can just remove the loop altogether. There's also no need to call `Arr::wrap` for the same reason- `str_(i)replace` supports both arrays and strings as input.