### PR TITLE
Add a md5() string helper

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -395,6 +395,17 @@ class Str
     }
 
     /**
+     * Returns the md5 hash from a string.
+     *
+     * @param  string  $string
+     * @return string
+     */
+    public static function md5($string)
+    {
+        return md5($string);
+    }
+
+    /**
      * Pad both sides of a string with another.
      *
      * @param  string  $value

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -366,6 +366,16 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Returns the md5 hash from a string.
+     *
+     * @return string
+     */
+    public function md5()
+    {
+        return md5($this->value);
+    }
+
+    /**
      * Determine if the string matches the given pattern.
      *
      * @param  string  $pattern

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -516,6 +516,12 @@ class SupportStrTest extends TestCase
         $this->assertEquals(10, Str::wordCount('Hi, this is my first contribution to the Laravel framework.'));
     }
 
+    public function testMd5()
+    {
+        $this->assertEquals(md5('Hello, world!'), Str::md5('Hello, world!'));
+        $this->assertEquals(md5('My name is Jeroen!'), Str::md5('My name is Jeroen!'));
+    }
+
     public function validUuidList()
     {
         return [

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -652,4 +652,10 @@ class SupportStringableTest extends TestCase
         $this->assertEquals(2, $this->stringable('Hello, world!')->wordCount());
         $this->assertEquals(10, $this->stringable('Hi, this is my first contribution to the Laravel framework.')->wordCount());
     }
+
+    public function testMd5()
+    {
+        $this->assertEquals(md5('Hello, world!'), $this->stringable('Hello, world!')->md5());
+        $this->assertEquals(md5('My name is Jeroen!'), $this->stringable('My name is Jeroen!')->md5());
+    }
 }


### PR DESCRIPTION
Hello,

I added a `md5()` string helper in this PR.

Using this helper, this code:

```php
$email = md5(Str::of($this->email)->trim()->lower());
```

Can become:

```php
$email = Str::of($this->email)->trim()->lower()->md5();
```

**Note:** I used [Gravatar ](http://nl.gravatar.com/site/implement/images/php/)for the example.

Thanks! Jeroen