### PR TITLE
[8.x] Add Collection@containsAll method

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -176,6 +176,23 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
+     * Determine if all items exists in the collection.
+     *
+     * @param  mixed  $arr
+     * @return bool
+     */
+    public function containsAll($arr)
+    {
+        foreach ($arr as $elem) {
+            if (! $this->contains($elem)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * Cross join with the given lists, returning all possible permutations.
      *
      * @param  mixed  ...$lists

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -205,6 +205,27 @@ class LazyCollection implements Enumerable
     }
 
     /**
+     * Determine if all items exists in the collection.
+     *
+     * @param  mixed  $arr
+     * @return bool
+     */
+    public function containsAll($arr)
+    {
+        // same code as in regular collection
+        // but not exactly the same behavior
+        // so we're better copying it here than
+        // using passthru
+        foreach ($arr as $elem) {
+            if (! $this->contains($elem)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * Cross join the given iterables, returning all possible permutations.
      *
      * @param  array  ...$arrays

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2951,6 +2951,27 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testContainsAll($collection)
+    {
+        $c = new $collection([1, 3, 5]);
+
+        $this->assertTrue($c->containsAll([1, 3]));
+        $this->assertTrue($c->containsAll([1, 5]));
+        $this->assertFalse($c->containsAll([1, 2]));
+        $this->assertFalse($c->containsAll([1, 3, 5, 7]));
+
+        $this->assertTrue($c->containsAll(collect([1, 3])));
+        $this->assertTrue($c->containsAll(collect([1, 5])));
+        $this->assertFalse($c->containsAll(collect([1, 2])));
+        $this->assertFalse($c->containsAll(collect([1, 3, 5, 7])));
+
+        $this->assertTrue($c->containsAll([]));
+        $this->assertTrue($c->containsAll(collect([])));
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testSome($collection)
     {
         $c = new $collection([1, 3, 5]);


### PR DESCRIPTION
This commit adds a new `containsAll` method to both `Collection` and `LazyCollection`, and some tests to make sure it works correctly.

This method allows to determine if a smaller array/collection items are all present in a laravel collection.

## Usage

```PHP
$collection->containsAll($arr);
```
with `$arr` being an `array`, a `Collection`, a `LazyCollection` or whatever implements `Enumerable`.

It will crash if `$arr` is `null` because we can't do a `foreach` on a `null` element.
I think it is the intended behavior and that it could just be stated in the documentation.

## Why is that needed?

I think this is clearly something Laravel collections lacks of.
In my case, I need to check if a laravel collection contains all the stuff a user sent to the controller. In other words, I need to check if the user has sent only stuff contained in a laravel collection.
I've got something like an enterprise admin panel (not to be confused with the global admin panel) which allows the administrator to manage the employees permissions.
Since the enterprise administrator is sending ids via a form, I must verify all the ids provided are all their own employees, to avoid malicious users to revoke access to employees of other enterprises by sending random ids for example.

I think this use case is not a niche one, but a relatively current one.

In order to illustrate my use case, here is a snippet of code based on it:
```PHP
if (! $this->containsAll($enterpriseEmployeesIds, $employeesId)) {
    $flash->error("Specified employees does not belong to your enterprise!");
    return back();
}
```
will become
```PHP
if (! $enterpriseEmployeesIds->containsAll($employeesId)) {
    $flash->error("Specified employees does not belong to your enterprise!");
    return back();
}
```
with `$flash` being an instance of an utility class wrapping `$request->flash('whatever', [$logLevel, $msg])`.

## Implementation notes

At first, I plan to use `LazyCollection#passthru` for the `LazyCollection#containsAll` implementation but I wasn't able to make it work.
Then, I realize that copying the code of the `Collection#containsAll` implementation is the thing to do.
The code does not behave the same with a `LazyCollection` as it does with a `Collection` in terms of memory usage.
Basically, the difference is that calling `passthru` creates a `Collection`, which is entirely allocated in memory.
Furthermore, the creation of an intermediary `Collection` adds unnecessary overhead and would forbid the usage of `containsAll` with large `LazyCollections`.

I'm not familiar with the laravel internals, so the implementation is pretty simple to understand without specific knowledge about these.

I tried to test it the best I can, but if you want me to add more tests for some weird edge cases for example, don't hesitate to ask.

## Questions

I don't know if I may use something like `takeUntilTimeout` in the `LazyCollection` implementation or if something already prevents `foreach` on infinite generator `LazyCollection` to loop infinitely.
If I may use that kind of thing, how long do you think I must set by default? May I add it as an optional parameter?

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->