### PR TITLE
[8.x] Change the order of the bindings for a Sql Server query with a offset and a subquery order by

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -181,13 +181,13 @@ class SqlServerGrammar extends Grammar
 
         unset($components['orders']);
 
-        // As this moves the order statement to be part of the "select" statement, we need to
+        // As this moves the order statement to be part of the "select" statement, we might need to
         // move the bindings to the right position: right after "select".
-        $preferredBindingOrder = ['select', 'order', 'from', 'join', 'where', 'groupBy', 'having', 'union', 'unionOrder'];
-        $sortedBindings = Arr::sort($query->bindings, function ($bindings, $key) use ($preferredBindingOrder) {
-            return array_search($key, $preferredBindingOrder);
-        });
-        $query->bindings = $sortedBindings;
+        if ($this->queryOrderContainsSubquery($query)) {
+            $preferredBindingOrder = ['select', 'order', 'from', 'join', 'where', 'groupBy', 'having', 'union', 'unionOrder'];
+            $sortedBindings = Arr::sort($query->bindings, fn ($bindings, $key) => array_search($key, $preferredBindingOrder));
+            $query->bindings = $sortedBindings;
+        }
 
         // Next we need to calculate the constraints that should be placed on the query
         // to get the right offset and limit from our query but if there is no limit
@@ -195,6 +195,23 @@ class SqlServerGrammar extends Grammar
         $sql = $this->concatenate($components);
 
         return $this->compileTableExpression($sql, $query);
+    }
+
+    /**
+     * Check if the query order by clauses contain a subquery.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @return bool
+     */
+    protected function queryOrderContainsSubquery($query)
+    {
+        if (!is_array($query->orders)) {
+            return false;
+        }
+
+        return Arr::first($query->orders, function ($value) {
+            return $this->isExpression($value['column']);
+        }, false) !== false;
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -184,7 +184,9 @@ class SqlServerGrammar extends Grammar
         // As this moves the order statement to be part of the "select" statement, we need to
         // move the bindings to the right position: right after "select".
         $preferredBindingOrder = ['select', 'order', 'from', 'join', 'where', 'groupBy', 'having', 'union', 'unionOrder'];
-        $sortedBindings = Arr::sort($query->bindings, fn ($bindings, $key) => array_search($key, $preferredBindingOrder));
+        $sortedBindings = Arr::sort($query->bindings, function ($bindings, $key) use ($preferredBindingOrder) {
+            return array_search($key, $preferredBindingOrder);
+        });
         $query->bindings = $sortedBindings;
 
         // Next we need to calculate the constraints that should be placed on the query

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -184,7 +184,7 @@ class SqlServerGrammar extends Grammar
         // As this moves the order statement to be part of the "select" statement, we need to
         // move the bindings to the right position: right after "select".
         $preferredBindingOrder = ['select', 'order', 'from', 'join', 'where', 'groupBy', 'having', 'union', 'unionOrder'];
-        $sortedBindings = Arr::sort($query->bindings, fn($bindings, $key) => array_search($key, $preferredBindingOrder));
+        $sortedBindings = Arr::sort($query->bindings, fn ($bindings, $key) => array_search($key, $preferredBindingOrder));
         $query->bindings = $sortedBindings;
 
         // Next we need to calculate the constraints that should be placed on the query

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -205,7 +205,7 @@ class SqlServerGrammar extends Grammar
      */
     protected function queryOrderContainsSubquery($query)
     {
-        if (!is_array($query->orders)) {
+        if (! is_array($query->orders)) {
             return false;
         }
 

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -185,7 +185,9 @@ class SqlServerGrammar extends Grammar
         // move the bindings to the right position: right after "select".
         if ($this->queryOrderContainsSubquery($query)) {
             $preferredBindingOrder = ['select', 'order', 'from', 'join', 'where', 'groupBy', 'having', 'union', 'unionOrder'];
-            $sortedBindings = Arr::sort($query->bindings, fn ($bindings, $key) => array_search($key, $preferredBindingOrder));
+            $sortedBindings = Arr::sort($query->bindings, function ($bindings, $key) use ($preferredBindingOrder) {
+                return array_search($key, $preferredBindingOrder);
+            });
             $query->bindings = $sortedBindings;
         }
 

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -181,6 +181,12 @@ class SqlServerGrammar extends Grammar
 
         unset($components['orders']);
 
+        // As this moves the order statement to be part of the "select" statement, we need to
+        // move the bindings to the right position: right after "select".
+        $preferredBindingOrder = ['select', 'order', 'from', 'join', 'where', 'groupBy', 'having', 'union', 'unionOrder'];
+        $sortedBindings = Arr::sort($query->bindings, fn($bindings, $key) => array_search($key, $preferredBindingOrder));
+        $query->bindings = $sortedBindings;
+
         // Next we need to calculate the constraints that should be placed on the query
         // to get the right offset and limit from our query but if there is no limit
         // set we will just handle the offset only since that is all that matters.


### PR DESCRIPTION
As SQL Server moves the OrderBy part to be part of the "select" part of
the query when using an offset, we need to move the Order bindings to be in the right place.

### Example
When using a subquery in the OrderBy
```php
User::query()
    ->where('email', ':emailbinding:')
    ->orderBy(Login::select('created_at')->where('name', ':namebinding:')->limit(1))
    ->skip(10)->take(10),  
```

this in the following query
```sql
select * from (select *, row_number() over (order by (select top 1 [created_at] from [logins] where [logins].[name] = ? and [user_id] = [users].[id]) asc) as row_num from [users] where [email] = ?) as temp_table where row_num between 11 and 20 order by row_num
```

Notice the that `[logins].[name] = ?` (part of the original order part) comes **before** the `[email = ?]` (part of the where clause) part.

The normal order of the bindings is:

```php
    public $bindings = [
        'select' => [],
        'from' => [],
        'join' => [],
        'where' => [],
        'groupBy' => [],
        'having' => [],
        'order' => [],
        'union' => [],
        'unionOrder' => [],
    ];
```

When getting the bindings, this results in the `order` bindings coming after the `where` bindings.
This results in the following query:
```sql
select * from (select *, row_number() over (order by (select top 1 [created_at] from [logins] where [logins].[name] = ':emailbinding:' and [user_id] = [users].[id]) asc) as row_num from [users] where [email] = ':namebinding:') as temp_table where row_num between 11 and 20 order by row_num
```

This pull requests changes the order of the bindings by moving `order` to come right after `select`**when a offset is used**


-- edit: Changed as "limit" to "offset" as that is what determines the current issue.
-- edit 2021-07-21: Fix example to use :namebinding: consistently