### PR TITLE
[8.x] Adds `whereRelationKey()` and `whereRelationKeyNot()`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -188,29 +188,45 @@ trait QueriesRelationships
     /**
      * Add a strict relationship condition to the query by its primary key.
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\Relation|string  $relation
-     * @param  mixed $id
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation|string|array  $relation
+     * @param  mixed|null $id
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
-    public function whereRelationKey($relation, $id)
+    public function whereRelationKey($relation, $id = null)
     {
-        return $this->whereHas($relation, static function (Builder $query) use ($id): void {
-            $query->whereKey($id);
-        });
+        if (! is_array($relation) && null !== $id) {
+            $relation = [$relation => $id];
+        }
+
+        foreach ($relation as $name => $ids) {
+            $this->whereHas($name, static function (Builder $query) use ($id): void {
+                $query->whereKey($id);
+            });
+        }
+
+        return $this;
     }
 
     /**
      * Add a strict relationship condition to the query by its primary key.
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\Relation|string  $relation
-     * @param  mixed $id
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation|string|array  $relation
+     * @param  mixed|null $id
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
-    public function whereRelationKeyNot($relation, $id)
+    public function whereRelationKeyNot($relation, $id = null)
     {
-        return $this->whereHas($relation, static function (Builder $query) use ($id): void {
-            $query->whereKeyNot($id);
-        });
+        if (! is_array($relation) && null !== $id) {
+            $relation = [$relation => $id];
+        }
+
+        foreach ($relation as $name => $ids) {
+            $this->whereHas($name, static function (Builder $query) use ($id): void {
+                $query->whereKeyNot($id);
+            });
+        }
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -189,8 +189,8 @@ trait QueriesRelationships
     /**
      * Add a strict relationship condition to the query by its primary key.
      *
-     * @param  \Illuminate\Database\Eloquent\Model|string|array  $relation
-     * @param  mixed|null $id
+     * @param  string|iterable  $relation
+     * @param  \Illuminate\Database\Eloquent\Model|string|int|null $id
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function whereRelationKey($relation, $id = null)
@@ -207,8 +207,8 @@ trait QueriesRelationships
     /**
      * Add a strict relationship condition to the query by its primary key.
      *
-     * @param  \Illuminate\Database\Eloquent\Model|string|array  $relation
-     * @param  mixed|null $id
+     * @param  string|iterable  $relation
+     * @param  \Illuminate\Database\Eloquent\Model|string|int|null $id
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function whereRelationKeyNot($relation, $id = null)
@@ -225,8 +225,8 @@ trait QueriesRelationships
     /**
      * Parses the relation key for querying.
      *
-     * @param  $relation
-     * @param  $id
+     * @param  string|iterable $relation
+     * @param  \Illuminate\Database\Eloquent\Model|string|int|null $id
      * @return iterable
      */
     protected function parseRelationKey($relation, $id): iterable

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -197,7 +197,7 @@ trait QueriesRelationships
     {
         foreach ($this->parseRelationKey($relation, $id) as $name => $ids) {
             $this->whereHas($name, static function (Builder $query) use ($ids): void {
-                $query->whereKey($ids);
+                $query->whereKey($ids instanceof Model ? $ids->getKey() : $ids);
             });
         }
 
@@ -215,7 +215,7 @@ trait QueriesRelationships
     {
         foreach ($this->parseRelationKey($relation, $id) as $name => $ids) {
             $this->whereHas($name, static function (Builder $query) use ($ids): void {
-                $query->whereKeyNot($ids);
+                $query->whereKeyNot($ids instanceof Model ? $ids->getKey() : $ids);
             });
         }
 
@@ -231,11 +231,11 @@ trait QueriesRelationships
      */
     protected function parseRelationKey($relation, $id): iterable
     {
-        if (is_iterable($relation) && null === $id) {
-            return $relation;
+        if (!is_iterable($relation) && null !== $id) {
+            return [$relation => $id];
         }
 
-        return [$relation => $id instanceof Model ? $id->getKey() : $id];
+        return $relation;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -194,7 +194,7 @@ trait QueriesRelationships
      */
     public function whereRelationKey($relation, $id = null)
     {
-        if (! is_array($relation) && null !== $id) {
+        if (! is_iterable($relation) && null !== $id) {
             $relation = [$relation => $id];
         }
 
@@ -216,7 +216,7 @@ trait QueriesRelationships
      */
     public function whereRelationKeyNot($relation, $id = null)
     {
-        if (! is_array($relation) && null !== $id) {
+        if (! is_iterable($relation) && null !== $id) {
             $relation = [$relation => $id];
         }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database\Eloquent\Concerns;
 
 use Closure;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Builder as QueryBuilder;
@@ -183,6 +184,34 @@ trait QueriesRelationships
     public function orWhereDoesntHave($relation, Closure $callback = null)
     {
         return $this->doesntHave($relation, 'or', $callback);
+    }
+
+    /**
+     * Add a strict relationship condition to the query by its primary key.
+     *
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation|string  $relation
+     * @param  mixed $id
+     * @return \Illuminate\Database\Eloquent\Builder|static
+     */
+    public function whereRelationKey($relation, $id)
+    {
+        return $this->whereHas($relation, static function (Builder $query) use ($id): void {
+            $query->whereKey($id);
+        });
+    }
+
+    /**
+     * Add a strict relationship condition to the query by its primary key.
+     *
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation|string  $relation
+     * @param  mixed $id
+     * @return \Illuminate\Database\Eloquent\Builder|static
+     */
+    public function whereRelationKeyNot($relation, $id)
+    {
+        return $this->whereHas($relation, static function (Builder $query) use ($id): void {
+            $query->whereKeyNot($id);
+        });
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -4,7 +4,6 @@ namespace Illuminate\Database\Eloquent\Concerns;
 
 use Closure;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Builder as QueryBuilder;

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -231,7 +231,7 @@ trait QueriesRelationships
      */
     protected function parseRelationKey($relation, $id): iterable
     {
-        if (!is_iterable($relation) && null !== $id) {
+        if (! is_iterable($relation) && null !== $id) {
             return [$relation => $id];
         }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -199,8 +199,8 @@ trait QueriesRelationships
         }
 
         foreach ($relation as $name => $ids) {
-            $this->whereHas($name, static function (Builder $query) use ($id): void {
-                $query->whereKey($id);
+            $this->whereHas($name, static function (Builder $query) use ($ids): void {
+                $query->whereKey($ids);
             });
         }
 
@@ -221,8 +221,8 @@ trait QueriesRelationships
         }
 
         foreach ($relation as $name => $ids) {
-            $this->whereHas($name, static function (Builder $query) use ($id): void {
-                $query->whereKeyNot($id);
+            $this->whereHas($name, static function (Builder $query) use ($ids): void {
+                $query->whereKeyNot($ids);
             });
         }
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1210,7 +1210,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model->foo_id = 'baz';
 
         $child = (new EloquentBuilderTestModelCloseRelatedStub())->forceFill([
-            'id' => 'quux'
+            'id' => 'quux',
         ])->setKeyType('string');
 
         $builder = $model->address()->whereRelationKey('bar', $child);
@@ -1225,12 +1225,12 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model->foo_id = 'baz';
 
         $child = (new EloquentBuilderTestModelCloseRelatedStub())->forceFill([
-           'id' => 'quux'
+            'id' => 'quux',
         ])->setKeyType('string');
 
         $builder = $model->address()->whereRelationKey([
             'bar' => $child,
-            'baz' => 'bax'
+            'baz' => 'bax',
         ]);
 
         $this->assertSame('select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_close_related_stubs"."id" = ? and exists (select * from "eloquent_builder_test_model_far_related_stubs" where "eloquent_builder_test_model_close_related_stubs"."id" = "eloquent_builder_test_model_far_related_stubs"."eloquent_builder_test_model_close_related_stub_id" and "eloquent_builder_test_model_far_related_stubs"."id" in (?)) and exists (select * from "eloquent_builder_test_model_far_related_stubs" where "eloquent_builder_test_model_close_related_stubs"."id" = "eloquent_builder_test_model_far_related_stubs"."eloquent_builder_test_model_close_related_stub_id" and "eloquent_builder_test_model_far_related_stubs"."id" = ?)', $builder->toSql());
@@ -1254,7 +1254,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model->foo_id = 'baz';
 
         $child = (new EloquentBuilderTestModelCloseRelatedStub())->forceFill([
-            'id' => 'quux'
+            'id' => 'quux',
         ])->setKeyType('string');
 
         $builder = $model->address()->whereRelationKeyNot('bar', $child);
@@ -1269,12 +1269,12 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model->foo_id = 'baz';
 
         $child = (new EloquentBuilderTestModelCloseRelatedStub())->forceFill([
-            'id' => 'quux'
+            'id' => 'quux',
         ])->setKeyType('string');
 
         $builder = $model->address()->whereRelationKey([
             'bar' => $child,
-            'baz' => 'bax'
+            'baz' => 'bax',
         ]);
 
         $this->assertSame('select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_close_related_stubs"."id" = ? and exists (select * from "eloquent_builder_test_model_far_related_stubs" where "eloquent_builder_test_model_close_related_stubs"."id" = "eloquent_builder_test_model_far_related_stubs"."eloquent_builder_test_model_close_related_stub_id" and "eloquent_builder_test_model_far_related_stubs"."id" in (?)) and exists (select * from "eloquent_builder_test_model_far_related_stubs" where "eloquent_builder_test_model_close_related_stubs"."id" = "eloquent_builder_test_model_far_related_stubs"."eloquent_builder_test_model_close_related_stub_id" and "eloquent_builder_test_model_far_related_stubs"."id" = ?)', $builder->toSql());

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1193,6 +1193,52 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals(['baz', 'quux'], $builder->getBindings());
     }
 
+    public function testWhereRelationKey()
+    {
+        $model = new EloquentBuilderTestModelParentStub;
+
+        $builder = $model->where('bar', 'baz')->whereRelationKey('foo', 'quux');
+
+        $this->assertSame('select * from "eloquent_builder_test_model_parent_stubs" where "bar" = ? and exists (select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" and "eloquent_builder_test_model_close_related_stubs"."id" = ?)', $builder->toSql());
+        $this->assertEquals(['baz', 'quux'], $builder->getBindings());
+    }
+
+    public function testWhereRelationKeyWithModel()
+    {
+        $model = new EloquentBuilderTestModelParentStub;
+        $child = (new EloquentBuilderTestModelCloseRelatedStub())->forceFill([
+            'id' => 'quux'
+        ])->setKeyType('string');
+
+        $builder = $model->where('bar', 'baz')->whereRelationKey('foo', $child);
+
+        $this->assertSame('select * from "eloquent_builder_test_model_parent_stubs" where "bar" = ? and exists (select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" and "eloquent_builder_test_model_close_related_stubs"."id" in (?))', $builder->toSql());
+        $this->assertEquals(['baz', 'quux'], $builder->getBindings());
+    }
+
+    public function testWhereRelationKeyNot()
+    {
+        $model = new EloquentBuilderTestModelParentStub;
+
+        $builder = $model->where('bar', 'baz')->whereRelationKeyNot('foo', 'quux');
+
+        $this->assertSame('select * from "eloquent_builder_test_model_parent_stubs" where "bar" = ? and exists (select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" and "eloquent_builder_test_model_close_related_stubs"."id" != ?)', $builder->toSql());
+        $this->assertEquals(['baz', 'quux'], $builder->getBindings());
+    }
+
+    public function testWhereRelationKeyNotWithModel()
+    {
+        $model = new EloquentBuilderTestModelParentStub;
+        $child = (new EloquentBuilderTestModelCloseRelatedStub())->forceFill([
+            'id' => 'quux'
+        ])->setKeyType('string');
+
+        $builder = $model->where('bar', 'baz')->whereRelationKeyNot('foo', $child);
+
+        $this->assertSame('select * from "eloquent_builder_test_model_parent_stubs" where "bar" = ? and exists (select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" and "eloquent_builder_test_model_close_related_stubs"."id" not in (?))', $builder->toSql());
+        $this->assertEquals(['baz', 'quux'], $builder->getBindings());
+    }
+
     public function testWhereKeyMethodWithInt()
     {
         $model = $this->getMockModel();

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1197,9 +1197,11 @@ class DatabaseEloquentBuilderTest extends TestCase
     {
         $model = new EloquentBuilderTestModelParentStub;
 
-        $builder = $model->where('bar', 'baz')->whereRelationKey('foo', 'quux');
+        $builder = $model->foo()->whereRelationKey('bar', 'quux');
 
-        $this->assertSame('select * from "eloquent_builder_test_model_parent_stubs" where "bar" = ? and exists (select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" and "eloquent_builder_test_model_close_related_stubs"."id" = ?)', $builder->toSql());
+        // TODO: Get correct SQL.
+
+        $this->assertSame('select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_close_related_stubs"."id" is null and exists (select * from "eloquent_builder_test_model_far_related_stubs" where "eloquent_builder_test_model_close_related_stubs"."id" = "eloquent_builder_test_model_far_related_stubs"."eloquent_builder_test_model_close_related_stub_id" and "eloquent_builder_test_model_far_related_stubs"."id" = ?)', $builder->toSql());
         $this->assertEquals(['baz', 'quux'], $builder->getBindings());
     }
 
@@ -1210,7 +1212,27 @@ class DatabaseEloquentBuilderTest extends TestCase
             'id' => 'quux'
         ])->setKeyType('string');
 
-        $builder = $model->where('bar', 'baz')->whereRelationKey('foo', $child);
+        $builder = $model->foo()->whereRelationKey('bar', $child);
+
+        // TODO: Get correct SQL.
+
+        $this->assertSame('select * from "eloquent_builder_test_model_parent_stubs" where "bar" = ? and exists (select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" and "eloquent_builder_test_model_close_related_stubs"."id" in (?))', $builder->toSql());
+        $this->assertEquals(['baz', 'quux'], $builder->getBindings());
+    }
+
+    public function testWhereRelationKeyWithArray()
+    {
+        $model = new EloquentBuilderTestModelParentStub;
+        $child = (new EloquentBuilderTestModelCloseRelatedStub())->forceFill([
+           'id' => 'quux'
+        ])->setKeyType('string');
+
+        $builder = $model->foo()->whereRelationKey([
+            'bar' => $child,
+            'baz' => 'bax'
+        ]);
+
+        // TODO: Get correct SQL.
 
         $this->assertSame('select * from "eloquent_builder_test_model_parent_stubs" where "bar" = ? and exists (select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" and "eloquent_builder_test_model_close_related_stubs"."id" in (?))', $builder->toSql());
         $this->assertEquals(['baz', 'quux'], $builder->getBindings());
@@ -1220,7 +1242,9 @@ class DatabaseEloquentBuilderTest extends TestCase
     {
         $model = new EloquentBuilderTestModelParentStub;
 
-        $builder = $model->where('bar', 'baz')->whereRelationKeyNot('foo', 'quux');
+        $builder = $model->foo()->whereRelationKeyNot('bar', 'quux');
+
+        // TODO: Get correct SQL.
 
         $this->assertSame('select * from "eloquent_builder_test_model_parent_stubs" where "bar" = ? and exists (select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" and "eloquent_builder_test_model_close_related_stubs"."id" != ?)', $builder->toSql());
         $this->assertEquals(['baz', 'quux'], $builder->getBindings());
@@ -1233,9 +1257,29 @@ class DatabaseEloquentBuilderTest extends TestCase
             'id' => 'quux'
         ])->setKeyType('string');
 
-        $builder = $model->where('bar', 'baz')->whereRelationKeyNot('foo', $child);
+        $builder = $model->foo()->whereRelationKeyNot('bar', $child);
+
+        // TODO: Get correct SQL.
 
         $this->assertSame('select * from "eloquent_builder_test_model_parent_stubs" where "bar" = ? and exists (select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" and "eloquent_builder_test_model_close_related_stubs"."id" not in (?))', $builder->toSql());
+        $this->assertEquals(['baz', 'quux'], $builder->getBindings());
+    }
+
+    public function testWhereRelationKeyNotWithArray()
+    {
+        $model = new EloquentBuilderTestModelParentStub;
+        $child = (new EloquentBuilderTestModelCloseRelatedStub())->forceFill([
+            'id' => 'quux'
+        ])->setKeyType('string');
+
+        $builder = $model->foo()->whereRelationKey([
+            'bar' => $child,
+            'baz' => 'bax'
+        ]);
+
+        // TODO: Get correct SQL.
+
+        $this->assertSame('select * from "eloquent_builder_test_model_parent_stubs" where "bar" = ? and exists (select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" and "eloquent_builder_test_model_close_related_stubs"."id" in (?))', $builder->toSql());
         $this->assertEquals(['baz', 'quux'], $builder->getBindings());
     }
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1225,6 +1225,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model->foo_id = 'baz';
 
         $child = (new EloquentBuilderTestModelCloseRelatedStub())->forceFill([
+            '0' => 'invalid',
             'id' => 'quux',
         ])->setKeyType('string');
 
@@ -1269,6 +1270,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model->foo_id = 'baz';
 
         $child = (new EloquentBuilderTestModelCloseRelatedStub())->forceFill([
+            '0' => 'invalid',
             'id' => 'quux',
         ])->setKeyType('string');
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1215,7 +1215,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $builder = $model->address()->whereRelationKey('bar', $child);
 
-        $this->assertSame('select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_close_related_stubs"."id" = ? and exists (select * from "eloquent_builder_test_model_far_related_stubs" where "eloquent_builder_test_model_close_related_stubs"."id" = "eloquent_builder_test_model_far_related_stubs"."eloquent_builder_test_model_close_related_stub_id" and "eloquent_builder_test_model_far_related_stubs"."id" in (?))', $builder->toSql());
+        $this->assertSame('select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_close_related_stubs"."id" = ? and exists (select * from "eloquent_builder_test_model_far_related_stubs" where "eloquent_builder_test_model_close_related_stubs"."id" = "eloquent_builder_test_model_far_related_stubs"."eloquent_builder_test_model_close_related_stub_id" and "eloquent_builder_test_model_far_related_stubs"."id" = ?)', $builder->toSql());
         $this->assertEquals(['baz', 'quux'], $builder->getBindings());
     }
 
@@ -1259,7 +1259,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $builder = $model->address()->whereRelationKeyNot('bar', $child);
 
-        $this->assertSame('select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_close_related_stubs"."id" = ? and exists (select * from "eloquent_builder_test_model_far_related_stubs" where "eloquent_builder_test_model_close_related_stubs"."id" = "eloquent_builder_test_model_far_related_stubs"."eloquent_builder_test_model_close_related_stub_id" and "eloquent_builder_test_model_far_related_stubs"."id" not in (?))', $builder->toSql());
+        $this->assertSame('select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_close_related_stubs"."id" = ? and exists (select * from "eloquent_builder_test_model_far_related_stubs" where "eloquent_builder_test_model_close_related_stubs"."id" = "eloquent_builder_test_model_far_related_stubs"."eloquent_builder_test_model_close_related_stub_id" and "eloquent_builder_test_model_far_related_stubs"."id" != ?)', $builder->toSql());
         $this->assertEquals(['baz', 'quux'], $builder->getBindings());
     }
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1196,91 +1196,89 @@ class DatabaseEloquentBuilderTest extends TestCase
     public function testWhereRelationKey()
     {
         $model = new EloquentBuilderTestModelParentStub;
+        $model->foo_id = 'baz';
 
-        $builder = $model->foo()->whereRelationKey('bar', 'quux');
+        $builder = $model->address()->whereRelationKey('bar', 'quux');
 
-        // TODO: Get correct SQL.
-
-        $this->assertSame('select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_close_related_stubs"."id" is null and exists (select * from "eloquent_builder_test_model_far_related_stubs" where "eloquent_builder_test_model_close_related_stubs"."id" = "eloquent_builder_test_model_far_related_stubs"."eloquent_builder_test_model_close_related_stub_id" and "eloquent_builder_test_model_far_related_stubs"."id" = ?)', $builder->toSql());
+        $this->assertSame('select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_close_related_stubs"."id" = ? and exists (select * from "eloquent_builder_test_model_far_related_stubs" where "eloquent_builder_test_model_close_related_stubs"."id" = "eloquent_builder_test_model_far_related_stubs"."eloquent_builder_test_model_close_related_stub_id" and "eloquent_builder_test_model_far_related_stubs"."id" = ?)', $builder->toSql());
         $this->assertEquals(['baz', 'quux'], $builder->getBindings());
     }
 
     public function testWhereRelationKeyWithModel()
     {
         $model = new EloquentBuilderTestModelParentStub;
+        $model->foo_id = 'baz';
+
         $child = (new EloquentBuilderTestModelCloseRelatedStub())->forceFill([
             'id' => 'quux'
         ])->setKeyType('string');
 
-        $builder = $model->foo()->whereRelationKey('bar', $child);
+        $builder = $model->address()->whereRelationKey('bar', $child);
 
-        // TODO: Get correct SQL.
-
-        $this->assertSame('select * from "eloquent_builder_test_model_parent_stubs" where "bar" = ? and exists (select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" and "eloquent_builder_test_model_close_related_stubs"."id" in (?))', $builder->toSql());
+        $this->assertSame('select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_close_related_stubs"."id" = ? and exists (select * from "eloquent_builder_test_model_far_related_stubs" where "eloquent_builder_test_model_close_related_stubs"."id" = "eloquent_builder_test_model_far_related_stubs"."eloquent_builder_test_model_close_related_stub_id" and "eloquent_builder_test_model_far_related_stubs"."id" in (?))', $builder->toSql());
         $this->assertEquals(['baz', 'quux'], $builder->getBindings());
     }
 
     public function testWhereRelationKeyWithArray()
     {
         $model = new EloquentBuilderTestModelParentStub;
+        $model->foo_id = 'baz';
+
         $child = (new EloquentBuilderTestModelCloseRelatedStub())->forceFill([
            'id' => 'quux'
         ])->setKeyType('string');
 
-        $builder = $model->foo()->whereRelationKey([
+        $builder = $model->address()->whereRelationKey([
             'bar' => $child,
             'baz' => 'bax'
         ]);
 
-        // TODO: Get correct SQL.
-
-        $this->assertSame('select * from "eloquent_builder_test_model_parent_stubs" where "bar" = ? and exists (select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" and "eloquent_builder_test_model_close_related_stubs"."id" in (?))', $builder->toSql());
-        $this->assertEquals(['baz', 'quux'], $builder->getBindings());
+        $this->assertSame('select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_close_related_stubs"."id" = ? and exists (select * from "eloquent_builder_test_model_far_related_stubs" where "eloquent_builder_test_model_close_related_stubs"."id" = "eloquent_builder_test_model_far_related_stubs"."eloquent_builder_test_model_close_related_stub_id" and "eloquent_builder_test_model_far_related_stubs"."id" in (?)) and exists (select * from "eloquent_builder_test_model_far_related_stubs" where "eloquent_builder_test_model_close_related_stubs"."id" = "eloquent_builder_test_model_far_related_stubs"."eloquent_builder_test_model_close_related_stub_id" and "eloquent_builder_test_model_far_related_stubs"."id" = ?)', $builder->toSql());
+        $this->assertEquals(['baz', 'quux', 'bax'], $builder->getBindings());
     }
 
     public function testWhereRelationKeyNot()
     {
         $model = new EloquentBuilderTestModelParentStub;
+        $model->foo_id = 'baz';
 
-        $builder = $model->foo()->whereRelationKeyNot('bar', 'quux');
+        $builder = $model->address()->whereRelationKeyNot('bar', 'quux');
 
-        // TODO: Get correct SQL.
-
-        $this->assertSame('select * from "eloquent_builder_test_model_parent_stubs" where "bar" = ? and exists (select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" and "eloquent_builder_test_model_close_related_stubs"."id" != ?)', $builder->toSql());
+        $this->assertSame('select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_close_related_stubs"."id" = ? and exists (select * from "eloquent_builder_test_model_far_related_stubs" where "eloquent_builder_test_model_close_related_stubs"."id" = "eloquent_builder_test_model_far_related_stubs"."eloquent_builder_test_model_close_related_stub_id" and "eloquent_builder_test_model_far_related_stubs"."id" != ?)', $builder->toSql());
         $this->assertEquals(['baz', 'quux'], $builder->getBindings());
     }
 
     public function testWhereRelationKeyNotWithModel()
     {
         $model = new EloquentBuilderTestModelParentStub;
+        $model->foo_id = 'baz';
+
         $child = (new EloquentBuilderTestModelCloseRelatedStub())->forceFill([
             'id' => 'quux'
         ])->setKeyType('string');
 
-        $builder = $model->foo()->whereRelationKeyNot('bar', $child);
+        $builder = $model->address()->whereRelationKeyNot('bar', $child);
 
-        // TODO: Get correct SQL.
-
-        $this->assertSame('select * from "eloquent_builder_test_model_parent_stubs" where "bar" = ? and exists (select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" and "eloquent_builder_test_model_close_related_stubs"."id" not in (?))', $builder->toSql());
+        $this->assertSame('select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_close_related_stubs"."id" = ? and exists (select * from "eloquent_builder_test_model_far_related_stubs" where "eloquent_builder_test_model_close_related_stubs"."id" = "eloquent_builder_test_model_far_related_stubs"."eloquent_builder_test_model_close_related_stub_id" and "eloquent_builder_test_model_far_related_stubs"."id" not in (?))', $builder->toSql());
         $this->assertEquals(['baz', 'quux'], $builder->getBindings());
     }
 
     public function testWhereRelationKeyNotWithArray()
     {
         $model = new EloquentBuilderTestModelParentStub;
+        $model->foo_id = 'baz';
+
         $child = (new EloquentBuilderTestModelCloseRelatedStub())->forceFill([
             'id' => 'quux'
         ])->setKeyType('string');
 
-        $builder = $model->foo()->whereRelationKey([
+        $builder = $model->address()->whereRelationKey([
             'bar' => $child,
             'baz' => 'bax'
         ]);
 
-        // TODO: Get correct SQL.
-
-        $this->assertSame('select * from "eloquent_builder_test_model_parent_stubs" where "bar" = ? and exists (select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" and "eloquent_builder_test_model_close_related_stubs"."id" in (?))', $builder->toSql());
-        $this->assertEquals(['baz', 'quux'], $builder->getBindings());
+        $this->assertSame('select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_close_related_stubs"."id" = ? and exists (select * from "eloquent_builder_test_model_far_related_stubs" where "eloquent_builder_test_model_close_related_stubs"."id" = "eloquent_builder_test_model_far_related_stubs"."eloquent_builder_test_model_close_related_stub_id" and "eloquent_builder_test_model_far_related_stubs"."id" in (?)) and exists (select * from "eloquent_builder_test_model_far_related_stubs" where "eloquent_builder_test_model_close_related_stubs"."id" = "eloquent_builder_test_model_far_related_stubs"."eloquent_builder_test_model_close_related_stub_id" and "eloquent_builder_test_model_far_related_stubs"."id" = ?)', $builder->toSql());
+        $this->assertEquals(['baz', 'quux', 'bax'], $builder->getBindings());
     }
 
     public function testWhereKeyMethodWithInt()

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1233,7 +1233,7 @@ class DatabaseEloquentBuilderTest extends TestCase
             'baz' => 'bax',
         ]);
 
-        $this->assertSame('select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_close_related_stubs"."id" = ? and exists (select * from "eloquent_builder_test_model_far_related_stubs" where "eloquent_builder_test_model_close_related_stubs"."id" = "eloquent_builder_test_model_far_related_stubs"."eloquent_builder_test_model_close_related_stub_id" and "eloquent_builder_test_model_far_related_stubs"."id" in (?)) and exists (select * from "eloquent_builder_test_model_far_related_stubs" where "eloquent_builder_test_model_close_related_stubs"."id" = "eloquent_builder_test_model_far_related_stubs"."eloquent_builder_test_model_close_related_stub_id" and "eloquent_builder_test_model_far_related_stubs"."id" = ?)', $builder->toSql());
+        $this->assertSame('select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_close_related_stubs"."id" = ? and exists (select * from "eloquent_builder_test_model_far_related_stubs" where "eloquent_builder_test_model_close_related_stubs"."id" = "eloquent_builder_test_model_far_related_stubs"."eloquent_builder_test_model_close_related_stub_id" and "eloquent_builder_test_model_far_related_stubs"."id" = ?) and exists (select * from "eloquent_builder_test_model_far_related_stubs" where "eloquent_builder_test_model_close_related_stubs"."id" = "eloquent_builder_test_model_far_related_stubs"."eloquent_builder_test_model_close_related_stub_id" and "eloquent_builder_test_model_far_related_stubs"."id" = ?)', $builder->toSql());
         $this->assertEquals(['baz', 'quux', 'bax'], $builder->getBindings());
     }
 
@@ -1277,7 +1277,7 @@ class DatabaseEloquentBuilderTest extends TestCase
             'baz' => 'bax',
         ]);
 
-        $this->assertSame('select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_close_related_stubs"."id" = ? and exists (select * from "eloquent_builder_test_model_far_related_stubs" where "eloquent_builder_test_model_close_related_stubs"."id" = "eloquent_builder_test_model_far_related_stubs"."eloquent_builder_test_model_close_related_stub_id" and "eloquent_builder_test_model_far_related_stubs"."id" in (?)) and exists (select * from "eloquent_builder_test_model_far_related_stubs" where "eloquent_builder_test_model_close_related_stubs"."id" = "eloquent_builder_test_model_far_related_stubs"."eloquent_builder_test_model_close_related_stub_id" and "eloquent_builder_test_model_far_related_stubs"."id" = ?)', $builder->toSql());
+        $this->assertSame('select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_close_related_stubs"."id" = ? and exists (select * from "eloquent_builder_test_model_far_related_stubs" where "eloquent_builder_test_model_close_related_stubs"."id" = "eloquent_builder_test_model_far_related_stubs"."eloquent_builder_test_model_close_related_stub_id" and "eloquent_builder_test_model_far_related_stubs"."id" = ?) and exists (select * from "eloquent_builder_test_model_far_related_stubs" where "eloquent_builder_test_model_close_related_stubs"."id" = "eloquent_builder_test_model_far_related_stubs"."eloquent_builder_test_model_close_related_stub_id" and "eloquent_builder_test_model_far_related_stubs"."id" = ?)', $builder->toSql());
         $this->assertEquals(['baz', 'quux', 'bax'], $builder->getBindings());
     }
 


### PR DESCRIPTION
This PR allows adds `whereRelationKey()` and `whereRelationKeyNot()` methods to the Builder for relationships.

It allows to quickly add a `whereKey()` and `whereKeyNot()` to the related model query, quickly.

## Problem

Let's say we have a `Passenger` model that has many `Tickets`. Each of the `Ticket` belongs to the `Passenger` but also an `Airline`.

We want to filter the tickets by their `Airline` they belong. To do it, we can use the query builder via the relationship method.

```php
$passenger->tickets()->whereHas('airline', function (Builder $query) use ($airline) {
    $query->where('id', $airline->id);
})->get();
```

While that sounds like not too much work, adding more relationships filters can quickly become an endless lines of anonymous functions calls. For example, if we also need to filter them by departure and destination `Airport`.

```php
$passenger->tickets()->whereHas('airline', function (Builder $query) use ($airline) {
    $query->where('id', $airline->id);
})->whereHas('departure', function (Builder $query) use ($departureAirport) {
    $query->where('id', $departureAirport->id);
})->whereHas('destination', function (Builder $query) use ($destinationAirport) {
    $query->where('id', $destinationAirport->id);
})->get();
```

## Solution

The `whereRelationKey()`  uses the power of `whereKey()` underneath to make the code above just a method call away.

```php
$passenger->tickets()->whereRelationKey('airline', $airline)->get();
```

Behind the scenes, if it's a model, it will extract the key from it so there is no need to do it manually with `$airline->id` or `$airline->getKey()`.

It also accepts multiple relations when issuing an array. In this case, we want all the tickets for a given airline, a given departure `Airport`, and destination `Airport`.

```php
$passenger->tickets()->whereRelationKey([
    'airline' => $airline,
    'departure' => $departureAirport
    'destination' => $destinationAirport,
])->get();
```

## Details

- Non breaking changes.
- It adds `whereRelationKey()` and `whereRelationKeyNot()` to the `QueriesRelationships` trait.
- Adds a small helper to parse the relations if it's an `array` and the `id` its a `Model` instance.
- Test included
- Works for any relationship as long it has a primary key declared, otherwise `whereHas()` should be used.