### PR TITLE
[6.x] Fix Cache store with a name other than 'dynamodb'

### DIFF
--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -2,10 +2,12 @@
 
 namespace Illuminate\Cache;
 
+use Aws\DynamoDb\DynamoDbClient;
 use Closure;
 use Illuminate\Contracts\Cache\Factory as FactoryContract;
 use Illuminate\Contracts\Cache\Store;
 use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
+use Illuminate\Support\Arr;
 use InvalidArgumentException;
 
 /**
@@ -224,9 +226,11 @@ class CacheManager implements FactoryContract
      */
     protected function createDynamodbDriver(array $config)
     {
+        $client = $this->newDynamodbClient($config);
+
         return $this->repository(
             new DynamoDbStore(
-                $this->app['cache.dynamodb.client'],
+                $client,
                 $config['table'],
                 $config['attributes']['key'] ?? 'key',
                 $config['attributes']['value'] ?? 'value',
@@ -234,6 +238,28 @@ class CacheManager implements FactoryContract
                 $this->getPrefix($config)
             )
         );
+    }
+
+    /**
+     * Create new DynamoDb Client instance
+     *
+     * @return DynamoDbClient
+     */
+    protected function newDynamodbClient(array $config)
+    {
+        $dynamoConfig = [
+            'region' => $config['region'],
+            'version' => 'latest',
+            'endpoint' => $config['endpoint'] ?? null,
+        ];
+
+        if (isset($config['key']) && isset($config['secret'])) {
+            $dynamoConfig['credentials'] = Arr::only(
+                $config, ['key', 'secret', 'token']
+            );
+        }
+
+        return new DynamoDbClient($dynamoConfig);
     }
 
     /**

--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -241,7 +241,7 @@ class CacheManager implements FactoryContract
     }
 
     /**
-     * Create new DynamoDb Client instance
+     * Create new DynamoDb Client instance.
      *
      * @return DynamoDbClient
      */

--- a/src/Illuminate/Cache/CacheServiceProvider.php
+++ b/src/Illuminate/Cache/CacheServiceProvider.php
@@ -32,24 +32,6 @@ class CacheServiceProvider extends ServiceProvider implements DeferrableProvider
         $this->app->singleton('memcached.connector', function () {
             return new MemcachedConnector;
         });
-
-        $this->app->singleton('cache.dynamodb.client', function ($app) {
-            $config = $app['config']->get('cache.stores.dynamodb');
-
-            $dynamoConfig = [
-                'region' => $config['region'],
-                'version' => 'latest',
-                'endpoint' => $config['endpoint'] ?? null,
-            ];
-
-            if ($config['key'] && $config['secret']) {
-                $dynamoConfig['credentials'] = Arr::only(
-                    $config, ['key', 'secret', 'token']
-                );
-            }
-
-            return new DynamoDbClient($dynamoConfig);
-        });
     }
 
     /**
@@ -60,7 +42,7 @@ class CacheServiceProvider extends ServiceProvider implements DeferrableProvider
     public function provides()
     {
         return [
-            'cache', 'cache.store', 'cache.psr6', 'memcached.connector', 'cache.dynamodb.client',
+            'cache', 'cache.store', 'cache.psr6', 'memcached.connector',
         ];
     }
 }

--- a/src/Illuminate/Cache/CacheServiceProvider.php
+++ b/src/Illuminate/Cache/CacheServiceProvider.php
@@ -2,9 +2,7 @@
 
 namespace Illuminate\Cache;
 
-use Aws\DynamoDb\DynamoDbClient;
 use Illuminate\Contracts\Support\DeferrableProvider;
-use Illuminate\Support\Arr;
 use Illuminate\Support\ServiceProvider;
 use Symfony\Component\Cache\Adapter\Psr16Adapter;
 

--- a/src/Illuminate/Cache/DynamoDbStore.php
+++ b/src/Illuminate/Cache/DynamoDbStore.php
@@ -527,7 +527,7 @@ class DynamoDbStore implements LockProvider, Store
     }
 
     /**
-     * Get the DynamoDb Client Instance
+     * Get the DynamoDb Client instance.
      *
      * @return DynamoDbClient
      */

--- a/src/Illuminate/Cache/DynamoDbStore.php
+++ b/src/Illuminate/Cache/DynamoDbStore.php
@@ -525,4 +525,14 @@ class DynamoDbStore implements LockProvider, Store
     {
         $this->prefix = ! empty($prefix) ? $prefix.':' : '';
     }
+
+    /**
+     * Get the DynamoDb Client Instance
+     *
+     * @return DynamoDbClient
+     */
+    public function getClient()
+    {
+        return $this->dynamo;
+    }
 }

--- a/tests/Integration/Cache/DynamoDbStoreTest.php
+++ b/tests/Integration/Cache/DynamoDbStoreTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Integration\Cache;
 
 use Aws\DynamoDb\DynamoDbClient;
 use Aws\Exception\AwsException;
+use Illuminate\Contracts\Cache\Repository;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Str;
 use Orchestra\Testbench\TestCase;
@@ -85,7 +86,7 @@ class DynamoDbStoreTest extends TestCase
         $config = $app['config']->get('cache.stores.dynamodb');
 
         /** @var \Aws\DynamoDb\DynamoDbClient $client */
-        $client = $app['cache.dynamodb.client'];
+        $client = $app->make(Repository::class)->getStore()->getClient();
 
         if ($this->dynamoTableExists($client, $config['table'])) {
             return;


### PR DESCRIPTION
This pull request partially reverts changes introduced in https://github.com/laravel/framework/pull/36749 (ping @driesvints).

The problem particularly is located here: https://github.com/laravel/framework/pull/36749/commits/a20c9e54e54291322f9653d6d324e9777f5e3a75#diff-5c56e532b7bf21453188f98f7999ed558eff31a6374ebd83c9f811961fde02b1R37

It is forcing applications to reserve the `cache.stores.dynamodb` as the only way to configure an AWS DynamoDb Client instance. If, for instance, we rename `dynamodb` in our application to anything else, then the `region`, `key` and `secret` won't take effect because it will rely on the DynamoDb Client bound by `cache.stores.dynamodb`. The consequences of relying on this binding are:

- Applications cannot rename `dynamodb` on the cache configuration.
- Applications cannot have 2 or more `dynamodb` cache configurations which are not in the same region / access key / secret key.
- A secondary cache not called `dynamodb` will still use the region and access configured for the `dynamodb` key.

By reverting that, we bring control back to users so that they're free to change the skeleton configuration without invisible side effects.

For my particular use-case, I created a Cache Store configuration called `session` and then configured it as follows:

```
        'session' => [
            'driver' => 'dynamodb',
            'region' => env('AWS_REGION'),
            'table' => env('DYNAMODB_SESSION_TABLE'),
        ],
```

This means that access is determined by IAM Role (assume role) instead of key and secret. I also configured `session.store` as `session` so that Laravel's Session is managed by the Cache Store called `session`. This is how I detected the problem.
