### PR TITLE
[8.x] Added getAuthIdentifierForBroadcasting method

### DIFF
--- a/src/Illuminate/Auth/Authenticatable.php
+++ b/src/Illuminate/Auth/Authenticatable.php
@@ -32,6 +32,16 @@ trait Authenticatable
     }
 
     /**
+     * Get the unique broadcast identifier for the user .
+     *
+     * @return mixed
+     */
+    public function getAuthIdentifierForBroadcasting()
+    {
+        return $this->getAuthIdentifier();
+    }
+
+    /**
      * Get the password for the user.
      *
      * @return string

--- a/src/Illuminate/Broadcasting/Broadcasters/AblyBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/AblyBroadcaster.php
@@ -76,7 +76,7 @@ class AblyBroadcaster extends Broadcaster
             $request->channel_name,
             $request->socket_id,
             $userData = array_filter([
-                'user_id' => (string) $this->retrieveUser($request, $channelName)->getAuthIdentifier(),
+                'user_id' => (string) $this->retrieveUser($request, $channelName)->getAuthIdentifierForBroadcasting(),
                 'user_info' => $result,
             ])
         );

--- a/src/Illuminate/Broadcasting/Broadcasters/AblyBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/AblyBroadcaster.php
@@ -22,7 +22,7 @@ class AblyBroadcaster extends Broadcaster
     /**
      * Create a new broadcaster instance.
      *
-     * @param \Ably\AblyRest $ably
+     * @param  \Ably\AblyRest  $ably
      * @return void
      */
     public function __construct(AblyRest $ably)
@@ -33,7 +33,7 @@ class AblyBroadcaster extends Broadcaster
     /**
      * Authenticate the incoming request for a given channel.
      *
-     * @param \Illuminate\Http\Request $request
+     * @param  \Illuminate\Http\Request  $request
      * @return mixed
      *
      * @throws \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
@@ -44,7 +44,7 @@ class AblyBroadcaster extends Broadcaster
 
         if (empty($request->channel_name) ||
             ($this->isGuardedChannel($request->channel_name) &&
-                !$this->retrieveUser($request, $channelName))) {
+            ! $this->retrieveUser($request, $channelName))) {
             throw new AccessDeniedHttpException;
         }
 
@@ -56,8 +56,8 @@ class AblyBroadcaster extends Broadcaster
     /**
      * Return the valid authentication response.
      *
-     * @param \Illuminate\Http\Request $request
-     * @param mixed $result
+     * @param  \Illuminate\Http\Request  $request
+     * @param  mixed  $result
      * @return mixed
      */
     public function validAuthenticationResponse($request, $result)
@@ -67,7 +67,7 @@ class AblyBroadcaster extends Broadcaster
                 $request->channel_name, $request->socket_id
             );
 
-            return ['auth' => $this->getPublicToken() . ':' . $signature];
+            return ['auth' => $this->getPublicToken().':'.$signature];
         }
 
         $channelName = $this->normalizeChannelName($request->channel_name);
@@ -79,13 +79,13 @@ class AblyBroadcaster extends Broadcaster
             $request->channel_name,
             $request->socket_id,
             $userData = array_filter([
-                'user_id' => (string)$broadcastIdentifier,
+                'user_id' => (string) $broadcastIdentifier,
                 'user_info' => $result,
             ])
         );
 
         return [
-            'auth' => $this->getPublicToken() . ':' . $signature,
+            'auth' => $this->getPublicToken().':'.$signature,
             'channel_data' => json_encode($userData),
         ];
     }
@@ -93,16 +93,16 @@ class AblyBroadcaster extends Broadcaster
     /**
      * Generate the signature needed for Ably authentication headers.
      *
-     * @param string $channelName
-     * @param string $socketId
-     * @param array|null $userData
+     * @param  string  $channelName
+     * @param  string  $socketId
+     * @param  array|null  $userData
      * @return string
      */
     public function generateAblySignature($channelName, $socketId, $userData = null)
     {
         return hash_hmac(
             'sha256',
-            sprintf('%s:%s%s', $socketId, $channelName, $userData ? ':' . json_encode($userData) : ''),
+            sprintf('%s:%s%s', $socketId, $channelName, $userData ? ':'.json_encode($userData) : ''),
             $this->getPrivateToken(),
         );
     }
