### PR TITLE
[8.x] Bugfix for cloning issues with PendingRequest object

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -137,7 +137,7 @@ class PendingRequest
      *
      * @var \Illuminate\Http\Client\Request|null
      */
-    protected $request;
+    protected $request = null;
 
     /**
      * Create a new HTTP Client instance.
@@ -156,11 +156,11 @@ class PendingRequest
             'http_errors' => false,
         ];
 
-        $this->beforeSendingCallbacks = collect([function (Request $request, array $options) {
-            $this->request = $request;
-            $this->cookies = $options['cookies'];
+        $this->beforeSendingCallbacks = collect([function (Request $request, array $options, PendingRequest $instance) {
+            $instance->request = $request;
+            $instance->cookies = $options['cookies'];
 
-            $this->dispatchRequestSendingEvent();
+            $instance->dispatchRequestSendingEvent();
         }]);
     }
 
@@ -913,7 +913,8 @@ class PendingRequest
         return tap($request, function ($request) use ($options) {
             $this->beforeSendingCallbacks->each->__invoke(
                 (new Request($request))->withData($options['laravel_data']),
-                $options
+                $options,
+                $this
             );
         });
     }
@@ -985,9 +986,15 @@ class PendingRequest
      */
     protected function dispatchResponseReceivedEvent(Response $response)
     {
-        if ($dispatcher = optional($this->factory)->getDispatcher()) {
-            $dispatcher->dispatch(new ResponseReceived($this->request, $response));
+        if (! $dispatcher = optional($this->factory)->getDispatcher()) {
+            return;
         }
+
+        if (! $this->request) {
+            return;
+        }
+
+        $dispatcher->dispatch(new ResponseReceived($this->request, $response));
     }
 
     /**

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -15,7 +15,6 @@ use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\Client\Response;
 use Illuminate\Http\Client\ResponseSequence;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
 use Mockery as m;
 use OutOfBoundsException;

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -15,6 +15,7 @@ use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\Client\Response;
 use Illuminate\Http\Client\ResponseSequence;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
 use Mockery as m;
 use OutOfBoundsException;
@@ -936,6 +937,22 @@ class HttpClientTest extends TestCase
         $factory->post('https://example.com');
         $factory->patch('https://example.com');
         $factory->delete('https://example.com');
+
+        m::close();
+    }
+
+    public function testClonedClientsWorkSuccessfullyWithTheRequestObject()
+    {
+        $events = m::mock(Dispatcher::class);
+        $events->shouldReceive('dispatch')->once()->with(m::type(RequestSending::class));
+        $events->shouldReceive('dispatch')->once()->with(m::type(ResponseReceived::class));
+
+        $factory = new Factory($events);
+
+        $client = $factory->timeout(10);
+        $clonedClient = clone $client;
+
+        $clonedClient->get('https://example.com');
 
         m::close();
     }


### PR DESCRIPTION
Fixes #37594

This was caused by the closures registered in the `beforeSendingCallbacks` referencing the original instance in memory. These callbacks now receive the current instance as the third parameter, which allows them to set the provided request and cookies on the correct object instance.