### PR TITLE
[8.x] Improved unions condition check legibility

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1982,18 +1982,20 @@ class Builder
         if (! in_array($direction, ['asc', 'desc'], true)) {
             throw new InvalidArgumentException('Order direction must be "asc" or "desc".');
         }
+        
+        $unions = &$this->{$this->unions ? 'unionOrders' : 'orders'};
 
-        if (is_array($this->{$this->unions ? 'unionOrders' : 'orders'})) {
-            foreach ($this->{$this->unions ? 'unionOrders' : 'orders'} as $key => $value) {
+        if (is_array($unions)) {
+            foreach ($unions as $key => $value) {
                 if (isset($value['column']) && $value['column'] === $column) {
-                    $this->{$this->unions ? 'unionOrders' : 'orders'}[$key]['direction'] = $direction;
+                    $unions[$key]['direction'] = $direction;
 
                     return $this;
                 }
             }
         }
 
-        $this->{$this->unions ? 'unionOrders' : 'orders'}[] = [
+        $unions[] = [
             'column' => $column,
             'direction' => $direction,
         ];

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1982,7 +1982,7 @@ class Builder
         if (! in_array($direction, ['asc', 'desc'], true)) {
             throw new InvalidArgumentException('Order direction must be "asc" or "desc".');
         }
-        
+
         $unions = &$this->{$this->unions ? 'unionOrders' : 'orders'};
 
         if (is_array($unions)) {


### PR DESCRIPTION
This code is very confused to read due multiple lines reading dynamic object properties using the ternary operator.

```php
if (is_array($this->{$this->unions ? 'unionOrders' : 'orders'})) {
    foreach ($this->{$this->unions ? 'unionOrders' : 'orders'} as $key => $value) {
        if (isset($value['column']) && $value['column'] === $column) {
            $this->{$this->unions ? 'unionOrders' : 'orders'}[$key]['direction'] = $direction;

            return $this;
        }
    }
}

$this->{$this->unions ? 'unionOrders' : 'orders'}[] = [
    'column' => $column,
    'direction' => $direction,
];
```

Same code is used in other methods, but here we have same check in 4 lines.

I think moving the variable to a reference is a better choice in this case.

```php
$unions = &$this->{$this->unions ? 'unionOrders' : 'orders'};

if (is_array($unions)) {
    foreach ($unions as $key => $value) {
        if (isset($value['column']) && $value['column'] === $column) {
            $unions[$key]['direction'] = $direction;

            return $this;
        }
    }
}

$unions[] = [
    'column' => $column,
    'direction' => $direction,
];
```
