### PR TITLE
[8.x] Update mime extension check

### DIFF
--- a/tests/Http/HttpMimeTypeTest.php
+++ b/tests/Http/HttpMimeTypeTest.php
@@ -35,7 +35,9 @@ class HttpMimeTypeTest extends TestCase
 
     public function testSearchExtensionFromMimeType()
     {
-        $this->assertSame('qt', MimeType::search('video/quicktime'));
+        // Regression: check for both "qt" & "mov" because of a behavioral change in Symfony 5.3
+        // See: https://github.com/symfony/symfony/pull/41016
+        $this->assertContains(MimeType::search('video/quicktime'), ['qt', 'mov']);
         $this->assertNull(MimeType::search('foo/bar'));
     }
 }


### PR DESCRIPTION
This PR fixes a regression introduced in Symfony 5.3 here: https://github.com/symfony/symfony/pull/41016

The order of returned mime extensions was changed so `mov` is returned before `qt`. Current tests on 8.x aren't failing yet because 8.x only pulls the latest stable Symfony 5.2.x version. It'll start failing as soon as Symfony 5.3 hits GA. Tests on master were already failing.

On master I'll update the test to only check for the `mov` extension.