### PR TITLE
[8.x] bind mock instances as singletons so they are not overwritten

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
@@ -42,6 +42,22 @@ trait InteractsWithContainer
     }
 
     /**
+     * Register an instance of an object as a singleton in the container.
+     *
+     * @param $abstract
+     * @param $instance
+     * @return \Mockery\MockInterface
+     */
+    protected function singletonInstance($abstract, $instance)
+    {
+        $this->app->singleton($abstract, function () use ($instance) {
+            return $instance;
+        });
+
+        return $instance;
+    }
+
+    /**
      * Mock an instance of an object in the container.
      *
      * @param  string  $abstract
@@ -50,7 +66,7 @@ trait InteractsWithContainer
      */
     protected function mock($abstract, Closure $mock = null)
     {
-        return $this->instance($abstract, Mockery::mock(...array_filter(func_get_args())));
+        return $this->singletonInstance($abstract, Mockery::mock(...array_filter(func_get_args())));
     }
 
     /**
@@ -62,7 +78,7 @@ trait InteractsWithContainer
      */
     protected function partialMock($abstract, Closure $mock = null)
     {
-        return $this->instance($abstract, Mockery::mock(...array_filter(func_get_args()))->makePartial());
+        return $this->singletonInstance($abstract, Mockery::mock(...array_filter(func_get_args()))->makePartial());
     }
 
     /**
@@ -74,7 +90,7 @@ trait InteractsWithContainer
      */
     protected function spy($abstract, Closure $mock = null)
     {
-        return $this->instance($abstract, Mockery::spy(...array_filter(func_get_args())));
+        return $this->singletonInstance($abstract, Mockery::spy(...array_filter(func_get_args())));
     }
 
     /**

--- a/tests/Foundation/Testing/Concerns/InteractsWithContainerTest.php
+++ b/tests/Foundation/Testing/Concerns/InteractsWithContainerTest.php
@@ -27,4 +27,12 @@ class InteractsWithContainerTest extends TestCase
         $this->assertSame($handler, resolve(Mix::class));
         $this->assertSame($this, $instance);
     }
+
+    public function testSingletonBoundInstancesCanBeResolved()
+    {
+        $this->singletonInstance('foo', 'bar');
+
+        $this->assertEquals('bar', $this->app->make('foo'));
+        $this->assertEquals('bar', $this->app->make('foo', ['with' => 'params']));
+    }
 }


### PR DESCRIPTION
Addresses #37706 

Mocked instances are bound to the container as a singleton so that attempts to resolve them using `resolve($abstract, $withParams)` does not create a new instance and ignore the mocked instance.