### PR TITLE
[9.x] AOP transaction management

### DIFF
--- a/src/Illuminate/Contracts/Routing/TransactionManager.php
+++ b/src/Illuminate/Contracts/Routing/TransactionManager.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Illuminate\Contracts\Routing;
+
+interface TransactionManager
+{
+    /**
+     * Start a new database transaction.
+     *
+     * @return void
+     */
+    public function beginTransaction();
+
+    /**
+     * Commit the active database transaction.
+     *
+     * @return void
+     */
+    public function commit();
+
+    /**
+     * Rollback the active database transaction.
+     *
+     * @return void
+     */
+    public function rollback();
+}

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -9,6 +9,7 @@ use Exception;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Database\Events\StatementPrepared;
+use Illuminate\Contracts\Routing\TransactionManager;
 use Illuminate\Database\Events\TransactionBeginning;
 use Illuminate\Database\Events\TransactionCommitted;
 use Illuminate\Database\Events\TransactionRolledBack;
@@ -22,7 +23,7 @@ use LogicException;
 use PDO;
 use PDOStatement;
 
-class Connection implements ConnectionInterface
+class Connection implements ConnectionInterface,TransactionManager
 {
     use DetectsConcurrencyErrors,
         DetectsLostConnections,

--- a/src/Illuminate/Database/DatabaseServiceProvider.php
+++ b/src/Illuminate/Database/DatabaseServiceProvider.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Types\Type;
 use Faker\Factory as FakerFactory;
 use Faker\Generator as FakerGenerator;
 use Illuminate\Contracts\Queue\EntityResolver;
+use Illuminate\Contracts\Routing\TransactionManager;
 use Illuminate\Database\Connectors\ConnectionFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\QueueEntityResolver;
@@ -74,6 +75,10 @@ class DatabaseServiceProvider extends ServiceProvider
 
         $this->app->singleton('db.transactions', function ($app) {
             return new DatabaseTransactionsManager;
+        });
+
+        $this->app->bind(TransactionManager::class,function ($app){
+            return $app['db.connection'];
         });
     }
 

--- a/src/Illuminate/Routing/TransactionalControllerDispatcher.php
+++ b/src/Illuminate/Routing/TransactionalControllerDispatcher.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Illuminate\Routing;
+
+use Throwable;
+use Illuminate\Contracts\Routing\TransactionManager;
+use Illuminate\Routing\Contracts\ControllerDispatcher as ControllerDispatcherContract;
+
+class TransactionalControllerDispatcher implements ControllerDispatcherContract
+{
+    /**
+     * @var ControllerDispatcherContract
+     */
+    private $controllerDispatcher;
+
+    /**
+     * @var TransactionManager
+     */
+    private $transactionManager;
+
+    public function __construct(ControllerDispatcherContract $controllerDispatcher, TransactionManager $transactionManager)
+    {
+        $this->controllerDispatcher = $controllerDispatcher;
+        $this->transactionManager = $transactionManager;
+    }
+
+    /**
+     * Dispatch a request to a given controller and method in a transactional manner
+     *
+     * @param  \Illuminate\Routing\Route  $route
+     * @param  mixed  $controller
+     * @param  string  $method
+     * @return mixed
+     */
+    public function dispatch(Route $route, $controller, $method)
+    {
+        $this->transactionManager->beginTransaction();
+        try {
+            $response = $this->controllerDispatcher->dispatch($route, $controller, $method);
+            $this->transactionManager->commit();
+            return $response;
+        } catch (Throwable $throwable) {
+            $this->transactionManager->rollback();
+            throw $throwable;
+        }
+    }
+
+    /**
+     * Get the middleware for the controller instance.
+     *
+     * @param  \Illuminate\Routing\Controller  $controller
+     * @param  string  $method
+     * @return array
+     */
+    public function getMiddleware($controller, $method)
+    {
+        return $this->controllerDispatcher->getMiddleware($controller, $method);
+    }
+}

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -9,6 +9,7 @@ use Illuminate\Auth\Middleware\Authenticate;
 use Illuminate\Auth\Middleware\Authorize;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Routing\Registrar;
