### PR TITLE
[8.x] Allow connecting to read or write connections with the db command

### DIFF
--- a/src/Illuminate/Database/Console/DbCommand.php
+++ b/src/Illuminate/Database/Console/DbCommand.php
@@ -14,7 +14,9 @@ class DbCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'db {connection? : The database connection that should be used}';
+    protected $signature = 'db {connection? : The database connection that should be used}
+               {--read : Connect to the read connection}
+               {--write : Connect to the write connection}';
 
     /**
      * The console command description.
@@ -62,6 +64,12 @@ class DbCommand extends Command
 
         if (! empty($connection['url'])) {
             $connection = (new ConfigurationUrlParser)->parseConfiguration($connection);
+        }
+
+        if ($this->option('read')) {
+            $connection = array_merge($connection, $connection['read']);
+        } elseif ($this->option('write')) {
+            $connection = array_merge($connection, $connection['write']);
         }
 
         return $connection;


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/37520

This pr allows passing the connection type to the DB command:

```
php artisan db mysql --read
```

```
php artisan db mysql --write
```