### PR TITLE
[8.x] Improve the exception thrown when JSON encoding response contents fails

### DIFF
--- a/src/Illuminate/Http/Response.php
+++ b/src/Illuminate/Http/Response.php
@@ -53,6 +53,10 @@ class Response extends SymfonyResponse
             $this->header('Content-Type', 'application/json');
 
             $content = $this->morphToJson($content);
+            
+            if ($content === false) {
+                throw new \UnexpectedValueException(sprintf("Failed to convert the provided Response content to JSON with the message: %s", json_last_error_msg()));
+            }
         }
 
         // If this content implements the "Renderable" interface then we will call the

--- a/src/Illuminate/Http/Response.php
+++ b/src/Illuminate/Http/Response.php
@@ -53,9 +53,9 @@ class Response extends SymfonyResponse
             $this->header('Content-Type', 'application/json');
 
             $content = $this->morphToJson($content);
-            
+
             if ($content === false) {
-                throw new \UnexpectedValueException(sprintf("Failed to convert the provided Response content to JSON with the message: %s", json_last_error_msg()));
+                throw new \UnexpectedValueException(sprintf('Failed to convert the provided Response content to JSON with the message: %s', json_last_error_msg()));
             }
         }
 


### PR DESCRIPTION
This improves on the opaque exception of "The Response content must be a string or object implementing __toString(), “boolean” given." that occurs whenever a call to $response->setContent($varThatFailsJsonEncoding) is made. It is difficult to debug the original exception, because to the developer they are not providing a boolean anywhere in their code, they are passing an array or an object to setContent() and expecting it to work; not knowing that Laravel internally tries to json_encode() that value before passing it along to Symfony, which only understands string values as response contents.

Refs:
- https://stackoverflow.com/a/38772790/6652884
- https://octobercms.com/forum/post/error-on-reset-password
- https://octobercms.com/plugin/support/pixel-shop/bug-and-italian-translation
- https://laravelquestions.com/2017/08/16/the-response-content-must-be-a-string-or-object-implementing-__tostring-boolean-given/
- https://github.com/rainlab/user-plugin/issues/294

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
