### PR TITLE
Send requests with empty body if no data is sent

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -560,7 +560,7 @@ class PendingRequest
      */
     public function post(string $url, array $data = [])
     {
-        return $this->send('POST', $url, [
+        return $this->send('POST', $url, empty($data) ? [] : [
             $this->bodyFormat => $data,
         ]);
     }
@@ -574,7 +574,7 @@ class PendingRequest
      */
     public function patch($url, $data = [])
     {
-        return $this->send('PATCH', $url, [
+        return $this->send('PATCH', $url, empty($data) ? [] : [
             $this->bodyFormat => $data,
         ]);
     }
@@ -588,7 +588,7 @@ class PendingRequest
      */
     public function put($url, $data = [])
     {
-        return $this->send('PUT', $url, [
+        return $this->send('PUT', $url, empty($data) ? [] : [
             $this->bodyFormat => $data,
         ]);
     }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -967,4 +967,18 @@ class HttpClientTest extends TestCase
 
         m::close();
     }
+
+    public function testRequestsBodyIsEmptyIfNoDataIsProvided()
+    {
+        $factory = new Factory();
+        $factory->fake(function (Request $request) {
+            $this->assertSame('', $request->body());
+            return Factory::response();
+        });
+
+        $factory->post('https://example.com');
+        $factory->patch('https://example.com');
+        $factory->put('https://example.com');
+        $factory->delete('https://example.com');
+    }
 }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -973,6 +973,7 @@ class HttpClientTest extends TestCase
         $factory = new Factory();
         $factory->fake(function (Request $request) {
             $this->assertSame('', $request->body());
+
             return Factory::response();
         });
 


### PR DESCRIPTION
This PR makes sure that HTTP requests are sent with an empty body if no data is provided.

At the moment the HTTP client adds an empty JSON to the body when a request with no data and content type `application/json` is sent, which may cause validation errors in 3rd party services (e.g. PayPal APIs).

This PR fixes this issue by avoiding to add data to the body when the data is empty, just like the `delete()` method currently does.