### PR TITLE
Updated Arr null key behavior

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -290,7 +290,7 @@ class Arr
         }
 
         if (is_null($key)) {
-            return $array;
+            return $default ?: $array;
         }
 
         if (static::exists($array, $key)) {


### PR DESCRIPTION
No point in retrieving whole array on `null` key if you already provided the default you'd like returned if no match is found.

```php
// Wrong
Arr::get([], null, 'default');
// returns
[]

// Right
Arr::get([], null, 'default');
// returns
'default'
```



