### PR TITLE
[8.x] Add withOnly method 

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1237,7 +1237,7 @@ class Builder
     }
 
     /**
-     * Provide the specified relations for eager loading.
+     * Set the relationships that should be eager loaded while removing any previously added eager loading specifications.
      *
      * @param  mixed  $relations
      * @return $this

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1237,16 +1237,16 @@ class Builder
     }
 
     /**
-     * Prevent the specified relations from being eager loaded.
+     * Provide the specified relations for eager loading.
      *
      * @param  mixed  $relations
      * @return $this
      */
     public function withOnly($relations)
     {
-        $this->eagerLoad = array_flip(is_string($relations) ? func_get_args() : $relations);
+        $this->eagerLoad = [];
 
-        return $this;
+        return $this->with($relations);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1237,6 +1237,19 @@ class Builder
     }
 
     /**
+     * Prevent the specified relations from being eager loaded.
+     *
+     * @param  mixed  $relations
+     * @return $this
+     */
+    public function withOnly($relations)
+    {
+        $this->eagerLoad = array_flip(is_string($relations) ? func_get_args() : $relations);
+
+        return $this;
+    }
+
+    /**
      * Create a new instance of the model being queried.
      *
      * @param  array  $attributes

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -327,6 +327,15 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEmpty($instance->getEagerLoads());
     }
 
+    public function testWithOnlyMethodLoadsRelationshipCorrectly()
+    {
+        $model = new EloquentModelWithoutRelationStub();
+        $this->addMockConnection($model);
+        $instance = $model->newInstance()->newQuery()->withOnly('taylor');
+        $this->assertNotNull($instance->getEagerLoads()['taylor']);
+        $this->assertArrayNotHasKey('foo', $instance->getEagerLoads());
+    }
+
     public function testEagerLoadingWithColumns()
     {
         $model = new EloquentModelWithoutRelationStub;


### PR DESCRIPTION
I have a model, that has many `$with` and new relationships are added frequently. These relationships are used throughout 95% of the customer-facing websites. However, for certain sections of the Admin system, where only a few relationships need to be loaded. 

Imagine you have a model like this:
```php
class Product extends Model{
    protected $with = ['prices', 'colours', 'brand'];

    public function colours(){ ... }
    public function prices(){ ... }
    public function brand(){ ... }
}
```

At the moment, I would only be able to achieve this by doing:
```php
Product::without(['prices', 'colours'])->get();
```
When adding future relationships to my base model, they would be included by default, it would be nice to be able to do something like:

I have added a new method called `withOnly` (I couldn't think of a better name - any suggestions?) - which will exclude all the base `$with` and only add the relations that you specify like the following:

```php
Product::withOnly(['brand']);
```

If you are happy to merge this in, I'll send a PR to update the docs repo. :+1: 

Thanks,
James.