### PR TITLE
[8.x] Schedule list timezone

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -39,7 +39,7 @@ class ScheduleListCommand extends Command
                 (new CronExpression($event->expression))
                             ->getNextRunDate(Carbon::now()->setTimezone($event->timezone))
                             ->setTimezone($this->option('timezone', config('app.timezone')))
-                            ->format("Y-m-d H:i:s P"),
+                            ->format('Y-m-d H:i:s P'),
             ];
         }
 

--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -38,7 +38,8 @@ class ScheduleListCommand extends Command
                 $event->description,
                 (new CronExpression($event->expression))
                             ->getNextRunDate(Carbon::now())
-                            ->setTimezone($this->option('timezone', config('app.timezone'))),
+                            ->setTimezone($this->option('timezone', config('app.timezone')))
+                            ->format("Y-m-d H:i:s P"),
             ];
         }
 

--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -37,7 +37,7 @@ class ScheduleListCommand extends Command
                 $event->expression,
                 $event->description,
                 (new CronExpression($event->expression))
-                            ->getNextRunDate(Carbon::now())
+                            ->getNextRunDate(Carbon::now()->setTimezone($event->timezone))
                             ->setTimezone($this->option('timezone', config('app.timezone')))
                             ->format("Y-m-d H:i:s P"),
             ];


### PR DESCRIPTION
I needed the timezone output as some of my schedules utilized `->timezone()`
Also fixed an issue where the `next due` was incorrect.