### PR TITLE
[8.x] Add ScheduledBackgroundTaskFinished event to fire on completion of background tasks

### DIFF
--- a/src/Illuminate/Console/Events/ScheduledBackgroundTaskFinished.php
+++ b/src/Illuminate/Console/Events/ScheduledBackgroundTaskFinished.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Illuminate\Console\Events;
+
+use Illuminate\Console\Scheduling\Event;
+
+class ScheduledBackgroundTaskFinished
+{
+    /**
+     * The scheduled event that ran.
+     *
+     * @var \Illuminate\Console\Scheduling\Event
+     */
+    public $task;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  \Illuminate\Console\Scheduling\Event  $task
+     * @return void
+     */
+    public function __construct(Event $task)
+    {
+        $this->task = $task;
+    }
+}

--- a/src/Illuminate/Console/Scheduling/ScheduleFinishCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleFinishCommand.php
@@ -3,6 +3,8 @@
 namespace Illuminate\Console\Scheduling;
 
 use Illuminate\Console\Command;
+use Illuminate\Console\Events\ScheduledBackgroundTaskFinished;
+use Illuminate\Contracts\Events\Dispatcher;
 
 class ScheduleFinishCommand extends Command
 {
@@ -31,12 +33,17 @@ class ScheduleFinishCommand extends Command
      * Execute the console command.
      *
      * @param  \Illuminate\Console\Scheduling\Schedule  $schedule
+     * @param  \Illuminate\Contracts\Events\Dispatcher  $dispatcher
      * @return void
      */
-    public function handle(Schedule $schedule)
+    public function handle(Schedule $schedule, Dispatcher $dispatcher)
     {
         collect($schedule->events())->filter(function ($value) {
             return $value->mutexName() == $this->argument('id');
-        })->each->callAfterCallbacksWithExitCode($this->laravel, $this->argument('code'));
+        })->each(function ($event) use ($dispatcher) {
+            $event->callafterCallbacksWithExitCode($this->laravel, $this->argument('code'));
+
+            $dispatcher->dispatch(new ScheduledBackgroundTaskFinished($event));
+        });
     }
 }


### PR DESCRIPTION
PR https://github.com/laravel/framework/pull/29888 added excellent new events ScheduledTaskStarting and ScheduledTaskFinished which are fired before and after a scheduled task runs.

However, where the scheduled task is set to run in background, ScheduledTaskFinished fires immediately because we push the task off to a separate process. This makes it difficult to run any relevant activities after a background task finishes, without having to hack on to the after callbacks.

This PR adds a new event ScheduledBackgroundTaskFinished which we fire within the schedule:finish command which allows us to reliably determine when a background task actually completed without having to attach after callbacks to each scheduled task.

We're adding a brand new event class and firing it without changing any additional functionality so should not be a breaking change. 
