### PR TITLE
[8.x] Add binding field to explicit model binding

### DIFF
--- a/src/Illuminate/Routing/RouteBinding.php
+++ b/src/Illuminate/Routing/RouteBinding.php
@@ -57,7 +57,7 @@ class RouteBinding
      */
     public static function forModel($container, $class, $callback = null)
     {
-        return function ($value) use ($container, $class, $callback) {
+        return function ($value, $route = null, $key = null) use ($container, $class, $callback) {
             if (is_null($value)) {
                 return;
             }
@@ -67,7 +67,7 @@ class RouteBinding
             // throw a not found exception otherwise we will return the instance.
             $instance = $container->make($class);
 
-            if ($model = $instance->resolveRouteBinding($value)) {
+            if ($model = $instance->resolveRouteBinding($value, $route && $key ? $route->bindingFieldFor($key) : null)) {
                 return $model;
             }
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -842,7 +842,7 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     protected function performBinding($key, $value, $route)
     {
-        return call_user_func($this->binders[$key], $value, $route);
+        return call_user_func($this->binders[$key], $value, $route, $key);
     }
 
     /**


### PR DESCRIPTION
This PR adds binding field support to model bindings registered via `Route::model`.

Example:

RouteSerivceProvider.php:
```php
Route::model('root_category', Category::class);
```

routes/web.php:
```php
Route::get('category/{root_category:slug}', CategoryController::class)->name('category');
```

Using `route` function will give us this output:
```php
route('category', ['root_category' => $category]); // http://localhost/category/category-slug
```

But opening the URL shows a `404` error page.

This PR fixes this issue.