### PR TITLE
[8.x] Deprecate dispatch_now & dispatchNow

### DIFF
--- a/src/Illuminate/Foundation/Bus/Dispatchable.php
+++ b/src/Illuminate/Foundation/Bus/Dispatchable.php
@@ -61,6 +61,8 @@ trait Dispatchable
      * Dispatch a command to its appropriate handler in the current process.
      *
      * @return mixed
+     *
+     * @deprecated Will be removed in a future Laravel version.
      */
     public static function dispatchNow()
     {

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -397,6 +397,8 @@ if (! function_exists('dispatch_now')) {
      * @param  mixed  $job
      * @param  mixed  $handler
      * @return mixed
+     *
+     * @deprecated Will be removed in a future Laravel version.
      */
     function dispatch_now($job, $handler = null)
     {


### PR DESCRIPTION
Deprecate `dispatch_now` helper and `dispatchNow` method on the `Dispatchable` trait so we can remove it in a future Laravel version. See https://github.com/laravel/framework/pull/36743#issuecomment-811107049