### PR TITLE
Ensure order by overrides global scope

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1983,17 +1983,19 @@ class Builder
             throw new InvalidArgumentException('Order direction must be "asc" or "desc".');
         }
 
-        if (is_array($this->{$this->unions ? 'unionOrders' : 'orders'})) {
-            foreach ($this->{$this->unions ? 'unionOrders' : 'orders'} as $key => $value) {
+        $ordersProperty = $this->unions ? 'unionOrders' : 'orders';
+
+        if (is_array($this->{$ordersProperty})) {
+            foreach ($this->{$ordersProperty} as $key => $value) {
                 if (isset($value['column']) && $value['column'] === $column) {
-                    $this->{$this->unions ? 'unionOrders' : 'orders'}[$key]['direction'] = $direction;
+                    $this->{$ordersProperty}[$key]['direction'] = $direction;
 
                     return $this;
                 }
             }
         }
 
-        $this->{$this->unions ? 'unionOrders' : 'orders'}[] = [
+        $this->{$ordersProperty}[] = [
             'column' => $column,
             'direction' => $direction,
         ];

--- a/tests/Database/DatabaseEloquentGlobalScopesTest.php
+++ b/tests/Database/DatabaseEloquentGlobalScopesTest.php
@@ -35,6 +35,16 @@ class DatabaseEloquentGlobalScopesTest extends TestCase
         $this->assertEquals([1], $query->getBindings());
     }
 
+    public function testOrderByOverridesGlobalScope()
+    {
+        $model = new EloquentGlobalScopeOrderTestModel;
+        $query = $model->newQuery();
+        $this->assertSame('select * from "table" order by "name" asc', $query->toSql());
+
+        $query = $model->newQuery()->orderBy('name', 'desc');
+        $this->assertSame('select * from "table" order by "name" desc', $query->toSql());
+    }
+
     public function testGlobalScopeCanBeRemoved()
     {
         $model = new EloquentGlobalScopesTestModel;
@@ -149,6 +159,20 @@ class EloquentClosureGlobalScopesTestModel extends Model
     public function scopeOrApproved($query)
     {
         return $query->orWhere('approved', 1)->orWhere('should_approve', 0);
+    }
+}
+
+class EloquentGlobalScopeOrderTestModel extends Model
+{
+    protected $table = 'table';
+
+    public static function boot()
+    {
+        static::addGlobalScope(function ($query) {
+            $query->orderBy('name', 'asc');
+        });
+
+        parent::boot();
     }
 }
 


### PR DESCRIPTION
This test shows the behaviour of applying an order by clause that conflicts with a global scope.
Prior to https://github.com/laravel/framework/pull/37582, the overriden order by clause had precedence. Now, only the clause from the global scope is applied.

This behavioural change broke our application and I believe it should be fixed.