### PR TITLE
[8.x] Create getter for the middleware priority

### DIFF
--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -332,6 +332,16 @@ class Kernel implements KernelContract
     }
 
     /**
+     * Return the priority-sorted list of middleware.
+     *
+     * @return array
+     */
+    public function getMiddlewarePriority()
+    {
+        return $this->middlewarePriority;
+    }
+
+    /**
      * Prepend the given middleware to the middleware priority list.
      *
      * @param  string  $middleware

--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -332,16 +332,6 @@ class Kernel implements KernelContract
     }
 
     /**
-     * Return the priority-sorted list of middleware.
-     *
-     * @return array
-     */
-    public function getMiddlewarePriority()
-    {
-        return $this->middlewarePriority;
-    }
-
-    /**
      * Prepend the given middleware to the middleware priority list.
      *
      * @param  string  $middleware
@@ -391,6 +381,16 @@ class Kernel implements KernelContract
         foreach ($this->routeMiddleware as $key => $middleware) {
             $this->router->aliasMiddleware($key, $middleware);
         }
+    }
+
+    /**
+     * Get the priority-sorted list of middleware.
+     *
+     * @return array
+     */
+    public function getMiddlewarePriority()
+    {
+        return $this->middlewarePriority;
     }
 
     /**

--- a/tests/Foundation/Http/KernelTest.php
+++ b/tests/Foundation/Http/KernelTest.php
@@ -24,6 +24,22 @@ class KernelTest extends TestCase
         $this->assertEquals([], $kernel->getRouteMiddleware());
     }
 
+    public function testGetMiddlewarePriority()
+    {
+        $kernel = new Kernel($this->getApplication(), $this->getRouter());
+
+        $this->assertEquals([
+            \Illuminate\Cookie\Middleware\EncryptCookies::class,
+            \Illuminate\Session\Middleware\StartSession::class,
+            \Illuminate\View\Middleware\ShareErrorsFromSession::class,
+            \Illuminate\Contracts\Auth\Middleware\AuthenticatesRequests::class,
+            \Illuminate\Routing\Middleware\ThrottleRequests::class,
+            \Illuminate\Session\Middleware\AuthenticateSession::class,
+            \Illuminate\Routing\Middleware\SubstituteBindings::class,
+            \Illuminate\Auth\Middleware\Authorize::class,
+        ], $kernel->getMiddlewarePriority());
+    }
+
     /**
      * @return \Illuminate\Contracts\Foundation\Application
      */


### PR DESCRIPTION
This getter will help to create tests to ensure that middlewares are registered in the right priority.

My use case for this is a middleware that I want to ensure gets registered after the `StartSession` but right before the `AuthenticatesRequests` one, so with this getter I can use their indexes to write a test for it.