### PR TITLE
[8.x] Added "close" method to Http response

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -208,6 +208,18 @@ class Response implements ArrayAccess
     }
 
     /**
+     * Closes the stream and any underlying resources.
+     *
+     * @return $this
+     */
+    public function close()
+    {
+        $this->response->getBody()->close();
+
+        return $this;
+    }
+
+    /**
      * Get the response cookies.
      *
      * @return \GuzzleHttp\Cookie\CookieJar


### PR DESCRIPTION
I added the close method to the Http client response.

The reason why I added the method is because sometimes is necessary to close the connections manually in environments where the PHP garbage collector cannot release those connections very frequently like Laravel running on Octane or jobs.

The "close" method is described by [PSR-7]( https://www.php-fig.org/psr/psr-7/).