### PR TITLE
[8.x] Fixes for Stringable (updated)

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\View\Compilers;
 
-use Closure;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\ReflectsClosures;
@@ -259,7 +258,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
         // If there are blade echo handlers defined, we will prepend the file
         // with a resolved instance of the blade compiler, stored inside a
         // variable, so that it only has to be resolved a single time.
-        if (!empty($this->echoHandlers)) {
+        if (! empty($this->echoHandlers)) {
             $result = $this->addBladeCompilerVariable($result);
         }
 

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -103,13 +103,6 @@ class BladeCompiler extends Compiler implements CompilerInterface
     protected $echoFormat = 'e(%s)';
 
     /**
-     * Custom rendering callbacks for stringable objects.
-     *
-     * @var array
-     */
-    public $echoHandlers = [];
-
-    /**
      * Array of footer lines to be added to the template.
      *
      * @var array
@@ -261,6 +254,13 @@ class BladeCompiler extends Compiler implements CompilerInterface
         // template inheritance via the extends keyword that should be appended.
         if (count($this->footer) > 0) {
             $result = $this->addFooters($result);
+        }
+
+        // If there are blade echo handlers defined, we will prepend the file
+        // with a resolved instance of the blade compiler, stored inside a
+        // variable, so that it only has to be resolved a single time.
+        if (!empty($this->echoHandlers)) {
+            $result = $this->addBladeCompilerVariable($result);
         }
 
         return str_replace(
@@ -709,22 +709,6 @@ class BladeCompiler extends Compiler implements CompilerInterface
     public function getCustomDirectives()
     {
         return $this->customDirectives;
-    }
-
-    /**
-     * Add a handler to be executed before echoing a given class.
-     *
-     * @param  string|callable  $class
-     * @param  callable|null  $handler
-     * @return void
-     */
-    public function stringable($class, $handler = null)
-    {
-        if ($class instanceof Closure) {
-            [$class, $handler] = [$this->firstClosureParameterType($class), $class];
-        }
-
-        $this->echoHandlers[$class] = $handler;
     }
 
     /**

--- a/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
@@ -130,7 +130,7 @@ trait CompilesEchos
      */
     protected function addBladeCompilerVariable($result)
     {
-        return "<?php \$__bladeCompiler = app('blade.compiler'); ?>" . $result;
+        return "<?php \$__bladeCompiler = app('blade.compiler'); ?>".$result;
     }
 
     /**
@@ -141,7 +141,7 @@ trait CompilesEchos
      */
     protected function wrapInEchoHandler($value)
     {
-        return empty($this->echoHandlers) ? $value : '$__bladeCompiler->applyEchoHandler(' . Str::beforeLast($value, ';') . ')';
+        return empty($this->echoHandlers) ? $value : '$__bladeCompiler->applyEchoHandler('.Str::beforeLast($value, ';').')';
     }
 
     /**

--- a/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
@@ -2,8 +2,34 @@
 
 namespace Illuminate\View\Compilers\Concerns;
 
+use Closure;
+use Illuminate\Support\Str;
+
 trait CompilesEchos
 {
+    /**
+     * Custom rendering callbacks for stringable objects.
+     *
+     * @var array
+     */
+    protected $echoHandlers = [];
+
+    /**
+     * Add a handler to be executed before echoing a given class.
+     *
+     * @param  string|callable  $class
+     * @param  callable|null  $handler
+     * @return void
+     */
+    public function stringable($class, $handler = null)
+    {
+        if ($class instanceof Closure) {
+            [$class, $handler] = [$this->firstClosureParameterType($class), $class];
+        }
+
+        $this->echoHandlers[$class] = $handler;
+    }
+
     /**
      * Compile Blade echos into valid PHP.
      *
@@ -48,7 +74,7 @@ trait CompilesEchos
 
             return $matches[1]
                 ? substr($matches[0], 1)
-                : "<?php echo {$this->applyEchoHandlerFor($matches[2])}; ?>{$whitespace}";
+                : "<?php echo {$this->wrapInEchoHandler($matches[2])}; ?>{$whitespace}";
         };
 
         return preg_replace_callback($pattern, $callback, $value);
@@ -67,7 +93,7 @@ trait CompilesEchos
         $callback = function ($matches) {
             $whitespace = empty($matches[3]) ? '' : $matches[3].$matches[3];
 
-            $wrapped = sprintf($this->echoFormat, $this->applyEchoHandlerFor($matches[2]));
+            $wrapped = sprintf($this->echoFormat, $this->wrapInEchoHandler($matches[2]));
 
             return $matches[1] ? substr($matches[0], 1) : "<?php echo {$wrapped}; ?>{$whitespace}";
         };
@@ -90,10 +116,21 @@ trait CompilesEchos
 
             return $matches[1]
                 ? $matches[0]
-                : "<?php echo e({$this->applyEchoHandlerFor($matches[2])}); ?>{$whitespace}";
+                : "<?php echo e({$this->wrapInEchoHandler($matches[2])}); ?>{$whitespace}";
         };
 
         return preg_replace_callback($pattern, $callback, $value);
+    }
+
+    /**
+     * Add an instance of the blade echo handler to the start of the compiled string.
+     *
+     * @param string $result
+     * @return string
+     */
+    protected function addBladeCompilerVariable($result)
+    {
+        return "<?php \$__bladeCompiler = app('blade.compiler'); ?>" . $result;
     }
 
     /**
@@ -102,10 +139,23 @@ trait CompilesEchos
      * @param  string  $value
      * @return string
      */
-    protected function applyEchoHandlerFor($value)
+    protected function wrapInEchoHandler($value)
     {
-        return empty($this->echoHandlers)
-            ? $value
-            : "is_object($value) && isset(app('blade.compiler')->echoHandlers[get_class($value)]) ? call_user_func_array(app('blade.compiler')->echoHandlers[get_class($value)], [$value]) : $value";
+        return empty($this->echoHandlers) ? $value : '$__bladeCompiler->applyEchoHandler(' . Str::beforeLast($value, ';') . ')';
+    }
+
+    /**
+     * Apply the echo handler for the value if it exists.
+     *
+     * @param  $value  string
+     * @return string
+     */
+    public function applyEchoHandler($value)
+    {
+        if (is_object($value) && isset($this->echoHandlers[get_class($value)])) {
+            return call_user_func($this->echoHandlers[get_class($value)], $value);
+        }
+
+        return $value;
     }
 }

