### PR TITLE
[8.x] Adds class handling for Blade echo statements

### DIFF
--- a/src/Illuminate/Support/Facades/Blade.php
+++ b/src/Illuminate/Support/Facades/Blade.php
@@ -26,6 +26,7 @@ namespace Illuminate\Support\Facades;
  * @method static void withDoubleEncoding()
  * @method static void withoutComponentTags()
  * @method static void withoutDoubleEncoding()
+ * @method static void handle(string $className, callable $handler)
  *
  * @see \Illuminate\View\Compilers\BladeCompiler
  */

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -128,6 +128,13 @@ class BladeCompiler extends Compiler implements CompilerInterface
     protected $classComponentNamespaces = [];
 
     /**
+     * The array of handlers objects should be passed through.
+     *
+     * @var array
+     */
+    public static $echoHandlers = [];
+
+    /**
      * Indicates if component tags should be compiled.
      *
      * @var bool
@@ -751,5 +758,15 @@ class BladeCompiler extends Compiler implements CompilerInterface
     public function withoutComponentTags()
     {
         $this->compilesComponentTags = false;
+    }
+
+    /**
+     * Add a handler to be executed before echoing a given class.
+     *
+     * @return void
+     */
+    public function handle(string $className, callable $handler)
+    {
+        static::$echoHandlers[$className] = $handler;
     }
 }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
@@ -100,7 +100,7 @@ trait CompilesEchos
     {
         $echoHandlerArray = static::class . "::\$echoHandlers";
 
-        return "isset({$echoHandlerArray}[get_class($data)])
+        return "is_object($data) && isset({$echoHandlerArray}[get_class($data)])
             ? call_user_func_array({$echoHandlerArray}[get_class($data)], [$data])
             : $data";
     }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
@@ -100,7 +100,7 @@ trait CompilesEchos
     {
         $echoHandlerArray = static::class . "::\$echoHandlers";
 
-        return "array_key_exists(get_class($data), $echoHandlerArray)
+        return "isset({$echoHandlerArray}[get_class($data)])
             ? call_user_func_array({$echoHandlerArray}[get_class($data)], [$data])
             : $data";
     }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
@@ -46,6 +46,8 @@ trait CompilesEchos
         $callback = function ($matches) {
             $whitespace = empty($matches[3]) ? '' : $matches[3].$matches[3];
 
+            $matches[2] = $this->applyEchoHandlerFor($matches[2]);
+
             return $matches[1] ? substr($matches[0], 1) : "<?php echo {$matches[2]}; ?>{$whitespace}";
         };
 
@@ -64,6 +66,8 @@ trait CompilesEchos
 
         $callback = function ($matches) {
             $whitespace = empty($matches[3]) ? '' : $matches[3].$matches[3];
+
+            $matches[2] = $this->applyEchoHandlerFor($matches[2]);
 
             $wrapped = sprintf($this->echoFormat, $matches[2]);
 
@@ -90,5 +94,14 @@ trait CompilesEchos
         };
 
         return preg_replace_callback($pattern, $callback, $value);
+    }
+
+    protected function applyEchoHandlerFor($data)
+    {
+        $echoHandlerArray = static::class . "::\$echoHandlers";
+
+        return "array_key_exists(get_class($data), $echoHandlerArray)
+            ? call_user_func_array({$echoHandlerArray}[get_class($data)], [$data])
+            : $data";
     }
 }

--- a/tests/View/Blade/BladeEchoHandlerTest.php
+++ b/tests/View/Blade/BladeEchoHandlerTest.php
@@ -20,7 +20,7 @@ class BladeEchoHandlerTest extends AbstractBladeTestCase
         $echoHandlerArray = get_class($this->compiler) . "::\$echoHandlers";
 
         $this->assertSame(
-            "<?php echo e(isset({$echoHandlerArray}[get_class(\$exampleObject)])
+            "<?php echo e(is_object(\$exampleObject) && isset({$echoHandlerArray}[get_class(\$exampleObject)])
             ? call_user_func_array({$echoHandlerArray}[get_class(\$exampleObject)], [\$exampleObject])
             : \$exampleObject); ?>",
             $this->compiler->compileString('{{$exampleObject}}')
