### PR TITLE
[8.x] Use jsonSerialize instead toJSON

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1074,7 +1074,7 @@ trait HasAttributes
      */
     protected function serializeDate(DateTimeInterface $date)
     {
-        return Carbon::instance($date)->toJSON();
+        return Carbon::instance($date)->jsonSerialize();
     }
 
     /**


### PR DESCRIPTION
```php
Carbon::serializeUsing(function ($carbon) {

});
```
```php
/**
     * Prepare the object for JSON serialization.
     *
     * @return array|string
     */
    public function jsonSerialize()
    {
        $serializer = $this->localSerializer ?? static::$serializer;

        if ($serializer) {
            return \is_string($serializer)
                ? $this->rawFormat($serializer)
                : $serializer($this);
        }

        return $this->toJSON();
}
```
`Carbon::serializeUsing` only work if use jsonSerialize

I can use `serializeUsing` to modify toJSON of Carbon, for all Carbon instance. I dont need define
```php
protected function serializeDate(\DateTimeInterface $date)
{
}
```

in all model

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
