### PR TITLE
[8.x] Fixes correct return type

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -827,7 +827,7 @@ class Builder
      * @param  array  $columns
      * @param  string  $cursorName
      * @param  string|null  $cursor
-     * @return \Illuminate\Contracts\Pagination\Paginator
+     * @return \Illuminate\Contracts\Pagination\CursorPaginator
      * @throws \Illuminate\Pagination\CursorPaginationException
      */
     public function cursorPaginate($perPage = null, $columns = ['*'], $cursorName = 'cursor', $cursor = null)


### PR DESCRIPTION
This commit fixes the correct return type of the cursorPaginate method from `\Illuminate\Contracts\Pagination\Paginator` (which it doesn't return) to `\Illuminate\Contracts\Pagination\CursorPaginator`