### PR TITLE
Change order of 'deleting' event

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
@@ -128,8 +128,6 @@ trait AsPivot
             return (int) parent::delete();
         }
 
-
-
         $this->touchOwners();
 
         return tap($this->getDeleteQuery()->delete(), function () {

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
@@ -121,13 +121,15 @@ trait AsPivot
      */
     public function delete()
     {
+        if ($this->fireModelEvent('deleting') === false) {
+            return 0;
+        }
+        
         if (isset($this->attributes[$this->getKeyName()])) {
             return (int) parent::delete();
         }
 
-        if ($this->fireModelEvent('deleting') === false) {
-            return 0;
-        }
+
 
         $this->touchOwners();
 

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
@@ -124,7 +124,6 @@ trait AsPivot
         if ($this->fireModelEvent('deleting') === false) {
             return 0;
         }
-        
         if (isset($this->attributes[$this->getKeyName()])) {
             return (int) parent::delete();
         }


### PR DESCRIPTION
It is my humble opinion that. The 'deleting' event should be fired before the item gets deleted from the database. Not after
Before this PR pivot::deleting would not have access to the Primary key  because its parent class usually model::delete already deleted so any listener will not have access to the full pivot table entry. because it would not exist in the database.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
