### PR TITLE
Allow users to translate the message on ValidationException

### DIFF
--- a/src/Illuminate/Validation/ValidationException.php
+++ b/src/Illuminate/Validation/ValidationException.php
@@ -53,7 +53,7 @@ class ValidationException extends Exception
      */
     public function __construct($validator, $response = null, $errorBag = 'default')
     {
-        parent::__construct('The given data was invalid.');
+        parent::__construct(__'The given data was invalid.'));
 
         $this->response = $response;
         $this->errorBag = $errorBag;

--- a/src/Illuminate/Validation/ValidationException.php
+++ b/src/Illuminate/Validation/ValidationException.php
@@ -53,7 +53,7 @@ class ValidationException extends Exception
      */
     public function __construct($validator, $response = null, $errorBag = 'default')
     {
-        parent::__construct(__'The given data was invalid.'));
+        parent::__construct(__('The given data was invalid.'));
 
         $this->response = $response;
         $this->errorBag = $errorBag;


### PR DESCRIPTION
This PR allows users to translate the `ValidationException` message.

Currently, it returns the exception message in english even if i use other language in my `config/app.php` locale.
Using, `en` locale:

```json
{
    "message": "The given data was invalid.",
    "errors": {
        "username": [
            "The username field is required."
        ],
        "name": [
            "The name field is required."
        ]
    }
}
```

This is the actual return using `pt-br` locale:
```json
{
    "message": "The given data was invalid.",
    "errors": {
        "username": [
            "O campo username é obrigatório."
        ],
        "name": [
            "O campo name é obrigatório."
        ]
    }
}
```
Using `__('The given data was invalid.')` i can translate the message to any language:
```json
{
    "message": "Dados inválidos.",
    "errors": {
        "username": [
            "O campo username é obrigatório."
        ],
        "name": [
            "O campo name é obrigatório."
        ]
    }
}
```