### PR TITLE
[8.x] Bug-fix and performance improvements in "TaggedCache" for "getMultiple" and "many" methods

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -115,8 +115,7 @@ class Repository implements ArrayAccess, CacheContract
      *
      * Items not found in the cache will use the provided default value, or `null` if not specified.
      *
-     * @param  array  $keys A list of keys that can obtained in a single operation. To specify a default value, use the
-     * array key as the cache key, and the array value as the default value.
+     * @param  array  $keys
      * @return array
      */
     public function many(array $keys)
@@ -134,7 +133,6 @@ class Repository implements ArrayAccess, CacheContract
         $formattedKeys = array_keys($formattedKeysToOriginalKeys);
         $valuesForFormattedKeys = $this->store->many($formattedKeys);
 
-        // convert formatted keys back to its original key
         $values = [];
 
         foreach ($valuesForFormattedKeys as $newKey => $value) {

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -125,18 +125,18 @@ class Repository implements ArrayAccess, CacheContract
             return is_string($key) ? [$key => $value] : [$value => null];
         })->all();
 
-        $formattedToOriginalKeys = [];
+        $formattedKeysToOriginalKeys = [];
         foreach ($keysDefaultValues as $key => $defaultValue) {
-            $formattedToOriginalKeys[$this->itemKey($key)] = $key;
+            $formattedKeysToOriginalKeys[$this->itemKey($key)] = $key;
         }
 
-        $formattedKeys = array_keys($formattedToOriginalKeys);
+        $formattedKeys = array_keys($formattedKeysToOriginalKeys);
         $valuesForFormattedKeys = $this->store->many($formattedKeys);
 
         // convert formatted keys back to its original key
         $values = [];
         foreach ($valuesForFormattedKeys as $newKey => $value) {
-            $originalKey = $formattedToOriginalKeys[$newKey];
+            $originalKey = $formattedKeysToOriginalKeys[$newKey];
             $values[$originalKey] = $value;
         }
 
@@ -260,12 +260,12 @@ class Repository implements ArrayAccess, CacheContract
             return $this->deleteMultiple(array_keys($values));
         }
 
-        $newValues = [];
+        $valuesWithFormattedKeys = [];
         foreach ($values as $key => $value) {
-            $newValues[$this->itemKey($key)] = $value;
+            $valuesWithFormattedKeys[$this->itemKey($key)] = $value;
         }
 
-        $result = $this->store->putMany($newValues, $seconds);
+        $result = $this->store->putMany($valuesWithFormattedKeys, $seconds);
 
         if ($result) {
             foreach ($values as $key => $value) {

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -126,6 +126,7 @@ class Repository implements ArrayAccess, CacheContract
         })->all();
 
         $formattedKeysToOriginalKeys = [];
+
         foreach ($keysDefaultValues as $key => $defaultValue) {
             $formattedKeysToOriginalKeys[$this->itemKey($key)] = $key;
         }
@@ -135,6 +136,7 @@ class Repository implements ArrayAccess, CacheContract
 
         // convert formatted keys back to its original key
         $values = [];
+
         foreach ($valuesForFormattedKeys as $newKey => $value) {
             $originalKey = $formattedKeysToOriginalKeys[$newKey];
             $values[$originalKey] = $value;
@@ -261,6 +263,7 @@ class Repository implements ArrayAccess, CacheContract
         }
 
         $valuesWithFormattedKeys = [];
+
         foreach ($values as $key => $value) {
             $valuesWithFormattedKeys[$this->itemKey($key)] = $value;
         }

