### PR TITLE
[8.x] Add unshift method to collection

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -808,6 +808,18 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
+     * Push an item onto the beginning of the collection.
+     *
+     * @param  mixed  $value
+     * @param  mixed  $key
+     * @return $this
+     */
+    public function unshift($value, $key = null)
+    {
+        return $this->prepend(...func_get_args());
+    }
+
+    /**
      * Push one or more items onto the end of the collection.
      *
      * @param  mixed  $values [optional]

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3261,6 +3261,27 @@ class SupportCollectionTest extends TestCase
         );
     }
 
+    public function testUnshift()
+    {
+        $c = new Collection(['one', 'two', 'three', 'four']);
+        $this->assertEquals(
+            ['zero', 'one', 'two', 'three', 'four'],
+            $c->unshift('zero')->all()
+        );
+
+        $c = new Collection(['one' => 1, 'two' => 2]);
+        $this->assertEquals(
+            ['zero' => 0, 'one' => 1, 'two' => 2],
+            $c->unshift(0, 'zero')->all()
+        );
+
+        $c = new Collection(['one' => 1, 'two' => 2]);
+        $this->assertEquals(
+            [null => 0, 'one' => 1, 'two' => 2],
+            $c->unshift(0, null)->all()
+        );
+    }
+
     public function testPushWithOneItem()
     {
         $expected = [


### PR DESCRIPTION
from javascript world,
there are 4 methods used to handle array as dequeue
push() to add to end of array
pop() to remove from end of array
unshift() to add to beginning of array
shift() to remove from beginning of array

so right now, collections have push,pop,shift methods but lack the unshift
well, the behavior exists but with different name called prepend()

so i just created shift method as an alias for prepend and have the same functionality, just to unify the interface between laravel collection and javascript array

me as a developer switching between php and js so i think it will be nice if we can have same interface to deal with arrays then we won't have to remember unshift from javascript is prepend in collection