### PR TITLE
[8.x] Adds new `RequestSent` and `ResponseReceived` events to the HTTP Client

### DIFF
--- a/src/Illuminate/Http/Client/Events/RequestSending.php
+++ b/src/Illuminate/Http/Client/Events/RequestSending.php
@@ -16,7 +16,7 @@ class RequestSending
     /**
      * Create a new event instance.
      *
-     * @param  Request $request
+     * @param  \Illuminate\Http\Client\Request $request
      * @return void
      */
     public function __construct(Request $request)

--- a/src/Illuminate/Http/Client/Events/RequestSending.php
+++ b/src/Illuminate/Http/Client/Events/RequestSending.php
@@ -2,41 +2,25 @@
 
 namespace Illuminate\Http\Client\Events;
 
+use Illuminate\Http\Client\Request;
+
 class RequestSending
 {
     /**
-     * The HTTP method used to send the request.
+     * The request object used by the Http Client.
      *
-     * @var string
+     * @var \Illuminate\Http\Client\Request
      */
-    public $method;
-
-    /**
-     * The URL that the request was sent to.
-     *
-     * @var string
-     */
-    public $url;
-
-    /**
-     * The options that were sent along with the request.
-     *
-     * @var array
-     */
-    public $options;
+    public $request;
 
     /**
      * Create a new event instance.
      *
-     * @param  string  $method
-     * @param  string  $url
-     * @param  array  $options
+     * @param  Request $request
      * @return void
      */
-    public function __construct(string $method, string $url, array $options)
+    public function __construct(Request $request)
     {
-        $this->method = $method;
-        $this->url = $url;
-        $this->options = $options;
+        $this->request = $request;
     }
 }

