### PR TITLE
[8.x] allow for named global class scopes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasGlobalScopes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasGlobalScopes.php
@@ -13,14 +13,14 @@ trait HasGlobalScopes
      * Register a new global scope on the model.
      *
      * @param  \Illuminate\Database\Eloquent\Scope|\Closure|string  $scope
-     * @param  \Closure|null  $implementation
+     * @param  \Illuminate\Database\Eloquent\Scope|\Closure|null  $implementation
      * @return mixed
      *
      * @throws \InvalidArgumentException
      */
-    public static function addGlobalScope($scope, Closure $implementation = null)
+    public static function addGlobalScope($scope, $implementation = null)
     {
-        if (is_string($scope) && ! is_null($implementation)) {
+        if (is_string($scope) && ($implementation instanceof Closure || $implementation instanceof Scope)) {
             return static::$globalScopes[static::class][$scope] = $implementation;
         } elseif ($scope instanceof Closure) {
             return static::$globalScopes[static::class][spl_object_hash($scope)] = $scope;


### PR DESCRIPTION
This pull requests proposes a possibility to assign a name to a global scope defined by a scope class.

Right now, it is possible to define a global scope in three different ways:

1. `static::addGlobalScope('nameOfScope', function ($builder) { $builder->where('someColumn', '>', 1); });`
2. `static::addGlobalScope(function ($builder) { $builder->where('someColumn', '>', 1); });`
3. `static::addGlocalScope(new MyCustomScope());`

The first would be named `nameOfScope`, the second something like `0000000017da6fe1000000003ed5b2bc` and the third will go by the fully qualified class name of MyCustomScope.

In cases where `MyCustomScope` actually takes parameters, you are therefore not able to apply multiple scopes like:

```php
static::addGlocalScope(new OrderByScope('name', 'desc'));
static::addGlocalScope(new OrderByScope('birth_date'));
```

because the scope ordering by birth_date would overwrite the one previously assigned that ordered by name.

Of course it would be possible to call the Scope like `static::addGlocalScope(new OrderByScope(['name', 'desc'], 'birth_date'));` and chain the orderBys within the Scope, but then you would not be able to disable one of them selectively in a later query.

This PR suggests a change that, additionally to the existing invocations, allows to define a global scope on a Model like this:

```php
static::addGlocalScope('orderByName', new OrderByScope('name', 'desc'));
static::addGlocalScope('orderByBirthDate', new OrderByScope('birth_date'));
```

The scopes are distinctively named `orderByName` and `orderByBirthDate`, respectively, which allows for multiple class scopes to be stacked on a model with different parameters and of course to dynamically disable each one of them.