### PR TITLE
[8.x] Ensure attribute is Collection when casting even if value is null

### DIFF
--- a/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
@@ -19,9 +19,7 @@ class AsCollection implements Castable
         return new class implements CastsAttributes {
             public function get($model, $key, $value, $attributes)
             {
-                $items = isset($attributes[$key]) ? json_decode($attributes[$key], true) : [];
-
-                return new Collection($items);
+                return new Collection(isset($attributes[$key]) ? json_decode($attributes[$key], true) : []);
             }
 
             public function set($model, $key, $value, $attributes)

--- a/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
@@ -19,12 +19,34 @@ class AsCollection implements Castable
         return new class implements CastsAttributes {
             public function get($model, $key, $value, $attributes)
             {
-                return isset($attributes[$key]) ? new Collection(json_decode($attributes[$key], true)) : null;
+                return new Collection(json_decode($attributes[$key] ?? '[]', true));
             }
 
             public function set($model, $key, $value, $attributes)
             {
+                if ($this->isEmpty($value) && $this->wasEmpty($model, $key)) {
+                    return [$key => null];
+                }
+
                 return [$key => json_encode($value)];
+            }
+
+            protected function isEmpty($value)
+            {
+                if ($value instanceof Collection) {
+                    return $value->isEmpty();
+                }
+
+                return ! $value;
+            }
+
+            protected function wasEmpty($model, $key)
+            {
+                if ($model instanceof Model) {
+                    return $model->getRawOriginal($key) === null;
+                }
+
+                return false;
             }
         };
     }

--- a/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
@@ -39,7 +39,7 @@ class AsCollection implements Castable
                     return $value->isEmpty();
                 }
 
-                return empty($value);
+                return $value === null;
             }
         };
     }

--- a/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
@@ -19,12 +19,14 @@ class AsCollection implements Castable
         return new class implements CastsAttributes {
             public function get($model, $key, $value, $attributes)
             {
-                return new Collection(json_decode($attributes[$key] ?? '[]', true));
+                $items = isset($attributes[$key]) ? json_decode($attributes[$key], true) : [];
+
+                return new Collection($items);
             }
 
             public function set($model, $key, $value, $attributes)
             {
-                if ($this->isEmpty($value) && $this->wasEmpty($model, $key)) {
+                if ($this->isEmpty($value) && $this->wasNull($model, $key)) {
                     return [$key => null];
                 }
 
@@ -37,16 +39,12 @@ class AsCollection implements Castable
                     return $value->isEmpty();
                 }
 
-                return ! $value;
+                return empty($value);
             }
 
-            protected function wasEmpty($model, $key)
+            protected function wasNull($model, $key)
             {
-                if ($model instanceof Model) {
-                    return $model->getRawOriginal($key) === null;
-                }
-
-                return false;
+                return $model->getRawOriginal($key) === null;
             }
         };
     }

--- a/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
@@ -26,7 +26,7 @@ class AsCollection implements Castable
 
             public function set($model, $key, $value, $attributes)
             {
-                if ($this->isEmpty($value) && $this->wasNull($model, $key)) {
+                if (is_null($model->getRawOriginal($key)) && $this->isEmpty($value)) {
                     return [$key => null];
                 }
 
@@ -40,11 +40,6 @@ class AsCollection implements Castable
                 }
 
                 return empty($value);
-            }
-
-            protected function wasNull($model, $key)
-            {
-                return $model->getRawOriginal($key) === null;
             }
         };
     }

--- a/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
@@ -24,20 +24,11 @@ class AsCollection implements Castable
 
             public function set($model, $key, $value, $attributes)
             {
-                if (is_null($model->getRawOriginal($key)) && $this->isEmpty($value)) {
+                if (is_null($value) || ($value instanceof Collection && $value->isEmpty())) {
                     return [$key => null];
                 }
 
                 return [$key => json_encode($value)];
-            }
-
-            protected function isEmpty($value)
-            {
-                if ($value instanceof Collection) {
-                    return $value->isEmpty();
-                }
-
-                return $value === null;
             }
         };
     }


### PR DESCRIPTION
Currently when casting an attribute to `asCollection` it only casts it if the value isn't `null`, creating an issue when you want to start pushing or using the collection.

This PR ensures you always get a `Collection` but still maintains the `null` value in the database if the attribute is still empty and the original value was `null` upon saving.

Benefit: You can just use the attribute as a collection without checking if it is indeed a `Collection`
