### PR TITLE
[8.x] Add hasSlot Blade conditional tag

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -304,4 +304,15 @@ trait CompilesConditionals
     {
         return '<?php endif; ?>';
     }
+
+    /**
+     * Compile the has-slot statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileHasSlot($expression)
+    {
+        return "<?php if (\$__env->hasSlot{$expression}): ?>";
+    }
 }

--- a/src/Illuminate/View/Concerns/ManagesComponents.php
+++ b/src/Illuminate/View/Concerns/ManagesComponents.php
@@ -152,6 +152,17 @@ trait ManagesComponents
     }
 
     /**
+     * Check if the slot exists.
+     *
+     * @param  string  $name
+     * @return bool
+     */
+    public function hasSlot($name)
+    {
+        return array_key_exists($name, $this->slots[max(0, $this->currentComponent())]);
+    }
+
+    /**
      * Get the index for the current component.
      *
      * @return int

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -764,6 +764,24 @@ class ViewFactoryTest extends TestCase
         $this->assertSame('Hello World', $factory->getFoo());
     }
 
+    public function testHasSlot()
+    {
+        $factory = $this->getFactory();
+        $factory->getFinder()->shouldReceive('find')->andReturn(__DIR__.'/fixtures/component.php');
+        $factory->getEngineResolver()->shouldReceive('resolve')->andReturn(new PhpEngine(new Filesystem));
+        $factory->getDispatcher()->shouldReceive('dispatch');
+        $factory->startComponent('component', ['name' => 'Taylor']);
+        $factory->slot('title');
+        $factory->slot('website', 'laravel.com');
+        echo 'title<hr>';
+        $factory->endSlot();
+        echo 'component';
+
+        $this->assertTrue($factory->hasSlot('title'));
+        $this->assertTrue($factory->hasSlot('website'));
+        $this->assertFalse($factory->hasSlot('bar'));
+    }
+
     protected function getFactory()
     {
         return new Factory(


### PR DESCRIPTION
This PR aims to implement a new `hasSlot` conditional tag for Blade components. I was looking for a smarter way to check if a slot is provided and tried to implement it. Please see below for some important considerations.

```blade
<!-- /resources/views/components/alert.blade.php -->

@hasSlot('title')
    <span class="alert-title">{{ $title }}</span>
@endif

<div class="alert alert-danger">
    {{ $slot }}
</div>
```

**Considerations**

1. I used `max(0, $this->currentComponent())` because on using "standard" components (class or anonymous) `$this->currentComponent()` would return -1, but on tests with `$factory->make('component')` it would return the correct index, therefore had to write this little check.
2. This currently _does not work_ if you use nested components. For example, if inside `alert.blade.php` you put another component like `<x-small-tag>{{ $title }}</x-small-tag>`, hasSlot would not detect the given slot because variables like `$this->slots` will contain the child data. I don't much about the flow here, sorry.
2.1. About that, maybe `hasSlot` could be moved where you can access the actual `$slots` of the component and not inside the `CompilesConditionals`?
3. Is this *actually* better than just checking for the variable existance with `@isset`? Because I tried to replace all the `hasSlot` method with just the following code and it works with nested components too, but it would return "true" also for variables not declared within a slot (e.g. from the view or global variables), so I don't know...

```php
protected function compileHasSlot($name)
{
    $slotName = trim($this->stripParentheses($name), "'");

    return "<?php if (isset(\${$slotName})): ?>";
}
```