### PR TITLE
[8.x] Added new assertDispatchedSync methods to BusFake

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -43,6 +43,13 @@ class BusFake implements QueueingDispatcher
     protected $commandsAfterResponse = [];
 
     /**
+     * The commands that have been explicitly dispatched synchronously.
+     *
+     * @var array
+     */
+    protected $commandsSync = [];
+
+    /**
      * The batches that have been dispatched.
      *
      * @var array
@@ -82,7 +89,8 @@ class BusFake implements QueueingDispatcher
 
         PHPUnit::assertTrue(
             $this->dispatched($command, $callback)->count() > 0 ||
-            $this->dispatchedAfterResponse($command, $callback)->count() > 0,
+            $this->dispatchedAfterResponse($command, $callback)->count() > 0 ||
+            $this->dispatchedSync($command, $callback)->count() > 0,
             "The expected [{$command}] job was not dispatched."
         );
     }
@@ -97,7 +105,8 @@ class BusFake implements QueueingDispatcher
     public function assertDispatchedTimes($command, $times = 1)
     {
         $count = $this->dispatched($command)->count() +
-                 $this->dispatchedAfterResponse($command)->count();
+                 $this->dispatchedAfterResponse($command)->count() +
+                 $this->dispatchedSync($command)->count();
 
         PHPUnit::assertSame(
             $times, $count,
@@ -120,7 +129,8 @@ class BusFake implements QueueingDispatcher
 
         PHPUnit::assertTrue(
             $this->dispatched($command, $callback)->count() === 0 &&
-            $this->dispatchedAfterResponse($command, $callback)->count() === 0,
+            $this->dispatchedAfterResponse($command, $callback)->count() === 0 &&
+            $this->dispatchedSync($command, $callback)->count() === 0,
             "The unexpected [{$command}] job was dispatched."
         );
     }
@@ -181,6 +191,65 @@ class BusFake implements QueueingDispatcher
         PHPUnit::assertCount(
             0, $this->dispatchedAfterResponse($command, $callback),
             "The unexpected [{$command}] job was dispatched for after sending the response."
+        );
+    }
+
+    /**
+     * Assert if a job was explicitly dispatched synchronously based on a truth-test callback.
+     *
+     * @param  string|\Closure  $command
+     * @param  callable|int|null  $callback
+     * @return void
+     */
+    public function assertDispatchedSync($command, $callback = null)
+    {
+        if ($command instanceof Closure) {
+            [$command, $callback] = [$this->firstClosureParameterType($command), $command];
+        }
+
+        if (is_numeric($callback)) {
+            return $this->assertDispatchedSyncTimes($command, $callback);
+        }
+
+        PHPUnit::assertTrue(
+            $this->dispatchedSync($command, $callback)->count() > 0,
+            "The expected [{$command}] job was not dispatched synchronously."
+        );
+    }
+
+    /**
+     * Assert if a job was pushed synchronously a number of times.
+     *
+     * @param  string  $command
+     * @param  int  $times
+     * @return void
+     */
+    public function assertDispatchedSyncTimes($command, $times = 1)
+    {
+        $count = $this->dispatchedSync($command)->count();
+
+        PHPUnit::assertSame(
+            $times, $count,
+            "The expected [{$command}] job was synchronously pushed {$count} times instead of {$times} times."
+        );
+    }
+
+    /**
+     * Determine if a job was dispatched based on a truth-test callback.
+     *
+     * @param  string|\Closure  $command
+     * @param  callable|null  $callback
+     * @return void
+     */
+    public function assertNotDispatchedSync($command, $callback = null)
+    {
+        if ($command instanceof Closure) {
+            [$command, $callback] = [$this->firstClosureParameterType($command), $command];
+        }
+
+        PHPUnit::assertCount(
+            0, $this->dispatchedSync($command, $callback),
+            "The unexpected [{$command}] job was dispatched synchronously."
         );
     }
 
