### PR TITLE
[8.x] Revert isDownForMaintenance function to use file_exists()

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1093,7 +1093,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function isDownForMaintenance()
     {
-        return is_file($this->storagePath().'/framework/down');
+        return file_exists($this->storagePath().'/framework/down');
     }
 
     /**


### PR DESCRIPTION
After updating one of our applications to Laravel 8.x, we noticed a recurring issue with our queue workers after deployments. When we would run `php artisan queue:restart` during the deployment process, the worker processes would restart as expected, but they would no longer work jobs from the queue. 

After some investigation, we determined this issue was specifically occurring because our deployment script executes `php artisan queue:restart` while the application is still in maintenance mode. It appeared that even after we brought the application out of maintenance mode, the `isDownForMaintenance` check from within the worker processes was still returning `true`.

It appears the issue was introduced in [this PR](https://github.com/laravel/framework/pull/33124), which would explain why we never encountered this issue prior to updating to Laravel 8.x. We believe the issue is related to differences in how the statcache is utilized between `is_file()` and `file_exists()`.

**Steps to reproduce issue**
1. Setup a supervised process to run the `php artisan queue:work` command.
2. Start the queue worker.
3. Run `php artisan down` to bring the application into maintenance mode.
4. Run `php artisan queue:restart` to restart the queue worker.
5. Run `php artisan up` to bring the application out of maintenance mode.
6. Dispatch a job onto the worker's queue. The job will never be processed.