### PR TITLE
[8.x] Improvements in character encoding methods.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,8 +41,7 @@
         "symfony/routing": "^5.1.4",
         "symfony/var-dumper": "^5.1.4",
         "tijsverkoyen/css-to-inline-styles": "^2.2.2",
-        "vlucas/phpdotenv": "^5.2",
-        "voku/portable-ascii": "^1.4.8"
+        "vlucas/phpdotenv": "^5.2"
     },
     "replace": {
         "illuminate/auth": "self.version",

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -8,7 +8,6 @@ use Ramsey\Uuid\Codec\TimestampFirstCombCodec;
 use Ramsey\Uuid\Generator\CombGenerator;
 use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidFactory;
-use voku\helper\ASCII;
 
 class Str
 {
@@ -91,12 +90,35 @@ class Str
      * Transliterate a UTF-8 value to ASCII.
      *
      * @param  string  $value
-     * @param  string  $language
      * @return string
      */
-    public static function ascii($value, $language = 'en')
+    public static function ascii($value)
     {
-        return ASCII::to_ascii((string) $value, $language);
+        return static::encoding($value, 'UTF-8', 'ASCII');
+    }
+
+    /**
+     * Transliterate a ASCII value to UTF-8.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    public static function utf8($value)
+    {
+        return static::encoding($value, 'ASCII', 'UTF-8');
+    }
+
+    /**
+     * Transliterate a given value to target encoding.
+     *
+     * @param  string  $value
+     * @param  string  $to
+     * @param  string|string[]|null  $from
+     * @return string
+     */
+    public static function encoding($value, $to, $from)
+    {
+        return mb_convert_encoding((string) $value, $to, $from);
     }
 
     /**
@@ -288,7 +310,31 @@ class Str
      */
     public static function isAscii($value)
     {
-        return ASCII::is_ascii((string) $value);
+        return static::isEncoding($value, 'ASCII');
+    }
+
+    /**
+     * Determine if a given string is UTF-8.
+     *
+     * @param  string  $value
+     * @return bool
+     */
+    public static function isUtf8($value)
+    {
+        return static::isEncoding($value, 'UTF-8');
+    }
+
+    /**
+     * Determine the encoding of a particular string.
+     *
+     * @param  string  $value
+     * @param  string|string[]|null  $encodings
+     * @param  bool  $strict
+     * @return bool
+     */
+    public static function isEncoding($value, $encodings, $strict = false)
+    {
+        return mb_detect_encoding((string) $value, $encodings, $strict);
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -87,28 +87,6 @@ class Str
     }
 
     /**
-     * Transliterate a UTF-8 value to ASCII.
-     *
-     * @param  string  $value
-     * @return string
-     */
-    public static function ascii($value)
-    {
-        return static::encoding($value, 'UTF-8', 'ASCII');
-    }
-
-    /**
-     * Transliterate a ASCII value to UTF-8.
-     *
-     * @param  string  $value
-     * @return string
-     */
-    public static function utf8($value)
-    {
-        return static::encoding($value, 'ASCII', 'UTF-8');
-    }
-
-    /**
      * Transliterate a given value to target encoding.
      *
      * @param  string  $value
@@ -300,28 +278,6 @@ class Str
         }
 
         return false;
-    }
-
-    /**
-     * Determine if a given string is 7 bit ASCII.
-     *
-     * @param  string  $value
-     * @return bool
-     */
-    public static function isAscii($value)
-    {
-        return static::isEncoding($value, 'ASCII');
-    }
-
-    /**
-     * Determine if a given string is UTF-8.
-     *
-     * @param  string  $value
-     * @return bool
-     */
-    public static function isUtf8($value)
-    {
-        return static::isEncoding($value, 'UTF-8');
     }
 
     /**


### PR DESCRIPTION
### Changes :
- The package `voku/portable-ascii` has been removed, Instead, the mbstring library was used.
- The method `isAscii()` has been removed.
- The method `ascii()` has been removed.

- The method `isEncoding()` has been included.
```php
// Basic (See : https://www.php.net/manual/en/function.mb-detect-encoding.php)
Str::isEncoding('foo', 'UTF-8'); // Returns whether the character encoding is UTF-8.
Str::isEncoding('foo', 'ASCII'); // Returns whether the character encoding is ASCII.
Str::isEncoding('foo', 'UTF-7'); // Returns whether the character encoding is UTF-7.
Str::isEncoding('foo', 'UCS-2LE'); // Returns whether the character encoding is UCS-2LE.
Str::isEncoding('foo', 'EUC-JP'); // Returns whether the character encoding is EUC-JP.

// Advanced (See : https://www.php.net/manual/en/function.mb-detect-encoding.php)
Str::isEncoding('foo', 'auto'); // See : https://www.php.net/manual/en/function.mb-detect-encoding.php
Str::isEncoding('foo', ['UTF-8', 'ASCII', 'UTF-7']); // See : https://www.php.net/manual/en/function.mb-detect-encoding.php
```
- The method `encoding()` has been included.
```php
// Basic (See : https://www.php.net/manual/en/function.mb-convert-encoding.php)
Str::encoding('foo', 'UTF-8', 'ASCII'); // Converts the character encoding to UTF-8.
Str::encoding('foo', 'ASCII', 'UTF-8'); // Converts the character encoding to ASCII.
Str::encoding('foo', 'UTF-7', 'EUC-JP'); // Converts the character encoding to UTF-7.

// Advanced (See : https://www.php.net/manual/en/function.mb-convert-encoding.php)
Str::encoding('foo', 'UTF-8', 'auto'); // Converts the character encoding to UTF-8.
Str::encoding('foo', ,'ASCII', ['UTF-8', 'ASCII', 'UTF-7']); // Converts the character encoding to ASCII.
```

### To do list :
- [ ] Test files will be updated according to the new updated version.
- [ ] Changes will be sent as pull request to `laravel/docs`.
- [ ] Same things will be done inside the Stringable class.