### PR TITLE
[8.x] Use "Conditionable" in existing classes that implement when()

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -10,11 +10,14 @@ use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Collection;
 use Illuminate\Support\LazyCollection;
+use Illuminate\Support\Traits\Conditionable;
 use InvalidArgumentException;
 use RuntimeException;
 
 trait BuildsQueries
 {
+    use Conditionable;
+
     /**
      * Chunk the results of the query.
      *
@@ -279,25 +282,6 @@ trait BuildsQueries
     }
 
     /**
-     * Apply the callback's query changes if the given "value" is true.
-     *
-     * @param  mixed  $value
-     * @param  callable  $callback
-     * @param  callable|null  $default
-     * @return mixed|$this
-     */
-    public function when($value, $callback, $default = null)
-    {
-        if ($value) {
-            return $callback($this, $value) ?: $this;
-        } elseif ($default) {
-            return $default($this, $value) ?: $this;
-        }
-
-        return $this;
-    }
-
-    /**
      * Pass the query to a given callback.
      *
      * @param  callable  $callback
@@ -306,25 +290,6 @@ trait BuildsQueries
     public function tap($callback)
     {
         return $this->when(true, $callback);
-    }
-
-    /**
-     * Apply the callback's query changes if the given "value" is false.
-     *
-     * @param  mixed  $value
-     * @param  callable  $callback
-     * @param  callable|null  $default
-     * @return mixed|$this
-     */
-    public function unless($value, $callback, $default = null)
-    {
-        if (! $value) {
-            return $callback($this, $value) ?: $this;
-        } elseif ($default) {
-            return $default($this, $value) ?: $this;
-        }
-
-        return $this;
     }
 
     /**

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -12,6 +12,7 @@ use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
+use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\ForwardsCalls;
 use Illuminate\Support\Traits\Localizable;
 use PHPUnit\Framework\Assert as PHPUnit;
@@ -20,7 +21,7 @@ use ReflectionProperty;
 
 class Mailable implements MailableContract, Renderable
 {
-    use ForwardsCalls, Localizable;
+    use ForwardsCalls, Localizable, Conditionable;
 
     /**
      * The locale of the message.
@@ -988,25 +989,6 @@ class Mailable implements MailableContract, Renderable
     public static function buildViewDataUsing(callable $callback)
     {
         static::$viewDataCallback = $callback;
-    }
-
-    /**
-     * Apply the callback's message changes if the given "value" is true.
-     *
-     * @param  mixed  $value
-     * @param  callable  $callback
-     * @param  mixed  $default
-     * @return mixed|$this
-     */
-    public function when($value, $callback, $default = null)
-    {
-        if ($value) {
-            return $callback($this, $value) ?: $this;
-        } elseif ($default) {
-            return $default($this, $value) ?: $this;
-        }
-
-        return $this;
     }
 
     /**

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -21,7 +21,7 @@ use ReflectionProperty;
 
 class Mailable implements MailableContract, Renderable
 {
-    use ForwardsCalls, Localizable, Conditionable;
+    use Conditionable, ForwardsCalls, Localizable;
 
     /**
      * The locale of the message.

--- a/src/Illuminate/Notifications/Messages/MailMessage.php
+++ b/src/Illuminate/Notifications/Messages/MailMessage.php
@@ -6,9 +6,12 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Mail\Markdown;
+use Illuminate\Support\Traits\Conditionable;
 
 class MailMessage extends SimpleMessage implements Renderable
 {
+    use Conditionable;
+
     /**
      * The view to be rendered.
      *
@@ -327,44 +330,6 @@ class MailMessage extends SimpleMessage implements Renderable
     public function withSwiftMessage($callback)
     {
         $this->callbacks[] = $callback;
-
-        return $this;
-    }
-
-    /**
-     * Apply the callback's message changes if the given "value" is true.
-     *
-     * @param  mixed  $value
-     * @param  callable  $callback
-     * @param  callable|null  $default
-     * @return mixed|$this
-     */
-    public function when($value, $callback, $default = null)
-    {
-        if ($value) {
-            return $callback($this, $value) ?: $this;
-        } elseif ($default) {
-            return $default($this, $value) ?: $this;
-        }
-
-        return $this;
-    }
-
-    /**
-     * Apply the callback's message changes if the given "value" is false.
-     *
-     * @param  mixed  $value
-     * @param  callable  $callback
-     * @param  callable|null  $default
-     * @return mixed|$this
-     */
-    public function unless($value, $callback, $default = null)
-    {
-        if (! $value) {
-            return $callback($this, $value) ?: $this;
-        } elseif ($default) {
-            return $default($this, $value) ?: $this;
-        }
 
         return $this;
     }

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -11,7 +11,7 @@ use Symfony\Component\VarDumper\VarDumper;
 
 class Stringable implements JsonSerializable
 {
-    use Macroable, Tappable, Conditionable;
+    use Conditionable, Macroable, Tappable;
 
     /**
      * The underlying string value.

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Support;
 
 use Closure;
+use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Support\Traits\Tappable;
 use JsonSerializable;
@@ -10,7 +11,7 @@ use Symfony\Component\VarDumper\VarDumper;
 
 class Stringable implements JsonSerializable
 {
-    use Macroable, Tappable;
+    use Macroable, Tappable, Conditionable;
 
     /**
      * The underlying string value.
@@ -706,38 +707,6 @@ class Stringable implements JsonSerializable
     public function ucfirst()
     {
         return new static(Str::ucfirst($this->value));
-    }
-
-    /**
-     * Apply the callback's string changes if the given "value" is false.
-     *
-     * @param  mixed  $value
-     * @param  callable  $callback
-     * @param  callable|null  $default
-     * @return mixed|$this
-     */
-    public function unless($value, $callback, $default = null)
-    {
-        return $this->when(! $value, $callback, $default);
-    }
-
-    /**
-     * Apply the callback's string changes if the given "value" is true.
-     *
-     * @param  mixed  $value
-     * @param  callable  $callback
-     * @param  callable|null  $default
-     * @return mixed|$this
-     */
-    public function when($value, $callback, $default = null)
-    {
-        if ($value) {
-            return $callback($this, $value) ?: $this;
-        } elseif ($default) {
-            return $default($this, $value) ?: $this;
-        }
-
-        return $this;
     }
 
     /**

--- a/src/Illuminate/Support/Traits/Conditionable.php
+++ b/src/Illuminate/Support/Traits/Conditionable.php
@@ -5,7 +5,7 @@ namespace Illuminate\Support\Traits;
 trait Conditionable
 {
     /**
-     * Apply the callback if the given "value" is true.
+     * Apply the callback if the given "value" is truthy.
      *
      * @param  mixed  $value
      * @param  callable  $callback
@@ -25,7 +25,7 @@ trait Conditionable
     }
 
     /**
-     * Apply the callback if the given "value" is false.
+     * Apply the callback if the given "value" is falsy.
      *
      * @param  mixed  $value
      * @param  callable  $callback
@@ -35,6 +35,12 @@ trait Conditionable
      */
     public function unless($value, $callback, $default = null)
     {
-        return $this->when(! $value, $callback, $default);
+        if (! $value) {
+            return $callback($this, $value) ?: $this;
+        } elseif ($default) {
+            return $default($this, $value) ?: $this;
+        }
+
+        return $this;
     }
 }

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -165,6 +165,34 @@ class SupportStringableTest extends TestCase
         }));
     }
 
