### PR TITLE
[8.x] Add tinyText data type to Blueprint and to available database grammars

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -678,6 +678,17 @@ class Blueprint
     }
 
     /**
+     * Create a new tiny text column on the table.
+     *
+     * @param  string  $column
+     * @return \Illuminate\Database\Schema\ColumnDefinition
+     */
+    public function tinyText($column)
+    {
+        return $this->addColumn('tinyText', $column);
+    }
+
+    /**
      * Create a new text column on the table.
      *
      * @param  string  $column

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -491,6 +491,17 @@ class MySqlGrammar extends Grammar
     }
 
     /**
+     * Create the column definition for a tiny text type.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+    protected function typeTinyText(Fluent $column)
+    {
+        return 'tinytext';
+    }
+
+    /**
      * Create the column definition for a text type.
      *
      * @param  \Illuminate\Support\Fluent  $column

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -473,6 +473,17 @@ class PostgresGrammar extends Grammar
     }
 
     /**
+     * Create the column definition for a tiny text type.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+    protected function typeTinyText(Fluent $column)
+    {
+        return 'varchar(255)';
+    }
+
+    /**
      * Create the column definition for a text type.
      *
      * @param  \Illuminate\Support\Fluent  $column

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -433,6 +433,17 @@ class SQLiteGrammar extends Grammar
     }
 
     /**
+     * Create the column definition for a tiny text type.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+    protected function typeTinyText(Fluent $column)
+    {
+        return 'text';
+    }
+
+    /**
      * Create the column definition for a text type.
      *
      * @param  \Illuminate\Support\Fluent  $column

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -418,6 +418,17 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
+     * Create the column definition for a tiny text type.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+    protected function typeTinyText(Fluent $column)
+    {
+        return 'nvarchar(255)';
+    }
+
+    /**
      * Create the column definition for a text type.
      *
      * @param  \Illuminate\Support\Fluent  $column

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -292,7 +292,8 @@ class DatabaseSchemaBlueprintTest extends TestCase
         ], $blueprint->toSql($connection, new MySqlGrammar));
     }
 
-    public function testTinyTextColumn(){
+    public function testTinyTextColumn()
+    {
         $base = new Blueprint('posts', function ($table) {
             $table->tinyText('note');
         });
@@ -320,7 +321,8 @@ class DatabaseSchemaBlueprintTest extends TestCase
         ], $blueprint->toSql($connection, new SqlServerGrammar));
     }
 
-    public function testTinyTextNullableColumn(){
+    public function testTinyTextNullableColumn()
+    {
         $base = new Blueprint('posts', function ($table) {
             $table->tinyText('note')->nullable();
         });

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -291,4 +291,32 @@ class DatabaseSchemaBlueprintTest extends TestCase
             'alter table `posts` add `eloquent_model_uuid_stub_id` char(36) not null',
         ], $blueprint->toSql($connection, new MySqlGrammar));
     }
+
+    public function testTinyTextColumn(){
+        $base = new Blueprint('posts', function ($table) {
+            $table->tinyText('note');
+        });
+
+        $connection = m::mock(Connection::class);
+
+        $blueprint = clone $base;
+        $this->assertEquals([
+            'alter table `posts` add `note` tinytext not null',
+        ], $blueprint->toSql($connection, new MySqlGrammar));
+
+        $blueprint = clone $base;
+        $this->assertEquals([
+            'alter table "posts" add column "note" text not null',
+        ], $blueprint->toSql($connection, new SQLiteGrammar));
+
+        $blueprint = clone $base;
+        $this->assertEquals([
+            'alter table "posts" add column "note" varchar(255) not null',
+        ], $blueprint->toSql($connection, new PostgresGrammar));
+
+        $blueprint = clone $base;
+        $this->assertEquals([
+            'alter table "posts" add "note" nvarchar(255) not null',
+        ], $blueprint->toSql($connection, new SqlServerGrammar));
+    }
 }

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -319,4 +319,32 @@ class DatabaseSchemaBlueprintTest extends TestCase
             'alter table "posts" add "note" nvarchar(255) not null',
         ], $blueprint->toSql($connection, new SqlServerGrammar));
     }
+
+    public function testTinyTextNullableColumn(){
+        $base = new Blueprint('posts', function ($table) {
+            $table->tinyText('note')->nullable();
+        });
+
+        $connection = m::mock(Connection::class);
+
+        $blueprint = clone $base;
+        $this->assertEquals([
+            'alter table `posts` add `note` tinytext null',
+        ], $blueprint->toSql($connection, new MySqlGrammar));
+
+        $blueprint = clone $base;
+        $this->assertEquals([
+            'alter table "posts" add column "note" text',
+        ], $blueprint->toSql($connection, new SQLiteGrammar));
+
+        $blueprint = clone $base;
+        $this->assertEquals([
+            'alter table "posts" add column "note" varchar(255) null',
+        ], $blueprint->toSql($connection, new PostgresGrammar));
+
+        $blueprint = clone $base;
+        $this->assertEquals([
+            'alter table "posts" add "note" nvarchar(255) null',
+        ], $blueprint->toSql($connection, new SqlServerGrammar));
+    }
 }


### PR DESCRIPTION
`tinytext` is a valid MySQL data type that indicates a 255-byte string field, and is easily stubbed with varchar or text fields for the other DBMS's. tinyInteger is lonely! Currently, `tinytext` is not implemented for use in Blueprint.

This PR aims to add the `tinyText` method to Blueprint, with the native `tinytext` data type being used for MySQL; SQLite will use a `text` field, Postgres will use a `varchar(255)` field, and SQL Server will use a `nvarchar(255)`.

This PR only adds new functionality, so it would be backwards compatible since no one would be using `tinyText` in their migrations.

This could be helpful to those that wanted native support for the `tinytext` data type in MySQL databases.