### PR TITLE
[8.x] Extend api resource `wrap` and `preserveKeys`

### DIFF
--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -209,7 +209,7 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
 
         return $this;
     }
-    
+
     /**
      * Set whether to preserve collection keys.
      *
@@ -222,7 +222,7 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
 
         return $this;
     }
-    
+
     /**
      * Transform the resource into an HTTP response.
      *

--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -206,6 +206,7 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     public function wrapAs($value)
     {
         $this->wrap = $value;
+
         return $this;
     }
     
@@ -218,6 +219,7 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     public function preserveKeys($value = true)
     {
         $this->preserveKeys = $value;
+
         return $this;
     }
     

--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -212,7 +212,7 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     /**
      * Set whether to preserve collection keys.
      *
-     * @param  string  $value
+     * @param  bool  $value
      * @return $this
      */
     public function preserveKeys($value = true)

--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -198,6 +198,30 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     }
 
     /**
+     * Set the string that should wrap the outer-most resource array.
+     *
+     * @param  string  $value
+     * @return $this
+     */
+    public function wrapAs($value)
+    {
+        $this->wrap = $value;
+        return $this;
+    }
+    
+    /**
+     * Set whether to preserve collection keys.
+     *
+     * @param  string  $value
+     * @return $this
+     */
+    public function preserveKeys($value = true)
+    {
+        $this->preserveKeys = $value;
+        return $this;
+    }
+    
+    /**
      * Transform the resource into an HTTP response.
      *
      * @param  \Illuminate\Http\Request|null  $request


### PR DESCRIPTION
Currently, `wrap` only has methods to alter it statically, and `preserveKeys` can only be altered manually.
The two added methods provide a simple way for altering individual resources.

Example use case for `wrapAs()`:
    A collection of `user` objects with another collection of `user` objects nested inside it are being returned in a response. The programmer would like to wrap the child `users` in an attribute called `subUsers`, but leave the parent `users` unwrapped.

Example use case for `preserveKeys()`:
    Two separate collections of `user` objects are being returned. The programmer would like one of them to preserve its keys, but not the other.

Both these examples can be handled without the new methods, but not nearly as cleanly. For the `preserveKeys` example...
```
$resource = UserResource::collection($userColleciton);
$resource->preserveKeys = true;
return $resource;
```
becomes
``` return UserResource::collection($userColleciton)->preserveKeys(); ```

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
