### PR TITLE
[8.x] Relax the lazy loading restrictions

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -351,10 +351,12 @@ class Builder
     {
         $instance = $this->newModelInstance();
 
-        return $instance->newCollection(array_map(function ($item) use ($instance) {
+        return $instance->newCollection(array_map(function ($item) use ($items, $instance) {
             $model = $instance->newFromBuilder($item);
 
-            $model->preventsLazyLoading = Model::preventsLazyLoading();
+            if (count($items) > 1) {
+                $model->preventsLazyLoading = Model::preventsLazyLoading();
+            }
 
             return $model;
         }, $items));

--- a/tests/Integration/Database/EloquentStrictLoadingTest.php
+++ b/tests/Integration/Database/EloquentStrictLoadingTest.php
@@ -48,6 +48,15 @@ class EloquentStrictLoadingTest extends DatabaseTestCase
         $models[0]->modelTwos;
     }
 
+    public function testStrictModeDoesntThrowAnExceptionOnLazyLoadingWithSingleModel()
+    {
+        EloquentStrictLoadingTestModel1::create();
+
+        $models = EloquentStrictLoadingTestModel1::get();
+
+        $this->assertInstanceOf(Collection::class, $models);
+    }
+
     public function testStrictModeDoesntThrowAnExceptionOnAttributes()
     {
         EloquentStrictLoadingTestModel1::create();
@@ -85,6 +94,8 @@ class EloquentStrictLoadingTest extends DatabaseTestCase
     {
         $model = EloquentStrictLoadingTestModel1::create();
 
+        $model = EloquentStrictLoadingTestModel1::find($model->id);
+
         $this->assertInstanceOf(Collection::class, $model->modelTwos);
     }
 
@@ -94,6 +105,7 @@ class EloquentStrictLoadingTest extends DatabaseTestCase
         $this->expectExceptionMessage('Attempted to lazy load');
 
         $model1 = EloquentStrictLoadingTestModel1::create();
+        EloquentStrictLoadingTestModel2::create(['model_1_id' => $model1->id]);
         EloquentStrictLoadingTestModel2::create(['model_1_id' => $model1->id]);
 
         $models = EloquentStrictLoadingTestModel1::with('modelTwos')->get();


### PR DESCRIPTION
This PR will only throw the exception if the models being hydrated are more than 1. If it's only a single model then it means `N` in `N+1` will always be 1. So no problem here.