### PR TITLE
[8.x] Add default options to Http client

### DIFF
--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -79,6 +79,13 @@ class Factory
     protected $responseSequences = [];
 
     /**
+     * Default options set on all created requests.
+     *
+     * @var array
+     */
+    protected $defaultOptions = [];
+
+    /**
      * Create a new factory instance.
      *
      * @return void
@@ -323,13 +330,30 @@ class Factory
     }
 
     /**
+     * Set default options for all created requests.
+     *
+     * @param  array|null  $defaultOptions
+     * @return array
+     */
+    public function defaultOptions(?array $defaultOptions = null)
+    {
+        if (! is_null($defaultOptions)) {
+            $this->defaultOptions = $defaultOptions;
+        }
+
+        return $this->defaultOptions;
+    }
+
+    /**
      * Create a new pending request instance for this factory.
      *
      * @return \Illuminate\Http\Client\PendingRequest
      */
     protected function newPendingRequest()
     {
-        return new PendingRequest($this);
+        return tap(new PendingRequest($this), function (PendingRequest $request) {
+            $request->withOptions($this->defaultOptions);
+        });
     }
 
     /**

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -812,4 +812,27 @@ class HttpClientTest extends TestCase
 
         $this->assertSame('yes!', $this->factory->fakeSequence()->customMethod());
     }
+
+    public function testDefaultOptions()
+    {
+        $defaultOptions = [
+            'headers' => [
+                'Foo' => 'Bar',
+            ],
+        ];
+
+        $this->factory->fake();
+
+        $this->assertEquals([], $this->factory->defaultOptions());
+
+        $this->factory->defaultOptions($defaultOptions);
+
+        $this->assertEquals($defaultOptions, $this->factory->defaultOptions());
+
+        $this->factory->get('http://foo.com');
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com' && $request->hasHeader('Foo', 'Bar');
+        });
+    }
 }


### PR DESCRIPTION
Hi,

This PR gives a way to globally configure options on the http client. 

In the test I added an example using headers to make it easy, however this the PR is motivated by the same needs described in https://github.com/laravel/framework/discussions/36710. This would be possible by just doing :

```
Http::defaultOptions([
    'timeout' => 10
])
```

Have a good day.