### PR TITLE
[8.x] Update SoftDeletes docblock

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -3,9 +3,10 @@
 namespace Illuminate\Database\Eloquent;
 
 /**
- * @method static static|\Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder withTrashed()
+ * @method static static|\Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder withTrashed(bool $withTrashed = true)
  * @method static static|\Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder onlyTrashed()
  * @method static static|\Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder withoutTrashed()
+ * @method static static|\Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder restore()
  */
 trait SoftDeletes
 {


### PR DESCRIPTION
[SoftDeletingScope](https://github.com/laravel/framework/blob/master/src/Illuminate/Database/Eloquent/SoftDeletingScope.php) also adds [`restore`](https://github.com/laravel/framework/blob/master/src/Illuminate/Database/Eloquent/SoftDeletingScope.php#L68) method.

So this PR:
- changes the docblock for [SoftDeletes trait](https://github.com/laravel/framework/blob/master/src/Illuminate/Database/Eloquent/SoftDeletes.php) to include `restore` method
- fixes `withTrashed` method docblock, so that it [accepts](https://github.com/laravel/framework/blob/master/src/Illuminate/Database/Eloquent/SoftDeletingScope.php#L85) a bool argument