### PR TITLE
[8.x] Allow Blade components to be cacheable

### DIFF
--- a/src/Illuminate/Contracts/View/CanBeCached.php
+++ b/src/Illuminate/Contracts/View/CanBeCached.php
@@ -1,10 +1,7 @@
 <?php
 
-
 namespace Illuminate\Contracts\View;
-
 
 interface CanBeCached
 {
-
 }

--- a/src/Illuminate/Contracts/View/CanBeCached.php
+++ b/src/Illuminate/Contracts/View/CanBeCached.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace Illuminate\Contracts\View;
+
+
+interface CanBeCached
+{
+
+}

--- a/src/Illuminate/View/AnonymousComponent.php
+++ b/src/Illuminate/View/AnonymousComponent.php
@@ -2,7 +2,9 @@
 
 namespace Illuminate\View;
 
-class AnonymousComponent extends Component
+use Illuminate\Contracts\View\CanBeCached;
+
+class AnonymousComponent extends Component implements CanBeCached
 {
     /**
      * The component view.

--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -85,11 +85,11 @@ abstract class Component
             $resolvedView = $view instanceof Closure ? function (array $data = []) use ($view, $resolver) {
                 return $resolver($view($data));
             }
-                : $resolver($view);
+            : $resolver($view);
         }
 
         if ($this->canBeCached()) {
-            return function($data) use ($resolvedView) {
+            return function ($data) use ($resolvedView) {
                 return $this->cacheResolvedView($resolvedView, $data);
             };
         }

--- a/src/Illuminate/View/Concerns/CachesComponents.php
+++ b/src/Illuminate/View/Concerns/CachesComponents.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Illuminate\View\Concerns;
+
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Contracts\View\CanBeCached;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Cache;
+
+trait CachesComponents
+{
+    /**
+     * The attributes that can be passed to the component to control the
+     * caching behavior.
+     * @return array
+     */
+    protected function cacheAttributes()
+    {
+        return [
+            'x-cache',
+            'x-cache-key',
+            'x-cache-ttl',
+        ];
+    }
+
+    /**
+     * Determines if the component can be cached.
+     *
+     * @return bool
+     */
+    protected function canBeCached()
+    {
+        return $this instanceof CanBeCached;
+    }
+
+    /**
+     * Determines if the component should be cached.
+     *
+     * @return bool
+     */
+    protected function shouldBeCached()
+    {
+        return $this->attributes->get('x-cache', false) && $this->canBeCached();
+    }
+
+    /**
+     * The key used to cache the component.
+     *
+     * @return bool
+     */
+    protected function cacheKey()
+    {
+        return $this->attributes->get('x-cache-key', sha1(static::class . $this->attributes->except($this->cacheAttributes())->toHtml()));
+    }
+
+    /**
+     * The cache TTL to use for the component.
+     *
+     * @return mixed
+     */
+    protected function cacheTtl()
+    {
+        return $this->attributes->get('x-cache-ttl', now()->addHour());
+    }
+
+    /**
+     * Render the resolved component view so that it can be cached.
+     *
+     * @param \Illuminate\Contracts\View\View|\Illuminate\Contracts\Support\Htmlable|string $view
+     * @param array $data
+     * @return string
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     */
+    protected function renderResolvedView($view, $data)
+    {
+        $data['attributes'] = $data['attributes']->filter(function ($value, $attribute) {
+            return ! in_array($attribute, $this->cacheAttributes());
+        });
+
+        if ($view instanceof View) {
+            return $view->with($data)->render();
+        }
+
+        if ($view instanceof Htmlable) {
+            return $view->toHtml();
+        }
+
+        return Container::getInstance()->make('view')->make($view, $data)->render();
+    }
+
+    /**
+     * Cache the resolved component view and return a Htmlable class that will
+     * return the cached result.
+     *
+     * @param \Illuminate\Contracts\View\View|\Illuminate\Contracts\Support\Htmlable|string $view
+     * @param array $data
+     * @return Htmlable
+     */
+    protected function cacheResolvedView($view, $data)
+    {
+        if (! $this->shouldBeCached()) {
+            return $view;
+        }
+
+        $html = Cache::remember($this->cacheKey(), $this->cacheTtl(), function() use ($view, $data) {
+            return $this->renderResolvedView($view, $data);
+        });
+
+        return new class($html) implements Htmlable {
+            protected $html;
+
+            public function __construct($html)
+            {
+                $this->html = $html;
+            }
+
+            public function toHtml()
+            {
+                return $this->html;
+            }
+        };
+    }
+}

