### PR TITLE
[8.x] Remove array_walk

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -891,9 +891,9 @@ class Application extends Container implements ApplicationContract, CachesConfig
         // finished. This is useful when ordering the boot-up processes we run.
         $this->fireAppCallbacks($this->bootingCallbacks);
 
-        array_walk($this->serviceProviders, function ($p) {
-            $this->bootProvider($p);
-        });
+        foreach ($this->serviceProviders as $provider) {
+            $this->bootProvider($provider);
+        }
 
         $this->booted = true;
 


### PR DESCRIPTION
~~It is enough for the use case to just use a simple PHP block `{ }` for this method.~~

~~Replacing the array_walk with a simple foreach loop gains:~~

- ~~Code Clarity~~
- ~~Performance (might be negligible, but not a trade either)~~

~~In short, PHP blocks are faster than calling functions.~~
~~The cost of array_walk goes up by the number of providers registered in the application.~~

~~More info can be found at: https://www.reddit.com/r/PHP/comments/aurlqt/ive_been_messing_around_with_the_array_walk/ehbbh76~~

<hr />

## Edit

####  Breaks due:

> foreach uses a "copy" of the array, while array_walk continues walking the array while elements are added to it.
So Service Providers added by other Service Providers aren't correctly booted.

#### Use case for registering a provider in the boot method of another provider:

> When packages auto discovery has been released, you partially lost control when your package ServiceProvider should be booted. All discovered providers are booted before local config/app.php providers . If some package providers need to boot after all local providers , you need to inject your package providers in boot() method. Or another solution is to use $this->app->booted(closure) callback in the register method of your main package provider.

> Useful example is when you need to have routes fully loaded in your package provider boot state. Because initially app/Providers/RouteServiceProvider will fire before all packages discovery.
