### PR TITLE
[8.x] Add eloquent strict loading mode

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -352,9 +352,12 @@ class Builder
         $instance = $this->newModelInstance();
 
         return $instance->newCollection(array_map(function ($item) use ($instance) {
-            return tap($instance->newFromBuilder($item), function ($instance) {
-                $instance->withStrictLoading = Model::strictLoadingEnabled();
-            });
+            $model = $instance->newFromBuilder($item);
+
+            $model->preventsLazyLoading = Model::preventsLazyLoading();
+
+
+            return $model;
         }, $items));
     }
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -352,7 +352,9 @@ class Builder
         $instance = $this->newModelInstance();
 
         return $instance->newCollection(array_map(function ($item) use ($instance) {
-            return $instance->newFromBuilder($item);
+            return tap($instance->newFromBuilder($item), function ($instance) {
+                $instance->withStrictLoading = Model::strictLoadingEnabled();
+            });
         }, $items));
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\InvalidCastException;
 use Illuminate\Database\Eloquent\JsonEncodingException;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Database\StrictLoadingViolationException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection as BaseCollection;
@@ -426,6 +427,10 @@ trait HasAttributes
      */
     public function getRelationValue($key)
     {
+        if ($this->withStrictLoading && ! $this->relationLoaded($key)) {
+            throw new StrictLoadingViolationException($this, $key);
+        }
+
         // If the key already exists in the relationships array, it just means the
         // relationship has already been loaded, so we'll just return it out of
         // here because there is no need to query within the relations twice.

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -427,8 +427,11 @@ trait HasAttributes
      */
     public function getRelationValue($key)
     {
-        if ($this->withStrictLoading && ! $this->relationLoaded($key) &&
-            method_exists($this, $key)) {
+        if (! $this->isRelation($key)) {
+            return;
+        }
+
+        if ($this->withStrictLoading && ! $this->relationLoaded($key)) {
             throw new StrictLoadingViolationException($this, $key);
         }
 
@@ -442,10 +445,19 @@ trait HasAttributes
         // If the "attribute" exists as a method on the model, we will just assume
         // it is a relationship and will load and return results from the query
         // and hydrate the relationship's value on the "relationships" array.
-        if (method_exists($this, $key) ||
-            (static::$relationResolvers[get_class($this)][$key] ?? null)) {
-            return $this->getRelationshipFromMethod($key);
-        }
+        return $this->getRelationshipFromMethod($key);
+    }
+
+    /**
+     * Determine if the given key is a relation.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    protected function isRelation($key)
+    {
+        return method_exists($this, $key) ||
+            (static::$relationResolvers[get_class($this)][$key] ?? null);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -427,7 +427,8 @@ trait HasAttributes
      */
     public function getRelationValue($key)
     {
-        if ($this->withStrictLoading && ! $this->relationLoaded($key)) {
+        if ($this->withStrictLoading && ! $this->relationLoaded($key) &&
+            method_exists($this, $key)) {
             throw new StrictLoadingViolationException($this, $key);
         }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\InvalidCastException;
 use Illuminate\Database\Eloquent\JsonEncodingException;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Database\LazyLoadingViolationException;
 use Illuminate\Database\StrictLoadingViolationException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
@@ -438,8 +439,8 @@ trait HasAttributes
             return;
         }
 
-        if ($this->withStrictLoading) {
-            throw new StrictLoadingViolationException($this, $key);
+        if ($this->preventsLazyLoading) {
+            throw new LazyLoadingViolationException($this, $key);
         }
 
         // If the "attribute" exists as a method on the model, we will just assume
@@ -449,7 +450,7 @@ trait HasAttributes
     }
 
     /**
-     * Determine if the given key is a relation.
+     * Determine if the given key is a relationship method on the model.
      *
      * @param  string  $key
      * @return bool

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -454,7 +454,7 @@ trait HasAttributes
      * @param  string  $key
      * @return bool
      */
-    protected function isRelation($key)
+    public function isRelation($key)
     {
         return method_exists($this, $key) ||
             (static::$relationResolvers[get_class($this)][$key] ?? null);

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -427,19 +427,19 @@ trait HasAttributes
      */
     public function getRelationValue($key)
     {
-        if (! $this->isRelation($key)) {
-            return;
-        }
-
-        if ($this->withStrictLoading && ! $this->relationLoaded($key)) {
-            throw new StrictLoadingViolationException($this, $key);
-        }
-
         // If the key already exists in the relationships array, it just means the
         // relationship has already been loaded, so we'll just return it out of
         // here because there is no need to query within the relations twice.
         if ($this->relationLoaded($key)) {
             return $this->relations[$key];
+        }
+
+        if (! $this->isRelation($key)) {
+            return;
+        }
+
+        if ($this->withStrictLoading) {
+            throw new StrictLoadingViolationException($this, $key);
         }
 
         // If the "attribute" exists as a method on the model, we will just assume

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -82,6 +82,13 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     protected $withCount = [];
 
     /**
+     * Indicates whether strict loading should be enforced on this model.
+     *
+     * @var bool
+     */
+    public $withStrictLoading = false;
+
+    /**
      * The number of models to return for pagination.
      *
      * @var int
@@ -143,6 +150,13 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
      * @var array
      */
     protected static $ignoreOnTouch = [];
+
+    /**
+     * Indicates whether strict loading should be enforced on all models.
+     *
+     * @var bool
+     */
+    protected static $strictLoading = false;
 
     /**
      * The name of the "created at" column.
@@ -331,6 +345,16 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
         }
 
         return false;
+    }
+
+    /**
+     * Enable the strict loading mode.
+     *
+     * @return void
+     */
+    public static function enableStrictLoading()
+    {
+        static::$strictLoading = true;
     }
 
     /**
@@ -1761,6 +1785,16 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
         } else {
             return $relationship->where($field, $value)->first();
         }
+    }
+
+    /**
+     * Determine if strict loading is enabled.
+     *
+     * @return bool
+     */
+    public static function strictLoadingEnabled()
+    {
+        return static::$strictLoading;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -82,11 +82,11 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     protected $withCount = [];
 
     /**
-     * Indicates whether strict loading should be enforced on this model.
+     * Indicates whether lazy loading will be prevented on this model.
      *
      * @var bool
      */
-    public $withStrictLoading = false;
+    public $preventsLazyLoading = false;
 
     /**
      * The number of models to return for pagination.
@@ -152,11 +152,11 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     protected static $ignoreOnTouch = [];
 
     /**
-     * Indicates whether strict loading should be enforced on all models.
+     * Indicates whether lazy loading should be restricted on all models.
      *
      * @var bool
      */
-    protected static $strictLoading = false;
+    protected static $modelsShouldPreventLazyLoading = false;
 
     /**
      * The name of the "created at" column.
@@ -348,13 +348,14 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     }
 
     /**
-     * Enable the strict loading mode.
+     * Prevent model relationships from being lazy loaded.
      *
+     * @param  bool  $value
      * @return void
      */
-    public static function enableStrictLoading()
+    public static function preventLazyLoading($value = true)
     {
-        static::$strictLoading = true;
+        static::$modelsShouldPreventLazyLoading = $value;
     }
 
     /**
@@ -1788,16 +1789,6 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     }
 
     /**
-     * Determine if strict loading is enabled.
-     *
-     * @return bool
-     */
-    public static function strictLoadingEnabled()
-    {
-        return static::$strictLoading;
-    }
-
-    /**
      * Get the default foreign key name for the model.
      *
      * @return string
@@ -1828,6 +1819,16 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
         $this->perPage = $perPage;
 
         return $this;
+    }
+
+    /**
+     * Determine if lazy loading is disabled.
+     *
+     * @return bool
+     */
+    public static function preventsLazyLoading()
+    {
+        return static::$modelsShouldPreventLazyLoading;
     }
 
     /**

--- a/src/Illuminate/Database/LazyLoadingViolationException.php
+++ b/src/Illuminate/Database/LazyLoadingViolationException.php
@@ -4,7 +4,7 @@ namespace Illuminate\Database;
 
 use RuntimeException;
 
-class StrictLoadingViolationException extends RuntimeException
+class LazyLoadingViolationException extends RuntimeException
 {
     /**
      * The name of the affected Eloquent model.
@@ -31,7 +31,7 @@ class StrictLoadingViolationException extends RuntimeException
     {
         $class = get_class($model);
 
-        parent::__construct("Trying to lazy load [{$relation}] in model [{$class}] is restricted.");
+        parent::__construct("Attempted to lazy load [{$relation}] on model [{$class}] but lazy loading is disabled.");
 
         $this->model = $class;
         $this->relation = $relation;

--- a/src/Illuminate/Database/StrictLoadingViolationException.php
+++ b/src/Illuminate/Database/StrictLoadingViolationException.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Illuminate\Database;
+
+use RuntimeException;
+
+class StrictLoadingViolationException extends RuntimeException
+{
+    /**
+     * The name of the affected Eloquent model.
+     *
+     * @var string
+     */
+    public $model;
+
+    /**
+     * The name of the relation.
+     *
+     * @var string
+     */
+    public $relation;
+
+    /**
+     * Create a new exception instance.
+     *
+     * @param  object  $model
+     * @param  string  $relation
+     * @return static
+     */
+    public function __construct($model, $relation)
+    {
+        $class = get_class($model);
+
+        parent::__construct("Trying to lazy load [{$relation}] in model [{$class}] is restricted.");
+
+        $this->model = $class;
+        $this->relation = $relation;
+    }
+}

--- a/tests/Database/DatabaseEloquentBelongsToManyWithCastedAttributesTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyWithCastedAttributesTest.php
@@ -24,14 +24,14 @@ class DatabaseEloquentBelongsToManyWithCastedAttributesTest extends TestCase
         $model1->shouldReceive('getAttribute')->with('foo')->passthru();
         $model1->shouldReceive('hasGetMutator')->andReturn(false);
         $model1->shouldReceive('getCasts')->andReturn([]);
-        $model1->shouldReceive('getRelationValue', 'relationLoaded', 'setRelation')->passthru();
+        $model1->shouldReceive('getRelationValue', 'relationLoaded', 'setRelation', 'isRelation')->passthru();
 
         $model2 = m::mock(Model::class);
         $model2->shouldReceive('getAttribute')->with('parent_key')->andReturn(2);
         $model2->shouldReceive('getAttribute')->with('foo')->passthru();
         $model2->shouldReceive('hasGetMutator')->andReturn(false);
         $model2->shouldReceive('getCasts')->andReturn([]);
-        $model2->shouldReceive('getRelationValue', 'relationLoaded', 'setRelation')->passthru();
+        $model2->shouldReceive('getRelationValue', 'relationLoaded', 'setRelation', 'isRelation')->passthru();
 
         $result1 = (object) [
             'pivot' => (object) [

--- a/tests/Integration/Database/EloquentStrictLoadingTest.php
+++ b/tests/Integration/Database/EloquentStrictLoadingTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\StrictLoadingViolationException;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * @group integration
+ */
+class EloquentStrictLoadingTest extends DatabaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('test_model1', function (Blueprint $table) {
+            $table->increments('id');
+        });
+
+        Schema::create('test_model2', function (Blueprint $table) {
+            $table->increments('id');
+            $table->foreignId('model_1_id');
+        });
+
+        Schema::create('test_model3', function (Blueprint $table) {
+            $table->increments('id');
+            $table->foreignId('model_2_id');
+        });
+
+        Model::enableStrictLoading();
+    }
+
+    public function testStrictModeThrowsAnExceptionOnLazyLoading()
+    {
+        $this->expectException(StrictLoadingViolationException::class);
+        $this->expectExceptionMessage('Trying to lazy load [modelTwos] in model [Illuminate\Tests\Integration\Database\EloquentStrictLoadingTestModel1] is restricted');
+
+        EloquentStrictLoadingTestModel1::create();
+        EloquentStrictLoadingTestModel1::create();
+
+        $models = EloquentStrictLoadingTestModel1::get();
+
+        $models[0]->modelTwos;
+    }
+
+    public function testStrictModeDoesntThrowAnExceptionOnEagerLoading()
+    {
+        $this->app['config']->set('database.connections.testbench.zxc', false);
+
+        EloquentStrictLoadingTestModel1::create();
+        EloquentStrictLoadingTestModel1::create();
+
+        $models = EloquentStrictLoadingTestModel1::with('modelTwos')->get();
+
+        $this->assertInstanceOf(Collection::class, $models[0]->modelTwos);
+    }
+
+    public function testStrictModeDoesntThrowAnExceptionOnLazyEagerLoading()
+    {
+        EloquentStrictLoadingTestModel1::create();
+        EloquentStrictLoadingTestModel1::create();
+
+        $models = EloquentStrictLoadingTestModel1::get();
+
+        $models->load('modelTwos');
+
+        $this->assertInstanceOf(Collection::class, $models[0]->modelTwos);
+    }
+
+    public function testStrictModeDoesntThrowAnExceptionOnSingleModelLoading()
+    {
+        $model = EloquentStrictLoadingTestModel1::create();
+
+        $this->assertInstanceOf(Collection::class, $model->modelTwos);
+    }
+
+    public function testStrictModeThrowsAnExceptionOnLazyLoadingInRelations()
+    {
+        $this->expectException(StrictLoadingViolationException::class);
+        $this->expectExceptionMessage('Trying to lazy load [modelThrees] in model [Illuminate\Tests\Integration\Database\EloquentStrictLoadingTestModel2] is restricted');
+
+        $model1 = EloquentStrictLoadingTestModel1::create();
+        EloquentStrictLoadingTestModel2::create(['model_1_id' => $model1->id]);
+
+        $models = EloquentStrictLoadingTestModel1::with('modelTwos')->get();
+
+        $models[0]->modelTwos[0]->modelThrees;
+    }
+}
+
+class EloquentStrictLoadingTestModel1 extends Model
+{
+    public $table = 'test_model1';
+    public $timestamps = false;
+    protected $guarded = [];
+
+    public function modelTwos()
+    {
+        return $this->hasMany(EloquentStrictLoadingTestModel2::class, 'model_1_id');
+    }
+}
+
+class EloquentStrictLoadingTestModel2 extends Model
+{
+    public $table = 'test_model2';
+    public $timestamps = false;
+    protected $guarded = [];
+
+    public function modelThrees()
+    {
+        return $this->hasMany(EloquentStrictLoadingTestModel3::class, 'model_2_id');
+    }
+}
+
+class EloquentStrictLoadingTestModel3 extends Model
+{
+    public $table = 'test_model3';
+    public $timestamps = false;
+    protected $guarded = [];
+}

--- a/tests/Integration/Database/EloquentStrictLoadingTest.php
+++ b/tests/Integration/Database/EloquentStrictLoadingTest.php
@@ -19,6 +19,7 @@ class EloquentStrictLoadingTest extends DatabaseTestCase
 
         Schema::create('test_model1', function (Blueprint $table) {
             $table->increments('id');
+            $table->integer('number')->default(1);
         });
 
         Schema::create('test_model2', function (Blueprint $table) {
@@ -45,6 +46,15 @@ class EloquentStrictLoadingTest extends DatabaseTestCase
         $models = EloquentStrictLoadingTestModel1::get();
 
         $models[0]->modelTwos;
+    }
+
+    public function testStrictModeDoesntThrowAnExceptionOnAttributes()
+    {
+        EloquentStrictLoadingTestModel1::create();
+
+        $models = EloquentStrictLoadingTestModel1::get(['id']);
+
+        $this->assertNull($models[0]->number);
     }
 
     public function testStrictModeDoesntThrowAnExceptionOnEagerLoading()

--- a/tests/Integration/Database/EloquentStrictLoadingTest.php
+++ b/tests/Integration/Database/EloquentStrictLoadingTest.php
@@ -5,7 +5,7 @@ namespace Illuminate\Tests\Integration\Database;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Database\StrictLoadingViolationException;
+use Illuminate\Database\LazyLoadingViolationException;
 use Illuminate\Support\Facades\Schema;
 
 /**
@@ -32,13 +32,13 @@ class EloquentStrictLoadingTest extends DatabaseTestCase
             $table->foreignId('model_2_id');
         });
 
-        Model::enableStrictLoading();
+        Model::preventLazyLoading();
     }
 
     public function testStrictModeThrowsAnExceptionOnLazyLoading()
     {
-        $this->expectException(StrictLoadingViolationException::class);
-        $this->expectExceptionMessage('Trying to lazy load [modelTwos] in model [Illuminate\Tests\Integration\Database\EloquentStrictLoadingTestModel1] is restricted');
+        $this->expectException(LazyLoadingViolationException::class);
+        $this->expectExceptionMessage('Attempted to lazy load');
 
         EloquentStrictLoadingTestModel1::create();
         EloquentStrictLoadingTestModel1::create();
@@ -90,8 +90,8 @@ class EloquentStrictLoadingTest extends DatabaseTestCase
 
     public function testStrictModeThrowsAnExceptionOnLazyLoadingInRelations()
     {
-        $this->expectException(StrictLoadingViolationException::class);
-        $this->expectExceptionMessage('Trying to lazy load [modelThrees] in model [Illuminate\Tests\Integration\Database\EloquentStrictLoadingTestModel2] is restricted');
+        $this->expectException(LazyLoadingViolationException::class);
+        $this->expectExceptionMessage('Attempted to lazy load');
 
         $model1 = EloquentStrictLoadingTestModel1::create();
         EloquentStrictLoadingTestModel2::create(['model_1_id' => $model1->id]);


### PR DESCRIPTION
This PR introduces a `Model::enableStrictLoading()` configuration method that when used throws an exception on lazy loading eloquent relations.

When the mode is turned on, the following will throw an exception:

```php
$users = User::get();

$users[0]->posts
```

```
StrictLoadingViolationException: Trying to lazy load [posts] in model [User] is restricted
```

However, this will work:

```php
$user = User::find(1);

$user->posts
```