### PR TITLE
[8.x] Model::delete throw LogicException not Exception

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Database\Eloquent;
 
 use ArrayAccess;
-use Exception;
 use Illuminate\Contracts\Queue\QueueableCollection;
 use Illuminate\Contracts\Queue\QueueableEntity;
 use Illuminate\Contracts\Routing\UrlRoutable;
@@ -932,14 +931,14 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
      *
      * @return bool|null
      *
-     * @throws \Exception
+     * @throws \LogicException
      */
     public function delete()
     {
         $this->mergeAttributesFromClassCasts();
 
         if (is_null($this->getKeyName())) {
-            throw new Exception('No primary key defined on model.');
+            throw new \LogicException('No primary key defined on model.');
         }
 
         // If the model doesn't exist, there is nothing to delete so we'll just return

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -18,6 +18,7 @@ use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\ForwardsCalls;
 use JsonSerializable;
+use LogicException;
 
 abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializable, QueueableEntity, UrlRoutable
 {
@@ -938,7 +939,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
         $this->mergeAttributesFromClassCasts();
 
         if (is_null($this->getKeyName())) {
-            throw new \LogicException('No primary key defined on model.');
+            throw new LogicException('No primary key defined on model.');
         }
 
         // If the model doesn't exist, there is nothing to delete so we'll just return


### PR DESCRIPTION
# Issue

Currently eloquent model->delete() checks to see if a primary key is set on the model and throws a top level Exception if missing. This causes many static analysis tools to suggest using try catch anytime a model is deleted. Since this exception is only thrown when there is a mistake in the code (not setting the primary key) it could be changed to throw a LogicException instead.

# Change

This PR changes the exception thrown by Model::delete() from \Exception to \LogicException.

# Why logic exception?

> LogicException: 
Exception that represents error in the program logic. This kind of exceptions should directly lead to a fix in your code.

Static analysis tools typically consider LogicException to be unchecked and won't suggest callers use try catch. This should reduce the amount of unnecessary try catch blocks in those projects.

# Will this break anything?

Since LogicException extends Exception any user code that used to check for Exception will still work.
