### PR TITLE
[8.x] Adds class handling for Blade echo statements

### DIFF
--- a/src/Illuminate/Support/Facades/Blade.php
+++ b/src/Illuminate/Support/Facades/Blade.php
@@ -26,7 +26,7 @@ namespace Illuminate\Support\Facades;
  * @method static void withDoubleEncoding()
  * @method static void withoutComponentTags()
  * @method static void withoutDoubleEncoding()
- * @method static void handle(string $className, callable $handler)
+ * @method static void addEchoHandler(string $className, callable $handler)
  *
  * @see \Illuminate\View\Compilers\BladeCompiler
  */

--- a/src/Illuminate/Support/Facades/Blade.php
+++ b/src/Illuminate/Support/Facades/Blade.php
@@ -26,7 +26,7 @@ namespace Illuminate\Support\Facades;
  * @method static void withDoubleEncoding()
  * @method static void withoutComponentTags()
  * @method static void withoutDoubleEncoding()
- * @method static void addEchoHandler(string $className, callable $handler)
+ * @method static void stringable(string|callable $class, callable|null $handler)
  *
  * @see \Illuminate\View\Compilers\BladeCompiler
  */

--- a/src/Illuminate/Support/Facades/Blade.php
+++ b/src/Illuminate/Support/Facades/Blade.php
@@ -26,6 +26,7 @@ namespace Illuminate\Support\Facades;
  * @method static void withDoubleEncoding()
  * @method static void withoutComponentTags()
  * @method static void withoutDoubleEncoding()
+ * @method static void handle(string $className, callable $handler)
  *
  * @see \Illuminate\View\Compilers\BladeCompiler
  */

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -765,7 +765,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      *
      * @return void
      */
-    public function handle(string $className, callable $handler)
+    public function addEchoHandler(string $className, callable $handler)
     {
         $this->echoHandlers[$className] = $handler;
     }

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -128,6 +128,13 @@ class BladeCompiler extends Compiler implements CompilerInterface
     protected $classComponentNamespaces = [];
 
     /**
+     * The array of handlers objects should be passed through.
+     *
+     * @var array
+     */
+    public static $echoHandlers = [];
+
+    /**
      * Indicates if component tags should be compiled.
      *
      * @var bool
@@ -751,5 +758,15 @@ class BladeCompiler extends Compiler implements CompilerInterface
     public function withoutComponentTags()
     {
         $this->compilesComponentTags = false;
+    }
+
+    /**
+     * Add a handler to be executed before echoing a given class.
+     *
+     * @return void
+     */
+    public function handle(string $className, callable $handler)
+    {
+        static::$echoHandlers[$className] = $handler;
     }
 }

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -132,7 +132,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      *
      * @var array
      */
