### PR TITLE
[8.x] mixed orders for cursor paginate

### DIFF
--- a/src/Illuminate/Pagination/CursorPaginationException.php
+++ b/src/Illuminate/Pagination/CursorPaginationException.php
@@ -4,6 +4,9 @@ namespace Illuminate\Pagination;
 
 use RuntimeException;
 
+/**
+ * @deprecated Will be removed in a future Laravel version.
+ */
 class CursorPaginationException extends RuntimeException
 {
     //


### PR DESCRIPTION
It is possible to remove the following limitation from `cursorPaginate()` function:

> It requires that the "order by" directions (descending / ascending) are the same if there are multiple "order by" clauses.

Example:
```php
$cursor = ['test' => 'foo', 'another' => 'bar', 'third' => 'baz'];
$query->...->orderBy('test')->orderByDesc('another')->orderBy('third');
```
A desired SQL statement:
```sql
SELECT * FROM table
WHERE
    test > 'foo' or
       (test = 'foo' and another < 'bar' or
           (another = 'bar' and third > 'baz'))
ORDER BY test asc, another desc, third asc
LIMIT 100
```

#### Todo
1. I tested it manually and it seems to be fine. It may need more automated tests in the framework.
2. Remove the limitation from docs.
3. Extract 23 duplicate lines of code in `Query|Eloquet\Builder::cursorPaginate()` functions, probably into `BuildsQueries` trait.
4. Remove the deprecated `CursorPaginationException` in 9.x.
5. Check if DBMS query optimizer can handle queries generated by this PR as efficiently as queries generated by the current Laravel release.