### PR TITLE
[8.x] Columns in the order by list must be unique

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1983,6 +1983,14 @@ class Builder
             throw new InvalidArgumentException('Order direction must be "asc" or "desc".');
         }
 
+        if (is_array($this->{$this->unions ? 'unionOrders' : 'orders'})) {
+            foreach ($this->{$this->unions ? 'unionOrders' : 'orders'} as $value) {
+                if ($value['column'] === $column) {
+                    return $this;
+                }
+            }
+        }
+
         $this->{$this->unions ? 'unionOrders' : 'orders'}[] = [
             'column' => $column,
             'direction' => $direction,

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1188,6 +1188,13 @@ class DatabaseQueryBuilderTest extends TestCase
             ->orderByRaw('field(category, ?, ?) asc', ['news', 'opinion']);
         $this->assertSame('(select * from "posts" where "public" = ?) union all (select * from "videos" where "public" = ?) order by field(category, ?, ?) asc', $builder->toSql());
         $this->assertEquals([1, 1, 'news', 'opinion'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->orderBy('name');
+        $builder->orderBy('email');
+        $builder->orderBy('name');
+        $builder->orderBy('email');
+        $this->assertSame('select * from "users" order by "name" asc, "email" asc', $builder->toSql());
     }
 
     public function testReorder()


### PR DESCRIPTION
In my application I have this kind of code:

```php
    public function scopeEnabled(Builder $query)
    {
        return $query->where('is_enabled', true)->orderBy('position');
    }

    public function scopeParents(Builder $query)
    {
        return $query->whereNull('parent_id')->orderBy('position');
    }
```

Somewhere else I have : `Model::scopes(['parents', 'enabled'])->first()`

The SQL produced by this query is: 
`select * from models where parent_id is null and is_enabled = 1 order by position asc, position asc`

This works in MySql however SQLServer complain saying:
`A column has been specified more than once in the order by list. Columns in the order by list must be unique`

You might say "Then just remove one orderBy() in either scope" however both are used independently.

I saw it happened to Nova see : https://github.com/laravel/nova-issues/issues/1621

What I suggest is to make sure this cannot happen, let me know if I need to change anything!
