### PR TITLE
[8.x] Include dispatchSync in the DispatchesJobs trait

### DIFF
--- a/src/Illuminate/Foundation/Bus/DispatchesJobs.php
+++ b/src/Illuminate/Foundation/Bus/DispatchesJobs.php
@@ -27,7 +27,7 @@ trait DispatchesJobs
     {
         return app(Dispatcher::class)->dispatchNow($job);
     }
-    
+
     /**
      * Dispatch a command to its appropriate handler in the current process.
      *

--- a/src/Illuminate/Foundation/Bus/DispatchesJobs.php
+++ b/src/Illuminate/Foundation/Bus/DispatchesJobs.php
@@ -27,4 +27,17 @@ trait DispatchesJobs
     {
         return app(Dispatcher::class)->dispatchNow($job);
     }
+    
+    /**
+     * Dispatch a command to its appropriate handler in the current process.
+     *
+     * Queueable jobs will be dispatched to the "sync" queue.
+     *
+     * @param  mixed  $job
+     * @return mixed
+     */
+    public function dispatchSync($job)
+    {
+        return app(Dispatcher::class)->dispatchSync($job);
+    }
 }

--- a/src/Illuminate/Foundation/Bus/DispatchesJobs.php
+++ b/src/Illuminate/Foundation/Bus/DispatchesJobs.php
@@ -22,6 +22,8 @@ trait DispatchesJobs
      *
      * @param  mixed  $job
      * @return mixed
+     *
+     * @deprecated Will be removed in a future Laravel version.
      */
     public function dispatchNow($job)
     {


### PR DESCRIPTION
Include `dispatchSync` in the `DispatchesJobs` trait, allowing users to use the new method when dispatching jobs from a controller directly.
