### PR TITLE
[8.x] clean

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -224,17 +224,13 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     {
         $class = static::class;
 
-        $booted = [];
-
         static::$traitInitializers[$class] = [];
 
         foreach (class_uses_recursive($class) as $trait) {
             $method = 'boot'.class_basename($trait);
 
-            if (method_exists($class, $method) && ! in_array($method, $booted)) {
+            if (method_exists($class, $method)) {
                 forward_static_call([$class, $method]);
-
-                $booted[] = $method;
             }
 
             if (method_exists($class, $method = 'initialize'.class_basename($trait))) {


### PR DESCRIPTION
There is no way to call a trait boot methods twice since [the array values are already unique](https://github.com/laravel/framework/blob/8.x/src/Illuminate/Support/helpers.php#L96)

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
