### PR TITLE
Fix empty parameter handling in signed URLs

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -388,13 +388,16 @@ class UrlGenerator implements UrlGeneratorContract
     {
         $url = $absolute ? $request->url() : '/'.$request->path();
 
-        $original = rtrim($url.'?'.Arr::query(
-            Arr::except($request->query(), 'signature')
-        ), '?');
+        $queryString = '';
+        foreach (Arr::except($request->query(), 'signature') as $key => $value) {
+            $queryString .= '&'.(is_null($value) ? \urlencode($key) : \urlencode($key).'='.\urlencode($value));
+        }
 
-        $signature = hash_hmac('sha256', $original, call_user_func($this->keyResolver));
+        $original = \rtrim($url.'?'.\ltrim($queryString, '&'), '?');
 
-        return hash_equals($signature, (string) $request->query('signature', ''));
+        $signature = \hash_hmac('sha256', $original, \call_user_func($this->keyResolver));
+
+        return \hash_equals($signature, (string) $request->query('signature', ''));
     }
 
     /**

--- a/tests/Integration/Routing/UrlSigningTest.php
+++ b/tests/Integration/Routing/UrlSigningTest.php
@@ -59,6 +59,36 @@ class UrlSigningTest extends TestCase
         $this->assertSame('invalid', $this->get('/foo/1')->original);
     }
 
+    public function testSignedUrlWithQueryParameters()
+    {
+        Route::get('/foo', function (Request $request) {
+            return $request->hasValidSignature() ? 'valid' : 'invalid';
+        })->name('foo');
+
+        $this->assertIsString($url = URL::signedRoute('foo', ['id' => 1, 'order' => 'asc']));
+        $this->assertSame('valid', $this->get($url)->original);
+    }
+
+    public function testSignedUrlWithEmptyQueryParameters()
+    {
+        Route::get('/foo/{id}', function (Request $request, $id) {
+            return $request->hasValidSignature() ? 'valid' : 'invalid';
+        })->name('foo');
+
+        $this->assertIsString($url = URL::signedRoute('foo', ['id' => 1, 'order']));
+        $this->assertSame('valid', $this->get($url)->original);
+    }
+
+    public function testSignedUrlCantBeAppendedQueryStringKeys()
+    {
+        Route::get('/foo/{id}', function (Request $request, $id) {
+            return $request->hasValidSignature() ? 'valid' : 'invalid';
+        })->name('foo');
+
+        $this->assertIsString($url = URL::signedRoute('foo', ['id' => 1]));
+        $this->assertSame('invalid', $this->get($url.'&additional&keys')->original);
+    }
+
     public function testSignedMiddleware()
     {
         Route::get('/foo/{id}', function (Request $request, $id) {


### PR DESCRIPTION
Proof-of-concept for handling key-only query string parameters in signed urls.