### PR TITLE
[6.x] Fix when passed object as parameters to scopes method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -920,7 +920,7 @@ class Builder
             // messed up when adding scopes. Then we'll return back out the builder.
             $builder = $builder->callScope(
                 [$this->model, 'scope'.ucfirst($scope)],
-                (array) $parameters
+                Arr::wrap($parameters)
             );
         }
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1873,10 +1873,13 @@ class DatabaseEloquentModelTest extends TestCase
         $model = new EloquentModelStub;
         $this->addMockConnection($model);
 
+        Carbon::setTestNow();
+
         $scopes = [
             'published',
             'category' => 'Laravel',
             'framework' => ['Laravel', '5.3'],
+            'date' => Carbon::now()
         ];
 
         $this->assertInstanceOf(Builder::class, $model->scopes($scopes));
@@ -2111,6 +2114,11 @@ class EloquentModelStub extends Model
     public function scopeFramework(Builder $builder, $framework, $version)
     {
         $this->scopesCalled['framework'] = [$framework, $version];
+    }
+
+    public function scopeDate(Builder $builder, Carbon $date)
+    {
+        $this->scopesCalled['date'] = $date;
     }
 }
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1879,7 +1879,7 @@ class DatabaseEloquentModelTest extends TestCase
             'published',
             'category' => 'Laravel',
             'framework' => ['Laravel', '5.3'],
-            'date' => Carbon::now()
+            'date' => Carbon::now(),
         ];
 
         $this->assertInstanceOf(Builder::class, $model->scopes($scopes));


### PR DESCRIPTION
When passing parameters to the callScope method, the behavior is not what you expect because it casts them to an array.

Via the __call method it works as expected.

```php

// some instance
$now = Carbon::now();

// it works
SomeModel::query()->date($now);

// it doesn't work
SomeModel()::query()->scopes(['date' => $now]);

```

Fixed calling to Arr::wrap() instead of casting to an array.