### PR TITLE
[8.x ] Update Cursor.php

### DIFF
--- a/src/Illuminate/Pagination/Cursor.php
+++ b/src/Illuminate/Pagination/Cursor.php
@@ -43,7 +43,7 @@ class Cursor implements Arrayable
      */
     public function parameter(string $parameterName)
     {
-        if (! isset($this->parameters[$parameterName])) {
+        if (! array_key_exists($parameterName, $this->parameters)) {
             throw new UnexpectedValueException("Unable to find parameter [{$parameterName}] in pagination item.");
         }
 


### PR DESCRIPTION
Order by column that can be null given me "Unable to find parameter [last_answer] in pagination item.".
I solved it by this change and make 2 orders by, first is the id that won't be null, second is "last_answer" that can be null, and worked.