### PR TITLE
[8.x] Fix for dropping columns when using MSSQL as database

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -75,7 +75,7 @@ class SqlServerGrammar extends Grammar
      */
     public function compileColumnListing($table)
     {
-        return "select name from sys.columns where object_id = object_id('$table', 'U')";
+        return "select name from master.sys.columns where object_id = object_id('$table', 'U')";
     }
 
     /**
@@ -239,7 +239,7 @@ class SqlServerGrammar extends Grammar
 
         $sql = "DECLARE @sql NVARCHAR(MAX) = '';";
         $sql .= "SELECT @sql += 'ALTER TABLE [dbo].[{$tableName}] DROP CONSTRAINT ' + OBJECT_NAME([default_object_id]) + ';' ";
-        $sql .= 'FROM SYS.COLUMNS ';
+        $sql .= 'FROM MASTER.SYS.COLUMNS ';
         $sql .= "WHERE [object_id] = OBJECT_ID('[dbo].[{$tableName}]') AND [name] in ({$columns}) AND [default_object_id] <> 0;";
         $sql .= 'EXEC(@sql)';
 


### PR DESCRIPTION
When using MSSQL as the database for an application you are unable to drop columns.

```php
 $table->dropColumn('name');
```

The error received is 

`SQLSTATE[42S02]: [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]Invalid object name 'SYS.COLUMNS'. (SQL: DECLARE @sql NVARCHAR(MAX) = '';SELECT @sql += 'ALTER TABLE...`

This is due to the fact that the SYS.COLUMNS table is actually located in the "master" database, so that is why you are unable to query this table from any other database.

This (very) simple PR fixes this by prefixing the table name with the master database.