### PR TITLE
[6.x] Fix setting DynamoDB credentials

### DIFF
--- a/src/Illuminate/Cache/CacheServiceProvider.php
+++ b/src/Illuminate/Cache/CacheServiceProvider.php
@@ -36,14 +36,19 @@ class CacheServiceProvider extends ServiceProvider implements DeferrableProvider
         $this->app->singleton('cache.dynamodb.client', function ($app) {
             $config = $app['config']->get('cache.stores.dynamodb');
 
-            return new DynamoDbClient([
+            $dynamoConfig = [
                 'region' => $config['region'],
                 'version' => 'latest',
                 'endpoint' => $config['endpoint'] ?? null,
-                'credentials' => Arr::only(
+            ];
+
+            if ($config['key'] && $config['secret']) {
+                $dynamoConfig['credentials'] = Arr::only(
                     $config, ['key', 'secret', 'token']
-                ),
-            ]);
+                );
+            }
+
+            return new DynamoDbClient($dynamoConfig);
         });
     }
 


### PR DESCRIPTION
This fixes an issue for AWS accounts which don't use API keys to connect to their DynamoDB setup.

Fixes https://github.com/laravel/framework/issues/36819