### PR TITLE
[8.x] Fix the return type on the password broker factory

### DIFF
--- a/src/Illuminate/Contracts/Auth/PasswordBrokerFactory.php
+++ b/src/Illuminate/Contracts/Auth/PasswordBrokerFactory.php
@@ -8,7 +8,7 @@ interface PasswordBrokerFactory
      * Get a password broker instance by name.
      *
      * @param  string|null  $name
-     * @return mixed
+     * @return \Illuminate\Contracts\Auth\PasswordBroker
      */
     public function broker($name = null);
 }


### PR DESCRIPTION
This makes IDEs understand the type, for instance when injecting the factory