### PR TITLE
[8.x] Correctly merge object payload data

### DIFF
--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -157,10 +157,10 @@ abstract class Queue
                     : serialize(clone $job);
 
         return array_merge($payload, [
-            'data' => [
+            'data' => array_merge($payload['data'], [
                 'commandName' => get_class($job),
                 'command' => $command,
-            ],
+            ]),
         ]);
     }
 


### PR DESCRIPTION
This fixes a bug that @freekmurze and I discovered, which occurs when trying to create a payload when the job is an object.

Specifically, this fixes this test case, https://github.com/spatie/laravel-interacts-with-payload/blob/master/tests/AllJobsTest.php which without this fix fails.