### PR TITLE
[8.x] Add `removeGlobalScope()` option to HasGlobalScopes trait

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasGlobalScopes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasGlobalScopes.php
@@ -32,6 +32,41 @@ trait HasGlobalScopes
     }
 
     /**
+     * Unregister a global scope from the model.
+     * 
+     * @param  \Illuminate\Database\Eloquent\Scope|\Closure|string  $scope
+     * @return void
+     *
+     * @throws \InvalidArgumentException
+     */
+    public static function removeGlobalScope($scope)
+    {
+        if (is_string($scope)) {
+            unset(static::$globalScopes[static::class][$scope]);
+        } elseif ($scope instanceof Closure) {
+            unset(static::$globalScopes[static::class][spl_object_hash($scope)]);
+        } elseif ($scope instanceof Scope) {
+            unset(static::$globalScopes[static::class][get_class($scope)]);
+        }
+        else {
+            throw new InvalidArgumentException('Global scope must be an instance of Closure or Scope.');
+        }
+    }
+
+    /**
+     * Unregister all global scopes from the model.
+     * 
+     * @return void
+     */
+    public static function removeGlobalScopes()
+    {
+        $scopes = Arr::get(static::$globalScopes, static::class, []);
+        foreach ($scopes as $scope => $implementation) {
+            self::removeGlobalScope($scope);
+        }
+    }
+
+    /**
      * Determine if a model has a global scope.
      *
      * @param  \Illuminate\Database\Eloquent\Scope|string  $scope

--- a/src/Illuminate/Database/Eloquent/Concerns/HasGlobalScopes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasGlobalScopes.php
@@ -33,7 +33,7 @@ trait HasGlobalScopes
 
     /**
      * Unregister a global scope from the model.
-     * 
+     *
      * @param  \Illuminate\Database\Eloquent\Scope|\Closure|string  $scope
      * @return void
      *
@@ -47,15 +47,14 @@ trait HasGlobalScopes
             unset(static::$globalScopes[static::class][spl_object_hash($scope)]);
         } elseif ($scope instanceof Scope) {
             unset(static::$globalScopes[static::class][get_class($scope)]);
-        }
-        else {
+        } else {
             throw new InvalidArgumentException('Global scope must be an instance of Closure or Scope.');
         }
     }
 
     /**
      * Unregister all global scopes from the model.
-     * 
+     *
      * @return void
      */
     public static function removeGlobalScopes()

--- a/tests/Database/DatabaseEloquentGlobalScopesTest.php
+++ b/tests/Database/DatabaseEloquentGlobalScopesTest.php
@@ -44,6 +44,19 @@ class DatabaseEloquentGlobalScopesTest extends TestCase
         $this->assertEquals([], $query->getBindings());
     }
 
+    public function testGlobalScopeCanBePermanentlyRemoved()
+    {
+        $model = new EloquentGlobalScopesWithRemovedScopeTestModel;
+        $model::removeGlobalScope(ActiveScope::class);
+        $query = $model->newQuery();
+        $this->assertSame('select * from "table"', $query->toSql());
+        $this->assertEquals([], $query->getBindings());
+
+        $query = $model->newQuery();
+        $this->assertSame('select * from "table"', $query->toSql());
+        $this->assertEquals([], $query->getBindings());
+    }
+
     public function testClosureGlobalScopeIsApplied()
     {
         $model = new EloquentClosureGlobalScopesTestModel;
@@ -180,6 +193,18 @@ class EloquentClosureGlobalScopesWithOrTestModel extends EloquentClosureGlobalSc
 }
 
 class EloquentGlobalScopesTestModel extends Model
+{
+    protected $table = 'table';
+
+    public static function boot()
+    {
+        static::addGlobalScope(new ActiveScope);
+
+        parent::boot();
+    }
+}
+
+class EloquentGlobalScopesWithRemovedScopeTestModel extends Model
 {
     protected $table = 'table';
 


### PR DESCRIPTION
This PR adds `removeGlobalScope()` and `removeGlobalScopes()` to the `HasGlobalScopes` trait. It allows to remove global scopes from a model until it is turned back on.

I have a situation where I need to remove a global scope for multiple queries. This new function allows me to remove a scope until I turn it back on.

In my situation I need to remove a global scope (e.g. softdelete) when executing multiple queries from an external package (`Model::fixTree()` from [NestedSet](https://github.com/lazychaser/laravel-nestedset) in my case). In this case I could use:
```php
Content::removeGlobalScope('active_scope');
Content::fixTree();
Content::addGlobalScope('active_scope', function ($query) {
    $query->where('active', 1);
});
```

First time PR so I'm not sure if everything is correct.