### PR TITLE
[9.x] Add query execution start timestamps to DB queryLog

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -646,7 +646,7 @@ class Connection implements ConnectionInterface
         // then log the query, bindings, and execution time so we will report them on
         // the event that the developer needs them. We'll log time in milliseconds.
         $this->logQuery(
-            $query, $bindings, $this->getElapsedTime($start)
+            $query, $bindings, $this->getElapsedTime($start), $start
         );
 
         return $result;
@@ -689,14 +689,15 @@ class Connection implements ConnectionInterface
      * @param  string  $query
      * @param  array  $bindings
      * @param  float|null  $time
+     * @param  float|null  $started
      * @return void
      */
-    public function logQuery($query, $bindings, $time = null)
+    public function logQuery($query, $bindings, $time = null, $started = null)
     {
-        $this->event(new QueryExecuted($query, $bindings, $time, $this));
+        $this->event(new QueryExecuted($query, $bindings, $time, $this, $started));
 
         if ($this->loggingQueries) {
-            $this->queryLog[] = compact('query', 'bindings', 'time');
+            $this->queryLog[] = compact('query', 'bindings', 'time', 'started');
         }
     }
 

--- a/src/Illuminate/Database/Events/QueryExecuted.php
+++ b/src/Illuminate/Database/Events/QueryExecuted.php
@@ -56,7 +56,7 @@ class QueryExecuted
      * @param  float|null  $started
      * @return void
      */
-    public function __construct($sql, $bindings, $time, $connection, $started)
+    public function __construct($sql, $bindings, $time, $connection, $started = null)
     {
         $this->sql = $sql;
         $this->time = $time;

--- a/src/Illuminate/Database/Events/QueryExecuted.php
+++ b/src/Illuminate/Database/Events/QueryExecuted.php
@@ -26,6 +26,13 @@ class QueryExecuted
     public $time;
 
     /**
+     * The Unix timestamp with microseconds right before executing the query.
+     *
+     * @var float
+     */
+    public $started;
+
+    /**
      * The database connection instance.
      *
      * @var \Illuminate\Database\Connection
@@ -46,14 +53,16 @@ class QueryExecuted
      * @param  array  $bindings
      * @param  float|null  $time
      * @param  \Illuminate\Database\Connection  $connection
+     * @param  float|null  $started
      * @return void
      */
-    public function __construct($sql, $bindings, $time, $connection)
+    public function __construct($sql, $bindings, $time, $connection, $started)
     {
         $this->sql = $sql;
         $this->time = $time;
         $this->bindings = $bindings;
         $this->connection = $connection;
         $this->connectionName = $connection->getName();
+        $this->started = $started;
     }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Timestamp of query execution start should be part of queryLog information, so that this information could be retrieved in DB::getQueryLog().