### PR TITLE
[8.x] Fix asterisks validation rules bug

### DIFF
--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -62,7 +62,7 @@ class ValidationRuleParser
      */
     protected function explodeRules($rules)
     {
-        foreach ($rules as $key => $rule) {
+        foreach ($rules as $key => &$rule) {
             if (Str::contains($key, '*')) {
                 $rules = $this->explodeWildcardRules($rules, $key, [$rule]);
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4100,6 +4100,16 @@ class ValidationValidatorTest extends TestCase
         ]);
         $this->assertFalse($v->passes());
 
+        // array rules with array elements
+        $v = new Validator($trans, $data, [
+            'foo' => 'Array',
+            'foo.*' => ['Numeric', 'Min:6'],
+            'foo.0' => ['Max:8'],
+            'foo.1' => ['Max:9'],
+            'foo.2' => ['Max:16'],
+        ]);
+        $this->assertFalse($v->passes());
+
         // array rules passes
         $v = new Validator($trans, $data, [
             'foo' => 'Array',


### PR DESCRIPTION
Please Do not just close the pull request, I am pretty sure this is a bug I'm facing in our project.

I described the issue we had with the `distinct` validation rule in our project, in issues (#37282, #37257).

I realized it's not just an issue with `distinct`, All kinds of validation rules that using with asterisk attribute names could have this issue.

I provide example codes that show this issue.

This is a simple validation rule which works normally and fine.
```php
Validator::make(
    ['foo' => [10 , 30]], 
    ['foo.*' => 'numeric|min:20']
)->errors()->all(); // The foo.0 must be at least 20.
```

Now I add validation rules for each array element like this that also works normally and fine.
```php
Validator::make(
    ['foo' => [10 , 30]], 
    [
        'foo.0' => 'max:15', 
        'foo.1' => 'max:25', 
        'foo.*' => 'numeric|min:20'
    ]
)->errors()->all(); // The foo.0 must be at least 20, The foo.1 must not be greater than 25.
```

This bug shows itself when I simply change the position of the validation rule with an asterisk attribute name.
```php
 Validator::make(
    ['foo' => [10 , 30]], 
    [
        'foo.*' => 'numeric|min:20', // I moved this from bottom to top
        'foo.0' => 'max:15', 
        'foo.1' => 'max:25'
    ]
)->errors()->all(); // [] , Empty which is not true
```

## Reason behind this bug
The code at [ValidationRuleParser.php(67)](https://github.com/amir9480/framework/blob/fix_wildcard_validation_bug/src/Illuminate/Validation/ValidationRuleParser.php#L67) converts any kind of attributes with an asterisk in their name to individual array element rule.

For the above examples it will convert:
```php
[
    'foo.*' => 'numeric|min:20'
]
```
To
```php
[
    'foo.0' => 'numeric|min:20',
    'foo.1' => 'numeric|min:20',
]
```

If we put each array element validation rule after rule with an asterisk in their name, It will simply merge them together.
For example, it will convert:
```php
[
    'foo.*' => 'numeric|min:20',
    'foo.0' => 'max:15', 
    'foo.1' => 'max:25'
]
```

To:
```php
[
    'foo.0' => ["max:15", "numeric", "min:20"],
    'foo.1' => ["max:25", "numeric", "min:20"],
]
```
But the issue here is the loop at [ValidationRuleParser.php(66)](https://github.com/amir9480/framework/blob/fix_wildcard_validation_bug/src/Illuminate/Validation/ValidationRuleParser.php#L66) uses a value to iterate not reference and when it parsing above validation rule it will use array value before merging validation rules at [ValidationRuleParser.php(71)](https://github.com/amir9480/framework/blob/fix_wildcard_validation_bug/src/Illuminate/Validation/ValidationRuleParser.php#L71) which cause losing merged rules.

```php
$rules[$key] = $this->explodeExplicitRule($rule); // For second rule value of `$rule` is 'max:25', But it should be `['max:15', 'numeric', 'min:20']`
```

This will convert the final rules to:
```php
[
    'foo.0' => ['max:15'],
    'foo.1' => ['max:25'],
]
```
This is the reason why validation passes rules.

## Fix
Just simply using a reference to iterate rules with adding an `&` or accessing array with a key so it will iterate over updated rules, not cached rules.
I also provided a unit test that shows this fix working.