### PR TITLE
[8.x] fix JsonResponse::fromJasonString() double encoding string

### DIFF
--- a/src/Illuminate/Http/JsonResponse.php
+++ b/src/Illuminate/Http/JsonResponse.php
@@ -22,13 +22,14 @@ class JsonResponse extends BaseJsonResponse
      * @param  int  $status
      * @param  array  $headers
      * @param  int  $options
+     * @param bool  $json
      * @return void
      */
-    public function __construct($data = null, $status = 200, $headers = [], $options = 0)
+    public function __construct($data = null, $status = 200, $headers = [], $options = 0, $json = false)
     {
         $this->encodingOptions = $options;
 
-        parent::__construct($data, $status, $headers);
+        parent::__construct($data, $status, $headers, $json);
     }
 
     /**
@@ -117,5 +118,13 @@ class JsonResponse extends BaseJsonResponse
     public function hasEncodingOption($option)
     {
         return (bool) ($this->encodingOptions & $option);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function fromJsonString(?string $data = null, int $status = 200, array $headers = [])
+    {
+        return new static($data, $status, $headers, 0, true);
     }
 }

--- a/tests/Http/HttpJsonResponseTest.php
+++ b/tests/Http/HttpJsonResponseTest.php
@@ -104,6 +104,14 @@ class HttpJsonResponseTest extends TestCase
             [$nan],
         ];
     }
+
+    public function testFromJsonString()
+    {
+        $json_string = '{"foo":"bar"}';
+        $response = JsonResponse::fromJsonString($json_string);
+
+        $this->assertSame('bar', $response->getData()->foo);
+    }
 }
 
 class JsonResponseTestJsonableObject implements Jsonable


### PR DESCRIPTION
The Illuminate\Http\JsonResponse class inherits a static fromJsonString() method from the base Symfony\Component\HttpFoundation\JsonResponse class for creating a JsonResponse from an already encoded JSON string, but because of changes to the constructor signature it does not perform as expected, returning a response with the provided string reencoded as a literal string. While you can achieve the desired result like so:
```
$response = new JsonResponse();
$response->setJson($jsonString);
```
(and that's probably the preferred way to do it anyway) it seems wrong to just leave the broken function there.