### PR TITLE
[8.x] Build an on-demand filesystem disk

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -91,6 +91,19 @@ class FilesystemManager implements FactoryContract
     }
 
     /**
+     * Build an on-demand disk.
+     *
+     * @param  string|array  $root
+     * @return \Illuminate\Contracts\Filesystem\Filesystem
+     */
+    public function build($root)
+    {
+        $config = is_array($root) ? $root : ['driver' => 'local', 'root' => $root];
+
+        return $this->disks['ondemand'] = $this->resolve('ondemand', $config);
+    }
+
+    /**
      * Attempt to get the disk from the local cache.
      *
      * @param  string  $name
@@ -109,9 +122,9 @@ class FilesystemManager implements FactoryContract
      *
      * @throws \InvalidArgumentException
      */
-    protected function resolve($name)
+    protected function resolve($name, $config = null)
     {
-        $config = $this->getConfig($name);
+        $config = $config ?? $this->getConfig($name);
 
         if (empty($config['driver'])) {
             throw new InvalidArgumentException("Disk [{$name}] does not have a configured driver.");

--- a/src/Illuminate/Support/Facades/Storage.php
+++ b/src/Illuminate/Support/Facades/Storage.php
@@ -8,6 +8,7 @@ use Illuminate\Filesystem\Filesystem;
  * @method static \Illuminate\Contracts\Filesystem\Filesystem assertExists(string|array $path)
  * @method static \Illuminate\Contracts\Filesystem\Filesystem assertMissing(string|array $path)
  * @method static \Illuminate\Contracts\Filesystem\Filesystem cloud()
+ * @method static \Illuminate\Contracts\Filesystem\Filesystem build(string|array $root)
  * @method static \Illuminate\Contracts\Filesystem\Filesystem disk(string|null $name = null)
  * @method static \Illuminate\Filesystem\FilesystemManager extend(string $driver, \Closure $callback)
  * @method static \Symfony\Component\HttpFoundation\StreamedResponse download(string $path, string|null $name = null, array|null $headers = [])

--- a/tests/Filesystem/FilesystemManagerTest.php
+++ b/tests/Filesystem/FilesystemManagerTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Filesystem;
 
+use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Filesystem\FilesystemManager;
 use Illuminate\Foundation\Application;
 use InvalidArgumentException;
@@ -19,5 +20,19 @@ class FilesystemManagerTest extends TestCase
         }));
 
         $filesystem->disk('local');
+    }
+
+    public function testCanBuildOnDemandDisk()
+    {
+        $filesystem = new FilesystemManager(new Application);
+
+        $this->assertInstanceOf(Filesystem::class, $filesystem->build('my-custom-path'));
+
+        $this->assertInstanceOf(Filesystem::class, $filesystem->build([
+            'driver'     => 'local',
+            'root'       => 'my-custom-path',
+            'url'        => 'my-custom-url',
+            'visibility' => 'public',
+        ]));
     }
 }


### PR DESCRIPTION
Occasionally I will need to access a file that does not currently reside within the root of a configured filesystem disk. I don't really want to create a full "disk" for them, because often this is a very one-off, or even temporary need. Sometimes it won't even get committed, but I just need it for a quick local dev use.

This PR allows us to make "on-demand" disks using the `build()` method.

There are 2 ways to build this on-demand disk.  If you pass a string to the `build()` method, it will build a disk with a local driver, and the root pointed to the passed path.

```php
Storage::build(storage_path('logs'));
```

You can also pass an array to have full control of the configuration:

```php
Storage::build([
    'driver'     => 'local',
    'root'       => 'my-custom-path',
    'url'        => 'my-custom-url',
    'visibility' => 'public',
]);
```