### PR TITLE
[6.x] DynamoDB in CI suite

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,6 +72,9 @@ jobs:
           DB_PORT: ${{ job.services.mysql.ports[3306] }}
           DB_USERNAME: root
           DYNAMODB_CACHE_TABLE: laravel_dynamodb_test
+          DYNAMODB_ENDPOINT: "http://dynamodb-local:8000"
+          AWS_ACCESS_KEY_ID: random_key
+          AWS_SECRET_ACCESS_KEY: random_secret
 
   windows_tests:
     runs-on: windows-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,8 +63,11 @@ jobs:
           max_attempts: 5
           command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
 
+      - name: Setup DynamoDB Local
+        uses: rrainn/dynamodb-action@v2.0.0
+
       - name: Execute tests
-        run: vendor/bin/phpunit --verbose
+        run: vendor/bin/phpunit tests/Integration/Cache/DynamoDbStoreTest.php --verbose
         env:
           DB_PORT: ${{ job.services.mysql.ports[3306] }}
           DB_USERNAME: root

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,7 +74,7 @@ jobs:
           DB_PORT: ${{ job.services.mysql.ports[3306] }}
           DB_USERNAME: root
           DYNAMODB_CACHE_TABLE: laravel_dynamodb_test
-          DYNAMODB_ENDPOINT: "http://dynamodb-local:8888"
+          DYNAMODB_ENDPOINT: "http://localhost:8888"
           AWS_ACCESS_KEY_ID: random_key
           AWS_SECRET_ACCESS_KEY: random_secret
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,7 +69,7 @@ jobs:
           port: 8888
 
       - name: Execute tests
-        run: vendor/bin/phpunit tests/Integration/Cache/DynamoDbStoreTest.php --verbose
+        run: vendor/bin/phpunit --verbose
         env:
           DB_PORT: ${{ job.services.mysql.ports[3306] }}
           DB_USERNAME: root

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,6 +65,8 @@ jobs:
 
       - name: Setup DynamoDB Local
         uses: rrainn/dynamodb-action@v2.0.0
+        with:
+          port: 8888
 
       - name: Execute tests
         run: vendor/bin/phpunit tests/Integration/Cache/DynamoDbStoreTest.php --verbose
@@ -72,7 +74,7 @@ jobs:
           DB_PORT: ${{ job.services.mysql.ports[3306] }}
           DB_USERNAME: root
           DYNAMODB_CACHE_TABLE: laravel_dynamodb_test
-          DYNAMODB_ENDPOINT: "http://dynamodb-local:8000"
+          DYNAMODB_ENDPOINT: "http://dynamodb-local:8888"
           AWS_ACCESS_KEY_ID: random_key
           AWS_SECRET_ACCESS_KEY: random_secret
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,6 +71,7 @@ jobs:
         env:
           DB_PORT: ${{ job.services.mysql.ports[3306] }}
           DB_USERNAME: root
+          DYNAMODB_CACHE_TABLE: laravel_dynamodb_test
 
   windows_tests:
     runs-on: windows-latest

--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -2,12 +2,10 @@
 
 namespace Illuminate\Cache;
 
-use Aws\DynamoDb\DynamoDbClient;
 use Closure;
 use Illuminate\Contracts\Cache\Factory as FactoryContract;
 use Illuminate\Contracts\Cache\Store;
 use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
