### PR TITLE
[8.x] Fix stringable implementation

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\View\Compilers;
 
-use Closure;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\ReflectsClosures;
@@ -101,13 +100,6 @@ class BladeCompiler extends Compiler implements CompilerInterface
      * @var string
      */
     protected $echoFormat = 'e(%s)';
-
-    /**
-     * Custom rendering callbacks for stringable objects.
-     *
-     * @var array
-     */
-    public $echoHandlers = [];
 
     /**
      * Array of footer lines to be added to the template.
@@ -712,22 +704,6 @@ class BladeCompiler extends Compiler implements CompilerInterface
     }
 
     /**
-     * Add a handler to be executed before echoing a given class.
-     *
-     * @param  string|callable  $class
-     * @param  callable|null  $handler
-     * @return void
-     */
-    public function stringable($class, $handler = null)
-    {
-        if ($class instanceof Closure) {
-            [$class, $handler] = [$this->firstClosureParameterType($class), $class];
-        }
-
-        $this->echoHandlers[$class] = $handler;
-    }
-
-    /**
      * Register a new precompiler.
      *
      * @param  callable  $precompiler
@@ -777,5 +753,19 @@ class BladeCompiler extends Compiler implements CompilerInterface
     public function withoutComponentTags()
     {
         $this->compilesComponentTags = false;
+    }
+
+    /**
+     * Add a handler to be executed before echoing a given class.
+     *
+     * @deprecated Will be removed in a future Laravel version.
+     *
+     * @param  string|callable  $class
+     * @param  callable|null  $handler
+     * @return void
+     */
+    public function stringable($class, $handler = null)
+    {
+        app('view')->stringable($class, $handler);
     }
 }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
@@ -48,7 +48,7 @@ trait CompilesEchos
 
             return $matches[1]
                 ? substr($matches[0], 1)
-                : "<?php echo {$this->applyEchoHandlerFor($matches[2])}; ?>{$whitespace}";
+                : "<?php echo {$this->wrapInEchoHandler($matches[2])}; ?>{$whitespace}";
         };
 
         return preg_replace_callback($pattern, $callback, $value);
@@ -67,7 +67,7 @@ trait CompilesEchos
         $callback = function ($matches) {
             $whitespace = empty($matches[3]) ? '' : $matches[3].$matches[3];
 
-            $wrapped = sprintf($this->echoFormat, $this->applyEchoHandlerFor($matches[2]));
+            $wrapped = sprintf($this->echoFormat, $this->wrapInEchoHandler($matches[2]));
 
             return $matches[1] ? substr($matches[0], 1) : "<?php echo {$wrapped}; ?>{$whitespace}";
         };
@@ -90,22 +90,22 @@ trait CompilesEchos
 
             return $matches[1]
                 ? $matches[0]
-                : "<?php echo e({$this->applyEchoHandlerFor($matches[2])}); ?>{$whitespace}";
+                : "<?php echo e({$this->wrapInEchoHandler($matches[2])}); ?>{$whitespace}";
         };
 
         return preg_replace_callback($pattern, $callback, $value);
     }
 
     /**
-     * Wrap the echoable value in an echo handler if applicable.
+     * Stringify the value if it's an object.
      *
      * @param  string  $value
      * @return string
      */
-    protected function applyEchoHandlerFor($value)
+    protected function wrapInEchoHandler($value)
     {
-        return empty($this->echoHandlers)
-            ? $value
-            : "is_object($value) && isset(app('blade.compiler')->echoHandlers[get_class($value)]) ? call_user_func_array(app('blade.compiler')->echoHandlers[get_class($value)], [$value]) : $value";
+        $value = trim($value, ';');
+
+        return "is_object($value) ? \$__env->stringifyObject($value) : ($value)";
     }
 }

