### PR TITLE
[8.x] Remove invalid Blade compiler test

### DIFF
--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -177,16 +177,6 @@ class ViewBladeCompilerTest extends TestCase
         $compiler->compile();
     }
 
-    public function testDontIncludeNullPath()
-    {
-        $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
-        $files->shouldReceive('get')->once()->with(null)->andReturn('Hello World');
-        $files->shouldReceive('exists')->once()->with(__DIR__)->andReturn(true);
-        $files->shouldReceive('put')->once()->with(__DIR__.'/'.sha1(null).'.php', 'Hello World');
-        $compiler->setPath(null);
-        $compiler->compile();
-    }
-
     public function testShouldStartFromStrictTypesDeclaration()
     {
         $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);


### PR DESCRIPTION
I'm not sure what is `ViewBladeCompilerTest::testDontIncludeNullPath()` meant to test, but within this test `null` is passed to `BladeCompiler::setPath()`, which docblock says it only accepts strings. It's a setter for `BladeCompiler::$path` which, according to docblock, also isn't nullable.

https://github.com/laravel/framework/blob/9267b0c4b2ea31b82f45715d047d76657635152e/tests/View/ViewBladeCompilerTest.php#L186

~~Unless I'm missing something, I'll send a PR to 9.x to remove this test and revert changes in `BladeCompiler`. If you decide this is the desired behavior, I'll update this PR to change types in docblocks to `?string`.~~