### PR TITLE
[8.x] Bugfix passing errorlevel when command is run in background

### DIFF
--- a/src/Illuminate/Console/Scheduling/CommandBuilder.php
+++ b/src/Illuminate/Console/Scheduling/CommandBuilder.php
@@ -52,7 +52,7 @@ class CommandBuilder
         $finished = Application::formatCommandString('schedule:finish').' "'.$event->mutexName().'"';
 
         if (windows_os()) {
-            return 'start /b cmd /c "('.$event->command.' & '.$finished.' "%errorlevel%")'.$redirect.$output.' 2>&1"';
+            return 'start /b cmd /c "('.$event->command.' && '.$finished.' "0" || '.$finished.' "1")'.$redirect.$output.' 2>&1"';
         }
 
         return $this->ensureCorrectUser($event,

--- a/tests/Console/Scheduling/EventTest.php
+++ b/tests/Console/Scheduling/EventTest.php
@@ -61,7 +61,7 @@ class EventTest extends TestCase
 
         $scheduleId = '"framework'.DIRECTORY_SEPARATOR.'schedule-eeb46c93d45e928d62aaf684d727e213b7094822"';
 
-        $this->assertSame('start /b cmd /c "(php -i & "'.PHP_BINARY.'" artisan schedule:finish '.$scheduleId.' "%errorlevel%") > "NUL" 2>&1"', $event->buildCommand());
+        $this->assertSame('start /b cmd /c "(php -i && "'.PHP_BINARY.'" artisan schedule:finish '.$scheduleId.' "0" || "'.PHP_BINARY.'" artisan schedule:finish '.$scheduleId.' "1") > "NUL" 2>&1"', $event->buildCommand());
     }
 
     public function testBuildCommandSendOutputTo()


### PR DESCRIPTION
On windows machines, when console commands are run in background, using
`$schedule->command('inspire')->runInBackground()`
an `errorlevel` variable is supposed to be passed to the schedule:finish command, enabling the after hooks for success/failure

However, default behaviour in the cmd.exe shell is that variables are read and expanded line-by-line. 
As the background commands are started in a fresh cmd.exe instance, and contain a single-line command, the errorlevel variable is not set to the exit code of the command, and will always be the default 0. 

This prevents using the onFailure... methods on the scheduled command as it will always take the succesful route.

in a fresh terminal:
`cmd /c exit 2 & echo "errorlevel=%errorlevel%"`
will display "errorlevel=0"

while executing this line twice in a terminal:
`cmd /c exit 2 & echo "errorlevel=%errorlevel%"`
`cmd /c exit 4 & echo "errorlevel=%errorlevel%"`
will display
"errorlevel=0"
"errorlevel=2" --> at this time the errorlevel set in the first line is used. 

This behaviour can be changed by enabling delayed expansion (https://ss64.com/nt/delayedexpansion.html), however setting this with SETLOCAL would also require a newline itself.

So probably the best thing to do is using the `command1 && command2 || command3` syntax (https://ss64.com/nt/syntax-redirection.html), in which case command 2 (finishing succesful with errorlevel 0) is only executed when command1 is succesfuly run, otherwise command 3 (finishing with errorlevel 1) is executed. 
Note that command3 will also be executed when command 2 may fail.
