### PR TITLE
[8.x] Add model support for database assertions

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -17,7 +17,7 @@ trait InteractsWithDatabase
     /**
      * Assert that a given where condition exists in the database.
      *
-     * @param  string  $table
+     * @param  \Illuminate\Database\Eloquent\Model|string  $table
      * @param  array  $data
      * @param  string|null  $connection
      * @return $this
@@ -25,7 +25,7 @@ trait InteractsWithDatabase
     protected function assertDatabaseHas($table, array $data, $connection = null)
     {
         $this->assertThat(
-            $table, new HasInDatabase($this->getConnection($connection), $data)
+            $this->getTable($table), new HasInDatabase($this->getConnection($connection), $data)
         );
 
         return $this;
@@ -34,7 +34,7 @@ trait InteractsWithDatabase
     /**
      * Assert that a given where condition does not exist in the database.
      *
-     * @param  string  $table
+     * @param  \Illuminate\Database\Eloquent\Model|string  $table
      * @param  array  $data
      * @param  string|null  $connection
      * @return $this
@@ -45,7 +45,7 @@ trait InteractsWithDatabase
             new HasInDatabase($this->getConnection($connection), $data)
         );
 
-        $this->assertThat($table, $constraint);
+        $this->assertThat($this->getTable($table), $constraint);
 
         return $this;
     }
@@ -53,7 +53,7 @@ trait InteractsWithDatabase
     /**
      * Assert the count of table entries.
      *
-     * @param  string  $table
+     * @param  \Illuminate\Database\Eloquent\Model|string  $table
      * @param  int  $count
      * @param  string|null  $connection
      * @return $this
@@ -61,7 +61,7 @@ trait InteractsWithDatabase
     protected function assertDatabaseCount($table, int $count, $connection = null)
     {
         $this->assertThat(
-            $table, new CountInDatabase($this->getConnection($connection), $count)
+            $this->getTable($table), new CountInDatabase($this->getConnection($connection), $count)
         );
 
         return $this;
@@ -81,7 +81,7 @@ trait InteractsWithDatabase
             return $this->assertDatabaseMissing($table->getTable(), [$table->getKeyName() => $table->getKey()], $table->getConnectionName());
         }
 
-        $this->assertDatabaseMissing($table, $data, $connection);
+        $this->assertDatabaseMissing($this->getTable($table), $data, $connection);
 
         return $this;
     }
@@ -102,7 +102,7 @@ trait InteractsWithDatabase
         }
 
         $this->assertThat(
-            $table, new SoftDeletedInDatabase($this->getConnection($connection), $data, $deletedAtColumn)
+            $this->getTable($table), new SoftDeletedInDatabase($this->getConnection($connection), $data, $deletedAtColumn)
         );
 
         return $this;
@@ -150,6 +150,21 @@ trait InteractsWithDatabase
         $connection = $connection ?: $database->getDefaultConnection();
 
         return $database->connection($connection);
+    }
+
+    /**
+     * Get the table name.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model|string  $table
+     * @return string
+     */
+    protected function getTable($table)
+    {
+        if (is_subclass_of($table, Model::class)) {
+            return (new $table)->getTable();
+        }
+
+        return $table;
     }
 
     /**

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -41,6 +41,14 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertDatabaseHas($this->table, $this->data);
     }
 
+    public function testAssertDatabaseHasSupportModels()
+    {
+        $this->mockCountBuilder(1);
+
+        $this->assertDatabaseHas(ProductStub::class, $this->data);
+        $this->assertDatabaseHas(new ProductStub, $this->data);
+    }
+
     public function testSeeInDatabaseDoesNotFindResults()
     {
         $this->expectException(ExpectationFailedException::class);
@@ -91,6 +99,14 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertDatabaseMissing($this->table, $this->data);
     }
 
+    public function testAssertDatabaseMissingSupportModels()
+    {
+        $this->mockCountBuilder(0);
+
+        $this->assertDatabaseMissing(ProductStub::class, $this->data);
+        $this->assertDatabaseMissing(new ProductStub, $this->data);
+    }
+
     public function testDontSeeInDatabaseFindsResults()
     {
         $this->expectException(ExpectationFailedException::class);
@@ -108,6 +124,14 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->mockCountBuilder(1);
 
         $this->assertDatabaseCount($this->table, 1);
+    }
+
+    public function testAssertDatabaseCountSupportModels()
+    {
+        $this->mockCountBuilder(1);
+
+        $this->assertDatabaseCount(ProductStub::class, 1);
+        $this->assertDatabaseCount(new ProductStub, 1);
     }
 
     public function testAssertTableEntriesCountWrong()
@@ -168,6 +192,13 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertSoftDeleted($this->table, $this->data);
     }
 
+    public function testAssertSoftDeletedSupportModelStrings()
+    {
+        $this->mockCountBuilder(1);
+
+        $this->assertSoftDeleted(ProductStub::class, $this->data);
+    }
+
     public function testAssertSoftDeletedInDatabaseDoesNotFindResults()
     {
         $this->expectException(ExpectationFailedException::class);
@@ -206,6 +237,13 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $builder->shouldReceive('get')->andReturn(collect());
 
         $this->assertSoftDeleted(new CustomProductStub($this->data));
+    }
+
+    public function testGetTableNameFromModel()
+    {
+        $this->assertEquals($this->table, $this->getTable(ProductStub::class));
+        $this->assertEquals($this->table, $this->getTable(new ProductStub));
+        $this->assertEquals($this->table, $this->getTable($this->table));
     }
 
     protected function mockCountBuilder($countResult, $deletedAtColumn = 'deleted_at')


### PR DESCRIPTION
Hey Guys!

A good thing when working with Eloquent, you never ever have to care about the table name.
But when it comes to testing there are some nice [assertions](https://laravel.com/docs/8.x/database-testing#available-assertions) `assertDatabase*()`

Currently, I have to "hardcode" the table name in my tests (which makes it hard to rename a model and its table name later) `$this->assertDatabaseCount('users', 5);`

Wouldnt it be great to just pass the model?
This PR adds exactly this!
```php
$this->assertDatabaseCount('users', 5);
$this->assertDatabaseCount(Users::class, 5);
$this->assertDatabaseCount(new User, 5);
```

I know we could also resolve the connection from the model but this could be done in a follow-up PR.

Cheers Adrian

