### PR TITLE
[8.x] Dispatch 'connection failed' event in http client

### DIFF
--- a/src/Illuminate/Http/Client/Events/ConnectionFailed.php
+++ b/src/Illuminate/Http/Client/Events/ConnectionFailed.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Illuminate\Http\Client\Events;
+
+use Illuminate\Http\Client\Request;
+
+class ConnectionFailed
+{
+    /**
+     * The request instance.
+     *
+     * @var \Illuminate\Http\Client\Request
+     */
+    public $request;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param \Illuminate\Http\Client\Request $request
+     * @return void
+     */
+    public function __construct(Request $request)
+    {
+        $this->request = $request;
+    }
+}

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -8,6 +8,7 @@ use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Exception\TransferException;
 use GuzzleHttp\HandlerStack;
+use Illuminate\Http\Client\Events\ConnectionFailed;
 use Illuminate\Http\Client\Events\RequestSending;
 use Illuminate\Http\Client\Events\ResponseReceived;
 use Illuminate\Support\Collection;
@@ -676,6 +677,8 @@ class PendingRequest
                     $this->dispatchResponseReceivedEvent($response);
                 });
             } catch (ConnectException $e) {
+                $this->dispatchConnectionFailedEvent();
+
                 throw new ConnectionException($e->getMessage(), 0, $e);
             }
         }, $this->retryDelay ?? 100);
@@ -992,6 +995,18 @@ class PendingRequest
         }
 
         $dispatcher->dispatch(new ResponseReceived($this->request, $response));
+    }
+
+    /**
+     * Dispatch the ConnectionFailed event if a dispatcher is available.
+     *
+     * @return void
+     */
+    protected function dispatchConnectionFailedEvent()
+    {
+        if ($dispatcher = optional($this->factory)->getDispatcher()) {
+            $dispatcher->dispatch(new ConnectionFailed($this->request));
+        }
     }
 
     /**


### PR DESCRIPTION
Currently, if a `ConnectException` is thrown by Guzzle, then no event is fired as there is no response. This PR adds a `ConnectionFailed` event that is fired before Laravel throws its own `ConnectionException`.

This event will make it possible to also track those failed requests in Telescope or other tools that listen for the events of the Http Client.

I did not add a test for this because I could not find an existing test that simulates a Guzzle `ConnectException`.