### PR TITLE
[6.x] SQL Server build

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -124,7 +124,7 @@ jobs:
         run: vendor/bin/phpunit tests/Integration/Database --verbose --stop-on-failure --exclude-group MySQL
         env:
           DB_CONNECTION: sqlsrv
-          DB_HOST=0.0.0.0
+          DB_HOST: "0.0.0.0"
           DB_PASSWORD: Forge123
 
 #  windows_tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -123,7 +123,7 @@ jobs:
         run: vendor/bin/phpunit tests/Integration/Database --verbose --stop-on-failure --exclude-group MySQL
         env:
           DB_CONNECTION: sqlsrv
-          DB_USERNAME: ""
+          DB_USERNAME: SA
           DB_PASSWORD: Forge123
 
 #  windows_tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,77 +7,77 @@ on:
     - cron: '0 0 * * *'
 
 jobs:
-#  linux_tests:
-#    runs-on: ubuntu-20.04
-#
-#    services:
-#      memcached:
-#        image: memcached:1.6-alpine
-#        ports:
-#          - 11211:11211
-#      mysql:
-#        image: mysql:5.7
-#        env:
-#          MYSQL_ALLOW_EMPTY_PASSWORD: yes
-#          MYSQL_DATABASE: forge
-#        ports:
-#          - 33306:3306
-#        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
-#      redis:
-#        image: redis:5.0
-#        ports:
-#          - 6379:6379
-#        options: --entrypoint redis-server
-#
-#    strategy:
-#      fail-fast: true
-#      matrix:
-#        php: ['7.2', '7.3', '7.4', '8.0']
-#        stability: [prefer-lowest, prefer-stable]
-#
-#    name: PHP ${{ matrix.php }} - ${{ matrix.stability }}
-#
-#    steps:
-#      - name: Checkout code
-#        uses: actions/checkout@v2
-#
-#      - name: Setup PHP
-#        uses: shivammathur/setup-php@v2
-#        with:
-#          php-version: ${{ matrix.php }}
-#          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, gd, redis, memcached
-#          tools: composer:v2
-#          coverage: none
-#
-#      - name: Set Minimum Guzzle Version
-#        uses: nick-invision/retry@v1
-#        with:
-#          timeout_minutes: 5
-#          max_attempts: 5
-#          command: composer require guzzlehttp/guzzle:^7.2 --no-interaction --no-update
-#        if: matrix.php >= 8
-#
-#      - name: Install dependencies
-#        uses: nick-invision/retry@v1
-#        with:
-#          timeout_minutes: 5
-#          max_attempts: 5
-#          command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
-#
-#      - name: Setup DynamoDB Local
-#        uses: rrainn/dynamodb-action@v2.0.0
-#        with:
-#          port: 8888
-#
-#      - name: Execute tests
-#        run: vendor/bin/phpunit --verbose
-#        env:
-#          DB_PORT: ${{ job.services.mysql.ports[3306] }}
-#          DB_USERNAME: root
-#          DYNAMODB_CACHE_TABLE: laravel_dynamodb_test
-#          DYNAMODB_ENDPOINT: "http://localhost:8888"
-#          AWS_ACCESS_KEY_ID: random_key
-#          AWS_SECRET_ACCESS_KEY: random_secret
+  linux_tests:
+    runs-on: ubuntu-20.04
+
+    services:
+      memcached:
+        image: memcached:1.6-alpine
+        ports:
+          - 11211:11211
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: yes
+          MYSQL_DATABASE: forge
+        ports:
+          - 33306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+      redis:
+        image: redis:5.0
+        ports:
+          - 6379:6379
+        options: --entrypoint redis-server
+
+    strategy:
+      fail-fast: true
+      matrix:
+        php: ['7.2', '7.3', '7.4', '8.0']
+        stability: [prefer-lowest, prefer-stable]
+
+    name: PHP ${{ matrix.php }} - ${{ matrix.stability }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, gd, redis, memcached
+          tools: composer:v2
+          coverage: none
+
+      - name: Set Minimum Guzzle Version
+        uses: nick-invision/retry@v1
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          command: composer require guzzlehttp/guzzle:^7.2 --no-interaction --no-update
+        if: matrix.php >= 8
+
+      - name: Install dependencies
+        uses: nick-invision/retry@v1
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
+
+      - name: Setup DynamoDB Local
+        uses: rrainn/dynamodb-action@v2.0.0
+        with:
+          port: 8888
+
+      - name: Execute tests
+        run: vendor/bin/phpunit --verbose
+        env:
+          DB_PORT: ${{ job.services.mysql.ports[3306] }}
+          DB_USERNAME: root
+          DYNAMODB_CACHE_TABLE: laravel_dynamodb_test
+          DYNAMODB_ENDPOINT: "http://localhost:8888"
+          AWS_ACCESS_KEY_ID: random_key
+          AWS_SECRET_ACCESS_KEY: random_secret
 
   sqlsrv_tests:
     runs-on: ubuntu-20.04
@@ -127,48 +127,48 @@ jobs:
           DB_USERNAME: SA
           DB_PASSWORD: Forge123
 
-#  windows_tests:
-#    runs-on: windows-2019
-#
-#    strategy:
-#      fail-fast: true
-#      matrix:
-#        php: ['7.2', '7.3', '7.4', '8.0']
-#        stability: [prefer-lowest, prefer-stable]
-#
-#    name: PHP ${{ matrix.php }} - ${{ matrix.stability }} - Windows
-#
-#    steps:
-#      - name: Set git to use LF
-#        run: |
-#          git config --global core.autocrlf false
-#          git config --global core.eol lf
-#
-#      - name: Checkout code
-#        uses: actions/checkout@v2
-#
-#      - name: Setup PHP
-#        uses: shivammathur/setup-php@v2
-#        with:
-#          php-version: ${{ matrix.php }}
-#          extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite, gd, pdo_mysql, fileinfo, ftp, redis, memcached
-#          tools: composer:v2
-#          coverage: none
-#
-#      - name: Set Minimum Guzzle Version
-#        uses: nick-invision/retry@v1
-#        with:
-#          timeout_minutes: 5
-#          max_attempts: 5
-#          command: composer require guzzlehttp/guzzle:^7.2 --no-interaction --no-update
-#        if: matrix.php >= 8
-#
-#      - name: Install dependencies
-#        uses: nick-invision/retry@v1
-#        with:
-#          timeout_minutes: 5
-#          max_attempts: 5
-#          command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
-#
-#      - name: Execute tests
-#        run: vendor/bin/phpunit --verbose
+  windows_tests:
+    runs-on: windows-2019
+
+    strategy:
+      fail-fast: true
+      matrix:
+        php: ['7.2', '7.3', '7.4', '8.0']
+        stability: [prefer-lowest, prefer-stable]
+
+    name: PHP ${{ matrix.php }} - ${{ matrix.stability }} - Windows
+
+    steps:
+      - name: Set git to use LF
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite, gd, pdo_mysql, fileinfo, ftp, redis, memcached
+          tools: composer:v2
+          coverage: none
+
+      - name: Set Minimum Guzzle Version
+        uses: nick-invision/retry@v1
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          command: composer require guzzlehttp/guzzle:^7.2 --no-interaction --no-update
+        if: matrix.php >= 8
+
+      - name: Install dependencies
+        uses: nick-invision/retry@v1
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
+
+      - name: Execute tests
+        run: vendor/bin/phpunit --verbose

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,80 +7,90 @@ on:
     - cron: '0 0 * * *'
 
 jobs:
-  linux_tests:
-    runs-on: ubuntu-20.04
-
-    services:
-      memcached:
-        image: memcached:1.6-alpine
-        ports:
-          - 11211:11211
-      mysql:
-        image: mysql:5.7
-        env:
-          MYSQL_ALLOW_EMPTY_PASSWORD: yes
-          MYSQL_DATABASE: forge
-        ports:
-          - 33306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
-      redis:
-        image: redis:5.0
-        ports:
-          - 6379:6379
-        options: --entrypoint redis-server
-
-    strategy:
-      fail-fast: true
-      matrix:
-        php: ['7.2', '7.3', '7.4', '8.0']
-        stability: [prefer-lowest, prefer-stable]
-
-    name: PHP ${{ matrix.php }} - ${{ matrix.stability }}
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, gd, redis, memcached
-          tools: composer:v2
-          coverage: none
-
-      - name: Set Minimum Guzzle Version
-        uses: nick-invision/retry@v1
-        with:
-          timeout_minutes: 5
-          max_attempts: 5
-          command: composer require guzzlehttp/guzzle:^7.2 --no-interaction --no-update
-        if: matrix.php >= 8
-
-      - name: Install dependencies
-        uses: nick-invision/retry@v1
-        with:
-          timeout_minutes: 5
-          max_attempts: 5
-          command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
-
-      - name: Setup DynamoDB Local
-        uses: rrainn/dynamodb-action@v2.0.0
-        with:
-          port: 8888
-
-      - name: Execute tests
-        run: vendor/bin/phpunit --verbose
-        env:
-          DB_PORT: ${{ job.services.mysql.ports[3306] }}
-          DB_USERNAME: root
-          DYNAMODB_CACHE_TABLE: laravel_dynamodb_test
-          DYNAMODB_ENDPOINT: "http://localhost:8888"
-          AWS_ACCESS_KEY_ID: random_key
-          AWS_SECRET_ACCESS_KEY: random_secret
+#  linux_tests:
+#    runs-on: ubuntu-20.04
+#
+#    services:
+#      memcached:
+#        image: memcached:1.6-alpine
+#        ports:
+#          - 11211:11211
+#      mysql:
+#        image: mysql:5.7
+#        env:
+#          MYSQL_ALLOW_EMPTY_PASSWORD: yes
+#          MYSQL_DATABASE: forge
+#        ports:
+#          - 33306:3306
+#        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+#      redis:
+#        image: redis:5.0
+#        ports:
+#          - 6379:6379
+#        options: --entrypoint redis-server
+#
+#    strategy:
+#      fail-fast: true
+#      matrix:
+#        php: ['7.2', '7.3', '7.4', '8.0']
+#        stability: [prefer-lowest, prefer-stable]
+#
+#    name: PHP ${{ matrix.php }} - ${{ matrix.stability }}
+#
+#    steps:
+#      - name: Checkout code
+#        uses: actions/checkout@v2
+#
+#      - name: Setup PHP
+#        uses: shivammathur/setup-php@v2
+#        with:
+#          php-version: ${{ matrix.php }}
+#          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, gd, redis, memcached
+#          tools: composer:v2
+#          coverage: none
+#
+#      - name: Set Minimum Guzzle Version
+#        uses: nick-invision/retry@v1
+#        with:
+#          timeout_minutes: 5
+#          max_attempts: 5
+#          command: composer require guzzlehttp/guzzle:^7.2 --no-interaction --no-update
+#        if: matrix.php >= 8
+#
+#      - name: Install dependencies
+#        uses: nick-invision/retry@v1
+#        with:
+#          timeout_minutes: 5
+#          max_attempts: 5
+#          command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
+#
+#      - name: Setup DynamoDB Local
+#        uses: rrainn/dynamodb-action@v2.0.0
+#        with:
+#          port: 8888
+#
+#      - name: Execute tests
+#        run: vendor/bin/phpunit --verbose
+#        env:
+#          DB_PORT: ${{ job.services.mysql.ports[3306] }}
+#          DB_USERNAME: root
+#          DYNAMODB_CACHE_TABLE: laravel_dynamodb_test
+#          DYNAMODB_ENDPOINT: "http://localhost:8888"
+#          AWS_ACCESS_KEY_ID: random_key
+#          AWS_SECRET_ACCESS_KEY: random_secret
 
   windows_tests:
     runs-on: windows-2019
+
+    services:
+      sqlsrv:
+        image: mcr.microsoft.com/mssql/server:2019-latest
+        env:
+          ACCEPT_EULA: Y
+          SA_PASSWORD: forge
+          MSSQL_PID: forge
+        ports:
+          - 1433:1433
 
     strategy:
       fail-fast: true
@@ -123,6 +133,6 @@ jobs:
           command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
 
       - name: Execute tests
-        run: vendor/bin/phpunit --verbose
+        run: vendor/bin/phpunit tests/Integration/Database/EloquentDeleteTest.php --verbose
         env:
           DB_CONNECTION: sqlsrv

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -122,7 +122,7 @@ jobs:
           command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
 
       - name: Execute tests
-        run: vendor/bin/phpunit tests/Integration/Database --verbose --stop-on-failure
+        run: vendor/bin/phpunit tests/Integration/Database --verbose --stop-on-failure --exclude-group MySQL
         env:
           DB_CONNECTION: sqlsrv
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,6 +28,7 @@ jobs:
         ports:
           - 6379:6379
         options: --entrypoint redis-server
+
     strategy:
       fail-fast: true
       matrix:
@@ -79,7 +80,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: random_secret
 
   windows_tests:
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     strategy:
       fail-fast: true
@@ -123,3 +124,5 @@ jobs:
 
       - name: Execute tests
         run: vendor/bin/phpunit --verbose
+        env:
+          DB_CONNECTION: sqlsrv

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -120,7 +120,7 @@ jobs:
           command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
 
       - name: Execute tests
-        run: vendor/bin/phpunit tests/Integration/Database --verbose --stop-on-failure --exclude-group MySQL
+        run: vendor/bin/phpunit tests/Integration/Database --exclude-group MySQL --verbose
         env:
           DB_CONNECTION: sqlsrv
           DB_DATABASE: master

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -123,6 +123,7 @@ jobs:
         run: vendor/bin/phpunit tests/Integration/Database --verbose --stop-on-failure --exclude-group MySQL
         env:
           DB_CONNECTION: sqlsrv
+          DB_DATABASE: master
           DB_USERNAME: SA
           DB_PASSWORD: Forge123
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,7 +88,6 @@ jobs:
         env:
           ACCEPT_EULA: Y
           SA_PASSWORD: Forge123
-          MSSQL_PID: Developer
         ports:
           - 1433:1433
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -122,6 +122,7 @@ jobs:
         run: vendor/bin/phpunit tests/Integration/Database --verbose --stop-on-failure --exclude-group MySQL
         env:
           DB_CONNECTION: sqlsrv
+          DB_USERNAME: ""
           DB_PASSWORD: Forge123
 
 #  windows_tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,7 +88,6 @@ jobs:
         env:
           ACCEPT_EULA: Y
           SA_PASSWORD: forge
-          MSSQL_PID: forge
         ports:
           - 1433:1433
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,10 +94,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-#        php: ['7.2', '7.3', '7.4', '8.0']
-#        stability: [ prefer-lowest, prefer-stable ]
         php: ['8.0']
-        stability: [ prefer-stable ]
+        stability: [prefer-stable]
 
     name: PHP ${{ matrix.php }} - ${{ matrix.stability }} - SQL Server
 
@@ -109,7 +107,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, pdo_sqlsrv
           tools: composer:v2
           coverage: none
 
@@ -124,7 +122,6 @@ jobs:
         run: vendor/bin/phpunit tests/Integration/Database --verbose --stop-on-failure --exclude-group MySQL
         env:
           DB_CONNECTION: sqlsrv
-          DB_HOST: "0.0.0.0"
           DB_PASSWORD: Forge123
 
 #  windows_tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,6 +88,7 @@ jobs:
         env:
           ACCEPT_EULA: Y
           SA_PASSWORD: Forge123
+          MSSQL_PID: Developer
         ports:
           - 1433:1433
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -124,6 +124,7 @@ jobs:
         run: vendor/bin/phpunit tests/Integration/Database --verbose --stop-on-failure --exclude-group MySQL
         env:
           DB_CONNECTION: sqlsrv
+          DB_HOST=0.0.0.0
           DB_PASSWORD: Forge123
 
 #  windows_tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,7 +87,7 @@ jobs:
         image: mcr.microsoft.com/mssql/server:2019-latest
         env:
           ACCEPT_EULA: Y
-          SA_PASSWORD: forge
+          SA_PASSWORD: Forge123
         ports:
           - 1433:1433
 
@@ -124,6 +124,7 @@ jobs:
         run: vendor/bin/phpunit tests/Integration/Database --verbose --stop-on-failure --exclude-group MySQL
         env:
           DB_CONNECTION: sqlsrv
+          DB_PASSWORD: Forge123
 
 #  windows_tests:
 #    runs-on: windows-2019

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,8 +79,8 @@ jobs:
 #          AWS_ACCESS_KEY_ID: random_key
 #          AWS_SECRET_ACCESS_KEY: random_secret
 
-  windows_tests:
-    runs-on: windows-2019
+  sqlsrv_tests:
+    runs-on: ubuntu-20.04
 
     services:
       sqlsrv:
@@ -95,17 +95,14 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: ['7.2', '7.3', '7.4', '8.0']
-        stability: [prefer-lowest, prefer-stable]
+#        php: ['7.2', '7.3', '7.4', '8.0']
+#        stability: [ prefer-lowest, prefer-stable ]
+        php: ['8.0']
+        stability: [ prefer-stable ]
 
-    name: PHP ${{ matrix.php }} - ${{ matrix.stability }} - Windows
+    name: PHP ${{ matrix.php }} - ${{ matrix.stability }} - SQL Server
 
     steps:
-      - name: Set git to use LF
-        run: |
-          git config --global core.autocrlf false
-          git config --global core.eol lf
-
       - name: Checkout code
         uses: actions/checkout@v2
 
@@ -113,17 +110,9 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite, gd, pdo_mysql, fileinfo, ftp, redis, memcached
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo
           tools: composer:v2
           coverage: none
-
-      - name: Set Minimum Guzzle Version
-        uses: nick-invision/retry@v1
-        with:
-          timeout_minutes: 5
-          max_attempts: 5
-          command: composer require guzzlehttp/guzzle:^7.2 --no-interaction --no-update
-        if: matrix.php >= 8
 
       - name: Install dependencies
         uses: nick-invision/retry@v1
@@ -133,6 +122,52 @@ jobs:
           command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
 
       - name: Execute tests
-        run: vendor/bin/phpunit tests/Integration/Database/EloquentDeleteTest.php --verbose
+        run: vendor/bin/phpunit tests/Integration/Database --verbose
         env:
           DB_CONNECTION: sqlsrv
+
+#  windows_tests:
+#    runs-on: windows-2019
+#
+#    strategy:
+#      fail-fast: true
+#      matrix:
+#        php: ['7.2', '7.3', '7.4', '8.0']
+#        stability: [prefer-lowest, prefer-stable]
+#
+#    name: PHP ${{ matrix.php }} - ${{ matrix.stability }} - Windows
+#
+#    steps:
+#      - name: Set git to use LF
+#        run: |
+#          git config --global core.autocrlf false
+#          git config --global core.eol lf
+#
+#      - name: Checkout code
+#        uses: actions/checkout@v2
+#
+#      - name: Setup PHP
+#        uses: shivammathur/setup-php@v2
+#        with:
+#          php-version: ${{ matrix.php }}
+#          extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite, gd, pdo_mysql, fileinfo, ftp, redis, memcached
+#          tools: composer:v2
+#          coverage: none
+#
+#      - name: Set Minimum Guzzle Version
+#        uses: nick-invision/retry@v1
+#        with:
+#          timeout_minutes: 5
+#          max_attempts: 5
+#          command: composer require guzzlehttp/guzzle:^7.2 --no-interaction --no-update
+#        if: matrix.php >= 8
+#
+#      - name: Install dependencies
+#        uses: nick-invision/retry@v1
+#        with:
+#          timeout_minutes: 5
+#          max_attempts: 5
+#          command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
+#
+#      - name: Execute tests
+#        run: vendor/bin/phpunit --verbose

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -122,7 +122,7 @@ jobs:
           command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
 
       - name: Execute tests
-        run: vendor/bin/phpunit tests/Integration/Database --verbose
+        run: vendor/bin/phpunit tests/Integration/Database --verbose --stop-on-failure
         env:
           DB_CONNECTION: sqlsrv
 

--- a/tests/Integration/Database/DatabaseEmulatePreparesMySqlConnectionTest.php
+++ b/tests/Integration/Database/DatabaseEmulatePreparesMySqlConnectionTest.php
@@ -6,6 +6,7 @@ use PDO;
 
 /**
  * @requires extension pdo_mysql
+ * @group MySQL
  */
 class DatabaseEmulatePreparesMySqlConnectionTest extends DatabaseMySqlConnectionTest
 {

--- a/tests/Integration/Database/DatabaseMySqlConnectionTest.php
+++ b/tests/Integration/Database/DatabaseMySqlConnectionTest.php
@@ -9,6 +9,7 @@ use Orchestra\Testbench\TestCase;
 
 /**
  * @requires extension pdo_mysql
+ * @group MySQL
  */
 class DatabaseMySqlConnectionTest extends TestCase
 {

--- a/tests/Integration/Database/DatabaseTestCase.php
+++ b/tests/Integration/Database/DatabaseTestCase.php
@@ -23,7 +23,7 @@ class DatabaseTestCase extends TestCase
 
     protected function tearDown(): void
     {
-        if (! env('DB_CONNECTION')) {
+        if (env('DB_CONNECTION')) {
             $this->artisan('db:wipe');
         }
 

--- a/tests/Integration/Database/DatabaseTestCase.php
+++ b/tests/Integration/Database/DatabaseTestCase.php
@@ -20,4 +20,13 @@ class DatabaseTestCase extends TestCase
             ]);
         }
     }
+
+    protected function tearDown(): void
+    {
+        if (! env('DB_CONNECTION')) {
+            $this->artisan('db:wipe');
+        }
+
+        parent::tearDown();
+    }
 }

