### PR TITLE
[8.x] Allow sending a refresh header with maintenance mode response

### DIFF
--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -17,6 +17,7 @@ class DownCommand extends Command
     protected $signature = 'down {--redirect= : The path that users should be redirected to}
                                  {--render= : The view that should be prerendered for display during maintenance mode}
                                  {--retry= : The number of seconds after which the request may be retried}
+                                 {--refresh= : The number of seconds after which the browser may refresh}
                                  {--secret= : The secret phrase that may be used to bypass maintenance mode}
                                  {--status=503 : The status code that should be used when returning the maintenance mode response}';
 
@@ -71,6 +72,7 @@ class DownCommand extends Command
         return [
             'redirect' => $this->redirectPath(),
             'retry' => $this->getRetryTime(),
+            'refresh' => $this->option('refresh'),
             'secret' => $this->option('secret'),
             'status' => (int) $this->option('status', 503),
             'template' => $this->option('render') ? $this->prerenderView() : null,

--- a/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
+++ b/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
@@ -71,7 +71,7 @@ class PreventRequestsDuringMaintenance
                 return response(
                     $data['template'],
                     $data['status'] ?? 503,
-                    isset($data['retry']) ? ['Retry-After' => $data['retry']] : []
+                    $this->getHeaders($data)
                 );
             }
 
@@ -79,7 +79,7 @@ class PreventRequestsDuringMaintenance
                 $data['status'] ?? 503,
                 'Service Unavailable',
                 null,
-                isset($data['retry']) ? ['Retry-After' => $data['retry']] : []
+                $this->getHeaders($data)
             );
         }
 
@@ -135,5 +135,22 @@ class PreventRequestsDuringMaintenance
         return redirect('/')->withCookie(
             MaintenanceModeBypassCookie::create($secret)
         );
+    }
+
+    /**
+     * Determine the response headers.
+     *
+     * @param  array  $data
+     * @return array
+     */
+    protected function getHeaders($data)
+    {
+        $headers = isset($data['retry']) ? ['Retry-After' => $data['retry']] : [];
+
+        if (isset($data['refresh'])) {
+            $headers['Refresh'] = $data['refresh'];
+        }
+
+        return $headers;
     }
 }

--- a/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
+++ b/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
@@ -138,7 +138,7 @@ class PreventRequestsDuringMaintenance
     }
 
     /**
-     * Determine the response headers.
+     * Get the headers that should be sent with the response.
      *
      * @param  array  $data
      * @return array

--- a/tests/Integration/Foundation/MaintenanceModeTest.php
+++ b/tests/Integration/Foundation/MaintenanceModeTest.php
@@ -23,6 +23,7 @@ class MaintenanceModeTest extends TestCase
     {
         file_put_contents(storage_path('framework/down'), json_encode([
             'retry' => 60,
+            'refresh' => 60,
         ]));
 
         Route::get('/foo', function () {
@@ -33,6 +34,7 @@ class MaintenanceModeTest extends TestCase
 
         $response->assertStatus(503);
         $response->assertHeader('Retry-After', '60');
+        $response->assertHeader('Refresh', '60');
     }
 
     public function testMaintenanceModeCanHaveCustomStatus()


### PR DESCRIPTION
This PR adds a `--refresh` option to the `php artisan down` command. When used, a `Refresh` header will be sent with maintenance mode responses forcing the browser to refresh after x seconds.