### PR TITLE
[8.x] Avoid SwiftMailer forceReconnection when not running from a queue daemon

### DIFF
--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -117,7 +117,8 @@ class MailManager implements FactoryContract
             $name,
             $this->app['view'],
             $this->createSwiftMailer($config),
-            $this->app['events']
+            $this->app['events'],
+            $this->app['config']['app.is_executed_from_daemon_queue'] ?? false
         );
 
         if ($this->app->bound('queue')) {

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -12,7 +12,7 @@ use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Mail\Events\MessageSending;
 use Illuminate\Mail\Events\MessageSent;
-use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
@@ -521,7 +521,7 @@ class Mailer implements MailerContract, MailQueueContract
         try {
             return $this->swift->send($message, $this->failedRecipients);
         } finally {
-            if (config('app.is_run_from_queue_daemon', false)) {
+            if (Config::get('app.is_run_from_queue_daemon', false)) {
                 $this->forceReconnection();
             }
         }

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -12,6 +12,7 @@ use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Mail\Events\MessageSending;
 use Illuminate\Mail\Events\MessageSent;
+use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
@@ -520,7 +521,9 @@ class Mailer implements MailerContract, MailQueueContract
         try {
             return $this->swift->send($message, $this->failedRecipients);
         } finally {
-            $this->forceReconnection();
+            if (config('app.is_run_from_queue_daemon', false)) {
+                $this->forceReconnection();
+            }
         }
     }
 

--- a/src/Illuminate/Queue/QueueServiceProvider.php
+++ b/src/Illuminate/Queue/QueueServiceProvider.php
@@ -166,11 +166,16 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
                 return $this->app->isDownForMaintenance();
             };
 
