### PR TITLE
[9.x] Autowire public typed properties

### DIFF
--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -565,6 +565,13 @@ class ContainerTest extends TestCase
         $this->assertInstanceOf(ContainerConcreteStub::class, $class);
     }
 
+    public function testContainerCanAutoWirePublicProperties() {
+        $container = new Container;
+        $class = $container->get(AutoWiredPropertyStub::class);
+
+        $this->assertInstanceOf(FrameWorkAuthorStub::class, $class->author);
+    }
+
     // public function testContainerCanCatchCircularDependency()
     // {
     //     $this->expectException(CircularDependencyException::class);
@@ -682,4 +689,14 @@ class ContainerInjectVariableStubWithInterfaceImplementation implements IContain
     {
         $this->something = $something;
     }
+}
+
+class AutoWiredPropertyStub implements IContainerContractStub
+{
+    /** @required */
+    public FrameWorkAuthorStub $author;
+}
+
+class FrameWorkAuthorStub {
+    public string $name = 'Taylor Otwell';
 }


### PR DESCRIPTION
Hello, 

This **POC** PR adds the Autowiring of **public typed properties in PHP 7.4**.  it's inspired by Symfony 5.1.

- It works only for public properties
- doc block `/** @required */` is required to tell the container to resolve.

Example usage would be:
```php
<?php

namespace App\Http\Controllers;

use App\Repositories\UserRepository;

class UserController extends Controller
{
    /** @required */
    protected UserRepository $usersRepository;

    public function index() {
       $users = $this->usersRepository->all();

       return view('users.index', compact('users'));
    }
}
```

The PR itself is a POC. If Taylor feels good about it. I would improve the existing code to make it ready