### PR TITLE
[8.x] Allow multiple SES configuration with IAM Role authentication 

### DIFF
--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -262,11 +262,11 @@ class MailManager implements FactoryContract
      */
     protected function createSesTransport(array $config)
     {
-        if (! isset($config['secret'])) {
-            $config = array_merge($this->app['config']->get('services.ses', []), [
-                'version' => 'latest', 'service' => 'email',
-            ]);
-        }
+        $global = $this->app['config']->get('services.ses', []);
+
+        $default = ['version' => 'latest', 'service' => 'email'];
+
+        $config = array_merge($global, $default, $config);
 
         $config = Arr::except($config, ['transport']);
 

--- a/tests/Mail/MailSesTransportTest.php
+++ b/tests/Mail/MailSesTransportTest.php
@@ -8,6 +8,7 @@ use Illuminate\Container\Container;
 use Illuminate\Mail\MailManager;
 use Illuminate\Mail\Transport\SesTransport;
 use Illuminate\Support\Str;
+use Illuminate\View\Factory;
 use PHPUnit\Framework\TestCase;
 use Swift_Message;
 
@@ -67,6 +68,58 @@ class MailSesTransportTest extends TestCase
 
         $this->assertEquals($messageId, $message->getHeaders()->get('X-Message-ID')->getFieldBody());
         $this->assertEquals($messageId, $message->getHeaders()->get('X-SES-Message-ID')->getFieldBody());
+    }
+
+    public function testSesLocalConfiguration()
+    {
+        $container = new Container;
+
+        $container->singleton('config', function () {
+            return new Repository([
+                'mail' => [
+                    'mailers' => [
+                        'ses' => [
+                            'transport' => 'ses',
+                            'region' => 'eu-west-1',
+                            'options' => [
+                                'ConfigurationSetName' => 'Laravel',
+                                'Tags' => [
+                                    ['Name' => 'Laravel', 'Value' => 'Framework'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                'services' => [
+                    'ses' => [
+                        'region' => 'us-east-1',
+                    ],
+                ],
+            ]);
+        });
+
+        $container->instance('view', $this->createMock(Factory::class));
+
+        $container->bind('events', function () {
+            return null;
+        });
+
+        $manager = new MailManager($container);
+
+        /** @var \Illuminate\Mail\Mailer $mailer */
+        $mailer = $manager->mailer('ses');
+
+        /** @var \Illuminate\Mail\Transport\SesTransport $transport */
+        $transport = $mailer->getSwiftMailer()->getTransport();
+
+        $this->assertSame('eu-west-1', $transport->ses()->getRegion());
+
+        $this->assertSame([
+            'ConfigurationSetName' => 'Laravel',
+            'Tags' => [
+                ['Name' => 'Laravel', 'Value' => 'Framework'],
+            ],
+        ], $transport->getOptions());
     }
 }
 


### PR DESCRIPTION
When trying to use multiple mailers with `ses` as the transport, Laravel is trying to rely on the secret key to decide whether to use a local configuration (within mailers) or a global configuration (at services.ses). However, IAM Role-based authentication (assume role) doesn't require any key or secret to be present, which makes Laravel fallback to the global configuration and the mailer loses all 'local' configuration.

This pull request will broaden the usage of specific mailer configuration, but still allow fallback to global configuration through the array_merge execution preference