### PR TITLE
[8.x] Add `addIf` method to `Illuminate\Support\Collection` class

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -4,6 +4,7 @@ namespace Illuminate\Support;
 
 use ArrayAccess;
 use ArrayIterator;
+use Closure;
 use Illuminate\Collections\ItemNotFoundException;
 use Illuminate\Collections\MultipleItemsFoundException;
 use Illuminate\Support\Traits\EnumeratesValues;
@@ -1420,6 +1421,27 @@ class Collection implements ArrayAccess, Enumerable
     public function add($item)
     {
         $this->items[] = $item;
+
+        return $this;
+    }
+
+    /**
+     * Add an item to this collection if the provided callback returns true.
+     * 
+     * @param  mixed  $items
+     * @return $this
+     */
+    public function addIf($items, Closure $callback)
+    {
+        $items = Arr::wrap($items);
+
+        foreach ($items as $item) {
+            $shouldAdd = $callback($item);
+
+            if ($shouldAdd) {
+                $this->add($item);
+            }
+        }
 
         return $this;
     }

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1427,7 +1427,7 @@ class Collection implements ArrayAccess, Enumerable
 
     /**
      * Add an item to this collection if the provided callback returns true.
-     * 
+     *
      * @param  mixed  $items
      * @return $this
      */

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -616,7 +616,7 @@ class SupportCollectionTest extends TestCase
     public function testAddIf()
     {
         $c = new Collection();
-        $c->addIf('a', function($item) {
+        $c->addIf('a', function ($item) {
             return $item == 'a';
         });
         $this->assertCount(1, $c);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -613,6 +613,21 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['a' => 4, 'b' => 3], $c->countBy('key')->all());
     }
 
+    public function testAddIf()
+    {
+        $c = new Collection();
+        $c->addIf('a', function($item) {
+            return $item == 'a';
+        });
+        $this->assertCount(1, $c);
+
+        $c = new Collection();
+        $c->addIf(['a', 1, 'b', 2, 'c', 3], function ($item) {
+            return is_int($item);
+        });
+        $this->assertCount(3, $c);
+    }
+
     /**
      * @dataProvider collectionClassProvider
      */


### PR DESCRIPTION
This creates a method called `addIf` into the `Illuminate\Support\Collection` class.

The method will only add the `$items` to the collection if the supplied `$callback` closure returns true.
The closure should take one parameter, which is the item being tested to be added or not.

Usage:
```php
$collection = new Collection();
$collection->addIf([1, 2, 3, 'a', 'b', 'c'], function ($item) {
    return is_int($item);
});
// $collection will have [1, 2, 3]
```

In the past I would loop, for example, an Eloquent collection and determine if it should be added to a separate Collection - but with this it saves me a few lines of code and looks more elegant.

Without:
```php
$collection = new Collection();
foreach ([1, 2, 3, 'a', 'b', 'c'] as $item) {
	if (is_int($item)) {
        $collection->add($item);
    }
}
```

My first PR to Laravel, please let me know if I could have done anything better or differently.
