### PR TITLE
[8.x] Make mailable html and markdown properties public

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -76,14 +76,14 @@ class Mailable implements MailableContract, Renderable
      *
      * @var string
      */
-    protected $markdown;
+    public $markdown;
 
     /**
      * The HTML to use for the message.
      *
      * @var string
      */
-    protected $html;
+    public $html;
 
     /**
      * The view to use for the message.


### PR DESCRIPTION
I already have some tests that perform assertions on the mailable being built like:

```php
tap($mailable->build(), function (Mailable $mailable) {
    $this->assertEquals('emails.users.invite', $mailable->view);
});
```

And that works great with the `view` method allowing to verify the view path being used, but the `markdown` and `html` methods store the content in `protected` properties, which prevents the same kind of tests to be written.

This PR allow to write those kind of tests by making those properties `public` and brings consistency with the `view` method.