### PR TITLE
[8.x] Use value helper when applicable

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HidesAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HidesAttributes.php
@@ -94,9 +94,7 @@ trait HidesAttributes
      */
     public function makeVisibleIf($condition, $attributes)
     {
-        $condition = $condition instanceof Closure ? $condition($this) : $condition;
-
-        return $condition ? $this->makeVisible($attributes) : $this;
+        return value($condition, $this) ? $this->makeVisible($attributes) : $this;
     }
 
     /**
@@ -123,8 +121,6 @@ trait HidesAttributes
      */
     public function makeHiddenIf($condition, $attributes)
     {
-        $condition = $condition instanceof Closure ? $condition($this) : $condition;
-
-        return value($condition) ? $this->makeHidden($attributes) : $this;
+        return value($condition, $this) ? $this->makeHidden($attributes) : $this;
     }
 }

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithViews.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithViews.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Foundation\Testing\Concerns;
 
-use Closure;
 use Illuminate\Support\Facades\View as ViewFacade;
 use Illuminate\Support\MessageBag;
 use Illuminate\Support\Str;
@@ -57,11 +56,7 @@ trait InteractsWithViews
     {
         $component = $this->app->make($componentClass, $data);
 
-        $view = $component->resolveView();
-
-        if ($view instanceof Closure) {
-            $view = $view($data);
-        }
+        $view = value($component->resolveView(), $data);
 
         return $view instanceof View
                 ? new TestView($view->with($component->data()))

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -659,7 +659,7 @@ if (! function_exists('rescue')) {
                 report($e);
             }
 
-            return $rescue instanceof Closure ? $rescue($e) : $rescue;
+            return value($rescue, $e);
         }
     }
 }

--- a/src/Illuminate/View/Concerns/ManagesComponents.php
+++ b/src/Illuminate/View/Concerns/ManagesComponents.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\View\Concerns;
 
-use Closure;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Arr;
@@ -84,9 +83,7 @@ trait ManagesComponents
 
         $data = $this->componentData();
 
-        if ($view instanceof Closure) {
-            $view = $view($data);
-        }
+        $view = value($view, $data);
 
         if ($view instanceof View) {
             return $view->with($data)->render();
@@ -151,8 +148,7 @@ trait ManagesComponents
             $this->slotStack[$this->currentComponent()]
         );
 
-        $this->slots[$this->currentComponent()]
-                    [$currentSlot] = new HtmlString(trim(ob_get_clean()));
+        $this->slots[$this->currentComponent()][$currentSlot] = new HtmlString(trim(ob_get_clean()));
     }
 
     /**


### PR DESCRIPTION
With #36506 merged the codebase can be simplified in few places this PR replaces ternary operators with `value` calll where applicable.