### PR TITLE
[6.x] Support username parameter for predis

### DIFF
--- a/src/Illuminate/Redis/RedisManager.php
+++ b/src/Illuminate/Redis/RedisManager.php
@@ -192,7 +192,7 @@ class RedisManager implements Factory
         }
 
         return array_filter($parsed, function ($key) {
-            return ! in_array($key, ['driver', 'username'], true);
+            return ! in_array($key, ['driver'], true);
         }, ARRAY_FILTER_USE_KEY);
     }
 

--- a/tests/Redis/RedisConnectorTest.php
+++ b/tests/Redis/RedisConnectorTest.php
@@ -160,4 +160,27 @@ class RedisConnectorTest extends TestCase
         $this->assertEquals("tcp://{$host}", $phpRedisClient->getHost());
         $this->assertEquals($port, $phpRedisClient->getPort());
     }
+
+    public function testPredisConfigurationWithUsername()
+    {
+        $host = env('REDIS_HOST', '127.0.0.1');
+        $port = env('REDIS_PORT', 6379);
+        $username = 'testuser';
+        $password = 'testpw';
+
+        $predis = new RedisManager(new Application, 'predis', [
+            'default' => [
+                'host' => $host,
+                'port' => $port,
+                'username' => $username,
+                'password' => $password,
+                'database' => 5,
+                'timeout' => 0.5,
+            ],
+        ]);
+        $predisClient = $predis->connection()->client();
+        $parameters = $predisClient->getConnection()->getParameters();
+        $this->assertEquals($username, $parameters->username);
+        $this->assertEquals($password, $parameters->password);
+    }
 }


### PR DESCRIPTION
__Changelog__
- [x] Ports fix merged into 8.x [here](https://github.com/laravel/framework/pull/36299) into 6.x (LTS) as well.

   Ref https://github.com/laravel/framework/pull/36299
   > Removed filter on username for redis configuration parameter.

   > As mentioned in Issue #36298 the username parameter got filtered on creating parameters for the predis connection. I removed the filter to enable the username parameter for the connection.
   