### PR TITLE
[8.x] Fix deprecation warning in SimpleMessage::formatLine

### DIFF
--- a/src/Illuminate/Notifications/Messages/SimpleMessage.php
+++ b/src/Illuminate/Notifications/Messages/SimpleMessage.php
@@ -192,7 +192,7 @@ class SimpleMessage
             return implode(' ', array_map('trim', $line));
         }
 
-        return trim(implode(' ', array_map('trim', preg_split('/\\r\\n|\\r|\\n/', $line))));
+        return trim(implode(' ', array_map('trim', preg_split('/\\r\\n|\\r|\\n/', $line ?? ''))));
     }
 
     /**


### PR DESCRIPTION
This PR fixes a deprecation warning that occurs if a `null` line is appended to a mail using either of these syntaxes:

```php
(new \Illuminate\Notifications\Messages\MailMessage)->line(null);
(new \Illuminate\Notifications\Messages\MailMessage)->with(null);
```

The `SendingMailNotificationsTest` does not have a test case passing null lines yet, I would have added one but I am not sure what it should really test for. It might be useful to test if a null parameter is handled gracefully and results into an empty string item in the `introLines` attribute.

Let me know if that would be a useful addition, otherwise I'll leave it at that.
