### PR TITLE
[8.x] Add public methods from PasswordBroker concrete class to interface

### DIFF
--- a/CHANGELOG-8.x.md
+++ b/CHANGELOG-8.x.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased](https://github.com/laravel/framework/compare/v8.37.0...8.x)
 
+- Added missing public methods from `PasswordBroker` concrete class to the contract
 
 ## [v8.37.0 (2021-04-13)](https://github.com/laravel/framework/compare/v8.36.2...v8.37.0)
 

--- a/src/Illuminate/Contracts/Auth/PasswordBroker.php
+++ b/src/Illuminate/Contracts/Auth/PasswordBroker.php
@@ -58,4 +58,46 @@ interface PasswordBroker
      * @return mixed
      */
     public function reset(array $credentials, Closure $callback);
+
+    /**
+     * Get the user for the given credentials.
+     *
+     * @param  array  $credentials
+     * @return \Illuminate\Contracts\Auth\CanResetPassword|null
+     *
+     * @throws \UnexpectedValueException
+     */
+    public function getUser(array $credentials);
+
+    /**
+     * Create a new password reset token for the given user.
+     *
+     * @param  \Illuminate\Contracts\Auth\CanResetPassword  $user
+     * @return string
+     */
+    public function createToken(CanResetPassword $user);
+
+    /**
+     * Delete password reset tokens of the given user.
+     *
+     * @param  \Illuminate\Contracts\Auth\CanResetPassword  $user
+     * @return void
+     */
+    public function deleteToken(CanResetPassword $user);
+
+    /**
+     * Validate the given password reset token.
+     *
+     * @param  \Illuminate\Contracts\Auth\CanResetPassword  $user
+     * @param  string  $token
+     * @return bool
+     */
+    public function tokenExists(CanResetPassword $user, $token);
+
+    /**
+     * Get the password reset token repository implementation.
+     *
+     * @return \Illuminate\Auth\Passwords\TokenRepositoryInterface
+     */
+    public function getRepository();
 }


### PR DESCRIPTION
Currently there is only one concrete class for the `PasswordBroker` contract. This class has more public methods than the contract, some of which can be quite useful.  Especially all the methods regarding tokens, considering you can't directly `make` a `TokenRepositoryInterface`. So I've decided to add the methods to the contract. That way you only have to work with the contract and still have all the methods available.

If there's a strong case against adding these methods, I'd like to know.