### PR TITLE
Add method to send output email on event success

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -455,6 +455,23 @@ class Event
     }
 
     /**
+     * E-mail the results of the scheduled operation if it success.
+     *
+     * @param  array|mixed  $addresses
+     * @return $this
+     */
+    public function emailOutputOnSuccess($addresses)
+    {
+        $this->ensureOutputIsBeingCaptured();
+
+        $addresses = Arr::wrap($addresses);
+
+        return $this->onSuccess(function (Mailer $mailer) use ($addresses) {
+            $this->emailOutput($mailer, $addresses, false);
+        });
+    }
+
+    /**
      * Ensure that the command output is being captured.
      *
      * @return void


### PR DESCRIPTION
Currently laravel has 2 methods for sending the output of an event by email.

`emailOutputTo` -> send the output regardless of the result

`emailOutputOnFailure` -> send output only on failure

In this PR, I'm adding the `emailOutputOnSuccess` method, which sends output only if the event doesn't throw an error.
This is interesting so that you can indicate different emails in each event result, for example.

The Event would then make these 3 methods available:

`emailOutputTo` -> send the output regardless of the result

`emailOutputOnFailure` -> send output only on failure

`emailOutputOnSuccess` -> send output only on success