### PR TITLE
[8.x] Pass $field to explicit route bindings

### DIFF
--- a/src/Illuminate/Routing/RouteBinding.php
+++ b/src/Illuminate/Routing/RouteBinding.php
@@ -33,7 +33,7 @@ class RouteBinding
      */
     protected static function createClassBinding($container, $binding)
     {
-        return function ($value, $route) use ($container, $binding) {
+        return function ($value, $route, $field) use ($container, $binding) {
             // If the binding has an @ sign, we will assume it's being used to delimit
             // the class name from the bind method name. This allows for bindings
             // to run multiple bind methods in a single class for convenience.
@@ -41,7 +41,7 @@ class RouteBinding
 
             $callable = [$container->make($class), $method];
 
-            return $callable($value, $route);
+            return $callable($value, $route, $field);
         };
     }
 
@@ -57,7 +57,7 @@ class RouteBinding
      */
     public static function forModel($container, $class, $callback = null)
     {
-        return function ($value) use ($container, $class, $callback) {
+        return function ($value, $route, $field) use ($container, $class, $callback) {
             if (is_null($value)) {
                 return;
             }
@@ -67,7 +67,7 @@ class RouteBinding
             // throw a not found exception otherwise we will return the instance.
             $instance = $container->make($class);
 
-            if ($model = $instance->resolveRouteBinding($value)) {
+            if ($model = $instance->resolveRouteBinding($value, $field)) {
                 return $model;
             }
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -842,7 +842,7 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     protected function performBinding($key, $value, $route)
     {
-        return call_user_func($this->binders[$key], $value, $route);
+        return call_user_func($this->binders[$key], $value, $route, $route->bindingFieldFor($key));
     }
 
     /**


### PR DESCRIPTION
This PR makes the field of a route binding available to the callbacks. It fills the `$field` parameter on `resolveRouteBinding($value, $field = null)` for explicit model bindings, as opposed to only implicit bindings. Furthermore, the field is easier accessible on `Route::bind()` callbacks without needing to know the name of the binding inside the callback.

I've also modified the tests for these cases, not sure if that's correct or if I should have created new test methods instead of modifying the existing ones.

---

In the case of explicit model bindings, the following setup would return a 404 because `$field` on `resolveRouteBinding` is null and thus fallback to `getRouteKeyName`.

```php
Route::model('post', Post::class);
Route::get('post/{post:slug}', [ContentController::class, 'show']); // where the controller method might not be type hinted
```

The following scenario with implicit model bindings works however, because the `$field` parameter is set in the `ImplicitRouteBinding::resolveForRoute` method.

```php
Route::get('post/{post:slug}', function(Post $post) {});
```

The bind method also gets an additional parameter

```php
Route::bind('post', function($value, $route, $field) {
    // here $field contains the value of $route->bindingFieldFor('post')
});

Route::get('post/{post}')      // $field = null
Route::get('post/{post:slug}') // $field = 'slug'
```