### PR TITLE
[8.x] Add anonymous migrations

### DIFF
--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -410,7 +410,12 @@ class Migrator
     protected function pretendToRun($migration, $method)
     {
         foreach ($this->getQueries($migration, $method) as $query) {
-            $name = $this->getMigrationName((new ReflectionClass($migration))->getFileName());
+            $name = get_class($migration);
+
+            $reflectionClass = new ReflectionClass($migration);
+            if ($reflectionClass->isAnonymous()) {
+                $name = $this->getMigrationName($reflectionClass->getFileName());
+            }
 
             $this->note("<info>{$name}:</info> {$query['query']}");
         }

--- a/tests/Integration/Migration/MigratorTest.php
+++ b/tests/Integration/Migration/MigratorTest.php
@@ -2,11 +2,29 @@
 
 namespace Illuminate\Tests\Integration\Migration;
 
+use Illuminate\Support\Facades\DB;
+use Mockery;
+use Mockery\Mock;
 use Orchestra\Testbench\TestCase;
-use PDOException;
+use Symfony\Component\Console\Output\OutputInterface;
 
 class MigratorTest extends TestCase
 {
+    /**
+     * @var Mock
+     */
+    private $output;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->output = Mockery::mock(OutputInterface::class);
+        $this->subject = $this->app->make('migrator');
+        $this->subject->setOutput($this->output);
+        $this->subject->getRepository()->createRepository();
+    }
+
     protected function getEnvironmentSetUp($app)
     {
         $app['config']->set('app.debug', 'true');
@@ -19,25 +37,55 @@ class MigratorTest extends TestCase
         ]);
     }
 
-    public function testDontDisplayOutputWhenOutputObjectIsNotAvailable()
+    public function testMigrate()
     {
-        $migrator = $this->app->make('migrator');
+        $this->expectOutput('<comment>Migrating:</comment> 2014_10_12_000000_create_people_table');
+        $this->expectOutput(Mockery::pattern('#<info>Migrated:</info>  2014_10_12_000000_create_people_table (.*)#'));
+        $this->expectOutput('<comment>Migrating:</comment> 2015_10_04_000000_modify_people_table');
+        $this->expectOutput(Mockery::pattern('#<info>Migrated:</info>  2015_10_04_000000_modify_people_table (.*)#'));
+        $this->expectOutput('<comment>Migrating:</comment> 2016_10_04_000000_modify_people_table');
+        $this->expectOutput(Mockery::pattern('#<info>Migrated:</info>  2016_10_04_000000_modify_people_table (.*)#'));
 
-        $migrator->getRepository()->createRepository();
+        $this->subject->run([__DIR__.'/fixtures']);
 
-        $migrator->run([__DIR__.'/fixtures']);
-
-        $this->assertTrue($this->tableExists('people'));
+        self::assertTrue(DB::getSchemaBuilder()->hasTable('people'));
+        self::assertTrue(DB::getSchemaBuilder()->hasColumn('people', 'first_name'));
+        self::assertTrue(DB::getSchemaBuilder()->hasColumn('people', 'last_name'));
     }
 
