### PR TITLE
[8.x] Add dispatch_sync helper

### DIFF
--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -81,7 +81,7 @@ class Dispatcher implements QueueingDispatcher
     /**
      * Dispatch a command to its appropriate handler in the current process.
      *
-     * Queuable jobs will be dispatched to the "sync" queue.
+     * Queueable jobs will be dispatched to the "sync" queue.
      *
      * @param  mixed  $command
      * @param  mixed  $handler

--- a/src/Illuminate/Contracts/Bus/Dispatcher.php
+++ b/src/Illuminate/Contracts/Bus/Dispatcher.php
@@ -15,7 +15,7 @@ interface Dispatcher
     /**
      * Dispatch a command to its appropriate handler in the current process.
      *
-     * Queuable jobs will be dispatched to the "sync" queue.
+     * Queueable jobs will be dispatched to the "sync" queue.
      *
      * @param  mixed  $command
      * @param  mixed  $handler

--- a/src/Illuminate/Foundation/Bus/Dispatchable.php
+++ b/src/Illuminate/Foundation/Bus/Dispatchable.php
@@ -48,7 +48,7 @@ trait Dispatchable
     /**
      * Dispatch a command to its appropriate handler in the current process.
      *
-     * Queuable jobs will be dispatched to the "sync" queue.
+     * Queueable jobs will be dispatched to the "sync" queue.
      *
      * @return mixed
      */

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -390,6 +390,22 @@ if (! function_exists('dispatch')) {
     }
 }
 
+if (! function_exists('dispatch_sync')) {
+    /**
+     * Dispatch a command to its appropriate handler in the current process.
+     *
+     * Queueable jobs will be dispatched to the "sync" queue.
+     *
+     * @param  mixed  $job
+     * @param  mixed  $handler
+     * @return mixed
+     */
+    function dispatch_sync($job, $handler = null)
+    {
+        return app(Dispatcher::class)->dispatchSync($job, $handler);
+    }
+}
+
 if (! function_exists('dispatch_now')) {
     /**
      * Dispatch a command to its appropriate handler in the current process.

--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -435,7 +435,7 @@ class BusFake implements QueueingDispatcher
     /**
      * Dispatch a command to its appropriate handler in the current process.
      *
-     * Queuable jobs will be dispatched to the "sync" queue.
+     * Queueable jobs will be dispatched to the "sync" queue.
      *
      * @param  mixed  $command
      * @param  mixed  $handler


### PR DESCRIPTION
As an alternative for `dispatch_now`. See https://github.com/laravel/framework/pull/36743#issuecomment-811107049

Also fixes some wording.