-    public static $echoHandlers = [];
+    public $echoHandlers = [];
 
     /**
      * Indicates if component tags should be compiled.
@@ -767,6 +767,6 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     public function handle(string $className, callable $handler)
     {
-        static::$echoHandlers[$className] = $handler;
+        $this->echoHandlers[$className] = $handler;
     }
 }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
@@ -98,11 +98,11 @@ trait CompilesEchos
 
     protected function applyEchoHandlerFor($data)
     {
-        if (empty(static::$echoHandlers)) {
+        if (empty($this->echoHandlers)) {
             return $data;
         }
 
-        $echoHandlerArray = static::class . "::\$echoHandlers";
+        $echoHandlerArray = static::class . "->echoHandlers";
 
         return "is_object($data) && isset({$echoHandlerArray}[get_class($data)])
             ? call_user_func_array({$echoHandlerArray}[get_class($data)], [$data])

--- a/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
@@ -108,7 +108,7 @@ trait CompilesEchos
             return $value;
         }
 
-        $echoHandlerArray = static::class.'->echoHandlers';
+        $echoHandlerArray = "app('blade.compiler')->echoHandlers";
 
         return "is_object($value) && isset({$echoHandlerArray}[get_class($value)]) ? call_user_func_array({$echoHandlerArray}[get_class($value)], [$value]) : $value";
     }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
@@ -100,7 +100,7 @@ trait CompilesEchos
     {
         $echoHandlerArray = static::class . "::\$echoHandlers";
 
-        return "isset({$echoHandlerArray}[get_class($data)])
+        return "is_object($data) && isset({$echoHandlerArray}[get_class($data)])
             ? call_user_func_array({$echoHandlerArray}[get_class($data)], [$data])
             : $data";
     }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
@@ -46,9 +46,9 @@ trait CompilesEchos
         $callback = function ($matches) {
             $whitespace = empty($matches[3]) ? '' : $matches[3].$matches[3];
 
-            $matches[2] = $this->applyEchoHandlerFor($matches[2]);
-
-            return $matches[1] ? substr($matches[0], 1) : "<?php echo {$matches[2]}; ?>{$whitespace}";
+            return $matches[1]
+                ? substr($matches[0], 1)
+                : "<?php echo {$this->applyEchoHandlerFor($matches[2])}; ?>{$whitespace}";
         };
 
         return preg_replace_callback($pattern, $callback, $value);
@@ -67,9 +67,7 @@ trait CompilesEchos
         $callback = function ($matches) {
             $whitespace = empty($matches[3]) ? '' : $matches[3].$matches[3];
 
-            $matches[2] = $this->applyEchoHandlerFor($matches[2]);
-
-            $wrapped = sprintf($this->echoFormat, $matches[2]);
+            $wrapped = sprintf($this->echoFormat, $this->applyEchoHandlerFor($matches[2]));
 
             return $matches[1] ? substr($matches[0], 1) : "<?php echo {$wrapped}; ?>{$whitespace}";
         };
@@ -90,9 +88,9 @@ trait CompilesEchos
         $callback = function ($matches) {
             $whitespace = empty($matches[3]) ? '' : $matches[3].$matches[3];
 
-            $matches[2] = $this->applyEchoHandlerFor($matches[2]);
-
-            return $matches[1] ? $matches[0] : "<?php echo e({$matches[2]}); ?>{$whitespace}";
+            return $matches[1]
+                ? $matches[0]
+                : "<?php echo e({$this->applyEchoHandlerFor($matches[2])}); ?>{$whitespace}";
         };
 
         return preg_replace_callback($pattern, $callback, $value);

--- a/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
@@ -104,12 +104,8 @@ trait CompilesEchos
      */
     protected function applyEchoHandlerFor($value)
     {
-        if (empty($this->echoHandlers)) {
-            return $value;
-        }
-
-        $echoHandlerArray = "app('blade.compiler')->echoHandlers";
-
-        return "is_object($value) && isset({$echoHandlerArray}[get_class($value)]) ? call_user_func_array({$echoHandlerArray}[get_class($value)], [$value]) : $value";
+        return empty($this->echoHandlers)
+            ? $value
+            : "is_object($value) && isset(app('blade.compiler')->echoHandlers[get_class($value)]) ? call_user_func_array(app('blade.compiler')->echoHandlers[get_class($value)], [$value]) : $value";
     }
 }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
@@ -90,6 +90,8 @@ trait CompilesEchos
         $callback = function ($matches) {
             $whitespace = empty($matches[3]) ? '' : $matches[3].$matches[3];
 
+            $matches[2] = $this->applyEchoHandlerFor($matches[2]);
+
             return $matches[1] ? $matches[0] : "<?php echo e({$matches[2]}); ?>{$whitespace}";
         };
 

--- a/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
@@ -100,7 +100,7 @@ trait CompilesEchos
     {
         $echoHandlerArray = static::class . "::\$echoHandlers";
 
-        return "array_key_exists(get_class($data), $echoHandlerArray)
+        return "isset({$echoHandlerArray}[get_class($data)])
             ? call_user_func_array({$echoHandlerArray}[get_class($data)], [$data])
             : $data";
     }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
@@ -110,8 +110,6 @@ trait CompilesEchos
 
         $echoHandlerArray = static::class.'->echoHandlers';
 
-        return "is_object($value) && isset({$echoHandlerArray}[get_class($value)])
-            ? call_user_func_array({$echoHandlerArray}[get_class($value)], [$value])
-            : $value";
+        return "is_object($value) && isset({$echoHandlerArray}[get_class($value)]) ? call_user_func_array({$echoHandlerArray}[get_class($value)], [$value]) : $value";
     }
 }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
@@ -97,9 +97,9 @@ trait CompilesEchos
     }
 
     /**
-     * Wrap the value in a handler if applicable.
+     * Wrap the echoable value in an echo handler if applicable.
      *
-     * @param  string $value
+     * @param  string  $value
      * @return string
      */
     protected function applyEchoHandlerFor($value)

--- a/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
@@ -98,16 +98,22 @@ trait CompilesEchos
         return preg_replace_callback($pattern, $callback, $value);
     }
 
-    protected function applyEchoHandlerFor($data)
+    /**
+     * Wrap the value in a handler if applicable.
+     *
+     * @param  string $data
+     * @return string
+     */
+    protected function applyEchoHandlerFor($value)
     {
         if (empty($this->echoHandlers)) {
-            return $data;
+            return $value;
         }
 
         $echoHandlerArray = static::class.'->echoHandlers';
 
-        return "is_object($data) && isset({$echoHandlerArray}[get_class($data)])
-            ? call_user_func_array({$echoHandlerArray}[get_class($data)], [$data])
-            : $data";
+        return "is_object($value) && isset({$echoHandlerArray}[get_class($value)])
+            ? call_user_func_array({$echoHandlerArray}[get_class($value)], [$value])
+            : $value";
     }
 }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
