### PR TITLE
Fixed dns_get_record loose check of A records for active_url rule

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -56,7 +56,7 @@ trait ValidatesAttributes
 
         if ($url = parse_url($value, PHP_URL_HOST)) {
             try {
-                return count(dns_get_record($url, DNS_A | DNS_AAAA)) > 0;
+                return count(dns_get_record($url . '.', DNS_A | DNS_AAAA)) > 0;
             } catch (Exception $e) {
                 return false;
             }


### PR DESCRIPTION
Tested on Laravel v8.46.0, PHP v8.0.7. 

This patch is related to security issue I reported at https://huntr.dev/bounties/2-laravel/framework/. 