### PR TITLE
[8.x] Add type option to make controller

### DIFF
--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -197,7 +197,7 @@ class ControllerMakeCommand extends GeneratorCommand
     {
         return [
             ['api', null, InputOption::VALUE_NONE, 'Exclude the create and edit methods from the controller.'],
-            ['type', null, InputOption::VALUE_REQUIRED, 'Manually define the controller stub file to use.'],
+            ['type', null, InputOption::VALUE_REQUIRED, 'Manually specify the controller stub file to use.'],
             ['force', null, InputOption::VALUE_NONE, 'Create the class even if the controller already exists'],
             ['invokable', 'i', InputOption::VALUE_NONE, 'Generate a single method, invokable controller class.'],
             ['model', 'm', InputOption::VALUE_OPTIONAL, 'Generate a resource controller for the given model.'],

--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -38,7 +38,9 @@ class ControllerMakeCommand extends GeneratorCommand
     {
         $stub = null;
 
-        if ($this->option('parent')) {
+        if ($type = $this->option('type')) {
+            $stub = "/stubs/controller.{$type}.stub";
+        } elseif ($this->option('parent')) {
             $stub = '/stubs/controller.nested.stub';
         } elseif ($this->option('model')) {
             $stub = '/stubs/controller.model.stub';
@@ -195,6 +197,7 @@ class ControllerMakeCommand extends GeneratorCommand
     {
         return [
             ['api', null, InputOption::VALUE_NONE, 'Exclude the create and edit methods from the controller.'],
+            ['type', null, InputOption::VALUE_REQUIRED, 'Manually define the controller stub file to use.'],
             ['force', null, InputOption::VALUE_NONE, 'Create the class even if the controller already exists'],
             ['invokable', 'i', InputOption::VALUE_NONE, 'Generate a single method, invokable controller class.'],
             ['model', 'm', InputOption::VALUE_OPTIONAL, 'Generate a resource controller for the given model.'],


### PR DESCRIPTION
PR enables users to define a custom stub type for controllers. 

```
php artisan make:controller CustomController --type=custom
```
```
/stubs/controller.custom.stub
```

This PR does not change any current behavior except for which file to use.

So options like --model=Post  and --parent=Author work exactly the same:

```php
{{ namespacedModel }}
{{ namespacedParentModel }}
```
```php
App\Models\Post
App\Models\Author
```

### Usage:

This works great for any scenario where you have a slightly unique edge case.

Currently needing it for a repetitive controller format `pivot` that only has `store()` and `delete()`

### Note:

Only imperfection is the missing stub exception message:
```
File does not exist at path /Users/brian/Sites/app-name/framework/src/Illuminate/Routing/Console/stubs/controller.custom.stub
```
Im happy to add an exception If you would like: 
```php
abort_if(! file_exists(base_path("/stubs/controller.{$type}.stub")), 500, "Stub not found: controller.{$type}.stub");
```