### PR TITLE
[master] Allow passing an array of params to ignore when building the original url during signature validation

### DIFF
--- a/CHANGELOG-6.x.md
+++ b/CHANGELOG-6.x.md
@@ -1,6 +1,16 @@
 # Release Notes for 6.x
 
-## [Unreleased](https://github.com/laravel/framework/compare/v6.20.20...6.x)
+## [Unreleased](https://github.com/laravel/framework/compare/v6.20.21...6.x)
+
+
+## [v6.20.21 (2021-03-30)](https://github.com/laravel/framework/compare/v6.20.20...v6.20.21)
+
+### Added
+- Added support of DynamoDB in CI suite ([#36749](https://github.com/laravel/framework/pull/36749))
+- Support username parameter for predis ([#36762](https://github.com/laravel/framework/pull/36762))
+
+### Changed
+- Use qualified column names in pivot query ([#36720](https://github.com/laravel/framework/pull/36720))
 
 
 ## [v6.20.20 (2021-03-23)](https://github.com/laravel/framework/compare/v6.20.19...v6.20.20)

--- a/CHANGELOG-6.x.md
+++ b/CHANGELOG-6.x.md
@@ -1,6 +1,12 @@
 # Release Notes for 6.x
 
-## [Unreleased](https://github.com/laravel/framework/compare/v6.20.21...6.x)
+## [Unreleased](https://github.com/laravel/framework/compare/v6.20.22...6.x)
+
+
+## [v6.20.22 (2021-03-31)](https://github.com/laravel/framework/compare/v6.20.21...v6.20.22)
+
+### Fixed
+- Fixed setting DynamoDB credentials ([#36822](https://github.com/laravel/framework/pull/36822))
 
 
 ## [v6.20.21 (2021-03-30)](https://github.com/laravel/framework/compare/v6.20.20...v6.20.21)

--- a/CHANGELOG-8.x.md
+++ b/CHANGELOG-8.x.md
@@ -1,6 +1,32 @@
 # Release Notes for 8.x
 
-## [Unreleased](https://github.com/laravel/framework/compare/v8.35.1...8.x)
+## [Unreleased](https://github.com/laravel/framework/compare/v8.36.0...8.x)
+
+
+## [v8.36.0 (2021-04-06)](https://github.com/laravel/framework/compare/v8.35.1...v8.36.0)
+
+### Revert
+- Revert ["[8.x] Allow lazy collection to be instantiated from a generator"](https://github.com/laravel/framework/pull/36738) ([#36844](https://github.com/laravel/framework/pull/36844))
+
+### Added
+- Added support useCurrentOnUpdate for MySQL datetime column types ([#36817](https://github.com/laravel/framework/pull/36817))
+- Added `dispatch_sync()` helper ([#36835](https://github.com/laravel/framework/pull/36835))
+- Allowing skipping TransformRequests middlewares via Closure ([#36856](https://github.com/laravel/framework/pull/36856))
+- Added type option to make controller command ([#36853](https://github.com/laravel/framework/pull/36853))
+- Added missing return $this to `Illuminate\Support\Manager::forgetDrivers()` ([#36859](https://github.com/laravel/framework/pull/36859))
+- Added unfinished option to PruneBatchesCommand ([#36877](https://github.com/laravel/framework/pull/36877))
+- Added a simple Str::repeat() helper function ([#36887](https://github.com/laravel/framework/pull/36887))
+
+### Fixed
+- Fixed getMultiple and increment / decrement on tagged cache ([0d21194](https://github.com/laravel/framework/commit/0d211947da9ad222fa8eb092889bb7d7f5fb1726))
+- Implement proper return types in cache increment and decrement ([#36836](https://github.com/laravel/framework/pull/36836))
+- Fixed blade compiler regex issue ([#36843](https://github.com/laravel/framework/pull/36843), [#36848](https://github.com/laravel/framework/pull/36848))
+- Added missing temporary_url when creating flysystem  ([#36860](https://github.com/laravel/framework/pull/36860))
+- Fixed PostgreSQL schema:dump when read/write hosts are arrays ([#36881](https://github.com/laravel/framework/pull/36881))
+
+### Changed
+- Improve the exception thrown when JSON encoding response contents fails in `Response::setContent()` ([#36851](https://github.com/laravel/framework/pull/36851), [#36868](https://github.com/laravel/framework/pull/36868))
+- Revert isDownForMaintenance function to use file_exists() ([#36889](https://github.com/laravel/framework/pull/36889))
 
 
 ## [v8.35.1 (2021-03-31)](https://github.com/laravel/framework/compare/v8.35.0...v8.35.1)

--- a/CHANGELOG-8.x.md
+++ b/CHANGELOG-8.x.md
@@ -1,6 +1,31 @@
 # Release Notes for 8.x
 
-## [Unreleased](https://github.com/laravel/framework/compare/v8.34.0...8.x)
+## [Unreleased](https://github.com/laravel/framework/compare/v8.35.0...8.x)
+
+
+## [v8.35.0 (2021-03-30)](https://github.com/laravel/framework/compare/v8.34.0...v8.35.0)
+
+### Added
+- Added support of DynamoDB in CI suite ([#36749](https://github.com/laravel/framework/pull/36749))
+- Support username parameter for predis ([#36762](https://github.com/laravel/framework/pull/36762))
+- Added missing months() to Wormhole ([#36808](https://github.com/laravel/framework/pull/36808))
+
+### Deprecated
+- Deprecate MocksApplicationServices trait ([#36716](https://github.com/laravel/framework/pull/36716))
+
+### Fixed
+- Fixes missing lazy() and lazyById() on BelongsToMany and HasManyThrough relation query builder ([#36758](https://github.com/laravel/framework/pull/36758))
+- Ensure the compiled view directory exists  ([#36772](https://github.com/laravel/framework/pull/36772))
+- Fix Artisan test method PendingCommand::doesntExpectOutput() always causing a failed test ([#36806](https://github.com/laravel/framework/pull/36806))
+- FIXED: The use of whereHasMorph in a whereHas callback generates a wrong sql statements ([#36801](https://github.com/laravel/framework/pull/36801))
+
+### Changed
+- Allow lazy collection to be instantiated from a generator ([#36738](https://github.com/laravel/framework/pull/36738))
+- Use qualified column names in pivot query ([#36720](https://github.com/laravel/framework/pull/36720))
+- Octane Prep ([#36777](https://github.com/laravel/framework/pull/36777))
+
+### Refactoring
+- Remove useless loop in `Str::remove()` ([#36722](https://github.com/laravel/framework/pull/36722))
 
 
 ## [v8.34.0 (2021-03-23)](https://github.com/laravel/framework/compare/v8.33.1...v8.34.0)

--- a/CHANGELOG-8.x.md
+++ b/CHANGELOG-8.x.md
@@ -1,6 +1,12 @@
 # Release Notes for 8.x
 
-## [Unreleased](https://github.com/laravel/framework/compare/v8.35.0...8.x)
+## [Unreleased](https://github.com/laravel/framework/compare/v8.35.1...8.x)
+
+
+## [v8.35.1 (2021-03-31)](https://github.com/laravel/framework/compare/v8.35.0...v8.35.1)
+
+### Fixed
+- Fixed setting DynamoDB credentials ([#36822](https://github.com/laravel/framework/pull/36822))
 
 
 ## [v8.35.0 (2021-03-30)](https://github.com/laravel/framework/compare/v8.34.0...v8.35.0)

--- a/src/Illuminate/Bus/DatabaseBatchRepository.php
+++ b/src/Illuminate/Bus/DatabaseBatchRepository.php
@@ -256,6 +256,29 @@ class DatabaseBatchRepository implements PrunableBatchRepository
     }
 
     /**
+     * Prune all of the unfinished entries older than the given date.
+     *
+     * @param  \DateTimeInterface  $before
+     * @return int
+     */
+    public function pruneUnfinished(DateTimeInterface $before)
+    {
+        $query = $this->connection->table($this->table)
+            ->whereNull('finished_at')
+            ->where('created_at', '<', $before->getTimestamp());
+
+        $totalDeleted = 0;
+
+        do {
+            $deleted = $query->take(1000)->delete();
+
+            $totalDeleted += $deleted;
+        } while ($deleted !== 0);
+
+        return $totalDeleted;
+    }
+
+    /**
      * Execute the given Closure within a storage specific transaction.
      *
      * @param  \Closure  $callback

--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -81,7 +81,7 @@ class Dispatcher implements QueueingDispatcher
     /**
      * Dispatch a command to its appropriate handler in the current process.
      *
-     * Queuable jobs will be dispatched to the "sync" queue.
+     * Queueable jobs will be dispatched to the "sync" queue.
      *
      * @param  mixed  $command
      * @param  mixed  $handler

--- a/src/Illuminate/Cache/RedisTaggedCache.php
+++ b/src/Illuminate/Cache/RedisTaggedCache.php
@@ -10,6 +10,7 @@ class RedisTaggedCache extends TaggedCache
      * @var string
      */
     const REFERENCE_KEY_FOREVER = 'forever_ref';
+
     /**
      * Standard reference key.
      *
@@ -41,13 +42,13 @@ class RedisTaggedCache extends TaggedCache
      *
      * @param  string  $key
      * @param  mixed  $value
-     * @return void
+     * @return int|bool
      */
     public function increment($key, $value = 1)
     {
         $this->pushStandardKeys($this->tags->getNamespace(), $key);
 
-        parent::increment($key, $value);
+        return parent::increment($key, $value);
     }
 
     /**
@@ -55,13 +56,13 @@ class RedisTaggedCache extends TaggedCache
      *
      * @param  string  $key
      * @param  mixed  $value
-     * @return void
+     * @return int|bool
      */
     public function decrement($key, $value = 1)
     {
         $this->pushStandardKeys($this->tags->getNamespace(), $key);
 
-        parent::decrement($key, $value);
+        return parent::decrement($key, $value);
     }
 
     /**

--- a/src/Illuminate/Cache/RetrievesMultipleKeys.php
+++ b/src/Illuminate/Cache/RetrievesMultipleKeys.php
@@ -16,8 +16,12 @@ trait RetrievesMultipleKeys
     {
         $return = [];
 
-        foreach ($keys as $key) {
-            $return[$key] = $this->get($key);
+        $keys = collect($keys)->mapWithKeys(function ($value, $key) {
+            return [is_string($key) ? $key : $value => is_string($key) ? $value : null];
+        })->all();
+
+        foreach ($keys as $key => $default) {
+            $return[$key] = $this->get($key, $default);
         }
 
         return $return;

--- a/src/Illuminate/Cache/TaggedCache.php
+++ b/src/Illuminate/Cache/TaggedCache.php
@@ -56,7 +56,7 @@ class TaggedCache extends Repository
      */
     public function increment($key, $value = 1)
     {
-        $this->store->increment($this->itemKey($key), $value);
+        return $this->store->increment($this->itemKey($key), $value);
     }
 
     /**
@@ -68,7 +68,7 @@ class TaggedCache extends Repository
      */
     public function decrement($key, $value = 1)
     {
-        $this->store->decrement($this->itemKey($key), $value);
+        return $this->store->decrement($this->itemKey($key), $value);
     }
 
     /**

--- a/src/Illuminate/Cache/TaggedCache.php
+++ b/src/Illuminate/Cache/TaggedCache.php
@@ -52,7 +52,7 @@ class TaggedCache extends Repository
      *
      * @param  string  $key
      * @param  mixed  $value
-     * @return void
+     * @return int|bool
      */
     public function increment($key, $value = 1)
     {
@@ -64,7 +64,7 @@ class TaggedCache extends Repository
      *
      * @param  string  $key
      * @param  mixed  $value
-     * @return void
+     * @return int|bool
      */
     public function decrement($key, $value = 1)
     {

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -5,7 +5,6 @@ namespace Illuminate\Support;
 use ArrayIterator;
 use Closure;
 use DateTimeInterface;
-use Generator;
 use Illuminate\Support\Traits\EnumeratesValues;
 use Illuminate\Support\Traits\Macroable;
 use IteratorAggregate;
@@ -30,7 +29,7 @@ class LazyCollection implements Enumerable
      */
     public function __construct($source = null)
     {
-        if ($source instanceof Closure || $source instanceof Generator || $source instanceof self) {
+        if ($source instanceof Closure || $source instanceof self) {
             $this->source = $source;
         } elseif (is_null($source)) {
             $this->source = static::empty();
@@ -1365,10 +1364,6 @@ class LazyCollection implements Enumerable
      */
     protected function makeIterator($source)
     {
-        if ($source instanceof Generator) {
-            return $source;
-        }
-
         if ($source instanceof IteratorAggregate) {
             return $source->getIterator();
         }

--- a/src/Illuminate/Contracts/Bus/Dispatcher.php
+++ b/src/Illuminate/Contracts/Bus/Dispatcher.php
@@ -15,7 +15,7 @@ interface Dispatcher
     /**
      * Dispatch a command to its appropriate handler in the current process.
      *
-     * Queuable jobs will be dispatched to the "sync" queue.
+     * Queueable jobs will be dispatched to the "sync" queue.
      *
      * @param  mixed  $command
      * @param  mixed  $handler

--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -41,11 +41,13 @@ trait ManagesTransactions
             }
 
             try {
+                if ($this->transactions == 1) {
+                    $this->getPdo()->commit();
+                }
+
                 $this->transactions = max(0, $this->transactions - 1);
 
                 if ($this->transactions == 0) {
-                    $this->getPdo()->commit();
-
                     optional($this->transactionsManager)->commit($this->getName());
                 }
             } catch (Throwable $e) {
@@ -187,11 +189,13 @@ trait ManagesTransactions
     {
         if ($this->transactions == 1) {
             $this->getPdo()->commit();
-
-            optional($this->transactionsManager)->commit($this->getName());
         }
 
         $this->transactions = max(0, $this->transactions - 1);
+
+        if ($this->transactions == 0) {
+            optional($this->transactionsManager)->commit($this->getName());
+        }
 
         $this->fireConnectionEvent('committed');
     }

--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -41,13 +41,13 @@ trait ManagesTransactions
             }
 
             try {
-                if ($this->transactions == 1) {
+                $this->transactions = max(0, $this->transactions - 1);
+
+                if ($this->transactions == 0) {
                     $this->getPdo()->commit();
 
                     optional($this->transactionsManager)->commit($this->getName());
                 }
-
-                $this->transactions = max(0, $this->transactions - 1);
             } catch (Throwable $e) {
                 $this->handleCommitTransactionException(
                     $e, $currentAttempt, $attempts

--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -52,6 +52,8 @@ trait DetectsLostConnections
             'Temporary failure in name resolution',
             'SSL: Broken pipe',
             'SQLSTATE[08S01]: Communication link failure',
+            'SQLSTATE[08006] [7] could not connect to server: Connection refused Is the server running on host',
+            'SQLSTATE[HY000]: General error: 7 SSL SYSCALL error: No route to host',
         ]);
     }
 }

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1609,6 +1609,16 @@ class Builder
     }
 
     /**
+     * Clone the Eloquent query builder.
+     *
+     * @return static
+     */
+    public function clone()
+    {
+        return clone $this;
+    }
+
+    /**
      * Force a clone of the underlying query builder when cloning.
      *
      * @return void

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1323,6 +1323,16 @@ trait HasAttributes
     }
 
     /**
+     * Get all of the current attributes on the model for an insert operation.
+     *
+     * @return array
+     */
+    protected function getAttributesForInsert()
+    {
+        return $this->getAttributes();
+    }
+
+    /**
      * Set the array of model attributes. No checking is done.
      *
      * @param  array  $attributes

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -990,6 +990,16 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     }
 
     /**
+     * Get all of the current attributes on the model for insert.
+     *
+     * @return array
+     */
+    protected function getAttributesForInsert()
+    {
+        return $this->getAttributes();
+    }
+
+    /**
      * Perform a model insert operation.
      *
      * @param  \Illuminate\Database\Eloquent\Builder  $query
@@ -1011,7 +1021,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
         // If the model has an incrementing key, we can use the "insertGetId" method on
         // the query builder, which will give us back the final inserted ID for this
         // table from the database. Not all tables have to be incrementing though.
-        $attributes = $this->getAttributes();
+        $attributes = $this->getAttributesForInsert();
 
         if ($this->getIncrementing()) {
             $this->insertAndSetId($query, $attributes);

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -990,16 +990,6 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     }
 
     /**
-     * Get all of the current attributes on the model for insert.
-     *
-     * @return array
-     */
-    protected function getAttributesForInsert()
-    {
-        return $this->getAttributes();
-    }
-
-    /**
      * Perform a model insert operation.
      *
      * @param  \Illuminate\Database\Eloquent\Builder  $query

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Database\Eloquent;
 
 use ArrayAccess;
-use Exception;
 use Illuminate\Contracts\Queue\QueueableCollection;
 use Illuminate\Contracts\Queue\QueueableEntity;
 use Illuminate\Contracts\Routing\UrlRoutable;
@@ -20,6 +19,7 @@ use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\ForwardsCalls;
 use JsonSerializable;
+use LogicException;
 
 abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializable, QueueableEntity, UrlRoutable
 {
@@ -1097,14 +1097,14 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
      *
      * @return bool|null
      *
-     * @throws \Exception
+     * @throws \LogicException
      */
     public function delete()
     {
         $this->mergeAttributesFromClassCasts();
 
         if (is_null($this->getKeyName())) {
-            throw new Exception('No primary key defined on model.');
+            throw new LogicException('No primary key defined on model.');
         }
 
         // If the model doesn't exist, there is nothing to delete so we'll just return

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -410,7 +410,12 @@ class Migrator
     protected function pretendToRun($migration, $method)
     {
         foreach ($this->getQueries($migration, $method) as $query) {
-            $name = $this->getMigrationName((new ReflectionClass($migration))->getFileName());
+            $name = get_class($migration);
+
+            $reflectionClass = new ReflectionClass($migration);
+            if ($reflectionClass->isAnonymous()) {
+                $name = $this->getMigrationName($reflectionClass->getFileName());
+            }
 
             $this->note("<info>{$name}:</info> {$query['query']}");
         }

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -187,6 +187,7 @@ class Migrator
         // migration file name. Once we have the instances we can run the actual
         // command such as "up" or "down", or we can just simulate the action.
         $migration = $this->resolvePath($file);
+
         $name = $this->getMigrationName($file);
 
         if ($pretend) {
@@ -349,6 +350,7 @@ class Migrator
         // instance of the migration. Once we get an instance we can either run a
         // pretend execution of the migration or we can run the real migration.
         $instance = $this->resolvePath($file);
+
         $name = $this->getMigrationName($file);
 
         $this->note("<comment>Rolling back:</comment> {$name}");
@@ -413,6 +415,7 @@ class Migrator
             $name = get_class($migration);
 
             $reflectionClass = new ReflectionClass($migration);
+
             if ($reflectionClass->isAnonymous()) {
                 $name = $this->getMigrationName($reflectionClass->getFileName());
             }
@@ -458,7 +461,7 @@ class Migrator
     }
 
     /**
-     * Resolve a migration instance from migration path.
+     * Resolve a migration instance from a migration path.
      *
      * @param  string  $path
      * @return object
@@ -466,6 +469,7 @@ class Migrator
     protected function resolvePath(string $path)
     {
         $class = $this->getMigrationClass($this->getMigrationName($path));
+
         if (class_exists($class)) {
             return new $class;
         }
@@ -474,7 +478,7 @@ class Migrator
     }
 
     /**
-     * Generate migration class name based on migration name.
+     * Generate a migration class name based on the migration file name.
      *
      * @param  string  $migrationName
      * @return string

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -244,7 +244,7 @@ class Builder
     /**
      * Add a subselect expression to the query.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|string  $query
+     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|string  $query
      * @param  string  $as
      * @return $this
      *

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -678,6 +678,17 @@ class Blueprint
     }
 
     /**
+     * Create a new tiny text column on the table.
+     *
+     * @param  string  $column
+     * @return \Illuminate\Database\Schema\ColumnDefinition
+     */
+    public function tinyText($column)
+    {
+        return $this->addColumn('tinyText', $column);
+    }
+
+    /**
      * Create a new text column on the table.
      *
      * @param  string  $column

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -491,6 +491,17 @@ class MySqlGrammar extends Grammar
     }
 
     /**
+     * Create the column definition for a tiny text type.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+    protected function typeTinyText(Fluent $column)
+    {
+        return 'tinytext';
+    }
+
+    /**
      * Create the column definition for a text type.
      *
      * @param  \Illuminate\Support\Fluent  $column

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -691,7 +691,11 @@ class MySqlGrammar extends Grammar
     {
         $columnType = $column->precision ? "datetime($column->precision)" : 'datetime';
 
-        return $column->useCurrent ? "$columnType default CURRENT_TIMESTAMP" : $columnType;
+        $current = $column->precision ? "CURRENT_TIMESTAMP($column->precision)" : 'CURRENT_TIMESTAMP';
+
+        $columnType = $column->useCurrent ? "$columnType default $current" : $columnType;
+
+        return $column->useCurrentOnUpdate ? "$columnType on update $current" : $columnType;
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -473,6 +473,17 @@ class PostgresGrammar extends Grammar
     }
 
     /**
+     * Create the column definition for a tiny text type.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+    protected function typeTinyText(Fluent $column)
+    {
+        return 'varchar(255)';
+    }
+
+    /**
      * Create the column definition for a text type.
      *
      * @param  \Illuminate\Support\Fluent  $column

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -433,6 +433,17 @@ class SQLiteGrammar extends Grammar
     }
 
     /**
+     * Create the column definition for a tiny text type.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+    protected function typeTinyText(Fluent $column)
+    {
+        return 'text';
+    }
+
+    /**
      * Create the column definition for a text type.
      *
      * @param  \Illuminate\Support\Fluent  $column

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -418,6 +418,17 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
+     * Create the column definition for a tiny text type.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+    protected function typeTinyText(Fluent $column)
+    {
+        return 'nvarchar(255)';
+    }
+
+    /**
      * Create the column definition for a text type.
      *
      * @param  \Illuminate\Support\Fluent  $column

--- a/src/Illuminate/Database/Schema/PostgresSchemaState.php
+++ b/src/Illuminate/Database/Schema/PostgresSchemaState.php
@@ -70,8 +70,10 @@ class PostgresSchemaState extends SchemaState
      */
     protected function baseVariables(array $config)
     {
+        $config['host'] = $config['host'] ?? '';
+
         return [
-            'LARAVEL_LOAD_HOST' => $config['host'],
+            'LARAVEL_LOAD_HOST' => is_array($config['host']) ? $config['host'][0] : $config['host'],
             'LARAVEL_LOAD_PORT' => $config['port'],
             'LARAVEL_LOAD_USER' => $config['username'],
             'LARAVEL_LOAD_PASSWORD' => $config['password'],

--- a/src/Illuminate/Events/CallQueuedListener.php
+++ b/src/Illuminate/Events/CallQueuedListener.php
@@ -41,6 +41,13 @@ class CallQueuedListener implements ShouldQueue
     public $tries;
 
     /**
+     * The maximum number of exceptions allowed, regardless of attempts.
+     *
+     * @var int
+     */
+    public $maxExceptions;
+
+    /**
      * The number of seconds to wait before retrying a job that encountered an uncaught exception.
      *
      * @var int

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -591,6 +591,8 @@ class Dispatcher implements DispatcherContract
         return tap($job, function ($job) use ($listener) {
             $job->tries = $listener->tries ?? null;
 
+            $job->maxExceptions = $listener->maxExceptions ?? null;
+
             $job->backoff = method_exists($listener, 'backoff')
                                 ? $listener->backoff() : ($listener->backoff ?? null);
 

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -621,7 +621,7 @@ class FilesystemAdapter implements CloudFilesystemContract
     }
 
     /**
-     * Replace the scheme and host of the given UriInterface with values from the given URL.
+     * Replace the scheme, host and port of the given UriInterface with values from the given URL.
      *
      * @param  \Psr\Http\Message\UriInterface  $uri
      * @param  string  $url
@@ -631,7 +631,10 @@ class FilesystemAdapter implements CloudFilesystemContract
     {
         $parsed = parse_url($url);
 
-        return $uri->withScheme($parsed['scheme'])->withHost($parsed['host']);
+        return $uri
+            ->withScheme($parsed['scheme'])
+            ->withHost($parsed['host'])
+            ->withPort($parsed['port'] ?? null);
     }
 
     /**

--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -243,7 +243,7 @@ class FilesystemManager implements FactoryContract
     {
         $cache = Arr::pull($config, 'cache');
 
-        $config = Arr::only($config, ['visibility', 'disable_asserts', 'url']);
+        $config = Arr::only($config, ['visibility', 'disable_asserts', 'url', 'temporary_url']);
 
         if ($cache) {
             $adapter = new CachedAdapter($adapter, $this->createCacheStore($cache));

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -33,7 +33,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      *
      * @var string
      */
-    const VERSION = '8.36.0';
+    const VERSION = '8.36.1';
 
     /**
      * The base path for the Laravel installation.

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1093,7 +1093,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function isDownForMaintenance()
     {
-        return is_file($this->storagePath().'/framework/down');
+        return file_exists($this->storagePath().'/framework/down');
     }
 
     /**

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -33,7 +33,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      *
      * @var string
      */
-    const VERSION = '8.35.1';
+    const VERSION = '8.36.0';
 
     /**
      * The base path for the Laravel installation.

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -33,7 +33,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      *
      * @var string
      */
-    const VERSION = '8.36.1';
+    const VERSION = '8.36.2';
 
     /**
      * The base path for the Laravel installation.

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -33,7 +33,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      *
      * @var string
      */
-    const VERSION = '8.36.2';
+    const VERSION = '8.37.0';
 
     /**
      * The base path for the Laravel installation.

--- a/src/Illuminate/Foundation/Bus/Dispatchable.php
+++ b/src/Illuminate/Foundation/Bus/Dispatchable.php
@@ -61,6 +61,8 @@ trait Dispatchable
      * Dispatch a command to its appropriate handler in the current process.
      *
      * @return mixed
+     *
+     * @deprecated Will be removed in a future Laravel version.
      */
     public static function dispatchNow()
     {

--- a/src/Illuminate/Foundation/Bus/Dispatchable.php
+++ b/src/Illuminate/Foundation/Bus/Dispatchable.php
@@ -48,7 +48,7 @@ trait Dispatchable
     /**
      * Dispatch a command to its appropriate handler in the current process.
      *
-     * Queuable jobs will be dispatched to the "sync" queue.
+     * Queueable jobs will be dispatched to the "sync" queue.
      *
      * @return mixed
      */

--- a/src/Illuminate/Foundation/Http/Middleware/ConvertEmptyStringsToNull.php
+++ b/src/Illuminate/Foundation/Http/Middleware/ConvertEmptyStringsToNull.php
@@ -2,8 +2,35 @@
 
 namespace Illuminate\Foundation\Http\Middleware;
 
+use Closure;
+
 class ConvertEmptyStringsToNull extends TransformsRequest
 {
+    /**
+     * All of the registered skip callbacks.
+     *
+     * @var array
+     */
+    protected static $skipCallbacks = [];
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        foreach (static::$skipCallbacks as $callback) {
+            if ($callback($request)) {
+                return $next($request);
+            }
+        }
+
+        return parent::handle($request, $next);
+    }
+
     /**
      * Transform the given value.
      *
@@ -14,5 +41,16 @@ class ConvertEmptyStringsToNull extends TransformsRequest
     protected function transform($key, $value)
     {
         return is_string($value) && $value === '' ? null : $value;
+    }
+
+    /**
+     * Register a callback that instructs the middleware to be skipped.
+     *
+     * @param  \Closure  $callback
+     * @return void
+     */
+    public static function skipWhen(Closure $callback)
+    {
+        static::$skipCallbacks[] = $callback;
     }
 }

--- a/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
+++ b/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
@@ -2,8 +2,17 @@
 
 namespace Illuminate\Foundation\Http\Middleware;
 
+use Closure;
+
 class TrimStrings extends TransformsRequest
 {
+    /**
+     * All of the registered skip callbacks.
+     *
+     * @var array
+     */
+    protected static $skipCallbacks = [];
+
     /**
      * The attributes that should not be trimmed.
      *
@@ -12,6 +21,24 @@ class TrimStrings extends TransformsRequest
     protected $except = [
         //
     ];
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        foreach (static::$skipCallbacks as $callback) {
+            if ($callback($request)) {
+                return $next($request);
+            }
+        }
+
+        return parent::handle($request, $next);
+    }
 
     /**
      * Transform the given value.
@@ -27,5 +54,16 @@ class TrimStrings extends TransformsRequest
         }
 
         return is_string($value) ? trim($value) : $value;
+    }
+
+    /**
+     * Register a callback that instructs the middleware to be skipped.
+     *
+     * @param  \Closure  $callback
+     * @return void
+     */
+    public static function skipWhen(Closure $callback)
+    {
+        static::$skipCallbacks[] = $callback;
     }
 }

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithViews.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithViews.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Testing\Concerns;
 
+use Closure;
 use Illuminate\Support\Facades\View as ViewFacade;
 use Illuminate\Support\MessageBag;
 use Illuminate\Support\Str;
@@ -57,6 +58,10 @@ trait InteractsWithViews
         $component = $this->app->make($componentClass, $data);
 
         $view = $component->resolveView();
+
+        if ($view instanceof Closure) {
+            $view = $view($data);
+        }
 
         return $view instanceof View
                 ? new TestView($view->with($component->data()))

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -413,6 +413,8 @@ if (! function_exists('dispatch_now')) {
      * @param  mixed  $job
      * @param  mixed  $handler
      * @return mixed
+     *
+     * @deprecated Will be removed in a future Laravel version.
      */
     function dispatch_now($job, $handler = null)
     {

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -390,6 +390,22 @@ if (! function_exists('dispatch')) {
     }
 }
 
+if (! function_exists('dispatch_sync')) {
+    /**
+     * Dispatch a command to its appropriate handler in the current process.
+     *
+     * Queueable jobs will be dispatched to the "sync" queue.
+     *
+     * @param  mixed  $job
+     * @param  mixed  $handler
+     * @return mixed
+     */
+    function dispatch_sync($job, $handler = null)
+    {
+        return app(Dispatcher::class)->dispatchSync($job, $handler);
+    }
+}
+
 if (! function_exists('dispatch_now')) {
     /**
      * Dispatch a command to its appropriate handler in the current process.

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -3,11 +3,12 @@
 namespace Illuminate\Http\Client;
 
 use Closure;
-use GuzzleHttp\Promise\Create;
 use GuzzleHttp\Psr7\Response as Psr7Response;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use PHPUnit\Framework\Assert as PHPUnit;
+
+use function GuzzleHttp\Promise\promise_for;
 
 /**
  * @method \Illuminate\Http\Client\PendingRequest accept(string $contentType)
@@ -106,7 +107,7 @@ class Factory
             $headers['Content-Type'] = 'application/json';
         }
 
-        return Create::promiseFor(new Psr7Response($status, $headers, $body));
+        return promise_for(new Psr7Response($status, $headers, $body));
     }
 
     /**

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -3,12 +3,11 @@
 namespace Illuminate\Http\Client;
 
 use Closure;
+use function GuzzleHttp\Promise\promise_for;
 use GuzzleHttp\Psr7\Response as Psr7Response;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use PHPUnit\Framework\Assert as PHPUnit;
-
-use function GuzzleHttp\Promise\promise_for;
 
 /**
  * @method \Illuminate\Http\Client\PendingRequest accept(string $contentType)

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Http\Client;
 
 use Closure;
-use function GuzzleHttp\Promise\promise_for;
+use GuzzleHttp\Promise\Create;
 use GuzzleHttp\Psr7\Response as Psr7Response;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
@@ -34,6 +34,8 @@ use PHPUnit\Framework\Assert as PHPUnit;
  * @method \Illuminate\Http\Client\PendingRequest withoutVerifying()
  * @method \Illuminate\Http\Client\PendingRequest dump()
  * @method \Illuminate\Http\Client\PendingRequest dd()
+ * @method \Illuminate\Http\Client\PendingRequest async()
+ * @method \Illuminate\Http\Client\Pool pool()
  * @method \Illuminate\Http\Client\Response delete(string $url, array $data = [])
  * @method \Illuminate\Http\Client\Response get(string $url, array $query = [])
  * @method \Illuminate\Http\Client\Response head(string $url, array $query = [])
@@ -104,7 +106,7 @@ class Factory
             $headers['Content-Type'] = 'application/json';
         }
 
-        return promise_for(new Psr7Response($status, $headers, $body));
+        return Create::promiseFor(new Psr7Response($status, $headers, $body));
     }
 
     /**

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -932,7 +932,7 @@ class PendingRequest
     }
 
     /**
-     * Send a pool of asynchronous requests concurrently
+     * Send a pool of asynchronous requests concurrently.
      *
      * @param  callable  $callback
      * @return array

--- a/src/Illuminate/Http/Client/Pool.php
+++ b/src/Illuminate/Http/Client/Pool.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Illuminate\Http\Client;
+
+class Pool
+{
+    /**
+     * The factory instance.
+     *
+     * @var \Illuminate\Http\Client\Factory
+     */
+    protected $factory;
+
+    /**
+     * The client instance.
+     *
+     * @var \GuzzleHttp\Client
+     */
+    protected $client;
+
+    /**
+     * The pool of requests.
+     *
+     * @var array
+     */
+    protected $pool = [];
+
+    /**
+     * Create a new requests pool.
+     *
+     * @param  \Illuminate\Http\Client\Factory|null  $factory
+     * @return void
+     */
+    public function __construct(Factory $factory = null)
+    {
+        $this->factory = $factory ?: new Factory();
+
+        $this->client = $this->factory->buildClient();
+    }
+
+    /**
+     * Add a request to the pool with a key.
+     *
+     * @param  string  $key
+     * @return \Illuminate\Http\Client\PendingRequest
+     */
+    public function add(string $key)
+    {
+        return $this->pool[$key] = $this->asyncRequest();
+    }
+
+    /**
+     * Retrieve a new async pending request.
+     *
+     * @return \Illuminate\Http\Client\PendingRequest
+     */
+    protected function asyncRequest()
+    {
+        // the same client instance needs to be shared across all async requests
+        return $this->factory->setClient($this->client)->async();
+    }
+
+    /**
+     * Retrieve the requests in the pool.
+     *
+     * @return array
+     */
+    public function getRequests()
+    {
+        return $this->pool;
+    }
+
+    /**
+     * Add a request to the pool with a numeric index.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return \Illuminate\Http\Client\PendingRequest
+     */
+    public function __call($method, $parameters)
+    {
+        return $this->pool[] = $this->asyncRequest()->$method(...$parameters);
+    }
+}

--- a/src/Illuminate/Http/Client/Pool.php
+++ b/src/Illuminate/Http/Client/Pool.php
@@ -44,7 +44,7 @@ class Pool
      * @param  string  $key
      * @return \Illuminate\Http\Client\PendingRequest
      */
-    public function add(string $key)
+    public function as(string $key)
     {
         return $this->pool[$key] = $this->asyncRequest();
     }
@@ -56,7 +56,6 @@ class Pool
      */
     protected function asyncRequest()
     {
-        // the same client instance needs to be shared across all async requests
         return $this->factory->setClient($this->client)->async();
     }
 

--- a/src/Illuminate/Http/Client/RequestException.php
+++ b/src/Illuminate/Http/Client/RequestException.php
@@ -2,8 +2,6 @@
 
 namespace Illuminate\Http\Client;
 
-use GuzzleHttp\Psr7\Message;
-
 class RequestException extends HttpClientException
 {
     /**
@@ -36,7 +34,7 @@ class RequestException extends HttpClientException
     {
         $message = "HTTP request returned status code {$response->status()}";
 
-        $summary = Message::bodySummary($response->toPsrResponse());
+        $summary = \GuzzleHttp\Psr7\get_message_body_summary($response->toPsrResponse());
 
         return is_null($summary) ? $message : $message .= ":\n{$summary}\n";
     }

--- a/src/Illuminate/Http/Client/RequestException.php
+++ b/src/Illuminate/Http/Client/RequestException.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Http\Client;
 
+use GuzzleHttp\Psr7\Message;
+
 class RequestException extends HttpClientException
 {
     /**
@@ -34,7 +36,7 @@ class RequestException extends HttpClientException
     {
         $message = "HTTP request returned status code {$response->status()}";
 
-        $summary = \GuzzleHttp\Psr7\get_message_body_summary($response->toPsrResponse());
+        $summary = Message::bodySummary($response->toPsrResponse());
 
         return is_null($summary) ? $message : $message .= ":\n{$summary}\n";
     }

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -238,6 +238,18 @@ class Response implements ArrayAccess
     }
 
     /**
+     * Create an exception if a server or client error occurred.
+     *
+     * @return \Illuminate\Http\Client\RequestException|null
+     */
+    public function toException()
+    {
+        if ($this->failed()) {
+            return new RequestException($this);
+        }
+    }
+
+    /**
      * Throw an exception if a server or client error occurred.
      *
      * @param  \Closure|null  $callback
@@ -250,7 +262,7 @@ class Response implements ArrayAccess
         $callback = func_get_args()[0] ?? null;
 
         if ($this->failed()) {
-            throw tap(new RequestException($this), function ($exception) use ($callback) {
+            throw tap($this->toException(), function ($exception) use ($callback) {
                 if ($callback && is_callable($callback)) {
                     $callback($this, $exception);
                 }

--- a/src/Illuminate/Http/Response.php
+++ b/src/Illuminate/Http/Response.php
@@ -53,6 +53,10 @@ class Response extends SymfonyResponse
             $this->header('Content-Type', 'application/json');
 
             $content = $this->morphToJson($content);
+            
+            if ($content === false) {
+                throw new \UnexpectedValueException(sprintf("Failed to convert the provided Response content to JSON with the message: %s", json_last_error_msg()));
+            }
         }
 
         // If this content implements the "Renderable" interface then we will call the

--- a/src/Illuminate/Http/Response.php
+++ b/src/Illuminate/Http/Response.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Traits\Macroable;
 use JsonSerializable;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+use UnexpectedValueException;
 
 class Response extends SymfonyResponse
 {
@@ -55,7 +56,7 @@ class Response extends SymfonyResponse
             $content = $this->morphToJson($content);
 
             if ($content === false) {
-                throw new \UnexpectedValueException(sprintf('Failed to convert the provided Response content to JSON with the message: %s', json_last_error_msg()));
+                throw new UnexpectedValueException(sprintf('Unable to convert the provided response data to JSON: %s', json_last_error_msg()));
             }
         }
 

--- a/src/Illuminate/Http/Response.php
+++ b/src/Illuminate/Http/Response.php
@@ -7,10 +7,10 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Support\Traits\Macroable;
+use InvalidArgumentException;
 use JsonSerializable;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
-use UnexpectedValueException;
 
 class Response extends SymfonyResponse
 {
@@ -42,6 +42,8 @@ class Response extends SymfonyResponse
      *
      * @param  mixed  $content
      * @return $this
+     *
+     * @throws \InvalidArgumentException
      */
     public function setContent($content)
     {
@@ -56,7 +58,7 @@ class Response extends SymfonyResponse
             $content = $this->morphToJson($content);
 
             if ($content === false) {
-                throw new UnexpectedValueException(sprintf('Unable to convert the provided response data to JSON: %s', json_last_error_msg()));
+                throw new InvalidArgumentException(json_last_error_msg());
             }
         }
 

--- a/src/Illuminate/Http/Response.php
+++ b/src/Illuminate/Http/Response.php
@@ -53,9 +53,9 @@ class Response extends SymfonyResponse
             $this->header('Content-Type', 'application/json');
 
             $content = $this->morphToJson($content);
-            
+
             if ($content === false) {
-                throw new \UnexpectedValueException(sprintf("Failed to convert the provided Response content to JSON with the message: %s", json_last_error_msg()));
+                throw new \UnexpectedValueException(sprintf('Failed to convert the provided Response content to JSON with the message: %s', json_last_error_msg()));
             }
         }
 

--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -99,7 +99,7 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
      *
      * @return \Illuminate\Support\Collection
      */
-    protected function linkCollection()
+    public function linkCollection()
     {
         return collect($this->elements())->flatMap(function ($item) {
             if (! is_array($item)) {

--- a/src/Illuminate/Queue/Console/PruneBatchesCommand.php
+++ b/src/Illuminate/Queue/Console/PruneBatchesCommand.php
@@ -4,6 +4,7 @@ namespace Illuminate\Queue\Console;
 
 use Carbon\Carbon;
 use Illuminate\Bus\BatchRepository;
+use Illuminate\Bus\DatabaseBatchRepository;
 use Illuminate\Bus\PrunableBatchRepository;
 use Illuminate\Console\Command;
 
@@ -14,7 +15,9 @@ class PruneBatchesCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'queue:prune-batches {--hours=24 : The number of hours to retain batch data}';
+    protected $signature = 'queue:prune-batches
+                {--hours=24 : The number of hours to retain batch data}
+                {--unfinished= : The number of hours to retain unfinished batch data }';
 
     /**
      * The console command description.
@@ -30,14 +33,24 @@ class PruneBatchesCommand extends Command
      */
     public function handle()
     {
-        $count = 0;
-
         $repository = $this->laravel[BatchRepository::class];
+
+        $count = 0;
 
         if ($repository instanceof PrunableBatchRepository) {
             $count = $repository->prune(Carbon::now()->subHours($this->option('hours')));
         }
 
         $this->info("{$count} entries deleted!");
+
+        if ($unfinished = $this->option('unfinished')) {
+            $count = 0;
+
+            if ($repository instanceof DatabaseBatchRepository) {
+                $count = $repository->pruneUnfinished(Carbon::now()->subHours($this->option('unfinished')));
+            }
+
+            $this->info("{$count} unfinished entries deleted!");
+        }
     }
 }

--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -64,16 +64,7 @@ class RetryCommand extends Command
         }
 
         if ($queue = $this->option('queue')) {
-            $ids = collect($this->laravel['queue.failer']->all())
-                            ->where('queue', $queue)
-                            ->pluck('id')
-                            ->toArray();
-
-            if (count($ids) === 0) {
-                $this->error("Unable to find failed jobs for queue [{$queue}].");
-            }
-
-            return $ids;
+            return $this->getJobIdsByQueue($queue);
         }
 
         if ($ranges = (array) $this->option('range')) {
@@ -81,6 +72,26 @@ class RetryCommand extends Command
         }
 
         return array_values(array_filter(array_unique($ids)));
+    }
+
+    /**
+     * Get the job IDs by queue, if applicable.
+     *
+     * @param  string  $queue
+     * @return array
+     */
+    protected function getJobIdsByQueue($queue)
+    {
+        $ids = collect($this->laravel['queue.failer']->all())
+                        ->where('queue', $queue)
+                        ->pluck('id')
+                        ->toArray();
+
+        if (count($ids) === 0) {
+            $this->error("Unable to find failed jobs for queue [{$queue}].");
+        }
+
+        return $ids;
     }
 
     /**

--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -66,7 +66,7 @@ class RetryCommand extends Command
         if ($queue = $this->option('queue')) {
             $ids = collect($this->laravel['queue.failer']->all())->where('queue', $queue)->pluck('id')->toArray();
 
-            if (count($ids)===0) {
+            if (count($ids) === 0) {
                 $this->error("Unable to find failed jobs in a queue named [{$queue}].");
             }
 

--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -18,7 +18,7 @@ class RetryCommand extends Command
      */
     protected $signature = 'queue:retry
                             {id?* : The ID of the failed job or "all" to retry all jobs}
-                            {--queue= : Name of the queue to be retried}
+                            {--queue= : Retry all of the failed jobs for the specified queue}
                             {--range=* : Range of job IDs (numeric) to be retried}';
 
     /**
@@ -64,10 +64,13 @@ class RetryCommand extends Command
         }
 
         if ($queue = $this->option('queue')) {
-            $ids = collect($this->laravel['queue.failer']->all())->where('queue', $queue)->pluck('id')->toArray();
+            $ids = collect($this->laravel['queue.failer']->all())
+                            ->where('queue', $queue)
+                            ->pluck('id')
+                            ->toArray();
 
             if (count($ids) === 0) {
-                $this->error("Unable to find failed jobs in a queue named [{$queue}].");
+                $this->error("Unable to find failed jobs for queue [{$queue}].");
             }
 
             return $ids;

--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -18,6 +18,7 @@ class RetryCommand extends Command
      */
     protected $signature = 'queue:retry
                             {id?* : The ID of the failed job or "all" to retry all jobs}
+                            {--queue= : Name of the queue to be retried}
                             {--range=* : Range of job IDs (numeric) to be retried}';
 
     /**
@@ -60,6 +61,16 @@ class RetryCommand extends Command
 
         if (count($ids) === 1 && $ids[0] === 'all') {
             return Arr::pluck($this->laravel['queue.failer']->all(), 'id');
+        }
+
+        if ($queue = $this->option('queue')) {
+            $ids = collect($this->laravel['queue.failer']->all())->where('queue', $queue)->pluck('id')->toArray();
+
+            if (count($ids)===0) {
+                $this->error("Unable to find failed jobs in a queue named [{$queue}].");
+            }
+
+            return $ids;
         }
 
         if ($ranges = (array) $this->option('range')) {

--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -38,7 +38,9 @@ class ControllerMakeCommand extends GeneratorCommand
     {
         $stub = null;
 
-        if ($this->option('parent')) {
+        if ($type = $this->option('type')) {
+            $stub = "/stubs/controller.{$type}.stub";
+        } elseif ($this->option('parent')) {
             $stub = '/stubs/controller.nested.stub';
         } elseif ($this->option('model')) {
             $stub = '/stubs/controller.model.stub';
@@ -195,6 +197,7 @@ class ControllerMakeCommand extends GeneratorCommand
     {
         return [
             ['api', null, InputOption::VALUE_NONE, 'Exclude the create and edit methods from the controller.'],
+            ['type', null, InputOption::VALUE_REQUIRED, 'Manually specify the controller stub file to use.'],
             ['force', null, InputOption::VALUE_NONE, 'Create the class even if the controller already exists'],
             ['invokable', 'i', InputOption::VALUE_NONE, 'Generate a single method, invokable controller class.'],
             ['model', 'm', InputOption::VALUE_OPTIONAL, 'Generate a resource controller for the given model.'],

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -358,11 +358,12 @@ class UrlGenerator implements UrlGeneratorContract
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  bool  $absolute
+     * @param  array  $paramsToIgnoreInOriginal
      * @return bool
      */
-    public function hasValidSignature(Request $request, $absolute = true)
+    public function hasValidSignature(Request $request, $absolute = true, array $paramsToIgnoreInOriginal = ['signature'])
     {
-        return $this->hasCorrectSignature($request, $absolute)
+        return $this->hasCorrectSignature($request, $absolute, $paramsToIgnoreInOriginal)
             && $this->signatureHasNotExpired($request);
     }
 
@@ -370,11 +371,12 @@ class UrlGenerator implements UrlGeneratorContract
      * Determine if the given request has a valid signature for a relative URL.
      *
      * @param  \Illuminate\Http\Request  $request
+     * @param  array $paramsToIgnoreInOriginal
      * @return bool
      */
-    public function hasValidRelativeSignature(Request $request)
+    public function hasValidRelativeSignature(Request $request, array $paramsToIgnoreInOriginal = ['signature'])
     {
-        return $this->hasValidSignature($request, false);
+        return $this->hasValidSignature($request, false, $paramsToIgnoreInOriginal);
     }
 
     /**
@@ -384,12 +386,12 @@ class UrlGenerator implements UrlGeneratorContract
      * @param  bool  $absolute
      * @return bool
      */
-    public function hasCorrectSignature(Request $request, $absolute = true)
+    public function hasCorrectSignature(Request $request, $absolute = true, array $paramsToIgnoreInOriginal)
     {
-        $url = $absolute ? $request->url() : '/'.$request->path();
+        $url = $absolute ? $request->url() : '/' . $request->path();
 
-        $original = rtrim($url.'?'.Arr::query(
-            Arr::except($request->query(), 'signature')
+        $original = rtrim($url . '?' . Arr::query(
+            Arr::except($request->query(), $paramsToIgnoreInOriginal)
         ), '?');
 
         $signature = hash_hmac('sha256', $original, call_user_func($this->keyResolver));

--- a/src/Illuminate/Session/SessionServiceProvider.php
+++ b/src/Illuminate/Session/SessionServiceProvider.php
@@ -19,9 +19,9 @@ class SessionServiceProvider extends ServiceProvider
 
         $this->registerSessionDriver();
 
-        $this->app->singleton(StartSession::class, function () {
-            return new StartSession($this->app->make(SessionManager::class), function () {
-                return $this->app->make(CacheFactory::class);
+        $this->app->singleton(StartSession::class, function ($app) {
+            return new StartSession($app->make(SessionManager::class), function () use ($app) {
+                return $app->make(CacheFactory::class);
             });
         });
     }

--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -194,6 +194,17 @@ class Store implements Session
     }
 
     /**
+     * Determine if the given key is missing from the session data.
+     *
+     * @param  string|array  $key
+     * @return bool
+     */
+    public function missing($key)
+    {
+        return ! $this->exists($key);
+    }
+
+    /**
      * Checks if a key is present and not null.
      *
      * @param  string|array  $key

--- a/src/Illuminate/Support/Composer.php
+++ b/src/Illuminate/Support/Composer.php
@@ -39,7 +39,7 @@ class Composer
      * Regenerate the Composer autoloader files.
      *
      * @param  string|array  $extra
-     * @return void
+     * @return int
      */
     public function dumpAutoloads($extra = '')
     {
@@ -47,17 +47,17 @@ class Composer
 
         $command = array_merge($this->findComposer(), ['dump-autoload'], $extra);
 
-        $this->getProcess($command)->run();
+        return $this->getProcess($command)->run();
     }
 
     /**
      * Regenerate the optimized Composer autoloader files.
      *
-     * @return void
+     * @return int
      */
     public function dumpOptimized()
     {
-        $this->dumpAutoloads('--optimize');
+        return $this->dumpAutoloads('--optimize');
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Bus.php
+++ b/src/Illuminate/Support/Facades/Bus.php
@@ -16,6 +16,7 @@ use Illuminate\Support\Testing\Fakes\BusFake;
  * @method static bool|mixed getCommandHandler($command)
  * @method static mixed dispatch($command)
  * @method static mixed dispatchNow($command, $handler = null)
+ * @method static mixed dispatchSync($command, $handler = null)
  * @method static void assertDispatched(string|\Closure $command, callable|int $callback = null)
  * @method static void assertDispatchedTimes(string $command, int $times = 1)
  * @method static void assertNotDispatched(string|\Closure $command, callable|int $callback = null)

--- a/src/Illuminate/Support/Facades/Http.php
+++ b/src/Illuminate/Support/Facades/Http.php
@@ -32,6 +32,8 @@ use Illuminate\Http\Client\Factory;
  * @method static \Illuminate\Http\Client\PendingRequest withoutVerifying()
  * @method static \Illuminate\Http\Client\PendingRequest dump()
  * @method static \Illuminate\Http\Client\PendingRequest dd()
+ * @method static \Illuminate\Http\Client\PendingRequest async()
+ * @method static \Illuminate\Http\Client\Pool pool()
  * @method static \Illuminate\Http\Client\Response delete(string $url, array $data = [])
  * @method static \Illuminate\Http\Client\Response get(string $url, array $query = [])
  * @method static \Illuminate\Http\Client\Response head(string $url, array $query = [])

--- a/src/Illuminate/Support/Manager.php
+++ b/src/Illuminate/Support/Manager.php
@@ -175,6 +175,8 @@ abstract class Manager
     public function forgetDrivers()
     {
         $this->drivers = [];
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -492,6 +492,18 @@ class Str
     }
 
     /**
+     * Repeat the given string.
+     *
+     * @param  string  $string
+     * @param  int  $times
+     * @return string
+     */
+    public static function repeat(string $string, int $times)
+    {
+        return str_repeat($string, $times);
+    }
+
+    /**
      * Replace a given value in the string sequentially with an array.
      *
      * @param  string  $search

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -480,6 +480,17 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Repeat the string.
+     *
+     * @param  int  $times
+     * @return static
+     */
+    public function repeat(int $times)
+    {
+        return new static(Str::repeat($this->value, $times));
+    }
+
+    /**
      * Replace the given value in the given string.
      *
      * @param  string|string[]  $search

--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -435,7 +435,7 @@ class BusFake implements QueueingDispatcher
     /**
      * Dispatch a command to its appropriate handler in the current process.
      *
-     * Queuable jobs will be dispatched to the "sync" queue.
+     * Queueable jobs will be dispatched to the "sync" queue.
      *
      * @param  mixed  $command
      * @param  mixed  $handler

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1475,22 +1475,11 @@ trait ValidatesAttributes
 
         $values = array_slice($parameters, 1);
 
-        if ($this->shouldConvertToBoolean($parameters[0]) || is_bool($other)) {
+        if (is_bool($other)) {
             $values = $this->convertValuesToBoolean($values);
         }
 
         return [$values, $other];
-    }
-
-    /**
-     * Check if parameter should be converted to boolean.
-     *
-     * @param  string  $parameter
-     * @return bool
-     */
-    protected function shouldConvertToBoolean($parameter)
-    {
-        return in_array('boolean', Arr::get($this->rules, $parameter, []));
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1475,11 +1475,22 @@ trait ValidatesAttributes
 
         $values = array_slice($parameters, 1);
 
-        if (is_bool($other)) {
+        if ($this->shouldConvertToBoolean($parameters[0]) || is_bool($other)) {
             $values = $this->convertValuesToBoolean($values);
         }
 
         return [$values, $other];
+    }
+
+    /**
+     * Check if parameter should be converted to boolean.
+     *
+     * @param  string  $parameter
+     * @return bool
+     */
+    protected function shouldConvertToBoolean($parameter)
+    {
+        return in_array('boolean', Arr::get($this->rules, $parameter, []));
     }
 
     /**

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -417,7 +417,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
     protected function compileStatements($value)
     {
         return preg_replace_callback(
-            '/\B@(@?\w+(?:::\w+)?)([ \t]*)(\( ( (?>[^()]+) | (?3) )* \))?/x', function ($match) {
+            '/\B@(@?\w+(?:::\w+)?)([ \t]*)(\( ( (?>\'[^\']+\') | (?>"[^"]+") | (?>[^()\'"]+) | (?3) )* \))?/x', function ($match) {
                 return $this->compileStatement($match);
             }, $value
         );

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -417,7 +417,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
     protected function compileStatements($value)
     {
         return preg_replace_callback(
-            '/\B@(@?\w+(?:::\w+)?)([ \t]*)(\( ( (?>\'[^\']+\') | (?>"[^"]+") | (?>[^()\'"]+) | (?3) )* \))?/x', function ($match) {
+            '/\B@(@?\w+(?:::\w+)?)([ \t]*)(\( ( (?>\'[^\']*\') | (?>"[^"]*") | (?>[^()\'"]+) | (?3) )* \))?/x', function ($match) {
                 return $this->compileStatement($match);
             }, $value
         );

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -417,7 +417,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
     protected function compileStatements($value)
     {
         return preg_replace_callback(
-            '/\B@(@?\w+(?:::\w+)?)([ \t]*)(\( ( (?>\'[^\']*\') | (?>"[^"]*") | (?>[^()\'"]+) | (?3) )* \))?/x', function ($match) {
+            '/\B@(@?\w+(?:::\w+)?)([ \t]*)(\( ( (?>\'(?:\\\\\'|[^\'])*\') | (?>"(?:\\\\"|[^"])*") | (?>[^()\'"]+) | (?3) )* \))?/x', function ($match) {
                 return $this->compileStatement($match);
             }, $value
         );

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -417,7 +417,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
     protected function compileStatements($value)
     {
         return preg_replace_callback(
-            '/\B@(@?\w+(?:::\w+)?)([ \t]*)(\( ( (?>\'(?:\\\\\'|[^\'])*\') | (?>"(?:\\\\"|[^"])*") | (?>[^()\'"]+) | (?3) )* \))?/x', function ($match) {
+            '/\B@(@?\w+(?:::\w+)?)([ \t]*)(\( ( (?>[^()]+) | (?3) )* \))?/x', function ($match) {
                 return $this->compileStatement($match);
             }, $value
         );

--- a/src/Illuminate/View/Engines/EngineResolver.php
+++ b/src/Illuminate/View/Engines/EngineResolver.php
@@ -57,4 +57,15 @@ class EngineResolver
 
         throw new InvalidArgumentException("Engine [{$engine}] not found.");
     }
+
+    /**
+     * Remove a resolved engine.
+     *
+     * @param  string  $engine
+     * @return void
+     */
+    public function forget($engine)
+    {
+        unset($this->resolved[$engine]);
+    }
 }

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1497,6 +1497,18 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->withCasts(['foo' => 'bar']);
     }
 
+    public function testClone()
+    {
+        $query = new BaseBuilder(m::mock(ConnectionInterface::class), new Grammar, m::mock(Processor::class));
+        $builder = new Builder($query);
+        $builder->select('*')->from('users');
+        $clone = $builder->clone()->where('email', 'foo');
+
+        $this->assertNotSame($builder, $clone);
+        $this->assertSame('select * from "users"', $builder->toSql());
+        $this->assertSame('select * from "users" where "email" = ?', $clone->toSql());
+    }
+
     protected function mockConnectionForModel($model, $database)
     {
         $grammarClass = 'Illuminate\Database\Query\Grammars\\'.$database.'Grammar';

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -811,6 +811,42 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertSame('alter table `users` add `foo` datetime(1) not null', $statements[0]);
     }
 
+    public function testAddingDateTimeWithDefaultCurrent()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->dateTime('foo')->useCurrent();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `foo` datetime default CURRENT_TIMESTAMP not null', $statements[0]);
+    }
+
+    public function testAddingDateTimeWithOnUpdateCurrent()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->dateTime('foo')->useCurrentOnUpdate();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `foo` datetime on update CURRENT_TIMESTAMP not null', $statements[0]);
+    }
+
+    public function testAddingDateTimeWithDefaultCurrentAndOnUpdateCurrent()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->dateTime('foo')->useCurrent()->useCurrentOnUpdate();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `foo` datetime default CURRENT_TIMESTAMP on update CURRENT_TIMESTAMP not null', $statements[0]);
+    }
+
+    public function testAddingDateTimeWithDefaultCurrentOnUpdateCurrentAndPrecision()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->dateTime('foo', 3)->useCurrent()->useCurrentOnUpdate();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `foo` datetime(3) default CURRENT_TIMESTAMP(3) on update CURRENT_TIMESTAMP(3) not null', $statements[0]);
+    }
+
     public function testAddingDateTimeTz()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -291,4 +291,62 @@ class DatabaseSchemaBlueprintTest extends TestCase
             'alter table `posts` add `eloquent_model_uuid_stub_id` char(36) not null',
         ], $blueprint->toSql($connection, new MySqlGrammar));
     }
+
+    public function testTinyTextColumn()
+    {
+        $base = new Blueprint('posts', function ($table) {
+            $table->tinyText('note');
+        });
+
+        $connection = m::mock(Connection::class);
+
+        $blueprint = clone $base;
+        $this->assertEquals([
+            'alter table `posts` add `note` tinytext not null',
+        ], $blueprint->toSql($connection, new MySqlGrammar));
+
+        $blueprint = clone $base;
+        $this->assertEquals([
+            'alter table "posts" add column "note" text not null',
+        ], $blueprint->toSql($connection, new SQLiteGrammar));
+
+        $blueprint = clone $base;
+        $this->assertEquals([
+            'alter table "posts" add column "note" varchar(255) not null',
+        ], $blueprint->toSql($connection, new PostgresGrammar));
+
+        $blueprint = clone $base;
+        $this->assertEquals([
+            'alter table "posts" add "note" nvarchar(255) not null',
+        ], $blueprint->toSql($connection, new SqlServerGrammar));
+    }
+
+    public function testTinyTextNullableColumn()
+    {
+        $base = new Blueprint('posts', function ($table) {
+            $table->tinyText('note')->nullable();
+        });
+
+        $connection = m::mock(Connection::class);
+
+        $blueprint = clone $base;
+        $this->assertEquals([
+            'alter table `posts` add `note` tinytext null',
+        ], $blueprint->toSql($connection, new MySqlGrammar));
+
+        $blueprint = clone $base;
+        $this->assertEquals([
+            'alter table "posts" add column "note" text',
+        ], $blueprint->toSql($connection, new SQLiteGrammar));
+
+        $blueprint = clone $base;
+        $this->assertEquals([
+            'alter table "posts" add column "note" varchar(255) null',
+        ], $blueprint->toSql($connection, new PostgresGrammar));
+
+        $blueprint = clone $base;
+        $this->assertEquals([
+            'alter table "posts" add "note" nvarchar(255) null',
+        ], $blueprint->toSql($connection, new SqlServerGrammar));
+    }
 }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -465,6 +465,27 @@ class HttpClientTest extends TestCase
         });
     }
 
+    public function testExceptionAccessorOnSuccess()
+    {
+        $resp = new Response(new Psr7Response());
+
+        $this->assertNull($resp->toException());
+    }
+
+    public function testExceptionAccessorOnFailure()
+    {
+        $error = [
+            'error' => [
+                'code' => 403,
+                'message' => 'The Request can not be completed',
+            ],
+        ];
+        $response = new Psr7Response(403, [], json_encode($error));
+        $resp = new Response($response);
+
+        $this->assertInstanceOf(RequestException::class, $resp->toException());
+    }
+
     public function testRequestExceptionSummary()
     {
         $this->expectException(RequestException::class);

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -892,9 +892,9 @@ class HttpClientTest extends TestCase
 
         $responses = $this->factory->pool(function (Pool $pool) {
             return [
-                $pool->add('test200')->get('200.com'),
-                $pool->add('test400')->get('400.com'),
-                $pool->add('test500')->get('500.com'),
+                $pool->as('test200')->get('200.com'),
+                $pool->as('test400')->get('400.com'),
+                $pool->as('test500')->get('500.com'),
             ];
         });
 

--- a/tests/Integration/Http/JsonResponseTest.php
+++ b/tests/Integration/Http/JsonResponseTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Route;
+use Orchestra\Testbench\TestCase;
+
+/**
+ * @group integration
+ */
+class JsonResponseTest extends TestCase
+{
+    public function testResponseWithInvalidJsonThrowsException()
+    {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('Malformed UTF-8 characters, possibly incorrectly encoded');
+
+        Route::get('/response', function () {
+            return new JsonResponse(new class implements \JsonSerializable {
+                public function jsonSerialize()
+                {
+                    return "\xB1\x31";
+                }
+            });
+        });
+
+        $this->withoutExceptionHandling();
+
+        $this->get('/response');
+    }
+}

--- a/tests/Integration/Http/ResponseTest.php
+++ b/tests/Integration/Http/ResponseTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http;
+
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Route;
+use Orchestra\Testbench\TestCase;
+
+/**
+ * @group integration
+ */
+class ResponseTest extends TestCase
+{
+    public function testResponseWithInvalidJsonThrowsException()
+    {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('Malformed UTF-8 characters, possibly incorrectly encoded');
+
+        Route::get('/response', function () {
+            return (new Response())->setContent(new class implements \JsonSerializable {
+                public function jsonSerialize()
+                {
+                    return "\xB1\x31";
+                }
+            });
+        });
+
+        $this->withoutExceptionHandling();
+
+        $this->get('/response');
+    }
+}

--- a/tests/Integration/Migration/MigratorTest.php
+++ b/tests/Integration/Migration/MigratorTest.php
@@ -2,11 +2,29 @@
 
 namespace Illuminate\Tests\Integration\Migration;
 
+use Illuminate\Support\Facades\DB;
+use Mockery;
+use Mockery\Mock;
 use Orchestra\Testbench\TestCase;
-use PDOException;
+use Symfony\Component\Console\Output\OutputInterface;
 
 class MigratorTest extends TestCase
 {
+    /**
+     * @var Mock
+     */
+    private $output;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->output = Mockery::mock(OutputInterface::class);
+        $this->subject = $this->app->make('migrator');
+        $this->subject->setOutput($this->output);
+        $this->subject->getRepository()->createRepository();
+    }
+
     protected function getEnvironmentSetUp($app)
     {
         $app['config']->set('app.debug', 'true');
@@ -19,25 +37,55 @@ class MigratorTest extends TestCase
         ]);
     }
 
-    public function testDontDisplayOutputWhenOutputObjectIsNotAvailable()
+    public function testMigrate()
     {
-        $migrator = $this->app->make('migrator');
+        $this->expectOutput('<comment>Migrating:</comment> 2014_10_12_000000_create_people_table');
+        $this->expectOutput(Mockery::pattern('#<info>Migrated:</info>  2014_10_12_000000_create_people_table (.*)#'));
+        $this->expectOutput('<comment>Migrating:</comment> 2015_10_04_000000_modify_people_table');
+        $this->expectOutput(Mockery::pattern('#<info>Migrated:</info>  2015_10_04_000000_modify_people_table (.*)#'));
+        $this->expectOutput('<comment>Migrating:</comment> 2016_10_04_000000_modify_people_table');
+        $this->expectOutput(Mockery::pattern('#<info>Migrated:</info>  2016_10_04_000000_modify_people_table (.*)#'));
 
-        $migrator->getRepository()->createRepository();
+        $this->subject->run([__DIR__.'/fixtures']);
 
-        $migrator->run([__DIR__.'/fixtures']);
-
-        $this->assertTrue($this->tableExists('people'));
+        self::assertTrue(DB::getSchemaBuilder()->hasTable('people'));
+        self::assertTrue(DB::getSchemaBuilder()->hasColumn('people', 'first_name'));
+        self::assertTrue(DB::getSchemaBuilder()->hasColumn('people', 'last_name'));
     }
 
-    private function tableExists($table): bool
+    public function testRollback()
     {
-        try {
-            $this->app->make('db')->select("SELECT COUNT(*) FROM $table");
-        } catch (PDOException $e) {
-            return false;
-        }
+        $this->getConnection()->statement('CREATE TABLE people(id INT, first_name VARCHAR, last_name VARCHAR);');
+        $this->subject->getRepository()->log('2014_10_12_000000_create_people_table', 1);
+        $this->subject->getRepository()->log('2015_10_04_000000_modify_people_table', 1);
+        $this->subject->getRepository()->log('2016_10_04_000000_modify_people_table', 1);
 
-        return true;
+        $this->expectOutput('<comment>Rolling back:</comment> 2016_10_04_000000_modify_people_table');
+        $this->expectOutput(Mockery::pattern('#<info>Rolled back:</info>  2016_10_04_000000_modify_people_table (.*)#'));
+        $this->expectOutput('<comment>Rolling back:</comment> 2015_10_04_000000_modify_people_table');
+        $this->expectOutput(Mockery::pattern('#<info>Rolled back:</info>  2015_10_04_000000_modify_people_table (.*)#'));
+        $this->expectOutput('<comment>Rolling back:</comment> 2014_10_12_000000_create_people_table');
+        $this->expectOutput(Mockery::pattern('#<info>Rolled back:</info>  2014_10_12_000000_create_people_table (.*)#'));
+
+        $this->subject->rollback([__DIR__.'/fixtures']);
+
+        self::assertFalse(DB::getSchemaBuilder()->hasTable('people'));
+    }
+
+    public function testPretendMigrate()
+    {
+        $this->expectOutput('<info>2014_10_12_000000_create_people_table:</info> create table "people" ("id" integer not null primary key autoincrement, "name" varchar not null, "email" varchar not null, "password" varchar not null, "remember_token" varchar, "created_at" datetime, "updated_at" datetime)');
+        $this->expectOutput('<info>2014_10_12_000000_create_people_table:</info> create unique index "people_email_unique" on "people" ("email")');
+        $this->expectOutput('<info>2015_10_04_000000_modify_people_table:</info> alter table "people" add column "first_name" varchar');
+        $this->expectOutput('<info>2016_10_04_000000_modify_people_table:</info> alter table "people" add column "last_name" varchar');
+
+        $this->subject->run([__DIR__.'/fixtures'], ['pretend' => true]);
+
+        self::assertFalse(DB::getSchemaBuilder()->hasTable('people'));
+    }
+
+    private function expectOutput($argument): void
+    {
+        $this->output->shouldReceive('writeln')->once()->with($argument);
     }
 }

--- a/tests/Integration/Migration/MigratorTest.php
+++ b/tests/Integration/Migration/MigratorTest.php
@@ -74,8 +74,8 @@ class MigratorTest extends TestCase
 
     public function testPretendMigrate()
     {
-        $this->expectOutput('<info>2014_10_12_000000_create_people_table:</info> create table "people" ("id" integer not null primary key autoincrement, "name" varchar not null, "email" varchar not null, "password" varchar not null, "remember_token" varchar, "created_at" datetime, "updated_at" datetime)');
-        $this->expectOutput('<info>2014_10_12_000000_create_people_table:</info> create unique index "people_email_unique" on "people" ("email")');
+        $this->expectOutput('<info>CreatePeopleTable:</info> create table "people" ("id" integer not null primary key autoincrement, "name" varchar not null, "email" varchar not null, "password" varchar not null, "remember_token" varchar, "created_at" datetime, "updated_at" datetime)');
+        $this->expectOutput('<info>CreatePeopleTable:</info> create unique index "people_email_unique" on "people" ("email")');
         $this->expectOutput('<info>2015_10_04_000000_modify_people_table:</info> alter table "people" add column "first_name" varchar');
         $this->expectOutput('<info>2016_10_04_000000_modify_people_table:</info> alter table "people" add column "last_name" varchar');
 

--- a/tests/Integration/Migration/fixtures/2015_10_04_000000_modify_people_table.php
+++ b/tests/Integration/Migration/fixtures/2015_10_04_000000_modify_people_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('people', function (Blueprint $table) {
+            $table->string('first_name')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('people', function (Blueprint $table) {
+            $table->dropColumn('first_name');
+        });
+    }
+};

--- a/tests/Integration/Migration/fixtures/2016_10_04_000000_modify_people_table.php
+++ b/tests/Integration/Migration/fixtures/2016_10_04_000000_modify_people_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('people', function (Blueprint $table) {
+            $table->string('last_name')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('people', function (Blueprint $table) {
+            $table->dropColumn('last_name');
+        });
+    }
+};

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -452,6 +452,22 @@ class SessionStoreTest extends TestCase
         $this->assertFalse($session->exists(['hulk.two']));
     }
 
+    public function testKeyMissing()
+    {
+        $session = $this->getSession();
+        $session->put('foo', 'bar');
+        $this->assertFalse($session->missing('foo'));
+        $session->put('baz', null);
+        $session->put('hulk', ['one' => true]);
+        $this->assertFalse($session->has('baz'));
+        $this->assertFalse($session->missing('baz'));
+        $this->assertTrue($session->missing('bogus'));
+        $this->assertFalse($session->missing(['foo', 'baz']));
+        $this->assertTrue($session->missing(['foo', 'baz', 'bogus']));
+        $this->assertFalse($session->missing(['hulk.one']));
+        $this->assertTrue($session->missing(['hulk.two']));
+    }
+
     public function testRememberMethodCallsPutAndReturnsDefault()
     {
         $session = $this->getSession();

--- a/tests/Support/Concerns/CountsEnumerations.php
+++ b/tests/Support/Concerns/CountsEnumerations.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Illuminate\Tests\Support\Concerns;
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\LazyCollection;
+
+trait CountsEnumerations
+{
+    protected function makeGeneratorFunctionWithRecorder($numbers = 10)
+    {
+        $recorder = new Collection();
+
+        $generatorFunction = function () use ($numbers, $recorder) {
+            for ($i = 1; $i <= $numbers; $i++) {
+                $recorder->push($i);
+
+                yield $i;
+            }
+        };
+
+        return [$generatorFunction, $recorder];
+    }
+
+    protected function assertDoesNotEnumerate(callable $executor)
+    {
+        $this->assertEnumerates(0, $executor);
+    }
+
+    protected function assertDoesNotEnumerateCollection(
+        LazyCollection $collection,
+        callable $executor
+    ) {
+        $this->assertEnumeratesCollection($collection, 0, $executor);
+    }
+
+    protected function assertEnumerates($count, callable $executor)
+    {
+        $this->assertEnumeratesCollection(
+            LazyCollection::times(100),
+            $count,
+            $executor
+        );
+    }
+
+    protected function assertEnumeratesCollection(
+        LazyCollection $collection,
+        $count,
+        callable $executor
+    ) {
+        $enumerated = 0;
+
+        $data = $this->countEnumerations($collection, $enumerated);
+
+        $executor($data);
+
+        $this->assertEnumerations($count, $enumerated);
+    }
+
+    protected function assertEnumeratesOnce(callable $executor)
+    {
+        $this->assertEnumeratesCollectionOnce(LazyCollection::times(10), $executor);
+    }
+
+    protected function assertEnumeratesCollectionOnce(
+        LazyCollection $collection,
+        callable $executor
+    ) {
+        $enumerated = 0;
+        $count = $collection->count();
+        $collection = $this->countEnumerations($collection, $enumerated);
+
+        $executor($collection);
+
+        $this->assertEquals(
+            $count,
+            $enumerated,
+            $count > $enumerated ? 'Failed to enumerate in full.' : 'Enumerated more than once.'
+        );
+    }
+
+    protected function assertEnumerations($expected, $actual)
+    {
+        $this->assertEquals(
+            $expected,
+            $actual,
+            "Failed asserting that {$actual} items that were enumerated matches expected {$expected}."
+        );
+    }
+
+    protected function countEnumerations(LazyCollection $collection, &$count)
+    {
+        return $collection->tapEach(function () use (&$count) {
+            $count++;
+        });
+    }
+}

--- a/tests/Support/SupportLazyCollectionTest.php
+++ b/tests/Support/SupportLazyCollectionTest.php
@@ -69,31 +69,6 @@ class SupportLazyCollectionTest extends TestCase
         ], $data->all());
     }
 
-    public function testCanCreateCollectionFromGenerator()
-    {
-        $iterable = function () {
-            yield 1;
-            yield 2;
-            yield 3;
-        };
-        $data = LazyCollection::make($iterable());
-
-        $this->assertSame([1, 2, 3], $data->all());
-
-        $iterable = function () {
-            yield 'a' => 1;
-            yield 'b' => 2;
-            yield 'c' => 3;
-        };
-        $data = LazyCollection::make($iterable());
-
-        $this->assertSame([
-            'a' => 1,
-            'b' => 2,
-            'c' => 3,
-        ], $data->all());
-    }
-
     public function testEager()
     {
         $source = [1, 2, 3, 4, 5];

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -531,6 +531,12 @@ class SupportStrTest extends TestCase
         $this->assertSame("<p><em>hello world</em></p>\n", Str::markdown('*hello world*'));
         $this->assertSame("<h1>hello world</h1>\n", Str::markdown('# hello world'));
     }
+
+    public function testRepeat()
+    {
+        $this->assertSame('aaaaa', Str::repeat('a', 5));
+        $this->assertSame('', Str::repeat('', 5));
+    }
 }
 
 class StringableObjectStub

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -602,4 +602,10 @@ class SupportStringableTest extends TestCase
         $this->assertEquals("<p><em>hello world</em></p>\n", $this->stringable('*hello world*')->markdown());
         $this->assertEquals("<h1>hello world</h1>\n", $this->stringable('# hello world')->markdown());
     }
+
+    public function testRepeat()
+    {
+        $this->assertSame('aaaaa', (string) $this->stringable('a')->repeat(5));
+        $this->assertSame('', (string) $this->stringable('')->repeat(5));
+    }
 }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1090,6 +1090,17 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['first' => 'dayle', 'last' => ''], ['last' => 'RequiredIf:first,taylor,dayle']);
         $this->assertFalse($v->passes());
         $this->assertSame('The last field is required when first is dayle.', $v->messages()->first('last'));
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines(['validation.required_if' => 'The :attribute field is required when :other is :value.'], 'en');
+        $v = new Validator($trans, ['foo' => 0], [
+            'foo' => 'required|boolean',
+            'bar' => 'required_if:foo,true',
+            'baz' => 'required_if:foo,false',
+        ]);
+        $this->assertTrue($v->fails());
+        $this->assertCount(1, $v->messages());
+        $this->assertSame('The baz field is required when foo is 0.', $v->messages()->first('baz'));
     }
 
     public function testRequiredUnless()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1090,17 +1090,6 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['first' => 'dayle', 'last' => ''], ['last' => 'RequiredIf:first,taylor,dayle']);
         $this->assertFalse($v->passes());
         $this->assertSame('The last field is required when first is dayle.', $v->messages()->first('last'));
-
-        $trans = $this->getIlluminateArrayTranslator();
-        $trans->addLines(['validation.required_if' => 'The :attribute field is required when :other is :value.'], 'en');
-        $v = new Validator($trans, ['foo' => 0], [
-            'foo' => 'required|boolean',
-            'bar' => 'required_if:foo,true',
-            'baz' => 'required_if:foo,false',
-        ]);
-        $this->assertTrue($v->fails());
-        $this->assertCount(1, $v->messages());
-        $this->assertSame('The baz field is required when foo is 0.', $v->messages()->first('baz'));
     }
 
     public function testRequiredUnless()

--- a/tests/View/Blade/BladeForeachStatementsTest.php
+++ b/tests/View/Blade/BladeForeachStatementsTest.php
@@ -81,5 +81,14 @@ tag info
         $string = '@foreach ($tasks as $task)';
         $expected = '<?php $__currentLoopData = $tasks; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $task): $__env->incrementLoopIndices(); $loop = $__env->getLastLoop(); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
+
+        $string = "@foreach(resolve('App\\\\DataProviders\\\\'.\$provider)->data() as \$key => \$value)
+    <input {{ \$foo ? 'bar': 'baz' }}>
+@endforeach";
+        $expected = "<?php \$__currentLoopData = resolve('App\\\\DataProviders\\\\'.\$provider)->data(); \$__env->addLoop(\$__currentLoopData); foreach(\$__currentLoopData as \$key => \$value): \$__env->incrementLoopIndices(); \$loop = \$__env->getLastLoop(); ?>
+    <input <?php echo e(\$foo ? 'bar': 'baz'); ?>>
+<?php endforeach; \$__env->popLoop(); \$loop = \$__env->getLastLoop(); ?>";
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 }

--- a/tests/View/Blade/BladePhpStatementsTest.php
+++ b/tests/View/Blade/BladePhpStatementsTest.php
@@ -67,4 +67,19 @@ class BladePhpStatementsTest extends AbstractBladeTestCase
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
+
+    public function testStringWithEscapingDataValue()
+    {
+        $string = "@php(\$data = ['test' => 'won\\'t break'])";
+
+        $expected = "<?php (\$data = ['test' => 'won\\'t break']); ?>";
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+
+        $string = "@php(\$data = ['test' => \"\\\"escaped\\\"\"])";
+
+        $expected = "<?php (\$data = ['test' => \"\\\"escaped\\\"\"]); ?>";
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
 }

--- a/tests/View/Blade/BladePhpStatementsTest.php
+++ b/tests/View/Blade/BladePhpStatementsTest.php
@@ -43,4 +43,13 @@ class BladePhpStatementsTest extends AbstractBladeTestCase
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
+
+    public function testStringWithParenthesisDataValue()
+    {
+        $string = "@php(\$data = ['test' => ')'])";
+
+        $expected = "<?php (\$data = ['test' => ')']); ?>";
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
 }

--- a/tests/View/Blade/BladePhpStatementsTest.php
+++ b/tests/View/Blade/BladePhpStatementsTest.php
@@ -44,13 +44,15 @@ class BladePhpStatementsTest extends AbstractBladeTestCase
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
-    public function testStringWithParenthesisDataValue()
+    public function testStringWithParenthesisCannotBeCompiled()
     {
         $string = "@php(\$data = ['test' => ')'])";
 
         $expected = "<?php (\$data = ['test' => ')']); ?>";
 
-        $this->assertEquals($expected, $this->compiler->compileString($string));
+        $actual = "<?php (\$data = ['test' => '); ?>'])";
+
+        $this->assertEquals($actual, $this->compiler->compileString($string));
     }
 
     public function testStringWithEmptyStringDataValue()

--- a/tests/View/Blade/BladePhpStatementsTest.php
+++ b/tests/View/Blade/BladePhpStatementsTest.php
@@ -52,4 +52,19 @@ class BladePhpStatementsTest extends AbstractBladeTestCase
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
+
+    public function testStringWithEmptyStringDataValue()
+    {
+        $string = "@php(\$data = ['test' => ''])";
+
+        $expected = "<?php (\$data = ['test' => '']); ?>";
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+
+        $string = "@php(\$data = ['test' => \"\"])";
+
+        $expected = "<?php (\$data = ['test' => \"\"]); ?>";
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
 }


### PR DESCRIPTION
## Current use of the feature:

- Signed urls can be created for named routes using the following code:

```php
URL::temporarySignedRoute('users.posts.index', now()->addDays(1), [
        'user' => 1
]);

// https://laravel-pr.test/users/1/posts?expires=1618410316&signature=someSignature
```

## Problem:

- If the `users/{user}/posts` route supports pagination, or some filters, the signature validation fails.

- For example, if the front-end app calls the endpoint with either `page` param or a filter param or some other additional param like:
`https://laravel-pr.test/users/1/posts?expires=1618410316&signature=someSignature&page=3`,
`https://laravel-pr.test/users/1/posts?expires=1618410316&signature=someSignature&status=published`
`https://laravel-pr.test/users/1/posts?expires=1618410316&signature=someSignature&limit=10`

- The `hasValidSignature()` method would return `false` for the above requests. 

## Cause:

- This happens because while trying to validate the signature, Laravel tries to build the original url to compare against the signature, by fetching the current url **and removing the `signature` param from the query specifically**, whereas it should have removed the other params like `page`, `status`, etc as well, so it actually gets the original url.

## Solution this PR brings in:

- This PR adds a new param to the `hasValidSignature` & `hasValidRelativeSignature` methods that allows the dev to pass an array of param that needs to be ignored while building the original url rather than just the signature param.

