### PR TITLE
[8.x] Avoid using array_walk on array whose length can change while iterating

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -891,8 +891,6 @@ class Application extends Container implements ApplicationContract, CachesConfig
         // finished. This is useful when ordering the boot-up processes we run.
         $this->fireAppCallbacks($this->bootingCallbacks);
 
-        // Boot the service providers. Remember that additional providers
-        // might be pushed to the array while we are iterating over it.
         for ($i = 0; $i < count($this->serviceProviders); $i++) {
             $this->bootProvider($this->serviceProviders[$i]);
         }

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -891,9 +891,11 @@ class Application extends Container implements ApplicationContract, CachesConfig
         // finished. This is useful when ordering the boot-up processes we run.
         $this->fireAppCallbacks($this->bootingCallbacks);
 
-        array_walk($this->serviceProviders, function ($p) {
-            $this->bootProvider($p);
-        });
+        // Boot the service providers. Remember that additional providers
+        // might be pushed to the array while we are iterating over it.
+        for ($i = 0; $i < count($this->serviceProviders); $i++) {
+            $this->bootProvider($this->serviceProviders[$i]);
+        }
 
         $this->booted = true;
 


### PR DESCRIPTION
Follow-up to #37392, in particular starting from https://github.com/laravel/framework/pull/37392#issuecomment-845570709.

Let's proactively strengthen the code, rather than waiting that it breaks.
I let you adjust the comment according to your taste :)