### PR TITLE
[8.x] Minor clean up

### DIFF
--- a/src/Illuminate/Foundation/Console/EventListCommand.php
+++ b/src/Illuminate/Foundation/Console/EventListCommand.php
@@ -48,7 +48,7 @@ class EventListCommand extends Command
         $events = [];
 
         foreach ($this->laravel->getProviders(EventServiceProvider::class) as $provider) {
-            $providerEvents = array_merge_recursive($provider->shouldDiscoverEvents() ? $provider->discoverEvents() : [], $provider->listens());
+            $providerEvents = $provider->getEvents();
 
             $events = array_merge_recursive($events, $providerEvents);
         }


### PR DESCRIPTION
This whole line is available on the provider `discoveredEvents` method which `getEvents` also call if the events are not cached.

Size effect: List cached events if available