### PR TITLE
[8.x] Make pagination linkCollection() method public

### DIFF
--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -99,7 +99,7 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
      *
      * @return \Illuminate\Support\Collection
      */
-    protected function linkCollection()
+    public function linkCollection()
     {
         return collect($this->elements())->flatMap(function ($item) {
             if (! is_array($item)) {


### PR DESCRIPTION
This PR makes the `LengthAwarePaginator::linkCollection()` method `public`. I have a use-case in an Inertia app where I don't want to include all the data from `toArray()`, and would like to cherry pick the link collection. 👍

This is a non-breaking change.