### PR TITLE
[9.x] Add `Conditionable` support for callback conditions

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1069,7 +1069,7 @@ class Collection implements ArrayAccess, Enumerable
             ? $this->operatorForWhere(...func_get_args())
             : $key;
 
-        $items = $this->when($filter)->filter($filter);
+        $items = $this->unless($filter == null)->filter($filter);
 
         if ($items->isEmpty()) {
             throw new ItemNotFoundException;

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -268,7 +268,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function filter(callable $callback = null);
 
     /**
-     * Apply the callback if the value is truthy.
+     * Apply the callback if the given "value" is (or resolves to) truthy.
      *
      * @param  bool  $value
      * @param  callable|null  $callback
@@ -296,7 +296,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function whenNotEmpty(callable $callback, callable $default = null);
 
     /**
-     * Apply the callback if the value is falsy.
+     * Apply the callback if the given "value" is (or resolves to) truthy.
      *
      * @param  bool  $value
      * @param  callable  $callback

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1028,7 +1028,7 @@ class LazyCollection implements Enumerable
             : $key;
 
         return $this
-            ->when($filter)
+            ->unless($filter == null)
             ->filter($filter)
             ->take(2)
             ->collect()

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -138,7 +138,7 @@ trait EnumeratesValues
         }
 
         return static::range(1, $number)
-            ->when($callback)
+            ->unless($callback == null)
             ->map($callback);
     }
 

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -31,16 +31,18 @@ use Traversable;
  * @property-read HigherOrderCollectionProxy $min
  * @property-read HigherOrderCollectionProxy $partition
  * @property-read HigherOrderCollectionProxy $reject
+ * @property-read HigherOrderCollectionProxy $skipUntil
+ * @property-read HigherOrderCollectionProxy $skipWhile
  * @property-read HigherOrderCollectionProxy $some
  * @property-read HigherOrderCollectionProxy $sortBy
  * @property-read HigherOrderCollectionProxy $sortByDesc
- * @property-read HigherOrderCollectionProxy $skipUntil
- * @property-read HigherOrderCollectionProxy $skipWhile
  * @property-read HigherOrderCollectionProxy $sum
  * @property-read HigherOrderCollectionProxy $takeUntil
  * @property-read HigherOrderCollectionProxy $takeWhile
  * @property-read HigherOrderCollectionProxy $unique
+ * @property-read HigherOrderCollectionProxy $unless
  * @property-read HigherOrderCollectionProxy $until
+ * @property-read HigherOrderCollectionProxy $when
  */
 trait EnumeratesValues
 {
@@ -76,7 +78,9 @@ trait EnumeratesValues
         'takeUntil',
         'takeWhile',
         'unique',
+        'unless',
         'until',
+        'when',
     ];
 
     /**

--- a/src/Illuminate/Support/Traits/Conditionable.php
+++ b/src/Illuminate/Support/Traits/Conditionable.php
@@ -2,12 +2,13 @@
 
 namespace Illuminate\Support\Traits;
 
+use Closure;
 use Illuminate\Support\HigherOrderWhenProxy;
 
 trait Conditionable
 {
     /**
-     * Apply the callback if the given "value" is truthy.
+     * Apply the callback if the given "value" is (or resolves to) truthy.
      *
      * @param  mixed  $value
      * @param  callable|null  $callback
@@ -17,6 +18,8 @@ trait Conditionable
      */
     public function when($value, callable $callback = null, callable $default = null)
     {
+        $value = $value instanceof Closure ? $value($this) : $value;
+
         if (! $callback) {
             return new HigherOrderWhenProxy($this, $value);
         }
@@ -31,7 +34,7 @@ trait Conditionable
     }
 
     /**
-     * Apply the callback if the given "value" is falsy.
+     * Apply the callback if the given "value" is (or resolves to) falsy.
      *
      * @param  mixed  $value
      * @param  callable|null  $callback
@@ -41,6 +44,8 @@ trait Conditionable
      */
     public function unless($value, callable $callback = null, callable $default = null)
     {
+        $value = $value instanceof Closure ? $value($this) : $value;
+
         if (! $callback) {
             return new HigherOrderWhenProxy($this, ! $value);
         }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -4394,6 +4394,30 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testHigherOrderWhenAndUnlessWithProxy($collection)
+    {
+        $data = new $collection(['michael', 'tom']);
+
+        $data = $data->when->contains('michael')->concat(['chris']);
+
+        $this->assertSame(['michael', 'tom', 'chris'], $data->toArray());
+
+        $data = $data->when->contains('missing')->concat(['adam']);
+
+        $this->assertSame(['michael', 'tom', 'chris'], $data->toArray());
+
+        $data = $data->unless->contains('missing')->concat(['adam']);
+
+        $this->assertSame(['michael', 'tom', 'chris', 'adam'], $data->toArray());
+
+        $data = $data->unless->contains('adam')->concat(['bogdan']);
+
+        $this->assertSame(['michael', 'tom', 'chris', 'adam'], $data->toArray());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testUnless($collection)
     {
         $data = new $collection(['michael', 'tom']);

--- a/tests/Support/SupportConditionableTest.php
+++ b/tests/Support/SupportConditionableTest.php
@@ -9,68 +9,148 @@ class SupportConditionableTest extends TestCase
 {
     public function testWhenConditionCallback()
     {
+        // With static condition
         $logger = (new ConditionableLogger())
             ->when(2, function ($logger, $condition) {
                 $logger->log('when', $condition);
-            }, function () {
+            }, function ($logger, $condition) {
                 $logger->log('default', $condition);
             });
 
         $this->assertSame(['when', 2], $logger->values);
+
+        // With callback condition
+        $logger = (new ConditionableLogger())->log('init')
+            ->when(function ($logger) {
+                return $logger->has('init');
+            }, function ($logger, $condition) {
+                $logger->log('when', $condition);
+            }, function ($logger, $condition) {
+                $logger->log('default', $condition);
+            });
+
+        $this->assertSame(['init', 'when', true], $logger->values);
     }
 
     public function testWhenDefaultCallback()
     {
+        // With static condition
         $logger = (new ConditionableLogger())
-            ->when(null, function () {
+            ->when(null, function ($logger, $condition) {
                 $logger->log('when', $condition);
             }, function ($logger, $condition) {
                 $logger->log('default', $condition);
             });
 
         $this->assertSame(['default', null], $logger->values);
+
+        // With callback condition
+        $logger = (new ConditionableLogger())
+            ->when(function ($logger) {
+                return $logger->has('missing');
+            }, function ($logger, $condition) {
+                $logger->log('when', $condition);
+            }, function ($logger, $condition) {
+                $logger->log('default', $condition);
+            });
+
+        $this->assertSame(['default', false], $logger->values);
     }
 
     public function testUnlessConditionCallback()
     {
+        // With static condition
         $logger = (new ConditionableLogger())
             ->unless(null, function ($logger, $condition) {
                 $logger->log('unless', $condition);
-            }, function () {
+            }, function ($logger, $condition) {
                 $logger->log('default', $condition);
             });
 
         $this->assertSame(['unless', null], $logger->values);
+
+        // With callback condition
+        $logger = (new ConditionableLogger())
+            ->unless(function ($logger) {
+                return $logger->has('missing');
+            }, function ($logger, $condition) {
+                $logger->log('unless', $condition);
+            }, function ($logger, $condition) {
+                $logger->log('default', $condition);
+            });
+
+        $this->assertSame(['unless', false], $logger->values);
     }
 
     public function testUnlessDefaultCallback()
     {
+        // With static condition
         $logger = (new ConditionableLogger())
-            ->unless(2, function () {
+            ->unless(2, function ($logger, $condition) {
                 $logger->log('unless', $condition);
             }, function ($logger, $condition) {
                 $logger->log('default', $condition);
             });
 
         $this->assertSame(['default', 2], $logger->values);
+
+        // With callback condition
+        $logger = (new ConditionableLogger())->log('init')
+            ->unless(function ($logger) {
+                return $logger->has('init');
+            }, function ($logger, $condition) {
+                $logger->log('unless', $condition);
+            }, function ($logger, $condition) {
+                $logger->log('default', $condition);
+            });
+
+        $this->assertSame(['init', 'default', true], $logger->values);
     }
 
     public function testWhenProxy()
     {
+        // With static condition
         $logger = (new ConditionableLogger())
             ->when(true)->log('one')
             ->when(false)->log('two');
 
         $this->assertSame(['one'], $logger->values);
+
+        // With callback condition
+        $logger = (new ConditionableLogger())->log('init')
+            ->when(function ($logger) {
+                return $logger->has('init');
+            })
+            ->log('one')
+            ->when(function ($logger) {
+                return $logger->has('missing');
+            })
+            ->log('two');
+
+        $this->assertSame(['init', 'one'], $logger->values);
     }
 
     public function testUnlessProxy()
     {
+        // With static condition
         $logger = (new ConditionableLogger())
             ->unless(true)->log('one')
             ->unless(false)->log('two');
 
         $this->assertSame(['two'], $logger->values);
+
+        // With callback condition
+        $logger = (new ConditionableLogger())->log('init')
+            ->unless(function ($logger) {
+                return $logger->has('init');
+            })
+            ->log('one')
+            ->unless(function ($logger) {
+                return $logger->has('missing');
+            })
+            ->log('two');
+
+        $this->assertSame(['init', 'two'], $logger->values);
     }
 }
 
@@ -85,5 +165,10 @@ class ConditionableLogger
         array_push($this->values, ...$values);
 
         return $this;
+    }
+
+    public function has($value)
+    {
+        return in_array($value, $this->values);
     }
 }


### PR DESCRIPTION
This allows passing a `Closure` as the conditional to `when` and `unless`:

```php
return $this->getOptions()
    ->unless(fn ($options) => $options->has('share'))
    ->put('share', true);
```

Or even using a higher order collection proxy:

```php
return $this->getOptions()
    ->unless->has('share')
    ->put('share', true);
```

:heart: 

---

Here's a real-world example, converting @jbrooksuk's [Forge code snippet](https://james.brooks.page/blog/injecting-additional-data-into-laravel-queued-jobs/) from this:

```php
$jobData = $payload['data'];

if (! isset($jobData['initiated_by'])) {
    $jobData = array_merge($payload['data'], array_filter([
        'initiated_by' => request()->user()->id ?? null,
    ]));
}

return ['data' => $jobData];
```

...to a collection pipeline:

```php
return collect($payload['data'])
    ->unless->has('initiated_by')
    ->put('initiated_by', request()->user()->id ?? null)
    ->filter()
    ->pipe(fn ($data) => ['data' => $data->all()]);
```

:smile: 

---

**Note**: this includes a little breaking change. Previously, passing a closure would always be considered truthy, and wouldn't be executed.