### PR TITLE
[8.x] Cast JSON strings containing single quotes

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -134,7 +134,9 @@ trait InteractsWithDatabase
             $value = json_encode($value);
         }
 
-        return DB::raw("CAST('$value' AS JSON)");
+        $value = DB::connection()->getPdo()->quote($value);
+
+        return DB::raw("CAST($value AS JSON)");
     }
 
     /**


### PR DESCRIPTION
When using the `castAsJson()` method my tests would sometimes fail because the faker created a string which contained a single quote. It would generate the following error:

> Illuminate\Database\QueryException : SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 's Bar"}' AS JSON))' at line 1 (SQL: select count(*) as aggregate from `table` where (`column` = CAST('{"for":"Baz's Bar"}' AS JSON)))


Example code to reproduce the bug:

```php
$this->assertDatabaseHas('table', [
    'column' => $this->castAsJson([
        'for' => "Baz's Bar",
    ]),
]);
```

This pull request tries to fix that bug. Hopefully, it's of any use.