### PR TITLE
[8.x] Add `str` method to the HTTP Client response

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -4,7 +4,7 @@ namespace Illuminate\Http\Client;
 
 use ArrayAccess;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Str;
+use Illuminate\Support\Stringable;
 use Illuminate\Support\Traits\Macroable;
 use LogicException;
 
@@ -97,7 +97,7 @@ class Response implements ArrayAccess
      */
     public function str()
     {
-        return Str::of($this->body());
+        return new Stringable($this->body());
     }
 
     /**

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -4,6 +4,7 @@ namespace Illuminate\Http\Client;
 
 use ArrayAccess;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use LogicException;
 
@@ -87,6 +88,16 @@ class Response implements ArrayAccess
     public function collect($key = null)
     {
         return Collection::make($this->json($key));
+    }
+    
+    /**
+     * Get the body of the response as a stringable object.
+     *
+     * @return \Illuminate\Support\Stringable
+     */
+    public function str()
+    {
+        return Str::of($this->body());
     }
 
     /**


### PR DESCRIPTION
We have `collect` method in the Response class https://github.com/laravel/framework/pull/36331

It would be nice also to have `str` method so instead of:

```php
Str::of(Http::get('https://example.com')->body())->matchAll('~div~')
```
can be : 

```php
Http::get('https://example.com')->str()->matchAll('~div~')
```