### PR TITLE
[8.x] Adds attempt with callbacks

### DIFF
--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -395,7 +395,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     }
 
     /**
-     * Checks if the user should login by executing the given callbacks
+     * Checks if the user should login by executing the given callbacks.
      *
      * @param  array|callable|null  $callbacks
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -126,31 +126,44 @@ class AuthGuardTest extends TestCase
         $this->assertFalse($mock->attempt(['foo']));
     }
 
-    public function testAttemptWithCallbacks()
+    public function testAttemptAndWithCallbacks()
     {
         [$session, $provider, $request, $cookie] = $this->getMocks();
         $mock = $this->getMockBuilder(SessionGuard::class)->onlyMethods(['getName'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
         $mock->setDispatcher($events = m::mock(Dispatcher::class));
         $user = m::mock(Authenticatable::class);
-        $events->shouldReceive('dispatch')->twice()->with(m::type(Attempting::class));
+        $events->shouldReceive('dispatch')->times(3)->with(m::type(Attempting::class));
         $events->shouldReceive('dispatch')->once()->with(m::type(Login::class));
         $events->shouldReceive('dispatch')->once()->with(m::type(Authenticated::class));
         $events->shouldReceive('dispatch')->twice()->with(m::type(Validated::class));
-        $events->shouldReceive('dispatch')->once()->with(m::type(Failed::class));
+        $events->shouldReceive('dispatch')->twice()->with(m::type(Failed::class));
         $mock->expects($this->once())->method('getName')->willReturn('foo');
         $user->shouldReceive('getAuthIdentifier')->once()->andReturn('bar');
         $mock->getSession()->shouldReceive('put')->with('foo', 'bar')->once();
         $session->shouldReceive('migrate')->once();
-        $mock->getProvider()->shouldReceive('retrieveByCredentials')->twice()->with(['foo'])->andReturn($user);
+        $mock->getProvider()->shouldReceive('retrieveByCredentials')->times(3)->with(['foo'])->andReturn($user);
         $mock->getProvider()->shouldReceive('validateCredentials')->twice()->andReturnTrue();
+        $mock->getProvider()->shouldReceive('validateCredentials')->once()->andReturnFalse();
 
-        $this->assertTrue($mock->attempt(['foo'], false, function ($user) {
-            return $user;
+        $this->assertTrue($mock->attemptWith(['foo'], false, function ($user, $guard) {
+            static::assertInstanceOf(Authenticatable::class, $user);
+            static::assertInstanceOf(SessionGuard::class, $guard);
+            return true;
         }));
 
-        $this->assertFalse($mock->attempt(['foo'], false, function ($user) {
-            return ! $user;
+        $this->assertFalse($mock->attemptWith(['foo'], false, function ($user, $guard) {
+            static::assertInstanceOf(Authenticatable::class, $user);
+            static::assertInstanceOf(SessionGuard::class, $guard);
+            return false;
         }));
+
+        $executed = false;
+
+        $this->assertFalse($mock->attemptWith(['foo'], false, function () use (&$executed) {
+            return $executed = true;
+        }));
+
+        $this->assertFalse($executed);
     }
 
     public function testLoginStoresIdentifierInSession()

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -148,12 +148,14 @@ class AuthGuardTest extends TestCase
         $this->assertTrue($mock->attemptWith(['foo'], false, function ($user, $guard) {
             static::assertInstanceOf(Authenticatable::class, $user);
             static::assertInstanceOf(SessionGuard::class, $guard);
+
             return true;
         }));
 
         $this->assertFalse($mock->attemptWith(['foo'], false, function ($user, $guard) {
             static::assertInstanceOf(Authenticatable::class, $user);
             static::assertInstanceOf(SessionGuard::class, $guard);
+
             return false;
         }));
 


### PR DESCRIPTION
This PR expands on the [discussion here](https://github.com/laravel/framework/discussions/37028) about adding callbacks the `attempt()` authentication mechanisms.

## Problem

There is no way to add additional checks at runtime when using `attempt()`. Any addition forces the developer to create a new Guard, or use nonchalantly `validate()` and `getLastAttempted()`, and fire `Attempting` manually.

```php
if (Auth::validate($credentials) && $user = Auth::getLastAttempted()) {
    if ($user->isAwesomeAndCool()) {
        Auth::login($user, $request->filled('remember'));
        Event::fire(Attempting('session', $credentials, $request->filled('remember')));
        return $this->redirect();
    }
}


return $this->sendAttemptFailed();
```

## Solution

This PR allows the `SessionGuard::attempt()` method to the receive a third argument that receives one or multiple callbacks. Each of these receive the validated User, and if one returns false, the whole attempt fails.

```php
$result = Auth::attempt($credentials, false, function (Authenticatable $user) {
    return $user->isAwesomeAndCool();
});

return $result 
    ? $this->redirect() 
    : $this->sendAttemptFailed();
```

Since there are `callables`, the developer can add its own checks, or use checks made by external packages, all while controlling manually the flow and order of these.

## How it works

The change adds an internal function `shouldLogin()` that executes each callback and returns `false` if one of them "fails". This is called after the user is properly validated:

```php
if ($this->hasValidCredentials($user, $credentials) && $this->shouldLogin($callbacks, $user)) {
    $this->login($user, $remember);

     return true;
}
```

**Breaking changes: extending the Session Guard**

--- 

The above change is simple and non-breaking, since it doesn't changes the interface signature, but as a precaution I'm pushing it into the next version... unless it gets approved for 8.x. And this also includes an additional test.