### PR TITLE
[8.x] Fix blade compiler regex issue

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -417,7 +417,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
     protected function compileStatements($value)
     {
         return preg_replace_callback(
-            '/\B@(@?\w+(?:::\w+)?)([ \t]*)(\( ( (?>[^()]+) | (?3) )* \))?/x', function ($match) {
+            '/\B@(@?\w+(?:::\w+)?)([ \t]*)(\( ( (?>\'[^\']+\') | (?>"[^"]+") | (?>[^()\'"]+) | (?3) )* \))?/x', function ($match) {
                 return $this->compileStatement($match);
             }, $value
         );

--- a/tests/View/Blade/BladePhpStatementsTest.php
+++ b/tests/View/Blade/BladePhpStatementsTest.php
@@ -43,4 +43,13 @@ class BladePhpStatementsTest extends AbstractBladeTestCase
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
+
+    public function testStringWithParenthesisDataValue()
+    {
+        $string = "@php(\$data = ['test' => ')'])";
+
+        $expected = "<?php (\$data = ['test' => ')']); ?>";
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
 }


### PR DESCRIPTION
Draft PR with failing test for a current issue with Blade components where a single `)` is passed as a string argument. I've tracked it down to the regex below that doesn't seems to quite parse things correctly. Every attempt I made so far to fix it broke something else in the compiler.

https://github.com/laravel/framework/blob/d8a53a068c4b16187a9933ec5c5c9db33ff4e9c6/src/Illuminate/View/Compilers/BladeCompiler.php#L420

Update: thanks to @jasonmccreary for fixing this 🥳 

Fixes https://github.com/laravel/framework/issues/36815