### PR TITLE
[8.x] Improvement in the `Arr::query()` method

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -651,7 +651,7 @@ class Arr
     {
         $query = http_build_query($array, '', '&', PHP_QUERY_RFC3986);
 
-        foreach(['%5B' => '[', '%5D' => ']'] as $quote => $value) {
+        foreach (['%5B' => '[', '%5D' => ']'] as $quote => $value) {
             $query = Str::replace($quote, $value, $query);
         }
 

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -649,7 +649,13 @@ class Arr
      */
     public static function query($array)
     {
-        return http_build_query($array, '', '&', PHP_QUERY_RFC3986);
+        $query = http_build_query($array, '', '&', PHP_QUERY_RFC3986);
+
+        foreach(['%5B' => '[', '%5D' => ']'] as $quote => $value) {
+            $query = Str::replace($quote, $value, $query);
+        }
+
+        return $query;
     }
 
     /**

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -597,6 +597,7 @@ class SupportArrTest extends TestCase
         $this->assertSame('foo=bar&bar=1', Arr::query(['foo' => 'bar', 'bar' => true]));
         $this->assertSame('foo=bar', Arr::query(['foo' => 'bar', 'bar' => null]));
         $this->assertSame('foo=bar&bar=', Arr::query(['foo' => 'bar', 'bar' => '']));
+        $this->assertSame('foo=bar&baz[bam]=baz&baz[first]=two', Arr::query(['foo' => 'bar', 'baz' => ['bam' => 'baz', 'first' => 'two']]));
     }
 
     public function testRandom()


### PR DESCRIPTION
- Before :
```php
Arr::query(['foo' => 'bar', 'baz' => ['bam' => 'baz', 'first' => 'two']]);
// Result : foo=bar&baz%5Bbam%5D=baz&baz%5Bfirst%5D=two
```
- After :
```php
Arr::query(['foo' => 'bar', 'baz' => ['bam' => 'baz', 'first' => 'two']]);
// Result : foo=bar&baz[bam]=baz&baz[first]=two
```