### PR TITLE
[8.x] Add `Cookie::queueForget()` method

### DIFF
--- a/src/Illuminate/Cookie/CookieJar.php
+++ b/src/Illuminate/Cookie/CookieJar.php
@@ -154,6 +154,19 @@ class CookieJar implements JarContract
     }
 
     /**
+     * Queue a cookie to expire with the next response.
+     *
+     * @param  string  $name
+     * @param  string|null  $path
+     * @param  string|null  $domain
+     * @return void
+     */
+    public function queueForget($name, $path = null, $domain = null)
+    {
+        $this->queue($this->forget($name, $path, $domain));
+    }
+
+    /**
      * Remove a cookie from the queue.
      *
      * @param  string  $name

--- a/tests/Cookie/CookieTest.php
+++ b/tests/Cookie/CookieTest.php
@@ -118,6 +118,22 @@ class CookieTest extends TestCase
         $this->assertFalse($cookieJar->hasQueued('foo', '/wrongPath'));
     }
 
+    public function testQueueForget()
+    {
+        $cookieJar = $this->getCreator();
+        $this->assertCount(0, $cookieJar->getQueuedCookies());
+
+        $cookieJar->queueForget('foobar', '/path', '/domain');
+
+        $cookie = $cookieJar->queued('foobar');
+        $this->assertEquals('foobar', $cookie->getName());
+        $this->assertEquals(null, $cookie->getValue());
+        $this->assertEquals('/path', $cookie->getPath());
+        $this->assertEquals('/domain', $cookie->getDomain());
+        $this->assertTrue($cookie->getExpiresTime() < time());
+        $this->assertCount(1, $cookieJar->getQueuedCookies());
+    }
+
     public function testUnqueue()
     {
         $cookie = $this->getCreator();


### PR DESCRIPTION
This PR adds the `Cookie::queueForget()` method to queue a cookie to expire with the next response.

After reading [docs](https://laravel.com/docs/master/responses#expiring-cookies-early), I've noticed that in order to do that it's recommended to use the following combination:

```php
Cookie::queue(Cookie::forget('name'));
```

This PR makes it a bit more readable and easier for the end-user:

```php
Cookie::queueForget('name');
```

PS: Here's the proper [PR to fix the docs](https://github.com/laravel/docs/pull/7011) 👍