### PR TITLE
more unified testing environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ Thumbs.db
 /.idea
 /.vscode
 .phpunit.result.cache
+.env

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -1,23 +1,6 @@
 #!/usr/bin/env bash
 
 docker-compose down -t 0 &> /dev/null
-docker-compose up -d
+trap 'docker-compose down -t 0' EXIT
 
-echo "Waiting for services to boot   ..."
-
-if docker run -it --rm registry.gitlab.com/grahamcampbell/php:7.4-base -r "\$tries = 0; while (true) { try { \$tries++; if (\$tries > 30) { throw new RuntimeException('MySQL never became available'); } sleep(1); new PDO('mysql:host=docker.for.mac.localhost;dbname=forge', 'root', '', [PDO::ATTR_TIMEOUT => 3]); break; } catch (PDOException \$e) {} }"; then
-    if docker run -it -w /data -v ${PWD}:/data:delegated --entrypoint vendor/bin/phpunit \
-       --env CI=1 --env DB_HOST=docker.for.mac.localhost --env DB_USERNAME=root \
-       --env REDIS_HOST=docker.for.mac.localhost --env REDIS_PORT=6379 \
-       --env MEMCACHED_HOST=docker.for.mac.localhost --env MEMCACHED_PORT=11211 \
-       --rm registry.gitlab.com/grahamcampbell/php:7.4-base "$@"; then
-        docker-compose down -t 0
-    else
-        docker-compose down -t 0
-        exit 1
-    fi
-else
-    docker-compose logs
-    docker-compose down -t 0 &> /dev/null
-    exit 1
-fi
+docker-compose -f docker-compose.yml -f docker-compose.tests.yml run tests

--- a/bin/tests-entrypoint.sh
+++ b/bin/tests-entrypoint.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -e
+
+php -r "\$tries = 0; while (true) { try { \$tries++; if (\$tries > 30) { throw new RuntimeException('MySQL never became available'); } sleep(1); new PDO('mysql:host=${DB_HOST};dbname=forge', 'root', '', [PDO::ATTR_TIMEOUT => 3]); break; } catch (PDOException \$e) {} }"
+
+exec vendor/bin/phpunit $@

--- a/docker-compose.tests.yml
+++ b/docker-compose.tests.yml
@@ -1,0 +1,19 @@
+version: '3'
+services:
+  tests:
+    depends_on:
+      - mysql
+      - memcached
+      - redis
+    image: registry.gitlab.com/grahamcampbell/php:7.4-base
+    entrypoint: [ "/data/bin/tests-entrypoint.sh" ]
+    working_dir: /data
+    environment:
+      DB_HOST: mysql
+      REDIS_HOST: redis
+      MEMCACHED_HOST: memcached
+      DB_USERNAME: root
+      CI: ${CI:-1}
+    volumes:
+      - .:/data:delegated
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   memcached:
     image: memcached:1.6-alpine
     ports:
-      - "11211:11211"
+      - "${MEMCACHED_PORT:-11211}:11211"
     restart: always
   mysql:
     image: mysql:5.7
@@ -12,10 +12,10 @@ services:
       MYSQL_ROOT_PASSWORD: ""
       MYSQL_DATABASE: "forge"
     ports:
-      - "3306:3306"
+      - "${MYSQL_PORT:-3306}:3306"
     restart: always
   redis:
     image: redis:5.0-alpine
     ports:
-      - "6379:6379"
+      - "${REDIS_PORT:-6379}:6379"
     restart: always


### PR DESCRIPTION
Recently I faced an issue with running testing environment on my local machine.
With the patch the testing environment is no longer:
- Nailed to the Apple Inc. devices
- Nailed to the ports which services are listening to

Maybe we can keep even one docker-compose.yml (combined with docker-compose.tests.yml) ?