### PR TITLE
[8.x] Bugfix passing errorlevel when command is run in background

### DIFF
--- a/src/Illuminate/Console/Scheduling/CommandBuilder.php
+++ b/src/Illuminate/Console/Scheduling/CommandBuilder.php
@@ -52,7 +52,7 @@ class CommandBuilder
         $finished = Application::formatCommandString('schedule:finish').' "'.$event->mutexName().'"';
 
         if (windows_os()) {
-            return 'start /b cmd /c "('.$event->command.' & '.$finished.' "%errorlevel%")'.$redirect.$output.' 2>&1"';
+            return 'start /b cmd /c "('.$event->command.' && '.$finished.' "0" || '.$finished.' "1")'.$redirect.$output.' 2>&1"';
         }
 
         return $this->ensureCorrectUser($event,

--- a/src/Illuminate/Console/Scheduling/CommandBuilder.php
+++ b/src/Illuminate/Console/Scheduling/CommandBuilder.php
@@ -52,7 +52,7 @@ class CommandBuilder
         $finished = Application::formatCommandString('schedule:finish').' "'.$event->mutexName().'"';
 
         if (windows_os()) {
-            return 'start /b cmd /c "('.$event->command.' && '.$finished.' "0" || '.$finished.' "1")'.$redirect.$output.' 2>&1"';
+            return 'start /b cmd /v:on /c "('.$event->command.' & '.$finished.' ^!ERRORLEVEL^!)'.$redirect.$output.' 2>&1"';
         }
 
         return $this->ensureCorrectUser($event,

--- a/tests/Console/Scheduling/EventTest.php
+++ b/tests/Console/Scheduling/EventTest.php
@@ -61,7 +61,7 @@ class EventTest extends TestCase
 
         $scheduleId = '"framework'.DIRECTORY_SEPARATOR.'schedule-eeb46c93d45e928d62aaf684d727e213b7094822"';
 
-        $this->assertSame('start /b cmd /c "(php -i & "'.PHP_BINARY.'" artisan schedule:finish '.$scheduleId.' "%errorlevel%") > "NUL" 2>&1"', $event->buildCommand());
+        $this->assertSame('start /b cmd /c "(php -i && "'.PHP_BINARY.'" artisan schedule:finish '.$scheduleId.' "0" || "'.PHP_BINARY.'" artisan schedule:finish '.$scheduleId.' "1") > "NUL" 2>&1"', $event->buildCommand());
     }
 
     public function testBuildCommandSendOutputTo()

--- a/tests/Console/Scheduling/EventTest.php
+++ b/tests/Console/Scheduling/EventTest.php
@@ -61,7 +61,7 @@ class EventTest extends TestCase
 
         $scheduleId = '"framework'.DIRECTORY_SEPARATOR.'schedule-eeb46c93d45e928d62aaf684d727e213b7094822"';
 
-        $this->assertSame('start /b cmd /c "(php -i && "'.PHP_BINARY.'" artisan schedule:finish '.$scheduleId.' "0" || "'.PHP_BINARY.'" artisan schedule:finish '.$scheduleId.' "1") > "NUL" 2>&1"', $event->buildCommand());
+        $this->assertSame('start /b cmd /v:on /c "(php -i & "'.PHP_BINARY.'" artisan schedule:finish '.$scheduleId.' ^!ERRORLEVEL^!) > "NUL" 2>&1"', $event->buildCommand());
     }
 
     public function testBuildCommandSendOutputTo()


### PR DESCRIPTION
Hi Taylor,

Thanks for taking the time to look into #37423. 
I guess it depends whether the callbacks are considered to only serve as event hooks (as you described in docs), or as part of the process. The proposed fix would of course differ from the behaviour of scheduled commands on Linux and on Windows when not executed in the background. And that is at least unwanted i guess. 

Today I've spent a few hours to make it work, and came across a few particularities on my way (all tests started with `schedule:run` with a few commands due to start).

1. Firstly I  was pretty close when adding a flag `/v` to the command to signal the use of delayed expansion for the `!ERRORLEVEL!` variable. The commandline as passed to the Symfony Process component works when ran in a terminal
2. However, the Symfony Process component wraps it in a `cmd` itself which makes it necessary to escape the exclamations. (`^!ERRORLEVEL^!`)
3. With the exclamations escaped the wrapped command works when a single command instance of the command is scheduled to run at the time `schedule:run` is called.
4. For some reason when the same command is started twice with a different argument value, and one is failing with a thrown exception, that failure is not reported. Neither as a succes nor as a failure. 
I was stunned until I discovered that when the `handle` method returns an exit code instead of a thrown Exception it does work. So as long as the developer does something like this, it works:
```
public function handle()
    {
        try {
            $this->something();
            return 0;
        }
        catch(\Exception $e) {
            // handle exception 
            return 1;
        }
    }
```
Notice that there are no quotes around the ^!ERRORLEVEL^! as this will not work..
