### PR TITLE
[8.x] Support database_url for `php artisan db` command

### DIFF
--- a/src/Illuminate/Database/Console/DbCommand.php
+++ b/src/Illuminate/Database/Console/DbCommand.php
@@ -59,8 +59,7 @@ class DbCommand extends Command
         }
 
         if (! empty($connection['url'])) {
-            $connection = (new ConfigurationUrlParser)
-                ->parseConfiguration($connection);
+            $connection = (new ConfigurationUrlParser)->parseConfiguration($connection);
         }
 
         return $connection;

--- a/src/Illuminate/Database/Console/DbCommand.php
+++ b/src/Illuminate/Database/Console/DbCommand.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\ConfigurationUrlParser;
 use Symfony\Component\Process\Process;
 use UnexpectedValueException;
 
@@ -55,6 +56,11 @@ class DbCommand extends Command
 
         if (empty($connection)) {
             throw new UnexpectedValueException("Invalid database connection [{$db}].");
+        }
+
+        if (! empty($connection['url'])) {
+            $connection = (new ConfigurationUrlParser)
+                ->parseConfiguration($connection);
         }
 
         return $connection;


### PR DESCRIPTION
# Problem

When you are using `DATABASE_URL` in your `.env` and run `php artisan db` it doesn't open database CLI and throws an error 

`.env` file

```
DATABASE_URL=mysql://root:password@mysql:3306/database
````

The thrown error
```
Symfony\Component\Process\Exception\ProcessFailedException 

The command "'mysql' '--host=127.0.0.1' '--port=3306' '--user=forge' '--default-character-set=utf8mb4' 'forge'" failed.

Exit Code: 1(General error)
```

As you can see the `php artisan db` will look for `DB_CONNECTION`, `DB_HOST`, `DB_PORT` etc. in `.env` file and if they are not exist it will fallback to the default database configuration defined in `config/database.php` and it will not parse the `DATABASE_URL`

 # Solution

To fix this we need check if the `url` is set and not empty in the `$connection` array then parse and return the new `$connection` configuration

```
if (! empty($connection['url'])) {
    $connection = (new ConfigurationUrlParser)
        ->parseConfiguration($connection);
}
``` 