@@ -110,9 +110,9 @@ class AblyBroadcaster extends Broadcaster
     /**
      * Broadcast the given event.
      *
-     * @param array $channels
-     * @param string $event
-     * @param array $payload
+     * @param  array  $channels
+     * @param  string  $event
+     * @param  array  $payload
      * @return void
      */
     public function broadcast(array $channels, $event, array $payload = [])
@@ -125,7 +125,7 @@ class AblyBroadcaster extends Broadcaster
     /**
      * Return true if the channel is protected by authentication.
      *
-     * @param string $channel
+     * @param  string  $channel
      * @return bool
      */
     public function isGuardedChannel($channel)
@@ -136,15 +136,15 @@ class AblyBroadcaster extends Broadcaster
     /**
      * Remove prefix from channel name.
      *
-     * @param string $channel
+     * @param  string  $channel
      * @return string
      */
     public function normalizeChannelName($channel)
     {
         if ($this->isGuardedChannel($channel)) {
             return Str::startsWith($channel, 'private-')
-                ? Str::replaceFirst('private-', '', $channel)
-                : Str::replaceFirst('presence-', '', $channel);
+                        ? Str::replaceFirst('private-', '', $channel)
+                        : Str::replaceFirst('presence-', '', $channel);
         }
 
         return $channel;
@@ -153,13 +153,13 @@ class AblyBroadcaster extends Broadcaster
     /**
      * Format the channel array into an array of strings.
      *
-     * @param array $channels
+     * @param  array  $channels
      * @return array
      */
     protected function formatChannels(array $channels)
     {
         return array_map(function ($channel) {
-            $channel = (string)$channel;
+            $channel = (string) $channel;
 
             if (Str::startsWith($channel, ['private-', 'presence-'])) {
                 return Str::startsWith($channel, 'private-')
@@ -167,7 +167,7 @@ class AblyBroadcaster extends Broadcaster
                     : Str::replaceFirst('presence-', 'presence:', $channel);
             }
 
-            return 'public:' . $channel;
+            return 'public:'.$channel;
         }, $channels);
     }
 

--- a/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
@@ -23,7 +23,7 @@ class PusherBroadcaster extends Broadcaster
     /**
      * Create a new broadcaster instance.
      *
-     * @param  \Pusher\Pusher  $pusher
+     * @param \Pusher\Pusher $pusher
      * @return void
      */
     public function __construct(Pusher $pusher)
@@ -34,7 +34,7 @@ class PusherBroadcaster extends Broadcaster
     /**
      * Authenticate the incoming request for a given channel.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param \Illuminate\Http\Request $request
      * @return mixed
      *
      * @throws \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
@@ -45,7 +45,7 @@ class PusherBroadcaster extends Broadcaster
 
         if (empty($request->channel_name) ||
             ($this->isGuardedChannel($request->channel_name) &&
-            ! $this->retrieveUser($request, $channelName))) {
+                !$this->retrieveUser($request, $channelName))) {
             throw new AccessDeniedHttpException;
         }
 
@@ -57,8 +57,8 @@ class PusherBroadcaster extends Broadcaster
     /**
      * Return the valid authentication response.
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  mixed  $result
+     * @param \Illuminate\Http\Request $request
+     * @param mixed $result
      * @return mixed
      */
     public function validAuthenticationResponse($request, $result)
@@ -71,11 +71,14 @@ class PusherBroadcaster extends Broadcaster
 
         $channelName = $this->normalizeChannelName($request->channel_name);
 
+        $user = $this->retrieveUser($request, $channelName);
+        $broadcastIdentifier = method_exists($user, 'getAuthIdentifierForBroadcasting') ? $user->getAuthIdentifierForBroadcasting() : $user->getAuthIdentifier();
+
         return $this->decodePusherResponse(
             $request,
             $this->pusher->presence_auth(
                 $request->channel_name, $request->socket_id,
-                $this->retrieveUser($request, $channelName)->getAuthIdentifierForBroadcasting(), $result
+                $broadcastIdentifier, $result
             )
         );
     }
