### PR TITLE
[8.x] Add support for multiple columns in query()->whereIn

### DIFF
--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -117,6 +117,62 @@ abstract class Grammar
     }
 
     /**
+     * Convert array into sql group.
+     *
+     * @param  mixed  $values
+     * @return string
+     */
+    public function group($values)
+    {
+        return '('.implode(', ', $values).')';
+    }
+
+    /**
+     * Recursively group arrays containing values into groups.
+     *
+     * @param  mixed  $values
+     * @return string
+     */
+    public function groupify($values)
+    {
+        if (is_array($values)) {
+            return $this->group(array_map([$this, __FUNCTION__], $values));
+        }
+
+        return $this->parameter($values);
+    }
+
+    /**
+     * Recursively group arrays containing columns into groups.
+     *
+     * @param  mixed  $values
+     * @return string
+     */
+    public function groupifyColumns($values)
+    {
+        if (is_array($values)) {
+            return $this->group(array_map([$this, __FUNCTION__], $values));
+        }
+
+        return $this->wrap($values);
+    }
+
+    /**
+     * Recursively group arrays containing raw values into groups.
+     *
+     * @param  mixed  $values
+     * @return string
+     */
+    public function groupifyRaw($values)
+    {
+        if (is_array($values)) {
+            return $this->group(array_map([$this, __FUNCTION__], $values));
+        }
+
+        return $values;
+    }
+
+    /**
      * Convert an array of column names into a delimited string.
      *
      * @param  array  $columns

--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -117,56 +117,56 @@ abstract class Grammar
     }
 
     /**
-     * Convert array into sql group.
+     * Convert array into a tuple.
      *
      * @param  mixed  $values
      * @return string
      */
-    public function group($values)
+    public function tuple($values)
     {
         return '('.implode(', ', $values).')';
     }
 
     /**
-     * Recursively group arrays containing values into groups.
+     * Recursively group arrays containing values into a tuple.
      *
      * @param  mixed  $values
      * @return string
      */
-    public function groupify($values)
+    public function tuplify($values)
     {
         if (is_array($values)) {
-            return $this->group(array_map([$this, __FUNCTION__], $values));
+            return $this->tuple(array_map([$this, __FUNCTION__], $values));
         }
 
         return $this->parameter($values);
     }
 
     /**
-     * Recursively group arrays containing columns into groups.
+     * Recursively group arrays containing columns into a tuple.
      *
      * @param  mixed  $values
      * @return string
      */
-    public function groupifyColumns($values)
+    public function tuplifyColumns($values)
     {
         if (is_array($values)) {
-            return $this->group(array_map([$this, __FUNCTION__], $values));
+            return $this->tuple(array_map([$this, __FUNCTION__], $values));
         }
 
         return $this->wrap($values);
     }
 
     /**
-     * Recursively group arrays containing raw values into groups.
+     * Recursively group arrays containing raw values into a tuple.
      *
      * @param  mixed  $values
      * @return string
      */
