### PR TITLE
[8.x] Added --fake option to artisan migrate and migrate:rollback commands

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -23,6 +23,7 @@ class MigrateCommand extends BaseCommand
                 {--realpath : Indicate any provided migration file paths are pre-resolved absolute paths}
                 {--schema-path= : The path to a schema dump file}
                 {--pretend : Dump the SQL queries that would be run}
+                {--fake : Create migration records without running the migrations}
                 {--seed : Indicates if the seed task should be re-run}
                 {--step : Force the migrations to be run so they can be rolled back individually}';
 
@@ -82,13 +83,14 @@ class MigrateCommand extends BaseCommand
             $this->migrator->setOutput($this->output)
                     ->run($this->getMigrationPaths(), [
                         'pretend' => $this->option('pretend'),
+                        'fake' => $this->option('fake'),
                         'step' => $this->option('step'),
                     ]);
 
             // Finally, if the "seed" option has been given, we will re-run the database
             // seed task to re-populate the database, which is convenient when adding
             // a migration and a seed at the same time, as it is only this command.
-            if ($this->option('seed') && ! $this->option('pretend')) {
+            if ($this->option('seed') && ! $this->option('pretend') && ! $this->option('fake')) {
                 $this->call('db:seed', ['--force' => true]);
             }
         });

--- a/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
@@ -59,6 +59,7 @@ class RollbackCommand extends BaseCommand
             $this->migrator->setOutput($this->output)->rollback(
                 $this->getMigrationPaths(), [
                     'pretend' => $this->option('pretend'),
+                    'fake' => $this->option('fake'),
                     'step' => (int) $this->option('step'),
                 ]
             );
@@ -84,6 +85,8 @@ class RollbackCommand extends BaseCommand
             ['realpath', null, InputOption::VALUE_NONE, 'Indicate any provided migration file paths are pre-resolved absolute paths'],
 
             ['pretend', null, InputOption::VALUE_NONE, 'Dump the SQL queries that would be run'],
+
+            ['fake', null, InputOption::VALUE_NONE, 'Remove migration records without rolling back the migrations'],
 
             ['step', null, InputOption::VALUE_OPTIONAL, 'The number of migrations to be reverted'],
         ];

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -206,7 +206,6 @@ class Migrator
 
         $this->runMigration($migration, 'up');
 
-
         $runTime = number_format((microtime(true) - $startTime) * 1000, 2);
 
         // Once we have run a migrations class, we will log that it was run in this

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -155,6 +155,8 @@ class Migrator
 
         $pretend = $options['pretend'] ?? false;
 
+        $fake = $options['fake'] ?? false;
+
         $step = $options['step'] ?? false;
 
         $this->fireMigrationEvent(new MigrationsStarted);
@@ -163,7 +165,7 @@ class Migrator
         // migrations "up" so the changes are made to the databases. We'll then log
         // that the migration was run so we don't repeat it next time we execute.
         foreach ($migrations as $file) {
-            $this->runUp($file, $batch, $pretend);
+            $this->runUp($file, $batch, $pretend, $fake);
 
             if ($step) {
                 $batch++;
@@ -179,9 +181,10 @@ class Migrator
      * @param  string  $file
      * @param  int  $batch
      * @param  bool  $pretend
+     * @param  bool  $fake
      * @return void
      */
-    protected function runUp($file, $batch, $pretend)
+    protected function runUp($file, $batch, $pretend, $fake)
     {
         // First we will resolve a "real" instance of the migration class from this
         // migration file name. Once we have the instances we can run the actual
@@ -198,7 +201,9 @@ class Migrator
 
         $startTime = microtime(true);
 
-        $this->runMigration($migration, 'up');
+        if (!$fake) {
+            $this->runMigration($migration, 'up');
+        }
 
         $runTime = number_format((microtime(true) - $startTime) * 1000, 2);
 
@@ -282,7 +287,8 @@ class Migrator
 
             $this->runDown(
                 $file, $migration,
-                $options['pretend'] ?? false
+                $options['pretend'] ?? false,
+                $options['fake'] ?? false
             );
         }
 
@@ -342,9 +348,10 @@ class Migrator
      * @param  string  $file
      * @param  object  $migration
      * @param  bool  $pretend
+     * @param  bool  $fake
      * @return void
      */
-    protected function runDown($file, $migration, $pretend)
+    protected function runDown($file, $migration, $pretend, $fake)
     {
         // First we will get the file name of the migration so we can resolve out an
         // instance of the migration. Once we get an instance we can either run a
@@ -361,7 +368,9 @@ class Migrator
 
         $startTime = microtime(true);
 
-        $this->runMigration($instance, 'down');
+        if (!$fake) {
+            $this->runMigration($instance, 'down');
+        }
 
         $runTime = number_format((microtime(true) - $startTime) * 1000, 2);
 

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -201,7 +201,7 @@ class Migrator
 
         $startTime = microtime(true);
 
-        if (!$fake) {
+        if (! $fake) {
             $this->runMigration($migration, 'up');
         }
 
@@ -368,7 +368,7 @@ class Migrator
 
         $startTime = microtime(true);
 
-        if (!$fake) {
+        if (! $fake) {
             $this->runMigration($instance, 'down');
         }
 

--- a/tests/Database/DatabaseMigrationMigrateCommandTest.php
+++ b/tests/Database/DatabaseMigrationMigrateCommandTest.php
@@ -31,7 +31,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
             return $callback();
         });
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
-        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => false]);
+        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'fake' => false, 'step' => false]);
         $migrator->shouldReceive('getNotes')->andReturn([]);
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
 
