### PR TITLE
[8.x] Change default test method name to camelCase

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/test.stub
+++ b/src/Illuminate/Foundation/Console/stubs/test.stub
@@ -13,7 +13,7 @@ class {{ class }} extends TestCase
      *
      * @return void
      */
-    public function test_example()
+    public function testExample()
     {
         $response = $this->get('/');
 

--- a/src/Illuminate/Foundation/Console/stubs/test.unit.stub
+++ b/src/Illuminate/Foundation/Console/stubs/test.unit.stub
@@ -11,7 +11,7 @@ class {{ class }} extends TestCase
      *
      * @return void
      */
-    public function test_example()
+    public function testExample()
     {
         $this->assertTrue(true);
     }


### PR DESCRIPTION
When creating a new laravel project, example test methods are camelCase.

* [tests/Feature/ExampleTest.php](https://github.com/laravel/laravel/blob/8.x/tests/Feature/ExampleTest.php#L15)
* [tests/Unit/ExampleTest.php](https://github.com/laravel/laravel/blob/8.x/tests/Unit/ExampleTest.php#L14)

But when creating a new test with `php artisan make:test` command, the example method is snake_case.
```php
public function test_example()
```