### PR TITLE
[8.x] Missing `abort` method added to the App-Facade

### DIFF
--- a/src/Illuminate/Support/Facades/App.php
+++ b/src/Illuminate/Support/Facades/App.php
@@ -34,6 +34,7 @@ namespace Illuminate\Support\Facades;
  * @method static string storagePath(string $path = '')
  * @method static string version()
  * @method static string|bool environment(string|array ...$environments)
+ * @method static void abort(int $code, string $message = '', array $headers = [])
  * @method static void boot()
  * @method static void booted(callable $callback)
  * @method static void booting(callable $callback)


### PR DESCRIPTION
The App-Facade is missing the `abort` function. See: https://github.com/laravel/framework/blob/8.x/src/Illuminate/Foundation/Application.php#L1110

Otherwise PhpStorm does not know that the method exists:

![Screenshot 2021-04-28 at 11 59 10](https://user-images.githubusercontent.com/14092921/116385571-34e4f100-a819-11eb-9d9a-1609eea892c5.png)

