### PR TITLE
[9.x] Add age option to flush failed jobs command

### DIFF
--- a/src/Illuminate/Queue/Console/FlushFailedCommand.php
+++ b/src/Illuminate/Queue/Console/FlushFailedCommand.php
@@ -11,7 +11,7 @@ class FlushFailedCommand extends Command
      *
      * @var string
      */
-    protected $name = 'queue:flush';
+    protected $signature = 'queue:flush {--age= : Only clear failed jobs older than the given age in days}';
 
     /**
      * The name of the console command.
@@ -36,7 +36,13 @@ class FlushFailedCommand extends Command
      */
     public function handle()
     {
-        $this->laravel['queue.failer']->flush();
+        $this->laravel['queue.failer']->flush($this->option('age'));
+
+        if ($this->option('age')) {
+            $this->info("Failed jobs older than {$this->option('age')} days deleted successfully!");
+
+            return;
+        }
 
         $this->info('All failed jobs deleted successfully!');
     }

--- a/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
@@ -98,11 +98,14 @@ class DatabaseFailedJobProvider implements FailedJobProviderInterface
     /**
      * Flush all of the failed jobs from storage.
      *
+     * @param  int|null  $age
      * @return void
      */
-    public function flush()
+    public function flush($age = null)
     {
-        $this->getTable()->delete();
+        $this->getTable()->when($age, function ($query, $age) {
+            $query->where('failed_at', '<=', Date::now()->subDays($age));
+        })->delete();
     }
 
     /**

--- a/src/Illuminate/Queue/Failed/DatabaseUuidFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseUuidFailedJobProvider.php
@@ -111,11 +111,14 @@ class DatabaseUuidFailedJobProvider implements FailedJobProviderInterface
     /**
      * Flush all of the failed jobs from storage.
      *
+     * @param  int|null  $age
      * @return void
      */
-    public function flush()
+    public function flush($age = null)
     {
-        $this->getTable()->delete();
+        $this->getTable()->when($age, function ($query, $age) {
+            $query->where('failed_at', '<=', Date::now()->subDays($age));
+        })->delete();
     }
 
     /**

--- a/src/Illuminate/Queue/Failed/DynamoDbFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DynamoDbFailedJobProvider.php
@@ -165,11 +165,12 @@ class DynamoDbFailedJobProvider implements FailedJobProviderInterface
     /**
      * Flush all of the failed jobs from storage.
      *
+     * @param  int|null  $age
      * @return void
      *
      * @throws \Exception
      */
-    public function flush()
+    public function flush($age = null)
     {
         throw new Exception("DynamoDb failed job storage may not be flushed. Please use DynamoDb's TTL features on your expires_at attribute.");
     }

--- a/src/Illuminate/Queue/Failed/FailedJobProviderInterface.php
+++ b/src/Illuminate/Queue/Failed/FailedJobProviderInterface.php
@@ -41,7 +41,8 @@ interface FailedJobProviderInterface
     /**
      * Flush all of the failed jobs from storage.
      *
+     * @param  int|null  $age
      * @return void
      */
-    public function flush();
+    public function flush($age = null);
 }

--- a/src/Illuminate/Queue/Failed/NullFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/NullFailedJobProvider.php
@@ -53,9 +53,10 @@ class NullFailedJobProvider implements FailedJobProviderInterface
     /**
      * Flush all of the failed jobs from storage.
      *
+     * @param  int|null  $age
      * @return void
      */
-    public function flush()
+    public function flush($age = null)
     {
         //
     }

--- a/tests/Queue/DatabaseFailedJobProviderTest.php
+++ b/tests/Queue/DatabaseFailedJobProviderTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Illuminate\Tests\Queue;
+
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Queue\Failed\DatabaseFailedJobProvider;
+use Illuminate\Support\Facades\Date;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseFailedJobProviderTest extends TestCase
+{
+    public function testCanFlushFailedJobs()
+    {
+        Date::setTestNow(Date::now());
+
+        $db = new DB;
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+
+        $db->getConnection()->getSchemaBuilder()->create('failed_jobs', function (Blueprint $table) {
+            $table->id();
+            $table->timestamp('failed_at')->useCurrent();
+        });
+
+        $provider = new DatabaseFailedJobProvider($db->getDatabaseManager(), 'default', 'failed_jobs');
+
+        $db->getConnection()->table('failed_jobs')->insert(['failed_at' => Date::now()->subDays(10)]);
+        $provider->flush();
+        $this->assertSame(0, $db->getConnection()->table('failed_jobs')->count());
+
+        $db->getConnection()->table('failed_jobs')->insert(['failed_at' => Date::now()->subDays(10)]);
+        $provider->flush(15);
+        $this->assertSame(1, $db->getConnection()->table('failed_jobs')->count());
+
+        $db->getConnection()->table('failed_jobs')->insert(['failed_at' => Date::now()->subDays(10)]);
+        $provider->flush(10);
+        $this->assertSame(0, $db->getConnection()->table('failed_jobs')->count());
+    }
+}


### PR DESCRIPTION
The `failed_jobs` table can become quite large, to periodically clean up the table we can create a cron. However, the current `php artisan queue:flush` command will remove all failed jobs from the table. This PR gives the user the option to determine what failed jobs should be purged from the table.

`php artisan queue:flush` will remove all failed jobs.
`php artisan queue:flush --age=30` will only remove failed jobs older than 30 days.