### PR TITLE
[8.x] Add Collection@containsAll method

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -196,8 +196,8 @@ trait EnumeratesValues
     /**
      * Determine if all items exists in the collection.
      *
-     * @param mixed $values
-     * @param bool $strict
+     * @param  mixed  $values
+     * @param  bool  $strict
      * @return bool
      */
     public function containsAll($values, $strict = false)

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -210,12 +210,15 @@ trait EnumeratesValues
 
         foreach ($this as $item) {
             $index = array_search($item, $values, $strict);
+
             if ($index === false) {
                 continue;
             }
+
             if (count($values) === 1) {
                 return true;
             }
+
             unset($values[$index]);
         }
 

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -194,6 +194,35 @@ trait EnumeratesValues
     }
 
     /**
+     * Determine if all items exists in the collection.
+     *
+     * @param mixed $values
+     * @param bool $strict
+     * @return bool
+     */
+    public function containsAll($values, $strict = false)
+    {
+        $values = $this->getArrayableItems($values);
+
+        if (empty($values)) {
+            return true;
+        }
+
+        foreach ($this as $item) {
+            $index = array_search($item, $values, $strict);
+            if ($index === false) {
+                continue;
+            }
+            if (count($values) === 1) {
+                return true;
+            }
+            unset($values[$index]);
+        }
+
+        return false;
+    }
+
+    /**
      * Dump the items and end the script.
      *
      * @param  mixed  ...$args

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3039,6 +3039,38 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testContainsAll($collection)
+    {
+        $c = new $collection([1, 3, 5]);
+
+        $this->assertTrue($c->containsAll([1, 3]));
+        $this->assertTrue($c->containsAll([1, 5]));
+        $this->assertFalse($c->containsAll([1, 2]));
+        $this->assertFalse($c->containsAll([1, 3, 5, 7]));
+
+        $this->assertTrue($c->containsAll(collect([1, 3])));
+        $this->assertTrue($c->containsAll(collect([1, 5])));
+        $this->assertFalse($c->containsAll(collect([1, 2])));
+        $this->assertFalse($c->containsAll(collect([1, 3, 5, 7])));
+
+        $this->assertTrue($c->containsAll([]));
+        $this->assertTrue($c->containsAll(collect([])));
+        $this->assertTrue($c->containsAll(null));
+
+        $this->assertTrue($c->containsAll([1, '3']));
+        $this->assertFalse($c->containsAll([1, '3'], true));
+
+        $c = new $collection([[1, 3], [3, 5]]);
+
+        $this->assertTrue($c->containsAll([[1, 3]]));
+        $this->assertTrue($c->containsAll([[3, 5]]));
+        $this->assertFalse($c->containsAll([[1, 5]]));
+        $this->assertFalse($c->containsAll([[3]]));
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testSome($collection)
     {
         $c = new $collection([1, 3, 5]);

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -155,6 +155,13 @@ class SupportLazyCollectionIsLazyTest extends TestCase
         });
     }
 
+    public function testContainsAllIsLazy()
+    {
+        $this->assertEnumerates(5, function ($collection) {
+            $collection->containsAll([1, 2, 3, 4, 5]);
+        });
+    }
+
     public function testCountEnumeratesOnce()
     {
         $this->assertEnumeratesOnce(function ($collection) {


### PR DESCRIPTION
# To maintainers

Below is the complete description of the pull request, but because that's the second one (the first was: #36915), here I will summarize what changed for laravel maintainers.

I used the Joseph Silber implementation proposal and tweak it a bit (I check if the array is empty and returns true if that's the case + I used `unset` instead of `array_splice`).

I also moved the implementation of it in `EnumeratesValues` trait, because that's the same for both `Collection` and `LazyCollection`.

I added some more tests too, and speaking of that, I don't know if my IsLazyTest is correct. Can you please take a look at it when you have time? @JosephSilber

---
# Complete description

This commit adds a new `containsAll` method to both `Collection` and `LazyCollection`, and some tests to make sure it works correctly.

This method allows to determine if a smaller array/collection items are all present in a laravel collection.

## Usage

```PHP
$collection->containsAll($arr);
```
with `$arr` being an `array`, a `Collection`, a `LazyCollection` or whatever works with `getArrayableItems`.

When `$arr` is empty or null, `containsAll` returns true.

## Why is that needed?

I think this is clearly something Laravel collections lacks of.
In my case, I need to check if a laravel collection contains all the stuff a user sent to the controller.
I've got something like an enterprise admin panel (not to be confused with the global admin panel) which allows the administrator to manage the employees permissions.
Since the enterprise administrator is sending ids via a form, I must verify all the ids provided are all their own employees, to avoid malicious users to revoke access to employees of other enterprises by sending random ids for example.

I think this use case is not a niche one, but a relatively current one.

In order to illustrate my use case, here is a snippet of code based on it:
```PHP
if (!$this->containsAll($enterpriseEmployeesIds, $employeesId)) {
    $flash->error("Specified employees does not belong to your enterprise!");
    return back();
}
```
with `$flash` being an instance of an utility class wrapping `$request->flash('whatever', [logLevel, msg])`.

## Implementation notes

The implementation of `containsAll` is based on the one suggested by @JosephSilber in my precedent pull request (#36915).

For some reason, I didn't manage to make it work with `array_splice`, but it works with `unset`, so I used `unset`.

The code behaves the same with a `LazyCollection` as it does with a `Collection` because the `containsAll` implementation is the same, and located in `EnumeratesValues` trait.

I tried to test it the best I can, but if you want me to add more tests for some weird edge cases for example, don't hesitate to ask.