### PR TITLE
[8.x] Fixed aggregates (e.g.: withExists) for one of many relationships

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/CanBeOneOfMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/CanBeOneOfMany.php
@@ -184,6 +184,19 @@ trait CanBeOneOfMany
     }
 
     /**
+     * Merge relation ship query joins to the given query builder.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $builder
+     * @return void
+     */
+    protected function mergeJoinsTo(Builder $query)
+    {
+        $query->getQuery()->joins = $this->query->getQuery()->joins;
+
+        $query->addBinding($this->query->getBindings(), 'join');
+    }
+
+    /**
      * Get the qualified column name for the one-of-many relationship using the subselect join query's alias.
      *
      * @param  string  $column

--- a/src/Illuminate/Database/Eloquent/Relations/HasOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOne.php
@@ -70,15 +70,11 @@ class HasOne extends HasOneOrMany implements SupportsPartialRelations
      */
     public function getRelationExistenceQuery(Builder $query, Builder $parentQuery, $columns = ['*'])
     {
-        if (! $this->isOneOfMany()) {
-            return parent::getRelationExistenceQuery($query, $parentQuery, $columns);
+        if($this->isOneOfMany()) {
+            $this->mergeJoinsTo($query);
         }
-
-        $query->getQuery()->joins = $this->query->getQuery()->joins;
-
-        return $query->select($columns)->whereColumn(
-            $this->getQualifiedParentKeyName(), '=', $this->getExistenceCompareKey()
-        );
+        
+        return parent::getRelationExistenceQuery($query, $parentQuery, $columns);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/HasOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOne.php
@@ -70,10 +70,10 @@ class HasOne extends HasOneOrMany implements SupportsPartialRelations
      */
     public function getRelationExistenceQuery(Builder $query, Builder $parentQuery, $columns = ['*'])
     {
-        if($this->isOneOfMany()) {
+        if ($this->isOneOfMany()) {
             $this->mergeJoinsTo($query);
         }
-        
+
         return parent::getRelationExistenceQuery($query, $parentQuery, $columns);
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOne.php
@@ -68,7 +68,7 @@ class MorphOne extends MorphOneOrMany implements SupportsPartialRelations
      */
     public function getRelationExistenceQuery(Builder $query, Builder $parentQuery, $columns = ['*'])
     {
-        if($this->isOneOfMany()) {
+        if ($this->isOneOfMany()) {
             $this->mergeJoinsTo($query);
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOne.php
@@ -68,7 +68,9 @@ class MorphOne extends MorphOneOrMany implements SupportsPartialRelations
      */
     public function getRelationExistenceQuery(Builder $query, Builder $parentQuery, $columns = ['*'])
     {
-        $query->getQuery()->joins = $this->query->getQuery()->joins;
+        if($this->isOneOfMany()) {
+            $this->mergeJoinsTo($query);
+        }
 
         return parent::getRelationExistenceQuery($query, $parentQuery, $columns);
     }

--- a/tests/Database/DatabaseEloquentHasOneOfManyTest.php
+++ b/tests/Database/DatabaseEloquentHasOneOfManyTest.php
@@ -66,6 +66,8 @@ class DatabaseEloquentHasOneOfManyTest extends TestCase
     {
         $this->schema()->drop('users');
         $this->schema()->drop('logins');
+        $this->schema()->drop('states');
+        $this->schema()->drop('prices');
     }
 
     public function testItGuessesRelationName()
@@ -294,6 +296,34 @@ class DatabaseEloquentHasOneOfManyTest extends TestCase
 
         $user = HasOneOfManyTestUser::first();
         $this->assertSame($price->id, $user->price->id);
+    }
+
+    public function testWithExists()
+    {
+        $user = HasOneOfManyTestUser::create();
+
+        $user = HasOneOfManyTestUser::withExists('latest_login')->first();
+        $this->assertFalse($user->latest_login_exists);
+
+        $user->logins()->create();
+        $user = HasOneOfManyTestUser::withExists('latest_login')->first();
+        $this->assertTrue($user->latest_login_exists);
+    }
+
+    public function testWithExistsWithConstraintsInJoinSubSelect()
+    {
+        $user = HasOneOfManyTestUser::create();
+
+        $user = HasOneOfManyTestUser::withExists('foo_state')->first();
+
+        $this->assertFalse($user->foo_state_exists);
+
+        $user->states()->create([
+            'type'  => 'foo',
+            'state' => 'bar',
+        ]);
+        $user = HasOneOfManyTestUser::withExists('foo_state')->first();
+        $this->assertTrue($user->foo_state_exists);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentMorphOneOfManyTest.php
+++ b/tests/Database/DatabaseEloquentMorphOneOfManyTest.php
@@ -133,7 +133,7 @@ class DatabaseEloquentMorphOneOfManyTest extends TestCase
 
         $product->states()->create([
             'state' => 'draft',
-            'type' => 'foo'
+            'type' => 'foo',
         ]);
         $product = MorphOneOfManyTestProduct::withExists('current_foo_state')->first();
         $this->assertTrue($product->current_foo_state_exists);
@@ -183,7 +183,7 @@ class MorphOneOfManyTestProduct extends Eloquent
     {
         return $this->morphOne(MorphOneOfManyTestState::class, 'stateful')->ofMany(
             ['id' => 'max'],
-            function($q) {
+            function ($q) {
                 $q->where('type', 'foo');
             }
         );


### PR DESCRIPTION
This pr fixes aggregates like `withExists` when used for one of many relationships (https://github.com/laravel/framework/pull/37362).

The problem was that the join clause was passed to the existence query, but not the bindings.

The joins are now added included bindings in the following method:
https://github.com/laravel/framework/blob/3baf47598da6cfdefda6625c713e79f0ff2c29a5/src/Illuminate/Database/Eloquent/Relations/Concerns/CanBeOneOfMany.php#L192-L197

Used here in HasOne:

https://github.com/laravel/framework/blob/3baf47598da6cfdefda6625c713e79f0ff2c29a5/src/Illuminate/Database/Eloquent/Relations/HasOne.php#L71-L78

And MorphOne:

https://github.com/laravel/framework/blob/3baf47598da6cfdefda6625c713e79f0ff2c29a5/src/Illuminate/Database/Eloquent/Relations/MorphOne.php#L69-L76
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
