### PR TITLE
[8.x] Allowing skipping TransformRequests middleware via Closure

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/ConvertEmptyStringsToNull.php
+++ b/src/Illuminate/Foundation/Http/Middleware/ConvertEmptyStringsToNull.php
@@ -2,8 +2,35 @@
 
 namespace Illuminate\Foundation\Http\Middleware;
 
+use Closure;
+
 class ConvertEmptyStringsToNull extends TransformsRequest
 {
+    /**
+     * All of the registered skip callbacks.
+     *
+     * @var array
+     */
+    protected static $skipCallbacks = [];
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        foreach (static::$skipCallbacks as $callback) {
+            if ($callback($request)) {
+                return $next($request);
+            }
+        }
+
+        return parent::handle($request, $next);
+    }
+
     /**
      * Transform the given value.
      *
@@ -14,5 +41,16 @@ class ConvertEmptyStringsToNull extends TransformsRequest
     protected function transform($key, $value)
     {
         return is_string($value) && $value === '' ? null : $value;
+    }
+
+    /**
+     * Register a callback that instructs the middleware to be skipped.
+     *
+     * @param  \Closure  $callback
+     * @return void
+     */
+    public static function skipWhen(Closure $callback)
+    {
+        static::$skipCallbacks[] = $callback;
     }
 }

--- a/src/Illuminate/Foundation/Http/Middleware/TransformsRequest.php
+++ b/src/Illuminate/Foundation/Http/Middleware/TransformsRequest.php
@@ -8,13 +8,6 @@ use Symfony\Component\HttpFoundation\ParameterBag;
 class TransformsRequest
 {
     /**
-     * All of the registered skip callbacks.
-     *
-     * @var array
-     */
-    protected static $skipCallbacks = [];
-
-    /**
      * Handle an incoming request.
      *
      * @param  \Illuminate\Http\Request  $request
@@ -23,12 +16,6 @@ class TransformsRequest
      */
     public function handle($request, Closure $next)
     {
-        foreach (static::$skipCallbacks as $callback) {
-            if ($callback($request)) {
-                return $next($request);
-            }
-        }
-
         $this->clean($request);
 
         return $next($request);
@@ -104,16 +91,5 @@ class TransformsRequest
     protected function transform($key, $value)
     {
         return $value;
-    }
-
-    /**
-     * Register a callback that instructs the middleware to be skipped.
-     *
-     * @param  \Closure  $callback
-     * @return void
-     */
-    public static function skipWhen(Closure $callback)
-    {
-        static::$skipCallbacks[] = $callback;
     }
 }

--- a/src/Illuminate/Foundation/Http/Middleware/TransformsRequest.php
+++ b/src/Illuminate/Foundation/Http/Middleware/TransformsRequest.php
@@ -8,6 +8,13 @@ use Symfony\Component\HttpFoundation\ParameterBag;
 class TransformsRequest
 {
     /**
+     * All of the registered skip callbacks.
+     *
+     * @var array
+     */
+    protected static $skipCallbacks = [];
+
+    /**
      * Handle an incoming request.
      *
      * @param  \Illuminate\Http\Request  $request
@@ -16,6 +23,12 @@ class TransformsRequest
      */
     public function handle($request, Closure $next)
     {
+        foreach (static::$skipCallbacks as $callback) {
+            if ($callback($request)) {
+                return $next($request);
+            }
+        }
+
         $this->clean($request);
 
         return $next($request);
@@ -91,5 +104,16 @@ class TransformsRequest
     protected function transform($key, $value)
     {
         return $value;
+    }
+
+    /**
+     * Register a callback that instructs the middleware to be skipped.
+     *
+     * @param  \Closure  $callback
+     * @return void
+     */
+    public static function skipWhen(Closure $callback)
+    {
+        static::$skipCallbacks[] = $callback;
     }
 }

--- a/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
+++ b/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
@@ -2,8 +2,17 @@
 
 namespace Illuminate\Foundation\Http\Middleware;
 
+use Closure;
+
 class TrimStrings extends TransformsRequest
 {
+    /**
+     * All of the registered skip callbacks.
+     *
+     * @var array
+     */
+    protected static $skipCallbacks = [];
+
     /**
      * The attributes that should not be trimmed.
      *
@@ -12,6 +21,24 @@ class TrimStrings extends TransformsRequest
     protected $except = [
         //
     ];
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        foreach (static::$skipCallbacks as $callback) {
+            if ($callback($request)) {
+                return $next($request);
+            }
+        }
+
+        return parent::handle($request, $next);
+    }
 
     /**
      * Transform the given value.
@@ -27,5 +54,16 @@ class TrimStrings extends TransformsRequest
         }
 
         return is_string($value) ? trim($value) : $value;
+    }
+
+    /**
+     * Register a callback that instructs the middleware to be skipped.
+     *
+     * @param  \Closure  $callback
+     * @return void
+     */
+    public static function skipWhen(Closure $callback)
+    {
+        static::$skipCallbacks[] = $callback;
     }
 }


### PR DESCRIPTION
Currently, Livewire has to do some nasty hacking to skip these middleware on certain requests and the approach is not suitable for use with Octane. Adding this feature will allow Livewire and other libraries to register a callback with this base middleware during the framework's boot process to determine if the middleware should be skipped. That callback will receive the current request on each invocation.

```php
TrimStrings::skipWhen(fn ($request) => shouldBeSkipped($request));
ConvertEmptyStringsToNull::skipWhen(fn ($request) => shouldBeSkipped($request));
```