### PR TITLE
[8.x] Add mapValuesInto to collections

### DIFF
--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -609,12 +609,20 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function flatMap(callable $callback);
 
     /**
-     * Map the values into a new class.
+     * Map the values and keys into a new class.
      *
      * @param  string  $class
      * @return static
      */
     public function mapInto($class);
+
+    /**
+     * Map the values into a new class.
+     *
+     * @param  string  $class
+     * @return static
+     */
+    public function mapValuesInto($class);
 
     /**
      * Merge the collection with the given items.

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -344,7 +344,7 @@ trait EnumeratesValues
     }
 
     /**
-     * Map the values into a new class.
+     * Map the values and keys into a new class.
      *
      * @param  string  $class
      * @return static
@@ -353,6 +353,19 @@ trait EnumeratesValues
     {
         return $this->map(function ($value, $key) use ($class) {
             return new $class($value, $key);
+        });
+    }
+
+    /**
+     * Map the values into a new class.
+     *
+     * @param  string  $class
+     * @return static
+     */
+    public function mapValuesInto($class)
+    {
+        return $this->map(function ($value) use ($class) {
+            return new $class($value);
         });
     }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2675,6 +2675,23 @@ class SupportCollectionTest extends TestCase
 
         $this->assertSame('first', $data->get(0)->value);
         $this->assertSame('second', $data->get(1)->value);
+        $this->assertSame(0, $data->get(0)->key);
+        $this->assertSame(1, $data->get(1)->key);
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testMapValuesInto($collection)
+    {
+        $data = new $collection([
+            'first', 'second',
+        ]);
+
+        $data = $data->mapValuesInto(TestCollectionMapValuesIntoObject::class);
+
+        $this->assertSame('first', $data->get(0)->value);
+        $this->assertSame('second', $data->get(1)->value);
     }
 
     /**
@@ -4745,6 +4762,18 @@ class TestJsonSerializeWithScalarValueObject implements JsonSerializable
 }
 
 class TestCollectionMapIntoObject
+{
+    public $value;
+    public $key;
+
+    public function __construct($value, $key)
+    {
+        $this->value = $value;
+        $this->key = $key;
+    }
+}
+
+class TestCollectionMapValuesIntoObject
 {
     public $value;
 

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -592,6 +592,17 @@ class SupportLazyCollectionIsLazyTest extends TestCase
         });
     }
 
+    public function testMapValuesIntoIsLazy()
+    {
+        $this->assertDoesNotEnumerate(function ($collection) {
+            $collection->mapValuesInto(stdClass::class);
+        });
+
+        $this->assertEnumerates(2, function ($collection) {
+            $collection->mapValuesInto(stdClass::class)->take(2)->all();
+        });
+    }
+
     public function testMapSpreadIsLazy()
     {
         $data = $this->make([[1, 2], [3, 4], [5, 6], [7, 8]]);


### PR DESCRIPTION
Relates to #36351.

Instead of changing the existing `mapInto` method (which some apps might see as a BC), this PR adds a new method called `mapValuesInto`, which:

1. Is backwards-compatible as it does not alter the existing code.
2. Introduces a descriptive method that does exactly what it says in the name: only map the collection’s values into a class. This adds flexibility in terms of classes that might take something else (with a default) as the second argument.

This PR does not intend to solve the issue related to JSON resource constructors as it introduces the new method as a developer-facing convenience. As such, the `CollectsResources` trait has not been altered.