### PR TITLE
[8.x] Prevent PHP Warning when validating date against other input field

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -235,7 +235,7 @@ trait ValidatesAttributes
     {
         try {
             $validFormat = new DateTime($value);
-            
+
             return Date::parse($value);
         } catch (Exception $e) {
             //

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -228,13 +228,15 @@ trait ValidatesAttributes
     /**
      * Get a DateTime instance from a string with no format.
      *
-     * @param  string  $value
+     * @param  mixed  $value
      * @return \DateTime|null
      */
     protected function getDateTime($value)
     {
         try {
-            $validFormat = new DateTime($value);
+            if (is_string($value)) {
+                new DateTime($value);
+            }
 
             return Date::parse($value);
         } catch (Exception $e) {

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -235,6 +235,7 @@ trait ValidatesAttributes
     {
         try {
             $validFormat = new DateTime($value);
+            
             return Date::parse($value);
         } catch (Exception $e) {
             //

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -234,6 +234,7 @@ trait ValidatesAttributes
     protected function getDateTime($value)
     {
         try {
+            $validFormat = new DateTime($value);
             return Date::parse($value);
         } catch (Exception $e) {
             //


### PR DESCRIPTION
Previous PR #37122 did not pass `tests/Validation`. The tests now pass.

Some tests pass a DateTime object directly to the Validator. This change ensures only string values are checked to be a valid DateTime format.