### PR TITLE
[7.x]Fixes the issue when using cache:clear with PhpRedis and a clustered

### DIFF
--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -501,14 +501,8 @@ class PhpRedisConnection extends Connection implements ConnectionContract
             return $this->command('flushdb');
         }
 
-        foreach ($this->client->_masters() as [$host, $port]) {
-            $redis = tap(new Redis)->connect($host, $port);
-
-            if (isset($this->config['password']) && ! empty($this->config['password'])) {
-                $redis->auth($this->config['password']);
-            }
-
-            $redis->flushDb();
+        foreach ($this->client->_masters() as $master) {
+            $this->client->flushDb($master);
         }
     }
 


### PR DESCRIPTION
This is simply a replication of the fix by @willbrowningme in MR #36281 which was already merged to the 8.x release branch, 

@J5Dev in MR #36665 which was already merged to the 6.x release branch.

but it's still unfixed in the 7.x release, so this PR is a simple replication of previously above mentioned.

I have tested that as with the other branch, these changes not only work, but also have no adverse affects. 