### PR TITLE
[9.x] Universal HigherOrderWhenProxy

### DIFF
--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -271,11 +271,11 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Apply the callback if the value is truthy.
      *
      * @param  bool  $value
-     * @param  callable  $callback
+     * @param  callable|null  $callback
      * @param  callable|null  $default
      * @return static|mixed
      */
-    public function when($value, callable $callback, callable $default = null);
+    public function when($value, callable $callback = null, callable $default = null);
 
     /**
      * Apply the callback if the collection is empty.

--- a/src/Illuminate/Collections/HigherOrderWhenProxy.php
+++ b/src/Illuminate/Collections/HigherOrderWhenProxy.php
@@ -2,17 +2,14 @@
 
 namespace Illuminate\Support;
 
-/**
- * @mixin \Illuminate\Support\Enumerable
- */
 class HigherOrderWhenProxy
 {
     /**
-     * The collection being operated on.
+     * The target being conditionally operated on.
      *
-     * @var \Illuminate\Support\Enumerable
+     * @var mixed
      */
-    protected $collection;
+    protected $target;
 
     /**
      * The condition for proxying.
@@ -24,18 +21,18 @@ class HigherOrderWhenProxy
     /**
      * Create a new proxy instance.
      *
-     * @param  \Illuminate\Support\Enumerable  $collection
+     * @param  mixed  $target
      * @param  bool  $condition
      * @return void
      */
-    public function __construct(Enumerable $collection, $condition)
+    public function __construct($target, $condition)
     {
+        $this->target = $target;
         $this->condition = $condition;
-        $this->collection = $collection;
     }
 
     /**
-     * Proxy accessing an attribute onto the collection.
+     * Proxy accessing an attribute onto the target.
      *
      * @param  string  $key
      * @return mixed
@@ -43,12 +40,12 @@ class HigherOrderWhenProxy
     public function __get($key)
     {
         return $this->condition
-            ? $this->collection->{$key}
-            : $this->collection;
+            ? $this->target->{$key}
+            : $this->target;
     }
 
     /**
-     * Proxy a method call onto the collection.
+     * Proxy a method call on the target.
      *
      * @param  string  $method
      * @param  array  $parameters
@@ -57,7 +54,7 @@ class HigherOrderWhenProxy
     public function __call($method, $parameters)
     {
         return $this->condition
-            ? $this->collection->{$method}(...$parameters)
-            : $this->collection;
+            ? $this->target->{$method}(...$parameters)
+            : $this->target;
     }
 }

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -11,7 +11,6 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Enumerable;
 use Illuminate\Support\HigherOrderCollectionProxy;
-use Illuminate\Support\HigherOrderWhenProxy;
 use JsonSerializable;
 use Symfony\Component\VarDumper\VarDumper;
 use Traversable;
@@ -45,6 +44,8 @@ use Traversable;
  */
 trait EnumeratesValues
 {
+    use Conditionable;
+
     /**
      * The methods that can be proxied.
      *
@@ -454,29 +455,6 @@ trait EnumeratesValues
     }
 
     /**
-     * Apply the callback if the value is truthy.
-     *
-     * @param  bool|mixed  $value
-     * @param  callable|null  $callback
-     * @param  callable|null  $default
-     * @return static|mixed
-     */
-    public function when($value, callable $callback = null, callable $default = null)
-    {
-        if (! $callback) {
-            return new HigherOrderWhenProxy($this, $value);
-        }
-
-        if ($value) {
-            return $callback($this, $value);
-        } elseif ($default) {
-            return $default($this, $value);
-        }
-
-        return $this;
-    }
-
-    /**
      * Apply the callback if the collection is empty.
      *
      * @param  callable  $callback
@@ -498,19 +476,6 @@ trait EnumeratesValues
     public function whenNotEmpty(callable $callback, callable $default = null)
     {
         return $this->when($this->isNotEmpty(), $callback, $default);
-    }
-
-    /**
-     * Apply the callback if the value is falsy.
-     *
-     * @param  bool  $value
-     * @param  callable  $callback
-     * @param  callable|null  $default
-     * @return static|mixed
-     */
-    public function unless($value, callable $callback, callable $default = null)
-    {
-        return $this->when(! $value, $callback, $default);
     }
 
     /**

--- a/src/Illuminate/Support/Traits/Conditionable.php
+++ b/src/Illuminate/Support/Traits/Conditionable.php
@@ -2,19 +2,25 @@
 
 namespace Illuminate\Support\Traits;
 
+use Illuminate\Support\HigherOrderWhenProxy;
+
 trait Conditionable
 {
     /**
      * Apply the callback if the given "value" is truthy.
      *
      * @param  mixed  $value
-     * @param  callable  $callback
+     * @param  callable|null  $callback
      * @param  callable|null  $default
      *
      * @return mixed
      */
-    public function when($value, $callback, $default = null)
+    public function when($value, callable $callback = null, callable $default = null)
     {
+        if (! $callback) {
+            return new HigherOrderWhenProxy($this, $value);
+        }
+
         if ($value) {
             return $callback($this, $value) ?: $this;
         } elseif ($default) {
@@ -28,13 +34,17 @@ trait Conditionable
      * Apply the callback if the given "value" is falsy.
      *
      * @param  mixed  $value
-     * @param  callable  $callback
+     * @param  callable|null  $callback
      * @param  callable|null  $default
      *
      * @return mixed
      */
-    public function unless($value, $callback, $default = null)
+    public function unless($value, callable $callback = null, callable $default = null)
     {
+        if (! $callback) {
+            return new HigherOrderWhenProxy($this, ! $value);
+        }
+
         if (! $value) {
             return $callback($this, $value) ?: $this;
         } elseif ($default) {

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -4298,7 +4298,7 @@ class SupportCollectionTest extends TestCase
     {
         $data = new $collection(['michael', 'tom']);
 
-        $data = $data->whenEmpty(function ($collection) {
+        $data = $data->whenEmpty(function ($data) {
             return $data->concat(['adam']);
         });
 
@@ -4365,6 +4365,30 @@ class SupportCollectionTest extends TestCase
         });
 
         $this->assertSame(['michael', 'tom', 'adam'], $data->toArray());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testHigherOrderWhenAndUnless($collection)
+    {
+        $data = new $collection(['michael', 'tom']);
+
+        $data = $data->when(true)->concat(['chris']);
+
+        $this->assertSame(['michael', 'tom', 'chris'], $data->toArray());
+
+        $data = $data->when(false)->concat(['adam']);
+
+        $this->assertSame(['michael', 'tom', 'chris'], $data->toArray());
+
+        $data = $data->unless(false)->concat(['adam']);
+
+        $this->assertSame(['michael', 'tom', 'chris', 'adam'], $data->toArray());
+
+        $data = $data->unless(true)->concat(['bogdan']);
+
+        $this->assertSame(['michael', 'tom', 'chris', 'adam'], $data->toArray());
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -4298,8 +4298,8 @@ class SupportCollectionTest extends TestCase
     {
         $data = new $collection(['michael', 'tom']);
 
-        $data = $data->whenEmpty(function ($data) {
-            return $data->concat(['adam']);
+        $data = $data->whenEmpty(function () {
+            throw new Exception('whenEmpty() should not trigger on a collection with items');
         });
 
         $this->assertSame(['michael', 'tom'], $data->toArray());

--- a/tests/Support/SupportConditionableTest.php
+++ b/tests/Support/SupportConditionableTest.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use Illuminate\Support\Optional;
+use Illuminate\Support\Traits\Conditionable;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+class SupportConditionableTest extends TestCase
+{
+    public function testWhenConditionCallback()
+    {
+        $conditionTriggered = false;
+        $defaultTriggered = false;
+
+        $object = (new CustomConditionableObject())
+            ->when(2, function($object, $condition) use (&$conditionTriggered) {
+                $conditionTriggered = true;
+                $object->on();
+                $this->assertEquals(2, $condition);
+            }, function($object) use (&$defaultTriggered) {
+                $defaultTriggered = true;
+                $object->off();
+            });
+
+        $this->assertTrue($object->enabled);
+        $this->assertTrue($conditionTriggered);
+        $this->assertFalse($defaultTriggered);
+    }
+
+    public function testWhenDefaultCallback()
+    {
+        $conditionTriggered = false;
+        $defaultTriggered = false;
+
+        $object = (new CustomConditionableObject())
+            ->when(null, function ($object) use (&$conditionTriggered) {
+                $conditionTriggered = true;
+                $object->on();
+            }, function ($object, $condition) use (&$defaultTriggered) {
+                $defaultTriggered = true;
+                $object->up();
+                $this->assertNull($condition);
+            });
+
+        $this->assertFalse($object->enabled);
+        $this->assertEquals('up', $object->direction);
+        $this->assertFalse($conditionTriggered);
+        $this->assertTrue($defaultTriggered);
+    }
+
+    public function testUnlessConditionCallback()
+    {
+        $conditionTriggered = false;
+        $defaultTriggered = false;
+
+        $object = (new CustomConditionableObject())
+            ->unless(null, function ($object, $condition) use (&$conditionTriggered) {
+                $conditionTriggered = true;
+                $object->on();
+                $this->assertNull($condition);
+            }, function ($object) use (&$defaultTriggered) {
+                $defaultTriggered = true;
+                $object->up();
+            });
+
+        $this->assertTrue($object->enabled);
+        $this->assertEquals('down', $object->direction);
+        $this->assertTrue($conditionTriggered);
+        $this->assertFalse($defaultTriggered);
+    }
+
+    public function testUnlessDefaultCallback()
+    {
+        $conditionTriggered = false;
+        $defaultTriggered = false;
+
+        $object = (new CustomConditionableObject())
+            ->unless(2, function ($object) use (&$conditionTriggered) {
+                $conditionTriggered = true;
+                $object->on();
+            }, function ($object, $condition) use (&$defaultTriggered) {
+                $defaultTriggered = true;
+                $object->off();
+                $this->assertEquals(2, $condition);
+            });
+
+        $this->assertFalse($object->enabled);
+        $this->assertFalse($conditionTriggered);
+        $this->assertTrue($defaultTriggered);
+    }
+
+    public function testWhenProxy()
+    {
+        $object = (new CustomConditionableObject())->when(true)->on();
+
+        $this->assertInstanceOf(CustomConditionableObject::class, $object);
+        $this->assertTrue($object->enabled);
+
+        $object = (new CustomConditionableObject())->when(false)->on();
+
+        $this->assertInstanceOf(CustomConditionableObject::class, $object);
+        $this->assertFalse($object->enabled);
+    }
+
+    public function testUnlessProxy()
+    {
+        $object = (new CustomConditionableObject())->unless(false)->on();
+
+        $this->assertInstanceOf(CustomConditionableObject::class, $object);
+        $this->assertTrue($object->enabled);
+
+        $object = (new CustomConditionableObject())->unless(true)->on();
+
+        $this->assertInstanceOf(CustomConditionableObject::class, $object);
+        $this->assertFalse($object->enabled);
+    }
+}
+
+class CustomConditionableObject
+{
+    use Conditionable;
+
+    public $enabled = false;
+
+    public $direction = 'down';
+
+    public function on()
+    {
+        $this->enabled = true;
+
+        return $this;
+    }
+
+    public function off()
+    {
+        $this->enabled = false;
+
+        return $this;
+    }
+
+    public function down()
+    {
+        $this->direction = 'down';
+
+        return $this;
+    }
+
+    public function up()
+    {
+        $this->direction = 'up';
+
+        return $this;
+    }
+}

--- a/tests/Support/SupportConditionableTest.php
+++ b/tests/Support/SupportConditionableTest.php
@@ -2,10 +2,8 @@
 
 namespace Illuminate\Tests\Support;
 
-use Illuminate\Support\Optional;
 use Illuminate\Support\Traits\Conditionable;
 use PHPUnit\Framework\TestCase;
-use stdClass;
 
 class SupportConditionableTest extends TestCase
 {
@@ -15,11 +13,11 @@ class SupportConditionableTest extends TestCase
         $defaultTriggered = false;
 
         $object = (new CustomConditionableObject())
-            ->when(2, function($object, $condition) use (&$conditionTriggered) {
+            ->when(2, function ($object, $condition) use (&$conditionTriggered) {
                 $conditionTriggered = true;
                 $object->on();
                 $this->assertEquals(2, $condition);
-            }, function($object) use (&$defaultTriggered) {
+            }, function ($object) use (&$defaultTriggered) {
                 $defaultTriggered = true;
                 $object->off();
             });


### PR DESCRIPTION
This PR picks up the work in #37504 and #37561 to unify the behavior of `when()` and `unless()` across every implementation by:

- Expanding `HigherOrderWhenProxy` to support any proxied object, not just `Enumerables`
- Adding support for `HigherOrderWhenProxy` in the `Conditionable` trait
- Replacing the implementation of `when()` and `unless()` in `EnumeratesValues` with `Conditionable`

It's necessary to implement these changes in `9.x` because:

1. There were slight signature differences between the `when()` method on `Enumerable` and the `when()` method on `Conditionable` (related to type hints)
2. The signature of `HigherOrderWhenProxy::__construct` needs to be changed slightly to allow for any type of proxied object
3. The return value of `EnumeratesValues::when` was not defaulted to `$this` like it is in `Conditionable`

I want to call out that third item because it is a subtle change.

In Laravel `8.x`, the following code will return `null`. After this PR, the same code will return the `Collection` with `"c"` appended to it. I think that is preferable, and means that `when()` behaves the same way everywhere in the framework.

```php
$results = collect(['a', 'b'])
  ->when(true, function($collection) {
      $collection->push('c');
  });

$results === null; // In Laravel 8
$results instanceof Collection; // In Laravel 9 after this PR
```