### PR TITLE
[8.x] Add ability to define default Password Rule

### DIFF
--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -115,7 +115,29 @@ class Password implements Rule, DataAwareRule
      */
     public static function default()
     {
-        return value(static::$defaultCallback);
+        $password = value(static::$defaultCallback);
+
+        return $password instanceof static ? $password : static::min(8);
+    }
+
+    /**
+     * Get Password's default rules as required.
+     *
+     * @return array
+     */
+    public static function required()
+    {
+        return ['required', static::default()];
+    }
+
+    /**
+     * Get Password's default rules as sometimes.
+     *
+     * @return array
+     */
+    public static function sometimes()
+    {
+        return ['sometimes', static::default()];
     }
 
     /**

--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -97,7 +97,7 @@ class Password implements Rule, DataAwareRule
      * Set the default callback to be used for determining the Password's default rules.
      *
      * @param  static|callable $callback
-     * @return $this
+     * @return void
      */
     public static function defaultUsing($callback)
     {

--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -96,13 +96,13 @@ class Password implements Rule, DataAwareRule
     /**
      * Set the default callback to be used for determining the Password's default rules.
      *
-     * @param  string|array|callable $callback
+     * @param  static|callable $callback
      * @return $this
      */
     public static function defaultUsing($callback)
     {
-        if (! is_array($callback) && ! is_callable($callback)) {
-            throw new InvalidArgumentException('$callback should either be callable or an array');
+        if (! is_callable($callback) && ! $callback instanceof self) {
+            throw new InvalidArgumentException('$callback should either be callable or an instance of '.self::class);
         }
 
         static::$defaultCallback = $callback;
@@ -111,11 +111,11 @@ class Password implements Rule, DataAwareRule
     /**
      * Get Password's default rules.
      *
-     * @return array
+     * @return static
      */
     public static function default()
     {
-        return Arr::wrap(value(static::$defaultCallback));
+        return value(static::$defaultCallback);
     }
 
     /**

--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Contracts\Validation\UncompromisedVerifier;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Validator;
+use InvalidArgumentException;
 
 class Password implements Rule, DataAwareRule
 {
@@ -75,6 +76,13 @@ class Password implements Rule, DataAwareRule
     protected $messages = [];
 
     /**
+     * The callback to be used for the Password's default rules.
+     *
+     * @var string|array|callable|null
+     */
+    public static $defaultCallback;
+
+    /**
      * Create a new rule instance.
      *
      * @param  int  $min
@@ -83,6 +91,31 @@ class Password implements Rule, DataAwareRule
     public function __construct($min)
     {
         $this->min = max((int) $min, 1);
+    }
+
+    /**
+     * Set the default callback to be used for determining the Password's default rules.
+     *
+     * @param  string|array|callable $callback
+     * @return $this
+     */
+    public static function defaultUsing($callback)
+    {
+        if (! is_array($callback) && ! is_callable($callback)) {
+            throw new InvalidArgumentException('$callback should either be callable or an array');
+        }
+
+        static::$defaultCallback = $callback;
+    }
+
+    /**
+     * Get Password's default rules.
+     *
+     * @return array
+     */
+    public static function fromDefault()
+    {
+        return Arr::wrap(value(static::$defaultCallback));
     }
 
     /**

--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -113,7 +113,7 @@ class Password implements Rule, DataAwareRule
      *
      * @return array
      */
-    public static function fromDefault()
+    public static function default()
     {
         return Arr::wrap(value(static::$defaultCallback));
     }

--- a/tests/Validation/ValidationPasswordRuleTest.php
+++ b/tests/Validation/ValidationPasswordRuleTest.php
@@ -177,8 +177,15 @@ class ValidationPasswordRuleTest extends TestCase
         );
     }
 
+    public function testItCanUseDefault()
+    {
+        $this->assertInstanceOf(Password::class, Password::default());
+    }
+
     public function testItCanSetDefaultUsing()
     {
+        $this->assertInstanceOf(Password::class, Password::default());
+
         $password = Password::min(3);
         $password2 = Password::min(2)->mixedCase();
 
@@ -188,10 +195,14 @@ class ValidationPasswordRuleTest extends TestCase
 
         $this->passes(Password::default(), ['abcd', '454qb^', '接2133手田']);
         $this->assertSame($password, Password::default());
+        $this->assertSame(['required', $password], Password::required());
+        $this->assertSame(['sometimes', $password], Password::sometimes());
 
         Password::defaultUsing($password2);
         $this->passes(Password::default(), ['Nn', 'Mn', 'âA']);
         $this->assertSame($password2, Password::default());
+        $this->assertSame(['required', $password2], Password::required());
+        $this->assertSame(['sometimes', $password2], Password::sometimes());
     }
 
     public function testItCannotSetDefaultUsingGivenString()

--- a/tests/Validation/ValidationPasswordRuleTest.php
+++ b/tests/Validation/ValidationPasswordRuleTest.php
@@ -204,15 +204,15 @@ class ValidationPasswordRuleTest extends TestCase
 
     protected function passes($rule, $values)
     {
-        $this->testRule($rule, $values, true, []);
+        $this->assertValidationRules($rule, $values, true, []);
     }
 
     protected function fails($rule, $values, $messages)
     {
-        $this->testRule($rule, $values, false, $messages);
+        $this->assertValidationRules($rule, $values, false, $messages);
     }
 
-    protected function testRule($rule, $values, $result, $messages)
+    protected function assertValidationRules($rule, $values, $result, $messages)
     {
         foreach ($values as $value) {
             $v = new Validator(

--- a/tests/Validation/ValidationPasswordRuleTest.php
+++ b/tests/Validation/ValidationPasswordRuleTest.php
@@ -177,6 +177,28 @@ class ValidationPasswordRuleTest extends TestCase
         );
     }
 
+    public function testItCanSetDefaultUsing()
+    {
+        $password = Password::min(2)->numbers();
+
+        Password::defaultUsing(function () use ($password) {
+            return $password;
+        });
+
+        $this->assertSame([$password], Password::fromDefault());
+
+        Password::defaultUsing(['required', 'password']);
+        $this->assertSame(['required', 'password'], Password::fromDefault());
+    }
+
+    public function testItCannotSetDefaultUsingGivenString()
+    {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('$callback should either be callable or an array');
+
+        Password::defaultUsing('required|password');
+    }
+
     protected function passes($rule, $values)
     {
         $this->testRule($rule, $values, true, []);
@@ -227,5 +249,7 @@ class ValidationPasswordRuleTest extends TestCase
         Facade::clearResolvedInstances();
 
         Facade::setFacadeApplication(null);
+
+        Password::$defaultCallback = null;
     }
 }

--- a/tests/Validation/ValidationPasswordRuleTest.php
+++ b/tests/Validation/ValidationPasswordRuleTest.php
@@ -179,22 +179,25 @@ class ValidationPasswordRuleTest extends TestCase
 
     public function testItCanSetDefaultUsing()
     {
-        $password = Password::min(2)->numbers();
+        $password = Password::min(3);
+        $password2 = Password::min(2)->mixedCase();
 
         Password::defaultUsing(function () use ($password) {
             return $password;
         });
 
-        $this->assertSame([$password], Password::default());
+        $this->passes(Password::default(), ['abcd', '454qb^', '接2133手田']);
+        $this->assertSame($password, Password::default());
 
-        Password::defaultUsing(['required', 'password']);
-        $this->assertSame(['required', 'password'], Password::default());
+        Password::defaultUsing($password2);
+        $this->passes(Password::default(), ['Nn', 'Mn', 'âA']);
+        $this->assertSame($password2, Password::default());
     }
 
     public function testItCannotSetDefaultUsingGivenString()
     {
         $this->expectException('InvalidArgumentException');
-        $this->expectExceptionMessage('$callback should either be callable or an array');
+        $this->expectExceptionMessage('$callback should either be callable or an instance of '.Password::class);
 
         Password::defaultUsing('required|password');
     }

--- a/tests/Validation/ValidationPasswordRuleTest.php
+++ b/tests/Validation/ValidationPasswordRuleTest.php
@@ -185,10 +185,10 @@ class ValidationPasswordRuleTest extends TestCase
             return $password;
         });
 
-        $this->assertSame([$password], Password::fromDefault());
+        $this->assertSame([$password], Password::default());
 
         Password::defaultUsing(['required', 'password']);
-        $this->assertSame(['required', 'password'], Password::fromDefault());
+        $this->assertSame(['required', 'password'], Password::default());
     }
 
     public function testItCannotSetDefaultUsingGivenString()


### PR DESCRIPTION
This will make it easier to define a generic default password rules for login, register and password reset and useful for Laravel UI, Breeze, Jetstream and Nova.

### Defining Rules

Typically on the `App\Providers\AuthServiceProvider`
```php
use Illuminate\Validation\Rules\Password;

Password::defaultUsing(function() {
     return Password::min(8)->uncompromised();
});
```

### Using the rules

E.g in Laravel Nova.

```php
use Laravel\Nova\Fields\Password;
use Illuminate\Validation\Rules\Password as PasswordRule;

Password::make('Password', 'password')->rules(PasswordRule::default());
```

Also, you can use:

```php
Password::required(); // return ['required', Password::min(8)->uncompromised()];

Password::sometimes(); // return ['sometimes', Password::min(8)->uncompromised()];
```

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>