### PR TITLE
Custom route binding resolvers

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -211,4 +211,16 @@ trait SoftDeletes
     {
         return $this->qualifyColumn($this->getDeletedAtColumn());
     }
+
+    /**
+     * Retrieve the model for a bound value including trashed models.
+     *
+     * @param  mixed  $value
+     * @param  string|null  $field
+     * @return \Illuminate\Database\Eloquent\Model|null
+     */
+    public function resolveRouteBindingWithTrashed($value, $field = null)
+    {
+        return $this->withTrashed()->where($field ?? $this->getRouteKeyName(), $value)->first();
+    }
 }

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -143,6 +143,13 @@ class Route
     protected $bindingFields = [];
 
     /**
+     * Custom resolver for a given parameters
+     *
+     * @var array
+     */
+    protected $resolvers = [];
+
+    /**
      * The validators used by the routes.
      *
      * @var array
@@ -540,6 +547,53 @@ class Route
         $this->bindingFields = $bindingFields;
 
         return $this;
+    }
+
+    /**
+     * Attach custom route binding resolver
+     *
+     * @param  string  $parameter
+     * @param  \Closure|string  $resolver
+     * @return $this
+     */
+    public function resolve($parameter, $resolver)
+    {
+        $this->resolvers[$parameter] = $resolver;
+
+        return $this;
+    }
+
+    /**
+     * Include trashed models in route binding model query
+     *
+     * @param  string  $parameter
+     * @return $this
+     */
+    public function resolveWithTrashed($parameter)
+    {
+       return $this->resolve($parameter, 'resolveRouteBindingWithTrashed');
+    }
+
+    /**
+     * Determine if given parameter has custom resolver.
+     *
+     * @param  string  $parameter
+     * @return bool
+     */
+    public function hasResolver($parameter)
+    {
+        return array_key_exists($this->resolvers, $parameter);
+    }
+
+    /**
+     * Get the binding resolver for given parameter.
+     *
+     * @param  string  $parameter
+     * @return mixed|null
+     */
+    public function getResolver($parameter)
+    {
+        return $this->resolvers[$parameter] ?? null;
     }
 
     /**


### PR DESCRIPTION
Sometimes you may want to write custom query to resolve model binding in specific routes. Even though there are `resolveRouteBinding` method in `Model` class and explicit route parameter binding, But both ways are system-wide and you cannot write custom query for specific routes.
Consider writing a route which is responsible to restore a trashed model.

```php
public function restore(User $user)
{
    $user->restore();
}
```

```php
Route::post('users/{user}/restore', [UsersController::class, 'restore']);
```
Implicit route binding cannot find user equivalent model because it's deleted. You may change `resolveRouteBinding` method in `App\Models\User` class. But then all other routes will be affected which is not good.

This PR provides custom model binding resolver for each route parameters.

To define custom method that should be used to resolve model you can use resolver method this way:
```php
class User extends Model
{
    public function resolveActiveUsers($value, $field = null)
    {
        return $this->active()->where($field ?? $this->getRouteKeyName(), $value)->first();
    }
}

Route::get('/users/{user}', [UsersController::class, 'accept'])
    ->resolve('user', 'resolveActiveUsers');
```

Or using Closure function (It is not compatible with route caching yet):
```php
Route::get('/users/{user}', [UsersController::class, 'accept'])
    ->resolve('user', function ($user, $field) {
        return User::query()->approved()->findOrFail($user);
    });
```

To resolve trashed models you can use:
```php
Route::get('/users/{user}/restore', [UsersController::class, 'restore'])
    ->resolveWithTrashed('user');
```
