### PR TITLE
[8.x] Allow dabase password to be null

### DIFF
--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -125,7 +125,7 @@ class MySqlSchemaState extends SchemaState
             'LARAVEL_LOAD_HOST' => is_array($config['host']) ? $config['host'][0] : $config['host'],
             'LARAVEL_LOAD_PORT' => $config['port'] ?? '',
             'LARAVEL_LOAD_USER' => $config['username'],
-            'LARAVEL_LOAD_PASSWORD' => $config['password'],
+            'LARAVEL_LOAD_PASSWORD' => $config['password'] ?? '',
             'LARAVEL_LOAD_DATABASE' => $config['database'],
         ];
     }


### PR DESCRIPTION
The current implementation demands the password to be a string, not null. However a password is not required when working on local environments or when using socks. For that reason the password in the schema importing and exporting tooling should also allow for nullable database passwords.