### PR TITLE
[6.x] Type hinted arguments for Illuminate\Validation\Rules\RequiredIf

### DIFF
--- a/src/Illuminate/Validation/Rules/RequiredIf.php
+++ b/src/Illuminate/Validation/Rules/RequiredIf.php
@@ -19,7 +19,7 @@ class RequiredIf
      */
     public function __construct($condition)
     {
-        if(! is_string($condition) && (is_bool($condition) || is_callable($condition))) {
+        if (! is_string($condition) && (is_bool($condition) || is_callable($condition))) {
             $this->condition = $condition;
         } else {
             throw new InvalidArgumentException("Condition type must be 'callable' or 'bool'.");

--- a/src/Illuminate/Validation/Rules/RequiredIf.php
+++ b/src/Illuminate/Validation/Rules/RequiredIf.php
@@ -19,7 +19,11 @@ class RequiredIf
      */
     public function __construct($condition)
     {
-        $this->condition = $condition;
+        if(!is_string($condition) && (is_bool($condition) || is_callable($condition))) {
+            $this->condition = $condition;
+        } else {
+            throw new InvalidArgumentException("Condition type must be 'callable' or 'bool'.");
+        }
     }
 
     /**

--- a/src/Illuminate/Validation/Rules/RequiredIf.php
+++ b/src/Illuminate/Validation/Rules/RequiredIf.php
@@ -19,10 +19,10 @@ class RequiredIf
      */
     public function __construct($condition)
     {
-        if(!is_string($condition) && (is_bool($condition) || is_callable($condition))) {
+        if (! is_string($condition) && (is_bool($condition) || is_callable($condition))) {
             $this->condition = $condition;
         } else {
-            throw new InvalidArgumentException("Condition type must be 'callable' or 'bool'.");
+            throw new \InvalidArgumentException("Condition type must be 'callable' or 'bool'.");
         }
     }
 

--- a/src/Illuminate/Validation/Rules/RequiredIf.php
+++ b/src/Illuminate/Validation/Rules/RequiredIf.php
@@ -19,7 +19,7 @@ class RequiredIf
      */
     public function __construct($condition)
     {
-        if(!is_string($condition) && (is_bool($condition) || is_callable($condition))) {
+        if(! is_string($condition) && (is_bool($condition) || is_callable($condition))) {
             $this->condition = $condition;
         } else {
             throw new InvalidArgumentException("Condition type must be 'callable' or 'bool'.");

--- a/tests/Validation/ValidationRequiredIfTest.php
+++ b/tests/Validation/ValidationRequiredIfTest.php
@@ -2,9 +2,7 @@
 
 namespace Illuminate\Tests\Validation;
 
-use Exception;
 use Illuminate\Validation\Rules\RequiredIf;
-use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
 class ValidationRequiredIfTest extends TestCase

--- a/tests/Validation/ValidationRequiredIfTest.php
+++ b/tests/Validation/ValidationRequiredIfTest.php
@@ -3,8 +3,8 @@
 namespace Illuminate\Tests\Validation;
 
 use Exception;
-use InvalidArgumentException;
 use Illuminate\Validation\Rules\RequiredIf;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
 class ValidationRequiredIfTest extends TestCase

--- a/tests/Validation/ValidationRequiredIfTest.php
+++ b/tests/Validation/ValidationRequiredIfTest.php
@@ -36,7 +36,7 @@ class ValidationRequiredIfTest extends TestCase
 
         $rule = new RequiredIf(true);
 
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $rule = new RequiredIf('phpinfo');
 
@@ -47,7 +47,7 @@ class ValidationRequiredIfTest extends TestCase
 
     public function testItReturnedRuleIsNotSerializable()
     {
-        $this->expectException(Exception::class);
+        $this->expectException(\Exception::class);
 
         $rule = serialize(new RequiredIf(function () {
             return true;

--- a/tests/Validation/ValidationRequiredIfTest.php
+++ b/tests/Validation/ValidationRequiredIfTest.php
@@ -29,4 +29,30 @@ class ValidationRequiredIfTest extends TestCase
 
         $this->assertSame('', (string) $rule);
     }
+
+    public function testItOnlyCallableAndBooleanAreAcceptableArgumentsOfTheRule()
+    {
+        $rule = new RequiredIf(false);
+
+        $rule = new RequiredIf(true);
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $rule = new RequiredIf('phpinfo');
+
+        $rule = new RequiredIf(12.3);
+
+        $rule = new RequiredIf(new stdClass());
+    }
+
+    public function testItReturnedRuleIsNotSerializable()
+    {
+        $this->expectException(Exception::class);
+
+        $rule = serialize(new RequiredIf(function () {
+            return true;
+        }));
+
+        $rule = serialize(new RequiredIf());
+    }
 }

--- a/tests/Validation/ValidationRequiredIfTest.php
+++ b/tests/Validation/ValidationRequiredIfTest.php
@@ -2,9 +2,9 @@
 
 namespace Illuminate\Tests\Validation;
 
+use Exception;
 use Illuminate\Validation\Rules\RequiredIf;
 use PHPUnit\Framework\TestCase;
-use Exception;
 
 class ValidationRequiredIfTest extends TestCase
 {

--- a/tests/Validation/ValidationRequiredIfTest.php
+++ b/tests/Validation/ValidationRequiredIfTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Validation;
 
 use Exception;
+use InvalidArgumentException;
 use Illuminate\Validation\Rules\RequiredIf;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Validation/ValidationRequiredIfTest.php
+++ b/tests/Validation/ValidationRequiredIfTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Validation;
 
 use Illuminate\Validation\Rules\RequiredIf;
 use PHPUnit\Framework\TestCase;
+use Exception;
 
 class ValidationRequiredIfTest extends TestCase
 {


### PR DESCRIPTION
Fixes a security issue as explained in https://www.huntr.dev/bounties/3-laravel/framework/

If the argument to Illuminate\Validation\Rules\RequiredIf is not boolean or callable, it will throw InvalidArgumentException.

Added tests to check
1. that the provided input is either a callable or a boolean (as it was hinted in docblock)
2. that the provided callable is not serializable.
