### PR TITLE
[6.x] Bugfix on event:list

### DIFF
--- a/src/Illuminate/Events/SpyDispatcher.php
+++ b/src/Illuminate/Events/SpyDispatcher.php
@@ -2,6 +2,15 @@
 
 namespace Illuminate\Events;
 
+/**
+ * A Dispatcher to spy on event registration
+ *
+ * Laravel does not store reference to listeners, only
+ * store closures. Which made it difficult to list
+ * application registered events and listeners
+ *
+ * @internal
+ */
 class SpyDispatcher extends Dispatcher
 {
     public function makeListener($listener, $wildcard = false)

--- a/src/Illuminate/Events/SpyDispatcher.php
+++ b/src/Illuminate/Events/SpyDispatcher.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Events;
 
 /**
- * A Dispatcher to spy on event registration
+ * A Dispatcher to spy on event registration.
  *
  * Laravel does not store reference to listeners, only
  * store closures. Which made it difficult to list

--- a/src/Illuminate/Events/SpyDispatcher.php
+++ b/src/Illuminate/Events/SpyDispatcher.php
@@ -11,7 +11,7 @@ class SpyDispatcher extends Dispatcher
         }
 
         if (is_array($listener) && isset($listener[0]) && is_string($listener[0])) {
-            return $listener[0] . '@' . $listener[1] ?? 'handle';
+            return $listener[0].'@'.$listener[1] ?? 'handle';
         }
 
         return 'Closure';

--- a/src/Illuminate/Events/SpyDispatcher.php
+++ b/src/Illuminate/Events/SpyDispatcher.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Illuminate\Events;
+
+class SpyDispatcher extends Dispatcher
+{
+    public function makeListener($listener, $wildcard = false)
+    {
+        if (is_string($listener)) {
+            return $listener;
+        }
+
+        if (is_array($listener) && isset($listener[0]) && is_string($listener[0])) {
+            return $listener[0] . '@' . $listener[1] ?? 'handle';
+        }
+
+        return 'Closure';
+    }
+
+    public function events(): array
+    {
+        return array_merge_recursive($this->listeners, $this->wildcards);
+    }
+}

--- a/src/Illuminate/Foundation/Console/EventListCommand.php
+++ b/src/Illuminate/Foundation/Console/EventListCommand.php
@@ -4,8 +4,8 @@ namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
 use Illuminate\Events\SpyDispatcher;
-use Illuminate\Support\Facades\Event;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Str;
 
 class EventListCommand extends Command

--- a/src/Illuminate/Foundation/Console/EventListCommand.php
+++ b/src/Illuminate/Foundation/Console/EventListCommand.php
@@ -49,7 +49,7 @@ class EventListCommand extends Command
     {
         Event::swap($spy = $this->laravel->make(SpyDispatcher::class));
 
-        foreach ($this->getLaravel()->getProviders(EventServiceProvider::class) as $provider) {
+        foreach ($this->laravel->getProviders(EventServiceProvider::class) as $provider) {
             $provider->register();
 
             if (method_exists($provider, 'callBootingCallbacks')) {
@@ -65,15 +65,9 @@ class EventListCommand extends Command
             $events = $this->filterEvents($events);
         }
 
-        return collect($events)
-            ->map(
-                function ($listeners, $event) {
-                    return ['Event' => $event, 'Listeners' => implode(PHP_EOL, $listeners)];
-                }
-            )
-            ->sortBy('Event')
-            ->values()
-            ->toArray();
+        return collect($events)->map(function ($listeners, $event) {
+            return ['Event' => $event, 'Listeners' => implode(PHP_EOL, $listeners)];
+        })->sortBy('Event')->values()->toArray();
     }
 
     /**

--- a/tests/Foundation/Console/EventListCommandTest.php
+++ b/tests/Foundation/Console/EventListCommandTest.php
@@ -168,8 +168,7 @@ class EventListCommandTest extends TestCase
             '+-------------------------------+---------------------------------------------------------------------+'.PHP_EOL.
             '| Illuminate\Auth\Events\Login  | Illuminate\Tests\Foundation\Console\TestSubscriber@handleUserLogin  |'.PHP_EOL.
             '| Illuminate\Auth\Events\Logout | Illuminate\Tests\Foundation\Console\TestSubscriber@handleUserLogout |'.PHP_EOL.
-            '+-------------------------------+---------------------------------------------------------------------+'.PHP_EOL
-            , $output->fetch()
+            '+-------------------------------+---------------------------------------------------------------------+'.PHP_EOL, $output->fetch()
         );
     }
 }

--- a/tests/Foundation/Console/EventListCommandTest.php
+++ b/tests/Foundation/Console/EventListCommandTest.php
@@ -2,16 +2,16 @@
 
 namespace Illuminate\Tests\Foundation\Console;
 
+use Illuminate\Console\OutputStyle;
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Events\SpyDispatcher;
+use Illuminate\Foundation\Console\EventListCommand;
+use Illuminate\Foundation\Support\Providers\EventServiceProvider;
+use Illuminate\Support\Facades\Event;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
-use Illuminate\Console\OutputStyle;
-use Illuminate\Events\SpyDispatcher;
-use Illuminate\Support\Facades\Event;
 use Symfony\Component\Console\Input\ArrayInput;
-use Illuminate\Contracts\Foundation\Application;
-use Illuminate\Foundation\Console\EventListCommand;
 use Symfony\Component\Console\Output\BufferedOutput;
-use Illuminate\Foundation\Support\Providers\EventServiceProvider;
 
 class EventListCommandTest extends TestCase
 {
@@ -68,7 +68,7 @@ class EventListCommandTest extends TestCase
     {
         $this->testRoutine(
             [],
-            [TestMultipleEventsServiceProvider::class],
+            [TestMultipleEventsServiceProvider::class, EventServiceProvider::class],
             '+------------+------------------------------+'.PHP_EOL.
             '| Event      | Listeners                    |'.PHP_EOL.
             '+------------+------------------------------+'.PHP_EOL.
@@ -82,7 +82,7 @@ class EventListCommandTest extends TestCase
     {
         $this->testRoutine(
             ['--event' => 'Other'],
-            [TestMultipleEventsServiceProvider::class],
+            [TestMultipleEventsServiceProvider::class, TestClosureServiceProvider::class],
             '+------------+-----------------------------+'.PHP_EOL.
             '| Event      | Listeners                   |'.PHP_EOL.
             '+------------+-----------------------------+'.PHP_EOL.

--- a/tests/Foundation/Console/EventListCommandTest.php
+++ b/tests/Foundation/Console/EventListCommandTest.php
@@ -2,21 +2,19 @@
 
 namespace Illuminate\Tests\Foundation\Console;
 
-use Illuminate\Console\OutputStyle;
-use Illuminate\Contracts\Foundation\Application;
-use Illuminate\Events\SpyDispatcher;
-use Illuminate\Foundation\Console\EventListCommand;
-use Illuminate\Foundation\Support\Providers\EventServiceProvider;
-use Illuminate\Support\Facades\Event;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Console\OutputStyle;
+use Illuminate\Events\SpyDispatcher;
+use Illuminate\Support\Facades\Event;
 use Symfony\Component\Console\Input\ArrayInput;
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Foundation\Console\EventListCommand;
 use Symfony\Component\Console\Output\BufferedOutput;
+use Illuminate\Foundation\Support\Providers\EventServiceProvider;
 
 class EventListCommandTest extends TestCase
 {
-    const DOES_NOT_HAVE_ANY_EVENTS = "Your application doesn't have any events matching the given criteria.".PHP_EOL;
-
     protected function tearDown(): void
     {
         m::close();
@@ -56,12 +54,19 @@ class EventListCommandTest extends TestCase
         $command->run($input, $output);
         $command->handle();
 
-        $this->assertEquals($expectedOutput, $output->fetch());
+        $actualOutput = $output->fetch();
+        $actualLines = array_filter(explode(PHP_EOL, $actualOutput));
+        $expectedLines = array_filter(explode(PHP_EOL, $expectedOutput));
+
+        $this->assertEquals($expectedLines, $actualLines);
     }
 
     public function testWithNoEvent()
     {
-        $this->testRoutine([], [EventServiceProvider::class], self::DOES_NOT_HAVE_ANY_EVENTS);
+        $this->testRoutine(
+            [],
+            [EventServiceProvider::class],
+            "Your application doesn't have any events matching the given criteria.");
     }
 
     public function testWithMultipleEvents()
@@ -69,13 +74,16 @@ class EventListCommandTest extends TestCase
         $this->testRoutine(
             [],
             [TestMultipleEventsServiceProvider::class, EventServiceProvider::class],
-            '+------------+------------------------------+'.PHP_EOL.
-            '| Event      | Listeners                    |'.PHP_EOL.
-            '+------------+------------------------------+'.PHP_EOL.
-            '| Some\Event | Some\Listener\FirstListener  |'.PHP_EOL.
-            '|            | Some\Listener\SecondListener |'.PHP_EOL.
-            '| Some\Other | Some\Listener\ThirdListener  |'.PHP_EOL.
-            '+------------+------------------------------+'.PHP_EOL);
+            <<<OUTPUT
++------------+------------------------------+
+| Event      | Listeners                    |
++------------+------------------------------+
+| Some\Event | Some\Listener\FirstListener  |
+|            | Some\Listener\SecondListener |
+| Some\Other | Some\Listener\ThirdListener  |
++------------+------------------------------+
+OUTPUT
+        );
     }
 
     public function testWithFilteredMultipleEvents()
@@ -83,11 +91,14 @@ class EventListCommandTest extends TestCase
         $this->testRoutine(
             ['--event' => 'Other'],
             [TestMultipleEventsServiceProvider::class, TestClosureServiceProvider::class],
-            '+------------+-----------------------------+'.PHP_EOL.
-            '| Event      | Listeners                   |'.PHP_EOL.
-            '+------------+-----------------------------+'.PHP_EOL.
-            '| Some\Other | Some\Listener\ThirdListener |'.PHP_EOL.
-            '+------------+-----------------------------+'.PHP_EOL);
+            <<<OUTPUT
++------------+-----------------------------+
+| Event      | Listeners                   |
++------------+-----------------------------+
+| Some\Other | Some\Listener\ThirdListener |
++------------+-----------------------------+
+OUTPUT
+        );
     }
 
     public function testWithEventSubscribe()
@@ -95,12 +106,15 @@ class EventListCommandTest extends TestCase
         $this->testRoutine(
             [],
             [TestSubscriberServiceProvider::class],
-            '+-------------------------------+---------------------------------------------------------------------+'.PHP_EOL.
-            '| Event                         | Listeners                                                           |'.PHP_EOL.
-            '+-------------------------------+---------------------------------------------------------------------+'.PHP_EOL.
-            '| Illuminate\Auth\Events\Login  | Illuminate\Tests\Foundation\Console\TestSubscriber@handleUserLogin  |'.PHP_EOL.
-            '| Illuminate\Auth\Events\Logout | Illuminate\Tests\Foundation\Console\TestSubscriber@handleUserLogout |'.PHP_EOL.
-            '+-------------------------------+---------------------------------------------------------------------+'.PHP_EOL);
+            <<<OUTPUT
++-------------------------------+---------------------------------------------------------------------+
+| Event                         | Listeners                                                           |
++-------------------------------+---------------------------------------------------------------------+
+| Illuminate\Auth\Events\Login  | Illuminate\Tests\Foundation\Console\TestSubscriber@handleUserLogin  |
+| Illuminate\Auth\Events\Logout | Illuminate\Tests\Foundation\Console\TestSubscriber@handleUserLogout |
++-------------------------------+---------------------------------------------------------------------+
+OUTPUT
+        );
     }
 
     public function testWithClosure()
@@ -108,11 +122,14 @@ class EventListCommandTest extends TestCase
         $this->testRoutine(
             [],
             [TestClosureServiceProvider::class],
-            '+-------+-----------+'.PHP_EOL.
-            '| Event | Listeners |'.PHP_EOL.
-            '+-------+-----------+'.PHP_EOL.
-            '| test  | Closure   |'.PHP_EOL.
-            '+-------+-----------+'.PHP_EOL);
+            <<<OUTPUT
++-------+-----------+
+| Event | Listeners |
++-------+-----------+
+| test  | Closure   |
++-------+-----------+
+OUTPUT
+        );
     }
 
     public function testWithWildCards()
@@ -120,11 +137,14 @@ class EventListCommandTest extends TestCase
         $this->testRoutine(
             [],
             [TestWildCardServiceProvider::class],
-            '+--------+-----------+'.PHP_EOL.
-            '| Event  | Listeners |'.PHP_EOL.
-            '+--------+-----------+'.PHP_EOL.
-            '| test.* | Closure   |'.PHP_EOL.
-            '+--------+-----------+'.PHP_EOL);
+            <<<OUTPUT
++--------+-----------+
+| Event  | Listeners |
++--------+-----------+
+| test.* | Closure   |
++--------+-----------+
+OUTPUT
+        );
     }
 }
 
@@ -177,10 +197,12 @@ class TestSubscriber
 {
     public function handleUserLogin($event)
     {
+        //
     }
 
     public function handleUserLogout($event)
     {
+        //
     }
 
     public function subscribe($events)

--- a/tests/Foundation/Console/EventListCommandTest.php
+++ b/tests/Foundation/Console/EventListCommandTest.php
@@ -87,8 +87,7 @@ class EventListCommandTest extends TestCase
             '| Some\Event | Some\Listener\FirstListener  |'.PHP_EOL.
             '|            | Some\Listener\SecondListener |'.PHP_EOL.
             '| Some\Other | Some\Listener\ThirdListener  |'.PHP_EOL.
-            '+------------+------------------------------+'.PHP_EOL
-            , $output->fetch()
+            '+------------+------------------------------+'.PHP_EOL, $output->fetch()
         );
     }
 
@@ -132,6 +131,76 @@ class EventListCommandTest extends TestCase
             '+------------+-----------------------------+'.PHP_EOL.
             '| Some\Other | Some\Listener\ThirdListener |'.PHP_EOL.
             '+------------+-----------------------------+'.PHP_EOL, $output->fetch()
+        );
+    }
+
+    public function testWithEventSubscribe()
+    {
+        $input = new ArrayInput([]);
+        $output = new BufferedOutput();
+
+        $container = m::mock(Application::class);
+        $container->shouldReceive('call');
+        $container->shouldReceive('getProviders')
+            ->with(EventServiceProvider::class)
+            ->andReturn([new TestSubscriberServiceProvider($container)]);
+
+        $container->shouldReceive('make')
+            ->with(OutputStyle::class, m::any())
+            ->andReturn(
+                new OutputStyle($input, $output)
+            );
+
+        $container->shouldReceive('eventsAreCached')->andReturn(false);
+        $container->shouldReceive('make')
+            ->with(TestSubscriber::class)
+            ->andReturn(new TestSubscriber());
+
+        $command = new EventListCommand();
+        $command->setLaravel($container);
+
+        $command->run($input, $output);
+        $command->handle();
+
+        $this->assertEquals(
+            '+-------------------------------+---------------------------------------------------------------------+'.PHP_EOL.
+            '| Event                         | Listeners                                                           |'.PHP_EOL.
+            '+-------------------------------+---------------------------------------------------------------------+'.PHP_EOL.
+            '| Illuminate\Auth\Events\Login  | Illuminate\Tests\Foundation\Console\TestSubscriber@handleUserLogin  |'.PHP_EOL.
+            '| Illuminate\Auth\Events\Logout | Illuminate\Tests\Foundation\Console\TestSubscriber@handleUserLogout |'.PHP_EOL.
+            '+-------------------------------+---------------------------------------------------------------------+'.PHP_EOL
+            , $output->fetch()
+        );
+    }
+}
+
+class TestSubscriberServiceProvider extends EventServiceProvider
+{
+    protected $subscribe = [
+        TestSubscriber::class,
+    ];
+}
+
+class TestSubscriber
+{
+    public function handleUserLogin($event)
+    {
+    }
+
+    public function handleUserLogout($event)
+    {
+    }
+
+    public function subscribe($events)
+    {
+        $events->listen(
+            'Illuminate\Auth\Events\Login',
+            static::class.'@handleUserLogin'
+        );
+
+        $events->listen(
+            'Illuminate\Auth\Events\Logout',
+            static::class.'@handleUserLogout'
         );
     }
 }

--- a/tests/Foundation/Console/EventListCommandTest.php
+++ b/tests/Foundation/Console/EventListCommandTest.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Output\BufferedOutput;
 
 class EventListCommandTest extends TestCase
 {
-    const DOES_NOT_HAVE_ANY_EVENTS = "Your application doesn't have any events matching the given criteria.\n";
+    const DOES_NOT_HAVE_ANY_EVENTS = "Your application doesn't have any events matching the given criteria." . PHP_EOL;
 
     protected function tearDown(): void
     {
@@ -81,16 +81,13 @@ class EventListCommandTest extends TestCase
         $command->handle();
 
         $this->assertEquals(
-            <<<OUTPUT
-+------------+------------------------------+
-| Event      | Listeners                    |
-+------------+------------------------------+
-| Some\Event | Some\Listener\FirstListener  |
-|            | Some\Listener\SecondListener |
-| Some\Other | Some\Listener\ThirdListener  |
-+------------+------------------------------+
-
-OUTPUT
+            '+------------+------------------------------+' . PHP_EOL .
+            '| Event      | Listeners                    |' . PHP_EOL .
+            '+------------+------------------------------+' . PHP_EOL .
+            '| Some\Event | Some\Listener\FirstListener  |' . PHP_EOL .
+            '|            | Some\Listener\SecondListener |' . PHP_EOL .
+            '| Some\Other | Some\Listener\ThirdListener  |' . PHP_EOL .
+            '+------------+------------------------------+' . PHP_EOL
             , $output->fetch()
         );
     }
@@ -130,14 +127,11 @@ OUTPUT
         $command->handle();
 
         $this->assertEquals(
-            <<<OUTPUT
-+------------+-----------------------------+
-| Event      | Listeners                   |
-+------------+-----------------------------+
-| Some\Other | Some\Listener\ThirdListener |
-+------------+-----------------------------+
-
-OUTPUT
+            '+------------+-----------------------------+' . PHP_EOL .
+            '| Event      | Listeners                   |' . PHP_EOL .
+            '+------------+-----------------------------+' . PHP_EOL .
+            '| Some\Other | Some\Listener\ThirdListener |' . PHP_EOL .
+            '+------------+-----------------------------+' . PHP_EOL
             , $output->fetch()
         );
     }

--- a/tests/Foundation/Console/EventListCommandTest.php
+++ b/tests/Foundation/Console/EventListCommandTest.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Output\BufferedOutput;
 
 class EventListCommandTest extends TestCase
 {
-    const DOES_NOT_HAVE_ANY_EVENTS = "Your application doesn't have any events matching the given criteria." . PHP_EOL;
+    const DOES_NOT_HAVE_ANY_EVENTS = "Your application doesn't have any events matching the given criteria.".PHP_EOL;
 
     protected function tearDown(): void
     {
@@ -81,14 +81,13 @@ class EventListCommandTest extends TestCase
         $command->handle();
 
         $this->assertEquals(
-            '+------------+------------------------------+' . PHP_EOL .
-            '| Event      | Listeners                    |' . PHP_EOL .
-            '+------------+------------------------------+' . PHP_EOL .
-            '| Some\Event | Some\Listener\FirstListener  |' . PHP_EOL .
-            '|            | Some\Listener\SecondListener |' . PHP_EOL .
-            '| Some\Other | Some\Listener\ThirdListener  |' . PHP_EOL .
-            '+------------+------------------------------+' . PHP_EOL
-            , $output->fetch()
+            '+------------+------------------------------+'.PHP_EOL.
+            '| Event      | Listeners                    |'.PHP_EOL.
+            '+------------+------------------------------+'.PHP_EOL.
+            '| Some\Event | Some\Listener\FirstListener  |'.PHP_EOL.
+            '|            | Some\Listener\SecondListener |'.PHP_EOL.
+            '| Some\Other | Some\Listener\ThirdListener  |'.PHP_EOL.
+            '+------------+------------------------------+'.PHP_EOL, $output->fetch()
         );
     }
 
@@ -127,12 +126,11 @@ class EventListCommandTest extends TestCase
         $command->handle();
 
         $this->assertEquals(
-            '+------------+-----------------------------+' . PHP_EOL .
-            '| Event      | Listeners                   |' . PHP_EOL .
-            '+------------+-----------------------------+' . PHP_EOL .
-            '| Some\Other | Some\Listener\ThirdListener |' . PHP_EOL .
-            '+------------+-----------------------------+' . PHP_EOL
-            , $output->fetch()
+            '+------------+-----------------------------+'.PHP_EOL.
+            '| Event      | Listeners                   |'.PHP_EOL.
+            '+------------+-----------------------------+'.PHP_EOL.
+            '| Some\Other | Some\Listener\ThirdListener |'.PHP_EOL.
+            '+------------+-----------------------------+'.PHP_EOL, $output->fetch()
         );
     }
 }

--- a/tests/Foundation/Console/EventListCommandTest.php
+++ b/tests/Foundation/Console/EventListCommandTest.php
@@ -87,7 +87,8 @@ class EventListCommandTest extends TestCase
             '| Some\Event | Some\Listener\FirstListener  |'.PHP_EOL.
             '|            | Some\Listener\SecondListener |'.PHP_EOL.
             '| Some\Other | Some\Listener\ThirdListener  |'.PHP_EOL.
-            '+------------+------------------------------+'.PHP_EOL, $output->fetch()
+            '+------------+------------------------------+'.PHP_EOL
+            , $output->fetch()
         );
     }
 

--- a/tests/Foundation/Console/EventListCommandTest.php
+++ b/tests/Foundation/Console/EventListCommandTest.php
@@ -2,14 +2,14 @@
 
 namespace Illuminate\Tests\Foundation\Console;
 
-use Mockery as m;
-use PHPUnit\Framework\TestCase;
 use Illuminate\Console\OutputStyle;
-use Symfony\Component\Console\Input\ArrayInput;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Foundation\Console\EventListCommand;
-use Symfony\Component\Console\Output\BufferedOutput;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
 
 class EventListCommandTest extends TestCase
 {

--- a/tests/Foundation/Console/EventListCommandTest.php
+++ b/tests/Foundation/Console/EventListCommandTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Console;
+
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Console\OutputStyle;
+use Symfony\Component\Console\Input\ArrayInput;
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Foundation\Console\EventListCommand;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Illuminate\Foundation\Support\Providers\EventServiceProvider;
+
+class EventListCommandTest extends TestCase
+{
+    const DOES_NOT_HAVE_ANY_EVENTS = "Your application doesn't have any events matching the given criteria.\n";
+
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    public function testWithNoEvent()
+    {
+        $input = new ArrayInput([]);
+        $output = new BufferedOutput();
+
+        $container = m::mock(Application::class);
+        $container->shouldReceive('call');
+        $container->shouldReceive('getProviders')
+            ->with(EventServiceProvider::class)
+            ->andReturn([]);
+
+        $container->shouldReceive('make')
+            ->with(OutputStyle::class, m::any())
+            ->andReturn(
+                new OutputStyle($input, $output)
+            );
+
+        $command = new EventListCommand();
+        $command->setLaravel($container);
+
+        $command->run($input, $output);
+        $command->handle();
+
+        $this->assertEquals(self::DOES_NOT_HAVE_ANY_EVENTS, $output->fetch());
+    }
+
+    public function testWithMultipleEvents()
+    {
+        $input = new ArrayInput([]);
+        $output = new BufferedOutput();
+
+        $serviceProvider = m::mock(EventServiceProvider::class)->makePartial();
+        $serviceProvider->shouldReceive('listens')
+            ->andReturn([
+                \Some\Event::class => [
+                    \Some\Listener\FirstListener::class,
+                    \Some\Listener\SecondListener::class,
+                ],
+
+                \Some\Other::class => [
+                    \Some\Listener\ThirdListener::class,
+                ],
+            ]);
+
+        $container = m::mock(Application::class);
+        $container->shouldReceive('call');
+        $container->shouldReceive('getProviders')
+            ->with(EventServiceProvider::class)
+            ->andReturn([$serviceProvider]);
+
+        $container->shouldReceive('make')
+            ->with(OutputStyle::class, m::any())
+            ->andReturn(new OutputStyle($input, $output));
+
+        $command = new EventListCommand();
+        $command->setLaravel($container);
+
+        $command->run($input, $output);
+        $command->handle();
+
+        $this->assertEquals(
+            <<<OUTPUT
++------------+------------------------------+
+| Event      | Listeners                    |
++------------+------------------------------+
+| Some\Event | Some\Listener\FirstListener  |
+|            | Some\Listener\SecondListener |
+| Some\Other | Some\Listener\ThirdListener  |
++------------+------------------------------+
+
+OUTPUT
+            , $output->fetch()
+        );
+    }
+}

--- a/tests/Foundation/Console/EventListCommandTest.php
+++ b/tests/Foundation/Console/EventListCommandTest.php
@@ -77,13 +77,12 @@ class EventListCommandTest extends TestCase
             [],
             [TestMultipleEventsServiceProvider::class, EventServiceProvider::class],
             <<<OUTPUT
-+-------------------------------------+------------------------------------------------------------+
-| Event                               | Listeners                                                  |
-+-------------------------------------+------------------------------------------------------------+
-| Illuminate\Cache\Events\CacheHit    | Illuminate\Tests\Foundation\Console\FirstCacheHitListener  |
-|                                     | Illuminate\Tests\Foundation\Console\SecondCacheHitListener |
-| Illuminate\Cache\Events\CacheMissed | Illuminate\Tests\Foundation\Console\CacheMissedListener    |
-+-------------------------------------+------------------------------------------------------------+
++-------------------------------------+---------------------------------------------------------+
+| Event                               | Listeners                                               |
++-------------------------------------+---------------------------------------------------------+
+| Illuminate\Cache\Events\CacheHit    | Illuminate\Tests\Foundation\Console\CacheHitListener    |
+| Illuminate\Cache\Events\CacheMissed | Illuminate\Tests\Foundation\Console\CacheMissedListener |
++-------------------------------------+---------------------------------------------------------+
 OUTPUT
         );
     }
@@ -154,8 +153,7 @@ class TestMultipleEventsServiceProvider extends EventServiceProvider
 {
     protected $listen = [
         CacheHit::class => [
-            FirstCacheHitListener::class,
-            SecondCacheHitListener::class,
+            CacheHitListener::class,
         ],
 
         CacheMissed::class => [
@@ -221,14 +219,7 @@ class TestSubscriber
     }
 }
 
-class FirstCacheHitListener
-{
-    public function handle(CacheHit $event)
-    {
-    }
-}
-
-class SecondCacheHitListener
+class CacheHitListener
 {
     public function handle(CacheHit $event)
     {

--- a/tests/Foundation/Console/EventListCommandTest.php
+++ b/tests/Foundation/Console/EventListCommandTest.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Tests\Foundation\Console;
 
+use Illuminate\Cache\Events\CacheHit;
+use Illuminate\Cache\Events\CacheMissed;
 use Illuminate\Console\OutputStyle;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Events\SpyDispatcher;

--- a/tests/Foundation/Console/EventListCommandTest.php
+++ b/tests/Foundation/Console/EventListCommandTest.php
@@ -2,16 +2,16 @@
 
 namespace Illuminate\Tests\Foundation\Console;
 
+use Illuminate\Console\OutputStyle;
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Events\SpyDispatcher;
+use Illuminate\Foundation\Console\EventListCommand;
+use Illuminate\Foundation\Support\Providers\EventServiceProvider;
+use Illuminate\Support\Facades\Event;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
-use Illuminate\Console\OutputStyle;
-use Illuminate\Events\SpyDispatcher;
-use Illuminate\Support\Facades\Event;
 use Symfony\Component\Console\Input\ArrayInput;
-use Illuminate\Contracts\Foundation\Application;
-use Illuminate\Foundation\Console\EventListCommand;
 use Symfony\Component\Console\Output\BufferedOutput;
-use Illuminate\Foundation\Support\Providers\EventServiceProvider;
 
 class EventListCommandTest extends TestCase
 {
@@ -55,8 +55,8 @@ class EventListCommandTest extends TestCase
         $command->handle();
 
         $actualOutput = $output->fetch();
-        $actualLines = array_filter(explode(PHP_EOL, $actualOutput));
-        $expectedLines = array_filter(explode(PHP_EOL, $expectedOutput));
+        $actualLines = preg_split("/\r\n|\n|\r/", $actualOutput);
+        $expectedLines = preg_split("/\r\n|\n|\r/", $expectedOutput);
 
         $this->assertEquals($expectedLines, $actualLines);
     }
@@ -122,7 +122,7 @@ OUTPUT
         $this->testRoutine(
             [],
             [TestClosureServiceProvider::class],
-            <<<OUTPUT
+            <<<'OUTPUT'
 +-------+-----------+
 | Event | Listeners |
 +-------+-----------+
@@ -137,7 +137,7 @@ OUTPUT
         $this->testRoutine(
             [],
             [TestWildCardServiceProvider::class],
-            <<<OUTPUT
+            <<<'OUTPUT'
 +--------+-----------+
 | Event  | Listeners |
 +--------+-----------+


### PR DESCRIPTION
---
Bugfix on `event:list` command
---

- Laravel Version: >= 6.x
- PHP Version: >= 7.2
- Database Driver & Version:

### Description:
According to [laravel docs](https://laravel.com/docs/8.x/events#registering-events-and-listeners)

> The `event:list` command may be used to display a list of all events and listeners registered by your application.

I usually enjoy seeing laravel generate events and listeners listed in the `EventServiceProvider`.

Today I figured out the `event:list` command only show events listed on the `$listen` property and `discoveredEvents` from event service provider, but doesn't include events registered with [event subscribers](https://laravel.com/docs/6.x/events#event-subscribers) or [manually registered events](https://laravel.com/docs/6.x/events#manually-registering-events) inside the boot method.

### Steps To Reproduce:
1. Install a fresh copy of laravel/laravel
2. Register an [event subscribers](https://laravel.com/docs/6.x/events#event-subscribers) or [manually register an event listener](https://laravel.com/docs/6.x/events#manually-registering-events) in the `boot` method
3. Run `php artisan event:list`

### Demo
```php
class UserEventSubscriber {
    public function handleUserLogin($event) {}
    public function handleUserLogout($event) {}

    public function subscribe($events)
    {
        $events->listen(
            \Illuminate\Auth\Events\Login::class,
            [UserEventSubscriber::class, 'handleUserLogin']
        );

        $events->listen(
            'Illuminate\Auth\Events\Logout',
            [UserEventSubscriber::class, 'handleUserLogout']
        );
    }
}

class EventServiceProvider extends ServiceProvider
{
    protected $listen = [
        \Illuminate\Auth\Events\Registered::class => [
            \Some\Random\Cls::class,
        ]
    ];

    protected $subscribe = [
        UserEventSubscriber::class,
    ];

    public function boot()
    {
        parent::boot();

        Event::listen('user.logout', function () {
            //
        });

        Event::listen('user.*', \Some\Other\Cls::class);
    }
}
```
Currently `event:list` will output

```sh
+-----------------------------------+-----------------+
| Event                             | Listeners       |
+-----------------------------------+-----------------+
| Illuminate\Auth\Events\Registered | Some\Random\Cls |
+-----------------------------------+-----------------+
```

With this PR, `event:list` will output

```sh
+-----------------------------------+----------------------------------------------------+
| Event                             | Listeners                                          |
+-----------------------------------+----------------------------------------------------+
| Illuminate\Auth\Events\Login      | App\Providers\UserEventSubscriber@handleUserLogin  |
| Illuminate\Auth\Events\Logout     | App\Providers\UserEventSubscriber@handleUserLogout |
| Illuminate\Auth\Events\Registered | Some\Random\Cls                                    |
| user.*                            | Some\Other\Cls                                     |
| user.logout                       | Closure                                            |
+-----------------------------------+----------------------------------------------------+
```
