### PR TITLE
[8.x] Add make:scope console command

### DIFF
--- a/src/Illuminate/Foundation/Console/ScopeMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ScopeMakeCommand.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\GeneratorCommand;
+
+class ScopeMakeCommand extends GeneratorCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'make:scope';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new scope class';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Scope';
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return $this->resolveStubPath('/stubs/scope.stub');
+    }
+
+    /**
+     * Resolve the fully-qualified path to the stub.
+     *
+     * @param  string  $stub
+     * @return string
+     */
+    protected function resolveStubPath($stub)
+    {
+        return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
+            ? $customPath
+            : __DIR__.$stub;
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace.'\Scopes';
+    }
+
+}

--- a/src/Illuminate/Foundation/Console/ScopeMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ScopeMakeCommand.php
@@ -60,5 +60,4 @@ class ScopeMakeCommand extends GeneratorCommand
     {
         return $rootNamespace.'\Scopes';
     }
-
 }

--- a/src/Illuminate/Foundation/Console/stubs/scope.stub
+++ b/src/Illuminate/Foundation/Console/stubs/scope.stub
@@ -1,0 +1,22 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Scope;
+
+class {{ class }} implements Scope
+{
+    /**
+     * Apply the scope to a given Eloquent query builder.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $builder
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return void
+     */
+    public function apply(Builder $builder, Model $model)
+    {
+        //
+    }
+}

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -51,6 +51,7 @@ use Illuminate\Foundation\Console\RouteCacheCommand;
 use Illuminate\Foundation\Console\RouteClearCommand;
 use Illuminate\Foundation\Console\RouteListCommand;
 use Illuminate\Foundation\Console\RuleMakeCommand;
+use Illuminate\Foundation\Console\ScopeMakeCommand;
 use Illuminate\Foundation\Console\ServeCommand;
 use Illuminate\Foundation\Console\StorageLinkCommand;
 use Illuminate\Foundation\Console\StubPublishCommand;
@@ -149,7 +150,6 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'ListenerMake' => 'command.listener.make',
         'MailMake' => 'command.mail.make',
         'MiddlewareMake' => 'command.middleware.make',
-        'ModelMake' => 'command.model.make',
         'NotificationMake' => 'command.notification.make',
         'NotificationTable' => 'command.notification.table',
         'ObserverMake' => 'command.observer.make',
@@ -161,6 +161,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'RequestMake' => 'command.request.make',
         'ResourceMake' => 'command.resource.make',
         'RuleMake' => 'command.rule.make',
+        'ScopeMake' => 'command.scope.make',
         'SeederMake' => 'command.seeder.make',
         'SessionTable' => 'command.session.table',
         'Serve' => 'command.serve',
@@ -913,6 +914,19 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
             return new DumpCommand;
         });
     }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerScopeMakeCommand()
+    {
+        $this->app->singleton('command.scope.make', function ($app) {
+            return new ScopeMakeCommand($app['files']);
+        });
+    }
+
 
     /**
      * Register the command.

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -927,7 +927,6 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         });
     }
 
-
     /**
      * Register the command.
      *


### PR DESCRIPTION
This PR adds make:scope command to Laravel Foundation.
Foundation maker commands already have a large variety of commands available however the scope one is missing. 

This PR will allow creating new scopes via `php artisan make:scope DemoScope` command and will reduce the necessity of looking up how scope classes are structured every time its required. 

The implementation follows the format of other maker commands and the stub is built from the docs outlined example.