### PR TITLE
[8.x] Add firstOrFail into Eloquent Collection

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -5,6 +5,7 @@ namespace Illuminate\Database\Eloquent;
 use Illuminate\Contracts\Queue\QueueableCollection;
 use Illuminate\Contracts\Queue\QueueableEntity;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Database\RecordsNotFoundException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Support\Str;

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -43,7 +43,6 @@ class Collection extends BaseCollection implements QueueableCollection
         }, $default);
     }
 
-    
     /**
      * Find a model in the collection by key or throw an exception.
      *
@@ -59,8 +58,7 @@ class Collection extends BaseCollection implements QueueableCollection
 
         throw new RecordsNotFoundException;
     }
-    
-        
+
     /**
      * Get the first model from the collection or throw an exception.
      *

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -42,6 +42,40 @@ class Collection extends BaseCollection implements QueueableCollection
         }, $default);
     }
 
+    
+    /**
+     * Find a model in the collection by key or throw an exception.
+     *
+     * @return \Illuminate\Database\Eloquent\Model|static
+     *
+     * @throws \Illuminate\Database\RecordsNotFoundException
+     */
+    public function findOrFail($key)
+    {
+        if (! is_null($model = $this->find($key))) {
+            return $model;
+        }
+
+        throw new RecordsNotFoundException;
+    }
+    
+        
+    /**
+     * Get the first model from the collection or throw an exception.
+     *
+     * @return \Illuminate\Database\Eloquent\Model|static
+     *
+     * @throws \Illuminate\Database\RecordsNotFoundException
+     */
+    public function firstOrFail()
+    {
+        if (! is_null($model = $this->first())) {
+            return $model;
+        }
+
+        throw new RecordsNotFoundException;
+    }
+
     /**
      * Load a set of relationships onto the collection.
      *


### PR DESCRIPTION
I believe that we need something to get the first item or going to fail since we already handle an eloquent collection, not a base one, for example:

```php
$cars = Car::all();

$models = collect(json_decode('...'))->each(function ($models, $carName) {
    $cars->where('name', $carName)->firstOrFail();
});
```

Rather than using a model itself like `Car::where('name', $carName)->firstOrFail()`, this will save a lot of queries and memories.

What do you think?

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
