### PR TITLE
[9.x] Move to anonymous migrations

### DIFF
--- a/src/Illuminate/Cache/Console/stubs/cache.stub
+++ b/src/Illuminate/Cache/Console/stubs/cache.stub
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateCacheTable extends Migration
+return new class extends Migration
 {
     /**
      * Run the migrations.
@@ -29,4 +29,4 @@ class CreateCacheTable extends Migration
     {
         Schema::dropIfExists('cache');
     }
-}
+};

--- a/src/Illuminate/Database/Migrations/MigrationCreator.php
+++ b/src/Illuminate/Database/Migrations/MigrationCreator.php
@@ -68,7 +68,7 @@ class MigrationCreator
         $this->files->ensureDirectoryExists(dirname($path));
 
         $this->files->put(
-            $path, $this->populateStub($name, $stub, $table)
+            $path, $this->populateStub($stub, $table)
         );
 
         // Next, we will fire any hooks that are supposed to fire after a migration is
@@ -132,18 +132,12 @@ class MigrationCreator
     /**
      * Populate the place-holders in the migration stub.
      *
-     * @param  string  $name
      * @param  string  $stub
      * @param  string|null  $table
      * @return string
      */
-    protected function populateStub($name, $stub, $table)
+    protected function populateStub($stub, $table)
     {
-        $stub = str_replace(
-            ['DummyClass', '{{ class }}', '{{class}}'],
-            $this->getClassName($name), $stub
-        );
-
         // Here we will replace the table place-holders with the table specified by
         // the developer, which is useful for quickly creating a tables creation
         // or update migration from the console instead of typing it manually.

--- a/src/Illuminate/Notifications/Console/stubs/notifications.stub
+++ b/src/Illuminate/Notifications/Console/stubs/notifications.stub
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateNotificationsTable extends Migration
+return new class extends Migration
 {
     /**
      * Run the migrations.
@@ -32,4 +32,4 @@ class CreateNotificationsTable extends Migration
     {
         Schema::dropIfExists('notifications');
     }
-}
+};

--- a/src/Illuminate/Queue/Console/BatchesTableCommand.php
+++ b/src/Illuminate/Queue/Console/BatchesTableCommand.php
@@ -5,7 +5,6 @@ namespace Illuminate\Queue\Console;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Composer;
-use Illuminate\Support\Str;
 
 class BatchesTableCommand extends Command
 {
@@ -69,7 +68,7 @@ class BatchesTableCommand extends Command
         $table = $this->laravel['config']['queue.batching.table'] ?? 'job_batches';
 
         $this->replaceMigration(
-            $this->createBaseMigration($table), $table, Str::studly($table)
+            $this->createBaseMigration($table), $table
         );
 
         $this->info('Migration created successfully!');
@@ -95,15 +94,12 @@ class BatchesTableCommand extends Command
      *
      * @param  string  $path
      * @param  string  $table
-     * @param  string  $tableClassName
      * @return void
      */
-    protected function replaceMigration($path, $table, $tableClassName)
+    protected function replaceMigration($path, $table)
     {
         $stub = str_replace(
-            ['{{table}}', '{{tableClassName}}'],
-            [$table, $tableClassName],
-            $this->files->get(__DIR__.'/stubs/batches.stub')
+            '{{table}}', $table, $this->files->get(__DIR__.'/stubs/batches.stub')
         );
 
         $this->files->put($path, $stub);

--- a/src/Illuminate/Queue/Console/FailedTableCommand.php
+++ b/src/Illuminate/Queue/Console/FailedTableCommand.php
@@ -5,7 +5,6 @@ namespace Illuminate\Queue\Console;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Composer;
-use Illuminate\Support\Str;
 
 class FailedTableCommand extends Command
 {
@@ -69,7 +68,7 @@ class FailedTableCommand extends Command
         $table = $this->laravel['config']['queue.failed.table'];
 
         $this->replaceMigration(
-            $this->createBaseMigration($table), $table, Str::studly($table)
+            $this->createBaseMigration($table), $table
         );
 
         $this->info('Migration created successfully!');
@@ -95,15 +94,12 @@ class FailedTableCommand extends Command
      *
      * @param  string  $path
      * @param  string  $table
-     * @param  string  $tableClassName
      * @return void
      */
-    protected function replaceMigration($path, $table, $tableClassName)
+    protected function replaceMigration($path, $table)
     {
         $stub = str_replace(
-            ['{{table}}', '{{tableClassName}}'],
-            [$table, $tableClassName],
-            $this->files->get(__DIR__.'/stubs/failed_jobs.stub')
+            '{{table}}', $table, $this->files->get(__DIR__.'/stubs/failed_jobs.stub')
         );
 
         $this->files->put($path, $stub);

--- a/src/Illuminate/Queue/Console/TableCommand.php
+++ b/src/Illuminate/Queue/Console/TableCommand.php
@@ -5,7 +5,6 @@ namespace Illuminate\Queue\Console;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Composer;
-use Illuminate\Support\Str;
 
 class TableCommand extends Command
 {
@@ -69,7 +68,7 @@ class TableCommand extends Command
         $table = $this->laravel['config']['queue.connections.database.table'];
 
         $this->replaceMigration(
-            $this->createBaseMigration($table), $table, Str::studly($table)
+            $this->createBaseMigration($table), $table
         );
 
         $this->info('Migration created successfully!');
@@ -95,15 +94,12 @@ class TableCommand extends Command
      *
      * @param  string  $path
      * @param  string  $table
-     * @param  string  $tableClassName
      * @return void
      */
-    protected function replaceMigration($path, $table, $tableClassName)
+    protected function replaceMigration($path, $table)
     {
         $stub = str_replace(
-            ['{{table}}', '{{tableClassName}}'],
-            [$table, $tableClassName],
-            $this->files->get(__DIR__.'/stubs/jobs.stub')
+            '{{table}}', $table, $this->files->get(__DIR__.'/stubs/jobs.stub')
         );
 
         $this->files->put($path, $stub);

--- a/src/Illuminate/Queue/Console/stubs/batches.stub
+++ b/src/Illuminate/Queue/Console/stubs/batches.stub
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class Create{{tableClassName}}Table extends Migration
+return new class extends Migration
 {
     /**
      * Run the migrations.
@@ -36,4 +36,4 @@ class Create{{tableClassName}}Table extends Migration
     {
         Schema::dropIfExists('{{table}}');
     }
-}
+};

--- a/src/Illuminate/Queue/Console/stubs/failed_jobs.stub
+++ b/src/Illuminate/Queue/Console/stubs/failed_jobs.stub
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class Create{{tableClassName}}Table extends Migration
+return new class extends Migration
 {
     /**
      * Run the migrations.
@@ -33,4 +33,4 @@ class Create{{tableClassName}}Table extends Migration
     {
         Schema::dropIfExists('{{table}}');
     }
-}
+};

--- a/src/Illuminate/Queue/Console/stubs/jobs.stub
+++ b/src/Illuminate/Queue/Console/stubs/jobs.stub
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class Create{{tableClassName}}Table extends Migration
+return new class extends Migration
 {
     /**
      * Run the migrations.
@@ -33,4 +33,4 @@ class Create{{tableClassName}}Table extends Migration
     {
         Schema::dropIfExists('{{table}}');
     }
-}
+};

--- a/src/Illuminate/Session/Console/stubs/database.stub
+++ b/src/Illuminate/Session/Console/stubs/database.stub
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateSessionsTable extends Migration
+return new class extends Migration
 {
     /**
      * Run the migrations.
@@ -32,4 +32,4 @@ class CreateSessionsTable extends Migration
     {
         Schema::dropIfExists('sessions');
     }
-}
+};

--- a/tests/Database/DatabaseMigrationCreatorTest.php
+++ b/tests/Database/DatabaseMigrationCreatorTest.php
@@ -21,9 +21,9 @@ class DatabaseMigrationCreatorTest extends TestCase
 
         $creator->expects($this->any())->method('getDatePrefix')->willReturn('foo');
         $creator->getFilesystem()->shouldReceive('exists')->once()->with('stubs/migration.stub')->andReturn(false);
-        $creator->getFilesystem()->shouldReceive('get')->once()->with($creator->stubPath().'/migration.stub')->andReturn('DummyClass');
+        $creator->getFilesystem()->shouldReceive('get')->once()->with($creator->stubPath().'/migration.stub')->andReturn('return new class');
         $creator->getFilesystem()->shouldReceive('ensureDirectoryExists')->once()->with('foo');
-        $creator->getFilesystem()->shouldReceive('put')->once()->with('foo/foo_create_bar.php', 'CreateBar');
+        $creator->getFilesystem()->shouldReceive('put')->once()->with('foo/foo_create_bar.php', 'return new class');
         $creator->getFilesystem()->shouldReceive('glob')->once()->with('foo/*.php')->andReturn(['foo/foo_create_bar.php']);
         $creator->getFilesystem()->shouldReceive('requireOnce')->once()->with('foo/foo_create_bar.php');
 
@@ -44,9 +44,9 @@ class DatabaseMigrationCreatorTest extends TestCase
 
         $creator->expects($this->any())->method('getDatePrefix')->willReturn('foo');
         $creator->getFilesystem()->shouldReceive('exists')->once()->with('stubs/migration.update.stub')->andReturn(false);
-        $creator->getFilesystem()->shouldReceive('get')->once()->with($creator->stubPath().'/migration.update.stub')->andReturn('DummyClass DummyTable');
+        $creator->getFilesystem()->shouldReceive('get')->once()->with($creator->stubPath().'/migration.update.stub')->andReturn('return new class DummyTable');
         $creator->getFilesystem()->shouldReceive('ensureDirectoryExists')->once()->with('foo');
-        $creator->getFilesystem()->shouldReceive('put')->once()->with('foo/foo_create_bar.php', 'CreateBar baz');
+        $creator->getFilesystem()->shouldReceive('put')->once()->with('foo/foo_create_bar.php', 'return new class baz');
         $creator->getFilesystem()->shouldReceive('glob')->once()->with('foo/*.php')->andReturn(['foo/foo_create_bar.php']);
         $creator->getFilesystem()->shouldReceive('requireOnce')->once()->with('foo/foo_create_bar.php');
 
@@ -64,9 +64,9 @@ class DatabaseMigrationCreatorTest extends TestCase
         $creator = $this->getCreator();
         $creator->expects($this->any())->method('getDatePrefix')->willReturn('foo');
         $creator->getFilesystem()->shouldReceive('exists')->once()->with('stubs/migration.update.stub')->andReturn(false);
-        $creator->getFilesystem()->shouldReceive('get')->once()->with($creator->stubPath().'/migration.update.stub')->andReturn('DummyClass DummyTable');
+        $creator->getFilesystem()->shouldReceive('get')->once()->with($creator->stubPath().'/migration.update.stub')->andReturn('return new class DummyTable');
         $creator->getFilesystem()->shouldReceive('ensureDirectoryExists')->once()->with('foo');
-        $creator->getFilesystem()->shouldReceive('put')->once()->with('foo/foo_create_bar.php', 'CreateBar baz');
+        $creator->getFilesystem()->shouldReceive('put')->once()->with('foo/foo_create_bar.php', 'return new class baz');
         $creator->getFilesystem()->shouldReceive('glob')->once()->with('foo/*.php')->andReturn(['foo/foo_create_bar.php']);
         $creator->getFilesystem()->shouldReceive('requireOnce')->once()->with('foo/foo_create_bar.php');
 
@@ -78,9 +78,9 @@ class DatabaseMigrationCreatorTest extends TestCase
         $creator = $this->getCreator();
         $creator->expects($this->any())->method('getDatePrefix')->willReturn('foo');
         $creator->getFilesystem()->shouldReceive('exists')->once()->with('stubs/migration.create.stub')->andReturn(false);
-        $creator->getFilesystem()->shouldReceive('get')->once()->with($creator->stubPath().'/migration.create.stub')->andReturn('DummyClass DummyTable');
+        $creator->getFilesystem()->shouldReceive('get')->once()->with($creator->stubPath().'/migration.create.stub')->andReturn('return new class DummyTable');
         $creator->getFilesystem()->shouldReceive('ensureDirectoryExists')->once()->with('foo');
-        $creator->getFilesystem()->shouldReceive('put')->once()->with('foo/foo_create_bar.php', 'CreateBar baz');
+        $creator->getFilesystem()->shouldReceive('put')->once()->with('foo/foo_create_bar.php', 'return new class baz');
         $creator->getFilesystem()->shouldReceive('glob')->once()->with('foo/*.php')->andReturn(['foo/foo_create_bar.php']);
         $creator->getFilesystem()->shouldReceive('requireOnce')->once()->with('foo/foo_create_bar.php');
 


### PR DESCRIPTION
This PR removes class names for migration stubs since now with anonymous migrations these aren't needed anymore. 

https://github.com/laravel/framework/pull/37352 also already removed them from existing stubs for the `MigrationCreator` so I also made changes to remove the resolving of the class name when populating the stub in that class.