### PR TITLE
[8.x] Fixes missing `lazy()` and `lazyById()` on BelongsToMany and HasManyThrough relation query builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -502,6 +502,34 @@ class HasManyThrough extends Relation
     }
 
     /**
+     * Query lazily, by chunks of the given size.
+     *
+     * @param  int  $chunkSize
+     * @return \Illuminate\Support\LazyCollection
+     */
+    public function lazy($chunkSize = 1000)
+    {
+        return $this->prepareQueryBuilder()->lazy($chunkSize);
+    }
+
+    /**
+     * Query lazily, by chunking the results of a query by comparing IDs.
+     *
+     * @param  int  $count
+     * @param  string|null  $column
+     * @param  string|null  $alias
+     * @return \Illuminate\Support\LazyCollection
+     */
+    public function lazyById($chunkSize = 1000, $column = null, $alias = null)
+    {
+        $column = $column ?? $this->getRelated()->getQualifiedKeyName();
+
+        $alias = $alias ?? $this->getRelated()->getKeyName();
+
+        return $this->prepareQueryBuilder()->lazyById($chunkSize, $column, $alias);
+    }
+
+    /**
      * Prepare the query builder for query execution.
      *
      * @param  array  $columns

--- a/tests/Database/DatabaseEloquentBelongsToManyLazyByIdTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyLazyByIdTest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseEloquentBelongsToManyLazyByIdTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $db = new DB;
+
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+
+        $db->bootEloquent();
+        $db->setAsGlobal();
+
+        $this->createSchema();
+    }
+
+    /**
+     * Setup the database schema.
+     *
+     * @return void
+     */
+    public function createSchema()
+    {
+        $this->schema()->create('users', function ($table) {
+            $table->increments('id');
+            $table->string('email')->unique();
+        });
+
+        $this->schema()->create('articles', function ($table) {
+            $table->increments('aid');
+            $table->string('title');
+        });
+
+        $this->schema()->create('article_user', function ($table) {
+            $table->integer('article_id')->unsigned();
+            $table->foreign('article_id')->references('aid')->on('articles');
+            $table->integer('user_id')->unsigned();
+            $table->foreign('user_id')->references('id')->on('users');
+        });
+    }
+
+    public function testBelongsToLazyById()
+    {
+        $this->seedData();
+
+        $user = BelongsToManyLazyByIdTestTestUser::query()->first();
+        $i = 0;
+
+        $user->articles()->lazyById(1)->each(function ($model) use (&$i) {
+            $i++;
+            $this->assertEquals($i, $model->aid);
+        });
+
+        $this->assertSame(3, $i);
+    }
+
+    /**
+     * Tear down the database schema.
+     *
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        $this->schema()->drop('users');
+        $this->schema()->drop('articles');
+        $this->schema()->drop('article_user');
+    }
+
+    /**
+     * Helpers...
+     */
+    protected function seedData()
+    {
+        $user = BelongsToManyLazyByIdTestTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
+        BelongsToManyLazyByIdTestTestArticle::query()->insert([
+            ['aid' => 1, 'title' => 'Another title'],
+            ['aid' => 2, 'title' => 'Another title'],
+            ['aid' => 3, 'title' => 'Another title'],
+        ]);
+
+        $user->articles()->sync([3, 1, 2]);
+    }
+
+    /**
+     * Get a database connection instance.
+     *
+     * @return \Illuminate\Database\ConnectionInterface
+     */
+    protected function connection()
+    {
+        return Eloquent::getConnectionResolver()->connection();
+    }
+
+    /**
+     * Get a schema builder instance.
+     *
+     * @return \Illuminate\Database\Schema\Builder
+     */
+    protected function schema()
+    {
+        return $this->connection()->getSchemaBuilder();
+    }
+}
+
+class BelongsToManyLazyByIdTestTestUser extends Eloquent
+{
+    protected $table = 'users';
+    protected $fillable = ['id', 'email'];
+    public $timestamps = false;
+
+    public function articles()
+    {
+        return $this->belongsToMany(BelongsToManyLazyByIdTestTestArticle::class, 'article_user', 'user_id', 'article_id');
+    }
+}
+
+class BelongsToManyLazyByIdTestTestArticle extends Eloquent
+{
+    protected $primaryKey = 'aid';
+    protected $table = 'articles';
+    protected $keyType = 'string';
+    public $incrementing = false;
+    public $timestamps = false;
+    protected $fillable = ['aid', 'title'];
+}

--- a/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
@@ -321,6 +321,52 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
         });
     }
 
+    public function testLazyReturnsCorrectModels()
+    {
+        $this->seedData();
+        $this->seedDataExtended();
+        $country = HasManyThroughTestCountry::find(2);
+
+        $country->posts()->lazy(10)->each(function ($post) {
+            $this->assertEquals([
+                'id',
+                'user_id',
+                'title',
+                'body',
+                'email',
+                'created_at',
+                'updated_at',
+                'laravel_through_key',
+            ], array_keys($post->getAttributes()));
+        });
+    }
+
+    public function testLazyById()
+    {
+        $this->seedData();
+        $this->seedDataExtended();
+        $country = HasManyThroughTestCountry::find(2);
+
+        $i = 0;
+
+        $country->posts()->lazyById(2)->each(function ($post) use (&$i, &$count) {
+            $i++;
+
+            $this->assertEquals([
+                'id',
+                'user_id',
+                'title',
+                'body',
+                'email',
+                'created_at',
+                'updated_at',
+                'laravel_through_key',
+            ], array_keys($post->getAttributes()));
+        });
+
+        $this->assertEquals(6, $i);
+    }
+
     public function testIntermediateSoftDeletesAreIgnored()
     {
         $this->seedData();

--- a/tests/Database/DatabaseEloquentHasOneThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasOneThroughIntegrationTest.php
@@ -234,6 +234,25 @@ class DatabaseEloquentHasOneThroughIntegrationTest extends TestCase
         });
     }
 
+    public function testLazyReturnsCorrectModels()
+    {
+        $this->seedData();
+        $this->seedDataExtended();
+        $position = HasOneThroughTestPosition::find(1);
+
+        $position->contract()->lazy()->each(function ($contract) {
+            $this->assertEquals([
+                'id',
+                'user_id',
+                'title',
+                'body',
+                'email',
+                'created_at',
+                'updated_at',
+                'laravel_through_key', ], array_keys($contract->getAttributes()));
+        });
+    }
+
     public function testIntermediateSoftDeletesAreIgnored()
     {
         $this->seedData();


### PR DESCRIPTION
### Current Behaviour

```php
$user = User::find(1);

foreach ($user->roles()->lazy() as $role) {
     // $role->pivot === null because additional select to retrieve pivot wasn't available
}
```

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>