### PR TITLE
[8.x] Add missing port when replacing S3 temporary_url

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -631,7 +631,10 @@ class FilesystemAdapter implements CloudFilesystemContract
     {
         $parsed = parse_url($url);
 
-        return $uri->withScheme($parsed['scheme'])->withHost($parsed['host'])->withPort($parsed['port']);
+        return $uri
+            ->withScheme($parsed['scheme'])
+            ->withHost($parsed['host'])
+            ->withPort($parsed['port'] ?? null);
     }
 
     /**

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -621,7 +621,7 @@ class FilesystemAdapter implements CloudFilesystemContract
     }
 
     /**
-     * Replace the scheme and host of the given UriInterface with values from the given URL.
+     * Replace the scheme, host and port of the given UriInterface with values from the given URL.
      *
      * @param  \Psr\Http\Message\UriInterface  $uri
      * @param  string  $url
@@ -631,7 +631,7 @@ class FilesystemAdapter implements CloudFilesystemContract
     {
         $parsed = parse_url($url);
 
-        return $uri->withScheme($parsed['scheme'])->withHost($parsed['host']);
+        return $uri->withScheme($parsed['scheme'])->withHost($parsed['host'])->withPort($parsed['port']);
     }
 
     /**


### PR DESCRIPTION
When we change the `temporary_url` config for S3, laravel does not include the port.

Example config

```php
// ...
'endpoint' => env('AWS_ENDPOINT', 'https://example.com:8000'),
'temporary_url' => env('AWS_TEMPORARY_URL', 'http://temp.example.com:8888'),
//...
```

`Storage::temporaryUrl()` will return the port `8000` instead of `8888`. 

This PR resolve that issue.