### PR TITLE
[8.x] Explicitly set unit of sleep of retry function

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -216,13 +216,13 @@ if (! function_exists('retry')) {
      *
      * @param  int  $times
      * @param  callable  $callback
-     * @param  int  $sleepMs
+     * @param  int  $sleepMilliseconds
      * @param  callable|null  $when
      * @return mixed
      *
      * @throws \Exception
      */
-    function retry($times, callable $callback, $sleepMs = 0, $when = null)
+    function retry($times, callable $callback, $sleepMilliseconds = 0, $when = null)
     {
         $attempts = 0;
 
@@ -237,8 +237,8 @@ if (! function_exists('retry')) {
                 throw $e;
             }
 
-            if ($sleepMs) {
-                usleep($sleepMs * 1000);
+            if ($sleepMilliseconds) {
+                usleep($sleepMilliseconds * 1000);
             }
 
             goto beginning;

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -216,13 +216,13 @@ if (! function_exists('retry')) {
      *
      * @param  int  $times
      * @param  callable  $callback
-     * @param  int  $sleep
+     * @param  int  $sleepMs
      * @param  callable|null  $when
      * @return mixed
      *
      * @throws \Exception
      */
-    function retry($times, callable $callback, $sleep = 0, $when = null)
+    function retry($times, callable $callback, $sleepMs = 0, $when = null)
     {
         $attempts = 0;
 
@@ -237,8 +237,8 @@ if (! function_exists('retry')) {
                 throw $e;
             }
 
-            if ($sleep) {
-                usleep($sleep * 1000);
+            if ($sleepMs) {
+                usleep($sleepMs * 1000);
             }
 
             goto beginning;


### PR DESCRIPTION
When using the retry function it was not clear from the function signature function what the sleep timer was? seconds, milliseconds or microseconds.

You could look at the code and discover you're using **usleep** * 100 to get to ms

Or you could look at the docs on laravel.com to see the code example

```php
return retry(5, function () {
    // Attempt 5 times while resting 100ms in between attempts...
}, 100);
```
https://laravel.com/docs/8.x/helpers#method-retry

This PR just aims to save someone a few clicks and confusion

- No breaking change
- No test changes