--- a/src/Illuminate/View/Concerns/CachesComponents.php
+++ b/src/Illuminate/View/Concerns/CachesComponents.php
@@ -47,11 +47,12 @@ trait CachesComponents
     /**
      * The key used to cache the component.
      *
+     * @param array $slots
      * @return bool
      */
-    protected function cacheKey()
+    protected function cacheKey(array $slots)
     {
-        return $this->attributes->get('x-cache-key', sha1(static::class . $this->attributes->except($this->cacheAttributes())->toHtml()));
+        return $this->attributes->get('x-cache-key', static::class.sha1($this->attributes->except($this->cacheAttributes())->toHtml().serialize($slots)));
     }
 
     /**
@@ -103,7 +104,7 @@ trait CachesComponents
             return $view;
         }
 
-        $html = Cache::remember($this->cacheKey(), $this->cacheTtl(), function() use ($view, $data) {
+        $html = Cache::remember($this->cacheKey($data['__laravel_slots']), $this->cacheTtl(), function () use ($view, $data) {
             return $this->renderResolvedView($view, $data);
         });
 

--- a/src/Illuminate/View/Concerns/CachesComponents.php
+++ b/src/Illuminate/View/Concerns/CachesComponents.php
@@ -11,8 +11,8 @@ use Illuminate\Support\Facades\Cache;
 trait CachesComponents
 {
     /**
-     * The attributes that can be passed to the component to control the
-     * caching behavior.
+     * The cache controlling attributes for this component.
+     *
      * @return array
      */
     protected function cacheAttributes()
@@ -47,7 +47,7 @@ trait CachesComponents
     /**
      * The key used to cache the component.
      *
-     * @param array $slots
+     * @param  array  $slots
      * @return bool
      */
     protected function cacheKey(array $slots)
@@ -68,9 +68,10 @@ trait CachesComponents
     /**
      * Render the resolved component view so that it can be cached.
      *
-     * @param \Illuminate\Contracts\View\View|\Illuminate\Contracts\Support\Htmlable|string $view
-     * @param array $data
+     * @param  \Illuminate\Contracts\View\View|\Illuminate\Contracts\Support\Htmlable|string $view
+     * @param  array  $data
      * @return string
+     *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
     protected function renderResolvedView($view, $data)
@@ -94,9 +95,9 @@ trait CachesComponents
      * Cache the resolved component view and return a Htmlable class that will
      * return the cached result.
      *
-     * @param \Illuminate\Contracts\View\View|\Illuminate\Contracts\Support\Htmlable|string $view
-     * @param array $data
-     * @return Htmlable
+     * @param  \Illuminate\Contracts\View\View|\Illuminate\Contracts\Support\Htmlable|string  $view
+     * @param  array  $data
+     * @return \Illuminate\Contracts\Support\Htmlable
      */
     protected function cacheResolvedView($view, $data)
     {

--- a/tests/Integration/View/BladeTest.php
+++ b/tests/Integration/View/BladeTest.php
@@ -18,6 +18,17 @@ class BladeTest extends TestCase
         $this->assertSame('Hello Taylor', trim($view));
     }
 
