### PR TITLE
[8.x] Add a simple Str::repeat() helper function

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -492,6 +492,18 @@ class Str
     }
 
     /**
+     * Repeat the given string.
+     *
+     * @param  string  $string
+     * @param  int  $times
+     * @return string
+     */
+    public static function repeat(string $string, int $times)
+    {
+        return str_repeat($string, $times);
+    }
+
+    /**
      * Replace a given value in the string sequentially with an array.
      *
      * @param  string  $search

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -480,6 +480,17 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Repeat the string.
+     *
+     * @param  int  $times
+     * @return static
+     */
+    public function repeat(int $times)
+    {
+        return new static(Str::repeat($this->value, $times));
+    }
+
+    /**
      * Replace the given value in the given string.
      *
      * @param  string|string[]  $search

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -534,8 +534,8 @@ class SupportStrTest extends TestCase
 
     public function testRepeat()
     {
-        $this->assertSame('aaaaa', Str::repeat("a", 5));
-        $this->assertSame('', Str::repeat("", 5));
+        $this->assertSame('aaaaa', Str::repeat('a', 5));
+        $this->assertSame('', Str::repeat('', 5));
     }
 }
 

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -534,8 +534,8 @@ class SupportStrTest extends TestCase
 
     public function testRepeat()
     {
-        $this->assertSame("aaaaa", Str::repeat("a", 5));
-        $this->assertSame("", Str::repeat("", 5));
+        $this->assertSame('aaaaa', Str::repeat("a", 5));
+        $this->assertSame('', Str::repeat("", 5));
     }
 }
 

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -531,6 +531,12 @@ class SupportStrTest extends TestCase
         $this->assertSame("<p><em>hello world</em></p>\n", Str::markdown('*hello world*'));
         $this->assertSame("<h1>hello world</h1>\n", Str::markdown('# hello world'));
     }
+
+    public function testRepeat()
+    {
+        $this->assertSame("aaaaa", Str::repeat("a", 5));
+        $this->assertSame("", Str::repeat("", 5));
+    }
 }
 
 class StringableObjectStub

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -605,7 +605,7 @@ class SupportStringableTest extends TestCase
 
     public function testRepeat()
     {
-        $this->assertSame("aaaaa", (string) $this->stringable("a")->repeat(5));
-        $this->assertSame("", (string) $this->stringable("")->repeat(5));
+        $this->assertSame('aaaaa', (string) $this->stringable("a")->repeat(5));
+        $this->assertSame('', (string) $this->stringable("")->repeat(5));
     }
 }

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -605,7 +605,7 @@ class SupportStringableTest extends TestCase
 
     public function testRepeat()
     {
-        $this->assertSame('aaaaa', (string) $this->stringable("a")->repeat(5));
-        $this->assertSame('', (string) $this->stringable("")->repeat(5));
+        $this->assertSame('aaaaa', (string) $this->stringable('a')->repeat(5));
+        $this->assertSame('', (string) $this->stringable('')->repeat(5));
     }
 }

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -602,4 +602,10 @@ class SupportStringableTest extends TestCase
         $this->assertEquals("<p><em>hello world</em></p>\n", $this->stringable('*hello world*')->markdown());
         $this->assertEquals("<h1>hello world</h1>\n", $this->stringable('# hello world')->markdown());
     }
+
+    public function testRepeat()
+    {
+        $this->assertSame("aaaaa", (string) $this->stringable("a")->repeat(5));
+        $this->assertSame("", (string) $this->stringable("")->repeat(5));
+    }
 }


### PR DESCRIPTION
This PR adds a simple repeat() function to the Str and Stringable classes. 

Given most other string manipulation methods are present in these classes, one might also expect to find the `str_repeat()` functionality.