### PR TITLE
[8.x] kill process instantly on SIGALRM

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -194,20 +194,7 @@ class Worker
         // process if it is running too long because it has frozen. This uses the async
         // signals supported in recent versions of PHP to accomplish it conveniently.
         pcntl_signal(SIGALRM, function () use ($job, $options) {
-            if ($job) {
-                $this->markJobAsFailedIfWillExceedMaxAttempts(
-                    $job->getConnectionName(), $job, (int) $options->maxTries, $e = $this->maxAttemptsExceededException($job)
-                );
-
-                $this->markJobAsFailedIfWillExceedMaxExceptions(
-                    $job->getConnectionName(), $job, $e
-                );
-
-                $this->markJobAsFailedIfItShouldFailOnTimeout(
-                    $job->getConnectionName(), $job, $e
-                );
-            }
-
+            // No extra logic should be placed here or the process may stuck forever.
             $this->kill(static::EXIT_ERROR);
         });
 
@@ -716,8 +703,6 @@ class Worker
      */
     public function kill($status = 0)
     {
-        $this->events->dispatch(new WorkerStopping($status));
-
         if (extension_loaded('posix')) {
             posix_kill(getmypid(), SIGKILL);
         }


### PR DESCRIPTION
This PR is trying to fix 2 issues:
1. During handling SIGALRM, the worker may stuck in something caused the alarm in the first place. It is dangerous to put logic inside SIGALRM handler, before killing the process. Even call to die can be bad, that is why we use `posix_kill(getmypid(), SIGKILL);` to terminate the process.
Ideally, we need to set another timeout inside SIGALRM handler to make sure it doesn't stuck again, but it seems to be impossible.

2. Also call to `markJobAsFailedIfWillExceedMaxAttempts()` causes jobs to be inserted twice in the failed_jobs table, which is reported in #37319 Probably there is no need to save jobs in the failed_jobs table here, another process will eventually pick it up?

Please note that I am not sure this PR is correct, but I think something is wrong with the current implementation.