### PR TITLE
[8.x] Allow anonymous and class based migration coexisting

### DIFF
--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -470,7 +470,7 @@ class Migrator
     {
         $class = $this->getMigrationClass($this->getMigrationName($path));
 
-        if (class_exists($class)) {
+        if (class_exists($class) && realpath($path) == (new ReflectionClass($class))->getFileName()) {
             return new $class;
         }
 

--- a/tests/Integration/Migration/MigratorTest.php
+++ b/tests/Integration/Migration/MigratorTest.php
@@ -76,7 +76,7 @@ class MigratorTest extends TestCase
     {
         $this->expectOutput('<info>CreatePeopleTable:</info> create table "people" ("id" integer not null primary key autoincrement, "name" varchar not null, "email" varchar not null, "password" varchar not null, "remember_token" varchar, "created_at" datetime, "updated_at" datetime)');
         $this->expectOutput('<info>CreatePeopleTable:</info> create unique index "people_email_unique" on "people" ("email")');
-        $this->expectOutput('<info>2015_10_04_000000_modify_people_table:</info> alter table "people" add column "first_name" varchar');
+        $this->expectOutput('<info>ModifyPeopleTable:</info> alter table "people" add column "first_name" varchar');
         $this->expectOutput('<info>2016_10_04_000000_modify_people_table:</info> alter table "people" add column "last_name" varchar');
 
         $this->subject->run([__DIR__.'/fixtures'], ['pretend' => true]);

--- a/tests/Integration/Migration/fixtures/2015_10_04_000000_modify_people_table.php
+++ b/tests/Integration/Migration/fixtures/2015_10_04_000000_modify_people_table.php
@@ -4,7 +4,8 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration {
+class ModifyPeopleTable extends Migration
+{
     /**
      * Run the migrations.
      *
@@ -28,4 +29,4 @@ return new class extends Migration {
             $table->dropColumn('first_name');
         });
     }
-};
+}


### PR DESCRIPTION
#36906 introduces anonymous migrations but it fails when there is a class based migration too with the same name.

This PR fixes this by validating the class based migration's path against the wanted migration. Test are also updated to fail if problem is not fixed.