### PR TITLE
[8.x] Composer dumpAutoloads returns the status code of the process

### DIFF
--- a/src/Illuminate/Support/Composer.php
+++ b/src/Illuminate/Support/Composer.php
@@ -39,7 +39,7 @@ class Composer
      * Regenerate the Composer autoloader files.
      *
      * @param  string|array  $extra
-     * @return void
+     * @return int The process exit status code
      */
     public function dumpAutoloads($extra = '')
     {
@@ -47,17 +47,17 @@ class Composer
 
         $command = array_merge($this->findComposer(), ['dump-autoload'], $extra);
 
-        $this->getProcess($command)->run();
+        return $this->getProcess($command)->run();
     }
 
     /**
      * Regenerate the optimized Composer autoloader files.
      *
-     * @return void
+     * @return int The process exit status code
      */
     public function dumpOptimized()
     {
-        $this->dumpAutoloads('--optimize');
+        return $this->dumpAutoloads('--optimize');
     }
 
     /**

--- a/src/Illuminate/Support/Composer.php
+++ b/src/Illuminate/Support/Composer.php
@@ -39,7 +39,7 @@ class Composer
      * Regenerate the Composer autoloader files.
      *
      * @param  string|array  $extra
-     * @return int The process exit status code
+     * @return int
      */
     public function dumpAutoloads($extra = '')
     {
@@ -53,7 +53,7 @@ class Composer
     /**
      * Regenerate the optimized Composer autoloader files.
      *
-     * @return int The process exit status code
+     * @return int
      */
     public function dumpOptimized()
     {


### PR DESCRIPTION
I was having an issue where `dumpAutoloads` wasn't working, and it wasn't even giving me feedback about the it.
Since `dumpAutoloads` doesn't do any visible changes on the project I wrongly assumed it was working when it wasn't.

This PR changes the return of `dumpAutoloads` and `dumpOptimized` allowing developers to get the process status code, knowing it worked or not and deal with it the best way.

The status code comes from `Symfony\Component\Process` `run()` method.