### PR TITLE
Ably expects clientId as string

### DIFF
--- a/src/Illuminate/Broadcasting/Broadcasters/AblyBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/AblyBroadcaster.php
@@ -76,7 +76,7 @@ class AblyBroadcaster extends Broadcaster
             $request->channel_name,
             $request->socket_id,
             $userData = array_filter([
-                'user_id' => $this->retrieveUser($request, $channelName)->getAuthIdentifier(),
+                'user_id' => (string) $this->retrieveUser($request, $channelName)->getAuthIdentifier(),
                 'user_info' => $result,
             ])
         );


### PR DESCRIPTION
Ably uses the Pusher `user_id` and maps it to `clientId` which should be a `string`. Using `int` as `clientId` in presence channels results in "Malformed message; non-string clientId. (See https://help.ably.io/error/40012 for help.) (Ably error 40012)".