### PR TITLE
[6.x] Fix empty payload for sync job

### DIFF
--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -195,12 +195,12 @@ abstract class Job
      */
     protected function failed($e)
     {
-        $payload = $this->payload();
+        if ($payload = $this->payload()) {
+            [$class, $method] = JobName::parse($payload['job']);
 
-        [$class, $method] = JobName::parse($payload['job']);
-
-        if (method_exists($this->instance = $this->resolve($class), 'failed')) {
-            $this->instance->failed($payload['data'], $e);
+            if (method_exists($this->instance = $this->resolve($class), 'failed')) {
+                $this->instance->failed($payload['data'], $e);
+            }
         }
     }
 

--- a/tests/Integration/Queue/FailedJobTest.php
+++ b/tests/Integration/Queue/FailedJobTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Queue;
+
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\Events\JobFailed;
+use Illuminate\Queue\Jobs\Job;
+use Illuminate\Support\Facades\Event;
+use Orchestra\Testbench\TestCase;
+
+class FailedJobTest extends TestCase
+{
+    public function testEmptyFailingJobStillEmitsEvent()
+    {
+        Event::fake();
+
+        FailingJob::dispatchNow($this->app);
+
+        Event::assertDispatched(JobFailed::class, function (JobFailed $event) {
+            return 'foo' === $event->job->getJobId();
+        });
+    }
+}
+
+class FailingJob extends Job
+{
+    use Dispatchable;
+
+    public function __construct(Container $container)
+    {
+        $this->container = $container;
+    }
+
+    public function handle()
+    {
+        $this->fail();
+    }
+
+    /**
+     * Get the job identifier.
+     *
+     * @return string
+     */
+    public function getJobId()
+    {
+        return 'foo';
+    }
+
+    /**
+     * Get the raw body of the job.
+     *
+     * @return string
+     */
+    public function getRawBody()
+    {
+        return '';
+    }
+}


### PR DESCRIPTION
Although an edge case, when a job without a raw body gets dispatched synchronously, it'll fail because the `job` class cannot be found. By first checking if a payload is set or not we can prevent this exception from being thrown.

Fixes https://github.com/laravel/framework/issues/36740