### PR TITLE
[8.x] Encode objects when casting as JSON

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -130,7 +130,7 @@ trait InteractsWithDatabase
     {
         if ($value instanceof Jsonable) {
             $value = $value->toJson();
-        } elseif (is_array($value)) {
+        } elseif (is_array($value) || is_object($value)) {
             $value = json_encode($value);
         }
 


### PR DESCRIPTION
Currently one's not able to use objects with `castAsJson()`:

> ErrorException: PDO::quote() expects parameter 1 to be string, object given

The following code can be used to reproduce the bug:
```php
    $this->assertDatabaseHas('table', [
        'column' => $this->castAsJson((object)[
            'foo' => 'bar',
        ]),
    ]);
```