@@ -32,7 +32,7 @@ class BladeEchoHandlerTest extends AbstractBladeTestCase
         $echoHandlerArray = get_class($this->compiler) . "::\$echoHandlers";
 
         $this->assertSame(
-            "<?php echo isset({$echoHandlerArray}[get_class(\$exampleObject)])
+            "<?php echo is_object(\$exampleObject) && isset({$echoHandlerArray}[get_class(\$exampleObject)])
             ? call_user_func_array({$echoHandlerArray}[get_class(\$exampleObject)], [\$exampleObject])
             : \$exampleObject; ?>",
             $this->compiler->compileString('{!!$exampleObject!!}')

--- a/tests/View/Blade/BladeEchoHandlerTest.php
+++ b/tests/View/Blade/BladeEchoHandlerTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Illuminate\Tests\View\Blade;
+
+use Illuminate\Support\Fluent;
+
+class BladeEchoHandlerTest extends AbstractBladeTestCase
+{
+    public function testBladeHandlersCanBeAddedForAGivenClass()
+    {
+        $this->compiler->handle(Fluent::class, function($object) {
+            return "Hello World";
+        });
+
+        $this->assertSame('Hello World', $this->compiler::$echoHandlers[Fluent::class](new Fluent()));
+    }
+
+    public function testBladeHandlerCanInterceptEscapedEchos()
+    {
+        $echoHandlerArray = get_class($this->compiler) . "::\$echoHandlers";
+
+        $this->assertSame(
+            "<?php echo e(array_key_exists(get_class(\$exampleObject), $echoHandlerArray)
+            ? call_user_func_array({$echoHandlerArray}[get_class(\$exampleObject)], [\$exampleObject])
+            : \$exampleObject); ?>",
+            $this->compiler->compileString('{{$exampleObject}}')
+        );
+    }
+
+    public function testBladeHandlerCanInterceptRawEchos()
+    {
+        $echoHandlerArray = get_class($this->compiler) . "::\$echoHandlers";
+
+        $this->assertSame(
+            "<?php echo array_key_exists(get_class(\$exampleObject), $echoHandlerArray)
+            ? call_user_func_array({$echoHandlerArray}[get_class(\$exampleObject)], [\$exampleObject])
+            : \$exampleObject; ?>",
+            $this->compiler->compileString('{!!$exampleObject!!}')
+        );
+    }
+}

--- a/tests/View/Blade/BladeEchoHandlerTest.php
+++ b/tests/View/Blade/BladeEchoHandlerTest.php
@@ -20,7 +20,7 @@ class BladeEchoHandlerTest extends AbstractBladeTestCase
         $echoHandlerArray = get_class($this->compiler) . "::\$echoHandlers";
 
         $this->assertSame(
-            "<?php echo e(array_key_exists(get_class(\$exampleObject), $echoHandlerArray)
+            "<?php echo e(isset({$echoHandlerArray}[get_class(\$exampleObject)])
             ? call_user_func_array({$echoHandlerArray}[get_class(\$exampleObject)], [\$exampleObject])
             : \$exampleObject); ?>",
             $this->compiler->compileString('{{$exampleObject}}')
@@ -32,7 +32,7 @@ class BladeEchoHandlerTest extends AbstractBladeTestCase
         $echoHandlerArray = get_class($this->compiler) . "::\$echoHandlers";
 
         $this->assertSame(
-            "<?php echo array_key_exists(get_class(\$exampleObject), $echoHandlerArray)
+            "<?php echo isset({$echoHandlerArray}[get_class(\$exampleObject)])
             ? call_user_func_array({$echoHandlerArray}[get_class(\$exampleObject)], [\$exampleObject])
             : \$exampleObject; ?>",
             $this->compiler->compileString('{!!$exampleObject!!}')


### PR DESCRIPTION
## What is it?

When working in Blade, I'll often want to always output a class in the same manner. I'll use Brick/Money as the example here, but this can apply to pretty much any class you can think of. 

Brick/Money is a final class, so I can't add a `Stringable` interface to it. Whenever I output `{{ $moneyObject }}`, I would want it to format as `£100.00`, for example. The same could be said for a `Carbon` instance. 

This PR adds a new `Blade::handle()` method that can be placed in the boot method of a Service Provider and allows the user to add intercepting closures for any class. The returned value will be outputted in Blade.

Think of this as the Exception Handler, but for Blade.

## Usage

```php
// AppServiceProvider
Blade::handle(Money::class, fn($object) => $object->formatTo('en_GB'));
```

```blade
<dl>
    <dt>Total</dt>
    <dd>{{ $total }}</dd> <!-- This is a money object, but will be outputted as an en_GB formatted string -->
</dl>
```

## How does it work?

This works by wrapping a small piece of logic around php output at the parser level, which means that the object is evaluated just in time and can thus be treated as a standard object throughout the entire application; it is only transformed by the PHP script at the time of output.

Feel free to throw any questions back at me :-)

Thanks for all the hard work guys!