### PR TITLE
[8.x] Fix InteractsWithFlashData.php return types null in DocBlocks

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithFlashData.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithFlashData.php
@@ -9,7 +9,7 @@ trait InteractsWithFlashData
      *
      * @param  string|null  $key
      * @param  string|array|null  $default
-     * @return string|array
+     * @return string|array|null
      */
     public function old($key = null, $default = null)
     {


### PR DESCRIPTION
[InteractsWithFlashData old()](https://github.com/laravel/framework/blob/8.x/src/Illuminate/Http/Concerns/InteractsWithFlashData.php#L14)
This method may return null, when to pass the argument `$default` as null.

So this PR:
- add return types null in DocBlocks 