### PR TITLE
[8.x] Fix: fire a `NotificationFailed` event

### DIFF
--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -131,10 +131,10 @@ class NotificationSender
     /**
      * Send the given notification to the given notifiable via a channel.
      *
-     * @param mixed $notifiable
-     * @param string $id
-     * @param mixed $notification
-     * @param string $channel
+     * @param  mixed  $notifiable
+     * @param  string  $id
+     * @param  mixed  $notification
+     * @param  string  $channel
      * @return void
      * @throws Throwable
      */

--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -157,7 +157,7 @@ class NotificationSender
         } catch (Throwable $th) {
             $this->events->dispatch(
                 new NotificationFailed($notifiable, $notification, $channel, [
-                    'error' => $th->getMessage()
+                    'error' => $th->getMessage(),
                 ])
             );
 

--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -12,6 +12,7 @@ use Illuminate\Notifications\Events\NotificationSent;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Localizable;
+use Throwable;
 
 class NotificationSender
 {
@@ -135,7 +136,7 @@ class NotificationSender
      * @param mixed $notification
      * @param string $channel
      * @return void
-     * @throws \Throwable
+     * @throws Throwable
      */
     protected function sendToNotifiable($notifiable, $id, $notification, $channel)
     {
@@ -153,7 +154,7 @@ class NotificationSender
             $this->events->dispatch(
                 new NotificationSent($notifiable, $notification, $channel, $response)
             );
-        } catch (\Throwable $th) {
+        } catch (Throwable $th) {
             $this->events->dispatch(
                 new NotificationFailed($notifiable, $notification, $channel, [
                     'error' => $th->getMessage()


### PR DESCRIPTION
Laravel has the following events for notifications:

- NotificationSending
- NotificationSent
- NotificationFailed

`NotificationSending` and `NotificationSent` events are fired properly, but the other event `NotificationFailed` is not triggered at all. it just sits there in the code.

through this PR I'm exploring the possibility of firing this event when the driver fails to send the notification through the channel.  
