### PR TITLE
[8.x][POC] Sticky DB connections with session TTL

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -134,6 +134,13 @@ class Connection implements ConnectionInterface
     protected $recordsModified = false;
 
     /**
+     * Indicates if the connection should use the write PDO for reads.
+     *
+     * @var int
+     */
+    protected $readOnWritePDO = false;
+
+    /**
      * All of the queries run against the connection.
      *
      * @var array
@@ -875,6 +882,17 @@ class Connection implements ConnectionInterface
     }
 
     /**
+     * Indicate if the connection should use the write PDO for reads.
+     *
+     * @param  bool  $value
+     * @return void
+     */
+    public function readOnWritePdo($value = true)
+    {
+        $this->readOnWritePDO = $value;
+    }
+
+    /**
      * Reset the record modification state.
      *
      * @return void
@@ -882,6 +900,16 @@ class Connection implements ConnectionInterface
     public function forgetRecordModificationState()
     {
         $this->recordsModified = false;
+    }
+
+    /**
+     * Get the record modification state.
+     *
+     * @return bool
+     */
+    public function getRecordModificationState()
+    {
+        return $this->recordsModified;
     }
 
     /**
@@ -980,7 +1008,7 @@ class Connection implements ConnectionInterface
             return $this->getPdo();
         }
 
-        if ($this->recordsModified && $this->getConfig('sticky')) {
+        if ($this->readOnWritePDO || ($this->recordsModified && $this->getConfig('sticky'))) {
             return $this->getPdo();
         }
 

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -129,14 +129,14 @@ class Connection implements ConnectionInterface
     /**
      * Indicates if changes have been made to the database.
      *
-     * @var int
+     * @var bool
      */
     protected $recordsModified = false;
 
     /**
      * Indicates if the connection should use the write PDO for reads.
      *
-     * @var int
+     * @var bool
      */
     protected $readOnWritePDO = false;
 

--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -124,6 +124,12 @@ class StartSession
 
         $this->addCookieToResponse($response, $session);
 
+        foreach (app('db')->getConnections() as $connection) {
+            if ($connection->getRecordModificationState()) {
+                $session->databaseRecordsModified($connection->getName());
+            }
+        }
+
         // Again, if the session has been configured we will need to close out the session
         // so that the attributes may be persisted to some storage medium. We will also
         // add the session identifier cookie to the application response headers now.

--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -125,7 +125,7 @@ class StartSession
         $this->addCookieToResponse($response, $session);
 
         foreach (app('db')->getConnections() as $connection) {
-            if ($connection->getRecordModificationState()) {
+            if ($connection->getConfig('sticky_ttl') && $connection->getRecordModificationState()) {
                 $session->databaseRecordsModified($connection->getName());
             }
         }

--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -659,6 +659,28 @@ class Store implements Session
     }
 
     /**
+     * Specify that database records were modified on this connection.
+     *
+     * @param  string  $connection
+     * @return void
+     */
+    public function databaseRecordsModified($connection)
+    {
+        $this->put('db.'.$connection.'-mod', time());
+    }
+
+    /**
+     * Determine if that database records were modified on this connection.
+     *
+     * @param  string  $connection
+     * @return int|null
+     */
+    public function databaseRecordsHasBeenModified($connection)
+    {
+        return $this->get('db.'.$connection.'-mod');
+    }
+
+    /**
      * Get the underlying session handler implementation.
      *
      * @return \SessionHandlerInterface


### PR DESCRIPTION
Setting `sticky` to true on a DB connection switches to using the write PDO for reads until the request is handled.

This PR introduces the ability to keep using the write PDO for a bit on making further requests in the same user session.

Added a new attribute to database configuration `sticky_ttl` which will indicate the number of seconds the DB manager should keep using the write PDO for reads after new data has been written. 

This will help people avoid the side effects of replication lag when they make read requests right after write requests (e.g. POST /records followed by GET /records).