@@ -379,6 +448,28 @@ class BusFake implements QueueingDispatcher
     }
 
     /**
+     * Get all of the jobs dispatched synchronously matching a truth-test callback.
+     *
+     * @param  string  $command
+     * @param  callable|null  $callback
+     * @return \Illuminate\Support\Collection
+     */
+    public function dispatchedSync(string $command, $callback = null)
+    {
+        if (! $this->hasDispatchedSync($command)) {
+            return collect();
+        }
+
+        $callback = $callback ?: function () {
+            return true;
+        };
+
+        return collect($this->commandsSync[$command])->filter(function ($command) use ($callback) {
+            return $callback($command);
+        });
+    }
+
+    /**
      * Get all of the pending batches matching a truth-test callback.
      *
      * @param  callable  $callback
@@ -418,6 +509,17 @@ class BusFake implements QueueingDispatcher
     }
 
     /**
+     * Determine if there are any stored commands for a given class.
+     *
+     * @param  string  $command
+     * @return bool
+     */
+    public function hasDispatchedSync($command)
+    {
+        return isset($this->commandsSync[$command]) && ! empty($this->commandsSync[$command]);
+    }
+
+    /**
      * Dispatch a command to its appropriate handler.
      *
      * @param  mixed  $command
@@ -444,7 +546,7 @@ class BusFake implements QueueingDispatcher
     public function dispatchSync($command, $handler = null)
     {
         if ($this->shouldFakeJob($command)) {
-            $this->commands[get_class($command)][] = $command;
+            $this->commandsSync[get_class($command)][] = $command;
         } else {
             return $this->dispatcher->dispatchSync($command, $handler);
         }

--- a/tests/Support/SupportTestingBusFakeTest.php
+++ b/tests/Support/SupportTestingBusFakeTest.php
@@ -75,6 +75,41 @@ class SupportTestingBusFakeTest extends TestCase
         }
     }
 
+    public function testAssertDispatchedSync()
+    {
+        try {
+            $this->fake->assertDispatchedSync(BusJobStub::class);
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('The expected [Illuminate\Tests\Support\BusJobStub] job was not dispatched synchronously.'));
+        }
+
+        $this->fake->dispatch(new BusJobStub);
+
+        try {
+            $this->fake->assertDispatchedSync(BusJobStub::class);
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('The expected [Illuminate\Tests\Support\BusJobStub] job was not dispatched synchronously.'));
+        }
+
+        $this->fake->dispatchSync(new BusJobStub);
+
+        $this->fake->assertDispatchedSync(BusJobStub::class);
+    }
+
+    public function testAssertDispatchedSyncClosure()
+    {
+        try {
+            $this->fake->assertDispatchedSync(function (BusJobStub $job) {
+                return true;
+            });
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('The expected [Illuminate\Tests\Support\BusJobStub] job was not dispatched synchronously.'));
+        }
+    }
+
     public function testAssertDispatchedNow()
     {
         $this->fake->dispatchNow(new BusJobStub);
@@ -110,6 +145,21 @@ class SupportTestingBusFakeTest extends TestCase
         }
 
         $this->fake->assertDispatchedAfterResponse(BusJobStub::class, 2);
+    }
+
+    public function testAssertDispatchedSyncWithCallbackInt()
+    {
+        $this->fake->dispatchSync(new BusJobStub);
+        $this->fake->dispatchSync(new BusJobStub);
+
+        try {
+            $this->fake->assertDispatchedSync(BusJobStub::class, 1);
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('The expected [Illuminate\Tests\Support\BusJobStub] job was synchronously pushed 2 times instead of 1 times.'));
+        }
+
+        $this->fake->assertDispatchedSync(BusJobStub::class, 2);
     }
 
     public function testAssertDispatchedWithCallbackFunction()
@@ -158,6 +208,29 @@ class SupportTestingBusFakeTest extends TestCase
         });
     }
 
+    public function testAssertDispatchedSyncWithCallbackFunction()
+    {
+        $this->fake->dispatchSync(new OtherBusJobStub);
+        $this->fake->dispatchSync(new OtherBusJobStub(1));
+
+        try {
+            $this->fake->assertDispatchedSync(OtherBusJobStub::class, function ($job) {
+                return $job->id === 0;
+            });
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('The expected [Illuminate\Tests\Support\OtherBusJobStub] job was not dispatched synchronously.'));
+        }
+
+        $this->fake->assertDispatchedSync(OtherBusJobStub::class, function ($job) {
+            return $job->id === null;
+        });
+
+        $this->fake->assertDispatchedSync(OtherBusJobStub::class, function ($job) {
+            return $job->id === 1;
+        });
+    }
+
     public function testAssertDispatchedTimes()
     {
         $this->fake->dispatch(new BusJobStub);
@@ -186,6 +259,21 @@ class SupportTestingBusFakeTest extends TestCase
         }
 
         $this->fake->assertDispatchedAfterResponseTimes(BusJobStub::class, 2);
+    }
+
+    public function testAssertDispatchedSyncTimes()
+    {
+        $this->fake->dispatchSync(new BusJobStub);
+        $this->fake->dispatchSync(new BusJobStub);
+
+        try {
+            $this->fake->assertDispatchedSyncTimes(BusJobStub::class, 1);
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('The expected [Illuminate\Tests\Support\BusJobStub] job was synchronously pushed 2 times instead of 1 times.'));
+        }
+
+        $this->fake->assertDispatchedSyncTimes(BusJobStub::class, 2);
     }
 
     public function testAssertNotDispatched()
@@ -243,6 +331,34 @@ class SupportTestingBusFakeTest extends TestCase
             $this->fail();
         } catch (ExpectationFailedException $e) {
             $this->assertThat($e, new ExceptionMessage('The unexpected [Illuminate\Tests\Support\BusJobStub] job was dispatched for after sending the response.'));
+        }
+    }
+
+    public function testAssertNotDispatchedSync()
+    {
+        $this->fake->assertNotDispatchedSync(BusJobStub::class);
+
+        $this->fake->dispatchSync(new BusJobStub);
+
+        try {
+            $this->fake->assertNotDispatchedSync(BusJobStub::class);
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('The unexpected [Illuminate\Tests\Support\BusJobStub] job was dispatched synchronously.'));
+        }
+    }
+
+    public function testAssertNotDispatchedSyncClosure()
+    {
+        $this->fake->dispatchSync(new BusJobStub);
+
+        try {
+            $this->fake->assertNotDispatchedSync(function (BusJobStub $job) {
+                return true;
+            });
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('The unexpected [Illuminate\Tests\Support\BusJobStub] job was dispatched synchronously.'));
         }
     }
 


### PR DESCRIPTION
Added new `assertDispatchedSync` methods to the Bus Fake, following the pattern of `assertDispatched` and `assertDispatchedAfterResponse`.

This allows applications to assert that a given command was **explicitly** sent to the `sync` driver. This is useful where applications may want to conditionally handle a job synchronously in the current request/thread, rather than sending it to the application's default queue driver; And of course, assert that such logic executed correctly:

````php
use App\Jobs\ProcessAvatar;

public function test_it_dispatches_later()
{
    // ... set up

    Bus::assertDispatched(ProcessAvatar::class);
    Bus::assertNotDispatchedSync(ProcessAvatar::class);
}

public function test_it_dispatches_immediately()
{
    // ... set up

    Bus::assertDispatchedSync(ProcessAvatar::class);
}
````

Since this PR includes quite a few new lines (222 additions), it's understandable if this is too much change for a minor update. If that's the case, please feel free to let me know and I'll suggest over on the master branch for 9.x.

Cheers!

### Additions to the Public API of `BusFake`

These methods follow the existing patterns of `assertDispatched` and `assertDispatchedAfterResponse`:

- `+ assertDispatchedSync($command, $callback = null)`
- `+ assertDispatchedSyncTimes($command, $times = 1)`
- `+ assertNotDispatchedSync($command, $callback = null)`
- `+ dispatchedSync(string $command, $callback = null)`
- `+ hasDispatchedSync($command)`

6 additional tests have been added to `Illuminate\Tests\Support\SupportTestingBusFakeTest` to test these above new methods.

### No Breaking Changes

Existing applications that dispatch jobs using `dispatchSync` and test that such jobs were dispatched using `assertDispatched`, `assertDispatchedTimes` or `assertNotDispatched` will **not** be affected by this change. This is because these assertion methods have been updated in this PR to check against the `dispatchedSync` method.