### PR TITLE
[8.x] Fix Http::withBody() not being sent

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -642,6 +642,8 @@ class PendingRequest
                     $options[$this->bodyFormat], $this->pendingFiles
                 );
             }
+        } else {
+            $options[$this->bodyFormat] = $this->pendingBody;
         }
 
         [$this->pendingBody, $this->pendingFiles] = [null, []];

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -76,6 +76,21 @@ class HttpClientTest extends TestCase
         $this->assertEquals(collect(), $response->collect('missing_key'));
     }
 
+    public function testSendRequestBody()
+    {
+        $body = '{"test":"phpunit"}';
+
+        $fakeRequest = function(Request $request) use ($body) {
+            self::assertSame($body, $request->body());
+
+            return ['my' => 'response'];
+        };
+
+        $this->factory->fake($fakeRequest);
+
+        $this->factory->withBody($body, 'application/json')->send('get', 'http://foo.com/api');
+    }
+
     public function testUrlsCanBeStubbedByPath()
     {
         $this->factory->fake([

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -80,7 +80,7 @@ class HttpClientTest extends TestCase
     {
         $body = '{"test":"phpunit"}';
 
-        $fakeRequest = function(Request $request) use ($body) {
+        $fakeRequest = function (Request $request) use ($body) {
             self::assertSame($body, $request->body());
 
             return ['my' => 'response'];


### PR DESCRIPTION
I'm currently building an Outgoing Webhook feature where users can select which HTTP Method they want to call and which URL. At some point in code, I have the following snippet:

```
        $response = Http::withHeaders($headers)
            ->withBody($body, 'application/json')
            ->send($webhook->method, $webhook->url);
```

However, this doesn't work because it doesn't match any condition in the `send` method, which then sends a request with an empty request body.

This pull request sends the pending body automatically if there is no instruction in `$options` on how to construct the request body.