### PR TITLE
[8.x] Add exception accesor to HTTP client

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -247,8 +247,6 @@ class Response implements ArrayAccess
         if ($this->failed()) {
             return new RequestException($this);
         }
-
-        return null;
     }
 
     /**

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -238,6 +238,20 @@ class Response implements ArrayAccess
     }
 
     /**
+     * Create an exception if a server or client error occurred.
+     *
+     * @return \Illuminate\Http\Client\RequestException|null
+     */
+    public function toException()
+    {
+        if ($this->failed()) {
+            return new RequestException($this);
+        }
+
+        return null;
+    }
+
+    /**
      * Throw an exception if a server or client error occurred.
      *
      * @param  \Closure|null  $callback
@@ -250,7 +264,7 @@ class Response implements ArrayAccess
         $callback = func_get_args()[0] ?? null;
 
         if ($this->failed()) {
-            throw tap(new RequestException($this), function ($exception) use ($callback) {
+            throw tap($this->toException(), function ($exception) use ($callback) {
                 if ($callback && is_callable($callback)) {
                     $callback($this, $exception);
                 }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -465,6 +465,27 @@ class HttpClientTest extends TestCase
         });
     }
 
+    public function testExceptionAccessorOnSuccess()
+    {
+        $resp = new Response(new Psr7Response());
+
+        $this->assertNull($resp->toException());
+    }
+
+    public function testExceptionAccessorOnFailure()
+    {
+        $error = [
+            'error' => [
+                'code' => 403,
+                'message' => 'The Request can not be completed',
+            ],
+        ];
+        $response = new Psr7Response(403, [], json_encode($error));
+        $resp = new Response($response);
+
+        $this->assertInstanceOf(RequestException::class, $resp->toException());
+    }
+
     public function testRequestExceptionSummary()
     {
         $this->expectException(RequestException::class);


### PR DESCRIPTION
If a request fails, a new `toException()` method is available to generate the illuminate `RequestException` instances to do with as you please.

This breaks nothing because it's just an extraction of existing functionality on the `throw()` method.

Frequently I find I do not want to throw, but instead want do do something like this before 'manually' handling the response:

```php
if ($response->failed()) {
    Bugsnag::notifyException($response->toException());
}
```

The above cannot be done with the optional callback `throw()` supports.