### PR TITLE
[8.x] Fixes array to string conversion exception when using custom validation messages for size rules

### DIFF
--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -31,18 +31,16 @@ trait FormatsMessages
 
         $lowerRule = Str::snake($rule);
 
-        $customMessage = $this->getCustomMessageFromTranslator(
-            $customKey = "validation.custom.{$attribute}.{$lowerRule}"
-        );
+        $customKey = in_array($rule, $this->sizeRules)
+            ? "validation.custom.{$attribute}.{$lowerRule}.{$this->getAttributeType($attribute)}"
+            : "validation.custom.{$attribute}.{$lowerRule}";
+
+        $customMessage = $this->getCustomMessageFromTranslator($customKey);
 
         // First we check for a custom defined validation message for the attribute
         // and rule. This allows the developer to specify specific messages for
         // only some attributes and rules that need to get specially formed.
         if ($customMessage !== $customKey) {
-            if (in_array($rule, $this->sizeRules)) {
-                return $this->getCustomSizeMessage($attribute, $rule);
-            }
-
             return $customMessage;
         }
 
@@ -179,27 +177,6 @@ trait FormatsMessages
         $type = $this->getAttributeType($attribute);
 
         $key = "validation.{$lowerRule}.{$type}";
-
-        return $this->translator->get($key);
-    }
-
-    /**
-     * Get the proper error message for an attribute and size rule when using custom messages.
-     *
-     * @param  string  $attribute
-     * @param  string  $rule
-     * @return string
-     */
-    protected function getCustomSizeMessage($attribute, $rule)
-    {
-        $lowerRule = Str::snake($rule);
-
-        // There are three different types of size validations. The attribute may be
-        // either a number, file, or string so we will check a few things to know
-        // which type of value it is and return the correct line for that type.
-        $type = $this->getAttributeType($attribute);
-
-        $key = "validation.custom.{$attribute}.{$lowerRule}.{$type}";
 
         return $this->translator->get($key);
     }

--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -39,6 +39,9 @@ trait FormatsMessages
         // and rule. This allows the developer to specify specific messages for
         // only some attributes and rules that need to get specially formed.
         if ($customMessage !== $customKey) {
+            if (in_array($rule, $this->sizeRules)) {
+                return $this->getCustomSizeMessage($attribute, $rule);
+            }
             return $customMessage;
         }
 
@@ -175,6 +178,27 @@ trait FormatsMessages
         $type = $this->getAttributeType($attribute);
 
         $key = "validation.{$lowerRule}.{$type}";
+
+        return $this->translator->get($key);
+    }
+    
+    /**
+     * Get the proper error message for an attribute and size rule when using custom messages.
+     *
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @return string
+     */
+    protected function getCustomSizeMessage($attribute, $rule)
+    {
+        $lowerRule = Str::snake($rule);
+
+        // There are three different types of size validations. The attribute may be
+        // either a number, file, or string so we will check a few things to know
+        // which type of value it is and return the correct line for that type.
+        $type = $this->getAttributeType($attribute);
+
+        $key = "validation.custom.{$attribute}.{$lowerRule}.{$type}";
 
         return $this->translator->get($key);
     }

--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -42,6 +42,7 @@ trait FormatsMessages
             if (in_array($rule, $this->sizeRules)) {
                 return $this->getCustomSizeMessage($attribute, $rule);
             }
+
             return $customMessage;
         }
 
@@ -181,7 +182,7 @@ trait FormatsMessages
 
         return $this->translator->get($key);
     }
-    
+
     /**
      * Get the proper error message for an attribute and size rule when using custom messages.
      *

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -610,9 +610,9 @@ class ValidationValidatorTest extends TestCase
                         'file' => 'The :attribute must be between :min and :max kilobytes.',
                         'string' => 'Some custom message here',
                         'array' => 'The :attribute must have between :min and :max items.',
-                    ]
-                ]
-            ]
+                    ],
+                ],
+            ],
         ]);
         $v = new Validator($trans, ['name' => 'Taylor'], ['name' => 'between:10,20']);
         $this->assertFalse($v->passes());

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -598,6 +598,28 @@ class ValidationValidatorTest extends TestCase
         $this->assertSame('really required!', $v->messages()->first('name'));
     }
 
+    public function testCustomValidationLinesForSizeRules()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->getLoader()->addMessages('en', 'validation', [
+            'required' => 'required!',
+            'custom' => [
+                'name' => [
+                    'between' => [
+                        'numeric' => 'The :attribute must be between :min and :max.',
+                        'file' => 'The :attribute must be between :min and :max kilobytes.',
+                        'string' => 'Some custom message here',
+                        'array' => 'The :attribute must have between :min and :max items.',
+                    ]
+                ]
+            ]
+        ]);
+        $v = new Validator($trans, ['name' => ''], ['name' => 'between:5,20']);
+        $this->assertFalse($v->passes());
+        $v->messages()->setFormat(':message');
+        $this->assertSame('Some custom message here', $v->messages()->first('name'));
+    }
+
     public function testCustomValidationLinesAreRespectedWithAsterisks()
     {
         $trans = $this->getIlluminateArrayTranslator();

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -614,7 +614,7 @@ class ValidationValidatorTest extends TestCase
                 ]
             ]
         ]);
-        $v = new Validator($trans, ['name' => ''], ['name' => 'between:5,20']);
+        $v = new Validator($trans, ['name' => 'Taylor'], ['name' => 'between:10,20']);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
         $this->assertSame('Some custom message here', $v->messages()->first('name'));


### PR DESCRIPTION
This PR fixes a Array to string conversion exception when using custom validation messages for size rules.

When using laravel validation, you can specify custom validation messages for attributes using the convention "attribute.rule" to name the lines:
```php
'custom' => [
     'attribute-name' => [
        'rule-name' => 'custom-message',
    ],
],
```
The problem is: when using size rules, such as `Between`, if you define your custom message as something like this (i used the `email` field for this test:
```php
 'custom' => [
   'email' => [
        'between' => [
            'numeric' => 'The :attribute must be between :min and :max.',
            'file' => 'The :attribute must be between :min and :max kilobytes.',
            'string' => 'Some custom message here',
            'array' => 'The :attribute must have between :min and :max items.',
        ]
    ]
],
```
it will cause an exception:
![image](https://user-images.githubusercontent.com/19756164/113662719-08591180-967f-11eb-9a3f-84b93f347916.png)

This occurs because the actual custom message for size rules is returned before checking if the rule being validated is a size rule or not. So, the message passed to the `Illuminate\Support\MessageBag` `transform` method is this one:

```
array:1 [▼
  0 => array:4 [▼
    "numeric" => "The email must be between 20 and 24."
    "file" => "The email must be between 20 and 24 kilobytes."
    "string" => "Some custom message here."
    "array" => "The email must have between 20 and 24 items."
  ]
]
```

This PR fixes this error by adding a check for size rules before returning the custom validation message to the MessageBag class, and, if it actually is a size rule, get the message for the correct attribute type:

```diff
    if ($customMessage !== $customKey) {
+     if (in_array($rule, $this->sizeRules)) {         
+         return $this->getCustomSizeMessage($attribute, $rule);   
+     }
    return $customMessage;
    }

+ protected function getCustomSizeMessage($attribute, $rule)
+ {
+    $lowerRule = Str::snake($rule);
+    $type = $this->getAttributeType($attribute);
+    $key = "validation.custom.{$attribute}.{$lowerRule}.{$type}";
+    return $this->translator->get($key);
+ }
```
With this fix, the validation returns the correct message, which, in this case is `Some custom message here`.