### PR TITLE
[8.x] Add a queue:prune-failed command

### DIFF
--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -68,6 +68,7 @@ use Illuminate\Queue\Console\ForgetFailedCommand as ForgetFailedQueueCommand;
 use Illuminate\Queue\Console\ListenCommand as QueueListenCommand;
 use Illuminate\Queue\Console\ListFailedCommand as ListFailedQueueCommand;
 use Illuminate\Queue\Console\PruneBatchesCommand as PruneBatchesQueueCommand;
+use Illuminate\Queue\Console\PruneFailedJobsCommand;
 use Illuminate\Queue\Console\RestartCommand as QueueRestartCommand;
 use Illuminate\Queue\Console\RetryBatchCommand as QueueRetryBatchCommand;
 use Illuminate\Queue\Console\RetryCommand as QueueRetryCommand;
@@ -109,6 +110,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'QueueForget' => 'command.queue.forget',
         'QueueListen' => 'command.queue.listen',
         'QueuePruneBatches' => 'command.queue.prune-batches',
+        'QueuePruneFailedJobs' => 'command.queue.prune-failed-jobs',
         'QueueRestart' => 'command.queue.restart',
         'QueueRetry' => 'command.queue.retry',
         'QueueRetryBatch' => 'command.queue.retry-batch',
@@ -695,6 +697,18 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
     {
         $this->app->singleton('command.queue.prune-batches', function () {
             return new PruneBatchesQueueCommand;
+        });
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerQueuePruneFailedJobsCommand()
+    {
+        $this->app->singleton('command.queue.prune-failed-jobs', function () {
+            return new PruneFailedJobsCommand();
         });
     }
 

--- a/src/Illuminate/Queue/Console/PruneFailedJobsCommand.php
+++ b/src/Illuminate/Queue/Console/PruneFailedJobsCommand.php
@@ -3,9 +3,6 @@
 namespace Illuminate\Queue\Console;
 
 use Carbon\Carbon;
-use Illuminate\Bus\BatchRepository;
-use Illuminate\Bus\DatabaseBatchRepository;
-use Illuminate\Bus\PrunableBatchRepository;
 use Illuminate\Console\Command;
 use Illuminate\Queue\Failed\PrunableFailedJobProvider;
 

--- a/src/Illuminate/Queue/Console/PruneFailedJobsCommand.php
+++ b/src/Illuminate/Queue/Console/PruneFailedJobsCommand.php
@@ -17,7 +17,7 @@ class PruneFailedJobsCommand extends Command
      * @var string
      */
     protected $signature = 'queue:prune-failed
-                {--hours=24 : The number of hours to retain batch data}';
+                {--hours=24 : The number of hours to retain failed jobs data}';
 
     /**
      * The console command description.

--- a/src/Illuminate/Queue/Console/PruneFailedJobsCommand.php
+++ b/src/Illuminate/Queue/Console/PruneFailedJobsCommand.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Illuminate\Queue\Console;
+
+use Carbon\Carbon;
+use Illuminate\Bus\BatchRepository;
+use Illuminate\Bus\DatabaseBatchRepository;
+use Illuminate\Bus\PrunableBatchRepository;
+use Illuminate\Console\Command;
+use Illuminate\Queue\Failed\PrunableFailedJobProvider;
+
+class PruneFailedJobsCommand extends Command
+{
+    /**
+     * The console command signature.
+     *
+     * @var string
+     */
+    protected $signature = 'queue:prune-failed
+                {--hours=24 : The number of hours to retain batch data}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Prune stale entries from the failed jobs table';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $failer = $this->laravel['queue.failer'];
+
+        $count = 0;
+
+        if ($failer instanceof PrunableFailedJobProvider) {
+            $count = $failer->prune(Carbon::now()->subHours($this->option('hours')));
+        }
+
+        $this->info("{$count} entries deleted!");
+    }
+}

--- a/src/Illuminate/Queue/Failed/DatabaseUuidFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseUuidFailedJobProvider.php
@@ -2,10 +2,11 @@
 
 namespace Illuminate\Queue\Failed;
 
+use DateTimeInterface;
 use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Support\Facades\Date;
 
-class DatabaseUuidFailedJobProvider implements FailedJobProviderInterface
+class DatabaseUuidFailedJobProvider implements FailedJobProviderInterface, PrunableFailedJobProvider
 {
     /**
      * The connection resolver implementation.
@@ -126,5 +127,27 @@ class DatabaseUuidFailedJobProvider implements FailedJobProviderInterface
     protected function getTable()
     {
         return $this->resolver->connection($this->database)->table($this->table);
+    }
+
+    /**
+     * Prune all of the entries older than the given date.
+     *
+     * @param  \DateTimeInterface  $before
+     * @return int
+     */
+    public function prune(DateTimeInterface $before)
+    {
+        $query = $this->getTable()
+            ->where('failed_at', '<', $before);
+
+        $totalDeleted = 0;
+
+        do {
+            $deleted = $query->take(1000)->delete();
+
+            $totalDeleted += $deleted;
+        } while ($deleted !== 0);
+
+        return $totalDeleted;
     }
 }

--- a/src/Illuminate/Queue/Failed/PrunableFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/PrunableFailedJobProvider.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Illuminate\Queue\Failed;
+
+use DateTimeInterface;
+
+interface PrunableFailedJobProvider
+{
+    /**
+     * Prune all of the entries older than the given date.
+     *
+     * @param  \DateTimeInterface  $before
+     * @return int
+     */
+    public function prune(DateTimeInterface $before);
+}


### PR DESCRIPTION
This command removes stale records from the failed_jobs database table. You can pass an `--hours` option with the number of hours to retain jobs data