### PR TITLE
[8.x] Allow passing a closure to `Collection`'s `when` and `unless`

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -504,11 +504,11 @@ trait EnumeratesValues
      * Apply the callback if the value is falsy.
      *
      * @param  bool  $value
-     * @param  callable  $callback
+     * @param  callable|null  $callback
      * @param  callable|null  $default
      * @return static|mixed
      */
-    public function unless($value, callable $callback, callable $default = null)
+    public function unless($value, callable $callback = null, callable $default = null)
     {
         return $this->when(! $value, $callback, $default);
     }

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -456,13 +456,15 @@ trait EnumeratesValues
     /**
      * Apply the callback if the value is truthy.
      *
-     * @param  bool|mixed  $value
+     * @param  bool|\Closure  $value
      * @param  callable|null  $callback
      * @param  callable|null  $default
      * @return static|mixed
      */
     public function when($value, callable $callback = null, callable $default = null)
     {
+        $value = $value instanceof Closure ? $value($this) : $value;
+
         if (! $callback) {
             return new HigherOrderWhenProxy($this, $value);
         }
@@ -503,13 +505,15 @@ trait EnumeratesValues
     /**
      * Apply the callback if the value is falsy.
      *
-     * @param  bool  $value
+     * @param  bool|\Closure  $value
      * @param  callable|null  $callback
      * @param  callable|null  $default
      * @return static|mixed
      */
     public function unless($value, callable $callback = null, callable $default = null)
     {
+        $value = $value instanceof Closure ? $value($this) : $value;
+
         return $this->when(! $value, $callback, $default);
     }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -4201,6 +4201,62 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testWhenWithValueClosure($collection)
+    {
+        // Callback returns true
+        $data = new $collection([1]);
+
+        $data = $data->when(
+            function ($data) {
+                return $data->count() == 1;
+            },
+            function ($data) {
+                return $data->concat([2]);
+            }
+        );
+
+        $this->assertSame([1, 2], $data->all());
+
+        // Callback returns false
+        $data = new $collection([1]);
+
+        $data = $data->when(
+            function ($data) {
+                return $data->count() == 2;
+            },
+            function ($data) {
+                return $data->concat([2]);
+            }
+        );
+
+        $this->assertSame([1], $data->all());
+
+        // Callback returns true with proxy
+        $data = new $collection([1]);
+
+        $data = $data
+            ->when(function ($data) {
+                return $data->count() == 1;
+            })
+            ->concat([2]);
+
+        $this->assertSame([1, 2], $data->all());
+
+        // Callback returns false with proxy
+        $data = new $collection([1]);
+
+        $data = $data
+            ->when(function ($data) {
+                return $data->count() == 2;
+            })
+            ->concat([2]);
+
+        $this->assertSame([1], $data->all());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testWhenEmpty($collection)
     {
         $data = new $collection(['michael', 'tom']);
@@ -4310,6 +4366,62 @@ class SupportCollectionTest extends TestCase
         });
 
         $this->assertSame(['michael', 'tom', 'taylor'], $data->toArray());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testUnlessWithValueClosure($collection)
+    {
+        // Callback returns true
+        $data = new $collection([1]);
+
+        $data = $data->unless(
+            function ($data) {
+                return $data->count() == 1;
+            },
+            function ($data) {
+                return $data->concat([2]);
+            }
+        );
+
+        $this->assertSame([1], $data->all());
+
+        // Callback returns false
+        $data = new $collection([1]);
+
+        $data = $data->unless(
+            function ($data) {
+                return $data->count() == 2;
+            },
+            function ($data) {
+                return $data->concat([2]);
+            }
+        );
+
+        $this->assertSame([1, 2], $data->all());
+
+        // Callback returns true with proxy
+        $data = new $collection([1]);
+
+        $data = $data
+            ->unless(function ($data) {
+                return $data->count() == 1;
+            })
+            ->concat([2]);
+
+        $this->assertSame([1], $data->all());
+
+        // Callback returns false with proxy
+        $data = new $collection([1]);
+
+        $data = $data
+            ->unless(function ($data) {
+                return $data->count() == 2;
+            })
+            ->concat([2]);
+
+        $this->assertSame([1, 2], $data->all());
     }
 
     /**


### PR DESCRIPTION
This allows passing a `Closure` as the conditional to `when` and `unless`:

```php
return $this
    ->getOptions()
    ->when(fn ($options) => ! $options->has('share'))
    ->put('share', true);
```

---

Here's a real-world example, converting @jbrooksuk's [Forge code snippet](https://james.brooks.page/blog/injecting-additional-data-into-laravel-queued-jobs/) from this:

```php
$jobData = $payload['data'];

if (! isset($jobData['initiated_by'])) {
    $jobData = array_merge($payload['data'], array_filter([
        'initiated_by' => request()->user()->id ?? null,
    ]));
}

return ['data' => $jobData];
```

...to a collection pipeline:

```php
return collect($payload['data'])
    ->unless(fn ($data) => $data->has('initiated_by'))
    ->put('initiated_by', request()->user()->id ?? null)
    ->filter()
    ->pipe(fn ($data) => ['data' => $data->all()]);
```

:smiley: 

---

P.S. While at it, I realized that `unless` didn't have support for the proxy (like `when` already does), so I added it.

This necessitated making `$callback` optional. Do we consider that a breaking change?