--- a/src/Illuminate/Http/Client/Events/RequestSending.php
+++ b/src/Illuminate/Http/Client/Events/RequestSending.php
@@ -7,7 +7,7 @@ use Illuminate\Http\Client\Request;
 class RequestSending
 {
     /**
-     * The request object used by the Http Client.
+     * The request instance.
      *
      * @var \Illuminate\Http\Client\Request
      */

--- a/src/Illuminate/Http/Client/Events/RequestSending.php
+++ b/src/Illuminate/Http/Client/Events/RequestSending.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Http\Client\Events;
 
-class RequestSent
+class RequestSending
 {
     /**
      * The HTTP method used to send the request.
@@ -25,6 +25,14 @@ class RequestSent
      */
     public $options;
 
+    /**
+     * Create a new event instance.
+     *
+     * @param  string  $method
+     * @param  string  $url
+     * @param  array  $options
+     * @return void
+     */
     public function __construct(string $method, string $url, array $options)
     {
         $this->method = $method;

--- a/src/Illuminate/Http/Client/Events/RequestSent.php
+++ b/src/Illuminate/Http/Client/Events/RequestSent.php
@@ -4,7 +4,6 @@ namespace Illuminate\Http\Client\Events;
 
 class RequestSent
 {
-
     /**
      * The HTTP method used to send the request.
      *

--- a/src/Illuminate/Http/Client/Events/RequestSent.php
+++ b/src/Illuminate/Http/Client/Events/RequestSent.php
@@ -1,0 +1,38 @@
+<?php
+
+
+namespace Illuminate\Http\Client\Events;
+
+
+class RequestSent
+{
+
+    /**
+     * The HTTP method used to send the request.
+     *
+     * @var string
+     */
+    public $method;
+
+    /**
+     * The URL that the request was sent to.
+     *
+     * @var string
+     */
+    public $url;
+
+    /**
+     * The options that were sent along with the request.
+     *
+     * @var array
+     */
+    public $options;
+
+    public function __construct(string $method, string $url, array $options)
+    {
+        $this->method = $method;
+        $this->url = $url;
+        $this->options = $options;
+    }
+
+}

--- a/src/Illuminate/Http/Client/Events/RequestSent.php
+++ b/src/Illuminate/Http/Client/Events/RequestSent.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Illuminate\Http\Client\Events;
-
 
 class RequestSent
 {
@@ -34,5 +32,4 @@ class RequestSent
         $this->url = $url;
         $this->options = $options;
     }
-
 }

--- a/src/Illuminate/Http/Client/Events/ResponseReceived.php
+++ b/src/Illuminate/Http/Client/Events/ResponseReceived.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Illuminate\Http\Client\Events;
-
 
 use Illuminate\Http\Client\Response;
 
@@ -19,5 +17,4 @@ class ResponseReceived
     {
         $this->response = $response;
     }
-
 }

--- a/src/Illuminate/Http/Client/Events/ResponseReceived.php
+++ b/src/Illuminate/Http/Client/Events/ResponseReceived.php
@@ -7,12 +7,18 @@ use Illuminate\Http\Client\Response;
 class ResponseReceived
 {
     /**
-     * The Response object returned from the HTTP request.
+     * The response returned from an HTTP request.
      *
      * @var \Illuminate\Http\Client\Response
      */
     public $response;
 
+    /**
+     * Create a new event instance.
+     *
+     * @param  \Illuminate\Http\Client\Response  $response
+     * @return void
+     */
     public function __construct(Response $response)
     {
         $this->response = $response;

--- a/src/Illuminate/Http/Client/Events/ResponseReceived.php
+++ b/src/Illuminate/Http/Client/Events/ResponseReceived.php
@@ -1,0 +1,23 @@
+<?php
+
+
+namespace Illuminate\Http\Client\Events;
+
+
+use Illuminate\Http\Client\Response;
+
+class ResponseReceived
+{
+    /**
+     * The Response object returned from the HTTP request.
+     *
+     * @var \Illuminate\Http\Client\Response
+     */
+    public $response;
+
+    public function __construct(Response $response)
+    {
+        $this->response = $response;
+    }
+
+}

--- a/src/Illuminate/Http/Client/Events/ResponseReceived.php
+++ b/src/Illuminate/Http/Client/Events/ResponseReceived.php
@@ -8,14 +8,14 @@ use Illuminate\Http\Client\Response;
 class ResponseReceived
 {
     /**
-     * The request object used by the Http Client.
+     * The request instance.
      *
      * @var \Illuminate\Http\Client\Request
      */
     public $request;
 
     /**
-     * The response returned from an HTTP request.
+     * The response instance.
      *
      * @var \Illuminate\Http\Client\Response
      */

--- a/src/Illuminate/Http/Client/Events/ResponseReceived.php
+++ b/src/Illuminate/Http/Client/Events/ResponseReceived.php
@@ -2,10 +2,18 @@
 
 namespace Illuminate\Http\Client\Events;
 
+use Illuminate\Http\Client\Request;
 use Illuminate\Http\Client\Response;
 
 class ResponseReceived
 {
+    /**
+     * The request object used by the Http Client.
+     *
+     * @var \Illuminate\Http\Client\Request
+     */
+    public $request;
+
     /**
      * The response returned from an HTTP request.
      *
@@ -16,11 +24,13 @@ class ResponseReceived
     /**
      * Create a new event instance.
      *
+     * @param \Illuminate\Http\Client\Request $request
      * @param  \Illuminate\Http\Client\Response  $response
      * @return void
      */
-    public function __construct(Response $response)
+    public function __construct(Request $request, Response $response)
     {
+        $this->request = $request;
         $this->response = $response;
     }
 }

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -56,7 +56,7 @@ class Factory
     }
 
     /**
-     * The event dispatcher instance.
+     * The event dispatcher implementation.
      *
      * @var \Illuminate\Contracts\Events\Dispatcher|null
      */
@@ -93,11 +93,13 @@ class Factory
     /**
      * Create a new factory instance.
      *
+     * @param  \Illuminate\Contracts\Events\Dispatcher  $dispatcher
      * @return void
      */
     public function __construct(Dispatcher $dispatcher = null)
     {
         $this->dispatcher = $dispatcher;
+
         $this->stubCallbacks = collect();
     }
 
@@ -350,6 +352,16 @@ class Factory
     }
 
     /**
+     * Get the current event dispatcher implementation.
+     *
+     * @return \Illuminate\Contracts\Events\Dispatcher|null
+     */
+    public function getDispatcher()
+    {
+        return $this->dispatcher;
+    }
+
+    /**
      * Execute a method against a new pending request instance.
      *
      * @param  string  $method
@@ -365,15 +377,5 @@ class Factory
         return tap($this->newPendingRequest(), function ($request) {
             $request->stub($this->stubCallbacks);
         })->{$method}(...$parameters);
-    }
-
-    /**
-     * Retrieve the currently set Dispatcher instance.
-     *
-     * @return Dispatcher|null
-     */
-    public function getDispatcher()
-    {
-        return $this->dispatcher;
     }
 }

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -93,7 +93,7 @@ class Factory
     /**
      * Create a new factory instance.
      *
-     * @param  \Illuminate\Contracts\Events\Dispatcher  $dispatcher
+     * @param  \Illuminate\Contracts\Events\Dispatcher|null  $dispatcher
      * @return void
      */
     public function __construct(Dispatcher $dispatcher = null)

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -4,6 +4,7 @@ namespace Illuminate\Http\Client;
 
 use Closure;
 use GuzzleHttp\Psr7\Response as Psr7Response;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use PHPUnit\Framework\Assert as PHPUnit;
@@ -55,6 +56,13 @@ class Factory
     }
 
     /**
+     * The event dispatcher instance.
+     *
+     * @var \Illuminate\Contracts\Events\Dispatcher|null
+     */
+    protected $dispatcher;
+
+    /**
      * The stub callables that will handle requests.
      *
      * @var \Illuminate\Support\Collection
@@ -87,8 +95,9 @@ class Factory
      *
      * @return void
      */
