### PR TITLE
[8.x] Use helper functions filled() and blank() on collections

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -786,6 +786,28 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
+     * Get the items that are not filled.
+     *
+     * @param  mixed  $keys
+     * @return static
+     */
+    public function blank()
+    {
+        return $this->filter(fn($item) => blank($item));
+    }
+
+    /**
+     * Get the items that are not blank.
+     *
+     * @param  mixed  $keys
+     * @return static
+     */
+    public function filled()
+    {
+        return $this->filter(fn($item) => filled($item));
+    }
+
+    /**
      * Get and remove the last item from the collection.
      *
      * @return mixed

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -793,7 +793,7 @@ class Collection implements ArrayAccess, Enumerable
      */
     public function blank()
     {
-        return $this->filter(fn($item) => blank($item));
+        return $this->filter(fn ($item) => blank($item));
     }
 
     /**
@@ -804,7 +804,7 @@ class Collection implements ArrayAccess, Enumerable
      */
     public function filled()
     {
-        return $this->filter(fn($item) => filled($item));
+        return $this->filter(fn ($item) => filled($item));
     }
 
     /**

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -793,9 +793,7 @@ class Collection implements ArrayAccess, Enumerable
      */
     public function blank()
     {
-        return $this->filter(function ($item) {
-            return blank($item);
-        });
+        return $this->filter('blank');
     }
 
     /**

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -804,9 +804,7 @@ class Collection implements ArrayAccess, Enumerable
      */
     public function filled()
     {
-        return $this->filter(function ($item) {
-            return filled($item);
-        });
+        return $this->filter('filled');
     }
 
     /**

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -793,7 +793,9 @@ class Collection implements ArrayAccess, Enumerable
      */
     public function blank()
     {
-        return $this->filter(fn ($item) => blank($item));
+        return $this->filter(function ($item) {
+            return blank($item);
+        });
     }
 
     /**
@@ -804,7 +806,9 @@ class Collection implements ArrayAccess, Enumerable
      */
     public function filled()
     {
-        return $this->filter(fn ($item) => filled($item));
+        return $this->filter(function ($item) {
+            return filled($item);
+        });
     }
 
     /**

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -816,7 +816,7 @@ class LazyCollection implements Enumerable
      */
     public function blank()
     {
-        return $this->passthru('blank', func_get_args());
+        return $this->filter('blank');
     }
 
     /**

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -827,7 +827,7 @@ class LazyCollection implements Enumerable
      */
     public function filled()
     {
-        return $this->passthru('filled', func_get_args());
+        return $this->filter('filled');
     }
 
     /**

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -825,7 +825,7 @@ class LazyCollection implements Enumerable
      * @param  mixed  $keys
      * @return static
      */
-    public function filled($source)
+    public function filled()
     {
         return $this->passthru('filled', func_get_args());
     }

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -809,6 +809,28 @@ class LazyCollection implements Enumerable
     }
 
     /**
+     * Get the items that are not filled.
+     *
+     * @param  mixed  $keys
+     * @return static
+     */
+    public function blank()
+    {
+        return $this->passthru('blank', func_get_args());
+    }
+
+    /**
+     * Get the items that are not blank.
+     *
+     * @param  mixed  $keys
+     * @return static
+     */
+    public function filled($source)
+    {
+        return $this->passthru('filled', func_get_args());
+    }
+
+    /**
      * Push all of the given items onto the collection.
      *
      * @param  iterable  $source

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3510,7 +3510,7 @@ class SupportCollectionTest extends TestCase
     {
         $data = new $collection([0, true, false, '', '   ', null, collect()]);
 
-        $this->assertEquals([0, true, false], $data->filled());
+        $this->assertEquals([0, true, false], $data->filled()->all());
     }
 
     /**
@@ -3520,7 +3520,7 @@ class SupportCollectionTest extends TestCase
     {
         $data = new $collection(['', '   ', null, collect(), 0, true, false]);
 
-        $this->assertEquals(['', '   ', null, collect()], $data->blank());
+        $this->assertEquals(['', '   ', null, collect()], $data->blank()->all());
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3506,6 +3506,26 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testFilled($collection)
+    {
+        $data = new $collection([0, true, false, '', '   ', null, collect()]);
+
+        $this->assertEquals([0, true, false], $data->filled());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testBlank($collection)
+    {
+        $data = new $collection(['', '   ', null, collect(), 0, true, false]);
+
+        $this->assertEquals(['', '   ', null, collect()], $data->filled());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testOnly($collection)
     {
         $data = new $collection(['first' => 'Taylor', 'last' => 'Otwell', 'email' => 'taylorotwell@gmail.com']);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3520,7 +3520,7 @@ class SupportCollectionTest extends TestCase
     {
         $data = new $collection(['', '   ', null, collect(), 0, true, false]);
 
-        $this->assertEquals(['', '   ', null, collect()], $data->filled());
+        $this->assertEquals(['', '   ', null, collect()], $data->blank());
     }
 
     /**


### PR DESCRIPTION
This PR adds Laravel's helper functions `filled()` and `blank()` to collections.

Example

```php
// Get filled items
$array = [1, collect(), '', 3];
collect($array)->filled()->toArray() // [1, 3];

// Get blank items
$array = [1, collect(), '', 3];
collect($array)->blank()->toArray() // [collect(), ''];
```