### PR TITLE
[8.x] Add eager loading of pivot relations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -791,7 +791,7 @@ class BelongsToMany extends Relation
         if (count($models) > 0) {
             $pivotEagerLoad = $this->getPivotEagerLoads($builder);
 
-            if (!empty($pivotEagerLoad)) {
+            if (! empty($pivotEagerLoad)) {
                 $this->eagerLoadPivotRelations($models, $pivotEagerLoad);
             }
 
@@ -850,6 +850,7 @@ class BelongsToMany extends Relation
             $name = str_replace($this->accessor.'.', '', $name);
             $newEagerLoad[$name] = $callback;
         }
+
         return $newEagerLoad;
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -847,7 +847,7 @@ class BelongsToMany extends Relation
     {
         $newEagerLoad = [];
         foreach ($eagerLoad as $name => $callback) {
-            $name = substr($name, strlen($this->accessor)+1);
+            $name = substr($name, strlen($this->accessor) + 1);
             $newEagerLoad[$name] = $callback;
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -839,7 +839,7 @@ class BelongsToMany extends Relation
     }
 
     /**
-     * Remove the `pivot.` part of the eager load relations 
+     * Remove the `pivot.` part of the eager load relations
      * to get the actual relations of the pivot model.
      *
      * @param  array $eagerLoad

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -810,12 +810,13 @@ class BelongsToMany extends Relation
     protected function getPivotEagerLoads($builder)
     {
         // Only return the eagerLoad `pivot.*` but not the `pivot`
+        // because `pivot.*` contains the actual relations we want to eager load from the pivot model.
         $pivotEagerLoad = array_filter($builder->getEagerLoads(), function ($relation) {
             return Str::startsWith($relation, $this->accessor.'.');
         }, ARRAY_FILTER_USE_KEY);
 
         $builder->without(array_merge(
-            [$this->accessor], // we make sure to also remove the `pivot` in the eagerLoad
+            [$this->accessor], // We make sure to also remove the `pivot` in the eagerLoad.
             array_keys($pivotEagerLoad)
         ));
 
@@ -838,7 +839,8 @@ class BelongsToMany extends Relation
     }
 
     /**
-     * Remove the `pivot.` part of the eager load relations.
+     * Remove the `pivot.` part of the eager load relations 
+     * to get the actual relations of the pivot model.
      *
      * @param  array $eagerLoad
      * @return array

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -847,7 +847,7 @@ class BelongsToMany extends Relation
     {
         $newEagerLoad = [];
         foreach ($eagerLoad as $name => $callback) {
-            $name = str_replace($this->accessor.'.', '', $name);
+            $name = substr($name, strlen($this->accessor)+1);
             $newEagerLoad[$name] = $callback;
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -511,6 +511,8 @@ trait InteractsWithPivotTable
             $this->parent, $attributes, $this->table, $exists, $this->using
         );
 
+        $pivot->preventsLazyLoading = Pivot::preventsLazyLoading();
+
         return $pivot->setPivotKeys($this->foreignPivotKey, $this->relatedPivotKey);
     }
 

--- a/tests/Integration/Database/EloquentBelongsToManyEagerLoadPivotRelationsTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyEagerLoadPivotRelationsTest.php
@@ -53,6 +53,12 @@ class EloquentBelongsToManyEagerLoadPivotRelationsTest extends DatabaseTestCase
         });
     }
 
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        Model::preventLazyLoading(false);
+    }
+
     public function testCanEagerLoadPivotRelations()
     {
         $employee = Employee::create(['name' => Str::random()]);
@@ -62,8 +68,6 @@ class EloquentBelongsToManyEagerLoadPivotRelationsTest extends DatabaseTestCase
             'payroll_period_id' => $payrollPeriod->id,
             'amount' => 100,
         ]);
-
-        Model::preventLazyLoading();
 
         $employee = Employee::with('deductions.pivot.payrollPeriod')->get()->first();
 
@@ -85,8 +89,6 @@ class EloquentBelongsToManyEagerLoadPivotRelationsTest extends DatabaseTestCase
             'user_id' => $user->id,
             'amount' => 100,
         ]);
-
-        Model::preventLazyLoading();
 
         $employee = Employee::with([
             'deductions.pivot.payrollPeriod',

--- a/tests/Integration/Database/EloquentBelongsToManyEagerLoadPivotRelationsTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyEagerLoadPivotRelationsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Integration\Database\EloquentBelongsToManyTest;
+namespace Illuminate\Tests\Integration\Database\EloquentBelongsToManyEagerLoadPivotRelationsTest;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Pivot;

--- a/tests/Integration/Database/EloquentBelongsToManyEagerLoadPivotRelationsTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyEagerLoadPivotRelationsTest.php
@@ -2,14 +2,10 @@
 
 namespace Illuminate\Tests\Integration\Database\EloquentBelongsToManyTest;
 
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Database\LazyLoadingViolationException;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Carbon;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;

--- a/tests/Integration/Database/EloquentBelongsToManyEagerLoadPivotRelationsTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyEagerLoadPivotRelationsTest.php
@@ -67,10 +67,11 @@ class EloquentBelongsToManyEagerLoadPivotRelationsTest extends DatabaseTestCase
 
         $employee = Employee::with('deductions.pivot.payrollPeriod')->get()->first();
 
-        $this->assertInstanceOf(
-            PayrollPeriod::class,
-            $employee->deductions->first()->pivot->payrollPeriod
-        );
+        $pivot = $employee->deductions->first()->pivot;
+
+        $this->assertTrue($pivot->relationLoaded('payrollPeriod'));
+
+        $this->assertInstanceOf(PayrollPeriod::class, $pivot->payrollPeriod);
     }
 
     public function testCanEagerLoadManyPivotRelations()
@@ -92,15 +93,13 @@ class EloquentBelongsToManyEagerLoadPivotRelationsTest extends DatabaseTestCase
             'deductions.pivot.user',
         ])->get()->first();
 
-        $this->assertInstanceOf(
-            PayrollPeriod::class,
-            $employee->deductions->first()->pivot->payrollPeriod
-        );
+        $pivot = $employee->deductions->first()->pivot;
 
-        $this->assertInstanceOf(
-            User::class,
-            $employee->deductions->first()->pivot->user
-        );
+        $this->assertTrue($pivot->relationLoaded('payrollPeriod'));
+        $this->assertInstanceOf(PayrollPeriod::class, $pivot->payrollPeriod);
+
+        $this->assertTrue($pivot->relationLoaded('user'));
+        $this->assertInstanceOf(User::class, $pivot->user);
     }
 
     public function testAccessOnPivotRelationsWillThrowLazyLoadingViolationExceptionIfNotEagerLoaded()

--- a/tests/Integration/Database/EloquentBelongsToManyEagerLoadPivotRelationsTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyEagerLoadPivotRelationsTest.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentBelongsToManyTest;
+
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Database\Eloquent\Relations\Pivot;
+use Illuminate\Database\LazyLoadingViolationException;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+/**
+ * @group integration
+ */
+class EloquentBelongsToManyEagerLoadPivotRelationsTest extends DatabaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('employees', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->timestamps();
+        });
+
+        Schema::create('deductions', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->timestamps();
+        });
+
+        Schema::create('payroll_periods', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->timestamps();
+        });
+
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->timestamps();
+        });
+
+        Schema::create('employees_deductions', function (Blueprint $table) {
+            $table->foreignId('employee_id');
+            $table->foreignId('deduction_id');
+            $table->foreignId('payroll_period_id');
+            $table->foreignId('user_id')->nullable();
+            $table->decimal('amount', 8, 2)->default(0);
+            $table->timestamps();
+        });
+    }
+
+    public function testCanEagerLoadPivotRelations()
+    {
+        $employee = Employee::create(['name' => Str::random()]);
+        $deduction = Deduction::create(['name' => Str::random()]);
+        $payrollPeriod = PayrollPeriod::create(['name' => Str::random()]);
+        $employee->deductions()->attach($deduction->id, [
+            'payroll_period_id' => $payrollPeriod->id,
+            'amount' => 100,
+        ]);
+
+        Model::preventLazyLoading();
+
+        $employee = Employee::with('deductions.pivot.payrollPeriod')->get()->first();
+
+        $this->assertInstanceOf(
+            PayrollPeriod::class,
+            $employee->deductions->first()->pivot->payrollPeriod
+        );
+    }
+
+    public function testCanEagerLoadManyPivotRelations()
+    {
+        $employee = Employee::create(['name' => Str::random()]);
+        $deduction = Deduction::create(['name' => Str::random()]);
+        $payrollPeriod = PayrollPeriod::create(['name' => Str::random()]);
+        $user = User::create(['name' => Str::random()]);
+        $employee->deductions()->attach($deduction->id, [
+            'payroll_period_id' => $payrollPeriod->id,
+            'user_id' => $user->id,
+            'amount' => 100,
+        ]);
+
+        Model::preventLazyLoading();
+
+        $employee = Employee::with([
+            'deductions.pivot.payrollPeriod',
+            'deductions.pivot.user',
+        ])->get()->first();
+
+        $this->assertInstanceOf(
+            PayrollPeriod::class,
+            $employee->deductions->first()->pivot->payrollPeriod
+        );
+
+        $this->assertInstanceOf(
+            User::class,
+            $employee->deductions->first()->pivot->user
+        );
+    }
+
+    public function testAccessOnPivotRelationsWillThrowLazyLoadingViolationExceptionIfNotEagerLoaded()
+    {
+        $this->expectException(LazyLoadingViolationException::class);
+        $this->expectExceptionMessage('Attempted to lazy load');
+
+        $employee = Employee::create(['name' => Str::random()]);
+        $deduction = Deduction::create(['name' => Str::random()]);
+        $payrollPeriod = PayrollPeriod::create(['name' => Str::random()]);
+        $employee->deductions()->attach($deduction->id, [
+            'payroll_period_id' => $payrollPeriod->id,
+            'amount' => 100,
+        ]);
+
+        Model::preventLazyLoading();
+
+        $employee->deductions()->get()->first()->pivot->payrollPeriod;
+    }
+
+    public function testAccessOnPivotRelationsWillBeOkayIfEagerLoaded()
+    {
+        $employee = Employee::create(['name' => Str::random()]);
+        $deduction = Deduction::create(['name' => Str::random()]);
+        $payrollPeriod = PayrollPeriod::create(['name' => Str::random()]);
+        $employee->deductions()->attach($deduction->id, [
+            'payroll_period_id' => $payrollPeriod->id,
+            'amount' => 100,
+        ]);
+
+        Model::preventLazyLoading();
+
+        $employee->deductions()->with('pivot.payrollPeriod')->get()->first()->pivot->payrollPeriod;
+    }
+}
+
+class Employee extends Model
+{
+    public $table = 'employees';
+    public $timestamps = true;
+    protected $guarded = [];
+
+    public function deductions()
+    {
+        return $this->belongsToMany(Deduction::class, 'employees_deductions')
+            ->withTimestamps()
+            ->withPivot([
+                'payroll_period_id',
+                'user_id',
+                'amount',
+            ])
+            ->using(EmployeeDeduction::class);
+    }
+}
+
+class Deduction extends Model
+{
+    public $table = 'deductions';
+    public $timestamps = true;
+    protected $guarded = [];
+}
+
+class PayrollPeriod extends Model
+{
+    public $table = 'payroll_periods';
+    public $timestamps = true;
+    protected $guarded = [];
+}
+
+class User extends Model
+{
+    public $table = 'users';
+    public $timestamps = true;
+    protected $guarded = [];
+}
+
+class EmployeeDeduction extends Pivot
+{
+    protected $table = 'employees_deductions';
+
+    public function payrollPeriod()
+    {
+        return $this->belongsTo(PayrollPeriod::class);
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}


### PR DESCRIPTION
This PR provides a way for us to eager-load defined relations from a Pivot model. 
Currently, we can define relations in pivot models and access them via lazy-loading, but cannot be eager-loaded.

For example in my payroll project, where an `Employee` can have many `Deduction` instances (many-to-many). But these deductions should also be set if which `PayrollPeriod` it is included.
```php
class Employee extends Model 
{
    public function deductions()
    {
        return $this->belongsToMany(\App\Models\Deduction::class, 'employee_deduction')
            ->withTimestamps()
            ->withPivot([
                 // we make sure we included the payroll_period_id in the pivot attributes which we need to eager load later
                'payroll_period_id', 
            ])
            ->using(EmployeeDeduction::class)
            ->as('employeeDeduct');
    }
}
```
```php
// We need to have a custom pivot model which is in our case it is EmployeeDeduction 
// Then this pivot model has the relation to payrollPeriod.
class EmployeeDeduction extends Pivot
{
    public $incrementing = true;

    public function payrollPeriod()
    {
        return $this->belongsTo(PayrollPeriod::class);
    }
}
```
Below are sample usages:
__Lazy-loading, currently supported__:
```php
$employee = Employee::with('deductions')->find($id);
foreach ($employee->deductions as $deduction) {
   // this is lazy-loading the payrollPeriod relation in EmployeeDeduction  which is currently supported
   dump($deduction->pivot->payrollPeriod); 

   // or like this when using custom pivot accessor
   dump($deduction->employeeDeduct->payrollPeriod); 
}
```
But currently it cannot be eager loaded. But with this PR, we can achieve it like this:
```php
Employee::with('deductions.pivot.payrollPeriod')->get(); 

// or like this when using custom pivot accessor
Employee::with('deductions.employeeDeduct.payrollPeriod')->get(); 
```
The `BelongsToMany` relation can now detect if you intend to eager load a relation from your custom pivot model by checking if the `$accessor` name exists in the `$eagerLoad` variable of query builder. 

You can define as many relations in the Pivot model and eager-load them as many as you can as long as you make sure 
to include their foreign keys in in the `withPivot()` declaration. 

For example let's add a `user` relation in our `EmployeeDeduction` which means the user who created this record.

```php
class EmployeeDeduction extends Pivot
{
    public $incrementing = true;

    public function payrollPeriod()
    {
        return $this->belongsTo(PayrollPeriod::class);
    }

    public function user()
    {
        return $this->belongsTo(User::class);
    }
}
```
```php
class Employee extends Model
{
    public function deductions()
    {
        return $this->belongsToMany(\App\Models\Deduction::class, 'employee_deduction')
            ->withTimestamps()
            ->withPivot([
                'payroll_period_id',
                'user_id', // we also include the user_id foreign key here
            ])
            ->using(EmployeeDeduction::class)
            ->as('employeeDeduct');
    }
}
```
Then we can eager load the `payrollPeriod` and the `user` relations like so:
```php
Employee::with([
    'deductions.pivot.payrollPeriod',
    'deductions.pivot.user',
])->get();

// or if you define custom pivot accessor
Employee::with([
    'deductions.employeeDeduct.payrollPeriod',
    'deductions.employeeDeduct.user',
])->get();
```

This PR is also important in relevance with https://github.com/laravel/framework/pull/37363 which requires us to access on eager loaded relations only.

I have an itch of solving this feature since in Laravel 5.* (https://github.com/laravel/ideas/issues/175), but the setup there is different. I think this is the perfect timing for it.

I also have tested this manually on my local laravel 8 project.
