### PR TITLE
[8.x] Use `reduce()` from the `reduceWithKeys()` because they're identical

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -753,13 +753,7 @@ trait EnumeratesValues
      */
     public function reduceWithKeys(callable $callback, $initial = null)
     {
-        $result = $initial;
-
-        foreach ($this as $key => $value) {
-            $result = $callback($result, $value, $key);
-        }
-
-        return $result;
+        return $this->reduce($callback, $initial);
     }
 
     /**


### PR DESCRIPTION
While reading docs, I've noticed that Collection's `reduce()` method uses `reduceWithKeys()` in one of its examples.

I've created a [PR to fix that in docs](https://github.com/laravel/docs/pull/7012).

Also, I've noticed that these two methods are [100% identical](https://github.com/laravel/framework/blob/35a9d36b7d7f0b3d11417461f7b742a2c5df3fdb/src/Illuminate/Collections/Traits/EnumeratesValues.php#L736-L763) under the hood.

Probably we keep `reduceWithKeys()` for the backward compatibility, but in order to make it clear _(and slightly reduce the codebase)_ - we could use `reduce()` from the `reduceWithKeys()` instead of redefining the same logic.

PS: We still have [tests for the `reduceWithKeys()` method](https://github.com/laravel/framework/blob/35a9d36b7d7f0b3d11417461f7b742a2c5df3fdb/tests/Support/SupportCollectionTest.php#L3706-L3715), and they're still green 👍