### PR TITLE
[8.x] Add in doc blocks for scoped and scopedIf

### DIFF
--- a/src/Illuminate/Contracts/Container/Container.php
+++ b/src/Illuminate/Contracts/Container/Container.php
@@ -5,6 +5,10 @@ namespace Illuminate\Contracts\Container;
 use Closure;
 use Psr\Container\ContainerInterface;
 
+/**
+ * @method scoped($abstract, $concrete = null)
+ * @method scopedIf($abstract, $concrete = null)
+ */
 interface Container extends ContainerInterface
 {
     /**

--- a/src/Illuminate/Contracts/Foundation/Application.php
+++ b/src/Illuminate/Contracts/Foundation/Application.php
@@ -4,6 +4,10 @@ namespace Illuminate\Contracts\Foundation;
 
 use Illuminate\Contracts\Container\Container;
 
+/**
+ * @method scoped($abstract, $concrete = null)
+ * @method scopedIf($abstract, $concrete = null)
+ */
 interface Application extends Container
 {
     /**

--- a/src/Illuminate/Contracts/Foundation/Application.php
+++ b/src/Illuminate/Contracts/Foundation/Application.php
@@ -4,10 +4,6 @@ namespace Illuminate\Contracts\Foundation;
 
 use Illuminate\Contracts\Container\Container;
 
-/**
- * @method scoped($abstract, $concrete = null)
- * @method scopedIf($abstract, $concrete = null)
- */
 interface Application extends Container
 {
     /**


### PR DESCRIPTION
Seeing as we can't add the `scoped` and `scopedIf` methods onto the contract yet as that would be a breaking change. It might be good to add them as a doc block and remove this doc block in `9.x`.

<img width="691" alt="Screenshot 2021-06-16 at 15 09 51" src="https://user-images.githubusercontent.com/916500/122234592-e832a380-ceb4-11eb-9f54-5c200cbfc206.png">
