### PR TITLE
[8.x] firstWhere doc block missing return type of null

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -283,7 +283,7 @@ class Builder
      * @param  mixed  $operator
      * @param  mixed  $value
      * @param  string  $boolean
-     * @return \Illuminate\Database\Eloquent\Model|static
+     * @return \Illuminate\Database\Eloquent\Model|static|null
      */
     public function firstWhere($column, $operator = null, $value = null, $boolean = 'and')
     {


### PR DESCRIPTION
The `firstWhere` method returns `null` but the doc block doesn't have it as a return type.

This test proves it returns `null`: https://github.com/laravel/framework/blob/b1257c4e0d34423ce87a2d60333e547e3ea56631/tests/Integration/Database/EloquentWhereTest.php#L90

The `first()` method has a `null` return type.
https://github.com/laravel/framework/blob/b1257c4e0d34423ce87a2d60333e547e3ea56631/src/Illuminate/Database/Concerns/BuildsQueries.php#L253