### PR TITLE
[8.x] Add helper let method

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -386,6 +386,6 @@ if( ! function_exists('let')) {
      * @param callable $callback
      */
     function let($value , callable $callback){
-        if (! is_null($value)) $callback($value);
+        if (! is_null($value)) return $callback($value);
     }
 }

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -377,3 +377,15 @@ if (! function_exists('with')) {
         return is_null($callback) ? $value : $callback($value);
     }
 }
+
+if( ! function_exists('let')) {
+    /**
+     * Execute the callback if the value passed is not null
+     *
+     * @param  mixed $value
+     * @param callable $callback
+     */
+    function let($value , callable $callback){
+        if (! is_null($value)) $callback($value);
+    }
+}

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -384,6 +384,7 @@ if( ! function_exists('let')) {
      *
      * @param  mixed $value
      * @param callable $callback
+     * @return mixed
      */
     function let($value , callable $callback){
         if (! is_null($value)) return $callback($value);

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -704,15 +704,14 @@ class SupportHelpersTest extends TestCase
         $this->assertSame('From $_SERVER', env('foo'));
     }
 
-    public function testLetExecuteWhenValueNotNull()
+    public function testLetExecuteWhenValueNotNullAndReturnValue()
     {
-
         $person = new PersonTestLet(new TitleLetTest());
         $person->name = 'Gildas Tema';
-
-        let($person->name , function ($name) use($person){
-            $this->assertSame('Mr'.$name , $person->AddTitleToYourName($name) );
+        $resp =  let($person->name , function ($name) use($person){
+           return $person->AddTitleToYourName($name);
         });
+        $this->assertSame('Mr'.$person->name, $resp);
     }
 
     public function testLetNoExecuteCallBackWhenValueIsNotNull()

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -704,6 +704,39 @@ class SupportHelpersTest extends TestCase
         $this->assertSame('From $_SERVER', env('foo'));
     }
 
+    public function testLetExecuteWhenValueNotNull()
+    {
+
+        $person = new PersonTestLet(new TitleLetTest());
+        $person->name = 'Gildas Tema';
+
+        let($person->name , function ($name) use($person){
+            $this->assertSame('Mr'.$name , $person->AddTitleToYourName($name) );
+        });
+    }
+
+    public function testLetNoExecuteCallBackWhenValueIsNotNull()
+    {
+        $titleMock = m::mock(TitleLetTest::class);
+        $titleMock->expects('getTitle')->andReturn('Mrs')->times(0);
+        $person = new PersonTestLet($titleMock);
+        $person->name =null;
+        let($person->name, function ($name) use($person){
+            $person->AddTitleToYourName($name);
+        });
+    }
+
+    public function testtestLetExecuteWhenValueNotNullWithMock()
+    {
+        $titleMock = m::mock(TitleLetTest::class);
+        $titleMock->expects('getTitle')->andReturn('Mrs')->times(1);
+        $person = new PersonTestLet($titleMock);
+        $person->name ='Gildas Tema';
+        let($person->name, function ($name) use($person){
+            $person->AddTitleToYourName($name);
+        });
+    }
+
     public function providesPregReplaceArrayData()
     {
         $pointerArray = ['Taylor', 'Otwell'];
@@ -790,5 +823,31 @@ class SupportTestArrayAccess implements ArrayAccess
     public function offsetUnset($offset)
     {
         unset($this->attributes[$offset]);
+    }
+}
+
+
+class PersonTestLet {
+    public $name;
+
+    public $title;
+    public function __construct(TitleLetTest $title)
+    {
+        $this->title = $title;
+    }
+
+    public function AddTitleToYourName($name)
+    {
+        return $this->title->getTitle(). $name;
+    }
+}
+
+
+
+
+class TitleLetTest
+{
+    public function  getTitle(){
+        return 'Mr';
     }
 }


### PR DESCRIPTION
This PR introduice a `let` helper . 

There are times when we need to check if a variable is null before performing an action Like this.
`$person = new Person;`
`
 if($person->name !== null) {
   $person->showNameWithAge($person->name);
}
`
With `let` the code would become the following
`
  let($person->name, fn($name) => $person->showNameWithAge($name) );
`