@@ -98,6 +98,10 @@ trait CompilesEchos
 
     protected function applyEchoHandlerFor($data)
     {
+        if (empty(static::$echoHandlers)) {
+            return $data;
+        }
+
         $echoHandlerArray = static::class . "::\$echoHandlers";
 
         return "is_object($data) && isset({$echoHandlerArray}[get_class($data)])

--- a/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
@@ -102,7 +102,7 @@ trait CompilesEchos
             return $data;
         }
 
-        $echoHandlerArray = static::class . "->echoHandlers";
+        $echoHandlerArray = static::class.'->echoHandlers';
 
         return "is_object($data) && isset({$echoHandlerArray}[get_class($data)])
             ? call_user_func_array({$echoHandlerArray}[get_class($data)], [$data])

--- a/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
@@ -99,7 +99,7 @@ trait CompilesEchos
     /**
      * Wrap the value in a handler if applicable.
      *
-     * @param  string $data
+     * @param  string $value
      * @return string
      */
     protected function applyEchoHandlerFor($value)

--- a/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
@@ -46,6 +46,8 @@ trait CompilesEchos
         $callback = function ($matches) {
             $whitespace = empty($matches[3]) ? '' : $matches[3].$matches[3];
 
+            $matches[2] = $this->applyEchoHandlerFor($matches[2]);
+
             return $matches[1] ? substr($matches[0], 1) : "<?php echo {$matches[2]}; ?>{$whitespace}";
         };
 
@@ -64,6 +66,8 @@ trait CompilesEchos
 
         $callback = function ($matches) {
             $whitespace = empty($matches[3]) ? '' : $matches[3].$matches[3];
+
+            $matches[2] = $this->applyEchoHandlerFor($matches[2]);
 
             $wrapped = sprintf($this->echoFormat, $matches[2]);
 
@@ -90,5 +94,14 @@ trait CompilesEchos
         };
 
         return preg_replace_callback($pattern, $callback, $value);
+    }
+
+    protected function applyEchoHandlerFor($data)
+    {
+        $echoHandlerArray = static::class . "::\$echoHandlers";
+
+        return "array_key_exists(get_class($data), $echoHandlerArray)
+            ? call_user_func_array({$echoHandlerArray}[get_class($data)], [$data])
+            : $data";
     }
 }

--- a/tests/View/Blade/BladeEchoHandlerTest.php
+++ b/tests/View/Blade/BladeEchoHandlerTest.php
@@ -20,7 +20,7 @@ class BladeEchoHandlerTest extends AbstractBladeTestCase
         $this->assertSame('Hello World', $this->compiler->echoHandlers[Fluent::class](new Fluent()));
     }
 
-    public function testBladeHandlerCanInterceptEscapedEchos()
+    public function testBladeHandlerCanInterceptRegularEchos()
     {
         $echoHandlerArray = get_class($this->compiler).'->echoHandlers';
 
@@ -41,6 +41,18 @@ class BladeEchoHandlerTest extends AbstractBladeTestCase
             ? call_user_func_array({$echoHandlerArray}[get_class(\$exampleObject)], [\$exampleObject])
             : \$exampleObject; ?>",
             $this->compiler->compileString('{!!$exampleObject!!}')
+        );
+    }
+
+    public function testBladeHandlerCanInterceptEscapedEchos()
+    {
+        $echoHandlerArray = get_class($this->compiler).'->echoHandlers';
+
+        $this->assertSame(
+            "<?php echo e(is_object(\$exampleObject) && isset({$echoHandlerArray}[get_class(\$exampleObject)])
+            ? call_user_func_array({$echoHandlerArray}[get_class(\$exampleObject)], [\$exampleObject])
+            : \$exampleObject); ?>",
+            $this->compiler->compileString('{{{$exampleObject}}}')
         );
     }
 }

--- a/tests/View/Blade/BladeEchoHandlerTest.php
+++ b/tests/View/Blade/BladeEchoHandlerTest.php
@@ -15,24 +15,18 @@ class BladeEchoHandlerTest extends AbstractBladeTestCase
         });
     }
 
