### PR TITLE
feature: added local environment checker to skip over all validations…

### DIFF
--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -68,6 +68,13 @@ class Password implements Rule, DataAwareRule
     protected $compromisedThreshold = 0;
 
     /**
+     * Determines if the environment is local or not
+     *
+     * @var bool
+     */
+    protected $local = false;
+
+    /**
      * The failure messages, if any.
      *
      * @var array
@@ -173,6 +180,18 @@ class Password implements Rule, DataAwareRule
     }
 
     /**
+     * Skips over everything if the environment is local
+     *
+     * @return $this
+     */
+    public function local()
+    {
+        $this->local = true;
+
+        return $this;
+    }
+
+    /**
      * Determine if the validation rule passes.
      *
      * @param  string  $attribute
@@ -181,6 +200,12 @@ class Password implements Rule, DataAwareRule
      */
     public function passes($attribute, $value)
     {
+        if ($this->local) {
+            if (app()->environment() !== 'production') {
+                return true;
+            }
+        }
+
         $validator = Validator::make($this->data, [
             $attribute => 'string|min:'.$this->min,
         ]);


### PR DESCRIPTION
This is an update to the new release of Password Validator. Suggested on Twitter by João Alves: https://twitter.com/JohnnyBig0des/status/1387083304600485893?s=20

This offers an extra "local" method which can be chained and which ignores all the validation if the environment is local.