--- a/src/Illuminate/View/Concerns/StringifyObjects.php
+++ b/src/Illuminate/View/Concerns/StringifyObjects.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Illuminate\View\Concerns;
+
+use Closure;
+use Illuminate\Contracts\Support\Htmlable;
+
+trait StringifyObjects
+{
+    /**
+     * Custom rendering callbacks for stringable objects.
+     *
+     * @var array
+     */
+    protected $echoHandlers = [];
+
+    /**
+     * Add a handler to be executed before echoing a given class.
+     *
+     * @param  string|callable  $class
+     * @param  callable|null  $handler
+     * @return void
+     */
+    public function stringable($class, $handler = null)
+    {
+        if ($class instanceof Closure) {
+            [$class, $handler] = [$this->firstClosureParameterType($class), $class];
+        }
+
+        $this->echoHandlers[$class] = $handler;
+    }
+
+    /**
+     * Apply the echo handler for the value if it exists.
+     *
+     * @param  $value  object
+     * @return string
+     */
+    public function stringifyObject($value)
+    {
+        if (isset($this->echoHandlers[get_class($value)])) {
+            return call_user_func($this->echoHandlers[get_class($value)], $value);
+        }
+
+        return $value instanceof Htmlable ? $value : (string) $value;
+    }
+}

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\View\Factory as FactoryContract;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
+use Illuminate\Support\Traits\ReflectsClosures;
 use Illuminate\View\Engines\EngineResolver;
 use InvalidArgumentException;
 
@@ -20,7 +21,9 @@ class Factory implements FactoryContract
         Concerns\ManagesLayouts,
         Concerns\ManagesLoops,
         Concerns\ManagesStacks,
