### PR TITLE
[8.x] Allow lazy collection to be instantiated from a generator

### DIFF
--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -29,7 +29,7 @@ class LazyCollection implements Enumerable
      */
     public function __construct($source = null)
     {
-        if ($source instanceof Closure || $source instanceof self) {
+        if ($source instanceof Closure || $source instanceof self || is_iterable($source)) {
             $this->source = $source;
         } elseif (is_null($source)) {
             $this->source = static::empty();
@@ -1364,6 +1364,10 @@ class LazyCollection implements Enumerable
      */
     protected function makeIterator($source)
     {
+        if (is_iterable($source)) {
+            return $source;
+        }
+
         if ($source instanceof IteratorAggregate) {
             return $source->getIterator();
         }

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -5,6 +5,7 @@ namespace Illuminate\Support;
 use ArrayIterator;
 use Closure;
 use DateTimeInterface;
+use Generator;
 use Illuminate\Support\Traits\EnumeratesValues;
 use Illuminate\Support\Traits\Macroable;
 use IteratorAggregate;
@@ -29,7 +30,7 @@ class LazyCollection implements Enumerable
      */
     public function __construct($source = null)
     {
-        if ($source instanceof Closure || $source instanceof self || is_iterable($source)) {
+        if ($source instanceof Closure || $source instanceof Generator || $source instanceof self) {
             $this->source = $source;
         } elseif (is_null($source)) {
             $this->source = static::empty();
@@ -1364,7 +1365,7 @@ class LazyCollection implements Enumerable
      */
     protected function makeIterator($source)
     {
-        if (is_iterable($source)) {
+        if ($source instanceof Generator) {
             return $source;
         }
 

--- a/tests/Support/SupportLazyCollectionTest.php
+++ b/tests/Support/SupportLazyCollectionTest.php
@@ -69,6 +69,31 @@ class SupportLazyCollectionTest extends TestCase
         ], $data->all());
     }
 
+    public function testCanCreateCollectionFromIterable()
+    {
+        $iterable = function () {
+            yield 1;
+            yield 2;
+            yield 3;
+        };
+        $data = LazyCollection::make($iterable());
+
+        $this->assertSame([1, 2, 3], $data->all());
+
+        $iterable = function () {
+            yield 'a' => 1;
+            yield 'b' => 2;
+            yield 'c' => 3;
+        };
+        $data = LazyCollection::make($iterable());
+
+        $this->assertSame([
+            'a' => 1,
+            'b' => 2,
+            'c' => 3,
+        ], $data->all());
+    }
+
     public function testEager()
     {
         $source = [1, 2, 3, 4, 5];

--- a/tests/Support/SupportLazyCollectionTest.php
+++ b/tests/Support/SupportLazyCollectionTest.php
@@ -69,7 +69,7 @@ class SupportLazyCollectionTest extends TestCase
         ], $data->all());
     }
 
-    public function testCanCreateCollectionFromIterable()
+    public function testCanCreateCollectionFromGenerator()
     {
         $iterable = function () {
             yield 1;


### PR DESCRIPTION
Sometimes you may be in a position where you have a generator, which you would like to pass into a lazy collection. Right now you would have to do something like the following: 

```php
$source = /* some function that returns a generator */;
LazyCollection::make(function () use (&$source) {
    yield from $source;
});
```

With this change, you would be able to call `LazyCollection::make($source);` directly.