### PR TITLE
[8.x] Add has environment variable to startProcess method

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -97,7 +97,7 @@ class ServeCommand extends Command
     protected function startProcess($hasEnvironment)
     {
         $process = new Process($this->serverCommand(), null, collect($_ENV)->mapWithKeys(function ($value, $key) use ($hasEnvironment) {
-            if ($this->option('no-reload') || !$hasEnvironment) {
+            if ($this->option('no-reload') || ! $hasEnvironment) {
                 return [$key => $value];
             }
 

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -90,8 +90,7 @@ class ServeCommand extends Command
     /**
      * Start a new server process.
      *
-     * @param bool $hasEnvironment
-     *
+     * @param bool  $hasEnvironment
      * @return \Symfony\Component\Process\Process
      */
     protected function startProcess($hasEnvironment)

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -70,7 +70,7 @@ class ServeCommand extends Command
 
                 $process->stop(5);
 
-                $process = $this->startProcess();
+                $process = $this->startProcess($hasEnvironment);
             }
 
             usleep(500 * 1000);

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -54,7 +54,7 @@ class ServeCommand extends Command
                             ? filemtime($environmentFile)
                             : now()->addDays(30)->getTimestamp();
 
-        $process = $this->startProcess();
+        $process = $this->startProcess($hasEnvironment);
 
         while ($process->isRunning()) {
             if ($hasEnvironment) {
@@ -90,12 +90,14 @@ class ServeCommand extends Command
     /**
      * Start a new server process.
      *
+     * @param bool $hasEnvironment
+     *
      * @return \Symfony\Component\Process\Process
      */
-    protected function startProcess()
+    protected function startProcess($hasEnvironment)
     {
-        $process = new Process($this->serverCommand(), null, collect($_ENV)->mapWithKeys(function ($value, $key) {
-            if ($this->option('no-reload')) {
+        $process = new Process($this->serverCommand(), null, collect($_ENV)->mapWithKeys(function ($value, $key) use ($hasEnvironment) {
+            if ($this->option('no-reload') || !$hasEnvironment) {
                 return [$key => $value];
             }
 

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -90,7 +90,7 @@ class ServeCommand extends Command
     /**
      * Start a new server process.
      *
-     * @param bool  $hasEnvironment
+     * @param  bool  $hasEnvironment
      * @return \Symfony\Component\Process\Process
      */
     protected function startProcess($hasEnvironment)


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
I have this error in my local docker development stack. With this change, I can use my docker environment variables in my development command. This maybe happened to other users too so I want to share my fix.
