### PR TITLE
[8.x] Fix whenLoaded to accept null relationships

### DIFF
--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -183,10 +183,6 @@ trait ConditionallyLoadsAttributes
             return $this->resource->{$relationship};
         }
 
-        if ($this->resource->{$relationship} === null) {
-            return;
-        }
-
         return value($value);
     }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Let's say in a Resource class I want to do something when some hasOne relationship is loaded, like:

`'foo' => $this->whenLoaded('foo', fn() => // do something) `

When `foo` is loaded but is null, the closure is not executed because the method `whenLoaded` returns `null` when the relationship is null. But sometimes I need this closure to execute even when the relationship is null, and to achieve this behavior, I have to do this:

`'foo' => $this->when($this->relationLoaded('foo'), fn() => // do something) `

But this should be the default behavior of the `whenLoaded` method. 


