### PR TITLE
[9.x] Change behaviour of Str::snake() handling of digits

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -748,6 +748,8 @@ class Str
             $value = preg_replace('/\s+/u', '', ucwords($value));
 
             $value = static::lower(preg_replace('/(.)(?=[A-Z])/u', '$1'.$delimiter, $value));
+            $value = static::lower(preg_replace('/(\d+)(?=[A-Za-z])/u', '$1'.$delimiter, $value));
+            $value = static::lower(preg_replace('/(?<=[a-z])(\d+)/u', $delimiter.'$1', $value));
         }
 
         return static::$snakeCache[$key][$delimiter] = $value;

--- a/tests/Integration/Database/EloquentModelLoadCountTest.php
+++ b/tests/Integration/Database/EloquentModelLoadCountTest.php
@@ -22,12 +22,12 @@ class EloquentModelLoadCountTest extends DatabaseTestCase
             $table->increments('id');
         });
 
-        Schema::create('related1s', function (Blueprint $table) {
+        Schema::create('related_1_s', function (Blueprint $table) {
             $table->increments('id');
             $table->unsignedInteger('base_model_id');
         });
 
-        Schema::create('related2s', function (Blueprint $table) {
+        Schema::create('related_2_s', function (Blueprint $table) {
             $table->increments('id');
             $table->unsignedInteger('base_model_id');
         });
@@ -55,7 +55,7 @@ class EloquentModelLoadCountTest extends DatabaseTestCase
         $model->loadCount('related1');
 
         $this->assertCount(1, DB::getQueryLog());
-        $this->assertEquals(2, $model->related1_count);
+        $this->assertEquals(2, $model->related_1_count);
     }
 
     public function testLoadCountMultipleRelations()
@@ -67,8 +67,8 @@ class EloquentModelLoadCountTest extends DatabaseTestCase
         $model->loadCount(['related1', 'related2']);
 
         $this->assertCount(1, DB::getQueryLog());
-        $this->assertEquals(2, $model->related1_count);
-        $this->assertEquals(1, $model->related2_count);
+        $this->assertEquals(2, $model->related_1_count);
+        $this->assertEquals(1, $model->related_2_count);
     }
 
     public function testLoadCountDeletedRelations()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -414,6 +414,18 @@ class SupportStrTest extends TestCase
         $this->assertSame('foo-_bar', Str::snake('Foo-Bar'));
         $this->assertSame('foo__bar', Str::snake('Foo_Bar'));
         $this->assertSame('żółtałódka', Str::snake('ŻółtaŁódka'));
+        // test with digits inside
+        $this->assertSame('foo-bar-1', Str::snake('foo-bar-1'));
+        $this->assertSame('foo-1-bar', Str::snake('foo-1-bar'));
+        $this->assertSame('foo_bar_1', Str::snake('fooBar1'));
+        $this->assertSame('foo_1_bar', Str::snake('foo1Bar'));
+        $this->assertSame('foo_bar_1', Str::snake('foo bar  1'));
+        $this->assertSame('foo_12_bar', Str::snake('foo12Bar'));
+        $this->assertSame('12_foo_bar', Str::snake('12fooBar'));
+        $this->assertSame('12_foo', Str::snake('12foo'));
+        $this->assertSame('foo_12', Str::snake('foo12'));
+        $this->assertSame('12', Str::snake('12'));
+        $this->assertSame('foo', Str::snake('foo'));
     }
 
     public function testStudly()


### PR DESCRIPTION
### Currenty Str::snake don't handle digits correctly.

For example until now, this :
```php
Str::snake('test file 1');
```
returns 
```php 
'test_file1'
```

### Yeah, so it work. Why change ?

I came accross this when building a API with front end and back end validation. Laravel snake case conversion function didn't have the same behavior as the front end validator and my expectations.

It don't seems to exist a real convention about what to do with digits when converting to snake case, but [a lot of people](https://stackoverflow.com/questions/58009622/whats-the-correct-way-to-treat-numbers-in-snake-case) seems to add a '_' before digits.

This [javascript snake case library](https://www.npmjs.com/package/snake-case) has this behavior for example, and also [this online converter](https://textedit.tools/snakecase). Personnaly I found it way more readable and logic than the current Laravel function. If there is a reason why Laravel is using a different convention for snake case I would be happy to learn it.

### How this change will affect Str::snake ?

After this PR, the Str::snake will add a delimiter before words, uppercases AND digits, like this :
```php
Str::snake('test file 1');
// test_file_1
Str::snake('test 1file');
// test_1_file
```