### PR TITLE
[8.x] Add restoreOrDelete Method to softdelete trait

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -198,4 +198,18 @@ trait SoftDeletes
     {
         return $this->qualifyColumn($this->getDeletedAtColumn());
     }
+    
+    /**
+     * Restore or Delete a soft-deleted model instance.
+     *
+     * @return bool|null
+     */
+    public function restoreOrDelete()
+    {
+        if($this->trashed()){
+            return $this->restore();
+        }else{
+            return $this->delete();
+        }
+    }
 }

--- a/tests/Database/DatabaseSoftDeletingTraitTest.php
+++ b/tests/Database/DatabaseSoftDeletingTraitTest.php
@@ -56,6 +56,22 @@ class DatabaseSoftDeletingTraitTest extends TestCase
 
         $this->assertFalse($model->restore());
     }
+    
+    public function testRestoreOrDelete()
+    {
+        $model = m::mock(DatabaseSoftDeletingTraitStub::class);
+        $model->makePartial();
+        $wasTrashed = $model->trashed();
+        $model->shouldReceive('restoreOrDelete');
+
+        $model->restoreOrDelete();
+
+        if($wasTrashed){
+            $this->assertNotNull($model->deleted_at);
+        }else{
+            $this->assertNull($model->deleted_at);
+        }
+    }
 }
 
 class DatabaseSoftDeletingTraitStub


### PR DESCRIPTION
### Description
Enable toggling of the softdelete activity between `restore()` and `delete()`.

```php
// before
if( $model->trashed() ){
    return $model->restore();
}else{
    return $model->delete();
}

// after 
$model->restoreOrDelete();
```

Test Case:
*PS: Its my first time working on test case. I not sure if they are correctly written.*