### PR TITLE
[8.x] Add Collection method to get Nth Item

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -765,6 +765,17 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
+     * Get the nth item from the collection.
+     *
+     * @param  int $nth
+     * @return mixed
+     */
+    public function getNth($nth)
+    {
+        return $this->values()->get($nth - 1);
+    }
+
+    /**
      * Get the items with the specified keys.
      *
      * @param  mixed  $keys

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -674,6 +674,14 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function nth($step, $offset = 0);
 
     /**
+     * Get the nth item from the collection.
+     *
+     * @param  int $nth
+     * @return mixed
+     */
+    public function getNth($nth);
+
+    /**
      * Get the items with the specified keys.
      *
      * @param  mixed  $keys

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -774,6 +774,18 @@ class LazyCollection implements Enumerable
     }
 
     /**
+     * Get the nth item from the collection.
+     *
+     * @param int $nth
+     *
+     * @return mixed
+     */
+    public function getNth($nth)
+    {
+        return $this->values()->get($nth - 1);
+    }
+
+    /**
      * Get the items with the specified keys.
      *
      * @param  mixed  $keys

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2702,7 +2702,7 @@ class SupportCollectionTest extends TestCase
      */
     public function testGetNthReturnsNthItemInCollection($collection)
     {
-        $c = new $collection(['a', 'b', 'c','d']);
+        $c = new $collection(['a', 'b', 'c', 'd']);
         $this->assertSame('c', $c->getNth(3));
     }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2700,6 +2700,15 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testGetNthReturnsNthItemInCollection($collection)
+    {
+        $c = new $collection(['a', 'b', 'c','d']);
+        $this->assertSame('c', $c->getNth(3));
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testMapWithKeysOverwritingKeys($collection)
     {
         $data = new $collection([


### PR DESCRIPTION
When working with collection that don't have a numeric index or and numeric index that is sorted by some other parameter, it's not possible to use the `get()` method to get nth item from the collection.

_There is already an `nth()` method which creates a new collection consisting of every n-th element._ 
Which wouldn't solve this need.


In my scenario i am getting an array keyd by timestamp, one per day but with different times every day. I need to access the value for today, 7 days ago, 14 days ago and 30 days ago. Having this method would solve this.

I think 
``` 
$data->getNth(7)
```

Is much cleaner than

``` 
$data->values()->get(6) // which is actually item number 7
```

I also believe this is not something that would only benefit me as i found multiple threads on stackoverflow and other website asking how to accomplish something similar. [Here us one example](https://stackoverflow.com/questions/24443949/how-to-access-the-nth-object-in-a-laravel-collection-object/24444011)

It is using existing `values` and `get` methods so i don't see why it would break any existing feature.