@@ -57,7 +57,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
         $schemaState->shouldReceive('load')->once()->with(__DIR__.'/stubs/schema.sql');
         $dispatcher->shouldReceive('dispatch')->once()->with(m::type(SchemaLoaded::class));
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
-        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => false]);
+        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'fake' => false, 'step' => false]);
         $migrator->shouldReceive('getNotes')->andReturn([]);
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
 
@@ -77,7 +77,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
             return $callback();
         });
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
-        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => false]);
+        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'fake' => false, 'step' => false]);
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(false);
         $command->expects($this->once())->method('call')->with($this->equalTo('migrate:install'), $this->equalTo([]));
 
@@ -96,10 +96,28 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
             return $callback();
         });
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
-        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => true, 'step' => false]);
+        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => true, 'fake' => false, 'step' => false]);
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
 
         $this->runCommand($command, ['--pretend' => true]);
+    }
+
+    public function testTheCommandMayBeFake()
+    {
+        $command = new MigrateCommand($migrator = m::mock(Migrator::class), $dispatcher = m::mock(Dispatcher::class));
+        $app = new ApplicationDatabaseMigrationStub(['path.database' => __DIR__]);
+        $app->useDatabasePath(__DIR__);
+        $command->setLaravel($app);
+        $migrator->shouldReceive('paths')->once()->andReturn([]);
+        $migrator->shouldReceive('hasRunAnyMigrations')->andReturn(true);
+        $migrator->shouldReceive('usingConnection')->once()->andReturnUsing(function ($name, $callback) {
+            return $callback();
+        });
+        $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
+        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'fake' => true, 'step' => false]);
+        $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
+
+        $this->runCommand($command, ['--fake' => true]);
     }
 
     public function testTheDatabaseMayBeSet()
@@ -114,7 +132,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
             return $callback();
         });
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
-        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => false]);
+        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'fake' => false, 'step' => false]);
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
 
         $this->runCommand($command, ['--database' => 'foo']);
@@ -132,7 +150,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
             return $callback();
         });
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
-        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => true]);
+        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'fake' => false, 'step' => true]);
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
 
         $this->runCommand($command, ['--step' => true]);

--- a/tests/Database/DatabaseMigrationRollbackCommandTest.php
+++ b/tests/Database/DatabaseMigrationRollbackCommandTest.php
@@ -28,7 +28,7 @@ class DatabaseMigrationRollbackCommandTest extends TestCase
             return $callback();
         });
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
-        $migrator->shouldReceive('rollback')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => 0]);
+        $migrator->shouldReceive('rollback')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'fake' => false, 'step' => 0]);
 
         $this->runCommand($command);
     }
@@ -44,7 +44,7 @@ class DatabaseMigrationRollbackCommandTest extends TestCase
             return $callback();
         });
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
-        $migrator->shouldReceive('rollback')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => 2]);
+        $migrator->shouldReceive('rollback')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'fake' => false, 'step' => 2]);
 
         $this->runCommand($command, ['--step' => 2]);
     }
@@ -76,9 +76,25 @@ class DatabaseMigrationRollbackCommandTest extends TestCase
             return $callback();
         });
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
-        $migrator->shouldReceive('rollback')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => true, 'step' => 2]);
+        $migrator->shouldReceive('rollback')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => true, 'fake' => false, 'step' => 2]);
 
         $this->runCommand($command, ['--pretend' => true, '--database' => 'foo', '--step' => 2]);
+    }
+
+    public function testRollbackCommandCanBeFake()
+    {
+        $command = new RollbackCommand($migrator = m::mock(Migrator::class));
+        $app = new ApplicationDatabaseRollbackStub(['path.database' => __DIR__]);
+        $app->useDatabasePath(__DIR__);
+        $command->setLaravel($app);
+        $migrator->shouldReceive('paths')->once()->andReturn([]);
+        $migrator->shouldReceive('usingConnection')->once()->andReturnUsing(function ($name, $callback) {
+            return $callback();
+        });
+        $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
+        $migrator->shouldReceive('rollback')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], true);
+
+        $this->runCommand($command, ['--fake' => true, '--database' => 'foo']);
     }
 
     protected function runCommand($command, $input = [])


### PR DESCRIPTION
When working on projects with vague requirements, new database changes will come up regularly during development. In these cases, I find it much easier to make the changes directly in the development database, as opposed to adding them to a migration and rolling back / running the migration for each new change that comes up.  When the feature is complete, I then create a migration containing all the incremental changes made during development.  

This leaves my development environment in a state where the migration has not been run, but it's changes are already present in the database.  To get the migrations back into a consistent state, I would like to run the migrate command with the --fake option, which will add a record of the migration having been run, but not try to actually run the migration (which would throw errors or cause problems, since the changes are already present in the database).  At this point the state of the migrations is consistent again, and I can test the new migration by running migrate:rollback to test the down() part (by confirming that the schema has been restored to it's original state), and then run migrate again to test the up() part (by making sure all the expected changes are applied correctly, which is as simple as testing the new updates that rely on the database changes).

Using the --fake option this way, I'm able to work directly in the database during development, while still being able to use migrations to distribute the changes to the team, as well as testing both the up and down parts before committing anything.  Since this is an optional flag, it won't affect any existing code, and it is compatible with all the other existing migrate options.