### PR TITLE
[8.x] Copy password rule to current_password 

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -349,7 +349,7 @@ trait ValidatesAttributes
     }
 
     /**
-     * Validate that the current logged in user's password matches the given value.
+     * Validate that the password of the currently authenticated user matches the given value.
      *
      * @param  string  $attribute
      * @param  mixed  $value
@@ -1347,7 +1347,7 @@ trait ValidatesAttributes
     }
 
     /**
-     * Validate that the current logged in user's password matches the given value.
+     * Validate that the password of the currently authenticated user matches the given value.
      *
      * @param  string  $attribute
      * @param  mixed  $value

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -349,6 +349,28 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate that the current logged in user's password matches the given value.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array  $parameters
+     * @return bool
+     */
+    protected function validateCurrentPassword($attribute, $value, $parameters)
+    {
+        $auth = $this->container->make('auth');
+        $hasher = $this->container->make('hash');
+
+        $guard = $auth->guard(Arr::first($parameters));
+
+        if ($guard->guest()) {
+            return false;
+        }
+
+        return $hasher->check($value, $guard->user()->getAuthPassword());
+    }
+
+    /**
      * Validate that an attribute is a valid date.
      *
      * @param  string  $attribute
@@ -1334,16 +1356,7 @@ trait ValidatesAttributes
      */
     protected function validatePassword($attribute, $value, $parameters)
     {
-        $auth = $this->container->make('auth');
-        $hasher = $this->container->make('hash');
-
-        $guard = $auth->guard(Arr::first($parameters));
-
-        if ($guard->guest()) {
-            return false;
-        }
-
-        return $hasher->check($value, $guard->user()->getAuthPassword());
+        return $this->validateCurrentPassword($attribute, $value, $parameters);
     }
 
     /**


### PR DESCRIPTION
This PR does not contain breaking changes.

---

With the introduction of the new password rule we have to different rule under the same name:
- The Password class: which validates new passwords
- The `password` rule: which validates the current password

This creates communication problems where the referenced rule can only be selected by the application context.

This PR moves the `password` validation to `current_password` and adds an alias to keep backwards compatibility. This allows:
- All existing code function like nothing happened
- All new code to use the new rule
- Update existing projects when Laravel 9 is released

While not part of the PR, the main intention is to completely remove the `password` rule from the next major release (and maybe use it as an alias to Password::default() later in Laravel 10).

If this PR accepted I will create others to add the necessary translation lines to the laravel/laravel repository and the necessary documentation update to laravel/docs.