@@ -83,26 +86,26 @@ class PusherBroadcaster extends Broadcaster
     /**
      * Decode the given Pusher response.
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  mixed  $response
+     * @param \Illuminate\Http\Request $request
+     * @param mixed $response
      * @return array
      */
     protected function decodePusherResponse($request, $response)
     {
-        if (! $request->input('callback', false)) {
+        if (!$request->input('callback', false)) {
             return json_decode($response, true);
         }
 
         return response()->json(json_decode($response, true))
-                    ->withCallback($request->callback);
+            ->withCallback($request->callback);
     }
 
     /**
      * Broadcast the given event.
      *
-     * @param  array  $channels
-     * @param  string  $event
-     * @param  array  $payload
+     * @param array $channels
+     * @param string $event
+     * @param array $payload
      * @return void
      *
      * @throws \Illuminate\Broadcasting\BroadcastException
@@ -134,7 +137,7 @@ class PusherBroadcaster extends Broadcaster
             }
 
             throw new BroadcastException(
-                ! empty($response['body'])
+                !empty($response['body'])
                     ? sprintf('Pusher error: %s.', $response['body'])
                     : 'Failed to connect to Pusher.'
             );
@@ -164,7 +167,7 @@ class PusherBroadcaster extends Broadcaster
     /**
      * Set the Pusher SDK instance.
      *
-     * @param  \Pusher\Pusher  $pusher
+     * @param \Pusher\Pusher $pusher
      * @return void
      */
     public function setPusher($pusher)

--- a/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
@@ -23,7 +23,7 @@ class PusherBroadcaster extends Broadcaster
     /**
      * Create a new broadcaster instance.
      *
-     * @param \Pusher\Pusher $pusher
+     * @param  \Pusher\Pusher  $pusher
      * @return void
      */
     public function __construct(Pusher $pusher)
@@ -34,7 +34,7 @@ class PusherBroadcaster extends Broadcaster
     /**
      * Authenticate the incoming request for a given channel.
      *
-     * @param \Illuminate\Http\Request $request
+     * @param  \Illuminate\Http\Request  $request
      * @return mixed
      *
      * @throws \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
@@ -45,7 +45,7 @@ class PusherBroadcaster extends Broadcaster
 
         if (empty($request->channel_name) ||
             ($this->isGuardedChannel($request->channel_name) &&
-                !$this->retrieveUser($request, $channelName))) {
+            ! $this->retrieveUser($request, $channelName))) {
             throw new AccessDeniedHttpException;
         }
 
@@ -57,8 +57,8 @@ class PusherBroadcaster extends Broadcaster
     /**
      * Return the valid authentication response.
      *
-     * @param \Illuminate\Http\Request $request
-     * @param mixed $result
+     * @param  \Illuminate\Http\Request  $request
+     * @param  mixed  $result
      * @return mixed
      */
     public function validAuthenticationResponse($request, $result)
@@ -86,26 +86,26 @@ class PusherBroadcaster extends Broadcaster
     /**
      * Decode the given Pusher response.
      *
-     * @param \Illuminate\Http\Request $request
-     * @param mixed $response
+     * @param  \Illuminate\Http\Request  $request
+     * @param  mixed  $response
      * @return array
      */
     protected function decodePusherResponse($request, $response)
     {
-        if (!$request->input('callback', false)) {
+        if (! $request->input('callback', false)) {
             return json_decode($response, true);
         }
 
         return response()->json(json_decode($response, true))
-            ->withCallback($request->callback);
+                    ->withCallback($request->callback);
     }
 
     /**
      * Broadcast the given event.
      *
-     * @param array $channels
-     * @param string $event
-     * @param array $payload
+     * @param  array  $channels
+     * @param  string  $event
+     * @param  array  $payload
      * @return void
      *
      * @throws \Illuminate\Broadcasting\BroadcastException
@@ -137,7 +137,7 @@ class PusherBroadcaster extends Broadcaster
             }
 
             throw new BroadcastException(
-                !empty($response['body'])
+                ! empty($response['body'])
                     ? sprintf('Pusher error: %s.', $response['body'])
                     : 'Failed to connect to Pusher.'
             );
@@ -167,7 +167,7 @@ class PusherBroadcaster extends Broadcaster
     /**
      * Set the Pusher SDK instance.
      *
-     * @param \Pusher\Pusher $pusher
+     * @param  \Pusher\Pusher  $pusher
      * @return void
      */
     public function setPusher($pusher)

--- a/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
@@ -75,7 +75,7 @@ class PusherBroadcaster extends Broadcaster
             $request,
             $this->pusher->presence_auth(
                 $request->channel_name, $request->socket_id,
-                $this->retrieveUser($request, $channelName)->getAuthIdentifier(), $result
+                $this->retrieveUser($request, $channelName)->getAuthIdentifierForBroadcasting(), $result
             )
         );
     }

