### PR TITLE
[8.x] Fix fields not required with required_unless

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1547,10 +1547,6 @@ trait ValidatesAttributes
     {
         $this->requireParameterCount(2, $parameters, 'required_unless');
 
-        if (! Arr::has($this->data, $parameters[0])) {
-            return true;
-        }
-
         [$values, $other] = $this->parseDependentRuleParameters($parameters);
 
         if (! in_array($other, $values, is_bool($other) || is_null($other))) {

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1198,12 +1198,24 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
 
         $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, ['foo' => false], ['bar' => 'required_unless:foo,false']);
-        $this->assertTrue($v->passes());
+        $v = new Validator($trans, [], ['bar' => 'required_unless:foo,true']);
+        $this->assertTrue($v->fails());
 
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => false], ['bar' => 'required_unless:foo,true']);
         $this->assertTrue($v->fails());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['bar' => '1'], ['bar' => 'required_unless:foo,true']);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => false], ['bar' => 'required_unless:foo,false']);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, [], ['foo' => 'required_unless:bar,null']);
+        $this->assertTrue($v->passes());
 
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => true], ['bar' => 'required_unless:foo,null']);


### PR DESCRIPTION
In v8.40, given a form with this data:
```
['foo' => true]
```

...and this rule in the FormRequest: 
```
['bar' => 'required_unless:baz,true'],
```

The short-circuit introduced in #37128 prevents 'validateRequired' from being called on *bar* when *baz* is omitted from data - even though the very lack of it might mean "bar" *should* be required.

Removing the short-circuit from `required_unless` *seems* to solve the issue without breaking anything else. I tried `false` first, but that just broke it differently so I added cases to cover that too.