### PR TITLE
[8.x] Fix escaping within quoted strings

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -417,7 +417,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
     protected function compileStatements($value)
     {
         return preg_replace_callback(
-            '/\B@(@?\w+(?:::\w+)?)([ \t]*)(\( ( (?>\'[^\']*\') | (?>"[^"]*") | (?>[^()\'"]+) | (?3) )* \))?/x', function ($match) {
+            '/\B@(@?\w+(?:::\w+)?)([ \t]*)(\( ( (?>\'(?:\\\\\'|[^\'])*\') | (?>"(?:\\\\"|[^"])*") | (?>[^()\'"]+) | (?3) )* \))?/x', function ($match) {
                 return $this->compileStatement($match);
             }, $value
         );

--- a/tests/View/Blade/BladePhpStatementsTest.php
+++ b/tests/View/Blade/BladePhpStatementsTest.php
@@ -67,4 +67,19 @@ class BladePhpStatementsTest extends AbstractBladeTestCase
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
+
+    public function testStringWithEscapingDataValue()
+    {
+        $string = "@php(\$data = ['test' => 'won\\'t break'])";
+
+        $expected = "<?php (\$data = ['test' => 'won\\'t break']); ?>";
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+
+        $string = "@php(\$data = ['test' => \"\\\"escaped\\\"\"])";
+
+        $expected = "<?php (\$data = ['test' => \"\\\"escaped\\\"\"]); ?>";
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
 }


### PR DESCRIPTION
This is a patch for the issue noted in [36843](https://github.com/laravel/framework/pull/36843#issuecomment-814358305) to allow for escaping within quoted strings.

While this handles this common case, there may be other escape sequences it does not handle. Those will likely be beyond the abilities of a single pass regular expression.