+use Illuminate\Contracts\Routing\TransactionManager;
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
@@ -29,6 +30,7 @@ use Illuminate\Routing\Router;
 use Illuminate\Routing\UrlGenerator;
 use Illuminate\Support\Str;
 use LogicException;
+use Mockery;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
@@ -37,6 +39,11 @@ use UnexpectedValueException;
 
 class RoutingRouteTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        Mockery::close();
+    }
+
     public function testBasicDispatchingOfRoutes()
     {
         $router = $this->getRouter();
@@ -1926,6 +1933,47 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals(301, $response->getStatusCode());
     }
 
+    /**
+     * @test
+     */
+    public function begin_and_commit_transaction_when_method_is_transactional()
+    {
+        $request = Request::create('images/', 'GET');
+        $route = new Route('GET', 'images/', [RouteTestControllerWithTransactionalMethodStub::class, 'update']);
+        $route->bind($request);
+        $transactionManager = Mockery::mock(TransactionManager::class)
+            ->expects('beginTransaction')
+            ->getMock()
+            ->expects('commit')
+            ->getMock();
+        $container = new Container();
+        $container->instance(TransactionManager::class, $transactionManager);
+        $route->setContainer($container);
+
+        $route->run();
+    }
+
+    /**
+     * @test
+     */
+    public function begin_then_rollback_transaction_when_method_is_transactional_and_there_is_exception()
+    {
+        $request = Request::create('images/', 'GET');
+        $route = new Route('GET', 'images/', [RouteTestControllerWithTransactionalMethodStub::class, 'save']);
+        $route->bind($request);
+        $container = new Container();
+        $transactionManager = Mockery::mock(TransactionManager::class)
+            ->expects('beginTransaction')
+            ->getMock()
+            ->expects('rollback')
+            ->getMock();
+        $container->instance(TransactionManager::class, $transactionManager);
+        $route->setContainer($container);
+
+        $this->expectException(Exception::class);
+        $route->run();
+    }
+
     protected function getRouter()
     {
         $container = new Container;
@@ -1937,6 +1985,25 @@ class RoutingRouteTest extends TestCase
         });
 
         return $router;
+    }
+}
+
+class RouteTestControllerWithTransactionalMethodStub extends Controller
+{
+    /**
+     * @transactional
+     */
+    public function update()
+    {
+        return 'Hello World';
+    }
+
+    /**
+     * @transactional
+     */
+    public function save()
+    {
+        throw new Exception();
     }
 }
 


### PR DESCRIPTION
Like the Spring framework, Now it's possible to manage transactions by adding **@transactional** annotation to the doc block of a controller's method.
It automatically begins the transaction before the method gets invoked and commits it at the end or in the case of exception rolls it back.

**it doesn't introduce breaking changes to the framework because it decorates the base controller dispatcher.**

### how it makes building web applications easier?
Using annotation allows us to focus on the task itself in the method. managing transactions is a repetitive thing to consider. it's good to handle it with Aspect-Oriented-Programming

Before:
```
public function store()
    {
        DB::beginTransaction();
        try {
            $order = new Order([
            .
            .
            .
        ]);
        $invoice = new Invoice([
            .
            .
            .
        ]);
        $order->invoice()->associate($invoice);
        DB::commit();
        } catch (Throwable $throwable) {
            DB::rollback();
        }
    }
```

After implementing this feature:

```
    /**
     * @transactional
     */
    public function store()
    {
        $order = new Order([
//            .
//            .
//            .
        ]);
        $invoice = new Invoice([
//            .
//            .
//            .
        ]);
        $order->invoice()->associate($invoice);
    }
```


**Anyone using any other ORM instead of Eloquent,** can implement Illuminate\Contracts\Route\Contracts\TransactionManager and register it in the container.
