### PR TITLE
[8.x] Handle concurrent asynchronous requests in the HTTP client

### DIFF
--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -3,11 +3,12 @@
 namespace Illuminate\Http\Client;
 
 use Closure;
-use GuzzleHttp\Promise\Create;
 use GuzzleHttp\Psr7\Response as Psr7Response;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use PHPUnit\Framework\Assert as PHPUnit;
+
+use function GuzzleHttp\Promise\promise_for;
 
 /**
  * @method \Illuminate\Http\Client\PendingRequest accept(string $contentType)
@@ -106,7 +107,7 @@ class Factory
             $headers['Content-Type'] = 'application/json';
         }
 
-        return Create::promiseFor(new Psr7Response($status, $headers, $body));
+        return promise_for(new Psr7Response($status, $headers, $body));
     }
 
     /**

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -3,12 +3,11 @@
 namespace Illuminate\Http\Client;
 
 use Closure;
+use function GuzzleHttp\Promise\promise_for;
 use GuzzleHttp\Psr7\Response as Psr7Response;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use PHPUnit\Framework\Assert as PHPUnit;
-
-use function GuzzleHttp\Promise\promise_for;
 
 /**
  * @method \Illuminate\Http\Client\PendingRequest accept(string $contentType)

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Http\Client;
 
 use Closure;
-use function GuzzleHttp\Promise\promise_for;
+use GuzzleHttp\Promise\Create;
 use GuzzleHttp\Psr7\Response as Psr7Response;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
@@ -34,6 +34,8 @@ use PHPUnit\Framework\Assert as PHPUnit;
  * @method \Illuminate\Http\Client\PendingRequest withoutVerifying()
  * @method \Illuminate\Http\Client\PendingRequest dump()
  * @method \Illuminate\Http\Client\PendingRequest dd()
+ * @method \Illuminate\Http\Client\PendingRequest async()
+ * @method \Illuminate\Http\Client\Pool pool()
  * @method \Illuminate\Http\Client\Response delete(string $url, array $data = [])
  * @method \Illuminate\Http\Client\Response get(string $url, array $query = [])
  * @method \Illuminate\Http\Client\Response head(string $url, array $query = [])
@@ -104,7 +106,7 @@ class Factory
             $headers['Content-Type'] = 'application/json';
         }
 
-        return promise_for(new Psr7Response($status, $headers, $body));
+        return Create::promiseFor(new Psr7Response($status, $headers, $body));
     }
 
     /**

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -932,7 +932,7 @@ class PendingRequest
     }
 
     /**
-     * Send a pool of asynchronous requests concurrently
+     * Send a pool of asynchronous requests concurrently.
      *
      * @param  callable  $callback
      * @return array

--- a/src/Illuminate/Http/Client/Pool.php
+++ b/src/Illuminate/Http/Client/Pool.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Illuminate\Http\Client;
+
+class Pool
+{
+    /**
+     * The factory instance.
+     *
+     * @var \Illuminate\Http\Client\Factory
+     */
+    protected $factory;
+
+    /**
+     * The client instance.
+     *
+     * @var \GuzzleHttp\Client
+     */
+    protected $client;
+
+    /**
+     * The pool of requests.
+     *
+     * @var array
+     */
+    protected $pool = [];
+
+    /**
+     * Create a new requests pool.
+     *
+     * @param  \Illuminate\Http\Client\Factory|null  $factory
+     * @return void
+     */
+    public function __construct(Factory $factory = null)
+    {
+        $this->factory = $factory ?: new Factory();
+
+        $this->client = $this->factory->buildClient();
+    }
+
+    /**
+     * Add a request to the pool with a key.
+     *
+     * @param  string  $key
+     * @return \Illuminate\Http\Client\PendingRequest
+     */
+    public function add(string $key)
+    {
+        return $this->pool[$key] = $this->asyncRequest();
+    }
+
+    /**
+     * Retrieve a new async pending request.
+     *
+     * @return \Illuminate\Http\Client\PendingRequest
+     */
+    protected function asyncRequest()
+    {
+        // the same client instance needs to be shared across all async requests
+        return $this->factory->setClient($this->client)->async();
+    }
+
+    /**
+     * Retrieve the requests in the pool.
+     *
+     * @return array
+     */
+    public function getRequests()
+    {
+        return $this->pool;
+    }
+
+    /**
+     * Add a request to the pool with a numeric index.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return \Illuminate\Http\Client\PendingRequest
+     */
+    public function __call($method, $parameters)
+    {
+        return $this->pool[] = $this->asyncRequest()->$method(...$parameters);
+    }
+}

--- a/src/Illuminate/Http/Client/RequestException.php
+++ b/src/Illuminate/Http/Client/RequestException.php
@@ -2,8 +2,6 @@
 
 namespace Illuminate\Http\Client;
 
