### PR TITLE
[8.x] Add modelKeys to eloquent builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -752,6 +752,16 @@ class Builder
     }
 
     /**
+     * Get the array of primary keys.
+     *
+     * @return array
+     */
+    public function modelKeys()
+    {
+        return $this->pluck($this->defaultKeyName())->toArray();
+    }
+
+    /**
      * Paginate the given query.
      *
      * @param  int|null  $perPage

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -545,6 +545,18 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals(['bar', 'baz'], $builder->pluck('name')->all());
     }
 
+    public function testModelKeysReturnsModelPrimaryKeyValues()
+    {
+        $builder = $this->getBuilder();
+        $builder->setModel($model = $this->getMockModel());
+        $builder->getQuery()->shouldReceive('pluck')->with($primaryKeyName = $model->getKeyName(), null)->andReturn(new BaseCollection($keys = [1, 2, 3]));
+        $builder->getModel()->shouldReceive('hasGetMutator')->with($primaryKeyName)->andReturn(false);
+        $builder->getModel()->shouldReceive('hasCast')->with($primaryKeyName)->andReturn(false);
+        $builder->getModel()->shouldReceive('getDates')->andReturn(['created_at']);
+
+        $this->assertEquals($keys, $builder->modelKeys());
+    }
+
     public function testLocalMacrosAreCalledOnBuilder()
     {
         unset($_SERVER['__test.builder']);


### PR DESCRIPTION
This PR adds the `modelKeys` method to eloquent query builder inspired by the `Eloquent\Collection` method.

```php
<?php

// Instead of that.
$publishedKeys = Article::published()->pluck('id')->toArray();

// Do this.
$publishedKeys = Article::published()->modelKeys();
```