### PR TITLE
Fixes:37159 - Use AWS Client to get the S3 object url and then concat…

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -497,8 +497,13 @@ class FilesystemAdapter implements CloudFilesystemContract
         // it as the base URL instead of the default path. This allows the developer to
         // have full control over the base path for this filesystem's generated URLs.
         if (! is_null($url = $this->driver->getConfig()->get('url'))) {
-            return $this->concatPathToUrl($url, $adapter->getPathPrefix().$path);
-        }
+            return $this->concatPathToUrl($url, parse_url(
+                $adapter->getClient()->getObjectUrl(
+                    $adapter->getBucket(), $adapter->getPathPrefix() . $path
+                ),
+                PHP_URL_PATH
+            ));
+	}
 
         return $adapter->getClient()->getObjectUrl(
             $adapter->getBucket(), $adapter->getPathPrefix().$path

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -499,11 +499,11 @@ class FilesystemAdapter implements CloudFilesystemContract
         if (! is_null($url = $this->driver->getConfig()->get('url'))) {
             return $this->concatPathToUrl($url, parse_url(
                 $adapter->getClient()->getObjectUrl(
-                    $adapter->getBucket(), $adapter->getPathPrefix() . $path
+                    $adapter->getBucket(), $adapter->getPathPrefix().$path
                 ),
                 PHP_URL_PATH
             ));
-	}
+        }
 
         return $adapter->getClient()->getObjectUrl(
             $adapter->getBucket(), $adapter->getPathPrefix().$path


### PR DESCRIPTION
… path to url when url is defined by configuration.

This resolves Bug:37159 where if an S3 filesystem is used and a path contains certain special characters, the url returned can be invalid. This resolves it by utilizing the AWS client to build the proper S3 object URL and then concat the path to the configured url.