-use Illuminate\Support\Arr;
 use InvalidArgumentException;
 
 /**
@@ -226,21 +224,9 @@ class CacheManager implements FactoryContract
      */
     protected function createDynamodbDriver(array $config)
     {
-        $dynamoConfig = [
-            'region' => $config['region'],
-            'version' => 'latest',
-            'endpoint' => $config['endpoint'] ?? null,
-        ];
-
-        if ($config['key'] && $config['secret']) {
-            $dynamoConfig['credentials'] = Arr::only(
-                $config, ['key', 'secret', 'token']
-            );
-        }
-
         return $this->repository(
             new DynamoDbStore(
-                new DynamoDbClient($dynamoConfig),
+                $this->app['cache.dynamodb.client'],
                 $config['table'],
                 $config['attributes']['key'] ?? 'key',
                 $config['attributes']['value'] ?? 'value',

--- a/src/Illuminate/Cache/CacheServiceProvider.php
+++ b/src/Illuminate/Cache/CacheServiceProvider.php
@@ -36,19 +36,14 @@ class CacheServiceProvider extends ServiceProvider implements DeferrableProvider
         $this->app->singleton('cache.dynamodb.client', function ($app) {
             $config = $app['config']->get('cache.stores.dynamodb');
 
-            $dynamoConfig = [
+            return new DynamoDbClient([
                 'region' => $config['region'],
                 'version' => 'latest',
                 'endpoint' => $config['endpoint'] ?? null,
-            ];
-
-            if ($config['key'] && $config['secret']) {
-                $dynamoConfig['credentials'] = Arr::only(
+                'credentials' => Arr::only(
                     $config, ['key', 'secret', 'token']
-                );
-            }
-
-            return new DynamoDbClient($dynamoConfig);
+                ),
+            ]);
         });
     }
 

--- a/src/Illuminate/Cache/CacheServiceProvider.php
+++ b/src/Illuminate/Cache/CacheServiceProvider.php
@@ -60,7 +60,7 @@ class CacheServiceProvider extends ServiceProvider implements DeferrableProvider
     public function provides()
     {
         return [
-            'cache', 'cache.store', 'cache.psr6', 'memcached.connector',
+            'cache', 'cache.store', 'cache.psr6', 'memcached.connector', 'cache.dynamodb.client',
         ];
     }
 }

--- a/tests/Integration/Cache/DynamoDbStoreTest.php
+++ b/tests/Integration/Cache/DynamoDbStoreTest.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Tests\Integration\Cache;
 
+use Aws\DynamoDb\DynamoDbClient;
+use Aws\Exception\AwsException;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Str;
 use Orchestra\Testbench\TestCase;
@@ -81,6 +83,10 @@ class DynamoDbStoreTest extends TestCase
         /** @var \Aws\DynamoDb\DynamoDbClient $client */
         $client = $app['cache.dynamodb.client'];
 
+        if ($this->dynamoTableExists($client, $config['table'])) {
+            return;
+        }
+
         $client->createTable([
             'TableName' => $config['table'],
             'KeySchema' => [
@@ -95,6 +101,34 @@ class DynamoDbStoreTest extends TestCase
                     'AttributeType' => 'S',
                 ],
             ],
+            'ProvisionedThroughput' => [
+                'ReadCapacityUnits' => 1,
+                'WriteCapacityUnits' => 1,
+            ],
         ]);
+    }
+
+    /**
+     * Determine if the given DynamoDB table exists.
+     *
+     * @param  \Aws\DynamoDb\DynamoDbClient  $client
+     * @param  string  $table
+     * @return bool
+     */
+    public function dynamoTableExists(DynamoDbClient $client, $table)
+    {
+        try {
+            $client->describeTable([
+                'TableName' => $table,
+            ]);
+
+            return true;
+        } catch (AwsException $e) {
+            if (Str::contains($e->getAwsErrorMessage(), 'resource not found')) {
+                return false;
+            }
+
+            throw $e;
+        }
     }
 }

