### PR TITLE
[8.x] Add exception to chunkById() when last id cannot be determined

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -136,7 +136,7 @@ trait BuildsQueries
             $lastId = $results->last()->{$alias};
 
             if ($lastId === null) {
-                throw new RuntimeException('Unable to determine last id using alias:'.$alias);
+                throw new RuntimeException("The chunkById operation was aborted because the [{$alias}] column is not present in the query result.");
             }
 
             unset($results);

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -134,7 +134,7 @@ trait BuildsQueries
             }
 
             $lastId = $results->last()->{$alias};
-            
+
             if ($lastId === null) {
                 throw new RuntimeException('Unable to determine last id using alias:'.$alias);
             }

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -11,6 +11,7 @@ use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Collection;
 use Illuminate\Support\LazyCollection;
 use InvalidArgumentException;
+use RuntimeException;
 
 trait BuildsQueries
 {
@@ -133,6 +134,10 @@ trait BuildsQueries
             }
 
             $lastId = $results->last()->{$alias};
+            
+            if ($lastId === null) {
+                throw new RuntimeException('Unable to determine last id using alias:'.$alias);
+            }
 
             unset($results);
 


### PR DESCRIPTION
When `chunkById` is used in a query with joins, it creates an infinite loop if `$column` is provided but `$alias` is not provided.

This change makes sure If it is not possible to determine `$lastId`, then an exception is thrown because it is a fundamental requirement for the `chunkById` method to work.

Issue: https://github.com/laravel/framework/issues/37289