### PR TITLE
[8.x] Adds Model key extraction to id on `whereKey()` and `whereKeyNot()`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -210,6 +210,10 @@ class Builder
      */
     public function whereKey($id)
     {
+        if ($id instanceof Model) {
+            $id = $id->getKey();
+        }
+
         if (is_array($id) || $id instanceof Arrayable) {
             $this->query->whereIn($this->model->getQualifiedKeyName(), $id);
 
@@ -231,6 +235,10 @@ class Builder
      */
     public function whereKeyNot($id)
     {
+        if ($id instanceof Model) {
+            $id = $id->getKey();
+        }
+
         if (is_array($id) || $id instanceof Arrayable) {
             $this->query->whereNotIn($this->model->getQualifiedKeyName(), $id);
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1259,6 +1259,21 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->whereKey($collection);
     }
 
+    public function testWhereKeyMethodWithModel()
+    {
+        $model = new EloquentBuilderTestStubStringPrimaryKey;
+        $builder = $this->getBuilder()->setModel($model);
+        $keyName = $model->getQualifiedKeyName();
+
+        $builder->getQuery()->shouldReceive('where')->once()->with($keyName, '=', m::on(function ($argument) {
+            return $argument === '1';
+        }));
+
+        $builder->whereKey(new class extends Model {
+            protected $attributes = ['id' => 1];
+        });
+    }
+
     public function testWhereKeyNotMethodWithStringZero()
     {
         $model = new EloquentBuilderTestStubStringPrimaryKey;
@@ -1323,6 +1338,21 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->getQuery()->shouldReceive('whereNotIn')->once()->with($keyName, $collection);
 
         $builder->whereKeyNot($collection);
+    }
+
+    public function testWhereKeyNotMethodWithModel()
+    {
+        $model = new EloquentBuilderTestStubStringPrimaryKey;
+        $builder = $this->getBuilder()->setModel($model);
+        $keyName = $model->getQualifiedKeyName();
+
+        $builder->getQuery()->shouldReceive('where')->once()->with($keyName, '!=', m::on(function ($argument) {
+            return $argument === '1';
+        }));
+
+        $builder->whereKeyNot(new class extends Model {
+            protected $attributes = ['id' => 1];
+        });
     }
 
     public function testWhereIn()


### PR DESCRIPTION
This PR allows to get the key of a Model when a Model instance is issued on `whereKey()` and `whereKeyNot()` methods to the Builder for relationships.

## Problem & Solution

If a developer issues a Model instance to `whereKey()` or `whereKeyNot()`, these methods will make a `WHERE IN` clause with all the model attributes, mainly because a Model implements `Arrayable`.

To avoid this, these methods will check first if the `$id` is a Model instance, and get the key from it.

```php
$passenger->tickets()->whereHas('airline', fn (Builder $query) => $query->whereKey($airline))->get();
```