### PR TITLE
[8.x] Introduce Conditional trait on validation rules

### DIFF
--- a/src/Illuminate/Support/Traits/Conditional.php
+++ b/src/Illuminate/Support/Traits/Conditional.php
@@ -2,11 +2,6 @@
 
 namespace Illuminate\Support\Traits;
 
-use BadMethodCallException;
-use Closure;
-use ReflectionClass;
-use ReflectionMethod;
-
 trait Conditional
 {
     /**

--- a/src/Illuminate/Support/Traits/Conditional.php
+++ b/src/Illuminate/Support/Traits/Conditional.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Illuminate\Support\Traits;
+
+use BadMethodCallException;
+use Closure;
+use ReflectionClass;
+use ReflectionMethod;
+
+trait Conditional
+{
+    /**
+     * Apply the callback if the given "value" is true.
+     *
+     * @param mixed         $value
+     * @param callable      $callback
+     * @param callable|null $default
+     *
+     * @return mixed|$this
+     */
+    public function when($value, $callback, $default = null)
+    {
+        if ($value) {
+            return $callback($this, $value) ?: $this;
+        } elseif ($default) {
+            return $default($this, $value) ?: $this;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Apply the callback if the given "value" is false.
+     *
+     * @param mixed         $value
+     * @param callable      $callback
+     * @param callable|null $default
+     *
+     * @return mixed|$this
+     */
+    public function unless($value, $callback, $default = null)
+    {
+        return $this->when(! $value, $callback, $default);
+    }
+}

--- a/src/Illuminate/Support/Traits/Conditional.php
+++ b/src/Illuminate/Support/Traits/Conditional.php
@@ -7,11 +7,11 @@ trait Conditional
     /**
      * Apply the callback if the given "value" is true.
      *
-     * @param mixed         $value
-     * @param callable      $callback
-     * @param callable|null $default
+     * @param  mixed  $value
+     * @param  callable  $callback
+     * @param  callable|null  $default
      *
-     * @return mixed|$this
+     * @return mixed
      */
     public function when($value, $callback, $default = null)
     {
@@ -27,11 +27,11 @@ trait Conditional
     /**
      * Apply the callback if the given "value" is false.
      *
-     * @param mixed         $value
-     * @param callable      $callback
-     * @param callable|null $default
+     * @param  mixed  $value
+     * @param  callable  $callback
+     * @param  callable|null  $default
      *
-     * @return mixed|$this
+     * @return mixed
      */
     public function unless($value, $callback, $default = null)
     {

--- a/src/Illuminate/Validation/Rules/Dimensions.php
+++ b/src/Illuminate/Validation/Rules/Dimensions.php
@@ -2,8 +2,12 @@
 
 namespace Illuminate\Validation\Rules;
 
+use Illuminate\Support\Traits\Conditional;
+
 class Dimensions
 {
+    use Conditional;
+
     /**
      * The constraints for the dimensions rule.
      *

--- a/src/Illuminate/Validation/Rules/Exists.php
+++ b/src/Illuminate/Validation/Rules/Exists.php
@@ -2,9 +2,12 @@
 
 namespace Illuminate\Validation\Rules;
 
+use Illuminate\Support\Traits\Conditional;
+
 class Exists
 {
     use DatabaseRule;
+    use Conditional;
 
     /**
      * Convert the rule to a validation string.

--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -8,10 +8,13 @@ use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Contracts\Validation\UncompromisedVerifier;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Traits\Conditional;
 use InvalidArgumentException;
 
 class Password implements Rule, DataAwareRule
 {
+    use Conditional;
+
     /**
      * The data under validation.
      *

--- a/src/Illuminate/Validation/Rules/Unique.php
+++ b/src/Illuminate/Validation/Rules/Unique.php
@@ -3,10 +3,12 @@
 namespace Illuminate\Validation\Rules;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Traits\Conditional;
 
 class Unique
 {
     use DatabaseRule;
+    use Conditional;
 
     /**
      * The ID that should be ignored.

--- a/tests/Validation/ValidationDimensionsRuleTest.php
+++ b/tests/Validation/ValidationDimensionsRuleTest.php
@@ -31,10 +31,10 @@ class ValidationDimensionsRuleTest extends TestCase
         $this->assertSame('dimensions:min_width=300,min_height=400', (string) $rule);
 
         $rule = Rule::dimensions()
-            ->when(true, function($rule) {
+            ->when(true, function ($rule) {
                 $rule->height('100');
             })
-            ->unless(true, function($rule) {
+            ->unless(true, function ($rule) {
                 $rule->width('200');
             });
         $this->assertSame('dimensions:height=100', (string) $rule);

--- a/tests/Validation/ValidationDimensionsRuleTest.php
+++ b/tests/Validation/ValidationDimensionsRuleTest.php
@@ -29,5 +29,14 @@ class ValidationDimensionsRuleTest extends TestCase
         $rule = Rule::dimensions()->minWidth(300)->minHeight(400);
 
         $this->assertSame('dimensions:min_width=300,min_height=400', (string) $rule);
+
+        $rule = Rule::dimensions()
+            ->when(true, function($rule) {
+                $rule->height('100');
+            })
+            ->unless(true, function($rule) {
+                $rule->width('200');
+            });
+        $this->assertSame('dimensions:height=100', (string) $rule);
     }
 }

--- a/tests/Validation/ValidationExistsRuleTest.php
+++ b/tests/Validation/ValidationExistsRuleTest.php
@@ -119,29 +119,29 @@ class ValidationExistsRuleTest extends TestCase
     public function testItChoosesValidRecordsUsingConditionalModifiers()
     {
         $rule = new Exists('users', 'id');
-        $rule->when(true, function($rule) {
-            $rule->whereNotIn('type', [ 'foo', 'bar' ]);
+        $rule->when(true, function ($rule) {
+            $rule->whereNotIn('type', ['foo', 'bar']);
         });
-        $rule->unless(true, function($rule) {
-            $rule->whereNotIn('type', [ 'baz', 'other' ]);
+        $rule->unless(true, function ($rule) {
+            $rule->whereNotIn('type', ['baz', 'other']);
         });
 
-        User::create([ 'id' => '1', 'type' => 'foo' ]);
-        User::create([ 'id' => '2', 'type' => 'bar' ]);
-        User::create([ 'id' => '3', 'type' => 'baz' ]);
-        User::create([ 'id' => '4', 'type' => 'other' ]);
+        User::create(['id' => '1', 'type' => 'foo']);
+        User::create(['id' => '2', 'type' => 'bar']);
+        User::create(['id' => '3', 'type' => 'baz']);
+        User::create(['id' => '4', 'type' => 'other']);
 
         $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, [], [ 'id' => $rule ]);
+        $v = new Validator($trans, [], ['id' => $rule]);
         $v->setPresenceVerifier(new DatabasePresenceVerifier(Eloquent::getConnectionResolver()));
 
-        $v->setData([ 'id' => 1 ]);
+        $v->setData(['id' => 1]);
         $this->assertFalse($v->passes());
-        $v->setData([ 'id' => 2 ]);
+        $v->setData(['id' => 2]);
         $this->assertFalse($v->passes());
-        $v->setData([ 'id' => 3 ]);
+        $v->setData(['id' => 3]);
         $this->assertTrue($v->passes());
-        $v->setData([ 'id' => 4 ]);
+        $v->setData(['id' => 4]);
         $this->assertTrue($v->passes());
     }
 

--- a/tests/Validation/ValidationExistsRuleTest.php
+++ b/tests/Validation/ValidationExistsRuleTest.php
@@ -116,6 +116,35 @@ class ValidationExistsRuleTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
+    public function testItChoosesValidRecordsUsingConditionalModifiers()
+    {
+        $rule = new Exists('users', 'id');
+        $rule->when(true, function($rule) {
+            $rule->whereNotIn('type', [ 'foo', 'bar' ]);
+        });
+        $rule->unless(true, function($rule) {
+            $rule->whereNotIn('type', [ 'baz', 'other' ]);
+        });
+
+        User::create([ 'id' => '1', 'type' => 'foo' ]);
+        User::create([ 'id' => '2', 'type' => 'bar' ]);
+        User::create([ 'id' => '3', 'type' => 'baz' ]);
+        User::create([ 'id' => '4', 'type' => 'other' ]);
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, [], [ 'id' => $rule ]);
+        $v->setPresenceVerifier(new DatabasePresenceVerifier(Eloquent::getConnectionResolver()));
+
+        $v->setData([ 'id' => 1 ]);
+        $this->assertFalse($v->passes());
+        $v->setData([ 'id' => 2 ]);
+        $this->assertFalse($v->passes());
+        $v->setData([ 'id' => 3 ]);
+        $this->assertTrue($v->passes());
+        $v->setData([ 'id' => 4 ]);
+        $this->assertTrue($v->passes());
+    }
+
     public function testItChoosesValidRecordsUsingWhereNotInAndWhereNotInRulesTogether()
     {
         $rule = new Exists('users', 'id');

--- a/tests/Validation/ValidationPasswordRuleTest.php
+++ b/tests/Validation/ValidationPasswordRuleTest.php
@@ -44,20 +44,20 @@ class ValidationPasswordRuleTest extends TestCase
     public function testConditional()
     {
         $is_privileged_user = true;
-        $rule = (new Password(8))->when($is_privileged_user, function($rule) {
+        $rule = (new Password(8))->when($is_privileged_user, function ($rule) {
             $rule->symbols();
         });
 
-        $this->fails($rule, [ 'aaaaaaaa', '11111111' ], [
+        $this->fails($rule, ['aaaaaaaa', '11111111'], [
             'The my password must contain at least one symbol.',
         ]);
 
         $is_privileged_user = false;
-        $rule = (new Password(8))->when($is_privileged_user, function($rule) {
+        $rule = (new Password(8))->when($is_privileged_user, function ($rule) {
             $rule->symbols();
         });
 
-        $this->passes($rule, [ 'aaaaaaaa', '11111111' ]);
+        $this->passes($rule, ['aaaaaaaa', '11111111']);
     }
 
     public function testMixedCase()

--- a/tests/Validation/ValidationPasswordRuleTest.php
+++ b/tests/Validation/ValidationPasswordRuleTest.php
@@ -41,6 +41,25 @@ class ValidationPasswordRuleTest extends TestCase
         $this->passes(new Password(8), ['88888888']);
     }
 
+    public function testConditional()
+    {
+        $is_privileged_user = true;
+        $rule = (new Password(8))->when($is_privileged_user, function($rule) {
+            $rule->symbols();
+        });
+
+        $this->fails($rule, [ 'aaaaaaaa', '11111111' ], [
+            'The my password must contain at least one symbol.',
+        ]);
+
+        $is_privileged_user = false;
+        $rule = (new Password(8))->when($is_privileged_user, function($rule) {
+            $rule->symbols();
+        });
+
+        $this->passes($rule, [ 'aaaaaaaa', '11111111' ]);
+    }
+
     public function testMixedCase()
     {
         $this->fails(Password::min(2)->mixedCase(), ['nn', 'MM'], [

--- a/tests/Validation/ValidationUniqueRuleTest.php
+++ b/tests/Validation/ValidationUniqueRuleTest.php
@@ -42,10 +42,10 @@ class ValidationUniqueRuleTest extends TestCase
 
         $rule = new Unique(EloquentModelStub::class, 'column');
         $rule->where('foo', 'bar');
-        $rule->when(true, function($rule) {
+        $rule->when(true, function ($rule) {
             $rule->ignore('Taylor, Otwell', 'id_column');
         });
-        $rule->unless(true, function($rule) {
+        $rule->unless(true, function ($rule) {
             $rule->ignore('Chris', 'id_column');
         });
         $this->assertSame('unique:table,column,"Taylor, Otwell",id_column,foo,"bar"', (string) $rule);

--- a/tests/Validation/ValidationUniqueRuleTest.php
+++ b/tests/Validation/ValidationUniqueRuleTest.php
@@ -40,6 +40,16 @@ class ValidationUniqueRuleTest extends TestCase
         $rule->where('foo', 'bar');
         $this->assertSame('unique:table,column,"Taylor, Otwell",id_column,foo,"bar"', (string) $rule);
 
+        $rule = new Unique(EloquentModelStub::class, 'column');
+        $rule->where('foo', 'bar');
+        $rule->when(true, function($rule) {
+            $rule->ignore('Taylor, Otwell', 'id_column');
+        });
+        $rule->unless(true, function($rule) {
+            $rule->ignore('Chris', 'id_column');
+        });
+        $this->assertSame('unique:table,column,"Taylor, Otwell",id_column,foo,"bar"', (string) $rule);
+
         $rule = new Unique('table', 'column');
         $rule->ignore('Taylor, Otwell"\'..-"', 'id_column');
         $rule->where('foo', 'bar');


### PR DESCRIPTION
This introduces a new `Conditional` trait that adds the commonly-used `->when()` and `->unless()` helpers. I've limited this PR to adding these helpers to validation rules, although there's an opportunity to remove some duplication on the query builder, mailables, etc., if you want to expand the scope.

I find myself using `when()` more and more often, and usually miss it on objects that don't have it. One classic use case is in a FormRequest object:

```php
class PageRequest extends FormRequest
{
  public function rules()
  {
    return [
      'slug' => [
        Rule::unique(Page::class, 'slug')
          ->when($this->isMethod('put'), function($rule) {
            $rule->ignoreModel($this->route('page'));
          }),
      ],
    ];
  }
}
```

Something like this lets me re-use the same ruleset for create and update operations. If I'm updating an existing page, I ignore that model from the unique rule. If I'm creating a new page, there's nothing to ignore.

This can be used to add stricter options to a password rule if the logged in user has privileged access, or dynamically changing image dimension requirements based on some dynamic input.