### PR TITLE
[8.x] Delegate lazy loading violation to method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -439,7 +439,7 @@ trait HasAttributes
         }
 
         if ($this->preventsLazyLoading) {
-            throw new LazyLoadingViolationException($this, $key);
+            $this->violatedLazyLoading($key);
         }
 
         // If the "attribute" exists as a method on the model, we will just assume
@@ -458,6 +458,17 @@ trait HasAttributes
     {
         return method_exists($this, $key) ||
             (static::$relationResolvers[get_class($this)][$key] ?? null);
+    }
+
+    /**
+     * Handle a lazy loading violation, for example by throwing an exception.
+     *
+     * @param  string  $key
+     * @return void
+     */
+    protected function violatedLazyLoading($key)
+    {
+        throw new LazyLoadingViolationException($this, $key);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -468,6 +468,11 @@ trait HasAttributes
      */
     protected function violatedLazyLoading($key)
     {
+        if (isset(static::$violatedLazyLoadingCallback)) {
+            call_user_func(static::$violatedLazyLoadingCallback, $this, $key);
+            return;
+        }
+
         throw new LazyLoadingViolationException($this, $key);
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -470,6 +470,7 @@ trait HasAttributes
     {
         if (isset(static::$violatedLazyLoadingCallback)) {
             call_user_func(static::$violatedLazyLoadingCallback, $this, $key);
+
             return;
         }
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -159,6 +159,13 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     protected static $modelsShouldPreventLazyLoading = false;
 
     /**
+     * The callback that is responsible for handing lazy loading violations.
+     *
+     * @var callable|null
+     */
+    protected static $violatedLazyLoadingCallback;
+
+    /**
      * The name of the "created at" column.
      *
      * @var string|null
@@ -356,6 +363,16 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     public static function preventLazyLoading($value = true)
     {
         static::$modelsShouldPreventLazyLoading = $value;
+    }
+
+    /**
+     * Register a callback that is responsible for handling lazy loading violations.
+     *
+     * @param callable $callback
+     */
+    public static function handleLazyLoadingViolationUsing(callable $callback)
+    {
+        static::$violatedLazyLoadingCallback = $callback;
     }
 
     /**

--- a/tests/Integration/Database/EloquentStrictLoadingTest.php
+++ b/tests/Integration/Database/EloquentStrictLoadingTest.php
@@ -100,6 +100,35 @@ class EloquentStrictLoadingTest extends DatabaseTestCase
 
         $models[0]->modelTwos[0]->modelThrees;
     }
+
+    public function testStrictModeWithCustomCallbackOnLazyLoading()
+    {
+        $this->expectsEvents(ViolatedLazyLoadingEvent::class);
+
+        Model::handleLazyLoadingViolationUsing(function ($model, $key) {
+            event(new ViolatedLazyLoadingEvent($model, $key));
+        });
+
+        EloquentStrictLoadingTestModel1::create();
+        EloquentStrictLoadingTestModel1::create();
+
+        $models = EloquentStrictLoadingTestModel1::get();
+
+        $models[0]->modelTwos;
+    }
+
+    public function testStrictModeWithOverriddenHandlerOnLazyLoading()
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Violated');
+
+        EloquentStrictLoadingTestModel1WithCustomHandler::create();
+        EloquentStrictLoadingTestModel1WithCustomHandler::create();
+
+        $models = EloquentStrictLoadingTestModel1WithCustomHandler::get();
+
+        $models[0]->modelTwos;
+    }
 }
 
 class EloquentStrictLoadingTestModel1 extends Model
@@ -111,6 +140,23 @@ class EloquentStrictLoadingTestModel1 extends Model
     public function modelTwos()
     {
         return $this->hasMany(EloquentStrictLoadingTestModel2::class, 'model_1_id');
+    }
+}
+
+class EloquentStrictLoadingTestModel1WithCustomHandler extends Model
+{
+    public $table = 'test_model1';
+    public $timestamps = false;
+    protected $guarded = [];
+
+    public function modelTwos()
+    {
+        return $this->hasMany(EloquentStrictLoadingTestModel2::class, 'model_1_id');
+    }
+
+    protected function violatedLazyLoading($key)
+    {
+        throw new \RuntimeException("Violated {$key}");
     }
 }
 
@@ -131,4 +177,16 @@ class EloquentStrictLoadingTestModel3 extends Model
     public $table = 'test_model3';
     public $timestamps = false;
     protected $guarded = [];
+}
+
+class ViolatedLazyLoadingEvent
+{
+    public $model;
+    public $key;
+
+    public function __construct($model, $key)
+    {
+        $this->model = $model;
+        $this->key = $key;
+    }
 }


### PR DESCRIPTION
This PR delegates the throwing of the `LazyLoadingViolationException` to a new method. This first checks the existence of a static callback for overriding the behaviour in the service provider, if not defined throw the exception as before. The user may override the method on their own models to customise the behaviour for specific models.

This would allow the user to enable the preventLazyLoading flag on all environments while being able to log a message instead of throwing an exception on production environments or in certain other scenarios:

```php
// AppServiceProvider

public function boot()
{
    Model::handleLazyLoadingViolationUsing(function($model, $key) {
        \Log::warning("Lazy loaded relation [{$key}] on model [" . get_class($model) . "].");
    });
}

```

```php
// A model

protected function handleLazyLoadingViolation($key)
{
    if(app()->isProduction()) {
        \Log::warning("Lazy loaded relation [{$key}] on model [" . get_class($this) . "].");
    } else {
        throw new LazyLoadingViolationException($this, $key);
    }
}
```