### PR TITLE
[8.x] Add default "_of_many" to join alias when relation name is table name

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/CanBeOneOfMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/CanBeOneOfMany.php
@@ -113,7 +113,7 @@ trait CanBeOneOfMany
     }
 
     /**
-     * Get default alias for one of many inner join clause.
+     * Get the default alias for one of many inner join clause.
      *
      * @param  string  $relation
      * @return string

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/CanBeOneOfMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/CanBeOneOfMany.php
@@ -64,7 +64,9 @@ trait CanBeOneOfMany
     {
         $this->isOneOfMany = true;
 
-        $this->relationName = $relation ?: $this->guessRelationship();
+        $this->relationName = $relation ?: $this->getDefaultOneOfManyJoinAlias(
+            $this->guessRelationship()
+        );
 
         $keyName = $this->query->getModel()->getKeyName();
 
@@ -108,6 +110,19 @@ trait CanBeOneOfMany
         }
 
         return $this;
+    }
+
+    /**
+     * Get default alias for one of many inner join clause.
+     *
+     * @param  string  $relation
+     * @return string
+     */
+    protected function getDefaultOneOfManyJoinAlias($relation)
+    {
+        return $relation == $this->query->getModel()->getTable()
+            ? $relation.'_of_many'
+            : $relation;
     }
 
     /**

--- a/tests/Database/DatabaseEloquentHasOneOfManyTest.php
+++ b/tests/Database/DatabaseEloquentHasOneOfManyTest.php
@@ -70,15 +70,32 @@ class DatabaseEloquentHasOneOfManyTest extends TestCase
 
     public function testItGuessesRelationName()
     {
-        $user = HasOneOfManyTestUser::create();
+        $user = HasOneOfManyTestUser::make();
         $this->assertSame('latest_login', $user->latest_login()->getRelationName());
     }
 
-    // public function testRelationNameCanBeSet()
-    // {
-    //     $user = HasOneOfManyTestUser::create();
-    //     $this->assertSame('foo', $user->latest_login_with_other_name()->getRelationName());
-    // }
+    public function testItGuessesRelationNameAndAddsOfManyWhenTableNameIsRelationName()
+    {
+        $model = HasOneOfManyTestModel::make();
+        $this->assertSame('logins_of_many', $model->logins()->getRelationName());
+    }
+
+    public function testRelationNameCanBeSet()
+    {
+        $user = HasOneOfManyTestUser::create();
+
+        // Using "ofMany"
+        $relation = $user->latest_login()->ofMany('id', 'max', 'foo');
+        $this->assertSame('foo', $relation->getRelationName());
+
+        // Using "latestOfMAny"
+        $relation = $user->latest_login()->latestOfMAny('id', 'bar');
+        $this->assertSame('bar', $relation->getRelationName());
+
+        // Using "oldestOfMAny"
+        $relation = $user->latest_login()->oldestOfMAny('id', 'baz');
+        $this->assertSame('baz', $relation->getRelationName());
+    }
 
     public function testQualifyingSubSelectColumn()
     {
@@ -225,9 +242,6 @@ class DatabaseEloquentHasOneOfManyTest extends TestCase
         $this->assertFalse($user->latest_login()->isNot($login2));
     }
 
-    /**
-     * @group fail
-     */
     public function testGet()
     {
         $user = HasOneOfManyTestUser::create();
@@ -389,6 +403,14 @@ class HasOneOfManyTestUser extends Eloquent
     public function price_with_shortcut()
     {
         return $this->hasOne(HasOneOfManyTestPrice::class, 'user_id')->latestOfMany(['published_at', 'id']);
+    }
+}
+
+class HasOneOfManyTestModel extends Eloquent
+{
+    public function logins()
+    {
+        return $this->hasOne(HasOneOfManyTestLogin::class)->ofMany();
     }
 }
 


### PR DESCRIPTION
This pr appends "_of_many" to the one of many join alias when the relation name is the same as the table name. 

This should prevent people from running into this: https://github.com/laravel/framework/issues/37402

(Also added some tests regarding the one of many alias)

closes https://github.com/laravel/framework/issues/37402
ping https://github.com/laravel/framework/pull/37362
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
