### PR TITLE
[8.x] Warn if relation's foreign key is not in select list

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -187,6 +187,7 @@ abstract class HasOneOrMany extends Relation
             if (! isset($result->{$foreign})) {
                 throw new InvalidArgumentException('Relation needs foreign key "'.$result->qualifyColumn($foreign).'" to be fetched');
             }
+
             return [$this->getDictionaryKey($result->{$foreign}) => $result];
         })->all();
     }

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithDictionary;
+use InvalidArgumentException;
 
 abstract class HasOneOrMany extends Relation
 {
@@ -175,6 +176,7 @@ abstract class HasOneOrMany extends Relation
      * Build model dictionary keyed by the relation's foreign key.
      *
      * @param  \Illuminate\Database\Eloquent\Collection  $results
+     * @throws \InvalidArgumentException
      * @return array
      */
     protected function buildDictionary(Collection $results)
@@ -182,6 +184,9 @@ abstract class HasOneOrMany extends Relation
         $foreign = $this->getForeignKeyName();
 
         return $results->mapToDictionary(function ($result) use ($foreign) {
+            if (!isset($result->{$foreign})) {
+                throw new InvalidArgumentException('Relation needs foreign key "'.$result->qualifyColumn($foreign).'" to be fetched');
+            }
             return [$this->getDictionaryKey($result->{$foreign}) => $result];
         })->all();
     }

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -184,7 +184,7 @@ abstract class HasOneOrMany extends Relation
         $foreign = $this->getForeignKeyName();
 
         return $results->mapToDictionary(function ($result) use ($foreign) {
-            if (!isset($result->{$foreign})) {
+            if (! isset($result->{$foreign})) {
                 throw new InvalidArgumentException('Relation needs foreign key "'.$result->qualifyColumn($foreign).'" to be fetched');
             }
             return [$this->getDictionaryKey($result->{$foreign}) => $result];

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -12,6 +12,7 @@ use Illuminate\Database\Query\Expression;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Traits\ForwardsCalls;
 use Illuminate\Support\Traits\Macroable;
+use InvalidArgumentException;
 
 /**
  * @mixin \Illuminate\Database\Eloquent\Builder
@@ -262,11 +263,15 @@ abstract class Relation
      *
      * @param  array  $models
      * @param  string|null  $key
+     * @throws \InvalidArgumentException
      * @return array
      */
     protected function getKeys(array $models, $key = null)
     {
         return collect($models)->map(function ($value) use ($key) {
+            if (!isset($value->{$key})) {
+                throw new InvalidArgumentException('Relation needs parent key "'.$value->qualifyColumn($key).'" to be fetched');
+            }
             return $key ? $value->getAttribute($key) : $value->getKey();
         })->values()->unique(null, true)->sort()->all();
     }

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -269,9 +269,10 @@ abstract class Relation
     protected function getKeys(array $models, $key = null)
     {
         return collect($models)->map(function ($value) use ($key) {
-            if (!isset($value->{$key})) {
+            if (! isset($value->{$key})) {
                 throw new InvalidArgumentException('Relation needs parent key "'.$value->qualifyColumn($key).'" to be fetched');
             }
+
             return $key ? $value->getAttribute($key) : $value->getKey();
         })->values()->unique(null, true)->sort()->all();
     }


### PR DESCRIPTION
Fix [#2550](https://github.com/laravel/ideas/issues/2550)

If I have something like this

```php
class Post extends Model
{
    public function comments(): HasMany
    {
        return $this->hasMany(Comment::class)->select('body');
    }
}

class Comment extends Model
{
    public function attachments(): HasMany
    {
        return $this->hasMany(Attachment::class);
    }
}
```
`Comment` just has an empty `attachments` array. I know, why this happens and that I can solve this, by adding 'id' to the 'select()` method call, but wouldn't it be good if Eloquent _knew_ that it needs this key? Since there's no error message, the mistake is everything but obvious due to the abstraction Laravel and Eloquent have.
