### PR TITLE
[8.x] Add binding field to explicit model binding

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -143,6 +143,13 @@ class Route
     protected $bindingFields = [];
 
     /**
+     * Parameters that are listed in the route / controller signature.
+     *
+     * @var array|\ReflectionParameter[]
+     */
+    protected $signatureParameters = [];
+
+    /**
      * The validators used by the routes.
      *
      * @var array
@@ -496,14 +503,32 @@ class Route
     }
 
     /**
+     * Get the parameter that is listed in the route / controller signature via parameter name.
+     *
+     * @param  string       $name
+     * @param  string|null  $subClass
+     * @return \ReflectionParameter|null
+     */
+    public function signatureParameter(string $name, $subClass = null)
+    {
+        $parameters = $this->signatureParameters($subClass);
+
+        return $parameters[$name] ?? null;
+    }
+
+    /**
      * Get the parameters that are listed in the route / controller signature.
      *
      * @param  string|null  $subClass
-     * @return array
+     * @return array|\ReflectionParameter[]
      */
     public function signatureParameters($subClass = null)
     {
-        return RouteSignatureParameters::fromAction($this->action, $subClass);
+        if (! isset($this->signatureParameters[$subClass])) {
+            $this->signatureParameters[$subClass] = RouteSignatureParameters::fromAction($this->action, $subClass);
+        }
+
+        return $this->signatureParameters[$subClass];
     }
 
     /**
@@ -555,6 +580,8 @@ class Route
         if ($key === 0) {
             return;
         }
+
+        $this->router->substituteImplicitBinding($this, array_keys($this->parameters)[$key - 1]);
 
         return array_values($this->parameters)[$key - 1];
     }

--- a/src/Illuminate/Routing/RouteBinding.php
+++ b/src/Illuminate/Routing/RouteBinding.php
@@ -57,7 +57,7 @@ class RouteBinding
      */
     public static function forModel($container, $class, $callback = null)
     {
-        return function ($value) use ($container, $class, $callback) {
+        return function ($value, $route = null, $key = null) use ($container, $class, $callback) {
             if (is_null($value)) {
                 return;
             }
@@ -67,7 +67,7 @@ class RouteBinding
             // throw a not found exception otherwise we will return the instance.
             $instance = $container->make($class);
 
-            if ($model = $instance->resolveRouteBinding($value)) {
+            if ($model = $instance->resolveRouteBinding($value, $route && $key ? $route->bindingFieldFor($key) : null)) {
                 return $model;
             }
 

--- a/src/Illuminate/Routing/RouteBinding.php
+++ b/src/Illuminate/Routing/RouteBinding.php
@@ -57,7 +57,7 @@ class RouteBinding
      */
     public static function forModel($container, $class, $callback = null)
     {
-        return function ($value, $route = null, $key = null) use ($container, $class, $callback) {
+        return function ($value, $route = null, $field = null) use ($container, $class, $callback) {
             if (is_null($value)) {
                 return;
             }
@@ -67,7 +67,7 @@ class RouteBinding
             // throw a not found exception otherwise we will return the instance.
             $instance = $container->make($class);
 
-            if ($model = $instance->resolveRouteBinding($value, $route && $key ? $route->bindingFieldFor($key) : null)) {
+            if ($model = $instance->resolveRouteBinding($value, $field)) {
                 return $model;
             }
 

--- a/src/Illuminate/Routing/RouteSignatureParameters.php
+++ b/src/Illuminate/Routing/RouteSignatureParameters.php
@@ -26,6 +26,8 @@ class RouteSignatureParameters
                         ? static::fromClassMethodString($callback)
                         : (new ReflectionFunction($callback))->getParameters();
 
+        $parameters = static::parametersWithKeys($parameters);
+
         return is_null($subClass) ? $parameters : array_filter($parameters, function ($p) use ($subClass) {
             return Reflector::isParameterSubclassOf($p, $subClass);
         });
@@ -46,5 +48,21 @@ class RouteSignatureParameters
         }
 
         return (new ReflectionMethod($class, $method))->getParameters();
+    }
+
+    /**
+     * Get parameters array with parameter name as array key.
+     *
+     * @param  array  $parameters
+     * @return array
+     */
+    protected static function parametersWithKeys(array $parameters)
+    {
+        $parametersWithKeys = [];
+        foreach ($parameters as $parameter) {
+            $parametersWithKeys[$parameter->getName()] = $parameter;
+        }
+
+        return $parametersWithKeys;
     }
 }

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -8,6 +8,7 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Routing\BindingRegistrar;
 use Illuminate\Contracts\Routing\Registrar as RegistrarContract;
+use Illuminate\Contracts\Routing\UrlRoutable;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Responsable;
@@ -818,6 +819,24 @@ class Router implements BindingRegistrar, RegistrarContract
     }
 
     /**
+     * Substitute the implicit Eloquent model bindings for the route parameter if exists.
+     *
+     * @param  \Illuminate\Routing\Route  $route
+     * @param string  $parameter
+     * @return void
+     *
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
+     */
+    public function substituteImplicitBinding($route, string $parameter)
+    {
+        $signatureParameter = $route->signatureParameter($parameter, UrlRoutable::class);
+
+        if ($signatureParameter) {
+            ImplicitRouteBinding::resolveForRouteParameter($this->container, $route, $signatureParameter);
+        }
+    }
+
+    /**
      * Substitute the implicit Eloquent model bindings for the route.
      *
      * @param  \Illuminate\Routing\Route  $route
@@ -991,7 +1010,7 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     public function model($key, $class, Closure $callback = null)
     {
-        $this->bind($key, RouteBinding::forModel($this->container, $class, $callback));
+        $this->bind($key, RouteBinding::forModel($this->container, $class, $callback, $key));
     }
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -842,7 +842,7 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     protected function performBinding($key, $value, $route)
     {
-        return call_user_func($this->binders[$key], $value, $route);
+        return call_user_func($this->binders[$key], $value, $route, $key);
     }
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -842,7 +842,7 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     protected function performBinding($key, $value, $route)
     {
-        return call_user_func($this->binders[$key], $value, $route, $key);
+        return call_user_func($this->binders[$key], $value, $route, $route->bindingFieldFor($key));
     }
 
     /**

--- a/tests/Routing/RouteSignatureParametersTest.php
+++ b/tests/Routing/RouteSignatureParametersTest.php
@@ -19,7 +19,7 @@ class RouteSignatureParametersTest extends TestCase
         $parameters = RouteSignatureParameters::fromAction($action);
 
         $this->assertContainsOnlyInstancesOf(ReflectionParameter::class, $parameters);
-        $this->assertSame('user', $parameters[0]->getName());
+        $this->assertSame('user', array_values($parameters)[0]->getName());
     }
 }
 

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -879,6 +879,22 @@ class RoutingRouteTest extends TestCase
         $this->assertSame('TAYLOR', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
     }
 
+    public function testRouteBindingWithField()
+    {
+        $router = $this->getRouter();
+        $router->get('name/{bar:name}', ['middleware' => SubstituteBindings::class, 'uses' => function ($name) {
+            return $name;
+        }]);
+        $router->get('job/{bar:job}', ['middleware' => SubstituteBindings::class, 'uses' => function ($name) {
+            return $name;
+        }]);
+        $router->bind('bar', function ($value, $route = null, $key = null) {
+            return $route->bindingFieldFor($key).'='.strtoupper($value);
+        });
+        $this->assertSame('name=TAYLOR', $router->dispatch(Request::create('name/taylor', 'GET'))->getContent());
+        $this->assertSame('job=DEVELOPER', $router->dispatch(Request::create('job/developer', 'GET'))->getContent());
+    }
+
     public function testRouteClassBinding()
     {
         $router = $this->getRouter();
@@ -1677,7 +1693,6 @@ class RoutingRouteTest extends TestCase
 
         $this->assertSame('1|4', $router->dispatch(Request::create('foo/1/4', 'GET'))->getContent());
     }
-
 
     public function testParentChildExplicitBindings()
     {

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1678,6 +1678,26 @@ class RoutingRouteTest extends TestCase
         $this->assertSame('1|4', $router->dispatch(Request::create('foo/1/4', 'GET'))->getContent());
     }
 
+
+    public function testParentChildExplicitBindings()
+    {
+        $router = $this->getRouter();
+
+        $router->model('foo', RoutingTestPostModel::class);
+
+        $router->get('foo/{user}/{foo:slug}', [
+            'middleware' => SubstituteBindings::class,
+            'uses' => function (RoutingTestUserModel $user, RoutingTestPostModel $foo) {
+                $this->assertInstanceOf(RoutingTestUserModel::class, $user);
+                $this->assertInstanceOf(RoutingTestPostModel::class, $foo);
+
+                return $user->value.'|'.$foo->value;
+            },
+        ]);
+
+        $this->assertSame('1|test-slug', $router->dispatch(Request::create('foo/1/test-slug', 'GET'))->getContent());
+    }
+
     public function testImplicitBindingsWithOptionalParameterWithExistingKeyInUri()
     {
         $router = $this->getRouter();

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1690,6 +1690,7 @@ class RoutingRouteTest extends TestCase
             'uses' => function (RoutingTestUserModel $writer, RoutingTestPostModel $foo) {
                 $this->assertInstanceOf(RoutingTestUserModel::class, $writer);
                 $this->assertInstanceOf(RoutingTestPostModel::class, $foo);
+
                 return $writer->value.'|'.$foo->value.'|'.($foo->special ? 'special' : 'not_special');
             },
         ]);

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -2312,6 +2312,11 @@ class RoutingTestUserModel extends Model
         return (new RoutingTestPostModel)->whereSpecial();
     }
 
+    public function dailyPosts()
+    {
+        return static::throwBadMethodCallException('dailyPosts');
+    }
+
     public function testTeams()
     {
         return new RoutingTestTeamModel;
@@ -2338,15 +2343,6 @@ class RoutingTestUserModel extends Model
     public function firstOrFail()
     {
         return $this;
-    }
-
-    public function __call($method, $parameters)
-    {
-        if ($method == 'dailyPosts') {
-            return static::throwBadMethodCallException($method);
-        }
-
-        return parent::__call($method, $parameters);
     }
 }
 

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1719,6 +1719,7 @@ class RoutingRouteTest extends TestCase
             'uses' => function (RoutingTestUserModel $user, RoutingTestPostModel $specialPost) {
                 $this->assertInstanceOf(RoutingTestUserModel::class, $user);
                 $this->assertInstanceOf(RoutingTestPostModel::class, $specialPost);
+
                 return $user->value.'|'.$specialPost->value.'|'.($specialPost->special ? 'special' : 'not_special');
             },
         ]);

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -885,11 +885,11 @@ class RoutingRouteTest extends TestCase
         $router->get('name/{bar:name}', ['middleware' => SubstituteBindings::class, 'uses' => function ($name) {
             return $name;
         }]);
-        $router->get('job/{bar:job}', ['middleware' => SubstituteBindings::class, 'uses' => function ($name) {
-            return $name;
+        $router->get('job/{bar:job}', ['middleware' => SubstituteBindings::class, 'uses' => function ($job) {
+            return $job;
         }]);
-        $router->bind('bar', function ($value, $route = null, $key = null) {
-            return $route->bindingFieldFor($key).'='.strtoupper($value);
+        $router->bind('bar', function ($value, $route = null, $field = null) {
+            return $field.'='.strtoupper($value);
         });
         $this->assertSame('name=TAYLOR', $router->dispatch(Request::create('name/taylor', 'GET'))->getContent());
         $this->assertSame('job=DEVELOPER', $router->dispatch(Request::create('job/developer', 'GET'))->getContent());


### PR DESCRIPTION
This PR adds binding field support to model bindings registered via `Route::model`.

Example:

RouteSerivceProvider.php:
```php
Route::model('root_category', Category::class);
```

routes/web.php:
```php
Route::get('category/{root_category:slug}', CategoryController::class)->name('category');
```

Using `route` function will give us this output:
```php
route('category', ['root_category' => $category]); // http://localhost/category/category-slug
```

But opening the URL shows a `404` error page.

This PR fixes this issue.

(Also test for [parent-child](https://github.com/laravel/framework/pull/36966#issuecomment-818705838) scope added.)

Edit:
It's also possible to use the binding field for closure bind.

Example:
```php
Route::bind('custom_value', function ($value, $route = null, $field = null) {
    return Model::where($field ?? 'id', $value)->firstOrFail();
});
```