### PR TITLE
[6.x] Exclude `whereNotNull` check in relations query

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -67,9 +67,14 @@ abstract class HasOneOrMany extends Relation
     public function addConstraints()
     {
         if (static::$constraints) {
-            $this->query->where($this->foreignKey, '=', $this->getParentKey());
+            $parentKey = $this->getParentKey();
+            $this->query->where($this->foreignKey, '=', $parentKey);
 
-            $this->query->whereNotNull($this->foreignKey);
+            // When $parentKey is null the above line is treated as whereNull($this->foreignKey)
+            // Avoid loading all models with null foreignKey in that situation
+            if (is_null($parentKey)) {
+                $this->query->whereNotNull($this->foreignKey);
+            }
         }
     }
 

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -252,15 +252,17 @@ class DatabaseEloquentHasManyTest extends TestCase
         $this->assertEquals($colin, $instances[1]);
     }
 
-    protected function getRelation()
+    protected function getRelation($id = 1)
     {
         $builder = m::mock(Builder::class);
-        $builder->shouldReceive('whereNotNull')->with('table.foreign_key');
-        $builder->shouldReceive('where')->with('table.foreign_key', '=', 1);
+        if (is_null($id)) {
+            $builder->shouldReceive('whereNotNull')->once()->with('table.foreign_key');
+        }
+        $builder->shouldReceive('where')->once()->with('table.foreign_key', '=', $id);
         $related = m::mock(Model::class);
         $builder->shouldReceive('getModel')->andReturn($related);
         $parent = m::mock(Model::class);
-        $parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
+        $parent->shouldReceive('getAttribute')->with('id')->andReturn($id);
         $parent->shouldReceive('getCreatedAtColumn')->andReturn('created_at');
         $parent->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');
 

--- a/tests/Database/DatabaseEloquentHasOneTest.php
+++ b/tests/Database/DatabaseEloquentHasOneTest.php
@@ -196,15 +196,17 @@ class DatabaseEloquentHasOneTest extends TestCase
         $relation->getRelationExistenceCountQuery($builder, $builder);
     }
 
-    protected function getRelation()
+    protected function getRelation($id = 1)
     {
         $this->builder = m::mock(Builder::class);
-        $this->builder->shouldReceive('whereNotNull')->with('table.foreign_key');
-        $this->builder->shouldReceive('where')->with('table.foreign_key', '=', 1);
+        if (is_null($id)) {
+            $this->builder->shouldReceive('whereNotNull')->once()->with('table.foreign_key');
+        }
+        $this->builder->shouldReceive('where')->once()->with('table.foreign_key', '=', $id);
         $this->related = m::mock(Model::class);
         $this->builder->shouldReceive('getModel')->andReturn($this->related);
         $this->parent = m::mock(Model::class);
-        $this->parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
+        $this->parent->shouldReceive('getAttribute')->with('id')->andReturn($id);
         $this->parent->shouldReceive('getAttribute')->with('username')->andReturn('taylor');
         $this->parent->shouldReceive('getCreatedAtColumn')->andReturn('created_at');
         $this->parent->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');

--- a/tests/Database/DatabaseEloquentMorphTest.php
+++ b/tests/Database/DatabaseEloquentMorphTest.php
@@ -253,37 +253,41 @@ class DatabaseEloquentMorphTest extends TestCase
         $this->assertEquals($created, $relation->create(['name' => 'taylor']));
     }
 
-    protected function getOneRelation()
+    protected function getOneRelation($id = 1)
     {
         $builder = m::mock(Builder::class);
-        $builder->shouldReceive('whereNotNull')->once()->with('table.morph_id');
-        $builder->shouldReceive('where')->once()->with('table.morph_id', '=', 1);
+        if (is_null($id)) {
+            $builder->shouldReceive('whereNotNull')->once()->with('table.morph_id');
+        }
+        $builder->shouldReceive('where')->once()->with('table.morph_id', '=', $id);
         $related = m::mock(Model::class);
         $builder->shouldReceive('getModel')->andReturn($related);
         $parent = m::mock(Model::class);
-        $parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
+        $parent->shouldReceive('getAttribute')->with('id')->andReturn($id);
         $parent->shouldReceive('getMorphClass')->andReturn(get_class($parent));
         $builder->shouldReceive('where')->once()->with('table.morph_type', get_class($parent));
 
         return new MorphOne($builder, $parent, 'table.morph_type', 'table.morph_id', 'id');
     }
 
