### PR TITLE
[8.x] fix #37483 (aggregates with having)

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2826,8 +2826,8 @@ class Builder
      */
     public function aggregate($function, $columns = ['*'])
     {
-        $results = $this->cloneWithout($this->unions ? [] : ['columns'])
-                        ->cloneWithoutBindings($this->unions ? [] : ['select'])
+        $results = $this->cloneWithout($this->unions || $this->havings ? [] : ['columns'])
+                        ->cloneWithoutBindings($this->unions || $this->havings ? [] : ['select'])
                         ->setAggregate($function, $columns)
                         ->get($columns);
 

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -45,7 +45,7 @@ class Grammar extends BaseGrammar
      */
     public function compileSelect(Builder $query)
     {
-        if ($query->unions && $query->aggregate) {
+        if (($query->unions || $query->havings) && $query->aggregate) {
             return $this->compileUnionAggregate($query);
         }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
### The problem

Executing the following statement results in an sql error because the subquery is dismissed but the havings are kept:

```php
User::query()->withCount('roles')->having('roles_count', '>', '2')->count()
```

Query:
```mysql
select count(*) as aggregate from `users` having `roles_count` > 2
```
Error:
```
Illuminate\Database\QueryException with message 'SQLSTATE[42S22]: Column not found: 1054 Unknown column 'roles_count' in 'having clause' (SQL: select count(*) as aggregate from `users` having `roles_count` > 2)'
```

But executing the following runs without error
```php
User::query()->withCount('roles')->having('roles_count', '>', '2')->get()
```
Query:
```mysql
select `users`.*, (select count(*) from `roles` where `users`.`id` = `roles`.`user_id`) as `roles_count` from `users` having `roles_count` > 2
```

When comparing the queries of the previous statements, it is clear the original query should instead be wrapped within a subquery to be valid when dealing with havings to get a correct count (because having only applies to grouped data), exactly how it's currently done with unions, eg:

```mysql
select count(*) as aggregate from (select `users`.*, (select count(*) from `roles` where `users`.`id` = `roles`.`user_id`) as `roles_count` from `users` having `roles_count` > 2) as `temp_table`
```

## This PR
It applies the methodology of aggregates with union to aggregates with havings and does indeed fix the aforementioned issue #37483

It is not a breaking change because the previous behavior of this specific case wasn't previously working

## TLDR

Queries with havings should behave exactly the same way as unions when executing aggregates functions
