### PR TITLE
[8.x] Fix incorrect usage of firstOrFail in test

### DIFF
--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -334,7 +334,7 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
 
         $post = Post::create(['title' => Str::random()]);
 
-        $post->tags()->firstOrFail(['id' => 10]);
+        $post->tags()->firstOrFail(['id']);
     }
 
     public function testFindMethod()


### PR DESCRIPTION
Doesn't affect test results, just a typo in using findOrFail method that would be good to fix.

Query is actually selecting a column named `10`, sqlite doesn't complain though.

Found this while trying to run all tests on a mysql DB, mysql throws an error such as: `column 10 doesn't exist`.