### PR TITLE
[8.x] Allow to retry jobs by queue name

### DIFF
--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -66,7 +66,7 @@ class RetryCommand extends Command
         if ($queue = $this->option('queue')) {
             $ids = collect($this->laravel['queue.failer']->all())->where('queue', $queue)->pluck('id')->toArray();
 
-            if (count($ids)===0) {
+            if (count($ids) === 0) {
                 $this->error("Unable to find failed jobs in a queue named [{$queue}].");
             }
 

--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -18,6 +18,7 @@ class RetryCommand extends Command
      */
     protected $signature = 'queue:retry
                             {id?* : The ID of the failed job or "all" to retry all jobs}
+                            {--queue= : Name of the queue to be retried}
                             {--range=* : Range of job IDs (numeric) to be retried}';
 
     /**
@@ -60,6 +61,16 @@ class RetryCommand extends Command
 
         if (count($ids) === 1 && $ids[0] === 'all') {
             return Arr::pluck($this->laravel['queue.failer']->all(), 'id');
+        }
+
+        if ($queue = $this->option('queue')) {
+            $ids = collect($this->laravel['queue.failer']->all())->where('queue', $queue)->pluck('id')->toArray();
+
+            if (count($ids)===0) {
+                $this->error("Unable to find failed jobs in a queue named [{$queue}].");
+            }
+
+            return $ids;
         }
 
         if ($ranges = (array) $this->option('range')) {


### PR DESCRIPTION
(Alright - go easy, this is the first time I have ever contributed to a maintained package like this! - But I'm blooming excited to be doing so!)

This is an enhancement so that you can retry failed jobs by queue name, rather than list the IDs or a range of IDs. Also has been an "Idea" since 2019. https://github.com/laravel/ideas/issues/1648

Usage:
```
artisan queue:retry --queue=default
```
or 
```
artisan queue:retry --queue=myNamedQueue
```

 