### PR TITLE
[9.x] Combine signed url fix and feature addition PRs

### DIFF
--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -85,5 +85,9 @@ class FoundationServiceProvider extends AggregateServiceProvider
         Request::macro('hasValidRelativeSignature', function () {
             return URL::hasValidSignature($this, $absolute = false);
         });
+
+        Request::macro('hasValidSignatureWithExceptions', function ($ignoreQuery = [], $absolute = true) {
+            return URL::hasValidSignature($this, $absolute, $ignoreQuery);
+        });
     }
 }

--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -85,9 +85,5 @@ class FoundationServiceProvider extends AggregateServiceProvider
         Request::macro('hasValidRelativeSignature', function () {
             return URL::hasValidSignature($this, $absolute = false);
         });
-
-        Request::macro('hasValidSignatureWithExceptions', function ($ignoreQuery = [], $absolute = true) {
-            return URL::hasValidSignature($this, $absolute, $ignoreQuery);
-        });
     }
 }

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -393,16 +393,9 @@ class UrlGenerator implements UrlGeneratorContract
 
         $url = $absolute ? $request->url() : '/'.$request->path();
 
-        $queryString = $request->server->get('QUERY_STRING');
-        foreach ($ignoreQuery as $ignore) {
-            if (strlen($ignore) === 0) {
-                continue;
-            }
-
-            $queryString = ltrim(
-                preg_replace('/(^|&)'.preg_quote($ignore).'((=[^&]*)|(=?(&|$)))/', '', $queryString),
-            '&');
-        }
+        $queryString = collect(explode('&', $request->server->get('QUERY_STRING')))
+            ->filter(fn ($parameter) => ! in_array(Str::before($parameter, '='), $ignoreQuery))
+            ->join('&');
 
         $original = rtrim($url.'?'.$queryString, '?');
 

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -399,7 +399,9 @@ class UrlGenerator implements UrlGeneratorContract
                 continue;
             }
 
-            $queryString = ltrim(preg_replace('/(^|&)'.preg_quote($ignore).'=?[^&]*/', '', $queryString), '&');
+            $queryString = ltrim(
+                preg_replace('/(^|&)'.preg_quote($ignore).'((=[^&]*)|(=?(&|$)))/', '', $queryString),
+            '&');
         }
 
         $original = rtrim($url.'?'.$queryString, '?');

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -395,7 +395,11 @@ class UrlGenerator implements UrlGeneratorContract
 
         $queryString = $request->server->get('QUERY_STRING');
         foreach ($ignoreQuery as $ignore) {
-            $queryString = ltrim(preg_replace("/(^|&){$ignore}=[^&]+/", '', $queryString), '&');
+            if (strlen($ignore) === 0) {
+                continue;
+            }
+
+            $queryString = ltrim(preg_replace('/(^|&)'.preg_quote($ignore).'=?[^&]*/', '', $queryString), '&');
         }
 
         $original = rtrim($url.'?'.$queryString, '?');

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -394,7 +394,7 @@ class UrlGenerator implements UrlGeneratorContract
         $url = $absolute ? $request->url() : '/'.$request->path();
 
         $queryString = collect(explode('&', $request->server->get('QUERY_STRING')))
-            ->filter(fn ($parameter) => ! in_array(Str::before($parameter, '='), $ignoreQuery))
+            ->reject(fn ($parameter) => in_array(Str::before($parameter, '='), $ignoreQuery))
             ->join('&');
 
         $original = rtrim($url.'?'.$queryString, '?');

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -393,9 +393,12 @@ class UrlGenerator implements UrlGeneratorContract
 
         $url = $absolute ? $request->url() : '/'.$request->path();
 
-        $original = rtrim($url.'?'.Arr::query(
-            Arr::except($request->query(), $ignoreQuery)
-        ), '?');
+        $queryString = $request->server->get('QUERY_STRING');
+        foreach ($ignoreQuery as $ignore) {
+            $queryString = ltrim(preg_replace("/(^|&){$ignore}=[^&]+/", '', $queryString), '&');
+        }
+
+        $original = rtrim($url.'?'.$queryString, '?');
 
         $signature = hash_hmac('sha256', $original, call_user_func($this->keyResolver));
 

--- a/tests/Integration/Routing/UrlSigningTest.php
+++ b/tests/Integration/Routing/UrlSigningTest.php
@@ -167,6 +167,20 @@ class UrlSigningTest extends TestCase
         $this->assertSame('valid', $this->get($url.'&*=value&[a-z]+=value')->original);
     }
 
+    public function testExceptedParameterCanBeAPrefixOrSuffixOfAnotherParameter()
+    {
+        Route::get('/foo/{id}', function (Request $request, $id) {
+            return $request->hasValidSignatureWithExceptions(['pre', 'fix']) ? 'valid' : 'invalid';
+        })->name('foo');
+
+        $this->assertIsString($url = URL::signedRoute('foo', ['id' => 1,
+            'prefix' => 'value',
+            'suffix' => 'value',
+        ]));
+
+        $this->assertSame('valid', $this->get($url.'&pre=fix&fix=suff')->original);
+    }
+
     public function testSignedMiddleware()
     {
         Route::get('/foo/{id}', function (Request $request, $id) {


### PR DESCRIPTION
This PR combines the work of https://github.com/laravel/framework/pull/36974 (a feature addition to Laravel 9, later improved by https://github.com/laravel/framework/commit/7994795a89001505fa29199d0371d668b9fb9da7) and https://github.com/laravel/framework/pull/37432 (a bug and security fix in Laravel 8), as these two are conflicting when merging 8.x back into master. The original work was done by @introwit and @jelib3an 

The added tests here are exactly the same as in https://github.com/laravel/framework/pull/37432 along with one additional test for the excepted parameters feature which was previously untested.

I decided to add a new macro in order to use the validation with exceptions, rather than adding another parameter to the existing macro. The reasoning for this is:
 * I wanted exceptions to be very explicit, such that they never apply by mistake.
 * I did not want to force the user to provide the `$absolute` parameter. This is supported in the new macro but as a second optional parameter.

~~I did change the variable names slightly from the previous implementation, specifically `$exceptedParameters` instead of `$ignoreQuery`. Let me know if I should revert that change.~~ Reverted.

If this is merged, I'd be happy to make a documentation PR for the added request macro.

 
