### PR TITLE
[8.x] [POC] Track a loop variable for sequence and pass it with count to closure

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Sequence.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Sequence.php
@@ -19,11 +19,11 @@ class Sequence
     protected $count;
 
     /**
-     * The current index of the sequence.
+     * The current loop of the sequence.
      *
      * @var int
      */
-    protected $index = 0;
+    protected $loop = 0;
 
     /**
      * Create a new sequence instance.
@@ -44,12 +44,8 @@ class Sequence
      */
     public function __invoke()
     {
-        if ($this->index >= $this->count) {
-            $this->index = 0;
-        }
-
-        return tap(value($this->sequence[$this->index]), function () {
-            $this->index = $this->index + 1;
+        return tap(value($this->sequence[$this->loop % $this->count], $this->loop, $this->count), function () {
+            $this->loop = $this->loop + 1;
         });
     }
 }


### PR DESCRIPTION
I have a use case where I would like to know the loop count in a sequence, so I thought that others might like the ability too.

All this does is track a `loop` variable similar to `foreach` to use with `%` to get the index.  Then it passes it to the closure.
