### PR TITLE
[8.x] Add missing fix to DatabaseRule::resolveTableName fix #37580

### DIFF
--- a/src/Illuminate/Validation/Rules/DatabaseRule.php
+++ b/src/Illuminate/Validation/Rules/DatabaseRule.php
@@ -65,7 +65,7 @@ trait DatabaseRule
         if (is_subclass_of($table, Model::class)) {
             $model = new $table;
 
-            if(Str::contains($model->getTable(), '.')) {
+            if (Str::contains($model->getTable(), '.')) {
                 return $table;
             }
 

--- a/src/Illuminate/Validation/Rules/DatabaseRule.php
+++ b/src/Illuminate/Validation/Rules/DatabaseRule.php
@@ -65,6 +65,10 @@ trait DatabaseRule
         if (is_subclass_of($table, Model::class)) {
             $model = new $table;
 
+            if(Str::contains($model->getTable(), '.')) {
+                return $table;
+            }
+
             return implode('.', array_map(function (string $part) {
                 return trim($part, '.');
             }, array_filter([$model->getConnectionName(), $model->getTable()])));

--- a/tests/Validation/ValidationExistsRuleTest.php
+++ b/tests/Validation/ValidationExistsRuleTest.php
@@ -238,6 +238,7 @@ class User extends Eloquent
     protected $guarded = [];
     public $timestamps = false;
 }
+
 class UserWithPrefixedTable extends Eloquent
 {
     protected $table = 'public.users';

--- a/tests/Validation/ValidationExistsRuleTest.php
+++ b/tests/Validation/ValidationExistsRuleTest.php
@@ -43,6 +43,10 @@ class ValidationExistsRuleTest extends TestCase
         $rule->where('foo', 'bar');
         $this->assertSame('exists:users,NULL,foo,"bar"', (string) $rule);
 
+        $rule = new Exists(UserWithPrefixedTable::class);
+        $rule->where('foo', 'bar');
+        $this->assertSame('exists:'.UserWithPrefixedTable::class.',NULL,foo,"bar"', (string) $rule);
+
         $rule = new Exists('table', 'column');
         $rule->where('foo', 'bar');
         $this->assertSame('exists:table,column,foo,"bar"', (string) $rule);
@@ -231,6 +235,12 @@ class ValidationExistsRuleTest extends TestCase
 class User extends Eloquent
 {
     protected $table = 'users';
+    protected $guarded = [];
+    public $timestamps = false;
+}
+class UserWithPrefixedTable extends Eloquent
+{
+    protected $table = 'public.users';
     protected $guarded = [];
     public $timestamps = false;
 }

--- a/tests/Validation/ValidationUniqueRuleTest.php
+++ b/tests/Validation/ValidationUniqueRuleTest.php
@@ -35,6 +35,9 @@ class ValidationUniqueRuleTest extends TestCase
         $rule->where('foo', 'bar');
         $this->assertSame('unique:table,column,"Taylor, Otwell",id_column,foo,"bar"', (string) $rule);
 
+        $rule = new Unique(PrefixedTableEloquentModelStub::class);
+        $this->assertSame('unique:'.PrefixedTableEloquentModelStub::class.',NULL,NULL,id', (string) $rule);
+
         $rule = new Unique(EloquentModelStub::class, 'column');
         $rule->ignore('Taylor, Otwell', 'id_column');
         $rule->where('foo', 'bar');
@@ -83,6 +86,13 @@ class ValidationUniqueRuleTest extends TestCase
 class EloquentModelStub extends Model
 {
     protected $table = 'table';
+    protected $primaryKey = 'id_column';
+    protected $guarded = [];
+}
+
+class PrefixedTableEloquentModelStub extends Model
+{
+    protected $table = 'public.table';
     protected $primaryKey = 'id_column';
     protected $guarded = [];
 }


### PR DESCRIPTION
In my previous PR (#37606) I didn't noticed that the trait `DatabaseRule` has it's own `resolveTableName` method, and I did not apply the fixes there. This pull request adds the same fix to this trait. 