### PR TITLE
create migrations table if missing after schema import

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -146,6 +146,15 @@ class MigrateCommand extends BaseCommand
 
         $runTime = number_format((microtime(true) - $startTime) * 1000, 2);
 
+        // Next, we will ensure the "migrations" table was created by the stored database schema
+        // as it is possible for the schema file to be created in ways which would exclude it
+        // which would leave the database in an unexpected state and likely lead to errors
+        if (! $this->migrator->repositoryExists()) {
+            $this->call('migrate:install', array_filter([
+                '--database' => $this->option('database'),
+            ]));
+        }
+
         // Finally, we will fire an event that this schema has been loaded so developers
         // can perform any post schema load tasks that are necessary in listeners for
         // this event, which may seed the database tables with some necessary data.

--- a/tests/Database/DatabaseMigrationMigrateCommandTest.php
+++ b/tests/Database/DatabaseMigrationMigrateCommandTest.php
@@ -59,7 +59,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
         $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => false]);
         $migrator->shouldReceive('getNotes')->andReturn([]);
-        $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
+        $migrator->shouldReceive('repositoryExists')->twice()->andReturn(true);
 
         $this->runCommand($command, ['--schema-path' => __DIR__.'/stubs/schema.sql']);
     }


### PR DESCRIPTION
During migration execution which contains dumped schema processing, the migrations table is deleted with the expectation that the schema file will recreate it. 

It is possible to create a schema file which does not contain the table definition for this. For example, by executing schema:dump prior to migration or after an error on the database has deleted it.

When in this state, migration commands will result in an error and not be able to complete. 

This PR allows migration commands to handle those scenarios gracefully by adding a check for the migration table after the schema import, and creating it if it is not present.