### PR TITLE
[8.x] Fixes database offset tests

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2065,7 +2065,7 @@ class Builder
     {
         $property = $this->unions ? 'unionOffset' : 'offset';
 
-        $this->$property = max(0, $value);
+        $this->$property = max(0, (int) $value);
 
         return $this;
     }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2913,7 +2913,11 @@ SQL;
 
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('users')->take('foo')->offset('bar');
-        $this->assertSame('select * from (select *, row_number() over (order by (select 0)) as row_num from [users]) as temp_table where row_num between 1 and 0 order by row_num', $builder->toSql());
+        $this->assertSame('select * from [users]', $builder->toSql());
+
+        $builder = $this->getSqlServerBuilder();
+        $builder->select('*')->from('users')->offset('bar');
+        $this->assertSame('select * from [users]', $builder->toSql());
     }
 
     public function testMySqlSoundsLikeOperator()


### PR DESCRIPTION
This pull request fixes the database offset tests. The `max` php functions behaves differently depending on the PHP Version:

```
// PHP < 8 
max(0, "bar"); // 0
// PHP >= 8 
max(0, "bar"); // "bar"
```