### PR TITLE
[8.x] Add assertDownloadOffered test method to TestResponse class

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1077,6 +1077,44 @@ class TestResponse implements ArrayAccess
         return $this;
     }
 
+    public function assertDownloadOffered($filename = null)
+    {
+        $contentDisposition = explode(';', $this->headers->get('content-disposition'));
+
+        if (trim($contentDisposition[0]) !== 'attachment') {
+            PHPUnit::fail(
+                'Response does not offer a file download.'.PHP_EOL.
+                'Disposition param ['.trim($contentDisposition[0]).'] found in header, [attachment] expected.'
+            );
+        }
+
+        if (! is_null($filename)) {
+            if (isset($contentDisposition[1]) && trim(explode('=', $contentDisposition[1])[0]) !== 'filename') {
+                PHPUnit::fail(
+                    'Unsupported Content-Disposition header param provided.'.PHP_EOL.
+                    'Disposition param ['.trim(explode('=', $contentDisposition[1])[0]).'] found in header, [filename] expected.'
+                );
+            }
+
+            $message = "Expected file [{$filename}] is not present in Content-Disposition header.";
+            if (! isset($contentDisposition[1])) {
+                PHPUnit::fail($message);
+            } else {
+                PHPUnit::assertSame(
+                    $filename,
+                    isset(explode('=', $contentDisposition[1])[1])
+                        ? trim(explode('=', $contentDisposition[1])[1])
+                        : '',
+                    $message
+                );
+                return $this;
+            }
+        } else {
+            PHPUnit::assertTrue(true);
+            return $this;
+        }
+    }
+
     /**
      * Get the current session store.
      *

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -265,6 +265,54 @@ class TestResponse implements ArrayAccess
     }
 
     /**
+     * Assert that the response offers a file download.
+     *
+     * @param  string|null  $filename
+     * @return $this
+     */
+    public function assertDownloadOffered($filename = null)
+    {
+        $contentDisposition = explode(';', $this->headers->get('content-disposition'));
+
+        if (trim($contentDisposition[0]) !== 'attachment') {
+            PHPUnit::fail(
+                'Response does not offer a file download.'.PHP_EOL.
+                'Disposition ['.trim($contentDisposition[0]).'] found in header, [attachment] expected.'
+            );
+        }
+
+        if (! is_null($filename)) {
+            if (isset($contentDisposition[1]) &&
+                trim(explode('=', $contentDisposition[1])[0]) !== 'filename') {
+                PHPUnit::fail(
+                    'Unsupported Content-Disposition header provided.'.PHP_EOL.
+                    'Disposition ['.trim(explode('=', $contentDisposition[1])[0]).'] found in header, [filename] expected.'
+                );
+            }
+
+            $message = "Expected file [{$filename}] is not present in Content-Disposition header.";
+
+            if (! isset($contentDisposition[1])) {
+                PHPUnit::fail($message);
+            } else {
+                PHPUnit::assertSame(
+                    $filename,
+                    isset(explode('=', $contentDisposition[1])[1])
+                        ? trim(explode('=', $contentDisposition[1])[1])
+                        : '',
+                    $message
+                );
+
+                return $this;
+            }
+        } else {
+            PHPUnit::assertTrue(true);
+
+            return $this;
+        }
+    }
+
+    /**
      * Asserts that the response contains the given cookie and equals the optional value.
      *
      * @param  string  $cookieName
@@ -1075,52 +1123,6 @@ class TestResponse implements ArrayAccess
         }
 
         return $this;
-    }
-
-    /**
-     * Assert that the response offers file download.
-     *
-     * @param  string|null  $filename
-     * @return $this
-     */
-    public function assertDownloadOffered($filename = null)
-    {
-        $contentDisposition = explode(';', $this->headers->get('content-disposition'));
-
-        if (trim($contentDisposition[0]) !== 'attachment') {
-            PHPUnit::fail(
-                'Response does not offer a file download.'.PHP_EOL.
-                'Disposition param ['.trim($contentDisposition[0]).'] found in header, [attachment] expected.'
-            );
-        }
-
-        if (! is_null($filename)) {
-            if (isset($contentDisposition[1]) && trim(explode('=', $contentDisposition[1])[0]) !== 'filename') {
-                PHPUnit::fail(
-                    'Unsupported Content-Disposition header param provided.'.PHP_EOL.
-                    'Disposition param ['.trim(explode('=', $contentDisposition[1])[0]).'] found in header, [filename] expected.'
-                );
-            }
-
-            $message = "Expected file [{$filename}] is not present in Content-Disposition header.";
-            if (! isset($contentDisposition[1])) {
-                PHPUnit::fail($message);
-            } else {
-                PHPUnit::assertSame(
-                    $filename,
-                    isset(explode('=', $contentDisposition[1])[1])
-                        ? trim(explode('=', $contentDisposition[1])[1])
-                        : '',
-                    $message
-                );
-
-                return $this;
-            }
-        } else {
-            PHPUnit::assertTrue(true);
-
-            return $this;
-        }
     }
 
     /**

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -270,7 +270,7 @@ class TestResponse implements ArrayAccess
      * @param  string|null  $filename
      * @return $this
      */
