### PR TITLE
[8.x] Get queueable relationship when collection has non-numeric keys

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -692,7 +692,7 @@ class Collection extends BaseCollection implements QueueableCollection
         } elseif (count($relations) === 1) {
             return reset($relations);
         } else {
-            return array_intersect(...$relations);
+            return array_intersect(...array_values($relations));
         }
     }
 

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -485,6 +485,28 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertEquals(['user'], $c->getQueueableRelations());
     }
 
+    public function testQueueableRelationshipsIgnoreCollectionKeys()
+    {
+        $c = new Collection([
+            'foo' => new class
+            {
+                public function getQueueableRelations()
+                {
+                    return [];
+                }
+            },
+            'bar' => new class
+            {
+                public function getQueueableRelations()
+                {
+                    return [];
+                }
+            },
+        ]);
+
+        $this->assertEquals([], $c->getQueueableRelations());
+    }
+
     public function testEmptyCollectionStayEmptyOnFresh()
     {
         $c = new Collection;


### PR DESCRIPTION
Given there is a `Post` model with a has many relationship to `Translation` models and `Translation` models have a `locale` attribute, which is unique for every `Post`. For easier accessing the related `Translation` models, the collection of translations could be keyed by the `locale` attribute, so that getting a `Translation` model for locale `nl` is possible by calling `$post->translations->get('nl')`.

This would be the `Post` model class.

```php
class Post extends Model
{
    public function translations(): HasMany
    {
        return $this->hasMany(Translation::class);
    }
}
```

And this would be the `Translation` model class.

```php
class Translation extends Model
{
    public function newCollection(array $models = []): Collection
    {
        return parent::newCollection($models)->keyBy('locale');
    }
}
```

This is where an issue arises. By dispatching a job which requires an instance of `Post`, `$post->getQueueableRelations()` is called by the `SerializesAndRestoresModelIdentifiers` trait. It then fails with the following errors, as demonstrated in the test in this PR.

**On PHP 7.3 and 7.4:**
```
Cannot unpack array with string keys
```

**On PHP 8.0:**
```
array_intersect() does not accept unknown named parameters
```

A solution would be to change [`array_intersect(...$relations)`](https://github.com/laravel/framework/blob/8.x/src/Illuminate/Database/Eloquent/Collection.php#L695) to `array_intersect(...array_values($relations))`, which obviously would drop any keys.

I've applied this change locally and all the tests that I can run without any further configuration (some require additional modules) pass. What do you think?