--- a/tests/Integration/Cache/DynamoDbStoreTest.php
+++ b/tests/Integration/Cache/DynamoDbStoreTest.php
@@ -87,7 +87,7 @@ class DynamoDbStoreTest extends TestCase
                 [
                     'AttributeName' => $config['attributes']['key'] ?? 'key',
                     'KeyType' => 'HASH',
-                ]
+                ],
             ],
             'AttributeDefinitions' => [
                 [

--- a/tests/Integration/Cache/DynamoDbStoreTest.php
+++ b/tests/Integration/Cache/DynamoDbStoreTest.php
@@ -75,14 +75,5 @@ class DynamoDbStoreTest extends TestCase
     protected function getEnvironmentSetUp($app)
     {
         $app['config']->set('cache.default', 'dynamodb');
-
-        $app['config']->set('cache.stores.dynamodb', [
-            'driver' => 'dynamodb',
-            'key' => env('AWS_ACCESS_KEY_ID'),
-            'secret' => env('AWS_SECRET_ACCESS_KEY'),
-            'region' => 'us-east-1',
-            'table' => env('DYNAMODB_CACHE_TABLE', 'laravel_test'),
-            'endpoint' => env('DYNAMODB_ENDPOINT'),
-        ]);
     }
 }

--- a/tests/Integration/Cache/DynamoDbStoreTest.php
+++ b/tests/Integration/Cache/DynamoDbStoreTest.php
@@ -15,11 +15,11 @@ class DynamoDbStoreTest extends TestCase
 {
     protected function setUp(): void
     {
-        parent::setUp();
-
         if (! env('DYNAMODB_CACHE_TABLE')) {
             $this->markTestSkipped('DynamoDB not configured.');
         }
+
+        parent::setUp();
     }
 
     public function testItemsCanBeStoredAndRetrieved()
@@ -76,6 +76,10 @@ class DynamoDbStoreTest extends TestCase
      */
     protected function getEnvironmentSetUp($app)
     {
+        if (! env('DYNAMODB_CACHE_TABLE')) {
+            $this->markTestSkipped('DynamoDB not configured.');
+        }
+
         $app['config']->set('cache.default', 'dynamodb');
 
         $config = $app['config']->get('cache.stores.dynamodb');

--- a/tests/Integration/Cache/DynamoDbStoreTest.php
+++ b/tests/Integration/Cache/DynamoDbStoreTest.php
@@ -88,6 +88,14 @@ class DynamoDbStoreTest extends TestCase
                     'AttributeName' => $config['attributes']['key'] ?? 'key',
                     'KeyType' => 'HASH',
                 ],
+                [
+                    'AttributeName' => $config['attributes']['value'] ?? 'value',
+                    'KeyType' => 'HASH',
+                ],
+                [
+                    'AttributeName' => $config['attributes']['expiration'] ?? 'expires_at',
+                    'KeyType' => 'HASH',
+                ],
             ],
             'AttributeDefinitions' => [
                 [
@@ -100,7 +108,7 @@ class DynamoDbStoreTest extends TestCase
                 ],
                 [
                     'AttributeName' => $config['attributes']['expiration'] ?? 'expires_at',
-                    'AttributeType' => 'S',
+                    'AttributeType' => 'N',
                 ],
             ],
             'ProvisionedThroughput' => [

--- a/tests/Integration/Cache/DynamoDbStoreTest.php
+++ b/tests/Integration/Cache/DynamoDbStoreTest.php
@@ -124,7 +124,7 @@ class DynamoDbStoreTest extends TestCase
 
             return true;
         } catch (AwsException $e) {
-            if (Str::contains($e->getAwsErrorMessage(), 'resource not found')) {
+            if (Str::contains($e->getAwsErrorMessage(), ['resource not found', 'Cannot do operations on a non-existent table'])) {
                 return false;
             }
 

--- a/tests/Integration/Cache/DynamoDbStoreTest.php
+++ b/tests/Integration/Cache/DynamoDbStoreTest.php
@@ -86,7 +86,7 @@ class DynamoDbStoreTest extends TestCase
             'KeySchema' => [
                 [
                     'AttributeName' => $config['attributes']['key'] ?? 'key',
-                    'KeyType' => 'hash',
+                    'KeyType' => 'HASH',
                 ],
             ],
             'AttributeDefinitions' => [

--- a/tests/Integration/Cache/DynamoDbStoreTest.php
+++ b/tests/Integration/Cache/DynamoDbStoreTest.php
@@ -87,33 +87,13 @@ class DynamoDbStoreTest extends TestCase
                 [
                     'AttributeName' => $config['attributes']['key'] ?? 'key',
                     'KeyType' => 'HASH',
-                ],
-                [
-                    'AttributeName' => $config['attributes']['value'] ?? 'value',
-                    'KeyType' => 'HASH',
-                ],
-                [
-                    'AttributeName' => $config['attributes']['expiration'] ?? 'expires_at',
-                    'KeyType' => 'HASH',
-                ],
+                ]
             ],
             'AttributeDefinitions' => [
                 [
                     'AttributeName' => $config['attributes']['key'] ?? 'key',
                     'AttributeType' => 'S',
                 ],
-                [
-                    'AttributeName' => $config['attributes']['value'] ?? 'value',
-                    'AttributeType' => 'S',
-                ],
-                [
-                    'AttributeName' => $config['attributes']['expiration'] ?? 'expires_at',
-                    'AttributeType' => 'N',
-                ],
-            ],
-            'ProvisionedThroughput' => [
-                'ReadCapacityUnits' => 1,
-                'WriteCapacityUnits' => 1,
             ],
         ]);
     }

