### PR TITLE
[8.x] Added missing months() to Wormhole

### DIFF
--- a/src/Illuminate/Foundation/Testing/Wormhole.php
+++ b/src/Illuminate/Foundation/Testing/Wormhole.php
@@ -103,6 +103,19 @@ class Wormhole
     }
 
     /**
+     * Travel forward the given number of months.
+     *
+     * @param  callable|null  $callback
+     * @return mixed
+     */
+    public function months($callback = null)
+    {
+        Carbon::setTestNow(Carbon::now()->addMonths($this->value));
+
+        return $this->handleCallback($callback);
+    }
+
+    /**
      * Travel forward the given number of years.
      *
      * @param  callable|null  $callback


### PR DESCRIPTION
This PR adds the method ```months()``` for time travelling in tests. 

```
$this->travel(5)->months(); // current not possible
```

Before you had to use a work-around

```
$this->travelTo(now()->addMonths(5)); // current work-around
``` 