-    private function tableExists($table): bool
+    public function testRollback()
     {
-        try {
-            $this->app->make('db')->select("SELECT COUNT(*) FROM $table");
-        } catch (PDOException $e) {
-            return false;
-        }
+        $this->getConnection()->statement('CREATE TABLE people(id INT, first_name VARCHAR, last_name VARCHAR);');
+        $this->subject->getRepository()->log('2014_10_12_000000_create_people_table', 1);
+        $this->subject->getRepository()->log('2015_10_04_000000_modify_people_table', 1);
+        $this->subject->getRepository()->log('2016_10_04_000000_modify_people_table', 1);
 
-        return true;
+        $this->expectOutput('<comment>Rolling back:</comment> 2016_10_04_000000_modify_people_table');
+        $this->expectOutput(Mockery::pattern('#<info>Rolled back:</info>  2016_10_04_000000_modify_people_table (.*)#'));
+        $this->expectOutput('<comment>Rolling back:</comment> 2015_10_04_000000_modify_people_table');
+        $this->expectOutput(Mockery::pattern('#<info>Rolled back:</info>  2015_10_04_000000_modify_people_table (.*)#'));
+        $this->expectOutput('<comment>Rolling back:</comment> 2014_10_12_000000_create_people_table');
+        $this->expectOutput(Mockery::pattern('#<info>Rolled back:</info>  2014_10_12_000000_create_people_table (.*)#'));
+
+        $this->subject->rollback([__DIR__.'/fixtures']);
+
+        self::assertFalse(DB::getSchemaBuilder()->hasTable('people'));
+    }
+
+    public function testPretendMigrate()
+    {
+        $this->expectOutput('<info>2014_10_12_000000_create_people_table:</info> create table "people" ("id" integer not null primary key autoincrement, "name" varchar not null, "email" varchar not null, "password" varchar not null, "remember_token" varchar, "created_at" datetime, "updated_at" datetime)');
+        $this->expectOutput('<info>2014_10_12_000000_create_people_table:</info> create unique index "people_email_unique" on "people" ("email")');
+        $this->expectOutput('<info>2015_10_04_000000_modify_people_table:</info> alter table "people" add column "first_name" varchar');
+        $this->expectOutput('<info>2016_10_04_000000_modify_people_table:</info> alter table "people" add column "last_name" varchar');
+
+        $this->subject->run([__DIR__.'/fixtures'], ['pretend' => true]);
+
+        self::assertFalse(DB::getSchemaBuilder()->hasTable('people'));
+    }
+
+    private function expectOutput($argument): void
+    {
+        $this->output->shouldReceive('writeln')->once()->with($argument);
     }
 }

--- a/tests/Integration/Migration/MigratorTest.php
+++ b/tests/Integration/Migration/MigratorTest.php
@@ -74,8 +74,8 @@ class MigratorTest extends TestCase
 
     public function testPretendMigrate()
     {
-        $this->expectOutput('<info>2014_10_12_000000_create_people_table:</info> create table "people" ("id" integer not null primary key autoincrement, "name" varchar not null, "email" varchar not null, "password" varchar not null, "remember_token" varchar, "created_at" datetime, "updated_at" datetime)');
-        $this->expectOutput('<info>2014_10_12_000000_create_people_table:</info> create unique index "people_email_unique" on "people" ("email")');
+        $this->expectOutput('<info>CreatePeopleTable:</info> create table "people" ("id" integer not null primary key autoincrement, "name" varchar not null, "email" varchar not null, "password" varchar not null, "remember_token" varchar, "created_at" datetime, "updated_at" datetime)');
+        $this->expectOutput('<info>CreatePeopleTable:</info> create unique index "people_email_unique" on "people" ("email")');
         $this->expectOutput('<info>2015_10_04_000000_modify_people_table:</info> alter table "people" add column "first_name" varchar');
         $this->expectOutput('<info>2016_10_04_000000_modify_people_table:</info> alter table "people" add column "last_name" varchar');
 

--- a/tests/Integration/Migration/fixtures/2015_10_04_000000_modify_people_table.php
+++ b/tests/Integration/Migration/fixtures/2015_10_04_000000_modify_people_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('people', function (Blueprint $table) {
+            $table->string('first_name')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('people', function (Blueprint $table) {
+            $table->dropColumn('first_name');
+        });
+    }
+};

--- a/tests/Integration/Migration/fixtures/2016_10_04_000000_modify_people_table.php
+++ b/tests/Integration/Migration/fixtures/2016_10_04_000000_modify_people_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('people', function (Blueprint $table) {
+            $table->string('last_name')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('people', function (Blueprint $table) {
+            $table->dropColumn('last_name');
+        });
+    }
+};


### PR DESCRIPTION
This would solve https://github.com/laravel/framework/issues/5899.

With this approach, migrations won't have class names anymore (they didn't serve any purpose and cause some tricky to solve issues).

After a project was maintained for a long time, the chance that two migrations were created with the same name is very high. For example, consider the following migrations: 
- 2019_01_01_000000_add_content_to_posts_table
- 2020_01_01_000000_remove_content_from_posts_table
- 2021_01_01_000000_add_content_to_posts_table

With the current approach, the first and last migration have the same name. After the third migration is created, it is possible to run it just fine, unless you are trying to run all these migrations at the same time (like after creating an empty database, or while running tests). In a project where there were always tests since the beginning this will be barely an inconvenience, but it causes a lot of trouble for a project that has been developed for many years without tests.

With this new approach this won't be a problem, cause the names can be dropped completely. The new Migrator is still able to run named migration classes, so the solution is backward compatible.

I believe it would be possible to backport it to 6.x too, in case it is approved.