### PR TITLE
[8.x] Adds password rule

### DIFF
--- a/src/Illuminate/Contracts/Validation/DataAwareRule.php
+++ b/src/Illuminate/Contracts/Validation/DataAwareRule.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Illuminate\Contracts\Validation;
+
+interface DataAwareRule
+{
+    /**
+     * Set the data under validation.
+     *
+     * @param  array  $data
+     * @return $this
+     */
+    public function setData($data);
+}

--- a/src/Illuminate/Contracts/Validation/NotCompromisedVerifier.php
+++ b/src/Illuminate/Contracts/Validation/NotCompromisedVerifier.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Illuminate\Contracts\Validation;
+
+interface NotCompromisedVerifier
+{
+    /**
+     * Verify that the given value has not been compromised in data leaks.
+     *
+     * @param  string  $value
+     * @return bool
+     */
+    public function verify($value);
+}

--- a/src/Illuminate/Contracts/Validation/UncompromisedVerifier.php
+++ b/src/Illuminate/Contracts/Validation/UncompromisedVerifier.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Contracts\Validation;
 
-interface NotCompromisedVerifier
+interface UncompromisedVerifier
 {
     /**
      * Verify that the given value has not been compromised in data leaks.

--- a/src/Illuminate/Contracts/Validation/UncompromisedVerifier.php
+++ b/src/Illuminate/Contracts/Validation/UncompromisedVerifier.php
@@ -5,10 +5,10 @@ namespace Illuminate\Contracts\Validation;
 interface UncompromisedVerifier
 {
     /**
-     * Verify that the given value has not been compromised in data leaks.
+     * Verify that the given data has not been compromised in data leaks.
      *
-     * @param  string  $value
+     * @param  array  $data
      * @return bool
      */
-    public function verify($value);
+    public function verify($data);
 }

--- a/src/Illuminate/Validation/NotPwnedVerifier.php
+++ b/src/Illuminate/Validation/NotPwnedVerifier.php
@@ -45,7 +45,7 @@ class NotPwnedVerifier implements NotCompromisedVerifier
             ->contains(function ($line) use ($hash, $hashPrefix) {
                 [$hashSuffix, $count] = explode(':', $line);
 
-                return $hashPrefix.$hashSuffix == $hash && $count > 1;
+                return $hashPrefix.$hashSuffix == $hash && $count > 0;
             });
     }
 

