### PR TITLE
[8.x] Add setPusher() to PusherBroadcaster::class

### DIFF
--- a/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
@@ -160,4 +160,15 @@ class PusherBroadcaster extends Broadcaster
     {
         return $this->pusher;
     }
+
+    /**
+     * Set the Pusher SDK instance.
+     *
+     * @param \Pusher\Pusher $pusher
+     * @return void
+     */
+    public function setPusher($pusher)
+    {
+        $this->pusher = $pusher;
+    }
 }


### PR DESCRIPTION
Hi,

This PR only add a `setPusher()` to  the PusherBroadcaster class.

The reason is the `pusher` SDK instance is constructed from the configs using `app_id`, `key` and `secret`. 

When we register the channels for broadcasting during the Application boot phase this is cached inside the BroadcastManager singleton.

In an application with many pusher configurations saved in database (ex: multitenant) those configs need to be switch in a middleware for each request.

Without a setter to change the Pusher SDK instance we need to hack using reflexion or forget the driver and then re-configure it.

Thanks :-)