### PR TITLE
[8.x] Make `Illuminate\Http\Client\Request` macroable

### DIFF
--- a/src/Illuminate/Http/Client/Request.php
+++ b/src/Illuminate/Http/Client/Request.php
@@ -5,10 +5,13 @@ namespace Illuminate\Http\Client;
 use ArrayAccess;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Illuminate\Support\Traits\Macroable;
 use LogicException;
 
 class Request implements ArrayAccess
 {
+    use Macroable;
+
     /**
      * The underlying PSR request.
      *

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -967,4 +967,19 @@ class HttpClientTest extends TestCase
 
         m::close();
     }
+
+    public function testRequestIsMacroable()
+    {
+        Request::macro('customMethod', function () {
+            return 'yes!';
+        });
+
+        $this->factory->fake(function (Request $request) {
+            $this->assertSame('yes!', $request->customMethod());
+
+            return $this->factory->response();
+        });
+
+        $this->factory->get('https://example.com');
+    }
 }


### PR DESCRIPTION
This PR makes the `Illuminate\Http\Client\Request` class macroable.

Having the Request macroable will allow for the elimination of excess boilerplate code when faking Http requests with body content other than Form or JSON, XML for example.

```php
Request::macro('xml', function () {
    return CustomSuperDuperXmlParser::parse($this->body());
});

Http::fake([
    'example.com/*' => function (Request $request) {
        $this->assertSame($request->xml()->someProperty, 'some value')

        return Http::response();
    },
]);
```