--- a/tests/Integration/Database/DatabaseTestCase.php
+++ b/tests/Integration/Database/DatabaseTestCase.php
@@ -10,12 +10,14 @@ class DatabaseTestCase extends TestCase
     {
         $app['config']->set('app.debug', 'true');
 
-        $app['config']->set('database.default', 'testbench');
+        if (! env('DB_CONNECTION')) {
+            $app['config']->set('database.default', 'testbench');
 
-        $app['config']->set('database.connections.testbench', [
-            'driver' => 'sqlite',
-            'database' => ':memory:',
-            'prefix' => '',
-        ]);
+            $app['config']->set('database.connections.testbench', [
+                'driver' => 'sqlite',
+                'database' => ':memory:',
+                'prefix' => '',
+            ]);
+        }
     }
 }

--- a/tests/Integration/Database/EloquentDeleteTest.php
+++ b/tests/Integration/Database/EloquentDeleteTest.php
@@ -7,26 +7,12 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Tests\Integration\Database\Fixtures\Post;
-use Orchestra\Testbench\TestCase;
 
 /**
  * @group integration
  */
-class EloquentDeleteTest extends TestCase
+class EloquentDeleteTest extends DatabaseTestCase
 {
-    protected function getEnvironmentSetUp($app)
-    {
-        $app['config']->set('app.debug', 'true');
-
-        $app['config']->set('database.default', 'testbench');
-
-        $app['config']->set('database.connections.testbench', [
-            'driver' => 'sqlite',
-            'database' => ':memory:',
-            'prefix' => '',
-        ]);
-    }
-
     protected function setUp(): void
     {
         parent::setUp();

--- a/tests/Integration/Database/EloquentFactoryBuilderTest.php
+++ b/tests/Integration/Database/EloquentFactoryBuilderTest.php
@@ -8,23 +8,16 @@ use Illuminate\Database\Eloquent\Factory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-use Orchestra\Testbench\TestCase;
 
 /**
  * @group integration
  */
-class EloquentFactoryBuilderTest extends TestCase
+class EloquentFactoryBuilderTest extends DatabaseTestCase
 {
     protected function getEnvironmentSetUp($app)
     {
-        $app['config']->set('app.debug', 'true');
+        parent::getEnvironmentSetUp($app);
 
-        $app['config']->set('database.default', 'testbench');
-        $app['config']->set('database.connections.testbench', [
-            'driver' => 'sqlite',
-            'database' => ':memory:',
-            'prefix' => '',
-        ]);
         $app['config']->set('database.connections.alternative-connection', [
             'driver' => 'sqlite',
             'database' => ':memory:',

--- a/tests/Integration/Database/EloquentUpdateTest.php
+++ b/tests/Integration/Database/EloquentUpdateTest.php
@@ -7,26 +7,12 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
-use Orchestra\Testbench\TestCase;
 
 /**
  * @group integration
  */
-class EloquentUpdateTest extends TestCase
+class EloquentUpdateTest extends DatabaseTestCase
 {
-    protected function getEnvironmentSetUp($app)
-    {
-        $app['config']->set('app.debug', 'true');
-
-        $app['config']->set('database.default', 'testbench');
-
-        $app['config']->set('database.connections.testbench', [
-            'driver' => 'sqlite',
-            'database' => ':memory:',
-            'prefix' => '',
-        ]);
-    }
-
     protected function setUp(): void
     {
         parent::setUp();


### PR DESCRIPTION
This PR introduces a separate build for Microsoft SQL Server. It primarily focuses on the integration test suite. I've currently successfully set up the CI build. The next step will be to make all the tests to pass. There might be some gotchas concerning SQL Server (like the examples where dates are sent back with microsecond precision) where we'll have to work around.

Follow up PR's for separate MySQL & PostgreSQL builds can be worked on later.

Closes https://github.com/laravel/framework/issues/36398