### PR TITLE
[8.x] Add Arr::init() method

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -379,6 +379,19 @@ class Arr
     }
 
     /**
+     * Initializes a variable as an array and returns it.
+     *
+     * @param  array|null  $array
+     * @param  array  $default
+     *
+     * @return array
+     */
+    public static function init(?array &$array, array $default = []): array
+    {
+        return $array = ($array ?? $default);
+    }
+
+    /**
      * Determines if an array is associative.
      *
      * An array is "associative" if it doesn't have sequential numerical keys beginning with zero.

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -420,8 +420,8 @@ class SupportArrTest extends TestCase
         $this->assertIsArray(Arr::init($a));
         $this->assertIsArray(Arr::init($a['b'], ['c' => 'd']));
         $this->assertArrayHasKey('b', $a);
-        $this->assertArrayHasKey('c', $a);
-        $this->assertEquals('d', $a['c']);
+        $this->assertArrayHasKey('c', $a['b']);
+        $this->assertEquals('d', $a['b']['c']);
     }
 
     public function testIsAssoc()

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -415,6 +415,15 @@ class SupportArrTest extends TestCase
         $this->assertTrue(Arr::hasAny($array, ['foo.bax', 'foo.baz']));
     }
 
+    public function testInit()
+    {
+        $this->assertIsArray(Arr::init($a));
+        $this->assertIsArray(Arr::init($a['b'], ['c' => 'd']));
+        $this->assertArrayHasKey('b', $a);
+        $this->assertArrayHasKey('c', $a);
+        $this->assertEquals('d', $a['c']);
+    }
+
     public function testIsAssoc()
     {
         $this->assertTrue(Arr::isAssoc(['a' => 'a', 0 => 'b']));


### PR DESCRIPTION
## Introduction

This PR adds the method `Illuminate\Support\Arr::init()`. The goal is to simplify the initialization of arrays.

## Usage

```php
Arr::init($data, ['foo' => 'bar']);
```

## Utility

Using `Arr::init()` we can easily assert a variable is an array and is initialized with a default value if were empty. The best use case, I believe, is when a variable with a large accessor name must be initalized:

```php
// pure PHP
$variable_with_a_very_long_name['this_is_an_very_large_index_name'] = $variable_with_a_very_long_name['this_is_an_very_large_index_name'] ?? [];

// with a little help
Arr::init($variable_with_a_very_long_name['this_is_an_very_large_index_name']);
```

## Alternatives

`Arr::set()` could be used to achieve the same result, but we would still have to pass the second unused param, `$key`. Also we would have to explicitly pass the default value as an empty array:

```php
Arr::set($newArray, null, []);
```