### PR TITLE
[8.x] Remove invalid docblock

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -6,7 +6,6 @@ namespace Illuminate\Database\Eloquent;
  * @method static static|\Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder withTrashed(bool $withTrashed = true)
  * @method static static|\Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder onlyTrashed()
  * @method static static|\Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder withoutTrashed()
- * @method static static|\Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder restore()
  */
 trait SoftDeletes
 {


### PR DESCRIPTION
Introduced in #37022.

Now when I call `$someModel->restore()`, PHPStan uses this docblock:

https://github.com/laravel/framework/blob/68a269ad6b23327ae05e177a074c5a8e2847d589/src/Illuminate/Database/Eloquent/SoftDeletes.php#L9

Instead of the correct one:

https://github.com/laravel/framework/blob/68a269ad6b23327ae05e177a074c5a8e2847d589/src/Illuminate/Database/Eloquent/SoftDeletes.php#L102-L107

PhpStorm also complains about that:

<img width="502" alt="image" src="https://user-images.githubusercontent.com/26096713/115617428-abea2900-a2f1-11eb-8c47-7d6405529a7f.png">