### PR TITLE
[8.x] Allow symlink recreation in storage:link command

### DIFF
--- a/src/Illuminate/Foundation/Console/StorageLinkCommand.php
+++ b/src/Illuminate/Foundation/Console/StorageLinkCommand.php
@@ -33,7 +33,7 @@ class StorageLinkCommand extends Command
         $force = $this->option('force');
 
         foreach ($this->links() as $link => $target) {
-            if (file_exists($link) && ! (is_link($link) && $force)) {
+            if (file_exists($link) && ! $this->removableSymlink($link, $force)) {
                 $this->error("The [$link] link already exists.");
                 continue;
             }
@@ -63,5 +63,17 @@ class StorageLinkCommand extends Command
     {
         return $this->laravel['config']['filesystems.links'] ??
                [public_path('storage') => storage_path('app/public')];
+    }
+
+    /**
+     * Checks that the provided path is a symlink and force option is turned on.
+     *
+     * @param  string  $link
+     * @param  bool  $force
+     * @return bool
+     */
+    protected function removableSymlink(string $link, bool $force): bool
+    {
+        return is_link($link) && $force;
     }
 }

--- a/src/Illuminate/Foundation/Console/StorageLinkCommand.php
+++ b/src/Illuminate/Foundation/Console/StorageLinkCommand.php
@@ -11,7 +11,8 @@ class StorageLinkCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'storage:link {--relative : Create the symbolic link using relative paths}
+    protected $signature = 'storage:link
+                {--relative : Create the symbolic link using relative paths}
                 {--force : Recreate already existing symbolic links}';
 
     /**

--- a/src/Illuminate/Foundation/Console/StorageLinkCommand.php
+++ b/src/Illuminate/Foundation/Console/StorageLinkCommand.php
@@ -11,7 +11,8 @@ class StorageLinkCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'storage:link {--relative : Create the symbolic link using relative paths}';
+    protected $signature = 'storage:link {--relative : Create the symbolic link using relative paths}
+                {--force : Recreate already existing symbolic links}';
 
     /**
      * The console command description.
@@ -28,9 +29,10 @@ class StorageLinkCommand extends Command
     public function handle()
     {
         $relative = $this->option('relative');
+        $force = $this->option('force');
 
         foreach ($this->links() as $link => $target) {
-            if (file_exists($link)) {
+            if (file_exists($link) && ! (is_link($link) && $force)) {
                 $this->error("The [$link] link already exists.");
                 continue;
             }


### PR DESCRIPTION
This PR allows symlinks to be overridden when `--force` option is specified to the `storage:link` command. Existing behavior was not changed and regular files won't be replaced with symlinks.

This could come helpful:
 - When project location is changed but the original location is still valid
 - Symlink target location changed but the original location is still valid

Currently the only solution to these cases is to manually remove the existing symlinks

