### PR TITLE
[8.x] Fix mysql prefix support in `migrate:fresh`

### DIFF
--- a/src/Illuminate/Database/Schema/MySqlBuilder.php
+++ b/src/Illuminate/Database/Schema/MySqlBuilder.php
@@ -78,7 +78,7 @@ class MySqlBuilder extends Builder
         }
         
         $tables = array_filter($tables, function ($table) {
-             return str_starts_with($table, $this->connection->getTablePrefix());
+            return str_starts_with($table, $this->connection->getTablePrefix());
         });
 
         if (empty($tables)) {
@@ -110,7 +110,7 @@ class MySqlBuilder extends Builder
         }
         
         $views = array_filter($views, function ($view) {
-             return str_starts_with($view, $this->connection->getTablePrefix());
+            return str_starts_with($view, $this->connection->getTablePrefix());
         });
 
         if (empty($views)) {

--- a/src/Illuminate/Database/Schema/MySqlBuilder.php
+++ b/src/Illuminate/Database/Schema/MySqlBuilder.php
@@ -76,6 +76,10 @@ class MySqlBuilder extends Builder
 
             $tables[] = reset($row);
         }
+        
+        $tables = array_filter($tables, function ($table) {
+             return str_starts_with($table, $this->connection->getTablePrefix());
+        });
 
         if (empty($tables)) {
             return;
@@ -104,6 +108,10 @@ class MySqlBuilder extends Builder
 
             $views[] = reset($row);
         }
+        
+        $views = array_filter($views, function ($view) {
+             return str_starts_with($view, $this->connection->getTablePrefix());
+        });
 
         if (empty($views)) {
             return;

--- a/src/Illuminate/Database/Schema/MySqlBuilder.php
+++ b/src/Illuminate/Database/Schema/MySqlBuilder.php
@@ -76,7 +76,7 @@ class MySqlBuilder extends Builder
 
             $tables[] = reset($row);
         }
-        
+
         $tables = array_filter($tables, function ($table) {
             return str_starts_with($table, $this->connection->getTablePrefix());
         });
@@ -108,7 +108,7 @@ class MySqlBuilder extends Builder
 
             $views[] = reset($row);
         }
-        
+
         $views = array_filter($views, function ($view) {
             return str_starts_with($view, $this->connection->getTablePrefix());
         });


### PR DESCRIPTION
migrate:fresh did not respect configuration of prefixes for MySQL

If you have a configured prefix in database configuration, the command `migrate:fresh` will drop every table in the given database. This PR will respect this prefix, and only drops prefixed tables.