### PR TITLE
[8.x] Fix PostgreSQL schema:dump when read/write hosts are arrays

### DIFF
--- a/src/Illuminate/Database/Schema/PostgresSchemaState.php
+++ b/src/Illuminate/Database/Schema/PostgresSchemaState.php
@@ -70,8 +70,10 @@ class PostgresSchemaState extends SchemaState
      */
     protected function baseVariables(array $config)
     {
+        $config['host'] = $config['host'] ?? '';
+
         return [
-            'LARAVEL_LOAD_HOST' => $config['host'],
+            'LARAVEL_LOAD_HOST' => is_array($config['host']) ? $config['host'][0] : $config['host'],
             'LARAVEL_LOAD_PORT' => $config['port'],
             'LARAVEL_LOAD_USER' => $config['username'],
             'LARAVEL_LOAD_PASSWORD' => $config['password'],


### PR DESCRIPTION
PostgreSQL schema:dump fails when read/write connection hosts are arrays

Closes #36875