### PR TITLE
[8.x] Fix types of Console\Command properties

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -38,14 +38,14 @@ class Command extends SymfonyCommand
     /**
      * The console command description.
      *
-     * @var string|null
+     * @var string
      */
     protected $description;
 
     /**
      * The console command help text.
      *
-     * @var string|null
+     * @var string
      */
     protected $help;
 


### PR DESCRIPTION
`Command::$description` and `Command::$help` are never null, because they are set (to a non-null value) via `Command::setDescription()` and `Command::setHelp()` respectively in the constructor.

The incorrect type annotation for `Command::$description` causes Psalm to emit a `NonInvariantDocblockPropertyType` error for newly created commands, see https://github.com/psalm/psalm-plugin-laravel/issues/144.