### PR TITLE
[8.x] Add method to dump the SQL query replacing all bindings

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -98,6 +98,7 @@ class Builder
         'raw',
         'sum',
         'toSql',
+        'toSqlWithBindings',
     ];
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2275,7 +2275,7 @@ class Builder
             '?',
             collect($this->connection->prepareBindings($this->getBindings()))
                 ->map(function ($i) {
-                    return (is_string($i)) ? "'{$i}'" : $i;
+                    return (is_string($i)) ? $this->connection->getPdo()->quote($i) : $i;
                 })->all(),
             $this->toSql()
         );

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2275,7 +2275,17 @@ class Builder
             '?',
             collect($this->connection->prepareBindings($this->getBindings()))
                 ->map(function ($i) {
-                    return (is_string($i)) ? $this->connection->getPdo()->quote($i) : $i;
+                    if (is_string($i)) {
+                        if (method_exists($this->connection, 'getPdo')) {
+                            return is_string($i) ? $this->connection->getPdo()->quote($i) : $i;
+                        }
+                        $search = ["\\",  "\x00", "\n",  "\r",  "'",  '"', "\x1a"];
+                        $replace = ["\\\\","\\0","\\n", "\\r", "\'", '\"', "\\Z"];
+
+                        return "'" . str_replace($search, $replace, $value) . "'";
+                    }
+
+                    return $i;
                 })->all(),
             $this->toSql()
         );

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2273,12 +2273,8 @@ class Builder
     {
         return Str::replaceArray(
             '?',
-            collect($this->getBindings())
+            collect($this->connection->prepareBindings($this->getBindings()))
                 ->map(function ($i) {
-                    if (is_object($i)) {
-                        $i = (string) $i;
-                    }
-
                     return (is_string($i)) ? "'{$i}'" : $i;
                 })->all(),
             $this->toSql()

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2282,7 +2282,7 @@ class Builder
                         $search = ['\\',  "\x00", "\n",  "\r",  "'",  '"', "\x1a"];
                         $replace = ['\\\\', '\\0', '\\n', '\\r', "\'", '\"', '\\Z'];
 
-                        return "'".str_replace($search, $replace, $value)."'";
+                        return "'".str_replace($search, $replace, $i)."'";
                     }
 
                     return $i;

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2279,10 +2279,10 @@ class Builder
                         if (method_exists($this->connection, 'getPdo')) {
                             return is_string($i) ? $this->connection->getPdo()->quote($i) : $i;
                         }
-                        $search = ["\\",  "\x00", "\n",  "\r",  "'",  '"', "\x1a"];
-                        $replace = ["\\\\","\\0","\\n", "\\r", "\'", '\"', "\\Z"];
+                        $search = ['\\',  "\x00", "\n",  "\r",  "'",  '"', "\x1a"];
+                        $replace = ['\\\\', '\\0', '\\n', '\\r', "\'", '\"', '\\Z'];
 
-                        return "'" . str_replace($search, $replace, $value) . "'";
+                        return "'".str_replace($search, $replace, $value)."'";
                     }
 
                     return $i;

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2274,10 +2274,11 @@ class Builder
         return Str::replaceArray(
             '?',
             collect($this->getBindings())
-                ->map(function($i) {
+                ->map(function ($i) {
                     if (is_object($i)) {
                         $i = (string) $i;
                     }
+
                     return (is_string($i)) ? "'{$i}'" : $i;
                 })->all(),
             $this->toSql()

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2265,6 +2265,26 @@ class Builder
     }
 
     /**
+     * Get the SQL representation of the query replacing all bindings.
+     *
+     * @return string
+     */
+    public function toSqlWithBindings()
+    {
+        return Str::replaceArray(
+            '?',
+            collect($this->getBindings())
+                ->map(function($i) {
+                    if (is_object($i)) {
+                        $i = (string) $i;
+                    }
+                    return (is_string($i)) ? "'{$i}'" : $i;
+                })->all(),
+            $this->toSql()
+        );
+    }
+
+    /**
      * Execute a query for a single record by ID.
      *
      * @param  int|string  $id

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2277,7 +2277,7 @@ class Builder
                 ->map(function ($i) {
                     if (is_string($i)) {
                         if (method_exists($this->connection, 'getPdo')) {
-                            return is_string($i) ? $this->connection->getPdo()->quote($i) : $i;
+                            return $this->connection->getPdo()->quote($i);
                         }
                         $search = ['\\',  "\x00", "\n",  "\r",  "'",  '"', "\x1a"];
                         $replace = ['\\\\', '\\0', '\\n', '\\r', "\'", '\"', '\\Z'];

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -3807,11 +3807,32 @@ SQL;
         $this->assertEquals([], $clone->getBindings());
     }
 
-    public function testToSqlWithBindingsMethod()
+    public function testToSqlWithBindingsMethodUsingMysqlBuilder()
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->where('name', 'like', '%Taylor%');
         $this->assertSame("select * from `users` where `name` like '%Taylor%'", $builder->toSqlWithBindings());
+    }
+
+    public function testToSqlWithBindingsMethodUsingPostgresBuilder()
+    {
+        $builder = $this->getPostgresBuilder();
+        $builder->select('*')->from('users')->where('name', 'like', '%Taylor%');
+        $this->assertSame("select * from \"users\" where \"name\"::text like '%Taylor%'", $builder->toSqlWithBindings());
+    }
+
+    public function testToSqlWithBindingsMethodUsingSQLiteBuilder()
+    {
+        $builder = $this->getSQLiteBuilder();
+        $builder->select('*')->from('users')->where('name', 'like', '%Taylor%');
+        $this->assertSame("select * from \"users\" where \"name\" like '%Taylor%'", $builder->toSqlWithBindings());
+    }
+
+    public function testToSqlWithBindingsMethodUsingSqlServerBuilder()
+    {
+        $builder = $this->getSqlServerBuilder();
+        $builder->select('*')->from('users')->where('name', 'like', '%Taylor%');
+        $this->assertSame("select * from [users] where [name] like '%Taylor%'", $builder->toSqlWithBindings());
     }
 
     protected function getConnection()

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -19,7 +19,6 @@ use Illuminate\Pagination\AbstractPaginator as Paginator;
 use Illuminate\Pagination\LengthAwarePaginator;
 use InvalidArgumentException;
 use Mockery as m;
-use PDO;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use stdClass;
@@ -3814,10 +3813,6 @@ SQL;
         $processor = m::mock(Processor::class);
         $connection = m::mock(ConnectionInterface::class);
 
-        $pdo = $this->createMock(PDOStub::class);
-        $pdo->expects($this->once())->method('quote')->with('%Taylor%')->willReturn("'%Taylor%'");
-
-        $connection->shouldReceive('getPdo')->andReturn($pdo);
         $connection->expects('prepareBindings')
             ->with(['%Taylor%'])
             ->andReturn(['%Taylor%']);
@@ -3834,10 +3829,6 @@ SQL;
         $processor = m::mock(Processor::class);
         $connection = m::mock(ConnectionInterface::class);
 
-        $pdo = $this->createMock(PDOStub::class);
-        $pdo->expects($this->once())->method('quote')->with('%Taylor%')->willReturn("'%Taylor%'");
-
-        $connection->shouldReceive('getPdo')->andReturn($pdo);
         $connection->expects('prepareBindings')
             ->with(['%Taylor%'])
             ->andReturn(['%Taylor%']);
@@ -3854,10 +3845,6 @@ SQL;
         $processor = m::mock(Processor::class);
         $connection = m::mock(ConnectionInterface::class);
 
-        $pdo = $this->createMock(PDOStub::class);
-        $pdo->expects($this->once())->method('quote')->with('%Taylor%')->willReturn("'%Taylor%'");
-
-        $connection->shouldReceive('getPdo')->andReturn($pdo);
         $connection->expects('prepareBindings')
             ->with(['%Taylor%'])
             ->andReturn(['%Taylor%']);
@@ -3874,10 +3861,6 @@ SQL;
         $processor = m::mock(Processor::class);
         $connection = m::mock(ConnectionInterface::class);
 
-        $pdo = $this->createMock(PDOStub::class);
-        $pdo->expects($this->once())->method('quote')->with('%Taylor%')->willReturn("'%Taylor%'");
-
-        $connection->shouldReceive('getPdo')->andReturn($pdo);
         $connection->expects('prepareBindings')
             ->with(['%Taylor%'])
             ->andReturn(['%Taylor%']);
@@ -3896,12 +3879,6 @@ SQL;
 
         $datetime = new Datetime();
 
-        $pdo = $this->createMock(PDOStub::class);
-        $pdo->expects($this->once())->method('quote')
-            ->with($datetime->format('Y-m-d H:i:s'))
-            ->willReturn("'{$datetime->format('Y-m-d H:i:s')}'");
-
-        $connection->shouldReceive('getPdo')->andReturn($pdo);
         $connection->expects('prepareBindings')
             ->with([$datetime])
             ->andReturn([$datetime->format('Y-m-d H:i:s')]);
@@ -3922,10 +3899,6 @@ SQL;
         $processor = m::mock(Processor::class);
         $connection = m::mock(ConnectionInterface::class);
 
-        $pdo = $this->createMock(PDOStub::class);
-        $pdo->expects($this->once())->method('quote')->with("%Taylor's%")->willReturn("'%Taylor\'s%'");
-
-        $connection->shouldReceive('getPdo')->andReturn($pdo);
         $connection->expects('prepareBindings')
             ->with(['%Taylor\'s%'])
             ->andReturn(['%Taylor\'s%']);

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -3807,6 +3807,13 @@ SQL;
         $this->assertEquals([], $clone->getBindings());
     }
 
+    public function testToSqlWithBindingsMethod()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->where('name', 'like', '%Taylor%');
+        $this->assertSame("select * from `users` where `name` like '%Taylor%'", $builder->toSqlWithBindings());
+    }
+
     protected function getConnection()
     {
         $connection = m::mock(ConnectionInterface::class);

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -3977,16 +3977,3 @@ SQL;
         ])->makePartial();
     }
 }
-
-class PDOStub extends PDO
-{
-    public function __construct()
-    {
-        //
-    }
-
-    public function quote($string, $type = PDO::PARAM_STR)
-    {
-        //
-    }
-}


### PR DESCRIPTION
## About this PR
This PR adds a new `toSqlWithBindings` method to the Query Builder class.

It allows developers to dump the query with all binding replaced with it actual value, for example:

```php
Post::where('title', 'like', 'Example%');
```

With the actual `->toSql()` method, it returns this:

```text
"select * from `posts` where `title` like ?"
```

Of course you can use the `->dd()` method, and it returns your bindings as an array, which is useful but it kinda take some time to figure out the place for each binding within your query if you have a query with too many bindings:
```sql
"select * from `posts` where `title` like ?"
```
```
array:1 [
  0 => "Example%"
]
```

Using the new proposed `->toSqlWithBindings()` method, you can easily see  your query with all bindings:
```sql
select * from `posts` where `title` like 'Example%'
```

## Questions
I don't know if my tests were added to the correct class. If not, tell me what class they should be in and I make the correction.