### PR TITLE
[8.x] Implement DynamoDB table command

### DIFF
--- a/src/Illuminate/Cache/Console/DynamoDBTableCommand.php
+++ b/src/Illuminate/Cache/Console/DynamoDBTableCommand.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Illuminate\Cache\Console;
+
+use Aws\Exception\AwsException;
+use Illuminate\Console\Command;
+use Illuminate\Console\ConfirmableTrait;
+use Illuminate\Support\Str;
+
+class DynamoDBTableCommand extends Command
+{
+    use ConfirmableTrait;
+
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $signature = 'cache:dynamodb
+                    {--force : Force the operation to run when in production}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create the cache table for the DynamoDB cache store.';
+
+    /**
+     * @var \Aws\DynamoDb\DynamoDbClient
+     */
+    protected $client;
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        if (! $this->confirmToProceed()) {
+            return;
+        }
+
+        $config = $this->laravel['config']['cache.stores.dynamodb'];
+
+        if ($this->dynamoTableExists($config['table'])) {
+            $this->info('DynamoDB cache table already exists.');
+
+            return;
+        }
+
+        $this->client()->createTable([
+            'TableName' => $config['table'],
+            'KeySchema' => [
+                [
+                    'AttributeName' => $config['attributes']['key'] ?? 'key',
+                    'KeyType' => 'HASH',
+                ],
+            ],
+            'AttributeDefinitions' => [
+                [
+                    'AttributeName' => $config['attributes']['key'] ?? 'key',
+                    'AttributeType' => 'S',
+                ],
+            ],
+            'ProvisionedThroughput' => [
+                'ReadCapacityUnits' => 1,
+                'WriteCapacityUnits' => 1,
+            ],
+        ]);
+
+        $this->info('DynamoDB cache table created successfully!');
+    }
+
+    /**
+     * Determine if the given DynamoDB table exists.
+     *
+     * @param  string  $table
+     * @return bool
+     */
+    protected function dynamoTableExists($table)
+    {
+        try {
+            $this->client()->describeTable(['TableName' => $table]);
+
+            return true;
+        } catch (AwsException $e) {
+            $errorMessages = [
+                'resource not found',
+                'Cannot do operations on a non-existent table',
+            ];
+
+            if (Str::contains($e->getAwsErrorMessage(), $errorMessages)) {
+                return false;
+            }
+
+            throw $e;
+        }
+    }
+
+    /**
+     * Get the DynamoDB cache client.
+     *
+     * @return \Aws\DynamoDb\DynamoDbClient
+     */
+    protected function client()
+    {
+        if ($this->client) {
+            return $this->client;
+        }
+
+        return $this->client = $this->laravel->make('cache.dynamodb.client');
+    }
+}

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Providers;
 use Illuminate\Auth\Console\ClearResetsCommand;
 use Illuminate\Cache\Console\CacheTableCommand;
 use Illuminate\Cache\Console\ClearCommand as CacheClearCommand;
+use Illuminate\Cache\Console\DynamoDBTableCommand;
 use Illuminate\Cache\Console\ForgetCommand as CacheForgetCommand;
 use Illuminate\Console\Scheduling\ScheduleFinishCommand;
 use Illuminate\Console\Scheduling\ScheduleListCommand;
@@ -135,6 +136,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      * @var array
      */
     protected $devCommands = [
+        'CacheDynamoDBTable' => 'command.cache.dynamodb.table',
         'CacheTable' => 'command.cache.table',
         'CastMake' => 'command.cast.make',
         'ChannelMake' => 'command.channel.make',
@@ -229,6 +231,18 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
     {
         $this->app->singleton('command.cache.table', function ($app) {
             return new CacheTableCommand($app['files'], $app['composer']);
+        });
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerCacheDynamoDBTableCommand()
+    {
+        $this->app->singleton('command.cache.dynamodb.table', function ($app) {
+            return new DynamoDBTableCommand;
         });
     }
 

--- a/tests/Integration/Cache/DynamoDbStoreTest.php
+++ b/tests/Integration/Cache/DynamoDbStoreTest.php
@@ -11,6 +11,15 @@ use Orchestra\Testbench\TestCase;
  */
 class DynamoDbStoreTest extends TestCase
 {
+    protected function getEnvironmentSetUp($app)
+    {
+        if (! env('DYNAMODB_CACHE_TABLE')) {
+            $this->markTestSkipped('DynamoDB not configured.');
+        }
+
+        $app['config']->set('cache.default', 'dynamodb');
+    }
+
     protected function setUp(): void
     {
         if (! env('DYNAMODB_CACHE_TABLE')) {
@@ -18,6 +27,8 @@ class DynamoDbStoreTest extends TestCase
         }
 
         parent::setUp();
+
+        $this->artisan('cache:dynamodb');
     }
 
     public function testItemsCanBeStoredAndRetrieved()
@@ -64,22 +75,5 @@ class DynamoDbStoreTest extends TestCase
         Cache::driver('dynamodb')->lock('lock', 10)->get(function () {
             $this->assertFalse(Cache::driver('dynamodb')->lock('lock', 10)->get());
         });
-    }
-
-    /**
-     * Define environment setup.
-     *
-     * @param  \Illuminate\Foundation\Application  $app
-     * @return void
-     */
-    protected function getEnvironmentSetUp($app)
-    {
-        if (! env('DYNAMODB_CACHE_TABLE')) {
-            $this->markTestSkipped('DynamoDB not configured.');
-        }
-
-        $this->artisan('cache:dynamodb');
-
-        $app['config']->set('cache.default', 'dynamodb');
     }
 }


### PR DESCRIPTION
This PR implements a new `cache:dynamodb` command. It'll set up the cache table for the current DynamoDB cache store connection. This saves people from having to do this manually in AWS themselves. I've also re-used the command in the DynamoDB cache store tests so it's also tested.