### PR TITLE
[8.x] Added withSum by default to Eloquent Model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1248,9 +1248,16 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
      */
     public function newQueryWithoutScopes()
     {
-        return $this->newModelQuery()
+        $query = $this->newModelQuery()
                     ->with($this->with)
                     ->withCount($this->withCount);
+
+        foreach (($this->withSum ?: []) as $x) {
+            list($relation, $column) = explode('.', $x);
+            $query->withSum($relation, $column);
+        }
+
+        return $query;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1253,7 +1253,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
                     ->withCount($this->withCount);
 
         foreach (($this->withSum ?: []) as $x) {
-            list($relation, $column) = explode('.', $x);
+            [$relation, $column] = explode('.', $x);
             $query->withSum($relation, $column);
         }
 


### PR DESCRIPTION
I came in the need to eager lod a `withSum` but found that Eloquent Model eager load only `withCount`.

Now is possible to eager load an array of `sum` aggregates declaring a property as follow:

```php
class MyModel extends Model
{
    protected $withSum = [
        'relation_a.column',
        'relation_b.column',
    ];
}
```

I used short ternay operator to check property existence instead coalesce operator to keep compatibility with older PHP versions.