### PR TITLE
[8.x] The use of whereHasMorph in a whereHas callback generates a wrong sql statements

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -223,7 +223,7 @@ trait QueriesRelationships
                         };
                     }
 
-                    $query->where($this->query->from.'.'.$relation->getMorphType(), '=', (new $type)->getMorphClass())
+                    $query->where($this->qualifyColumn($relation->getMorphType()), '=', (new $type)->getMorphClass())
                                 ->whereHas($belongsTo, $callback, $operator, $count);
                 });
             }


### PR DESCRIPTION
The use of whereHasMorph in a whereHas callback generates a wrong sql statements. The reason for this is that it cannot capture the "where" part correctly during parsing in the "hasMorph" method.

One thing to be aware of is that if this is a situation that occurs only in very complex queries, it may be possible to spoil something that is going well. Although the correction I applied allows it to do the same thing correctly, we cannot see if it will cause errors at the extreme points without trying.

I believe we should look at what endpoints create a problem or not by implementing this PR.  It should not be forgotten that there is a possibility that it will not cause any problems.
