### PR TITLE
[8.x] Add Conditionable Trait to Relation

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\MultipleRecordsFoundException;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\ForwardsCalls;
 use Illuminate\Support\Traits\Macroable;
 
@@ -18,7 +19,7 @@ use Illuminate\Support\Traits\Macroable;
  */
 abstract class Relation
 {
-    use ForwardsCalls, Macroable {
+    use Conditionable, ForwardsCalls, Macroable {
         __call as macroCall;
     }
 

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -927,6 +927,34 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $relationTag2 = $post->tagsWithCustomExtraPivot()->orderByPivot('flag', 'desc')->first();
         $this->assertEquals($relationTag2->getAttributes(), $tag3->getAttributes());
     }
+
+    public function testOrderByPivotIsConditionable()
+    {
+        $tag1 = Tag::create(['name' => Str::random()]);
+        $tag2 = Tag::create(['name' => Str::random()]);
+        $tag3 = Tag::create(['name' => Str::random()]);
+        $tag4 = Tag::create(['name' => Str::random()]);
+        $post = Post::create(['title' => Str::random()]);
+
+        DB::table('posts_tags')->insert([
+            ['post_id' => $post->id, 'tag_id' => $tag1->id, 'flag' => 'foo3'],
+            ['post_id' => $post->id, 'tag_id' => $tag2->id, 'flag' => 'foo1'],
+            ['post_id' => $post->id, 'tag_id' => $tag3->id, 'flag' => 'foo4'],
+            ['post_id' => $post->id, 'tag_id' => $tag4->id, 'flag' => 'foo2'],
+        ]);
+
+        $relationTag1 = $post->tagsWithCustomExtraPivot()
+            ->when(true, function ($query) {
+                $query->orderByPivot('flag', 'asc');
+            })->first();
+        $this->assertEquals($relationTag1->getAttributes(), $tag2->getAttributes());
+
+        $relationTag2 = $post->tagsWithCustomExtraPivot()
+            ->unless(false, function ($query) {
+                $query->orderByPivot('flag', 'desc');
+            })->first();
+        $this->assertEquals($relationTag2->getAttributes(), $tag3->getAttributes());
+    }
 }
 
 class User extends Model


### PR DESCRIPTION
Hi!

Thank you for all the amazing work 🔥 

## Overview

This PR adds the new `Conditionable` trait to the base `Relation` class.

Currently, the following would not work for a relationship query...
```php
$user->posts()->when($shouldOrder, fn ($query) => $query->orderByPivot('..'))->get()
```
...because the `Relation` class does not have a native `when/unless`. So, it forwards it to the `Builder` but then this does not have access to the `Relation's` methods - in this case `orderByPivot`.

## Compatibility

The only thought is that this could be a breaking change in the sense that some relations override some `Relation` methods - eg. `get` in `BelongsToMany`. So if any apps do something along the lines of...
```php
$user->posts()->when($shouldPaginate, fn ($query) => $query->paginate(), fn ($query) => $query->get())
```
...the `get` method would now be elevated from the `Builder` up to the `Relation`?

## Tests

Testing wise, I appreciate there is only one test. I felt it illustrated the feature nicely using an existing set up. But very happy to add more if desired.