+    public function testUnlessTruthy()
+    {
+        $this->assertSame('unless', (string) $this->stringable('unless')->unless(1, function($stringable, $value) {
+            return $stringable->append($value)->append('true');
+        }));
+
+        $this->assertSame('unless true fallbacks to default with value 1',
+            (string) $this->stringable('unless true ')->unless(1, function($stringable, $value) {
+                return $stringable->append($value);
+            }, function($stringable, $value) {
+                return $stringable->append('fallbacks to default with value ')->append($value);
+            }));
+    }
+
+    public function testUnlessFalsy()
+    {
+        $this->assertSame('unless 0', (string) $this->stringable('unless ')->unless(0, function($stringable, $value) {
+            return $stringable->append($value);
+        }));
+
+        $this->assertSame('gets the value 0',
+            (string) $this->stringable('gets the value ')->unless(0, function($stringable, $value) {
+                return $stringable->append($value);
+            }, function($stringable) {
+                return $stringable->append('fallbacks to default');
+            }));
+    }
+
     public function testTrimmedOnlyWhereNecessary()
     {
         $this->assertSame(' Taylor Otwell ', (string) $this->stringable(' Taylor Otwell ')->words(3));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -167,28 +167,28 @@ class SupportStringableTest extends TestCase
 
     public function testUnlessTruthy()
     {
-        $this->assertSame('unless', (string) $this->stringable('unless')->unless(1, function($stringable, $value) {
+        $this->assertSame('unless', (string) $this->stringable('unless')->unless(1, function ($stringable, $value) {
             return $stringable->append($value)->append('true');
         }));
 
         $this->assertSame('unless true fallbacks to default with value 1',
-            (string) $this->stringable('unless true ')->unless(1, function($stringable, $value) {
+            (string) $this->stringable('unless true ')->unless(1, function ($stringable, $value) {
                 return $stringable->append($value);
-            }, function($stringable, $value) {
+            }, function ($stringable, $value) {
                 return $stringable->append('fallbacks to default with value ')->append($value);
             }));
     }
 
     public function testUnlessFalsy()
     {
-        $this->assertSame('unless 0', (string) $this->stringable('unless ')->unless(0, function($stringable, $value) {
+        $this->assertSame('unless 0', (string) $this->stringable('unless ')->unless(0, function ($stringable, $value) {
             return $stringable->append($value);
         }));
 
         $this->assertSame('gets the value 0',
-            (string) $this->stringable('gets the value ')->unless(0, function($stringable, $value) {
+            (string) $this->stringable('gets the value ')->unless(0, function ($stringable, $value) {
                 return $stringable->append($value);
-            }, function($stringable) {
+            }, function ($stringable) {
                 return $stringable->append('fallbacks to default');
             }));
     }


### PR DESCRIPTION
Right now, `BuildsQueries`, `Mailable`, `MailMessage`, and `Stringable` all implement their own version of `when()` that is exactly the same as the implementation in the new `Conditionable` trait. This PR just swaps them out for the new trait instead.

(This means that `Mailable` gets an `unless()` method as well. All other classes had both a `when()` and `unless()` method already.)

It's also worth noting that `unless()` was implemented in two different ways in the framework. One implementation was a mirror of the `when()` implementation, while another approach was to call `$this->when(! $value, ...)`. It turns out that the latter solution (calling `when()`) is incorrect, because it ends up passing the result of `! $value` to the callback, rather than the actual value. This PR fixes that issue in the `Conditionable` trait, thus standardizing it across all the classes that use it.