### PR TITLE
[8.x] Do not execute beforeSending callbacks twice

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -819,7 +819,7 @@ class PendingRequest
     {
         return function ($handler) {
             return function ($request, $options) use ($handler) {
-                $promise = $handler($this->runBeforeSendingCallbacks($request, $options), $options);
+                $promise = $handler($request, $options);
 
                 return $promise->then(function ($response) use ($request, $options) {
                     optional($this->factory)->recordRequestResponsePair(


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

As #37105 outlines, the HTTP client executes the `beforeSending` callbacks twice when sending a request.

This is due to both `buildBeforeSendingHandler` and `buildRecordHandler` running the `runBeforeSendingCallbacks` method, and both this `build*` methods being added to the request middleware stack.

https://github.com/laravel/framework/blob/5a65f25ba37d7b60e056ce9f2268d401925b6548/src/Illuminate/Http/Client/PendingRequest.php#L786-L797

https://github.com/laravel/framework/blob/5a65f25ba37d7b60e056ce9f2268d401925b6548/src/Illuminate/Http/Client/PendingRequest.php#L804-L811

https://github.com/laravel/framework/blob/5a65f25ba37d7b60e056ce9f2268d401925b6548/src/Illuminate/Http/Client/PendingRequest.php#L818-L834

This PR removes the redundant call from `buildRecordHandler` (as it is ran after `buildBeforeSendingHandler` in the middleware stack) and simply calling `$promise = $handler($request, $options);` to keep it as a "after" middleware, using the example in Guzzle docs:

https://docs.guzzlephp.org/en/stable/handlers-and-middleware.html#middleware

Closes #37105 
