### PR TITLE
[8.x] Http client fix to prevent str_parse for bodies that are not encoded forms

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -740,7 +740,7 @@ class PendingRequest
         }
 
         $contentType = $this->options['headers']['Content-Type'] ?? null;
-        $isPotentiallyFormRequest = !$contentType || $contentType === 'application/x-www-form-urlencoded';
+        $isPotentiallyFormRequest = ! $contentType || $contentType === 'application/x-www-form-urlencoded';
 
         // If no content type was provided or it's an encoded form request, parse the string to a usable array
         // We do not wish to parse any other content types
@@ -750,7 +750,7 @@ class PendingRequest
             $laravelData = is_array($parsedData) ? $parsedData : [];
         }
 
-        if (!is_array($laravelData)) {
+        if (! is_array($laravelData)) {
             return [];
         }
 

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -739,10 +739,19 @@ class PendingRequest
             $laravelData = (string) $urlString->after('?');
         }
 
-        if (is_string($laravelData)) {
+        $contentType = $this->options['headers']['Content-Type'] ?? null;
+        $isPotentiallyFormRequest = !$contentType || $contentType === 'application/x-www-form-urlencoded';
+
+        // If no content type was provided or it's an encoded form request, parse the string to a usable array
+        // We do not wish to parse any other content types
+        if (is_string($laravelData) && $isPotentiallyFormRequest) {
             parse_str($laravelData, $parsedData);
 
             $laravelData = is_array($parsedData) ? $parsedData : [];
+        }
+
+        if (!is_array($laravelData)) {
+            return [];
         }
 
         return $laravelData;

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -902,4 +902,17 @@ class HttpClientTest extends TestCase
         $this->assertSame(400, $responses['test400']->status());
         $this->assertSame(500, $responses['test500']->status());
     }
+    
+    public function testRequestWithXmlAndCustomContentType()
+    {
+        $this->factory->fake();
+
+        $xml = '<?xml version="1.0" encoding="UTF-8"?><body/>';
+
+        $this->factory->withBody($xml, 'application/octet-stream')->post('does-not-matter');
+
+        $this->factory->assertSent(function(Request $request) use ($xml) {
+            return $xml === $request->body();
+        });
+    }
 }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -902,7 +902,7 @@ class HttpClientTest extends TestCase
         $this->assertSame(400, $responses['test400']->status());
         $this->assertSame(500, $responses['test500']->status());
     }
-    
+
     public function testRequestWithXmlAndCustomContentType()
     {
         $this->factory->fake();
@@ -911,7 +911,7 @@ class HttpClientTest extends TestCase
 
         $this->factory->withBody($xml, 'application/octet-stream')->post('does-not-matter');
 
-        $this->factory->assertSent(function(Request $request) use ($xml) {
+        $this->factory->assertSent(function (Request $request) use ($xml) {
             return $xml === $request->body();
         });
     }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -915,4 +915,20 @@ class HttpClientTest extends TestCase
             return $xml === $request->body();
         });
     }
+
+    public function testRequestWithStreamAsBody()
+    {
+        $this->factory->fake();
+
+        $xml = '<?xml version="1.0" encoding="UTF-8"?><body/>';
+        $xmlStream = fopen('php://memory', 'r+');
+        fwrite($xmlStream, $xml);
+        rewind($xmlStream);
+
+        $this->factory->withBody($xmlStream, 'text/xml')->post('does-not-matter');
+
+        $this->factory->assertSent(function (Request $request) use ($xml) {
+            return $xml === $request->body();
+        });
+    }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This potentially fixes: https://github.com/laravel/framework/issues/36976

The idea is to parse_str only on content that either has no content type provided or it has explicit www-form-urlencoded type given.

I am not 100% sure about this fix, but it solves my issue and no other tests break.