### PR TITLE
[8.x] Differentiate warning output style from comment

### DIFF
--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -343,7 +343,7 @@ trait InteractsWithIO
     public function warn($string, $verbosity = null)
     {
         if (! $this->output->getFormatter()->hasStyle('warning')) {
-            $style = new OutputFormatterStyle('yellow');
+            $style = new OutputFormatterStyle('black', 'yellow');
 
             $this->output->getFormatter()->setStyle('warning', $style);
         }


### PR DESCRIPTION
In Symfony `comment` has the same style as Laravel's `warn` style and it's not possible to distinguish between them in console outputs

https://github.com/symfony/console/blob/959bfea5f92bd9b0b278f458a69cfd3f96dd411d/Formatter/OutputFormatter.php#L76

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
