### PR TITLE
[8.x] Add ValidatorAwareRule interface

### DIFF
--- a/src/Illuminate/Contracts/Validation/ValidatorAwareRule.php
+++ b/src/Illuminate/Contracts/Validation/ValidatorAwareRule.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Illuminate\Contracts\Validation;
+
+interface ValidatorAwareRule
+{
+    /**
+     * Set the current validator.
+     *
+     * @param  \Illuminate\Validation\Validator  $validator
+     * @return $this
+     */
+    public function setValidator($validator);
+}

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Validation\DataAwareRule;
 use Illuminate\Contracts\Validation\ImplicitRule;
 use Illuminate\Contracts\Validation\Rule as RuleContract;
 use Illuminate\Contracts\Validation\Validator as ValidatorContract;
+use Illuminate\Contracts\Validation\ValidatorAwareRule;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Fluent;
 use Illuminate\Support\MessageBag;
@@ -751,6 +752,10 @@ class Validator implements ValidatorContract
 
         if ($rule instanceof DataAwareRule) {
             $rule->setData($this->data);
+        }
+
+        if ($rule instanceof ValidatorAwareRule) {
+            $rule->setValidator($this);
         }
 
         if (! $rule->passes($attribute, $value)) {

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -750,12 +750,12 @@ class Validator implements ValidatorContract
 
         $value = is_array($value) ? $this->replacePlaceholders($value) : $value;
 
-        if ($rule instanceof DataAwareRule) {
-            $rule->setData($this->data);
-        }
-
         if ($rule instanceof ValidatorAwareRule) {
             $rule->setValidator($this);
+        }
+
+        if ($rule instanceof DataAwareRule) {
+            $rule->setData($this->data);
         }
 
         if (! $rule->passes($attribute, $value)) {


### PR DESCRIPTION
In https://github.com/laravel/framework/pull/36960 Nuno added a `DataAwareRule` interface which allows a `Rule` to have access to the data under validation. This is so great !

Unfortunately, it does not allows the `Rule` to gain access to :
- 1 - does the current field already have validation errors ?
- 2 - what are the other rules applied to the current field ?
- 3 - does other fields has validation errors ?
- 4 - what are the rules applied to other fields ?

Why do we need this ? I will give it some examples but possibilities are limitless

1 - If we want to check some model existence with some custom condition
Actually
```php
$rules = [
   'user_id' => [
        'required',
        'integer',
        Rule::exists(User::class)
        ->using(fn ($query) => (new User)->newEloquentBuilder($query)->whereIsAuthor())
    ]
]
```
or 
```php
$rules = ['user_id' => ['required', 'integer', 'bail', AuthorExists::class]];

class AuthorExists implements Rule 
{
    public function passes($attribute, $value)
    {
        return User::where('id', $value)->whereIsAuthor()->exists();
    }
}
```
Here the `bail` is required to ensure that `AuthorExists::passes` is not executed with unsafe data.
After
```php
$rules = ['user_id' => ['required', 'integer', AuthorExists::class]];

class AuthorExists implements Rule, ValidatorAwareRule
{
    private $validator;

    public function setValidator($validator)
    {
        $this->validator = $validator;

        return $this;
    }


    public function passes($attribute, $value)
    {
        if ($this->validator->errors()->has($attribute)) {
            return true; 
        }

        return User::where('id', $value)->whereIsAuthor()->exists();
    }
}
```
The bail here in included directly in the rule, which matches what is done with `exists` rule (see https://github.com/laravel/framework/blob/8.x/src/Illuminate/Validation/Validator.php#L657 and https://github.com/laravel/framework/blob/8.x/src/Illuminate/Validation/Validator.php#L733)

2 - We may want the rule applied in different ways depending on the previous defined rules.
Which is the way that `size`, `min`, ... actually work.
Another use case would be to fetch the `date_format` in order to have create a `DateTime` and make assertions about this : 
```php
class Monday implements Rule, ValidatorAwareRule
{
    public function passes($attribute, $value)
    {
        if (!$this->validator->hasRule($attribute, 'DateFormat')) {
             throw new Exception("The $attribute must be validated with date_format.");
        }
        if ($this->validator->errors()->has($attribute)) {
            return true;
        }
        // extract  format.
        // this part would be easier if Validator::getRule($attribute, $rules) was public but not in scope of this PR
        [, $params] = collect($v->getRules()[$attribute])
                                    ->map(fn ($rule) => ValidationRuleParser::parse($rule))
                                    ->first(fn ($items) => $items[0] === 'DateFormat'); 
        
         return Date::createFromFormat($params[0], '2021-05-21')->dayOfWeek === Carbon::MONDAY;
    }
}
```

3 - 4 - Imagine we are building a booking service and we want to validate that the location is available a given day.

With this PR we could simply do something like this : 
```php
$rules = [
    'date' => ['required', 'date_format:Y-m-d'],
    'location_id' => ['required', 'integer', Available::class],
];

class Available implements Rule, ValidatorAwareRule 
{
    public function passes($attribute, $value)
    {
        if ($this->validator->errors()->hasAny(['date', $attribute])) {
            return true; 
        }

        return Location::where('id', $value)->whereAvailableOn($this->validator->getData()['date'])->exists();
    }
}
```

TL;DR : this PR adds only a few lines in the framework but I believe opens up great possibilities and power to custom `Rule`s
