### PR TITLE
Update egulias/email-validator to V3.1.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "ext-openssl": "*",
         "doctrine/inflector": "^1.4|^2.0",
         "dragonmantank/cron-expression": "^3.0.2",
-        "egulias/email-validator": "^2.1.10",
+        "egulias/email-validator": "^3.1.1",
         "league/commonmark": "^1.3",
         "league/flysystem": "^1.1",
         "monolog/monolog": "^2.0",

--- a/src/Illuminate/Validation/composer.json
+++ b/src/Illuminate/Validation/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "^7.3|^8.0",
         "ext-json": "*",
-        "egulias/email-validator": "^2.1.10",
+        "egulias/email-validator": "^3.1.1",
         "illuminate/collections": "^8.0",
         "illuminate/container": "^8.0",
         "illuminate/contracts": "^8.0",


### PR DESCRIPTION
Update egulias/email-validator 2.1.25 -> 3.1.1
swiftmailer/swiftmailer is ready for version 3.

Breacking changes see https://github.com/egulias/EmailValidator/releases/tag/3.0.0