### PR TITLE
[8.x] Fix inconsistency in table names in validator

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -805,6 +805,9 @@ trait ValidatesAttributes
 
             $table = $model->getTable();
             $connection = $connection ?? $model->getConnectionName();
+            if (Str::contains($table, '.') && Str::startsWith($table, $connection)) {
+                $connection = null;
+            }
             $idColumn = $model->getKeyName();
         }
 

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -805,9 +805,11 @@ trait ValidatesAttributes
 
             $table = $model->getTable();
             $connection = $connection ?? $model->getConnectionName();
+
             if (Str::contains($table, '.') && Str::startsWith($table, $connection)) {
                 $connection = null;
             }
+
             $idColumn = $model->getKeyName();
         }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4955,6 +4955,14 @@ class ValidationValidatorTest extends TestCase
         $this->assertNull($explicit_no_connection[0]);
         $this->assertSame('explicits', $explicit_no_connection[1]);
 
+        $explicit_model_with_prefix = $v->parseTable(ExplicitPrefixedTableModel::class);
+        $this->assertNull($explicit_model_with_prefix[0]);
+        $this->assertSame('prefix.explicits', $explicit_model_with_prefix[1]);
+
+        $explicit_table_with_connection_prefix = $v->parseTable('connection.table');
+        $this->assertSame('connection', $explicit_table_with_connection_prefix[0]);
+        $this->assertSame('table', $explicit_table_with_connection_prefix[1]);
+
         $noneloquent_no_connection = $v->parseTable(NonEloquentModel::class);
         $this->assertNull($noneloquent_no_connection[0]);
         $this->assertEquals(NonEloquentModel::class, $noneloquent_no_connection[1]);
@@ -6204,6 +6212,13 @@ class ImplicitTableModel extends Model
 class ExplicitTableModel extends Model
 {
     protected $table = 'explicits';
+    protected $guarded = [];
+    public $timestamps = false;
+}
+
+class ExplicitPrefixedTableModel extends Model
+{
+    protected $table = 'prefix.explicits';
     protected $guarded = [];
     public $timestamps = false;
 }


### PR DESCRIPTION
This PR fix a issue where the ValidatesAttributes::parseTable return the wrong table when the $table attribute in the model is prefixed with a schema. This PR only affects calls where the model itself is provided as argument and it has a prefixed table name like `$table = 'prefix.table'`, so it should be backwards compatible, 

I also added two assertions to try to ensure this change does not affect other scenarios.

The original issue #37580 

The problem:

```php
Schema::create('public.users', function (Blueprint $table) { }); // works

$table = 'public.users'; // works

DB::table('public.users')->first() //works

class User extends Model {
   $table = 'public.users';
}
Rule::unique(User::class) // don't work -> Database connection [public] not configured.
```
