### PR TITLE
[8.x] Consistent column order across MySQL versions

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -74,7 +74,8 @@ class MySqlGrammar extends Grammar
      */
     public function compileColumnListing()
     {
-        return 'select column_name as `column_name` from information_schema.columns where table_schema = ? and table_name = ?';
+        return 'select column_name as `column_name` from information_schema.columns where table_schema = ? and table_name = ?'
+            . ' order by information_schema.columns.ordinal_position asc';
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -75,7 +75,7 @@ class MySqlGrammar extends Grammar
     public function compileColumnListing()
     {
         return 'select column_name as `column_name` from information_schema.columns where table_schema = ? and table_name = ?'
-            . ' order by information_schema.columns.ordinal_position asc';
+            .' order by information_schema.columns.ordinal_position asc';
     }
 
     /**


### PR DESCRIPTION
It looks like the ordinal position to sort columns from `information_schema.columns` in `MySqlGrammar::compileColumnListing()` is not always taken into account by MySQL/PDO. I have differing orders between mysql Ver 8.0.25 on Ubuntu 20.04.2 and the MySQL's official docker container for 5.7.32.
