### PR TITLE
[9.x] Implement nestWheres function for Eloquent Builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1122,7 +1122,7 @@ class Builder
         $result = $scope(...array_values($parameters)) ?? $this;
 
         if (count((array) $query->wheres) > $originalWhereCount) {
-            $this->addNewWheresWithinGroup($query, $originalWhereCount);
+            $query->nestWheres($originalWhereCount);
         }
 
         return $result;
@@ -1140,70 +1140,6 @@ class Builder
         return $this->callScope(function (...$parameters) use ($scope) {
             return $this->model->callNamedScope($scope, $parameters);
         }, $parameters);
-    }
-
-    /**
-     * Nest where conditions by slicing them at the given where count.
-     *
-     * @param  \Illuminate\Database\Query\Builder  $query
-     * @param  int  $originalWhereCount
-     * @return void
-     */
-    protected function addNewWheresWithinGroup(QueryBuilder $query, $originalWhereCount)
-    {
-        // Here, we totally remove all of the where clauses since we are going to
-        // rebuild them as nested queries by slicing the groups of wheres into
-        // their own sections. This is to prevent any confusing logic order.
-        $allWheres = $query->wheres;
-
-        $query->wheres = [];
-
-        $this->groupWhereSliceForScope(
-            $query, array_slice($allWheres, 0, $originalWhereCount)
-        );
-
-        $this->groupWhereSliceForScope(
-            $query, array_slice($allWheres, $originalWhereCount)
-        );
-    }
-
-    /**
-     * Slice where conditions at the given offset and add them to the query as a nested condition.
-     *
-     * @param  \Illuminate\Database\Query\Builder  $query
-     * @param  array  $whereSlice
-     * @return void
-     */
-    protected function groupWhereSliceForScope(QueryBuilder $query, $whereSlice)
-    {
-        $whereBooleans = collect($whereSlice)->pluck('boolean');
-
-        // Here we'll check if the given subset of where clauses contains any "or"
-        // booleans and in this case create a nested where expression. That way
-        // we don't add any unnecessary nesting thus keeping the query clean.
-        if ($whereBooleans->contains('or')) {
-            $query->wheres[] = $this->createNestedWhere(
-                $whereSlice, $whereBooleans->first()
-            );
-        } else {
-            $query->wheres = array_merge($query->wheres, $whereSlice);
-        }
-    }
-
-    /**
-     * Create a where array with nested where conditions.
-     *
-     * @param  array  $whereSlice
-     * @param  string  $boolean
-     * @return array
-     */
-    protected function createNestedWhere($whereSlice, $boolean = 'and')
-    {
-        $whereGroup = $this->getQuery()->forNestedWhere();
-
-        $whereGroup->wheres = $whereSlice;
-
-        return ['type' => 'Nested', 'query' => $whereGroup, 'boolean' => $boolean];
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1812,6 +1812,72 @@ class Builder
     }
 
     /**
+     * Slice where conditions at the given offset and add them to the query as a nested condition.
+     *
+     * @param  array  $whereSlice
+     * @return void
+     */
+    protected function groupWhereSlice($whereSlice)
+    {
+        $whereBooleans = collect($whereSlice)->pluck('boolean');
+
+        // Here we'll check if the given subset of where clauses contains any "or"
+        // booleans and in this case create a nested where expression. That way
+        // we don't add any unnecessary nesting thus keeping the query clean.
+        if ($whereBooleans->contains('or')) {
+            $this->wheres[] = $this->createNestedWhere(
+                $whereSlice, $whereBooleans->first()
+            );
+        } else {
+            $this->wheres = array_merge($this->wheres, $whereSlice);
+        }
+    }
+
+    /**
+     * Nest where conditions by slicing them at the given where count.
+     *
+     * @param  int|null  $originalWhereCount
+     * @return $this
+     */
+    public function nestWheres($originalWhereCount = null)
+    {
+        // Here, we totally remove all of the where clauses since we are going to
+        // rebuild them as nested queries by slicing the groups of wheres into
+        // their own sections. This is to prevent any confusing logic order.
+        $allWheres = $this->wheres;
+
+        $this->wheres = [];
+
+        $this->groupWhereSlice(
+            is_null($originalWhereCount) ? $allWheres : array_slice($allWheres, 0, $originalWhereCount)
+        );
+
+        if (! is_null($originalWhereCount)) {
+            $this->groupWhereSlice(
+                array_slice($allWheres, $originalWhereCount)
+            );
+        }
+
+        return $this;
+    }
+
+    /**
+     * Create a where array with nested where conditions.
+     *
+     * @param  array  $whereSlice
+     * @param  string  $boolean
+     * @return array
+     */
+    protected function createNestedWhere($whereSlice, $boolean = 'and')
+    {
+        $whereGroup = $this->forNestedWhere();
+
+        $whereGroup->wheres = $whereSlice;
+
+        return ['type' => 'Nested', 'query' => $whereGroup, 'boolean' => $boolean];
+    }
+
+    /**
      * Add a "group by" clause to the query.
      *
      * @param  array|string  ...$groups

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -313,8 +313,8 @@ class DatabaseQueryBuilderTest extends TestCase
             ->orWhere('status', 0)
             ->nestWheres()
             ->orWhere(function ($q) {
-            $q->where('is_active', 1)->orWhere('is_shared', 0);
-        })->nestWheres();
+                $q->where('is_active', 1)->orWhere('is_shared', 0);
+            })->nestWheres();
         $this->assertSame('select * from "users" where (("id" = ? or "status" = ?) or ("is_active" = ? or "is_shared" = ?))', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 0, 2 => 1, 3 => 0], $builder->getBindings());
     }


### PR DESCRIPTION
PR for [9.x] that adds functionality to solve query where-clause nesting (in particular: Eloquent relations with `->orWhere()` attached to it).

Original discussion:
https://github.com/laravel/framework/pull/37121

highlights:
- EloquentBuilder `protected addNewWheresWithinGroup(QueryBuilder $query, $originalWhereCount)`
  - moved to QueryBuilder as `public nestWheres(originalWhereCount = null)` (changed from **protected**  to **public**) with a minor logic change to make the default parameter work.
- EloquentBuilder `protected groupWhereSliceForScope(QueryBuilder $query, $whereSlice)`
   - moved to QueryBuilder  as `protected groupWhereSlice($whereSlice)`
- EloquentBuilder `protected createNestedWhere($whereSlice, $boolean = 'and')`
   - moved to QueryBuilder directly
