### PR TITLE
Avoid fetching user data on every call for the current request even for non logged-in user.

### DIFF
--- a/src/Illuminate/Auth/GuardHelpers.php
+++ b/src/Illuminate/Auth/GuardHelpers.php
@@ -25,6 +25,13 @@ trait GuardHelpers
     protected $provider;
 
     /**
+     * Indicates if the Authenticated user checked for the current request.
+     *
+     * @var bool
+     */
+    protected $isUserChecked = false;
+
+    /**
      * Determine if the current user is authenticated. If not, throw an exception.
      *
      * @return \Illuminate\Contracts\Auth\Authenticatable

--- a/src/Illuminate/Auth/RequestGuard.php
+++ b/src/Illuminate/Auth/RequestGuard.php
@@ -50,9 +50,11 @@ class RequestGuard implements Guard
         // If we've already retrieved the user for the current request we can just
         // return it back immediately. We do not want to fetch the user data on
         // every call to this method because that would be tremendously slow.
-        if (! is_null($this->user)) {
+        if ($this->isUserChecked) {
             return $this->user;
         }
+
+        $this->isUserChecked = true;
 
         return $this->user = call_user_func(
             $this->callback, $this->request, $this->getProvider()

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -129,9 +129,11 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
         // If we've already retrieved the user for the current request we can just
         // return it back immediately. We do not want to fetch the user data on
         // every call to this method because that would be tremendously slow.
-        if (! is_null($this->user)) {
+        if ($this->isUserChecked) {
             return $this->user;
         }
+
+        $this->isUserChecked = true;
 
         $id = $this->session->get($this->getName());
 

--- a/src/Illuminate/Auth/TokenGuard.php
+++ b/src/Illuminate/Auth/TokenGuard.php
@@ -72,9 +72,11 @@ class TokenGuard implements Guard
         // If we've already retrieved the user for the current request we can just
         // return it back immediately. We do not want to fetch the user data on
         // every call to this method because that would be tremendously slow.
-        if (! is_null($this->user)) {
+        if ($this->isUserChecked) {
             return $this->user;
         }
+
+        $this->isUserChecked = true;
 
         $user = null;
 


### PR DESCRIPTION
## Avoid fetching user data on every call for the current request even for non logged-in user.

The current implementation of null check always tries to fetch user details from database on every call, and every time it will return null and pass null check condition as user is not logged in.
```php
if (! is_null($this->user))
```

This PR tries to fix this issue by relying on one extra boolean varible for checking whether user function has been called once.