### PR TITLE
Updated JsonResource->toArray() method to work without $request parameter

### DIFF
--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -107,10 +107,10 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     /**
      * Transform the resource into an array.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Illuminate\Http\Request|null  $request
      * @return array
      */
-    public function toArray($request)
+    public function toArray($request = null)
     {
         if (is_null($this->resource)) {
             return [];


### PR DESCRIPTION
made $request null by default, since it's not used anyway and It's confusing why we should pass `request` to this method.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
