### PR TITLE
[8.x] Introduce scoped instances

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -52,6 +52,13 @@ class Container implements ArrayAccess, ContainerContract
     protected $instances = [];
 
     /**
+     * The container's scoped instances.
+     *
+     * @var array
+     */
+    protected $scopedInstances = [];
+
+    /**
      * The registered type aliases.
      *
      * @var string[]
@@ -394,6 +401,36 @@ class Container implements ArrayAccess, ContainerContract
     }
 
     /**
+     * Register a scoped binding in the container.
+     *
+     * @param  string  $abstract
+     * @param  \Closure|string|null  $concrete
+     * @return void
+     */
+    public function scoped($abstract, $concrete = null)
+    {
+        $this->scopedInstances[] = $abstract;
+
+        $this->singleton($abstract, $concrete);
+    }
+
+    /**
+     * Register a scoped binding if it hasn't already been registered.
+     *
+     * @param  string  $abstract
+     * @param  \Closure|string|null  $concrete
+     * @return void
+     */
+    public function scopedIf($abstract, $concrete = null)
+    {
+        if (! $this->bound($abstract)) {
+            $this->scopedInstances[] = $abstract;
+
+            $this->singleton($abstract, $concrete);
+        }
+    }
+
+    /**
      * "Extend" an abstract type in the container.
      *
      * @param  string  $abstract
@@ -426,7 +463,7 @@ class Container implements ArrayAccess, ContainerContract
      * @param  mixed  $instance
      * @return mixed
      */
-    public function instance($abstract, $instance)
+    public function  instance($abstract, $instance)
     {
         $this->removeAbstractAlias($abstract);
 
@@ -1308,6 +1345,18 @@ class Container implements ArrayAccess, ContainerContract
     }
 
     /**
+     * Clear all of the scoped instances from the container.
+     *
+     * @return void
+     */
+    public function resetScope()
+    {
+        foreach ($this->scopedInstances as $scoped) {
+            unset($this->instances[$scoped]);
+        }
+    }
+
+    /**
      * Flush the container of all bindings and resolved instances.
      *
      * @return void
@@ -1319,6 +1368,7 @@ class Container implements ArrayAccess, ContainerContract
         $this->bindings = [];
         $this->instances = [];
         $this->abstractAliases = [];
+        $this->scopedInstances = [];
     }
 
     /**

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -463,7 +463,7 @@ class Container implements ArrayAccess, ContainerContract
      * @param  mixed  $instance
      * @return mixed
      */
-    public function  instance($abstract, $instance)
+    public function instance($abstract, $instance)
     {
         $this->removeAbstractAlias($abstract);
 

--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -104,8 +104,6 @@ class Kernel implements KernelContract
      */
     public function handle($request)
     {
-        $this->app->resetScope();
-
         try {
             $request->enableHttpMethodParameterOverride();
 

--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -104,6 +104,8 @@ class Kernel implements KernelContract
      */
     public function handle($request)
     {
+        $this->app->resetScope();
+
         try {
             $request->enableHttpMethodParameterOverride();
 

--- a/src/Illuminate/Queue/QueueServiceProvider.php
+++ b/src/Illuminate/Queue/QueueServiceProvider.php
@@ -166,7 +166,7 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
                 return $this->app->isDownForMaintenance();
             };
 
-            $scopeResetter = function () use ($app){
+            $scopeResetter = function () use ($app) {
                 return $app->resetScope();
             };
 

--- a/src/Illuminate/Queue/QueueServiceProvider.php
+++ b/src/Illuminate/Queue/QueueServiceProvider.php
@@ -166,11 +166,16 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
                 return $this->app->isDownForMaintenance();
             };
 
+            $scopeResetter = function () use ($app){
+                return $app->resetScope();
+            };
+
             return new Worker(
                 $app['queue'],
                 $app['events'],
                 $app[ExceptionHandler::class],
-                $isDownForMaintenance
+                $isDownForMaintenance,
+                $scopeResetter
             );
         });
     }

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -66,6 +66,13 @@ class Worker
     protected $isDownForMaintenance;
 
     /**
+     * The callback used to reset the application scope.
+     *
+     * @var callable
+     */
+    protected $scopeResetter;
+
+    /**
      * Indicates if the worker should exit.
      *
      * @var bool
@@ -93,17 +100,20 @@ class Worker
      * @param  \Illuminate\Contracts\Events\Dispatcher  $events
      * @param  \Illuminate\Contracts\Debug\ExceptionHandler  $exceptions
      * @param  callable  $isDownForMaintenance
+     * @param  callable|null  $scopeResetter
      * @return void
      */
     public function __construct(QueueManager $manager,
                                 Dispatcher $events,
                                 ExceptionHandler $exceptions,
-                                callable $isDownForMaintenance)
+                                callable $isDownForMaintenance,
+                                callable $scopeResetter = null)
     {
         $this->events = $events;
         $this->manager = $manager;
         $this->exceptions = $exceptions;
         $this->isDownForMaintenance = $isDownForMaintenance;
+        $this->scopeResetter = $scopeResetter;
     }
 
     /**
@@ -136,6 +146,10 @@ class Worker
                 }
 
                 continue;
+            }
+
+            if (isset($this->scopeResetter)) {
+                ($this->scopeResetter)();
             }
 
             // First, we will attempt to get the next job off of the queue. We will also

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -106,6 +106,31 @@ class ContainerTest extends TestCase
         $this->assertSame($firstInstantiation, $secondInstantiation);
     }
 
+    public function testScopedClosureResolution()
+    {
+        $container = new Container;
+        $container->scoped('class', function () {
+            return new stdClass;
+        });
+        $firstInstantiation = $container->make('class');
+        $secondInstantiation = $container->make('class');
+        $this->assertSame($firstInstantiation, $secondInstantiation);
+    }
+
+    public function testScopedClosureResets()
+    {
+        $container = new Container;
+        $container->scoped('class', function () {
+            return new stdClass;
+        });
+        $firstInstantiation = $container->make('class');
+
+        $container->resetScope();
+
+        $secondInstantiation = $container->make('class');
+        $this->assertNotSame($firstInstantiation, $secondInstantiation);
+    }
+
     public function testAutoConcreteResolution()
     {
         $container = new Container;
@@ -120,6 +145,20 @@ class ContainerTest extends TestCase
         $var1 = $container->make(ContainerConcreteStub::class);
         $var2 = $container->make(ContainerConcreteStub::class);
         $this->assertSame($var1, $var2);
+    }
+
+    public function testScopedConcreteResolutionResets()
+    {
+        $container = new Container;
+        $container->scoped(ContainerConcreteStub::class);
+
+        $var1 = $container->make(ContainerConcreteStub::class);
+
+        $container->resetScope();
+
+        $var2 = $container->make(ContainerConcreteStub::class);
+
+        $this->assertNotSame($var1, $var2);
     }
 
     public function testBindFailsLoudlyWithInvalidArgument()


### PR DESCRIPTION
Scoped instances are singletons that must be flushed while switching the application context. e.g.


```php
$this->app->scoped('service', function (){
    return new Service(...);
});
```

1- On a new Octane request.
2- Before processing a new queued job.

In this PR, I only reset the scope before processing queued jobs. I original reset the scope inside `HttpKernel::handle()` but I figured the scope needs resetting earlier than that when handling an HTTP request. So if this request was merged, I'll add the scope resetting to Octane once the sandbox instance is cloned.