### PR TITLE
[8.x] Allow Route::middleware chaining

### DIFF
--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -97,6 +97,7 @@ class RouteRegistrar
 
         if ($key === 'middleware' && isset($this->attributes[$key])) {
             $this->attributes[$key] = array_merge($this->attributes[$key], $value);
+
             return $this;
         }
 

--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -93,7 +93,14 @@ class RouteRegistrar
             throw new InvalidArgumentException("Attribute [{$key}] does not exist.");
         }
 
-        $this->attributes[Arr::get($this->aliases, $key, $key)] = $value;
+        $key = Arr::get($this->aliases, $key, $key);
+
+        if ($key === 'middleware' && isset($this->attributes[$key])) {
+            $this->attributes[$key] = array_merge($this->attributes[$key], $value);
+            return $this;
+        }
+
+        $this->attributes[$key] = $value;
 
         return $this;
     }

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -58,6 +58,20 @@ class RouteRegistrarTest extends TestCase
 
         $this->seeResponse('all-users', Request::create('users', 'GET'));
         $this->assertEquals(['seven'], $this->getRoute()->middleware());
+
+        $this->router->middleware('eight')->middleware('nine')->get('users', function () {
+            return 'all-users';
+        });
+
+        $this->seeResponse('all-users', Request::create('users', 'GET'));
+        $this->assertEquals(['eight', 'nine'], $this->getRoute()->middleware());
+
+        $this->router->get('users', function () {
+            return 'all-users';
+        })->middleware('ten')->middleware('eleven');
+
+        $this->seeResponse('all-users', Request::create('users', 'GET'));
+        $this->assertEquals(['ten', 'eleven'], $this->getRoute()->middleware());
     }
 
     public function testWithoutMiddlewareRegistration()


### PR DESCRIPTION
There are some inconvenience in route registration. For now, if we write something like this
```php
Route::middleware('one')->middleware('two')->get(...);
```
the latest call of `middleware` overwrites previous ones.
At the same time we can chain middlewares after defining route, like
```php
Route::get(...)->middleware('one')->middleware('two');
```
and they will work together.

I guess it's not a clear behaviour, and could be hard to notice the error by looking at code. In the PR I've added a check in `RouteRegistrar` that middleware attribute already set up and if so, we merging them with new values rather than overwriting.