### PR TITLE
[8.x] Add a cooldown parameter to the retry helper function to slow down the retries

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -218,11 +218,12 @@ if (! function_exists('retry')) {
      * @param  callable  $callback
      * @param  int  $sleep
      * @param  callable|null  $when
+     * @param  int $cooldown
      * @return mixed
      *
      * @throws \Exception
      */
-    function retry($times, callable $callback, $sleep = 0, $when = null)
+    function retry($times, callable $callback, $sleep = 0, $when = null, $cooldown = 0)
     {
         $attempts = 0;
 
@@ -239,6 +240,7 @@ if (! function_exists('retry')) {
 
             if ($sleep) {
                 usleep($sleep * 1000);
+                $sleep += $cooldown;
             }
 
             goto beginning;

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -552,6 +552,25 @@ class SupportHelpersTest extends TestCase
         $this->assertEqualsWithDelta(0.1, microtime(true) - $startTime, 0.02);
     }
 
+    public function testRetryWithCooldown()
+    {
+        $startTime = microtime(true);
+
+        $attempts = retry(3, function ($attempts) {
+            if ($attempts > 2) {
+                return $attempts;
+            }
+
+            throw new RuntimeException;
+        }, 100, null, 500);
+
+        // Make sure we made three attempts
+        $this->assertEquals(3, $attempts);
+
+        // Make sure we waited 700ms for the first and second attempt to finish (100mx + 100ms + 500ms)
+        $this->assertEqualsWithDelta(0.7, microtime(true) - $startTime, 0.03);
+    }
+
     public function testRetryWithPassingWhenCallback()
     {
         $startTime = microtime(true);


### PR DESCRIPTION
# What it does

Sometimes when we want to retry a method which fails, we want to reduce the frequency of the retries. 

For example, in our application, we make a request to an API, however, this API sometimes has capacity issues, meaning we have to wait until we can try again. Rather than just setting a longer sleep period, we can gradually back off and make the request less frequently as to not upset the API server with continuous requests.

## Code Example

```PHP
public function isLoaded(Interaction $interaction) {
    return retry(
         10, 
         function () {
            return $this->hasExternalServerFinishedProcessingInteraction($interaction);
        },
        1000, //sleep for 1 second
        null,
        500, //after every retry, add another 500ms to the sleep time to gradually back off
}

public function hasExternalServerFinishedrProcessingInteraction {
   //some logic here which checks that the external server which will handle this interaction has finished loading it.
}
```

This PR adds a `$cooldown` parameter to the retry helper function, after each retry, the sleep value will be increased to decrease the speed of the retries. If no cooldown is passed, it will default to 0 and current behaviour will not change.

The PR is also supported by a test to make sure the cooldown period did happen.

Any feedback is welcome :)