### PR TITLE
[9.x] Allow passing an array of params to ignore when building the original url during signature validation

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -358,11 +358,12 @@ class UrlGenerator implements UrlGeneratorContract
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  bool  $absolute
+     * @param  array  $paramsToIgnoreInOriginal
      * @return bool
      */
-    public function hasValidSignature(Request $request, $absolute = true)
+    public function hasValidSignature(Request $request, $absolute = true, array $paramsToIgnoreInOriginal = ['signature'])
     {
-        return $this->hasCorrectSignature($request, $absolute)
+        return $this->hasCorrectSignature($request, $absolute, $paramsToIgnoreInOriginal)
             && $this->signatureHasNotExpired($request);
     }
 
@@ -370,11 +371,12 @@ class UrlGenerator implements UrlGeneratorContract
      * Determine if the given request has a valid signature for a relative URL.
      *
      * @param  \Illuminate\Http\Request  $request
+     * @param  array $paramsToIgnoreInOriginal
      * @return bool
      */
-    public function hasValidRelativeSignature(Request $request)
+    public function hasValidRelativeSignature(Request $request, array $paramsToIgnoreInOriginal = ['signature'])
     {
-        return $this->hasValidSignature($request, false);
+        return $this->hasValidSignature($request, false, $paramsToIgnoreInOriginal);
     }
 
     /**
@@ -382,14 +384,15 @@ class UrlGenerator implements UrlGeneratorContract
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  bool  $absolute
+     * @param  array $paramsToIgnoreInOriginal
      * @return bool
      */
-    public function hasCorrectSignature(Request $request, $absolute = true)
+    public function hasCorrectSignature(Request $request, $absolute = true, array $paramsToIgnoreInOriginal)
     {
-        $url = $absolute ? $request->url() : '/'.$request->path();
+        $url = $absolute ? $request->url() : '/' . $request->path();
 
-        $original = rtrim($url.'?'.Arr::query(
-            Arr::except($request->query(), 'signature')
+        $original = rtrim($url . '?' . Arr::query(
+            Arr::except($request->query(), $paramsToIgnoreInOriginal)
         ), '?');
 
         $signature = hash_hmac('sha256', $original, call_user_func($this->keyResolver));


### PR DESCRIPTION
## Current use of the feature:

- Signed urls can be created for named routes using the following code:

```php
URL::temporarySignedRoute('users.posts.index', now()->addDays(1), [
        'user' => 1
]);

// https://laravel-pr.test/users/1/posts?expires=1618410316&signature=someSignature
```

## Problem:

- If the `users/{user}/posts` route supports pagination, or some filters, the signature validation fails.

- For example, if the front-end app calls the endpoint with either `page` param or a filter param or some other additional param like:
`https://laravel-pr.test/users/1/posts?expires=1618410316&signature=someSignature&page=3`,
`https://laravel-pr.test/users/1/posts?expires=1618410316&signature=someSignature&status=published`
`https://laravel-pr.test/users/1/posts?expires=1618410316&signature=someSignature&limit=10`

- The `hasValidSignature()` method would return `false` for the above requests. 

## Cause:

- This happens because while trying to validate the signature, Laravel tries to build the original url to compare against the signature, by fetching the current url **and removing the `signature` param from the query specifically**, whereas it should have removed the other params like `page`, `status`, etc as well, so it actually gets the original url.

## Solution this PR brings in:

- This PR adds a new param to the `hasValidSignature` & `hasValidRelativeSignature` methods that allows the dev to pass an array of param that needs to be ignored while building the original url rather than just the signature param.

