### PR TITLE
[8.x] Add a method to remove a resolved view engine

### DIFF
--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\Http\Kernel as KernelContract;
 use Illuminate\Foundation\Http\Events\RequestHandled;
+use Illuminate\Http\Response;
 use Illuminate\Routing\Pipeline;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Facade;

--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -6,7 +6,6 @@ use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\Http\Kernel as KernelContract;
 use Illuminate\Foundation\Http\Events\RequestHandled;
-use Illuminate\Http\Response;
 use Illuminate\Routing\Pipeline;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Facade;

--- a/src/Illuminate/View/Engines/EngineResolver.php
+++ b/src/Illuminate/View/Engines/EngineResolver.php
@@ -57,4 +57,15 @@ class EngineResolver
 
         throw new InvalidArgumentException("Engine [{$engine}] not found.");
     }
+
+    /**
+     * Remove a resolved engine.
+     *
+     * @param  string  $engine
+     * @return void
+     */
+    public function forget($engine)
+    {
+        unset($this->resolved[$engine]);
+    }
 }


### PR DESCRIPTION
https://github.com/facade/ignition has memory leak: https://github.com/facade/ignition/blob/a8201d51aae83addceaef9344592a3b068b5d64d/src/Views/Concerns/CollectsViewExceptions.php#L15-L19.

This PR adds a method to forget a view engine. We can use this method to flush the resolved facade/ignition engines after each request.