-    public function assertDownloadOffered($filename = null)
+    public function assertDownload($filename = null)
     {
         $contentDisposition = explode(';', $this->headers->get('content-disposition'));
 

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1113,10 +1113,12 @@ class TestResponse implements ArrayAccess
                         : '',
                     $message
                 );
+
                 return $this;
             }
         } else {
             PHPUnit::assertTrue(true);
+
             return $this;
         }
     }

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1077,6 +1077,12 @@ class TestResponse implements ArrayAccess
         return $this;
     }
 
+    /**
+     * Assert that the response offers file download.
+     *
+     * @param  string|null  $filename
+     * @return $this
+     */
     public function assertDownloadOffered($filename = null)
     {
         $contentDisposition = explode(';', $this->headers->get('content-disposition'));

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -1201,7 +1201,7 @@ class TestResponseTest extends TestCase
                 'Content-Disposition' => 'attachment; filename=file.txt',
             ]
         ));
-        $testResponse->assertDownloadOffered();
+        $testResponse->assertDownload();
         $files->deleteDirectory($tempDir);
     }
 
@@ -1216,7 +1216,7 @@ class TestResponseTest extends TestCase
                 'Content-Disposition' => 'attachment; filename = file.txt',
             ]
         ));
-        $testResponse->assertDownloadOffered('file.txt');
+        $testResponse->assertDownload('file.txt');
         $files->deleteDirectory($tempDir);
     }
 
@@ -1229,7 +1229,7 @@ class TestResponseTest extends TestCase
         $testResponse = TestResponse::fromBaseResponse(new BinaryFileResponse(
             $tempDir.'/file.txt', 200, [], true, 'attachment'
         ));
-        $testResponse->assertDownloadOffered('file.txt');
+        $testResponse->assertDownload('file.txt');
         $files->deleteDirectory($tempDir);
     }
 
@@ -1243,7 +1243,7 @@ class TestResponseTest extends TestCase
         $testResponse = TestResponse::fromBaseResponse(new BinaryFileResponse(
             $tempDir.'/file.txt', 200, [], true, 'inline'
         ));
-        $testResponse->assertDownloadOffered();
+        $testResponse->assertDownload();
         $files->deleteDirectory($tempDir);
     }
 

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -1190,6 +1190,63 @@ class TestResponseTest extends TestCase
         $testResponse->assertJsonMissingValidationErrors('bar', 'data.errors');
     }
 
