### PR TITLE
[8.x] Allow global override of console confirm via handler

### DIFF
--- a/src/Illuminate/Console/ConfirmHandler.php
+++ b/src/Illuminate/Console/ConfirmHandler.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Illuminate\Console;
+
+class ConfirmHandler implements ConfirmHandlerInterface
+{
+    /**
+     * Return if the the console should ask to confirm by default
+     *
+     * @param \Illuminate\Contracts\Foundation\Application $larvel
+     * @return bool
+     */
+    public static function handle($larvel)
+    {
+        return $larvel->environment() === 'production';
+    }
+
+    /**
+     * Return warning message for console confirm
+     *
+     * @return string
+     */
+    public static function warning()
+    {
+        return 'Application In Production!';
+    }
+}

--- a/src/Illuminate/Console/ConfirmHandler.php
+++ b/src/Illuminate/Console/ConfirmHandler.php
@@ -2,7 +2,9 @@
 
 namespace Illuminate\Console;
 
-class ConfirmHandler implements ConfirmHandlerInterface
+use Illuminate\Contracts\Console\ConfirmHandler as ConfirmHandlerContract;
+
+class ConfirmHandler implements ConfirmHandlerContract
 {
     /**
      * Return if the the console should ask to confirm by default.

--- a/src/Illuminate/Console/ConfirmHandler.php
+++ b/src/Illuminate/Console/ConfirmHandler.php
@@ -7,12 +7,12 @@ class ConfirmHandler implements ConfirmHandlerInterface
     /**
      * Return if the the console should ask to confirm by default.
      *
-     * @param \Illuminate\Contracts\Foundation\Application $larvel
+     * @param \Illuminate\Contracts\Foundation\Application $laravel
      * @return bool
      */
-    public static function handle($larvel)
+    public static function handle($laravel)
     {
-        return $larvel->environment() === 'production';
+        return $laravel->environment() === 'production';
     }
 
     /**

--- a/src/Illuminate/Console/ConfirmHandler.php
+++ b/src/Illuminate/Console/ConfirmHandler.php
@@ -5,7 +5,7 @@ namespace Illuminate\Console;
 class ConfirmHandler implements ConfirmHandlerInterface
 {
     /**
-     * Return if the the console should ask to confirm by default
+     * Return if the the console should ask to confirm by default.
      *
      * @param \Illuminate\Contracts\Foundation\Application $larvel
      * @return bool
@@ -16,7 +16,7 @@ class ConfirmHandler implements ConfirmHandlerInterface
     }
 
     /**
-     * Return warning message for console confirm
+     * Return warning message for console confirm.
      *
      * @return string
      */

--- a/src/Illuminate/Console/ConfirmHandlerInterface.php
+++ b/src/Illuminate/Console/ConfirmHandlerInterface.php
@@ -5,7 +5,7 @@ namespace Illuminate\Console;
 interface ConfirmHandlerInterface
 {
     /**
-     * Return if the the console should ask to confirm by default
+     * Return if the the console should ask to confirm by default.
      *
      * @param \Illuminate\Contracts\Foundation\Application $larvel
      * @return bool
@@ -13,7 +13,7 @@ interface ConfirmHandlerInterface
     public static function handle($larvel);
 
     /**
-     * Return warning message for console confirm
+     * Return warning message for console confirm.
      *
      * @return string
      */

--- a/src/Illuminate/Console/ConfirmHandlerInterface.php
+++ b/src/Illuminate/Console/ConfirmHandlerInterface.php
@@ -7,10 +7,10 @@ interface ConfirmHandlerInterface
     /**
      * Return if the the console should ask to confirm by default.
      *
-     * @param \Illuminate\Contracts\Foundation\Application $larvel
+     * @param \Illuminate\Contracts\Foundation\Application $laravel
      * @return bool
      */
-    public static function handle($larvel);
+    public static function handle($laravel);
 
     /**
      * Return warning message for console confirm.

--- a/src/Illuminate/Console/ConfirmHandlerInterface.php
+++ b/src/Illuminate/Console/ConfirmHandlerInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Illuminate\Console;
+
+interface ConfirmHandlerInterface
+{
+    /**
+     * Return if the the console should ask to confirm by default
+     *
+     * @param \Illuminate\Contracts\Foundation\Application $larvel
+     * @return bool
+     */
+    public static function handle($larvel);
+
+    /**
+     * Return warning message for console confirm
+     *
+     * @return string
+     */
+    public static function warning();
+}

--- a/src/Illuminate/Console/ConfirmableTrait.php
+++ b/src/Illuminate/Console/ConfirmableTrait.php
@@ -9,7 +9,7 @@ trait ConfirmableTrait
      *
      * This method only asks for confirmation in production.
      *
-     * @param  ?string  $warning
+     * @param  string|null  $warning
      * @param  \Closure|bool|null  $callback
      * @return bool
      */

--- a/src/Illuminate/Console/ConfirmableTrait.php
+++ b/src/Illuminate/Console/ConfirmableTrait.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Console;
 
+use Illuminate\Contracts\Console\ConfirmHandler as ConfirmHandlerContract;
+
 trait ConfirmableTrait
 {
     /**
@@ -15,7 +17,11 @@ trait ConfirmableTrait
      */
     public function confirmToProceed($warning = null, $callback = null)
     {
-        $handler = $this->laravel->make(ConfirmHandler::class);
+        if ($this->laravel->bound(ConfirmHandlerContract::class)) {
+            $handler = $this->laravel->make(ConfirmHandlerContract::class);
+        } else {
+            $handler = new ConfirmHandler();
+        }
         $shouldConfirm = $callback !== null ? value($callback) : $handler::handle($this->laravel);
 
         if ($shouldConfirm) {

--- a/src/Illuminate/Console/ConfirmableTrait.php
+++ b/src/Illuminate/Console/ConfirmableTrait.php
@@ -15,12 +15,7 @@ trait ConfirmableTrait
      */
     public function confirmToProceed($warning = null, $callback = null)
     {
-        $config = $this->laravel['config'];
-        $handler = $config->get('console.confirm_handler');
-        if ($handler === null || ! is_a($handler, ConfirmHandlerInterface::class, true)) {
-            $handler = ConfirmHandler::class;
-        }
-
+        $handler = $this->laravel->make(ConfirmHandler::class);
         $shouldConfirm = $callback !== null ? value($callback) : $handler::handle($this->laravel);
 
         if ($shouldConfirm) {

--- a/src/Illuminate/Contracts/Console/ConfirmHandler.php
+++ b/src/Illuminate/Contracts/Console/ConfirmHandler.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Illuminate\Console;
+namespace Illuminate\Contracts\Console;
 
-interface ConfirmHandlerInterface
+interface ConfirmHandler
 {
     /**
      * Return if the the console should ask to confirm by default.

--- a/tests/Console/ConfirmHelperTest.php
+++ b/tests/Console/ConfirmHelperTest.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Tests\Console;
 
 use Illuminate\Console\ConfirmableTrait;
-use Illuminate\Console\ConfirmHandler;
 use Illuminate\Contracts\Config\Repository;
 use Illuminate\Contracts\Console\ConfirmHandler as ConfirmHandlerContract;
 use Illuminate\Foundation\Application;

--- a/tests/Console/ConfirmHelperTest.php
+++ b/tests/Console/ConfirmHelperTest.php
@@ -47,6 +47,24 @@ class ConfirmHelperTest extends TestCase
         $this->assertSame(false, $mock->confirmToProceed());
     }
 
+    public function testCustomCallbackTrue()
+    {
+        $mock = $this->setupMock('production');
+        $mock->method('hasOption')->willReturn(false);
+        $mock->expects($this->exactly(1))->method('alert')->with('Passed Param String!');
+
+        $this->assertSame(false, $mock->confirmToProceed('Passed Param String!', function () { return true; }));
+    }
+
+    public function testCustomCallbackFalse()
+    {
+        $mock = $this->setupMock('production');
+        $mock->method('hasOption')->willReturn(false);
+        $mock->expects($this->exactly(0))->method('alert');
+
+        $this->assertSame(true, $mock->confirmToProceed('Passed Param String!', function () { return false; }));
+    }
+
     protected function setupMock(string $env, $handler = null)
     {
         $app = new Application();

--- a/tests/Console/ConfirmHelperTest.php
+++ b/tests/Console/ConfirmHelperTest.php
@@ -4,8 +4,8 @@ namespace Illuminate\Tests\Console;
 
 use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Console\ConfirmHandler;
-use Illuminate\Contracts\Console\ConfirmHandler as ConfirmHandlerContract;
 use Illuminate\Contracts\Config\Repository;
+use Illuminate\Contracts\Console\ConfirmHandler as ConfirmHandlerContract;
 use Illuminate\Foundation\Application;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;

--- a/tests/Console/ConfirmHelperTest.php
+++ b/tests/Console/ConfirmHelperTest.php
@@ -53,7 +53,9 @@ class ConfirmHelperTest extends TestCase
         $mock->method('hasOption')->willReturn(false);
         $mock->expects($this->exactly(1))->method('alert')->with('Passed Param String!');
 
-        $this->assertSame(false, $mock->confirmToProceed('Passed Param String!', function () { return true; }));
+        $this->assertSame(false, $mock->confirmToProceed('Passed Param String!', function () {
+            return true;
+        }));
     }
 
     public function testCustomCallbackFalse()
@@ -62,7 +64,9 @@ class ConfirmHelperTest extends TestCase
         $mock->method('hasOption')->willReturn(false);
         $mock->expects($this->exactly(0))->method('alert');
 
-        $this->assertSame(true, $mock->confirmToProceed('Passed Param String!', function () { return false; }));
+        $this->assertSame(true, $mock->confirmToProceed('Passed Param String!', function () {
+            return false;
+        }));
     }
 
     protected function setupMock(string $env, $handler = null)

--- a/tests/Console/ConfirmHelperTest.php
+++ b/tests/Console/ConfirmHelperTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Illuminate\Tests\Console;
+
+use Illuminate\Console\ConfirmableTrait;
+use Illuminate\Console\ConfirmHandlerInterface;
+use Illuminate\Contracts\Config\Repository;
+use Illuminate\Foundation\Application;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class ConfirmHelperTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    public function testDefaultConfirmHelperProduction()
+    {
+        $mock = $this->setupMock('production');
+        $mock->method('hasOption')->willReturn(false);
+        $mock->expects($this->exactly(1))->method('alert')->with('Application In Production!');
+
+        $this->assertSame(false, $mock->confirmToProceed());
+    }
+
+    public function testDefaultConfirmHelperLocal()
+    {
+        $mock = $this->setupMock('local');
+        $mock->method('hasOption')->willReturn(false);
+        $mock->expects($this->exactly(0))->method('alert');
+
+        $this->assertSame(true, $mock->confirmToProceed());
+    }
+
+    public function testCustomConfirmHelper()
+    {
+        $handler = m::mock(ConfirmHandlerInterface::class);
+        $handler->shouldReceive('warning')->andReturn('Application In Custom!');
+        $handler->shouldReceive('handle')->andReturn(true);
+
+        $mock = $this->setupMock('custom', $handler);
+        $mock->method('hasOption')->willReturn(false);
+        $mock->expects($this->exactly(1))->method('alert')->with('Application In Custom!');
+
+        $this->assertSame(false, $mock->confirmToProceed());
+    }
+
+    protected function setupMock(string $env, $handler = null)
+    {
+        $app = new Application();
+        $app['config'] = m::mock(Repository::class);
+        $app['config']->shouldReceive('get')->with('console.confirm_handler')->andReturn($handler);
+        $app['env'] = $env;
+
+        $mock = $this->getMockForTrait(
+            ConfirmableTrait::class,
+            [],
+            '',
+            true,
+            true,
+            true,
+            [
+                'hasOption',
+                'alert',
+                'confirm',
+                'comment',
+            ]
+        );
+        $mock->laravel = $app;
+
+        return $mock;
+    }
+}

--- a/tests/Console/ConfirmHelperTest.php
+++ b/tests/Console/ConfirmHelperTest.php
@@ -72,7 +72,7 @@ class ConfirmHelperTest extends TestCase
         $app['config'] = m::mock(Repository::class);
         $app['env'] = $env;
         if ($handlerClass !== null) {
-            $app->bind(ConfirmHandler::class, $handlerClass);
+            $app->bind(ConfirmHandlerContract::class, $handlerClass);
         }
 
         $mock = $this->getMockForTrait(


### PR DESCRIPTION
This gives developers a more convenient way to globally override the actions taken by `confirmToProceed` on console commands, with a handler.  The benefit here is developers can set a handler to change the behavior rather than manually overriding/aliasing the migration and queue commands that come with the framework.

The backstory for how I will be using this.  At my company, we maintain multiple tiers that are technically all production but that have different environment variables `production`, `beta`, and `latest` these tiers share the same production database but are used to do things like give external developers access to beta APIs or canary a release by routing a subset of site traffic to a tier, internal dogfooding, etc.  We want a more convenient way to ensure dangerous console commands like `queue:clear`, `migrate:*` are treated with the same reverence as production without having to alias/override them in every vendor package.