### PR TITLE
[8.x] More Convenient Model Broadcasting

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastEvent.php
+++ b/src/Illuminate/Broadcasting/BroadcastEvent.php
@@ -60,8 +60,14 @@ class BroadcastEvent implements ShouldQueue
         $name = method_exists($this->event, 'broadcastAs')
                 ? $this->event->broadcastAs() : get_class($this->event);
 
+        $channels = Arr::wrap($this->event->broadcastOn());
+
+        if (empty($channels)) {
+            return;
+        }
+
         $broadcaster->broadcast(
-            Arr::wrap($this->event->broadcastOn()), $name,
+            $channels, $name,
             $this->getPayloadFromEvent($this->event)
         );
     }

--- a/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
@@ -5,6 +5,7 @@ namespace Illuminate\Broadcasting\Broadcasters;
 use Exception;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Broadcasting\Broadcaster as BroadcasterContract;
+use Illuminate\Contracts\Broadcasting\HasBroadcastChannel;
 use Illuminate\Contracts\Routing\BindingRegistrar;
 use Illuminate\Contracts\Routing\UrlRoutable;
 use Illuminate\Support\Arr;
@@ -40,13 +41,19 @@ abstract class Broadcaster implements BroadcasterContract
     /**
      * Register a channel authenticator.
      *
-     * @param  string  $channel
+     * @param  \Illuminate\Contracts\Broadcasting\HasBroadcastChannel|string  $channel
      * @param  callable|string  $callback
      * @param  array  $options
      * @return $this
      */
     public function channel($channel, $callback, $options = [])
     {
+        if ($channel instanceof HasBroadcastChannel) {
+            $channel = $channel->broadcastChannelRoute();
+        } elseif (is_string($channel) && class_exists($channel) && is_a($channel, HasBroadcastChannel::class, true)) {
+            $channel = (new $channel)->broadcastChannelRoute();
+        }
+
         $this->channels[$channel] = $callback;
 
         $this->channelOptions[$channel] = $options;

--- a/src/Illuminate/Broadcasting/Channel.php
+++ b/src/Illuminate/Broadcasting/Channel.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Broadcasting;
 
+use Illuminate\Contracts\Broadcasting\HasBroadcastChannel;
+
 class Channel
 {
     /**
@@ -14,12 +16,12 @@ class Channel
     /**
      * Create a new channel instance.
      *
-     * @param  string  $name
+     * @param  \Illuminate\Contracts\Broadcasting\HasBroadcastChannel|string  $name
      * @return void
      */
     public function __construct($name)
     {
-        $this->name = $name;
+        $this->name = $name instanceof HasBroadcastChannel ? $name->broadcastChannelName() : $name;
     }
 
     /**

--- a/src/Illuminate/Broadcasting/Channel.php
+++ b/src/Illuminate/Broadcasting/Channel.php
@@ -21,7 +21,7 @@ class Channel
      */
     public function __construct($name)
     {
-        $this->name = $name instanceof HasBroadcastChannel ? $name->broadcastChannelName() : $name;
+        $this->name = $name instanceof HasBroadcastChannel ? $name->broadcastChannel() : $name;
     }
 
     /**

--- a/src/Illuminate/Broadcasting/PrivateChannel.php
+++ b/src/Illuminate/Broadcasting/PrivateChannel.php
@@ -2,16 +2,20 @@
 
 namespace Illuminate\Broadcasting;
 
+use Illuminate\Contracts\Broadcasting\HasBroadcastChannel;
+
 class PrivateChannel extends Channel
 {
     /**
      * Create a new channel instance.
      *
-     * @param  string  $name
+     * @param  \Illuminate\Contracts\Broadcasting\HasBroadcastChannel|string  $name
      * @return void
      */
     public function __construct($name)
     {
+        $name = $name instanceof HasBroadcastChannel ? $name->broadcastChannelName() : $name;
+
         parent::__construct('private-'.$name);
     }
 }

--- a/src/Illuminate/Broadcasting/PrivateChannel.php
+++ b/src/Illuminate/Broadcasting/PrivateChannel.php
@@ -14,7 +14,7 @@ class PrivateChannel extends Channel
      */
     public function __construct($name)
     {
-        $name = $name instanceof HasBroadcastChannel ? $name->broadcastChannelName() : $name;
+        $name = $name instanceof HasBroadcastChannel ? $name->broadcastChannel() : $name;
 
         parent::__construct('private-'.$name);
     }

--- a/src/Illuminate/Contracts/Broadcasting/HasBroadcastChannel.php
+++ b/src/Illuminate/Contracts/Broadcasting/HasBroadcastChannel.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Contracts\Broadcasting;
+
+interface HasBroadcastChannel
+{
+    /**
+     * Get the broadcast channel name that is associated with the given entity.
+     *
+     * @return string
+     */
+    public function broadcastChannelName();
+}

--- a/src/Illuminate/Contracts/Broadcasting/HasBroadcastChannel.php
+++ b/src/Illuminate/Contracts/Broadcasting/HasBroadcastChannel.php
@@ -16,5 +16,5 @@ interface HasBroadcastChannel
      *
      * @return string
      */
-    public function broadcastChannelName();
+    public function broadcastChannel();
 }