-    protected function tearDown(): void
-    {
-        parent::tearDown();
-        $this->compiler::$echoHandlers = [];
-    }
-
     public function testBladeHandlersCanBeAddedForAGivenClass()
     {
         $this->compiler->handle(Fluent::class, function($object) {
             return "Hello World";
         });
 
-        $this->assertSame('Hello World', $this->compiler::$echoHandlers[Fluent::class](new Fluent()));
+        $this->assertSame('Hello World', $this->compiler->echoHandlers[Fluent::class](new Fluent()));
     }
 
     public function testBladeHandlerCanInterceptEscapedEchos()
     {
-        $echoHandlerArray = get_class($this->compiler) . "::\$echoHandlers";
+        $echoHandlerArray = get_class($this->compiler) . "->echoHandlers";
 
         $this->assertSame(
             "<?php echo e(is_object(\$exampleObject) && isset({$echoHandlerArray}[get_class(\$exampleObject)])
@@ -44,7 +38,7 @@ class BladeEchoHandlerTest extends AbstractBladeTestCase
 
     public function testBladeHandlerCanInterceptRawEchos()
     {
-        $echoHandlerArray = get_class($this->compiler) . "::\$echoHandlers";
+        $echoHandlerArray = get_class($this->compiler) . "->echoHandlers";
 
         $this->assertSame(
             "<?php echo is_object(\$exampleObject) && isset({$echoHandlerArray}[get_class(\$exampleObject)])

--- a/tests/View/Blade/BladeEchoHandlerTest.php
+++ b/tests/View/Blade/BladeEchoHandlerTest.php
@@ -20,7 +20,7 @@ class BladeEchoHandlerTest extends AbstractBladeTestCase
         $echoHandlerArray = get_class($this->compiler) . "::\$echoHandlers";
 
         $this->assertSame(
-            "<?php echo e(isset({$echoHandlerArray}[get_class(\$exampleObject)])
+            "<?php echo e(is_object(\$exampleObject) && isset({$echoHandlerArray}[get_class(\$exampleObject)])
             ? call_user_func_array({$echoHandlerArray}[get_class(\$exampleObject)], [\$exampleObject])
             : \$exampleObject); ?>",
             $this->compiler->compileString('{{$exampleObject}}')
@@ -32,7 +32,7 @@ class BladeEchoHandlerTest extends AbstractBladeTestCase
         $echoHandlerArray = get_class($this->compiler) . "::\$echoHandlers";
 
         $this->assertSame(
-            "<?php echo isset({$echoHandlerArray}[get_class(\$exampleObject)])
+            "<?php echo is_object(\$exampleObject) && isset({$echoHandlerArray}[get_class(\$exampleObject)])
             ? call_user_func_array({$echoHandlerArray}[get_class(\$exampleObject)], [\$exampleObject])
             : \$exampleObject; ?>",
             $this->compiler->compileString('{!!$exampleObject!!}')

--- a/tests/View/Blade/BladeEchoHandlerTest.php
+++ b/tests/View/Blade/BladeEchoHandlerTest.php
@@ -12,7 +12,7 @@ class BladeEchoHandlerTest extends AbstractBladeTestCase
     {
         parent::setUp();
 
-        $this->compiler->addEchoHandler(Fluent::class, function ($object) {
+        $this->compiler->stringable(function (Fluent $object) {
             return 'Hello World';
         });
     }
@@ -58,7 +58,7 @@ class BladeEchoHandlerTest extends AbstractBladeTestCase
     {
         $this->expectExceptionMessage('The fluent object has been successfully handled!');
 
-        $this->compiler->addEchoHandler(Fluent::class, function ($object) {
+        $this->compiler->stringable(Fluent::class, function ($object) {
             throw new Exception('The fluent object has been successfully handled!');
         });
 

--- a/tests/View/Blade/BladeEchoHandlerTest.php
+++ b/tests/View/Blade/BladeEchoHandlerTest.php
@@ -12,7 +12,7 @@ class BladeEchoHandlerTest extends AbstractBladeTestCase
     {
         parent::setUp();
 
-        $this->compiler->handle(Fluent::class, function ($object) {
+        $this->compiler->addEchoHandler(Fluent::class, function ($object) {
             return 'Hello World';
         });
     }
@@ -58,7 +58,7 @@ class BladeEchoHandlerTest extends AbstractBladeTestCase
     {
         $this->expectExceptionMessage('The fluent object has been successfully handled!');
 
-        $this->compiler->handle(Fluent::class, function ($object) {
+        $this->compiler->addEchoHandler(Fluent::class, function ($object) {
             throw new Exception('The fluent object has been successfully handled!');
         });
 

--- a/tests/View/Blade/BladeEchoHandlerTest.php
+++ b/tests/View/Blade/BladeEchoHandlerTest.php
@@ -3,11 +3,8 @@
 namespace Illuminate\Tests\View\Blade;
 
 use Exception;
-use Illuminate\Contracts\Container\Container;
-use Illuminate\Support\Facades\App;
 use Illuminate\Support\Fluent;
 use Illuminate\Support\Str;
-use Mockery as m;
 
 class BladeEchoHandlerTest extends AbstractBladeTestCase
 {
@@ -59,13 +56,15 @@ class BladeEchoHandlerTest extends AbstractBladeTestCase
 
     public function testHandlerLogicWorksCorrectly()
     {
-        $this->expectExceptionMessage("The fluent object has been successfully handled!");
+        $this->expectExceptionMessage('The fluent object has been successfully handled!');
 
-        $this->compiler->handle(Fluent::class, function($object) {
-            throw new Exception("The fluent object has been successfully handled!");
+        $this->compiler->handle(Fluent::class, function ($object) {
+            throw new Exception('The fluent object has been successfully handled!');
         });
 
-        app()->singleton('blade.compiler', function() { return $this->compiler; });
+        app()->singleton('blade.compiler', function () {
+            return $this->compiler;
+        });
 
         $exampleObject = new Fluent();
 

--- a/tests/View/Blade/BladeEchoHandlerTest.php
+++ b/tests/View/Blade/BladeEchoHandlerTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\View\Blade;
 
 use Illuminate\Support\Fluent;
+use Illuminate\Support\Str;
 
 class BladeEchoHandlerTest extends AbstractBladeTestCase
 {
@@ -25,9 +26,7 @@ class BladeEchoHandlerTest extends AbstractBladeTestCase
         $echoHandlerArray = get_class($this->compiler).'->echoHandlers';
 
         $this->assertSame(
-            "<?php echo e(is_object(\$exampleObject) && isset({$echoHandlerArray}[get_class(\$exampleObject)])
-            ? call_user_func_array({$echoHandlerArray}[get_class(\$exampleObject)], [\$exampleObject])
-            : \$exampleObject); ?>",
+            "<?php echo e(is_object(\$exampleObject) && isset({$echoHandlerArray}[get_class(\$exampleObject)]) ? call_user_func_array({$echoHandlerArray}[get_class(\$exampleObject)], [\$exampleObject]) : \$exampleObject); ?>",
             $this->compiler->compileString('{{$exampleObject}}')
         );
     }
@@ -37,9 +36,7 @@ class BladeEchoHandlerTest extends AbstractBladeTestCase
         $echoHandlerArray = get_class($this->compiler).'->echoHandlers';
 
         $this->assertSame(
-            "<?php echo is_object(\$exampleObject) && isset({$echoHandlerArray}[get_class(\$exampleObject)])
-            ? call_user_func_array({$echoHandlerArray}[get_class(\$exampleObject)], [\$exampleObject])
-            : \$exampleObject; ?>",
+            "<?php echo is_object(\$exampleObject) && isset({$echoHandlerArray}[get_class(\$exampleObject)]) ? call_user_func_array({$echoHandlerArray}[get_class(\$exampleObject)], [\$exampleObject]) : \$exampleObject; ?>",
             $this->compiler->compileString('{!!$exampleObject!!}')
         );
     }
@@ -49,10 +46,18 @@ class BladeEchoHandlerTest extends AbstractBladeTestCase
         $echoHandlerArray = get_class($this->compiler).'->echoHandlers';
 
         $this->assertSame(
-            "<?php echo e(is_object(\$exampleObject) && isset({$echoHandlerArray}[get_class(\$exampleObject)])
-            ? call_user_func_array({$echoHandlerArray}[get_class(\$exampleObject)], [\$exampleObject])
-            : \$exampleObject); ?>",
+            "<?php echo e(is_object(\$exampleObject) && isset({$echoHandlerArray}[get_class(\$exampleObject)]) ? call_user_func_array({$echoHandlerArray}[get_class(\$exampleObject)], [\$exampleObject]) : \$exampleObject); ?>",
             $this->compiler->compileString('{{{$exampleObject}}}')
+        );
+    }
+
+    public function testWhitespaceIsPreservedCorrectly()
+    {
+        $echoHandlerArray = get_class($this->compiler).'->echoHandlers';
+
+        $this->assertSame(
+            "<?php echo e(is_object(\$exampleObject) && isset({$echoHandlerArray}[get_class(\$exampleObject)]) ? call_user_func_array({$echoHandlerArray}[get_class(\$exampleObject)], [\$exampleObject]) : \$exampleObject); ?>\n\n",
+            $this->compiler->compileString("{{\$exampleObject}}\n")
         );
     }
 }

--- a/tests/View/Blade/BladeEchoHandlerTest.php
+++ b/tests/View/Blade/BladeEchoHandlerTest.php
@@ -22,7 +22,7 @@ class BladeEchoHandlerTest extends AbstractBladeTestCase
 
     public function testBladeHandlerCanInterceptRegularEchos()
     {
-        $echoHandlerArray = get_class($this->compiler).'->echoHandlers';
+        $echoHandlerArray = "app('blade.compiler')->echoHandlers";
 
         $this->assertSame(
             "<?php echo e(is_object(\$exampleObject) && isset({$echoHandlerArray}[get_class(\$exampleObject)]) ? call_user_func_array({$echoHandlerArray}[get_class(\$exampleObject)], [\$exampleObject]) : \$exampleObject); ?>",
@@ -32,7 +32,7 @@ class BladeEchoHandlerTest extends AbstractBladeTestCase
 
     public function testBladeHandlerCanInterceptRawEchos()
     {
-        $echoHandlerArray = get_class($this->compiler).'->echoHandlers';
+        $echoHandlerArray = "app('blade.compiler')->echoHandlers";
 
         $this->assertSame(
             "<?php echo is_object(\$exampleObject) && isset({$echoHandlerArray}[get_class(\$exampleObject)]) ? call_user_func_array({$echoHandlerArray}[get_class(\$exampleObject)], [\$exampleObject]) : \$exampleObject; ?>",
@@ -42,7 +42,7 @@ class BladeEchoHandlerTest extends AbstractBladeTestCase
 
     public function testBladeHandlerCanInterceptEscapedEchos()
     {
-        $echoHandlerArray = get_class($this->compiler).'->echoHandlers';
+        $echoHandlerArray = "app('blade.compiler')->echoHandlers";
 
         $this->assertSame(
             "<?php echo e(is_object(\$exampleObject) && isset({$echoHandlerArray}[get_class(\$exampleObject)]) ? call_user_func_array({$echoHandlerArray}[get_class(\$exampleObject)], [\$exampleObject]) : \$exampleObject); ?>",
@@ -52,7 +52,7 @@ class BladeEchoHandlerTest extends AbstractBladeTestCase
 
     public function testWhitespaceIsPreservedCorrectly()
     {
-        $echoHandlerArray = get_class($this->compiler).'->echoHandlers';
+        $echoHandlerArray = "app('blade.compiler')->echoHandlers";
 
         $this->assertSame(
             "<?php echo e(is_object(\$exampleObject) && isset({$echoHandlerArray}[get_class(\$exampleObject)]) ? call_user_func_array({$echoHandlerArray}[get_class(\$exampleObject)], [\$exampleObject]) : \$exampleObject); ?>\n\n",

--- a/tests/View/Blade/BladeEchoHandlerTest.php
+++ b/tests/View/Blade/BladeEchoHandlerTest.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Tests\View\Blade;
 
 use Illuminate\Support\Fluent;
-use Illuminate\Support\Str;
 
 class BladeEchoHandlerTest extends AbstractBladeTestCase
 {

--- a/tests/View/Blade/BladeEchoHandlerTest.php
+++ b/tests/View/Blade/BladeEchoHandlerTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Illuminate\Tests\View\Blade;
+
+use Illuminate\Support\Fluent;
+
+class BladeEchoHandlerTest extends AbstractBladeTestCase
+{
+    public function testBladeHandlersCanBeAddedForAGivenClass()
+    {
+        $this->compiler->handle(Fluent::class, function($object) {
+            return "Hello World";
+        });
+
+        $this->assertSame('Hello World', $this->compiler::$echoHandlers[Fluent::class](new Fluent()));
+    }
+
+    public function testBladeHandlerCanInterceptEscapedEchos()
+    {
+        $echoHandlerArray = get_class($this->compiler) . "::\$echoHandlers";
+
+        $this->assertSame(
+            "<?php echo e(array_key_exists(get_class(\$exampleObject), $echoHandlerArray)
+            ? call_user_func_array({$echoHandlerArray}[get_class(\$exampleObject)], [\$exampleObject])
+            : \$exampleObject); ?>",
+            $this->compiler->compileString('{{$exampleObject}}')
+        );
+    }
+
+    public function testBladeHandlerCanInterceptRawEchos()
+    {
+        $echoHandlerArray = get_class($this->compiler) . "::\$echoHandlers";
+
+        $this->assertSame(
+            "<?php echo array_key_exists(get_class(\$exampleObject), $echoHandlerArray)
+            ? call_user_func_array({$echoHandlerArray}[get_class(\$exampleObject)], [\$exampleObject])
+            : \$exampleObject; ?>",
+            $this->compiler->compileString('{!!$exampleObject!!}')
+        );
+    }
+}

--- a/tests/View/Blade/BladeEchoHandlerTest.php
+++ b/tests/View/Blade/BladeEchoHandlerTest.php
@@ -6,6 +6,21 @@ use Illuminate\Support\Fluent;
 
 class BladeEchoHandlerTest extends AbstractBladeTestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->compiler->handle(Fluent::class, function($object) {
+            return 'Hello World';
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        $this->compiler::$echoHandlers = [];
+    }
+
     public function testBladeHandlersCanBeAddedForAGivenClass()
     {
         $this->compiler->handle(Fluent::class, function($object) {

--- a/tests/View/Blade/BladeEchoHandlerTest.php
+++ b/tests/View/Blade/BladeEchoHandlerTest.php
@@ -20,7 +20,7 @@ class BladeEchoHandlerTest extends AbstractBladeTestCase
         $echoHandlerArray = get_class($this->compiler) . "::\$echoHandlers";
 
         $this->assertSame(
-            "<?php echo e(array_key_exists(get_class(\$exampleObject), $echoHandlerArray)
+            "<?php echo e(isset({$echoHandlerArray}[get_class(\$exampleObject)])
             ? call_user_func_array({$echoHandlerArray}[get_class(\$exampleObject)], [\$exampleObject])
             : \$exampleObject); ?>",
             $this->compiler->compileString('{{$exampleObject}}')
@@ -32,7 +32,7 @@ class BladeEchoHandlerTest extends AbstractBladeTestCase
         $echoHandlerArray = get_class($this->compiler) . "::\$echoHandlers";
 
         $this->assertSame(
-            "<?php echo array_key_exists(get_class(\$exampleObject), $echoHandlerArray)
+            "<?php echo isset({$echoHandlerArray}[get_class(\$exampleObject)])
             ? call_user_func_array({$echoHandlerArray}[get_class(\$exampleObject)], [\$exampleObject])
             : \$exampleObject; ?>",
             $this->compiler->compileString('{!!$exampleObject!!}')

--- a/tests/View/Blade/BladeEchoHandlerTest.php
+++ b/tests/View/Blade/BladeEchoHandlerTest.php
@@ -10,15 +10,15 @@ class BladeEchoHandlerTest extends AbstractBladeTestCase
     {
         parent::setUp();
 
-        $this->compiler->handle(Fluent::class, function($object) {
+        $this->compiler->handle(Fluent::class, function ($object) {
             return 'Hello World';
         });
     }
 
     public function testBladeHandlersCanBeAddedForAGivenClass()
     {
-        $this->compiler->handle(Fluent::class, function($object) {
-            return "Hello World";
+        $this->compiler->handle(Fluent::class, function ($object) {
+            return 'Hello World';
         });
 
         $this->assertSame('Hello World', $this->compiler->echoHandlers[Fluent::class](new Fluent()));
@@ -26,7 +26,7 @@ class BladeEchoHandlerTest extends AbstractBladeTestCase
 
     public function testBladeHandlerCanInterceptEscapedEchos()
     {
-        $echoHandlerArray = get_class($this->compiler) . "->echoHandlers";
+        $echoHandlerArray = get_class($this->compiler).'->echoHandlers';
 
         $this->assertSame(
             "<?php echo e(is_object(\$exampleObject) && isset({$echoHandlerArray}[get_class(\$exampleObject)])
@@ -38,7 +38,7 @@ class BladeEchoHandlerTest extends AbstractBladeTestCase
 
     public function testBladeHandlerCanInterceptRawEchos()
     {
-        $echoHandlerArray = get_class($this->compiler) . "->echoHandlers";
+        $echoHandlerArray = get_class($this->compiler).'->echoHandlers';
 
         $this->assertSame(
             "<?php echo is_object(\$exampleObject) && isset({$echoHandlerArray}[get_class(\$exampleObject)])

--- a/tests/View/Blade/BladeEchoHandlerTest.php
+++ b/tests/View/Blade/BladeEchoHandlerTest.php
@@ -22,40 +22,32 @@ class BladeEchoHandlerTest extends AbstractBladeTestCase
 
     public function testBladeHandlerCanInterceptRegularEchos()
     {
-        $echoHandlerArray = "app('blade.compiler')->echoHandlers";
-
         $this->assertSame(
-            "<?php echo e(is_object(\$exampleObject) && isset({$echoHandlerArray}[get_class(\$exampleObject)]) ? call_user_func_array({$echoHandlerArray}[get_class(\$exampleObject)], [\$exampleObject]) : \$exampleObject); ?>",
+            "<?php echo e(is_object(\$exampleObject) && isset(app('blade.compiler')->echoHandlers[get_class(\$exampleObject)]) ? call_user_func_array(app('blade.compiler')->echoHandlers[get_class(\$exampleObject)], [\$exampleObject]) : \$exampleObject); ?>",
             $this->compiler->compileString('{{$exampleObject}}')
         );
     }
 
     public function testBladeHandlerCanInterceptRawEchos()
     {
-        $echoHandlerArray = "app('blade.compiler')->echoHandlers";
-
         $this->assertSame(
-            "<?php echo is_object(\$exampleObject) && isset({$echoHandlerArray}[get_class(\$exampleObject)]) ? call_user_func_array({$echoHandlerArray}[get_class(\$exampleObject)], [\$exampleObject]) : \$exampleObject; ?>",
+            "<?php echo is_object(\$exampleObject) && isset(app('blade.compiler')->echoHandlers[get_class(\$exampleObject)]) ? call_user_func_array(app('blade.compiler')->echoHandlers[get_class(\$exampleObject)], [\$exampleObject]) : \$exampleObject; ?>",
             $this->compiler->compileString('{!!$exampleObject!!}')
         );
     }
 
     public function testBladeHandlerCanInterceptEscapedEchos()
     {
-        $echoHandlerArray = "app('blade.compiler')->echoHandlers";
-
         $this->assertSame(
-            "<?php echo e(is_object(\$exampleObject) && isset({$echoHandlerArray}[get_class(\$exampleObject)]) ? call_user_func_array({$echoHandlerArray}[get_class(\$exampleObject)], [\$exampleObject]) : \$exampleObject); ?>",
+            "<?php echo e(is_object(\$exampleObject) && isset(app('blade.compiler')->echoHandlers[get_class(\$exampleObject)]) ? call_user_func_array(app('blade.compiler')->echoHandlers[get_class(\$exampleObject)], [\$exampleObject]) : \$exampleObject); ?>",
             $this->compiler->compileString('{{{$exampleObject}}}')
         );
     }
 
     public function testWhitespaceIsPreservedCorrectly()
     {
-        $echoHandlerArray = "app('blade.compiler')->echoHandlers";
-
         $this->assertSame(
-            "<?php echo e(is_object(\$exampleObject) && isset({$echoHandlerArray}[get_class(\$exampleObject)]) ? call_user_func_array({$echoHandlerArray}[get_class(\$exampleObject)], [\$exampleObject]) : \$exampleObject); ?>\n\n",
+            "<?php echo e(is_object(\$exampleObject) && isset(app('blade.compiler')->echoHandlers[get_class(\$exampleObject)]) ? call_user_func_array(app('blade.compiler')->echoHandlers[get_class(\$exampleObject)], [\$exampleObject]) : \$exampleObject); ?>\n\n",
             $this->compiler->compileString("{{\$exampleObject}}\n")
         );
     }

--- a/tests/View/Blade/BladeEchoHandlerTest.php
+++ b/tests/View/Blade/BladeEchoHandlerTest.php
@@ -17,10 +17,6 @@ class BladeEchoHandlerTest extends AbstractBladeTestCase
 
     public function testBladeHandlersCanBeAddedForAGivenClass()
     {
-        $this->compiler->handle(Fluent::class, function ($object) {
-            return 'Hello World';
-        });
-
         $this->assertSame('Hello World', $this->compiler->echoHandlers[Fluent::class](new Fluent()));
     }
 


### PR DESCRIPTION
## What is it?

When working in Blade, I'll often want to always output a class in the same manner. I'll use Brick/Money as the example here, but this can apply to pretty much any class you can think of. 

Brick/Money is a final class, so I can't add a `Stringable` interface to it. Whenever I output `{{ $moneyObject }}`, I would want it to format as `£100.00`, for example. The same could be said for a `Carbon` instance. 

This PR adds a new `Blade::handle()` method that can be placed in the boot method of a Service Provider and allows the user to add intercepting closures for any class. The returned value will be outputted in Blade.

Think of this as the Exception Handler, but for Blade.

## Usage

```php
// AppServiceProvider
Blade::handle(Money::class, fn($object) => $object->formatTo('en_GB'));
Blade::handle(Carbon::class, fn($object) => $object->format('d/m/Y')));
```

```blade
<dl>
    <dt>Total</dt>
    <dd>{{ $product->total }}</dd> <!-- This is a money object, but will be outputted as an en_GB formatted string -->
    <dt>Created at</dt>
    <dd>{{ $product->created_at }}</dd> <!-- This is a Carbon object, but will be outputted as English date format -->
</dl>
```

## How does it work?

This works by wrapping a small piece of logic around php output at the parser level, which means that the object is evaluated just in time and can thus be treated as a standard object throughout the entire application; it is only transformed by the PHP script at the time of output.

Feel free to throw any questions back at me :-)

Thanks for all the hard work guys!