### PR TITLE
[8.x] Add Stringable::whenNotEmpty()

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -745,6 +745,23 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Execute the given callback if the string is not empty.
+     *
+     * @param  callable  $callback
+     * @return static
+     */
+    public function whenNotEmpty($callback)
+    {
+        if ($this->isNotEmpty()) {
+            $result = $callback($this);
+
+            return is_null($result) ? $this : $result;
+        }
+
+        return $this;
+    }
+
+    /**
      * Limit the number of words in a string.
      *
      * @param  int  $words


### PR DESCRIPTION
This PR adds a `\Illuminate\Support\Stringable::whenNotEmpty()` method which is the inversion of the already existing `whenEmpty()` method.
This is useful if you want to handle something like prefixes - for example if the prefix isn't empty it should be finished with an underscore. Right now this isn't easily possible - with the `whenNotEmpty()` you can finish the prefix if it has a value and if not the prefix will remain empty.

```php
Str::of(env('SCOUT_PREFIX', ''))
    ->whenNotEmpty(fn (Stringable $prefix) => $prefix->finish('_'));
```