### PR TITLE
[8.x] Add one-of-many relationship

### DIFF
--- a/src/Illuminate/Contracts/Database/Eloquent/PartialRelation.php
+++ b/src/Illuminate/Contracts/Database/Eloquent/PartialRelation.php
@@ -7,10 +7,10 @@ interface PartialRelation
     /**
      * Wether the relation is a partial of a one-to-many relationship.
      *
-     * @param  bool $ofMany
+     * @param  string|null $relation
      * @return $this
      */
-    public function ofMany(bool $ofMany = true);
+    public function ofMany($relation = null);
 
     /**
      * Determines wether the relationship is one-of-many.

--- a/src/Illuminate/Contracts/Database/Eloquent/PartialRelation.php
+++ b/src/Illuminate/Contracts/Database/Eloquent/PartialRelation.php
@@ -7,7 +7,7 @@ interface PartialRelation
     /**
      * Wether the relation is a partial of a one-to-many relationship.
      *
-     * @param  boolean $ofMany
+     * @param  bool $ofMany
      * @return $this
      */
     public function ofMany(bool $ofMany = true);
@@ -15,7 +15,7 @@ interface PartialRelation
     /**
      * Determines wether the relationship is one-of-many.
      *
-     * @return boolean
+     * @return bool
      */
     public function isOneOfMany();
 

