### PR TITLE
[8.x] Adds support for Pusher 6.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -144,7 +144,7 @@
         "phpunit/phpunit": "Required to use assertions and run tests (^8.5.8|^9.3.3).",
         "predis/predis": "Required to use the predis connector (^1.1.2).",
         "psr/http-message": "Required to allow Storage::put to accept a StreamInterface (^1.0).",
-        "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (^4.0|^5.0).",
+        "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (^4.0|^5.0|^6.0).",
         "symfony/cache": "Required to PSR-6 cache bridge (^5.1.4).",
         "symfony/filesystem": "Required to enable support for relative symbolic links (^5.1.4).",
         "symfony/psr-http-message-bridge": "Required to use PSR-7 bridging features (^2.0).",

--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -212,7 +212,8 @@ class BroadcastManager implements FactoryContract
     {
         $pusher = new Pusher(
             $config['key'], $config['secret'],
-            $config['app_id'], $config['options'] ?? []
+            $config['app_id'], $config['options'] ?? [],
+            $config['guzzle'] ?? null
         );
 
         if ($config['log'] ?? false) {

--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -212,8 +212,7 @@ class BroadcastManager implements FactoryContract
     {
         $pusher = new Pusher(
             $config['key'], $config['secret'],
-            $config['app_id'], $config['options'] ?? [],
-            $config['guzzle'] ?? null
+            $config['app_id'], $config['options'] ?? []
         );
 
         if ($config['log'] ?? false) {


### PR DESCRIPTION
Minor bump for Pusher 6.x.

Ran the broadcast test locally and seems fine, but I'll wait for a proper check from the maintainers.