### PR TITLE
[9.x] disable sessions and csrf for staless domains

### DIFF
--- a/src/Illuminate/Foundation/Http/StatelessDetector.php
+++ b/src/Illuminate/Foundation/Http/StatelessDetector.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Illuminate\Foundation\Http;
+
+class StatelessDetector
+{
+    /**
+     * Detects whether the request is stateless.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return bool
+     */
+    public function isStateless($request)
+    {
+        return in_array($request->getHost(), config('app.stateless_domains', []), true);
+    }
+}

--- a/src/Illuminate/Session/SessionServiceProvider.php
+++ b/src/Illuminate/Session/SessionServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Session;
 
 use Illuminate\Contracts\Cache\Factory as CacheFactory;
+use Illuminate\Foundation\Http\StatelessDetector;
 use Illuminate\Session\Middleware\StartSession;
 use Illuminate\Support\ServiceProvider;
 
@@ -20,9 +21,10 @@ class SessionServiceProvider extends ServiceProvider
         $this->registerSessionDriver();
 
         $this->app->singleton(StartSession::class, function ($app) {
-            return new StartSession($app->make(SessionManager::class), function () use ($app) {
-                return $app->make(CacheFactory::class);
-            });
+            return new StartSession($app->make(SessionManager::class),
+                $app->make(StatelessDetector::class), function () use ($app) {
+                    return $app->make(CacheFactory::class);
+                });
         });
     }
 

--- a/src/Illuminate/View/Middleware/ShareErrorsFromSession.php
+++ b/src/Illuminate/View/Middleware/ShareErrorsFromSession.php
@@ -4,6 +4,7 @@ namespace Illuminate\View\Middleware;
 
 use Closure;
 use Illuminate\Contracts\View\Factory as ViewFactory;
+use Illuminate\Foundation\Http\StatelessDetector;
 use Illuminate\Support\ViewErrorBag;
 
 class ShareErrorsFromSession
@@ -16,14 +17,21 @@ class ShareErrorsFromSession
     protected $view;
 
     /**
+     * @var \Illuminate\Foundation\Http\StatelessDetector
+     */
+    private StatelessDetector $statelessDetector;
+
+    /**
      * Create a new error binder instance.
      *
      * @param  \Illuminate\Contracts\View\Factory  $view
+     * @param  \Illuminate\Foundation\Http\StatelessDetector $statelessDetector
      * @return void
      */
-    public function __construct(ViewFactory $view)
+    public function __construct(ViewFactory $view, StatelessDetector $statelessDetector)
     {
         $this->view = $view;
+        $this->statelessDetector = $statelessDetector;
     }
 
     /**
@@ -35,6 +43,9 @@ class ShareErrorsFromSession
      */
     public function handle($request, Closure $next)
     {
+        if ($this->statelessDetector->isStateless($request)) {
+            return $next($request);
+        }
         // If the current session has an "errors" variable bound to it, we will share
         // its value with all view instances so the views can easily access errors
         // without having to bind. An empty bag is set when there aren't errors.

--- a/tests/Integration/Http/Middleware/VerifyCsrfTokenExceptTest.php
+++ b/tests/Integration/Http/Middleware/VerifyCsrfTokenExceptTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Integration\Http\Middleware;
 
 use Illuminate\Encryption\Encrypter;
+use Illuminate\Foundation\Http\StatelessDetector;
 use Illuminate\Http\Request;
 use Orchestra\Testbench\TestCase;
 
@@ -15,7 +16,8 @@ class VerifyCsrfTokenExceptTest extends TestCase
     {
         parent::setUp();
 
-        $this->stub = new VerifyCsrfTokenExceptStub(app(), new Encrypter(Encrypter::generateKey('AES-128-CBC')));
+        $this->stub = new VerifyCsrfTokenExceptStub(app(), new Encrypter(Encrypter::generateKey('AES-128-CBC')),
+            app(StatelessDetector::class));
         $this->request = Request::create('http://example.com/foo/bar', 'POST');
     }
 


### PR DESCRIPTION
For domains that are not supposed to be used via browsers, session and csrf protection can be disabled. This can be done either in framework (via this PR), or by extending the corresponding middleware in laravel project, which doesn't requires any PR. Currently I am using the second approach in our application.

- Not disabling sessions in domains that doesn't require session is a waste of server resources.
- Not disabling CSRF protection in domains that doesn't require protection complicates client code because they need to fetch token before sending a post request. Note that domains that doesn't have session can't have CSRF token either.

The domain should be detected by `$request->getHost()` or `$request->getHttpHost()`. I don't think it is OK to user referer header for this purpose.

Alternative implementation is to move the config in `session.php`, instead of `app.php`, and move `isStateless()` function to an already existing class, e.g. `SessionManager`.