### PR TITLE
[8.x] Add getters to mailable markdown and html

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -1010,6 +1010,26 @@ class Mailable implements MailableContract, Renderable
     }
 
     /**
+     * Get the Markdown template for the message.
+     *
+     * @return string|null
+     */
+    public function getMarkdown()
+    {
+        return $this->markdown;
+    }
+
+    /**
+     * Get the rendered HTML content for the message.
+     *
+     * @return string|null
+     */
+    public function getHtml()
+    {
+        return $this->html;
+    }
+
+    /**
      * Dynamically bind parameters to the message.
      *
      * @param  string  $method


### PR DESCRIPTION
This is a re-submission of #37464 using the getters approach. Thanks for the feedback, @driesvints!

This getters will allow to write tests around mailable configurations like:


```php
// If the mailable uses a certain markdown view path:
public function build()
{
    return $this->markdown('emails.users.invite');
}

// Then in the test we can write
tap($mailable->build(), function (Mailable $mailable) {
    $this->assertEquals('emails.users.invite', $mailable->getMarkdown());
});
```

```php
// If the mailable uses certain HTML:
public function build()
{
    return $this->html('<p>Hello, world</p>');
}

// Then in the test we can write
tap($mailable->build(), function (Mailable $mailable) {
    $this->assertEquals('<p>Hello, world</p>', $mailable->getHtml());
});
```