### PR TITLE
[9.x] Add `withReverse` to `hasOneOrMany` relationships

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -131,6 +131,13 @@ trait HasAttributes
     public static $encrypter;
 
     /**
+     * Array of model relations that should be ignored.
+     *
+     * @var array
+     */
+    protected $ignoreRelations = [];
+
+    /**
      * Convert the model's attributes to an array.
      *
      * @return array
@@ -305,7 +312,11 @@ trait HasAttributes
             // toArray method on the instances which will convert both models and
             // collections to their proper array form and we'll set the values.
             if ($value instanceof Arrayable) {
-                $relation = $value->toArray();
+                if (! in_array($key, $this->ignoreRelations)) {
+                    array_push($this->ignoreRelations, $key);
+                    $relation = $value->toArray();
+                    array_pop($this->ignoreRelations);
+                }
             }
 
             // If the value is null, we'll still go ahead and set it in this list of

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/SupportsReverseRelations.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/SupportsReverseRelations.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Database\Eloquent\Relations\Concerns;
 
-use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Contracts\Pagination\Paginator;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
@@ -38,7 +38,7 @@ trait SupportsReverseRelations
     /**
      * Determine if the related model has any reverse relation.
      *
-     * @return boolean
+     * @return bool
      */
     public function hasReverse()
     {
@@ -71,8 +71,8 @@ trait SupportsReverseRelations
                 foreach ($this->withReverses as $reverseRelation) {
                     $results->setRelation($reverseRelation, $parent);
                 }
-            } elseif ($results instanceof Collection || $results instanceof LengthAwarePaginator) {
-                $items = $results instanceof LengthAwarePaginator ? $results->items() : $results;
+            } elseif ($results instanceof Collection || $results instanceof Paginator) {
+                $items = $results instanceof Paginator ? $results->items() : $results;
                 foreach ($items as $item) {
                     if ($item instanceof Model) {
                         foreach ($this->withReverses as $reverseRelation) {

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/SupportsReverseRelations.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/SupportsReverseRelations.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Relations\Concerns;
+
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
+
+trait SupportsReverseRelations
+{
+    /**
+     * Array of reverse relations names in related model.
+     *
+     * @var array
+     */
+    protected $withReverses = [];
+
+    /**
+     * Set reverse relation in related model to parent model.
+     *
+     * @param  null|string|array  $reverses
+     * @return $this
+     */
+    public function withReverse($reverses = null)
+    {
+        $reverses = is_null($reverses) ? [Str::camel(class_basename($this->parent))] : $reverses;
+
+        $reverses = is_array($reverses) ? $reverses : func_get_args();
+
+        $this->withReverses = array_merge($this->withReverses, $reverses);
+
+        $this->query->without($reverses);
+
+        return $this;
+    }
+
+    /**
+     * Determine if the related model has any reverse relation.
+     *
+     * @return boolean
+     */
+    public function hasReverse()
+    {
+        return count($this->withReverses) > 0;
+    }
+
+    /**
+     * Get array of reverse relationships.
+     *
+     * @return array
+     */
+    public function getReverses()
+    {
+        return $this->withReverses;
+    }
+
+    /**
+     * Set reverse relationship if reverse relation exists and results are valid.
+     *
+     * @param  mixed  $results
+     * @param  null|Model  $parent
+     * @return mixed
+     */
+    protected function setReverseRelation($results, $parent = null)
+    {
+        if ($this->hasReverse()) {
+            $parent = $parent ?? $this->parent;
+
+            if ($results instanceof Model) {
+                foreach ($this->withReverses as $reverseRelation) {
+                    $results->setRelation($reverseRelation, $parent);
+                }
+            } elseif ($results instanceof Collection || $results instanceof LengthAwarePaginator) {
+                $items = $results instanceof LengthAwarePaginator ? $results->items() : $results;
+                foreach ($items as $item) {
+                    if ($item instanceof Model) {
+                        foreach ($this->withReverses as $reverseRelation) {
+                            $item->setRelation($reverseRelation, $parent);
+                        }
+                    }
+                }
+            }
+        }
+
+        return $results;
+    }
+
+    /**
+     * Execute the query as a "select" statement.
+     *
+     * @param  array  $columns
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    public function get($columns = ['*'])
+    {
+        return $this->setReverseRelation(
+            parent::get($columns)
+        );
+    }
+
+    /**
+     * Handle dynamic method calls to the relationship.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     */
+    public function __call($method, $parameters)
+    {
+        return $this->setReverseRelation(
+            parent::__call($method, $parameters)
+        );
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Relations/HasMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasMany.php
@@ -14,7 +14,7 @@ class HasMany extends HasOneOrMany
     public function getResults()
     {
         return ! is_null($this->getParentKey())
-                ? $this->query->get()
+                ? $this->setReverseRelation($this->query->get())
                 : $this->related->newCollection();
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOne.php
@@ -22,7 +22,7 @@ class HasOne extends HasOneOrMany
             return $this->getDefaultFor($this->parent);
         }
 
-        return $this->query->first() ?: $this->getDefaultFor($this->parent);
+        return $this->setReverseRelation($this->query->first()) ?: $this->getDefaultFor($this->parent);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -6,10 +6,11 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithDictionary;
+use Illuminate\Database\Eloquent\Relations\Concerns\SupportsReverseRelations;
 
 abstract class HasOneOrMany extends Relation
 {
-    use InteractsWithDictionary;
+    use InteractsWithDictionary, SupportsReverseRelations;
 
     /**
      * The foreign key of the parent model.
@@ -145,9 +146,12 @@ abstract class HasOneOrMany extends Relation
         // matching very convenient and easy work. Then we'll just return them.
         foreach ($models as $model) {
             if (isset($dictionary[$key = $this->getDictionaryKey($model->getAttribute($this->localKey))])) {
-                $model->setRelation(
-                    $relation, $this->getRelationValue($dictionary, $key, $type)
+                $relationValue = $this->setReverseRelation(
+                    $this->getRelationValue($dictionary, $key, $type),
+                    $model
                 );
+
+                $model->setRelation($relation, $relationValue);
             }
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
@@ -14,7 +14,7 @@ class MorphMany extends MorphOneOrMany
     public function getResults()
     {
         return ! is_null($this->getParentKey())
-                ? $this->query->get()
+                ? $this->setReverseRelation($this->query->get())
                 : $this->related->newCollection();
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOne.php
@@ -22,7 +22,7 @@ class MorphOne extends MorphOneOrMany
             return $this->getDefaultFor($this->parent);
         }
 
-        return $this->query->first() ?: $this->getDefaultFor($this->parent);
+        return $this->setReverseRelation($this->query->first()) ?: $this->getDefaultFor($this->parent);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -273,11 +273,31 @@ class DatabaseEloquentHasManyTest extends TestCase
         $this->assertEquals($colin, $instances[1]);
     }
 
+    public function testHasManyWithReverse()
+    {
+        $relation = $this->getRelation()->withReverse('reverse');
+        $related = $relation->getRelated();
+        $relatedCollection = new Collection([$related]);
+        $relation->getQuery()->shouldReceive('get')->andReturn($relatedCollection);
+        $related->shouldReceive('setRelation')->once()->with('reverse', $relation->getParent());
+
+        $this->assertSame($relatedCollection, $relation->getResults());
+
+        $relation = $this->getRelation()->withReverse('reverse');
+        $related = $relation->getRelated();
+        $relatedCollection = new Collection([$related, $related]);
+        $relation->getQuery()->shouldReceive('get')->andReturn($relatedCollection);
+        $related->shouldReceive('setRelation')->twice()->with('reverse', $relation->getParent());
+
+        $this->assertSame($relatedCollection, $relation->getResults());
+    }
+
     protected function getRelation()
     {
         $builder = m::mock(Builder::class);
         $builder->shouldReceive('whereNotNull')->with('table.foreign_key');
         $builder->shouldReceive('where')->with('table.foreign_key', '=', 1);
+        $builder->shouldReceive('without')->with(['reverse'])->andReturn($builder);
         $related = m::mock(Model::class);
         $builder->shouldReceive('getModel')->andReturn($related);
         $parent = m::mock(Model::class);

--- a/tests/Database/DatabaseEloquentHasOneTest.php
+++ b/tests/Database/DatabaseEloquentHasOneTest.php
@@ -307,11 +307,21 @@ class DatabaseEloquentHasOneTest extends TestCase
         $this->assertFalse($relation->is($model));
     }
 
+    public function testHasOneWithReverse()
+    {
+        $relation = $this->getRelation()->withReverse('reverse');
+        $this->builder->shouldReceive('first')->once()->andReturn($this->related);
+        $this->related->shouldReceive('setRelation')->once()->with('reverse', $this->parent);
+
+        $this->assertSame($this->related, $relation->getResults());
+    }
+
     protected function getRelation()
     {
         $this->builder = m::mock(Builder::class);
         $this->builder->shouldReceive('whereNotNull')->with('table.foreign_key');
         $this->builder->shouldReceive('where')->with('table.foreign_key', '=', 1);
+        $this->builder->shouldReceive('without')->with(['reverse'])->andReturn($this->builder);
         $this->related = m::mock(Model::class);
         $this->builder->shouldReceive('getModel')->andReturn($this->related);
         $this->parent = m::mock(Model::class);

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -865,6 +865,50 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertSame('appended', $array['appendable']);
     }
 
+    public function testToArrayWithReverseRelations()
+    {
+        $model = new EloquentModelStub(['name' => 'model']);
+        $related1 = (new EloquentModelStubWithTrait(['name' => 'related 1']))->setRelation('parentModel', $model);
+        $related2 = (new EloquentModelStubWithTrait(['name' => 'related 2']))->setRelation('parentModel', $model);
+
+        $model->setRelation('foo', $related1);
+        $model->setRelation('bars', new BaseCollection([
+            $related1, $related2,
+        ]));
+
+        $array = $model->toArray();
+        $this->assertIsArray($array);
+        $this->assertArrayHasKey('name', $array);
+        $this->assertArrayHasKey('foo', $array);
+        $this->assertArrayHasKey('bars', $array);
+        $this->assertEquals('model', $array['name']);
+
+        $this->assertIsArray($array['foo']);
+        $this->assertArrayHasKey('name', $array['foo']);
+        $this->assertArrayHasKey('parent_model', $array['foo']);
+        $this->assertEquals('related 1', $array['foo']['name']);
+        $this->assertIsArray($array['foo']['parent_model']);
+        $this->assertArrayHasKey('name', $array['foo']['parent_model']);
+        $this->assertEquals('model', $array['foo']['parent_model']['name']);
+        $this->assertArrayNotHasKey('foo', $array['foo']['parent_model']);
+
+        $this->assertIsArray($array['bars']);
+        $this->assertIsArray($array['bars']);
+        $this->assertCount(2, $array['bars']);
+        $this->assertIsArray($array['bars'][0]);
+        $this->assertIsArray($array['bars'][1]);
+        $this->assertArrayHasKey('name', $array['bars'][0]);
+        $this->assertArrayHasKey('name', $array['bars'][1]);
+        $this->assertArrayHasKey('parent_model', $array['bars'][0]);
+        $this->assertArrayHasKey('parent_model', $array['bars'][1]);
+        $this->assertArrayHasKey('name', $array['bars'][0]['parent_model']);
+        $this->assertArrayHasKey('name', $array['bars'][1]['parent_model']);
+        $this->assertArrayNotHasKey('bars', $array['bars'][0]['parent_model']);
+        $this->assertArrayNotHasKey('bars', $array['bars'][1]['parent_model']);
+        $this->assertEquals('related 1', $array['bars'][0]['name']);
+        $this->assertEquals('related 2', $array['bars'][1]['name']);
+    }
+
     public function testVisibleCreatesArrayWhitelist()
     {
         $model = new EloquentModelStub;


### PR DESCRIPTION
This PR adds a new method to one or many relationships to set reverse relationship automatically.

## Advantages Of using `withReverse`
### 1. Better performance
Setting reverse will reduce the number of queries needed when working with one-to-one/many relationships.

Here is a sample that doesn't use reverse.

```php
class Category extends Model
{
    public function posts()
    {
        return $this->hasMany(Post::class);
    }
}

class Post extends Model
{
    public function category()
    {
        return $this->belongsTo(Category::class);
    }

    public function getLinkAttribute()
    {
        return route('post', ['category' => $this->category, 'post' => $this]);
    }
}
```

We also have a route that shows posts by their category.

```php
public function category(Category $category)
{
    $posts = $category->posts()->paginate();

	return view(...);
}
```

And view content would be something like this:

```blade
@foreach ($posts as $post)
    <li>
        <a href="{{ $post->link }}">{{ $post->name }}</a>
    </li>
@endforeach
```

And here are queries that executed to render the page:
![image](https://user-images.githubusercontent.com/16279288/117573809-01dd1000-b0eb-11eb-9e5d-b2de9ce857ee.png)

We can optimize this more by adding eager load to post model:

```
protected $with = ['category'];
```

And result:
![image](https://user-images.githubusercontent.com/16279288/117573829-16b9a380-b0eb-11eb-9d0f-fe0b77f4b691.png)

In the screenshot, I marked two queries that are equivalent.
We can prevent executing the second query by adding `withReverse` to our relationship.
```php
class Category extends Model
{
    public function posts()
    {
        return $this->hasMany(Post::class)->withReverse();
    }
}
```

And result after adding `withReverse`:
![image](https://user-images.githubusercontent.com/16279288/117573874-731cc300-b0eb-11eb-9b82-05d031d452c4.png)

It's also working completely fine with multiple parent instances.
```php
$categories = Category::with('posts')->get();
```
in view:
```blade
@foreach ($categories as $category)
    Posts in category {{ $category->name }}:
    @foreach ($category->posts as $post)
        <li>
            <a href="{{ $post->link }}">{{ $post->name }}</a>
        </li>
    @endforeach
@endforeach
```

Result without using `withReverse`:
![image](https://user-images.githubusercontent.com/16279288/117574015-2e455c00-b0ec-11eb-9057-bbd6cd8fa238.png)

Result after using `withReverse`:
![image](https://user-images.githubusercontent.com/16279288/117574044-40bf9580-b0ec-11eb-816d-f2d85c1ce194.png)

### 2. Related models referencing parent model
If we change any attribute in the parent model, It will affect the relationship loaded in related models.

Example without using `withReverse`:
```php
$category = Category::with('posts')->where('name', 'News')->first();
$post1 = $category->posts->first();
$post2 = $category->posts->slice(1)->first();

$category->name = 'Foo';
dump($category->name); // Foo
dump($post1->category->name); // News
dump($post2->category->name); // News

$post1->category->name = 'Bar';
dump($category->name); // Foo
dump($post1->category->name); // Bar
dump($post2->category->name); // News
```

We can keep all these attributes sync together via using `withReverse`:
```php
$category = Category::with('posts')->where('name', 'News')->first();
$post1 = $category->posts->first();
$post2 = $category->posts->slice(1)->first();

$category->name = 'Foo';

dump($category->name); // Foo
dump($post1->category->name); // Foo
dump($post2->category->name); // Foo

$post1->category->name = 'Bar';

dump($category->name); // Bar
dump($post1->category->name); // Bar
dump($post2->category->name); // Bar
```

## Description about `withReverse`
By default `withReverse` guesses reverse relationship name from parent class name, But we can also use a custom name for reverse relationship.

```php
public function posts()
{
    return $this->hasMany(Post::class)->withReverse('postCategory');
}
```

It's also possible to have multiple reverse relationships.

```php
public function posts()
{
    return $this->hasMany(Post::class)->withReverse('postCategory', 'anotherCategoryRelation');
}
```

## Description about changing model code
Models needed a few changes to work properly with referenced relationships.
[HasAttributes.php:315](https://github.com/amir9480/framework/blob/52724fd12c2b90bb4eead03e5278e78b47362f1c/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php#L315)

This line prevents infinite nested serializing when JSON serializing a model via reversed relationships.
Without this using relationships that referencing each other will throw an exception like this:
![image](https://user-images.githubusercontent.com/16279288/117575230-fe00bc00-b0f1-11eb-9a85-93cb44287ca9.png)


If you found any issue or somethings should change Please let me know. 
I hope we can have this feature in Laravel 9.