### PR TITLE
[8.x] Add `clean` method to model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1474,6 +1474,22 @@ abstract class Model implements Arrayable, ArrayAccess, HasBroadcastChannel, Jso
     }
 
     /**
+     * Reset the model's original attributes.
+     *
+     * @return $this
+     */
+    public function clean()
+    {
+        if (! $this->exists || $this->isClean()) {
+            return $this;
+        }
+
+        $this->setRawAttributes($this->getOriginal());
+
+        return $this;
+    }
+
+    /**
      * Clone the model into a new, non-existing instance.
      *
      * @param  array|null  $except


### PR DESCRIPTION
Adds a clean method to models. 

We already have `isClean`, so having a `clean` method on the model makes sense.

## Examples:
```
$user = User::find(1);
$user->foo = 'bar';
$user->isClean(); // false
$user->clean();
$user->isClean(); // true
```

## Use cases:

**- Caching attributes**

1. Cache some query results on custom attribute on model.
2. Re-use cached attribute throughout code. (if attribute not null, don't query DB)
3. Want to clear cached attributes to re-query DB and re-cache.

**- Cleaning model before updating**

1. Add custom attribute to model
2. Use custom attribute throughout code
3. Clean model
4. Update some of models original attributes and save (this would fail without `clean` due to non existing column in DB)


