### PR TITLE
[8.x] Sub select render only if necessary

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -203,6 +203,31 @@ class Builder
     }
 
     /**
+     * Add a new select column to the query.
+     *
+     * @param  array|mixed $column
+     * @return $this
+     */
+    public function addSelect($column)
+    {
+        $columns = is_array($column) ? $column : func_get_args();
+
+        foreach ($columns as $as => $column) {
+            if (is_string($as) && $column instanceof self) {
+                if (is_null($this->query->columns)) {
+                    $this->query->select($this->query->from.'.*');
+                }
+
+                $this->query->columns[] = new SubSelect($column, $as, $this);
+            } else {
+                $this->query->addSelect([$as => $column]);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
      * Add a where clause on the primary key to the query.
      *
      * @param  mixed  $id

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -218,7 +218,7 @@ class Builder
                     $this->query->select($this->query->from.'.*');
                 }
 
-                $this->query->columns[] = new SubSelect($column, $as, $this);
+                $this->query->columns[] = new SubSelect($this, $column, $as);
             } else {
                 $this->query->addSelect([$as => $column]);
             }

--- a/src/Illuminate/Database/Eloquent/SubSelect.php
+++ b/src/Illuminate/Database/Eloquent/SubSelect.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Illuminate\Database\Eloquent;
+
+use Illuminate\Database\Query\Expression;
+
+class SubSelect extends Expression
+{
+    /**
+     * The parent query builder.
+     *
+     * @var Builder
+     */
+    protected $parent;
+
+    /**
+     * The sub select query builder.
+     *
+     * @var Builder
+     */
+    protected $query;
+
+    /**
+     * The select alias.
+     *
+     * @var string
+     */
+    protected $as;
+
+    /**
+     * Create new SubSelect instance.
+     *
+     * @param Builder $parent
+     * @param Builder $query
+     * @param string  $as
+     */
+    public function __construct(Builder $parent, Builder $query, $as)
+    {
+        $this->parent = $parent;
+        $this->query = $query;
+        $this->as = $as;
+    }
+
+    /**
+     * Get the value of the expression.
+     *
+     * @return mixed
+     */
+    public function getValue()
+    {
+        $bindings = $this->query->getBindings();
+
+        $value = '('.$this->query->toSql().') as '.$this->parent->getGrammar()->wrap($this->as);
+
+        if ($bindings) {
+            $this->parent->getQuery()->addBinding($bindings, 'select');
+        }
+
+        return $value;
+    }
+}

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -28,6 +28,28 @@ class DatabaseEloquentBuilderTest extends TestCase
         m::close();
     }
 
+    public function testAddingSubSelects()
+    {
+        $subQuery = new Builder(new BaseBuilder(
+            m::mock(ConnectionInterface::class),
+            new Grammar,
+            m::mock(Processor::class)
+        ));
+        $query = new Builder(new BaseBuilder(
+            m::mock(ConnectionInterface::class),
+            new Grammar,
+            m::mock(Processor::class)
+        ));
+
+        $query->from('users')->addSelect([
+            'foo' => $subQuery,
+        ]);
+        $subQuery->where('bar', 'baz');
+
+        $this->assertSame('select "users".*, (select * where "bar" = ?) as "foo" from "users"', $query->toSql());
+        $this->assertSame(['baz'], $query->getBindings());
+    }
+
     public function testFindMethod()
     {
         $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);


### PR DESCRIPTION
This pr fixes that expressions of a subselect query are not applied to the parent query if the expression is added after calling `addSelect`.

The following example shows the problem:

```php
$query->addSelect([
    'foo' => $subQuery = new Builder()
]);
$subQuery->where('bar', 'baz');
```

Expected:
```sql
select "".*, (select * where "bar" = ?) as "foo"
```

Before fix:
```sql
select "".*, (select *) as "foo"
```

This is because the `addSelect` method renders the subQuery directly after it is applied. The solution is that an instance of an expression is added which will only be rendered when needed to keep the object alive.