### PR TITLE
[8.x] Fixes for parameter types

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -205,7 +205,7 @@ class Arr
      * Flatten a multi-dimensional array into a single level.
      *
      * @param  iterable  $array
-     * @param  int  $depth
+     * @param  int|float  $depth
      * @return array
      */
     public static function flatten($array, $depth = INF)

--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -58,7 +58,7 @@ class Fluent implements Arrayable, ArrayAccess, Jsonable, JsonSerializable
     /**
      * Convert the fluent instance to an array.
      *
-     * @return array|string
+     * @return array
      */
     public function toArray()
     {
@@ -68,7 +68,7 @@ class Fluent implements Arrayable, ArrayAccess, Jsonable, JsonSerializable
     /**
      * Convert the object into something JSON serializable.
      *
-     * @return array|string
+     * @return array
      */
     public function jsonSerialize()
     {

--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -58,7 +58,7 @@ class Fluent implements Arrayable, ArrayAccess, Jsonable, JsonSerializable
     /**
      * Convert the fluent instance to an array.
      *
-     * @return array
+     * @return array|string
      */
     public function toArray()
     {
@@ -68,7 +68,7 @@ class Fluent implements Arrayable, ArrayAccess, Jsonable, JsonSerializable
     /**
      * Convert the object into something JSON serializable.
      *
-     * @return array
+     * @return array|string
      */
     public function jsonSerialize()
     {


### PR DESCRIPTION
- When converting to json encoding the `toArray()` and `jsonSerialize()` methods return strings.
- The depth in the `flatten()` method can also be taken from the `float` data type.