### PR TITLE
[8.x] Incorrect usage of the validator has been fixed.

### DIFF
--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -62,7 +62,7 @@ class FoundationServiceProvider extends AggregateServiceProvider
 
         Request::macro('validateWithBag', function (string $errorBag, array $rules, ...$params) {
             try {
-                return $this->validate($rules, ...$params);
+                return validator()->validate($rules, ...$params);
             } catch (ValidationException $e) {
                 $e->errorBag = $errorBag;
 


### PR DESCRIPTION
There is no `validate()` method in the `FoundatinServiceProvider` class. Correct use has been applied.