### PR TITLE
return default value when array key is null for "Arr::get" function of class Arr

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -289,6 +289,10 @@ class Arr
             return value($default);
         }
 
+        if (is_null($key) && !is_null($default)) {
+            return value($default);
+        }
+
         if (is_null($key)) {
             return $array;
         }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -300,6 +300,10 @@ class SupportArrTest extends TestCase
         // Test null key returns the whole array
         $array = ['foo', 'bar'];
         $this->assertEquals($array, Arr::get($array, null));
+        
+        // Test null key and default is not null return default
+        $array = ['foo', 'bar'];
+        $this->assertSame('default', Arr::get($array, null, 'default'));
 
         // Test $array not an array
         $this->assertSame('default', Arr::get(null, 'foo', 'default'));


### PR DESCRIPTION
return default value when array key is null for "get" function of class Arr.
use Arr::get($array, $key, $default) to get value from a array, if the $key is null, the get function will return all item in the array even the default value is not null. Somtimes if return all items will crash the calling codes, for example: expect integer value, the default is 0, by unkonw reason the $key is null, so Arr::get($array, null, 0) will return all items of $array, In this case return default value 0 is better.