### PR TITLE
[8.x] Add prohibited_with and prohibited_without validation rules

### DIFF
--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -249,6 +249,62 @@ trait ReplacesAttributes
     }
 
     /**
+     * Replace all place-holders for the prohibited_with rule.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array  $parameters
+     * @return string
+     */
+    protected function replaceProhibitedWith($message, $attribute, $rule, $parameters)
+    {
+        return str_replace(':values', implode(' / ', $this->getAttributeList($parameters)), $message);
+    }
+
+    /**
+     * Replace all place-holders for the prohibited_with_all rule.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array  $parameters
+     * @return string
+     */
+    protected function replaceProhibitedWithAll($message, $attribute, $rule, $parameters)
+    {
+        return $this->replaceProhibitedWith($message, $attribute, $rule, $parameters);
+    }
+
+    /**
+     * Replace all place-holders for the prohibited_without rule.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array  $parameters
+     * @return string
+     */
+    protected function replaceProhibitedWithout($message, $attribute, $rule, $parameters)
+    {
+        return $this->replaceProhibitedWith($message, $attribute, $rule, $parameters);
+    }
+
+    /**
+     * Replace all place-holders for the prohibited_without_all rule.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array  $parameters
+     * @return string
+     */
+    protected function replaceProhibitedWithoutAll($message, $attribute, $rule, $parameters)
+    {
+        return $this->replaceProhibitedWith($message, $attribute, $rule, $parameters);
+    }
+
+    /**
      * Replace all place-holders for the size rule.
      *
      * @param  string  $message

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1490,6 +1490,58 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate that an attribute does not exist when any other attribute exists.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  mixed  $parameters
+     * @return bool
+     */
+    public function validateProhibitedWith($attribute, $value, $parameters)
+    {
+        return ! $this->anyPassingRequired($parameters);
+    }
+
+    /**
+     * Validate that an attribute does not exist when all other attributes exist.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  mixed  $parameters
+     * @return bool
+     */
+    public function validateProhibitedWithAll($attribute, $value, $parameters)
+    {
+        return ! $this->allPassingRequired($parameters);
+    }
+
+    /**
+     * Validate that an attribute does not exist when another attribute does not exist.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  mixed  $parameters
+     * @return bool
+     */
+    public function validateProhibitedWithout($attribute, $value, $parameters)
+    {
+        return ! $this->anyFailingRequired($parameters);
+    }
+
+    /**
+     * Validate that an attribute does not exist when all other attributes do not exist.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  mixed  $parameters
+     * @return bool
+     */
+    public function validateProhibitedWithoutAll($attribute, $value, $parameters)
+    {
+        return $this->anyPassingRequired($parameters);
+    }
+
+    /**
      * Indicate that an attribute should be excluded when another attribute has a given value.
      *
      * @param  string  $attribute
@@ -1722,6 +1774,40 @@ trait ValidatesAttributes
     {
         foreach ($attributes as $key) {
             if ($this->validateRequired($key, $this->getValue($key))) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Determine if any of the given attributes pass the required test.
+     *
+     * @param  array  $attributes
+     * @return bool
+     */
+    protected function anyPassingRequired(array $attributes)
+    {
+        foreach ($attributes as $key) {
+            if ($this->validateRequired($key, $this->getValue($key))) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Determine if all of the given attributes pass the required test.
+     *
+     * @param  array  $attributes
+     * @return bool
+     */
+    protected function allPassingRequired(array $attributes)
+    {
+        foreach ($attributes as $key) {
+            if (! $this->validateRequired($key, $this->getValue($key))) {
                 return false;
             }
         }

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -231,6 +231,10 @@ class Validator implements ValidatorContract
         'Prohibited',
         'ProhibitedIf',
         'ProhibitedUnless',
+        'ProhibitedWith',
+        'ProhibitedWithAll',
+        'ProhibitedWithout',
+        'ProhibitedWithoutAll',
         'Same',
         'Unique',
     ];

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1231,6 +1231,239 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->fails());
     }
 
