### PR TITLE
[8.x] Fix Str::replace docblock return

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -533,7 +533,7 @@ class Str
      * @param  string|string[]  $search
      * @param  string|string[]  $replace
      * @param  string|string[]  $subject
-     * @return static
+     * @return string
      */
     public static function replace($search, $replace, $subject)
     {


### PR DESCRIPTION
#37186 introduced the `Str::replace` helper method, but the Docblock incorrectly specified the return as `static` instead of `string`.

This causes an error in my editor where the code should work fine:

```php

use Illuminate\Support\Str;

class MyClass
{
    protected string $name;

    public function __construct($name)
    {
        /* Error: Incompatible types: Expected property of type 'string', 'Illuminate\Support\Str' provided */
        $this->name = Str::replace('SR', 'Senior', $name);
    }
}
```