### PR TITLE
[8.x] Added pluralPhrase() methods to Str and Stringable classes

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -470,7 +470,7 @@ class Str
             return Str::plural($words[0]);
         } else {
             $last = array_pop($words);
-            return implode(' ', $words) . ' ' . Str::plural($last);
+            return implode(' ', $words).' '.Str::plural($last);
         }
     }
 

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -464,14 +464,12 @@ class Str
     {
         $words = explode(' ', $value);
 
-        if (count($words) == 0) {
-            return $value;
-        } elseif (count($words) == 1) {
-            return Str::plural($words[0]);
-        } else {
-            $last = array_pop($words);
+        if (count($words) > 1) {
+            $lastWord = array_pop($words);
 
-            return implode(' ', $words).' '.Str::plural($last);
+            return implode(' ', $words).' '.self::plural($lastWord);
+        } else {
+            return self::plural($words[0]);
         }
     }
 

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -470,6 +470,7 @@ class Str
             return Str::plural($words[0]);
         } else {
             $last = array_pop($words);
+
             return implode(' ', $words).' '.Str::plural($last);
         }
     }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -455,6 +455,25 @@ class Str
     }
 
     /**
+     * Pluralize the last word of an English phrase (multi-word string).
+     *
+     * @param  string  $value
+     * @return string
+     */
+    public static function pluralPhrase($value) {
+        $words = explode(' ', $value);
+
+        if (count($words) == 0) {
+            return $value;
+        } elseif (count($words) == 1) {
+            return Str::plural($words[0]);
+        } else {
+            $last = array_pop($words);
+            return implode(' ', $words) . ' ' . Str::plural($last);
+        }
+    }
+
+    /**
      * Pluralize the last word of an English, studly caps case string.
      *
      * @param  string  $value

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -460,7 +460,8 @@ class Str
      * @param  string  $value
      * @return string
      */
-    public static function pluralPhrase($value) {
+    public static function pluralPhrase($value)
+    {
         $words = explode(' ', $value);
 
         if (count($words) == 0) {

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -446,6 +446,15 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Pluralize the last word of an English phrase (multi-word string).
+     *
+     * @return static
+     */
+    public function pluralPhrase() {
+        return new static(Str::pluralPhrase($this->value));
+    }
+
+    /**
      * Pluralize the last word of an English, studly caps case string.
      *
      * @param  int  $count

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -450,7 +450,8 @@ class Stringable implements JsonSerializable
      *
      * @return static
      */
-    public function pluralPhrase() {
+    public function pluralPhrase()
+    {
         return new static(Str::pluralPhrase($this->value));
     }
 


### PR DESCRIPTION
Added pluralPhrase() methods to the Illuminate\Support\Str and Illuminate\Support\Stringable classes which pluralise an English phrase composed of multiple words by only pluralising the last word of the phrase.