### PR TITLE
[8.x] Get table name from model statically

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1550,6 +1550,16 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
      *
      * @return string
      */
+    public static function table()
+    {
+        return (new static)->getTable();
+    }
+
+    /**
+     * Get the table associated with the model.
+     *
+     * @return string
+     */
     public function getTable()
     {
         return $this->table ?? Str::snake(Str::pluralStudly(class_basename($this)));

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -813,6 +813,12 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertSame('foo', $model->getTable());
     }
 
+    public function testGetTableNameStatically()
+    {
+        $model = new EloquentModelStub;
+        $this->assertSame($model->getTable(), EloquentModelStub::table());
+    }
+
     public function testGetKeyReturnsValueOfPrimaryKey()
     {
         $model = new EloquentModelStub;


### PR DESCRIPTION
We can get table name for each model by using `getTable` method on model. But there is no way to get table name statically. This PR adds `table` static method for getting table name from a model.
```php
Schema::create(User::table(), function (Blueprint $table) {});
Rule::unique(User::table());
DB::table(User::table())->first();
```
It can be useful for writing cleaner code.

![Screen Shot 2021-05-01 at 16 56 42](https://user-images.githubusercontent.com/49806042/116784832-fa8c8580-aa9e-11eb-8c98-b02b7a2f9766.png)
![Screen Shot 2021-05-01 at 17 00 19](https://user-images.githubusercontent.com/49806042/116784834-fceedf80-aa9e-11eb-9dfe-280a16288adc.png)
![Screen Shot 2021-05-01 at 17 01 16](https://user-images.githubusercontent.com/49806042/116784836-011afd00-aa9f-11eb-9a5d-8a70c8afd7a1.png)

Currently if i want to get table name from model i have to write this code:
```php
Rule::unique((new User)->getTable())
```