### PR TITLE
[8.x] Added eachWhere and eachHas to fluent json assertions

### DIFF
--- a/src/Illuminate/Testing/Fluent/Concerns/Has.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Has.php
@@ -127,7 +127,6 @@ trait Has
             sprintf('Property [%s] must be an Iterable.', $this->dotPath($key))
         );
 
-
         $this->interactsWith($key);
 
         foreach ($actual as $index => $value) {

--- a/src/Illuminate/Testing/Fluent/Concerns/Has.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Has.php
@@ -102,9 +102,9 @@ trait Has
 
         return $this;
     }
-    
+
     /**
-     * Assert that the prop is of the expected size inside all itens in an array
+     * Assert that the prop is of the expected size inside all itens in an array.
      *
      * @param  string|int  $key
      * @param  string|int  $property The property to verify

--- a/src/Illuminate/Testing/Fluent/Concerns/Has.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Has.php
@@ -102,6 +102,41 @@ trait Has
 
         return $this;
     }
+    
+    /**
+     * Assert that the prop is of the expected size inside all itens in an array
+     *
+     * @param  string|int  $key
+     * @param  string|int  $property The property to verify
+     * @param  int|null  $length
+     * @return $this
+     */
+    public function eachHas($key, $property, $length = null, Closure $callback = null): self
+    {
+        $this->has($key);
+
+        $actual = $this->prop($key);
+
+        PHPUnit::assertTrue(
+            Arr::has($this->prop(), $key),
+            sprintf('Property [%s] does not exist.', $this->dotPath($key))
+        );
+
+        PHPUnit::assertIsIterable(
+            $actual,
+            sprintf('Property [%s] must be an Iterable.', $this->dotPath($key))
+        );
+
+
+        $this->interactsWith($key);
+
+        foreach ($actual as $index => $value) {
+            $actualKey = "{$key}.{$index}.{$property}";
+            $this->has($actualKey, $length, $callback);
+        }
+
+        return $this;
+    }
 
     /**
      * Assert that none of the given props exist.

--- a/src/Illuminate/Testing/Fluent/Concerns/Matching.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Matching.php
@@ -85,10 +85,9 @@ trait Matching
             sprintf('Property [%s] must be an Iterable.', $this->dotPath($key))
         );
 
-
         $this->interactsWith($key);
 
-        foreach($actual as $index => $value){
+        foreach ($actual as $index => $value) {
             $actualKey = "{$key}.{$index}.{$property}";
             $this->where($actualKey, $expected);
         }

--- a/src/Illuminate/Testing/Fluent/Concerns/Matching.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Matching.php
@@ -4,6 +4,7 @@ namespace Illuminate\Testing\Fluent\Concerns;
 
 use Closure;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use PHPUnit\Framework\Assert as PHPUnit;
 
@@ -57,6 +58,39 @@ trait Matching
     {
         foreach ($bindings as $key => $value) {
             $this->where($key, $value);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Asserts that all properties inside an Collection match their expected value.
+     *
+     * @param  string  $key
+     * @param  string  $property The property to verify
+     * @param  mixed|\Closure  $expected
+     * @return $this
+     */
+    public function eachWhere(string $key, string $property, $expected): self
+    {
+        $actual = $this->prop($key);
+
+        PHPUnit::assertTrue(
+            Arr::has($this->prop(), $key),
+            sprintf('Property [%s] does not exist.', $this->dotPath($key))
+        );
+
+        PHPUnit::assertIsIterable(
+            $actual,
+            sprintf('Property [%s] must be an Iterable.', $this->dotPath($key))
+        );
+
+
+        $this->interactsWith($key);
+
+        foreach($actual as $index => $value){
+            $actualKey = "{$key}.{$index}.{$property}";
+            $this->where($actualKey, $expected);
         }
 
         return $this;

--- a/tests/Testing/Fluent/AssertTest.php
+++ b/tests/Testing/Fluent/AssertTest.php
@@ -832,6 +832,7 @@ class AssertTest extends TestCase
 
         $assert->eachWhere('foo', 'bar', 'value');
     }
+
     public function testAssertEachWhereMatchesValuesFailsWhenAtLeastOnePropDoesNotMatchValue()
     {
         $assert = AssertableJson::fromArray([
@@ -869,7 +870,6 @@ class AssertTest extends TestCase
             },
         ]);
     }