-    protected function getManyRelation()
+    protected function getManyRelation($id = 1)
     {
         $builder = m::mock(Builder::class);
-        $builder->shouldReceive('whereNotNull')->once()->with('table.morph_id');
-        $builder->shouldReceive('where')->once()->with('table.morph_id', '=', 1);
+        if (is_null($id)) {
+            $builder->shouldReceive('whereNotNull')->once()->with('table.morph_id');
+        }
+        $builder->shouldReceive('where')->once()->with('table.morph_id', '=', $id);
         $related = m::mock(Model::class);
         $builder->shouldReceive('getModel')->andReturn($related);
         $parent = m::mock(Model::class);
-        $parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
+        $parent->shouldReceive('getAttribute')->with('id')->andReturn($id);
         $parent->shouldReceive('getMorphClass')->andReturn(get_class($parent));
         $builder->shouldReceive('where')->once()->with('table.morph_type', get_class($parent));
 
         return new MorphMany($builder, $parent, 'table.morph_type', 'table.morph_id', 'id');
     }
 
-    protected function getNamespacedRelation($alias)
+    protected function getNamespacedRelation($alias, $id = 1)
     {
         require_once __DIR__.'/stubs/EloquentModelNamespacedStub.php';
 
@@ -292,12 +296,14 @@ class DatabaseEloquentMorphTest extends TestCase
         ]);
 
         $builder = m::mock(Builder::class);
-        $builder->shouldReceive('whereNotNull')->once()->with('table.morph_id');
-        $builder->shouldReceive('where')->once()->with('table.morph_id', '=', 1);
+        if (is_null($id)) {
+            $builder->shouldReceive('whereNotNull')->once()->with('table.morph_id');
+        }
+        $builder->shouldReceive('where')->once()->with('table.morph_id', '=', $id);
         $related = m::mock(Model::class);
         $builder->shouldReceive('getModel')->andReturn($related);
         $parent = m::mock(EloquentModelNamespacedStub::class);
-        $parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
+        $parent->shouldReceive('getAttribute')->with('id')->andReturn($id);
         $parent->shouldReceive('getMorphClass')->andReturn($alias);
         $builder->shouldReceive('where')->once()->with('table.morph_type', $alias);
 


### PR DESCRIPTION
Reference:
Original PR that applied this change: #8033
Inquiry from laravel/ideas regarding this fix: https://github.com/laravel/ideas/issues/1341

Change Notes:
A whereNotNull check was added to the constraints of all HasOne, HasMany, and HasMorph relations queries to avoid a corner-case where new models with auto incremented IDs are created and have not had an ID assigned.

This forcibly includes an additional IS NOT NULL clause to all relations queries, where in 99% of cases it is not required.

This rectifies that change by only applying that clause in the unlikely case where the parentKey is still null, and reduces the size of relations queries for most usage.

To visualize the potential impact of this change, here are the queries as they are now compared to with the change applied

Before:
```
select * from group_members
where group_members.group_id = 28
  and group_members.group_id is not null
```
After:
```
select * from group_members
where group_members.group_id = 28
```

Query when parentKey is null (unchanged):
```
select * from group_members
where group_members.group_id is null
  and group_members.group_id is not null
```


I'm unaware of any real-world situation where the corner-case that encouraged this original bug fix would actually apply, so I struggled writing tests for it.  I've updated the existing tests to prevent them from failing by adding an optional parameter to the shared getRelations* methods, and only applying the `whereNotNull` expectation when necessary. However I did not create any actual tests to simulate the actual null id condition.  Any suggestions on how those tests should actually be structured would be appreciated.

Impact: Remove unnecessary where clause for most real-world relations queries usages.  This results in reduced bandwidth to database and reduced effort by query parsers where the additional clause is (hopefully) optimized away.

I've applied this to 6.x as I consider the fix to be valuable to LTS devs (including myself on several projects) due to the positive impact to databases.
