### PR TITLE
[8.x] Add more readable `missing` method to Session\Store

### DIFF
--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -194,9 +194,9 @@ class Store implements Session
     }
 
     /**
-     * Checks if a key is missing.
+     * Determine if the given key is missing from the session data.
      *
-     * @param string|array $key
+     * @param  string|array  $key
      * @return bool
      */
     public function missing($key)

--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -194,6 +194,17 @@ class Store implements Session
     }
 
     /**
+     * Checks if a key is missing.
+     *
+     * @param string|array $key
+     * @return bool
+     */
+    public function missing($key)
+    {
+        return ! $this->exists($key);
+    }
+
+    /**
      * Checks if a key is present and not null.
      *
      * @param  string|array  $key

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -452,6 +452,22 @@ class SessionStoreTest extends TestCase
         $this->assertFalse($session->exists(['hulk.two']));
     }
 
+    public function testKeyMissing()
+    {
+        $session = $this->getSession();
+        $session->put('foo', 'bar');
+        $this->assertFalse($session->missing('foo'));
+        $session->put('baz', null);
+        $session->put('hulk', ['one' => true]);
+        $this->assertFalse($session->has('baz'));
+        $this->assertFalse($session->missing('baz'));
+        $this->assertTrue($session->missing('bogus'));
+        $this->assertFalse($session->missing(['foo', 'baz']));
+        $this->assertTrue($session->missing(['foo', 'baz', 'bogus']));
+        $this->assertFalse($session->missing(['hulk.one']));
+        $this->assertTrue($session->missing(['hulk.two']));
+    }
+
     public function testRememberMethodCallsPutAndReturnsDefault()
     {
         $session = $this->getSession();


### PR DESCRIPTION
This PR adds a new `missing()` method to `Illuminate\Session\Store` so we can check for missing keys in a more readable way.

```php
// Instead of
if (!Session::has('key') {
    // ...
}

// We can do
if (Session::missing('key') {
    // ...
}
```

Like the `missing` method on the filesystem, there is no much logic behind the method, and it shouldn't add too much maintenance overload.