### PR TITLE
[8.x] Enable mailgun batch sending

### DIFF
--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -315,7 +315,8 @@ class MailManager implements FactoryContract
             $this->guzzle($config),
             $config['secret'],
             $config['domain'],
-            $config['endpoint'] ?? null
+            $config['endpoint'] ?? null,
+            $config['batch_sending'] ?? false
         );
     }
 

--- a/src/Illuminate/Mail/Transport/MailgunTransport.php
+++ b/src/Illuminate/Mail/Transport/MailgunTransport.php
@@ -4,6 +4,7 @@ namespace Illuminate\Mail\Transport;
 
 use GuzzleHttp\ClientInterface;
 use Swift_Mime_SimpleMessage;
+use Illuminate\Support\Facades\Config;
 
 class MailgunTransport extends Transport
 {
@@ -93,7 +94,7 @@ class MailgunTransport extends Transport
      */
     protected function payload(Swift_Mime_SimpleMessage $message, $to)
     {
-        if (! config('services.mailgun.batch_sending') || count($message->getTo()) === 1) {
+        if (! Config::get('services.mailgun.batch_sending', false) || count($message->getTo()) === 1) {
             return [
                 'auth' => [
                     'api',

--- a/src/Illuminate/Mail/Transport/MailgunTransport.php
+++ b/src/Illuminate/Mail/Transport/MailgunTransport.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Mail\Transport;
 
 use GuzzleHttp\ClientInterface;
-use Illuminate\Support\Facades\Config;
 use Swift_Mime_SimpleMessage;
 
 class MailgunTransport extends Transport
@@ -37,19 +36,28 @@ class MailgunTransport extends Transport
     protected $endpoint;
 
     /**
+     * Whether enable Mailgun batch sending.
+     *
+     * @var bool
+     */
+    protected $batchSending;
+
+    /**
      * Create a new Mailgun transport instance.
      *
      * @param  \GuzzleHttp\ClientInterface  $client
      * @param  string  $key
      * @param  string  $domain
      * @param  string|null  $endpoint
+     * @param  bool $batchSending
      * @return void
      */
-    public function __construct(ClientInterface $client, $key, $domain, $endpoint = null)
+    public function __construct(ClientInterface $client, $key, $domain, $endpoint = null, $batchSending = false)
     {
         $this->key = $key;
         $this->client = $client;
         $this->endpoint = $endpoint ?? 'api.mailgun.net';
+        $this->batchSending = $batchSending;
 
         $this->setDomain($domain);
     }
@@ -94,7 +102,7 @@ class MailgunTransport extends Transport
      */
     protected function payload(Swift_Mime_SimpleMessage $message, $to)
     {
-        if (! Config::get('services.mailgun.batch_sending', false) || count($message->getTo()) === 1) {
+        if (! $this->batchSending || count($message->getTo()) === 1) {
             return [
                 'auth' => [
                     'api',

--- a/src/Illuminate/Mail/Transport/MailgunTransport.php
+++ b/src/Illuminate/Mail/Transport/MailgunTransport.php
@@ -93,7 +93,7 @@ class MailgunTransport extends Transport
      */
     protected function payload(Swift_Mime_SimpleMessage $message, $to)
     {
-        if (!config('services.mailgun.batch_sending') || count($message->getTo()) === 1) {
+        if (! config('services.mailgun.batch_sending') || count($message->getTo()) === 1) {
             return [
                 'auth' => [
                     'api',
@@ -115,22 +115,22 @@ class MailgunTransport extends Transport
 
         //  batch sending
         $ret = [
-                'auth' => [
-                    'api',
-                    $this->key,
+            'auth' => [
+                'api',
+                $this->key,
+            ],
+            'multipart' => [
+                [
+                    'name' => 'message',
+                    'contents' => str_replace(
+                        $message->getHeaders()->get('to')->toString(),
+                        'To: %recipient%' . PHP_EOL,
+                        $message->toString()
+                    ),
+                    'filename' => 'message.mime',
                 ],
-                'multipart' => [
-                    [
-                        'name' => 'message',
-                        'contents' => str_replace(
-                            $message->getHeaders()->get('to')->toString(),
-                            'To: %recipient%' . PHP_EOL,
-                            $message->toString()
-                        ),
-                        'filename' => 'message.mime',
-                    ],
-                ],
-            ];
+            ],
+        ];
 
         $recipients = [];
         foreach ($message->getTo() as $address => $name) {

--- a/src/Illuminate/Mail/Transport/MailgunTransport.php
+++ b/src/Illuminate/Mail/Transport/MailgunTransport.php
@@ -3,8 +3,8 @@
 namespace Illuminate\Mail\Transport;
 
 use GuzzleHttp\ClientInterface;
-use Swift_Mime_SimpleMessage;
 use Illuminate\Support\Facades\Config;
+use Swift_Mime_SimpleMessage;
 
 class MailgunTransport extends Transport
 {
@@ -125,7 +125,7 @@ class MailgunTransport extends Transport
                     'name' => 'message',
                     'contents' => str_replace(
                         $message->getHeaders()->get('to')->toString(),
-                        'To: %recipient%' . PHP_EOL,
+                        'To: %recipient%'.PHP_EOL,
                         $message->toString()
                     ),
                     'filename' => 'message.mime',


### PR DESCRIPTION
This patch enables batch sending of Mailgun, while still using Mailable class for mail.

Nothing will happen if the application developer does not add 'batch_sending' => true to config/services.php, mailgun section.

Have tested in my own project which requires https://github.com/leondeng/laravel-batch-mailgun.