### PR TITLE
[8.x] Allow Unique Chained Jobs 

### DIFF
--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -46,7 +46,7 @@ trait Queueable
     public $chainCatchCallbacks;
 
     /**
-     * The name of any lock for the chain
+     * The name of any lock for the chain.
      *
      * @var int|string
      */

--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -46,6 +46,13 @@ trait Queueable
     public $chainCatchCallbacks;
 
     /**
+     * The name of any lock for the chain
+     *
+     * @var int|string
+     */
+    public $chainLock;
+
+    /**
      * The number of seconds before the job should be made available.
      *
      * @var \DateTimeInterface|\DateInterval|int|null
@@ -229,6 +236,7 @@ trait Queueable
 
                 $next->chainConnection = $this->chainConnection;
                 $next->chainQueue = $this->chainQueue;
+                $next->chainLock = $this->chainLock;
                 $next->chainCatchCallbacks = $this->chainCatchCallbacks;
             }));
         }

--- a/src/Illuminate/Foundation/Bus/PendingChain.php
+++ b/src/Illuminate/Foundation/Bus/PendingChain.php
@@ -54,7 +54,7 @@ class PendingChain
     public $catchCallbacks = [];
 
     /**
-     *  The name of any lock for this chain
+     *  The name of any lock for this chain.
      *
      * @var int|string
      */

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -254,6 +254,11 @@ class CallQueuedHandler
             $this->ensureUniqueJobLockIsReleased($command);
         }
 
+        if ($chainLock = $command->chainLock) {
+            $cache = $this->container->make(Cache::class);
+            $cache->lock($chainLock)->forceRelease();
+        }
+
         $this->ensureFailedBatchJobIsRecorded($uuid, $command, $e);
         $this->ensureChainCatchCallbacksAreInvoked($uuid, $command, $e);
 

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -112,12 +112,13 @@ class CallQueuedHandler
     protected function dispatchThroughMiddleware(Job $job, $command)
     {
         return (new Pipeline($this->container))->send($command)
-                ->through(array_merge(method_exists($command, 'middleware') ? $command->middleware() : [], $command->middleware ?? []))
-                ->then(function ($command) use ($job) {
-                    return $this->dispatcher->dispatchNow(
-                        $command, $this->resolveHandler($job, $command)
-                    );
-                });
+            ->through(array_merge(method_exists($command, 'middleware') ? $command->middleware() : [],
+                $command->middleware ?? []))
+            ->then(function ($command) use ($job) {
+                return $this->dispatcher->dispatchNow(
+                    $command, $this->resolveHandler($job, $command)
+                );
+            });
     }
 
     /**
@@ -199,12 +200,12 @@ class CallQueuedHandler
         }
 
         $uniqueId = method_exists($command, 'uniqueId')
-                    ? $command->uniqueId()
-                    : ($command->uniqueId ?? '');
+            ? $command->uniqueId()
+            : ($command->uniqueId ?? '');
 
         $cache = method_exists($command, 'uniqueVia')
-                    ? $command->uniqueVia()
-                    : $this->container->make(Cache::class);
+            ? $command->uniqueVia()
+            : $this->container->make(Cache::class);
 
         $cache->lock(
             'laravel_unique_job:'.get_class($command).$uniqueId
@@ -254,9 +255,9 @@ class CallQueuedHandler
             $this->ensureUniqueJobLockIsReleased($command);
         }
 
-        if ($chainLock = $command->chainLock) {
+        if (isset($command->chainLock)) {
             $cache = $this->container->make(Cache::class);
-            $cache->lock($chainLock)->forceRelease();
+            $cache->lock($command->chainLock)->forceRelease();
         }
 
         $this->ensureFailedBatchJobIsRecorded($uuid, $command, $e);

--- a/tests/Integration/Queue/JobChainingTest.php
+++ b/tests/Integration/Queue/JobChainingTest.php
@@ -237,9 +237,11 @@ class JobChainingTest extends TestCase
         $this->app->get(Cache::class)->lock($this->getLockName('chain'), 10)->get();
         // dispatch second chain
         Bus::chain([
+            new JobChainingTestFirstJob(),
             new JobChainingTestSecondJob(),
         ])->dispatchUnique('chain');
 
+        $this->assertFalse(JobChainingTestFirstJob::$ran);
         $this->assertFalse(JobChainingTestSecondJob::$ran);
     }
 
@@ -299,7 +301,6 @@ class JobChainingTest extends TestCase
                 new JobChainingTestFailingJob(),
                 new JobChainingTestSecondJob(),
             ])->dispatchUnique('chain', 1);
-
         } finally {
             $this->assertTrue(JobChainingTestFailingJob::$ran);
             $this->assertTrue($this->app->get(Cache::class)->lock($this->getLockName('chain', 1))->get());

--- a/tests/Integration/Queue/JobChainingTest.php
+++ b/tests/Integration/Queue/JobChainingTest.php
@@ -233,9 +233,9 @@ class JobChainingTest extends TestCase
 
     public function testDuplicateUniqueChainedJobsAreNotDispatched()
     {
-        // first job acquires lock
+        // first chain acquires lock
         $this->app->get(Cache::class)->lock($this->getLockName('chain'), 10)->get();
-        // dispatch second job
+        // dispatch second chain
         Bus::chain([
             new JobChainingTestSecondJob(),
         ])->dispatchUnique('chain');
@@ -245,7 +245,6 @@ class JobChainingTest extends TestCase
 
     public function testUniqueChainedJobsWithIdAreDispatched()
     {
-        // dispatch second job
         Bus::chain([
             new JobChainingTestFirstJob(),
             new JobChainingTestSecondJob(),
@@ -271,7 +270,6 @@ class JobChainingTest extends TestCase
 
     public function testUniqueChainedJobsSetLockName()
     {
-        // dispatch second job
         $chain = Bus::chain([
             new JobChainingTestFirstJob(),
             new JobChainingTestSecondJob(),


### PR DESCRIPTION
At the moment we can dispatch unique jobs by applying the `ShouldBeUnique` interface to the job, however, there isn't a way to do this with chained jobs. 

I have a situation where I'm deploying code using chained jobs; the deployment can be activated via an API, scheduled or dispatched from a web interface. When this chain begins I am setting the deployment status to processing, which prevents other chains from dispatching, however, if the job does not start immediately it's possible for the chain to be dispatched multiple times and handling all the statuses to prevent jobs dispatching can quickly become confusing.

This PR adds a `dispatchUnique()` method for chained jobs in which you can pass in a `name`, `id` and `uniqueFor`:

```php
$siteId = 1;
Bus::chain([
  new PrepareDeployment(),
  new Deploy()
])->dispatchUnique('deployment', $siteId, 3600);
```

A few notes:

- The lock is automatically released on success and failure
- The default duration of the lock is 3600 (1 hour), which should cover the processing period for most jobs, however, I do appreciate that is quite long.
- The chain can be dispatched with just a name, (`id` is optional)
- If a duplicate job is dispatched, `null` is returned, the thinking behind this is that you could do:

```php
$chain = Bus::chain([
  new PrepareDeployment(),
  new Deploy()
])

if($chain->dispatchUnique('deployment')){
   // Chain is processing
} else {
  // throw duplicate chain exception
}
```

Let me know if there's anything you think can be improved.
