### PR TITLE
[6.x] Removed unnecessary checks in RequiredIf validation, fixed tests

### DIFF
--- a/src/Illuminate/Validation/Rules/RequiredIf.php
+++ b/src/Illuminate/Validation/Rules/RequiredIf.php
@@ -21,7 +21,7 @@ class RequiredIf
      */
     public function __construct($condition)
     {
-        if (! is_string($condition) && (is_bool($condition) || is_callable($condition))) {
+        if (! is_string($condition)) {
             $this->condition = $condition;
         } else {
             throw new InvalidArgumentException('The provided condition must be a callable or boolean.');

--- a/tests/Validation/ValidationRequiredIfTest.php
+++ b/tests/Validation/ValidationRequiredIfTest.php
@@ -39,10 +39,6 @@ class ValidationRequiredIfTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
 
         $rule = new RequiredIf('phpinfo');
-
-        $rule = new RequiredIf(12.3);
-
-        $rule = new RequiredIf(new stdClass());
     }
 
     public function testItReturnedRuleIsNotSerializable()
@@ -52,7 +48,5 @@ class ValidationRequiredIfTest extends TestCase
         $rule = serialize(new RequiredIf(function () {
             return true;
         }));
-
-        $rule = serialize(new RequiredIf());
     }
 }


### PR DESCRIPTION
In reference to discussion in https://github.com/laravel/framework/pull/37688 

* This patch removes the unnecessary boolean and callable check so that `null` and `0` as input works as expected before.
* Also, tests were fixed as pointed out in the older PR.
