### PR TITLE
[8.x] Add route caching integration tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -84,7 +84,7 @@
         "guzzlehttp/guzzle": "^6.5.5|^7.0.1",
         "league/flysystem-cached-adapter": "^1.0",
         "mockery/mockery": "^1.4.2",
-        "orchestra/testbench-core": "^6.8",
+        "orchestra/testbench-core": "^6.23",
         "pda/pheanstalk": "^4.0",
         "phpunit/phpunit": "^8.5.8|^9.3.3",
         "predis/predis": "^1.1.2",

--- a/tests/Integration/Routing/Fixtures/redirect_routes.php
+++ b/tests/Integration/Routing/Fixtures/redirect_routes.php
@@ -1,0 +1,13 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+Route::redirect('/foo/1', '/foo/1/bar');
+
+Route::get('/foo/1/bar', function () {
+    return 'Redirect response';
+});
+
+Route::get('/foo/1', function () {
+    return 'GET response';
+});

--- a/tests/Integration/Routing/Fixtures/wildcard_catch_all_routes.php
+++ b/tests/Integration/Routing/Fixtures/wildcard_catch_all_routes.php
@@ -1,0 +1,11 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+Route::get('/foo', function () {
+    return 'Regular route';
+});
+
+Route::get('{slug}', function () {
+    return 'Wildcard route';
+});

--- a/tests/Integration/Routing/RouteCachingTest.php
+++ b/tests/Integration/Routing/RouteCachingTest.php
@@ -8,7 +8,7 @@ class RouteCachingTest extends TestCase
 {
     public function testWildcardCatchAllRoutes()
     {
-        $this->routes(__DIR__."/Fixtures/wildcard_catch_all_routes.php");
+        $this->routes(__DIR__.'/Fixtures/wildcard_catch_all_routes.php');
 
         $this->get('/foo')->assertSee('Regular route');
         $this->get('/bar')->assertSee('Wildcard route');
@@ -16,7 +16,7 @@ class RouteCachingTest extends TestCase
 
     public function testRedirectRoutes()
     {
-        $this->routes(__DIR__."/Fixtures/redirect_routes.php");
+        $this->routes(__DIR__.'/Fixtures/redirect_routes.php');
 
         $this->post('/foo/1')->assertRedirect('/foo/1/bar');
         $this->get('/foo/1/bar')->assertSee('Redirect response');

--- a/tests/Integration/Routing/RouteCachingTest.php
+++ b/tests/Integration/Routing/RouteCachingTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Routing;
+
+use Orchestra\Testbench\TestCase;
+
+class RouteCachingTest extends TestCase
+{
+    public function testWildcardCatchAllRoutes()
+    {
+        $this->routes(__DIR__."/Fixtures/wildcard_catch_all_routes.php");
+
+        $this->get('/foo')->assertSee('Regular route');
+        $this->get('/bar')->assertSee('Wildcard route');
+    }
+
+    public function testRedirectRoutes()
+    {
+        $this->routes(__DIR__."/Fixtures/redirect_routes.php");
+
+        $this->post('/foo/1')->assertRedirect('/foo/1/bar');
+        $this->get('/foo/1/bar')->assertSee('Redirect response');
+        $this->get('/foo/1')->assertRedirect('/foo/1/bar');
+    }
+
+    protected function routes(string $file)
+    {
+        $this->defineCacheRoutes(file_get_contents($file));
+    }
+}


### PR DESCRIPTION
This PR adds actual integration tests for route caching. Over time, we can phase out other tests to this test class.