+    public function testAssertDownloadOffered()
+    {
+        $files = new Filesystem;
+        $tempDir = __DIR__.'/tmp';
+        $files->makeDirectory($tempDir, 0755, false, true);
+        $files->put($tempDir.'/file.txt', 'Hello World');
+        $testResponse = TestResponse::fromBaseResponse(new Response(
+            $files->get($tempDir.'/file.txt'), 200, [
+                'Content-Disposition' => 'attachment; filename=file.txt',
+            ]
+        ));
+        $testResponse->assertDownloadOffered();
+        $files->deleteDirectory($tempDir);
+    }
+
+    public function testAssertDownloadOfferedWithAFileName()
+    {
+        $files = new Filesystem;
+        $tempDir = __DIR__.'/tmp';
+        $files->makeDirectory($tempDir, 0755, false, true);
+        $files->put($tempDir.'/file.txt', 'Hello World');
+        $testResponse = TestResponse::fromBaseResponse(new Response(
+            $files->get($tempDir.'/file.txt'), 200, [
+                'Content-Disposition' => 'attachment; filename = file.txt',
+            ]
+        ));
+        $testResponse->assertDownloadOffered('file.txt');
+        $files->deleteDirectory($tempDir);
+    }
+
+    public function testAssertDownloadOfferedWorksWithBinaryFileResponse()
+    {
+        $files = new Filesystem;
+        $tempDir = __DIR__.'/tmp';
+        $files->makeDirectory($tempDir, 0755, false, true);
+        $files->put($tempDir.'/file.txt', 'Hello World');
+        $testResponse = TestResponse::fromBaseResponse(new BinaryFileResponse(
+            $tempDir.'/file.txt', 200, [], true, 'attachment'
+        ));
+        $testResponse->assertDownloadOffered('file.txt');
+        $files->deleteDirectory($tempDir);
+    }
+
+    public function testAssertDownloadOfferedFailsWithInlineContentDisposition()
+    {
+        $this->expectException(AssertionFailedError::class);
+        $files = new Filesystem;
+        $tempDir = __DIR__.'/tmp';
+        $files->makeDirectory($tempDir, 0755, false, true);
+        $files->put($tempDir.'/file.txt', 'Hello World');
+        $testResponse = TestResponse::fromBaseResponse(new BinaryFileResponse(
+            $tempDir.'/file.txt', 200, [], true, 'inline'
+        ));
+        $testResponse->assertDownloadOffered();
+        $files->deleteDirectory($tempDir);
+    }
+
     public function testMacroable()
     {
         TestResponse::macro('foo', function () {


### PR DESCRIPTION
This PR introduces a convenient `assertDownloadOffered($filename = null)` method which makes it easier to test different types of file responses such as:
```php
\Response::download(Storage::get($path), 'image.png');
```
```php
\Response::streamDownload(function() {
    return \Storage::get('download.png');
}, 'image.png');
```
```php
\Storage::download($path, 'image.png');
```
```php
new \Symfony\Component\HttpFoundation\BinaryFileResponse($path, 200, [], true, 'attachment');
```
```php
\Response::make(Storage::get($path), 200, [
    'Content-Disposition' => 'attachment; filename=image.png',
]);
```

Unless explicitly overridden, most of these approaches add `attachment` as the disposition-type to the Content-Disposition header, which asks the HTTP client to download the file locally, as shown in the screenshot below:

![image](https://user-images.githubusercontent.com/13091708/120065727-b340e700-c094-11eb-8fca-06c055b117be.png)

In order to test whether a route/controller action responds with a downloadable file or not and whether that file is indeed the correct one, currently one has to extract the header, split it and inspect the content in a hacky way. This kind of approach lacks chainability as well.

The proposed `TestResponse::assertDownloadOffered()` method ensures two things:
1. The file is downloaded (`$response->assertDownloadOffered()`)
2. The file _**with the expected name**_ is downloaded (`$response->assertDownloadOffered('image.png')`)

## Intent Resolution

As shown in the examples above, as long as the disposition-type parameter of the Content-Disposition header is set to `attachment`, it will be determined that the intention is to download the file. Hence, in cases where disposition-type is changed to something else like this:

```php
\Response::download(Storage::get($path), 'image.png', [], 'inline');
```
...even though the called method is download(), replacing `attachment` with `inline` [instructs the HTTP client to display the file instead of downloading](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition#as_a_response_header_for_the_main_body). In such cases, `$response->assertDownloadOffered()` will mark the test as failed.

## Examples
1. The test should pass when the specified file is sent from the response.
```php
// Action:
Route::get('/', function () {
    return Response::download(Storage::path('download.png'), 'image.png');
});

// Test:
public function testExample()
{
    $this->get('/')->assertDownloadOffered('image.png')->assertOk();
}

// Result:
// OK (1 test, 2 assertions)
```

2. The test should fail when a different file is sent than expected.
```php
// Action:
Route::get('/', function () {
    return Response::download(Storage::path('download.png'), 'something_else.png');
});

// Test:
public function testExample()
{
    $this->get('/')->assertDownloadOffered('image.png')->assertOk();
}

// Result:
// Expected file [image.png] is not present in Content-Disposition header.
// Failed asserting that two strings are identical.
// Expected :'image.png'
// Actual   :'something_else.png'
```

3. The test should pass even when the `attachment` option is manually passed to the header.
```php
// Action:
Route::get('/', function () {
    return \Response::make(Storage::get('download.png'), 200, [
        'Content-Disposition' => 'attachment; filename=image.png',
    ]);
});

// Test:
public function testExample()
{
    $this->get('/')->assertDownloadOffered('image.png')->assertOk();
}

// Result:
// OK (1 test, 2 assertions)
```

4. The test should fail when disposition is set to anything other than `attachment`.
```php
// Action:
Route::get('/', function () {
    return \Response::download(Storage::get('download.png'), 'image.png', [], 'inline');
});

// Test:
public function testExample()
{
    $this->get('/')->assertDownloadOffered('image.png')->assertOk();
}

// Result:
// Response does not offer a file download.
// Disposition param [inline] found in header, [attachment] expected.
```

5. The test should pass when the file is sent with a name but no name specified during assertion.
```php
// Action:
Route::get('/', function () {
    return Response::download(Storage::path('download.png'), 'image.png');
});

// Test:
public function testExample()
{
    $this->get('/')->assertDownloadOffered()->assertOk();
}

// Result:
// OK (1 test, 2 assertions)
```


## Compatibility
This PR does not include breaking changes.