### PR TITLE
[8.x] Allow setting middleware on queued Mailables

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -234,7 +234,13 @@ class Mailable implements MailableContract, Renderable
      */
     protected function newQueuedJob()
     {
-        return new SendQueuedMailable($this);
+        return (new SendQueuedMailable($this))
+                    ->through(
+                        array_merge(
+                            method_exists($this, 'middleware') ? $this->middleware() : [],
+                            $this->middleware ?? []
+                        )
+                    );
     }
 
     /**

--- a/tests/Integration/Mail/SendingQueuedMailTest.php
+++ b/tests/Integration/Mail/SendingQueuedMailTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Mail;
+
+use Illuminate\Contracts\Translation\HasLocalePreference;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Events\LocaleUpdated;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\SendQueuedMailable;
+use Illuminate\Queue\Middleware\RateLimited;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\View;
+use Illuminate\Testing\Assert;
+use Orchestra\Testbench\TestCase;
+
+/**
+ * @group integration
+ */
+class SendingQueuedMailTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('mail.driver', 'array');
+
+        View::addLocation(__DIR__.'/Fixtures');
+    }
+
+    public function testMailIsSentWithDefaultLocale()
+    {
+        Queue::fake();
+
+        Mail::to('test@mail.com')->queue(new SendingQueuedMailTestMail);
+
+        Queue::assertPushed(SendQueuedMailable::class, function($job){
+            return $job->middleware[0] instanceof RateLimited;
+        });
+    }
+}
+
+class SendingQueuedMailTestMail extends Mailable
+{
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
+    {
+        return $this->view('view');
+    }
+
+    public function middleware()
+    {
+        return [new RateLimited('limiter')];
+    }
+}

--- a/tests/Integration/Mail/SendingQueuedMailTest.php
+++ b/tests/Integration/Mail/SendingQueuedMailTest.php
@@ -2,18 +2,12 @@
 
 namespace Illuminate\Tests\Integration\Mail;
 
-use Illuminate\Contracts\Translation\HasLocalePreference;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Foundation\Events\LocaleUpdated;
 use Illuminate\Mail\Mailable;
 use Illuminate\Mail\SendQueuedMailable;
 use Illuminate\Queue\Middleware\RateLimited;
-use Illuminate\Support\Carbon;
-use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\View;
-use Illuminate\Testing\Assert;
 use Orchestra\Testbench\TestCase;
 
 /**
@@ -34,7 +28,7 @@ class SendingQueuedMailTest extends TestCase
 
         Mail::to('test@mail.com')->queue(new SendingQueuedMailTestMail);
 
-        Queue::assertPushed(SendQueuedMailable::class, function($job){
+        Queue::assertPushed(SendQueuedMailable::class, function ($job) {
             return $job->middleware[0] instanceof RateLimited;
         });
     }


### PR DESCRIPTION
This PR allows setting job middleware on queued mailables via a `middleware` method or property.