### PR TITLE
[8.x] Add cursor pagination support to API resources

### DIFF
--- a/src/Illuminate/Http/Resources/CollectsResources.php
+++ b/src/Illuminate/Http/Resources/CollectsResources.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Http\Resources;
 
+use Illuminate\Pagination\AbstractCursorPaginator;
 use Illuminate\Pagination\AbstractPaginator;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
@@ -30,7 +31,7 @@ trait CollectsResources
             ? $resource->mapInto($collects)
             : $resource->toBase();
 
-        return $resource instanceof AbstractPaginator
+        return ($resource instanceof AbstractPaginator || $resource instanceof AbstractCursorPaginator)
                     ? $resource->setCollection($this->collection)
                     : $this->collection;
     }

--- a/src/Illuminate/Http/Resources/Json/ResourceCollection.php
+++ b/src/Illuminate/Http/Resources/Json/ResourceCollection.php
@@ -4,6 +4,7 @@ namespace Illuminate\Http\Resources\Json;
 
 use Countable;
 use Illuminate\Http\Resources\CollectsResources;
+use Illuminate\Pagination\AbstractCursorPaginator;
 use Illuminate\Pagination\AbstractPaginator;
 use IteratorAggregate;
 
@@ -108,7 +109,7 @@ class ResourceCollection extends JsonResource implements Countable, IteratorAggr
      */
     public function toResponse($request)
     {
-        if ($this->resource instanceof AbstractPaginator) {
+        if ($this->resource instanceof AbstractPaginator || $this->resource instanceof AbstractCursorPaginator) {
             return $this->preparePaginatedResponse($request);
         }
 


### PR DESCRIPTION
As a follow-up to https://github.com/laravel/framework/pull/37216, this PR adds cursor pagination support to API resources.