### PR TITLE
[8.x] Introduce weightedAvg method to the Collection

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -86,6 +86,33 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
+     * Get the weighted average value of a given key.
+     *
+     * @param  callable|string|null  $callback
+     * @return mixed
+     */
+    public function weightedAvg($callback = null)
+    {
+        $callback = $this->valueRetriever($callback);
+
+        $dividend = 0;
+        $divisor = 0;
+
+        $this->map(function ($value) use ($callback) {
+            return $callback($value) ?: $value;
+        })->filter(function ($value) {
+            return ! is_null($value);
+        })->each(function ($item) use (&$dividend, &$divisor) {
+            $divisor += current($item);
+            $dividend += current($item) * end($item);
+        });
+
+        if ($dividend) {
+            return $dividend / $divisor;
+        }
+    }
+
+    /**
      * Get the median of a given key.
      *
      * @param  string|array|null  $key

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -125,6 +125,14 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function avg($callback = null);
 
     /**
+     * Get the weighted average value of a given key.
+     *
+     * @param  callable|string|null  $callback
+     * @return mixed
+     */
+    public function weightedAvg($callback = null);
+
+    /**
      * Determine if an item exists in the enumerable.
      *
      * @param  mixed  $key

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -134,6 +134,17 @@ class LazyCollection implements Enumerable
     }
 
     /**
+     * Get the weighted average value of a given key.
+     *
+     * @param  callable|string|null  $callback
+     * @return mixed
+     */
+    public function weightedAvg($callback = null)
+    {
+        return $this->collect()->weightedAvg($callback);
+    }
+
+    /**
      * Get the median of a given key.
      *
      * @param  string|array|null  $key

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3555,6 +3555,33 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testGettingWeightedAvgItemsFromCollection($collection)
+    {
+        $c = new $collection([(object) ['foo' => 10, 'bar' => 15], (object) ['foo' => 20, 'bar' => 15]]);
+        $this->assertEquals(15, $c->weightedAvg(function ($item) {
+            return [$item->foo, $item->bar];
+        }));
+        $this->assertEquals(15, $c->weightedAvg(['foo', 'bar']));
+
+        $c = new $collection([(object) ['foo' => 10, 'bar' => 15], (object) ['foo' => 20, 'bar' => 15], (object) ['foo' => null, 'bar' => null]]);
+        $this->assertEquals(15, $c->weightedAvg(function ($item) {
+            return [$item->foo, $item->bar];
+        }));
+        $this->assertEquals(15, $c->weightedAvg(['foo', 'bar']));
+
+        $c = new $collection([['foo' => 10, 'bar' => 15], ['foo' => 20, 'bar' => 15]]);
+        $this->assertEquals(15, $c->weightedAvg(['foo', 'bar']));
+
+        $c = new $collection([[1, 2, 3, 4, 5]]);
+        $this->assertEquals(5, $c->weightedAvg());
+
+        $c = new $collection;
+        $this->assertNull($c->weightedAvg());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testJsonSerialize($collection)
     {
         $c = new $collection([


### PR DESCRIPTION
This PR will add a new Collection/LazyCollection method called weightedAvg (weighted average) because a weighted average is sometimes more accurate than a simple average.

The weighted average takes into account the relative importance or frequency of some factors in a data set.

Example usage:
```php
$weightedAverage = collect([
    ['interest' => 1, 'loan' => 20],
    ['interest' => 2.2, 'loan' => 10],
    ['interest' => 3.8, 'loan' => 20],
    ['interest' => 2, 'loan' => 30],
    ['interest' => 1, 'loan' => 10],
])->weightedAvg(['interest', 'loan']);

$weightedAverage = collect([[1, 2, 3, 4, 5]])->weightedAvg();
```