### PR TITLE
[8.x] Notification stubs

### DIFF
--- a/src/Illuminate/Foundation/Console/NotificationMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/NotificationMakeCommand.php
@@ -87,8 +87,21 @@ class NotificationMakeCommand extends GeneratorCommand
     protected function getStub()
     {
         return $this->option('markdown')
-                        ? __DIR__.'/stubs/markdown-notification.stub'
-                        : __DIR__.'/stubs/notification.stub';
+                    ? $this->resolveStubPath('/stubs/markdown-notification.stub')
+                    : $this->resolveStubPath('/stubs/notification.stub');
+    }
+
+    /**
+     * Resolve the fully-qualified path to the stub.
+     *
+     * @param  string  $stub
+     * @return string
+     */
+    protected function resolveStubPath($stub)
+    {
+        return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
+                        ? $customPath
+                        : __DIR__.$stub;
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/StubPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/StubPublishCommand.php
@@ -38,6 +38,8 @@ class StubPublishCommand extends Command
             __DIR__.'/stubs/job.stub' => $stubsPath.'/job.stub',
             __DIR__.'/stubs/model.pivot.stub' => $stubsPath.'/model.pivot.stub',
             __DIR__.'/stubs/model.stub' => $stubsPath.'/model.stub',
+            __DIR__.'/stubs/markdown-notification.stub' => $stubsPath.'/markdown-notification.stub',
+            __DIR__.'/stubs/notification.stub' => $stubsPath.'/notification.stub',
             __DIR__.'/stubs/observer.stub' => $stubsPath.'/observer.stub',
             __DIR__.'/stubs/observer.plain.stub' => $stubsPath.'/observer.plain.stub',
             __DIR__.'/stubs/request.stub' => $stubsPath.'/request.stub',


### PR DESCRIPTION
When publishing stubs the `notification.stub` and `markdown-notification.stub` wasn't being published with it.

Just added those 2 files to the `stubs:publish` command and implement the same logic to get the custom stub from the existing commands.