--- a/src/Illuminate/Contracts/Database/Eloquent/PartialRelation.php
+++ b/src/Illuminate/Contracts/Database/Eloquent/PartialRelation.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Illuminate\Contracts\Database\Eloquent;
+
+interface PartialRelation
+{
+    /**
+     * Wether the relation is a partial of a one-to-many relationship.
+     *
+     * @param  boolean $ofMany
+     * @return $this
+     */
+    public function ofMany(bool $ofMany = true);
+
+    /**
+     * Determines wether the relationship is one-of-many.
+     *
+     * @return boolean
+     */
+    public function isOneOfMany();
+
+    /**
+     * Resolve the one-of-many query.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder|null $query
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function resolveOneOfManyQuery();
+}

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -412,7 +412,7 @@ trait QueriesRelationships
             $query->orders = null;
             $query->setBindings([], 'order');
 
-            if (count($query->columns) > 1 && !$this->isOneOfMany($relation)) {
+            if (count($query->columns) > 1 && ! $this->isOneOfMany($relation)) {
                 $query->columns = [$query->columns[0]];
                 $query->bindings['select'] = [];
             }
@@ -437,7 +437,7 @@ trait QueriesRelationships
      * Determines whether the given relation is one-of-many.
      *
      * @param  \Illuminate\Database\Eloquent\Relations\Relation $relation
-     * @return boolean
+     * @return bool
      */
     protected function isOneOfMany($relation)
     {
@@ -516,7 +516,7 @@ trait QueriesRelationships
      */
     protected function addHasWhere(Builder $hasQuery, Relation $relation, $operator, $count, $boolean)
     {
-        if(!$this->isOneOfMany($relation)) {
+        if (! $this->isOneOfMany($relation)) {
             $hasQuery->mergeConstraintsFrom($relation->getQuery());
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/CanBeOneOfMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/CanBeOneOfMany.php
@@ -3,8 +3,8 @@
 namespace Illuminate\Database\Eloquent\Relations\Concerns;
 
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\SQLiteConnection;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Database\SQLiteConnection;
 
 trait CanBeOneOfMany
 {
@@ -207,7 +207,7 @@ trait CanBeOneOfMany
                     );
                 } else {
                     $existsQuery->havingRaw(
-                        $this->getSubSelectAlias() . ' = '. $this->getRelatedKeyName()
+                        $this->getSubSelectAlias().' = '.$this->getRelatedKeyName()
                     );
                 }
             });

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/CanBeOneOfMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/CanBeOneOfMany.php
@@ -49,7 +49,7 @@ trait CanBeOneOfMany
         $this->isOneOfMany = true;
 
         $this->setOneOfManyQuery();
-        
+
         if (! $this->relationName = $relation) {
             $this->relationName = $this->guessRelationship();
         }

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/CanBeOneOfMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/CanBeOneOfMany.php
@@ -27,13 +27,13 @@ trait CanBeOneOfMany
      * @var array
      */
     protected $forwardToOneOfManyQuery = [
-        'get', 'exists', 'count'
+        'get', 'exists', 'count',
     ];
 
     /**
      * Wether the relation is a partial of a one-to-many relationship.
      *
-     * @param  boolean $ofMany
+     * @param  bool $ofMany
      * @return $this
      */
     public function ofMany(bool $ofMany = true)
@@ -84,7 +84,7 @@ trait CanBeOneOfMany
     /**
      * Determines wether the relationship is one-of-many.
      *
-     * @return boolean
+     * @return bool
      */
     public function isOneOfMany()
     {
@@ -199,7 +199,7 @@ trait CanBeOneOfMany
         }
 
         $query = $this->query;
-        if($this->shouldForwardedToOneOfManyQuery($method)) {
+        if ($this->shouldForwardedToOneOfManyQuery($method)) {
             $query = $this->resolveOneOfManyQuery();
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/CanBeOneOfMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/CanBeOneOfMany.php
@@ -27,7 +27,7 @@ trait CanBeOneOfMany
      * @var array
      */
     protected $forwardToOneOfManyQuery = [
-        'get', 'exists', 'count',
+        'get', 'exists', 'count', 'sum', 'avg', 'first', 'join', 'crossJoin'
     ];
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/CanBeOneOfMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/CanBeOneOfMany.php
@@ -27,7 +27,7 @@ trait CanBeOneOfMany
      * @var array
      */
     protected $forwardToOneOfManyQuery = [
-        'get', 'exists', 'count', 'sum', 'avg', 'first', 'join', 'crossJoin'
+        'get', 'exists', 'count', 'sum', 'avg', 'first', 'join', 'crossJoin',
     ];
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/CanBeOneOfMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/CanBeOneOfMany.php
@@ -1,0 +1,214 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Relations\Concerns;
+
+use Illuminate\Database\Eloquent\Builder;
+
+trait CanBeOneOfMany
+{
+    /**
+     * Determines wether the relationship is one-of-many.
+     *
+     * @var bool
+     */
+    protected $isOneOfMany = false;
+
+    /**
+     * The one-of-many parent query builder.
+     *
+     * @var \Illuminate\Database\Eloquent\Builder
+     */
+    protected $oneOfManyQuery;
+
+    /**
+     * The methods that should be forwarded to the one-of-many query builder
+     * instance.
+     *
+     * @var array
+     */
+    protected $forwardToOneOfManyQuery = [
+        'get', 'exists', 'count'
+    ];
+
+    /**
+     * Wether the relation is a partial of a one-to-many relationship.
+     *
+     * @param  boolean $ofMany
+     * @return $this
+     */
+    public function ofMany(bool $ofMany = true)
+    {
+        $this->isOneOfMany = true;
+
+        if ($ofMany) {
+            $this->setOneOfManyQuery();
+        }
+
+        return $this;
+    }
+
+    /**
+     * Initially set one-of-many parent query.
+     *
+     * @return void
+     */
+    protected function setOneOfManyQuery()
+    {
+        if ($this->oneOfManyQuery) {
+            return;
+        }
+
+        $this->oneOfManyQuery = $this->getOneOfManyQueryFor($this->query);
+    }
+
+    /**
+     * Get related key name.
+     *
+     * @return string
+     */
+    protected function getRelatedKeyName()
+    {
+        return $this->getRelatedTableName().'.'.$this->query->getModel()->getKeyName();
+    }
+
+    /**
+     * Get sub select alias.
+     *
+     * @return string
+     */
+    protected function getSubSelectAlias()
+    {
+        return $this->getRelatedTableName()."_{$this->localKey}_".spl_object_id($this);
+    }
+
+    /**
+     * Determines wether the relationship is one-of-many.
+     *
+     * @return boolean
+     */
+    public function isOneOfMany()
+    {
+        return $this->isOneOfMany;
+    }
+
+    /**
+     * Add subselect contstraints to the given query builder.
+     *
+     * @param  Builder $query
+     * @return void
+     */
+    protected function addSubSelectConstraintsTo(Builder $query)
+    {
+        $query
+            ->from($this->getRelatedTableName(), $this->getSubSelectTableAlias())
+            ->whereColumn($this->qualifySubSelectColumn($this->foreignKey), $this->foreignKey)
+            ->select($this->qualifySubSelectColumn($query->getModel()->getKeyName()))
+            ->take(1);
+    }
+
+    /**
+     * Get the subselect table alias.
+     *
+     * @return string
+     */
+    protected function getSubSelectTableAlias()
+    {
+        return $this->getRelatedTableName().'_'.spl_object_id($this);
+    }
+
+    /**
+     * Get the qualified subselect column name.
+     *
+     * @param  string $column
+     * @return string
+     */
+    protected function qualifySubSelectColumn($column)
+    {
+        $segments = explode('.', $column);
+
+        return $this->getSubSelectTableAlias().'.'.end($segments);
+    }
+
+    /**
+     * Get the related table name.
+     *
+     * @return string
+     */
+    protected function getRelatedTableName()
+    {
+        return $this->query->getModel()->getTable();
+    }
+
+    /**
+     * Get the result query builder instance for the given query builder.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder $query
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    protected function getOneOfManyQueryFor(Builder $query)
+    {
+        return $query->clone();
+    }
+
+    /**
+     * Resolve the one-of-many query.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder|null $query
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function resolveOneOfManyQuery(Builder $query = null)
+    {
+        if (is_null($query)) {
+            $query = $this->query;
+        }
+
+        $this->addSubSelectConstraintsTo($query);
+
+        return $this->oneOfManyQuery
+            ->whereExists(function ($existsQuery) use ($query) {
+                $existsQuery
+                    ->selectSub($query, $this->getSubSelectAlias())
+                    ->whereColumn($this->getSubSelectAlias(), $this->getRelatedKeyName());
+            });
+    }
+
+    /**
+     * Determines wether the given query method should be forwarded to the
+     * one-of-many query.
+     *
+     * @param string $method
+     * @return bool
+     */
+    protected function shouldForwardedToOneOfManyQuery($method)
+    {
+        return $this->isOneOfMany()
+            && in_array($method, $this->forwardToOneOfManyQuery);
+    }
+
+    /**
+     * Handle dynamic method calls to the relationship.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     */
+    public function __call($method, $parameters)
+    {
+        if (static::hasMacro($method)) {
+            return $this->macroCall($method, $parameters);
+        }
+
+        $query = $this->query;
+        if($this->shouldForwardedToOneOfManyQuery($method)) {
+            $query = $this->resolveOneOfManyQuery();
+        }
+
+        $result = $this->forwardCallTo($query, $method, $parameters);
+
+        if ($result === $query) {
+            return $this;
+        }
+
+        return $result;
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/ComparesRelatedModels.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/ComparesRelatedModels.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Eloquent\Relations\Concerns;
 
+use Illuminate\Contracts\Database\Eloquent\PartialRelation;
 use Illuminate\Database\Eloquent\Model;
 
 trait ComparesRelatedModels
@@ -17,7 +18,8 @@ trait ComparesRelatedModels
         return ! is_null($model) &&
                $this->compareKeys($this->getParentKey(), $this->getRelatedKeyFrom($model)) &&
                $this->related->getTable() === $model->getTable() &&
-               $this->related->getConnectionName() === $model->getConnectionName();
+               $this->related->getConnectionName() === $model->getConnectionName() &&
+               $this->compareOneOfMany($model);
     }
 
     /**
@@ -64,5 +66,26 @@ trait ComparesRelatedModels
         }
 
         return $parentKey === $relatedKey;
+    }
+
+    /**
+     * Determine if the given model is the correct relationship model.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model|null  $model
+     * @return bool
+     */
+    protected function compareOneOfMany($model)
+    {
+        if (! $this instanceof PartialRelation) {
+            return true;
+        }
+
+        if(! $this->isOneOfMany()) {
+            return true;
+        }
+
+        return $this->resolveOneOfManyQuery()
+            ->whereKey($model->getKey())
+            ->exists();
     }
 }

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/ComparesRelatedModels.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/ComparesRelatedModels.php
@@ -80,7 +80,7 @@ trait ComparesRelatedModels
             return true;
         }
 
-        if(! $this->isOneOfMany()) {
+        if (! $this->isOneOfMany()) {
             return true;
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOne.php
@@ -25,7 +25,7 @@ class HasOne extends HasOneOrMany implements PartialRelation
             return $this->getDefaultFor($this->parent);
         }
 
-        if($this->isOneOfMany()) {
+        if ($this->isOneOfMany()) {
             $result = $this->resolveOneOfManyQuery()->first();
         } else {
             $result = $this->query->first();

--- a/src/Illuminate/Database/Eloquent/Relations/HasOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOne.php
@@ -25,7 +25,13 @@ class HasOne extends HasOneOrMany implements PartialRelation
             return $this->getDefaultFor($this->parent);
         }
 
-        return $this->query->first() ?: $this->getDefaultFor($this->parent);
+        if($this->isOneOfMany()) {
+            $result = $this->resolveOneOfManyQuery()->first();
+        } else {
+            $result = $this->query->first();
+        }
+
+        return $result ?: $this->getDefaultFor($this->parent);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/HasOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOne.php
@@ -89,7 +89,7 @@ class HasOne extends HasOneOrMany implements PartialRelation
      */
     public function addEagerConstraints(array $models)
     {
-        if(! $this->isOneOfMany()) {
+        if (! $this->isOneOfMany()) {
             return parent::addEagerConstraints($models);
         }
 
@@ -112,7 +112,7 @@ class HasOne extends HasOneOrMany implements PartialRelation
      */
     public function getRelationExistenceQuery(Builder $query, Builder $parentQuery, $columns = ['*'])
     {
-        if(! $this->isOneOfMany()) {
+        if (! $this->isOneOfMany()) {
             return parent::getRelationExistenceQuery($query, $parentQuery, $columns);
         }
 

--- a/tests/Database/DatabaseEloquentHasOneOfManyTest.php
+++ b/tests/Database/DatabaseEloquentHasOneOfManyTest.php
@@ -54,6 +54,27 @@ class DatabaseEloquentHasOneOfManyTest extends TestCase
         $this->schema()->drop('logins');
     }
 
+    public function testItGetsCorrectResults()
+    {
+        $user = HasOneOfManyTestUser::create();
+        $previousLogin = $user->logins()->create();
+        $latestLogin = $user->logins()->create();
+
+        $result = $user->latest_login()->getResults();
+        $this->assertNotNull($result);
+        $this->assertSame($latestLogin->id, $result->id);
+    }
+
+    public function testItGetsWithConstraintsCorrectResults()
+    {
+        $user = HasOneOfManyTestUser::create();
+        $previousLogin = $user->logins()->create();
+        $user->logins()->create();
+
+        $result = $user->latest_login()->whereKey($previousLogin->getKey())->getResults();
+        $this->assertNull($result);
+    }
+
     public function testItEagerLoadsCorrectModels()
     {
         $user = HasOneOfManyTestUser::create();

--- a/tests/Database/DatabaseEloquentHasOneOfManyTest.php
+++ b/tests/Database/DatabaseEloquentHasOneOfManyTest.php
@@ -54,6 +54,24 @@ class DatabaseEloquentHasOneOfManyTest extends TestCase
         $this->schema()->drop('logins');
     }
 
+    public function testItGuessesRelationName()
+    {
+        $user = HasOneOfManyTestUser::create();
+        $this->assertSame('latest_login', $user->latest_login()->getRelationName());
+    }
+
+    public function testRelationNameCanBeSet()
+    {
+        $user = HasOneOfManyTestUser::create();
+        $this->assertSame('foo', $user->latest_login_with_other_name()->getRelationName());
+    }
+
+    public function testQualifyingSubSelectColumn()
+    {
+        $user = HasOneOfManyTestUser::create();
+        $this->assertSame('latest_login.id', $user->latest_login()->qualifySubSelectColumn('id'));
+    }
+
     public function testItGetsCorrectResults()
     {
         $user = HasOneOfManyTestUser::create();
@@ -208,6 +226,13 @@ class HasOneOfManyTestUser extends Eloquent
     public function latest_login()
     {
         return $this->hasOne(HasOneOfManyTestLogin::class, 'user_id')->ofMany()->orderByDesc('id');
+    }
+
+    public function latest_login_with_other_name()
+    {
+        return $this->hasOne(HasOneOfManyTestLogin::class, 'user_id')
+            ->ofMany('foo')
+            ->orderByDesc('id');
     }
 }
 

--- a/tests/Database/DatabaseEloquentHasOneOfManyTest.php
+++ b/tests/Database/DatabaseEloquentHasOneOfManyTest.php
@@ -1,0 +1,199 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+
+/**
+ * @group one-of-many
+ */
+class DatabaseEloquentHasOneOfManyTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $db = new DB;
+
+        $db->addConnection([
+            'driver'    => 'sqlite',
+            'database'  => ':memory:',
+        ]);
+
+        $db->bootEloquent();
+        $db->setAsGlobal();
+
+        $this->createSchema();
+    }
+
+    /**
+     * Setup the database schema.
+     *
+     * @return void
+     */
+    public function createSchema()
+    {
+        $this->schema()->create('users', function ($table) {
+            $table->increments('id');
+        });
+
+        $this->schema()->create('logins', function ($table) {
+            $table->increments('id');
+            $table->foreignId('user_id');
+        });
+    }
+
+    /**
+     * Tear down the database schema.
+     *
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        $this->schema()->drop('users');
+        $this->schema()->drop('logins');
+    }
+
+    public function testItEagerLoadsCorrectModels()
+    {
+        $user = HasOneOfManyTestUser::create();
+        $user->logins()->create();
+        $latestLogin = $user->logins()->create();
+
+        $user = HasOneOfManyTestUser::with('latest_login')->first();
+
+        $this->assertTrue($user->relationLoaded('latest_login'));
+        $this->assertSame($latestLogin->id, $user->latest_login->id);
+    }
+
+    
+    public function testHasNested()
+    {
+        $user = HasOneOfManyTestUser::create();
+        $previousLogin = $user->logins()->create();
+        $latestLogin = $user->logins()->create();
+
+        $found = HasOneOfManyTestUser::whereHas('latest_login', function ($query) use ($latestLogin) {
+            $query->where('id', $latestLogin->id);
+        })->exists();
+        $this->assertTrue($found);
+
+        $found = HasOneOfManyTestUser::whereHas('latest_login', function ($query) use ($previousLogin) {
+            $query->where('id', $previousLogin->id);
+        })->exists();
+        $this->assertFalse($found);
+    }
+
+    public function testHasCount()
+    {
+        $user = HasOneOfManyTestUser::create();
+        $user->logins()->create();
+        $user->logins()->create();
+
+        $user = HasOneOfManyTestUser::withCount('latest_login')->first();
+        $this->assertEquals(1, $user->latest_login_count);
+    }
+
+    public function testExists()
+    {
+        $user = HasOneOfManyTestUser::create();
+        $previousLogin = $user->logins()->create();
+        $latestLogin = $user->logins()->create();
+
+        $this->assertFalse($user->latest_login()->whereKey($previousLogin->getKey())->exists());
+        $this->assertTrue($user->latest_login()->whereKey($latestLogin->getKey())->exists());
+    }
+
+    public function testIsMethod()
+    {
+        $user = HasOneOfManyTestUser::create();
+        $login1 = $user->latest_login()->create();
+        $login2 = $user->latest_login()->create();
+
+        $this->assertFalse($user->latest_login()->is($login1));
+        $this->assertTrue($user->latest_login()->is($login2));
+    }
+
+    public function testIsNotMethod()
+    {
+        $user = HasOneOfManyTestUser::create();
+        $login1 = $user->latest_login()->create();
+        $login2 = $user->latest_login()->create();
+
+        $this->assertTrue($user->latest_login()->isNot($login1));
+        $this->assertFalse($user->latest_login()->isNot($login2));
+    }
+
+    /**
+     * @group fail
+     */
+    public function testGet()
+    {
+        $user = HasOneOfManyTestUser::create();
+        $previousLogin = $user->logins()->create();
+        $latestLogin = $user->logins()->create();
+
+        $latestLogins = $user->latest_login()->get();
+        $this->assertCount(1, $latestLogins);
+        $this->assertSame($latestLogin->id, $latestLogins->first()->id);
+
+        $latestLogins = $user->latest_login()->whereKey($previousLogin->getKey())->get();
+        $this->assertCount(0, $latestLogins);
+    }
+
+    public function testCount()
+    {
+        $user = HasOneOfManyTestUser::create();
+        $user->logins()->create();
+        $user->logins()->create();
+
+        $this->assertSame(1, $user->latest_login()->count());
+    }
+
+    /**
+     * Get a database connection instance.
+     *
+     * @return \Illuminate\Database\Connection
+     */
+    protected function connection()
+    {
+        return Eloquent::getConnectionResolver()->connection();
+    }
+
+    /**
+     * Get a schema builder instance.
+     *
+     * @return \Illuminate\Database\Schema\Builder
+     */
+    protected function schema()
+    {
+        return $this->connection()->getSchemaBuilder();
+    }
+}
+
+/**
+ * Eloquent Models...
+ */
+class HasOneOfManyTestUser extends Eloquent
+{
+    protected $table = 'users';
+    protected $guarded = [];
+    public $timestamps = false;
+
+    public function logins()
+    {
+        return $this->hasMany(HasOneOfManyTestLogin::class, 'user_id');
+    }
+
+    public function latest_login()
+    {
+        return $this->hasOne(HasOneOfManyTestLogin::class, 'user_id')->ofMany()->orderByDesc('id');
+    }
+}
+
+class HasOneOfManyTestLogin extends Eloquent
+{
+    protected $table = 'logins';
+    protected $guarded = [];
+    public $timestamps = false;
+}

--- a/tests/Database/DatabaseEloquentHasOneOfManyTest.php
+++ b/tests/Database/DatabaseEloquentHasOneOfManyTest.php
@@ -2,9 +2,9 @@
 
 namespace Illuminate\Tests\Database;
 
-use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Model as Eloquent;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group one-of-many
@@ -66,7 +66,6 @@ class DatabaseEloquentHasOneOfManyTest extends TestCase
         $this->assertSame($latestLogin->id, $user->latest_login->id);
     }
 
-    
     public function testHasNested()
     {
         $user = HasOneOfManyTestUser::create();

--- a/tests/Integration/Database/EloquentHasOneOfManyTest.php
+++ b/tests/Integration/Database/EloquentHasOneOfManyTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentHasOneOfManyTest;
+
+use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+/**
+ * @group integration
+ * @group one-of-many
+ */
+class EloquentHasOneOfManyTest extends DatabaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('users', function ($table) {
+            $table->id();
+        });
+
+        Schema::create('logins', function ($table) {
+            $table->id();
+            $table->foreignId('user_id');
+        });
+    }
+
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+        $app['config']->set('app.debug', 'true');
+    }
+
+    public function testItOnlyEagerLoadsRequiredModels()
+    {
+        $this->retrievedLogins = 0;
+        User::getEventDispatcher()->listen('eloquent.retrieved:*', function ($event, $models) {
+            foreach ($models as $model) {
+                if (get_class($model) == Login::class) {
+                    $this->retrievedLogins++;
+                }
+            }
+        });
+        
+        $user = User::create();
+        $user->latest_login()->create();
+        $user->latest_login()->create();
+        $user = User::create();
+        $user->latest_login()->create();
+        $user->latest_login()->create();
+
+        User::with('latest_login')->get();
+
+        $this->assertSame(2, $this->retrievedLogins);
+    }
+}
+
+class User extends Model
+{
+    protected $guarded = [];
+    public $timestamps = false;
+
+    public function latest_login()
+    {
+        return $this->hasOne(Login::class)->ofMany()->orderByDesc('id');
+    }
+}
+
+class Login extends Model
+{
+    protected $guarded = [];
+    public $timestamps = false;
+}

--- a/tests/Integration/Database/EloquentHasOneOfManyTest.php
+++ b/tests/Integration/Database/EloquentHasOneOfManyTest.php
@@ -2,11 +2,8 @@
 
 namespace Illuminate\Tests\Integration\Database\EloquentHasOneOfManyTest;
 
-use Illuminate\Support\Str;
-use Illuminate\Support\Facades\Event;
-use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
 /**
@@ -45,7 +42,7 @@ class EloquentHasOneOfManyTest extends DatabaseTestCase
                 }
             }
         });
-        
+
         $user = User::create();
         $user->latest_login()->create();
         $user->latest_login()->create();


### PR DESCRIPTION
## Background

This pr provides a solution for creating one-to-one relations that are a partial relation of a one-to-many relation. 

These are: **hasOne** ∈ hasMany, **morphOne** ∈ morphMany

### Example

An example is the **user -> logins** relation, where a user has many `logins` but only one `latest_login` (latest_login ∈ logins). One might think that this can build as follows:

```php
public function latest_login()
{
    $this->hasOne(Login::class)->orderByDesc('id');
}
```

However this does not work for several reasons. 

#### 1. This creates a `n+1` problem when eager loading the relationship.

If we take a look at the query that is executed when eager loading the relationship we see that all logins for the given users are loaded where we only need one for each user:

```sql
select * from "logins" where "logins"."user_id" in (?) order by "id" desc
```

Adding a `->limit(1)` obviously does not solve this since only one login is loaded where we need all latest logins for the given users:

```sql
select * from "logins" where "logins"."user_id" in (?) order by "id" desc limit 1
```

#### 2. Querying works not as expected.

- e.g.: `latest_login()->get()` gets all logins (Same problem with `count`, ...)
- e.g.: `latest_login()->is($firstLogin)` returns `true` even if there are newer logins.
- ...

## The Solution

Query the relationship using an existence constraint:

```sql
SELECT *
FROM "logins"
WHERE EXISTS (
	SELECT (
		SELECT "latest_login"."id"
		FROM "logins" AS "latest_login"
		WHERE "latest_login"."user_id" = "logins"."user_id"
		ORDER BY "id" DESC
		LIMIT 1
	) AS "latest_login_id"
	WHERE "latest_login_id" = "logins"."id"
)
```

This query can be used to correctly eager load the relationship, filter parent using `whereHas` and all other relationship methods.

Constraints like `where`, `orderBy` are added to the **subselect** of the **existence** query where else other methods like `get`, `count`, `select`, `join` are applied to the parent query.

## Usage

You may set a `hasOne` relation to be a **one-of-many** relation by using the `ofMany` method:

```php
public function latest_login()
{
    $this->hasOne(Login::class)->ofMany()->orderByDesc('id');
}
```

Determine wether the relation is a one-of-many relation:

```php
$user->latest_login()->is($login);
$user->latest_login()->isNot($login);
$user->latest_login()->where('foo', 'bar')->first();
$user->latest_login()->isOneOfMany() // true/false
$user->latest_login() instanceof PartialRelation // Determine wether the relationship type can be used as one-of-many

User::whereHas('latest_login')->get();
User::with('latest_login')->get();
// ...
```

## More Use Cases

### current_state

It allows you to easily store all changes where you also need one model depending on a certain order.

```php
public function current_state()
{
    $this->hasOne(State::class)->ofMany()->orderByDesc('id');
}
```

Filter models by the current state:

```php
$activeModels = Model::whereHas('current_state', fn($q) => $q->where('state', 'active'))->get();
```

### current_price

Get the current price which may dependent on constraints. The current price in this example is the one where the current release date is before the current time and is also closest to it.

```php
public function current_price()
{
    $this->hasOne(ProductPrice::class)
        ->ofMany()
        ->where('current_price.published_at', '<', now())
        ->orderByDesc('published_at');
}
```

You might think, I could just store the current_price in a `price` column of the priced model?

This is not always possible. For example, if you want to load the price depending on the authenticated user. E.g.: Load a higher price when the user has visited the product multiple times in the last week.

## If This Is Wanted

If the feature is wanted, there are a view open points till the pr is ready to merge.

- Opinions or suggestions on the method name `ofMany`.
- Opinions or suggestions on the interface name `PartialRelation`.
- Add to `morphOne`.
- More tests?
- I will give a detailed description of what happens under the hood to facilitate the review.

## Alternative Solution

Another approach, which is even faster, is to use an inner join:

```sql
SELECT *
FROM `logins`
INNER JOIN (
    SELECT
    MAX(`id`) AS `id`
    FROM `logins`
    GROUP BY `user_id`
) AS `latest_login` 
ON `latest_login`.`id` = `logins`.`id`
```

This could be achieved like this:

```php
$this->hasOne(Login::class)->ofMany(function($q, $join) {
    $q->selectRaw('MAX(id) as id');
});

// Or like this:
$this->hasOne(Login::class)->ofMany('id', 'max');
$this->hasOne(Price::class)->ofMany('published_at', 'max');

// This one requires modifying the subselect query builder that is used within the join:
$this->hasOne(Login::class)->ofMany(fn($q) => $q->max('id'));

// Using additional constraints (payment_state ∈ payment_states ⊆ states):
$this->hasOne(State::class)->ofMany(function($q, $join) {
    $q->selectRaw('MAX(id) as id')->where('type', 'payment_state');
});

// The state example using a morphOne via "stateful":
$this->morphOne(State::class, 'stateful')->ofMany(function($q, $join) {
    $q->selectRaw('MAX(id) as id')->where('type', 'payment_state');
});
```
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
