### PR TITLE
[8.x] Align CSRF cookie duration to session cookie duration

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -190,7 +190,8 @@ class VerifyCsrfToken
 
         $response->headers->setCookie(
             new Cookie(
-                'XSRF-TOKEN', $request->session()->token(), $this->availableAt(60 * $config['lifetime']),
+                'XSRF-TOKEN', $request->session()->token(),
+                $config['expire_on_close'] ? 0 : $this->availableAt(60 * $config['lifetime']),
                 $config['path'], $config['domain'], $config['secure'], false, false, $config['same_site'] ?? null
             )
         );


### PR DESCRIPTION
The duration of the session cookie is defined by two configuration variables: `session.lifetime` and `session.expire_on_close`. If `session.expire_on_close` is `true`, then the cookie expires on close; if it is `false` (default), then the cookie has a duration of `session.lifetime` minutes (this happens in the `getCookieExpirationDate` method of `Illuminate\Session\Middleware\StartSession`).

The CSRF cookie (`XSRF-TOKEN`, set by the `VerifyCsrfToken` middleware) uses the same duration of the session cookies (`session.lifetime`), but the middleware does not consider the `session.expire_on_close` variable 
(this happens in the `addCookieToResponse` method of `Illuminate\Foundation\Http\Middleware\VerifyCsrfToken`).

This is an unexpected behaviour, and looks like a bug. As a result, if `session.expire_on_close` is `true` it is possible that the session cookie expires while the CSRF cookie is still valid, or that the session cookie is still valid while the CSRF cookie expires. None of these seems a desirable behaviour.

This pull request aligns the behaviour of the CSRF cookie to the one of the session cookie, by taking into account the value of the `session.expire_on_close` variable.