### PR TITLE
[8.x] Add withExists method to QueriesRelationships

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -387,9 +387,11 @@ trait QueriesRelationships
                                             ? "{$relation->getRelationCountHash(false)}.$column"
                                             : $column;
 
-                $expression = sprintf('%s(%s)', $function, $this->getQuery()->getGrammar()->wrap(
+                $wrappedColumn = $this->getQuery()->getGrammar()->wrap(
                     $column === '*' ? $column : $relation->getRelated()->qualifyColumn($hashedColumn)
-                ));
+                );
+
+                $expression = $function === 'exists' ? $wrappedColumn : sprintf('%s(%s)', $function, $wrappedColumn);
             } else {
                 $expression = $column;
             }
@@ -423,10 +425,17 @@ trait QueriesRelationships
                 preg_replace('/[^[:alnum:][:space:]_]/u', '', "$name $function $column")
             );
 
-            $this->selectSub(
-                $function ? $query : $query->limit(1),
-                $alias
-            );
+            if ($function === 'exists') {
+                $this->selectRaw(
+                    sprintf('exists(%s) as %s', $query->toSql(), $this->getQuery()->grammar->wrap($alias)),
+                    $query->getBindings()
+                )->withCasts([$alias => 'bool']);
+            } else {
+                $this->selectSub(
+                    $function ? $query : $query->limit(1),
+                    $alias
+                );
+            }
         }
 
         return $this;
@@ -489,6 +498,17 @@ trait QueriesRelationships
     public function withAvg($relation, $column)
     {
         return $this->withAggregate($relation, $column, 'avg');
+    }
+
+    /**
+     * Add subselect queries to include the existence of related models.
+     *
+     * @param  string|array  $relation
+     * @return $this
+     */
+    public function withExists($relation)
+    {
+        return $this->withAggregate($relation, '*', 'exists');
     }
 
     /**


### PR DESCRIPTION
This PR is another implementation of https://github.com/laravel/framework/pull/37295 which adds less code to the framework.

I won't be sad if it is not merged but I wanted to provide another way of implementing the same behaviour.

For more information about the motivations of this feature, I add here the original description.

This PR adds `withExists` method to `QueriesRelationships`.

If we want to list our `User`s with an extra columns `is_author` (based on the fact that the user wrote a `Post`), at the moment we can only do something like 
```php
$users = User::withCount('posts')->get();
//...
$isAuthor = $user->posts_count > 0;
```

It works but it is not very efficient as the database needs to count every posts whereas we only need to know if there is at least one of them.

With this PR, we could simply do an existence check with sql `exists` wich is more efficient
```php
$users = User::withExists('posts')->get();
//...
$isAuthor = $user->posts_exists;
```

The column name can also be aliased
```php
$users = User::withExists('posts as is_author')->get();
//...
$isAuthor = $user->is_author;
```

Relations can be filtered and multiple relation existences can be fetched at the same time :
```php
$users = User::withExists([
        'posts as is_author',
        'posts as is_tech_author' => function ($query) {
            return $query->where('category', 'tech');
        },
        'comments',
    ])->get();
//...
$user->is_author;
$user->is_tech_author;
$user->comments_exists;
```

In a future PR we could add `loadExists` for both `Model` and `Illuminate\Database\Eloquent\Collection`
