### PR TITLE
[8.x] Allow fallback encryption keys

### DIFF
--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -17,6 +17,34 @@ class EncrypterTest extends TestCase
         $this->assertSame('foo', $e->decrypt($encrypted));
     }
 
+    public function testFallbackEncryption()
+    {
+        $e = new Encrypter(str_repeat('a', 16));
+        $encrypted = $e->encrypt('foo');
+
+        $this->assertNotSame('foo', $encrypted);
+
+        $e = new Encrypter(str_repeat('b', 16));
+        $e->additionalDecryptionKeys([str_repeat('c', 16), str_repeat('a', 16)]);
+
+        $this->assertSame('foo', $e->decrypt($encrypted));
+    }
+
+    public function testFallbackEncryptionThrowsExceptionIfAllKeysFail()
+    {
+        $this->expectException(RuntimeException::class);
+
+        $e = new Encrypter(str_repeat('a', 16));
+        $encrypted = $e->encrypt('foo');
+
+        $this->assertNotSame('foo', $encrypted);
+
+        $e = new Encrypter(str_repeat('b', 16));
+        $e->additionalDecryptionKeys([str_repeat('c', 16), str_repeat('x', 16)]);
+
+        $e->decrypt($encrypted);
+    }
+
     public function testRawStringEncryption()
     {
         $e = new Encrypter(str_repeat('a', 16));


### PR DESCRIPTION
This pull request allows users to gracefully rotate encryption keys (`app.key`) by moving old keys to an `app.previous_keys` configuration item and placing the new key in `app.key`. The encrypter will encrypt data using the latest application key, but will attempt to use the current key as well as all previous keys when decrypting. This approach is similar to the approach taken by Ruby on Rails.