-    public function __construct()
+    public function __construct(Dispatcher $dispatcher = null)
     {
+        $this->dispatcher = $dispatcher;
         $this->stubCallbacks = collect();
     }
 
@@ -356,5 +365,15 @@ class Factory
         return tap($this->newPendingRequest(), function ($request) {
             $request->stub($this->stubCallbacks);
         })->{$method}(...$parameters);
+    }
+
+    /**
+     * Retrieve the currently set Dispatcher instance.
+     *
+     * @return Dispatcher|null
+     */
+    public function getDispatcher()
+    {
+        return $this->dispatcher;
     }
 }

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -133,6 +133,13 @@ class PendingRequest
     protected $promise;
 
     /**
+     * The sent request object, if a request has been made.
+     *
+     * @var \Illuminate\Http\Client\Request|null
+     */
+    protected $request = null;
+
+    /**
      * Create a new HTTP Client instance.
      *
      * @param  \Illuminate\Http\Client\Factory|null  $factory
@@ -150,8 +157,9 @@ class PendingRequest
         ];
 
         $this->beforeSendingCallbacks = collect([function (Request $request, array $options) {
+            $this->request = $request;
             $this->cookies = $options['cookies'];
-            $this->dispatchRequestSendingEvent($request);
+            $this->dispatchRequestSendingEvent();
         }]);
     }
 
@@ -959,13 +967,12 @@ class PendingRequest
     /**
      * Dispatch the RequestSending event if a dispatcher is available.
      *
-     * @param  \Illuminate\Http\Client\Request $request
      * @return void
      */
-    protected function dispatchRequestSendingEvent(Request $request)
+    protected function dispatchRequestSendingEvent()
     {
         if ($dispatcher = optional($this->factory)->getDispatcher()) {
-            $dispatcher->dispatch(new RequestSending($request));
+            $dispatcher->dispatch(new RequestSending($this->request));
         }
     }
 
@@ -978,7 +985,7 @@ class PendingRequest
     protected function dispatchResponseReceivedEvent(Response $response)
     {
         if ($dispatcher = optional($this->factory)->getDispatcher()) {
-            $dispatcher->dispatch(new ResponseReceived($response));
+            $dispatcher->dispatch(new ResponseReceived($this->request, $response));
         }
     }
 

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -137,7 +137,7 @@ class PendingRequest
      *
      * @var \Illuminate\Http\Client\Request|null
      */
