### PR TITLE
[8.x] Resolve `GithubFlavoredMarkdownConverter` from the container

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Support;
 
+use Illuminate\Container\Container;
 use Illuminate\Support\Traits\Macroable;
 use League\CommonMark\GithubFlavoredMarkdownConverter;
 use Ramsey\Uuid\Codec\TimestampFirstCombCodec;
@@ -386,7 +387,11 @@ class Str
      */
     public static function markdown($string, array $options = [])
     {
-        $converter = new GithubFlavoredMarkdownConverter($options);
+        $app = Container::getInstance();
+
+        $converter = $app->make(GithubFlavoredMarkdownConverter::class, [
+            'config' => $options,
+        ]);
 
         return $converter->convertToHtml($string);
     }


### PR DESCRIPTION
This pull request modifies the `Str::markdown` method, now resolving the `GithubFlavoredMarkdownConverter` from the container so that developers can create a custom binding and add extensions, etc.

> I'm not sure about the usage of `Container` inside of the `Support` namespace, since it doesn't actually have a hard dependency on `illuminate/container`, however the `Illuminate\Support\Traits\Localizable` trait actually uses the `Container` too, so I figured it was fine.