### PR TITLE
[8.x] Add assertUnprocessableEntity method on TestResponse

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -173,6 +173,23 @@ class TestResponse implements ArrayAccess
     }
 
     /**
+     * Assert that the response has an unprocessable entity status code.
+     *
+     * @return $this
+     */
+    public function assertUnprocessableEntity()
+    {
+        $actual = $this->getStatusCode();
+
+        PHPUnit::assertSame(
+            422, $actual,
+            "Response status code [{$actual}] is not an unprocessable entity status code."
+        );
+
+        return $this;
+    }
+
+    /**
      * Assert that the response has the given status code.
      *
      * @param  int  $status

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -465,6 +465,22 @@ class TestResponseTest extends TestCase
         $response->assertUnauthorized();
     }
 
+    public function testAssertUnprocessableEntity()
+    {
+        $statusCode = 500;
+
+        $this->expectException(AssertionFailedError::class);
+
+        $this->expectExceptionMessage('Response status code ['.$statusCode.'] is not an unprocessable entity status code.');
+
+        $baseResponse = tap(new Response, function ($response) use ($statusCode) {
+            $response->setStatusCode($statusCode);
+        });
+
+        $response = TestResponse::fromBaseResponse($baseResponse);
+        $response->assertUnprocessableEntity();
+    }
+
     public function testAssertNoContentAsserts204StatusCodeByDefault()
     {
         $statusCode = 500;


### PR DESCRIPTION
I wonder why TestResponse class has usufeful methods like assertOk, assertForbidden, assertUnauthorized etc but has no method to assert 422.

I usually test against input validation errors (that send a 422 response) and I would like to use 

```php
$response->assertUnprocessableEntity();
```

 instead of

```php
$response->assertStatus(422);
```