### PR TITLE
[8.x] Add collection `sliding` method

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -960,6 +960,22 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
+     * Create chunks representing a "sliding window" view of the items in the collection.
+     *
+     * @param  int  $size
+     * @param  int  $step
+     * @return static
+     */
+    public function sliding($size = 2, $step = 1)
+    {
+        $chunks = floor(($this->count() - $size) / $step) + 1;
+
+        return static::times($chunks, function ($number) use ($size, $step) {
+            return $this->slice(($number - 1) * $step, $size);
+        });
+    }
+
+    /**
      * Skip the first {$count} items.
      *
      * @param  int  $count

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -921,6 +921,45 @@ class LazyCollection implements Enumerable
     }
 
     /**
+     * Create chunks representing a "sliding window" view of the items in the collection.
+     *
+     * @param  int  $size
+     * @param  int  $step
+     * @return static
+     */
+    public function sliding($size = 2, $step = 1)
+    {
+        return new static(function () use ($size, $step) {
+            $iterator = $this->getIterator();
+
+            $chunk = [];
+
+            while ($iterator->valid()) {
+                $chunk[$iterator->key()] = $iterator->current();
+
+                if (count($chunk) == $size) {
+                    yield tap(new static($chunk), function () use (&$chunk, $step) {
+                        $chunk = array_slice($chunk, $step, null, true);
+                    });
+
+                    // If the $step between chunks is bigger than each chunk's $size,
+                    // we will skip the extra items (which should never be in any
+                    // chunk) before we continue to the next chunk in the loop.
+                    if ($step > $size) {
+                        $skip = $step - $size;
+
+                        for ($i = 0; $i < $skip && $iterator->valid(); $i++) {
+                            $iterator->next();
+                        }
+                    }
+                }
+
+                $iterator->next();
+            }
+        });
+    }
+
+    /**
      * Skip the first {$count} items.
      *
      * @param  int  $count

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -238,6 +238,65 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testSliding($collection)
+    {
+        // Default parameters: $size = 2, $step = 1
+        $this->assertSame([], $collection::times(0)->sliding()->toArray());
+        $this->assertSame([], $collection::times(1)->sliding()->toArray());
+        $this->assertSame([[1, 2]], $collection::times(2)->sliding()->toArray());
+        $this->assertSame(
+            [[1, 2], [2, 3]],
+            $collection::times(3)->sliding()->map->values()->toArray()
+        );
+
+        // Custom step: $size = 2, $step = 3
+        $this->assertSame([], $collection::times(1)->sliding(2, 3)->toArray());
+        $this->assertSame([[1, 2]], $collection::times(2)->sliding(2, 3)->toArray());
+        $this->assertSame([[1, 2]], $collection::times(3)->sliding(2, 3)->toArray());
+        $this->assertSame([[1, 2]], $collection::times(4)->sliding(2, 3)->toArray());
+        $this->assertSame(
+            [[1, 2], [4, 5]],
+            $collection::times(5)->sliding(2, 3)->map->values()->toArray()
+        );
+
+        // Custom size: $size = 3, $step = 1
+        $this->assertSame([], $collection::times(2)->sliding(3)->toArray());
+        $this->assertSame([[1, 2, 3]], $collection::times(3)->sliding(3)->toArray());
+        $this->assertSame(
+            [[1, 2, 3], [2, 3, 4]],
+            $collection::times(4)->sliding(3)->map->values()->toArray()
+        );
+        $this->assertSame(
+            [[1, 2, 3], [2, 3, 4]],
+            $collection::times(4)->sliding(3)->map->values()->toArray()
+        );
+
+        // Custom size and custom step: $size = 3, $step = 2
+        $this->assertSame([], $collection::times(2)->sliding(3, 2)->toArray());
+        $this->assertSame([[1, 2, 3]], $collection::times(3)->sliding(3, 2)->toArray());
+        $this->assertSame([[1, 2, 3]], $collection::times(4)->sliding(3, 2)->toArray());
+        $this->assertSame(
+            [[1, 2, 3], [3, 4, 5]],
+            $collection::times(5)->sliding(3, 2)->map->values()->toArray()
+        );
+        $this->assertSame(
+            [[1, 2, 3], [3, 4, 5]],
+            $collection::times(6)->sliding(3, 2)->map->values()->toArray()
+        );
+
+        // Ensure keys are preserved, and inner chunks are also collections
+        $chunks = $collection::times(3)->sliding();
+
+        $this->assertSame([[0 => 1, 1 => 2], [1 => 2, 2 => 3]], $chunks->toArray());
+
+        $this->assertInstanceOf($collection, $chunks);
+        $this->assertInstanceOf($collection, $chunks->first());
+        $this->assertInstanceOf($collection, $chunks->skip(1)->first());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testEmptyCollectionIsEmpty($collection)
     {
         $c = new $collection;

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -897,6 +897,29 @@ class SupportLazyCollectionIsLazyTest extends TestCase
         });
     }
 
+    public function testSlidingIsLazy()
+    {
+        $this->assertDoesNotEnumerate(function ($collection) {
+            $collection->sliding();
+        });
+
+        $this->assertEnumerates(2, function ($collection) {
+            $collection->sliding()->take(1)->all();
+        });
+
+        $this->assertEnumerates(3, function ($collection) {
+            $collection->sliding()->take(2)->all();
+        });
+
+        $this->assertEnumerates(13, function ($collection) {
+            $collection->sliding(3, 5)->take(3)->all();
+        });
+
+        $this->assertEnumeratesOnce(function ($collection) {
+            $collection->sliding()->all();
+        });
+    }
+
     public function testSkipIsLazy()
     {
         $this->assertDoesNotEnumerate(function ($collection) {


### PR DESCRIPTION
This method was extracted from [this old PR](https://github.com/laravel/framework/pull/20281).

---

Adds a `sliding` method to the collection, which creates chunks representing a "sliding window" view of the items in the collection:

```php
Collection::times(5)->sliding(2); // [[1, 2], [2, 3], [3, 4], [4, 5]]
Collection::times(5)->sliding(3); // [[1, 2, 3], [2, 3, 4], [3, 4, 5]]

Collection::times(5)->sliding(3, step: 2); // [[1, 2, 3], [3, 4, 5]]
```

## Examples:

1. Imagine you have a collection of nodes, which you want to link up into a linked list.

    The `sliding` method makes that really trivial:

    ```php
    $nodes->sliding(2)->eachSpread(fn ($parent, $child) => $parent->next = $child);
    ```

    You can see similar usage in [the original PR](https://github.com/laravel/framework/pull/20281/files#diff-cf2960e55f67e04eaf0a7fbfdacd866227defc2a3701f2a60f01304cac99b10dR86-R99).

2. Or imagine you have a list of transactions, and want to fill in their running total:

    ```php
    $transactions->sliding(2)->eachSpread(
        fn ($previous, $current) => $transaction->total = $previous->total + $current->amount
    );
    ```