### PR TITLE
[8.x] Allow testing of Blade components that return closures

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithViews.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithViews.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Testing\Concerns;
 
+use Closure;
 use Illuminate\Support\Facades\View as ViewFacade;
 use Illuminate\Support\MessageBag;
 use Illuminate\Support\Str;
@@ -57,6 +58,10 @@ trait InteractsWithViews
         $component = $this->app->make($componentClass, $data);
 
         $view = $component->resolveView();
+
+        if ($view instanceof Closure) {
+            $view = $view($data);
+        }
 
         return $view instanceof View
                 ? new TestView($view->with($component->data()))


### PR DESCRIPTION
A Blade component can not only return a view or an HTML string but also a closure, that gets evaluated to retrieve the actual view.
The test helper for Blade components did not yet support this and resulted in an exception. This PR fixes this by evaluating the closure with the view data (just like it is done when rendering components).