### PR TITLE
[9.x] Flush DB record modification state on queue start

### DIFF
--- a/src/Illuminate/Queue/QueueServiceProvider.php
+++ b/src/Illuminate/Queue/QueueServiceProvider.php
@@ -167,7 +167,13 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
             };
 
             $resetScope = function () use ($app) {
-                return $app->forgetScopedInstances();
+                $app->forgetScopedInstances();
+
+                if ($app->resolved('db')) {
+                    foreach ($app->make('db')->getConnections() as $connection) {
+                        $connection->forgetRecordModificationState();
+                    }
+                }
             };
 
             return new Worker(


### PR DESCRIPTION
## Current issue

The `queue:work` command combined with the database connection option `sticky` persists using the write PDO when processing jobs after a previous job wrote to the DB.

This issue is results in long-running `queue:work` processes exclusively using the write PDO.

Additionally, running multiple `queue:work` processes will result in some jobs being processed on the read PDO, and some on the write PDO, depending on unrelated changes in previous jobs.

## ytho?

It's broken yo!

Splitting the read and write DB hosts is a viable performance strategy to assign resources specific to the use-case of the read/write nodes respectively. Excessive usage on the write resource, especially when unintended, is counter to that performance enhancement.

Currently there is no way to know if the next job that will be processed will land on a queue process that's using the read or the write PDO... that level of uncertainty should not exist.

## Notes

Breaking change - `queue:work` will now consistently start each job on the read PDO, and switch to the write PDO when a DB write occurs. Just like requests, the write PDO will be used until the completion of the job (or chain). Subsequent jobs will use start with the read PDO. 

## Additional resources and reading

Fixes https://github.com/laravel/framework/issues/37646
Example repo with breaking use-cases https://github.com/matthewnessworthy/sticky-db-queue-write-pdo