### PR TITLE
[9.x] Add option to ignore case in `Str::contains` and `Str::containsAll`

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -176,10 +176,16 @@ class Str
      *
      * @param  string  $haystack
      * @param  string|string[]  $needles
+     * @param  bool  $ignoreCase
      * @return bool
      */
-    public static function contains($haystack, $needles)
+    public static function contains($haystack, $needles, $ignoreCase = false)
     {
+        if ($ignoreCase) {
+            $haystack = mb_strtolower($haystack);
+            $needles = array_map('mb_strtolower', (array) $needles);
+        }
+
         foreach ((array) $needles as $needle) {
             if ($needle !== '' && mb_strpos($haystack, $needle) !== false) {
                 return true;
@@ -194,10 +200,16 @@ class Str
      *
      * @param  string  $haystack
      * @param  string[]  $needles
+     * @param  bool  $ignoreCase
      * @return bool
      */
-    public static function containsAll($haystack, array $needles)
+    public static function containsAll($haystack, array $needles, $ignoreCase = false)
     {
+        if ($ignoreCase) {
+            $haystack = mb_strtolower($haystack);
+            $needles = array_map('mb_strtolower', $needles);
+        }
+
         foreach ($needles as $needle) {
             if (! static::contains($haystack, $needle)) {
                 return false;

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -176,23 +176,20 @@ class SupportStrTest extends TestCase
         $this->assertSame('foo', Str::afterLast('----foo', '---'));
     }
 
-    public function testStrContains()
+    /**
+     * @dataProvider strContainsProvider
+     */
+    public function testStrContains($haystack, $needles, $expected, $ignoreCase = false)
     {
-        $this->assertTrue(Str::contains('taylor', 'ylo'));
-        $this->assertTrue(Str::contains('taylor', 'taylor'));
-        $this->assertTrue(Str::contains('taylor', ['ylo']));
-        $this->assertTrue(Str::contains('taylor', ['xxx', 'ylo']));
-        $this->assertFalse(Str::contains('taylor', 'xxx'));
-        $this->assertFalse(Str::contains('taylor', ['xxx']));
-        $this->assertFalse(Str::contains('taylor', ''));
-        $this->assertFalse(Str::contains('', ''));
+        $this->assertEquals($expected, Str::contains($haystack, $needles, $ignoreCase));
     }
 
-    public function testStrContainsAll()
+    /**
+     * @dataProvider strContainsAllProvider
+     */
+    public function testStrContainsAll($haystack, $needles, $expected, $ignoreCase = false)
     {
-        $this->assertTrue(Str::containsAll('taylor otwell', ['taylor', 'otwell']));
-        $this->assertTrue(Str::containsAll('taylor otwell', ['taylor']));
-        $this->assertFalse(Str::containsAll('taylor otwell', ['taylor', 'xxx']));
+        $this->assertEquals($expected, Str::containsAll($haystack, $needles, $ignoreCase));
     }
 
     public function testParseCallback()
@@ -542,6 +539,36 @@ class SupportStrTest extends TestCase
             ['af6f8cb-c57d-11e1-9b21-0800200c9a66'],
             ['af6f8cb0c57d11e19b210800200c9a66'],
             ['ff6f8cb0-c57da-51e1-9b21-0800200c9a66'],
+        ];
+    }
+
+    public function strContainsProvider()
+    {
+        return [
+            ['Taylor', 'ylo', true, true],
+            ['Taylor', 'ylo', true, false],
+            ['Taylor', 'taylor', true, true],
+            ['Taylor', 'taylor', false, false],
+            ['Taylor', ['ylo'], true, true],
+            ['Taylor', ['ylo'], true, false],
+            ['Taylor', ['xxx', 'ylo'], true, true],
+            ['Taylor', ['xxx', 'ylo'], true, false],
+            ['Taylor', 'xxx', false],
+            ['Taylor', ['xxx'], false],
+            ['Taylor', '', false],
+            ['', '', false],
+        ];
+    }
+
+    public function strContainsAllProvider()
+    {
+        return [
+            ['Taylor Otwell', ['taylor', 'otwell'], false, false],
+            ['Taylor Otwell', ['taylor', 'otwell'], true, true],
+            ['Taylor Otwell', ['taylor'], false, false],
+            ['Taylor Otwell', ['taylor'], true, true],
+            ['Taylor Otwell', ['taylor', 'xxx'], false, false],
+            ['Taylor Otwell', ['taylor', 'xxx'], false, true],
         ];
     }
 


### PR DESCRIPTION
This PR adds a third parameter `$ignoreCase` to `Str::contains` and `Str::containsAll` to allow for case-insensitive comparisons. 

## Motivation

I often find myself doing something like this in my code

```php
Str::contains(Str::lower($user->first_name), Str::lower($request->query('q'));
```

This gets especially annoying when trying to compare against multiple fields

```php
$normalizedQuery = Str::lower($request->query('q'));

$matches = Str::contains(Str::lower($user->first_name), $normalizedQuery) 
          || Str::contains(Str::lower($user->last_name), $normalizedQuery);
```

## Changes

With this PR, it would be possible to do this instead:

```php
Str::contains($user->first_name, $request->query('q'), true);
```

I added the same parameter to `Str::containsAll`. To avoid doing the transformation inside a loop, it gets applied only once inside `containsAll` before calling `static::contains`.

The `$ignoreCase` parameter is `false` by default so the existing behavior doesn’t change.