### PR TITLE
Make AssertableJson easier to extend by replacing `self` with `static`

### DIFF
--- a/src/Illuminate/Testing/Fluent/AssertableJson.php
+++ b/src/Illuminate/Testing/Fluent/AssertableJson.php
@@ -79,7 +79,7 @@ class AssertableJson implements Arrayable
      * @param  \Closure  $callback
      * @return $this
      */
-    protected function scope(string $key, Closure $callback): static
+    protected function scope(string $key, Closure $callback): self
     {
         $props = $this->prop($key);
         $path = $this->dotPath($key);
@@ -99,7 +99,7 @@ class AssertableJson implements Arrayable
      * @param  \Closure  $callback
      * @return $this
      */
-    public function first(Closure $callback): static
+    public function first(Closure $callback): self
     {
         $props = $this->prop();
 
@@ -123,7 +123,7 @@ class AssertableJson implements Arrayable
      * @param  array  $data
      * @return static
      */
-    public static function fromArray(array $data): static
+    public static function fromArray(array $data): self
     {
         return new static($data);
     }
@@ -134,7 +134,7 @@ class AssertableJson implements Arrayable
      * @param  \Illuminate\Testing\AssertableJsonString  $json
      * @return static
      */
-    public static function fromAssertableJsonString(AssertableJsonString $json): static
+    public static function fromAssertableJsonString(AssertableJsonString $json): self
     {
         return static::fromArray($json->json());
     }

--- a/src/Illuminate/Testing/Fluent/AssertableJson.php
+++ b/src/Illuminate/Testing/Fluent/AssertableJson.php
@@ -79,14 +79,14 @@ class AssertableJson implements Arrayable
      * @param  \Closure  $callback
      * @return $this
      */
-    protected function scope(string $key, Closure $callback): self
+    protected function scope(string $key, Closure $callback): static
     {
         $props = $this->prop($key);
         $path = $this->dotPath($key);
 
         PHPUnit::assertIsArray($props, sprintf('Property [%s] is not scopeable.', $path));
 
-        $scope = new self($props, $path);
+        $scope = new static($props, $path);
         $callback($scope);
         $scope->interacted();
 
@@ -99,7 +99,7 @@ class AssertableJson implements Arrayable
      * @param  \Closure  $callback
      * @return $this
      */
-    public function first(Closure $callback): self
+    public function first(Closure $callback): static
     {
         $props = $this->prop();
 
@@ -123,9 +123,9 @@ class AssertableJson implements Arrayable
      * @param  array  $data
      * @return static
      */
-    public static function fromArray(array $data): self
+    public static function fromArray(array $data): static
     {
-        return new self($data);
+        return new static($data);
     }
 
     /**
@@ -134,9 +134,9 @@ class AssertableJson implements Arrayable
      * @param  \Illuminate\Testing\AssertableJsonString  $json
      * @return static
      */
-    public static function fromAssertableJsonString(AssertableJsonString $json): self
+    public static function fromAssertableJsonString(AssertableJsonString $json): static
     {
-        return self::fromArray($json->json());
+        return static::fromArray($json->json());
     }
 
     /**


### PR DESCRIPTION
I was trying to add a couple of features to `AssertableJson` but ended up having to override multiple other methods which returned or expected the default class because of the `self`.

This PR changes all occurences of `static` to `self` so these methods keep working without change when the class is extended.