### PR TITLE
[8.x] Add a `mergeToTop()` method

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -700,11 +700,25 @@ class Collection implements ArrayAccess, Enumerable
      * Merge the collection with the given items.
      *
      * @param  mixed  $items
+     * @param  bool   $appendToTop
      * @return static
      */
-    public function merge($items)
+    public function merge($items, $appendToTop = false)
     {
-        return new static(array_merge($this->items, $this->getArrayableItems($items)));
+        return $appendToTop
+            ? new static(array_merge($this->getArrayableItems($items), $this->items))
+            : new static(array_merge($this->items, $this->getArrayableItems($items)));
+    }
+
+    /**
+     * Merge the collection, but append the given items at the top.
+     *
+     * @param  mixed  $items
+     * @return static
+     */
+    public function mergeToTop($items)
+    {
+        return $this->merge($items, $appendToTop = true);
     }
 
     /**

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -699,6 +699,17 @@ class LazyCollection implements Enumerable
     }
 
     /**
+     * Merge the collection, but append the given items at the top.
+     *
+     * @param  mixed $items
+     * @return static
+     */
+    public function mergeToTop($items)
+    {
+        return $this->passthru('mergeToTop', func_get_args());
+    }
+
+    /**
      * Recursively merge the collection with the given items.
      *
      * @param  mixed  $items

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -315,7 +315,7 @@ class Collection extends BaseCollection implements QueueableCollection
      * @param  \ArrayAccess|array  $items
      * @return static
      */
-    public function merge($items)
+    public function merge($items, $appendToTop = false)
     {
         $dictionary = $this->getDictionary();
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1034,10 +1034,64 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testMergeArrayWithoutKeys($collection)
+    {
+        $collection = new $collection(['Apple', 'Banana']);
+        $this->assertEquals(['Apple', 'Banana', 'Pineapple'], $collection->merge(['Pineapple'])->all());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testMergeCollection($collection)
     {
         $c = new $collection(['name' => 'Hello']);
         $this->assertEquals(['name' => 'World', 'id' => 1], $c->merge(new $collection(['name' => 'World', 'id' => 1]))->all());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testMergeCollectionWithoutKeys($collection)
+    {
+        $collection = new $collection(['Banana', 'Apple']);
+        $this->assertEquals(['Banana', 'Apple', 'Pineapple'], $collection->merge(new $collection(['Pineapple']))->all());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testMergeArrayAppendToTop($collection)
+    {
+        $collection = new $collection(['Apple', 'Banana']);
+        $this->assertEquals(['Pineapple', 'Apple', 'Banana'], $collection->merge(['Pineapple'], $appendToTop = true)->all());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testMergeCollectionAppendToTop($collection)
+    {
+        $collection = new $collection(['Banana', 'Apple']);
+        $this->assertEquals(['Pineapple', 'Banana', 'Apple'], $collection->merge(new $collection(['Pineapple']), $appendToTop = true)->all());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testMergeArrayAppendToTopAsMethod($collection)
+    {
+        $collection = new $collection(['Apple', 'Banana']);
+        $this->assertEquals(['Pineapple', 'Apple', 'Banana'], $collection->mergeToTop(['Pineapple'])->all());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testMergeCollectionAppendToTopAsMethod($collection)
+    {
+        $collection = new $collection(['Banana', 'Apple']);
+        $this->assertEquals(['Pineapple', 'Banana', 'Apple'], $collection->mergeToTop(new $collection(['Pineapple']))->all());
     }
 
     /**


### PR DESCRIPTION
Hi,

I created a PR with a new `mergeToTop()` method for collections.

This allows users to merge a collection, but append it to the top.

An example:

```php
$collection = collect(['Apple', 'Banana']);

$collection->mergeToTop(['Pineapple']); // ['Pineapple', 'Apple', 'Banana']
```

Thanks! Jeroen