### PR TITLE
[8.x] Avoid deprecated guzzle code

### DIFF
--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -111,7 +111,7 @@ class Factory
         $response = new Psr7Response($status, $headers, $body);
 
         return class_exists(GuzzleHttp\Promise\Create::class)
-            ? \GuzzleHttp\Promise\promiseFor($response);
+            ? \GuzzleHttp\Promise\promiseFor($response)
             : \GuzzleHttp\Promise\promise_for($response);
     }
 

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Http\Client;
 
 use Closure;
-use function GuzzleHttp\Promise\promise_for;
 use GuzzleHttp\Psr7\Response as Psr7Response;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
@@ -109,7 +108,11 @@ class Factory
             $headers['Content-Type'] = 'application/json';
         }
 
-        return promise_for(new Psr7Response($status, $headers, $body));
+        $response = new Psr7Response($status, $headers, $body);
+
+        return class_exists(GuzzleHttp\Promise\Create::class)
+            ? \GuzzleHttp\Promise\promiseFor($response);
+            : \GuzzleHttp\Promise\promise_for($response);
     }
 
     /**

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -111,7 +111,7 @@ class Factory
         $response = new Psr7Response($status, $headers, $body);
 
         return class_exists(GuzzleHttp\Promise\Create::class)
-            ? \GuzzleHttp\Promise\promiseFor($response)
+            ? \GuzzleHttp\Promise\Create::promiseFor($response)
             : \GuzzleHttp\Promise\promise_for($response);
     }
 

--- a/src/Illuminate/Http/Client/RequestException.php
+++ b/src/Illuminate/Http/Client/RequestException.php
@@ -34,7 +34,9 @@ class RequestException extends HttpClientException
     {
         $message = "HTTP request returned status code {$response->status()}";
 
-        $summary = \GuzzleHttp\Psr7\get_message_body_summary($response->toPsrResponse());
+        $summary = class_exists(\GuzzleHttp\Psr7\Message::class)
+            ? \GuzzleHttp\Psr7\Message::bodySummary($response->toPsrResponse())
+            : \GuzzleHttp\Psr7\get_message_body_summary($response->toPsrResponse());
 
         return is_null($summary) ? $message : $message .= ":\n{$summary}\n";
     }


### PR DESCRIPTION
In particular this will matter when `guzzle/psr7:2.0.0` is released later this month. The `GuzzleHttp\Psr7\get_message_body_summary` function doesn't exist, and most people will be auto-updated to this version since `guzzle/psr7` is probably a transitive dependency for most people.