### PR TITLE
[8.x] Add a wordCount() string helper

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -767,7 +767,7 @@ class Str
     }
 
     /**
-     * Get the amount of words a string contains.
+     * Get the number of words a string contains.
      *
      * @param  string  $string
      * @return int

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -767,6 +767,17 @@ class Str
     }
 
     /**
+     * Get the amount of words a string contains.
+     *
+     * @param  string  $string
+     * @return int
+     */
+    public static function wordCount($string)
+    {
+        return str_word_count($string);
+    }
+
+    /**
      * Generate a UUID (version 4).
      *
      * @return \Ramsey\Uuid\UuidInterface

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -757,7 +757,7 @@ class Stringable implements JsonSerializable
     }
 
     /**
-     * Get the amount of words a string contains.
+     * Get the number of words a string contains.
      *
      * @return int
      */

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -757,6 +757,16 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Get the amount of words a string contains.
+     *
+     * @return int
+     */
+    public function wordCount()
+    {
+        return str_word_count($this->value);
+    }
+
+    /**
      * Dump the string.
      *
      * @return $this

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -494,6 +494,12 @@ class SupportStrTest extends TestCase
         $this->assertSame('Alien     ', Str::padRight('Alien', 10));
     }
 
+    public function testWordCount()
+    {
+        $this->assertEquals(2, Str::wordCount('Hello, world!'));
+        $this->assertEquals(10, Str::wordCount('Hi, this is my first contribution to the Laravel framework.'));
+    }
+
     public function validUuidList()
     {
         return [

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -608,4 +608,10 @@ class SupportStringableTest extends TestCase
         $this->assertSame('aaaaa', (string) $this->stringable('a')->repeat(5));
         $this->assertSame('', (string) $this->stringable('')->repeat(5));
     }
+
+    public function testWordCount()
+    {
+        $this->assertEquals(2, $this->stringable('Hello, world!')->wordCount());
+        $this->assertEquals(10, $this->stringable('Hi, this is my first contribution to the Laravel framework.')->wordCount());
+    }
 }


### PR DESCRIPTION
Hi everyone,

This is my first contribution to the Laravel framework.

I added a `wordCount()` string helper.

Now you can shorten this:

```php
public function getWordCountAttribute(): int
{
    $text = Str::of($this->body)
        ->replace('x', 'y') // do something
        ->replace('a', 'b'); // do something else

    return str_word_count($text);
}
```

To:

```php
public function getWordCountAttribute(): int
{
    return Str::of($this->body)
        ->replace('x', 'y') // do something
        ->replace('a', 'b') // do something else
        ->wordCount();
}
```

At least to me, this seems a lot nicer.

If this get's merged, I would like to write the corresponding docs.

Thank you!
Jeroen