### PR TITLE
[9.x] Fix the return type on the password broker factory

### DIFF
--- a/src/Illuminate/Contracts/Auth/PasswordBrokerFactory.php
+++ b/src/Illuminate/Contracts/Auth/PasswordBrokerFactory.php
@@ -8,7 +8,7 @@ interface PasswordBrokerFactory
      * Get a password broker instance by name.
      *
      * @param  string|null  $name
-     * @return mixed
+     * @return \Illuminate\Contracts\Auth\PasswordBroker
      */
     public function broker($name = null);
 }


### PR DESCRIPTION
Recreation of #37345. This time targetting 9.x, as a contract change is technically breaking as pointed out by @driesvints 