### PR TITLE
[8.x] Fix password rule closure validation

### DIFF
--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -120,7 +120,7 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
         }
 
         if (! $callback instanceof Closure && ! $callback instanceof static) {
-            throw new InvalidArgumentException('The given callback should be a Closure or an instance of '.static::class);
+            throw new InvalidArgumentException('The given callback should be a closure or an instance of '.static::class);
         }
 
         static::$defaultCallback = $callback;

--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Validation\Rules;
 
+use Closure;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Validation\DataAwareRule;
 use Illuminate\Contracts\Validation\Rule;
@@ -109,7 +110,7 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
      *
      * If no arguments are passed, the default password rule configuration will be returned.
      *
-     * @param  static|callable|null  $callback
+     * @param  static|\Closure|null  $callback
      * @return static|null
      */
     public static function defaults($callback = null)
@@ -118,8 +119,8 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
             return static::default();
         }
 
-        if (! is_callable($callback) && ! $callback instanceof static) {
-            throw new InvalidArgumentException('The given callback should be callable or an instance of '.static::class);
+        if (! $callback instanceof Closure && ! $callback instanceof static) {
+            throw new InvalidArgumentException('The given callback should be a Closure or an instance of '.static::class);
         }
 
         static::$defaultCallback = $callback;

--- a/tests/Validation/ValidationPasswordRuleTest.php
+++ b/tests/Validation/ValidationPasswordRuleTest.php
@@ -227,7 +227,7 @@ class ValidationPasswordRuleTest extends TestCase
     public function testItCannotSetDefaultUsingGivenString()
     {
         $this->expectException('InvalidArgumentException');
-        $this->expectExceptionMessage('given callback should be callable');
+        $this->expectExceptionMessage('given callback should be a Closure');
 
         Password::defaults('required|password');
     }

--- a/tests/Validation/ValidationPasswordRuleTest.php
+++ b/tests/Validation/ValidationPasswordRuleTest.php
@@ -227,7 +227,7 @@ class ValidationPasswordRuleTest extends TestCase
     public function testItCannotSetDefaultUsingGivenString()
     {
         $this->expectException('InvalidArgumentException');
-        $this->expectExceptionMessage('given callback should be a Closure');
+        $this->expectExceptionMessage('given callback should be a closure');
 
         Password::defaults('required|password');
     }


### PR DESCRIPTION
Currently the password rule accepts callables but if the callable is not a closure it silently fails and uses Password::min(8) as default.

This PR updates the defaults method to only accept Closures.