### PR TITLE
[6.x] Fix required_if boolean validation

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1475,11 +1475,22 @@ trait ValidatesAttributes
 
         $values = array_slice($parameters, 1);
 
-        if (is_bool($other)) {
+        if ($this->shouldConvertToBoolean($parameters[0]) || is_bool($other)) {
             $values = $this->convertValuesToBoolean($values);
         }
 
         return [$values, $other];
+    }
+
+    /**
+     * Check if parameter should be converted to boolean.
+     *
+     * @param  string  $parameter
+     * @return bool
+     */
+    protected function shouldConvertToBoolean($parameter)
+    {
+        return in_array('boolean', Arr::get($this->rules, $parameter, []));
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1090,6 +1090,17 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['first' => 'dayle', 'last' => ''], ['last' => 'RequiredIf:first,taylor,dayle']);
         $this->assertFalse($v->passes());
         $this->assertSame('The last field is required when first is dayle.', $v->messages()->first('last'));
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines(['validation.required_if' => 'The :attribute field is required when :other is :value.'], 'en');
+        $v = new Validator($trans, ['foo' => 0], [
+            'foo' => 'required|boolean',
+            'bar' => 'required_if:foo,true',
+            'baz' => 'required_if:foo,false',
+        ]);
+        $this->assertTrue($v->fails());
+        $this->assertCount(1, $v->messages());
+        $this->assertSame('The baz field is required when foo is 0.', $v->messages()->first('baz'));
     }
 
     public function testRequiredUnless()


### PR DESCRIPTION
Re-send of https://github.com/laravel/framework/pull/36967

This should fix some regressions for the changed behavior introduced in https://github.com/laravel/framework/pull/36504. The PR now takes into account the `boolean` validation rule when combining rules like `required_if`. As reported in https://github.com/laravel/framework/issues/36952 atm the validator will incorrectly return incorrect error messages when a boolean value of `0` is used. By first checking if the rules for the subject of `required_if` contains `boolean` we can safely know that it should be converted to a boolean. This doesn't breaks previous tests and all tests introduced by @jessarcher still pass.

I'd appreciate a second pair of eyes on this @jessarcher @timacdonald @SjorsO @taylorotwell.

Fixes https://github.com/laravel/framework/issues/36952