### PR TITLE
[8.x] Accept any instance of `Rule` and not just `Password`

### DIFF
--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -123,7 +123,7 @@ class Password implements Rule, DataAwareRule
     {
         $password = value(static::$defaultCallback);
 
-        return $password instanceof static ? $password : static::min(8);
+        return $password instanceof Rule ? $password : static::min(8);
     }
 
     /**


### PR DESCRIPTION
This would be useful if there a requirement to use custom Password implementation such as `Laravel\Fortify\Rules\Password` etc.
