### PR TITLE
add --seeder option to artisan migrate command

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -24,6 +24,7 @@ class MigrateCommand extends BaseCommand
                 {--schema-path= : The path to a schema dump file}
                 {--pretend : Dump the SQL queries that would be run}
                 {--seed : Indicates if the seed task should be re-run}
+                {--seeder= : The class name of the root seeder}
                 {--step : Force the migrations to be run so they can be rolled back individually}';
 
     /**
@@ -89,7 +90,10 @@ class MigrateCommand extends BaseCommand
             // seed task to re-populate the database, which is convenient when adding
             // a migration and a seed at the same time, as it is only this command.
             if ($this->option('seed') && ! $this->option('pretend')) {
-                $this->call('db:seed', ['--force' => true]);
+                $this->call('db:seed', [
+                    '--class' => $this->option('seeder') ?: 'Database\\Seeders\\DatabaseSeeder',
+                    '--force' => true,
+                ]);
             }
         });
 


### PR DESCRIPTION
Add the `--seeder` option to the artisan `migrate` command.
Allows to specify the seeder class name when running the command with the `--seed` option.

```php
php artisan migrate --seed --seeder=CustomSeeder
```

This is the same that is already available in `migrate:fresh` and `migrate:refresh`:

https://github.com/laravel/framework/blob/277c2fbd0cebd2cb194807654d870f4040e288c0/src/Illuminate/Database/Console/Migrations/FreshCommand.php#L89-L93

https://github.com/laravel/framework/blob/277c2fbd0cebd2cb194807654d870f4040e288c0/src/Illuminate/Database/Console/Migrations/RefreshCommand.php#L135-L139