--- a/src/Illuminate/Cache/TaggedCache.php
+++ b/src/Illuminate/Cache/TaggedCache.php
@@ -6,10 +6,6 @@ use Illuminate\Contracts\Cache\Store;
 
 class TaggedCache extends Repository
 {
-    use RetrievesMultipleKeys {
-        putMany as putManyAlias;
-    }
-
     /**
      * The tag set instance.
      *
@@ -29,46 +25,6 @@ class TaggedCache extends Repository
         parent::__construct($store);
 
         $this->tags = $tags;
-    }
-
-    /**
-     * Store multiple items in the cache for a given number of seconds.
-     *
-     * @param  array  $values
-     * @param  int|null  $ttl
-     * @return bool
-     */
-    public function putMany(array $values, $ttl = null)
-    {
-        if ($ttl === null) {
-            return $this->putManyForever($values);
-        }
-
-        return $this->putManyAlias($values, $ttl);
-    }
-
-    /**
-     * Increment the value of an item in the cache.
-     *
-     * @param  string  $key
-     * @param  mixed  $value
-     * @return void
-     */
-    public function increment($key, $value = 1)
-    {
-        $this->store->increment($this->itemKey($key), $value);
-    }
-
-    /**
-     * Decrement the value of an item in the cache.
-     *
-     * @param  string  $key
-     * @param  mixed  $value
-     * @return void
-     */
-    public function decrement($key, $value = 1)
-    {
-        $this->store->decrement($this->itemKey($key), $value);
     }
 
     /**

--- a/tests/Cache/CacheTaggedCacheTest.php
+++ b/tests/Cache/CacheTaggedCacheTest.php
@@ -56,6 +56,131 @@ class CacheTaggedCacheTest extends TestCase
         $this->assertSame('bar', $store->tags('bop')->get('foo'));
     }
 
+    public function testWithIncrement()
+    {
+        $store = new ArrayStore;
+        $taggableStore = $store->tags('bop');
+
+        $taggableStore->put('foo', 5, 10);
+
+        $value = $taggableStore->increment('foo');
+        $this->assertSame(6, $value);
+
+        $value = $taggableStore->increment('foo');
+        $this->assertSame(7, $value);
+
+        $value = $taggableStore->increment('foo', 3);
+        $this->assertSame(10, $value);
+
+        $value = $taggableStore->increment('foo', -2);
+        $this->assertSame(8, $value);
+
+        $value = $taggableStore->increment('x');
+        $this->assertSame(1, $value);
+
+        $value = $taggableStore->increment('y', 10);
+        $this->assertSame(10, $value);
+    }
+
+    public function testWithDecrement()
+    {
+        $store = new ArrayStore;
+        $taggableStore = $store->tags('bop');
+
+        $taggableStore->put('foo', 50, 10);
+
+        $value = $taggableStore->decrement('foo');
+        $this->assertSame(49, $value);
+
+        $value = $taggableStore->decrement('foo');
+        $this->assertSame(48, $value);
+
+        $value = $taggableStore->decrement('foo', 3);
+        $this->assertSame(45, $value);
+
+        $value = $taggableStore->decrement('foo', -2);
+        $this->assertSame(47, $value);
+
+        $value = $taggableStore->decrement('x');
+        $this->assertSame(-1, $value);
+
+        $value = $taggableStore->decrement('y', 10);
+        $this->assertSame(-10, $value);
+    }
+
+    public function testMany()
+    {
+        $store = $this->getTestCacheStoreWithTagValues();
+
+        $values = $store->tags(['fruit'])->many(['a', 'e', 'b', 'd', 'c']);
+        $this->assertSame([
+            'a' => 'apple',
+            'e' => null,
+            'b' => 'banana',
+            'd' => null,
+            'c' => 'orange',
+        ], $values);
+    }
+
+    public function testManyWithDefaultValues()
+    {
+        $store = $this->getTestCacheStoreWithTagValues();
+
+        $values = $store->tags(['fruit'])->many([
+            'a' => 147,
+            'e' => 547,
+            'b' => "hello world!",
+            'x' => "hello world!",
+            'd',
+            'c',
+        ]);
+        $this->assertSame([
+            'a' => 'apple',
+            'e' => 547,
+            'b' => 'banana',
+            'x' => 'hello world!',
+            'd' => null,
+            'c' => 'orange',
+        ], $values);
+    }
+
+    public function testGetMultiple()
+    {
+        $store = $this->getTestCacheStoreWithTagValues();
+
+        $values = $store->tags(['fruit'])->getMultiple(['a', 'e', 'b', 'd', 'c']);
+        $this->assertSame([
+            'a' => 'apple',
+            'e' => null,
+            'b' => 'banana',
+            'd' => null,
+            'c' => 'orange',
+        ], $values);
+
+        $values = $store->tags(['fruit', 'color'])->getMultiple(['a', 'e', 'b', 'd', 'c']);
+        $this->assertSame([
+            'a' => 'red',
+            'e' => 'blue',
+            'b' => null,
+            'd' => 'yellow',
+            'c' => null,
+        ], $values);
+    }
+
+    public function testGetMultipleWithDefaultValue()
+    {
+        $store = $this->getTestCacheStoreWithTagValues();
+
+        $values = $store->tags(['fruit', 'color'])->getMultiple(['a', 'e', 'b', 'd', 'c'], 547);
+        $this->assertSame([
+            'a' => 'red',
+            'e' => 'blue',
+            'b' => 547,
+            'd' => 'yellow',
+            'c' => 547,
+        ], $values);
+    }
+
     public function testTagsWithIncrementCanBeFlushed()
     {
         $store = new ArrayStore;
@@ -160,5 +285,31 @@ class CacheTaggedCacheTest extends TestCase
         $tagSet->shouldReceive('reset')->once();
 
         $redis->flush();
+    }
+
+    private function getTestCacheStoreWithTagValues(): ArrayStore
+    {
+        $store = new ArrayStore;
+
+        $tags = ['fruit'];
+        $store->tags($tags)->put('a', 'apple', 10);
+        $store->tags($tags)->put('b', 'banana', 10);
+        $store->tags($tags)->put('c', 'orange', 10);
+
+        $tags = ['fruit', 'color'];
+        $store->tags($tags)->putMany([
+            'a' => 'red',
+            'd' => 'yellow',
+            'e' => 'blue',
+        ], 10);
+
+        $tags = ['sizes', 'shirt'];
+        $store->tags($tags)->putMany([
+            'a' => 'small',
+            'b' => 'medium',
+            'c' => 'large',
+        ], 10);
+
+        return $store;
     }
 }

--- a/tests/Cache/CacheTaggedCacheTest.php
+++ b/tests/Cache/CacheTaggedCacheTest.php
@@ -129,8 +129,8 @@ class CacheTaggedCacheTest extends TestCase
         $values = $store->tags(['fruit'])->many([
             'a' => 147,
             'e' => 547,
-            'b' => "hello world!",
-            'x' => "hello world!",
+            'b' => 'hello world!',
+            'x' => 'hello world!',
             'd',
             'c',
         ]);


### PR DESCRIPTION
- This fixes the issue in: https://github.com/laravel/framework/issues/36778

- Improved documentation of `many` method in `Repository`

- Improves performance of `getMultiple` and `many` for `TaggedCache`. The method no longer calls the cache store with multiple `get` calls, but with one `many` call.

- Fixes repository so that it uses the `itemKey` method for `many`, `increment` and `decrement`, so it's consistent with other methods like `get` and `put`. This also makes a lot of the code in `TaggedCache` redundant.


