### PR TITLE
Fixed iterator used as array_map argument

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -213,7 +213,7 @@ abstract class Factory
         return new EloquentCollection(
             array_map(function ($record) {
                 return $this->state($record)->create();
-            }, $records)
+            }, iterator_to_array($records))
         );
     }
 


### PR DESCRIPTION
In `Illuminate\Database\Eloquent\Factories\Factory` class the method `createMany()` had *iterable* type `$records` as a parameter, but inside the method it is passed to array_map function, which uses *array* type arguments. So, I passed the `$records` variable through `iterator_to_array()` function to convert it into an array.

```php
    // Before
    public function createMany(iterable $records)
    {
        return new EloquentCollection(
            array_map(function ($record) {
                return $this->state($record)->create();
            }, $records)
        );
    }

    // After
    public function createMany(iterable $records)
    {
        return new EloquentCollection(
            array_map(function ($record) {
                return $this->state($record)->create();
            }, iterator_to_array($records))
        );
    }
```
