### PR TITLE
[8.x] Replace non ASCII apostrophe in the email notification template

### DIFF
--- a/src/Illuminate/Notifications/resources/views/email.blade.php
+++ b/src/Illuminate/Notifications/resources/views/email.blade.php
@@ -51,7 +51,7 @@
 @isset($actionText)
 @slot('subcopy')
 @lang(
-    "If you’re having trouble clicking the \":actionText\" button, copy and paste the URL below\n".
+    "If you're having trouble clicking the \":actionText\" button, copy and paste the URL below\n".
     'into your web browser:',
     [
         'actionText' => $actionText,


### PR DESCRIPTION
This pr just replaces the non-ASCII apostrophe with the ASCII version in the notification email template view. This could help emails not get marked as spam in some clients, and printers can have a hissy fit sometimes when trying to print non-ASCII characters.