### PR TITLE
[8.x] Add tests for `LazyCollection` constructor laziness

### DIFF
--- a/tests/Support/Concerns/CountsEnumerations.php
+++ b/tests/Support/Concerns/CountsEnumerations.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Illuminate\Tests\Support\Concerns;
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\LazyCollection;
+
+trait CountsEnumerations
+{
+    protected function assertDoesNotEnumerate(callable $executor)
+    {
+        $this->assertEnumerates(0, $executor);
+    }
+
+    protected function assertDoesNotEnumerateCollection(
+        LazyCollection $collection,
+        callable $executor
+    ) {
+        $this->assertEnumeratesCollection($collection, 0, $executor);
+    }
+
+    protected function assertEnumerates($count, callable $executor)
+    {
+        $this->assertEnumeratesCollection(
+            LazyCollection::times(100),
+            $count,
+            $executor
+        );
+    }
+
+    protected function assertEnumeratesCollection(
+        LazyCollection $collection,
+        $count,
+        callable $executor
+    ) {
+        $enumerated = 0;
+
+        $data = $this->countEnumerations($collection, $enumerated);
+
+        $executor($data);
+
+        $this->assertEnumerations($count, $enumerated);
+    }
+
+    protected function assertEnumeratesOnce(callable $executor)
+    {
+        $this->assertEnumeratesCollectionOnce(LazyCollection::times(10), $executor);
+    }
+
+    protected function assertEnumeratesCollectionOnce(
+        LazyCollection $collection,
+        callable $executor
+    ) {
+        $enumerated = 0;
+        $count = $collection->count();
+        $collection = $this->countEnumerations($collection, $enumerated);
+
+        $executor($collection);
+
+        $this->assertEquals(
+            $count,
+            $enumerated,
+            $count > $enumerated ? 'Failed to enumerate in full.' : 'Enumerated more than once.'
+        );
+    }
+
+    protected function assertEnumerations($expected, $actual)
+    {
+        $this->assertEquals(
+            $expected,
+            $actual,
+            "Failed asserting that {$actual} items that were enumerated matches expected {$expected}."
+        );
+    }
+
+    protected function countEnumerations(LazyCollection $collection, &$count)
+    {
+        return $collection->tapEach(function () use (&$count) {
+            $count++;
+        });
+    }
+}

--- a/tests/Support/Concerns/CountsEnumerations.php
+++ b/tests/Support/Concerns/CountsEnumerations.php
@@ -7,6 +7,21 @@ use Illuminate\Support\LazyCollection;
 
 trait CountsEnumerations
 {
+    protected function makeGeneratorFunctionWithRecorder($numbers = 10)
+    {
+        $recorder = new Collection();
+
+        $generatorFunction = function () use ($numbers, $recorder) {
+            for ($i = 1; $i <= $numbers; $i++) {
+                $recorder->push($i);
+
+                yield $i;
+            }
+        };
+
+        return [$generatorFunction, $recorder];
+    }
+
     protected function assertDoesNotEnumerate(callable $executor)
     {
         $this->assertEnumerates(0, $executor);

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -10,6 +10,31 @@ class SupportLazyCollectionIsLazyTest extends TestCase
 {
     use Concerns\CountsEnumerations;
 
+    public function testMakeWithClosureIsLazy()
+    {
+        [$closure, $recorder] = $this->makeGeneratorFunctionWithRecorder();
+
+        LazyCollection::make($closure);
+
+        $this->assertEquals([], $recorder->all());
+    }
+
+    public function testMakeWithLazyCollectionIsLazy()
+    {
+        $this->assertDoesNotEnumerate(function ($collection) {
+            LazyCollection::make($collection);
+        });
+    }
+
+    public function testMakeWithGeneratorIsNotLazy()
+    {
+        [$closure, $recorder] = $this->makeGeneratorFunctionWithRecorder(5);
+
+        LazyCollection::make($closure());
+
+        $this->assertEquals([1, 2, 3, 4, 5], $recorder->all());
+    }
+
     public function testEagerEnumeratesOnce()
     {
         $this->assertEnumeratesOnce(function ($collection) {

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -8,6 +8,8 @@ use stdClass;
 
 class SupportLazyCollectionIsLazyTest extends TestCase
 {
+    use Concerns\CountsEnumerations;
+
     public function testEagerEnumeratesOnce()
     {
         $this->assertEnumeratesOnce(function ($collection) {
@@ -1445,78 +1447,5 @@ class SupportLazyCollectionIsLazyTest extends TestCase
     protected function make($source)
     {
         return new LazyCollection($source);
-    }
-
-    protected function assertDoesNotEnumerate(callable $executor)
-    {
-        $this->assertEnumerates(0, $executor);
-    }
-
-    protected function assertDoesNotEnumerateCollection(
-        LazyCollection $collection,
-        callable $executor
-    ) {
-        $this->assertEnumeratesCollection($collection, 0, $executor);
-    }
-
-    protected function assertEnumerates($count, callable $executor)
-    {
-        $this->assertEnumeratesCollection(
-            LazyCollection::times(100),
-            $count,
-            $executor
-        );
-    }
-
-    protected function assertEnumeratesCollection(
-        LazyCollection $collection,
-        $count,
-        callable $executor
-    ) {
-        $enumerated = 0;
-
-        $data = $this->countEnumerations($collection, $enumerated);
-
-        $executor($data);
-
-        $this->assertEnumerations($count, $enumerated);
-    }
-
-    protected function assertEnumeratesOnce(callable $executor)
-    {
-        $this->assertEnumeratesCollectionOnce(LazyCollection::times(10), $executor);
-    }
-
-    protected function assertEnumeratesCollectionOnce(
-        LazyCollection $collection,
-        callable $executor
-    ) {
-        $enumerated = 0;
-        $count = $collection->count();
-        $collection = $this->countEnumerations($collection, $enumerated);
-
-        $executor($collection);
-
-        $this->assertEquals(
-            $count,
-            $enumerated,
-            $count > $enumerated ? 'Failed to enumerate in full.' : 'Enumerated more than once.'
-        );
-    }
-
-    protected function assertEnumerations($expected, $actual)
-    {
-        $this->assertEquals(
-            $expected,
-            $actual,
-            "Failed asserting that {$actual} items that were enumerated matches expected {$expected}."
-        );
-    }
-
-    protected function countEnumerations(LazyCollection $collection, &$count)
-    {
-        return $collection->tapEach(function () use (&$count) {
-            $count++;
-        });
     }
 }


### PR DESCRIPTION
This adds tests ensuring that:

1. Constructing a new `LazyCollection` instance from a generator function _is_ lazy.
2. Constructing a new `LazyCollection` instance from another `LazyCollection` instance _is_ lazy.
3. Constructing a new `LazyCollection` instance from a `Generator` object _is not_ lazy.

See here for reference: https://github.com/laravel/framework/issues/36837#issuecomment-811926022