### PR TITLE
[9.x] Raise ScheduledBackgroundTaskFinished event to signal when a run in background task finishes

### DIFF
--- a/src/Illuminate/Console/Events/ScheduledBackgroundTaskFinished.php
+++ b/src/Illuminate/Console/Events/ScheduledBackgroundTaskFinished.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Illuminate\Console\Events;
+
+use Illuminate\Console\Scheduling\Event;
+
+class ScheduledBackgroundTaskFinished
+{
+    /**
+     * The scheduled event that ran.
+     *
+     * @var \Illuminate\Console\Scheduling\Event
+     */
+    public $task;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  \Illuminate\Console\Scheduling\Event  $task
+     * @return void
+     */
+    public function __construct(Event $task)
+    {
+        $this->task = $task;
+    }
+}


### PR DESCRIPTION
PR https://github.com/laravel/framework/pull/29888 added excellent new events ScheduledTaskStarting and ScheduledTaskFinished which are fired before and after a scheduled task runs.

However, where the scheduled task is set to run in background, ScheduledTaskFinished fires immediately because we push the task off to a separate process. This makes it difficult to run any relevant activities after a background task finishes, without having to hack on to the after callbacks.

This PR adds a new event ScheduledBackgroundTaskFinished which we fire within the schedule:finish command which allows us to reliably determine when a background task actually completed without having to attach after callbacks to each scheduled task.

We're adding a brand new event class and firing it without changing any additional functionality but since we're introducing a new argument to the handle method on the schedule:finish command, so targetting master branch for this.