-use GuzzleHttp\Psr7\Message;
-
 class RequestException extends HttpClientException
 {
     /**
@@ -36,7 +34,7 @@ class RequestException extends HttpClientException
     {
         $message = "HTTP request returned status code {$response->status()}";
 
-        $summary = Message::bodySummary($response->toPsrResponse());
+        $summary = \GuzzleHttp\Psr7\get_message_body_summary($response->toPsrResponse());
 
         return is_null($summary) ? $message : $message .= ":\n{$summary}\n";
     }

--- a/src/Illuminate/Http/Client/RequestException.php
+++ b/src/Illuminate/Http/Client/RequestException.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Http\Client;
 
+use GuzzleHttp\Psr7\Message;
+
 class RequestException extends HttpClientException
 {
     /**
@@ -34,7 +36,7 @@ class RequestException extends HttpClientException
     {
         $message = "HTTP request returned status code {$response->status()}";
 
-        $summary = \GuzzleHttp\Psr7\get_message_body_summary($response->toPsrResponse());
+        $summary = Message::bodySummary($response->toPsrResponse());
 
         return is_null($summary) ? $message : $message .= ":\n{$summary}\n";
     }

--- a/src/Illuminate/Support/Facades/Http.php
+++ b/src/Illuminate/Support/Facades/Http.php
@@ -32,6 +32,8 @@ use Illuminate\Http\Client\Factory;
  * @method static \Illuminate\Http\Client\PendingRequest withoutVerifying()
  * @method static \Illuminate\Http\Client\PendingRequest dump()
  * @method static \Illuminate\Http\Client\PendingRequest dd()
+ * @method static \Illuminate\Http\Client\PendingRequest async()
+ * @method static \Illuminate\Http\Client\Pool pool()
  * @method static \Illuminate\Http\Client\Response delete(string $url, array $data = [])
  * @method static \Illuminate\Http\Client\Response get(string $url, array $query = [])
  * @method static \Illuminate\Http\Client\Response head(string $url, array $query = [])


### PR DESCRIPTION
This PR aims to bring concurrency while sending asynchronous requests with the Laravel HTTP client.

Laravel Octane is not required to make this feature work, however Octane should be compatible with this feature as the latest version of [Swoole supports curl_multi operations](https://www.swoole.co.uk/article/v4-6-5-released).

The PR introduces:
- asynchronous requests
- a pool to handle asynchronous requests concurrently

Asynchronous requests can be created with the following syntax:
```php
$promise = Http::async()->get($url);
```
The result is an instance of `GuzzleHttp\Promise\Promise`.

Based on whether a promise is fulfilled or rejected, the `then()` method of the promise receives:
- An instance of `Illuminate\Http\Client\Response` if the promise is fulfilled
- An instance of `Illuminate\Http\Client\Response` if the promise is rejected but a response was provided (4xx, 5xx errors)
- An instance of `GuzzleHttp\Exception\TransferException` if the promise is rejected with no response (e.g. timeout)

```php
$promise = Http::async()->get($url)->then(fn (Response|TransferException $result) => $this->handleResult($result));
```

The pool collects asynchronous requests and send them concurrently, so that the slowest request determines the maximum waiting time for all promises to be fulfilled.

```php
// the waiting time will be ~3 seconds instead of 15

$responses = Http::pool(fn (Pool $pool) => [
    $pool->get('https://httpbin.org/delay/3')->then(/* ... */),
    $pool->get('https://httpbin.org/delay/3')->then(/* ... */),
    $pool->get('https://httpbin.org/delay/3')->then(/* ... */),
    $pool->get('https://httpbin.org/delay/3')->then(/* ... */),
    $pool->get('https://httpbin.org/delay/3')->then(/* ... */),
]);

$responses[0]->ok();
$responses[1]->successful();
// ...
```
Asynchronous requests can also be added to the pool with a key:

```php
$responses = Http::pool(fn (Pool $pool) => [
    $pool->add('foo')->get('https://httpbin.org/delay/3')->then(/* ... */),
    $pool->add('bar')->get('https://httpbin.org/delay/3')->then(/* ... */),
    $pool->add('baz')->get('https://httpbin.org/delay/3')->then(/* ... */),
]);

$responses['foo']->ok();
$responses['bar']->successful();
$connectionFailed = $responses['baz'] instanceof GuzzleHttp\Exception\ConnectException;
```
Responses are instances of `Illuminate\Http\Client\Response` if requests were responded (2xx, 3xx, 4xx, 5xx). Otherwise if no response was received, the exception that provoked the promise rejection is returned.

All requests added to the pool are asynchronous by default, so there is no need to chain the `async()` method. It may also be worth mentioning that all the fluent methods of `PendingRequest` are available to the requests in the pool:

```php
$responses = Http::pool(fn (Pool $pool) => [
    $pool->withOptions(['timeout' => 3])->get('https://foo.test')->then(/* ... */),
    $pool->asForm()->post($url, $data)->then(/* ... */),
]);
```

The pool leverages `Illuminate\Http\Client\Factory` under the hood, so we can take advantage of all its testing functionalities in our unit tests:
```php
$this->factory->fake([
    '200.com' => $this->factory::response('', 200),
    '400.com' => $this->factory::response('', 400),
    '500.com' => $this->factory::response('', 500),
]);

$responses = $this->factory->pool(fn (Pool $pool) => [
    $pool->get('200.com'),
    $pool->get('400.com'),
    $pool->get('500.com'),
]);

$this->assertSame(200, $responses[0]->status());
$this->assertSame(400, $responses[1]->status());
$this->assertSame(500, $responses[2]->status());
```