### PR TITLE
[8.x] Allow the use of temporary views for Blade testing on Windows machines

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithViews.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithViews.php
@@ -38,11 +38,12 @@ trait InteractsWithViews
             ViewFacade::addLocation(sys_get_temp_dir());
         }
 
-        $tempFile = tempnam($tempDirectory, 'laravel-blade').'.blade.php';
+        $tempFileInfo = pathinfo(tempnam($tempDirectory, 'laravel-blade'));
+        $tempFile = $tempFileInfo['dirname'].'/'.$tempFileInfo['filename'].'.blade.php';
 
         file_put_contents($tempFile, $template);
 
-        return new TestView(view(Str::before(basename($tempFile), '.blade.php'), $data));
+        return new TestView(view($tempFileInfo['filename'], $data));
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithViews.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithViews.php
@@ -38,6 +38,7 @@ trait InteractsWithViews
         }
 
         $tempFileInfo = pathinfo(tempnam($tempDirectory, 'laravel-blade'));
+
         $tempFile = $tempFileInfo['dirname'].'/'.$tempFileInfo['filename'].'.blade.php';
 
         file_put_contents($tempFile, $template);

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithViews.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithViews.php
@@ -4,7 +4,6 @@ namespace Illuminate\Foundation\Testing\Concerns;
 
 use Illuminate\Support\Facades\View as ViewFacade;
 use Illuminate\Support\MessageBag;
-use Illuminate\Support\Str;
 use Illuminate\Support\ViewErrorBag;
 use Illuminate\Testing\TestView;
 use Illuminate\View\View;

--- a/tests/Foundation/Testing/Concerns/InteractsWithViewsTest.php
+++ b/tests/Foundation/Testing/Concerns/InteractsWithViewsTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Testing\Concerns;
+
+use Orchestra\Testbench\TestCase;
+use Illuminate\Foundation\Testing\Concerns\InteractsWithViews;
+
+class InteractsWithViewsTest extends TestCase
+{
+    use InteractsWithViews;
+
+    public function testBladeCorrectlyRendersString()
+    {
+        $string = (string) $this->blade("@if(true)test @endif");
+
+        $this->assertEquals('test ', $string);
+    }
+}

--- a/tests/Foundation/Testing/Concerns/InteractsWithViewsTest.php
+++ b/tests/Foundation/Testing/Concerns/InteractsWithViewsTest.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Tests\Foundation\Testing\Concerns;
 
-use Orchestra\Testbench\TestCase;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithViews;
+use Orchestra\Testbench\TestCase;
 
 class InteractsWithViewsTest extends TestCase
 {
@@ -11,7 +11,7 @@ class InteractsWithViewsTest extends TestCase
 
     public function testBladeCorrectlyRendersString()
     {
-        $string = (string) $this->blade("@if(true)test @endif");
+        $string = (string) $this->blade('@if(true)test @endif');
 
         $this->assertEquals('test ', $string);
     }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

For testing simple Blade strings, there is a `blade` function that creates a temporary file containing some strings content. This procedure breaks on Windows, as the created file receives a `.tmp` extension (e.g. `lar0000.tmp`). As the view name resolver replaces dots in view names with directory separators (as they are considered to be in some nested directory structure), the resolver searches for wrong path on Windows (e.g. `%TEMP%/lar0000/tmp.blade.php`).

This PR uses the filename (from `pathinfo`) rather than the basename as view name and filename, hence also works on Windows machines.