### PR TITLE
[8.x] For JSON casts, only check key/value pairs are equal since JSON is an unordered set

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1583,6 +1583,9 @@ trait HasAttributes
             }
 
             return abs($this->castAttribute($key, $attribute) - $this->castAttribute($key, $original)) < PHP_FLOAT_EPSILON * 4;
+        } elseif ($this->hasCast($key, ['json'])) {
+            return $this->castAttribute($key, $attribute) ==
+                   $this->castAttribute($key, $original);
         } elseif ($this->hasCast($key, static::$primitiveCastTypes)) {
             return $this->castAttribute($key, $attribute) ===
                    $this->castAttribute($key, $original);

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -1035,6 +1035,17 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals(['x' => 0, 'y' => 1, 'a' => ['b' => 3]], $model->json);
     }
 
+    public function testUpdatingJSONFields()
+    {
+        $model = EloquentTestWithJSON::create(['json' => ['x' => 0, 'y' => 1, 'z' => [1, 2, 3]]]);
+
+        $model->update(['json' => ['z' => [1, 2, 3], 'y' => 1, 'x' => 0]]);
+        $this->assertEquals(false, $model->wasChanged());
+
+        $model->update(['json' => ['x' => 0, 'y' => 1, 'z' => [3, 2, 1]]]);
+        $this->assertEquals(true, $model->wasChanged());
+    }
+
     public function testSaveOrFailWithDuplicatedEntry()
     {
         $this->expectException(QueryException::class);
@@ -2059,7 +2070,7 @@ class EloquentTestWithJSON extends Eloquent
     protected $table = 'with_json';
     public $timestamps = false;
     protected $casts = [
-        'json' => 'array',
+        'json' => 'json',
     ];
 }
 


### PR DESCRIPTION
When writing a product data import that runs daily using `Product::updateOrCreate` I noticed via the MySQL query log that updates were being sent to the database even though no changes were present in the import file. We use a JSON type column for some of the miscellaneous product attributes.  

Normally when using `update` or `updateOrCreate` Eloquent will not send updates to the database when data hasn't changed.

Since JSON is an [unordered data structure](https://www.json.org/json-en.html) it should be compared with `==` instead of `===` because `===` also makes sure the order is the same between the two arrays https://www.php.net/manual/en/language.operators.array.php.  When you change a nested array inside a JSON object, that does trigger a change and trip to database.

This PR helps prevent Eloquent from thinking JSON types have changed causing an unnecessary trip to the database for an update during `updateOrCreate` for example.  

The main benefit is speed for many thousands of `update`s or `updateOrCreate`s when using JSON database columns.  We do product imports from many companies daily (or multiple times a day) and often only some products have changes.  This change reduces the time to process these imports down to minutes instead of hours (dependent on how many products are in the feed)

Thanks to @crynobone for help with how to test this issue