--- a/tests/Integration/Cache/DynamoDbStoreTest.php
+++ b/tests/Integration/Cache/DynamoDbStoreTest.php
@@ -78,8 +78,8 @@ class DynamoDbStoreTest extends TestCase
 
         $app['config']->set('cache.stores.dynamodb', [
             'driver' => 'dynamodb',
-            'key' => env('AWS_ACCESS_KEY_ID', 'random-key'),
-            'secret' => env('AWS_SECRET_ACCESS_KEY', 'random-secret'),
+            'key' => env('AWS_ACCESS_KEY_ID'),
+            'secret' => env('AWS_SECRET_ACCESS_KEY'),
             'region' => 'us-east-1',
             'table' => env('DYNAMODB_CACHE_TABLE', 'laravel_test'),
             'endpoint' => env('DYNAMODB_ENDPOINT'),

--- a/tests/Integration/Cache/DynamoDbStoreTest.php
+++ b/tests/Integration/Cache/DynamoDbStoreTest.php
@@ -75,5 +75,38 @@ class DynamoDbStoreTest extends TestCase
     protected function getEnvironmentSetUp($app)
     {
         $app['config']->set('cache.default', 'dynamodb');
+
+        $config = $app['config']->get('cache.stores.dynamodb');
+
+        /** @var \Aws\DynamoDb\DynamoDbClient $client */
+        $client = $app['cache.dynamodb.client'];
+
+        $client->createTable([
+            'TableName' => $config['table'],
+            'KeySchema' => [
+                [
+                    'AttributeName' => $config['attributes']['key'] ?? 'key',
+                    'KeyType' => 'hash',
+                ],
+            ],
+            'AttributeDefinitions' => [
+                [
+                    'AttributeName' => $config['attributes']['key'] ?? 'key',
+                    'AttributeType' => 'S',
+                ],
+                [
+                    'AttributeName' => $config['attributes']['value'] ?? 'value',
+                    'AttributeType' => 'S',
+                ],
+                [
+                    'AttributeName' => $config['attributes']['expiration'] ?? 'expires_at',
+                    'AttributeType' => 'S',
+                ],
+            ],
+            'ProvisionedThroughput' => [
+                'ReadCapacityUnits' => 1,
+                'WriteCapacityUnits' => 1,
+            ],
+        ]);
     }
 }

--- a/tests/Integration/Cache/DynamoDbStoreTest.php
+++ b/tests/Integration/Cache/DynamoDbStoreTest.php
@@ -78,8 +78,8 @@ class DynamoDbStoreTest extends TestCase
 
         $app['config']->set('cache.stores.dynamodb', [
             'driver' => 'dynamodb',
-            'key' => env('AWS_ACCESS_KEY_ID'),
-            'secret' => env('AWS_SECRET_ACCESS_KEY'),
+            'key' => env('AWS_ACCESS_KEY_ID', 'random-key'),
+            'secret' => env('AWS_SECRET_ACCESS_KEY', 'random-secret'),
             'region' => 'us-east-1',
             'table' => env('DYNAMODB_CACHE_TABLE', 'laravel_test'),
             'endpoint' => env('DYNAMODB_ENDPOINT'),


### PR DESCRIPTION
This PR adds support for DynamoDB in our CI suite. It'll dynamically create the DynamoDB cache table if it doesn't exists. 

Additionally, I've extracted the DynamoDB Client into a separate singleton call so it's stored in the container as `cache.dynamodb.client`. I contemplated on storing it as `dynamodb.client` but think it's best it's bound as a separate instance so it doesn't conflicts with other implementations.

Normally this PR should be backwards compatible. Feel free to let me know if you see it differently.

Closes https://github.com/laravel/framework/issues/36364