### PR TITLE
[8.x] Added Arr::swap() method

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -680,6 +680,8 @@ class Arr
     }
 
     /**
+     * Swap the order of two items in array.
+     *
      * @param  array  $array
      * @param  string|int $keyOne
      * @param  string|int $keyTwo

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -678,4 +678,34 @@ class Arr
 
         return is_array($value) ? $value : [$value];
     }
+
+    /**
+     * @param  array  $array
+     * @param  string|int $keyOne
+     * @param  string|int $keyTwo
+     * @return array
+     */
+    public static function swap($array, $keyOne, $keyTwo)
+    {
+        if (! static::isAssoc($array)) {
+            $itemOneTmp = $array[$keyOne];
+
+            $array[$keyOne] = $array[$keyTwo];
+            $array[$keyTwo] = $itemOneTmp;
+
+            return $array;
+        }
+
+        $updatedArray = [];
+        foreach ($array as $key => $value) {
+            if ($key === $keyOne) {
+                $updatedArray[$keyTwo] = $array[$keyTwo];
+            } elseif ($key === $keyTwo) {
+                $updatedArray[$keyOne] = $array[$keyOne];
+            } else {
+                $updatedArray[$key] = $value;
+            }
+        }
+        return $updatedArray;
+    }
 }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -956,4 +956,37 @@ class SupportArrTest extends TestCase
             ['name' => 'John', 'age' => 8,  'meta' => ['key' => 3]],
         ], $sortedWithCallable);
     }
+
+    public function testSwap()
+    {
+        // Test with integer indexed array.
+        $array = [
+            ['name' => 'One', 'age' => 8, 'meta' => ['key' => 3]],
+            ['name' => 'Two', 'age' => 10, 'meta' => ['key' => 5]],
+            ['name' => 'Three', 'age' => 10, 'meta' => ['key' => 3]],
+            ['name' => 'Four', 'age' => 8, 'meta' => ['key' => 2]],
+        ];
+
+        $this->assertEquals([
+            ['name' => 'Three', 'age' => 10, 'meta' => ['key' => 3]],
+            ['name' => 'Two', 'age' => 10, 'meta' => ['key' => 5]],
+            ['name' => 'One', 'age' => 8, 'meta' => ['key' => 3]],
+            ['name' => 'Four', 'age' => 8, 'meta' => ['key' => 2]],
+        ], Arr::swap($array, 0, 2));
+
+        // Test with associative array.
+        $assocArray = [
+            'item_one'   => ['name' => 'One', 'age' => 8, 'meta' => ['key' => 3]],
+            'item_two'   => ['name' => 'Two', 'age' => 10, 'meta' => ['key' => 5]],
+            'item_three' => ['name' => 'Three', 'age' => 10, 'meta' => ['key' => 3]],
+            'item_four'  => ['name' => 'Four', 'age' => 8, 'meta' => ['key' => 2]],
+        ];
+
+        $this->assertEquals([
+            'item_three' => ['name' => 'Three', 'age' => 10, 'meta' => ['key' => 3]],
+            'item_two'   => ['name' => 'Two', 'age' => 10, 'meta' => ['key' => 5]],
+            'item_one'   => ['name' => 'One', 'age' => 8, 'meta' => ['key' => 3]],
+            'item_four'  => ['name' => 'Four', 'age' => 8, 'meta' => ['key' => 2]],
+        ], Arr::swap($assocArray, 'item_one', 'item_three'));
+    }
 }


### PR DESCRIPTION
Hi guys!

This PR adds a new `` Arr::swap() `` method that can be used to swap two items in an array. Here's an example of how it could be used with a non-associative array:

```php
$array = [
    ['name' => 'One'],
    ['name' => 'Two'],
    ['name' => 'Three'],
    ['name' => 'Four'],
];

$newArray = Arr::swap($array, 0, 2);

/*
 * $newArray is now:
 * [
 *     ['name' => 'Three'],
 *     ['name' => 'Two'],
 *     ['name' => 'One'],
 *     ['name' => 'Four'],
 * ]
 */
```

Here's another example of how it could be used with an associative array:

```php
$assocArray = [
    'item_one'   => ['name' => 'One'],
    'item_two'   => ['name' => 'Two'],
    'item_three' => ['name' => 'Three'],
    'item_four'  => ['name' => 'Four'],
];

$newArray = Arr::swap($array, 'item_one', 'item_three');

/*
 * $newArray is now:
 * [
 *     'item_three' => ['name' => 'Three'],
 *     'item_two'   => ['name' => 'Two'],
 *     'item_one'   => ['name' => 'One'],
 *     'item_four'  => ['name' => 'Four'],
 * ]
 */

```

I've written a quick test for this as well. Please let me know if there's anything wrong with this or if any updates need making :smile: 