### PR TITLE
[8.x] Laravel maintenance mode Cookie doesn't follow the session configurations

### DIFF
--- a/src/Illuminate/Foundation/Http/MaintenanceModeBypassCookie.php
+++ b/src/Illuminate/Foundation/Http/MaintenanceModeBypassCookie.php
@@ -2,9 +2,9 @@
 
 namespace Illuminate\Foundation\Http;
 
+use function config;
 use Illuminate\Support\Carbon;
 use Symfony\Component\HttpFoundation\Cookie;
-use function config;
 
 class MaintenanceModeBypassCookie
 {

--- a/src/Illuminate/Foundation/Http/MaintenanceModeBypassCookie.php
+++ b/src/Illuminate/Foundation/Http/MaintenanceModeBypassCookie.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Http;
 
 use Illuminate\Support\Carbon;
 use Symfony\Component\HttpFoundation\Cookie;
+use function config;
 
 class MaintenanceModeBypassCookie
 {
@@ -16,11 +17,22 @@ class MaintenanceModeBypassCookie
     public static function create(string $key)
     {
         $expiresAt = Carbon::now()->addHours(12);
+        $config = config('session');
 
-        return new Cookie('laravel_maintenance', base64_encode(json_encode([
-            'expires_at' => $expiresAt->getTimestamp(),
-            'mac' => hash_hmac('SHA256', $expiresAt->getTimestamp(), $key),
-        ])), $expiresAt, '/', env('SESSION_DOMAIN', null));
+        return new Cookie(
+            'laravel_maintenance',
+            base64_encode(json_encode([
+                'expires_at' => $expiresAt->getTimestamp(),
+                'mac' => hash_hmac('SHA256', $expiresAt->getTimestamp(), $key),
+            ])),
+            $expiresAt,
+            $config['path'] ?? '/',
+            $config['domain'] ?? null,
+            $config['secure'] ?? null,
+            $config['httpOnly'] ?? false,
+            $config['raw'] ?? false,
+            $config['same_site'] ?? null
+        );
     }
 
     /**

--- a/src/Illuminate/Foundation/Http/MaintenanceModeBypassCookie.php
+++ b/src/Illuminate/Foundation/Http/MaintenanceModeBypassCookie.php
@@ -20,7 +20,7 @@ class MaintenanceModeBypassCookie
         return new Cookie('laravel_maintenance', base64_encode(json_encode([
             'expires_at' => $expiresAt->getTimestamp(),
             'mac' => hash_hmac('SHA256', $expiresAt->getTimestamp(), $key),
-        ])), $expiresAt, config('session.path'), config('session.domain'), config('session.secure'));
+        ])), $expiresAt, '/', env('SESSION_DOMAIN', null));
     }
 
     /**

--- a/src/Illuminate/Foundation/Http/MaintenanceModeBypassCookie.php
+++ b/src/Illuminate/Foundation/Http/MaintenanceModeBypassCookie.php
@@ -20,7 +20,7 @@ class MaintenanceModeBypassCookie
         return new Cookie('laravel_maintenance', base64_encode(json_encode([
             'expires_at' => $expiresAt->getTimestamp(),
             'mac' => hash_hmac('SHA256', $expiresAt->getTimestamp(), $key),
-        ])), $expiresAt);
+        ])), $expiresAt, config('session.path'), config('session.domain'), config('session.secure'));
     }
 
     /**


### PR DESCRIPTION
# Subject
Fixing the Laravel MaintenanceModeBypassCookie.php missing the session information (path, domain, secure), in order to follow the application session config file.

# How to reproduce:
 - New laravel installation.
 - Use `.example.com` as `session.domain` (Note: this should affect all the subdomains, in the `example.com` domain name)
 - Or you can use any other setting path, domain or secure setting.
# The problem:
 The laravel cookie doesn't contain the session configuration, so when we change the laravel session configuration it is only available in the root domain name, not the subdomains.