### PR TITLE
[9.x] assertDatabaseHas accepts Model

### DIFF
--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -81,7 +81,7 @@ class Dispatcher implements QueueingDispatcher
     /**
      * Dispatch a command to its appropriate handler in the current process.
      *
-     * Queuable jobs will be dispatched to the "sync" queue.
+     * Queueable jobs will be dispatched to the "sync" queue.
      *
      * @param  mixed  $command
      * @param  mixed  $handler

--- a/src/Illuminate/Cache/RedisTaggedCache.php
+++ b/src/Illuminate/Cache/RedisTaggedCache.php
@@ -10,6 +10,7 @@ class RedisTaggedCache extends TaggedCache
      * @var string
      */
     const REFERENCE_KEY_FOREVER = 'forever_ref';
+
     /**
      * Standard reference key.
      *
@@ -41,13 +42,13 @@ class RedisTaggedCache extends TaggedCache
      *
      * @param  string  $key
      * @param  mixed  $value
-     * @return void
+     * @return int|bool
      */
     public function increment($key, $value = 1)
     {
         $this->pushStandardKeys($this->tags->getNamespace(), $key);
 
-        parent::increment($key, $value);
+        return parent::increment($key, $value);
     }
 
     /**
@@ -55,13 +56,13 @@ class RedisTaggedCache extends TaggedCache
      *
      * @param  string  $key
      * @param  mixed  $value
-     * @return void
+     * @return int|bool
      */
     public function decrement($key, $value = 1)
     {
         $this->pushStandardKeys($this->tags->getNamespace(), $key);
 
-        parent::decrement($key, $value);
+        return parent::decrement($key, $value);
     }
 
     /**

--- a/src/Illuminate/Cache/RetrievesMultipleKeys.php
+++ b/src/Illuminate/Cache/RetrievesMultipleKeys.php
@@ -16,8 +16,12 @@ trait RetrievesMultipleKeys
     {
         $return = [];
 
-        foreach ($keys as $key) {
-            $return[$key] = $this->get($key);
+        $keys = collect($keys)->mapWithKeys(function ($value, $key) {
+            return [is_string($key) ? $key : $value => is_string($key) ? $value : null];
+        })->all();
+
+        foreach ($keys as $key => $default) {
+            $return[$key] = $this->get($key, $default);
         }
 
         return $return;

--- a/src/Illuminate/Cache/TaggedCache.php
+++ b/src/Illuminate/Cache/TaggedCache.php
@@ -56,7 +56,7 @@ class TaggedCache extends Repository
      */
     public function increment($key, $value = 1)
     {
-        $this->store->increment($this->itemKey($key), $value);
+        return $this->store->increment($this->itemKey($key), $value);
     }
 
     /**
@@ -68,7 +68,7 @@ class TaggedCache extends Repository
      */
     public function decrement($key, $value = 1)
     {
-        $this->store->decrement($this->itemKey($key), $value);
+        return $this->store->decrement($this->itemKey($key), $value);
     }
 
     /**

--- a/src/Illuminate/Cache/TaggedCache.php
+++ b/src/Illuminate/Cache/TaggedCache.php
@@ -52,7 +52,7 @@ class TaggedCache extends Repository
      *
      * @param  string  $key
      * @param  mixed  $value
-     * @return void
+     * @return int|bool
      */
     public function increment($key, $value = 1)
     {
@@ -64,7 +64,7 @@ class TaggedCache extends Repository
      *
      * @param  string  $key
      * @param  mixed  $value
-     * @return void
+     * @return int|bool
      */
     public function decrement($key, $value = 1)
     {

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -5,7 +5,6 @@ namespace Illuminate\Support;
 use ArrayIterator;
 use Closure;
 use DateTimeInterface;
-use Generator;
 use Illuminate\Support\Traits\EnumeratesValues;
 use Illuminate\Support\Traits\Macroable;
 use IteratorAggregate;
@@ -30,7 +29,7 @@ class LazyCollection implements Enumerable
      */
     public function __construct($source = null)
     {
-        if ($source instanceof Closure || $source instanceof Generator || $source instanceof self) {
+        if ($source instanceof Closure || $source instanceof self) {
             $this->source = $source;
         } elseif (is_null($source)) {
             $this->source = static::empty();
@@ -1365,10 +1364,6 @@ class LazyCollection implements Enumerable
      */
     protected function makeIterator($source)
     {
-        if ($source instanceof Generator) {
-            return $source;
-        }
-
         if ($source instanceof IteratorAggregate) {
             return $source->getIterator();
         }

--- a/src/Illuminate/Contracts/Bus/Dispatcher.php
+++ b/src/Illuminate/Contracts/Bus/Dispatcher.php
@@ -15,7 +15,7 @@ interface Dispatcher
     /**
      * Dispatch a command to its appropriate handler in the current process.
      *
-     * Queuable jobs will be dispatched to the "sync" queue.
+     * Queueable jobs will be dispatched to the "sync" queue.
      *
      * @param  mixed  $command
      * @param  mixed  $handler

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -691,7 +691,11 @@ class MySqlGrammar extends Grammar
     {
         $columnType = $column->precision ? "datetime($column->precision)" : 'datetime';
 
-        return $column->useCurrent ? "$columnType default CURRENT_TIMESTAMP" : $columnType;
+        $current = $column->precision ? "CURRENT_TIMESTAMP($column->precision)" : 'CURRENT_TIMESTAMP';
+
+        $columnType = $column->useCurrent ? "$columnType default $current" : $columnType;
+
+        return $column->useCurrentOnUpdate ? "$columnType on update $current" : $columnType;
     }
 
     /**

--- a/src/Illuminate/Foundation/Bus/Dispatchable.php
+++ b/src/Illuminate/Foundation/Bus/Dispatchable.php
@@ -61,6 +61,8 @@ trait Dispatchable
      * Dispatch a command to its appropriate handler in the current process.
      *
      * @return mixed
+     *
+     * @deprecated Will be removed in a future Laravel version.
      */
     public static function dispatchNow()
     {

--- a/src/Illuminate/Foundation/Bus/Dispatchable.php
+++ b/src/Illuminate/Foundation/Bus/Dispatchable.php
@@ -48,7 +48,7 @@ trait Dispatchable
     /**
      * Dispatch a command to its appropriate handler in the current process.
      *
-     * Queuable jobs will be dispatched to the "sync" queue.
+     * Queueable jobs will be dispatched to the "sync" queue.
      *
      * @return mixed
      */

--- a/src/Illuminate/Foundation/Http/Middleware/ConvertEmptyStringsToNull.php
+++ b/src/Illuminate/Foundation/Http/Middleware/ConvertEmptyStringsToNull.php
@@ -2,8 +2,35 @@
 
 namespace Illuminate\Foundation\Http\Middleware;
 
+use Closure;
+
 class ConvertEmptyStringsToNull extends TransformsRequest
 {
+    /**
+     * All of the registered skip callbacks.
+     *
+     * @var array
+     */
+    protected static $skipCallbacks = [];
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        foreach (static::$skipCallbacks as $callback) {
+            if ($callback($request)) {
+                return $next($request);
+            }
+        }
+
+        return parent::handle($request, $next);
+    }
+
     /**
      * Transform the given value.
      *
@@ -14,5 +41,16 @@ class ConvertEmptyStringsToNull extends TransformsRequest
     protected function transform($key, $value)
     {
         return is_string($value) && $value === '' ? null : $value;
+    }
+
+    /**
+     * Register a callback that instructs the middleware to be skipped.
+     *
+     * @param  \Closure  $callback
+     * @return void
+     */
+    public static function skipWhen(Closure $callback)
+    {
+        static::$skipCallbacks[] = $callback;
     }
 }

--- a/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
+++ b/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
@@ -2,8 +2,17 @@
 
 namespace Illuminate\Foundation\Http\Middleware;
 
+use Closure;
+
 class TrimStrings extends TransformsRequest
 {
+    /**
+     * All of the registered skip callbacks.
+     *
+     * @var array
+     */
+    protected static $skipCallbacks = [];
+
     /**
      * The attributes that should not be trimmed.
      *
@@ -12,6 +21,24 @@ class TrimStrings extends TransformsRequest
     protected $except = [
         //
     ];
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        foreach (static::$skipCallbacks as $callback) {
+            if ($callback($request)) {
+                return $next($request);
+            }
+        }
+
+        return parent::handle($request, $next);
+    }
 
     /**
      * Transform the given value.
@@ -27,5 +54,16 @@ class TrimStrings extends TransformsRequest
         }
 
         return is_string($value) ? trim($value) : $value;
+    }
+
+    /**
+     * Register a callback that instructs the middleware to be skipped.
+     *
+     * @param  \Closure  $callback
+     * @return void
+     */
+    public static function skipWhen(Closure $callback)
+    {
+        static::$skipCallbacks[] = $callback;
     }
 }

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -17,13 +17,17 @@ trait InteractsWithDatabase
     /**
      * Assert that a given where condition exists in the database.
      *
-     * @param  string  $table
+     * @param  \Illuminate\Database\Eloquent\Model|string  $table
      * @param  array  $data
      * @param  string|null  $connection
      * @return $this
      */
-    protected function assertDatabaseHas($table, array $data, $connection = null)
+    protected function assertDatabaseHas($table, array $data = [], $connection = null)
     {
+        if ($table instanceof Model) {
+            return $this->assertDatabaseHas($table->getTable(), [$table->getKeyName() => $table->getKey()], $table->getConnectionName());
+        }
+
         $this->assertThat(
             $table, new HasInDatabase($this->getConnection($connection), $data)
         );

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -413,6 +413,8 @@ if (! function_exists('dispatch_now')) {
      * @param  mixed  $job
      * @param  mixed  $handler
      * @return mixed
+     *
+     * @deprecated Will be removed in a future Laravel version.
      */
     function dispatch_now($job, $handler = null)
     {

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -390,6 +390,22 @@ if (! function_exists('dispatch')) {
     }
 }
 
+if (! function_exists('dispatch_sync')) {
+    /**
+     * Dispatch a command to its appropriate handler in the current process.
+     *
+     * Queueable jobs will be dispatched to the "sync" queue.
+     *
+     * @param  mixed  $job
+     * @param  mixed  $handler
+     * @return mixed
+     */
+    function dispatch_sync($job, $handler = null)
+    {
+        return app(Dispatcher::class)->dispatchSync($job, $handler);
+    }
+}
+
 if (! function_exists('dispatch_now')) {
     /**
      * Dispatch a command to its appropriate handler in the current process.

--- a/src/Illuminate/Http/Response.php
+++ b/src/Illuminate/Http/Response.php
@@ -53,6 +53,10 @@ class Response extends SymfonyResponse
             $this->header('Content-Type', 'application/json');
 
             $content = $this->morphToJson($content);
+            
+            if ($content === false) {
+                throw new \UnexpectedValueException(sprintf("Failed to convert the provided Response content to JSON with the message: %s", json_last_error_msg()));
+            }
         }
 
         // If this content implements the "Renderable" interface then we will call the

--- a/src/Illuminate/Http/Response.php
+++ b/src/Illuminate/Http/Response.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Traits\Macroable;
 use JsonSerializable;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+use UnexpectedValueException;
 
 class Response extends SymfonyResponse
 {
@@ -55,7 +56,7 @@ class Response extends SymfonyResponse
             $content = $this->morphToJson($content);
 
             if ($content === false) {
-                throw new \UnexpectedValueException(sprintf('Failed to convert the provided Response content to JSON with the message: %s', json_last_error_msg()));
+                throw new UnexpectedValueException(sprintf('Unable to convert the provided response data to JSON: %s', json_last_error_msg()));
             }
         }
 

--- a/src/Illuminate/Http/Response.php
+++ b/src/Illuminate/Http/Response.php
@@ -53,9 +53,9 @@ class Response extends SymfonyResponse
             $this->header('Content-Type', 'application/json');
 
             $content = $this->morphToJson($content);
-            
+
             if ($content === false) {
-                throw new \UnexpectedValueException(sprintf("Failed to convert the provided Response content to JSON with the message: %s", json_last_error_msg()));
+                throw new \UnexpectedValueException(sprintf('Failed to convert the provided Response content to JSON with the message: %s', json_last_error_msg()));
             }
         }
 

--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -38,7 +38,9 @@ class ControllerMakeCommand extends GeneratorCommand
     {
         $stub = null;
 
-        if ($this->option('parent')) {
+        if ($type = $this->option('type')) {
+            $stub = "/stubs/controller.{$type}.stub";
+        } elseif ($this->option('parent')) {
             $stub = '/stubs/controller.nested.stub';
         } elseif ($this->option('model')) {
             $stub = '/stubs/controller.model.stub';
@@ -195,6 +197,7 @@ class ControllerMakeCommand extends GeneratorCommand
     {
         return [
             ['api', null, InputOption::VALUE_NONE, 'Exclude the create and edit methods from the controller.'],
+            ['type', null, InputOption::VALUE_REQUIRED, 'Manually specify the controller stub file to use.'],
             ['force', null, InputOption::VALUE_NONE, 'Create the class even if the controller already exists'],
             ['invokable', 'i', InputOption::VALUE_NONE, 'Generate a single method, invokable controller class.'],
             ['model', 'm', InputOption::VALUE_OPTIONAL, 'Generate a resource controller for the given model.'],

--- a/src/Illuminate/Session/SessionServiceProvider.php
+++ b/src/Illuminate/Session/SessionServiceProvider.php
@@ -19,9 +19,9 @@ class SessionServiceProvider extends ServiceProvider
 
         $this->registerSessionDriver();
 
-        $this->app->singleton(StartSession::class, function () {
-            return new StartSession($this->app->make(SessionManager::class), function () {
-                return $this->app->make(CacheFactory::class);
+        $this->app->singleton(StartSession::class, function ($app) {
+            return new StartSession($app->make(SessionManager::class), function () use ($app) {
+                return $app->make(CacheFactory::class);
             });
         });
     }

--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -435,7 +435,7 @@ class BusFake implements QueueingDispatcher
     /**
      * Dispatch a command to its appropriate handler in the current process.
      *
-     * Queuable jobs will be dispatched to the "sync" queue.
+     * Queueable jobs will be dispatched to the "sync" queue.
      *
      * @param  mixed  $command
      * @param  mixed  $handler

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -417,7 +417,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
     protected function compileStatements($value)
     {
         return preg_replace_callback(
-            '/\B@(@?\w+(?:::\w+)?)([ \t]*)(\( ( (?>[^()]+) | (?3) )* \))?/x', function ($match) {
+            '/\B@(@?\w+(?:::\w+)?)([ \t]*)(\( ( (?>\'[^\']+\') | (?>"[^"]+") | (?>[^()\'"]+) | (?3) )* \))?/x', function ($match) {
                 return $this->compileStatement($match);
             }, $value
         );

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -417,7 +417,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
     protected function compileStatements($value)
     {
         return preg_replace_callback(
-            '/\B@(@?\w+(?:::\w+)?)([ \t]*)(\( ( (?>\'[^\']+\') | (?>"[^"]+") | (?>[^()\'"]+) | (?3) )* \))?/x', function ($match) {
+            '/\B@(@?\w+(?:::\w+)?)([ \t]*)(\( ( (?>\'[^\']*\') | (?>"[^"]*") | (?>[^()\'"]+) | (?3) )* \))?/x', function ($match) {
                 return $this->compileStatement($match);
             }, $value
         );

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -811,6 +811,42 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertSame('alter table `users` add `foo` datetime(1) not null', $statements[0]);
     }
 
+    public function testAddingDateTimeWithDefaultCurrent()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->dateTime('foo')->useCurrent();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `foo` datetime default CURRENT_TIMESTAMP not null', $statements[0]);
+    }
+
+    public function testAddingDateTimeWithOnUpdateCurrent()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->dateTime('foo')->useCurrentOnUpdate();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `foo` datetime on update CURRENT_TIMESTAMP not null', $statements[0]);
+    }
+
+    public function testAddingDateTimeWithDefaultCurrentAndOnUpdateCurrent()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->dateTime('foo')->useCurrent()->useCurrentOnUpdate();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `foo` datetime default CURRENT_TIMESTAMP on update CURRENT_TIMESTAMP not null', $statements[0]);
+    }
+
+    public function testAddingDateTimeWithDefaultCurrentOnUpdateCurrentAndPrecision()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->dateTime('foo', 3)->useCurrent()->useCurrentOnUpdate();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `foo` datetime(3) default CURRENT_TIMESTAMP(3) on update CURRENT_TIMESTAMP(3) not null', $statements[0]);
+    }
+
     public function testAddingDateTimeTz()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -41,6 +41,17 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertDatabaseHas($this->table, $this->data);
     }
 
+    public function testSeeInDatabaseFindModelResults()
+    {
+        $this->data = ['id' => 1];
+
+        $builder = $this->mockCountBuilder(1);
+
+        $builder->shouldReceive('get')->andReturn(collect());
+
+        $this->assertDatabaseHas(new ProductStub($this->data));
+    }
+
     public function testSeeInDatabaseDoesNotFindResults()
     {
         $this->expectException(ExpectationFailedException::class);

--- a/tests/Support/Concerns/CountsEnumerations.php
+++ b/tests/Support/Concerns/CountsEnumerations.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Illuminate\Tests\Support\Concerns;
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\LazyCollection;
+
+trait CountsEnumerations
+{
+    protected function makeGeneratorFunctionWithRecorder($numbers = 10)
+    {
+        $recorder = new Collection();
+
+        $generatorFunction = function () use ($numbers, $recorder) {
+            for ($i = 1; $i <= $numbers; $i++) {
+                $recorder->push($i);
+
+                yield $i;
+            }
+        };
+
+        return [$generatorFunction, $recorder];
+    }
+
+    protected function assertDoesNotEnumerate(callable $executor)
+    {
+        $this->assertEnumerates(0, $executor);
+    }
+
+    protected function assertDoesNotEnumerateCollection(
+        LazyCollection $collection,
+        callable $executor
+    ) {
+        $this->assertEnumeratesCollection($collection, 0, $executor);
+    }
+
+    protected function assertEnumerates($count, callable $executor)
+    {
+        $this->assertEnumeratesCollection(
+            LazyCollection::times(100),
+            $count,
+            $executor
+        );
+    }
+
+    protected function assertEnumeratesCollection(
+        LazyCollection $collection,
+        $count,
+        callable $executor
+    ) {
+        $enumerated = 0;
+
+        $data = $this->countEnumerations($collection, $enumerated);
+
+        $executor($data);
+
+        $this->assertEnumerations($count, $enumerated);
+    }
+
+    protected function assertEnumeratesOnce(callable $executor)
+    {
+        $this->assertEnumeratesCollectionOnce(LazyCollection::times(10), $executor);
+    }
+
+    protected function assertEnumeratesCollectionOnce(
+        LazyCollection $collection,
+        callable $executor
+    ) {
+        $enumerated = 0;
+        $count = $collection->count();
+        $collection = $this->countEnumerations($collection, $enumerated);
+
+        $executor($collection);
+
+        $this->assertEquals(
+            $count,
+            $enumerated,
+            $count > $enumerated ? 'Failed to enumerate in full.' : 'Enumerated more than once.'
+        );
+    }
+
+    protected function assertEnumerations($expected, $actual)
+    {
+        $this->assertEquals(
+            $expected,
+            $actual,
+            "Failed asserting that {$actual} items that were enumerated matches expected {$expected}."
+        );
+    }
+
+    protected function countEnumerations(LazyCollection $collection, &$count)
+    {
+        return $collection->tapEach(function () use (&$count) {
+            $count++;
+        });
+    }
+}

--- a/tests/Support/SupportLazyCollectionTest.php
+++ b/tests/Support/SupportLazyCollectionTest.php
@@ -69,31 +69,6 @@ class SupportLazyCollectionTest extends TestCase
         ], $data->all());
     }
 
-    public function testCanCreateCollectionFromGenerator()
-    {
-        $iterable = function () {
-            yield 1;
-            yield 2;
-            yield 3;
-        };
-        $data = LazyCollection::make($iterable());
-
-        $this->assertSame([1, 2, 3], $data->all());
-
-        $iterable = function () {
-            yield 'a' => 1;
-            yield 'b' => 2;
-            yield 'c' => 3;
-        };
-        $data = LazyCollection::make($iterable());
-
-        $this->assertSame([
-            'a' => 1,
-            'b' => 2,
-            'c' => 3,
-        ], $data->all());
-    }
-
     public function testEager()
     {
         $source = [1, 2, 3, 4, 5];

--- a/tests/View/Blade/BladePhpStatementsTest.php
+++ b/tests/View/Blade/BladePhpStatementsTest.php
@@ -43,4 +43,13 @@ class BladePhpStatementsTest extends AbstractBladeTestCase
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
+
+    public function testStringWithParenthesisDataValue()
+    {
+        $string = "@php(\$data = ['test' => ')'])";
+
+        $expected = "<?php (\$data = ['test' => ')']); ?>";
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
 }

--- a/tests/View/Blade/BladePhpStatementsTest.php
+++ b/tests/View/Blade/BladePhpStatementsTest.php
@@ -52,4 +52,19 @@ class BladePhpStatementsTest extends AbstractBladeTestCase
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
+
+    public function testStringWithEmptyStringDataValue()
+    {
+        $string = "@php(\$data = ['test' => ''])";
+
+        $expected = "<?php (\$data = ['test' => '']); ?>";
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+
+        $string = "@php(\$data = ['test' => \"\"])";
+
+        $expected = "<?php (\$data = ['test' => \"\"]); ?>";
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
 }


### PR DESCRIPTION
Breaking change to test assertion assertDatabaseHas's parameters. Much like assertSoftDeleted or assertDeleted the assertDatabaseHas method will now accept a Eloquent model instead of the table parameter with no further parameters to the method. This then automatically applies the model's table and key + key value to the assertDatabaseHas making test readability that tiny bit better with models already created in the test.

$model = new User(['id' => 1]);

// Current usage
$this->assertDatabaseHas('users', ['id' => $model->id]);

// New usage
$this->assertDatabaseHas($model);