+    public function test_caching_a_component_uses_slots_for_default_cache_key()
+    {
+        $view = View::make('uses-link-cached', ['title' => 'Laravel'])->render();
+
+        $this->assertSame('This is a sentence with a <a href="https://laravel.com">Laravel</a>.', trim($view));
+
+        $view = View::make('uses-link-cached', ['title' => 'PHP Framework'])->render();
+
+        $this->assertSame('This is a sentence with a <a href="https://laravel.com">PHP Framework</a>.', trim($view));
+    }
+
     public function test_caching_a_component()
     {
         $view = View::make('uses-panel-cached', ['name' => 'Taylor'])->render();

--- a/tests/Integration/View/BladeTest.php
+++ b/tests/Integration/View/BladeTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\View;
 
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\View;
 use Orchestra\Testbench\TestCase;
 
@@ -15,6 +16,67 @@ class BladeTest extends TestCase
         $view = View::make('hello', ['name' => 'Taylor'])->render();
 
         $this->assertSame('Hello Taylor', trim($view));
+    }
+
+    public function test_caching_a_component()
+    {
+        $view = View::make('uses-panel-cached', ['name' => 'Taylor'])->render();
+
+        $this->assertSame('<div class="ml-2">
+    Hello Taylor
+</div>', trim($view));
+
+        $view = View::make('uses-panel-cached', ['name' => 'Marcel'])->render();
+
+        $this->assertSame('<div class="ml-2">
+    Hello Taylor
+</div>', trim($view));
+    }
+
+    public function test_caching_a_component_with_custom_cache_ttl()
+    {
+        $view = View::make('uses-panel-cached', ['name' => 'Taylor', 'ttl' => 10])->render();
+
+        $this->assertSame('<div class="ml-2">
+    Hello Taylor
+</div>', trim($view));
+
+        Carbon::setTestNow(Carbon::now()->addSeconds(9));
+
+        $view = View::make('uses-panel-cached', ['name' => 'Marcel'])->render();
+
+        $this->assertSame('<div class="ml-2">
+    Hello Taylor
+</div>', trim($view));
+
+        Carbon::setTestNow(Carbon::now()->addSeconds(10));
+
+        $view = View::make('uses-panel-cached', ['name' => 'Marcel'])->render();
+
+        $this->assertSame('<div class="ml-2">
+    Hello Marcel
+</div>', trim($view));
+    }
+
+    public function test_caching_a_component_with_custom_cache_keys()
+    {
+        $view = View::make('uses-panel-cached', ['name' => 'Taylor', 'cacheKey' => 'cache-key'])->render();
+
+        $this->assertSame('<div class="ml-2">
+    Hello Taylor
+</div>', trim($view));
+
+        $view = View::make('uses-panel-cached', ['name' => 'Marcel', 'cacheKey' => 'cache-key'])->render();
+
+        $this->assertSame('<div class="ml-2">
+    Hello Taylor
+</div>', trim($view));
+
+        $view = View::make('uses-panel-cached', ['name' => 'Marcel', 'cacheKey' => 'cache-key-2'])->render();
+
+        $this->assertSame('<div class="ml-2">
+    Hello Marcel
+</div>', trim($view));
     }
 
     public function test_rendering_a_component()

--- a/tests/Integration/View/templates/uses-link-cached.blade.php
+++ b/tests/Integration/View/templates/uses-link-cached.blade.php
@@ -1,0 +1,1 @@
+This is a sentence with a <x-link x-cache href="https://laravel.com">{{ $title }}</x-link>.

--- a/tests/Integration/View/templates/uses-panel-cached.blade.php
+++ b/tests/Integration/View/templates/uses-panel-cached.blade.php
@@ -1,0 +1,3 @@
+<x-panel class="ml-2" :name="$name" x-cache :x-cache-key="$cacheKey ?? 'cache'" :x-cache-ttl="$ttl ?? null">
+    Panel contents
+</x-panel>


### PR DESCRIPTION
This PR adds the ability to cache individual Blade components. Since Blade components (especially class-based components) can contain quite a lot of code that gets evaluated within the views, caching those components could bring an additional performance boost.

For example, a markdown Blade component, like the one Blade UI Kit provides, looks like this:

```blade
<x-markdown>
# Hello World

Blade UI components are **awesome**.
</x-markdown>
```

This component renders the slot into markdown every time that the component gets rendered - regardless of the already existing view cache.

With this PR, users can determine which Blade components they want to cache. By default, all anonymous components can be cached - if class-based components should be cacheable, they need to implement the new `CanBeCached` interface.

To make a component cacheable, users can apply a `x-cache` attribute on the component:

```blade
<x-markdown x-cache>
# Hello World

Blade UI components are **awesome**.
</x-markdown>
```

The default cache TTL is 1 hour, and the default cache key gets generated using the component name, the provided attributes, as well as all provided slots.

## Custom TTL

Users can customize the TTL of the component cache, by providing a `x-cache-ttl` attribute on the component:

```blade
<x-markdown x-cache x-cache-ttl="120">
# Hello World

Blade UI components are **awesome**.
</x-markdown>
```

This can either be an integer, which will be used as the number of seconds to cache, or as a datetime instance, for example by providing a carbon instance: `:x-cache-ttl="now()->addDay()"`

## Custom Cache Key

As mentioned above, the cache key gets generated using the component name, all attributes, as well as the slots. In order to customize the cache key, users can provide a `x-cache-key` attribute to the component.

### Why `CanBeCached`? 

The reason that a `CanBeCached` interface exists, is because I didn't want to change the default behavior of the `resolveView` method. In order to cache a component, I need to return a callable that itself returns the cached view (if caching should take place). 