### PR TITLE
Add support for multiple columns in query()->whereIn

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -6,7 +6,7 @@ use Closure;
 use DateTimeInterface;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Concerns\BuildsQueries;
-use Illuminate\Database\Concerns\ExplainsQueries;
+use Illuminate\Database\Concerns\ExplainsQueries;w
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Relations\Relation;
@@ -933,7 +933,7 @@ class Builder
      * @param  bool  $not
      * @return $this
      */
-    public function whereIn($columns, $values, $boolean = 'and', $not = false)
+    public function whereIn($column, $values, $boolean = 'and', $not = false)
     {
         $type = $not ? 'NotIn' : 'In';
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1000,7 +1000,7 @@ class Builder
     {
         return $this->whereNotIn($column, $values, 'or');
     }
-    
+
     /**
      * Add a "where (x,y) in ((a,b),(c,d))" clause to the query.
      *

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -922,17 +922,18 @@ class Builder
     {
         return $this->whereRaw($sql, $bindings, 'or');
     }
-
+    
+    
     /**
      * Add a "where in" clause to the query.
      *
-     * @param  string  $column
+     * @param  string|array  $column
      * @param  mixed  $values
      * @param  string  $boolean
      * @param  bool  $not
      * @return $this
      */
-    public function whereIn($column, $values, $boolean = 'and', $not = false)
+    public function whereIn($columns, $values, $boolean = 'and', $not = false)
     {
         $type = $not ? 'NotIn' : 'In';
 
@@ -967,7 +968,7 @@ class Builder
     /**
      * Add an "or where in" clause to the query.
      *
-     * @param  string  $column
+     * @param  string|array  $column
      * @param  mixed  $values
      * @return $this
      */
@@ -979,7 +980,7 @@ class Builder
     /**
      * Add a "where not in" clause to the query.
      *
-     * @param  string  $column
+     * @param  string|array  $column
      * @param  mixed  $values
      * @param  string  $boolean
      * @return $this
@@ -999,59 +1000,6 @@ class Builder
     public function orWhereNotIn($column, $values)
     {
         return $this->whereNotIn($column, $values, 'or');
-    }
-
-    /**
-     * Add a "where (x,y) in ((a,b),(c,d))" clause to the query.
-     *
-     * @param  array  $columns
-     * @param  mixed  $values
-     * @param  string $boolean
-     * @param  bool  $not
-     * @return $this
-     */
-    public function whereInArray($columns, $values, $boolean = 'and', $not = false)
-    {
-        $type = $not ? 'NotInArray' : 'InArray';
-
-        // If the value is a query builder instance we will assume the developer wants to
-        // look for any values that exists within this given query. So we will add the
-        // query accordingly so that this query is properly executed when it is run.
-        if ($this->isQueryable($values)) {
-            [$query, $bindings] = $this->createSub($values);
-
-            $values = [new Expression($query)];
-
-            $this->addBinding($bindings, 'where');
-        }
-
-        // Next, if the value is Arrayable we need to cast it to its raw array form so we
-        // have the underlying array value instead of an Arrayable object which is not
-        // able to be added as a binding, etc. We will then add to the wheres array.
-        if ($values instanceof Arrayable) {
-            $values = $values->toArray();
-        }
-
-        $this->wheres[] = compact('type', 'columns', 'values', 'boolean');
-
-        // Finally we'll add a binding for each values unless that value is an expression
-        // in which case we will just skip over it since it will be the query as a raw
-        // string and not as a parameterized place-holder to be replaced by the PDO.
-        $this->addBinding($this->cleanBindings($values), 'where');
-
-        return $this;
-    }
-
-    /**
-     * Add an "where (x,y) not in ((a,b),(c,d))" clause to the query.
-     *
-     * @param  string  $column
-     * @param  mixed  $values
-     * @return $this
-     */
-    public function whereNotInArray($column, $values)
-    {
-        return $this->whereInArray($column, $values, 'or', true);
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1000,6 +1000,59 @@ class Builder
     {
         return $this->whereNotIn($column, $values, 'or');
     }
+    
+    /**
+     * Add a "where (x,y) in ((a,b),(c,d))" clause to the query.
+     *
+     * @param  array  $columns
+     * @param  mixed  $values
+     * @param  string $boolean
+     * @param  bool  $not
+     * @return $this
+     */
+    public function whereInArray($columns, $values, $boolean = 'and', $not = false)
+    {
+        $type = $not ? 'NotInArray' : 'InArray';
+
+        // If the value is a query builder instance we will assume the developer wants to
+        // look for any values that exists within this given query. So we will add the
+        // query accordingly so that this query is properly executed when it is run.
+        if ($this->isQueryable($values)) {
+            [$query, $bindings] = $this->createSub($values);
+
+            $values = [new Expression($query)];
+
+            $this->addBinding($bindings, 'where');
+        }
+
+        // Next, if the value is Arrayable we need to cast it to its raw array form so we
+        // have the underlying array value instead of an Arrayable object which is not
+        // able to be added as a binding, etc. We will then add to the wheres array.
+        if ($values instanceof Arrayable) {
+            $values = $values->toArray();
+        }
+
+        $this->wheres[] = compact('type', 'columns', 'values', 'boolean');
+
+        // Finally we'll add a binding for each values unless that value is an expression
+        // in which case we will just skip over it since it will be the query as a raw
+        // string and not as a parameterized place-holder to be replaced by the PDO.
+        $this->addBinding($this->cleanBindings($values), 'where');
+
+        return $this;
+    }
+
+    /**
+     * Add an "where (x,y) not in ((a,b),(c,d))" clause to the query.
+     *
+     * @param  string  $column
+     * @param  mixed  $values
+     * @return $this
+     */
+    public function whereNotInArray($column, $values)
+    {
+        return $this->whereInArray($column, $values, 'or', true);
+    }
 
     /**
      * Add a "where in raw" clause for integer values to the query.

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -266,7 +266,9 @@ class Grammar extends BaseGrammar
     {
         if (! empty($where['values'])) {
             if (is_array($where['column'])) {
-                return '('.$this->columnize($where['column']).') in (('.implode('), (', array_map([$this, 'parameterize'], $where['values'])).'))';
+                $parameters = implode('), (', array_map($this, 'parameterize'], $where['values']));
+                $columns = $this->columnize($where['column']);                
+                return "($columns) in (($parameters))";
             } else {
                 return $this->wrap($where['column']).' in ('.$this->parameterize($where['values']).')';
             }
@@ -286,28 +288,12 @@ class Grammar extends BaseGrammar
     {
         if (! empty($where['values'])) {
             if (is_array($where['column'])) {
-                return '('.$this->columnize($where['column']).') not in (('.implode('), (', array_map([$this, 'parameterize'], $where['values'])).'))';
+                $parameters = implode('), (', array_map($this, 'parameterize'], $where['values']));
+                $columns = $this->columnize($where['column']);                
+                return "($columns) not in (($parameters))";
             } else {
                 return $this->wrap($where['column']).' not in ('.$this->parameterize($where['values']).')';
             }
-        }
-
-        return '1 = 1';
-    }
-
-    /**
-     * Compile a "where not in raw" clause.
-     *
-     * For safety, whereIntegerInRaw ensures this method is only used with integer values.
-     *
-     * @param  \Illuminate\Database\Query\Builder  $query
-     * @param  array  $where
-     * @return string
-     */
-    protected function whereNotInRaw(Builder $query, $where)
-    {
-        if (! empty($where['values'])) {
-            return $this->wrap($where['column']).' not in ('.implode(', ', $where['values']).')';
         }
 
         return '1 = 1';
@@ -325,10 +311,41 @@ class Grammar extends BaseGrammar
     protected function whereInRaw(Builder $query, $where)
     {
         if (! empty($where['values'])) {
-            return $this->wrap($where['column']).' in ('.implode(', ', $where['values']).')';
+            if (is_array($where['column'])) {
+                $parameters = implode('), (', array_map(fn ($record) => implode(', ', $record), $where['values']));
+                $columns = $this->columnize($where['column']);
+                return "($columns) in (($parameters))";
+            } else {
+                return $this->wrap($where['column']).' in ('.implode(', ', $where['values']).')';
+            }
+            
         }
 
         return '0 = 1';
+    }
+    
+    /**
+     * Compile a "where not in raw" clause.
+     *
+     * For safety, whereIntegerInRaw ensures this method is only used with integer values.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereNotInRaw(Builder $query, $where)
+    {
+        if (! empty($where['values'])) {
+            if (is_array($where['column'])) {
+                $parameters = implode('), (', array_map(fn ($record) => implode(', ', $record), $where['values']));
+                $columns = $this->columnize($where['column']);
+                return "($columns) not in (($parameters))";
+            } else {
+                return $this->wrap($where['column']).' not in ('.implode(', ', $where['values']).')';
+            }
+        }
+
+        return '1 = 1';
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -265,7 +265,11 @@ class Grammar extends BaseGrammar
     protected function whereIn(Builder $query, $where)
     {
         if (! empty($where['values'])) {
-            return $this->wrap($where['column']).' in ('.$this->parameterize($where['values']).')';
+            if (is_array($where['column'])) {
+                return '('.$this->columnize($where['column']).') in (('.implode('), (', array_map([$this, 'parameterize'], $where['values'])).'))';
+            } else {
+                return $this->wrap($where['column']).' in ('.$this->parameterize($where['values']).')';
+            }
         }
 
         return '0 = 1';
@@ -281,42 +285,14 @@ class Grammar extends BaseGrammar
     protected function whereNotIn(Builder $query, $where)
     {
         if (! empty($where['values'])) {
-            return $this->wrap($where['column']).' not in ('.$this->parameterize($where['values']).')';
+            if (is_array($where['column'])) {
+                return '('.$this->columnize($where['column']).') not in (('.implode('), (', array_map([$this, 'parameterize'], $where['values'])).'))';
+            } else {
+                return $this->wrap($where['column']).' not in ('.$this->parameterize($where['values']).')';
+            }
         }
 
         return '1 = 1';
-    }
-
-    /**
-     * Compile a "where (x,y) in ((a,b),(c,d))" clause.
-     *
-     * @param  \Illuminate\Database\Query\Builder  $query
-     * @param  array  $where
-     * @return string
-     */
-    protected function whereInArray(Builder $query, $where)
-    {
-        if (! empty($where['values'])) {
-            return '('.$this->columnize($where['columns']).') in (('.implode('), (', array_map([$this, 'parameterize'], $where['values'])).'))';
-        }
-
-        return '0 = 1';
-    }
-
-    /**
-     * Compile a "where (x,y) not in ((a,b),(c,d))" clause.
-     *
-     * @param  \Illuminate\Database\Query\Builder  $query
-     * @param  array  $where
-     * @return string
-     */
-    protected function whereNotInArray(Builder $query, $where)
-    {
-        if (! empty($where['values'])) {
-            return '('.$this->columnize($where['columns']).') not in (('.implode('), (', array_map([$this, 'parameterize'], $where['values'])).'))';
-        }
-
-        return '0 = 1';
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -286,6 +286,38 @@ class Grammar extends BaseGrammar
 
         return '1 = 1';
     }
+ 
+    /**
+     * Compile a "where (x,y) in ((a,b),(c,d))" clause.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereInArray(Builder $query, $where)
+    {
+        if (! empty($where['values'])) {
+            return '('.$this->columnize($where['columns']).') in (('.implode('), (', array_map([$this, 'parameterize'], $where['values'])).'))';
+        }
+
+        return '0 = 1';
+    }
+
+    /**
+     * Compile a "where (x,y) not in ((a,b),(c,d))" clause.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereNotInArray(Builder $query, $where)
+    {
+        if (! empty($where['values'])) {
+            return '('.$this->columnize($where['columns']).') not in (('.implode('), (', array_map([$this, 'parameterize'], $where['values'])).'))';
+        }
+
+        return '0 = 1';
+    }
 
     /**
      * Compile a "where not in raw" clause.

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -286,7 +286,7 @@ class Grammar extends BaseGrammar
 
         return '1 = 1';
     }
- 
+
     /**
      * Compile a "where (x,y) in ((a,b),(c,d))" clause.
      *


### PR DESCRIPTION
Add support to execute a `where in` on multiple values against more than one column, instead of needing to do multiple orWhere closure queries.

Tested with select, delete and update.

### Example:

```php
DB::table('settings')
  ->whereIn(['key', 'locale'], [
    ['title', 'en'],
    ['url', 'fr'],
    ['logo', 'es']
  ])->get();
```

Whereas currently in Laravel to achieve the same affect you need to do:
```php
DB::table('settings')
  ->where([
    'key' => 'title',
    'locale' => 'en'
  ])->orWhere(fn($q) => $q->where([
    'key' => 'url',
    'locale' => 'fr'
   ]))->orWhere(fn($q) => $q->where([
    'key' => 'logo',
    'locale' => 'es'
   ]))->get();
```

### Comparison of sql queries:

Using new **whereIn**: 
```mysql
select * from `settings` where (`key`, `locale`) in ((?, ?), (?, ?), (?, ?))
```

vs current **orWhere closure**:
 ```mysql
select * from `settings` where (`key` = ? and `locale` = ?) or ((`key` = ? and `locale` = ?)) or ((`key` = ? and `locale` = ?))
```


