### PR TITLE
[8.x] Add validateWith() method to Request class

### DIFF
--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -62,6 +62,7 @@ class FoundationServiceProvider extends AggregateServiceProvider
 
         Request::macro('validateWith', function ($rules, array $fields) {
             $rules = array_fill_keys($fields, $rules);
+            
             return validator()->validate($this->all(), $rules);
         });
 

--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -62,7 +62,7 @@ class FoundationServiceProvider extends AggregateServiceProvider
 
         Request::macro('validateWith', function ($rules, array $fields) {
             $rules = array_fill_keys($fields, $rules);
-            
+
             return validator()->validate($this->all(), $rules);
         });
 

--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -60,6 +60,11 @@ class FoundationServiceProvider extends AggregateServiceProvider
             return validator()->validate($this->all(), $rules, ...$params);
         });
 
+        Request::macro('validateWith', function ($rules, array $fields) {
+            $rules = array_fill_keys($fields, $rules);
+            return validator()->validate($this->all(), $rules);
+        });
+
         Request::macro('validateWithBag', function (string $errorBag, array $rules, ...$params) {
             try {
                 return $this->validate($rules, ...$params);

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -14,6 +14,7 @@ use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
 /**
  * @method array validate(array $rules, ...$params)
+ * @method array validateWith(array|string $rules, array $fields)
  * @method array validateWithBag(string $errorBag, array $rules, ...$params)
  * @method bool hasValidSignature(bool $absolute = true)
  */

--- a/tests/Integration/Validation/RequestValidationTest.php
+++ b/tests/Integration/Validation/RequestValidationTest.php
@@ -54,7 +54,7 @@ class RequestValidationTest extends TestCase
         $input = [
             'age' => 23,
             'height' => 175,
-            'weight' => 62
+            'weight' => 62,
         ];
 
         $request = Request::create('/', 'GET', $input);
@@ -70,7 +70,7 @@ class RequestValidationTest extends TestCase
 
         $request = Request::create('/', 'GET', [
             'first_name' => 'John2',
-            'last_name' => 'Doe^'
+            'last_name' => 'Doe^',
         ]);
 
         $request->validateWith('alpha', ['first_name', 'last_name']);

--- a/tests/Integration/Validation/RequestValidationTest.php
+++ b/tests/Integration/Validation/RequestValidationTest.php
@@ -48,4 +48,31 @@ class RequestValidationTest extends TestCase
             $this->assertSame('some_bag', $validationException->errorBag);
         }
     }
+
+    public function testValidateWithMacro()
+    {
+        $input = [
+            'age' => 23,
+            'height' => 175,
+            'weight' => 62
+        ];
+
+        $request = Request::create('/', 'GET', $input);
+
+        $validated = $request->validateWith('numeric', ['age', 'height', 'weight']);
+
+        $this->assertSame($input, $validated);
+    }
+
+    public function testValidateWithMacroWhenItFails()
+    {
+        $this->expectException(ValidationException::class);
+
+        $request = Request::create('/', 'GET', [
+            'first_name' => 'John2',
+            'last_name' => 'Doe^'
+        ]);
+
+        $request->validateWith('alpha', ['first_name', 'last_name']);
+    }
 }


### PR DESCRIPTION
Hello!
This is my first pull request.

I have added a method named **validateWith()** to the Request class, and I think it will be very useful and elegant when we need to apply a single rule to all input fields. For instance I have a method in my controller, and I need some fields to be required, "there's no difference between our fields!"

This is how we was doing this before:
```
$request->validate([
        'first_name' => 'required',
        'last_name' => 'required',
        'another_name' => 'required',
]);
```

And this is how it works after adding my method:
`$request->validateWith('required', ['first_name', 'last_name', 'another_name']);`