### PR TITLE
[8.x] Tweak the DB Facade docblock

### DIFF
--- a/src/Illuminate/Support/Facades/DB.php
+++ b/src/Illuminate/Support/Facades/DB.php
@@ -4,7 +4,7 @@ namespace Illuminate\Support\Facades;
 
 /**
  * @method static \Doctrine\DBAL\Driver\PDOConnection getPdo()
- * @method static \Illuminate\Database\ConnectionInterface connection(string $name = null)
+ * @method static \Illuminate\Database\Connection connection(string $name = null)
  * @method static \Illuminate\Database\Query\Builder table(string $table, string $as = null)
  * @method static \Illuminate\Database\Query\Expression raw($value)
  * @method static array getQueryLog()


### PR DESCRIPTION
When calling `DB::connection('name')->query()->`, you can get a linting error as Connection Interface class does not contain the "query" function