### PR TITLE
Show Falsy values in table output for Laravel artisan commands

### DIFF
--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -259,6 +259,7 @@ trait InteractsWithIO
                 if ($element == false) {
                     return 'FALSE';
                 }
+
                 return $element;
             })->toArray();
         })->toArray();

--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -219,7 +219,7 @@ trait InteractsWithIO
      * @param  \Illuminate\Contracts\Support\Arrayable|array  $rows
      * @param  string  $tableStyle
      * @param  array  $columnStyles
-     * @param  boolean  $showFalsy
+     * @param  bool  $showFalsy
      * @return void
      */
     public function table($headers, $rows, $tableStyle = 'default', array $columnStyles = [], $showFalsy = false)
@@ -243,7 +243,6 @@ trait InteractsWithIO
         $table->render();
     }
 
-    
     /**
      * Show falsy values in tables.
      *
@@ -252,13 +251,13 @@ trait InteractsWithIO
      */
     protected function showFalsyValues($rows)
     {
-        return collect($rows)->map(function($row){
-            return collect($row)->map(function($element){
+        return collect($rows)->map(function ($row) {
+            return collect($row)->map(function ($element) {
                 if (is_null($element)) {
-                    return "NULL";
+                    return 'NULL';
                 }
                 if ($element == false) {
-                    return "FALSE";
+                    return 'FALSE';
                 }
                 return $element;
             })->toArray();

--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -219,14 +219,19 @@ trait InteractsWithIO
      * @param  \Illuminate\Contracts\Support\Arrayable|array  $rows
      * @param  string  $tableStyle
      * @param  array  $columnStyles
+     * @param  boolean  $showFalsy
      * @return void
      */
-    public function table($headers, $rows, $tableStyle = 'default', array $columnStyles = [])
+    public function table($headers, $rows, $tableStyle = 'default', array $columnStyles = [], $showFalsy = false)
     {
         $table = new Table($this->output);
 
         if ($rows instanceof Arrayable) {
             $rows = $rows->toArray();
+        }
+
+        if ($showFalsy) {
+            $rows = $this->showFalsyValues($rows);
         }
 
         $table->setHeaders((array) $headers)->setRows($rows)->setStyle($tableStyle);
@@ -236,6 +241,28 @@ trait InteractsWithIO
         }
 
         $table->render();
+    }
+
+    
+    /**
+     * Show falsy values in tables.
+     *
+     * @param  array  $rows
+     * @return array
+     */
+    protected function showFalsyValues($rows)
+    {
+        return collect($rows)->map(function($row){
+            return collect($row)->map(function($element){
+                if (is_null($element)) {
+                    return "NULL";
+                }
+                if ($element == false) {
+                    return "FALSE";
+                }
+                return $element;
+            })->toArray();
+        })->toArray();
     }
 
     /**


### PR DESCRIPTION
This PR suggest to users to show the falsy values instead of blank results.

`$this->table($headers, $rows, $style, $columnStyles**, true**);`
