### PR TITLE
[8.x] remove function is_null - overheads for function call

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -122,9 +122,9 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
             $locales = $fallback ? $this->localeArray($locale) : [$locale];
 
             foreach ($locales as $locale) {
-                if (! is_null($line = $this->getLine(
+                if (($line = $this->getLine(
                     $namespace, $group, $locale, $item, $replace
-                ))) {
+                )) != null) {
                     return $line;
                 }
             }


### PR DESCRIPTION
Remove function is_null and changed condition for not equal null (optimization - overheads for function call)

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
