### PR TITLE
Add missing "withQueryString" method to Paginator Interface

### DIFF
--- a/src/Illuminate/Contracts/Pagination/Paginator.php
+++ b/src/Illuminate/Contracts/Pagination/Paginator.php
@@ -27,7 +27,7 @@ interface Paginator
      * @return $this
      */
     public function withQueryString();
-
+    
     /**
      * Get / set the URL fragment to be appended to URLs.
      *

--- a/src/Illuminate/Contracts/Pagination/Paginator.php
+++ b/src/Illuminate/Contracts/Pagination/Paginator.php
@@ -20,14 +20,14 @@ interface Paginator
      * @return $this
      */
     public function appends($key, $value = null);
-    
+
     /**
      * Add all current query string values to the paginator.
      *
      * @return $this
      */
     public function withQueryString();
-    
+
     /**
      * Get / set the URL fragment to be appended to URLs.
      *

--- a/src/Illuminate/Contracts/Pagination/Paginator.php
+++ b/src/Illuminate/Contracts/Pagination/Paginator.php
@@ -20,6 +20,13 @@ interface Paginator
      * @return $this
      */
     public function appends($key, $value = null);
+    
+    /**
+     * Add all current query string values to the paginator.
+     *
+     * @return $this
+     */
+    public function withQueryString();
 
     /**
      * Get / set the URL fragment to be appended to URLs.


### PR DESCRIPTION
To get full IDE autocompletion support this PR adds the `withQueryString()` method from `Illuminate\Pagination\AbstractPaginator` to the `Illuminate\Contracts\Pagination\Paginator` Interface.

I'm not quite sure if `Illuminate\Contracts\Pagination\LengthAwarePaginator` would be a better place to add the method, but as the `appends()` method is also present on `Illuminate\Contracts\Pagination\Paginator` I chose to add it there.

Does this has to be considered as a breaking change because custom implementations of `Illuminate\Contracts\Pagination\Paginator` or `Illuminate\Contracts\Pagination\LengthAwarePaginator` could be missing the `withQueryString()` method?