--- a/src/Illuminate/Contracts/Broadcasting/HasBroadcastChannel.php
+++ b/src/Illuminate/Contracts/Broadcasting/HasBroadcastChannel.php
@@ -5,6 +5,13 @@ namespace Illuminate\Contracts\Broadcasting;
 interface HasBroadcastChannel
 {
     /**
+     * Get the broadcast channel route definition that is associated with the given entity.
+     *
+     * @return string
+     */
+    public function broadcastChannelRoute();
+
+    /**
      * Get the broadcast channel name that is associated with the given entity.
      *
      * @return string

--- a/src/Illuminate/Database/Eloquent/BroadcastableModelEventOccurred.php
+++ b/src/Illuminate/Database/Eloquent/BroadcastableModelEventOccurred.php
@@ -33,6 +33,20 @@ class BroadcastableModelEventOccurred implements ShouldBroadcast
     protected $channels = [];
 
     /**
+     * The queue connection that should be used to queue the broadcast job.
+     *
+     * @var string
+     */
+    public $connection;
+
+    /**
+     * The queue that should be used to queue the broadcast job.
+     *
+     * @var string
+     */
+    public $queue;
+
+    /**
      * Create a new event instance.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model

--- a/src/Illuminate/Database/Eloquent/BroadcastableModelEventOccurred.php
+++ b/src/Illuminate/Database/Eloquent/BroadcastableModelEventOccurred.php
@@ -44,7 +44,7 @@ class BroadcastableModelEventOccurred implements ShouldBroadcast
      */
     public function broadcastOn()
     {
-        return collect($this->model->broadcastOn($this->event))->map(function ($channel) {
+        return collect($this->model->broadcastOn($this->event) ?: [])->map(function ($channel) {
             return $channel instanceof Model ? new PrivateChannel($channel) : $channel;
         })->all();
     }

--- a/src/Illuminate/Database/Eloquent/BroadcastableModelEventOccurred.php
+++ b/src/Illuminate/Database/Eloquent/BroadcastableModelEventOccurred.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Illuminate\Database\Eloquent;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+
+class BroadcastableModelEventOccurred implements ShouldBroadcast
+{
+    use InteractsWithSockets;
+
+    /**
+     * The model instance corresponding to the event.
+     *
+     * @var \Illuminate\Database\Eloquent\Model
+     */
+    public $model;
+
+    /**
+     * The event name (created, updated, etc.).
+     *
+     * @var string
+     */
+    protected $event;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $event
+     * @return void
+     */
+    public function __construct($model, $event)
+    {
+        $this->model = $model;
+        $this->event = $event;
+    }
+
+    /**
+     * The channels the event should broadcast on.
+     *
+     * @return array
+     */
+    public function broadcastOn()
+    {
+        return collect($this->model->broadcastOn($this->event))->map(function ($channel) {
+            return $channel instanceof Model ? new PrivateChannel($channel) : $channel;
+        })->all();
+    }
+
+    /**
+     * The name the event should broadcast as.
+     *
+     * @return string
+     */
+    public function broadcastAs()
+    {
+        return class_basename($this->model).ucfirst($this->event);
+    }
+}

--- a/src/Illuminate/Database/Eloquent/BroadcastableModelEventOccurred.php
+++ b/src/Illuminate/Database/Eloquent/BroadcastableModelEventOccurred.php
@@ -5,10 +5,11 @@ namespace Illuminate\Database\Eloquent;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Broadcasting\PrivateChannel;
 use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Queue\SerializesModels;
 
 class BroadcastableModelEventOccurred implements ShouldBroadcast
 {
-    use InteractsWithSockets;
+    use InteractsWithSockets, SerializesModels;
 
     /**
      * The model instance corresponding to the event.

--- a/src/Illuminate/Database/Eloquent/BroadcastableModelEventOccurred.php
+++ b/src/Illuminate/Database/Eloquent/BroadcastableModelEventOccurred.php
@@ -26,6 +26,13 @@ class BroadcastableModelEventOccurred implements ShouldBroadcast
     protected $event;
 
     /**
+     * The channels that the event should be broadcast on.
+     *
+     * @var array
+     */
+    protected $channels = [];
+
+    /**
      * Create a new event instance.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model
@@ -45,7 +52,11 @@ class BroadcastableModelEventOccurred implements ShouldBroadcast
      */
     public function broadcastOn()
     {
-        return collect($this->model->broadcastOn($this->event) ?: [])->map(function ($channel) {
+        $channels = empty($this->channels)
+                ? ($this->model->broadcastOn($this->event) ?: [])
+                : $this->channels;
+
+        return collect($channels)->map(function ($channel) {
             return $channel instanceof Model ? new PrivateChannel($channel) : $channel;
         })->all();
     }
@@ -58,5 +69,18 @@ class BroadcastableModelEventOccurred implements ShouldBroadcast
     public function broadcastAs()
     {
         return class_basename($this->model).ucfirst($this->event);
+    }
+
+    /**
+     * Manually specify the channels the event should broadcast on.
+     *
+     * @param  array  $channels
+     * @return $this
+     */
+    public function onChannels(array $channels)
+    {
+        $this->channels = $channels;
+
+        return $this;
     }
 }

--- a/src/Illuminate/Database/Eloquent/BroadcastsEvents.php
+++ b/src/Illuminate/Database/Eloquent/BroadcastsEvents.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Illuminate\Database\Eloquent;
+
+trait BroadcastsEvents
+{
+    /**
+     * Boot the event broadcasting trait.
+     *
+     * @return void
+     */
+    public static function bootBroadcastsEvents()
+    {
+        static::created(function ($model) {
+            broadcast($model->newBroadcastableModelEvent('created'));
+        });
+
+        static::updated(function ($model) {
+            broadcast($model->newBroadcastableModelEvent('updated'));
+        });
+
+        if (method_exists(static::class, 'bootSoftDeletes')) {
+            static::trashed(function ($model) {
+                broadcast($model->newBroadcastableModelEvent('trashed'));
+            });
+
+            static::restored(function ($model) {
+                broadcast($model->newBroadcastableModelEvent('restored'));
+            });
+        }
+
+        static::deleted(function ($model) {
+            broadcast($model->newBroadcastableModelEvent('deleted'));
+        });
+    }
+
+    /**
+     * Get the channels that model events should broadcast on.
+     *
+     * @param  string  $event
+     * @return \Illuminate\Broadcasting\Channel|array
+     */
+    public function broadcastOn($event)
+    {
+        return [$this];
+    }
+
+    /**
+     * Create a new broadcastable model event event.
+     *
+     * @param  string  $event
+     * @return mixed
+     */
+    public function newBroadcastableModelEvent($event)
+    {
+        return new BroadcastableModelEventOccurred($this, $event);
+    }
+}

--- a/src/Illuminate/Database/Eloquent/BroadcastsEvents.php
+++ b/src/Illuminate/Database/Eloquent/BroadcastsEvents.php
@@ -41,7 +41,9 @@ trait BroadcastsEvents
      */
     public function broadcastCreated()
     {
-        return broadcast($this->newBroadcastableModelEvent('created'));
+        return $this->broadcastIfBroadcastChannelsExistForEvent(
+            $this->newBroadcastableModelEvent('created'), 'created'
+        );
     }
 
     /**
@@ -51,7 +53,9 @@ trait BroadcastsEvents
      */
     public function broadcastUpdated()
     {
-        return broadcast($this->newBroadcastableModelEvent('updated'));
+        return $this->broadcastIfBroadcastChannelsExistForEvent(
+            $this->newBroadcastableModelEvent('updated'), 'updated'
+        );
     }
 
     /**
@@ -61,7 +65,9 @@ trait BroadcastsEvents
      */
     public function broadcastTrashed()
     {
-        return broadcast($this->newBroadcastableModelEvent('trashed'));
+        return $this->broadcastIfBroadcastChannelsExistForEvent(
+            $this->newBroadcastableModelEvent('trashed'), 'trashed'
+        );
     }
 
     /**
@@ -71,7 +77,9 @@ trait BroadcastsEvents
      */
     public function broadcastRestored()
     {
-        return broadcast($this->newBroadcastableModelEvent('restored'));
+        return $this->broadcastIfBroadcastChannelsExistForEvent(
+            $this->newBroadcastableModelEvent('restored'), 'restored'
+        );
     }
 
     /**
@@ -81,7 +89,23 @@ trait BroadcastsEvents
      */
     public function broadcastDeleted()
     {
-        return broadcast($this->newBroadcastableModelEvent('deleted'));
+        return $this->broadcastIfBroadcastChannelsExistForEvent(
+            $this->newBroadcastableModelEvent('deleted'), 'deleted'
+        );
+    }
+
+    /**
+     * Broadcast the given event instance if channels are configured for the model event.
+     *
+     * @param  mixed  $instance
+     * @param  string  $event
+     * @return \Illuminate\Broadcasting\PendingBroadcast|null
+     */
+    protected function broadcastIfBroadcastChannelsExistForEvent($instance, $event)
+    {
+        if (! empty($this->broadcastOn($event))) {
+            return broadcast($instance);
+        }
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/BroadcastsEvents.php
+++ b/src/Illuminate/Database/Eloquent/BroadcastsEvents.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Database\Eloquent;
 
+use Illuminate\Support\Arr;
+
 trait BroadcastsEvents
 {
     /**
@@ -37,60 +39,65 @@ trait BroadcastsEvents
     /**
      * Broadcast that the model was created.
      *
+     * @param  \Illuminate\Broadcasting\Channel|\Illuminate\Contracts\Broadcasting\HasBroadcastChannel|array|null  $channels
      * @return \Illuminate\Broadcasting\PendingBroadcast
      */
-    public function broadcastCreated()
+    public function broadcastCreated($channels = null)
     {
         return $this->broadcastIfBroadcastChannelsExistForEvent(
-            $this->newBroadcastableModelEvent('created'), 'created'
+            $this->newBroadcastableModelEvent('created'), 'created', $channels
         );
     }
 
     /**
      * Broadcast that the model was updated.
      *
+     * @param  \Illuminate\Broadcasting\Channel|\Illuminate\Contracts\Broadcasting\HasBroadcastChannel|array|null  $channels
      * @return \Illuminate\Broadcasting\PendingBroadcast
      */
-    public function broadcastUpdated()
+    public function broadcastUpdated($channels = null)
     {
         return $this->broadcastIfBroadcastChannelsExistForEvent(
-            $this->newBroadcastableModelEvent('updated'), 'updated'
+            $this->newBroadcastableModelEvent('updated'), 'updated', $channels
         );
     }
 
     /**
      * Broadcast that the model was trashed.
      *
+     * @param  \Illuminate\Broadcasting\Channel|\Illuminate\Contracts\Broadcasting\HasBroadcastChannel|array|null  $channels
      * @return \Illuminate\Broadcasting\PendingBroadcast
      */
-    public function broadcastTrashed()
+    public function broadcastTrashed($channels = null)
     {
         return $this->broadcastIfBroadcastChannelsExistForEvent(
-            $this->newBroadcastableModelEvent('trashed'), 'trashed'
+            $this->newBroadcastableModelEvent('trashed'), 'trashed', $channels
         );
     }
 
     /**
      * Broadcast that the model was restored.
      *
+     * @param  \Illuminate\Broadcasting\Channel|\Illuminate\Contracts\Broadcasting\HasBroadcastChannel|array|null  $channels
      * @return \Illuminate\Broadcasting\PendingBroadcast
      */
-    public function broadcastRestored()
+    public function broadcastRestored($channels = null)
     {
         return $this->broadcastIfBroadcastChannelsExistForEvent(
-            $this->newBroadcastableModelEvent('restored'), 'restored'
+            $this->newBroadcastableModelEvent('restored'), 'restored', $channels
         );
     }
 
     /**
      * Broadcast that the model was deleted.
      *
+     * @param  \Illuminate\Broadcasting\Channel|\Illuminate\Contracts\Broadcasting\HasBroadcastChannel|array|null  $channels
      * @return \Illuminate\Broadcasting\PendingBroadcast
      */
-    public function broadcastDeleted()
+    public function broadcastDeleted($channels = null)
     {
         return $this->broadcastIfBroadcastChannelsExistForEvent(
-            $this->newBroadcastableModelEvent('deleted'), 'deleted'
+            $this->newBroadcastableModelEvent('deleted'), 'deleted', $channels
         );
     }
 
@@ -99,12 +106,13 @@ trait BroadcastsEvents
      *
      * @param  mixed  $instance
      * @param  string  $event
+     * @param  mixed  $channels
      * @return \Illuminate\Broadcasting\PendingBroadcast|null
      */
-    protected function broadcastIfBroadcastChannelsExistForEvent($instance, $event)
+    protected function broadcastIfBroadcastChannelsExistForEvent($instance, $event, $channels = null)
     {
-        if (! empty($this->broadcastOn($event))) {
-            return broadcast($instance);
+        if (! empty($this->broadcastOn($event)) || ! empty($channels)) {
+            return broadcast($instance->onChannels(Arr::wrap($channels)));
         }
     }
 

--- a/src/Illuminate/Database/Eloquent/BroadcastsEvents.php
+++ b/src/Illuminate/Database/Eloquent/BroadcastsEvents.php
@@ -12,26 +12,76 @@ trait BroadcastsEvents
     public static function bootBroadcastsEvents()
     {
         static::created(function ($model) {
-            broadcast($model->newBroadcastableModelEvent('created'));
+            $model->broadcastCreated();
         });
 
         static::updated(function ($model) {
-            broadcast($model->newBroadcastableModelEvent('updated'));
+            $model->broadcastUpdated();
         });
 
         if (method_exists(static::class, 'bootSoftDeletes')) {
             static::trashed(function ($model) {
-                broadcast($model->newBroadcastableModelEvent('trashed'));
+                $model->broadcastTrashed();
             });
 
             static::restored(function ($model) {
-                broadcast($model->newBroadcastableModelEvent('restored'));
+                $model->broadcastRestored();
             });
         }
 
         static::deleted(function ($model) {
-            broadcast($model->newBroadcastableModelEvent('deleted'));
+            $model->broadcastDeleted();
         });
+    }
+
+    /**
+     * Broadcast that the model was created.
+     *
+     * @return \Illuminate\Broadcasting\PendingBroadcast
+     */
+    public function broadcastCreated()
+    {
+        return broadcast($this->newBroadcastableModelEvent('created'));
+    }
+
+    /**
+     * Broadcast that the model was updated.
+     *
+     * @return \Illuminate\Broadcasting\PendingBroadcast
+     */
+    public function broadcastUpdated()
+    {
+        return broadcast($this->newBroadcastableModelEvent('updated'));
+    }
+
+    /**
+     * Broadcast that the model was trashed.
+     *
+     * @return \Illuminate\Broadcasting\PendingBroadcast
+     */
+    public function broadcastTrashed()
+    {
+        return broadcast($this->newBroadcastableModelEvent('trashed'));
+    }
+
+    /**
+     * Broadcast that the model was restored.
+     *
+     * @return \Illuminate\Broadcasting\PendingBroadcast
+     */
+    public function broadcastRestored()
+    {
+        return broadcast($this->newBroadcastableModelEvent('restored'));
+    }
+
+    /**
+     * Broadcast that the model was deleted.
+     *
+     * @return \Illuminate\Broadcasting\PendingBroadcast
+     */
+    public function broadcastDeleted()
+    {
+        return broadcast($this->newBroadcastableModelEvent('deleted'));
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/BroadcastsEvents.php
+++ b/src/Illuminate/Database/Eloquent/BroadcastsEvents.php
@@ -117,6 +117,29 @@ trait BroadcastsEvents
     }
 
     /**
+     * Create a new broadcastable model event event.
+     *
+     * @param  string  $event
+     * @return mixed
+     */
+    public function newBroadcastableModelEvent($event)
+    {
+        return tap(new BroadcastableModelEventOccurred($this, $event), function ($event) {
+            $event->connection = property_exists($this, 'broadcastConnection')
+                            ? $this->broadcastConnection
+                            : $this->broadcastConnection();
+
+            $event->queue = property_exists($this, 'broadcastQueue')
+                            ? $this->broadcastQueue
+                            : $this->broadcastQueue();
+
+            $event->afterCommit = property_exists($this, 'broadcastAfterCommit')
+                            ? $this->broadcastAfterCommit
+                            : $this->broadcastAfterCommit();
+        });
+    }
+
+    /**
      * Get the channels that model events should broadcast on.
      *
      * @param  string  $event
@@ -128,13 +151,32 @@ trait BroadcastsEvents
     }
 
     /**
-     * Create a new broadcastable model event event.
+     * Get the queue connection that should be used to broadcast model events.
      *
-     * @param  string  $event
-     * @return mixed
+     * @return string|null
      */
-    public function newBroadcastableModelEvent($event)
+    public function broadcastConnection()
     {
-        return new BroadcastableModelEventOccurred($this, $event);
+        //
+    }
+
+    /**
+     * Get the queue that should be used to broadcast model events.
+     *
+     * @return string|null
+     */
+    public function broadcastQueue()
+    {
+        //
+    }
+
+    /**
+     * Determine if the model event broadcast queued job should be dispatched after all transactions are committed.
+     *
+     * @return string|null
+     */
+    public function broadcastAfterCommit()
+    {
+        return false;
     }
 }

--- a/src/Illuminate/Database/Eloquent/BroadcastsEvents.php
+++ b/src/Illuminate/Database/Eloquent/BroadcastsEvents.php
@@ -173,7 +173,7 @@ trait BroadcastsEvents
     /**
      * Determine if the model event broadcast queued job should be dispatched after all transactions are committed.
      *
-     * @return string|null
+     * @return bool
      */
     public function broadcastAfterCommit()
     {

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1844,6 +1844,16 @@ abstract class Model implements Arrayable, ArrayAccess, HasBroadcastChannel, Jso
     }
 
     /**
+     * Get the broadcast channel route definition that is associated with the given entity.
+     *
+     * @return string
+     */
+    public function broadcastChannelRoute()
+    {
+        return str_replace('\\', '.', get_class($this)).'.{'.$this->getKeyName().'}';
+    }
+
+    /**
      * Get the broadcast channel name that is associated with the given entity.
      *
      * @return string

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Eloquent;
 
 use ArrayAccess;
+use Illuminate\Contracts\Broadcasting\HasBroadcastChannel;
 use Illuminate\Contracts\Queue\QueueableCollection;
 use Illuminate\Contracts\Queue\QueueableEntity;
 use Illuminate\Contracts\Routing\UrlRoutable;
@@ -21,7 +22,7 @@ use Illuminate\Support\Traits\ForwardsCalls;
 use JsonSerializable;
 use LogicException;
 
-abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializable, QueueableEntity, UrlRoutable
+abstract class Model implements Arrayable, ArrayAccess, HasBroadcastChannel, Jsonable, JsonSerializable, QueueableEntity, UrlRoutable
 {
     use Concerns\HasAttributes,
         Concerns\HasEvents,
@@ -1840,6 +1841,16 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     public static function preventsLazyLoading()
     {
         return static::$modelsShouldPreventLazyLoading;
+    }
+
+    /**
+     * Get the broadcast channel name that is associated with the given entity.
+     *
+     * @return string
+     */
+    public function broadcastChannelName()
+    {
+        return str_replace('\\', '.', get_class($this)).'.'.$this->getKey();
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1858,7 +1858,7 @@ abstract class Model implements Arrayable, ArrayAccess, HasBroadcastChannel, Jso
      *
      * @return string
      */
-    public function broadcastChannelName()
+    public function broadcastChannel()
     {
         return str_replace('\\', '.', get_class($this)).'.'.$this->getKey();
     }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1850,7 +1850,7 @@ abstract class Model implements Arrayable, ArrayAccess, HasBroadcastChannel, Jso
      */
     public function broadcastChannelRoute()
     {
-        return str_replace('\\', '.', get_class($this)).'.{'.$this->getKeyName().'}';
+        return str_replace('\\', '.', get_class($this)).'.{'.Str::camel(class_basename($this)).'}';
     }
 
     /**

--- a/tests/Integration/Database/DatabaseEloquentBroadcastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentBroadcastingTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Database\Eloquent\BroadcastableModelEventOccurred;
+use Illuminate\Database\Eloquent\BroadcastsEvents;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * @group integration
+ */
+class DatabaseEloquentBroadcastingTest extends DatabaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('test_eloquent_broadcasting_users', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+
+    public function testBasicBroadcasting()
+    {
+        Event::fake([BroadcastableModelEventOccurred::class]);
+
+        $model = new TestEloquentBroadcastUser;
+        $model->name = 'Taylor';
+        $model->save();
+
+        Event::assertDispatched(function (BroadcastableModelEventOccurred $event) {
+            return $event->model instanceof TestEloquentBroadcastUser &&
+                   count($event->broadcastOn()) === 1 &&
+                   $event->broadcastOn()[0]->name == 'private-Illuminate.Tests.Integration.Database.TestEloquentBroadcastUser.'.$event->model->id;
+        });
+    }
+}
+
+class TestEloquentBroadcastUser extends Model
+{
+    use BroadcastsEvents;
+
+    protected $table = 'test_eloquent_broadcasting_users';
+}

--- a/tests/Integration/Database/DatabaseEloquentBroadcastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentBroadcastingTest.php
@@ -39,6 +39,13 @@ class DatabaseEloquentBroadcastingTest extends DatabaseTestCase
                    $event->broadcastOn()[0]->name == 'private-Illuminate.Tests.Integration.Database.TestEloquentBroadcastUser.'.$event->model->id;
         });
     }
+
+    public function testChannelRouteFormatting()
+    {
+        $model = new TestEloquentBroadcastUser;
+
+        $this->assertEquals('Illuminate.Tests.Integration.Database.TestEloquentBroadcastUser.{testEloquentBroadcastUser}', $model->broadcastChannelRoute());
+    }
 }
 
 class TestEloquentBroadcastUser extends Model


### PR DESCRIPTION
This PR adds some convenience features around broadcasting model state changes - inspired by @tonysm's work on his Turbo + Laravel integration.

### Broadcasting Model Events

There is a new trait which can be added to models to allow for the easy broadcasting of model events (created, updated, trashed, restored, deleted). Before adding this feature I previously used to create event classes for these model events, such as a `DeploymentUpdated` event in Laravel Vapor. These events would then be marked as `ShouldBroadcast`. If you are using these events for other purposes in your application that approach works great but if you only need the event so that it can be broadcast to your frontend then the new Eloquent `BroadcastsEvents` trait can save you some boilerplate code.

Usage of the trait looks like this:

```php
<?php

namespace App\Models;

use Illuminate\Broadcasting\PrivateChannel;
use Illuminate\Database\Eloquent\BroadcastsEvents;
use Illuminate\Database\Eloquent\Factories\HasFactory;
use Illuminate\Database\Eloquent\Model;

class Post extends Model
{
    use BroadcastsEvents, HasFactory;

    /**
     * Get the user that the post belongs to.
     */
    public function user()
    {
        return $this->belongsTo(User::class);
    }

    /**
     * Get the channels that model events should broadcast on.
     *
     * @param  string  $event
     * @return \Illuminate\Broadcasting\Channel|array
     */
    public function broadcastOn($event)
    {
        return [$this];
    }
}
```

Note that the `broadcastOn` method receives the event type (string of `created`, `updated`, etc.) and returns the channels that the event should be broadcast on. Also note that you may simply return Eloquent instances as channels. Of course, you can still return full `Channel` or `PrivateChannel` instances. This brings me to the next point...

**Eloquent model channel conventions...** If you provide an Eloquent model instance in place a channel, the framework will automatically derive the channel name by calling the `broadcastChannel` method on the instance and create a `PrivateChannel` instance for that channel string. All Eloquent models now implement the `Illuminate\Broadcasting\HasBroadcastChannel` interface which dictates they implement this method. The base implementation will return a string channel name of the given format: `App.Models.ModelName.{id}` where, of course, the actual model name and ID value are replaced in the string with their actual values.

Often, you will want to broadcast an event on the model's own channel as well as its parent channel. For example, when a deployment is updated in Vapor, we broadcast that on the deployment's own channel as well as the environment's channel so that the list of deployments on the environment page can be live updated. With this new feature, you may simply return the model itself as well as the related model from the `broadcastOn` method:

```php
/**
 * Get the channels that model events should broadcast on.
 *
 * @param  string  $event
 * @return \Illuminate\Broadcasting\Channel|array
 */
public function broadcastOn($event)
{
    return [$this, $this->user];
}
```

Of course, using the new PHP 8 `match` construct, it is easy to disable broadcasting for certain events:

```php
/**
 * Get the channels that model events should broadcast on.
 *
 * @param  string  $event
 * @return \Illuminate\Broadcasting\Channel|array
 */
public function broadcastOn($event)
{
    return match($event) {
        'updated' => [],
        default => [$this],
    };
}
```

### Broadcast Routes

To leverage the automatic determination of broadcast channel routes for models when actually registering your channel authentication callbacks, you may now pass an Eloquent model instance or class name into the `Broadcast::channel` method:

```php
Broadcast::channel(User::class, function ($user, $id) {
    return (int) $user->id === (int) $id;
});
```

### Listening For Model Events

Since there is not an actual event class that corresponds to these events that are automatically broadcasted, you need to listen to them slightly differently in Echo's client (I may improve this a bit in a separate PR). By convention, the events will be broadcast using the following convention: `ModelNameCreated`, `ModelNameUpdated`, etc. Since these events are broadcast outside of any namespace, you must prefix them with a `.` in Echo (I would like to improve this UX). The events will have a public `model` property where you can access the corresponding model attributes in your client side JavaScript application:

So, listening to the events looks like the following:

```js
Echo.private('App.Models.User.1')
    .listen('.UserUpdated', (e) => {
        console.log(e.model)
    })
    .listen('.PostCreated', (e) => {
        console.log(e.model);
    });
```