+    public function testValidateProhibitedWith()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['first' => 'Taylor'], ['last' => 'prohibited_with:first']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['first' => 'Taylor', 'last' => ''], ['last' => 'prohibited_with:first']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['first' => ''], ['last' => 'prohibited_with:first']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, [], ['last' => 'prohibited_with:first']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['first' => 'Taylor', 'last' => 'Otwell'], ['last' => 'prohibited_with:first']);
+        $this->assertTrue($v->fails());
+
+        $file = new File('', false);
+        $v = new Validator($trans, ['file' => $file, 'foo' => ''], ['foo' => 'prohibited_with:file']);
+        $this->assertTrue($v->passes());
+
+        $file = new File(__FILE__, false);
+        $foo = new File(__FILE__, false);
+        $v = new Validator($trans, ['file' => $file, 'foo' => $foo], ['foo' => 'prohibited_with:file']);
+        $this->assertTrue($v->fails());
+
+        $file = new File('', false);
+        $foo = new File(__FILE__, false);
+        $v = new Validator($trans, ['file' => $file, 'foo' => $foo], ['foo' => 'prohibited_with:file']);
+        $this->assertTrue($v->passes());
+
+        $file = new File(__FILE__, false);
+        $foo = new File('', false);
+        $v = new Validator($trans, ['file' => $file, 'foo' => $foo], ['foo' => 'prohibited_with:file']);
+        $this->assertTrue($v->fails());
+    }
+
+    public function testProhibitedWithMultiple()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+
+        $rules = [
+            'f1' => 'prohibited_with:f2,f3',
+            'f2' => 'prohibited_with:f1,f3',
+            'f3' => 'prohibited_with:f1,f2',
+        ];
+
+        $v = new Validator($trans, [], $rules);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['f1' => 'foo'], $rules);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['f2' => 'foo'], $rules);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['f3' => 'foo'], $rules);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['f1' => 'foo', 'f2' => 'bar'], $rules);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['f1' => 'foo', 'f3' => 'bar'], $rules);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['f2' => 'foo', 'f3' => 'bar'], $rules);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['f1' => 'foo', 'f2' => 'bar', 'f3' => 'baz'], $rules);
+        $this->assertTrue($v->fails());
+    }
+
+    public function testProhibitedWithAll()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+
+        $rules = [
+            'f1' => 'prohibited_with_all:f2,f3',
+            'f2' => 'prohibited_with_all:f1,f3',
+            'f3' => 'prohibited_with_all:f1,f2',
+
+        ];
+
+        $v = new Validator($trans, [], $rules);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['f1' => 'foo'], $rules);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['f2' => 'foo'], $rules);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['f3' => 'foo'], $rules);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['f1' => 'foo', 'f2' => 'bar'], $rules);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['f1' => 'foo', 'f3' => 'bar'], $rules);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['f2' => 'foo', 'f3' => 'bar'], $rules);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['f1' => 'foo', 'f2' => 'bar', 'f3' => 'baz'], $rules);
+        $this->assertTrue($v->fails());
+    }
+
+    public function testValidateProhibitedWithout()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['first' => 'Taylor'], ['last' => 'prohibited_without:first']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['first' => 'Taylor', 'last' => ''], ['last' => 'prohibited_without:first']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['first' => ''], ['last' => 'prohibited_without:first']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, [], ['last' => 'prohibited_without:first']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['first' => 'Taylor', 'last' => 'Otwell'], ['last' => 'prohibited_without:first']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['last' => 'Otwell'], ['last' => 'prohibited_without:first']);
+        $this->assertTrue($v->fails());
+
+        $file = new File('', false);
+        $v = new Validator($trans, ['file' => $file], ['foo' => 'prohibited_without:file']);
+        $this->assertTrue($v->passes());
+
+        $foo = new File('', false);
+        $v = new Validator($trans, ['foo' => $foo], ['foo' => 'prohibited_without:file']);
+        $this->assertTrue($v->fails());
+
+        $foo = new File(__FILE__, false);
+        $v = new Validator($trans, ['foo' => $foo], ['foo' => 'prohibited_without:file']);
+        $this->assertTrue($v->fails());
+
+        $file = new File(__FILE__, false);
+        $foo = new File(__FILE__, false);
+        $v = new Validator($trans, ['file' => $file, 'foo' => $foo], ['foo' => 'prohibited_without:file']);
+        $this->assertTrue($v->passes());
+
+        $file = new File(__FILE__, false);
+        $foo = new File('', false);
+        $v = new Validator($trans, ['file' => $file, 'foo' => $foo], ['foo' => 'prohibited_without:file']);
+        $this->assertTrue($v->passes());
+
+        $file = new File('', false);
+        $foo = new File(__FILE__, false);
+        $v = new Validator($trans, ['file' => $file, 'foo' => $foo], ['foo' => 'prohibited_without:file']);
+        $this->assertTrue($v->fails());
+
+        $file = new File('', false);
+        $foo = new File('', false);
+        $v = new Validator($trans, ['file' => $file, 'foo' => $foo], ['foo' => 'prohibited_without:file']);
+        $this->assertTrue($v->fails());
+    }
+
+    public function testProhibitedWithoutMultiple()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+
+        $rules = [
+            'f1' => 'prohibited_without:f2,f3',
+            'f2' => 'prohibited_without:f1,f3',
+            'f3' => 'prohibited_without:f1,f2',
+        ];
+
+        $v = new Validator($trans, [], $rules);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['f1' => 'foo'], $rules);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['f2' => 'foo'], $rules);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['f3' => 'foo'], $rules);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['f1' => 'foo', 'f2' => 'bar'], $rules);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['f1' => 'foo', 'f3' => 'bar'], $rules);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['f2' => 'foo', 'f3' => 'bar'], $rules);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['f1' => 'foo', 'f2' => 'bar', 'f3' => 'baz'], $rules);
+        $this->assertTrue($v->passes());
+    }
+
+    public function testProhibitedWithoutAll()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+
+        $rules = [
+            'f1' => 'prohibited_without_all:f2,f3',
+            'f2' => 'prohibited_without_all:f1,f3',
+            'f3' => 'prohibited_without_all:f1,f2',
+        ];
+
+        $v = new Validator($trans, [], $rules);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['f1' => 'foo'], $rules);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['f2' => 'foo'], $rules);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['f3' => 'foo'], $rules);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['f1' => 'foo', 'f2' => 'bar'], $rules);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['f1' => 'foo', 'f3' => 'bar'], $rules);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['f2' => 'foo', 'f3' => 'bar'], $rules);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['f1' => 'foo', 'f2' => 'bar', 'f3' => 'baz'], $rules);
+        $this->assertTrue($v->passes());
+    }
+
     public function testProhibitedIf()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
Now that #36516 and #36667 are merged, I would like to add the missing rules to have same ruleset that the `required` ones.

This PR add : 
   * `prohibited_with`: Validate that this attribute does not exist when any indicated attribute exists.
   * `prohibited_with_all`: Validate that this attribute does not exist when all indicated attributes exist.
   * `prohibited_without`: Validate that this attribute does not exist when indicated attribute does not exist. 
   * `prohibited_without_all`: Validate that this attribute does not exist when all indicated attributes do not exist.

Example from the application I am currently working on:
```php
Validator::validate([
    'start_date' => '2021-01', 
    'end_date' => '2021-03',
    'duration' => 'quarter'
], [
    'start_date' => ['date_format:Y-m', 'required_with:end_date'],
    'end_date' => [
        'date_format:Y-m',
        'prohibited_with:duration',
        'prohibited_without:start_date',
        'after_or_equal:options.start',
    ],
    'duration' => ['sometimes', 'in:month,quarter,custom'],
]);
```