### PR TITLE
[8.x] Columns in the order by list must be unique

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1984,8 +1984,9 @@ class Builder
         }
 
         if (is_array($this->{$this->unions ? 'unionOrders' : 'orders'})) {
-            foreach ($this->{$this->unions ? 'unionOrders' : 'orders'} as $value) {
+            foreach ($this->{$this->unions ? 'unionOrders' : 'orders'} as $key => $value) {
                 if ($value['column'] === $column) {
+                    $this->{$this->unions ? 'unionOrders' : 'orders'}[$key]['direction'] = $direction;
                     return $this;
                 }
             }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1988,6 +1988,11 @@ class Builder
         if (is_array($this->{$ordersProperty})) {
             foreach ($this->{$ordersProperty} as $key => $value) {
                 if (isset($value['column']) && $value['column'] === $column) {
+                    $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 6);
+
+                    if($trace[5]['function'] === 'callScope')
+                        return $this;
+
                     $this->{$ordersProperty}[$key]['direction'] = $direction;
 
                     return $this;

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1983,17 +1983,19 @@ class Builder
             throw new InvalidArgumentException('Order direction must be "asc" or "desc".');
         }
 
-        if (is_array($this->{$this->unions ? 'unionOrders' : 'orders'})) {
-            foreach ($this->{$this->unions ? 'unionOrders' : 'orders'} as $key => $value) {
+        $ordersProperty = $this->unions ? 'unionOrders' : 'orders';
+
+        if (is_array($this->{$ordersProperty})) {
+            foreach ($this->{$ordersProperty} as $key => $value) {
                 if (isset($value['column']) && $value['column'] === $column) {
-                    $this->{$this->unions ? 'unionOrders' : 'orders'}[$key]['direction'] = $direction;
+                    $this->{$ordersProperty}[$key]['direction'] = $direction;
 
                     return $this;
                 }
             }
         }
 
-        $this->{$this->unions ? 'unionOrders' : 'orders'}[] = [
+        $this->{$ordersProperty}[] = [
             'column' => $column,
             'direction' => $direction,
         ];

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1985,7 +1985,7 @@ class Builder
 
         if (is_array($this->{$this->unions ? 'unionOrders' : 'orders'})) {
             foreach ($this->{$this->unions ? 'unionOrders' : 'orders'} as $key => $value) {
-                if ($value['column'] === $column) {
+                if (isset($value['column']) && $value['column'] === $column) {
                     $this->{$this->unions ? 'unionOrders' : 'orders'}[$key]['direction'] = $direction;
                     return $this;
                 }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1983,6 +1983,14 @@ class Builder
             throw new InvalidArgumentException('Order direction must be "asc" or "desc".');
         }
 
+        if (is_array($this->{$this->unions ? 'unionOrders' : 'orders'})) {
+            foreach ($this->{$this->unions ? 'unionOrders' : 'orders'} as $value) {
+                if ($value['column'] === $column) {
+                    return $this;
+                }
+            }
+        }
+
         $this->{$this->unions ? 'unionOrders' : 'orders'}[] = [
             'column' => $column,
             'direction' => $direction,

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1987,6 +1987,7 @@ class Builder
             foreach ($this->{$this->unions ? 'unionOrders' : 'orders'} as $key => $value) {
                 if ($value['column'] === $column) {
                     $this->{$this->unions ? 'unionOrders' : 'orders'}[$key]['direction'] = $direction;
+
                     return $this;
                 }
             }

--- a/tests/Database/DatabaseEloquentGlobalScopesTest.php
+++ b/tests/Database/DatabaseEloquentGlobalScopesTest.php
@@ -35,6 +35,16 @@ class DatabaseEloquentGlobalScopesTest extends TestCase
         $this->assertEquals([1], $query->getBindings());
     }
 
+    public function testOrderByOverridesGlobalScope()
+    {
+        $model = new EloquentGlobalScopeOrderTestModel;
+        $query = $model->newQuery();
+        $this->assertSame('select * from "table" order by "name" asc', $query->toSql());
+
+        $query = $model->newQuery()->orderBy('name', 'desc');
+        $this->assertSame('select * from "table" order by "name" desc', $query->toSql());
+    }
+
     public function testGlobalScopeCanBeRemoved()
     {
         $model = new EloquentGlobalScopesTestModel;
@@ -149,6 +159,20 @@ class EloquentClosureGlobalScopesTestModel extends Model
     public function scopeOrApproved($query)
     {
         return $query->orWhere('approved', 1)->orWhere('should_approve', 0);
+    }
+}
+
+class EloquentGlobalScopeOrderTestModel extends Model
+{
+    protected $table = 'table';
+
+    public static function boot()
+    {
+        static::addGlobalScope(function ($query) {
+            $query->orderBy('name', 'asc');
+        });
+
+        parent::boot();
     }
 }
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1194,7 +1194,8 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->orderBy('name', 'desc');
         $builder->orderBy('email', 'desc');
         $builder->orderBy('email', 'asc');
-        $this->assertSame('select * from "users" order by "name" desc, "email" asc', $builder->toSql());
+        $builder->orderByRaw('"age" ? desc', ['foo']);
+        $this->assertSame('select * from "users" order by "name" desc, "email" asc, "age" ? desc', $builder->toSql());
     }
 
     public function testReorder()

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1190,11 +1190,11 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([1, 1, 'news', 'opinion'], $builder->getBindings());
 
         $builder = $this->getBuilder();
-        $builder->select('*')->from('users')->orderBy('name');
-        $builder->orderBy('email');
-        $builder->orderBy('name');
-        $builder->orderBy('email');
-        $this->assertSame('select * from "users" order by "name" asc, "email" asc', $builder->toSql());
+        $builder->select('*')->from('users')->orderBy('name', 'asc');
+        $builder->orderBy('name', 'desc');
+        $builder->orderBy('email', 'desc');
+        $builder->orderBy('email', 'asc');
+        $this->assertSame('select * from "users" order by "name" desc, "email" asc', $builder->toSql());
     }
 
     public function testReorder()

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1188,6 +1188,13 @@ class DatabaseQueryBuilderTest extends TestCase
             ->orderByRaw('field(category, ?, ?) asc', ['news', 'opinion']);
         $this->assertSame('(select * from "posts" where "public" = ?) union all (select * from "videos" where "public" = ?) order by field(category, ?, ?) asc', $builder->toSql());
         $this->assertEquals([1, 1, 'news', 'opinion'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->orderBy('name');
+        $builder->orderBy('email');
+        $builder->orderBy('name');
+        $builder->orderBy('email');
+        $this->assertSame('select * from "users" order by "name" asc, "email" asc', $builder->toSql());
     }
 
     public function testReorder()


### PR DESCRIPTION
Hello, it's me again, lot of things break, and I'm sorry for it.
Context:  #37505, #37582, #37647
I've found that using the function `debug_backtrace()` I could see if the orderBy were called by a `callScope()` 
and simply ignoring the call
The test that were wrote pass but I'll let github run all the others
This fixes: #37660