### PR TITLE
[8.x] Add cursor pagination (aka keyset pagination)

### DIFF
--- a/src/Illuminate/Contracts/Pagination/CursorPaginator.php
+++ b/src/Illuminate/Contracts/Pagination/CursorPaginator.php
@@ -7,7 +7,7 @@ interface CursorPaginator
     /**
      * Get the URL for a given cursor.
      *
-     * @param  string  $cursor
+     * @param  \Illuminate\Pagination\Cursor|null  $cursor
      * @return string
      */
     public function url($cursor);
@@ -15,7 +15,7 @@ interface CursorPaginator
     /**
      * Add a set of query string values to the paginator.
      *
-     * @param  array|string  $key
+     * @param  array|string|null  $key
      * @param  string|null  $value
      * @return $this
      */
@@ -25,7 +25,7 @@ interface CursorPaginator
      * Get / set the URL fragment to be appended to URLs.
      *
      * @param  string|null  $fragment
-     * @return $this|string
+     * @return $this|string|null
      */
     public function fragment($fragment = null);
 

--- a/src/Illuminate/Contracts/Pagination/CursorPaginator.php
+++ b/src/Illuminate/Contracts/Pagination/CursorPaginator.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Illuminate\Contracts\Pagination;
+
+interface CursorPaginator
+{
+    /**
+     * Get the URL for a given cursor.
+     *
+     * @param  string  $cursor
+     * @return string
+     */
+    public function url($cursor);
+
+    /**
+     * Add a set of query string values to the paginator.
+     *
+     * @param  array|string  $key
+     * @param  string|null  $value
+     * @return $this
+     */
+    public function appends($key, $value = null);
+
+    /**
+     * Get / set the URL fragment to be appended to URLs.
+     *
+     * @param  string|null  $fragment
+     * @return $this|string
+     */
+    public function fragment($fragment = null);
+
+    /**
+     * Get the URL for the previous page, or null.
+     *
+     * @return string|null
+     */
+    public function previousPageUrl();
+
+    /**
+     * The URL for the next page, or null.
+     *
+     * @return string|null
+     */
+    public function nextPageUrl();
+
+    /**
+     * Get all of the items being paginated.
+     *
+     * @return array
+     */
+    public function items();
+
+    /**
+     * Get the "cursor" of the previous set of items.
+     *
+     * @return \Illuminate\Pagination\Cursor|null
+     */
+    public function previousCursor();
+
+    /**
+     * Get the "cursor" of the next set of items.
+     *
+     * @return \Illuminate\Pagination\Cursor|null
+     */
+    public function nextCursor();
+
+    /**
+     * Determine how many items are being shown per page.
+     *
+     * @return int
+     */
+    public function perPage();
+
+    /**
+     * Get the current cursor being paginated.
+     *
+     * @return \Illuminate\Pagination\Cursor|null
+     */
+    public function cursor();
+
+    /**
+     * Determine if there are enough items to split into multiple pages.
+     *
+     * @return bool
+     */
+    public function hasPages();
+
+    /**
+     * Get the base path for paginator generated URLs.
+     *
+     * @return string|null
+     */
+    public function path();
+
+    /**
+     * Determine if the list of items is empty or not.
+     *
+     * @return bool
+     */
+    public function isEmpty();
+
+    /**
+     * Determine if the list of items is not empty.
+     *
+     * @return bool
+     */
+    public function isNotEmpty();
+
+    /**
+     * Render the paginator using a given view.
+     *
+     * @param  string|null  $view
+     * @param  array  $data
+     * @return string
+     */
+    public function render($view = null, $data = []);
+}

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -5,6 +5,7 @@ namespace Illuminate\Database\Concerns;
 use Illuminate\Container\Container;
 use Illuminate\Database\MultipleRecordsFoundException;
 use Illuminate\Database\RecordsNotFoundException;
+use Illuminate\Pagination\CursorPaginator;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Collection;
@@ -345,6 +346,22 @@ trait BuildsQueries
     {
         return Container::getInstance()->makeWith(Paginator::class, compact(
             'items', 'perPage', 'currentPage', 'options'
+        ));
+    }
+
+    /**
+     * Create a new cursor paginator instance.
+     *
+     * @param  \Illuminate\Support\Collection  $items
+     * @param  int  $perPage
+     * @param  \Illuminate\Pagination\Cursor  $cursor
+     * @param  array  $options
+     * @return \Illuminate\Pagination\Paginator
+     */
+    protected function cursorPaginator($items, $perPage, $cursor, $options)
+    {
+        return Container::getInstance()->makeWith(CursorPaginator::class, compact(
+            'items', 'perPage', 'cursor', 'options'
         ));
     }
 }

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -12,6 +12,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Database\RecordsNotFoundException;
+use Illuminate\Pagination\CursorPaginator;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
@@ -810,6 +811,75 @@ class Builder
             'path' => Paginator::resolveCurrentPath(),
             'pageName' => $pageName,
         ]);
