### PR TITLE
[8.x] Allow to Router to accept array of keys in Model Explicit Bindings

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -16,6 +16,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Events\RouteMatched;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
@@ -986,14 +987,16 @@ class Router implements BindingRegistrar, RegistrarContract
     /**
      * Register a model binder for a wildcard.
      *
-     * @param  string  $key
+     * @param  string|array  $keys
      * @param  string  $class
      * @param  \Closure|null  $callback
      * @return void
      */
-    public function model($key, $class, Closure $callback = null)
+    public function model($keys, $class, Closure $callback = null)
     {
-        $this->bind($key, RouteBinding::forModel($this->container, $class, $callback));
+        foreach (Arr::wrap($keys) as $key) {
+            $this->bind($key, RouteBinding::forModel($this->container, $class, $callback));
+        }
     }
 
     /**

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -938,6 +938,16 @@ class RoutingRouteTest extends TestCase
         $this->assertSame('TAYLOR', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
     }
 
+    public function testModelBindingArray()
+    {
+        $router = $this->getRouter();
+        $router->get('foo/{bar}/{baz}', ['middleware' => SubstituteBindings::class, 'uses' => function ($firstName, $lastName) {
+            return $firstName.' '.$lastName;
+        }]);
+        $router->model(['bar', 'baz'], RouteModelBindingStub::class);
+        $this->assertSame('TAYLOR OTWELL', $router->dispatch(Request::create('foo/taylor/otwell', 'GET'))->getContent());
+    }
+
     public function testModelBindingWithNullReturn()
     {
         $this->expectException(ModelNotFoundException::class);


### PR DESCRIPTION
This feature is useful when you have dealing with wallets and transfer operations.

Before:
```php
// RouteServiceProvider.php
Route::model('payer', Wallet::class);
Route::model('payee', Wallet::class);

// routes/web.php
Route::get('/transaction/transfer/{payer}/{payee}', function ($payer, $payee) {
    // Transfer money from `$payer` wallet to `$payee` wallet...
});
```

After:
```php
// RouteServiceProvider.php
Route::model(['payer', 'payee'], Wallet::class);

// routes/web.php
Route::get('/transaction/transfer/{payer}/{payee}', function ($payer, $payee) {
    // Transfer money from `$payer` wallet to `$payee` wallet...
});
```

I'm not sure about how many tests this change is needed, so if there is not enough by your opinion, just let me know. 
