### PR TITLE
[9.x] Add key support to FormRequest validated method

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -188,10 +188,18 @@ class FormRequest extends Request implements ValidatesWhenResolved
     /**
      * Get the validated data from the request.
      *
-     * @return array
+     * @param  string|null  $key
+     * @param  string|array|null  $default
+     * @return mixed
      */
-    public function validated()
+    public function validated($key = null, $default = null)
     {
+        if (! is_null($key)) {
+            return data_get(
+                $this->validator->validated(), $key, $default
+            );
+        }
+
         return $this->validator->validated();
     }
 

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -106,7 +106,7 @@ class FoundationFormRequestTest extends TestCase
         $this->createRequest([], FoundationTestFormRequestHooks::class)->validateResolved();
     }
 
-    public function test_after_validation_runs_after_validation()
+    public function testAfterValidationRunsAfterValidation()
     {
         $request = $this->createRequest([], FoundationTestFormRequestHooks::class);
 

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -115,6 +115,26 @@ class FoundationFormRequestTest extends TestCase
         $this->assertEquals(['name' => 'Adam'], $request->all());
     }
 
+    public function testValidatedMethodReturnsOnlyRequestedValidatedData()
+    {
+        $request = $this->createRequest(['name' => 'specified', 'with' => 'extras']);
+
+        $request->validateResolved();
+
+        $this->assertEquals('specified', $request->validated('name'));
+    }
+
+    public function testValidatedMethodReturnsOnlyRequestedNestedValidatedData()
+    {
+        $payload = ['nested' => ['foo' => 'bar', 'baz' => ''], 'array' => [1, 2]];
+
+        $request = $this->createRequest($payload, FoundationTestFormRequestNestedStub::class);
+
+        $request->validateResolved();
+
+        $this->assertEquals('bar', $request->validated('nested.foo'));
+    }
+
     /**
      * Catch the given exception thrown from the executor, and return it.
      *


### PR DESCRIPTION
When interacting with FormRequests and using validated data it's a little clunky to get single values. This PR extends the current `FormRequest@validated` method to make this more expressive.

You can currently get a single validated value with the following:
```php
// this does not seem obviously validated:
$name = $request->input('name');

// ouch
$name = $request->validated()['name'];
```

I think it's more expressive and clean to use:
```php
$name = $request->validated('name');
```