--- a/src/Illuminate/Broadcasting/Broadcasters/RedisBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/RedisBroadcaster.php
@@ -34,9 +34,9 @@ class RedisBroadcaster extends Broadcaster
     /**
      * Create a new broadcaster instance.
      *
-     * @param  \Illuminate\Contracts\Redis\Factory  $redis
-     * @param  string|null  $connection
-     * @param  string  $prefix
+     * @param \Illuminate\Contracts\Redis\Factory $redis
+     * @param string|null $connection
+     * @param string $prefix
      * @return void
      */
     public function __construct(Redis $redis, $connection = null, $prefix = '')
@@ -49,7 +49,7 @@ class RedisBroadcaster extends Broadcaster
     /**
      * Authenticate the incoming request for a given channel.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param \Illuminate\Http\Request $request
      * @return mixed
      *
      * @throws \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
@@ -62,7 +62,7 @@ class RedisBroadcaster extends Broadcaster
 
         if (empty($request->channel_name) ||
             ($this->isGuardedChannel($request->channel_name) &&
-            ! $this->retrieveUser($request, $channelName))) {
+                !$this->retrieveUser($request, $channelName))) {
             throw new AccessDeniedHttpException;
         }
 
@@ -74,8 +74,8 @@ class RedisBroadcaster extends Broadcaster
     /**
      * Return the valid authentication response.
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  mixed  $result
+     * @param \Illuminate\Http\Request $request
+     * @param mixed $result
      * @return mixed
      */
     public function validAuthenticationResponse($request, $result)
@@ -86,8 +86,11 @@ class RedisBroadcaster extends Broadcaster
 
         $channelName = $this->normalizeChannelName($request->channel_name);
 
+        $user = $this->retrieveUser($request, $channelName);
+        $broadcastIdentifier = method_exists($user, 'getAuthIdentifierForBroadcasting') ? $user->getAuthIdentifierForBroadcasting() : $user->getAuthIdentifier();
+
         return json_encode(['channel_data' => [
-            'user_id' => $this->retrieveUser($request, $channelName)->getAuthIdentifierForBroadcasting(),
+            'user_id' => $broadcastIdentifier,
             'user_info' => $result,
         ]]);
     }
@@ -95,9 +98,9 @@ class RedisBroadcaster extends Broadcaster
     /**
      * Broadcast the given event.
      *
-     * @param  array  $channels
-     * @param  string  $event
-     * @param  array  $payload
+     * @param array $channels
+     * @param string $event
+     * @param array $payload
      * @return void
      */
     public function broadcast(array $channels, $event, array $payload = [])
@@ -140,13 +143,13 @@ LUA;
     /**
      * Format the channel array into an array of strings.
      *
-     * @param  array  $channels
+     * @param array $channels
      * @return array
      */
     protected function formatChannels(array $channels)
     {
         return array_map(function ($channel) {
-            return $this->prefix.$channel;
+            return $this->prefix . $channel;
         }, parent::formatChannels($channels));
     }
 }

