### PR TITLE
[8.x] Add `timestamps` to model save options

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -843,10 +843,16 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
             return false;
         }
 
+        $timestamps = $this->timestamps;
+
         // If the model already exists in the database we can just update our record
         // that is already in this database using the current IDs in this "where"
         // clause to only update this model. Otherwise, we'll just insert them.
         if ($this->exists) {
+            if (($options['timestamps'] ?? null) === false) {
+                $this->timestamps = false;
+            }
+
             $saved = $this->isDirty() ?
                         $this->performUpdate($query) : true;
         }
@@ -869,6 +875,8 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
         if ($saved) {
             $this->finishSave($options);
         }
+
+        $this->timestamps = $timestamps;
 
         return $saved;
     }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -443,6 +443,23 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertTrue($model->save());
     }
 
+    public function testUpdateProcessWithoutTimestampsUsingSaveOptions()
+    {
+        $model = $this->getMockBuilder(EloquentModelEventObjectStub::class)->onlyMethods(['newModelQuery', 'updateTimestamps', 'fireModelEvent'])->getMock();
+        $query = m::mock(Builder::class);
+        $query->shouldReceive('where')->once()->with('id', '=', 1);
+        $query->shouldReceive('update')->once()->with(['name' => 'taylor'])->andReturn(1);
+        $model->expects($this->once())->method('newModelQuery')->willReturn($query);
+        $model->expects($this->never())->method('updateTimestamps');
+        $model->expects($this->any())->method('fireModelEvent')->willReturn(true);
+
+        $model->id = 1;
+        $model->syncOriginal();
+        $model->name = 'taylor';
+        $model->exists = true;
+        $this->assertTrue($model->save(['timestamps' => false]));
+    }
+
     public function testUpdateUsesOldPrimaryKey()
     {
         $model = $this->getMockBuilder(EloquentModelStub::class)->onlyMethods(['newModelQuery', 'updateTimestamps'])->getMock();


### PR DESCRIPTION
This PR adds disable timestamps option to model `save` function.

A sample code before this change:
```php
// updating model without touching updated_at
$user->name = 'new name';
$user->timestamps = false;
$user->save();
$user->timestamps = true;
```

Same code after this change:
```php
$user->name = 'new name';
$user->save(['timestamps' => false]);
```
Or using `update`:
```php
$user->update(['name ' => 'new name'], ['timestamps' => false]);
```
