### PR TITLE
[8.x] Add Eloquent builder to allowed types of selectSub()

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -244,7 +244,7 @@ class Builder
     /**
      * Add a subselect expression to the query.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|string  $query
+     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|string  $query
      * @param  string  $as
      * @return $this
      *


### PR DESCRIPTION
Add the Eloquent Builder class to the allowed types of query for `selectSub` method.

This is useful for static analysis when using an Eloquent-driven query like the following one. Without this fix, PHPStan and other tools will throw an error.

```php
$query->selectSub(
	Comment::select('author')
		->latest()
		->take(1),
	'author'
);
```
