### PR TITLE
[8.x] Typo fix in Bus::hasFinallyCallbacks() docblock

### DIFF
--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -368,7 +368,7 @@ class Batch implements Arrayable, JsonSerializable
     }
 
     /**
-     * Determine if the batch has "then" callbacks.
+     * Determine if the batch has "finally" callbacks.
      *
      * @return bool
      */


### PR DESCRIPTION
In the `Bus::hasFinallyCallbacks()` method there is a docblock that says about `then` callbacks, while the method body checks for `finally`, and the method name is all about `finally` callback.