### PR TITLE
[8.x] Use standard `InvalidArgumentException` when `json_encode()` failed

### DIFF
--- a/src/Illuminate/Http/Response.php
+++ b/src/Illuminate/Http/Response.php
@@ -10,7 +10,7 @@ use Illuminate\Support\Traits\Macroable;
 use JsonSerializable;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
-use UnexpectedValueException;
+use InvalidArgumentException;
 
 class Response extends SymfonyResponse
 {
@@ -42,6 +42,8 @@ class Response extends SymfonyResponse
      *
      * @param  mixed  $content
      * @return $this
+     *
+     * @throws \InvalidArgumentException
      */
     public function setContent($content)
     {
@@ -56,7 +58,7 @@ class Response extends SymfonyResponse
             $content = $this->morphToJson($content);
 
             if ($content === false) {
-                throw new UnexpectedValueException(sprintf('Unable to convert the provided response data to JSON: %s', json_last_error_msg()));
+                throw new InvalidArgumentException(json_last_error_msg());
             }
         }
 

--- a/src/Illuminate/Http/Response.php
+++ b/src/Illuminate/Http/Response.php
@@ -7,10 +7,10 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Support\Traits\Macroable;
+use InvalidArgumentException;
 use JsonSerializable;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
-use InvalidArgumentException;
 
 class Response extends SymfonyResponse
 {

--- a/tests/Integration/Http/JsonResponseTest.php
+++ b/tests/Integration/Http/JsonResponseTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Route;
+use Orchestra\Testbench\TestCase;
+
+/**
+ * @group integration
+ */
+class JsonResponseTest extends TestCase
+{
+    public function testResponseWithInvalidJsonThrowsException()
+    {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('Malformed UTF-8 characters, possibly incorrectly encoded');
+
+        Route::get('/response', function () {
+            return new JsonResponse(new class implements \JsonSerializable {
+                public function jsonSerialize()
+                {
+                    return "\xB1\x31";
+                }
+            });
+        });
+
+        $this->withoutExceptionHandling();
+
+        $this->get('/response');
+    }
+}

--- a/tests/Integration/Http/ResponseTest.php
+++ b/tests/Integration/Http/ResponseTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http;
+
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Route;
+use Orchestra\Testbench\TestCase;
+
+/**
+ * @group integration
+ */
+class ResponseTest extends TestCase
+{
+    public function testResponseWithInvalidJsonThrowsException()
+    {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('Malformed UTF-8 characters, possibly incorrectly encoded');
+
+        Route::get('/response', function () {
+            return (new Response())->setContent(new class implements \JsonSerializable {
+                public function jsonSerialize()
+                {
+                    return "\xB1\x31";
+                }
+            });
+        });
+
+        $this->withoutExceptionHandling();
+
+        $this->get('/response');
+    }
+}


### PR DESCRIPTION
We already throwing the same error https://github.com/laravel/framework/blob/8.x/src/Illuminate/Http/JsonResponse.php#L75

At first, considered using `JSON_THROW_ON_ERROR` but it would be weird to throw a different exception on different classes (See above). We should definitely revisit this for 9.x release.

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>