### PR TITLE
[8.x] Adds a small fix for unicode with blade echo handlers

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
@@ -143,7 +143,9 @@ trait CompilesEchos
     {
         $value = Str::of($value)
             ->trim()
-            ->when(Str::endsWith($value, ';'), function($str) { return $str->beforeLast(';'); });
+            ->when(Str::endsWith($value, ';'), function ($str) {
+                return $str->beforeLast(';');
+            });
 
         return empty($this->echoHandlers) ? $value : '$__bladeCompiler->applyEchoHandler('.$value.')';
     }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
@@ -141,7 +141,11 @@ trait CompilesEchos
      */
     protected function wrapInEchoHandler($value)
     {
-        return empty($this->echoHandlers) ? $value : '$__bladeCompiler->applyEchoHandler('.Str::beforeLast($value, ';').')';
+        $value = Str::of($value)
+            ->trim()
+            ->when(Str::endsWith($value, ';'), function($str) { return $str->beforeLast(';'); });
+
+        return empty($this->echoHandlers) ? $value : '$__bladeCompiler->applyEchoHandler('.$value.')';
     }
 
     /**

--- a/tests/View/Blade/BladeEchoHandlerTest.php
+++ b/tests/View/Blade/BladeEchoHandlerTest.php
@@ -102,6 +102,7 @@ class BladeEchoHandlerTest extends AbstractBladeTestCase
             ['{{"foo" . "bar"}}', 'foobar'],
             ['{{ 1 + 2 }}{{ "test"; }}', '3test'],
             ['@php($test = "hi"){{ $test }}', 'hi'],
+            ['{!! "&nbsp;" !!}', "&nbsp;"]
         ];
     }
 }

--- a/tests/View/Blade/BladeEchoHandlerTest.php
+++ b/tests/View/Blade/BladeEchoHandlerTest.php
@@ -102,7 +102,7 @@ class BladeEchoHandlerTest extends AbstractBladeTestCase
             ['{{"foo" . "bar"}}', 'foobar'],
             ['{{ 1 + 2 }}{{ "test"; }}', '3test'],
             ['@php($test = "hi"){{ $test }}', 'hi'],
-            ['{!! "&nbsp;" !!}', "&nbsp;"]
+            ['{!! "&nbsp;" !!}', '&nbsp;']
         ];
     }
 }

--- a/tests/View/Blade/BladeEchoHandlerTest.php
+++ b/tests/View/Blade/BladeEchoHandlerTest.php
@@ -102,7 +102,7 @@ class BladeEchoHandlerTest extends AbstractBladeTestCase
             ['{{"foo" . "bar"}}', 'foobar'],
             ['{{ 1 + 2 }}{{ "test"; }}', '3test'],
             ['@php($test = "hi"){{ $test }}', 'hi'],
-            ['{!! "&nbsp;" !!}', '&nbsp;']
+            ['{!! "&nbsp;" !!}', '&nbsp;'],
         ];
     }
 }


### PR DESCRIPTION
Howdy!

I noticed when working with blade echo handlers today that when outputting string values (such as unicode characters) that include ';', an error would be thrown. This PR fixes this issue by checking that the value really ends with ';' before stripping it.

I've added a test to prove it works correctly now.

As always, thanks for everything!

Regards,
Luke