### PR TITLE
[6.x] Fix nullable values for required_if

### DIFF
--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -337,7 +337,7 @@ trait FormatsMessages
         }
 
         if (is_null($value)) {
-            return 'null';
+            return 'empty';
         }
 
         return $value;

--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -336,6 +336,10 @@ trait FormatsMessages
             return $value ? 'true' : 'false';
         }
 
+        if (is_null($value)) {
+            return 'null';
+        }
+
         return $value;
     }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1094,13 +1094,44 @@ class ValidationValidatorTest extends TestCase
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.required_if' => 'The :attribute field is required when :other is :value.'], 'en');
         $v = new Validator($trans, ['foo' => 0], [
-            'foo' => 'required|boolean',
+            'foo' => 'nullable|required|boolean',
             'bar' => 'required_if:foo,true',
             'baz' => 'required_if:foo,false',
         ]);
         $this->assertTrue($v->fails());
         $this->assertCount(1, $v->messages());
         $this->assertSame('The baz field is required when foo is 0.', $v->messages()->first('baz'));
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, [], [
+            'foo' => 'nullable|boolean',
+            'baz' => 'nullable|required_if:foo,false',
+        ]);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => null], [
+            'foo' => 'nullable|boolean',
+            'baz' => 'nullable|required_if:foo,false',
+        ]);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, [], [
+            'foo' => 'nullable|boolean',
+            'baz' => 'nullable|required_if:foo,null',
+        ]);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines(['validation.required_if' => 'The :attribute field is required when :other is :value.'], 'en');
+        $v = new Validator($trans, ['foo' => null], [
+            'foo' => 'nullable|boolean',
+            'baz' => 'nullable|required_if:foo,null',
+        ]);
+        $this->assertTrue($v->fails());
+        $this->assertCount(1, $v->messages());
+        $this->assertSame('The baz field is required when foo is null.', $v->messages()->first('baz'));
     }
 
     public function testRequiredUnless()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1131,7 +1131,7 @@ class ValidationValidatorTest extends TestCase
         ]);
         $this->assertTrue($v->fails());
         $this->assertCount(1, $v->messages());
-        $this->assertSame('The baz field is required when foo is null.', $v->messages()->first('baz'));
+        $this->assertSame('The baz field is required when foo is empty.', $v->messages()->first('baz'));
     }
 
     public function testRequiredUnless()


### PR DESCRIPTION
> `required_if`, `required_unless`, `exclude_if`, `exclude_unless` (referred to below as "these rules").

This PR fixes several things:

1. A regression introduced in https://github.com/laravel/framework/pull/36969#issuecomment-826140483: we now will take into account `nullable` values the same way as we do for`boolean` values. This will make sure that if someone adds `null` to these rules, it'll get properly handled for the targetted key's value.
2. These rules will now automatically pass when the targeted key isn't present in the data. That's the `if (! Arr::has($this->data, $parameters[0])) {` part that was added to each of them. This was already expected I believe but should now fail early.
3. I've added an `if (is_null($value)) {` to `FormatsMessages` so that validation messages can display things like `The baz field is required when foo is null.`. This might be a bigger breaking change so if you want that part reverted I'll do so. Keep in mind that that will cause the validation message to display `The baz field is required when foo is .` instead.

I'd very much like a some second pair of eyes on this. @timacdonald @jessarcher if you're willing?