### PR TITLE
[8.x] Allow to unset limit

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -134,7 +134,7 @@ class Builder
     /**
      * The maximum number of records to return.
      *
-     * @var null|int
+     * @var int|null
      */
     public $limit;
 
@@ -155,7 +155,7 @@ class Builder
     /**
      * The maximum number of union records to return.
      *
-     * @var null|int
+     * @var int|null
      */
     public $unionLimit;
 
@@ -2073,7 +2073,7 @@ class Builder
     /**
      * Alias to set the "limit" value of the query.
      *
-     * @param  null|int  $value
+     * @param  int|null  $value
      * @return $this
      */
     public function take($value)
@@ -2084,7 +2084,7 @@ class Builder
     /**
      * Set the "limit" value of the query.
      *
-     * @param  null|int  $value
+     * @param  int|null  $value
      * @return $this
      */
     public function limit($value)

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -134,7 +134,7 @@ class Builder
     /**
      * The maximum number of records to return.
      *
-     * @var int
+     * @var null|int
      */
     public $limit;
 
@@ -155,7 +155,7 @@ class Builder
     /**
      * The maximum number of union records to return.
      *
-     * @var int
+     * @var null|int
      */
     public $unionLimit;
 
@@ -2073,7 +2073,7 @@ class Builder
     /**
      * Alias to set the "limit" value of the query.
      *
-     * @param  int  $value
+     * @param  null|int  $value
      * @return $this
      */
     public function take($value)
@@ -2084,14 +2084,14 @@ class Builder
     /**
      * Set the "limit" value of the query.
      *
-     * @param  int  $value
+     * @param  null|int  $value
      * @return $this
      */
     public function limit($value)
     {
         $property = $this->unions ? 'unionLimit' : 'limit';
 
-        if ($value >= 0) {
+        if ($value >= 0 || $value === null) {
             $this->$property = $value;
         }
 


### PR DESCRIPTION
In the case you want to reuse a Builder Object that previously has a limit set, is not possible to do $builder->limit(null);
The use case in my case, is to retrieve the 20 first items and the total number of items, without builder again the query, just unsetting the limit.
