### PR TITLE
[8.x] Test relation count when disabling its constraints

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -14,6 +14,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\Concerns\AsPivot;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\Relations\Pivot;
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Support\Str;
@@ -206,13 +207,15 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
         if (! isset(static::$booted[static::class])) {
             static::$booted[static::class] = true;
 
-            $this->fireModelEvent('booting', false);
+            Relation::withConstraints(function () {
+                $this->fireModelEvent('booting', false);
 
-            static::booting();
-            static::boot();
-            static::booted();
+                static::booting();
+                static::boot();
+                static::booted();
 
-            $this->fireModelEvent('booted', false);
+                $this->fireModelEvent('booted', false);
+            });
         }
     }
 
@@ -275,9 +278,11 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
      */
     protected function initializeTraits()
     {
-        foreach (static::$traitInitializers[static::class] as $method) {
-            $this->{$method}();
-        }
+        Relation::withConstraints(function () {
+            foreach (static::$traitInitializers[static::class] as $method) {
+                $this->{$method}();
+            }
+        });
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -103,6 +103,25 @@ abstract class Relation
     }
 
     /**
+     * Run a callback with constraints enabled on the relation.
+     *
+     * @param  \Closure  $callback
+     * @return mixed
+     */
+    public static function withConstraints(Closure $callback)
+    {
+        $previous = static::$constraints;
+
+        static::$constraints = true;
+
+        try {
+            return $callback();
+        } finally {
+            static::$constraints = $previous;
+        }
+    }
+
+    /**
      * Set the base constraints on the relation query.
      *
      * @return void

--- a/tests/Integration/Database/EloquentWithCountTest.php
+++ b/tests/Integration/Database/EloquentWithCountTest.php
@@ -51,6 +51,13 @@ class EloquentWithCountTest extends DatabaseTestCase
         $this->assertEquals([
             ['id' => 1, 'twos_count' => 1],
         ], $results->get()->toArray());
+
+        $one = Model1::create();
+        $one->twos()->create();
+
+        Model1::with('fours')->first();
+
+        $this->assertEquals(1, Model4::$twosCount);
     }
 
     public function testGlobalScopes()
@@ -138,6 +145,7 @@ class Model3 extends Model
 
 class Model4 extends Model
 {
+    public static $twosCount = 0;
     public $table = 'four';
     public $timestamps = false;
     protected $guarded = [];
@@ -145,6 +153,8 @@ class Model4 extends Model
     protected static function boot()
     {
         parent::boot();
+
+        self::$twosCount = Model1::first()->twos()->count();
 
         static::addGlobalScope('app', function ($builder) {
             $builder->where('id', '>', 1);

--- a/tests/Integration/Database/EloquentWithCountTest.php
+++ b/tests/Integration/Database/EloquentWithCountTest.php
@@ -57,6 +57,7 @@ class EloquentWithCountTest extends DatabaseTestCase
 
         Model1::with('fours')->first();
 
+        $this->assertEquals(1, Model1::first()->twos()->count());
         $this->assertEquals(1, Model4::$twosCount);
     }
 


### PR DESCRIPTION
I am opening this PR with only the test case to show and prove that this will **fail** because of not getting the correct count of a model relationship.

Here, on [`testItBasic`](https://github.com/mtawil/framework/blob/disabling-constraints-leads-test-to-fail/tests/Integration/Database/EloquentWithCountTest.php#L39-L61) test, we've created two records for `Model1`, each one of it is created only one record of `Model2`, so basically, we have only one record of `Model2` for each `Model1`, and a total of two records when doing `Model2::all()->count()`

This closed PR is solving this test case: https://github.com/laravel/framework/pull/37489