### PR TITLE
[8.x] Refactoring code that responsible for call (define method)

### DIFF
--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -17,9 +17,7 @@ class AuthAccessGateTest extends TestCase
     {
         $gate = $this->getBasicGate();
 
-        $gate->define('foo', function ($user) {
-            return true;
-        });
+        $this->getGateDefine($gate);
         $gate->define('bar', function ($user) {
             return false;
         });
@@ -225,9 +223,7 @@ class AuthAccessGateTest extends TestCase
     {
         $gate = $this->getBasicGate();
 
-        $gate->define('foo', function ($user) {
-            return true;
-        });
+        $this->getGateDefine($gate);
         $gate->before(function ($user, $ability) {
             $this->assertSame('foo', $ability);
 
@@ -241,9 +237,7 @@ class AuthAccessGateTest extends TestCase
     {
         $gate = $this->getBasicGate();
 
-        $gate->define('foo', function ($user) {
-            return true;
-        });
+        $this->getGateDefine($gate);
         $gate->before(function () {
             //
         });
@@ -255,9 +249,7 @@ class AuthAccessGateTest extends TestCase
     {
         $gate = $this->getBasicGate();
 
-        $gate->define('foo', function ($user) {
-            return true;
-        });
+        $this->getGateDefine($gate);
 
         $gate->define('bar', function ($user) {
             return false;
@@ -832,6 +824,16 @@ class AuthAccessGateTest extends TestCase
         $this->assertSame('Nullable __invoke was called', AccessGateTestGuestNullableInvokable::$calledMethod);
 
         $this->assertFalse($gate->check('absent_invokable'));
+    }
+
+    /**
+     * @param Gate $gate
+     */
+    private function getGateDefine(Gate $gate): void
+    {
+        $gate->define('foo', function ($user) {
+            return true;
+        });
     }
 }
 


### PR DESCRIPTION

In AuthAccessGateTest.php, the code that calls the **(define)** a method in **Gate.php** repeated four times in the file so I create a new private function called **(getGateDefine)** take one parameter **(Gate Object)**, and replace the code with calling the new function getGateDefine.

it'll help in case of change the (define) method in the future like add new parameters, instead of going to every line call this function in the (AuthAccessGateTest.php) file just we can change the method in the new function that calls the define method in the Gate.php file.

Also, it'll be easier to understand.