--- a/tests/View/Blade/BladeEchoHandlerTest.php
+++ b/tests/View/Blade/BladeEchoHandlerTest.php
@@ -86,7 +86,6 @@ class BladeEchoHandlerTest extends AbstractBladeTestCase
             return $this->compiler;
         });
 
-        // We output to the buffer to avoid outputting in the test console.
         ob_start();
         eval(Str::of($this->compiler->compileString($blade))->remove(['<?php', '?>']));
         $output = ob_get_contents();
@@ -100,7 +99,7 @@ class BladeEchoHandlerTest extends AbstractBladeTestCase
         return [
             ['{{"foo" . "bar"}}', 'foobar'],
             ['{{ 1 + 2 }}{{ "test"; }}', '3test'],
-            ['@php($test = "hi"){{ $test }}', 'hi']
+            ['@php($test = "hi"){{ $test }}', 'hi'],
         ];
     }
 }

--- a/tests/View/Blade/BladeEchoHandlerTest.php
+++ b/tests/View/Blade/BladeEchoHandlerTest.php
@@ -74,6 +74,8 @@ class BladeEchoHandlerTest extends AbstractBladeTestCase
         return [
             ['{{$exampleObject}}'],
             ['{{$exampleObject;}}'],
+            ['{{{$exampleObject;}}}'],
+            ['{!!$exampleObject;!!}'],
         ];
     }
 


### PR DESCRIPTION
This is an extension of (and replacement for) #37603. 

One of the concerns raised was the amount of times the `BladeCompiler` would need to be resolved from the container. In this PR, if an echo handler has been defined, the compiled view will have a variable prepended to it with the value of the blade compiler, and all handler statements will then reference this variable rather than resolving a fresh instance.

I have kept the reformatting from @ibrasho's PR.

This also handles the semicolon issue mentioned in https://github.com/livewire/livewire/pull/2935 by removing the semicolon at the end of an echo statement.

Here is an example of the new compiled output when an echo handler is found.

```php
<?php $__bladeCompiler = app('blade.compiler'); ?><!DOCTYPE html>
<html lang="<?php echo e($__bladeCompiler->applyEchoHandler(str_replace('_', '-', app()->getLocale()))); ?>">
// etc...
```