--- a/src/Illuminate/Validation/NotPwnedVerifier.php
+++ b/src/Illuminate/Validation/NotPwnedVerifier.php
@@ -72,7 +72,9 @@ class NotPwnedVerifier implements NotCompromisedVerifier
     protected function search($hashPrefix)
     {
         try {
-            $response = $this->factory->get(
+            $response = $this->factory->withHeaders([
+                'Add-Padding' => true,
+            ])->get(
                 'https://api.pwnedpasswords.com/range/'.$hashPrefix
             );
         } catch (Exception $e) {

--- a/src/Illuminate/Validation/NotPwnedVerifier.php
+++ b/src/Illuminate/Validation/NotPwnedVerifier.php
@@ -3,11 +3,11 @@
 namespace Illuminate\Validation;
 
 use Exception;
-use Illuminate\Contracts\Validation\NotCompromisedVerifier;
+use Illuminate\Contracts\Validation\UncompromisedVerifier;
 use Illuminate\Http\Client\Factory;
 use Illuminate\Support\Str;
 
-class NotPwnedVerifier implements NotCompromisedVerifier
+class NotPwnedVerifier implements UncompromisedVerifier
 {
     /**
      * The http factory instance.
@@ -64,9 +64,9 @@ class NotPwnedVerifier implements NotCompromisedVerifier
     }
 
     /**
-     * Search by the given hash prefix and returns all occurrences.
+     * Search by the given hash prefix and returns all occurrences of leaked passwords.
      *
-     * @param  string $hashPrefix
+     * @param  string  $hashPrefix
      * @return \Illuminate\Support\Collection
      */
     protected function search($hashPrefix)

--- a/src/Illuminate/Validation/NotPwnedVerifier.php
+++ b/src/Illuminate/Validation/NotPwnedVerifier.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Illuminate\Validation;
+
+use Exception;
+use Illuminate\Contracts\Validation\NotCompromisedVerifier;
+use Illuminate\Http\Client\Factory;
+use Illuminate\Support\Str;
+
+class NotPwnedVerifier implements NotCompromisedVerifier
+{
+    /**
+     * The http factory instance.
+     *
+     * @var \Illuminate\Http\Client\Factory
+     */
+    protected $factory;
+
+    /**
+     * Create a new not compromised verifier.
+     *
+     * @param  \Illuminate\Http\Client\Factory  $factory
+     * @return void
+     */
+    public function __construct($factory)
+    {
+        $this->factory = $factory;
+    }
+
+    /**
+     * Verify that the given value has not been compromised in public breaches.
+     *
+     * @param  string  $value
+     * @return bool
+     */
+    public function verify($value)
+    {
+        if (empty($value = (string) $value)) {
+            return false;
+        }
+
+        [$hash, $hashPrefix] = $this->getHash($value);
+
+        return ! $this->search($hashPrefix)
+            ->contains(function ($line) use ($hash, $hashPrefix) {
+                [$hashSuffix, $count] = explode(':', $line);
+
+                return $hashPrefix.$hashSuffix == $hash && $count > 1;
+            });
+    }
+
+    /**
+     * Get the hash and its first 5 chars.
+     *
+     * @param  string  $value
+     * @return array
+     */
+    protected function getHash($value)
+    {
+        $hash = strtoupper(sha1((string) $value));
+        $hashPrefix = substr($hash, 0, 5);
+
+        return [$hash, $hashPrefix];
+    }
+
+    /**
+     * Search by the given hash prefix and returns all occurrences.
+     *
+     * @param  string $hashPrefix
+     * @return \Illuminate\Support\Collection
+     */
+    protected function search($hashPrefix)
+    {
+        try {
+            $response = $this->factory->get(
+                'https://api.pwnedpasswords.com/range/'.$hashPrefix
+            );
+        } catch (Exception $e) {
+            report($e);
+        }
+
+        $body = (isset($response) && $response->successful())
+            ? $response->body()
+            : '';
+
+        return Str::of($body)->trim()->explode("\n")->filter(function ($line) {
+            return Str::contains($line, ':');
+        });
+    }
+}

--- a/src/Illuminate/Validation/NotPwnedVerifier.php
+++ b/src/Illuminate/Validation/NotPwnedVerifier.php
@@ -28,13 +28,16 @@ class NotPwnedVerifier implements UncompromisedVerifier
     }
 
     /**
-     * Verify that the given value has not been compromised in public breaches.
+     * Verify that the given data has not been compromised in public breaches.
      *
-     * @param  string  $value
+     * @param  array  $data
      * @return bool
      */
-    public function verify($value)
+    public function verify($data)
     {
+        $value = $data['value'];
+        $threshold = $data['threshold'];
+
         if (empty($value = (string) $value)) {
             return false;
         }
@@ -42,10 +45,10 @@ class NotPwnedVerifier implements UncompromisedVerifier
         [$hash, $hashPrefix] = $this->getHash($value);
 
         return ! $this->search($hashPrefix)
-            ->contains(function ($line) use ($hash, $hashPrefix) {
+            ->contains(function ($line) use ($hash, $hashPrefix, $threshold) {
                 [$hashSuffix, $count] = explode(':', $line);
 
-                return $hashPrefix.$hashSuffix == $hash && $count > 0;
+                return $hashPrefix.$hashSuffix == $hash && $count > $threshold;
             });
     }
 

--- a/src/Illuminate/Validation/NotPwnedVerifier.php
+++ b/src/Illuminate/Validation/NotPwnedVerifier.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Str;
 class NotPwnedVerifier implements UncompromisedVerifier
 {
     /**
-     * The http factory instance.
+     * The HTTP factory instance.
      *
      * @var \Illuminate\Http\Client\Factory
      */
@@ -60,6 +60,7 @@ class NotPwnedVerifier implements UncompromisedVerifier
     protected function getHash($value)
     {
         $hash = strtoupper(sha1((string) $value));
+
         $hashPrefix = substr($hash, 0, 5);
 
         return [$hash, $hashPrefix];

--- a/src/Illuminate/Validation/NotPwnedVerifier.php
+++ b/src/Illuminate/Validation/NotPwnedVerifier.php
@@ -17,7 +17,7 @@ class NotPwnedVerifier implements UncompromisedVerifier
     protected $factory;
 
     /**
-     * Create a new not compromised verifier.
+     * Create a new uncompromised verifier.
      *
      * @param  \Illuminate\Http\Client\Factory  $factory
      * @return void

--- a/src/Illuminate/Validation/NotPwnedVerifier.php
+++ b/src/Illuminate/Validation/NotPwnedVerifier.php
@@ -4,7 +4,6 @@ namespace Illuminate\Validation;
 
 use Exception;
 use Illuminate\Contracts\Validation\UncompromisedVerifier;
-use Illuminate\Http\Client\Factory;
 use Illuminate\Support\Str;
 
 class NotPwnedVerifier implements UncompromisedVerifier

--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -1,0 +1,233 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+use Illuminate\Contracts\Validation\DataAwareRule;
+use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Validator;
+
+class Password implements Rule, DataAwareRule
+{
+    /**
+     * If the password requires at least one uppercase and one lowercase letter.
+     *
+     * @var bool
+     */
+    protected $caseDiff = false;
+
+    /**
+     * The data under validation.
+     *
+     * @var array
+     */
+    protected $data;
+
+    /**
+     * If the password requires at least one letter.
+     *
+     * @var bool
+     */
+    protected $letters = false;
+
+    /**
+     * The minimum size of the password.
+     *
+     * @var int
+     */
+    protected $min = 8;
+
+    /**
+     * If the password should has not been compromised in data leaks.
+     *
+     * @var bool
+     */
+    protected $notCompromised = false;
+
+    /**
+     * If the password requires at least one number.
+     *
+     * @var bool
+     */
+    protected $numbers = false;
+
+    /**
+     * If the password requires at least one symbol.
+     *
+     * @var bool
+     */
+    protected $symbols = false;
+
+    /**
+     * The failure messages, if any.
+     *
+     * @var array
+     */
+    protected $messages = [];
+
+    /**
+     * Create a new rule instance.
+     *
+     * @param  int  $min
+     * @return void
+     */
+    public function __construct($min)
+    {
+        $this->min = max((int) $min, 1);
+    }
+
+    /**
+     * Set the data under validation.
+     *
+     * @param  array  $data
+     * @return $this
+     */
+    public function setData($data)
+    {
+        $this->data = $data;
+
+        return $this;
+    }
+
+    /**
+     * Sets the minimum size of the password.
+     *
+     * @param  int $size
+     * @return $this
+     */
+    public static function min($size)
+    {
+        return new static($size);
+    }
+
+    /**
+     * Ensures the password has not been compromised in data leaks.
+     *
+     * @return $this
+     */
+    public function ensureNotCompromised()
+    {
+        $this->notCompromised = true;
+
+        return $this;
+    }
+
+    /**
+     * Makes the password require at least one uppercase and one lowercase letter.
+     *
+     * @return $this
+     */
+    public function requireCaseDiff()
+    {
+        $this->caseDiff = true;
+
+        return $this;
+    }
+
+    /**
+     * Makes the password require at least one letter.
+     *
+     * @return $this
+     */
+    public function requireLetters()
+    {
+        $this->letters = true;
+
+        return $this;
+    }
+
+    /**
+     * Makes the password require at least one number.
+     *
+     * @return $this
+     */
+    public function requireNumbers()
+    {
+        $this->numbers = true;
+
+        return $this;
+    }
+
+    /**
+     * Makes the password require at least one symbol.
+     *
+     * @return $this
+     */
+    public function requireSymbols()
+    {
+        $this->symbols = true;
+
+        return $this;
+    }
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        $validator = Validator::make($this->data, [
+            $attribute => 'required|string|confirmed|min:'.$this->min,
+        ]);
+
+        if ($validator->fails()) {
+            return $this->fail($validator->messages()->all());
+        }
+
+        $value = (string) $value;
+
+        if ($this->caseDiff && ! preg_match('/(\p{Ll}+.*\p{Lu})|(\p{Lu}+.*\p{Ll})/u', $value)) {
+            $this->fail('The :attribute must contain at least one uppercase and one lowercase letter.');
+        }
+
+        if ($this->letters && ! preg_match('/\pL/', $value)) {
+            $this->fail('The :attribute must contain at least one letter.');
+        }
+
+        if ($this->symbols && ! preg_match('/\p{Z}|\p{S}|\p{P}/', $value)) {
+            $this->fail('The :attribute must contain at least one symbol.');
+        }
+
+        if ($this->numbers && ! preg_match('/\pN/', $value)) {
+            $this->fail('The :attribute must contain at least one number.');
+        }
+
+        if (! empty($this->messages)) {
+            return false;
+        }
+
+        if ($this->notCompromised && ! app('validation.not_compromised')->verify($value)) {
+            return $this->fail(
+                'The given :attribute has appeared in a data leak. Please choose a different :attribute.'
+            );
+        }
+
+        return true;
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return array
+     */
+    public function message()
+    {
+        return $this->messages;
+    }
+
+    /**
+     * Adds the given failures, and return false.
+     *
+     * @param  array|string $message
+     * @return bool
+     */
+    protected function fail($messages)
+    {
+        $this->messages = array_merge($this->messages, Arr::wrap($messages));
+
+        return false;
+    }
+}

--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -195,15 +195,15 @@ class Password implements Rule, DataAwareRule
             $this->fail('The :attribute must contain at least one uppercase and one lowercase letter.');
         }
 
-        if ($this->letters && ! preg_match('/\pL/', $value)) {
+        if ($this->letters && ! preg_match('/\pL/u', $value)) {
             $this->fail('The :attribute must contain at least one letter.');
         }
 
-        if ($this->symbols && ! preg_match('/\p{Z}|\p{S}|\p{P}/', $value)) {
+        if ($this->symbols && ! preg_match('/\p{Z}|\p{S}|\p{P}/u', $value)) {
             $this->fail('The :attribute must contain at least one symbol.');
         }
 
-        if ($this->numbers && ! preg_match('/\pN/', $value)) {
+        if ($this->numbers && ! preg_match('/\pN/u', $value)) {
             $this->fail('The :attribute must contain at least one number.');
         }
 

--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -61,6 +61,13 @@ class Password implements Rule, DataAwareRule
     protected $uncompromised = false;
 
     /**
+     * The number of times a password can appear in data leaks before being consider compromised.
+     *
+     * @var int
+     */
+    protected $uncompromisedThreshold = 0;
+
+    /**
      * The failure messages, if any.
      *
      * @var array
@@ -105,11 +112,14 @@ class Password implements Rule, DataAwareRule
     /**
      * Ensures the password has not been compromised in data leaks.
      *
+     * @param  int  $threshold
      * @return $this
      */
-    public function uncompromised()
+    public function uncompromised($threshold = 0)
     {
         $this->uncompromised = true;
+
+        $this->uncompromisedThreshold = $threshold;
 
         return $this;
     }
@@ -201,7 +211,10 @@ class Password implements Rule, DataAwareRule
             return false;
         }
 
-        if ($this->uncompromised && ! Container::getInstance()->make(UncompromisedVerifier::class)->verify($value)) {
+        if ($this->uncompromised && ! Container::getInstance()->make(UncompromisedVerifier::class)->verify([
+            'value' => $value,
+            'threshold' => $this->uncompromisedThreshold,
+        ])) {
             return $this->fail(
                 'The given :attribute has appeared in a data leak. Please choose a different :attribute.'
             );

--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -65,7 +65,7 @@ class Password implements Rule, DataAwareRule
      *
      * @var int
      */
-    protected $uncompromisedThreshold = 0;
+    protected $compromisedThreshold = 0;
 
     /**
      * The failure messages, if any.
@@ -119,7 +119,7 @@ class Password implements Rule, DataAwareRule
     {
         $this->uncompromised = true;
 
-        $this->uncompromisedThreshold = $threshold;
+        $this->compromisedThreshold = $threshold;
 
         return $this;
     }
@@ -213,7 +213,7 @@ class Password implements Rule, DataAwareRule
 
         if ($this->uncompromised && ! Container::getInstance()->make(UncompromisedVerifier::class)->verify([
             'value' => $value,
-            'threshold' => $this->uncompromisedThreshold,
+            'threshold' => $this->compromisedThreshold,
         ])) {
             return $this->fail(
                 'The given :attribute has appeared in a data leak. Please choose a different :attribute.'

--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -236,7 +236,7 @@ class Password implements Rule, DataAwareRule
     /**
      * Adds the given failures, and return false.
      *
-     * @param  array|string $message
+     * @param  array|string  $messages
      * @return bool
      */
     protected function fail($messages)

--- a/src/Illuminate/Validation/ValidationServiceProvider.php
+++ b/src/Illuminate/Validation/ValidationServiceProvider.php
@@ -56,7 +56,7 @@ class ValidationServiceProvider extends ServiceProvider implements DeferrablePro
     }
 
     /**
-     * Register the not compromise verifier.
+     * Register the not compromised verifier.
      *
      * @return void
      */

--- a/src/Illuminate/Validation/ValidationServiceProvider.php
+++ b/src/Illuminate/Validation/ValidationServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Validation;
 
 use Illuminate\Contracts\Support\DeferrableProvider;
+use Illuminate\Contracts\Validation\UncompromisedVerifier;
 use Illuminate\Http\Client\Factory as HttpFactory;
 use Illuminate\Support\ServiceProvider;
 
@@ -16,9 +17,7 @@ class ValidationServiceProvider extends ServiceProvider implements DeferrablePro
     public function register()
     {
         $this->registerPresenceVerifier();
-
-        $this->registerNotCompromisedVerifier();
-
+        $this->registerUncompromisedVerifier();
         $this->registerValidationFactory();
     }
 
@@ -56,16 +55,14 @@ class ValidationServiceProvider extends ServiceProvider implements DeferrablePro
     }
 
     /**
-     * Register the not compromised verifier.
+     * Register the uncompromised password verifier.
      *
      * @return void
      */
-    protected function registerNotCompromisedVerifier()
+    protected function registerUncompromisedVerifier()
     {
-        $this->app->singleton('validation.not_compromised', function ($app) {
-            return new NotPwnedVerifier(
-                $app[HttpFactory::class]
-            );
+        $this->app->singleton(UncompromisedVerifier::class, function ($app) {
+            return new NotPwnedVerifier($app[HttpFactory::class]);
         });
     }
 

--- a/src/Illuminate/Validation/ValidationServiceProvider.php
+++ b/src/Illuminate/Validation/ValidationServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Validation;
 
 use Illuminate\Contracts\Support\DeferrableProvider;
+use Illuminate\Http\Client\Factory as HttpFactory;
 use Illuminate\Support\ServiceProvider;
 
 class ValidationServiceProvider extends ServiceProvider implements DeferrableProvider
@@ -15,6 +16,8 @@ class ValidationServiceProvider extends ServiceProvider implements DeferrablePro
     public function register()
     {
         $this->registerPresenceVerifier();
+
+        $this->registerNotCompromisedVerifier();
 
         $this->registerValidationFactory();
     }
@@ -49,6 +52,20 @@ class ValidationServiceProvider extends ServiceProvider implements DeferrablePro
     {
         $this->app->singleton('validation.presence', function ($app) {
             return new DatabasePresenceVerifier($app['db']);
+        });
+    }
+
+    /**
+     * Register the not compromise verifier.
+     *
+     * @return void
+     */
+    protected function registerNotCompromisedVerifier()
+    {
+        $this->app->singleton('validation.not_compromised', function ($app) {
+            return new NotPwnedVerifier(
+                $app[HttpFactory::class]
+            );
         });
     }
 

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -5,6 +5,7 @@ namespace Illuminate\Validation;
 use BadMethodCallException;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Translation\Translator;
+use Illuminate\Contracts\Validation\DataAwareRule;
 use Illuminate\Contracts\Validation\ImplicitRule;
 use Illuminate\Contracts\Validation\Rule as RuleContract;
 use Illuminate\Contracts\Validation\Validator as ValidatorContract;
@@ -747,6 +748,10 @@ class Validator implements ValidatorContract
         $attribute = $this->replacePlaceholderInString($attribute);
 
         $value = is_array($value) ? $this->replacePlaceholders($value) : $value;
+
+        if ($rule instanceof DataAwareRule) {
+            $rule->setData($this->data);
+        }
 
         if (! $rule->passes($attribute, $value)) {
             $this->failedRules[$attribute][get_class($rule)] = [];

--- a/tests/Validation/ValidationNotPwnedVerifierTest.php
+++ b/tests/Validation/ValidationNotPwnedVerifierTest.php
@@ -39,16 +39,20 @@ class ValidationNotPwnedVerifierTest extends TestCase
 
         $httpFactory
             ->shouldReceive('withHeaders')
+            ->once()
             ->with(['Add-Padding' => true])
-            ->andThrow($httpFactory);
+            ->andReturn($httpFactory);
 
         $httpFactory->shouldReceive('get')
+            ->once()
             ->andReturn($response);
 
         $response->shouldReceive('successful')
+            ->once()
             ->andReturn(true);
 
         $response->shouldReceive('body')
+            ->once()
             ->andReturn('');
 
         $verifier = new NotPwnedVerifier($httpFactory);
@@ -63,13 +67,16 @@ class ValidationNotPwnedVerifierTest extends TestCase
 
         $httpFactory
             ->shouldReceive('withHeaders')
+            ->once()
             ->with(['Add-Padding' => true])
-            ->andThrow($httpFactory);
+            ->andReturn($httpFactory);
 
         $httpFactory->shouldReceive('get')
+            ->once()
             ->andReturn($response);
 
         $response->shouldReceive('successful')
+            ->once()
             ->andReturn(false);
 
         $verifier = new NotPwnedVerifier($httpFactory);
@@ -92,11 +99,13 @@ class ValidationNotPwnedVerifierTest extends TestCase
 
         $httpFactory
             ->shouldReceive('withHeaders')
+            ->once()
             ->with(['Add-Padding' => true])
-            ->andThrow($httpFactory);
+            ->andReturn($httpFactory);
 
         $httpFactory
             ->shouldReceive('get')
+            ->once()
             ->andThrow($exception);
 
         $verifier = new NotPwnedVerifier($httpFactory);

--- a/tests/Validation/ValidationNotPwnedVerifierTest.php
+++ b/tests/Validation/ValidationNotPwnedVerifierTest.php
@@ -35,6 +35,13 @@ class ValidationNotPwnedVerifierTest extends TestCase
         $httpFactory = m::mock(HttpFactory::class);
         $response = m::mock(Response::class);
 
+        $httpFactory = m::mock(HttpFactory::class);
+
+        $httpFactory
+            ->shouldReceive('withHeaders')
+            ->with(['Add-Padding' => true])
+            ->andThrow($httpFactory);
+
         $httpFactory->shouldReceive('get')
             ->andReturn($response);
 
@@ -53,6 +60,11 @@ class ValidationNotPwnedVerifierTest extends TestCase
     {
         $httpFactory = m::mock(HttpFactory::class);
         $response = m::mock(Response::class);
+
+        $httpFactory
+            ->shouldReceive('withHeaders')
+            ->with(['Add-Padding' => true])
+            ->andThrow($httpFactory);
 
         $httpFactory->shouldReceive('get')
             ->andReturn($response);
@@ -77,7 +89,14 @@ class ValidationNotPwnedVerifierTest extends TestCase
         });
 
         $httpFactory = m::mock(HttpFactory::class);
-        $httpFactory->shouldReceive('get')
+
+        $httpFactory
+            ->shouldReceive('withHeaders')
+            ->with(['Add-Padding' => true])
+            ->andThrow($httpFactory);
+
+        $httpFactory
+            ->shouldReceive('get')
             ->andThrow($exception);
 
         $verifier = new NotPwnedVerifier($httpFactory);

--- a/tests/Validation/ValidationNotPwnedVerifierTest.php
+++ b/tests/Validation/ValidationNotPwnedVerifierTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Debug\ExceptionHandler;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\Factory as HttpFactory;
+use Illuminate\Http\Client\Response;
+use Illuminate\Validation\NotPwnedVerifier;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class ValidationNotPwnedVerifierTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+
+        Container::setInstance(null);
+    }
+
+    public function testEmptyValues()
+    {
+        $httpFactory = m::mock(HttpFactory::class);
+        $verifier = new NotPwnedVerifier($httpFactory);
+
+        foreach (['', false, 0] as $password) {
+            $this->assertFalse($verifier->verify($password));
+        }
+    }
+
+    public function testApiResponseGoesWrong()
+    {
+        $httpFactory = m::mock(HttpFactory::class);
+        $response = m::mock(Response::class);
+
+        $httpFactory->shouldReceive('get')
+            ->andReturn($response);
+
+        $response->shouldReceive('successful')
+            ->andReturn(true);
+
+        $response->shouldReceive('body')
+            ->andReturn('');
+
+        $verifier = new NotPwnedVerifier($httpFactory);
+
+        $this->assertTrue($verifier->verify(123123123));
+    }
+
+    public function testApiGoesDown()
+    {
+        $httpFactory = m::mock(HttpFactory::class);
+        $response = m::mock(Response::class);
+
+        $httpFactory->shouldReceive('get')
+            ->andReturn($response);
+
+        $response->shouldReceive('successful')
+            ->andReturn(false);
+
+        $verifier = new NotPwnedVerifier($httpFactory);
+
+        $this->assertTrue($verifier->verify(123123123));
+    }
+
+    public function testDnsDown()
+    {
+        $container = Container::getInstance();
+        $exception = new ConnectionException();
+
+        $exceptionHandler = m::mock(ExceptionHandler::class);
+        $exceptionHandler->shouldReceive('report')->once()->with($exception);
+        $container->bind(ExceptionHandler::class, function () use ($exceptionHandler) {
+            return $exceptionHandler;
+        });
+
+        $httpFactory = m::mock(HttpFactory::class);
+        $httpFactory->shouldReceive('get')
+            ->andThrow($exception);
+
+        $verifier = new NotPwnedVerifier($httpFactory);
+        $this->assertTrue($verifier->verify(123123123));
+    }
+}

--- a/tests/Validation/ValidationNotPwnedVerifierTest.php
+++ b/tests/Validation/ValidationNotPwnedVerifierTest.php
@@ -26,7 +26,10 @@ class ValidationNotPwnedVerifierTest extends TestCase
         $verifier = new NotPwnedVerifier($httpFactory);
 
         foreach (['', false, 0] as $password) {
-            $this->assertFalse($verifier->verify($password));
+            $this->assertFalse($verifier->verify([
+                'value' => $password,
+                'threshold' => 0,
+            ]));
         }
     }
 
@@ -57,7 +60,10 @@ class ValidationNotPwnedVerifierTest extends TestCase
 
         $verifier = new NotPwnedVerifier($httpFactory);
 
-        $this->assertTrue($verifier->verify(123123123));
+        $this->assertTrue($verifier->verify([
+            'value' => 123123123,
+            'threshold' => 0,
+        ]));
     }
 
     public function testApiGoesDown()
@@ -81,7 +87,10 @@ class ValidationNotPwnedVerifierTest extends TestCase
 
         $verifier = new NotPwnedVerifier($httpFactory);
 
-        $this->assertTrue($verifier->verify(123123123));
+        $this->assertTrue($verifier->verify([
+            'value' => 123123123,
+            'threshold' => 0,
+        ]));
     }
 
     public function testDnsDown()
@@ -109,6 +118,9 @@ class ValidationNotPwnedVerifierTest extends TestCase
             ->andThrow($exception);
 
         $verifier = new NotPwnedVerifier($httpFactory);
-        $this->assertTrue($verifier->verify(123123123));
+        $this->assertTrue($verifier->verify([
+            'value' => 123123123,
+            'threshold' => 0,
+        ]));
     }
 }

--- a/tests/Validation/ValidationPasswordRuleTest.php
+++ b/tests/Validation/ValidationPasswordRuleTest.php
@@ -1,0 +1,209 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Illuminate\Container\Container;
+use Illuminate\Support\Facades\Facade;
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
+use Illuminate\Validation\Rules\Password;
+use Illuminate\Validation\ValidationServiceProvider;
+use Illuminate\Validation\Validator;
+use PHPUnit\Framework\TestCase;
+
+class ValidationPasswordRuleTest extends TestCase
+{
+    public function testRequired()
+    {
+        $this->fails(Password::min(3), [null], [
+            'validation.required',
+        ]);
+
+        $this->passes(Password::min(3), ['1234', 'abcd', 'a z s']);
+    }
+
+    public function testString()
+    {
+        $this->fails(Password::min(3), [['foo' => 'bar'], ['foo']], [
+            'validation.string',
+            'validation.min.string',
+        ]);
+
+        $this->fails(Password::min(3), [1234567, 545], [
+            'validation.string',
+        ]);
+
+        $this->passes(Password::min(3), ['abcd', '454qb^']);
+    }
+
+    public function testMin()
+    {
+        $this->fails(Password::min(3), ['a', 'ff', '12'], [
+            'validation.min.string',
+        ]);
+
+        $this->passes(Password::min(3), ['1234', 'abcd']);
+    }
+
+    public function testCaseDiff()
+    {
+        $this->fails(Password::min(2)->requireCaseDiff(), ['nn', 'MM'], [
+            'The my password must contain at least one uppercase and one lowercase letter.',
+        ]);
+
+        $this->passes(Password::min(2)->requireCaseDiff(), ['Nn', 'Mn', 'âA']);
+    }
+
+    public function testLetters()
+    {
+        $this->fails(Password::min(2)->requireLetters(), ['11', '22', '^^', '``', '**'], [
+            'The my password must contain at least one letter.',
+        ]);
+
+        $this->passes(Password::min(2)->requireLetters(), ['1a', 'b2', 'â1']);
+    }
+
+    public function testNumbers()
+    {
+        $this->fails(Password::min(2)->requireNumbers(), ['aa', 'bb', '  a'], [
+            'The my password must contain at least one number.',
+        ]);
+
+        $this->passes(Password::min(2)->requireNumbers(), ['1a', 'b2', '00']);
+    }
+
+    public function testSymbols()
+    {
+        $this->fails(Password::min(2)->requireSymbols(), ['ab', '1v'], [
+            'The my password must contain at least one symbol.',
+        ]);
+
+        $this->passes(Password::min(2)->requireSymbols(), ['n^d', 'd^!', 'âè']);
+    }
+
+    public function testNotCompromised()
+    {
+        $this->fails(Password::min(2)->ensureNotCompromised(), [
+            '123456',
+            'password',
+            'welcome',
+            'ninja',
+            'abc123',
+            '123456789',
+            '12345678',
+            'nuno',
+        ], [
+            'The given my password has appeared in a data leak. Please choose a different my password.',
+        ]);
+
+        $this->passes(Password::min(2)->ensureNotCompromised(), [
+            '!p8VrB',
+            '&xe6VeKWF#n4',
+            '%HurHUnw7zM!',
+            'rundeliekend',
+            '7Z^k5EvqQ9g%c!Jt9$ufnNpQy#Kf',
+            'NRs*Gz2@hSmB$vVBSPDfqbRtEzk4nF7ZAbM29VMW$BPD%b2U%3VmJAcrY5eZGVxP%z%apnwSX',
+        ]);
+    }
+
+    public function testMessages()
+    {
+        $makeRule = function () {
+            return Password::min(8)
+                ->requireCaseDiff()
+                ->requireLetters()
+                ->requireNumbers()
+                ->requireSymbols()
+                ->ensureNotCompromised();
+        };
+
+        $this->fails($makeRule(), ['foo', 'azdazd', '1231231'], [
+            'validation.min.string',
+        ]);
+
+        $this->fails($makeRule(), ['aaaaaaaaa', 'TJQSJQSIUQHS'], [
+            'The my password must contain at least one uppercase and one lowercase letter.',
+            'The my password must contain at least one symbol.',
+            'The my password must contain at least one number.',
+        ]);
+
+        $this->fails($makeRule(), ['4564654564564'], [
+            'The my password must contain at least one uppercase and one lowercase letter.',
+            'The my password must contain at least one letter.',
+            'The my password must contain at least one symbol.',
+        ]);
+    }
+
+    public function testConfirmed()
+    {
+        $v = new Validator(
+            resolve('translator'),
+            ['my_password' => '1234', 'my_password_confirmation' => '5678'],
+            ['my_password' => Password::min(3)]
+        );
+
+        $this->assertSame(false, $v->passes());
+        $this->assertSame(['my_password' => ['validation.confirmed']], $v->messages()->toArray());
+
+        $v = new Validator(
+            resolve('translator'),
+            ['my_password' => '1234'],
+            ['my_password' => Password::min(3)]
+        );
+
+        $this->assertSame(false, $v->passes());
+        $this->assertSame(['my_password' => ['validation.confirmed']], $v->messages()->toArray());
+    }
+
+    protected function passes($rule, $values)
+    {
+        $this->testRule($rule, $values, true, []);
+    }
+
+    protected function fails($rule, $values, $messages)
+    {
+        $this->testRule($rule, $values, false, $messages);
+    }
+
+    protected function testRule($rule, $values, $result, $messages)
+    {
+        foreach ($values as $value) {
+            $v = new Validator(
+                resolve('translator'),
+                ['my_password' => $value, 'my_password_confirmation' => $value],
+                ['my_password' => clone $rule]
+            );
+
+            $this->assertSame($result, $v->passes());
+
+            $this->assertSame(
+                $result ? [] : ['my_password' => $messages],
+                $v->messages()->toArray()
+            );
+        }
+    }
+
+    protected function setUp(): void
+    {
+        $container = Container::getInstance();
+
+        $container->bind('translator', function () {
+            return new Translator(
+                new ArrayLoader, 'en'
+            );
+        });
+
+        Facade::setFacadeApplication($container);
+
+        (new ValidationServiceProvider($container))->register();
+    }
+
+    protected function tearDown(): void
+    {
+        Container::setInstance(null);
+
+        Facade::clearResolvedInstances();
+
+        Facade::setFacadeApplication(null);
+    }
+}

--- a/tests/Validation/ValidationPasswordRuleTest.php
+++ b/tests/Validation/ValidationPasswordRuleTest.php
@@ -13,15 +13,6 @@ use PHPUnit\Framework\TestCase;
 
 class ValidationPasswordRuleTest extends TestCase
 {
-    public function testRequired()
-    {
-        $this->fails(Password::min(3), [null], [
-            'validation.required',
-        ]);
-
-        $this->passes(Password::min(3), ['1234', 'abcd', 'a z s']);
-    }
-
     public function testString()
     {
         $this->fails(Password::min(3), [['foo' => 'bar'], ['foo']], [
@@ -47,43 +38,43 @@ class ValidationPasswordRuleTest extends TestCase
 
     public function testCaseDiff()
     {
-        $this->fails(Password::min(2)->requireCaseDiff(), ['nn', 'MM'], [
+        $this->fails(Password::min(2)->mixedCase(), ['nn', 'MM'], [
             'The my password must contain at least one uppercase and one lowercase letter.',
         ]);
 
-        $this->passes(Password::min(2)->requireCaseDiff(), ['Nn', 'Mn', 'âA']);
+        $this->passes(Password::min(2)->mixedCase(), ['Nn', 'Mn', 'âA']);
     }
 
     public function testLetters()
     {
-        $this->fails(Password::min(2)->requireLetters(), ['11', '22', '^^', '``', '**'], [
+        $this->fails(Password::min(2)->letters(), ['11', '22', '^^', '``', '**'], [
             'The my password must contain at least one letter.',
         ]);
 
-        $this->passes(Password::min(2)->requireLetters(), ['1a', 'b2', 'â1']);
+        $this->passes(Password::min(2)->letters(), ['1a', 'b2', 'â1']);
     }
 
     public function testNumbers()
     {
-        $this->fails(Password::min(2)->requireNumbers(), ['aa', 'bb', '  a'], [
+        $this->fails(Password::min(2)->numbers(), ['aa', 'bb', '  a'], [
             'The my password must contain at least one number.',
         ]);
 
-        $this->passes(Password::min(2)->requireNumbers(), ['1a', 'b2', '00']);
+        $this->passes(Password::min(2)->numbers(), ['1a', 'b2', '00']);
     }
 
     public function testSymbols()
     {
-        $this->fails(Password::min(2)->requireSymbols(), ['ab', '1v'], [
+        $this->fails(Password::min(2)->symbols(), ['ab', '1v'], [
             'The my password must contain at least one symbol.',
         ]);
 
-        $this->passes(Password::min(2)->requireSymbols(), ['n^d', 'd^!', 'âè']);
+        $this->passes(Password::min(2)->symbols(), ['n^d', 'd^!', 'âè']);
     }
 
     public function testNotCompromised()
     {
-        $this->fails(Password::min(2)->ensureNotCompromised(), [
+        $this->fails(Password::min(2)->uncompromised(), [
             '123456',
             'password',
             'welcome',
@@ -96,7 +87,7 @@ class ValidationPasswordRuleTest extends TestCase
             'The given my password has appeared in a data leak. Please choose a different my password.',
         ]);
 
-        $this->passes(Password::min(2)->ensureNotCompromised(), [
+        $this->passes(Password::min(2)->uncompromised(), [
             '!p8VrB',
             '&xe6VeKWF#n4',
             '%HurHUnw7zM!',
@@ -110,11 +101,11 @@ class ValidationPasswordRuleTest extends TestCase
     {
         $makeRule = function () {
             return Password::min(8)
-                ->requireCaseDiff()
-                ->requireLetters()
-                ->requireNumbers()
-                ->requireSymbols()
-                ->ensureNotCompromised();
+                ->mixedCase()
+                ->letters()
+                ->numbers()
+                ->symbols()
+                ->uncompromised();
         };
 
         $this->fails($makeRule(), ['foo', 'azdazd', '1231231'], [
@@ -132,27 +123,6 @@ class ValidationPasswordRuleTest extends TestCase
             'The my password must contain at least one letter.',
             'The my password must contain at least one symbol.',
         ]);
-    }
-
-    public function testConfirmed()
-    {
-        $v = new Validator(
-            resolve('translator'),
-            ['my_password' => '1234', 'my_password_confirmation' => '5678'],
-            ['my_password' => Password::min(3)]
-        );
-
-        $this->assertSame(false, $v->passes());
-        $this->assertSame(['my_password' => ['validation.confirmed']], $v->messages()->toArray());
-
-        $v = new Validator(
-            resolve('translator'),
-            ['my_password' => '1234'],
-            ['my_password' => Password::min(3)]
-        );
-
-        $this->assertSame(false, $v->passes());
-        $this->assertSame(['my_password' => ['validation.confirmed']], $v->messages()->toArray());
     }
 
     protected function passes($rule, $values)

--- a/tests/Validation/ValidationPasswordRuleTest.php
+++ b/tests/Validation/ValidationPasswordRuleTest.php
@@ -36,7 +36,7 @@ class ValidationPasswordRuleTest extends TestCase
         $this->passes(Password::min(3), ['1234', 'abcd']);
     }
 
-    public function testCaseDiff()
+    public function testMixedCase()
     {
         $this->fails(Password::min(2)->mixedCase(), ['nn', 'MM'], [
             'The my password must contain at least one uppercase and one lowercase letter.',
@@ -72,7 +72,7 @@ class ValidationPasswordRuleTest extends TestCase
         $this->passes(Password::min(2)->symbols(), ['n^d', 'd^!', 'âè']);
     }
 
-    public function testNotCompromised()
+    public function testUncompromised()
     {
         $this->fails(Password::min(2)->uncompromised(), [
             '123456',

--- a/tests/Validation/ValidationPasswordRuleTest.php
+++ b/tests/Validation/ValidationPasswordRuleTest.php
@@ -24,7 +24,7 @@ class ValidationPasswordRuleTest extends TestCase
             'validation.string',
         ]);
 
-        $this->passes(Password::min(3), ['abcd', '454qb^']);
+        $this->passes(Password::min(3), ['abcd', '454qb^', '接2133手田']);
     }
 
     public function testMin()
@@ -69,7 +69,7 @@ class ValidationPasswordRuleTest extends TestCase
             'The my password must contain at least one symbol.',
         ]);
 
-        $this->passes(Password::min(2)->symbols(), ['n^d', 'd^!', 'âè$']);
+        $this->passes(Password::min(2)->symbols(), ['n^d', 'd^!', 'âè$', '金廿土弓竹中；']);
     }
 
     public function testUncompromised()
@@ -92,6 +92,7 @@ class ValidationPasswordRuleTest extends TestCase
         ]);
 
         $this->passes(Password::min(2)->uncompromised(), [
+            '手田日尸Ｚ難金木水口火女月土廿卜竹弓一十山',
             '!p8VrB',
             '&xe6VeKWF#n4',
             '%HurHUnw7zM!',

--- a/tests/Validation/ValidationPasswordRuleTest.php
+++ b/tests/Validation/ValidationPasswordRuleTest.php
@@ -38,11 +38,11 @@ class ValidationPasswordRuleTest extends TestCase
 
     public function testMixedCase()
     {
-        $this->fails(Password::min(2)->mixedCase(), ['nn', 'MM'], [
+        $this->fails(Password::min(2)->mixedCase(), ['nn', 'MM', '京都府'], [
             'The my password must contain at least one uppercase and one lowercase letter.',
         ]);
 
-        $this->passes(Password::min(2)->mixedCase(), ['Nn', 'Mn', 'âA']);
+        $this->passes(Password::min(2)->mixedCase(), ['Nn', 'Mn', 'âA', '京都府']);
     }
 
     public function testLetters()
@@ -51,16 +51,16 @@ class ValidationPasswordRuleTest extends TestCase
             'The my password must contain at least one letter.',
         ]);
 
-        $this->passes(Password::min(2)->letters(), ['1a', 'b2', 'â1']);
+        $this->passes(Password::min(2)->letters(), ['1a', 'b2', 'â1', '1 京都府']);
     }
 
     public function testNumbers()
     {
-        $this->fails(Password::min(2)->numbers(), ['aa', 'bb', '  a'], [
+        $this->fails(Password::min(2)->numbers(), ['aa', 'bb', '  a', '京都府'], [
             'The my password must contain at least one number.',
         ]);
 
-        $this->passes(Password::min(2)->numbers(), ['1a', 'b2', '00']);
+        $this->passes(Password::min(2)->numbers(), ['1a', 'b2', '00', '京都府 1']);
     }
 
     public function testSymbols()
@@ -69,7 +69,7 @@ class ValidationPasswordRuleTest extends TestCase
             'The my password must contain at least one symbol.',
         ]);
 
-        $this->passes(Password::min(2)->symbols(), ['n^d', 'd^!', 'âè']);
+        $this->passes(Password::min(2)->symbols(), ['n^d', 'd^!', 'âè$']);
     }
 
     public function testUncompromised()

--- a/tests/Validation/ValidationPasswordRuleTest.php
+++ b/tests/Validation/ValidationPasswordRuleTest.php
@@ -38,11 +38,11 @@ class ValidationPasswordRuleTest extends TestCase
 
     public function testMixedCase()
     {
-        $this->fails(Password::min(2)->mixedCase(), ['nn', 'MM', '京都府'], [
+        $this->fails(Password::min(2)->mixedCase(), ['nn', 'MM'], [
             'The my password must contain at least one uppercase and one lowercase letter.',
         ]);
 
-        $this->passes(Password::min(2)->mixedCase(), ['Nn', 'Mn', 'âA', '京都府']);
+        $this->passes(Password::min(2)->mixedCase(), ['Nn', 'Mn', 'âA']);
     }
 
     public function testLetters()

--- a/tests/Validation/ValidationPasswordRuleTest.php
+++ b/tests/Validation/ValidationPasswordRuleTest.php
@@ -87,6 +87,10 @@ class ValidationPasswordRuleTest extends TestCase
             'The given my password has appeared in a data leak. Please choose a different my password.',
         ]);
 
+        $this->passes(Password::min(2)->uncompromised(9999999), [
+            'nuno',
+        ]);
+
         $this->passes(Password::min(2)->uncompromised(), [
             '!p8VrB',
             '&xe6VeKWF#n4',


### PR DESCRIPTION
This pull request adds a new custom rule object to the framework that allows to replace existing password rules like so:

```php
    public function store(Request $request)
    {
        $request->validate([
            'name' => 'required|string|max:255',
            'email' => 'required|string|email|max:255|unique:users',
        //  'password' => 'required|string|confirmed|min:8',
            'password' => ['required', 'confirmed', Password::min(8)],
        ]);
````

In addition, this new custom rule object contains built-in methods that you may use to ensure strong passwords:
```php
        $request->validate([

            // Makes the password require at least one uppercase and one lowercase letter.
            'password' =>  ['required', 'confirmed', Password::min(8)->mixedCase()],

             // Makes the password require at least one letter.
            'password' =>  ['required', 'confirmed', Password::min(8)->letters()],

            // Makes the password require at least one number.
            'password' =>  ['required', 'confirmed', Password::min(8)->numbers()],

            // Makes the password require at least one symbol.
            'password' =>  ['required', 'confirmed', Password::min(8)->symbols()],

            // Ensures the password has not been compromised in data leaks.
            'password' =>  ['required', 'confirmed', Password::min(8)->uncompromised()],
        ]);
````

Of course, you can always use them all combined like so:

```php
    public function store(Request $request)
    {
        $request->validate([
            'name' => 'required|string|max:255',
            'email' => 'required|string|email|max:255|unique:users',
            'password' => ['required', 'confirmed', Password::min(8)
                    ->mixedCase()
                    ->letters()
                    ->numbers()
                    ->symbols()
                    ->uncompromised(),
            ],
        ]);
````

Here is an example of the output:

![EyycZD-XAAMs2Nm](https://user-images.githubusercontent.com/5457236/114450322-c58ec080-9bcd-11eb-90a7-559eb0aef0c9.jpeg)