--- a/src/Illuminate/Broadcasting/Broadcasters/RedisBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/RedisBroadcaster.php
@@ -87,7 +87,7 @@ class RedisBroadcaster extends Broadcaster
         $channelName = $this->normalizeChannelName($request->channel_name);
 
         return json_encode(['channel_data' => [
-            'user_id' => $this->retrieveUser($request, $channelName)->getAuthIdentifier(),
+            'user_id' => $this->retrieveUser($request, $channelName)->getAuthIdentifierForBroadcasting(),
             'user_info' => $result,
         ]]);
     }

--- a/src/Illuminate/Broadcasting/Broadcasters/RedisBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/RedisBroadcaster.php
@@ -34,9 +34,9 @@ class RedisBroadcaster extends Broadcaster
     /**
      * Create a new broadcaster instance.
      *
-     * @param \Illuminate\Contracts\Redis\Factory $redis
-     * @param string|null $connection
-     * @param string $prefix
+     * @param  \Illuminate\Contracts\Redis\Factory  $redis
+     * @param  string|null  $connection
+     * @param  string  $prefix
      * @return void
      */
     public function __construct(Redis $redis, $connection = null, $prefix = '')
@@ -49,7 +49,7 @@ class RedisBroadcaster extends Broadcaster
     /**
      * Authenticate the incoming request for a given channel.
      *
-     * @param \Illuminate\Http\Request $request
+     * @param  \Illuminate\Http\Request  $request
      * @return mixed
      *
      * @throws \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
@@ -62,7 +62,7 @@ class RedisBroadcaster extends Broadcaster
 
         if (empty($request->channel_name) ||
             ($this->isGuardedChannel($request->channel_name) &&
-                !$this->retrieveUser($request, $channelName))) {
+            ! $this->retrieveUser($request, $channelName))) {
             throw new AccessDeniedHttpException;
         }
 
@@ -74,8 +74,8 @@ class RedisBroadcaster extends Broadcaster
     /**
      * Return the valid authentication response.
      *
-     * @param \Illuminate\Http\Request $request
-     * @param mixed $result
+     * @param  \Illuminate\Http\Request  $request
+     * @param  mixed  $result
      * @return mixed
      */
     public function validAuthenticationResponse($request, $result)
@@ -98,9 +98,9 @@ class RedisBroadcaster extends Broadcaster
     /**
      * Broadcast the given event.
      *
-     * @param array $channels
-     * @param string $event
-     * @param array $payload
+     * @param  array  $channels
+     * @param  string  $event
+     * @param  array  $payload
      * @return void
      */
     public function broadcast(array $channels, $event, array $payload = [])
@@ -143,13 +143,13 @@ LUA;
     /**
      * Format the channel array into an array of strings.
      *
-     * @param array $channels
+     * @param  array  $channels
      * @return array
      */
     protected function formatChannels(array $channels)
     {
         return array_map(function ($channel) {
-            return $this->prefix . $channel;
+            return $this->prefix.$channel;
         }, parent::formatChannels($channels));
     }
 }

--- a/tests/Broadcasting/AblyBroadcasterTest.php
+++ b/tests/Broadcasting/AblyBroadcasterTest.php
@@ -125,6 +125,8 @@ class AblyBroadcasterTest extends TestCase
         $user = m::mock('User');
         $user->shouldReceive('getAuthIdentifierForBroadcasting')
              ->andReturn(42);
+        $user->shouldReceive('getAuthIdentifier')
+             ->andReturn(42);
 
         $request->shouldReceive('user')
                 ->andReturn($user);

--- a/tests/Broadcasting/AblyBroadcasterTest.php
+++ b/tests/Broadcasting/AblyBroadcasterTest.php
@@ -123,7 +123,7 @@ class AblyBroadcasterTest extends TestCase
                 ->andReturn(false);
 
         $user = m::mock('User');
