### PR TITLE
[8.x] Add UncompromisedVerifier facade and UncompromisedVerifierFake

### DIFF
--- a/src/Illuminate/Support/Facades/UncompromisedVerifier.php
+++ b/src/Illuminate/Support/Facades/UncompromisedVerifier.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Illuminate\Support\Facades;
+
+use Illuminate\Contracts\Validation\UncompromisedVerifier as UncompromisedVerifierContract;
+use Illuminate\Support\Testing\Fakes\UncompromisedVerifierFake;
+
+/**
+ * @method static bool verify(array $data)
+ *
+ * @see \Illuminate\Validation\NotPwnedVerifier
+ * @see \Illuminate\Support\Testing\Fakes\UncompromisedVerifierFake
+ */
+class UncompromisedVerifier extends Facade
+{
+    /**
+     * Replace the bound instance with a fake.
+     *
+     * @return \Illuminate\Support\Testing\Fakes\UncompromisedVerifierFake
+     */
+    public static function fake()
+    {
+        static::swap($fake = new UncompromisedVerifierFake());
+
+        return $fake;
+    }
+
+    /**
+     * Get the registered name of the component.
+     *
+     * @return string
+     */
+    protected static function getFacadeAccessor()
+    {
+        return UncompromisedVerifierContract::class;
+    }
+}

--- a/src/Illuminate/Support/Testing/Fakes/UncompromisedVerifierFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/UncompromisedVerifierFake.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\Support\Testing\Fakes;
+
+use Illuminate\Contracts\Validation\UncompromisedVerifier;
+
+class UncompromisedVerifierFake implements UncompromisedVerifier
+{
+    /**
+     * Verify that the given data has not been compromised in data leaks.
+     *
+     * @param  array  $data
+     * @return bool
+     */
+    public function verify($data)
+    {
+        return true;
+    }
+}

--- a/tests/Validation/ValidationPasswordRuleTest.php
+++ b/tests/Validation/ValidationPasswordRuleTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Validation;
 
 use Illuminate\Container\Container;
 use Illuminate\Support\Facades\Facade;
+use Illuminate\Support\Facades\UncompromisedVerifier;
 use Illuminate\Translation\ArrayLoader;
 use Illuminate\Translation\Translator;
 use Illuminate\Validation\Rules\Password;
@@ -112,6 +113,22 @@ class ValidationPasswordRuleTest extends TestCase
             'rundeliekend',
             '7Z^k5EvqQ9g%c!Jt9$ufnNpQy#Kf',
             'NRs*Gz2@hSmB$vVBSPDfqbRtEzk4nF7ZAbM29VMW$BPD%b2U%3VmJAcrY5eZGVxP%z%apnwSX',
+        ]);
+    }
+
+    public function testUncompromisedFake()
+    {
+        UncompromisedVerifier::fake();
+
+        $this->passes(Password::min(2)->uncompromised(), [
+            '123456',
+            'password',
+            'welcome',
+            'ninja',
+            'abc123',
+            '123456789',
+            '12345678',
+            'nuno',
         ]);
     }
 


### PR DESCRIPTION
The [NotPwnedVerifier](https://github.com/laravel/framework/blob/8.x/src/Illuminate/Validation/NotPwnedVerifier.php) makes HTTP request every time the `uncompromised()` feature of the [Password](https://github.com/laravel/framework/blob/8.x/src/Illuminate/Validation/Rules/Password.php) rule is being used. This might be an undesirable behaviour in some environment, especially in local or testing environment. When the new Password rule was first introduced, [some were wondering](https://github.com/laravel/framework/pull/36960#issuecomment-827625422) if there was an easy way to mock the `uncompromised()` feature.

This PR add the UncompromisedVerifier facade and the UncompromisedVerifierFake, a fake implementation of the [UncompromisedVerifier](https://github.com/laravel/framework/blob/8.x/src/Illuminate/Contracts/Validation/UncompromisedVerifier.php) contract. With a facade, we can easily reuse the fake mechanism to swap the instance for the fake one.

While this solution address the initial problem, I'm not sure that this is the right way to go. I'm curious to know if you would think of a better approach and I would gladly implement a different solution.