### PR TITLE
[8.x] Eager Loaded Pseudo Relationships

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -635,6 +635,9 @@ class Builder
      */
     protected function eagerLoadRelation(array $models, $name, Closure $constraints)
     {
+        // Extract any aliased relationships.
+        [$name, $alias] = array_pad(explode(' as ', $name), 2, $name);
+
         // First we will "back up" the existing where conditions on the query so we can
         // add our eager constraints. Then we will merge the wheres that were on the
         // query back to it in order that any where conditions might be specified.
@@ -648,8 +651,8 @@ class Builder
         // using the relationship instance. Then we just return the finished arrays
         // of models which have been eagerly hydrated and are readied for return.
         return $relation->match(
-            $relation->initRelation($models, $name),
-            $relation->getEager(), $name
+            $relation->initRelation($models, $alias),
+            $relation->getEager(), $alias
         );
     }
 

--- a/tests/Integration/Database/EloquentEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentEagerLoadingTest.php
@@ -38,9 +38,9 @@ class EloquentEagerLoadingTest extends DatabaseTestCase
             ['status' => 'inactive'],
         ]);
 
-        $model = Post::with(['comments as activeComments' => function($query) {
+        $model = Post::with(['comments as activeComments' => function ($query) {
             return $query->where('status', 'active');
-        }])->with(['comments as inactiveComments' => function($query){
+        }])->with(['comments as inactiveComments' => function ($query){
             return $query->where('status', 'inactive');
         }])->find($post->id);
 

--- a/tests/Integration/Database/EloquentEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentEagerLoadingTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentEagerLoadingTest;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+/**
+ * @group integration
+ */
+class EloquentEagerLoadingTest extends DatabaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('posts', function (Blueprint $table) {
+            $table->increments('id');
+        });
+
+        Schema::create('comments', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('post_id');
+            $table->string('status')->default('active');
+        });
+    }
+
+    public function testAliasedEagerLoading()
+    {
+        $post = Post::create();
+        $post->comments()->createMany([
+            ['status' => 'active'],
+            ['status' => 'inactive'],
+            ['status' => 'inactive'],
+            ['status' => 'active'],
+            ['status' => 'inactive'],
+        ]);
+
+        $model = Post::with(['comments as activeComments' => function($query) {
+            return $query->where('status', 'active');
+        }])->with(['comments as inactiveComments' => function($query){
+            return $query->where('status', 'inactive');
+        }])->find($post->id);
+
+        $this->assertFalse($model->relationLoaded('comments'));
+        $this->assertTrue($model->relationLoaded('activeComments'));
+        $this->assertTrue($model->relationLoaded('inactiveComments'));
+
+        $this->assertCount(2, $model->activeComments);
+        $this->assertCount(3, $model->inactiveComments);
+    }
+}
+
+class Post extends Model
+{
+    public $timestamps = false;
+    protected $guarded = [];
+
+    public function comments()
+    {
+        return $this->hasMany(Comment::class);
+    }
+}
+
+class Comment extends Model
+{
+    public $timestamps = false;
+    protected $guarded = [];
+
+    public function post()
+    {
+        return $this->belongsTo(Post::class);
+    }
+}

--- a/tests/Integration/Database/EloquentEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentEagerLoadingTest.php
@@ -40,7 +40,7 @@ class EloquentEagerLoadingTest extends DatabaseTestCase
 
         $model = Post::with(['comments as activeComments' => function ($query) {
             return $query->where('status', 'active');
-        }])->with(['comments as inactiveComments' => function ($query){
+        }])->with(['comments as inactiveComments' => function ($query) {
             return $query->where('status', 'inactive');
         }])->find($post->id);
 


### PR DESCRIPTION
### TLDR

Create pseudo relationship that can be eager loaded:

```php
$salesperson = Salesperson::with(['leads as openLeads' => fn($query) => $query->where('status', 'open')])
    ->with(['leads as completedLeads' => fn($query) => $query->where('status', 'completed')])
    ->with(['leads as completedLeadsWithSale' => fn($query) => $query->where('status', 'completed')->where('result', 'sale')])
    ->with(['leads as completedLeadsWithNoSale' => fn($query) => $query->where('status', 'completed')->where('result', 'no sale')])
    ->first();

$salesperson->openLeads;
$salesperson->completedLeads;
$salesperson->completedLeadsWithSale;
$salesperson->completedLeadsWithNoSale;
```

---

### Current Scenario

Imagine you have a `Salesperson` with many `Lead`s. `Lead`s have a `status` of "open" or "completed", and a `result` of "sale" or "no sale".

You are trying to build a dashboard that shows the `Salesperson`'s metrics.

| Salesperson | Open | Completed | No Sale | Sale | Close Rate |
| ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
| Taylor  | 15 | 20 | 15 | 5 | 25% |
| Mohammed  | 7 | 6 | 1 | 5 | 83% |
| Dries  | 12 | 15 | 5 | 10 | 66% |

It is a simple 1:many relationship between the models.

```php
class Salesperson extends Model
{
    public function leads()
    {
        return $this->hasMany(Lead::class);
    }
}
```

