### PR TITLE
[8.x] GeneratorCommand class name StudlyCaps

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -172,6 +172,8 @@ abstract class GeneratorCommand extends Command
         $name = ltrim($name, '\\/');
 
         $name = str_replace('/', '\\', $name);
+        
+        $name = Str::studly($name);
 
         $rootNamespace = $this->rootNamespace();
 

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -172,7 +172,7 @@ abstract class GeneratorCommand extends Command
         $name = ltrim($name, '\\/');
 
         $name = str_replace('/', '\\', $name);
-        
+
         $name = Str::studly($name);
 
         $rootNamespace = $this->rootNamespace();


### PR DESCRIPTION
According to the PSR-4 standard, class names should be StudlyCaps.

Right now if we create a controller using the `make:controller` command and a snake cased name, the generated class won't be valid.

![image](https://user-images.githubusercontent.com/33923690/117574002-609a8d80-b0db-11eb-8dc1-d64c16075774.png)

I think it should either throw an exception or convert the class name to pascal case.