### PR TITLE
[8.x] assertDatabaseHas accepts Model

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -17,13 +17,17 @@ trait InteractsWithDatabase
     /**
      * Assert that a given where condition exists in the database.
      *
-     * @param  string  $table
+     * @param  \Illuminate\Database\Eloquent\Model|string  $table
      * @param  array  $data
      * @param  string|null  $connection
      * @return $this
      */
-    protected function assertDatabaseHas($table, array $data, $connection = null)
+    protected function assertDatabaseHas($table, array $data = [], $connection = null)
     {
+        if ($table instanceof Model) {
+            return $this->assertDatabaseHas($table->getTable(), [$table->getKeyName() => $table->getKey()], $table->getConnectionName());
+        }
+
         $this->assertThat(
             $table, new HasInDatabase($this->getConnection($connection), $data)
         );

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -41,6 +41,17 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertDatabaseHas($this->table, $this->data);
     }
 
+    public function testSeeInDatabaseFindModelResults()
+    {
+        $this->data = ['id' => 1];
+
+        $builder = $this->mockCountBuilder(1);
+
+        $builder->shouldReceive('get')->andReturn(collect());
+
+        $this->assertDatabaseHas(new ProductStub($this->data));
+    }
+
     public function testSeeInDatabaseDoesNotFindResults()
     {
         $this->expectException(ExpectationFailedException::class);


### PR DESCRIPTION
Small but non-breaking change to test assertion `assertDatabaseHas`'s parameters. Much like `assertSoftDeleted` or `assertDeleted` the `assertDatabaseHas` method will now accept a Eloquent model instead of the `table` parameter with no further parameters to the method. This then automatically applies the model's table and key + key value to the `assertDatabaseHas` making test readability that tiny bit better with models already created in the test.

```php
$model = new User(['id' => 1]);

// Current usage
$this->assertDatabaseHas('users', ['id' => $model->id]);

// New usage
$this->assertDatabaseHas($model);
```