### PR TITLE
[8.x] Add beforeQuery to base query builder

### DIFF
--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2567,26 +2567,26 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testPreserveAddsClosureToArray()
     {
         $builder = $this->getBuilder();
-        $builder->preserve(function () {
+        $builder->beforeQuery(function () {
         });
-        $this->assertCount(1, $builder->preserved);
-        $this->assertInstanceOf(Closure::class, $builder->preserved[0]);
+        $this->assertCount(1, $builder->beforeQueryCallbacks);
+        $this->assertInstanceOf(Closure::class, $builder->beforeQueryCallbacks[0]);
     }
 
     public function testApplyPreserveCleansArray()
     {
         $builder = $this->getBuilder();
-        $builder->preserve(function () {
+        $builder->beforeQuery(function () {
         });
-        $this->assertCount(1, $builder->preserved);
-        $builder->applyPreserved();
-        $this->assertCount(0, $builder->preserved);
+        $this->assertCount(1, $builder->beforeQueryCallbacks);
+        $builder->applyBeforeQueryCallbacks();
+        $this->assertCount(0, $builder->beforeQueryCallbacks);
     }
 
     public function testPreservedAreAppliedByToSql()
     {
         $builder = $this->getBuilder();
-        $builder->preserve(function ($builder) {
+        $builder->beforeQuery(function ($builder) {
             $builder->where('foo', 'bar');
         });
         $this->assertSame('select * where "foo" = ?', $builder->toSql());
@@ -2597,7 +2597,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->getConnection()->shouldReceive('insert')->once()->with('insert into "users" ("email") values (?)', ['foo']);
-        $builder->preserve(function ($builder) {
+        $builder->beforeQuery(function ($builder) {
             $builder->from('users');
         });
         $builder->insert(['email' => 'foo']);
@@ -2608,7 +2608,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->called = false;
         $builder = $this->getBuilder();
         $builder->getProcessor()->shouldReceive('processInsertGetId')->once()->with($builder, 'insert into "users" ("email") values (?)', ['foo'], 'id');
-        $builder->preserve(function ($builder) {
+        $builder->beforeQuery(function ($builder) {
             $builder->from('users');
         });
         $builder->insertGetId(['email' => 'foo'], 'id');
@@ -2618,7 +2618,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->getConnection()->shouldReceive('affectingStatement')->once()->with('insert into "users" () select *', []);
-        $builder->preserve(function ($builder) {
+        $builder->beforeQuery(function ($builder) {
             $builder->from('users');
         });
         $builder->insertUsing([], $this->getBuilder());
@@ -2628,7 +2628,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getMySqlBuilder();
         $builder->getConnection()->shouldReceive('affectingStatement')->once()->with('insert into `users` (`email`) values (?) on duplicate key update `email` = values(`email`)', ['foo']);
-        $builder->preserve(function ($builder) {
+        $builder->beforeQuery(function ($builder) {
             $builder->from('users');
         });
         $builder->upsert(['email' => 'foo'], 'id');
@@ -2638,7 +2638,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "email" = ? where "id" = ?', ['foo', 1]);
-        $builder->from('users')->preserve(function ($builder) {
+        $builder->from('users')->beforeQuery(function ($builder) {
             $builder->where('id', 1);
         });
         $builder->update(['email' => 'foo']);
@@ -2648,7 +2648,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->getConnection()->shouldReceive('delete')->once()->with('delete from "users"', []);
-        $builder->preserve(function ($builder) {
+        $builder->beforeQuery(function ($builder) {
             $builder->from('users');
         });
         $builder->delete();
@@ -2658,7 +2658,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->getConnection()->shouldReceive('statement')->once()->with('truncate table "users"', []);
-        $builder->preserve(function ($builder) {
+        $builder->beforeQuery(function ($builder) {
             $builder->from('users');
         });
         $builder->truncate();
@@ -2668,7 +2668,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->getConnection()->shouldReceive('select')->once()->with('select exists(select * from "users") as "exists"', [], true);
-        $builder->preserve(function ($builder) {
+        $builder->beforeQuery(function ($builder) {
             $builder->from('users');
         });
         $builder->exists();

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2567,7 +2567,7 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testPreserveAddsClosureToArray()
     {
         $builder = $this->getBuilder();
-        $builder->preserve(function() {
+        $builder->preserve(function () {
         });
         $this->assertCount(1, $builder->preserved);
         $this->assertInstanceOf(Closure::class, $builder->preserved[0]);
@@ -2576,7 +2576,7 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testApplyPreserveCleansArray()
     {
         $builder = $this->getBuilder();
-        $builder->preserve(function() {
+        $builder->preserve(function () {
         });
         $this->assertCount(1, $builder->preserved);
         $builder->applyPreserved();
@@ -2586,7 +2586,7 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testPreservedAreAppliedByToSql()
     {
         $builder = $this->getBuilder();
-        $builder->preserve(function($builder) {
+        $builder->preserve(function ($builder) {
             $builder->where('foo', 'bar');
         });
         $this->assertSame('select * where "foo" = ?', $builder->toSql());
@@ -2597,7 +2597,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->getConnection()->shouldReceive('insert')->once()->with('insert into "users" ("email") values (?)', ['foo']);
-        $builder->preserve(function($builder) {
+        $builder->preserve(function ($builder) {
             $builder->from('users');
         });
         $builder->insert(['email' => 'foo']);
@@ -2608,7 +2608,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->called = false;
         $builder = $this->getBuilder();
         $builder->getProcessor()->shouldReceive('processInsertGetId')->once()->with($builder, 'insert into "users" ("email") values (?)', ['foo'], 'id');
-        $builder->preserve(function($builder) {
+        $builder->preserve(function ($builder) {
             $builder->from('users');
         });
         $builder->insertGetId(['email' => 'foo'], 'id');
@@ -2618,7 +2618,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->getConnection()->shouldReceive('affectingStatement')->once()->with('insert into "users" () select *', []);
-        $builder->preserve(function($builder) {
+        $builder->preserve(function ($builder) {
             $builder->from('users');
         });
         $builder->insertUsing([], $this->getBuilder());
@@ -2628,7 +2628,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getMySqlBuilder();
         $builder->getConnection()->shouldReceive('affectingStatement')->once()->with('insert into `users` (`email`) values (?) on duplicate key update `email` = values(`email`)', ['foo']);
-        $builder->preserve(function($builder) {
+        $builder->preserve(function ($builder) {
             $builder->from('users');
         });
         $builder->upsert(['email' => 'foo'], 'id');
@@ -2638,7 +2638,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "email" = ? where "id" = ?', ['foo', 1]);
-        $builder->from('users')->preserve(function($builder) {
+        $builder->from('users')->preserve(function ($builder) {
             $builder->where('id', 1);
         });
         $builder->update(['email' => 'foo']);
@@ -2648,7 +2648,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->getConnection()->shouldReceive('delete')->once()->with('delete from "users"', []);
-        $builder->preserve(function($builder) {
+        $builder->preserve(function ($builder) {
             $builder->from('users');
         });
         $builder->delete();
@@ -2658,7 +2658,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->getConnection()->shouldReceive('statement')->once()->with('truncate table "users"', []);
-        $builder->preserve(function($builder) {
+        $builder->preserve(function ($builder) {
             $builder->from('users');
         });
         $builder->truncate();
@@ -2668,7 +2668,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->getConnection()->shouldReceive('select')->once()->with('select exists(select * from "users") as "exists"', [], true);
-        $builder->preserve(function($builder) {
+        $builder->preserve(function ($builder) {
             $builder->from('users');
         });
         $builder->exists();

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Database;
 
 use BadMethodCallException;
+use Closure;
 use DateTime;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
@@ -2561,6 +2562,116 @@ class DatabaseQueryBuilderTest extends TestCase
             'delete from sqlite_sequence where name = ?' => ['users'],
             'delete from "users"' => [],
         ], $sqlite->compileTruncate($builder));
+    }
+
+    public function testPreserveAddsClosureToArray()
+    {
+        $builder = $this->getBuilder();
+        $builder->preserve(function() {
+        });
+        $this->assertCount(1, $builder->preserved);
+        $this->assertInstanceOf(Closure::class, $builder->preserved[0]);
+    }
+
+    public function testApplyPreserveCleansArray()
+    {
+        $builder = $this->getBuilder();
+        $builder->preserve(function() {
+        });
+        $this->assertCount(1, $builder->preserved);
+        $builder->applyPreserved();
+        $this->assertCount(0, $builder->preserved);
+    }
+
+    public function testPreservedAreAppliedByToSql()
+    {
+        $builder = $this->getBuilder();
+        $builder->preserve(function($builder) {
+            $builder->where('foo', 'bar');
+        });
+        $this->assertSame('select * where "foo" = ?', $builder->toSql());
+        $this->assertEquals(['bar'], $builder->getBindings());
+    }
+
+    public function testPreservedAreAppliedByInsert()
+    {
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('insert')->once()->with('insert into "users" ("email") values (?)', ['foo']);
+        $builder->preserve(function($builder) {
+            $builder->from('users');
+        });
+        $builder->insert(['email' => 'foo']);
+    }
+
+    public function testPreservedAreAppliedByInsertGetId()
+    {
+        $this->called = false;
+        $builder = $this->getBuilder();
+        $builder->getProcessor()->shouldReceive('processInsertGetId')->once()->with($builder, 'insert into "users" ("email") values (?)', ['foo'], 'id');
+        $builder->preserve(function($builder) {
+            $builder->from('users');
+        });
+        $builder->insertGetId(['email' => 'foo'], 'id');
+    }
+
+    public function testPreservedAreAppliedByInsertUsing()
+    {
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('affectingStatement')->once()->with('insert into "users" () select *', []);
+        $builder->preserve(function($builder) {
+            $builder->from('users');
+        });
+        $builder->insertUsing([], $this->getBuilder());
+    }
+
+    public function testPreservedAreAppliedByUpsert()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->getConnection()->shouldReceive('affectingStatement')->once()->with('insert into `users` (`email`) values (?) on duplicate key update `email` = values(`email`)', ['foo']);
+        $builder->preserve(function($builder) {
+            $builder->from('users');
+        });
+        $builder->upsert(['email' => 'foo'], 'id');
+    }
+
+    public function testPreservedAreAppliedByUpdate()
+    {
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "email" = ? where "id" = ?', ['foo', 1]);
+        $builder->from('users')->preserve(function($builder) {
+            $builder->where('id', 1);
+        });
+        $builder->update(['email' => 'foo']);
+    }
+
+    public function testPreservedAreAppliedByDelete()
+    {
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('delete')->once()->with('delete from "users"', []);
+        $builder->preserve(function($builder) {
+            $builder->from('users');
+        });
+        $builder->delete();
+    }
+
+    public function testPreservedAreAppliedByTruncate()
+    {
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('statement')->once()->with('truncate table "users"', []);
+        $builder->preserve(function($builder) {
+            $builder->from('users');
+        });
+        $builder->truncate();
+    }
+
+    public function testPreservedAreAppliedByExists()
+    {
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('select')->once()->with('select exists(select * from "users") as "exists"', [], true);
+        $builder->preserve(function($builder) {
+            $builder->from('users');
+        });
+        $builder->exists();
     }
 
     public function testPostgresInsertGetId()


### PR DESCRIPTION
## Background

Currently there is no way to change subselect-builder whereby the changes are applied to the parent query builder as well. This is because the subselect query is rendered when applied.

## The Solution

Preserve query modifications that are applied when the builder gets rendered.

This pr adds a `beforeQuery` method to the base query builder. The preserved closures will be called before the query gets rendered. This allows keeping sub query builders alive and modifying the sub query after applying it to the parent builder:

```php
// 1. Add the subquery
$builder->beforeQuery(function($query) use($subQuery){
    $query->joinSub($subQuery, ...);
});

// 2. Add constraints to the subquery
$subQuery->where('foo', 'bar');

// 3. Render the subquery, the constraints from 2. are applied
$builder->get();
```

The preserved closures will be executed in the following builder methods:

- `toSql`
- `exists`
- `insert`
- `insertOrIgnore`
- `insertGetId`
- `insertUsing`
- `update`
- `upsert`
- `delete`
- `truncate`

## Usage

If wanted the preserved modifiers can be applied using `applyBeforeQueryCallbacks`

```php
$builder->applyBeforeQueryCallbacks();
```

The preserved modifiers may be passed to other builders

```php
$otherBuilder->beforeQueryCallbacks = $builder->beforeQueryCallbacks;
```

## Where This Is Usefull

This is particularly useful for the new one-of-many feature, where performance can be improved for tables with millions of entries by limiting the groups inside the sub-queries during eager loading.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
