### PR TITLE
[8.x] Fire a `trashed` model event and listen to it for broadcasting events

### DIFF
--- a/src/Illuminate/Database/Eloquent/BroadcastableModelEventOccurred.php
+++ b/src/Illuminate/Database/Eloquent/BroadcastableModelEventOccurred.php
@@ -97,4 +97,14 @@ class BroadcastableModelEventOccurred implements ShouldBroadcast
 
         return $this;
     }
+
+    /**
+     * Get the event name.
+     *
+     * @return string
+     */
+    public function event()
+    {
+        return $this->event;
+    }
 }

--- a/src/Illuminate/Database/Eloquent/BroadcastsEvents.php
+++ b/src/Illuminate/Database/Eloquent/BroadcastsEvents.php
@@ -22,7 +22,7 @@ trait BroadcastsEvents
         });
 
         if (method_exists(static::class, 'bootSoftDeletes')) {
-            static::trashed(function ($model) {
+            static::softDeleted(function ($model) {
                 $model->broadcastTrashed();
             });
 

--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -96,6 +96,8 @@ trait SoftDeletes
         $query->update($columns);
 
         $this->syncOriginalAttributes(array_keys($columns));
+
+        $this->fireModelEvent('trashed', false);
     }
 
     /**
@@ -134,6 +136,17 @@ trait SoftDeletes
     public function trashed()
     {
         return ! is_null($this->{$this->getDeletedAtColumn()});
+    }
+
+    /**
+     * Register a "softDeleted" model event callback with the dispatcher.
+     *
+     * @param  \Closure|string  $callback
+     * @return void
+     */
+    public static function softDeleted($callback)
+    {
+        static::registerModelEvent('trashed', $callback);
     }
 
     /**

--- a/tests/Integration/Database/DatabaseEloquentBroadcastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentBroadcastingTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Integration\Database;
 use Illuminate\Database\Eloquent\BroadcastableModelEventOccurred;
 use Illuminate\Database\Eloquent\BroadcastsEvents;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Schema;
@@ -21,6 +22,7 @@ class DatabaseEloquentBroadcastingTest extends DatabaseTestCase
         Schema::create('test_eloquent_broadcasting_users', function (Blueprint $table) {
             $table->increments('id');
             $table->string('name');
+            $table->softDeletes();
             $table->timestamps();
         });
     }
@@ -46,11 +48,36 @@ class DatabaseEloquentBroadcastingTest extends DatabaseTestCase
 
         $this->assertEquals('Illuminate.Tests.Integration.Database.TestEloquentBroadcastUser.{testEloquentBroadcastUser}', $model->broadcastChannelRoute());
     }
+
+    public function testBroadcastingOnModelTrashing()
+    {
+        Event::fake([BroadcastableModelEventOccurred::class]);
+
+        $model = new SoftDeletableTestEloquentBroadcastUser;
+        $model->name = 'Bean';
+        $model->saveQuietly();
+
+        $model->delete();
+
+        Event::assertDispatched(function (BroadcastableModelEventOccurred $event) {
+            return $event->model instanceof SoftDeletableTestEloquentBroadcastUser &&
+                $event->event() == 'trashed' &&
+                count($event->broadcastOn()) === 1 &&
+                $event->broadcastOn()[0]->name == 'private-Illuminate.Tests.Integration.Database.SoftDeletableTestEloquentBroadcastUser.'.$event->model->id;
+        });
+    }
 }
 
 class TestEloquentBroadcastUser extends Model
 {
     use BroadcastsEvents;
+
+    protected $table = 'test_eloquent_broadcasting_users';
+}
+
+class SoftDeletableTestEloquentBroadcastUser extends Model
+{
+    use BroadcastsEvents, SoftDeletes;
 
     protected $table = 'test_eloquent_broadcasting_users';
 }


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/37601

This PR fires a `trashed` model event while soft deleting a model and listens to it inside the new `BroadcastsEvents` trait.