### PR TITLE
Changing method bounding signature and ability to set defaultParam while resolving from array.

### DIFF
--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -62,14 +62,14 @@ class BoundMethod
         // name. We will split on this @ sign and then build a callable array that
         // we can pass right back into the "call" method for dependency binding.
         $method = count($segments) === 2
-            ? $segments[1] : $defaultMethod;
+                    ? $segments[1] : $defaultMethod;
 
         if (is_null($method)) {
             throw new InvalidArgumentException('Method not provided.');
         }
 
         $instance = is_string($segments[0])
-            ? $container->make($segments[0]) : $segments[0];
+                    ? $container->make($segments[0]) : $segments[0];
 
         return static::call(
             $container, [$instance, $method], $parameters

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -599,7 +599,7 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * Call the given Closure / class@method and inject its dependencies.
      *
-     * @param  callable|string  $callback
+     * @param  callable|string|array  $callback
      * @param  array<string, mixed>  $parameters
      * @param  string|null  $defaultMethod
      * @return mixed

--- a/tests/Container/ContainerCallTest.php
+++ b/tests/Container/ContainerCallTest.php
@@ -6,7 +6,6 @@ use Closure;
 use Error;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Container\BindingResolutionException;
-use Illuminate\Http\Request;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 

--- a/tests/Container/ContainerCallTest.php
+++ b/tests/Container/ContainerCallTest.php
@@ -6,6 +6,7 @@ use Closure;
 use Error;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Container\BindingResolutionException;
+use Illuminate\Http\Request;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
@@ -90,6 +91,15 @@ class ContainerCallTest extends TestCase
         $result = $container->call([new ContainerTestCallStub, 'inject'], ['_stub' => 'foo']);
         $this->assertInstanceOf(ContainerCallConcreteStub::class, $result[0]);
         $this->assertSame('taylor', $result[1]);
+
+        $container = new Container;
+        $result = $container->call([new ContainerTestCallStub, 'inject'], [], 'defaultMethod');
+        $this->assertInstanceOf(ContainerCallConcreteStub::class, $result[0]);
+
+        $container = new Container;
+        $result = $container->call([new ContainerTestCallStub], ['default' => 'foo'], 'inject');
+        $this->assertInstanceOf(ContainerCallConcreteStub::class, $result[0]);
+        $this->assertSame('foo', $result[1]);
     }
 
     public function testBindMethodAcceptsAnArray()
@@ -119,6 +129,12 @@ class ContainerCallTest extends TestCase
         $container->call(function (ContainerCallConcreteStub $stub) {
             //
         }, ['foo' => 'bar', 'stub' => new ContainerCallConcreteStub]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Callback function cannot use defaultMethod parameter.');
+        $container->call(function (ContainerCallConcreteStub $stub) {
+            //
+        }, ['foo' => 'bar'], 'defaultMethod');
     }
 
     public function testCallWithDependencies()


### PR DESCRIPTION
I faced the problem that if I want to resolve and call some methods dynamically using an array of class and method and I'm not sure that I have the second element in my array where the second one is the method I cannot use default method.
 A default method can be passed only when you using `classname@method` signature. If you will try to pass an array as `$callback` param with the default method you will face an error. So I made some fixes that solve this problem and now you can dynamically put an array with `$defaultMethod` on your prefer. 
Also, I check if the user wants to use the callback function as `$callback` param with `$defaultMethod` he will face an error too so I throw `InvalidArgumentException` which will be expected behavior now.
And in this PR I changed PHPdoc for methods that were not correct.