### PR TITLE
[8.x] Add closure support for Database Factory count / times methods

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -30,7 +30,7 @@ abstract class Factory
     /**
      * The number of models that should be generated.
      *
-     * @var int|null
+     * @var Closure|int|null
      */
     protected $count;
 
@@ -107,7 +107,7 @@ abstract class Factory
     /**
      * Create a new factory instance.
      *
-     * @param  int|null  $count
+     * @param  Closure|int|null  $count
      * @param  \Illuminate\Support\Collection|null  $states
      * @param  \Illuminate\Support\Collection|null  $has
      * @param  \Illuminate\Support\Collection|null  $for
@@ -155,10 +155,10 @@ abstract class Factory
     /**
      * Get a new factory instance for the given number of models.
      *
-     * @param  int  $count
+     * @param  Closure|int  $count
      * @return static
      */
-    public static function times(int $count)
+    public static function times($count)
     {
         return static::new()->count($count);
     }
@@ -182,6 +182,10 @@ abstract class Factory
      */
     public function raw($attributes = [], ?Model $parent = null)
     {
+        if ($this->count instanceof Closure) {
+            $this->count = call_user_func($this->count, $parent);
+        }
+
         if ($this->count === null) {
             return $this->state($attributes)->getExpandedAttributes($parent);
         }
@@ -315,6 +319,10 @@ abstract class Factory
     {
         if (! empty($attributes)) {
             return $this->state($attributes)->make([], $parent);
+        }
+
+        if ($this->count instanceof Closure) {
+            $this->count = call_user_func($this->count, $parent);
         }
 
         if ($this->count === null) {
@@ -577,10 +585,10 @@ abstract class Factory
     /**
      * Specify how many models should be generated.
      *
-     * @param  int|null  $count
+     * @param  Closure|int|null  $count
      * @return static
      */
-    public function count(?int $count)
+    public function count($count = null)
     {
         return $this->newInstance(['count' => $count]);
     }

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -182,9 +182,7 @@ abstract class Factory
      */
     public function raw($attributes = [], ?Model $parent = null)
     {
-        if ($this->count instanceof Closure) {
-            $this->count = call_user_func($this->count, $parent);
-        }
+        $this->count = value($this->count, $parent);
 
         if ($this->count === null) {
             return $this->state($attributes)->getExpandedAttributes($parent);
@@ -321,9 +319,7 @@ abstract class Factory
             return $this->state($attributes)->make([], $parent);
         }
 
-        if ($this->count instanceof Closure) {
-            $this->count = call_user_func($this->count, $parent);
-        }
+        $this->count = value($this->count, $parent);
 
         if ($this->count === null) {
             return tap($this->makeInstance($parent), function ($instance) {


### PR DESCRIPTION
This PR allows `count` / `times` to accept a closure that will execute each time a new factory model is made or created. Specifically, this becomes useful when working with relationships where you might want a variable number of related models to be created.

```php
// Create 10 users, each with between 5 and 10 posts.
UserFactory::times(10)
    ->has(PostFactory::times(fn () => rand(5, 10)))
    ->create();
```

Additionally, when used in a relationship context, the closure is passed the parent model, so the count can vary based on attributes of the parent.

```php
// Create 10 users, where moderators have 100 posts and everyone else has 10 posts.
UserFactory::times(10)
    ->has(PostFactory::times(function ($user) {
        return $user->is_moderator ? 100 : 10;
    })
    ->create();
```

I added a handful of tests to ensure current functionality remains unchanged.