### PR TITLE
[6.x] Support mass assignment to SQL Server views

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -29,13 +29,13 @@ class SqlServerGrammar extends Grammar
     protected $serials = ['tinyInteger', 'smallInteger', 'mediumInteger', 'integer', 'bigInteger'];
 
     /**
-     * Compile the query to determine if a table exists.
+     * Compile the query to determine if a table or view exists.
      *
      * @return string
      */
     public function compileTableExists()
     {
-        return "select * from sysobjects where type = 'U' and name = ?";
+        return "select * from sysobjects where type in ('U', 'V') and name = ?";
     }
 
     /**
@@ -48,7 +48,7 @@ class SqlServerGrammar extends Grammar
     {
         return "select col.name from sys.columns as col
                 join sys.objects as obj on col.object_id = obj.object_id
-                where obj.type = 'U' and obj.name = '$table'";
+                where obj.type in ('U', 'V') and obj.name = '$table'";
     }
 
     /**


### PR DESCRIPTION
SqlServerGrammar assumes that the model is backed by a table, but some unfortunate souls attach to views in SQL Server. Since we now check mass assignment keys against the database columns, we need to be able to fetch the columns for views.

SQL Server will not allow a table and a view to have the same name in the same namespace, so this should not introduce any problems with matching multiple items.

Commit which introduced the problem: https://github.com/laravel/framework/commit/70d261d9832fc30575276fd9042b02f5debdad8f