### PR TITLE
[8.x] Adds `match` and `matchAll` to `Str`

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -406,7 +406,7 @@ class Str
         preg_match($pattern, $subject, $matches);
 
         if (! $matches) {
-            return "";
+            return '';
         }
 
         return $matches[1] ?? $matches[0];

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -395,6 +395,42 @@ class Str
     }
 
     /**
+     * Get the string matching the given pattern.
+     *
+     * @param  string  $pattern
+     * @param  string  $subject
+     * @return string
+     */
+    public static function match($pattern, $subject)
+    {
+        preg_match($pattern, $subject, $matches);
+
+        if (! $matches) {
+            return "";
+        }
+
+        return $matches[1] ?? $matches[0];
+    }
+
+    /**
+     * Get the string matching the given pattern.
+     *
+     * @param  string  $pattern
+     * @param  string  $subject
+     * @return \Illuminate\Support\Collection
+     */
+    public static function matchAll($pattern, $subject)
+    {
+        preg_match_all($pattern, $subject, $matches);
+
+        if (empty($matches[0])) {
+            return collect();
+        }
+
+        return collect($matches[1] ?? $matches[0]);
+    }
+
+    /**
      * Pad both sides of a string with another.
      *
      * @param  string  $value

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -340,13 +340,7 @@ class Stringable implements JsonSerializable
      */
     public function match($pattern)
     {
-        preg_match($pattern, $this->value, $matches);
-
-        if (! $matches) {
-            return new static;
-        }
-
-        return new static($matches[1] ?? $matches[0]);
+        return new static(Str::match($pattern, $this->value));
     }
 
     /**
@@ -357,13 +351,7 @@ class Stringable implements JsonSerializable
      */
     public function matchAll($pattern)
     {
-        preg_match_all($pattern, $this->value, $matches);
-
-        if (empty($matches[0])) {
-            return collect();
-        }
-
-        return collect($matches[1] ?? $matches[0]);
+        return Str::matchAll($pattern, $this->value);
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -428,6 +428,18 @@ class SupportStrTest extends TestCase
         $this->assertSame('FooBarBaz', Str::studly('foo-bar_baz'));
     }
 
+    public function testMatch()
+    {
+        $this->assertSame('bar', Str::match('/bar/', 'foo bar'));
+        $this->assertSame('bar', Str::match('/foo (.*)/', 'foo bar'));
+        $this->assertEmpty(Str::match('/nothing/', 'foo bar'));
+
+        $this->assertEquals(['bar', 'bar'], Str::matchAll('/bar/', 'bar foo bar')->all());
+
+        $this->assertEquals(['un', 'ly'], Str::matchAll('/f(\w*)/', 'bar fun bar fly')->all());
+        $this->assertEmpty(Str::matchAll('/nothing/', 'bar fun bar fly'));
+    }
+
     public function testCamel()
     {
         $this->assertSame('laravelPHPFramework', Str::camel('Laravel_p_h_p_framework'));


### PR DESCRIPTION
Hi all,

Previously, `match` and `matchAll` were exclusively part of the `Stringable` class. You couldn't use those methods with the standard `Str` helper.

```php
Str::of('xyz')->match('/(xyz)/'); // works
Str::match('/(xyz)/'); // does not work
```

This PR moves the logic of `match` and `matchAll` into two methods on the `Str` helper class, rather than the `Stringable` class, so that it can be used in both instances.

Thanks as always for you time and hard work maintaining such a great framework 😀

Luke