### PR TITLE
[8.x] Add setter to minutes for CacheBasedSessionHandler

### DIFF
--- a/src/Illuminate/Session/CacheBasedSessionHandler.php
+++ b/src/Illuminate/Session/CacheBasedSessionHandler.php
@@ -91,4 +91,14 @@ class CacheBasedSessionHandler implements SessionHandlerInterface
     {
         return $this->cache;
     }
+    
+    /**
+     * Set minutes until expiration
+     * 
+     * @param  mixed  $minutes 
+     * @return void 
+     */
+    public function setMinutes($minutes) {
+        $this->minutes = $minutes;
+    }
 }

--- a/src/Illuminate/Session/CacheBasedSessionHandler.php
+++ b/src/Illuminate/Session/CacheBasedSessionHandler.php
@@ -93,12 +93,13 @@ class CacheBasedSessionHandler implements SessionHandlerInterface
     }
     
     /**
-     * Set minutes until expiration
-     * 
-     * @param  mixed  $minutes 
-     * @return void 
+     * Set minutes until expiration.
+     *
+     * @param  int  $minutes
+     * @return void
      */
-    public function setMinutes($minutes) {
+    public function setMinutes($minutes)
+    {
         $this->minutes = $minutes;
     }
 }

--- a/src/Illuminate/Session/CacheBasedSessionHandler.php
+++ b/src/Illuminate/Session/CacheBasedSessionHandler.php
@@ -91,7 +91,7 @@ class CacheBasedSessionHandler implements SessionHandlerInterface
     {
         return $this->cache;
     }
-    
+
     /**
      * Set minutes until expiration.
      *


### PR DESCRIPTION
My website receives a lot of bot requests from programs that don't properly handle sessions. This leads to Laravel creating a lot of sessions that are only ever used once, eating up storage that is doesn't need. Being able to set the minutes until expiration saves a lot of effort in extending multiple Laravel files.