### PR TITLE
[8.x] Call on_stats handler in Http stub callbacks

### DIFF
--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -3,7 +3,9 @@
 namespace Illuminate\Http\Client;
 
 use Closure;
+use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7\Response as Psr7Response;
+use GuzzleHttp\TransferStats;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
@@ -162,11 +164,20 @@ class Factory
         }
 
         $this->stubCallbacks = $this->stubCallbacks->merge(collect([
-            $callback instanceof Closure
-                    ? $callback
-                    : function () use ($callback) {
-                        return $callback;
-                    },
+            function ($request, $options) use ($callback) {
+                $response = $callback instanceof Closure
+                    ? $callback($request, $options)
+                    : $callback;
+
+                if ($response instanceof PromiseInterface) {
+                    $options['on_stats'](new TransferStats(
+                        $request->toPsrRequest(),
+                        $response->wait(),
+                    ));
+                }
+
+                return $response;
+            }
         ]));
 
         return $this;

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -177,7 +177,7 @@ class Factory
                 }
 
                 return $response;
-            }
+            },
         ]));
 
         return $this;

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -942,7 +942,7 @@ class HttpClientTest extends TestCase
 
     public function testTheTransferStatsAreCalledSafelyWhenFakingTheRequest()
     {
-        $this->factory->fake(['https://example.com' => $this->factory->response()]);
+        $this->factory->fake(['https://example.com' => ['world' => 'Hello world']]);
         $stats = $this->factory->get('https://example.com')->handlerStats();
         $effectiveUri = $this->factory->get('https://example.com')->effectiveUri();
 
@@ -950,6 +950,14 @@ class HttpClientTest extends TestCase
         $this->assertEmpty($stats);
 
         $this->assertNull($effectiveUri);
+    }
+
+    public function testTransferStatsArePresentWhenFakingTheRequestUsingAPromiseResponse()
+    {
+        $this->factory->fake(['https://example.com' => $this->factory->response()]);
+        $effectiveUri = $this->factory->get('https://example.com')->effectiveUri();
+
+        $this->assertSame('https://example.com', (string) $effectiveUri);
     }
 
     public function testClonedClientsWorkSuccessfullyWithTheRequestObject()


### PR DESCRIPTION
This updates the `Http::fake()` method to call the `on_stats` handler if possible when executing the stub callbacks. This change ensures that `transferStats` property gets populated on the faked Http response. 

The `transferStats` property is a critical/vital component to some production code as it provides access to the underlying request that precipitated the response. For example if you have the following mixin.

```php
use Psr\Http\Message\RequestInterface;

/** @mixin \Illuminate\Http\Client\Response */
class ResponseMixin
{
    public function getRequest()
    {
        return function (): ?RequestInterface {
            return optional($this->transferStats)->getRequest();
        };
    }
}
```

If the `transferStats` property is always null any code which is dependant on getting the request in this fashion becomes untestable without additional stubbing to call the `on_stats` handler.