### PR TITLE
[8.x] Ability to pass a model to database assertions

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -27,7 +27,7 @@ trait InteractsWithDatabase
         if ($table instanceof Model) {
             return $this->assertDatabaseHas($table->getTable(), $data, $table->getConnectionName());
         }
-        
+
         $this->assertThat(
             $table, new HasInDatabase($this->getConnection($connection), $data)
         );
@@ -48,7 +48,7 @@ trait InteractsWithDatabase
         if ($table instanceof Model) {
             return $this->assertDatabaseMissing($table->getTable(), $data, $table->getConnectionName());
         }
-        
+
         $constraint = new ReverseConstraint(
             new HasInDatabase($this->getConnection($connection), $data)
         );

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -38,13 +38,17 @@ trait InteractsWithDatabase
     /**
      * Assert that a given where condition does not exist in the database.
      *
-     * @param  string  $table
+     * @param  \Illuminate\Database\Eloquent\Model|string  $table
      * @param  array  $data
      * @param  string|null  $connection
      * @return $this
      */
     protected function assertDatabaseMissing($table, array $data, $connection = null)
     {
+        if ($table instanceof Model) {
+            return $this->assertDatabaseMissing($table->getTable(), $data, $table->getConnectionName());
+        }
+        
         $constraint = new ReverseConstraint(
             new HasInDatabase($this->getConnection($connection), $data)
         );

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -17,13 +17,17 @@ trait InteractsWithDatabase
     /**
      * Assert that a given where condition exists in the database.
      *
-     * @param  string  $table
+     * @param  \Illuminate\Database\Eloquent\Model|string  $table
      * @param  array  $data
      * @param  string|null  $connection
      * @return $this
      */
     protected function assertDatabaseHas($table, array $data, $connection = null)
     {
+        if ($table instanceof Model) {
+            return $this->assertDatabaseHas($table->getTable(), $data, $table->getConnectionName());
+        }
+        
         $this->assertThat(
             $table, new HasInDatabase($this->getConnection($connection), $data)
         );

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -61,13 +61,17 @@ trait InteractsWithDatabase
     /**
      * Assert the count of table entries.
      *
-     * @param  string  $table
+     * @param  \Illuminate\Database\Eloquent\Model|string  $table
      * @param  int  $count
      * @param  string|null  $connection
      * @return $this
      */
     protected function assertDatabaseCount($table, int $count, $connection = null)
     {
+        if ($table instanceof Model) {
+            return $this->assertDatabaseCount($table->getTable(), $count, $table->getConnectionName());
+        }
+
         $this->assertThat(
             $table, new CountInDatabase($this->getConnection($connection), $count)
         );

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -149,6 +149,13 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertDatabaseCount($this->table, 1);
     }
 
+    public function testAssertModelEntriesCount()
+    {
+        $this->mockCountBuilder(1);
+
+        $this->assertDatabaseCount(new ProductStub(), 1);
+    }
+
     public function testAssertTableEntriesCountWrong()
     {
         $this->expectException(ExpectationFailedException::class);
@@ -156,6 +163,15 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->mockCountBuilder(1);
 
         $this->assertDatabaseCount($this->table, 3);
+    }
+
+    public function testAssertModelEntriesCountWrong()
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('Failed asserting that table [products] matches expected entries count of 3. Entries found: 1.');
+        $this->mockCountBuilder(1);
+
+        $this->assertDatabaseCount(new ProductStub(), 3);
     }
 
     public function testAssertDeletedPassesWhenDoesNotFindResults()

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -48,7 +48,6 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertDatabaseHas(new ProductStub(), $this->data);
     }
 
-
     public function testSeeInDatabaseDoesNotFindResults()
     {
         $this->expectException(ExpectationFailedException::class);

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -111,6 +111,13 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertDatabaseMissing($this->table, $this->data);
     }
 
+    public function testDontSeeInDatabaseDoesNotFindModelResults()
+    {
+        $this->mockCountBuilder(0);
+
+        $this->assertDatabaseMissing(new ProductStub(), $this->data);
+    }
+
     public function testDontSeeInDatabaseFindsResults()
     {
         $this->expectException(ExpectationFailedException::class);
@@ -121,6 +128,18 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $builder->shouldReceive('get')->andReturn(collect([$this->data]));
 
         $this->assertDatabaseMissing($this->table, $this->data);
+    }
+
+    public function testDontSeeInDatabaseFindsModelResults()
+    {
+        $this->expectException(ExpectationFailedException::class);
+
+        $builder = $this->mockCountBuilder(1);
+
+        $builder->shouldReceive('take')->andReturnSelf();
+        $builder->shouldReceive('get')->andReturn(collect([$this->data]));
+
+        $this->assertDatabaseMissing(new ProductStub(), $this->data);
     }
 
     public function testAssertTableEntriesCount()

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -41,6 +41,14 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertDatabaseHas($this->table, $this->data);
     }
 
+    public function testSeeInDatabaseFindsModelResults()
+    {
+        $this->mockCountBuilder(1);
+
+        $this->assertDatabaseHas(new ProductStub(), $this->data);
+    }
+
+
     public function testSeeInDatabaseDoesNotFindResults()
     {
         $this->expectException(ExpectationFailedException::class);
@@ -51,6 +59,18 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $builder->shouldReceive('get')->andReturn(collect());
 
         $this->assertDatabaseHas($this->table, $this->data);
+    }
+
+    public function testSeeInDatabaseDoesNotFindModelResults()
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The table is empty.');
+
+        $builder = $this->mockCountBuilder(0);
+
+        $builder->shouldReceive('get')->andReturn(collect());
+
+        $this->assertDatabaseHas(new ProductStub(), $this->data);
     }
 
     public function testSeeInDatabaseFindsNotMatchingResults()


### PR DESCRIPTION
This PR adds the ability to pass a model class to the database interaction assertions: `assertDatabaseHas()`, `assertDatabaseMissing()`, and  `assertDatabaseCount()`.

Example:
```php
$this->assertDatabaseHas(User::class, [
    'email' => 'foo@bar.com'
]);

$this->assertDatabaseMissing(User::class, [
    'email' => 'foo@bar.com'
]);

$this->assertDatabaseCount(User::class, 1);
```