### PR TITLE
[8.x] Revert Blade compiler changes

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -417,7 +417,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
     protected function compileStatements($value)
     {
         return preg_replace_callback(
-            '/\B@(@?\w+(?:::\w+)?)([ \t]*)(\( ( (?>\'(?:\\\\\'|[^\'])*\') | (?>"(?:\\\\"|[^"])*") | (?>[^()\'"]+) | (?3) )* \))?/x', function ($match) {
+            '/\B@(@?\w+(?:::\w+)?)([ \t]*)(\( ( (?>[^()]+) | (?3) )* \))?/x', function ($match) {
                 return $this->compileStatement($match);
             }, $value
         );

--- a/tests/View/Blade/BladeForeachStatementsTest.php
+++ b/tests/View/Blade/BladeForeachStatementsTest.php
@@ -81,5 +81,14 @@ tag info
         $string = '@foreach ($tasks as $task)';
         $expected = '<?php $__currentLoopData = $tasks; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $task): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
+
+        $string = "@foreach(resolve('App\\\\DataProviders\\\\'.\$provider)->data() as \$key => \$value)
+    <input {{ \$foo ? 'bar': 'baz' }}>
+@endforeach";
+        $expected = "<?php \$__currentLoopData = resolve('App\\\\DataProviders\\\\'.\$provider)->data(); \$__env->addLoop(\$__currentLoopData); foreach(\$__currentLoopData as \$key => \$value): \$__env->incrementLoopIndices(); \$loop = \$__env->getLastLoop(); ?>
+    <input <?php echo e(\$foo ? 'bar': 'baz'); ?>>
+<?php endforeach; \$__env->popLoop(); \$loop = \$__env->getLastLoop(); ?>";
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 }

--- a/tests/View/Blade/BladePhpStatementsTest.php
+++ b/tests/View/Blade/BladePhpStatementsTest.php
@@ -44,13 +44,15 @@ class BladePhpStatementsTest extends AbstractBladeTestCase
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
-    public function testStringWithParenthesisDataValue()
+    public function testStringWithParenthesisCannotBeCompiled()
     {
         $string = "@php(\$data = ['test' => ')'])";
 
         $expected = "<?php (\$data = ['test' => ')']); ?>";
 
-        $this->assertEquals($expected, $this->compiler->compileString($string));
+        $actual = "<?php (\$data = ['test' => '); ?>'])";
+
+        $this->assertEquals($actual, $this->compiler->compileString($string));
     }
 
     public function testStringWithEmptyStringDataValue()


### PR DESCRIPTION
This PR reverts all changes to the `compileStatements` regex from the past week because it's proven to cause more bugs. I've added a test for the latest uncovered issue here: https://github.com/laravel/framework/issues/36900. I've left the test in that fixed the original issue to highlight that this is from now on expected and won't be fixed for the time being.

Fixes https://github.com/laravel/framework/issues/36900