### PR TITLE
[8.x] Treat missing UUID in failed Queue Job as empty string (failed driver = database)

### DIFF
--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -210,7 +210,7 @@ abstract class Job
         [$class, $method] = JobName::parse($payload['job']);
 
         if (method_exists($this->instance = $this->resolve($class), 'failed')) {
-            $this->instance->failed($payload['data'], $e, $this->uuid() ?? '');
+            $this->instance->failed($payload['data'], $e, $payload['uuid'] ?? '');
         }
     }
 

--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -210,7 +210,7 @@ abstract class Job
         [$class, $method] = JobName::parse($payload['job']);
 
         if (method_exists($this->instance = $this->resolve($class), 'failed')) {
-            $this->instance->failed($payload['data'], $e, $payload['uuid']);
+            $this->instance->failed($payload['data'], $e, $this->uuid() ?? '');
         }
     }
 


### PR DESCRIPTION
This PR treats missing UUID in failed Queue Job as empty string. The reason for this is the following `ErrorException` I am getting on failed Queue Job:
```
ErrorException Undefined index: uuid 
    vendor/laravel/framework/src/Illuminate/Queue/Jobs/Job.php:213 Illuminate\Foundation\Bootstrap\HandleExceptions::handleError
    vendor/laravel/framework/src/Illuminate/Queue/Jobs/Job.php:213 Illuminate\Queue\Jobs\Job::failed
    vendor/laravel/framework/src/Illuminate/Queue/Jobs/Job.php:192 Illuminate\Queue\Jobs\Job::fail
    vendor/laravel/framework/src/Illuminate/Queue/Worker.php:548 Illuminate\Queue\Worker::failJob
    vendor/laravel/framework/src/Illuminate/Queue/Worker.php:509 Illuminate\Queue\Worker::markJobAsFailedIfWillExceedMaxAttempts
    vendor/laravel/framework/src/Illuminate/Queue/Worker.php:437 Illuminate\Queue\Worker::handleJobException
    vendor/laravel/framework/src/Illuminate/Queue/Worker.php:414 Illuminate\Queue\Worker::process
    vendor/laravel/framework/src/Illuminate/Queue/Worker.php:360 Illuminate\Queue\Worker::runJob
    vendor/laravel/framework/src/Illuminate/Queue/Worker.php:158 Illuminate\Queue\Worker::daemon
    vendor/laravel/framework/src/Illuminate/Queue/Console/WorkCommand.php:117 Illuminate\Queue\Console\WorkCommand::runWorker
    vendor/laravel/framework/src/Illuminate/Queue/Console/WorkCommand.php:101 Illuminate\Queue\Console\WorkCommand::handle
    vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php:36 Illuminate\Container\BoundMethod::Illuminate\Container\{closure}
    vendor/laravel/framework/src/Illuminate/Container/Util.php:40 Illuminate\Container\Util::unwrapIfClosure
    vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php:93 Illuminate\Container\BoundMethod::callBoundMethod
    vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php:37 Illuminate\Container\BoundMethod::call
    vendor/laravel/framework/src/Illuminate/Container/Container.php:611 Illuminate\Container\Container::call
    vendor/laravel/framework/src/Illuminate/Console/Command.php:136 Illuminate\Console\Command::execute
    vendor/symfony/console/Command/Command.php:256 Symfony\Component\Console\Command\Command::run
    vendor/laravel/framework/src/Illuminate/Console/Command.php:121 Illuminate\Console\Command::run
    vendor/symfony/console/Application.php:971 Symfony\Component\Console\Application::doRunCommand
    vendor/symfony/console/Application.php:290 Symfony\Component\Console\Application::doRun
    vendor/symfony/console/Application.php:166 Symfony\Component\Console\Application::run
    vendor/laravel/framework/src/Illuminate/Console/Application.php:92 Illuminate\Console\Application::run
    vendor/laravel/framework/src/Illuminate/Foundation/Console/Kernel.php:129 Illuminate\Foundation\Console\Kernel::handle
    artisan:35 [main]
```

My app is Laravel 8, upgraded from 7 and still having `config('queue.failed.driver') === 'database'`. I haven't changed the failed driver to `database-uuids`, as mentioned here https://laravel.com/docs/8.x/upgrade#failed-jobs-table-batch-support, as it should be optional and I'm not using Job Batching yet. So I believe this is a bug, which this PR will fix.