### PR TITLE
[8.x] Added anonymous static method to Notification facade

### DIFF
--- a/src/Illuminate/Support/Facades/Notification.php
+++ b/src/Illuminate/Support/Facades/Notification.php
@@ -48,6 +48,16 @@ class Notification extends Facade
     }
 
     /**
+     * Begin sending a notification to an anonymous notifiable.
+     * 
+     * @return \Illuminate\Notifications\AnonymousNotifiable
+     */
+    public static function anonymous()
+    {
+        return new AnonymousNotifiable;
+    }
+
+    /**
      * Get the registered name of the component.
      *
      * @return string

--- a/src/Illuminate/Support/Facades/Notification.php
+++ b/src/Illuminate/Support/Facades/Notification.php
@@ -49,7 +49,7 @@ class Notification extends Facade
 
     /**
      * Begin sending a notification to an anonymous notifiable.
-     * 
+     *
      * @return \Illuminate\Notifications\AnonymousNotifiable
      */
     public static function anonymous()

--- a/tests/Integration/Notifications/SendingNotificationsViaAnonymousNotifiableTest.php
+++ b/tests/Integration/Notifications/SendingNotificationsViaAnonymousNotifiableTest.php
@@ -59,6 +59,11 @@ class SendingNotificationsViaAnonymousNotifiableTest extends TestCase
             }
         );
     }
+
+    public function testItReturnsAnonymousNotifiable()
+    {
+        $this->assertInstanceOf(AnonymousNotifiable::class, NotificationFacade::anonymous());
+    }
 }
 
 class TestMailNotificationForAnonymousNotifiable extends Notification


### PR DESCRIPTION
This is a very small, static convenience method added on the notification facade, aimed at making notifications with default routing more semantic.

Take the Twitter notification channel for example, which simply defines a [set of credentials in a configuration file](https://laravel-notification-channels.com/twitter/#installation). To send a Tweet **where a notifiable is not relevant**, the syntax is

````php
use Illuminate\Support\Facades\Notification;
use Illuminate\Notification\AnonymousNotifiable;

$notification = new MyTwitterNotification;

// Notification::route(...) <-- Can't use this, because there is no real concept of routing for this particular channel

(new AnonymousNotifiable)->send($notification);
````

With this convenience method, the syntax for sending ad-hoc notifications is a little cleaner and saves the use of a namespace:

````php
use Illuminate\Support\Facades\Notification;

$notification = new MyTwitterNotification;

Notification::anonymous()->send($notification);
````

Just a suggestion, and thought I might as well suggest via a PR :)
Cheers!