-        $user->shouldReceive('getAuthIdentifier')
+        $user->shouldReceive('getAuthIdentifierForBroadcasting')
              ->andReturn(42);
 
         $request->shouldReceive('user')

--- a/tests/Broadcasting/PusherBroadcasterTest.php
+++ b/tests/Broadcasting/PusherBroadcasterTest.php
@@ -164,7 +164,7 @@ class PusherBroadcasterTest extends TestCase
         $user->shouldReceive('getAuthIdentifierForBroadcasting')
              ->andReturn(42);
         $user->shouldReceive('getAuthIdentifier')
-            ->andReturn(42);
+             ->andReturn(42);
 
         $request->shouldReceive('user')
                 ->andReturn($user);

--- a/tests/Broadcasting/PusherBroadcasterTest.php
+++ b/tests/Broadcasting/PusherBroadcasterTest.php
@@ -161,7 +161,7 @@ class PusherBroadcasterTest extends TestCase
                 ->andReturn(false);
 
         $user = m::mock('User');
-        $user->shouldReceive('getAuthIdentifier')
+        $user->shouldReceive('getAuthIdentifierForBroadcasting')
              ->andReturn(42);
 
         $request->shouldReceive('user')

--- a/tests/Broadcasting/PusherBroadcasterTest.php
+++ b/tests/Broadcasting/PusherBroadcasterTest.php
@@ -163,6 +163,8 @@ class PusherBroadcasterTest extends TestCase
         $user = m::mock('User');
         $user->shouldReceive('getAuthIdentifierForBroadcasting')
              ->andReturn(42);
+        $user->shouldReceive('getAuthIdentifier')
+            ->andReturn(42);
 
         $request->shouldReceive('user')
                 ->andReturn($user);

--- a/tests/Broadcasting/RedisBroadcasterTest.php
+++ b/tests/Broadcasting/RedisBroadcasterTest.php
@@ -173,7 +173,7 @@ class RedisBroadcasterTest extends TestCase
         $user->shouldReceive('getAuthIdentifierForBroadcasting')
              ->andReturn(42);
         $user->shouldReceive('getAuthIdentifier')
-            ->andReturn(42);
+             ->andReturn(42);
 
         $request->shouldReceive('user')
                 ->andReturn($user);

--- a/tests/Broadcasting/RedisBroadcasterTest.php
+++ b/tests/Broadcasting/RedisBroadcasterTest.php
@@ -172,6 +172,8 @@ class RedisBroadcasterTest extends TestCase
         $user = m::mock('User');
         $user->shouldReceive('getAuthIdentifierForBroadcasting')
              ->andReturn(42);
+        $user->shouldReceive('getAuthIdentifier')
+            ->andReturn(42);
 
         $request->shouldReceive('user')
                 ->andReturn($user);

--- a/tests/Broadcasting/RedisBroadcasterTest.php
+++ b/tests/Broadcasting/RedisBroadcasterTest.php
@@ -170,7 +170,7 @@ class RedisBroadcasterTest extends TestCase
         $request->channel_name = $channel;
 
         $user = m::mock('User');
-        $user->shouldReceive('getAuthIdentifier')
+        $user->shouldReceive('getAuthIdentifierForBroadcasting')
              ->andReturn(42);
 
         $request->shouldReceive('user')


### PR DESCRIPTION
I am working on a project where doctor can chat with patients. Doctor and Patient are two different auth guard and different model also. I am using pusher and Laravel echo for real-time chat.

Everything is fine when doctor and patient id is different. But facing issue when doctor and patient id is same. But, doctor and patient id can be same because of they are from different model and different database table.

Currently Laravel is sending **getAuthIdentifier** method value to broadcaster (pusher, redis) and those broadcaster is identifying users by this value. It can be resolved by modifying **getAuthIdentifier** method into relevant authenticatable model. But, **getAuthIdentifier** method is a common used method by various packages and libraries. They expect id from using it. So, it is risky to modify it.

I have added a new method named **getAuthIdentifierForBroadcasting** to resolve it.

Thanks in advance 