### PR TITLE
[8.x] Remove whitespace when eager loading with columns

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1393,8 +1393,8 @@ class Builder
      */
     protected function createSelectWithConstraint($name)
     {
-        $name =  preg_replace('/\s+/', '', $name);
-        
+        $name = preg_replace('/\s+/', '', $name);
+
         return [explode(':', $name)[0], static function ($query) use ($name) {
             $query->select(array_map(static function ($column) use ($query) {
                 if (Str::contains($column, '.')) {

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1393,6 +1393,8 @@ class Builder
      */
     protected function createSelectWithConstraint($name)
     {
+        $name =  preg_replace('/\s+/', '', $name);
+        
         return [explode(':', $name)[0], static function ($query) use ($name) {
             $query->select(array_map(static function ($column) use ($query) {
                 if (Str::contains($column, '.')) {

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -348,6 +348,18 @@ class DatabaseEloquentModelTest extends TestCase
         $closure($builder);
     }
 
+    public function testEagerLoadingWithWhitespacedColumns()
+    {
+        $model = new EloquentModelWithoutRelationStub;
+        $instance = $model->newInstance()->newQuery()->with('foo: bar, baz ', 'hadi');
+        $builder = m::mock(Builder::class);
+        $builder->shouldReceive('select')->once()->with(['bar', 'baz']);
+        $this->assertNotNull($instance->getEagerLoads()['hadi']);
+        $this->assertNotNull($instance->getEagerLoads()['foo']);
+        $closure = $instance->getEagerLoads()['foo'];
+        $closure($builder);
+    }
+
     public function testWithMethodCallsQueryBuilderCorrectlyWithArray()
     {
         $result = EloquentModelWithStub::with(['foo', 'bar']);


### PR DESCRIPTION
When we have whitespaces with relation columns `Model::with('foo: bar,  baz ')->first()` the model is not hydrated correctly. 
Expect results:

```
[
  "bar" => "bar value"
  "baz" => " baz value"
]
```

Current results
```
[
  "" bar"" => " bar"
  "" baz "" => " baz "
]
```