### PR TITLE
[8.x] Mark MaintenanceModeException as deprecated

### DIFF
--- a/src/Illuminate/Foundation/Http/Exceptions/MaintenanceModeException.php
+++ b/src/Illuminate/Foundation/Http/Exceptions/MaintenanceModeException.php
@@ -7,6 +7,9 @@ use Illuminate\Support\Facades\Date;
 use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
 use Throwable;
 
+/**
+ * @deprecated Will be removed in a future Laravel version.
+ */
 class MaintenanceModeException extends ServiceUnavailableHttpException
 {
     /**


### PR DESCRIPTION
**Ref**: https://github.com/laravel/framework/issues/35635
