### PR TITLE
[8.x] Add fallback when migration is not anonymous class

### DIFF
--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -474,7 +474,9 @@ class Migrator
             return new $class;
         }
 
-        return $this->files->getRequire($path);
+        $migration = $this->files->getRequire($path);
+
+        return is_object($migration) ? $migration : new $class;
     }
 
     /**


### PR DESCRIPTION
This PR makes migrator try to fall back named migration when it fails to load an anonymous one.

This is a fix for an edge case described by @Tofandel in #37006 and does not have any negative consequences.