### PR TITLE
[8.x] Add new behavior to distinct method on QueryBuilder

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -138,7 +138,7 @@ class Grammar extends BaseGrammar
             return 'select '.$this->columnize($columns);
         }
 
-        if(is_bool($query->distinct) or $columns !== ['*']){
+        if($query->distinct === true or $columns !== ['*']){
             return 'select distinct ' .$this->columnize($columns);
         }
 

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -138,8 +138,8 @@ class Grammar extends BaseGrammar
             return 'select '.$this->columnize($columns);
         }
 
-        if($query->distinct === true or $columns !== ['*']){
-            return 'select distinct ' .$this->columnize($columns);
+        if ($query->distinct === true or $columns !== ['*']) {
+            return 'select distinct '.$this->columnize($columns);
         }
 
         return 'select distinct '.$this->columnize($query->distinct);

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -134,13 +134,15 @@ class Grammar extends BaseGrammar
             return;
         }
 
-        if ($query->distinct) {
-            $select = 'select distinct ';
-        } else {
-            $select = 'select ';
+        if (! $query->distinct) {
+            return 'select '.$this->columnize($columns);
         }
 
-        return $select.$this->columnize($columns);
+        if(is_bool($query->distinct) or $columns !== ['*']){
+            return 'select distinct ' .$this->columnize($columns);
+        }
+
+        return 'select distinct '.$this->columnize($query->distinct);
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -118,12 +118,24 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->distinct()->select('foo', 'bar')->from('users');
         $this->assertSame('select distinct "foo", "bar" from "users"', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->distinct()->from('users');
+        $this->assertSame('select distinct * from "users"', $builder->toSql());
     }
 
     public function testBasicSelectDistinctOnColumns()
     {
         $builder = $this->getBuilder();
         $builder->distinct('foo')->select('foo', 'bar')->from('users');
+        $this->assertSame('select distinct "foo", "bar" from "users"', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->distinct('foo')->from('users');
+        $this->assertSame('select distinct "foo" from "users"', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->distinct('foo', 'bar')->from('users');
         $this->assertSame('select distinct "foo", "bar" from "users"', $builder->toSql());
 
         $builder = $this->getPostgresBuilder();

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -122,6 +122,10 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->distinct()->from('users');
         $this->assertSame('select distinct * from "users"', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->distinct(false)->from('users');
+        $this->assertSame('select * from "users"', $builder->toSql());
     }
 
     public function testBasicSelectDistinctOnColumns()


### PR DESCRIPTION
Now we can't use the `distinct` method like this example:
```php
DB::table(‘users’)->distinct(‘name’);
```
And we must pass our columns which want to distinct with `select` method like this:
```php
DB::table(‘users’)->distinct()->select('name');
```
With these changes, we will be able to use the top example which is more readable and more understandable than the previous syntax.
Of course, if we use `select` method without `*` param it will ignore the `distinct` parameters because of conflict between them.

I guess these changes help us to write readable codes.
