### PR TITLE
[8.x] Models: Support attributes casting in batch raw `insert` queries

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1055,7 +1055,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     }
 
     /**
-     * Insert new records while casting attributes
+     * Insert new records while casting attributes.
      *
      * @param  array  $values
      * @return bool

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1055,6 +1055,37 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     }
 
     /**
+     * Insert new records while casting attributes
+     *
+     * @param  array  $values
+     * @return bool
+     */
+    protected function insertWithCasts(array $values)
+    {
+        if (empty($values)) {
+            return true;
+        }
+
+        if (! is_array(reset($values))) {
+            $values = [$values];
+        }
+
+        return $this->insert(
+            collect($values)
+            ->map(function ($attributes) {
+                foreach ($attributes as $key => $value) {
+                    $this->setAttribute($key, $value);
+
+                    $attributes[$key] = $this->attributes[$key];
+                }
+
+                return $attributes;
+            })
+            ->toArray()
+        );
+    }
+
+    /**
      * Destroy the models for the given IDs.
      *
      * @param  \Illuminate\Support\Collection|array|int|string  $ids
@@ -1879,7 +1910,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
      */
     public function __call($method, $parameters)
     {
-        if (in_array($method, ['increment', 'decrement'])) {
+        if (in_array($method, ['increment', 'decrement', 'insertWithCasts'])) {
             return $this->$method(...$parameters);
         }
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -644,7 +644,6 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertFalse($model->exists);
     }
 
-
     public function testInsertWithCastsWithoutEntries()
     {
         $model = $this->getMockBuilder(EloquentModelCastingStub::class)->onlyMethods(['newQuery'])->getMock();
@@ -666,7 +665,7 @@ class DatabaseEloquentModelTest extends TestCase
             [
                 'intAttribute' => 5,
                 'jsonAttribute' => '{"foo":"bar"}',
-            ]
+            ],
         ])
         ->andReturn(true);
 


### PR DESCRIPTION
### Background:

It's common by now for users to differentiate between `Model::create` and `Model::insert` methods.

One of the main differences how the behaviour will change for attributes casting, where `create` -or all `save` based methods-, will cast values before the insertion to the database, while `insert` should only receive already-casted values.

This led to multiple workarounds where the casting logic is repeated/reimplemented by the user, like the accepted answer in [this SO post](https://stackoverflow.com/a/51878607/4330182).

---

This PR introduces a new function called `insertWithCasts` -couldn't think of better name- where it's just a bridge for the `insert` method, a bridge that will `setAttribute` for each attribute in the entry then receive it's casted ready-to-database value back.

---

## Example:

Assuming we have:

``` php
class User extends Model
{
     protected $casts = [
        'options' => 'json',
        'shelf' => 'collection',
    ];
}
```

### To insert multiple users before this PR:

``` php
User::insert([
    [
        'options' => json_encode(['sms' => true]),
        'shelf'     => collect(['book1', 'book2', 'book3'])->__toString(),
    ],
    [
        'options' => json_encode(['sms' => false]),
        'shelf'     => collect(['book1', 'book2'])->__toString(),
    ],
]);
```

### To insert multiple users after this PR:

``` php
User::insertWithCasts([
    [
        'options' => ['sms' => true],
        'shelf'     => collect(['book1', 'book2', 'book3']),
    ],
    [
        'options' => ['sms' => false],
        'shelf'     => collect(['book1', 'book2']),
    ],
]);
```