### PR TITLE
[9.x] Added WorkerStarted, WorkerSleeping and workerAwakend event to queue worker

### DIFF
--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -90,7 +90,7 @@ class WorkCommand extends Command
     public function handle()
     {
         if ($this->downForMaintenance() && $this->option('once')) {
-            return $this->worker->sleep($this->option('sleep'));
+            return $this->worker->sleep($this->option('sleep'), null, Worker::WORKER_SLEEPING_NO_EVENT);
         }
 
         // We'll listen to the processed and failed events so we can write information

--- a/src/Illuminate/Queue/Events/WorkerAwakend.php
+++ b/src/Illuminate/Queue/Events/WorkerAwakend.php
@@ -12,22 +12,31 @@ class WorkerAwakend
     public $connectionName;
 
     /**
-     * The the type of sleeping event.
+     * The the type of awakend event.
      *
-     * @var int
+     * @var int|null
      */
-    public $sleepingType;
+    public $awakendType;
+
+    /**
+     * Indicates if the event was fired because a new job was found.
+     *
+     * @var bool
+     */
+    public $awakendOnJobFound;
 
     /**
      * Create a new event instance.
      *
-     * @param  string  $connectionName
-     * @param  int     $sleepingType
+     * @param  string    $connectionName
+     * @param  int|null  $awakendType
+     * @param  bool      $awakendOnJobFound
      * @return void
      */
-    public function __construct($connectionName, $sleepingType)
+    public function __construct($connectionName, $awakendType = null, $awakendOnJobFound = false)
     {
         $this->connectionName = $connectionName;
-        $this->sleepingType = $sleepingType;
+        $this->awakendType = $awakendType;
+        $this->awakendOnJobFound = $awakendOnJobFound;
     }
 }

--- a/src/Illuminate/Queue/Events/WorkerAwakend.php
+++ b/src/Illuminate/Queue/Events/WorkerAwakend.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Illuminate\Queue\Events;
+
+class WorkerAwakend
+{
+    /**
+     * The connection name.
+     *
+     * @var string
+     */
+    public $connectionName;
+
+    /**
+     * The the type of sleeping event.
+     *
+     * @var int
+     */
+    public $sleepingType;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  string  $connectionName
+     * @param  int     $sleepingType
+     * @return void
+     */
+    public function __construct($connectionName, $sleepingType)
+    {
+        $this->connectionName = $connectionName;
+        $this->sleepingType = $sleepingType;
+    }
+}

--- a/src/Illuminate/Queue/Events/WorkerSleeping.php
+++ b/src/Illuminate/Queue/Events/WorkerSleeping.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Illuminate\Queue\Events;
+
+class WorkerSleeping
+{
+    /**
+     * The connection name.
+     *
+     * @var string
+     */
+    public $connectionName;
+
+    /**
+     * The the type of sleeping event.
+     *
+     * @var int
+     */
+    public $sleepingType;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  string  $connectionName
+     * @param  int     $sleepingType
+     * @return void
+     */
+    public function __construct($connectionName, $sleepingType)
+    {
+        $this->connectionName = $connectionName;
+        $this->sleepingType = $sleepingType;
+    }
+}

--- a/src/Illuminate/Queue/Events/WorkerStarting.php
+++ b/src/Illuminate/Queue/Events/WorkerStarting.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Illuminate\Queue\Events;
+
+class WorkerStarting
+{
+    /**
+     * The connection name.
+     *
+     * @var string
+     */
+    public $connectionName;
+
+    /**
+     * The the type of starting event.
+     *
+     * @var int
+     */
+    public $startingType;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  string  $connectionName
+     * @param  int     $startingType
+     * @return void
+     */
+    public function __construct($connectionName, $startingType)
+    {
+        $this->connectionName = $connectionName;
+        $this->startingType = $startingType;
+    }
+}

--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -111,6 +111,39 @@ class QueueManager implements FactoryContract, MonitorContract
     }
 
     /**
+     * Register an event listener for the daemon queue starting.
+     *
+     * @param  mixed  $callback
+     * @return void
+     */
+    public function starting($callback)
+    {
+        $this->app['events']->listen(Events\WorkerStarting::class, $callback);
+    }
+
+    /**
+     * Register an event listener for the daemon queue sleeping.
+     *
+     * @param  mixed  $callback
+     * @return void
+     */
+    public function sleeping($callback)
+    {
+        $this->app['events']->listen(Events\WorkerSleeping::class, $callback);
+    }
+
+    /**
+     * Register an event listener for the daemon queue awakend.
+     *
+     * @param  mixed  $callback
+     * @return void
+     */
+    public function awakend($callback)
+    {
+        $this->app['events']->listen(Events\WorkerAwakend::class, $callback);
+    }
+
+    /**
      * Determine if the driver is connected.
      *
      * @param  string|null  $name

--- a/tests/Queue/QueueSyncQueueTest.php
+++ b/tests/Queue/QueueSyncQueueTest.php
@@ -41,7 +41,7 @@ class QueueSyncQueueTest extends TestCase
         $container = new Container;
         Container::setInstance($container);
         $events = m::mock(Dispatcher::class);
-        $events->shouldReceive('dispatch')->times(3);
+        $events->shouldReceive('dispatch')->times(4);
         $container->instance('events', $events);
         $container->instance(Dispatcher::class, $events);
         $sync->setContainer($container);

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -401,7 +401,7 @@ class InsomniacWorker extends Worker
     public $sleptFor;
     public $stopOnMemoryExceeded = false;
 
-    public function sleep($seconds)
+    public function sleep($seconds, $connectionName, $sleepingType)
     {
         $this->sleptFor = $seconds;
     }


### PR DESCRIPTION
Hiya folks,

This PR adds 3 new events to the queue deamon

**WorkerStarted**
Allows the programmer to add a listener just before the worker is going to start up processing jobs.
Within the event a `startingType` property is specified, so the programmer knows what kind of starting was done:

- WORKER_STARTED_DEAMON
- WORKER_STARTED_ONCE

**WorkerSleeping**
Allows the programmer to add a listener just before the worker is going to sleep.
Within the event a `sleepingType` property is specified, so the programmer knows what kind of sleeping was done:

- WORKER_SLEEPING_NO_JOBS
- WORKER SLEEPING_BETWEEN_JOBS
- WORKER_SLEEPING_DEAMON

**WorkerAwakend**
Allows the programmer to add a listener after the  worker has slept for the specified time.
Within the event a `awakendType` property is specified, the values are the same as for the `WorkerSleeping` event with one addition:

- WORKER_AWAKEND_JOB_FOUND

One additional property is available on the `workerAwakend` event and that is `awakendOnJobsFound` this is set to `true` when the worker awakend because there were new jobs found. In this situation `WorkerAwakend` events will be fired one for `WORKER_SLEEPING_NO_JOBS` and one for `WORKER_AWAKEND_JOB_FOUND`.

The `SyncQueue` is changed to allow the event fire of `WorkerStarted`.
The `QueueManager` is changed to allow adding callbacks to the new events.

The use case for this is from my experience that I need a way to kill of a connection between the script and a webservice when the worker is going to sleep when there are no jobs available and reconnect when there are new jobs to process. When there are allot of jobs to process it is much faster to keep that connection open, but when there are no jobs to process for a couple of hours no need to keep that connection open.

I am PR'ing this to master because method signatures are changed.