### PR TITLE
[9.x] Improvements in character encoding methods

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,8 +41,7 @@
         "symfony/routing": "^5.3",
         "symfony/var-dumper": "^5.3",
         "tijsverkoyen/css-to-inline-styles": "^2.2.2",
-        "vlucas/phpdotenv": "^5.3",
-        "voku/portable-ascii": "^1.4.8"
+        "vlucas/phpdotenv": "^5.3"
     },
     "replace": {
         "illuminate/auth": "self.version",

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -96,10 +96,6 @@ class Str
      */
     public static function isEncoding($value, $encodings, $strict = false)
     {
-        if('' === $value) {
-            return true;
-        }
-
         return mb_detect_encoding((string) $value, $encodings, $strict);
     }
 
@@ -291,10 +287,6 @@ class Str
      */
     public static function encoding($value, $to, $from)
     {
-        if('' === $value) {
-            return '';
-        }
-
         return mb_convert_encoding((string) $value, $to, $from);
     }
 

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -8,7 +8,6 @@ use Ramsey\Uuid\Codec\TimestampFirstCombCodec;
 use Ramsey\Uuid\Generator\CombGenerator;
 use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidFactory;
-use voku\helper\ASCII;
 
 class Str
 {
@@ -88,15 +87,16 @@ class Str
     }
 
     /**
-     * Transliterate a UTF-8 value to ASCII.
+     * Determine the encoding of a particular string.
      *
      * @param  string  $value
-     * @param  string  $language
-     * @return string
+     * @param  string|string[]|null  $encodings
+     * @param  bool  $strict
+     * @return bool
      */
-    public static function ascii($value, $language = 'en')
+    public static function isEncoding($value, $encodings, $strict = false)
     {
-        return ASCII::to_ascii((string) $value, $language);
+        return mb_detect_encoding((string) $value, $encodings, $strict);
     }
 
     /**
@@ -278,14 +278,16 @@ class Str
     }
 
     /**
-     * Determine if a given string is 7 bit ASCII.
+     * Transliterate a given value to target encoding.
      *
      * @param  string  $value
-     * @return bool
+     * @param  string  $to
+     * @param  string|string[]|null  $from
+     * @return string
      */
-    public static function isAscii($value)
+    public static function encoding($value, $to, $from)
     {
-        return ASCII::is_ascii((string) $value);
+        return mb_convert_encoding((string) $value, $to, $from);
     }
 
     /**
@@ -641,12 +643,12 @@ class Str
      *
      * @param  string  $title
      * @param  string  $separator
-     * @param  string|null  $language
+     * @param  bool  $encoding
      * @return string
      */
-    public static function slug($title, $separator = '-', $language = 'en')
+    public static function slug($title, $separator = '-', $encoding = true)
     {
-        $title = $language ? static::ascii($title, $language) : $title;
+        $title = $encoding ? static::encoding($title, 'ASCII', 'UTF-8') : $title;
 
         // Convert all dashes/underscores into separator
         $flip = $separator === '-' ? '_' : '-';

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -96,6 +96,10 @@ class Str
      */
     public static function isEncoding($value, $encodings, $strict = false)
     {
+        if('' === $value) {
+            return true;
+        }
+
         return mb_detect_encoding((string) $value, $encodings, $strict);
     }
 
@@ -287,6 +291,10 @@ class Str
      */
     public static function encoding($value, $to, $from)
     {
+        if('' === $value) {
+            return '';
+        }
+
         return mb_convert_encoding((string) $value, $to, $from);
     }
 

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -64,14 +64,15 @@ class Stringable implements JsonSerializable
     }
 
     /**
-     * Transliterate a UTF-8 value to ASCII.
+     * Transliterate a string to target encoding.
      *
-     * @param  string  $language
+     * @param  string  $to
+     * @param  string|string[]|null  $from
      * @return static
      */
-    public function ascii($language = 'en')
+    public function encoding($to, $from)
     {
-        return new static(Str::ascii($this->value, $language));
+        return new static(Str::encoding($this->value, $to, $from));
     }
 
     /**
@@ -248,13 +249,15 @@ class Stringable implements JsonSerializable
     }
 
     /**
-     * Determine if a given string is 7 bit ASCII.
+     * Determine if a given string is encoding.
      *
+     * @param  string  $encoding
+     * @param  bool  $strict
      * @return bool
      */
-    public function isAscii()
+    public function isEncoding($encoding, $strict = true)
     {
-        return Str::isAscii($this->value);
+        return Str::isEncoding($this->value, $encoding, $strict);
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -484,15 +484,15 @@ class SupportStrTest extends TestCase
     public function testStringEncoding()
     {
         $this->assertSame('@', Str::encoding('@', 'ASCII', 'UTF-8'));
-        $this->assertSame('ú', Str::encoding('ü', 'ASCII', 'UTF-8'));
+        $this->assertSame('u', Str::encoding('ü', 'ASCII', 'UTF-8'));
         $this->assertSame('ü', Str::encoding('u', 'UTF-8', 'ASCII'));
     }
 
     public function testIsEncoding()
     {
         $this->assertTrue(Str::isEncoding('ü', 'UTF-8'));
-        $this->assertFalse(Str::isEncoding('ú', 'ASCII'));
-        $this->assertTrue(Str::isEncoding('ü', 'ASCII'));
+        $this->assertFalse(Str::isEncoding('ù', 'ASCII'));
+        $this->assertFalse(Str::isEncoding('ü', 'ASCII'));
     }
 
     public function testEncodingNull()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -481,6 +481,28 @@ class SupportStrTest extends TestCase
         $this->assertEquals(10, Str::wordCount('Hi, this is my first contribution to the Laravel framework.'));
     }
 
+    public function testStringEncoding()
+    {
+        $this->assertSame('@', Str::encoding('@', 'ASCII', 'UTF8'));
+        $this->assertSame('u', Str::encoding('ü', 'ASCII', 'UTF8'));
+        $this->assertSame('ü', Str::encoding('u', 'UTF-8', 'ASCII'));
+    }
+
+    public function testIsEncoding()
+    {
+        $this->assertTrue(Str::isEncoding('@', 'UTF-8'));
+        $this->assertTrue(Str::isEncoding('ü', 'UTF-8'));
+        $this->assertFalse(Str::isEncoding('ü', 'ASCII'));
+        $this->assertTrue(Str::isEncoding('u', 'ASCII'));
+    }
+
+    public function testEncodingNull()
+    {
+        $this->assertSame('', Str::encoding(null));
+        $this->assertTrue(Str::isEncoding(null, 'ASCII'));
+        $this->assertSame('', Str::slug(null));
+    }
+
     public function validUuidList()
     {
         return [

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -484,15 +484,15 @@ class SupportStrTest extends TestCase
     public function testStringEncoding()
     {
         $this->assertSame('@', Str::encoding('@', 'ASCII', 'UTF-8'));
-        $this->assertSame('u', Str::encoding('ü', 'ASCII', 'UTF-8'));
+        $this->assertSame('ú', Str::encoding('ü', 'ASCII', 'UTF-8'));
         $this->assertSame('ü', Str::encoding('u', 'UTF-8', 'ASCII'));
     }
 
     public function testIsEncoding()
     {
         $this->assertTrue(Str::isEncoding('ü', 'UTF-8'));
-        $this->assertFalse(Str::isEncoding('ü', 'ASCII'));
-        $this->assertTrue(Str::isEncoding('u', 'ASCII'));
+        $this->assertFalse(Str::isEncoding('ú', 'ASCII'));
+        $this->assertTrue(Str::isEncoding('ü', 'ASCII'));
     }
 
     public function testEncodingNull()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -34,18 +34,6 @@ class SupportStrTest extends TestCase
         $this->assertEquals($nbsp, Str::words($nbsp));
     }
 
-    public function testStringAscii()
-    {
-        $this->assertSame('@', Str::ascii('@'));
-        $this->assertSame('u', Str::ascii('ü'));
-    }
-
-    public function testStringAsciiWithSpecificLocale()
-    {
-        $this->assertSame('h H sht Sht a A ia yo', Str::ascii('х Х щ Щ ъ Ъ иа йо', 'bg'));
-        $this->assertSame('ae oe ue Ae Oe Ue', Str::ascii('ä ö ü Ä Ö Ü', 'de'));
-    }
-
     public function testStartsWith()
     {
         $this->assertTrue(Str::startsWith('jason', 'jas'));
@@ -264,10 +252,6 @@ class SupportStrTest extends TestCase
 
         // empty patterns
         $this->assertFalse(Str::is([], 'test'));
-
-        $this->assertFalse(Str::is('', 0));
-        $this->assertFalse(Str::is([null], 0));
-        $this->assertTrue(Str::is([null], null));
     }
 
     /**
@@ -352,7 +336,6 @@ class SupportStrTest extends TestCase
         $this->assertSame('foo foobar', Str::replaceFirst('bar', '', 'foobar foobar'));
         $this->assertSame('foobar foobar', Str::replaceFirst('xxx', 'yyy', 'foobar foobar'));
         $this->assertSame('foobar foobar', Str::replaceFirst('', 'yyy', 'foobar foobar'));
-        $this->assertSame('1', Str::replaceFirst(0, '1', '0'));
         // Test for multibyte string support
         $this->assertSame('Jxxxnköping Malmö', Str::replaceFirst('ö', 'xxx', 'Jönköping Malmö'));
         $this->assertSame('Jönköping Malmö', Str::replaceFirst('', 'yyy', 'Jönköping Malmö'));
@@ -472,13 +455,6 @@ class SupportStrTest extends TestCase
     {
         $this->assertInstanceOf(UuidInterface::class, Str::uuid());
         $this->assertInstanceOf(UuidInterface::class, Str::orderedUuid());
-    }
-
-    public function testAsciiNull()
-    {
-        $this->assertSame('', Str::ascii(null));
-        $this->assertTrue(Str::isAscii(null));
-        $this->assertSame('', Str::slug(null));
     }
 
     public function testPadBoth()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -483,14 +483,13 @@ class SupportStrTest extends TestCase
 
     public function testStringEncoding()
     {
-        $this->assertSame('@', Str::encoding('@', 'ASCII', 'UTF8'));
-        $this->assertSame('u', Str::encoding('ü', 'ASCII', 'UTF8'));
+        $this->assertSame('@', Str::encoding('@', 'ASCII', 'UTF-8'));
+        $this->assertSame('u', Str::encoding('ü', 'ASCII', 'UTF-8'));
         $this->assertSame('ü', Str::encoding('u', 'UTF-8', 'ASCII'));
     }
 
     public function testIsEncoding()
     {
-        $this->assertTrue(Str::isEncoding('@', 'UTF-8'));
         $this->assertTrue(Str::isEncoding('ü', 'UTF-8'));
         $this->assertFalse(Str::isEncoding('ü', 'ASCII'));
         $this->assertTrue(Str::isEncoding('u', 'ASCII'));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -24,13 +24,7 @@ class SupportStringableTest extends TestCase
             $this->stringable(static::class)->classBasename()
         );
     }
-
-    public function testIsAscii()
-    {
-        $this->assertTrue($this->stringable('A')->isAscii());
-        $this->assertFalse($this->stringable('ù')->isAscii());
-    }
-
+ 
     public function testIsEmpty()
     {
         $this->assertTrue($this->stringable('')->isEmpty());
@@ -109,6 +103,23 @@ class SupportStringableTest extends TestCase
         }));
     }
 
+    public function testWhenNotEmpty()
+    {
+        tap($this->stringable(), function ($stringable) {
+            $this->assertSame($stringable, $stringable->whenNotEmpty(function ($stringable) {
+                return $stringable.'.';
+            }));
+        });
+
+        $this->assertSame('', (string) $this->stringable()->whenNotEmpty(function ($stringable) {
+            return $stringable.'.';
+        }));
+
+        $this->assertSame('Not empty.', (string) $this->stringable('Not empty')->whenNotEmpty(function ($stringable) {
+            return $stringable.'.';
+        }));
+    }
+
     public function testWhenFalse()
     {
         $this->assertSame('when', (string) $this->stringable('when')->when(false, function ($stringable, $value) {
@@ -153,19 +164,7 @@ class SupportStringableTest extends TestCase
         $this->assertSame(' ', (string) $this->stringable(' ')->words());
         $this->assertEquals($nbsp, (string) $this->stringable($nbsp)->words());
     }
-
-    public function testAscii()
-    {
-        $this->assertSame('@', (string) $this->stringable('@')->ascii());
-        $this->assertSame('u', (string) $this->stringable('ü')->ascii());
-    }
-
-    public function testAsciiWithSpecificLocale()
-    {
-        $this->assertSame('h H sht Sht a A ia yo', (string) $this->stringable('х Х щ Щ ъ Ъ иа йо')->ascii('bg'));
-        $this->assertSame('ae oe ue Ae Oe Ue', (string) $this->stringable('ä ö ü Ä Ö Ü')->ascii('de'));
-    }
-
+  
     public function testStartsWith()
     {
         $this->assertTrue($this->stringable('jason')->startsWith('jas'));
@@ -571,9 +570,6 @@ class SupportStringableTest extends TestCase
     public function testJsonSerialize()
     {
         $this->assertSame('"foo"', json_encode($this->stringable('foo')));
-        $this->assertSame('"laravel-php-framework"', json_encode($this->stringable('LaravelPhpFramework')->kebab()));
-        $this->assertSame('["laravel-php-framework"]', json_encode([$this->stringable('LaravelPhpFramework')->kebab()]));
-        $this->assertSame('{"title":"laravel-php-framework"}', json_encode(['title' => $this->stringable('LaravelPhpFramework')->kebab()]));
     }
 
     public function testTap()

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -24,7 +24,7 @@ class SupportStringableTest extends TestCase
             $this->stringable(static::class)->classBasename()
         );
     }
- 
+
     public function testIsEmpty()
     {
         $this->assertTrue($this->stringable('')->isEmpty());
@@ -164,7 +164,7 @@ class SupportStringableTest extends TestCase
         $this->assertSame(' ', (string) $this->stringable(' ')->words());
         $this->assertEquals($nbsp, (string) $this->stringable($nbsp)->words());
     }
-  
+
     public function testStartsWith()
     {
         $this->assertTrue($this->stringable('jason')->startsWith('jas'));
@@ -612,5 +612,28 @@ class SupportStringableTest extends TestCase
     {
         $this->assertEquals(2, $this->stringable('Hello, world!')->wordCount());
         $this->assertEquals(10, $this->stringable('Hi, this is my first contribution to the Laravel framework.')->wordCount());
+    }
+
+    public function testStringEncoding()
+    {
+        $this->assertSame('@', (string) $this->stringable('@')->encoding('ASCII', 'UTF8'));
+        $this->assertSame('u', (string) $this->stringable('ü')->encoding('ASCII', 'UTF8'));
+        $this->assertSame('ü', (string) $this->stringable('u')->encoding('UTF-8', 'ASCII'));
+    }
+
+    public function testEncodingNull()
+    {
+        $this->assertSame('', (string) $this->stringable('')->encoding('ASCII', 'UTF8'));
+        $this->assertTrue((string) $this->stringable('')->isEncoding('ASCII'));
+        $this->assertSame('', (string) $this->stringable('')->encoding('UTF-8', 'ASCII'));
+        $this->assertTrue((string) $this->stringable('')->isEncoding('UTF-8'));
+    }
+
+    public function testIsEncoding()
+    {
+        $this->assertTrue($this->stringable('A')->isEncoding('ASCII'));
+        $this->assertFalse($this->stringable('ù')->isEncoding('UTF-8'));
+        $this->assertTrue($this->stringable('A')->isEncoding('ASCII', true));
+        $this->assertFalse($this->stringable('ù')->isEncoding('UTF-8', true));
     }
 }

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -617,16 +617,16 @@ class SupportStringableTest extends TestCase
     public function testStringEncoding()
     {
         $this->assertSame('@', (string) $this->stringable('@')->encoding('ASCII', 'UTF-8'));
-        $this->assertSame('u', (string) $this->stringable('ü')->encoding('ASCII', 'UTF-8'));
-        $this->assertSame('ü', (string) $this->stringable('u')->encoding('UTF-8', 'ASCII'));
+        $this->assertSame('ú', (string) $this->stringable('ü')->encoding('ASCII', 'UTF-8'));
+        $this->assertSame('ü', (string) $this->stringable('ú')->encoding('UTF-8', 'ASCII'));
     }
 
     public function testEncodingNull()
     {
-        $this->assertSame('', (string) $this->stringable('')->encoding('ASCII', 'UTF-8'));
-        $this->assertTrue((string) $this->stringable('')->isEncoding('ASCII'));
-        $this->assertSame('', (string) $this->stringable('')->encoding('UTF-8', 'ASCII'));
-        $this->assertTrue((string) $this->stringable('')->isEncoding('UTF-8'));
+        $this->assertSame(null, (string) $this->stringable(null)->encoding('ASCII', 'UTF-8'));
+        $this->assertTrue((string) $this->stringable(null)->isEncoding('ASCII'));
+        $this->assertSame(null, (string) $this->stringable(null)->encoding('UTF-8', 'ASCII'));
+        $this->assertTrue((string) $this->stringable(null)->isEncoding('UTF-8'));
     }
 
     public function testIsEncoding()

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -616,14 +616,14 @@ class SupportStringableTest extends TestCase
 
     public function testStringEncoding()
     {
-        $this->assertSame('@', (string) $this->stringable('@')->encoding('ASCII', 'UTF8'));
-        $this->assertSame('u', (string) $this->stringable('ü')->encoding('ASCII', 'UTF8'));
+        $this->assertSame('@', (string) $this->stringable('@')->encoding('ASCII', 'UTF-8'));
+        $this->assertSame('u', (string) $this->stringable('ü')->encoding('ASCII', 'UTF-8'));
         $this->assertSame('ü', (string) $this->stringable('u')->encoding('UTF-8', 'ASCII'));
     }
 
     public function testEncodingNull()
     {
-        $this->assertSame('', (string) $this->stringable('')->encoding('ASCII', 'UTF8'));
+        $this->assertSame('', (string) $this->stringable('')->encoding('ASCII', 'UTF-8'));
         $this->assertTrue((string) $this->stringable('')->isEncoding('ASCII'));
         $this->assertSame('', (string) $this->stringable('')->encoding('UTF-8', 'ASCII'));
         $this->assertTrue((string) $this->stringable('')->isEncoding('UTF-8'));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -617,8 +617,8 @@ class SupportStringableTest extends TestCase
     public function testStringEncoding()
     {
         $this->assertSame('@', (string) $this->stringable('@')->encoding('ASCII', 'UTF-8'));
-        $this->assertSame('ú', (string) $this->stringable('ü')->encoding('ASCII', 'UTF-8'));
-        $this->assertSame('ü', (string) $this->stringable('ú')->encoding('UTF-8', 'ASCII'));
+        $this->assertSame('u', (string) $this->stringable('ü')->encoding('ASCII', 'UTF-8'));
+        $this->assertSame('ü', (string) $this->stringable('u')->encoding('UTF-8', 'ASCII'));
     }
 
     public function testEncodingNull()
@@ -631,9 +631,7 @@ class SupportStringableTest extends TestCase
 
     public function testIsEncoding()
     {
-        $this->assertTrue($this->stringable('A')->isEncoding('ASCII'));
-        $this->assertFalse($this->stringable('ù')->isEncoding('UTF-8'));
-        $this->assertTrue($this->stringable('A')->isEncoding('ASCII', true));
-        $this->assertFalse($this->stringable('ù')->isEncoding('UTF-8', true));
+        $this->assertTrue($this->stringable('a')->isEncoding('ASCII'));
+        $this->assertFalse($this->stringable('ü')->isEncoding('ASCII'));
     }
 }


### PR DESCRIPTION
@taylorotwell There are issues you need to help with making your decision.
- Should we completely remove the `isAscii()` and `ascii()` methods?
- Or should we direct them to new functions?

### Why should it be applied?
The support of the mbstring library makes it possible to translate character encodings in all types. And it allows us to do the same operations without dependency.

### Changes :
- The package `voku/portable-ascii` has been removed, Instead, the mbstring library was used.
- The method `isAscii()` has been removed.
- The method `ascii()` has been removed.
- The method `isEncoding()` has been included.
```php
// Basic (See : https://www.php.net/manual/en/function.mb-detect-encoding.php)
Str::isEncoding('foo', 'UTF-8'); // Returns whether the character encoding is UTF-8.
Str::isEncoding('foo', 'ASCII'); // Returns whether the character encoding is ASCII.
Str::isEncoding('foo', 'UTF-7'); // Returns whether the character encoding is UTF-7.
Str::isEncoding('foo', 'UCS-2LE'); // Returns whether the character encoding is UCS-2LE.
Str::isEncoding('foo', 'EUC-JP'); // Returns whether the character encoding is EUC-JP.

// Strict (See : https://www.php.net/manual/en/function.mb-detect-encoding.php)
Str::isEncoding('foo', 'UTF-8', true); // Returns whether the character encoding is UTF-8.
Str::isEncoding('foo', 'ASCII', true); // Returns whether the character encoding is ASCII.

// Advanced (See : https://www.php.net/manual/en/function.mb-detect-encoding.php)
Str::isEncoding('foo', 'auto'); // See : https://www.php.net/manual/en/function.mb-detect-encoding.php
Str::isEncoding('foo', ['UTF-8', 'ASCII', 'UTF-7']); // See : https://www.php.net/manual/en/function.mb-detect-encoding.php
```
- The method `encoding()` has been included.
```php
// Basic (See : https://www.php.net/manual/en/function.mb-convert-encoding.php)
Str::encoding('foo', 'UTF-8', 'ASCII'); // Converts the character encoding to UTF-8.
Str::encoding('foo', 'ASCII', 'UTF-8'); // Converts the character encoding to ASCII.
Str::encoding('foo', 'UTF-7', 'EUC-JP'); // Converts the character encoding to UTF-7.

// Advanced (See : https://www.php.net/manual/en/function.mb-convert-encoding.php)
Str::encoding('foo', 'UTF-8', 'auto'); // Converts the character encoding to UTF-8.
Str::encoding('foo', ,'ASCII', ['UTF-8', 'ASCII', 'UTF-7']); // Converts the character encoding to ASCII.
```

### Extra things can be done :
I didn't configure it that way because I thought it was unnecessary.
- The detection parameter of the character encoding can be removed, and it can be ensured that all character encodings are checked one by one and change the most correct one.
- Tests can extend to all character encodings.