-    public function groupifyRaw($values)
+    public function tuplifyRaw($values)
     {
         if (is_array($values)) {
-            return $this->group(array_map([$this, __FUNCTION__], $values));
+            return $this->tuple(array_map([$this, __FUNCTION__], $values));
         }
 
         return $values;

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1000,7 +1000,7 @@ class Builder
     {
         return $this->whereNotIn($column, $values, 'or');
     }
-    
+
     /**
      * Add a "where (x,y) in ((a,b),(c,d))" clause to the query.
      *

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1000,6 +1000,59 @@ class Builder
     {
         return $this->whereNotIn($column, $values, 'or');
     }
+    
+    /**
+     * Add a "where (x,y) in ((a,b),(c,d))" clause to the query.
+     *
+     * @param  array  $columns
+     * @param  mixed  $values
+     * @param  string $boolean
+     * @param  bool  $not
+     * @return $this
+     */
+    public function whereInArray($columns, $values, $boolean = 'and', $not = false)
+    {
+        $type = $not ? 'NotInArray' : 'InArray';
+
+        // If the value is a query builder instance we will assume the developer wants to
+        // look for any values that exists within this given query. So we will add the
+        // query accordingly so that this query is properly executed when it is run.
+        if ($this->isQueryable($values)) {
+            [$query, $bindings] = $this->createSub($values);
+
+            $values = [new Expression($query)];
+
+            $this->addBinding($bindings, 'where');
+        }
+
+        // Next, if the value is Arrayable we need to cast it to its raw array form so we
+        // have the underlying array value instead of an Arrayable object which is not
+        // able to be added as a binding, etc. We will then add to the wheres array.
+        if ($values instanceof Arrayable) {
+            $values = $values->toArray();
+        }
+
+        $this->wheres[] = compact('type', 'columns', 'values', 'boolean');
+
+        // Finally we'll add a binding for each values unless that value is an expression
+        // in which case we will just skip over it since it will be the query as a raw
+        // string and not as a parameterized place-holder to be replaced by the PDO.
+        $this->addBinding($this->cleanBindings($values), 'where');
+
+        return $this;
+    }
+
+    /**
+     * Add an "where (x,y) not in ((a,b),(c,d))" clause to the query.
+     *
+     * @param  string  $column
+     * @param  mixed  $values
+     * @return $this
+     */
+    public function whereNotInArray($column, $values)
+    {
+        return $this->whereInArray($column, $values, 'or', true);
+    }
 
     /**
      * Add a "where in raw" clause for integer values to the query.

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -926,7 +926,7 @@ class Builder
     /**
      * Add a "where in" clause to the query.
      *
-     * @param  string  $column
+     * @param  string|array  $column
      * @param  mixed  $values
      * @param  string  $boolean
      * @param  bool  $not
@@ -967,7 +967,7 @@ class Builder
     /**
      * Add an "or where in" clause to the query.
      *
-     * @param  string  $column
+     * @param  string|array  $column
      * @param  mixed  $values
      * @return $this
      */
@@ -979,7 +979,7 @@ class Builder
     /**
      * Add a "where not in" clause to the query.
      *
-     * @param  string  $column
+     * @param  string|array  $column
      * @param  mixed  $values
      * @param  string  $boolean
      * @return $this
@@ -992,66 +992,13 @@ class Builder
     /**
      * Add an "or where not in" clause to the query.
      *
-     * @param  string  $column
+     * @param  string|array  $column
      * @param  mixed  $values
      * @return $this
      */
     public function orWhereNotIn($column, $values)
     {
         return $this->whereNotIn($column, $values, 'or');
-    }
-
-    /**
-     * Add a "where (x,y) in ((a,b),(c,d))" clause to the query.
-     *
-     * @param  array  $columns
-     * @param  mixed  $values
-     * @param  string $boolean
-     * @param  bool  $not
-     * @return $this
-     */
-    public function whereInArray($columns, $values, $boolean = 'and', $not = false)
-    {
-        $type = $not ? 'NotInArray' : 'InArray';
-
-        // If the value is a query builder instance we will assume the developer wants to
-        // look for any values that exists within this given query. So we will add the
-        // query accordingly so that this query is properly executed when it is run.
-        if ($this->isQueryable($values)) {
-            [$query, $bindings] = $this->createSub($values);
-
-            $values = [new Expression($query)];
-
-            $this->addBinding($bindings, 'where');
-        }
-
-        // Next, if the value is Arrayable we need to cast it to its raw array form so we
-        // have the underlying array value instead of an Arrayable object which is not
-        // able to be added as a binding, etc. We will then add to the wheres array.
-        if ($values instanceof Arrayable) {
-            $values = $values->toArray();
-        }
-
-        $this->wheres[] = compact('type', 'columns', 'values', 'boolean');
-
-        // Finally we'll add a binding for each values unless that value is an expression
-        // in which case we will just skip over it since it will be the query as a raw
-        // string and not as a parameterized place-holder to be replaced by the PDO.
-        $this->addBinding($this->cleanBindings($values), 'where');
-
-        return $this;
-    }
-
-    /**
-     * Add an "where (x,y) not in ((a,b),(c,d))" clause to the query.
-     *
-     * @param  string  $column
-     * @param  mixed  $values
-     * @return $this
-     */
-    public function whereNotInArray($column, $values)
-    {
-        return $this->whereInArray($column, $values, 'or', true);
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -265,8 +265,8 @@ class Grammar extends BaseGrammar
     protected function whereIn(Builder $query, $where)
     {
         if (! empty($where['values'])) {
-            $parameters = $this->groupify($where['values']);
-            $column = $this->groupifyColumns($where['column']);
+            $parameters = $this->tuplify($where['values']);
+            $column = $this->tuplifyColumns($where['column']);
 
             return "$column in $parameters";
         }
@@ -284,8 +284,8 @@ class Grammar extends BaseGrammar
     protected function whereNotIn(Builder $query, $where)
     {
         if (! empty($where['values'])) {
-            $parameters = $this->groupify($where['values']);
-            $column = $this->groupifyColumns($where['column']);
+            $parameters = $this->tuplify($where['values']);
+            $column = $this->tuplifyColumns($where['column']);
 
             return "$column not in $parameters";
         }
@@ -305,8 +305,8 @@ class Grammar extends BaseGrammar
     protected function whereInRaw(Builder $query, $where)
     {
         if (! empty($where['values'])) {
-            $parameters = $this->groupifyRaw($where['values']);
-            $column = $this->groupifyColumns($where['column']);
+            $parameters = $this->tuplifyRaw($where['values']);
+            $column = $this->tuplifyColumns($where['column']);
 
             return "$column in $parameters";
         }
@@ -326,8 +326,8 @@ class Grammar extends BaseGrammar
     protected function whereNotInRaw(Builder $query, $where)
     {
         if (! empty($where['values'])) {
-            $parameters = $this->groupifyRaw($where['values']);
-            $column = $this->groupifyColumns($where['column']);
+            $parameters = $this->tuplifyRaw($where['values']);
+            $column = $this->tuplifyColumns($where['column']);
 
             return "$column not in $parameters";
         }
@@ -894,7 +894,7 @@ class Grammar extends BaseGrammar
         // We need to build a list of parameter place-holders of values that are bound
         // to the query. Each insert should have the exact same amount of parameter
         // bindings so we will loop through the record and parameterize them all.
-        $parameters = collect($values)->map([$this, 'groupify'])->implode(', ');
+        $parameters = collect($values)->map([$this, 'tuplify'])->implode(', ');
 
         return "insert into $table ($columns) values $parameters";
     }

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -286,6 +286,38 @@ class Grammar extends BaseGrammar
 
         return '1 = 1';
     }
+ 
+    /**
+     * Compile a "where (x,y) in ((a,b),(c,d))" clause.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereInArray(Builder $query, $where)
+    {
+        if (! empty($where['values'])) {
+            return '('.$this->columnize($where['columns']).') in (('.implode('), (', array_map([$this, 'parameterize'], $where['values'])).'))';
+        }
+
+        return '0 = 1';
+    }
+
+    /**
+     * Compile a "where (x,y) not in ((a,b),(c,d))" clause.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereNotInArray(Builder $query, $where)
+    {
+        if (! empty($where['values'])) {
+            return '('.$this->columnize($where['columns']).') not in (('.implode('), (', array_map([$this, 'parameterize'], $where['values'])).'))';
+        }
+
+        return '0 = 1';
+    }
 
     /**
      * Compile a "where not in raw" clause.

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -286,7 +286,7 @@ class Grammar extends BaseGrammar
 
         return '1 = 1';
     }
- 
+
     /**
      * Compile a "where (x,y) in ((a,b),(c,d))" clause.
      *

--- a/tests/Integration/Database/QueryBuilderTest.php
+++ b/tests/Integration/Database/QueryBuilderTest.php
@@ -203,6 +203,24 @@ class QueryBuilderTest extends DatabaseTestCase
         $this->assertSame(2, DB::table('posts')->where('id', 1)->orWhereTime('created_at', new Carbon('2018-01-02 03:04:05'))->count());
     }
 
+    public function testWhereIn()
+    {
+        $this->assertEquals('select * from "posts" where "id" in (?, ?)',
+            DB::table('posts')->whereIn('id', [1, 2])->toSql());
+
+        $this->assertEquals('select * from "posts" where ("id", "title") in ((?, ?), (?, ?))',
+            DB::table('posts')->whereIn(['id', 'title'], [[1, 'Foo Post'], [2, 'No Post']])->toSql());
+    }
+
+    public function testWhereNotIn()
+    {
+        $this->assertEquals('select * from "posts" where "id" not in (?, ?)',
+            DB::table('posts')->whereNotIn('id', [1, 2])->toSql());
+
+        $this->assertEquals('select * from "posts" where ("id", "title") not in ((?, ?), (?, ?))',
+            DB::table('posts')->whereNotIn(['id', 'title'], [[1, 'Foo Post'], [2, 'No Post']])->toSql());
+    }
+
     public function testPaginateWithSpecificColumns()
     {
         $result = DB::table('posts')->paginate(5, ['title', 'content']);


### PR DESCRIPTION
Add support to execute a `where in` on multiple values against more than one column, instead of needing to do multiple orWhere closure queries.

Tested with select, delete and update.

### Example:

```php
DB::table('settings')
  ->whereIn(['key', 'locale'], [
    ['title', 'en'],
    ['url', 'fr'],
    ['logo', 'es']
  ])->get();
```

Whereas currently in Laravel to achieve the same affect you need to do:
```php
DB::table('settings')
  ->where([
    'key' => 'title',
    'locale' => 'en'
  ])->orWhere(fn($q) => $q->where([
    'key' => 'url',
    'locale' => 'fr'
   ]))->orWhere(fn($q) => $q->where([
    'key' => 'logo',
    'locale' => 'es'
   ]))->get();
```

### Comparison of sql queries:

Using new **whereIn**: 
```mysql
select * from `settings` where (`key`, `locale`) in ((?, ?), (?, ?), (?, ?))
```

vs current **orWhere closure**:
 ```mysql
select * from `settings` where (`key` = ? and `locale` = ?) or ((`key` = ? and `locale` = ?)) or ((`key` = ? and `locale` = ?))
```