### PR TITLE
[9.x] Add sole() to Enumerable contract

### DIFF
--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -809,6 +809,20 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function split($numberOfGroups);
 
     /**
+     * Get the first item in the collection, but only if exactly
+     * item exists. Otherwise, throw an exception.
+     *
+     * @param  mixed  $key
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return mixed
+     *
+     * @throws \Illuminate\Collections\ItemNotFoundException
+     * @throws \Illuminate\Collections\MultipleItemsFoundException
+     */
+    public function sole($key = null, $operator = null, $value = null);
+
+    /**
      * Chunk the collection into chunks of the given size.
      *
      * @param  int  $size

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -809,8 +809,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function split($numberOfGroups);
 
     /**
-     * Get the first item in the collection, but only if exactly
-     * item exists. Otherwise, throw an exception.
+     * Get the first item in the collection, but only if exactly one item exists. Otherwise, throw an exception.
      *
      * @param  mixed  $key
      * @param  mixed  $operator


### PR DESCRIPTION
Hey! I'm just making this PR so that the ` sole() ` method that got merged in today (https://github.com/laravel/framework/pull/37034) will be in the ` Enumerable ` contract for Laravel 9.

If this is the wrong time/place to make the PR, please let me know.