### PR TITLE
[8.x] Add TestResponse->assertJsonPathExists

### DIFF
--- a/src/Illuminate/Testing/AssertableJsonString.php
+++ b/src/Illuminate/Testing/AssertableJsonString.php
@@ -233,9 +233,8 @@ class AssertableJsonString implements ArrayAccess, Countable
         $pathParts = explode('.', $path);
         $regexPathParts = [];
 
-        foreach($pathParts as $pathPart)
-        {
-            if($pathPart === '*') {
+        foreach ($pathParts as $pathPart) {
+            if ($pathPart === '*') {
                 $regexPathParts[] = '[0-9]+';
             } else {
                 $regexPathParts[] = $pathPart;

--- a/src/Illuminate/Testing/AssertableJsonString.php
+++ b/src/Illuminate/Testing/AssertableJsonString.php
@@ -222,6 +222,19 @@ class AssertableJsonString implements ArrayAccess, Countable
     }
 
     /**
+     * Assert that the given path exists in the response.
+     *
+     * @param  string $path
+     * @return $this
+     */
+    public function assertPathExists($path)
+    {
+        PHPUnit::assertTrue(Arr::exists(Arr::dot($this->json()), $path));
+
+        return $this;
+    }
+
+    /**
      * Assert that the response has a given JSON structure.
      *
      * @param  array|null  $structure

--- a/src/Illuminate/Testing/AssertableJsonString.php
+++ b/src/Illuminate/Testing/AssertableJsonString.php
@@ -236,7 +236,7 @@ class AssertableJsonString implements ArrayAccess, Countable
         foreach($pathParts as $pathPart)
         {
             if($pathPart === '*') {
-                $regexPathParts[] = '[0-9]';
+                $regexPathParts[] = '[0-9]+';
             } else {
                 $regexPathParts[] = $pathPart;
             }

--- a/src/Illuminate/Testing/AssertableJsonString.php
+++ b/src/Illuminate/Testing/AssertableJsonString.php
@@ -9,7 +9,6 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Testing\Assert as PHPUnit;
 use JsonSerializable;
-use PHPUnit\Framework\AssertionFailedError;
 
 class AssertableJsonString implements ArrayAccess, Countable
 {
@@ -253,7 +252,9 @@ class AssertableJsonString implements ArrayAccess, Countable
             }
         }
 
-        throw new AssertionFailedError("Failed asserting the path $path was found in the response.");
+        PHPUnit::fail("Failed asserting the path $path was found in the response.");
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -594,6 +594,19 @@ class TestResponse implements ArrayAccess
     }
 
     /**
+     * Assert that the given path exists in the response.
+     *
+     * @param  string $path
+     * @return $this
+     */
+    public function assertJsonPathExists($path)
+    {
+        $this->decodeResponseJson()->assertPathExists($path);
+
+        return $this;
+    }
+
+    /**
      * Assert that the response has the exact given JSON.
      *
      * @param  array  $data

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -698,6 +698,29 @@ class TestResponseTest extends TestCase
         $response->assertJsonPath('0.id', '10');
     }
 
+    public function testAssertJsonPathExists()
+    {
+        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceStub));
+
+        $response->assertJsonPathExists('0.foo');
+        $response->assertJsonPathExists('0.bar');
+        $response->assertJsonPathExists('0.foobar');
+
+        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));
+
+        $response->assertJsonPathExists('foo');
+
+        $response->assertJsonPathExists('foobar.foobar_foo');
+        $response->assertJsonPathExists('foobar.foobar_bar');
+
+        $response->assertJsonPathExists('foobar.foobar_foo')->assertJsonPathExists('foobar.foobar_bar');
+
+        $response->assertJsonPathExists('0.0');
+        $response->assertJsonPathExists('bars.0.bar');
+        $response->assertJsonPathExists('barfoo.0.bar.bar');
+        $response->assertJsonPathExists('numeric_keys.2.bar');
+    }
+
     public function testAssertJsonFragment()
     {
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceStub));

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -740,6 +740,15 @@ class TestResponseTest extends TestCase
         $response->assertJsonPathExists('numeric_keys.2');
         $response->assertJsonPathExists('numeric_keys.*.bar');
         $response->assertJsonPathExists('numeric_keys.2.bar');
+
+        // Test when using * and key is above 9
+        $response = TestResponse::fromBaseResponse(new Response([
+            10 => ['foo' => 'bar 10'],
+
+        ]));
+
+        $response->assertJsonPathExists('*');
+        $response->assertJsonPathExists('*.foo');
     }
 
     public function testAssertJsonPathExistCanFail()

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -751,6 +751,17 @@ class TestResponseTest extends TestCase
         $response->assertJsonPathExists('*.foo');
     }
 
+    public function testAssertJsonPathExistFailsIfPathNotAtTheBeginning()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $response = TestResponse::fromBaseResponse(new Response([
+            ['foo' => 'bar'], // 0.foo
+        ]));
+
+        $response->assertJsonPathExists('foo');
+    }
+
     public function testAssertJsonPathExistCanFail()
     {
         $this->expectException(AssertionFailedError::class);

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -702,6 +702,10 @@ class TestResponseTest extends TestCase
     {
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceStub));
 
+        $response->assertJsonPathExists('*');
+        $response->assertJsonPathExists('0');
+
+        $response->assertJsonPathExists('*.foo');
         $response->assertJsonPathExists('0.foo');
         $response->assertJsonPathExists('0.bar');
         $response->assertJsonPathExists('0.foobar');
@@ -710,15 +714,42 @@ class TestResponseTest extends TestCase
 
         $response->assertJsonPathExists('foo');
 
+        $response->assertJsonPathExists('foobar');
         $response->assertJsonPathExists('foobar.foobar_foo');
         $response->assertJsonPathExists('foobar.foobar_bar');
 
         $response->assertJsonPathExists('foobar.foobar_foo')->assertJsonPathExists('foobar.foobar_bar');
 
+        $response->assertJsonPathExists('0.*');
         $response->assertJsonPathExists('0.0');
+
+        $response->assertJsonPathExists('bars.*');
+        $response->assertJsonPathExists('bars.0');
         $response->assertJsonPathExists('bars.0.bar');
+
+        $response->assertJsonPathExists('barfoo.*.bar');
+        $response->assertJsonPathExists('barfoo.0.bar');
         $response->assertJsonPathExists('barfoo.0.bar.bar');
+
+        $response->assertJsonPathExists('barfoobaz.*.*');
+        $response->assertJsonPathExists('barfoobaz.*.*.baz');
+
+        $response->assertJsonPathExists('barfoobaz.*.baz.*');
+        $response->assertJsonPathExists('barfoobaz.*.baz.*.bar');
+
+        $response->assertJsonPathExists('numeric_keys.2');
+        $response->assertJsonPathExists('numeric_keys.*.bar');
         $response->assertJsonPathExists('numeric_keys.2.bar');
+    }
+
+    public function testAssertJsonPathExistCanFail()
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Failed asserting the path 0.notfound was found in the response.');
+
+        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceWithIntegersStub));
+
+        $response->assertJsonPathExists('0.notfound');
     }
 
     public function testAssertJsonFragment()
@@ -1426,6 +1457,10 @@ class JsonSerializableMixedResourcesStub implements JsonSerializable
                 ['bar' => ['bar' => 'foo 0']],
                 ['bar' => ['bar' => 'foo 0', 'foo' => 'foo 0']],
                 ['bar' => ['foo' => 'bar 0', 'bar' => 'foo 0', 'rab' => 'rab 0']],
+            ],
+            'barfoobaz' => [
+                ['bar' => 'foo 0', 'foo' => 'bar 0', ['baz' => 'foo 0'], 'baz' => [['bar' => 'foo 0']]],
+                ['bar' => 'foo 1', 'foo' => 'bar 1', ['baz' => 'foo 1'], 'baz' => [['bar' => 'foo 1']]],
             ],
             'numeric_keys' => [
                 2 => ['bar' => 'foo 0', 'foo' => 'bar 0'],


### PR DESCRIPTION
This PR adds a new test assertion `assertJsonPathExists` to the TestResponse. This allows users to test if a JSON response has a certain path using dot notation without caring about the value. This is an addition to `assertJsonPath` that checks for both the path and the value.

**Example JSON response**

```json
{
  "data": {
    "username": "Foo Bar",
    "email": "test@test.com",
    "addresses": [
      {
        "address1": "Test 123",
        "city": "Kalamazoo",
        "state": "Michigan",
        "country": "US"
      },
      {
        "address1": "Test 456",
        "city": "Grand Rapids",
        "state": "Michigan",
        "country": "US"
      }
    ]
  }
}
```

**Current option**
```php
$response->assertJsonStructure([
    'data' => [
        'username',
        'addresses' => [
            ['address1', 'city']
        ]
    ],
]);
```

This option is quite verbose especially if you just want to make sure an address has `address1`. You have to build out the entire array structure.

**New options**
```php
$response->assertJsonPathExists('data.addresses.0.address1')
```

`*` is also supported:
```php
$response->assertJsonPathExists('data.addresses.*.address1')
```

Along with partial path matches:
```php
$response->assertJsonPathExists('data.addresses');
$response->assertJsonPathExists('data.addresses.');
$response->assertJsonPathExists('data.addresses.0');
$response->assertJsonPathExists('data.addresses.*');
```

**Possible suggestions**
`assertJsonPath` currently uses the `data_get` helper. Should we create a `data_exists` helper and then refactor the logic to that helper?


