### PR TITLE
[8.x] Add loadExists on Model and Eloquent Collection

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -146,6 +146,17 @@ class Collection extends BaseCollection implements QueueableCollection
     }
 
     /**
+     * Load a set of related existences onto the collection.
+     *
+     * @param  array|string  $relations
+     * @return $this
+     */
+    public function loadExists($relations)
+    {
+        return $this->loadAggregate($relations, '*', 'exists');
+    }
+
+    /**
      * Load a set of relationship's average column values onto the collection.
      *
      * @param  array|string  $relations

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -146,17 +146,6 @@ class Collection extends BaseCollection implements QueueableCollection
     }
 
     /**
-     * Load a set of related existences onto the collection.
-     *
-     * @param  array|string  $relations
-     * @return $this
-     */
-    public function loadExists($relations)
-    {
-        return $this->loadAggregate($relations, '*', 'exists');
-    }
-
-    /**
      * Load a set of relationship's average column values onto the collection.
      *
      * @param  array|string  $relations
@@ -166,6 +155,17 @@ class Collection extends BaseCollection implements QueueableCollection
     public function loadAvg($relations, $column)
     {
         return $this->loadAggregate($relations, $column, 'avg');
+    }
+
+    /**
+     * Load a set of related existences onto the collection.
+     *
+     * @param  array|string  $relations
+     * @return $this
+     */
+    public function loadExists($relations)
+    {
+        return $this->loadAggregate($relations, '*', 'exists');
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -620,6 +620,17 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     }
 
     /**
+     * Eager load related model existence values on the model.
+     *
+     * @param  array|string  $relations
+     * @return $this
+     */
+    public function loadExists($relations)
+    {
+        return $this->loadAggregate($relations, '*', 'exists');
+    }
+
+    /**
      * Eager load relationship column aggregation on the polymorphic relation of a model.
      *
      * @param  string  $relation


### PR DESCRIPTION
This PR follows https://github.com/laravel/framework/pull/37302 in order to add `loadExists` methods in both `Model` and `Eloquent Collection`
