### PR TITLE
[8.x] Correct minimum Predis version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -87,7 +87,7 @@
         "orchestra/testbench-core": "^6.8",
         "pda/pheanstalk": "^4.0",
         "phpunit/phpunit": "^8.5.8|^9.3.3",
-        "predis/predis": "^1.1.1",
+        "predis/predis": "^1.1.2",
         "symfony/cache": "^5.1.4"
     },
     "provide": {


### PR DESCRIPTION
Predis did not support php7.2 until 1.1.2：
https://github.com/predis/predis/releases/tag/v1.1.2
