### PR TITLE
[8.x] Add withHeadersIf() method

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -305,6 +305,32 @@ class PendingRequest
     }
 
     /**
+     * Add the given headers to the request if the condition evauluates to true
+     *
+     * @param  mixed  $condition
+     * @param  array  $headers
+     * @return $this
+     */
+    public function withHeadersIf(mixed $condition, array $headers)
+    {
+        $status = false;
+
+        if (is_callable($condition)) {
+            $status = (bool) $condition();
+        } else {
+            $status = (bool) $condition;
+        }
+
+        if (! $status) {
+            return $this;
+        }
+
+        return tap($this, function () use ($headers) {
+            $this->withHeaders($headers);
+        });
+    }
+
+    /**
      * Specify the basic authentication username and password for the request.
      *
      * @param  string  $username

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -523,14 +523,14 @@ class HttpClientTest extends TestCase
         $this->factory->fake();
 
         $this->factory->withHeadersIf(function() {
-            return true;
+            return false;
         }, [
             'X-Test-Header' => 'foo',
         ])->post('http://foo.com/json');
 
         $this->factory->assertSent(function (Request $request) {
             return $request->url() === 'http://foo.com/json' &&
-                   $request->hasHeaders([
+                   ! $request->hasHeaders([
                        'X-Test-Header' => 'foo',
                    ]);
         });

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -468,6 +468,74 @@ class HttpClientTest extends TestCase
         });
     }
 
+    public function testCanConditionallyAddHeadersSimpleTrue()
+    {
+        $this->factory->fake();
+
+        $this->factory->withHeadersIf(true, [
+            'X-Test-Header' => 'foo',
+        ])->post('http://foo.com/json');
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/json' &&
+                   $request->hasHeaders([
+                       'X-Test-Header' => 'foo',
+                   ]);
+        });
+    }
+
+    public function testCanConditionallyAddHeadersSimpleFalse()
+    {
+        $this->factory->fake();
+
+        $this->factory->withHeadersIf(false, [
+            'X-Test-Header' => 'foo',
+        ])->post('http://foo.com/json');
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/json' &&
+                   ! $request->hasHeaders([
+                       'X-Test-Header' => 'foo',
+                   ]);
+        });
+    }
+
+    public function testCanConditionallyAddHeadersCallbackTrue()
+    {
+        $this->factory->fake();
+
+        $this->factory->withHeadersIf(function() {
+            return true;
+        }, [
+            'X-Test-Header' => 'foo',
+        ])->post('http://foo.com/json');
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/json' &&
+                   $request->hasHeaders([
+                       'X-Test-Header' => 'foo',
+                   ]);
+        });
+    }
+
+    public function testCanConditionallyAddHeadersCallbackFalse()
+    {
+        $this->factory->fake();
+
+        $this->factory->withHeadersIf(function() {
+            return true;
+        }, [
+            'X-Test-Header' => 'foo',
+        ])->post('http://foo.com/json');
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/json' &&
+                   $request->hasHeaders([
+                       'X-Test-Header' => 'foo',
+                   ]);
+        });
+    }
+
     public function testCanConfirmManyHeadersUsingAString()
     {
         $this->factory->fake();


### PR DESCRIPTION
Laravel Community 👋,

This PR adds a `withHeadersIf` method to the `PendingRequest` class. As the name suggests it allows you to conditionally add headers if the first parameter evaluates to true. 

An example use case is conditionally adding an authorization header if a token value is not null:

```php
// Simple 
Http::withHeadersIf(auth()->check(), [
      'Authorization' => 'token ' . auth()->user()->auth_token,
])->get("https://example.com/api/test");

// Using a callback
Http::withHeadersIf(function() {
    return true;
}, [
      'Authorization' => 'token ' . auth()->user()->auth_token,
])->get("https://example.com/api/test");
```

I added four tests to cover the true/false conditions when using a simple expression, and to cover the true/false when using a callback.

I will reference this PR in the PR to update the docs.

Cheers Wyatt 🍻