### PR TITLE
[8.x] Bug-fix - Extra comma

### DIFF
--- a/src/Illuminate/Testing/Concerns/TestDatabases.php
+++ b/src/Illuminate/Testing/Concerns/TestDatabases.php
@@ -155,12 +155,12 @@ trait TestDatabases
         if ($url) {
             config()->set(
                 "database.connections.{$default}.url",
-                preg_replace('/^(.*)(\/[\w-]*)(\??.*)$/', "$1/{$database}$3", $url),
+                preg_replace('/^(.*)(\/[\w-]*)(\??.*)$/', "$1/{$database}$3", $url)
             );
         } else {
             config()->set(
                 "database.connections.{$default}.database",
-                $database,
+                $database
             );
         }
     }


### PR DESCRIPTION
Fatal Error!
Syntax problem: extra comma in line 158 and 163 when calling config()->set()
