### PR TITLE
[8.x] Micro optimisation: Improve middleware performance

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -711,31 +711,31 @@ class Router implements BindingRegistrar, RegistrarContract
 
         $middleware = collect($route->gatherMiddleware())->map(function ($name) {
             return (array) MiddlewareNameResolver::resolve($name, $this->middleware, $this->middlewareGroups);
-        })->flatten()->reject(function ($name) use ($excluded) {
-            if (empty($excluded)) {
-                return false;
-            }
+        })->flatten();
 
-            if ($name instanceof Closure) {
-                return false;
-            }
+        if (! empty($excluded)) {
+            $middleware = $middleware->reject(function ($name) use ($excluded) {
+                if ($name instanceof Closure) {
+                    return false;
+                }
 
-            if (in_array($name, $excluded, true)) {
-                return true;
-            }
+                if (in_array($name, $excluded, true)) {
+                    return true;
+                }
 
-            if (! class_exists($name)) {
-                return false;
-            }
+                if (! class_exists($name)) {
+                    return false;
+                }
 
-            $reflection = new ReflectionClass($name);
+                $reflection = new ReflectionClass($name);
 
-            return collect($excluded)->contains(function ($exclude) use ($reflection) {
-                return class_exists($exclude) && $reflection->isSubclassOf($exclude);
+                return collect($excluded)->contains(function ($exclude) use ($reflection) {
+                    return class_exists($exclude) && $reflection->isSubclassOf($exclude);
+                });
             });
-        })->values();
+        }
 
-        return $this->sortMiddleware($middleware);
+        return $this->sortMiddleware($middleware->values());
     }
 
     /**


### PR DESCRIPTION
Improves the performance by avoiding iterating the middleware array of the matched route again if the 'excluded' array is empty (which happens most of the time)



May improve performance of TTFB by 1ms-2ms if there is a lot of middleware in the current route because this processing is not included in route:cache and this avoids a closure and second collection loop

No breaking change

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
