### PR TITLE
[8.x] Fix JSON column based HasOneOrMany load() method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -180,7 +180,9 @@ abstract class HasOneOrMany extends Relation
         $foreign = $this->getForeignKeyName();
 
         return $results->mapToDictionary(function ($result) use ($foreign) {
-            return [$this->getDictionaryKey($result->{$foreign}) => $result];
+            $key = data_get($result, str_replace('->', '.', $foreign));
+
+            return [$this->getDictionaryKey($key) => $result];
         })->all();
     }
 


### PR DESCRIPTION
Currently we can use a nested JSON key as a column of the HasMany relationship. In my case:

```php
class Message extends Model
{
    public function notifications(): HasMany
    {
        return $this->hasMany(DatabaseNotification::class, 'data->message_id');
    }
}
```

I do nothing else, but on the `database` channel, I save the ID of the passed message model into the data payload of the DatabaseNotification model.

So we can say – I don't know if it's intentional, I was quite suprised btw – JSON keys are supported in HasMany/HasOne relationships by Laravel. I know it's not the suggested way of using it, but in some cases it can be handy.

-------

However, there is a bug, when I try to use load/loadMissing on the relationships with a JSON key.

```php
$message->notifications // work as expected

$message->load('notifications') // loads an empty collection

$message->loadMissing('notifications') // loads an empty collection
```

-------

As it turned out, because of the "wrong" extraction of the foreign key the loaded relationship value gets an empty key `""`, this is what I fixed in the PR.

Normally this is not a BC.