+            $setQueueDaemonFlag = function ($flag) {
+                $this->app['config']->set('app.is_executed_from_daemon_queue', $flag);
+            };
+
             return new Worker(
                 $app['queue'],
                 $app['events'],
                 $app[ExceptionHandler::class],
-                $isDownForMaintenance
+                $isDownForMaintenance,
+                $setQueueDaemonFlag
             );
         });
     }

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -66,7 +66,7 @@ class Worker
     protected $isDownForMaintenance;
 
     /**
-     * The callback used to set the flag for when the app is executed from a queue daemon
+     * The callback used to set the flag for when the app is executed from a queue daemon.
      *
      * @var callable
      */

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -116,6 +116,10 @@ class Worker
      */
     public function daemon($connectionName, $queue, WorkerOptions $options)
     {
+        if ($connectionName !== 'sync') {
+            config()->set('app.is_run_from_queue_daemon', true);
+        }
+
         if ($this->supportsAsyncSignals()) {
             $this->listenForSignals();
         }

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -13,6 +13,7 @@ use Illuminate\Queue\Events\JobProcessing;
 use Illuminate\Queue\Events\Looping;
 use Illuminate\Queue\Events\WorkerStopping;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Config;
 use Throwable;
 
 class Worker
@@ -117,7 +118,7 @@ class Worker
     public function daemon($connectionName, $queue, WorkerOptions $options)
     {
         if ($connectionName !== 'sync') {
-            config()->set('app.is_run_from_queue_daemon', true);
+            Config::set('app.is_run_from_queue_daemon', true);
         }
 
         if ($this->supportsAsyncSignals()) {

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -68,7 +68,7 @@ class Worker
     /**
      * The callback used to set the flag for when the app is executed from a queue daemon.
      *
-     * @var callable
+     * @var callable|null
      */
     protected $setQueueDaemonFlag;
 
@@ -100,20 +100,21 @@ class Worker
      * @param  \Illuminate\Contracts\Events\Dispatcher  $events
      * @param  \Illuminate\Contracts\Debug\ExceptionHandler  $exceptions
      * @param  callable  $isDownForMaintenance
-     * @param  callable  $setQueueDaemonFlag
+     * @param  callable|null  $setQueueDaemonFlag
      * @return void
      */
     public function __construct(QueueManager $manager,
                                 Dispatcher $events,
                                 ExceptionHandler $exceptions,
                                 callable $isDownForMaintenance,
-                                callable $setQueueDaemonFlag)
+                                ?callable $setQueueDaemonFlag = null)
     {
         $this->events = $events;
         $this->manager = $manager;
         $this->exceptions = $exceptions;
         $this->isDownForMaintenance = $isDownForMaintenance;
-        $this->setQueueDaemonFlag = $setQueueDaemonFlag;
+        $this->setQueueDaemonFlag = $setQueueDaemonFlag ?? function () {
+        };
     }
 
     /**

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -13,7 +13,6 @@ use Illuminate\Queue\Events\JobProcessing;
 use Illuminate\Queue\Events\Looping;
 use Illuminate\Queue\Events\WorkerStopping;
 use Illuminate\Support\Carbon;
-use Illuminate\Support\Facades\Config;
 use Throwable;
 
 class Worker
@@ -67,6 +66,13 @@ class Worker
     protected $isDownForMaintenance;
 
     /**
+     * The callback used to set the flag for when the app is executed from a queue daemon
+     *
+     * @var callable
+     */
+    protected $setQueueDaemonFlag;
+
+    /**
      * Indicates if the worker should exit.
      *
      * @var bool
@@ -94,17 +100,20 @@ class Worker
      * @param  \Illuminate\Contracts\Events\Dispatcher  $events
      * @param  \Illuminate\Contracts\Debug\ExceptionHandler  $exceptions
      * @param  callable  $isDownForMaintenance
+     * @param  callable  $setQueueDaemonFlag
      * @return void
      */
     public function __construct(QueueManager $manager,
                                 Dispatcher $events,
                                 ExceptionHandler $exceptions,
-                                callable $isDownForMaintenance)
+                                callable $isDownForMaintenance,
+                                callable $setQueueDaemonFlag)
     {
         $this->events = $events;
         $this->manager = $manager;
         $this->exceptions = $exceptions;
         $this->isDownForMaintenance = $isDownForMaintenance;
+        $this->setQueueDaemonFlag = $setQueueDaemonFlag;
     }
 
     /**
@@ -118,7 +127,7 @@ class Worker
     public function daemon($connectionName, $queue, WorkerOptions $options)
     {
         if ($connectionName !== 'sync') {
-            Config::set('app.is_run_from_queue_daemon', true);
+            ($this->setQueueDaemonFlag)(true);
         }
 
         if ($this->supportsAsyncSignals()) {

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -380,8 +380,7 @@ class QueueWorkerTest extends TestCase
             $isInMaintenanceMode ?? function () {
                 return false;
             },
-            $setQueueDaemonFlag ?? function () {
-            },
+            $setQueueDaemonFlag,
         ];
     }
 

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -380,7 +380,8 @@ class QueueWorkerTest extends TestCase
             $isInMaintenanceMode ?? function () {
                 return false;
             },
-            $setQueueDaemonFlag ?? function () {},
+            $setQueueDaemonFlag ?? function () {
+            },
         ];
     }
 

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -118,6 +118,8 @@ class QueueWorkerTest extends TestCase
             $this->exceptionHandler,
             function () {
                 return false;
+            },
+            function () {
             }
         );
 

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -362,14 +362,14 @@ class QueueWorkerTest extends TestCase
     /**
      * Helpers...
      */
-    private function getWorker($connectionName = 'default', $jobs = [], ?callable $isInMaintenanceMode = null)
+    private function getWorker($connectionName = 'default', $jobs = [], ?callable $isInMaintenanceMode = null, ?callable $setQueueDaemonFlag = null)
     {
         return new InsomniacWorker(
-            ...$this->workerDependencies($connectionName, $jobs, $isInMaintenanceMode)
+            ...$this->workerDependencies($connectionName, $jobs, $isInMaintenanceMode, $setQueueDaemonFlag)
         );
     }
 
-    private function workerDependencies($connectionName = 'default', $jobs = [], ?callable $isInMaintenanceMode = null)
+    private function workerDependencies($connectionName = 'default', $jobs = [], ?callable $isInMaintenanceMode = null, ?callable $setQueueDaemonFlag = null)
     {
         return [
             new WorkerFakeManager($connectionName, new WorkerFakeConnection($jobs)),
@@ -378,6 +378,7 @@ class QueueWorkerTest extends TestCase
             $isInMaintenanceMode ?? function () {
                 return false;
             },
+            $setQueueDaemonFlag ?? function () {},
         ];
     }
 


### PR DESCRIPTION
I have noticed that emails that are sent in bulk all use separate connections (even though they are not simultaneous, there can be a limit of connections per minute per IP set for an SMTP server). As I've found in multiple pull requests (i.e., [https://github.com/laravel/framework/issues/4573](https://github.com/laravel/framework/issues/4573)), there has been a problem with long lasting SMTP connections due to some problems with SwiftMailer and a simple solution for it:

```
protected function sendSwiftMessage($message)
{
    $this->failedRecipients = [];

    try {
        return $this->swift->send($message, $this->failedRecipients);
    } finally {
        $this->forceReconnection();
    }
}
```

However, these problems are only encountered when a program is executed from a queue daemon (`php artisan queue:work` or `php artisan queue:listen`), so there can be a compromise between dealing with the SSL broken pipe error and sending multiple emails.

I propose setting a flag (or checking somehow else, if there's a better way for it) for when the script is executed from a queue daemon, then, when an email is sent via SMTP and the flag is not present, the SMTP connection will no longer be stopped. This would help in CRON jobs or in case of synchronous mail sending and wouldn't ruin queues a second time.

### Note: this is the second pull request on this matter (first: [https://github.com/laravel/framework/pull/36709](https://github.com/laravel/framework/pull/36709)) due to failing test and consequent reimplementation of the solution.