### PR TITLE
[8.x] Fix: Update Single JSON Field with Guarded

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
@@ -203,6 +203,10 @@ trait GuardsAttributes
             return false;
         }
 
+        if (strpos($key, '->') !== false) {
+            $key = Str::before($key, '->');
+        }
+
         return $this->getGuarded() == ['*'] ||
                ! empty(preg_grep('/^'.preg_quote($key).'$/i', $this->getGuarded())) ||
                ! $this->isGuardableColumn($key);

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -185,6 +185,21 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertFalse($model->originalIsEquivalent('castedFloat'));
     }
 
+    public function testUpdateSingleFieldJsonAttributeWithGuard()
+    {
+        $model = new EloquentModelStub(['id' => 1, 'arrayAttribute' => '{"foo":"bar"}']);
+
+        EloquentModelStub::setConnectionResolver($resolver = m::mock(Resolver::class));
+        $resolver->shouldReceive('connection')->andReturn($connection = m::mock(stdClass::class));
+        $connection->shouldReceive('getSchemaBuilder->getColumnListing')->andReturn(['id', 'arrayAttribute']);
+
+        $model->guard(['id']);
+
+        $model->fill(['arrayAttribute->foo' => 'baz']);
+
+        $this->assertEquals('{"foo":"baz"}', $model->arrayAttribute);
+    }
+
     public function testCalculatedAttributes()
     {
         $model = new EloquentModelStub;


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Closes #37724 

This resolves a bug preventing the updating of a JSON field attribute when the a model `$guarded` has specified values. 
```
class User extends Model
{
    protected $guarded = ['id'];
    ...
```

The following is currently broken because `'options->key'` will not appear among the `isGuardableColumn()`
```
$user = User::find(1);

$user->update(['options->key' => 'value']);
```