+    }
+
+    /**
+     * Paginate the given query into a cursor paginator.
+     *
+     * @param  int|null  $perPage
+     * @param  array  $columns
+     * @param  string  $cursorName
+     * @param  string|null  $cursor
+     * @return \Illuminate\Contracts\Pagination\Paginator
+     * @throws \Exception
+     */
+    public function cursorPaginate($perPage = null, $columns = ['*'], $cursorName = 'cursor', $cursor = null)
+    {
+        $cursor = $cursor ?: CursorPaginator::resolveCurrentCursor($cursorName);
+
+        $perPage = $perPage ?: $this->model->getPerPage();
+
+        $orders = $this->ensureOrderForCursorPagination(! is_null($cursor) && $cursor->isPrev());
+
+        $orderDirection = $orders->first()['direction'] ?? 'asc';
+
+        $comparisonOperator = ($orderDirection === 'asc' ? '>' : '<');
+
+        $parameters = $orders->pluck('column')->toArray();
+
+        if (count($parameters) === 1 && ! is_null($cursor)) {
+            $this->where($column = $parameters[0], $comparisonOperator, $cursor->getParam($column));
+        } else if (count($parameters) > 1 && ! is_null($cursor)) {
+            $this->whereRowValues($parameters, $comparisonOperator, $cursor->getParams($parameters));
+        }
+
+        $this->take($perPage + 1);
+
+        return $this->cursorPaginator($this->get($columns), $perPage, $cursor, [
+            'path' => Paginator::resolveCurrentPath(),
+            'cursorName' => $cursorName,
+            'parameters' => $parameters,
+        ]);
+    }
+
+    /**
+     * Ensure the proper order by required for cursor pagination.
+     *
+     * @param  bool  $shouldReverse
+     * @return \Illuminate\Support\Collection
+     * @throws \Exception
+     */
+    protected function ensureOrderForCursorPagination($shouldReverse = false)
+    {
+        $orderDirections = collect($this->query->orders)->pluck('direction')->unique();
+
+        if ($orderDirections->count() > 1) {
+            throw new Exception('Only a single order by direction is supported in cursor pagination.');
+        }
+
+        if ($orderDirections->count() === 0) {
+            $this->enforceOrderBy();
+        }
+
+        if ($shouldReverse) {
+            $this->query->orders = collect($this->query->orders)->map(function($order) {
+                $order['direction'] = ($order['direction'] === 'asc' ? 'desc' : 'asc');
+
+                return $order;
+            })->toArray();
+        }
+
+        return collect($this->query->orders);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -822,7 +822,7 @@ class Builder
      * @param  string  $cursorName
      * @param  string|null  $cursor
      * @return \Illuminate\Contracts\Pagination\Paginator
-     * @throws \Exception
+     * @throws \Illuminate\Pagination\CursorPaginationException
      */
     public function cursorPaginate($perPage = null, $columns = ['*'], $cursorName = 'cursor', $cursor = null)
     {
@@ -860,7 +860,7 @@ class Builder
      *
      * @param  bool  $shouldReverse
      * @return \Illuminate\Support\Collection
-     * @throws \Exception
+     * @throws \Illuminate\Pagination\CursorPaginationException
      */
     protected function ensureOrderForCursorPagination($shouldReverse = false)
     {

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -839,7 +839,7 @@ class Builder
 
         if (count($parameters) === 1 && ! is_null($cursor)) {
             $this->where($column = $parameters[0], $comparisonOperator, $cursor->getParam($column));
-        } else if (count($parameters) > 1 && ! is_null($cursor)) {
+        } elseif (count($parameters) > 1 && ! is_null($cursor)) {
             $this->whereRowValues($parameters, $comparisonOperator, $cursor->getParams($parameters));
         }
 
@@ -872,7 +872,7 @@ class Builder
         }
 
         if ($shouldReverse) {
-            $this->query->orders = collect($this->query->orders)->map(function($order) {
+            $this->query->orders = collect($this->query->orders)->map(function ($order) {
                 $order['direction'] = ($order['direction'] === 'asc' ? 'desc' : 'asc');
 
                 return $order;

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2379,19 +2379,19 @@ class Builder
     {
         $cursor = $cursor ?: CursorPaginator::resolveCurrentCursor($cursorName);
 
-        $orders = $this->ensureOrderForCursorPagination(! is_null($cursor) && $cursor->isPrev());
+        $orders = $this->ensureOrderForCursorPagination(! is_null($cursor) && $cursor->pointsToPreviousItems());
 
         $orderDirection = $orders->first()['direction'] ?? 'asc';
 
-        $comparisonOperator = ($orderDirection === 'asc' ? '>' : '<');
+        $comparisonOperator = $orderDirection === 'asc' ? '>' : '<';
 
         $parameters = $orders->pluck('column')->toArray();
 
         if (! is_null($cursor)) {
             if (count($parameters) === 1) {
-                $this->where($column = $parameters[0], $comparisonOperator, $cursor->getParam($column));
+                $this->where($column = $parameters[0], $comparisonOperator, $cursor->parameter($column));
             } elseif (count($parameters) > 1) {
-                $this->whereRowValues($parameters, $comparisonOperator, $cursor->getParams($parameters));
+                $this->whereRowValues($parameters, $comparisonOperator, $cursor->parameters($parameters));
             }
         }
 
@@ -2418,12 +2418,12 @@ class Builder
         $orderDirections = collect($this->orders)->pluck('direction')->unique();
 
         if ($orderDirections->count() > 1) {
-            throw new CursorPaginationException('Only a single order by direction is supported in cursor pagination.');
+            throw new CursorPaginationException('Only a single order by direction is supported when using cursor pagination.');
         }
 
         if ($shouldReverse) {
             $this->orders = collect($this->orders)->map(function ($order) {
-                $order['direction'] = ($order['direction'] === 'asc' ? 'desc' : 'asc');
+                $order['direction'] = $order['direction'] === 'asc' ? 'desc' : 'asc';
 
                 return $order;
             })->toArray();

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -4,7 +4,6 @@ namespace Illuminate\Database\Query;
 
 use Closure;
 use DateTimeInterface;
-use Exception;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Concerns\BuildsQueries;
 use Illuminate\Database\Concerns\ExplainsQueries;
@@ -2373,7 +2372,7 @@ class Builder
      * @param  string  $cursorName
      * @param  string|null  $cursor
      * @return \Illuminate\Contracts\Pagination\Paginator
-     * @throws \Exception
+     * @throws \Illuminate\Pagination\CursorPaginationException
      */
     public function cursorPaginate($perPage = 15, $columns = ['*'], $cursorName = 'cursor', $cursor = null)
     {
@@ -2409,7 +2408,7 @@ class Builder
      *
      * @param  bool  $shouldReverse
      * @return \Illuminate\Support\Collection
-     * @throws \Exception
+     * @throws \Illuminate\Pagination\CursorPaginationException
      */
     protected function ensureOrderForCursorPagination($shouldReverse = false)
     {

--- a/src/Illuminate/Pagination/AbstractCursorPaginator.php
+++ b/src/Illuminate/Pagination/AbstractCursorPaginator.php
@@ -140,14 +140,14 @@ abstract class AbstractCursorPaginator implements Htmlable
     }
 
     /**
-     * Get the "cursor" of the previous set of items.
+     * Get the "cursor" that points to the previous set of items.
      *
      * @return \Illuminate\Pagination\Cursor|null
      */
     public function previousCursor()
     {
         if (is_null($this->cursor) ||
-            ($this->cursor->isPrev() && ! $this->hasMore)) {
+            ($this->cursor->pointsToPreviousItems() && ! $this->hasMore)) {
             return null;
         }
 
@@ -155,14 +155,14 @@ abstract class AbstractCursorPaginator implements Htmlable
     }
 
     /**
-     * Get the "cursor" of the next set of items.
+     * Get the "cursor" that points to the next set of items.
      *
      * @return \Illuminate\Pagination\Cursor|null
      */
     public function nextCursor()
     {
         if ((is_null($this->cursor) && ! $this->hasMore) ||
-            (! is_null($this->cursor) && $this->cursor->isNext() && ! $this->hasMore)) {
+            (! is_null($this->cursor) && $this->cursor->pointsToNextItems() && ! $this->hasMore)) {
             return null;
         }
 
@@ -182,7 +182,10 @@ abstract class AbstractCursorPaginator implements Htmlable
     }
 
     /**
+     * Get the cursor parameters for a given object.
+     *
      * @param  \ArrayAccess|\stdClass  $item
+     * @return array
      */
     public function getParametersForItem($item)
     {
@@ -195,7 +198,7 @@ abstract class AbstractCursorPaginator implements Htmlable
                     return $item->{$parameterName} ?? $item->{Str::afterLast($parameterName, '.')};
                 }
 
-                throw new Exception('Only arrays and objects are supported for pagination items');
+                throw new Exception('Only arrays and objects are supported when cursor paginating items.');
             })->toArray();
     }
 

--- a/src/Illuminate/Pagination/AbstractCursorPaginator.php
+++ b/src/Illuminate/Pagination/AbstractCursorPaginator.php
@@ -189,9 +189,9 @@ abstract class AbstractCursorPaginator implements Htmlable
         return collect($this->parameters)
             ->flip()
             ->map(function ($_, $parameterName) use ($item) {
-                if ($item instanceof ArrayAccess) {
+                if ($item instanceof ArrayAccess || is_array($item)) {
                     return $item[$parameterName] ?? $item[Str::afterLast($parameterName, '.')];
-                } else if ($item instanceof stdClass) {
+                } elseif ($item instanceof stdClass) {
                     return $item->{$parameterName} ?? $item->{Str::afterLast($parameterName, '.')};
                 }
 

--- a/src/Illuminate/Pagination/AbstractCursorPaginator.php
+++ b/src/Illuminate/Pagination/AbstractCursorPaginator.php
@@ -4,12 +4,12 @@ namespace Illuminate\Pagination;
 
 use ArrayAccess;
 use Closure;
+use Exception;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\ForwardsCalls;
-use stdClass;
 
 /**
  * @mixin \Illuminate\Support\Collection
@@ -191,11 +191,11 @@ abstract class AbstractCursorPaginator implements Htmlable
             ->map(function ($_, $parameterName) use ($item) {
                 if ($item instanceof ArrayAccess || is_array($item)) {
                     return $item[$parameterName] ?? $item[Str::afterLast($parameterName, '.')];
-                } elseif ($item instanceof stdClass) {
+                } elseif (is_object($item)) {
                     return $item->{$parameterName} ?? $item->{Str::afterLast($parameterName, '.')};
                 }
 
-                throw new \Exception('A cursor paginator item must either implement ArrayAccess or be an stdClass instance');
+                throw new Exception('Only arrays and objects are supported for pagination items');
             })->toArray();
     }
 

--- a/src/Illuminate/Pagination/AbstractCursorPaginator.php
+++ b/src/Illuminate/Pagination/AbstractCursorPaginator.php
@@ -145,7 +145,7 @@ abstract class AbstractCursorPaginator implements Htmlable
     public function previousCursor()
     {
         if (is_null($this->cursor) ||
-            ($this->cursor->isPrev() && ! $this->hasMore) ) {
+            ($this->cursor->isPrev() && ! $this->hasMore)) {
             return null;
         }
 
@@ -160,7 +160,7 @@ abstract class AbstractCursorPaginator implements Htmlable
     public function nextCursor()
     {
         if ((is_null($this->cursor) && ! $this->hasMore) ||
-            (! is_null($this->cursor) && $this->cursor->isNext() && ! $this->hasMore) ) {
+            (! is_null($this->cursor) && $this->cursor->isNext() && ! $this->hasMore)) {
             return null;
         }
 

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -459,21 +459,6 @@ abstract class AbstractPaginator implements Htmlable
     }
 
     /**
-     * Resolve the query string or return the default value.
-     *
-     * @param  string|array|null  $default
-     * @return string
-     */
-    public static function resolveQueryString($default = null)
-    {
-        if (isset(static::$queryStringResolver)) {
-            return (static::$queryStringResolver)();
-        }
-
-        return $default;
-    }
-
-    /**
      * Resolve the current request path or return the default value.
      *
      * @param  string  $default
@@ -524,6 +509,21 @@ abstract class AbstractPaginator implements Htmlable
     public static function currentPageResolver(Closure $resolver)
     {
         static::$currentPageResolver = $resolver;
+    }
+
+    /**
+     * Resolve the query string or return the default value.
+     *
+     * @param  string|array|null  $default
+     * @return string
+     */
+    public static function resolveQueryString($default = null)
+    {
+        if (isset(static::$queryStringResolver)) {
+            return (static::$queryStringResolver)();
+        }
+
+        return $default;
     }
 
     /**

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -467,7 +467,7 @@ abstract class AbstractPaginator implements Htmlable
     public static function resolveQueryString($default = null)
     {
         if (isset(static::$queryStringResolver)) {
-            return call_user_func(static::$queryStringResolver);
+            return (static::$queryStringResolver)();
         }
 
         return $default;

--- a/src/Illuminate/Pagination/Cursor.php
+++ b/src/Illuminate/Pagination/Cursor.php
@@ -124,7 +124,7 @@ class Cursor implements Arrayable
      */
     public function encode()
     {
-        return str_replace(['+','/','='], ['-','_',''], base64_encode(json_encode($this->toArray())));
+        return str_replace(['+', '/', '='], ['-', '_', ''], base64_encode(json_encode($this->toArray())));
     }
 
     /**
@@ -139,7 +139,7 @@ class Cursor implements Arrayable
             return null;
         }
 
-        $parameters = json_decode(base64_decode(str_replace(['-','_'], ['+','/'], $encodedString)), true);
+        $parameters = json_decode(base64_decode(str_replace(['-', '_'], ['+', '/'], $encodedString)), true);
 
         if (json_last_error() !== JSON_ERROR_NONE) {
             return null;

--- a/src/Illuminate/Pagination/Cursor.php
+++ b/src/Illuminate/Pagination/Cursor.php
@@ -19,18 +19,18 @@ class Cursor implements Arrayable
      *
      * @var bool
      */
-    protected $isNext;
+    protected $pointsToNextItems;
 
     /**
      * Create a new cursor instance.
      *
      * @param  array  $parameters
-     * @param  bool  $isNext
+     * @param  bool  $pointsToNextItems
      */
-    public function __construct(array $parameters, $isNext = true)
+    public function __construct(array $parameters, $pointsToNextItems = true)
     {
         $this->parameters = $parameters;
-        $this->isNext = $isNext;
+        $this->pointsToNextItems = $pointsToNextItems;
     }
 
     /**
@@ -39,7 +39,7 @@ class Cursor implements Arrayable
      * @param  string  $parameterName
      * @return string|null
      */
-    public function getParam(string $parameterName)
+    public function parameter(string $parameterName)
     {
         if (! isset($this->parameters[$parameterName])) {
             throw new UnexpectedValueException("Unable to find parameter [{$parameterName}] in pagination item.");
@@ -54,10 +54,10 @@ class Cursor implements Arrayable
      * @param  array  $parameterNames
      * @return array
      */
-    public function getParams(array $parameterNames)
+    public function parameters(array $parameterNames)
     {
         return collect($parameterNames)->map(function ($parameterName) {
-            return $this->getParam($parameterName);
+            return $this->parameter($parameterName);
         })->toArray();
     }
 
@@ -66,9 +66,9 @@ class Cursor implements Arrayable
      *
      * @return bool
      */
-    public function isNext()
+    public function pointsToNextItems()
     {
-        return $this->isNext;
+        return $this->pointsToNextItems;
     }
 
     /**
@@ -76,33 +76,9 @@ class Cursor implements Arrayable
      *
      * @return bool
      */
-    public function isPrev()
+    public function pointsToPreviousItems()
     {
-        return ! $this->isNext;
-    }
-
-    /**
-     * Set the cursor to point to the next set of items.
-     *
-     * @return $this
-     */
-    public function setNext()
-    {
-        $this->isNext = true;
-
-        return $this;
-    }
-
-    /**
-     * Set the cursor to point to the previous set of items.
-     *
-     * @return $this
-     */
-    public function setPrev()
-    {
-        $this->isNext = false;
-
-        return $this;
+        return ! $this->pointsToNextItems;
     }
 
     /**
@@ -113,7 +89,7 @@ class Cursor implements Arrayable
     public function toArray()
     {
         return array_merge($this->parameters, [
-            '_isNext' => $this->isNext,
+            '_pointsToNextItems' => $this->pointsToNextItems,
         ]);
     }
 
@@ -145,10 +121,10 @@ class Cursor implements Arrayable
             return null;
         }
 
-        $isNext = $parameters['_isNext'];
+        $pointsToNextItems = $parameters['_pointsToNextItems'];
 
-        unset($parameters['_isNext']);
+        unset($parameters['_pointsToNextItems']);
 
-        return new static($parameters, $isNext);
+        return new static($parameters, $pointsToNextItems);
     }
 }

--- a/src/Illuminate/Pagination/Cursor.php
+++ b/src/Illuminate/Pagination/Cursor.php
@@ -72,7 +72,7 @@ class Cursor implements Arrayable
     }
 
     /**
-     * Determine whether the cursor points to the next set of items.
+     * Determine whether the cursor points to the previous set of items.
      *
      * @return bool
      */

--- a/src/Illuminate/Pagination/Cursor.php
+++ b/src/Illuminate/Pagination/Cursor.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace Illuminate\Pagination;
+
+use Illuminate\Contracts\Support\Arrayable;
+use UnexpectedValueException;
+
+class Cursor implements Arrayable
+{
+    /**
+     * The parameters associated with the cursor.
+     *
+     * @var array
+     */
+    protected $parameters;
+
+    /**
+     * Determine whether the cursor points to the next or previous set of items.
+     *
+     * @var bool
+     */
+    protected $isNext;
+
+    /**
+     * Create a new cursor instance.
+     *
+     * @param  array  $parameters
+     * @param  bool  $isNext
+     */
+    public function __construct(array $parameters, $isNext = true)
+    {
+        $this->parameters = $parameters;
+        $this->isNext = $isNext;
+    }
+
+    /**
+     * Get the given parameter from the cursor.
+     *
+     * @param  string  $parameterName
+     * @return string|null
+     */
+    public function getParam(string $parameterName)
+    {
+        if (! isset($this->parameters[$parameterName])) {
+            throw new UnexpectedValueException("Unable to find parameter [{$parameterName}] in pagination item.");
+        }
+
+        return $this->parameters[$parameterName];
+    }
+
+    /**
+     * Get the given parameters from the cursor.
+     *
+     * @param  array  $parameterNames
+     * @return array
+     */
+    public function getParams(array $parameterNames)
+    {
+        return collect($parameterNames)->map(function ($parameterName) {
+            return $this->getParam($parameterName);
+        })->toArray();
+    }
+
+    /**
+     * Determine whether the cursor points to the next set of items.
+     *
+     * @return bool
+     */
+    public function isNext()
+    {
+        return $this->isNext;
+    }
+
+    /**
+     * Determine whether the cursor points to the next set of items.
+     *
+     * @return bool
+     */
+    public function isPrev()
+    {
+        return ! $this->isNext;
+    }
+
+    /**
+     * Set the cursor to point to the next set of items.
+     *
+     * @return $this
+     */
+    public function setNext()
+    {
+        $this->isNext = true;
+
+        return $this;
+    }
+
+    /**
+     * Set the cursor to point to the previous set of items.
+     *
+     * @return $this
+     */
+    public function setPrev()
+    {
+        $this->isNext = false;
+
+        return $this;
+    }
+
+    /**
+     * Get the array representation of the cursor.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return array_merge($this->parameters, [
+            '_isNext' => $this->isNext,
+        ]);
+    }
+
+    /**
+     * Get the encoded string representation of the cursor to construct a URL.
+     *
+     * @return string
+     */
+    public function encode()
+    {
+        return str_replace(['+','/','='], ['-','_',''], base64_encode(json_encode($this->toArray())));
+    }
+
+    /**
+     * Get a cursor instance from the encoded string representation.
+     *
+     * @param  string|null  $encodedString
+     * @return static|null
+     */
+    public static function fromEncoded($encodedString)
+    {
+        if (is_null($encodedString) || ! is_string($encodedString)) {
+            return null;
+        }
+
+        $parameters = json_decode(base64_decode(str_replace(['-','_'], ['+','/'], $encodedString)), true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            return null;
+        }
+
+        $isNext = $parameters['_isNext'];
+
+        unset($parameters['_isNext']);
+
+        return new static($parameters, $isNext);
+    }
+}

--- a/src/Illuminate/Pagination/CursorPaginationException.php
+++ b/src/Illuminate/Pagination/CursorPaginationException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Pagination;
+
+use RuntimeException;
+
+class CursorPaginationException extends RuntimeException
+{
+
+}

--- a/src/Illuminate/Pagination/CursorPaginationException.php
+++ b/src/Illuminate/Pagination/CursorPaginationException.php
@@ -6,5 +6,5 @@ use RuntimeException;
 
 class CursorPaginationException extends RuntimeException
 {
-
+    //
 }

--- a/src/Illuminate/Pagination/CursorPaginator.php
+++ b/src/Illuminate/Pagination/CursorPaginator.php
@@ -14,7 +14,7 @@ use JsonSerializable;
 class CursorPaginator extends AbstractCursorPaginator implements Arrayable, ArrayAccess, Countable, IteratorAggregate, Jsonable, JsonSerializable, PaginatorContract
 {
     /**
-     * Determine if there are more items in the data source.
+     * Indicates whether there are more items in the data source.
      *
      * @return bool
      */

--- a/src/Illuminate/Pagination/CursorPaginator.php
+++ b/src/Illuminate/Pagination/CursorPaginator.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace Illuminate\Pagination;
+
+use ArrayAccess;
+use Countable;
+use Illuminate\Contracts\Pagination\CursorPaginator as PaginatorContract;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Jsonable;
+use Illuminate\Support\Collection;
+use IteratorAggregate;
+use JsonSerializable;
+
+class CursorPaginator extends AbstractCursorPaginator implements Arrayable, ArrayAccess, Countable, IteratorAggregate, Jsonable, JsonSerializable, PaginatorContract
+{
+    /**
+     * Determine if there are more items in the data source.
+     *
+     * @return bool
+     */
+    protected $hasMore;
+
+    /**
+     * Create a new paginator instance.
+     *
+     * @param  mixed  $items
+     * @param  int  $perPage
+     * @param  \Illuminate\Pagination\Cursor|null  $cursor
+     * @param  array  $options (path, query, fragment, pageName)
+     * @return void
+     */
+    public function __construct($items, $perPage, $cursor = null, array $options = [])
+    {
+        $this->options = $options;
+
+        foreach ($options as $key => $value) {
+            $this->{$key} = $value;
+        }
+
+        $this->perPage = $perPage;
+        $this->cursor = $cursor;
+        $this->path = $this->path !== '/' ? rtrim($this->path, '/') : $this->path;
+
+        $this->setItems($items);
+    }
+
+    /**
+     * Set the items for the paginator.
+     *
+     * @param  mixed  $items
+     * @return void
+     */
+    protected function setItems($items)
+    {
+        $this->items = $items instanceof Collection ? $items : Collection::make($items);
+
+        $this->hasMore = $this->items->count() > $this->perPage;
+
+        $this->items = $this->items->slice(0, $this->perPage);
+
+        if (! is_null($this->cursor) && $this->cursor->isPrev()) {
+            $this->items = $this->items->reverse();
+        }
+    }
+
+    /**
+     * Render the paginator using the given view.
+     *
+     * @param  string|null  $view
+     * @param  array  $data
+     * @return \Illuminate\Contracts\Support\Htmlable
+     */
+    public function links($view = null, $data = [])
+    {
+        return $this->render($view, $data);
+    }
+
+    /**
+     * Render the paginator using the given view.
+     *
+     * @param  string|null  $view
+     * @param  array  $data
+     * @return \Illuminate\Contracts\Support\Htmlable
+     */
+    public function render($view = null, $data = [])
+    {
+        return static::viewFactory()->make($view ?: Paginator::$defaultSimpleView, array_merge($data, [
+            'paginator' => $this,
+        ]));
+    }
+
+    /**
+     * Determine if there are more items in the data source.
+     *
+     * @return bool
+     */
+    public function hasMorePages()
+    {
+        return (is_null($this->cursor) && $this->hasMore) ||
+            (! is_null($this->cursor) && $this->cursor->isNext() && $this->hasMore) ||
+            (! is_null($this->cursor) && $this->cursor->isPrev());
+    }
+
+    /**
+     * Determine if there are enough items to split into multiple pages.
+     *
+     * @return bool
+     */
+    public function hasPages()
+    {
+        return ! $this->onFirstPage() || $this->hasMorePages();
+    }
+
+    /**
+     * Determine if the paginator is on the first page.
+     *
+     * @return bool
+     */
+    public function onFirstPage()
+    {
+        return is_null($this->cursor) || ($this->cursor->isPrev() && ! $this->hasMore);
+    }
+
+    /**
+     * Get the instance as an array.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return [
+            'data' => $this->items->toArray(),
+            'path' => $this->path(),
+            'per_page' => $this->perPage(),
+            'next_page_url' => $this->nextPageUrl(),
+            'prev_page_url' => $this->previousPageUrl(),
+        ];
+    }
+
+    /**
+     * Convert the object into something JSON serializable.
+     *
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return $this->toArray();
+    }
+
+    /**
+     * Convert the object to its JSON representation.
+     *
+     * @param  int  $options
+     * @return string
+     */
+    public function toJson($options = 0)
+    {
+        return json_encode($this->jsonSerialize(), $options);
+    }
+}

--- a/src/Illuminate/Pagination/CursorPaginator.php
+++ b/src/Illuminate/Pagination/CursorPaginator.php
@@ -58,7 +58,7 @@ class CursorPaginator extends AbstractCursorPaginator implements Arrayable, Arra
 
         $this->items = $this->items->slice(0, $this->perPage);
 
-        if (! is_null($this->cursor) && $this->cursor->isPrev()) {
+        if (! is_null($this->cursor) && $this->cursor->pointsToPreviousItems()) {
             $this->items = $this->items->reverse()->values();
         }
     }
@@ -97,8 +97,8 @@ class CursorPaginator extends AbstractCursorPaginator implements Arrayable, Arra
     public function hasMorePages()
     {
         return (is_null($this->cursor) && $this->hasMore) ||
-            (! is_null($this->cursor) && $this->cursor->isNext() && $this->hasMore) ||
-            (! is_null($this->cursor) && $this->cursor->isPrev());
+            (! is_null($this->cursor) && $this->cursor->pointsToNextItems() && $this->hasMore) ||
+            (! is_null($this->cursor) && $this->cursor->pointsToPreviousItems());
     }
 
     /**
@@ -118,7 +118,7 @@ class CursorPaginator extends AbstractCursorPaginator implements Arrayable, Arra
      */
     public function onFirstPage()
     {
-        return is_null($this->cursor) || ($this->cursor->isPrev() && ! $this->hasMore);
+        return is_null($this->cursor) || ($this->cursor->pointsToPreviousItems() && ! $this->hasMore);
     }
 
     /**

--- a/src/Illuminate/Pagination/CursorPaginator.php
+++ b/src/Illuminate/Pagination/CursorPaginator.php
@@ -59,7 +59,7 @@ class CursorPaginator extends AbstractCursorPaginator implements Arrayable, Arra
         $this->items = $this->items->slice(0, $this->perPage);
 
         if (! is_null($this->cursor) && $this->cursor->isPrev()) {
-            $this->items = $this->items->reverse();
+            $this->items = $this->items->reverse()->values();
         }
     }
 

--- a/src/Illuminate/Pagination/PaginationState.php
+++ b/src/Illuminate/Pagination/PaginationState.php
@@ -33,5 +33,11 @@ class PaginationState
         Paginator::queryStringResolver(function () use ($app) {
             return $app['request']->query();
         });
+
+        CursorPaginator::currentCursorResolver(function ($cursorName = 'cursor') use ($app) {
+            $encodedCursor = $app['request']->input($cursorName);
+
+            return Cursor::fromEncoded($encodedCursor);
+        });
     }
 }

--- a/src/Illuminate/Pagination/PaginationState.php
+++ b/src/Illuminate/Pagination/PaginationState.php
@@ -35,9 +35,7 @@ class PaginationState
         });
 
         CursorPaginator::currentCursorResolver(function ($cursorName = 'cursor') use ($app) {
-            $encodedCursor = $app['request']->input($cursorName);
-
-            return Cursor::fromEncoded($encodedCursor);
+            return Cursor::fromEncoded($app['request']->input($cursorName));
         });
     }
 }

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Model as Eloquent;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\SoftDeletingScope;
 use Illuminate\Database\Query\Builder;
+use Illuminate\Pagination\CursorPaginator;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Carbon;
 use PHPUnit\Framework\TestCase;
@@ -136,11 +137,18 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
             return 1;
         });
 
+        CursorPaginator::currentCursorResolver(function () {
+            return null;
+        });
+
         $query = SoftDeletesTestUser::query();
         $this->assertCount(1, $query->paginate(2)->all());
 
         $query = SoftDeletesTestUser::query();
         $this->assertCount(1, $query->simplePaginate(2)->all());
+
+        $query = SoftDeletesTestUser::query();
+        $this->assertCount(1, $query->cursorPaginate(2)->all());
 
         $this->assertEquals(0, SoftDeletesTestUser::where('email', 'taylorotwell@gmail.com')->increment('id'));
         $this->assertEquals(0, SoftDeletesTestUser::where('email', 'taylorotwell@gmail.com')->decrement('id'));

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -16,6 +16,8 @@ use Illuminate\Database\Query\Grammars\SqlServerGrammar;
 use Illuminate\Database\Query\Processors\MySqlProcessor;
 use Illuminate\Database\Query\Processors\Processor;
 use Illuminate\Pagination\AbstractPaginator as Paginator;
+use Illuminate\Pagination\Cursor;
+use Illuminate\Pagination\CursorPaginator;
 use Illuminate\Pagination\LengthAwarePaginator;
 use InvalidArgumentException;
 use Mockery as m;
@@ -3481,6 +3483,143 @@ SQL;
         $this->assertEquals(new LengthAwarePaginator($results, 2, $perPage, $page, [
             'path' => $path,
             'pageName' => $pageName,
+        ]), $result);
+    }
+
+    public function testCursorPaginate()
+    {
+        $perPage = 16;
+        $columns = ['test'];
+        $cursorName = 'cursor-name';
+        $cursor = new Cursor(['test' => 'bar']);
+        $builder = $this->getMockQueryBuilder()->orderBy('test');
+        $path = 'http://foo.bar?cursor='.$cursor->encode();
+
+        $results = collect([['test' => 'foo'], ['test' => 'bar']]);
+
+        $builder->shouldReceive('where')->with('test', '>', 'bar')->once()->andReturnSelf();
+        $builder->shouldReceive('get')->once()->andReturn($results);
+
+        Paginator::currentPathResolver(function () use ($path) {
+            return $path;
+        });
+
+        $result = $builder->cursorPaginate($perPage, $columns, $cursorName, $cursor);
+
+        $this->assertEquals(new CursorPaginator($results, $perPage, $cursor, [
+            'path' => $path,
+            'cursorName' => $cursorName,
+            'parameters' => ['test'],
+        ]), $result);
+    }
+
+    public function testCursorPaginateMultipleOrderColumns()
+    {
+        $perPage = 16;
+        $columns = ['test'];
+        $cursorName = 'cursor-name';
+        $cursor = new Cursor(['test' => 'bar', 'another' => 'foo']);
+        $builder = $this->getMockQueryBuilder()->orderBy('test')->orderBy('another');
+        $path = 'http://foo.bar?cursor='.$cursor->encode();
+
+        $results = collect([['test' => 'foo'], ['test' => 'bar']]);
+
+        $builder->shouldReceive('whereRowValues')->with(['test', 'another'], '>', ['bar', 'foo'])->once()->andReturnSelf();
+        $builder->shouldReceive('get')->once()->andReturn($results);
+
+        Paginator::currentPathResolver(function () use ($path) {
+            return $path;
+        });
+
+        $result = $builder->cursorPaginate($perPage, $columns, $cursorName, $cursor);
+
+        $this->assertEquals(new CursorPaginator($results, $perPage, $cursor, [
+            'path' => $path,
+            'cursorName' => $cursorName,
+            'parameters' => ['test', 'another'],
+        ]), $result);
+    }
+
+    public function testCursorPaginateWithDefaultArguments()
+    {
+        $perPage = 15;
+        $cursorName = 'cursor';
+        $cursor = new Cursor(['test' => 'bar']);
+        $builder = $this->getMockQueryBuilder()->orderBy('test');
+        $path = 'http://foo.bar?cursor='.$cursor->encode();
+
+        $results = collect([['test' => 'foo'], ['test' => 'bar']]);
+
+        $builder->shouldReceive('get')->once()->andReturn($results);
+
+        CursorPaginator::currentCursorResolver(function () use ($cursor) {
+            return $cursor;
+        });
+
+        Paginator::currentPathResolver(function () use ($path) {
+            return $path;
+        });
+
+        $result = $builder->cursorPaginate();
+
+        $this->assertEquals(new CursorPaginator($results, $perPage, $cursor, [
+            'path' => $path,
+            'cursorName' => $cursorName,
+            'parameters' => ['test'],
+        ]), $result);
+    }
+
+    public function testCursorPaginateWhenNoResults()
+    {
+        $perPage = 15;
+        $cursorName = 'cursor';
+        $builder = $this->getMockQueryBuilder()->orderBy('test');
+        $path = 'http://foo.bar?cursor=3';
+
+        $results = [];
+
+        $builder->shouldReceive('get')->once()->andReturn($results);
+
+        CursorPaginator::currentCursorResolver(function () {
+            return null;
+        });
+
+        Paginator::currentPathResolver(function () use ($path) {
+            return $path;
+        });
+
+        $result = $builder->cursorPaginate();
+
+        $this->assertEquals(new CursorPaginator($results, $perPage, null, [
+            'path' => $path,
+            'cursorName' => $cursorName,
+            'parameters' => ['test'],
+        ]), $result);
+    }
+
+    public function testCursorPaginateWithSpecificColumns()
+    {
+        $perPage = 16;
+        $columns = ['id', 'name'];
+        $cursorName = 'cursor-name';
+        $cursor = new Cursor(['id' => 2]);
+        $builder = $this->getMockQueryBuilder()->orderBy('id');
+        $path = 'http://foo.bar?cursor=3';
+
+        $results = collect([['id' => 3, 'name' => 'Taylor'], ['id' => 5, 'name' => 'Mohamed']]);
+
+        $builder->shouldReceive('get')->once()->andReturn($results);
+
+        Paginator::currentPathResolver(function () use ($path) {
+            return $path;
+        });
+
+        $result = $builder->cursorPaginate($perPage, $columns, $cursorName, $cursor);
+
+        $this->assertEquals(new CursorPaginator($results, $perPage, $cursor, [
+            'path' => $path,
+            'cursorName' => $cursorName,
+            'parameters' => ['id'],
         ]), $result);
     }
 

--- a/tests/Integration/Database/EloquentCursorPaginateTest.php
+++ b/tests/Integration/Database/EloquentCursorPaginateTest.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Facades\Schema;
 /**
  * @group integration
  */
-class EloquentPaginateTest extends DatabaseTestCase
+class EloquentCursorPaginateTest extends DatabaseTestCase
 {
     protected function setUp(): void
     {
@@ -28,7 +28,7 @@ class EloquentPaginateTest extends DatabaseTestCase
         });
     }
 
-    public function testPaginationOnTopOfColumns()
+    public function testCursorPaginationOnTopOfColumns()
     {
         for ($i = 1; $i <= 50; $i++) {
             Post::create([
@@ -36,7 +36,7 @@ class EloquentPaginateTest extends DatabaseTestCase
             ]);
         }
 
-        $this->assertCount(15, Post::paginate(15, ['id', 'title']));
+        $this->assertCount(15, Post::cursorPaginate(15, ['id', 'title']));
     }
 
     public function testPaginationWithDistinct()
@@ -50,22 +50,7 @@ class EloquentPaginateTest extends DatabaseTestCase
 
         $this->assertEquals(6, $query->get()->count());
         $this->assertEquals(6, $query->count());
-        $this->assertEquals(6, $query->paginate()->total());
-    }
-
-    public function testPaginationWithDistinctAndSelect()
-    {
-        // This is the 'broken' behaviour, but this test is added to show backwards compatibility.
-        for ($i = 1; $i <= 3; $i++) {
-            Post::create(['title' => 'Hello world']);
-            Post::create(['title' => 'Goodbye world']);
-        }
-
-        $query = Post::query()->distinct()->select('title');
-
-        $this->assertEquals(2, $query->get()->count());
-        $this->assertEquals(6, $query->count());
-        $this->assertEquals(6, $query->paginate()->total());
+        $this->assertCount(6, $query->cursorPaginate()->items());
     }
 
     public function testPaginationWithDistinctColumnsAndSelect()
@@ -79,7 +64,7 @@ class EloquentPaginateTest extends DatabaseTestCase
 
         $this->assertEquals(2, $query->get()->count());
         $this->assertEquals(2, $query->count());
-        $this->assertEquals(2, $query->paginate()->total());
+        $this->assertCount(2, $query->cursorPaginate()->items());
     }
 
     public function testPaginationWithDistinctColumnsAndSelectAndJoin()
@@ -99,7 +84,7 @@ class EloquentPaginateTest extends DatabaseTestCase
 
         $this->assertEquals(5, $query->get()->count());
         $this->assertEquals(5, $query->count());
-        $this->assertEquals(5, $query->paginate()->total());
+        $this->assertCount(5, $query->cursorPaginate()->items());
     }
 }
 

--- a/tests/Integration/Database/EloquentCursorPaginateTest.php
+++ b/tests/Integration/Database/EloquentCursorPaginateTest.php
@@ -15,14 +15,14 @@ class EloquentCursorPaginateTest extends DatabaseTestCase
     {
         parent::setUp();
 
-        Schema::create('posts', function (Blueprint $table) {
+        Schema::create('test_posts', function (Blueprint $table) {
             $table->increments('id');
             $table->string('title')->nullable();
             $table->unsignedInteger('user_id')->nullable();
             $table->timestamps();
         });
 
-        Schema::create('users', function ($table) {
+        Schema::create('test_users', function ($table) {
             $table->increments('id');
             $table->timestamps();
         });
@@ -31,22 +31,22 @@ class EloquentCursorPaginateTest extends DatabaseTestCase
     public function testCursorPaginationOnTopOfColumns()
     {
         for ($i = 1; $i <= 50; $i++) {
-            Post::create([
+            TestPost::create([
                 'title' => 'Title '.$i,
             ]);
         }
 
-        $this->assertCount(15, Post::cursorPaginate(15, ['id', 'title']));
+        $this->assertCount(15, TestPost::cursorPaginate(15, ['id', 'title']));
     }
 
     public function testPaginationWithDistinct()
     {
         for ($i = 1; $i <= 3; $i++) {
-            Post::create(['title' => 'Hello world']);
-            Post::create(['title' => 'Goodbye world']);
+            TestPost::create(['title' => 'Hello world']);
+            TestPost::create(['title' => 'Goodbye world']);
         }
 
-        $query = Post::query()->distinct();
+        $query = TestPost::query()->distinct();
 
         $this->assertEquals(6, $query->get()->count());
         $this->assertEquals(6, $query->count());
@@ -56,11 +56,11 @@ class EloquentCursorPaginateTest extends DatabaseTestCase
     public function testPaginationWithDistinctColumnsAndSelect()
     {
         for ($i = 1; $i <= 3; $i++) {
-            Post::create(['title' => 'Hello world']);
-            Post::create(['title' => 'Goodbye world']);
+            TestPost::create(['title' => 'Hello world']);
+            TestPost::create(['title' => 'Goodbye world']);
         }
 
-        $query = Post::query()->distinct('title')->select('title');
+        $query = TestPost::query()->distinct('title')->select('title');
 
         $this->assertEquals(2, $query->get()->count());
         $this->assertEquals(2, $query->count());
@@ -70,17 +70,17 @@ class EloquentCursorPaginateTest extends DatabaseTestCase
     public function testPaginationWithDistinctColumnsAndSelectAndJoin()
     {
         for ($i = 1; $i <= 5; $i++) {
-            $user = User::create();
+            $user = TestUser::create();
             for ($j = 1; $j <= 10; $j++) {
-                Post::create([
+                TestPost::create([
                     'title' => 'Title '.$i,
                     'user_id' => $user->id,
                 ]);
             }
         }
 
-        $query = User::query()->join('posts', 'posts.user_id', '=', 'users.id')
-            ->distinct('users.id')->select('users.*');
+        $query = TestUser::query()->join('test_posts', 'test_posts.user_id', '=', 'test_users.id')
+            ->distinct('test_users.id')->select('test_users.*');
 
         $this->assertEquals(5, $query->get()->count());
         $this->assertEquals(5, $query->count());
@@ -88,12 +88,12 @@ class EloquentCursorPaginateTest extends DatabaseTestCase
     }
 }
 
-class Post extends Model
+class TestPost extends Model
 {
     protected $guarded = [];
 }
 
-class User extends Model
+class TestUser extends Model
 {
     protected $guarded = [];
 }

--- a/tests/Integration/Database/EloquentCursorPaginateTest.php
+++ b/tests/Integration/Database/EloquentCursorPaginateTest.php
@@ -4,6 +4,8 @@ namespace Illuminate\Tests\Integration\Database;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Pagination\Cursor;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 /**
@@ -53,6 +55,127 @@ class EloquentCursorPaginateTest extends DatabaseTestCase
         $this->assertCount(6, $query->cursorPaginate()->items());
     }
 
+    public function testPaginationWithWhereClause()
+    {
+        for ($i = 1; $i <= 3; $i++) {
+            TestPost::create(['title' => 'Hello world', 'user_id' => null]);
+            TestPost::create(['title' => 'Goodbye world', 'user_id' => 2]);
+        }
+
+        $query = TestPost::query()->whereNull('user_id');
+
+        $this->assertEquals(3, $query->get()->count());
+        $this->assertEquals(3, $query->count());
+        $this->assertCount(3, $query->cursorPaginate()->items());
+    }
+
+    public function testPaginationWithHasClause()
+    {
+        for ($i = 1; $i <= 3; $i++) {
+            TestUser::create(['id' => $i]);
+            TestPost::create(['title' => 'Hello world', 'user_id' => null]);
+            TestPost::create(['title' => 'Goodbye world', 'user_id' => 2]);
+            TestPost::create(['title' => 'Howdy', 'user_id' => 3]);
+        }
+
+        $query = TestUser::query()->has('posts');
+
+        $this->assertEquals(2, $query->get()->count());
+        $this->assertEquals(2, $query->count());
+        $this->assertCount(2, $query->cursorPaginate()->items());
+    }
+
+    public function testPaginationWithWhereHasClause()
+    {
+        for ($i = 1; $i <= 3; $i++) {
+            TestUser::create(['id' => $i]);
+            TestPost::create(['title' => 'Hello world', 'user_id' => null]);
+            TestPost::create(['title' => 'Goodbye world', 'user_id' => 2]);
+            TestPost::create(['title' => 'Howdy', 'user_id' => 3]);
+        }
+
+        $query = TestUser::query()->whereHas('posts', function ($query) {
+            $query->where('title', 'Howdy');
+        });
+
+        $this->assertEquals(1, $query->get()->count());
+        $this->assertEquals(1, $query->count());
+        $this->assertCount(1, $query->cursorPaginate()->items());
+    }
+
+    public function testPaginationWithWhereExistsClause()
+    {
+        for ($i = 1; $i <= 3; $i++) {
+            TestUser::create(['id' => $i]);
+            TestPost::create(['title' => 'Hello world', 'user_id' => null]);
+            TestPost::create(['title' => 'Goodbye world', 'user_id' => 2]);
+            TestPost::create(['title' => 'Howdy', 'user_id' => 3]);
+        }
+
+        $query = TestUser::query()->whereExists(function ($query) {
+            $query->select(DB::raw(1))
+                ->from('test_posts')
+                ->whereColumn('test_posts.user_id', 'test_users.id');
+        });
+
+        $this->assertEquals(2, $query->get()->count());
+        $this->assertEquals(2, $query->count());
+        $this->assertCount(2, $query->cursorPaginate()->items());
+    }
+
+    public function testPaginationWithMultipleWhereClauses()
+    {
+        for ($i = 1; $i <= 4; $i++) {
+            TestUser::create(['id' => $i]);
+            TestPost::create(['title' => 'Hello world', 'user_id' => null]);
+            TestPost::create(['title' => 'Goodbye world', 'user_id' => 2]);
+            TestPost::create(['title' => 'Howdy', 'user_id' => 3]);
+            TestPost::create(['title' => 'Howdy', 'user_id' => 4]);
+        }
+
+        $query = TestUser::query()->whereExists(function ($query) {
+            $query->select(DB::raw(1))
+                ->from('test_posts')
+                ->whereColumn('test_posts.user_id', 'test_users.id');
+        })->whereHas('posts', function ($query) {
+            $query->where('title', 'Howdy');
+        })->where('id', '<', 5)->orderBy('id');
+
+        $clonedQuery = $query->clone();
+        $anotherQuery = $query->clone();
+
+        $this->assertEquals(2, $query->get()->count());
+        $this->assertEquals(2, $query->count());
+        $this->assertCount(2, $query->cursorPaginate()->items());
+        $this->assertCount(1, $clonedQuery->cursorPaginate(1)->items());
+        $this->assertCount(
+            1,
+            $anotherQuery->cursorPaginate(5, ['*'], 'cursor', new Cursor(['id' => 3]))
+                        ->items()
+        );
+    }
+
+    public function testPaginationWithAliasedOrderBy()
+    {
+        for ($i = 1; $i <= 6; $i++) {
+            TestUser::create(['id' => $i]);
+        }
+
+        $query = TestUser::query()->select('id as user_id')->orderBy('user_id');
+        $clonedQuery = $query->clone();
+        $anotherQuery = $query->clone();
+
+        $this->assertEquals(6, $query->get()->count());
+        $this->assertEquals(6, $query->count());
+        $this->assertCount(6, $query->cursorPaginate()->items());
+        $this->assertCount(3, $clonedQuery->cursorPaginate(3)->items());
+        $this->assertCount(
+            4,
+            $anotherQuery->cursorPaginate(10, ['*'], 'cursor', new Cursor(['user_id' => 2]))
+                        ->items()
+        );
+    }
+
     public function testPaginationWithDistinctColumnsAndSelect()
     {
         for ($i = 1; $i <= 3; $i++) {
@@ -96,4 +219,9 @@ class TestPost extends Model
 class TestUser extends Model
 {
     protected $guarded = [];
+
+    public function posts()
+    {
+        return $this->hasMany(TestPost::class, 'user_id');
+    }
 }

--- a/tests/Pagination/CursorPaginatorLoadMorphCountTest.php
+++ b/tests/Pagination/CursorPaginatorLoadMorphCountTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Illuminate\Tests\Pagination;
+
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Pagination\AbstractCursorPaginator;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class CursorPaginatorLoadMorphCountTest extends TestCase
+{
+    public function testCollectionLoadMorphCountCanChainOnThePaginator()
+    {
+        $relations = [
+            'App\\User' => 'photos',
+            'App\\Company' => ['employees', 'calendars'],
+        ];
+
+        $items = m::mock(Collection::class);
+        $items->shouldReceive('loadMorphCount')->once()->with('parentable', $relations);
+
+        $p = (new class extends AbstractCursorPaginator {
+            //
+        })->setCollection($items);
+
+        $this->assertSame($p, $p->loadMorphCount('parentable', $relations));
+    }
+}

--- a/tests/Pagination/CursorPaginatorLoadMorphCountTest.php
+++ b/tests/Pagination/CursorPaginatorLoadMorphCountTest.php
@@ -19,7 +19,8 @@ class CursorPaginatorLoadMorphCountTest extends TestCase
         $items = m::mock(Collection::class);
         $items->shouldReceive('loadMorphCount')->once()->with('parentable', $relations);
 
-        $p = (new class extends AbstractCursorPaginator {
+        $p = (new class extends AbstractCursorPaginator
+        {
             //
         })->setCollection($items);
 

--- a/tests/Pagination/CursorPaginatorLoadMorphTest.php
+++ b/tests/Pagination/CursorPaginatorLoadMorphTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Illuminate\Tests\Pagination;
+
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Pagination\AbstractCursorPaginator;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class CursorPaginatorLoadMorphTest extends TestCase
+{
+    public function testCollectionLoadMorphCanChainOnThePaginator()
+    {
+        $relations = [
+            'App\\User' => 'photos',
+            'App\\Company' => ['employees', 'calendars'],
+        ];
+
+        $items = m::mock(Collection::class);
+        $items->shouldReceive('loadMorph')->once()->with('parentable', $relations);
+
+        $p = (new class extends AbstractCursorPaginator {
+            //
+        })->setCollection($items);
+
+        $this->assertSame($p, $p->loadMorph('parentable', $relations));
+    }
+}

--- a/tests/Pagination/CursorPaginatorLoadMorphTest.php
+++ b/tests/Pagination/CursorPaginatorLoadMorphTest.php
@@ -19,7 +19,8 @@ class CursorPaginatorLoadMorphTest extends TestCase
         $items = m::mock(Collection::class);
         $items->shouldReceive('loadMorph')->once()->with('parentable', $relations);
 
-        $p = (new class extends AbstractCursorPaginator {
+        $p = (new class extends AbstractCursorPaginator
+        {
             //
         })->setCollection($items);
 

--- a/tests/Pagination/CursorPaginatorTest.php
+++ b/tests/Pagination/CursorPaginatorTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Illuminate\Tests\Pagination;
+
+use Illuminate\Pagination\Cursor;
+use Illuminate\Pagination\CursorPaginator;
+use PHPUnit\Framework\TestCase;
+
+class CursorPaginatorTest extends TestCase
+{
+    public function testReturnsRelevantContextInformation()
+    {
+        $p = new CursorPaginator($array = [['id' => 1], ['id' => 2], ['id' => 3]], 2, null, [
+            'parameters' => ['id'],
+        ]);
+
+        $this->assertTrue($p->hasPages());
+        $this->assertTrue($p->hasMorePages());
+        $this->assertEquals([['id' => 1], ['id' => 2]], $p->items());
+
+        $pageInfo = [
+            'data' => [['id' => 1], ['id' => 2]],
+            'path' => '/',
+            'per_page' => 2,
+            'next_page_url' => '/?cursor='.$this->getCursor(['id' => 2]),
+            'prev_page_url' => null,
+        ];
+
+        $this->assertEquals($pageInfo, $p->toArray());
+    }
+
+    public function testPaginatorRemovesTrailingSlashes()
+    {
+        $p = new CursorPaginator($array = [['id' => 4], ['id' => 5], ['id' => 6]], 2, null,
+            ['path' => 'http://website.com/test/', 'parameters' => ['id']]);
+
+        $this->assertSame('http://website.com/test?cursor='.$this->getCursor(['id' => 5]), $p->nextPageUrl());
+    }
+
+    public function testPaginatorGeneratesUrlsWithoutTrailingSlash()
+    {
+        $p = new CursorPaginator($array = [['id' => 4], ['id' => 5], ['id' => 6]], 2, null,
+            ['path' => 'http://website.com/test', 'parameters' => ['id']]);
+
+        $this->assertSame('http://website.com/test?cursor='.$this->getCursor(['id' => 5]), $p->nextPageUrl());
+    }
+
+    public function testItRetrievesThePaginatorOptions()
+    {
+        $p = new CursorPaginator($array = [['id' => 4], ['id' => 5], ['id' => 6]], 2, null,
+            $options = ['path' => 'http://website.com/test', 'parameters' => ['id']]);
+
+        $this->assertSame($p->getOptions(), $options);
+    }
+
+    public function testPaginatorReturnsPath()
+    {
+        $p = new CursorPaginator($array = [['id' => 4], ['id' => 5], ['id' => 6]], 2, null,
+            $options = ['path' => 'http://website.com/test', 'parameters' => ['id']]);
+
+        $this->assertSame($p->path(), 'http://website.com/test');
+    }
+
+    public function testCanTransformPaginatorItems()
+    {
+        $p = new CursorPaginator($array = [['id' => 4], ['id' => 5], ['id' => 6]], 2, null,
+            $options = ['path' => 'http://website.com/test', 'parameters' => ['id']]);
+
+        $p->through(function ($item) {
+            $item['id'] = $item['id'] + 2;
+
+            return $item;
+        });
+
+        $this->assertInstanceOf(CursorPaginator::class, $p);
+        $this->assertSame([['id' => 6], ['id' => 7]], $p->items());
+    }
+
+    protected function getCursor($params, $isNext = true)
+    {
+        return (new Cursor($params, $isNext))->encode();
+    }
+}

--- a/tests/Pagination/CursorTest.php
+++ b/tests/Pagination/CursorTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Illuminate\Tests\Pagination;
+
+use Carbon\Carbon;
+use Illuminate\Pagination\Cursor;
+use PHPUnit\Framework\TestCase;
+
+class CursorTest extends TestCase
+{
+    public function testCanEncodeAndDecodeSuccessfully()
+    {
+        $cursor = new Cursor([
+            'id' => 422,
+            'created_at' => Carbon::now()->toDateTimeString(),
+        ], true);
+
+        $this->assertEquals($cursor, Cursor::fromEncoded($cursor->encode()));
+    }
+
+    public function testCanGetParams()
+    {
+        $cursor = new Cursor([
+            'id' => 422,
+            'created_at' => ($now = Carbon::now()->toDateTimeString()),
+        ], true);
+
+        $this->assertEquals([$now, 422], $cursor->getParams(['created_at', 'id']));
+    }
+
+    public function testCanGetParam()
+    {
+        $cursor = new Cursor([
+            'id' => 422,
+            'created_at' => ($now = Carbon::now()->toDateTimeString()),
+        ], true);
+
+        $this->assertEquals($now, $cursor->getParam('created_at'));
+    }
+}

--- a/tests/Pagination/CursorTest.php
+++ b/tests/Pagination/CursorTest.php
@@ -25,7 +25,7 @@ class CursorTest extends TestCase
             'created_at' => ($now = Carbon::now()->toDateTimeString()),
         ], true);
 
-        $this->assertEquals([$now, 422], $cursor->getParams(['created_at', 'id']));
+        $this->assertEquals([$now, 422], $cursor->parameters(['created_at', 'id']));
     }
 
     public function testCanGetParam()
@@ -35,6 +35,6 @@ class CursorTest extends TestCase
             'created_at' => ($now = Carbon::now()->toDateTimeString()),
         ], true);
 
-        $this->assertEquals($now, $cursor->getParam('created_at'));
+        $this->assertEquals($now, $cursor->parameter('created_at'));
     }
 }


### PR DESCRIPTION
## Background

This PR implements cursor pagination in Laravel. The cursor is a base 64 encoded string that contains the comparison parameter values (see below).

## Laravel Current Pagination (Offset Pagination)

Laravel's current implementation of pagination is offset based. This generates queries like so (for the 2nd page):

```sql
select * from users order by id asc offset 10 limit 10;
```

OR for a multiple ordered table

```sql
select * from users order by id, name offset 10 limit 10;
```

## Cursor Pagination (aka Keyset Pagination)

Cursor pagination on the other hand, uses comparison operations instead of offset. This generates queries like so (for the 2nd page):

```sql
select * from users where id > 10 order by id asc limit 10;
```

OR for a multiple ordered table

```sql
select * from users where (id, name) > (10, 'Paras') order by id, name limit 10;
```

## Usage

Usage is exactly the same as `simplePaginate`:

```php
use App\Models\User;
use Illuminate\Support\Facades\DB;

$users = User::orderBy('id')->cursorPaginate(10);
$users = DB::table('users')->orderBy('id')->cursorPaginate(10);
```

## Advantages Of Cursor Pagination

1. **Solves the "duplicate" issue in offset pagination**: Offset pagination skips or returns duplicate records if records are deleted or added between network calls. This is especially prominent in infinite scrolling and APIs.
2. **Handles big data sets efficiently**: If the order by column is indexed, cursor pagination is more efficient v/s offset pagination. This is because offset scans through all the previous data unlike comparison queries. [Upto 400x better performance](https://shopify.engineering/pagination-relative-cursors).
3. [Easy pagination across shards](https://twitter.com/dhh/status/1261786904451661824).

## Limitations Of Cursor Pagination

1. Requires that the ordering is based on at least one unique sequential column (or a combination of sequential columns to be unique).
2. Only enhances performance if the order by columns are indexed.

## References

- https://uxdesign.cc/why-facebook-says-cursor-pagination-is-the-greatest-d6b98d86b6c0
- https://medium.com/swlh/how-to-implement-cursor-pagination-like-a-pro-513140b65f32

## Implementations In Other Frameworks

- [Django](https://www.django-rest-framework.org/api-guide/pagination/#cursorpagination)
- [Rails](https://github.com/basecamp/geared_pagination)

## Note

I've implemented this as separate classes (for the interface, abstract, etc.) rather than extending Paginator because several methods in the contract/abstract classes did not make sense for cursor pagination (e.g. currentPage() returning an int, or url expecting an int page).

**UPDATE:** I've written a [blog post](https://www.laravel-enlightn.com/blog/offset-vs-cursor-pagination-in-laravel-in-depth-guide/) on this if anyone's interested to read the pros and cons of offset and cursor pagination.