### PR TITLE
[8.x] Added App::userOrFail() function

### DIFF
--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -156,6 +156,19 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
 
         return $this->user;
     }
+    
+    
+    /**
+     * Get the currently authenticated user or throws exception.
+     *
+     * @return \Illuminate\Contracts\Auth\Authenticatable
+     *
+     * @throws \Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException
+     */
+    public function userOrFail()
+    {
+        return $this->user() ?? $this->failedBasicResponse();
+    }
 
     /**
      * Pull a user from the repository by its "remember me" cookie token.


### PR DESCRIPTION
I propose to have a `userOrFail()` method, similar to [firstOrFail](https://github.com/laravel/framework/blob/fcc94677e0e2869f5204f22b7f5f147f03aee67f/src/Illuminate/Database/Eloquent/Builder.php#L497). Returning only the current user (not null).

If I have guarded the route I know the user is logged in but my IDE claims $user might be `null`, because `App::user()` could return `null`.