### PR TITLE
[8.x] Add default timeout to NotPwnedVerifier

### DIFF
--- a/src/Illuminate/Validation/NotPwnedVerifier.php
+++ b/src/Illuminate/Validation/NotPwnedVerifier.php
@@ -16,14 +16,23 @@ class NotPwnedVerifier implements UncompromisedVerifier
     protected $factory;
 
     /**
+     * The number of seconds the request can run before timing out.
+     *
+     * @var int
+     */
+    public $timeout;
+
+    /**
      * Create a new uncompromised verifier.
      *
      * @param  \Illuminate\Http\Client\Factory  $factory
+     * @param  int|null  $timeout
      * @return void
      */
-    public function __construct($factory)
+    public function __construct($factory, $timeout = null)
     {
         $this->factory = $factory;
+        $this->timeout = $timeout ?? 15;
     }
 
     /**
@@ -77,7 +86,7 @@ class NotPwnedVerifier implements UncompromisedVerifier
         try {
             $response = $this->factory->withHeaders([
                 'Add-Padding' => true,
-            ])->get(
+            ])->timeout($this->timeout)->get(
                 'https://api.pwnedpasswords.com/range/'.$hashPrefix
             );
         } catch (Exception $e) {

--- a/tests/Validation/ValidationNotPwnedVerifierTest.php
+++ b/tests/Validation/ValidationNotPwnedVerifierTest.php
@@ -46,6 +46,12 @@ class ValidationNotPwnedVerifierTest extends TestCase
             ->with(['Add-Padding' => true])
             ->andReturn($httpFactory);
 
+        $httpFactory
+            ->shouldReceive('timeout')
+            ->once()
+            ->with(15)
+            ->andReturn($httpFactory);
+
         $httpFactory->shouldReceive('get')
             ->once()
             ->andReturn($response);
@@ -75,6 +81,12 @@ class ValidationNotPwnedVerifierTest extends TestCase
             ->shouldReceive('withHeaders')
             ->once()
             ->with(['Add-Padding' => true])
+            ->andReturn($httpFactory);
+
+        $httpFactory
+            ->shouldReceive('timeout')
+            ->once()
+            ->with(15)
             ->andReturn($httpFactory);
 
         $httpFactory->shouldReceive('get')
@@ -110,6 +122,12 @@ class ValidationNotPwnedVerifierTest extends TestCase
             ->shouldReceive('withHeaders')
             ->once()
             ->with(['Add-Padding' => true])
+            ->andReturn($httpFactory);
+
+        $httpFactory
+            ->shouldReceive('timeout')
+            ->once()
+            ->with(15)
             ->andReturn($httpFactory);
 
         $httpFactory


### PR DESCRIPTION
The [NotPwnedVerifier](https://github.com/laravel/framework/blob/8.x/src/Illuminate/Validation/NotPwnedVerifier.php) makes HTTP request to verify that the given password has not been compromised in public breaches using the [Have I Been Pwned public API](https://haveibeenpwned.com/API/v3#PwnedPasswords). [Any HTTP request made to an external service can hang for a long time](https://blog.bearer.sh/http-request-timeouts/) if this service is under heavy load and not responding in a prompt manner. The HTTP request is made using Guzzle, [which default to wait indefinitely.](https://docs.guzzlephp.org/en/stable/request-options.html#timeout)

This PR defines a default timeout value of 15 seconds to be use by the NotPwnedVerifier when making HTTP request to the API. The value of 15 seconds is a value that we use in production for some API. We could argue that this value could be higher or lower, and I would happily change it. But I do think that it is important that _some_ timeout value be configured to prevent the request made by the end user from hanging for a long time or reaching PHP's max_execution_time of 30 seconds.

I would like to expose this value to the configuration (it is already configurable by the service provider), but I'm not sure in which configuration file it should be.

Also, I would have like to add a unit test to simulate this exact scenario, but unfortunately, since the request never reaches CURL in the testing environment, the timeout value has no effect.

