### PR TITLE
[8.x] Add unless method on stringable

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -709,6 +709,25 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Apply the callback's string changes if the given "value" is false.
+     *
+     * @param  mixed  $value
+     * @param  callable  $callback
+     * @param  callable|null  $default
+     * @return mixed|$this
+     */
+    public function unless($value, $callback, $default = null)
+    {
+        if (! $value) {
+            return $this->when(true, $callback);
+        } elseif ($default) {
+            return $this->when(false, $callback, $default);
+        }
+
+        return $this;
+    }
+
+    /**
      * Apply the callback's string changes if the given "value" is true.
      *
      * @param  mixed  $value

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -718,13 +718,7 @@ class Stringable implements JsonSerializable
      */
     public function unless($value, $callback, $default = null)
     {
-        if (! $value) {
-            return $this->when(true, $callback);
-        } elseif ($default) {
-            return $this->when(false, $callback, $default);
-        }
-
-        return $this;
+        return $this->when(! $value, $callback, $default);
     }
 
     /**

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -92,6 +92,19 @@ class SupportStringableTest extends TestCase
         $this->assertSame('Taylor Otwell', (string) $this->stringable('Taylor Otwell')->words(3));
     }
 
+    public function testUnless()
+    {
+        $this->assertSame('unless false', (string) $this->stringable('unless')->unless(false, function ($stringable, $value) {
+            return $stringable->append(' false');
+        }));
+
+        $this->assertSame('unless true fallbacks to default', (string) $this->stringable('unless')->unless(true, function ($stringable, $value) {
+            return $stringable->append($value);
+        }, function ($stringable) {
+            return $stringable->append(' true fallbacks to default');
+        }));
+    }
+
     public function testWhenEmpty()
     {
         tap($this->stringable(), function ($stringable) {


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This pr aims to increase the code reading by placing the unless function to perform some callback.

Example of use:
```
$authenticated = false;

Str::of('Hello')
  ->unless($authenticated, function($stringable) {
    return $stringable->append(' Guest!');
    
  })
  ->when($authenticated, function($stringable) {
    return $stringable->append(' ' . auth()->user()->name);
  });
```