### PR TITLE
[8.x] `Str::builder()` method

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -54,6 +54,16 @@ class Str
     }
 
     /**
+     * Get a new stringable object.
+     *
+     * @return \Illuminate\Support\Stringable
+     */
+    public static function builder()
+    {
+        return new Stringable;
+    }
+
+    /**
      * Return the remainder of a string after the first occurrence of a given value.
      *
      * @param  string  $subject

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Support;
 
 use Illuminate\Support\Str;
+use Illuminate\Support\Stringable;
 use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\UuidInterface;
 
@@ -542,6 +543,18 @@ class SupportStrTest extends TestCase
     {
         $this->assertSame('aaaaa', Str::repeat('a', 5));
         $this->assertSame('', Str::repeat('', 5));
+    }
+
+    public function testOf()
+    {
+        $this->assertInstanceOf(Stringable::class, Str::of('foo'));
+        $this->assertSame('foo', (string) Str::of('foo'));
+    }
+
+    public function testBuilder()
+    {
+        $this->assertInstanceOf(Stringable::class, Str::builder());
+        $this->assertSame('', (string) Str::builder());
     }
 }
 


### PR DESCRIPTION
This pull requests add a new convenience method to the `Illuminate\Support\Str` class - `Str::builder()`.

This is in the same vein as the `Str::of()` method, except it returns a completely empty `Stringable` instance, acting purely as a builder and in my opinion, reads much better than `Str::of('')` and `(new Stringable)->methodNameHere()`.

> Note: there wasn't a test for the `Str::of` method, so I've added a very simple one for that, as well as the `Str::builder()` method.