### PR TITLE
[9.x] Update Container\Util::unwrapIfClosure to match value helper

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -961,7 +961,7 @@ class Container implements ArrayAccess, ContainerContract
     protected function resolvePrimitive(ReflectionParameter $parameter)
     {
         if (! is_null($concrete = $this->getContextualConcrete('$'.$parameter->getName()))) {
-            return $concrete instanceof Closure ? $concrete($this) : $concrete;
+            return Util::unwrapIfClosure($concrete, $this);
         }
 
         if ($parameter->isDefaultValueAvailable()) {

--- a/src/Illuminate/Container/Util.php
+++ b/src/Illuminate/Container/Util.php
@@ -33,11 +33,12 @@ class Util
      * From global value() helper in Illuminate\Support.
      *
      * @param  mixed  $value
+     * @param  mixed  ...$args
      * @return mixed
      */
-    public static function unwrapIfClosure($value)
+    public static function unwrapIfClosure($value, ...$args)
     {
-        return $value instanceof Closure ? $value() : $value;
+        return $value instanceof Closure ? $value(...$args) : $value;
     }
 
     /**


### PR DESCRIPTION
The unwrapIfClosure method is supposed to be a carbon copy of the value helper in order to not depend on the support package. This PR updates the mentioned method to match value helper which was changed in #36506.

It also uses the new functionality in one place.

9.x is targeted because unlike global functions this counts as a breaking change.