### PR TITLE
[9.x] Adds the `scoped` method to the container contract

### DIFF
--- a/src/Illuminate/Contracts/Container/Container.php
+++ b/src/Illuminate/Contracts/Container/Container.php
@@ -82,6 +82,15 @@ interface Container extends ContainerInterface
     public function singletonIf($abstract, $concrete = null);
 
     /**
+     * Register a scoped binding in the container.
+     *
+     * @param  string  $abstract
+     * @param  \Closure|string|null  $concrete
+     * @return void
+     */
+    public function scoped($abstract, $concrete = null);
+
+    /**
      * "Extend" an abstract type in the container.
      *
      * @param  string  $abstract

--- a/src/Illuminate/Contracts/Container/Container.php
+++ b/src/Illuminate/Contracts/Container/Container.php
@@ -91,6 +91,15 @@ interface Container extends ContainerInterface
     public function scoped($abstract, $concrete = null);
 
     /**
+     * Register a scoped binding if it hasn't already been registered.
+     *
+     * @param  string  $abstract
+     * @param  \Closure|string|null  $concrete
+     * @return void
+     */
+    public function scopedIf($abstract, $concrete = null);
+
+    /**
      * "Extend" an abstract type in the container.
      *
      * @param  string  $abstract


### PR DESCRIPTION
### Added

- Adds the `scoped` method to the container contract

---

The method was added to Laravel 8 ([here](https://github.com/laravel/framework/pull/37521)), but I guess this is a breaking change for the contract? Not sure.