### PR TITLE
[8.x] Support empty strings

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -417,7 +417,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
     protected function compileStatements($value)
     {
         return preg_replace_callback(
-            '/\B@(@?\w+(?:::\w+)?)([ \t]*)(\( ( (?>\'[^\']+\') | (?>"[^"]+") | (?>[^()\'"]+) | (?3) )* \))?/x', function ($match) {
+            '/\B@(@?\w+(?:::\w+)?)([ \t]*)(\( ( (?>\'[^\']*\') | (?>"[^"]*") | (?>[^()\'"]+) | (?3) )* \))?/x', function ($match) {
                 return $this->compileStatement($match);
             }, $value
         );

--- a/tests/View/Blade/BladePhpStatementsTest.php
+++ b/tests/View/Blade/BladePhpStatementsTest.php
@@ -52,4 +52,19 @@ class BladePhpStatementsTest extends AbstractBladeTestCase
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
+
+    public function testStringWithEmptyStringDataValue()
+    {
+        $string = "@php(\$data = ['test' => ''])";
+
+        $expected = "<?php (\$data = ['test' => '']); ?>";
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+
+        $string = "@php(\$data = ['test' => \"\"])";
+
+        $expected = "<?php (\$data = ['test' => \"\"]); ?>";
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
 }


### PR DESCRIPTION
This is a fast follow fix for #36843 to match both single and double quoted strings. Complete with additional tests.