### PR TITLE
[8.x] nestWheres function for Eloquent Builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1194,10 +1194,12 @@ class Builder
     {
         $query = $this->query;
 
+        $allWheres = $query->wheres;
+
         $query->wheres = [];
 
         $this->groupWhereSliceForScope(
-            $query, $query->wheres
+            $query, $allWheres
         );
 
         return $this;

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1186,6 +1186,24 @@ class Builder
     }
 
     /**
+     * Nest all current where statements in a single group.
+     *
+     * @return $this
+     */
+    public function nestWheres()
+    {
+        $query = $this->query;
+
+        $query->wheres = [];
+
+        $this->groupWhereSliceForScope(
+            $query, $query->wheres
+        );
+
+        return $this;
+    }
+
+    /**
      * Create a where array with nested where conditions.
      *
      * @param  array  $whereSlice

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1117,7 +1117,7 @@ class Builder
         $result = $scope(...array_values($parameters)) ?? $this;
 
         if (count((array) $query->wheres) > $originalWhereCount) {
-            $this->addNewWheresWithinGroup($query, $originalWhereCount);
+            $query->nestWheres($originalWhereCount);
         }
 
         return $result;
@@ -1135,90 +1135,6 @@ class Builder
         return $this->callScope(function (...$parameters) use ($scope) {
             return $this->model->callNamedScope($scope, $parameters);
         }, $parameters);
-    }
-
-    /**
-     * Nest where conditions by slicing them at the given where count.
-     *
-     * @param  \Illuminate\Database\Query\Builder  $query
-     * @param  int  $originalWhereCount
-     * @return void
-     */
-    protected function addNewWheresWithinGroup(QueryBuilder $query, $originalWhereCount)
-    {
-        // Here, we totally remove all of the where clauses since we are going to
-        // rebuild them as nested queries by slicing the groups of wheres into
-        // their own sections. This is to prevent any confusing logic order.
-        $allWheres = $query->wheres;
-
-        $query->wheres = [];
-
-        $this->groupWhereSliceForScope(
-            $query, array_slice($allWheres, 0, $originalWhereCount)
-        );
-
-        $this->groupWhereSliceForScope(
-            $query, array_slice($allWheres, $originalWhereCount)
-        );
-    }
-
-    /**
-     * Slice where conditions at the given offset and add them to the query as a nested condition.
-     *
-     * @param  \Illuminate\Database\Query\Builder  $query
-     * @param  array  $whereSlice
-     * @return void
-     */
-    protected function groupWhereSliceForScope(QueryBuilder $query, $whereSlice)
-    {
-        $whereBooleans = collect($whereSlice)->pluck('boolean');
-
-        // Here we'll check if the given subset of where clauses contains any "or"
-        // booleans and in this case create a nested where expression. That way
-        // we don't add any unnecessary nesting thus keeping the query clean.
-        if ($whereBooleans->contains('or')) {
-            $query->wheres[] = $this->createNestedWhere(
-                $whereSlice, $whereBooleans->first()
-            );
-        } else {
-            $query->wheres = array_merge($query->wheres, $whereSlice);
-        }
-    }
-
-    /**
-     * Nest all current where statements in a single group.
-     *
-     * @return $this
-     */
-    public function nestWheres()
-    {
-        $query = $this->query;
-
-        $allWheres = $query->wheres;
-
-        $query->wheres = [];
-
-        $this->groupWhereSliceForScope(
-            $query, $allWheres
-        );
-
-        return $this;
-    }
-
-    /**
-     * Create a where array with nested where conditions.
-     *
-     * @param  array  $whereSlice
-     * @param  string  $boolean
-     * @return array
-     */
-    protected function createNestedWhere($whereSlice, $boolean = 'and')
-    {
-        $whereGroup = $this->getQuery()->forNestedWhere();
-
-        $whereGroup->wheres = $whereSlice;
-
-        return ['type' => 'Nested', 'query' => $whereGroup, 'boolean' => $boolean];
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1833,7 +1833,6 @@ class Builder
         }
     }
 
-
     /**
      * Nest where conditions by slicing them at the given where count.
      *

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1853,7 +1853,7 @@ class Builder
             is_null($originalWhereCount) ? $allWheres : array_slice($allWheres, 0, $originalWhereCount)
         );
 
-        if (!is_null($originalWhereCount)) {
+        if (! is_null($originalWhereCount)) {
             $this->groupWhereSlice(
                 array_slice($allWheres, $originalWhereCount)
             );

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -313,8 +313,8 @@ class DatabaseQueryBuilderTest extends TestCase
             ->orWhere('status', 0)
             ->nestWheres()
             ->orWhere(function ($q) {
-            $q->where('is_active', 1)->orWhere('is_shared', 0);
-        })->nestWheres();
+                $q->where('is_active', 1)->orWhere('is_shared', 0);
+            })->nestWheres();
         $this->assertSame('select * from "users" where (("id" = ? or "status" = ?) or ("is_active" = ? or "is_shared" = ?))', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 0, 2 => 1, 3 => 0], $builder->getBindings());
     }


### PR DESCRIPTION
This pull request adds an extra function to the Eloquent query builder to nest all `WHERE` statements of the current query, which solves a shortcoming in relations with `orWhere()` clauses.

### Case description showcasing the current limitation
Say a user can have many accounts through a one-to-many relationship, where an account simply has a `user_id` property on it. However, it appears that there is also functionality for so called "shared" accounts: accounts that have an `is_shared` property set to `1`. This results in the following relation:

```php
// Models/User.php
public function accounts()
{
    return $this->hasMany(Account::class, 'user_id')->orWhere('is_shared', 1);
}
```

Now, this relation works exactly as expected. All accounts that have the `user_id` equal the user's id OR all accounts that have `is_shared=1` will come up in this relation.

However, when chaining additional query elements onto this relation, an issue arises as shown here:
```php
public function activeAccounts()
{
    return $this->accounts()->where('active', 1);
}
```
Which results in the query:
```
select *
from `accounts`
where
    `accounts`.`user_id` = 1 and
    `accounts`.`user_id` is not null or
    `is_shared` = 1 and
    `active` = 1
```
If you look closely, this may return accounts that have `active=0`, namely if the `user_id` matches. This is caused by the missing parentheses of the initial where clause:
```
// Wrong (current)
select * from `accounts` where A AND B OR C AND D
// Correct
select * from `accounts` where ( A AND B OR C ) AND D
```

### Solution
Interestingly enough, there already appears to be a fix for this which is directed solely at Query Scopes, see:
https://github.com/laravel/framework/blob/8.x/src/Illuminate/Database/Eloquent/Builder.php#L1119
(`Database/Eloquent/Builder.php :: callScope()`)

This piece of code appears to nest pre-existing where-conditions in order to apply the new query scope successfully.

However, as far as I can see there is no way to apply this nesting manually while working on a query. This means that in order to fix the described issue above, you MUST make use of a query scope which imho increases complexity. So this pull request introduces a new function that can be chained onto your query to nest all current `where` like so:

```php
// Models/User.php
public function accounts()
{
    return $this->hasMany(Account::class, 'user_id')->orWhere('is_shared', 1)->nestWheres();
}
```
outputs: ```select * from `accounts` where ( A AND B OR C )```

Now, the issue is fixed since the `OR` is bracketed with the main hasMany-where clause.

### Open ideas
- Add a `$whereCount` parameter to `nestWheres()` to only nest the first `n` where clauses (this increases complexity)
- Refactor the Eloquent Builder function `addNewWheresWithinGroup()` since it has some overlap with this problem
- Should this become a part of the main Query Builder class?
