### PR TITLE
[8.x] Generalized stub path resolution

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -4,6 +4,7 @@ namespace Illuminate\Console;
 
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
+use ReflectionClass;
 use Symfony\Component\Console\Input\InputArgument;
 
 abstract class GeneratorCommand extends Command
@@ -117,6 +118,22 @@ abstract class GeneratorCommand extends Command
      * @return string
      */
     abstract protected function getStub();
+
+    /**
+     * Resolve the fully-qualified path to the stub.
+     *
+     * @param  string  $stub
+     * @return string
+     */
+    protected function resolveStubPath($stub)
+    {
+        $reflection = new ReflectionClass(get_class($this));
+        $directory = dirname($reflection->getFileName());
+
+        return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
+            ? $customPath
+            : $directory.$stub;
+    }
 
     /**
      * Execute the console command.

--- a/src/Illuminate/Foundation/Console/CastMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/CastMakeCommand.php
@@ -38,19 +38,6 @@ class CastMakeCommand extends GeneratorCommand
     }
 
     /**
-     * Resolve the fully-qualified path to the stub.
-     *
-     * @param  string  $stub
-     * @return string
-     */
-    protected function resolveStubPath($stub)
-    {
-        return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
-            ? $customPath
-            : __DIR__.$stub;
-    }
-
-    /**
      * Get the default namespace for the class.
      *
      * @param  string  $rootNamespace

--- a/src/Illuminate/Foundation/Console/ChannelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ChannelMakeCommand.php
@@ -49,7 +49,7 @@ class ChannelMakeCommand extends GeneratorCommand
      */
     protected function getStub()
     {
-        return __DIR__.'/stubs/channel.stub';
+        return $this->resolveStubPath('/stubs/channel.stub');
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
@@ -121,7 +121,7 @@ class ComponentMakeCommand extends GeneratorCommand
      */
     protected function getStub()
     {
-        return __DIR__.'/stubs/view-component.stub';
+        return $this->resolveStubPath('/stubs/view-component.stub');
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/ConsoleMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ConsoleMakeCommand.php
@@ -50,11 +50,7 @@ class ConsoleMakeCommand extends GeneratorCommand
      */
     protected function getStub()
     {
-        $relativePath = '/stubs/console.stub';
-
-        return file_exists($customPath = $this->laravel->basePath(trim($relativePath, '/')))
-            ? $customPath
-            : __DIR__.$relativePath;
+        return $this->resolveStubPath('/stubs/console.stub');
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/EventMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/EventMakeCommand.php
@@ -46,7 +46,7 @@ class EventMakeCommand extends GeneratorCommand
      */
     protected function getStub()
     {
-        return __DIR__.'/stubs/event.stub';
+        return $this->resolveStubPath('/stubs/event.stub');
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/ExceptionMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ExceptionMakeCommand.php
@@ -37,13 +37,13 @@ class ExceptionMakeCommand extends GeneratorCommand
     {
         if ($this->option('render')) {
             return $this->option('report')
-                ? __DIR__.'/stubs/exception-render-report.stub'
-                : __DIR__.'/stubs/exception-render.stub';
+                ? $this->resolveStubPath('/stubs/exception-render-report.stub')
+                : $this->resolveStubPath('/stubs/exception-render.stub');
         }
 
         return $this->option('report')
-            ? __DIR__.'/stubs/exception-report.stub'
-            : __DIR__.'/stubs/exception.stub';
+            ? $this->resolveStubPath('/stubs/exception-report.stub')
+            : $this->resolveStubPath('/stubs/exception.stub');
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/JobMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/JobMakeCommand.php
@@ -36,21 +36,8 @@ class JobMakeCommand extends GeneratorCommand
     protected function getStub()
     {
         return $this->option('sync')
-                        ? $this->resolveStubPath('/stubs/job.stub')
-                        : $this->resolveStubPath('/stubs/job.queued.stub');
-    }
-
-    /**
-     * Resolve the fully-qualified path to the stub.
-     *
-     * @param  string  $stub
-     * @return string
-     */
-    protected function resolveStubPath($stub)
-    {
-        return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
-                        ? $customPath
-                        : __DIR__.$stub;
+            ? $this->resolveStubPath('/stubs/job.stub')
+            : $this->resolveStubPath('/stubs/job.queued.stub');
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
@@ -65,13 +65,13 @@ class ListenerMakeCommand extends GeneratorCommand
     {
         if ($this->option('queued')) {
             return $this->option('event')
-                        ? __DIR__.'/stubs/listener-queued.stub'
-                        : __DIR__.'/stubs/listener-queued-duck.stub';
+                ? $this->resolveStubPath('/stubs/listener-queued.stub')
+                : $this->resolveStubPath('/stubs/listener-queued-duck.stub');
         }
 
         return $this->option('event')
-                    ? __DIR__.'/stubs/listener.stub'
-                    : __DIR__.'/stubs/listener-duck.stub';
+            ? $this->resolveStubPath('/stubs/listener.stub')
+            : $this->resolveStubPath('/stubs/listener-duck.stub');
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/MailMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/MailMakeCommand.php
@@ -87,8 +87,8 @@ class MailMakeCommand extends GeneratorCommand
     protected function getStub()
     {
         return $this->option('markdown')
-                        ? __DIR__.'/stubs/markdown-mail.stub'
-                        : __DIR__.'/stubs/mail.stub';
+            ? $this->resolveStubPath('/stubs/markdown-mail.stub')
+            : $this->resolveStubPath('/stubs/mail.stub');
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -139,21 +139,8 @@ class ModelMakeCommand extends GeneratorCommand
     protected function getStub()
     {
         return $this->option('pivot')
-                    ? $this->resolveStubPath('/stubs/model.pivot.stub')
-                    : $this->resolveStubPath('/stubs/model.stub');
-    }
-
-    /**
-     * Resolve the fully-qualified path to the stub.
-     *
-     * @param  string  $stub
-     * @return string
-     */
-    protected function resolveStubPath($stub)
-    {
-        return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
-                        ? $customPath
-                        : __DIR__.$stub;
+            ? $this->resolveStubPath('/stubs/model.pivot.stub')
+            : $this->resolveStubPath('/stubs/model.stub');
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/NotificationMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/NotificationMakeCommand.php
@@ -87,8 +87,8 @@ class NotificationMakeCommand extends GeneratorCommand
     protected function getStub()
     {
         return $this->option('markdown')
-                        ? __DIR__.'/stubs/markdown-notification.stub'
-                        : __DIR__.'/stubs/notification.stub';
+                        ? $this->resolveStubPath('/stubs/markdown-notification.stub')
+                        : $this->resolveStubPath('/stubs/notification.stub');
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/ObserverMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ObserverMakeCommand.php
@@ -102,19 +102,6 @@ class ObserverMakeCommand extends GeneratorCommand
     }
 
     /**
-     * Resolve the fully-qualified path to the stub.
-     *
-     * @param  string  $stub
-     * @return string
-     */
-    protected function resolveStubPath($stub)
-    {
-        return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
-            ? $customPath
-            : __DIR__.$stub;
-    }
-
-    /**
      * Get the default namespace for the class.
      *
      * @param  string  $rootNamespace

--- a/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
@@ -151,21 +151,8 @@ class PolicyMakeCommand extends GeneratorCommand
     protected function getStub()
     {
         return $this->option('model')
-                    ? $this->resolveStubPath('/stubs/policy.stub')
-                    : $this->resolveStubPath('/stubs/policy.plain.stub');
-    }
-
-    /**
-     * Resolve the fully-qualified path to the stub.
-     *
-     * @param  string  $stub
-     * @return string
-     */
-    protected function resolveStubPath($stub)
-    {
-        return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
-                        ? $customPath
-                        : __DIR__.$stub;
+            ? $this->resolveStubPath('/stubs/policy.stub')
+            : $this->resolveStubPath('/stubs/policy.plain.stub');
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/ProviderMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ProviderMakeCommand.php
@@ -34,7 +34,7 @@ class ProviderMakeCommand extends GeneratorCommand
      */
     protected function getStub()
     {
-        return __DIR__.'/stubs/provider.stub';
+        return $this->resolveStubPath('/stubs/provider.stub');
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/RequestMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/RequestMakeCommand.php
@@ -38,19 +38,6 @@ class RequestMakeCommand extends GeneratorCommand
     }
 
     /**
-     * Resolve the fully-qualified path to the stub.
-     *
-     * @param  string  $stub
-     * @return string
-     */
-    protected function resolveStubPath($stub)
-    {
-        return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
-                        ? $customPath
-                        : __DIR__.$stub;
-    }
-
-    /**
      * Get the default namespace for the class.
      *
      * @param  string  $rootNamespace

--- a/src/Illuminate/Foundation/Console/ResourceMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ResourceMakeCommand.php
@@ -51,8 +51,8 @@ class ResourceMakeCommand extends GeneratorCommand
     protected function getStub()
     {
         return $this->collection()
-                    ? $this->resolveStubPath('/stubs/resource-collection.stub')
-                    : $this->resolveStubPath('/stubs/resource.stub');
+            ? $this->resolveStubPath('/stubs/resource-collection.stub')
+            : $this->resolveStubPath('/stubs/resource.stub');
     }
 
     /**
@@ -64,19 +64,6 @@ class ResourceMakeCommand extends GeneratorCommand
     {
         return $this->option('collection') ||
                Str::endsWith($this->argument('name'), 'Collection');
-    }
-
-    /**
-     * Resolve the fully-qualified path to the stub.
-     *
-     * @param  string  $stub
-     * @return string
-     */
-    protected function resolveStubPath($stub)
-    {
-        return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
-                        ? $customPath
-                        : __DIR__.$stub;
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/RuleMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/RuleMakeCommand.php
@@ -32,13 +32,9 @@ class RuleMakeCommand extends GeneratorCommand
      *
      * @return string
      */
-    protected function getStub()
+    public function getStub()
     {
-        $relativePath = '/stubs/rule.stub';
-
-        return file_exists($customPath = $this->laravel->basePath(trim($relativePath, '/')))
-            ? $customPath
-            : __DIR__.$relativePath;
+        return $this->resolveStubPath('/stubs/rule.stub');
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/TestMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/TestMakeCommand.php
@@ -37,21 +37,8 @@ class TestMakeCommand extends GeneratorCommand
     protected function getStub()
     {
         return $this->option('unit')
-                    ? $this->resolveStubPath('/stubs/test.unit.stub')
-                    : $this->resolveStubPath('/stubs/test.stub');
-    }
-
-    /**
-     * Resolve the fully-qualified path to the stub.
-     *
-     * @param  string  $stub
-     * @return string
-     */
-    protected function resolveStubPath($stub)
-    {
-        return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
-                        ? $customPath
-                        : __DIR__.$stub;
+            ? $this->resolveStubPath('/stubs/test.unit.stub')
+            : $this->resolveStubPath('/stubs/test.stub');
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This PR solves the issue described in #37389: Several `make:` commands do not use custom stubs in a project but are hard-wired to their default stub files instead.  
While creating the PR, I discovered several different ways to resolve the stub path in the existing code, which have all been reduced to a single protected method in the `GeneratorCommand`, leading to a net negative of lines and simplified code. This new `resolveStubPath` helper uses a reflection class to locate the directory of the current class, which I deemed acceptable for a command intended to be used during development. This makes it possible to let all generator commands (even third-party ones) use the same, uniform way to locate stubs, while preserving backwards-compatibility.

Please note that this PR does _not_ change which stubs are published and which aren't, as I think that's out of scope and not my decision to make. It merely gives users the option to override any stubs to fit their own requirements, if that is necessary.

While there are no tests for generator commands as far as I could see, I did run the test suite without issues and monkey-patched the changes in a standard Laravel project to verify path resolution is working as intended.