### PR TITLE
[8.x] Fix one-of-many bindings

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/CanBeOneOfMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/CanBeOneOfMany.php
@@ -205,6 +205,8 @@ trait CanBeOneOfMany
     protected function addOneOfManyJoinSubQuery(Builder $parent, Builder $subQuery, $on)
     {
         $parent->beforeQuery(function ($parent) use ($subQuery, $on) {
+            $subQuery->applyBeforeQueryCallbacks();
+
             $parent->joinSub($subQuery, $this->relationName, function ($join) use ($on) {
                 $join->on($this->qualifySubSelectColumn($on), '=', $this->qualifyRelatedColumn($on));
 

--- a/tests/Database/DatabaseEloquentHasOneOfManyTest.php
+++ b/tests/Database/DatabaseEloquentHasOneOfManyTest.php
@@ -380,22 +380,11 @@ class DatabaseEloquentHasOneOfManyTest extends TestCase
         $this->assertTrue($user->foo_state_exists);
     }
 
-    /**
-     * @group fix
-     */
     public function testSubqueryBindingsAreAdded()
     {
         $relation = HasOneOfManyTestUser::create()->latest_login_with_soft_deletes();
         $relation->applyBeforeQueryCallbacks();
         $this->assertCount(2, $relation->getBindings());
-    }
-
-    protected function getMySqlBuilder()
-    {
-        $grammar = new MySqlGrammar;
-        $processor = m::mock(Processor::class);
-
-        return new Builder(m::mock(ConnectionInterface::class), $grammar, $processor);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentHasOneOfManyTest.php
+++ b/tests/Database/DatabaseEloquentHasOneOfManyTest.php
@@ -42,6 +42,7 @@ class DatabaseEloquentHasOneOfManyTest extends TestCase
         $this->schema()->create('logins', function ($table) {
             $table->increments('id');
             $table->foreignId('user_id');
+            $table->dateTime('deleted_at')->nullable();
         });
 
         $this->schema()->create('states', function ($table) {
@@ -380,11 +381,12 @@ class DatabaseEloquentHasOneOfManyTest extends TestCase
         $this->assertTrue($user->foo_state_exists);
     }
 
-    public function testSubqueryBindingsAreAdded()
+    public function testWithSoftDelets()
     {
-        $relation = HasOneOfManyTestUser::create()->latest_login_with_soft_deletes();
-        $relation->applyBeforeQueryCallbacks();
-        $this->assertCount(2, $relation->getBindings());
+        $user = HasOneOfManyTestUser::create();
+        $user->logins()->create();
+        $user->latest_login_with_soft_deletes;
+        $this->assertNotNull($user->latest_login_with_soft_deletes);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentHasOneOfManyTest.php
+++ b/tests/Database/DatabaseEloquentHasOneOfManyTest.php
@@ -381,7 +381,7 @@ class DatabaseEloquentHasOneOfManyTest extends TestCase
         $this->assertTrue($user->foo_state_exists);
     }
 
-    public function testWithSoftDelets()
+    public function testWithSoftDeletes()
     {
         $user = HasOneOfManyTestUser::create();
         $user->logins()->create();


### PR DESCRIPTION
This pr fixes https://github.com/laravel/framework/issues/37608. 

Bindings were not passed to the sub query, so all `beforeQuery` closures must be applied before passing the sub query to the join clause.

ping https://github.com/laravel/framework/pull/37362
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
