### PR TITLE
[8.x] Public visibility in SessionGuard

### DIFF
--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -381,7 +381,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      * @param  array  $credentials
      * @return bool
      */
-    protected function hasValidCredentials($user, $credentials)
+    public function hasValidCredentials($user, $credentials)
     {
         $validated = ! is_null($user) && $this->provider->validateCredentials($user, $credentials);
 

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -643,7 +643,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      * @param  bool  $remember
      * @return void
      */
-    protected function fireAttemptEvent(array $credentials, $remember = false)
+    public function fireAttemptEvent(array $credentials, $remember = false)
     {
         if (isset($this->events)) {
             $this->events->dispatch(new Attempting(
@@ -658,7 +658,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @return void
      */
-    protected function fireValidatedEvent($user)
+    public function fireValidatedEvent($user)
     {
         if (isset($this->events)) {
             $this->events->dispatch(new Validated(
@@ -674,7 +674,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      * @param  bool  $remember
      * @return void
      */
-    protected function fireLoginEvent($user, $remember = false)
+    public function fireLoginEvent($user, $remember = false)
     {
         if (isset($this->events)) {
             $this->events->dispatch(new Login(
@@ -689,7 +689,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @return void
      */
-    protected function fireAuthenticatedEvent($user)
+    public function fireAuthenticatedEvent($user)
     {
         if (isset($this->events)) {
             $this->events->dispatch(new Authenticated(
@@ -704,7 +704,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @return void
      */
-    protected function fireOtherDeviceLogoutEvent($user)
+    public function fireOtherDeviceLogoutEvent($user)
     {
         if (isset($this->events)) {
             $this->events->dispatch(new OtherDeviceLogout(
@@ -720,7 +720,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      * @param  array  $credentials
      * @return void
      */
-    protected function fireFailedEvent($user, array $credentials)
+    public function fireFailedEvent($user, array $credentials)
     {
         if (isset($this->events)) {
             $this->events->dispatch(new Failed(


### PR DESCRIPTION
This PR changes the visibility of the 6 `fire...Event` and `hasValidCredentials` functions from protected to public.

## Scenario
I am looking to implement a two factor authentication solution, much like the one that is implemented in Fortify, but without actually using Fortify because we don't need everything in there.

## Code examples
### `hasValidCredentials`
This function already fires the Failed event if the credentials if the credentials are invalid.

The current implementation in Fortify:
```php
// Laravel\Fortify\Actions\RedirectIfTwoFactorAuthenticatable::validateCredentials

return tap($model::where(Fortify::username(), $request->{Fortify::username()})->first(), function ($user) use ($request) {
    if (! $user || ! $this->guard->getProvider()->validateCredentials($user, ['password' => $request->password])) {
        $this->fireFailedEvent($request, $user);

        $this->throwFailedAuthenticationException($request);
    }
});
```

could be shortened to:
```php
return tap($model::where(Fortify::username(), function($user) use ($request) {
    if(! $this->guard->hasValidCredentials($user, ['password' => $request->password])) {
        $this->throwFailedAuthenticationException($request);
    }
});
```

and in one's own controller, they could:
```php
if(! $this->guard->hasValidCredentials($user, ['password' => $request->password])) {
    return $this->sendFailedLoginResponse($request);
}
```

### `fireFailedEvent`

Furthermore, if I also built a custom authentication callback like Fortify, for example one based on SSO that returns a user based on the request, I'd also like to be able to fire the Failed event without essentially needing to copy the fireFailedEvent function from the SessionGuard to achieve that what the guard already provides under the hood for the normal authentication flow.

The current implementation in Fortify:
```php
// Laravel\Fortify\Actions\AttemptToAuthenticate::handleUsingCustomCallback

protected function handleUsingCustomCallback($request, $next)
{
    $user = call_user_func(Fortify::$authenticateUsingCallback, $request);

    if (! $user) {
        $this->fireFailedEvent($request);

        return $this->throwFailedAuthenticationException($request);
    }

    $this->guard->login($user, $request->filled('remember'));

    return $next($request);
}
```

could be changed to:
```php
// Laravel\Fortify\Actions\AttemptToAuthenticate::handleUsingCustomCallback

protected function handleUsingCustomCallback($request, $next)
{
    $user = call_user_func(Fortify::$authenticateUsingCallback, $request);

    if (! $user) {
        $this->guard->fireFailedEvent(null, [
            Fortify::username() => $request->{Fortify::username()},
            'password' => $request->password,
        ]);

        return $this->throwFailedAuthenticationException($request);
    }

    $this->guard->login($user, $request->filled('remember'));

    return $next($request);
}
```