### PR TITLE
[8.x] Fix clone() on EloquentBuilder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1609,7 +1609,7 @@ class Builder
     }
 
     /**
-     * Clone the query.
+     * Clone the Eloquent query builder.
      *
      * @return static
      */

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1609,6 +1609,16 @@ class Builder
     }
 
     /**
+     * Clone the query.
+     *
+     * @return static
+     */
+    public function clone()
+    {
+        return clone $this;
+    }
+
+    /**
      * Force a clone of the underlying query builder when cloning.
      *
      * @return void

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1497,6 +1497,18 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->withCasts(['foo' => 'bar']);
     }
 
+    public function testClone()
+    {
+        $query = new BaseBuilder(m::mock(ConnectionInterface::class), new Grammar, m::mock(Processor::class));
+        $builder = new Builder($query);
+        $builder->select('*')->from('users');
+        $clone = $builder->clone()->where('email', 'foo');
+
+        $this->assertNotSame($builder, $clone);
+        $this->assertSame('select * from "users"', $builder->toSql());
+        $this->assertSame('select * from "users" where "email" = ?', $clone->toSql());
+    }
+
     protected function mockConnectionForModel($model, $database)
     {
         $grammarClass = 'Illuminate\Database\Query\Grammars\\'.$database.'Grammar';


### PR DESCRIPTION
This PR fixes `clone()` usage on `EloquentBuilder`.

`clone()` is currently being forwarded to the underlying `QueryBuilder`.

Now, here's the thing:

`clone $builder` effectively clones the underlying `QueryBuilder` object, but `$builder->clone()` doesn't. References are kept so this is basicly an unexpected noop.