### PR TITLE
[8.x] Added workerSleeping and workerStarting events to queue worker

### DIFF
--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -81,7 +81,7 @@ class WorkCommand extends Command
     public function handle()
     {
         if ($this->downForMaintenance() && $this->option('once')) {
-            return $this->worker->sleep($this->option('sleep'));
+            return $this->worker->sleep($this->option('sleep'), 'unknown', 0);
         }
 
         // We'll listen to the processed and failed events so we can write information

--- a/src/Illuminate/Queue/Events/WorkerAwakend.php
+++ b/src/Illuminate/Queue/Events/WorkerAwakend.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Illuminate\Queue\Events;
+
+class WorkerAwakend
+{
+    /**
+     * The connection name.
+     *
+     * @var string
+     */
+    public $connectionName;
+
+    /**
+     * The the type of sleeping event.
+     *
+     * @var int
+     */
+    public $sleepingType;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  string  $connectionName
+     * @param  int     $sleepingType
+     * @return void
+     */
+    public function __construct($connectionName, $sleepingType)
+    {
+        $this->connectionName = $connectionName;
+        $this->sleepingType = $sleepingType;
+    }
+}

--- a/src/Illuminate/Queue/Events/WorkerSleeping.php
+++ b/src/Illuminate/Queue/Events/WorkerSleeping.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Illuminate\Queue\Events;
+
+class WorkerSleeping
+{
+    /**
+     * The connection name.
+     *
+     * @var string
+     */
+    public $connectionName;
+
+    /**
+     * The the type of sleeping event.
+     *
+     * @var int
+     */
+    public $sleepingType;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  string  $connectionName
+     * @param  int     $sleepingType
+     * @return void
+     */
+    public function __construct($connectionName, $sleepingType)
+    {
+        $this->connectionName = $connectionName;
+        $this->sleepingType = $sleepingType;
+    }
+}

--- a/src/Illuminate/Queue/Events/WorkerStarting.php
+++ b/src/Illuminate/Queue/Events/WorkerStarting.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Illuminate\Queue\Events;
+
+class WorkerStarting
+{
+    /**
+     * The connection name.
+     *
+     * @var string
+     */
+    public $connectionName;
+
+    /**
+     * The the type of starting event.
+     *
+     * @var int
+     */
+    public $startingType;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  string  $connectionName
+     * @param  int     $startingType
+     * @return void
+     */
+    public function __construct($connectionName, $startingType)
+    {
+        $this->connectionName = $connectionName;
+        $this->startingType = $startingType;
+    }
+}

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -795,7 +795,11 @@ class Worker
         }
 
         // Inform the developer that the worker is awoken again.
-        $this->raiseWorkerAwakendEvent($connectionName, $sleepingType);
+        // We are only informing the developer of the awakend event when the sleeping
+        // event was also fired.
+        if ($sleepingType !== 0) {
+            $this->raiseWorkerAwakendEvent($connectionName, $sleepingType);
+        }
     }
 
     /**

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -11,6 +11,7 @@ use Illuminate\Queue\Events\JobExceptionOccurred;
 use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Queue\Events\JobProcessing;
 use Illuminate\Queue\Events\Looping;
+use Illuminate\Queue\Events\WorkerAwakend;
 use Illuminate\Queue\Events\WorkerSleeping;
 use Illuminate\Queue\Events\WorkerStarting;
 use Illuminate\Queue\Events\WorkerStopping;
@@ -633,6 +634,20 @@ class Worker
     }
 
     /**
+     * Raise the worker awakend event.
+     *
+     * @param  string  $connectionName
+     * @param  int     $sleepingType
+     * @return void
+     */
+    protected function raiseWorkerAwakendEvent($connectionName, $sleepingType)
+    {
+        $this->events->dispatch(new WorkerAwakend(
+            $connectionName, $sleepingType
+        ));
+    }
+
+    /**
      * Raise the exception occurred queue job event.
      *
      * @param  string  $connectionName
@@ -778,6 +793,9 @@ class Worker
         } else {
             sleep($seconds);
         }
+
+        // Inform the developer that the worker is awoken again.
+        $this->raiseWorkerAwakendEvent($connectionName, $sleepingType);
     }
 
     /**

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -401,7 +401,7 @@ class InsomniacWorker extends Worker
     public $sleptFor;
     public $stopOnMemoryExceeded = false;
 
-    public function sleep($seconds)
+    public function sleep($seconds, $connectionName, $sleepingType)
     {
         $this->sleptFor = $seconds;
     }


### PR DESCRIPTION
Hiya huys,

With this PR I am trying to fill the gap where there was a `workerStopping` event but not an `workerSleeping` or `workerStarting` event. This PR fixxes that.

The `workerStartingEvent` is fired when the deamon starts up OR when then `--once` option is used.
The event has a public property called `startingType` to let the developer know what kind of starting type is happening. (1 = deamon, 2 = once).

The `workerSleepingEvent` is fired in different locations but has been added to the `sleep()` method.
The sleep event is only fired when needed and not when the sleep command is called for internal uses. The `workerSleepingEvent` has a public property called `sleepingType` to let the developer know what kind of sleeping type is happening. (1 = Sleeping because of no jobs, 2 = sleeping between jobs, 3 = sleeping because of signal).

The use case for this is the fact of my experience that I needed to have a starting event and a sleeping event. The starting event to start a connection with an ancient webservice and the sleeping connection because well I was already working on it.

First PR so don't be harsh :-)