### PR TITLE
[8.x] Allow to use string for mergeFillable function.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
@@ -61,10 +61,10 @@ trait GuardsAttributes
     /**
      * Merge new fillable attributes with existing fillable attributes on the model.
      *
-     * @param  array  $fillable
+     * @param  array|string  $fillable
      * @return $this
      */
-    public function mergeFillable(array|string $fillable)
+    public function mergeFillable($fillable)
     {
         $this->fillable = array_merge($this->fillable, Arr::wrap($fillable));
 

--- a/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Eloquent\Concerns;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 
 trait GuardsAttributes
@@ -63,9 +64,9 @@ trait GuardsAttributes
      * @param  array  $fillable
      * @return $this
      */
-    public function mergeFillable(array $fillable)
+    public function mergeFillable(array|string $fillable)
     {
-        $this->fillable = array_merge($this->fillable, $fillable);
+        $this->fillable = array_merge($this->fillable, Arr::wrap($fillable));
 
         return $this;
     }


### PR DESCRIPTION
This can allow packages to quickly add fillables to the model using only 
```php 
$this->mergeFillable($this->getCustomColumnName());
```
instead of

```php 
$this->mergeFillable([
    $this->getCustomColumnName(),
]);
```
which can be tiresome.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
