### PR TITLE
[8.x] Composer dumpAutoloads mustRun

### DIFF
--- a/src/Illuminate/Support/Composer.php
+++ b/src/Illuminate/Support/Composer.php
@@ -47,7 +47,7 @@ class Composer
 
         $command = array_merge($this->findComposer(), ['dump-autoload'], $extra);
 
-        $this->getProcess($command)->run();
+        $this->getProcess($command)->mustRun();
     }
 
     /**


### PR DESCRIPTION
I was having an issue where `dumpAutoloads` wasn't working, and it wasn't even giving feedback about the it.
Since `dumpAutoloads` doesn't do any visible changes on the project I wrongly assumed it was working when it wasn't.

By having `mustRun` instead of `run`, `Symfony\Component\Process` will throw a `ProcessFailedException` which will let developers know it is not working, and perhaps catch the error and do whatever is needed.