### PR TITLE
[8.x] Reconnect the correct connection when using ::read or ::write

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -162,6 +162,13 @@ class Connection implements ConnectionInterface
     protected static $resolvers = [];
 
     /**
+     * The type of the connection.
+     *
+     * @var string|null
+     */
+    protected $type;
+
+    /**
      * Create a new database connection instance.
      *
      * @param  \PDO|\Closure  $pdo
@@ -1046,6 +1053,16 @@ class Connection implements ConnectionInterface
     }
 
     /**
+     * Get the database connection full name.
+     *
+     * @return string|null
+     */
+    public function getFullName()
+    {
+        return $this->getName().($this->type ? '::'.$this->type : '');
+    }
+
+    /**
      * Get an option from the configuration options.
      *
      * @param  string|null  $option
@@ -1270,6 +1287,19 @@ class Connection implements ConnectionInterface
     public function setDatabaseName($database)
     {
         $this->database = $database;
+
+        return $this;
+    }
+
+    /**
+     * Set the type of the connection.
+     *
+     * @param  string  $type
+     * @return $this
+     */
+    public function setType($type)
+    {
+        $this->type = $type;
 
         return $this;
     }

--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -62,7 +62,7 @@ class DatabaseManager implements ConnectionResolverInterface
         $this->factory = $factory;
 
         $this->reconnector = function ($connection) {
-            $this->reconnect($connection->getName());
+            $this->reconnect($connection->getFullName());
         };
     }
 
@@ -165,7 +165,7 @@ class DatabaseManager implements ConnectionResolverInterface
      */
     protected function configure(Connection $connection, $type)
     {
-        $connection = $this->setPdoForType($connection, $type);
+        $connection = $this->setPdoForType($connection, $type)->setType($type);
 
         // First we'll set the fetch mode and a few other dependencies of the database
         // connection. This method basically just configures and prepares it to get
@@ -275,7 +275,11 @@ class DatabaseManager implements ConnectionResolverInterface
      */
     protected function refreshPdoConnections($name)
     {
-        $fresh = $this->makeConnection($name);
+        [$database, $type] = $this->parseConnectionName($name);
+
+        $fresh = $this->configure(
+            $this->makeConnection($database), $type
+        );
 
         return $this->connections[$name]
                                 ->setPdo($fresh->getRawPdo())


### PR DESCRIPTION
This PR fixes https://github.com/laravel/octane/issues/285

The problem is that when using `connection('mysql::write')`, the connection name is stored as `mysql::write` but when reconnecting we use `mysql` only so it actually creates a new connection and doesn't reconnect the `mysql::write` connection.

This PR fixes that by storing the connection type on the connection object and using this type to reconnect the correct connection.