### PR TITLE
[8.x] Fix eager loading one-of-many relationships with multiple aggregates

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/CanBeOneOfMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/CanBeOneOfMany.php
@@ -89,7 +89,7 @@ trait CanBeOneOfMany
             }
 
             $subQuery = $this->newOneOfManySubQuery(
-                isset($previous) ? $previous['column'] : $this->getOneOfManySubQuerySelectColumns(),
+                $this->getOneOfManySubQuerySelectColumns(),
                 $column, $aggregate
             );
 

--- a/tests/Database/DatabaseEloquentHasOneOfManyTest.php
+++ b/tests/Database/DatabaseEloquentHasOneOfManyTest.php
@@ -335,7 +335,7 @@ class DatabaseEloquentHasOneOfManyTest extends TestCase
         ]);
 
         $users = HasOneOfManyTestUser::with('price')->get();
-        
+
         $this->assertNotNull($users[0]->price);
         $this->assertSame($user1Price->id, $users[0]->price->id);
 

--- a/tests/Database/DatabaseEloquentHasOneOfManyTest.php
+++ b/tests/Database/DatabaseEloquentHasOneOfManyTest.php
@@ -312,6 +312,37 @@ class DatabaseEloquentHasOneOfManyTest extends TestCase
         $this->assertSame($price->id, $user->price->id);
     }
 
+    public function testEagerLoadingWithMultipleAggregates()
+    {
+        $user1 = HasOneOfManyTestUser::create();
+        $user2 = HasOneOfManyTestUser::create();
+
+        $user1->prices()->create([
+            'published_at' => '2021-05-01 00:00:00',
+        ]);
+        $user1Price = $user1->prices()->create([
+            'published_at' => '2021-05-01 00:00:00',
+        ]);
+        $user1->prices()->create([
+            'published_at' => '2021-04-01 00:00:00',
+        ]);
+
+        $user2Price = $user2->prices()->create([
+            'published_at' => '2021-05-01 00:00:00',
+        ]);
+        $user2->prices()->create([
+            'published_at' => '2021-04-01 00:00:00',
+        ]);
+
+        $users = HasOneOfManyTestUser::with('price')->get();
+        
+        $this->assertNotNull($users[0]->price);
+        $this->assertSame($user1Price->id, $users[0]->price->id);
+
+        $this->assertNotNull($users[1]->price);
+        $this->assertSame($user2Price->id, $users[1]->price->id);
+    }
+
     public function testWithExists()
     {
         $user = HasOneOfManyTestUser::create();


### PR DESCRIPTION
This pr fixes eager loading one-of-many relations with multiple aggregates.

Before fix: http://sqlfiddle.com/#!9/cef514/7
After fix: http://sqlfiddle.com/#!9/cef514/8

All inner join sub queries must be grouped by the relationship group columns, not the previous aggregated column from the previous sub query.

The issue was pointed out by @sblawrie in https://github.com/laravel/framework/pull/37362#issuecomment-845220488

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
