### PR TITLE
Update TestDatabases.php comma then a bracket causes error. Moving the comma resolves it. 

### DIFF
--- a/src/Illuminate/Testing/Concerns/TestDatabases.php
+++ b/src/Illuminate/Testing/Concerns/TestDatabases.php
@@ -155,12 +155,12 @@ trait TestDatabases
         if ($url) {
             config()->set(
                 "database.connections.{$default}.url",
-                preg_replace('/^(.*)(\/[\w-]*)(\??.*)$/', "$1/{$database}$3", $url),
+                preg_replace('/^(.*)(\/[\w-]*)(\??.*)$/', "$1/{$database}$3", $url)
             );
         } else {
             config()->set(
                 "database.connections.{$default}.database",
-                $database,
+                $database
             );
         }
     }


### PR DESCRIPTION
If I clone the laravel\laravel and start the project on php 8.0. After I do permissions and do a composer update. This package comes down and it causes an error.

On the 2 lines the comma at the end, followed by a ) causes an error. Removing both comma's fixed the issue.
The error response is: In TestDatabases.php line 148: syntax error, unexpected ')'

I do not know how this could break anything else. I am not an experience github user. This is actually my first ever pull request.
Someone else had the same issue as me: https://stackoverflow.com/questions/66061548/syntax-error-unexpected-after-laravel-update/67574907#67574907


