### PR TITLE
[8.x] Fix Artisan test method `PendingCommand::doesntExpectOutput()` always causing a failed test

### DIFF
--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -329,7 +329,6 @@ class PendingCommand
 
         foreach ($this->test->unexpectedOutput as $output => $displayed) {
             $mock->shouldReceive('doWrite')
-                ->once()
                 ->ordered()
                 ->with($output, Mockery::any())
                 ->andReturnUsing(function () use ($output) {

--- a/tests/Integration/Testing/ArtisanCommandTest.php
+++ b/tests/Integration/Testing/ArtisanCommandTest.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Testing;
+
+use Illuminate\Support\Facades\Artisan;
+use Mockery;
+use Mockery\Exception\InvalidCountException;
+use Mockery\Exception\InvalidOrderException;
+use Orchestra\Testbench\TestCase;
+use PHPUnit\Framework\AssertionFailedError;
+
+class ArtisanCommandTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Artisan::command('survey', function () {
+            $name = $this->ask('What is your name?');
+
+            $language = $this->choice('Which language do you prefer?', [
+                'PHP',
+                'Ruby',
+                'Python',
+            ]);
+
+            $this->line("Your name is $name and you prefer $language.");
+        });
+
+        Artisan::command('slim', function () {
+            $this->line($this->ask('Who?'));
+            $this->line($this->ask('What?'));
+            $this->line($this->ask('Huh?'));
+        });
+    }
+
+    public function test_console_command_that_passes()
+    {
+        $this->artisan('survey')
+             ->expectsQuestion('What is your name?', 'Taylor Otwell')
+             ->expectsQuestion('Which language do you prefer?', 'PHP')
+             ->expectsOutput('Your name is Taylor Otwell and you prefer PHP.')
+             ->doesntExpectOutput('Your name is Taylor Otwell and you prefer Ruby.')
+             ->assertExitCode(0);
+    }
+
+    public function test_console_command_that_passes_with_repeating_output()
+    {
+        $this->artisan('slim')
+             ->expectsQuestion('Who?', 'Taylor')
+             ->expectsQuestion('What?', 'Taylor')
+             ->expectsQuestion('Huh?', 'Taylor')
+             ->expectsOutput('Taylor')
+             ->doesntExpectOutput('Otwell')
+             ->expectsOutput('Taylor')
+             ->expectsOutput('Taylor')
+             ->assertExitCode(0);
+    }
+
+    public function test_console_command_that_fails_from_unexpected_output()
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Output "Your name is Taylor Otwell and you prefer PHP." was printed.');
+
+        $this->artisan('survey')
+             ->expectsQuestion('What is your name?', 'Taylor Otwell')
+             ->expectsQuestion('Which language do you prefer?', 'PHP')
+             ->doesntExpectOutput('Your name is Taylor Otwell and you prefer PHP.')
+             ->assertExitCode(0);
+    }
+
+    public function test_console_command_that_fails_from_missing_output()
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Output "Your name is Taylor Otwell and you prefer PHP." was not printed.');
+
+        $this->ignoringMockOnceExceptions(function () {
+            $this->artisan('survey')
+                 ->expectsQuestion('What is your name?', 'Taylor Otwell')
+                 ->expectsQuestion('Which language do you prefer?', 'Ruby')
+                 ->expectsOutput('Your name is Taylor Otwell and you prefer PHP.')
+                 ->assertExitCode(0);
+        });
+    }
+
+    public function test_console_command_that_fails_from_exit_code_mismatch()
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Expected status code 1 but received 0.');
+
+        $this->artisan('survey')
+             ->expectsQuestion('What is your name?', 'Taylor Otwell')
+             ->expectsQuestion('Which language do you prefer?', 'PHP')
+             ->assertExitCode(1);
+    }
+
+    public function test_console_command_that_fails_from_unordered_output()
+    {
+        $this->expectException(InvalidOrderException::class);
+
+        $this->ignoringMockOnceExceptions(function () {
+            $this->artisan('slim')
+                 ->expectsQuestion('Who?', 'Taylor')
+                 ->expectsQuestion('What?', 'Danger')
+                 ->expectsQuestion('Huh?', 'Otwell')
+                 ->expectsOutput('Taylor')
+                 ->expectsOutput('Otwell')
+                 ->expectsOutput('Danger')
+                 ->assertExitCode(0);
+        });
+    }
+
+    /**
+     * Don't allow Mockery's InvalidCountException to be reported. Mocks setup
+     * in PendingCommand cause PHPUnit tearDown() to later throw the exception.
+     *
+     * @param  callable  $callback
+     * @return void
+     */
+    protected function ignoringMockOnceExceptions(callable $callback)
+    {
+        try {
+            $callback();
+        } finally {
+            try {
+                Mockery::close();
+            } catch (InvalidCountException $e) {
+                // Ignore mock exception from PendingCommand::expectsOutput().
+            }
+        }
+    }
+}


### PR DESCRIPTION
It seems https://github.com/laravel/framework/pull/35160 added in v8.15.0 (2020-11-17) has never worked for the successful test case. e.g.,

```php
$this->artisan('dusk:firefox-driver')
    ->doesntExpectOutput('Geckodriver binary installation failed for Linux.');
```

When that string isn't output by the command, this test should pass. Instead this exception is thrown and the test fails:

```
Mockery\Exception\InvalidCountException: Method doWrite('Geckodriver binary installation failed for Linux.', <Any>)
from Mockery_0_Symfony_Component_Console_Output_BufferedOutput should be called
exactly 1 times but called 0 times.
```

`Mockery::close()` in `tearDown()` throws this exception because `->once()` was called when setting up the `doesntExpectOutput()` mock. But that isn't needed. During a successful test run, that _should_ be called zero times. It looks like that code snippet was copy and pasted from the opposite `expectedOutput` case a few lines up.

So I've added some `InteractsWithConsole::artisan()` test coverage on assertion methods `assertExitCode()`, `doesntExpectOutput()`, and `expectsOutput()` (this one requires some Mockery `once()` exception suppression).