### PR TITLE
[8.x] Fix docblock on throw_* methods

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -272,7 +272,7 @@ if (! function_exists('throw_if')) {
      *
      * @param  mixed  $condition
      * @param  \Throwable|string  $exception
-     * @param  array  ...$parameters
+     * @param  mixed  ...$parameters
      * @return mixed
      *
      * @throws \Throwable
@@ -297,7 +297,7 @@ if (! function_exists('throw_unless')) {
      *
      * @param  mixed  $condition
      * @param  \Throwable|string  $exception
-     * @param  array  ...$parameters
+     * @param  mixed  ...$parameters
      * @return mixed
      *
      * @throws \Throwable


### PR DESCRIPTION
Currently the docblock is set to `array ...$parameters` since the spread operator is there this is handled like every additional parameter is an array (meaning `$parameter` is an array of arrays).
The correct docblock is `mixed` since the parameters can be anything (meaning `$parameters` is an array of mixed things).