### PR TITLE
[8.x] Add withExists method to QueriesRelationships

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -492,6 +492,84 @@ trait QueriesRelationships
     }
 
     /**
+     * Add subselect queries to include an existance value for a relationship.
+     *
+     * @param  string|array  $relations
+     * @return $this
+     */
+    public function withExists($relations)
+    {
+        if (empty($relations)) {
+            return $this;
+        }
+
+        if (is_null($this->query->columns)) {
+            $this->query->select([$this->query->from.'.*']);
+        }
+
+        $relations = is_array($relations) ? $relations : [$relations];
+
+        foreach ($this->parseWithRelations($relations) as $name => $constraints) {
+            // First we will determine if the name has been aliased using an "as" clause on the name
+            // and if it has we will extract the actual relationship name and the desired name of
+            // the resulting column. This allows multiple existences on the same relationships.
+            $segments = explode(' ', $name);
+
+            unset($alias);
+
+            if (count($segments) === 3 && Str::lower($segments[1]) === 'as') {
+                [$name, $alias] = [$segments[0], $segments[2]];
+            }
+
+            $relation = $this->getRelationWithoutConstraints($name);
+
+            $column = $relation->getModel()->getKeyName();
+
+            $hashedColumn = $this->getQuery()->from === $relation->getQuery()->getQuery()->from
+                ? "{$relation->getRelationCountHash(false)}.$column"
+                : $column;
+
+            $expression = $this->getQuery()->grammar->wrap($relation->getRelated()->qualifyColumn($hashedColumn));
+
+            // Here, we will grab the relationship sub-query and prepare to add it to the main query
+            // as a sub-select. First, we'll get the "has" query and use that to get the relation
+            // sub-query. We'll format this relationship name and append this column if needed.
+            $query = $relation->getRelationExistenceQuery(
+                $relation->getRelated()->newQuery(), $this, new Expression($expression)
+            )->setBindings([], 'select');
+
+            $query->callScope($constraints);
+
+            $query = $query->mergeConstraintsFrom($relation->getQuery())->toBase();
+
+            // If the query contains certain elements like orderings / more than one column selected
+            // then we will remove those elements from the query so that it will execute properly
+            // when given to the database. Otherwise, we may receive SQL errors or poor syntax.
+            $query->orders = null;
+            $query->setBindings([], 'order');
+
+            if (count($query->columns) > 1) {
+                $query->columns = [$query->columns[0]];
+                $query->bindings['select'] = [];
+            }
+
+            // Finally, we will make the proper column alias to the query and run this sub-select on
+            // the query builder. Then, we will return the builder instance back to the developer
+            // for further constraint chaining that needs to take place on the query as needed.
+            $alias = $alias ?? Str::snake(
+                    preg_replace('/[^[:alnum:][:space:]_]/u', '', "$name exists")
+                );
+
+            $this->selectRaw(
+                sprintf('exists(%s) as %s', $query->toSql(), $this->getQuery()->grammar->wrap($alias)),
+                $query->getBindings()
+            )->withCasts([$alias => 'bool']);
+        }
+
+        return $this;
+    }
+
+    /**
      * Add the "has" condition where clause to the query.
      *
      * @param  \Illuminate\Database\Eloquent\Builder  $hasQuery

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -992,6 +992,95 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertSame('select "eloquent_builder_test_model_parent_stubs".*, (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_bar", (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_count" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
     }
 
+    public function testWithExists()
+    {
+        $model = new EloquentBuilderTestModelParentStub;
+
+        $builder = $model->withExists('foo');
+
+        $this->assertSame('select "eloquent_builder_test_model_parent_stubs".*, exists(select "eloquent_builder_test_model_close_related_stubs"."id" from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_exists" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
+    }
+
+    public function testWithExistsAndSelect()
+    {
+        $model = new EloquentBuilderTestModelParentStub;
+
+        $builder = $model->select('id')->withExists('foo');
+
+        $this->assertSame('select "id", exists(select "eloquent_builder_test_model_close_related_stubs"."id" from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_exists" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
+    }
+
+    public function testWithExistsAndMergedWheres()
+    {
+        $model = new EloquentBuilderTestModelParentStub;
+
+        $builder = $model->select('id')->withExists(['activeFoo' => function ($q) {
+            $q->where('bam', '>', 'qux');
+        }]);
+
+        $this->assertSame('select "id", exists(select "eloquent_builder_test_model_close_related_stubs"."id" from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" and "bam" > ? and "active" = ?) as "active_foo_exists" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
+        $this->assertEquals(['qux', true], $builder->getBindings());
+    }
+
+    public function testWithExistsAndGlobalScope()
+    {
+        $model = new EloquentBuilderTestModelParentStub;
+        EloquentBuilderTestModelCloseRelatedStub::addGlobalScope('withExists', function ($query) {
+            return $query->addSelect('id');
+        });
+
+        $builder = $model->select('id')->withExists(['foo']);
+
+        // Remove the global scope so it doesn't interfere with any other tests
+        EloquentBuilderTestModelCloseRelatedStub::addGlobalScope('withExists', function ($query) {
+            //
+        });
+
+        $this->assertSame('select "id", exists(select "eloquent_builder_test_model_close_related_stubs"."id" from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_exists" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
+    }
+
+    public function testWithExistsOnBelongsToMany()
+    {
+        $model = new EloquentBuilderTestModelParentStub;
+
+        $builder = $model->withExists('roles');
+
+        $this->assertSame('select "eloquent_builder_test_model_parent_stubs".*, exists(select "eloquent_builder_test_model_far_related_stubs"."id" from "eloquent_builder_test_model_far_related_stubs" inner join "user_role" on "eloquent_builder_test_model_far_related_stubs"."id" = "user_role"."related_id" where "eloquent_builder_test_model_parent_stubs"."id" = "user_role"."self_id") as "roles_exists" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
+    }
+
+    public function testWithExistsOnSelfRelated()
+    {
+        $model = new EloquentBuilderTestModelSelfRelatedStub;
+
+        $sql = $model->withExists('childFoos')->toSql();
+
+        // alias has a dynamic hash, so replace with a static string for comparison
+        $alias = 'self_alias_hash';
+        $aliasRegex = '/\b(laravel_reserved_\d)(\b|$)/i';
+
+        $sql = preg_replace($aliasRegex, $alias, $sql);
+
+        $this->assertSame('select "self_related_stubs".*, exists(select "self_alias_hash"."id" from "self_related_stubs" as "self_alias_hash" where "self_related_stubs"."id" = "self_alias_hash"."parent_id") as "child_foos_exists" from "self_related_stubs"', $sql);
+    }
+
+    public function testWithExistsAndRename()
+    {
+        $model = new EloquentBuilderTestModelParentStub;
+
+        $builder = $model->withExists('foo as foo_bar');
+
+        $this->assertSame('select "eloquent_builder_test_model_parent_stubs".*, exists(select "eloquent_builder_test_model_close_related_stubs"."id" from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_bar" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
+    }
+
+    public function testWithExistsMultipleAndPartialRename()
+    {
+        $model = new EloquentBuilderTestModelParentStub;
+
+        $builder = $model->withExists(['foo as foo_bar', 'foo']);
+
+        $this->assertSame('select "eloquent_builder_test_model_parent_stubs".*, exists(select "eloquent_builder_test_model_close_related_stubs"."id" from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_bar", exists(select "eloquent_builder_test_model_close_related_stubs"."id" from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_exists" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
+    }
+
     public function testHasWithConstraintsAndHavingInSubquery()
     {
         $model = new EloquentBuilderTestModelParentStub;
@@ -1058,6 +1147,19 @@ class DatabaseEloquentBuilderTest extends TestCase
         }]);
 
         $this->assertSame('select "eloquent_builder_test_model_parent_stubs".*, (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_count" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
+        $this->assertSame([], $builder->getBindings());
+    }
+
+    public function testWithExistsAndConstraintsWithBindingInSelectSub()
+    {
+        $model = new EloquentBuilderTestModelParentStub;
+
+        $builder = $model->newQuery();
+        $builder->withExists(['foo' => function ($q) use ($model) {
+            $q->selectSub($model->newQuery()->where('bam', '=', 3)->selectRaw('count(0)'), 'bam_3_count');
+        }]);
+
+        $this->assertSame('select "eloquent_builder_test_model_parent_stubs".*, exists(select "eloquent_builder_test_model_close_related_stubs"."id" from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_exists" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
         $this->assertSame([], $builder->getBindings());
     }
 


### PR DESCRIPTION
This PR adds `withExists` method to `QueriesRelationships`.

If we want to list our `User`s with an extra columns `is_author` (based on the fact that the user wrote a `Post`), at the moment we can only do something like 
```php
$users = User::withCount('posts')->get();
//...
$isAuthor = $user->posts_count > 0;
```

It works but it is not very efficient as the database needs to count every posts whereas we only need to know if there is at least one of them.

With this PR, we could simply do an existence check with sql `exists` wich is more efficient
```php
$users = User::withExists('posts')->get();
//...
$isAuthor = $user->posts_exists;
```

The column name can also be aliased
```php
$users = User::withExists('posts as is_author')->get();
//...
$isAuthor = $user->is_author;
```

Relations can be filtered and multiple relation existences can be fetched at the same time :
```php
$users = User::withExists([
        'posts as is_author',
        'posts as is_tech_author' => function ($query) {
            return $query->where('category', 'tech');
        },
        'comments',
    ])->get();
//...
$user->is_author;
$user->is_tech_author;
$user->comments_exists;
```

In a future PR we could add `loadExists` for both `Model` and `Illuminate\Database\Eloquent\Collection`

    