In your controller you fetch all the `Salesperson`s.

```php
class SalespersonController
{
    public function index()
    {
        $salespersons = Salesperson::with('leads')->get();
    }
}
```

In your view you loop through the `Salesperson`s.

```blade
@foreach($salespersons as $salesperson)
    <tr>
        <td>{{ $salesperson->name }}</td>
        <td>{{ count($salesperson->leads()->where('status', 'open')->get()) }}</td>
        <td>{{ count($salesperson->leads()->where('status', 'completed')->get()) }}</td>
        <td>{{ count($salesperson->leads()->where('status', 'completed')->where('result', 'no sale')->get()) }}</td>
        <td>{{ count($salesperson->leads()->where('status', 'completed')->where('result', 'sale')->get()) }}</td>
        <td>{{ count($salesperson->leads()->where('status', 'completed')->where('result', 'sale')->get()) / count($salesperson->leads()->where('status', 'completed')->get()) }}</td>
    </tr>
@endforeach
```

Because we are calling `->leads()` as a method and not a property (in order to tack on our additional conditions), this will result in new queries being run for each of these groupings, and we don't benefit from the eager loading we did in the controller.

There are 2 ways we could currently handle this. We could create additional constrained relationships in the Model:

```php
class Salesperson extends Model
{
    public function leads()
    {
        return $this->hasMany(Lead::class);
    }

    public function openLeads()
    {
        return $this->hasMany(Lead::class)->where('status', 'open');
    }

    public function completedLeads()
    {
        return $this->hasMany(Lead::class)->where('status', 'completed');
    }
    
    public function completedLeadsWithSale()
    {
        return $this->hasMany(Lead::class)->where('status', 'completed')->where('result', 'sale');
    }
    
    public function completedLeadsWithNoSale()
    {
        return $this->hasMany(Lead::class)->where('status', 'completed')->where('result', 'no sale');
    }
}
```

and then eager load these in the Controller:

```php
class SalespersonController
{
    public function index()
    {
        $salespersons = Salesperson::with('leads')
            ->with('openLeads')
            ->with('completedLeads')
            ->with('completedLeadsWithSale')
            ->with('completedLeadsWithNoSale')
            ->get();
    }
}
```

This gets rid of our N+1, but the problem with this is it quickly becomes very verbose and unmanageable.

The other option is to filter in PHP (rather than the query) using the returned Collections. In our controller we revert to our simple eager load on the `leads` relationship:

```php
class SalespersonController
{
    public function index()
    {
        $salespersons = Salesperson::with('leads')->get();
    }
}
```

and now in our view we use Collection methods to filter out our desired data:

```blade
@foreach($salespersons as $salesperson)
    <tr>
        <td>{{ $salesperson->name }}</td>
        <td>{{ count($salesperson->leads->where('status', 'open')) }}</td>
        <td>{{ count($salesperson->leads->where('status', 'completed')) }}</td>
        <td>{{ count($salesperson->leads->where('status', 'completed')->where('result', 'no sale')) }}</td>
        <td>{{ count($salesperson->leads->where('status', 'completed')->where('result', 'sale')) }}</td>
        <td>{{ count($salesperson->leads->where('status', 'completed')->where('result', 'sale')) / count($salesperson->leads()->where('status', 'completed')) }}</td>
    </tr>
@endforeach
```

This option benefits from the eager loading, so our query count is very low. However, there is a lot of "logic" in the view, which some people do not like. We also duplicate 2 conditions in our "Close Rate" column that we've already determined. Finally, this does offload the filtering and sorting to PHP rather than the database, which could be undesirable in some scenarios, possibly for performance reasons.

---

### Proposed Improvement

This PR allows us to define eager loaded pseudo relationships. The benefit to this is it avoids our N+1 issues, keeps the filtering and sorting in the database, and keeps the majority of the logic out of the view.

```php
class SalespersonController
{
    public function index()
    {
        $salespersons = Salesperson::with(['leads as openLeads' => fn($query) => $query->where('status', 'open')])
            ->with(['leads as completedLeads' => fn($query) => $query->where('status', 'completed')])
            ->with(['leads as completedLeadsWithSale' => fn($query) => $query->where('status', 'completed')->where('result', 'sale')])
            ->with(['leads as completedLeadsWithNoSale' => fn($query) => $query->where('status', 'completed')->where('result', 'no sale')])
            ->get();
    }
}
```

These "relationships" are then available on the models in the view:

```blade
@foreach($salespersons as $salesperson)
    <tr>
        <td>{{ $salesperson->name }}</td>
        <td>{{ count($salesperson->openLeads) }}</td>
        <td>{{ count($salesperson->completedLeads) }}</td>
        <td>{{ count($salesperson->completedLeadsWithNoSale) }}</td>
        <td>{{ count($salesperson->completedLeadsWithSale) }}</td>
        <td>{{ count($salesperson->completedLeadsWithSale) / count($salesperson->completedLeads) }}</td>
    </tr>
@endforeach
```

Thanks!