### PR TITLE
[8.x] `@includeScoped` directive

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesIncludes.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesIncludes.php
@@ -29,6 +29,19 @@ trait CompilesIncludes
     }
 
     /**
+     * Compile the include-scoped statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileIncludeScoped($expression)
+    {
+        $expression = $this->stripParentheses($expression);
+
+        return "<?php echo \$__env->make({$expression})->render(); ?>";
+    }
+
+    /**
      * Compile the include-if statements into valid PHP.
      *
      * @param  string  $expression

--- a/tests/View/Blade/BladeIncludesTest.php
+++ b/tests/View/Blade/BladeIncludesTest.php
@@ -16,6 +16,12 @@ class BladeIncludesTest extends AbstractBladeTestCase
         $this->assertSame('<?php echo $__env->make(name(foo), \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>', $this->compiler->compileString('@include(name(foo))'));
     }
 
+    public function testIncludeScopesAreCompiled()
+    {
+        $this->assertSame('<?php echo $__env->make(\'foo\')->render(); ?>', $this->compiler->compileString('@includeScoped(\'foo\')'));
+        $this->assertSame('<?php echo $__env->make(name(foo))->render(); ?>', $this->compiler->compileString('@includeScoped(name(foo))'));
+    }
+
     public function testIncludeIfsAreCompiled()
     {
         $this->assertSame('<?php if ($__env->exists(\'foo\')) echo $__env->make(\'foo\', \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>', $this->compiler->compileString('@includeIf(\'foo\')'));


### PR DESCRIPTION
This pull request adds a new `@includeScoped` directive to Blade. This directive is similar to `@include`, but it doesn't include the outside environment / variables. / `get_defined_vars()`.

_view.blade.php_

```blade
@php($user = User::first())

@includeScoped('partial')
```

_partial.blade.php_

```blade
{{-- The `$user` variable isn't inherited here. --}}
```

I'm not 100% set on the name of the directive, but I couldn't actually think of a better name. This would have similar behaviour to components where the scope isn't inherited.

If this isn't something that is wanted / needed in core, I'll create a package instead but I figured it was worth a try.