### PR TITLE
Add compile x- attributes

### DIFF
--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -73,7 +73,24 @@ class ComponentTagCompiler
     {
         $value = $this->compileSlots($value);
 
+        $value = $this->compileAttributes($value);
+
         return $this->compileTags($value);
+    }
+
+    /**
+     * Compile the attribute within the given string.
+     *
+     * @param  string $value
+     * @return string
+     */
+    public function compileAttributes(string $value)
+    {
+        $pattern = '/x-(\S+)=["\']?((?:.(?!["\']?\s+(?:\S+)=|[>"\']))+.)["\']?/';
+
+        return preg_replace_callback($pattern, function (array $matches) {
+            return $matches[1].'="{{ '.$matches[2].' }}"';
+        }, $value);
     }
 
     /**


### PR DESCRIPTION
This pr adds a compiler for dynamic attribtues for tags that are not starting with `<x-`:

Usage:

```html
<div x-class="$foo">

</div>
```

Will be compiled to:

```html
<div class="{{ $foo }}">

</div>
```
