### PR TITLE
[8.x] Fix phpdoc block

### DIFF
--- a/src/Illuminate/Contracts/Container/ContextualBindingBuilder.php
+++ b/src/Illuminate/Contracts/Container/ContextualBindingBuilder.php
@@ -15,7 +15,7 @@ interface ContextualBindingBuilder
     /**
      * Define the implementation for the contextual binding.
      *
-     * @param  \Closure|string  $implementation
+     * @param  \Closure|string|array  $implementation
      * @return void
      */
     public function give($implementation);


### PR DESCRIPTION
Since the container knows how to handle an array of implementations for the contextual binding, and since it's even documented in the documentation https://laravel.com/docs/8.x/container#binding-typed-variadics we should update the contract
