### PR TITLE
[8.x] Remove illuminate/foundation dependency from Password validation

### DIFF
--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -6,14 +6,22 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\Validation\DataAwareRule;
 use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Contracts\Validation\UncompromisedVerifier;
+use Illuminate\Contracts\Validation\ValidatorAwareRule;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Traits\Conditionable;
 use InvalidArgumentException;
 
-class Password implements Rule, DataAwareRule
+class Password implements Rule, DataAwareRule, ValidatorAwareRule
 {
     use Conditionable;
+
+    /**
+     * The validator performing the validation.
+     *
+     * @var \Illuminate\Contracts\Validation\Validator
+     */
+    protected $validator;
 
     /**
      * The data under validation.
@@ -163,6 +171,19 @@ class Password implements Rule, DataAwareRule
     }
 
     /**
+     * Set the performing validator.
+     *
+     * @param \Illuminate\Contracts\Validation\Validator $validator
+     * @return $this
+     */
+    public function setValidator($validator)
+    {
+        $this->validator = $validator;
+
+        return $this;
+    }
+
+    /**
      * Sets the minimum size of the password.
      *
      * @param  int $size
@@ -306,7 +327,7 @@ class Password implements Rule, DataAwareRule
     protected function fail($messages)
     {
         $messages = collect(Arr::wrap($messages))->map(function ($message) {
-            return __($message);
+            return $this->validator->getTranslator()->get($message);
         })->all();
 
         $this->messages = array_merge($this->messages, $messages);

--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -158,19 +158,6 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
     }
 
     /**
-     * Set the data under validation.
-     *
-     * @param  array  $data
-     * @return $this
-     */
-    public function setData($data)
-    {
-        $this->data = $data;
-
-        return $this;
-    }
-
-    /**
      * Set the performing validator.
      *
      * @param \Illuminate\Contracts\Validation\Validator $validator
@@ -179,6 +166,19 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
     public function setValidator($validator)
     {
         $this->validator = $validator;
+
+        return $this;
+    }    
+
+    /**
+     * Set the data under validation.
+     *
+     * @param  array  $data
+     * @return $this
+     */
+    public function setData($data)
+    {
+        $this->data = $data;
 
         return $this;
     }


### PR DESCRIPTION
Currently the password validation rule uses the `__` foundation helper function but the `illuminate/validation` package does not depend on the `illuminate/foundation` package.

This PR will make the rule use the Translator from the Validator.

The only problem is that in theory `getTranslator` is not part of the `Validator` interface, but this happens many places in the framework.