### PR TITLE
[8.x] Add call private methods concern to TestCase

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/CallsPrivateMethods.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/CallsPrivateMethods.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Illuminate\Foundation\Testing\Concerns;
+
+trait CallsPrivateMethods
+{
+    /**
+     * Calls a private/protected method on the given object.
+     *
+     * @param  object  $object
+     * @param  string  $method
+     * @param  array  $parameters
+     *
+     * @return mixed
+     */
+    protected function callPrivate($object, $method, $parameters = [])
+    {
+        return (function () use ($method, $parameters) {
+            return $this->$method(...$parameters);
+        })->call($object);
+    }
+}

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -26,6 +26,7 @@ abstract class TestCase extends BaseTestCase
         Concerns\InteractsWithSession,
         Concerns\InteractsWithTime,
         Concerns\InteractsWithViews,
+        Concerns\CallsPrivateMethods,
         Concerns\MocksApplicationServices;
 
     /**


### PR DESCRIPTION
This gives the users a convenient way for calling non-public methods on objects while unit testing.
```php
$result = $this->callPrivate($obj, 'methodName', ['param1']);
```

- The same thing can be added to call `static` methods as well since PHP 8 does not support calling static methods by `->`.

- It is backward compatible, but if the user has defined a method with the same name, they can not use the new feature.