### PR TITLE
[8.x] Add `whereExists()` and `whereNotExists()` to many-to-many relationship

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -571,7 +571,6 @@ class BelongsToMany extends Relation
     {
         return $this->related->newQuery()->whereExists(function ($query) {
             return $this->newPivotQueryFrom($query)
-                        ->from($this->getTable())
                         ->select($this->getRelatedPivotKeyName())
                         ->whereColumn($this->getQualifiedRelatedKeyName(), $this->getQualifiedRelatedPivotKeyName());
         });
@@ -586,7 +585,6 @@ class BelongsToMany extends Relation
     {
         return $this->related->newQuery()->whereNotExists(function ($query) {
             return $this->newPivotQueryFrom($query)
-                        ->from($this->getTable())
                         ->select($this->getRelatedPivotKeyName())
                         ->whereColumn($this->getQualifiedRelatedKeyName(), $this->getQualifiedRelatedPivotKeyName());
         });

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -563,6 +563,36 @@ class BelongsToMany extends Relation
     }
 
     /**
+     * Query related where parent is attached.
+     *
+     * @return \Illuminate\Database\Query\Builder
+     */
+    public function whereExists()
+    {
+        return $this->related->newQuery()->whereExists(function ($query) {
+            return $this->newPivotQueryFrom($query)
+                        ->from($this->getTable())
+                        ->select($this->getRelatedPivotKeyName())
+                        ->whereColumn($this->getQualifiedRelatedKeyName(), $this->getQualifiedRelatedPivotKeyName());
+        });
+    }
+
+    /**
+     * Query related where parent is not attached.
+     *
+     * @return \Illuminate\Database\Query\Builder
+     */
+    public function whereNotExists()
+    {
+        return $this->related->newQuery()->whereNotExists(function ($query) {
+            return $this->newPivotQueryFrom($query)
+                        ->from($this->getTable())
+                        ->select($this->getRelatedPivotKeyName())
+                        ->whereColumn($this->getQualifiedRelatedKeyName(), $this->getQualifiedRelatedPivotKeyName());
+        });
+    }
+
+    /**
      * Add an "order by" clause for a pivot table column.
      *
      * @param  string  $column

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -553,18 +553,29 @@ trait InteractsWithPivotTable
      */
     public function newPivotQuery()
     {
-        return $this->newPivotQueryFrom(
+        return $this->applyDefaultPivotQuery(
             $this->newPivotStatement()
         );
     }
 
     /**
-     * Apply query builder for the pivot table from given query builder.
+     * Apply query for the pivot table from given query builder.
      *
      * @param  \Illuminate\Database\Query\Builder  $query
      * @return \Illuminate\Database\Query\Builder
      */
     public function newPivotQueryFrom($query)
+    {
+        return $this->applyDefaultPivotQuery($query->from($this->table));
+    }
+
+    /**
+     * Apply default query for the pivot table.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @return \Illuminate\Database\Query\Builder
+     */
+    protected function applyDefaultPivotQuery($query)
     {
         foreach ($this->pivotWheres as $arguments) {
             $query->where(...$arguments);

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -553,8 +553,19 @@ trait InteractsWithPivotTable
      */
     public function newPivotQuery()
     {
-        $query = $this->newPivotStatement();
+        return $this->newPivotQueryFrom(
+            $this->newPivotStatement()
+        );
+    }
 
+    /**
+     * Apply query builder for the pivot table from given query builder.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @return \Illuminate\Database\Query\Builder
+     */
+    public function newPivotQueryFrom($query)
+    {
         foreach ($this->pivotWheres as $arguments) {
             $query->where(...$arguments);
         }

--- a/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
@@ -141,6 +141,38 @@ class MorphToMany extends BelongsToMany
     }
 
     /**
+     * Query related where parent is attached.
+     *
+     * @return \Illuminate\Database\Query\Builder
+     */
+    public function whereExists()
+    {
+        return $this->related->newQuery()->whereExists(function ($query) {
+            return $this->newPivotQueryFrom($query)
+                        ->from($this->getTable())
+                        ->select($this->getRelatedPivotKeyName())
+                        ->where($this->getMorphType(), $this->getMorphClass())
+                        ->whereColumn($this->getQualifiedRelatedKeyName(), $this->getQualifiedRelatedPivotKeyName());
+        });
+    }
+
+    /**
+     * Query related where parent is not attached.
+     *
+     * @return \Illuminate\Database\Query\Builder
+     */
+    public function whereNotExists()
+    {
+        return $this->related->newQuery()->whereNotExists(function ($query) {
+            return $this->newPivotQueryFrom($query)
+                        ->from($this->getTable())
+                        ->select($this->getRelatedPivotKeyName())
+                        ->where($this->getMorphType(), $this->getMorphClass())
+                        ->whereColumn($this->getQualifiedRelatedKeyName(), $this->getQualifiedRelatedPivotKeyName());
+        });
+    }
+
+    /**
      * Create a new pivot model instance.
      *
      * @param  array  $attributes

--- a/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
@@ -141,6 +141,19 @@ class MorphToMany extends BelongsToMany
     }
 
     /**
+     * Apply query for the pivot table from given query builder.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @return \Illuminate\Database\Query\Builder
+     */
+    public function newPivotQueryFrom($query)
+    {
+        return parent::newPivotQueryFrom(
+            $query->where($this->morphType, $this->morphClass)
+        );
+    }
+
+    /**
      * Query related where parent is attached.
      *
      * @return \Illuminate\Database\Query\Builder
@@ -149,9 +162,7 @@ class MorphToMany extends BelongsToMany
     {
         return $this->related->newQuery()->whereExists(function ($query) {
             return $this->newPivotQueryFrom($query)
-                        ->from($this->getTable())
                         ->select($this->getRelatedPivotKeyName())
-                        ->where($this->getMorphType(), $this->getMorphClass())
                         ->whereColumn($this->getQualifiedRelatedKeyName(), $this->getQualifiedRelatedPivotKeyName());
         });
     }
@@ -165,9 +176,7 @@ class MorphToMany extends BelongsToMany
     {
         return $this->related->newQuery()->whereNotExists(function ($query) {
             return $this->newPivotQueryFrom($query)
-                        ->from($this->getTable())
                         ->select($this->getRelatedPivotKeyName())
-                        ->where($this->getMorphType(), $this->getMorphClass())
                         ->whereColumn($this->getQualifiedRelatedKeyName(), $this->getQualifiedRelatedPivotKeyName());
         });
     }

--- a/tests/Database/DatabaseEloquentMorphToManyTest.php
+++ b/tests/Database/DatabaseEloquentMorphToManyTest.php
@@ -47,7 +47,11 @@ class DatabaseEloquentMorphToManyTest extends TestCase
     {
         $relation = $this->getMockBuilder(MorphToMany::class)->onlyMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $query = m::mock(stdClass::class);
-        $query->shouldReceive('from')->once()->with('taggables')->andReturn($query);
+        $query->shouldReceive('from')->once()->with('taggables')->andReturnUsing(function ($table) use ($query) {
+            $query->from = $table;
+
+            return $query;
+        });
         $query->shouldReceive('where')->once()->with('taggables.taggable_id', 1)->andReturn($query);
         $query->shouldReceive('where')->once()->with('taggable_type', get_class($relation->getParent()))->andReturn($query);
         $query->shouldReceive('whereIn')->once()->with('taggables.tag_id', [1, 2, 3]);
@@ -63,7 +67,11 @@ class DatabaseEloquentMorphToManyTest extends TestCase
     {
         $relation = $this->getMockBuilder(MorphToMany::class)->onlyMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $query = m::mock(stdClass::class);
-        $query->shouldReceive('from')->once()->with('taggables')->andReturn($query);
+        $query->shouldReceive('from')->once()->with('taggables')->andReturnUsing(function ($table) use ($query) {
+            $query->from = $table;
+
+            return $query;
+        });
         $query->shouldReceive('where')->once()->with('taggables.taggable_id', 1)->andReturn($query);
         $query->shouldReceive('where')->once()->with('taggable_type', get_class($relation->getParent()))->andReturn($query);
         $query->shouldReceive('whereIn')->never();

--- a/tests/Database/DatabaseEloquentMorphToManyTest.php
+++ b/tests/Database/DatabaseEloquentMorphToManyTest.php
@@ -47,11 +47,7 @@ class DatabaseEloquentMorphToManyTest extends TestCase
     {
         $relation = $this->getMockBuilder(MorphToMany::class)->onlyMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $query = m::mock(stdClass::class);
-        $query->shouldReceive('from')->once()->with('taggables')->andReturnUsing(function ($table) use ($query) {
-            $query->from = $table;
-
-            return $query;
-        });
+        $query->shouldReceive('from')->once()->with('taggables')->andReturn($query);
         $query->shouldReceive('where')->once()->with('taggables.taggable_id', 1)->andReturn($query);
         $query->shouldReceive('where')->once()->with('taggable_type', get_class($relation->getParent()))->andReturn($query);
         $query->shouldReceive('whereIn')->once()->with('taggables.tag_id', [1, 2, 3]);
@@ -67,11 +63,7 @@ class DatabaseEloquentMorphToManyTest extends TestCase
     {
         $relation = $this->getMockBuilder(MorphToMany::class)->onlyMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $query = m::mock(stdClass::class);
-        $query->shouldReceive('from')->once()->with('taggables')->andReturnUsing(function ($table) use ($query) {
-            $query->from = $table;
-
-            return $query;
-        });
+        $query->shouldReceive('from')->once()->with('taggables')->andReturn($query);
         $query->shouldReceive('where')->once()->with('taggables.taggable_id', 1)->andReturn($query);
         $query->shouldReceive('where')->once()->with('taggable_type', get_class($relation->getParent()))->andReturn($query);
         $query->shouldReceive('whereIn')->never();

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -927,6 +927,42 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $relationTag2 = $post->tagsWithCustomExtraPivot()->orderByPivot('flag', 'desc')->first();
         $this->assertEquals($relationTag2->getAttributes(), $tag3->getAttributes());
     }
+
+    public function testItQueryWhereExists()
+    {
+        $post = Post::create(['title' => Str::random()]);
+
+        $tag = Tag::create(['name' => Str::random()]);
+        $tag2 = Tag::create(['name' => Str::random()]);
+        $tag3 = Tag::create(['name' => Str::random()]);
+
+        $post->tags()->sync([
+            $tag->id => ['flag' => 'taylor'],
+            $tag2->id => ['flag' => ''],
+        ]);
+
+        $tags = $post->tags()->whereExists()->pluck('id');
+
+        $this->assertSame([$tag->getKey(), $tag2->getKey()], $tags->all());
+    }
+
+    public function testItQueryWhereNotExists()
+    {
+        $post = Post::create(['title' => Str::random()]);
+
+        $tag = Tag::create(['name' => Str::random()]);
+        $tag2 = Tag::create(['name' => Str::random()]);
+        $tag3 = Tag::create(['name' => Str::random()]);
+
+        $post->tags()->sync([
+            $tag->id => ['flag' => 'taylor'],
+            $tag2->id => ['flag' => ''],
+        ]);
+
+        $tags = $post->tags()->whereNotExists()->pluck('id');
+
+        $this->assertSame([$tag3->getKey()], $tags->all());
+    }
 }
 
 class User extends Model

--- a/tests/Integration/Database/EloquentMorphToManyTest.php
+++ b/tests/Integration/Database/EloquentMorphToManyTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentMorphToManyTest;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+/**
+ * @group integration
+ */
+class EloquentMorphToManyTest extends DatabaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('posts', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('title');
+            $table->timestamps();
+        });
+
+        Schema::create('commentables', function (Blueprint $table) {
+            $table->foreignId('comment_id');
+            $table->integer('commentable_id');
+            $table->string('commentable_type');
+            $table->timestamps();
+        });
+
+        Schema::create('comments', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->timestamps();
+        });
+
+        Carbon::setTestNow(null);
+    }
+
+    public function testItQueryWhereExists()
+    {
+        $post = Post::create(['title' => Str::random()]);
+
+        $comment = Comment::create(['name' => Str::random()]);
+        $comment2 = Comment::create(['name' => Str::random()]);
+        $comment3 = Comment::create(['name' => Str::random()]);
+
+        $post->comments()->sync([
+            $comment->id,
+            $comment2->id,
+        ]);
+
+        $comments = $post->comments()->whereExists()->pluck('id');
+
+        $this->assertSame([$comment->getKey(), $comment2->getKey()], $comments->all());
+    }
+
+    public function testItQueryWhereNotExists()
+    {
+        $post = Post::create(['title' => Str::random()]);
+
+        $comment = Comment::create(['name' => Str::random()]);
+        $comment2 = Comment::create(['name' => Str::random()]);
+        $comment3 = Comment::create(['name' => Str::random()]);
+
+        $post->comments()->sync([
+            $comment->id,
+            $comment2->id,
+        ]);
+
+        $comments = $post->comments()->whereNotExists()->pluck('id');
+
+        $this->assertSame([$comment3->getKey()], $comments->all());
+    }
+}
+
+class Post extends Model
+{
+    public $table = 'posts';
+    public $timestamps = true;
+    protected $guarded = [];
+    protected $withCount = ['comments'];
+
+    public function comments()
+    {
+        return $this->morphToMany(Comment::class, 'commentable');
+    }
+}
+
+class Comment extends Model
+{
+    public $table = 'comments';
+    public $timestamps = true;
+    protected $guarded = [];
+
+    public function commentable()
+    {
+        return $this->morphTo();
+    }
+}


### PR DESCRIPTION
In events where we might need to use an advanced query on pivot table such as combined with `whereExists` or `whereNotExists` etc. It would be nice if we can attach the default pivot wheres to given `$query`.

In this example, we will query `roles` where not yet attached to User ID 4.

```php
$user = App\Models\User::find(4); 

$roles = $user->roles()->whereNotExists()->pluck('id');
```

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>