### PR TITLE
added the possibility to customize the validation error message in a …

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -73,6 +73,12 @@ class FormRequest extends Request implements ValidatesWhenResolved
     protected $validator;
 
     /**
+     * The message to be shown if validation fails.
+     *
+     */
+    protected $errorMessage;
+
+    /**
      * Get the validator instance for the request.
      *
      * @return \Illuminate\Contracts\Validation\Validator
@@ -134,9 +140,15 @@ class FormRequest extends Request implements ValidatesWhenResolved
      */
     protected function failedValidation(Validator $validator)
     {
-        throw (new ValidationException($validator))
+        $error = (new ValidationException($validator))
                     ->errorBag($this->errorBag)
                     ->redirectTo($this->getRedirectUrl());
+
+        if($this->errorMessage) {
+            $error->setMessage($this->errorMessage);
+        }
+
+        throw $error;
     }
 
     /**

--- a/src/Illuminate/Validation/ValidationException.php
+++ b/src/Illuminate/Validation/ValidationException.php
@@ -135,4 +135,16 @@ class ValidationException extends Exception
     {
         return $this->response;
     }
+
+    /**
+     * Set the message to be shown to on a validation error.
+     *
+     * @param  string  $message
+     * @return $this
+     */
+    public function setMessage($message){
+        $this->message = $message;
+
+        return $this;
+    }
 }

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -93,6 +93,18 @@ class FoundationFormRequestTest extends TestCase
         $request->validateResolved();
     }
 
+    public function testValidateThrowsCustomErrorMessageWhenValidationFails()
+    {
+        $message = "This is a custom error message";
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage($message);
+
+        $request = $this->createRequest(['no' => 'name'], FoundationTestFormRequestCustomErrorMessageStub::class);
+
+        $request->validateResolved();
+    }
+
     public function testValidateMethodThrowsWhenAuthorizationFails()
     {
         $this->expectException(AuthorizationException::class);
@@ -220,6 +232,21 @@ class FoundationFormRequestTest extends TestCase
 
 class FoundationTestFormRequestStub extends FormRequest
 {
+    public function rules()
+    {
+        return ['name' => 'required'];
+    }
+
+    public function authorize()
+    {
+        return true;
+    }
+}
+
+class FoundationTestFormRequestCustomErrorMessageStub extends FormRequest
+{
+    protected $errorMessage = "This is a custom error message";
+
     public function rules()
     {
         return ['name' => 'required'];


### PR DESCRIPTION
I have a use-case where I need to customize the 'The given data was invalid.' error message for a single API endpoint, so I added a variable for it in FormRequest, and function to support it in ValidationException.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
