### PR TITLE
[8.x] [POC] Raw upsert

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database\Query\Grammars;
 
 use Illuminate\Database\Grammar as BaseGrammar;
 use Illuminate\Database\Query\Builder;
+use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Query\JoinClause;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
@@ -1007,6 +1008,22 @@ class Grammar extends BaseGrammar
      * @throws \RuntimeException
      */
     public function compileUpsert(Builder $query, array $values, array $uniqueBy, array $update)
+    {
+        throw new RuntimeException('This database engine does not support upserts.');
+    }
+
+    /**
+     * Compile a raw "upsert" statement into SQL.
+     *
+     * @param  \Illuminate\Database\Query\Builder $query
+     * @param  array  $values
+     * @param  array  $uniqueBy
+     * @param  \Illuminate\Database\Query\Expression  $raw
+     * @return string
+     *
+     * @throws \RuntimeException
+     */
+    public function compileUpsertRaw(Builder $query, array $values, array $uniqueBy, Expression $raw)
     {
         throw new RuntimeException('This database engine does not support upserts.');
     }

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Query\Grammars;
 
 use Illuminate\Database\Query\Builder;
+use Illuminate\Database\Query\Expression;
 use Illuminate\Support\Str;
 
 class MySqlGrammar extends Grammar
@@ -172,6 +173,20 @@ class MySqlGrammar extends Grammar
         })->implode(', ');
 
         return $sql.$columns;
+    }
+
+    /**
+     * Compile a raw "upsert" statement into SQL.
+     *
+     * @param  \Illuminate\Database\Query\Builder $query
+     * @param  array  $values
+     * @param  array  $uniqueBy
+     * @param  \Illuminate\Database\Query\Expression  $raw
+     * @return string
+     */
+    public function compileUpsertRaw(Builder $query, array $values, array $uniqueBy, Expression $raw)
+    {
+        return $this->compileInsert($query, $values).' on duplicate key update '.$raw;
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2258,6 +2258,16 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(2, $result);
     }
 
+    public function testUpsertRawMethod()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->getConnection()->shouldReceive('affectingStatement')->once()->with('insert into `users` (`email`, `name`) values (?, ?), (?, ?) on duplicate key update `name` = concat(values(`name`), ?)', ['foo', 'bar', 'foo2', 'bar2', 'foo3'])->andReturn(1);
+        $result = $builder->from('users')->upsertRaw([['email' => 'foo', 'name' => 'bar'], ['name' => 'bar2', 'email' => 'foo2']], 'email', '`name` = concat(values(`name`), ?)', ['foo3']);
+        $this->assertEquals(1, $result);
+
+        // @todo Test other grammars
+    }
+
     public function testUpdateMethodWithJoins()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
Upserts save queries and perform well, they are a great alternative to insert-or-update solutions.

At the current stage, upserts update a value by **assigning** a new value if a record exists. This might be a limitation when we want to perform more complex computations with affected values than just reassignment.

An example may be incrementing a value or applying some math to calculate statistics, e.g.:

```sql
insert into `statistics` ...
on duplicate key update

`clicks` = `clicks` + values(`clicks`),
`conversions` = `conversions` + values(`conversions`),
`gross` = `gross` + values(`gross`),
`epc` = IF(`clicks` = 0, `epc`, `gross` / `clicks`),
`cr` = IF(`clicks` = 0, `cr`, `conversions` / `clicks` * 100)
```

Currently this is not achievable with `upsert()` and this PR would like to be a POC of what an upsert that accepts a raw SQL expression could look like:

```php
DB::table('statistics')->upsertRaw($values, $uniqueBy, '
    `clicks` = `clicks` + values(`clicks`),
    `conversions` = `conversions` + values(`conversions`),
    `gross` = `gross` + values(`gross`),
    `epc` = IF(`clicks` = 0, `epc`, `gross` / `clicks`),
    `cr` = IF(`clicks` = 0, `cr`, `conversions` / `clicks` * ?)
', [100]); // bindings of raw query
```

This PR produces the minimum changes to support `upsertRaw()` in MySQL, and the related test.
If it becomes a desired feature, I'll carry on with this checklist:

- [x] Add `upsertRaw()` to query builder
- [ ] Add `upsertRaw()` to Eloquent builder
- [x] Compile `upsertRaw()` for MySQL
- [ ] Compile `upsertRaw()` for Postgres
- [ ] Compile `upsertRaw()` for SQLite
- [ ] Compile `upsertRaw()` for SQL Server
- [x] Test `upsertRaw()` for MySQL
- [ ] Test `upsertRaw()` for Postgres
- [ ] Test `upsertRaw()` for SQLite
- [ ] Test `upsertRaw()` for SQL Server
- [ ] Test `upsertRaw()` in Eloquent

Feedback / suggestions / changes are more than welcome.