### PR TITLE
[8.x] Add datetime to scheduled command run output

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -107,7 +107,7 @@ class ScheduleRunCommand extends Command
         }
 
         if (! $this->eventsRan) {
-            $this->info('No scheduled commands are ready to run.');
+            $this->info('['.$this->getStartedAtAsString().'] No scheduled commands are ready to run.');
         }
     }
 
@@ -122,7 +122,7 @@ class ScheduleRunCommand extends Command
         if ($this->schedule->serverShouldRun($event, $this->startedAt)) {
             $this->runEvent($event);
         } else {
-            $this->line('<info>Skipping command (has already run on another server):</info> '.$event->getSummaryForDisplay());
+            $this->line('<info>['.$this->getStartedAtAsString().'] Skipping command (has already run on another server):</info> '.$event->getSummaryForDisplay());
         }
     }
 
@@ -134,8 +134,7 @@ class ScheduleRunCommand extends Command
      */
     protected function runEvent($event)
     {
-        $datetime = Carbon::now()->utc()->toDateTimeString();
-        $this->line('<info>['.$datetime.'] Running scheduled command:</info> '.$event->getSummaryForDisplay());
+        $this->line('<info>['.$this->getStartedAtAsString().'] Running scheduled command:</info> '.$event->getSummaryForDisplay());
 
         $this->dispatcher->dispatch(new ScheduledTaskStarting($event));
 
@@ -155,5 +154,15 @@ class ScheduleRunCommand extends Command
 
             $this->handler->report($e);
         }
+    }
+
+    /**
+     * Return started at time as string
+     *
+     * @return string
+     */
+    private function getStartedAtAsString()
+    {
+        return $this->startedAt->format('Y-m-d H:i:s');
     }
 }

--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -9,6 +9,7 @@ use Illuminate\Console\Events\ScheduledTaskSkipped;
 use Illuminate\Console\Events\ScheduledTaskStarting;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Date;
 use Throwable;
 
@@ -133,7 +134,8 @@ class ScheduleRunCommand extends Command
      */
     protected function runEvent($event)
     {
-        $this->line('<info>Running scheduled command:</info> '.$event->getSummaryForDisplay());
+        $datetime = Carbon::now()->utc()->toDateTimeString();
+        $this->line('<info>['.$datetime.'] Running scheduled command:</info> '.$event->getSummaryForDisplay());
 
         $this->dispatcher->dispatch(new ScheduledTaskStarting($event));
 


### PR DESCRIPTION
Add datetime to scheduled command run output
Change now date to startedAt datetime https://github.com/laravel/framework/pull/37340

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