-    protected $request = null;
+    protected $request;
 
     /**
      * Create a new HTTP Client instance.
@@ -159,6 +159,7 @@ class PendingRequest
         $this->beforeSendingCallbacks = collect([function (Request $request, array $options) {
             $this->request = $request;
             $this->cookies = $options['cookies'];
+
             $this->dispatchRequestSendingEvent();
         }]);
     }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Tests\Http;
 
-use GuzzleHttp\Cookie\CookieJarInterface;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7\Response as Psr7Response;
 use Illuminate\Contracts\Events\Dispatcher;

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -26,7 +26,7 @@ use Symfony\Component\VarDumper\VarDumper;
 class HttpClientTest extends TestCase
 {
     /**
-     * @var Factory
+     * @var \Illuminate\Http\Client\Factory
      */
     protected $factory;
 
@@ -372,7 +372,7 @@ class HttpClientTest extends TestCase
 
         $this->assertCount(1, $response->cookies()->toArray());
 
-        /** @var CookieJarInterface $responseCookies */
+        /** @var \GuzzleHttp\Cookie\CookieJarInterface $responseCookies */
         $responseCookie = $response->cookies()->toArray()[0];
 
         $this->assertSame('foo', $responseCookie['Name']);

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -17,11 +17,11 @@ use Illuminate\Http\Client\Response;
 use Illuminate\Http\Client\ResponseSequence;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use Mockery as m;
 use OutOfBoundsException;
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\VarDumper\VarDumper;
-use Mockery as m;
 
 class HttpClientTest extends TestCase
 {
@@ -932,11 +932,11 @@ class HttpClientTest extends TestCase
         $factory = new Factory($events);
         $factory->fake();
 
-        $factory->get("https://example.com");
-        $factory->head("https://example.com");
-        $factory->post("https://example.com");
-        $factory->patch("https://example.com");
-        $factory->delete("https://example.com");
+        $factory->get('https://example.com');
+        $factory->head('https://example.com');
+        $factory->post('https://example.com');
+        $factory->patch('https://example.com');
+        $factory->delete('https://example.com');
 
         m::close();
     }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -6,7 +6,7 @@ use GuzzleHttp\Cookie\CookieJarInterface;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7\Response as Psr7Response;
 use Illuminate\Contracts\Events\Dispatcher;
-use Illuminate\Http\Client\Events\RequestSent;
+use Illuminate\Http\Client\Events\RequestSending;
 use Illuminate\Http\Client\Events\ResponseReceived;
 use Illuminate\Http\Client\Factory;
 use Illuminate\Http\Client\PendingRequest;
@@ -923,10 +923,10 @@ class HttpClientTest extends TestCase
         $this->assertSame(500, $responses['test500']->status());
     }
 
-    public function testTheRequestSentAndResponseReceivedEventsAreFiredWhenARequestIsSent()
+    public function testTheRequestSendingAndResponseReceivedEventsAreFiredWhenARequestIsSent()
     {
         $events = m::mock(Dispatcher::class);
-        $events->shouldReceive('dispatch')->times(5)->with(m::type(RequestSent::class));
+        $events->shouldReceive('dispatch')->times(5)->with(m::type(RequestSending::class));
         $events->shouldReceive('dispatch')->times(5)->with(m::type(ResponseReceived::class));
 
         $factory = new Factory($events);


### PR DESCRIPTION
Hey guys,

This PR adds two new events, `RequestSent` and `ResponseReceived`, which are dispatched by the Http Client.

## `RequestSent`

The `RequestSent` event is fired when any request is made when calling any of the following Http Client methods: 'get', 'head', 'post', 'put' and 'delete'. It receives the HTTP method, URL, and any sent options.

## `ResponseReceived`

The `ResponseReceived` event is fired when a successful response is returned from the Http Client. It receives the `Response` instance.

## What are the benefits?

These two events allow a 3rd party package to listen for and react to HTTP Client requests. I can see it being used for debugging, logging, performance monitoring, service downtime analysis and more.

I decided to contribute this when I went to create a PR for the `spatie/laravel-ray` package to allow monitoring of Http Client requests only to realise there wasn't a way to do so.

As always, thank you very much for all the hard work and for considering my PR.

Regards,
Luke 