### PR TITLE
[8.x] Add support for $snake_case Blade component properties

### DIFF
--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -367,16 +367,18 @@ class ComponentTagCompiler
                     ? collect($constructor->getParameters())->map->getName()->all()
                     : [];
 
-        return collect($attributes)->reduce(function($partitioned, $value, $key) use ($parameterNames) {
+        return collect($attributes)->reduce(function ($partitioned, $value, $key) use ($parameterNames) {
             // This allows us to match to $camelCase and $snake_case style properties
             foreach ([Str::camel($key), str_replace('-', '_', $key)] as $format) {
                 if (in_array($format, $parameterNames)) {
                     $partitioned[0][$format] = $value;
+
                     return $partitioned;
                 }
             }
 
             $partitioned[1][$key] = $value;
+
             return $partitioned;
         }, [collect(), collect()]);
     }

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -64,6 +64,14 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
 <?php \$component->withAttributes([]); ?> @endComponentClass##END-COMPONENT-CLASS##", trim($result));
     }
 
+    public function testDataSnakeCasing()
+    {
+        $result = $this->compiler([ 'profile' => TestProfileSnakeCaseComponent::class ])->compileTags('<x-profile user-id="1"></x-profile>');
+
+        $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\Tests\View\Blade\TestProfileSnakeCaseComponent', 'profile', ['user_id' => '1'])
+<?php \$component->withAttributes([]); ?> @endComponentClass##END-COMPONENT-CLASS##", trim($result));
+    }
+
     public function testColonData()
     {
         $result = $this->compiler(['profile' => TestProfileComponent::class])->compileTags('<x-profile :user-id="1"></x-profile>');
@@ -332,6 +340,24 @@ class TestProfileComponent extends Component
     {
         $this->userId = $userId;
     }
+
+    public function render()
+    {
+        return 'profile';
+    }
+}
+
+class TestProfileSnakeCaseComponent extends Component
+{
+
+    public $user_id;
+
+
+    public function __construct($user_id = 'foo')
+    {
+        $this->user_id = $user_id;
+    }
+
 
     public function render()
     {

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -66,7 +66,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
 
     public function testDataSnakeCasing()
     {
-        $result = $this->compiler([ 'profile' => TestProfileSnakeCaseComponent::class ])->compileTags('<x-profile user-id="1"></x-profile>');
+        $result = $this->compiler(['profile' => TestProfileSnakeCaseComponent::class])->compileTags('<x-profile user-id="1"></x-profile>');
 
         $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\Tests\View\Blade\TestProfileSnakeCaseComponent', 'profile', ['user_id' => '1'])
 <?php \$component->withAttributes([]); ?> @endComponentClass##END-COMPONENT-CLASS##", trim($result));
@@ -349,15 +349,12 @@ class TestProfileComponent extends Component
 
 class TestProfileSnakeCaseComponent extends Component
 {
-
     public $user_id;
-
 
     public function __construct($user_id = 'foo')
     {
         $this->user_id = $user_id;
     }
-
 
     public function render()
     {


### PR DESCRIPTION
Currently Blade components require that all constructor properties be `camelCase`.  While this is the code style for the majority of modern PHP projects, some projects choose to use `snake_case` either for legacy reasons or [for code readability reasons](https://whatheco.de/2013/02/16/camelcase-vs-underscores-revisited/). This PR adds support for both styles, so that:

```php
<x-profile user-id="1" />
```

...will map just fine to either of the following components:

```php
class ProfileComponent extends Component {
  public function __construct($userId)
  {
    // ...
  }
}
```
```php
class ProfileComponent extends Component {
  public function __construct($user_id)
  {
    // ...
  }
}
```