### PR TITLE
[9.x] Fix paginator footer text

### DIFF
--- a/src/Illuminate/Pagination/resources/views/tailwind.blade.php
+++ b/src/Illuminate/Pagination/resources/views/tailwind.blade.php
@@ -25,13 +25,7 @@
         <div class="hidden sm:flex-1 sm:flex sm:items-center sm:justify-between">
             <div>
                 <p class="text-sm text-gray-700 leading-5">
-                    {!! __('Showing') !!}
-                    <span class="font-medium">{{ $paginator->firstItem() }}</span>
-                    {!! __('to') !!}
-                    <span class="font-medium">{{ $paginator->lastItem() }}</span>
-                    {!! __('of') !!}
-                    <span class="font-medium">{{ $paginator->total() }}</span>
-                    {!! __('results') !!}
+                    {!! __('pagination.footer', ['firstItem' => '<span class="font-medium">'.$paginator->firstItem().'</span>', 'lastItem' => '<span class="font-medium">'.$paginator->lastItem().'</span>', 'total' => '<span class="font-medium">'.$paginator->total().'</span>']) !!}
                 </p>
             </div>
 


### PR DESCRIPTION
The current codes were not compatible for all languages.

For example, in my language (Turkish), the places of words are different.

English: Showing 1 to 2 of 4 results
Turkish: Toplam 4 sonuç arasından 1 ile 2 arasındaki sonuçlar gösteriliyor

I think it will be more useful this way. After this update we will no longer need to customize this section for every project.

Ref: livewire/livewire#2628
Related to: laravel/laravel#5622