### PR TITLE
[8.x] Fix iterator for createMany

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -213,7 +213,7 @@ abstract class Factory
         return new EloquentCollection(
             array_map(function ($record) {
                 return $this->state($record)->create();
-            }, $records)
+            }, iterator_to_array($records))
         );
     }
 

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -210,11 +210,9 @@ abstract class Factory
      */
     public function createMany(iterable $records)
     {
-        return new EloquentCollection(
-            array_map(function ($record) {
-                return $this->state($record)->create();
-            }, iterator_to_array($records))
-        );
+        return (new EloquentCollection($records))->transform(function ($record) {
+            return $this->state($record)->create();
+        });
     }
 
     /**


### PR DESCRIPTION
Fixed iterator provided for `createMany()` function inside Factory class, replaced using EloquentCollection transform function.

```php
    // Before
    public function createMany(iterable $records)
    {
        return new EloquentCollection(
            array_map(function ($record) {
                return $this->state($record)->create();
            }, $records)
        );
    }
    // After
    public function createMany(iterable $records)
    {
        return (new EloquentCollection($records))->transform(function ($record) {
            return $this->state($record)->create();
        });
    }
```