### PR TITLE
Add `clear` method to collection.

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -178,6 +178,16 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
+     * Remove all of the items from the collection.
+     *
+     * @return static
+     */
+    public function clear()
+    {
+        return $this->slice(0, $this->count() - 1);
+    }
+
+    /**
      * Cross join with the given lists, returning all possible permutations.
      *
      * @param  mixed  ...$lists

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -5,6 +5,7 @@ namespace Illuminate\Support;
 use ArrayIterator;
 use Closure;
 use DateTimeInterface;
+use Exception;
 use Illuminate\Support\Traits\EnumeratesValues;
 use Illuminate\Support\Traits\Macroable;
 use IteratorAggregate;
@@ -171,6 +172,16 @@ class LazyCollection implements Enumerable
                 }
             }
         });
+    }
+
+    /**
+     * Remove all of the items from the collection.
+     *
+     * @return static
+     */
+    public function clear()
+    {
+        return $this->slice(0, $this->count() - 1);
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1502,6 +1502,15 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testClear($collection)
+    {
+        $data = new $collection(1, 2, 3);
+        $this->assertEquals([], $data->clear()->all());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testJoin($collection)
     {
         $this->assertSame('a, b, c', (new $collection(['a', 'b', 'c']))->join(', '));


### PR DESCRIPTION
The `clear` method removes all items from the given collection.  This would be useful in scenarios where a collection is used to store "running values" that get cleared at the end of an iteration.

```diff
function removeDuplicates($table, $columns) {
    $allDuplicates = getDuplicates($table, $columns); // [ { row_index: 1, id: 1 }, { row_index: 2, id: 2 }, { row_index: 1, id: 3 } ]
  
    $duplicateIds = new Collection();
  
    foreach ($duplicate in $allDuplicates) {
        if ($duplicate->row_index > 1) {
            $duplicateIds->push($duplicate->id);

            continue;
        }

        if ($duplicateIds->isNotEmpty()) {
            DB::table($table)->whereIn('id', $duplicateIds)->delete();

+            $duplicateIds->clear();
        }
    }
}
```