-        Concerns\ManagesTranslations;
+        Concerns\ManagesTranslations,
+        Concerns\StringifyObjects,
+        ReflectsClosures;
 
     /**
      * The engine implementation.

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -41,7 +41,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = $this->compiler(['alert' => TestAlertComponent::class])->compileTags('<div><x-alert type="foo" limit="5" @click="foo" wire:click="changePlan(\'{{ $plan }}\')" required /><x-alert /></div>');
 
         $this->assertSame("<div>##BEGIN-COMPONENT-CLASS##@component('Illuminate\Tests\View\Blade\TestAlertComponent', 'alert', [])
-<?php \$component->withAttributes(['type' => 'foo','limit' => '5','@click' => 'foo','wire:click' => 'changePlan(\''.e(\$plan).'\')','required' => true]); ?>\n".
+<?php \$component->withAttributes(['type' => 'foo','limit' => '5','@click' => 'foo','wire:click' => 'changePlan(\''.e(is_object(\$plan) ? \$__env->stringifyObject(\$plan) : (\$plan)).'\')','required' => true]); ?>\n".
 "@endComponentClass##END-COMPONENT-CLASS####BEGIN-COMPONENT-CLASS##@component('Illuminate\Tests\View\Blade\TestAlertComponent', 'alert', [])
 <?php \$component->withAttributes([]); ?>\n".
 '@endComponentClass##END-COMPONENT-CLASS##</div>', trim($result));

--- a/tests/View/Blade/BladeCustomTest.php
+++ b/tests/View/Blade/BladeCustomTest.php
@@ -13,7 +13,7 @@ class BladeCustomTest extends AbstractBladeTestCase
 
     public function testMixingYieldAndEcho()
     {
-        $this->assertSame('<?php echo $__env->yieldContent(\'title\'); ?> - <?php echo e(Config::get(\'site.title\')); ?>', $this->compiler->compileString("@yield('title') - {{Config::get('site.title')}}"));
+        $this->assertSame('<?php echo $__env->yieldContent(\'title\'); ?> - <?php echo e(is_object(Config::get(\'site.title\')) ? $__env->stringifyObject(Config::get(\'site.title\')) : (Config::get(\'site.title\'))); ?>', $this->compiler->compileString("@yield('title') - {{Config::get('site.title')}}"));
     }
 
     public function testCustomExtensionsAreCompiled()

--- a/tests/View/Blade/BladeEchoHandlerTest.php
+++ b/tests/View/Blade/BladeEchoHandlerTest.php
@@ -2,30 +2,12 @@
 
 namespace Illuminate\Tests\View\Blade;
 
-use Exception;
-use Illuminate\Support\Fluent;
-use Illuminate\Support\Str;
-
 class BladeEchoHandlerTest extends AbstractBladeTestCase
 {
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->compiler->stringable(function (Fluent $object) {
-            return 'Hello World';
-        });
-    }
-
-    public function testBladeHandlersCanBeAddedForAGivenClass()
-    {
-        $this->assertSame('Hello World', $this->compiler->echoHandlers[Fluent::class](new Fluent()));
-    }
-
     public function testBladeHandlerCanInterceptRegularEchos()
     {
         $this->assertSame(
-            "<?php echo e(is_object(\$exampleObject) && isset(app('blade.compiler')->echoHandlers[get_class(\$exampleObject)]) ? call_user_func_array(app('blade.compiler')->echoHandlers[get_class(\$exampleObject)], [\$exampleObject]) : \$exampleObject); ?>",
+            '<?php echo e(is_object($exampleObject) ? $__env->stringifyObject($exampleObject) : ($exampleObject)); ?>',
             $this->compiler->compileString('{{$exampleObject}}')
         );
     }
@@ -33,7 +15,7 @@ class BladeEchoHandlerTest extends AbstractBladeTestCase
     public function testBladeHandlerCanInterceptRawEchos()
     {
         $this->assertSame(
-            "<?php echo is_object(\$exampleObject) && isset(app('blade.compiler')->echoHandlers[get_class(\$exampleObject)]) ? call_user_func_array(app('blade.compiler')->echoHandlers[get_class(\$exampleObject)], [\$exampleObject]) : \$exampleObject; ?>",
+            '<?php echo is_object($exampleObject) ? $__env->stringifyObject($exampleObject) : ($exampleObject); ?>',
             $this->compiler->compileString('{!!$exampleObject!!}')
         );
     }
@@ -41,7 +23,7 @@ class BladeEchoHandlerTest extends AbstractBladeTestCase
     public function testBladeHandlerCanInterceptEscapedEchos()
     {
         $this->assertSame(
-            "<?php echo e(is_object(\$exampleObject) && isset(app('blade.compiler')->echoHandlers[get_class(\$exampleObject)]) ? call_user_func_array(app('blade.compiler')->echoHandlers[get_class(\$exampleObject)], [\$exampleObject]) : \$exampleObject); ?>",
+            '<?php echo e(is_object($exampleObject) ? $__env->stringifyObject($exampleObject) : ($exampleObject)); ?>',
             $this->compiler->compileString('{{{$exampleObject}}}')
         );
     }
@@ -49,29 +31,8 @@ class BladeEchoHandlerTest extends AbstractBladeTestCase
     public function testWhitespaceIsPreservedCorrectly()
     {
         $this->assertSame(
-            "<?php echo e(is_object(\$exampleObject) && isset(app('blade.compiler')->echoHandlers[get_class(\$exampleObject)]) ? call_user_func_array(app('blade.compiler')->echoHandlers[get_class(\$exampleObject)], [\$exampleObject]) : \$exampleObject); ?>\n\n",
+            "<?php echo e(is_object(\$exampleObject) ? \$__env->stringifyObject(\$exampleObject) : (\$exampleObject)); ?>\n\n",
             $this->compiler->compileString("{{\$exampleObject}}\n")
-        );
-    }
-
-    public function testHandlerLogicWorksCorrectly()
-    {
-        $this->expectExceptionMessage('The fluent object has been successfully handled!');
-
-        $this->compiler->stringable(Fluent::class, function ($object) {
-            throw new Exception('The fluent object has been successfully handled!');
-        });
-
-        app()->singleton('blade.compiler', function () {
-            return $this->compiler;
-        });
-
-        $exampleObject = new Fluent();
-
-        eval(
-            Str::of($this->compiler->compileString('{{$exampleObject}}'))
-            ->after('<?php')
-            ->beforeLast('?>')
         );
     }
 }

--- a/tests/View/Blade/BladeEchoTest.php
+++ b/tests/View/Blade/BladeEchoTest.php
@@ -6,45 +6,45 @@ class BladeEchoTest extends AbstractBladeTestCase
 {
     public function testEchosAreCompiled()
     {
-        $this->assertSame('<?php echo $name; ?>', $this->compiler->compileString('{!!$name!!}'));
-        $this->assertSame('<?php echo $name; ?>', $this->compiler->compileString('{!! $name !!}'));
-        $this->assertSame('<?php echo $name; ?>', $this->compiler->compileString('{!!
+        $this->assertSame('<?php echo is_object($name) ? $__env->stringifyObject($name) : ($name); ?>', $this->compiler->compileString('{!!$name!!}'));
+        $this->assertSame('<?php echo is_object($name) ? $__env->stringifyObject($name) : ($name); ?>', $this->compiler->compileString('{!! $name !!}'));
+        $this->assertSame('<?php echo is_object($name) ? $__env->stringifyObject($name) : ($name); ?>', $this->compiler->compileString('{!!
             $name
         !!}'));
 
-        $this->assertSame('<?php echo e($name); ?>', $this->compiler->compileString('{{{$name}}}'));
-        $this->assertSame('<?php echo e($name); ?>', $this->compiler->compileString('{{$name}}'));
-        $this->assertSame('<?php echo e($name); ?>', $this->compiler->compileString('{{ $name }}'));
-        $this->assertSame('<?php echo e($name); ?>', $this->compiler->compileString('{{
+        $this->assertSame('<?php echo e(is_object($name) ? $__env->stringifyObject($name) : ($name)); ?>', $this->compiler->compileString('{{{$name}}}'));
+        $this->assertSame('<?php echo e(is_object($name) ? $__env->stringifyObject($name) : ($name)); ?>', $this->compiler->compileString('{{$name}}'));
+        $this->assertSame('<?php echo e(is_object($name) ? $__env->stringifyObject($name) : ($name)); ?>', $this->compiler->compileString('{{ $name }}'));
+        $this->assertSame('<?php echo e(is_object($name) ? $__env->stringifyObject($name) : ($name)); ?>', $this->compiler->compileString('{{
             $name
         }}'));
-        $this->assertSame("<?php echo e(\$name); ?>\n\n", $this->compiler->compileString("{{ \$name }}\n"));
-        $this->assertSame("<?php echo e(\$name); ?>\r\n\r\n", $this->compiler->compileString("{{ \$name }}\r\n"));
-        $this->assertSame("<?php echo e(\$name); ?>\n\n", $this->compiler->compileString("{{ \$name }}\n"));
-        $this->assertSame("<?php echo e(\$name); ?>\r\n\r\n", $this->compiler->compileString("{{ \$name }}\r\n"));
+        $this->assertSame("<?php echo e(is_object(\$name) ? \$__env->stringifyObject(\$name) : (\$name)); ?>\n\n", $this->compiler->compileString("{{ \$name }}\n"));
+        $this->assertSame("<?php echo e(is_object(\$name) ? \$__env->stringifyObject(\$name) : (\$name)); ?>\r\n\r\n", $this->compiler->compileString("{{ \$name }}\r\n"));
+        $this->assertSame("<?php echo e(is_object(\$name) ? \$__env->stringifyObject(\$name) : (\$name)); ?>\n\n", $this->compiler->compileString("{{ \$name }}\n"));
+        $this->assertSame("<?php echo e(is_object(\$name) ? \$__env->stringifyObject(\$name) : (\$name)); ?>\r\n\r\n", $this->compiler->compileString("{{ \$name }}\r\n"));
 
-        $this->assertSame('<?php echo e("Hello world or foo"); ?>',
+        $this->assertSame('<?php echo e(is_object("Hello world or foo") ? $__env->stringifyObject("Hello world or foo") : ("Hello world or foo")); ?>',
             $this->compiler->compileString('{{ "Hello world or foo" }}'));
-        $this->assertSame('<?php echo e("Hello world or foo"); ?>',
+        $this->assertSame('<?php echo e(is_object("Hello world or foo") ? $__env->stringifyObject("Hello world or foo") : ("Hello world or foo")); ?>',
             $this->compiler->compileString('{{"Hello world or foo"}}'));
-        $this->assertSame('<?php echo e($foo + $or + $baz); ?>', $this->compiler->compileString('{{$foo + $or + $baz}}'));
-        $this->assertSame('<?php echo e("Hello world or foo"); ?>', $this->compiler->compileString('{{
+        $this->assertSame('<?php echo e(is_object($foo + $or + $baz) ? $__env->stringifyObject($foo + $or + $baz) : ($foo + $or + $baz)); ?>', $this->compiler->compileString('{{$foo + $or + $baz}}'));
+        $this->assertSame('<?php echo e(is_object("Hello world or foo") ? $__env->stringifyObject("Hello world or foo") : ("Hello world or foo")); ?>', $this->compiler->compileString('{{
             "Hello world or foo"
         }}'));
 
-        $this->assertSame('<?php echo e(\'Hello world or foo\'); ?>',
+        $this->assertSame('<?php echo e(is_object(\'Hello world or foo\') ? $__env->stringifyObject(\'Hello world or foo\') : (\'Hello world or foo\')); ?>',
             $this->compiler->compileString('{{ \'Hello world or foo\' }}'));
-        $this->assertSame('<?php echo e(\'Hello world or foo\'); ?>',
+        $this->assertSame('<?php echo e(is_object(\'Hello world or foo\') ? $__env->stringifyObject(\'Hello world or foo\') : (\'Hello world or foo\')); ?>',
             $this->compiler->compileString('{{\'Hello world or foo\'}}'));
-        $this->assertSame('<?php echo e(\'Hello world or foo\'); ?>', $this->compiler->compileString('{{
+        $this->assertSame('<?php echo e(is_object(\'Hello world or foo\') ? $__env->stringifyObject(\'Hello world or foo\') : (\'Hello world or foo\')); ?>', $this->compiler->compileString('{{
             \'Hello world or foo\'
         }}'));
 
-        $this->assertSame('<?php echo e(myfunc(\'foo or bar\')); ?>',
+        $this->assertSame('<?php echo e(is_object(myfunc(\'foo or bar\')) ? $__env->stringifyObject(myfunc(\'foo or bar\')) : (myfunc(\'foo or bar\'))); ?>',
             $this->compiler->compileString('{{ myfunc(\'foo or bar\') }}'));
-        $this->assertSame('<?php echo e(myfunc("foo or bar")); ?>',
+        $this->assertSame('<?php echo e(is_object(myfunc("foo or bar")) ? $__env->stringifyObject(myfunc("foo or bar")) : (myfunc("foo or bar"))); ?>',
             $this->compiler->compileString('{{ myfunc("foo or bar") }}'));
-        $this->assertSame('<?php echo e(myfunc("$name or \'foo\'")); ?>',
+        $this->assertSame('<?php echo e(is_object(myfunc("$name or \'foo\'")) ? $__env->stringifyObject(myfunc("$name or \'foo\'")) : (myfunc("$name or \'foo\'"))); ?>',
             $this->compiler->compileString('{{ myfunc("$name or \'foo\'") }}'));
     }
 

--- a/tests/View/Blade/BladeErrorTest.php
+++ b/tests/View/Blade/BladeErrorTest.php
@@ -16,7 +16,7 @@ $__bag = $errors->getBag($__errorArgs[1] ?? \'default\');
 if ($__bag->has($__errorArgs[0])) :
 if (isset($message)) { $__messageOriginal = $message; }
 $message = $__bag->first($__errorArgs[0]); ?>
-    <span><?php echo e($message); ?></span>
+    <span><?php echo e(is_object($message) ? $__env->stringifyObject($message) : ($message)); ?></span>
 <?php unset($message);
 if (isset($__messageOriginal)) { $message = $__messageOriginal; }
 endif;
@@ -37,7 +37,7 @@ $__bag = $errors->getBag($__errorArgs[1] ?? \'default\');
 if ($__bag->has($__errorArgs[0])) :
 if (isset($message)) { $__messageOriginal = $message; }
 $message = $__bag->first($__errorArgs[0]); ?>
-    <span><?php echo e($message); ?></span>
+    <span><?php echo e(is_object($message) ? $__env->stringifyObject($message) : ($message)); ?></span>
 <?php unset($message);
 if (isset($__messageOriginal)) { $message = $__messageOriginal; }
 endif;

--- a/tests/View/Blade/BladeExpressionTest.php
+++ b/tests/View/Blade/BladeExpressionTest.php
@@ -11,8 +11,8 @@ class BladeExpressionTest extends AbstractBladeTestCase
 
     public function testExpressionWithinHTML()
     {
-        $this->assertSame('<html <?php echo e($foo); ?>>', $this->compiler->compileString('<html {{ $foo }}>'));
-        $this->assertSame('<html<?php echo e($foo); ?>>', $this->compiler->compileString('<html{{ $foo }}>'));
-        $this->assertSame('<html <?php echo e($foo); ?> <?php echo app(\'translator\')->get(\'foo\'); ?>>', $this->compiler->compileString('<html {{ $foo }} @lang(\'foo\')>'));
+        $this->assertSame('<html <?php echo e(is_object($foo) ? $__env->stringifyObject($foo) : ($foo)); ?>>', $this->compiler->compileString('<html {{ $foo }}>'));
+        $this->assertSame('<html<?php echo e(is_object($foo) ? $__env->stringifyObject($foo) : ($foo)); ?>>', $this->compiler->compileString('<html{{ $foo }}>'));
+        $this->assertSame('<html <?php echo e(is_object($foo) ? $__env->stringifyObject($foo) : ($foo)); ?> <?php echo app(\'translator\')->get(\'foo\'); ?>>', $this->compiler->compileString('<html {{ $foo }} @lang(\'foo\')>'));
     }
 }

--- a/tests/View/Blade/BladeForeachStatementsTest.php
+++ b/tests/View/Blade/BladeForeachStatementsTest.php
@@ -86,7 +86,7 @@ tag info
     <input {{ \$foo ? 'bar': 'baz' }}>
 @endforeach";
         $expected = "<?php \$__currentLoopData = resolve('App\\\\DataProviders\\\\'.\$provider)->data(); \$__env->addLoop(\$__currentLoopData); foreach(\$__currentLoopData as \$key => \$value): \$__env->incrementLoopIndices(); \$loop = \$__env->getLastLoop(); ?>
-    <input <?php echo e(\$foo ? 'bar': 'baz'); ?>>
+    <input <?php echo e(is_object(\$foo ? 'bar': 'baz') ? \$__env->stringifyObject(\$foo ? 'bar': 'baz') : (\$foo ? 'bar': 'baz')); ?>>
 <?php endforeach; \$__env->popLoop(); \$loop = \$__env->getLastLoop(); ?>";
 
         $this->assertEquals($expected, $this->compiler->compileString($string));

--- a/tests/View/Blade/BladePhpStatementsTest.php
+++ b/tests/View/Blade/BladePhpStatementsTest.php
@@ -18,7 +18,7 @@ class BladePhpStatementsTest extends AbstractBladeTestCase
         $this->assertEquals($expected, $this->compiler->compileString($string));
 
         $string = '{{ "Ignore: @php" }}';
-        $expected = '<?php echo e("Ignore: @php"); ?>';
+        $expected = '<?php echo e(is_object("Ignore: @php") ? $__env->stringifyObject("Ignore: @php") : ("Ignore: @php")); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
@@ -38,7 +38,7 @@ class BladePhpStatementsTest extends AbstractBladeTestCase
 
         $expected = " {{ Hello, I'm not blade! }}"
                 ."\n@php echo 'And I'm not PHP!' @endphp"
-                ."\n <?php echo e('I am Blade'); ?>"
+                ."\n <?php echo e(is_object('I am Blade') ? \$__env->stringifyObject('I am Blade') : ('I am Blade')); ?>"
                 ."\n\n<?php echo 'I am PHP {{ not Blade }}' ?>";
 
         $this->assertEquals($expected, $this->compiler->compileString($string));

--- a/tests/View/Blade/BladeVerbatimTest.php
+++ b/tests/View/Blade/BladeVerbatimTest.php
@@ -33,7 +33,7 @@ class BladeVerbatimTest extends AbstractBladeTestCase
     public function testMultipleVerbatimBlocksAreCompiled()
     {
         $string = '@verbatim {{ $a }} @endverbatim {{ $b }} @verbatim {{ $c }} @endverbatim';
-        $expected = ' {{ $a }}  <?php echo e($b); ?>  {{ $c }} ';
+        $expected = ' {{ $a }}  <?php echo e(is_object($b) ? $__env->stringifyObject($b) : ($b)); ?>  {{ $c }} ';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
@@ -61,13 +61,13 @@ class BladeVerbatimTest extends AbstractBladeTestCase
 @endverbatim 
 @php echo $fifth; @endphp';
 
-        $expected = '<?php echo e($first); ?>
+        $expected = '<?php echo e(is_object($first) ? $__env->stringifyObject($first) : ($first)); ?>
 
 <?php
     echo $second;
 ?>
 <?php if($conditional): ?>
-    <?php echo e($third); ?>
+    <?php echo e(is_object($third) ? $__env->stringifyObject($third) : ($third)); ?>
 
 <?php endif; ?>
 <?php echo $__env->make("users", \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -99,9 +99,9 @@ class ViewBladeCompilerTest extends TestCase
         $compiler = new BladeCompiler($this->getFiles(), __DIR__);
         $compiler->setEchoFormat('%s');
 
-        $this->assertSame('<?php echo e($name); ?>', $compiler->compileString('{{{ $name }}}'));
-        $this->assertSame('<?php echo $name; ?>', $compiler->compileString('{{ $name }}'));
-        $this->assertSame('<?php echo $name; ?>', $compiler->compileString('{{
+        $this->assertSame('<?php echo e(is_object($name) ? $__env->stringifyObject($name) : ($name)); ?>', $compiler->compileString('{{{ $name }}}'));
+        $this->assertSame('<?php echo is_object($name) ? $__env->stringifyObject($name) : ($name); ?>', $compiler->compileString('{{ $name }}'));
+        $this->assertSame('<?php echo is_object($name) ? $__env->stringifyObject($name) : ($name); ?>', $compiler->compileString('{{
             $name
         }}'));
     }

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -10,7 +10,9 @@ use Illuminate\Contracts\View\Engine;
 use Illuminate\Contracts\View\View as ViewContract;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Fluent;
 use Illuminate\Support\HtmlString;
+use Illuminate\Support\MessageBag;
 use Illuminate\View\Compilers\CompilerInterface;
 use Illuminate\View\Engines\CompilerEngine;
 use Illuminate\View\Engines\EngineResolver;
@@ -762,6 +764,24 @@ class ViewFactoryTest extends TestCase
             return 'Hello World';
         });
         $this->assertSame('Hello World', $factory->getFoo());
+    }
+
+    public function testEchoForRegisteredClass()
+    {
+        $factory = $this->getFactory();
+
+        $factory->stringable(Fluent::class, function (Fluent $object) {
+            return 'String value for object';
+        });
+
+        $this->assertEquals('String value for object', $factory->stringifyObject(new Fluent));
+    }
+
+    public function testEchoForNotRegisteredClass()
+    {
+        $factory = $this->getFactory();
+
+        $this->assertEquals('[]', $factory->stringifyObject(new MessageBag));
     }
 
     protected function getFactory()


### PR DESCRIPTION
The current implementation compiles echo statements with ternary operators (e.g. `{{ $test ? "1" : "2" }}` to the following code which throws a `FatalError` on PHP 8:

```php
<?php echo e(is_object($test? "1" : "2") && isset(app('blade.compiler')->echoHandlers[get_class($test? "1" : "2")]) ? call_user_func_array(app('blade.compiler')->echoHandlers[get_class($test? "1" : "2")], [$test? "1" : "2"]) : $test? "1" : "2"); ?>
```

This PR tries to fix that issue by generating a compiled view without an included ternary operator.