### PR TITLE
[8.x] Add the ability to paginate all the items

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -768,9 +768,11 @@ class Builder
 
         $perPage = $perPage ?: $this->model->getPerPage();
 
-        $results = ($total = $this->toBase()->getCountForPagination())
-                                    ? $this->forPage($page, $perPage)->get($columns)
-                                    : $this->model->newCollection();
+        $total = $this->toBase()->getCountForPagination();
+
+        $perPage = ($perPage < 0 && $total > 0) ? $total : $perPage;
+
+        $results = $total ? $this->forPage($page, $perPage)->get($columns) : $this->model->newCollection();
 
         return $this->paginator($results, $total, $perPage, $page, [
             'path' => Paginator::resolveCurrentPath(),

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2329,6 +2329,8 @@ class Builder
 
         $total = $this->getCountForPagination();
 
+        $perPage = ($perPage < 0 && $total > 0) ? $total : $perPage;
+
         $results = $total ? $this->forPage($page, $perPage)->get($columns) : collect();
 
         return $this->paginator($results, $total, $perPage, $page, [

--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -46,7 +46,7 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
         }
 
         $this->total = $total;
-        $this->perPage = $perPage;
+        $this->perPage = ($perPage < 0 && $total > 0) ? $total : $perPage;
         $this->lastPage = max((int) ceil($total / $perPage), 1);
         $this->path = $this->path !== '/' ? rtrim($this->path, '/') : $this->path;
         $this->currentPage = $this->setCurrentPage($currentPage, $this->pageName);

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -3472,6 +3472,36 @@ SQL;
         ]), $result);
     }
 
+    public function testPaginateWithAllItems()
+    {
+        $perPage = -1;
+        $pageName = 'page';
+        $page = 1;
+        $builder = $this->getMockQueryBuilder();
+        $path = 'http://foo.bar?page=3';
+
+        $results = [];
+
+        $builder->shouldReceive('getCountForPagination')->once()->andReturn(0);
+        $builder->shouldNotReceive('forPage');
+        $builder->shouldNotReceive('get');
+
+        Paginator::currentPageResolver(function () {
+            return 1;
+        });
+
+        Paginator::currentPathResolver(function () use ($path) {
+            return $path;
+        });
+
+        $result = $builder->paginate(-1);
+
+        $this->assertEquals(new LengthAwarePaginator($results, 0, $perPage, $page, [
+            'path' => $path,
+            'pageName' => $pageName,
+        ]), $result);
+    }
+
     public function testWhereRowValues()
     {
         $builder = $this->getBuilder();

--- a/tests/Integration/Database/EloquentPaginateTest.php
+++ b/tests/Integration/Database/EloquentPaginateTest.php
@@ -102,6 +102,20 @@ class EloquentPaginateTest extends DatabaseTestCase
         $this->assertEquals(5, $query->count());
         $this->assertEquals(5, $query->paginate()->total());
     }
+
+    public function testPaginationWithAllItems()
+    {
+        for ($i = 1; $i <= 3; $i++) {
+            Post::create(['title' => 'Hello world']);
+            Post::create(['title' => 'Goodbye world']);
+        }
+
+        $query = Post::query();
+
+        $this->assertEquals(6, $query->get()->count());
+        $this->assertEquals(6, $query->count());
+        $this->assertEquals(6, $query->paginate(-1)->total());
+    }
 }
 
 class Post extends Model

--- a/tests/Pagination/LengthAwarePaginatorTest.php
+++ b/tests/Pagination/LengthAwarePaginatorTest.php
@@ -111,4 +111,16 @@ class LengthAwarePaginatorTest extends TestCase
     {
         $this->assertSame($this->options, $this->p->getOptions());
     }
+
+    public function testLengthAwarePaginatorCanRetrieveAllItems()
+    {
+        $paginator = new LengthAwarePaginator(['item1', 'item2', 'item3', 'item4'], 4, -1);
+
+        $this->assertEquals(4, $paginator->perPage());
+        $this->assertEquals(1, $paginator->lastPage());
+        $this->assertEquals(1, $paginator->currentPage());
+        $this->assertFalse($paginator->hasPages());
+        $this->assertFalse($paginator->hasMorePages());
+        $this->assertEquals(['item1', 'item2', 'item3', 'item4'], $paginator->items());
+    }
 }

--- a/tests/Pagination/LengthAwarePaginatorTest.php
+++ b/tests/Pagination/LengthAwarePaginatorTest.php
@@ -114,7 +114,7 @@ class LengthAwarePaginatorTest extends TestCase
 
     public function testLengthAwarePaginatorCanRetrieveAllItems()
     {
-        $paginator = new LengthAwarePaginator(['item1', 'item2', 'item3', 'item4'], 4, -1);
+        $paginator = new LengthAwarePaginator(['item1', 'item2', 'item3', 'item4'], 4, -1, 1);
 
         $this->assertEquals(4, $paginator->perPage());
         $this->assertEquals(1, $paginator->lastPage());


### PR DESCRIPTION
This PR is a reworked retry of https://github.com/laravel/framework/pull/28834.

In some cases, we might want to show all items on one page, when using pagination. While the point of the pagination component is not really to list all items, still it can be a real word scenario.

Unlike the PR above, I would suggest using the `-1` to list all items. This way we don't mix the parameter types.

```php
User::query()->paginatge(-1);
```

As far as I know, this should not be a breaking change.