-
 
     public function testAssertWhereTypeString()
     {
@@ -1080,6 +1080,7 @@ class AssertTest extends TestCase
 
         $assert->eachHas('foo', 'bar');
     }
+
     public function testAssertEachHasMatchesValuesFailsWhenAtLeastOnePropDoesNotMatchValue()
     {
         $assert = AssertableJson::fromArray([

--- a/tests/Testing/Fluent/AssertTest.php
+++ b/tests/Testing/Fluent/AssertTest.php
@@ -816,6 +816,61 @@ class AssertTest extends TestCase
         ]);
     }
 
+    public function testAssertEachWhereMatchesValues()
+    {
+        $assert = AssertableJson::fromArray([
+            'foo' => [
+                'baz' => [
+                    'bar' => 'value',
+                ],
+                'example' => [
+                    'bar' => 'value',
+                ],
+            ],
+
+        ]);
+
+        $assert->eachWhere('foo', 'bar', 'value');
+    }
+    public function testAssertEachWhereMatchesValuesFailsWhenAtLeastOnePropDoesNotMatchValue()
+    {
+        $assert = AssertableJson::fromArray([
+            'foo' => [
+                'baz' => [
+                    'bar' => 'notvalue',
+                ],
+                'example' => [
+                    'bar' => 'value',
+                ],
+            ],
+
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Property [foo.baz.bar] does not match the expected value.');
+
+        $assert->eachWhere('foo', 'bar', 'value');
+    }
+
+    public function testAssertEachWhereFailsWhenAtLeastOnePropDoesNotMatchValue()
+    {
+        $assert = AssertableJson::fromArray([
+            'foo' => 'bar',
+            'baz' => 'example',
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Property [baz] was marked as invalid using a closure.');
+
+        $assert->whereAll([
+            'foo' => 'bar',
+            'baz' => function ($value) {
+                return $value === 'foo';
+            },
+        ]);
+    }
+
+
     public function testAssertWhereTypeString()
     {
         $assert = AssertableJson::fromArray([
@@ -1007,6 +1062,42 @@ class AssertTest extends TestCase
         $this->expectExceptionMessage('Property [foo.baz] does not exist.');
 
         $assert->hasAll('foo.bar', 'foo.baz', 'baz');
+    }
+
+    public function testAssertEachHasMatchesValues()
+    {
+        $assert = AssertableJson::fromArray([
+            'foo' => [
+                'baz' => [
+                    'bar' => 'value',
+                ],
+                'example' => [
+                    'bar' => 'value',
+                ],
+            ],
+
+        ]);
+
+        $assert->eachHas('foo', 'bar');
+    }
+    public function testAssertEachHasMatchesValuesFailsWhenAtLeastOnePropDoesNotMatchValue()
+    {
+        $assert = AssertableJson::fromArray([
+            'foo' => [
+                'baz' => [
+                    'notbar' => 'notvalue',
+                ],
+                'example' => [
+                    'bar' => 'value',
+                ],
+            ],
+
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Property [foo.baz.bar] does not exist.');
+
+        $assert->eachHas('foo', 'bar');
     }
 
     public function testAssertCountMultipleProps()


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Added new method to fluent JSON testing to validate itens inside an Collection/Array

### Our Sample Json Response
```json
{
    "data": [
      {
        "id": 1192,
        "name": "Claudio Dekker",
        "active": true
    },
    {
        "id": 1193,
        "name": "Taylor Otwell",
        "active": true
    }
]
}

```
### eachWhere
Check if all properties inside of a given array matches the expected value.
This is useful when you're  updating or creating a bunch of models at the same request

```php
$response->assertJson(fn (Assert $json) => $json
    ->has('message', fn (Assert $json) => $json
        // Assert that all objects inside 'data' have an attribute 'active' with value = true
        ->eachWhere('data', 'active', true)
    )
);
```

### eachHas
Check if all properties inside of a given array exists
This is useful when you can have different properties based at some business rule, for example

```php
$response->assertJson(fn (Assert $json) => $json
    ->has('message', fn (Assert $json) => $json
        // Assert that all objects inside 'data' have an attribute 'active'
        ->eachHas('data', 'active')
    )
);
```
