### PR TITLE
[8.x] Makes the retrieval of Http client transferStats safe

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -125,11 +125,11 @@ class Response implements ArrayAccess
     /**
      * Get the effective URI of the response.
      *
-     * @return \Psr\Http\Message\UriInterface
+     * @return \Psr\Http\Message\UriInterface|null
      */
     public function effectiveUri()
     {
-        return $this->transferStats->getEffectiveUri();
+        return optional($this->transferStats)->getEffectiveUri();
     }
 
     /**

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -224,7 +224,7 @@ class Response implements ArrayAccess
      */
     public function handlerStats()
     {
-        return $this->transferStats->getHandlerStats();
+        return optional($this->transferStats)->getHandlerStats() ?? [];
     }
 
     /**

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -15,7 +15,6 @@ use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\Client\Response;
 use Illuminate\Http\Client\ResponseSequence;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
 use Mockery as m;
 use OutOfBoundsException;

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -15,6 +15,7 @@ use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\Client\Response;
 use Illuminate\Http\Client\ResponseSequence;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
 use Mockery as m;
 use OutOfBoundsException;
@@ -938,5 +939,14 @@ class HttpClientTest extends TestCase
         $factory->delete('https://example.com');
 
         m::close();
+    }
+
+    public function testTheHandlerStatsReturnAnEmptyArrayWhenFakingTheRequest()
+    {
+        $this->factory->fake(['https://example.com' => $this->factory->response()]);
+        $stats = $this->factory->get('https://example.com')->handlerStats();
+
+        $this->assertIsArray($stats);
+        $this->assertEmpty($stats);
     }
 }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -940,12 +940,15 @@ class HttpClientTest extends TestCase
         m::close();
     }
 
-    public function testTheHandlerStatsReturnAnEmptyArrayWhenFakingTheRequest()
+    public function testTheTransferStatsAreCalledSafelyWhenFakingTheRequest()
     {
         $this->factory->fake(['https://example.com' => $this->factory->response()]);
         $stats = $this->factory->get('https://example.com')->handlerStats();
+        $effectiveUri = $this->factory->get('https://example.com')->effectiveUri();
 
         $this->assertIsArray($stats);
         $this->assertEmpty($stats);
+
+        $this->assertNull($effectiveUri);
     }
 }


### PR DESCRIPTION
Hello there!

The Http Client returns some really nice details in the `handlerStats` method. However, when faking a request inside a test, the `transferStats` object is null. This causes an error when attempting to call the `handlerStats` method. This PR updates the `handlerStats` call by wrapping it in an `optional` call and returning an empty array by default. This makes consuming code much cleaner by no longer requiring a try/catch statement.

```php
Http::fake(['example.com' => Http::response()]);

// Before
try {
    $stats = Http::get('example.com')->handlerStats();
} catch ($e) {
    $stats = [];
}

// After
$stats = Http::get('example.com')->handlerStats()['some_stat'] ?? null;
```

There is another option, which is that we return a new `Fluent` from `handlerStats`, but that would be a breaking change because previous try/catches would now pass but return null, which could cause undesired side-effects. If that is desirable to you, let me know and I'll write a PR for 9.x that will expand on this one.

Thanks for your time guys :-) 

Regards,
Luke