### PR TITLE
[9.x] Consistent BelongsToMany::firstOrCreate behaviour

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -609,14 +609,15 @@ class BelongsToMany extends Relation
      * Get the first related record matching the attributes or create it.
      *
      * @param  array  $attributes
+     * @param  array  $values
      * @param  array  $joining
      * @param  bool  $touch
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function firstOrCreate(array $attributes, array $joining = [], $touch = true)
+    public function firstOrCreate(array $attributes, array $values = [], array $joining = [], $touch = true)
     {
         if (is_null($instance = $this->related->where($attributes)->first())) {
-            $instance = $this->create($attributes, $joining, $touch);
+            $instance = $this->create($attributes + $values, $joining, $touch);
         }
 
         return $instance;

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -439,6 +439,30 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $this->assertNotNull($new->id);
     }
 
+    public function testFirstOrCreateMethodWithValues()
+    {
+        $post = Post::create(['title' => Str::random()]);
+        $tag = Tag::create(['name' => Str::random()]);
+        $post->tags()->attach(Tag::all());
+
+        $existing = $post->tags()->firstOrCreate(
+            ['name' => $tag->name],
+            ['type' => 'featured']
+        );
+
+        $this->assertEquals($tag->id, $existing->id);
+        $this->assertNotEquals('foo', $existing->name);
+
+        $new = $post->tags()->firstOrCreate(
+            ['name' => 'foo'],
+            ['type' => 'featured']
+        );
+
+        $this->assertSame('foo', $new->name);
+        $this->assertSame('featured', $new->type);
+        $this->assertNotNull($new->id);
+    }
+
     public function testUpdateOrCreateMethod()
     {
         $post = Post::create(['title' => Str::random()]);


### PR DESCRIPTION
[From Laravel documentation:](https://laravel.com/docs/master/eloquent#retrieving-or-creating-models)

>The firstOrCreate method will attempt to locate a database record using the given column / value pairs. If the model can not be found in the database, **a record will be inserted with the attributes resulting from merging the first array argument with the optional second array argument**

This is the current behaviour for other instances of `firstOrCreate`, except for the `BelongsToMany` relationship. See below:

- [Eloquent\Builder#firstOrCreate](https://github.com/laravel/framework/blob/master/src/Illuminate/Database/Eloquent/Builder.php#L463)
- [HasOneOrMany#firstOrCreate](https://github.com/laravel/framework/blob/master/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php#L230)

Being consistent with the rest of the codebase for `firstOrCreate`/`firstOrNew`, I went with a union of the attributes and values when creating a model instead of using array_merge (despite the documentation saying otherwise).