### PR TITLE
[8.x] Add `nextPage` and `previousPage` methods to Paginator

### DIFF
--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -145,6 +145,18 @@ abstract class AbstractPaginator implements Htmlable
     }
 
     /**
+     * Get the URL for the next page.
+     *
+     * @return string|null
+     */
+    public function nextPageUrl()
+    {
+        if ($this->hasMorePages()) {
+            return $this->url($this->currentPage() + 1);
+        }
+    }
+
+    /**
      * Create a range of pagination URLs.
      *
      * @param  int  $start

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -133,14 +133,36 @@ abstract class AbstractPaginator implements Htmlable
     }
 
     /**
+     * Determine if there are previous items in the data source.
+     *
+     * @return bool
+     */
+    public function hasPreviousPages()
+    {
+        return $this->currentPage() > 1;
+    }
+
+    /**
+     * Get the previous page.
+     *
+     * @return int|null
+     */
+    public function previousPage()
+    {
+        if ($this->hasPreviousPages()) {
+            return $this->currentPage() - 1;
+        }
+    }
+
+    /**
      * Get the URL for the previous page.
      *
      * @return string|null
      */
     public function previousPageUrl()
     {
-        if ($this->currentPage() > 1) {
-            return $this->url($this->currentPage() - 1);
+        if ($this->hasPreviousPages()) {
+            return $this->url($this->previousPage());
         }
     }
 

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -145,6 +145,18 @@ abstract class AbstractPaginator implements Htmlable
     }
 
     /**
+     * Get the next page.
+     *
+     * @return int|null
+     */
+    public function nextPage()
+    {
+        if ($this->hasMorePages()) {
+            return $this->currentPage() + 1;
+        }
+    }
+
+    /**
      * Get the URL for the next page.
      *
      * @return string|null
@@ -152,7 +164,7 @@ abstract class AbstractPaginator implements Htmlable
     public function nextPageUrl()
     {
         if ($this->hasMorePages()) {
-            return $this->url($this->currentPage() + 1);
+            return $this->url($this->nextPage());
         }
     }
 

--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -173,6 +173,16 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
     }
 
     /**
+     * Get the URL for the last page.
+     *
+     * @return string
+     */
+    public function lastPageUrl()
+    {
+        return $this->url($this->lastPage());
+    }
+
+    /**
      * Get the instance as an array.
      *
      * @return array
@@ -185,7 +195,7 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
             'first_page_url' => $this->url(1),
             'from' => $this->firstItem(),
             'last_page' => $this->lastPage(),
-            'last_page_url' => $this->url($this->lastPage()),
+            'last_page_url' => $this->lastPageUrl(),
             'links' => $this->linkCollection()->toArray(),
             'next_page_url' => $this->nextPageUrl(),
             'path' => $this->path(),

--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -163,18 +163,6 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
     }
 
     /**
-     * Get the URL for the next page.
-     *
-     * @return string|null
-     */
-    public function nextPageUrl()
-    {
-        if ($this->hasMorePages()) {
-            return $this->url($this->currentPage() + 1);
-        }
-    }
-
-    /**
      * Get the last page.
      *
      * @return int

--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -73,18 +73,6 @@ class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Cou
     }
 
     /**
-     * Get the URL for the next page.
-     *
-     * @return string|null
-     */
-    public function nextPageUrl()
-    {
-        if ($this->hasMorePages()) {
-            return $this->url($this->currentPage() + 1);
-        }
-    }
-
-    /**
      * Render the paginator using the given view.
      *
      * @param  string|null  $view

--- a/tests/Pagination/LengthAwarePaginatorTest.php
+++ b/tests/Pagination/LengthAwarePaginatorTest.php
@@ -40,8 +40,11 @@ class LengthAwarePaginatorTest extends TestCase
     {
         $this->assertEquals(2, $this->p->lastPage());
         $this->assertEquals(2, $this->p->currentPage());
+        $this->assertEquals(null, $this->p->nextPage());
+        $this->assertEquals(1, $this->p->previousPage());
         $this->assertTrue($this->p->hasPages());
         $this->assertFalse($this->p->hasMorePages());
+        $this->assertTrue($this->p->hasPreviousPages());
         $this->assertEquals(['item1', 'item2', 'item3', 'item4'], $this->p->items());
     }
 
@@ -51,8 +54,11 @@ class LengthAwarePaginatorTest extends TestCase
 
         $this->assertEquals(1, $paginator->lastPage());
         $this->assertEquals(1, $paginator->currentPage());
+        $this->assertEquals(null, $paginator->nextPage());
+        $this->assertEquals(null, $paginator->previousPage());
         $this->assertFalse($paginator->hasPages());
         $this->assertFalse($paginator->hasMorePages());
+        $this->assertFalse($paginator->hasPreviousPages());
         $this->assertEmpty($paginator->items());
     }
 
@@ -72,6 +78,20 @@ class LengthAwarePaginatorTest extends TestCase
 
         $this->assertSame('http://website.com?foo=1',
                             $this->p->url($this->p->currentPage() - 2));
+    }
+
+    public function testLengthAwarePaginatorCanGeneratePageUrls()
+    {
+        $this->p->setPath('http://website.com');
+        $this->p->setPageName('foo');
+
+        $this->assertNull($this->p->nextPageUrl());
+
+        $this->assertSame('http://website.com?foo=1',
+                          $this->p->previousPageUrl());
+
+        $this->assertSame('http://website.com?foo=2',
+                          $this->p->lastPageUrl());
     }
 
     public function testLengthAwarePaginatorCanGenerateUrlsWithQuery()

--- a/tests/Pagination/PaginatorTest.php
+++ b/tests/Pagination/PaginatorTest.php
@@ -12,8 +12,11 @@ class PaginatorTest extends TestCase
         $p = new Paginator($array = ['item3', 'item4', 'item5'], 2, 2);
 
         $this->assertEquals(2, $p->currentPage());
+        $this->assertEquals(3, $p->nextPage());
+        $this->assertEquals(1, $p->previousPage());
         $this->assertTrue($p->hasPages());
         $this->assertTrue($p->hasMorePages());
+        $this->assertTrue($p->hasPreviousPages());
         $this->assertEquals(['item3', 'item4'], $p->items());
 
         $pageInfo = [


### PR DESCRIPTION
Added new methods to the paginator, and refactored it a bit.

#### New methods in `AbstractPaginator`:
- `nextPage()`
-  `previousPage()`
- `hasPreviousPages()`

#### New method in `LengthAwarePaginator`:
- `lastPageUrl()`

#### Refactoring
- Moved the duplicated `nextPageUrl()` method in `Paginator` and `LengthAwarePaginator` to the parent `AbstractPaginator` class.
