### PR TITLE
[8.x] Support views in SQLServerGrammar

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -64,7 +64,7 @@ class SqlServerGrammar extends Grammar
      */
     public function compileTableExists()
     {
-        return "select * from sys.sysobjects where id = object_id(?, 'U')";
+        return "select * from sys.sysobjects where id = object_id(?) and xtype in ('U', 'V')";
     }
 
     /**
@@ -75,7 +75,7 @@ class SqlServerGrammar extends Grammar
      */
     public function compileColumnListing($table)
     {
-        return "select name from sys.columns where object_id = object_id('$table', 'U')";
+        return "select name from sys.columns where object_id = object_id('$table')";
     }
 
     /**


### PR DESCRIPTION
8.x version of https://github.com/laravel/framework/pull/37307

SqlServerGrammar assumes that the model is backed by a table, but some unfortunate souls attach to views in SQL Server. Since we now check mass assignment keys against the database columns, we need to be able to fetch the columns for views.

This revision removes the "table" object type specification when hitting the DB for schema info, so that views also work. SQL Server will not allow multiple objects to have the same name in the same namespace, so this should not introduce any problems with matching multiple items.

Commit which introduced the problem: 70d261d