### PR TITLE
[8.x] Update phpdoc for event listeners

### DIFF
--- a/src/Illuminate/Contracts/Events/Dispatcher.php
+++ b/src/Illuminate/Contracts/Events/Dispatcher.php
@@ -7,7 +7,7 @@ interface Dispatcher
     /**
      * Register an event listener with the dispatcher.
      *
-     * @param  \Closure|string|array  $events
+     * @param  \Closure|\Illuminate\Events\QueuedClosure|string|array  $events
      * @param  \Closure|string|array|null  $listener
      * @return void
      */

--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -147,7 +147,7 @@ trait HasEvents
      * Register a model event with the dispatcher.
      *
      * @param  string  $event
-     * @param  \Closure|string  $callback
+     * @param  \Closure|\Illuminate\Events\QueuedClosure|string  $callback
      * @return void
      */
     protected static function registerModelEvent($event, $callback)
@@ -230,7 +230,7 @@ trait HasEvents
     /**
      * Register a retrieved model event with the dispatcher.
      *
-     * @param  \Closure|string  $callback
+     * @param  \Closure|\Illuminate\Events\QueuedClosure|string  $callback
      * @return void
      */
     public static function retrieved($callback)
@@ -241,7 +241,7 @@ trait HasEvents
     /**
      * Register a saving model event with the dispatcher.
      *
-     * @param  \Closure|string  $callback
+     * @param  \Closure|\Illuminate\Events\QueuedClosure|string  $callback
      * @return void
      */
     public static function saving($callback)
@@ -252,7 +252,7 @@ trait HasEvents
     /**
      * Register a saved model event with the dispatcher.
      *
-     * @param  \Closure|string  $callback
+     * @param  \Closure|\Illuminate\Events\QueuedClosure|string  $callback
      * @return void
      */
     public static function saved($callback)
@@ -263,7 +263,7 @@ trait HasEvents
     /**
      * Register an updating model event with the dispatcher.
      *
-     * @param  \Closure|string  $callback
+     * @param  \Closure|\Illuminate\Events\QueuedClosure|string  $callback
      * @return void
      */
     public static function updating($callback)
@@ -274,7 +274,7 @@ trait HasEvents
     /**
      * Register an updated model event with the dispatcher.
      *
-     * @param  \Closure|string  $callback
+     * @param  \Closure|\Illuminate\Events\QueuedClosure|string  $callback
      * @return void
      */
     public static function updated($callback)
@@ -285,7 +285,7 @@ trait HasEvents
     /**
      * Register a creating model event with the dispatcher.
      *
-     * @param  \Closure|string  $callback
+     * @param  \Closure|\Illuminate\Events\QueuedClosure|string  $callback
      * @return void
      */
     public static function creating($callback)
@@ -296,7 +296,7 @@ trait HasEvents
     /**
      * Register a created model event with the dispatcher.
      *
-     * @param  \Closure|string  $callback
+     * @param  \Closure|\Illuminate\Events\QueuedClosure|string  $callback
      * @return void
      */
     public static function created($callback)
@@ -307,7 +307,7 @@ trait HasEvents
     /**
      * Register a replicating model event with the dispatcher.
      *
-     * @param  \Closure|string  $callback
+     * @param  \Closure|\Illuminate\Events\QueuedClosure|string  $callback
      * @return void
      */
     public static function replicating($callback)
@@ -318,7 +318,7 @@ trait HasEvents
     /**
      * Register a deleting model event with the dispatcher.
      *
-     * @param  \Closure|string  $callback
+     * @param  \Closure|\Illuminate\Events\QueuedClosure|string  $callback
      * @return void
      */
     public static function deleting($callback)
@@ -329,7 +329,7 @@ trait HasEvents
     /**
      * Register a deleted model event with the dispatcher.
      *
-     * @param  \Closure|string  $callback
+     * @param  \Closure|\Illuminate\Events\QueuedClosure|string  $callback
      * @return void
      */
     public static function deleted($callback)

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -70,7 +70,7 @@ class Dispatcher implements DispatcherContract
     /**
      * Register an event listener with the dispatcher.
      *
-     * @param  \Closure|string|array  $events
+     * @param  \Closure|\Illuminate\Events\QueuedClosure|string|array  $events
      * @param  \Closure|string|array|null  $listener
      * @return void
      */

--- a/src/Illuminate/Events/NullDispatcher.php
+++ b/src/Illuminate/Events/NullDispatcher.php
@@ -67,7 +67,7 @@ class NullDispatcher implements DispatcherContract
     /**
      * Register an event listener with the dispatcher.
      *
-     * @param  \Closure|string|array  $events
+     * @param  \Closure|\Illuminate\Events\QueuedClosure|string|array  $events
      * @param  \Closure|string|array|null  $listener
      * @return void
      */

--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -190,7 +190,7 @@ class EventFake implements Dispatcher
     /**
      * Register an event listener with the dispatcher.
      *
-     * @param  \Closure|string|array  $events
+     * @param  \Closure|\Illuminate\Events\QueuedClosure|string|array  $events
      * @param  mixed  $listener
      * @return void
      */


### PR DESCRIPTION
Update phpdoc for event listeners - adds `\Illuminate\Events\QueuedClosure` (https://laravel.com/docs/8.x/events#queuable-anonymous-event-listeners)