### PR TITLE
[8.x] Extract attribute getter for `performInsert`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -990,6 +990,16 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     }
 
     /**
+     * Get all of the current attributes on the model for insert.
+     *
+     * @return array
+     */
+    protected function getAttributesForInsert()
+    {
+        return $this->getAttributes();
+    }
+
+    /**
      * Perform a model insert operation.
      *
      * @param  \Illuminate\Database\Eloquent\Builder  $query
@@ -1011,7 +1021,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
         // If the model has an incrementing key, we can use the "insertGetId" method on
         // the query builder, which will give us back the final inserted ID for this
         // table from the database. Not all tables have to be incrementing though.
-        $attributes = $this->getAttributes();
+        $attributes = $this->getAttributesForInsert();
 
         if ($this->getIncrementing()) {
             $this->insertAndSetId($query, $attributes);


### PR DESCRIPTION
With models we disabled `$guarded` or `$fillable` and instead opted for a `$columns` concept where we define all database columns on the model e.g. 

```php
protected static array $columns = [
    'id',
    'email',
    'password',
    'name',
    'last_name',
    'remember_token',
    'created_at',
    'updated_at',
    'deleted_at',
    'email_verified_at',
];
```

This allows us to have a column reference list without having to dig into the database, and also we use this list to filter attributes before saving to avoid some unexpected missing column exceptions when paired with custom properties (after joins etc.). For this to fully work we need to override `performInsert` where instead of `$this->getAttributes()` we do

```php
$columns = static::columns();
$attributes = empty($columns) ? $this->getAttributes() : Arr::only($this->getAttributes(), $columns);
```

While we have no problems overriding this, there still is a possibility of a breaking change to occur without us knowing and it'd be safer to manage if the attribute extraction is separated. This also helps us with computed columns where it exists in database as a column but is readonly, in that case we mark it as a comment in the column list.