### PR TITLE
Fix method arguments for session::flash() in the Facade.

### DIFF
--- a/src/Illuminate/Support/Facades/Session.php
+++ b/src/Illuminate/Support/Facades/Session.php
@@ -13,7 +13,7 @@ namespace Illuminate\Support\Facades;
  * @method static bool save()
  * @method static bool start()
  * @method static mixed get(string $key, $default = null)
- * @method static mixed flash(string $class, string $message)
+ * @method static mixed flash(string $key, $value = true)
  * @method static mixed pull(string $key, $default = null)
  * @method static mixed remove(string $key)
  * @method static string getId()


### PR DESCRIPTION
Just a small change to the method definition on the session facade. The argument names were not reflecting the actual arguments. 
