### PR TITLE
[8.x] Add unfinished option to PruneBatchesCommand

### DIFF
--- a/src/Illuminate/Bus/DatabaseBatchRepository.php
+++ b/src/Illuminate/Bus/DatabaseBatchRepository.php
@@ -241,8 +241,8 @@ class DatabaseBatchRepository implements PrunableBatchRepository
     public function prune(DateTimeInterface $before)
     {
         $query = $this->connection->table($this->table)
-            ->whereNotNull('finished_at')
-            ->where('finished_at', '<', $before->getTimestamp());
+            ->whereNotNull('created_at')
+            ->where('created_at', '<', $before->getTimestamp());
 
         $totalDeleted = 0;
 

--- a/src/Illuminate/Queue/Console/PruneBatchesCommand.php
+++ b/src/Illuminate/Queue/Console/PruneBatchesCommand.php
@@ -4,6 +4,7 @@ namespace Illuminate\Queue\Console;
 
 use Carbon\Carbon;
 use Illuminate\Bus\BatchRepository;
+use Illuminate\Bus\DatabaseBatchRepository;
 use Illuminate\Bus\PrunableBatchRepository;
 use Illuminate\Console\Command;
 
@@ -14,7 +15,9 @@ class PruneBatchesCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'queue:prune-batches {--hours=24 : The number of hours to retain batch data}';
+    protected $signature = 'queue:prune-batches
+                {--hours=24 : The number of hours to retain batch data}
+                {--unfinished= : Include unfinished batches }';
 
     /**
      * The console command description.
@@ -30,14 +33,24 @@ class PruneBatchesCommand extends Command
      */
     public function handle()
     {
-        $count = 0;
-
         $repository = $this->laravel[BatchRepository::class];
+
+        $count = 0;
 
         if ($repository instanceof PrunableBatchRepository) {
             $count = $repository->prune(Carbon::now()->subHours($this->option('hours')));
         }
 
         $this->info("{$count} entries deleted!");
+
+        if ($unfinished = $this->option('unfinished')) {
+            $count = 0;
+
+            if ($repository instanceof DatabaseBatchRepository) {
+                $count = $repository->pruneUnfinished(Carbon::now()->subHours($this->option('unfinished')));
+            }
+
+            $this->info("{$count} unfinished entries deleted!");
+        }
     }
 }

--- a/src/Illuminate/Queue/Console/PruneBatchesCommand.php
+++ b/src/Illuminate/Queue/Console/PruneBatchesCommand.php
@@ -17,7 +17,7 @@ class PruneBatchesCommand extends Command
      */
     protected $signature = 'queue:prune-batches
                 {--hours=24 : The number of hours to retain batch data}
-                {--unfinished= : Include unfinished batches }';
+                {--unfinished= : The number of hours to retain unfinished batch data }';
 
     /**
      * The console command description.


### PR DESCRIPTION
This adds a new `--unfinished=` option to the `PruneBatchesCommand` class. When passed along, the command will not only prune finished batches but also unfinished ones based on the amount of hours passed along.