### PR TITLE
[8.x] Adjust JsonResource $wrap DocBlock

### DIFF
--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -42,7 +42,7 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     /**
      * The "data" wrapper that should be applied.
      *
-     * @var string
+     * @var string|null
      */
     public static $wrap = 'data';
 


### PR DESCRIPTION
`$wrap` is allowed to be `null`. This adjusts the DocBlock to reflect that.