### PR TITLE
[8.x] Update Builder.php, fixing null column with cursorPaginate

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -270,6 +270,10 @@ class Builder
 
             $this->query->addNestedWhereQuery($query->getQuery(), $boolean);
         } else {
+            if ($value === null && in_array($operator,['>','<'])) {
+                $operator = '=';
+            }
+            
             $this->query->where(...func_get_args());
         }
 

--- a/src/Illuminate/Pagination/Cursor.php
+++ b/src/Illuminate/Pagination/Cursor.php
@@ -43,7 +43,7 @@ class Cursor implements Arrayable
      */
     public function parameter(string $parameterName)
     {
-        if (! isset($this->parameters[$parameterName])) {
+        if (! array_key_exists($parameterName, $this->parameters)) {
             throw new UnexpectedValueException("Unable to find parameter [{$parameterName}] in pagination item.");
         }
 


### PR DESCRIPTION
Change to make `cursorPaginate` work with nullable column in `orderBy`.

The `cursorPaginate` send where like this `column > null`, and error fires `Illegal operator and value combination.`.

This is solution for this case, I don't know if there is way to make it better, but i don't think there is one to do `->where('column','>',null)`, if there so this would help him :)