### PR TITLE
[8.x] Add GIF, WEBP, WBMP, BMP support to FileFactory::image()

### DIFF
--- a/src/Illuminate/Http/Testing/FileFactory.php
+++ b/src/Illuminate/Http/Testing/FileFactory.php
@@ -2,8 +2,6 @@
 
 namespace Illuminate\Http\Testing;
 
-use Illuminate\Support\Str;
-
 class FileFactory
 {
     /**
@@ -55,7 +53,7 @@ class FileFactory
     public function image($name, $width = 10, $height = 10)
     {
         return new File($name, $this->generateImage(
-            $width, $height, Str::endsWith(Str::lower($name), ['.jpg', '.jpeg']) ? 'jpeg' : 'png'
+            $width, $height, pathinfo($name, PATHINFO_EXTENSION)
         ));
     }
 
@@ -64,24 +62,21 @@ class FileFactory
      *
      * @param  int  $width
      * @param  int  $height
-     * @param  string  $type
+     * @param  string  $extension
      * @return resource
      */
-    protected function generateImage($width, $height, $type)
+    protected function generateImage($width, $height, $extension)
     {
-        return tap(tmpfile(), function ($temp) use ($width, $height, $type) {
+        return tap(tmpfile(), function ($temp) use ($width, $height, $extension) {
             ob_start();
+
+            $extension = in_array($extension, ['jpeg', 'png', 'gif', 'webp', 'wbmp', 'bmp'])
+                ? strtolower($extension)
+                : 'jpeg';
 
             $image = imagecreatetruecolor($width, $height);
 
-            switch ($type) {
-                case 'jpeg':
-                    imagejpeg($image);
-                    break;
-                case 'png':
-                    imagepng($image);
-                    break;
-            }
+            call_user_func("image{$extension}", $image);
 
             fwrite($temp, ob_get_clean());
         });

--- a/tests/Http/HttpTestingFileFactoryTest.php
+++ b/tests/Http/HttpTestingFileFactoryTest.php
@@ -28,13 +28,71 @@ class HttpTestingFileFactoryTest extends TestCase
             $this->markTestSkipped('The extension gd is missing from your system or was compiled without JPEG support.');
         }
 
-        $image = (new FileFactory)->image('test.jpeg', 15, 20);
+        $jpeg = (new FileFactory)->image('test.jpeg', 15, 20);
+        $jpg = (new FileFactory)->image('test.jpg');
 
-        $info = getimagesize($image->getRealPath());
+        $info = getimagesize($jpeg->getRealPath());
 
         $this->assertSame('image/jpeg', $info['mime']);
         $this->assertSame(15, $info[0]);
         $this->assertSame(20, $info[1]);
+        $this->assertSame(
+            'image/jpeg',
+            mime_content_type($jpg->getRealPath())
+        );
+    }
+
+    public function testImageGif()
+    {
+        if (! function_exists('imagegif'))
+            $this->markTestSkipped('The extension gd is missing from your system or was compiled without GIF support.');
+
+        $image = (new FileFactory)->image('test.gif');
+
+        $this->assertSame(
+            'image/gif',
+            mime_content_type($image->getRealPath())
+        );
+    }
+
+    public function testImageWebp()
+    {
+        if (! function_exists('imagewebp'))
+            $this->markTestSkipped('The extension gd is missing from your system or was compiled without WEBP support.');
+
+        $image = (new FileFactory)->image('test.webp');
+
+        $this->assertSame(
+            'image/webp',
+            mime_content_type($image->getRealPath())
+        );
+    }
+
+    public function testImageWbmp()
+    {
+        if (! function_exists('imagewbmp'))
+            $this->markTestSkipped('The extension gd is missing from your system or was compiled without WBMP support.');
+
+        $image = (new FileFactory)->image('test.wbmp');
+
+        $this->assertSame(
+            'image/vnd.wap.wbmp',
+            getimagesize($image->getRealPath())['mime']
+        );
+    }
+
+    public function testImageBmp()
+    {
+        if (! function_exists('imagebmp'))
+            $this->markTestSkipped('The extension gd is missing from your system or was compiled without BMP support.');
+
+        $image = (new FileFactory)->image('test.bmp');
+
+        $imagePath = $image->getRealPath();
+
+        $this->assertSame('image/x-ms-bmp', mime_content_type($imagePath));
+
+        $this->assertSame('image/bmp', getimagesize($imagePath)['mime']);
     }
 
     public function testCreateWithMimeType()


### PR DESCRIPTION
#37742 
Currently, when generating dummy images for testing, FileFactory::image() always creates a PNG or JPEG file.
PNG is default for other extensions (like gif):
```php
return new File($name, $this->generateImage(
      $width, $height, Str::endsWith(Str::lower($name), ['.jpg', '.jpeg']) ? 'jpeg' : 'png'
));
```

This PR checks the file extension and creates proper image.
**XBM** is not supported since ``imagexbm()`` needs location as second parameter.
