### PR TITLE
Make FormRequest resourceful

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/request.stub
+++ b/src/Illuminate/Foundation/Console/stubs/request.stub
@@ -17,11 +17,47 @@ class {{ class }} extends FormRequest
     }
 
     /**
-     * Get the validation rules that apply to the request.
+     * Get the validation rules that apply to the get request.
      *
      * @return array
      */
-    public function rules()
+    public function viewRules()
+    {
+        return [
+            //
+        ];
+    }
+
+    /**
+     * Get the validation rules that apply to the post request.
+     *
+     * @return array
+     */
+    public function storeRules()
+    {
+        return [
+            //
+        ];
+    }
+
+    /**
+     * Get the validation rules that apply to the put/patch request.
+     *
+     * @return array
+     */
+    public function updateRules()
+    {
+        return [
+            //
+        ];
+    }
+
+    /**
+     * Get the validation rules that apply to the detele request.
+     *
+     * @return array
+     */
+    public function destroyRules()
     {
         return [
             //

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -109,9 +109,30 @@ class FormRequest extends Request implements ValidatesWhenResolved
     protected function createDefaultValidator(ValidationFactory $factory)
     {
         return $factory->make(
-            $this->validationData(), $this->container->call([$this, 'rules']),
+            $this->validationData(), $this->callableRulesMethod(),
             $this->messages(), $this->attributes()
         )->stopOnFirstFailure($this->stopOnFirstFailure);
+    }
+
+    /**
+     * Get Callable Rules Method from Request.
+     *
+     * @return array
+     */
+    public function callableRulesMethod()
+    {
+        if(method_exists($this, 'rules')){
+            return $this->container->call([$this, 'rules']);
+        }
+
+        $method = match($this->getMethod()){
+            'POST' => 'store',
+            'PUT', 'PATCH' => 'update',
+            'DELETE' => 'destroy',
+            default => 'view'
+        };
+
+        return $this->container->call([$this, $method.'Rules']);
     }
 
     /**


### PR DESCRIPTION
The idea for making a _FormRequest_ resourceful will avoid us creating multiple files for one resource, it is like following the controller or route resource convention.

I think a lot of us create for example `StoreUserFormRequest` and `UpdateUserFormRequest` those are the most common use cases.

The first idea is using only two methods `store()` and `update()` but we may use FormRequest for GET or DELETE HTTP methods too.

So the names become `viewRules()` `storeRules()` `updateRules()` `destroyRules()`.  _'Rules'_  prefix may not be necessary.

This PR has no break changes for old files that using rules() is still supported as before and you can also create a function that may have the same rules  shared between `store()` and `update()`,  which was redundant when using two files