### PR TITLE
[8.x] Use/exclude specific resource abilities in AuthorizeRequests

### DIFF
--- a/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
+++ b/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
@@ -128,6 +128,7 @@ trait AuthorizesRequests
      * Use only the given abilities.
      *
      * @param string|array $abilities
+     * @return this
      */
     public function onlyResourceAbilities($abilities)
     {
@@ -143,7 +144,7 @@ trait AuthorizesRequests
     /**
      * Exclude resource abilities.
      *
-     * @param  array $abilities
+     * @param string|array $abilities
      * @return this
      */
     public function excludeResourceAbilities($abilities)

--- a/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
+++ b/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
@@ -168,7 +168,7 @@ trait AuthorizesRequests
     protected function resourceAbilityMap()
     {
         return array_filter($this->resourceAbilities, function ($ability) {
-            return !in_array($ability, $this->excludeResourceAbilities);
+            return ! in_array($ability, $this->excludeResourceAbilities);
         });
     }
 

--- a/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
+++ b/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
@@ -128,7 +128,7 @@ trait AuthorizesRequests
      * Use only the given abilities.
      *
      * @param string|array $abilities
-     * @return this
+     * @return $this
      */
     public function onlyResourceAbilities($abilities)
     {
@@ -145,7 +145,7 @@ trait AuthorizesRequests
      * Exclude resource abilities.
      *
      * @param string|array $abilities
-     * @return this
+     * @return $this
      */
     public function excludeResourceAbilities($abilities)
     {

--- a/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
+++ b/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
@@ -8,6 +8,28 @@ use Illuminate\Support\Str;
 trait AuthorizesRequests
 {
     /**
+     * Resource ability map.
+     *
+     * @var array
+     */
+    protected $resourceAbilities = [
+        'index' => 'viewAny',
+        'show' => 'view',
+        'create' => 'create',
+        'store' => 'create',
+        'edit' => 'update',
+        'update' => 'update',
+        'destroy' => 'delete',
+    ];
+
+    /**
+     * Excluded resource abilities.
+     *
+     * @var array
+     */
+    protected $excludeResourceAbilities = [];
+
+    /**
      * Authorize a given action for the current user.
      *
      * @param  mixed  $ability
@@ -98,21 +120,56 @@ trait AuthorizesRequests
     }
 
     /**
+     * Set resource abilities.
+     *
+     * @param array $resourceAbilities
+     */
+    public function setResourceAbilities(array $resourceAbilities)
+    {
+        $this->resourceAbilities = $resourceAbilities;
+
+        return $this;
+    }
+
+    /**
+     * Use only the given abilities.
+     *
+     * @param string|array $abilities
+     */
+    public function onlyResourceAbilities($abilities)
+    {
+        $abilities = is_array($abilities) ? $abilities : func_get_args();
+
+        $this->resourceAbilities = array_filter($this->resourceAbilities, function ($ability) use ($abilities) {
+            return in_array($ability, $abilities);
+        });
+
+        return $this;
+    }
+
+    /**
+     * Exclude resource abilities.
+     *
+     * @param  array $abilities
+     * @return this
+     */
+    public function excludeResourceAbilities($abilities)
+    {
+        $this->excludeResourceAbilities = is_array($abilities) ? $abilities : func_get_args();
+
+        return $this;
+    }
+
+    /**
      * Get the map of resource methods to ability names.
      *
      * @return array
      */
     protected function resourceAbilityMap()
     {
-        return [
-            'index' => 'viewAny',
-            'show' => 'view',
-            'create' => 'create',
-            'store' => 'create',
-            'edit' => 'update',
-            'update' => 'update',
-            'destroy' => 'delete',
-        ];
+        return array_filter($this->resourceAbilities, function ($ability) {
+            return !in_array($ability, $this->excludeResourceAbilities);
+        });
     }
 
     /**

--- a/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
+++ b/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
@@ -127,7 +127,7 @@ trait AuthorizesRequests
     /**
      * Use only the given abilities.
      *
-     * @param string|array $abilities
+     * @param  string|array  $abilities
      * @return $this
      */
     public function onlyResourceAbilities($abilities)
@@ -144,7 +144,7 @@ trait AuthorizesRequests
     /**
      * Exclude resource abilities.
      *
-     * @param string|array $abilities
+     * @param  string|array  $abilities
      * @return $this
      */
     public function excludeResourceAbilities($abilities)

--- a/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
+++ b/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
@@ -23,13 +23,6 @@ trait AuthorizesRequests
     ];
 
     /**
-     * Excluded resource abilities.
-     *
-     * @var array
-     */
-    protected $excludeResourceAbilities = [];
-
-    /**
      * Authorize a given action for the current user.
      *
      * @param  mixed  $ability
@@ -155,7 +148,11 @@ trait AuthorizesRequests
      */
     public function excludeResourceAbilities($abilities)
     {
-        $this->excludeResourceAbilities = is_array($abilities) ? $abilities : func_get_args();
+        $abilities = is_array($abilities) ? $abilities : func_get_args();
+
+        $this->resourceAbilities = array_filter($this->resourceAbilities, function ($ability) use ($abilities) {
+            return ! in_array($ability, $abilities);
+        });
 
         return $this;
     }
@@ -167,9 +164,7 @@ trait AuthorizesRequests
      */
     protected function resourceAbilityMap()
     {
-        return array_filter($this->resourceAbilities, function ($ability) {
-            return ! in_array($ability, $this->excludeResourceAbilities);
-        });
+        return $this->resourceAbilities;
     }
 
     /**


### PR DESCRIPTION
This PR provides a fluent way to set specific authorization model policies in the controller's constructor 
used together with `authorizeResource()` method. 
I believe this feature should be in the core so that everyone will be doing it in a uniform way instead of having different implementations. Feel free to choose if there is more approriate method names.

Example:
```php
class UsersController extends Controller
{
    public function __construct() 
    {
        $this->onlyResourceAbilities(['create', 'update', 'delete'])
             ->authorizeResource(User::class);
    }
}
```

```php
class UsersController extends Controller
{
    public function __construct() 
    {
        $this->excludeResourceAbilities(['viewAny', 'view'])
             ->authorizeResource(User::class);
    }
}
```

Extra feature: Set resource abilities in constructor.

```php
class UsersController extends Controller
{
    public function __construct() 
    {
        $this->setResouceAbilities([
            'index' => 'viewAny',
            'show' => 'view',
            'create' => 'create',
            'store' => 'create',
            'edit' => 'update',
            'update' => 'update',
            'destroy' => 'delete',
        ])
        ->authorizeResource(User::class);
    }
}
```
