### PR TITLE
[8.x] Simplify throw_unless method

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -304,13 +304,7 @@ if (! function_exists('throw_unless')) {
      */
     function throw_unless($condition, $exception = 'RuntimeException', ...$parameters)
     {
-        if (! $condition) {
-            if (is_string($exception) && class_exists($exception)) {
-                $exception = new $exception(...$parameters);
-            }
-
-            throw is_string($exception) ? new RuntimeException($exception) : $exception;
-        }
+        throw_if(! $condition, $exception, ...$parameters);
 
         return $condition;
     }


### PR DESCRIPTION
Currently `throw_unless` is almost a duplicate of `throw_if` resulting any change have to be done twice.

This PR removes the duplicated code and uses `throw_if` to handle the exception throwing, halving any required maintenance and chance of making mistakes.