### PR TITLE
Custom route binding resolver

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -211,4 +211,16 @@ trait SoftDeletes
     {
         return $this->qualifyColumn($this->getDeletedAtColumn());
     }
+
+    /**
+     * Retrieve the model for a bound value including trashed models.
+     *
+     * @param  mixed  $value
+     * @param  string|null  $field
+     * @return \Illuminate\Database\Eloquent\Model|null
+     */
+    public function resolveRouteBindingWithTrashed($value, $field = null)
+    {
+        return $this->withTrashed()->where($field ?? $this->getRouteKeyName(), $value)->first();
+    }
 }

--- a/src/Illuminate/Routing/AbstractRouteCollection.php
+++ b/src/Illuminate/Routing/AbstractRouteCollection.php
@@ -144,6 +144,7 @@ abstract class AbstractRouteCollection implements Countable, IteratorAggregate, 
                 'defaults' => $route->defaults,
                 'wheres' => $route->wheres,
                 'bindingFields' => $route->bindingFields(),
+                'resolvers' => $route->resolvers(),
                 'lockSeconds' => $route->locksFor(),
                 'waitSeconds' => $route->waitsFor(),
             ];

--- a/src/Illuminate/Routing/CompiledRouteCollection.php
+++ b/src/Illuminate/Routing/CompiledRouteCollection.php
@@ -302,6 +302,7 @@ class CompiledRouteCollection extends AbstractRouteCollection
             ->setDefaults($attributes['defaults'])
             ->setWheres($attributes['wheres'])
             ->setBindingFields($attributes['bindingFields'])
+            ->setResolvers($attributes['resolvers'])
             ->block($attributes['lockSeconds'] ?? null, $attributes['waitSeconds'] ?? null);
     }
 

--- a/src/Illuminate/Routing/ImplicitRouteBinding.php
+++ b/src/Illuminate/Routing/ImplicitRouteBinding.php
@@ -70,7 +70,7 @@ class ImplicitRouteBinding
     }
 
     /**
-     * Resolve model instance using custom or default resolver
+     * Resolve model instance using custom or default resolver.
      *
      * @param $route
      * @param $instance

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -143,6 +143,13 @@ class Route
     protected $bindingFields = [];
 
     /**
+     * Custom resolver for a given parameters
+     *
+     * @var array
+     */
+    protected $resolvers = [];
+
+    /**
      * The validators used by the routes.
      *
      * @var array
@@ -538,6 +545,76 @@ class Route
     public function setBindingFields(array $bindingFields)
     {
         $this->bindingFields = $bindingFields;
+
+        return $this;
+    }
+
+    /**
+     * Attach custom route binding resolver
+     *
+     * @param  string  $parameter
+     * @param  \Closure|string  $resolver
+     * @return $this
+     */
+    public function resolve($parameter, $resolver)
+    {
+        $this->resolvers[$parameter] = $resolver;
+
+        return $this;
+    }
+
+    /**
+     * Include trashed models in route binding model query
+     *
+     * @param  string  $parameter
+     * @return $this
+     */
+    public function resolveWithTrashed($parameter)
+    {
+       return $this->resolve($parameter, 'resolveRouteBindingWithTrashed');
+    }
+
+    /**
+     * Determine if given parameter has custom resolver.
+     *
+     * @param  string  $parameter
+     * @return bool
+     */
+    public function hasResolver($parameter)
+    {
+        return array_key_exists($this->resolvers, $parameter);
+    }
+
+    /**
+     * Get the binding resolver for given parameter.
+     *
+     * @param  string  $parameter
+     * @return mixed|null
+     */
+    public function getResolver($parameter)
+    {
+        return $this->resolvers[$parameter] ?? null;
+    }
+
+    /**
+     * Get the parameter resolvers for the route.
+     *
+     * @return array
+     */
+    public function resolvers()
+    {
+        return $this->resolvers;
+    }
+
+    /**
+     * Set the resolvers for the route.
+     *
+     * @param array $resolvers
+     * @return $this
+     */
+    public function setResolvers(array $resolvers)
+    {
+        $this->resolvers = $resolvers;
 
         return $this;
     }

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -143,7 +143,7 @@ class Route
     protected $bindingFields = [];
 
     /**
-     * Custom resolver for a given parameters
+     * Custom resolver for a given parameters.
      *
      * @var array
      */
@@ -550,7 +550,7 @@ class Route
     }
 
     /**
-     * Attach custom route binding resolver
+     * Attach custom route binding resolver.
      *
      * @param  string  $parameter
      * @param  \Closure|string  $resolver
@@ -571,7 +571,7 @@ class Route
      */
     public function resolveWithTrashed($parameter)
     {
-       return $this->resolve($parameter, 'resolveRouteBindingWithTrashed');
+        return $this->resolve($parameter, 'resolveRouteBindingWithTrashed');
     }
 
     /**


### PR DESCRIPTION
Sometimes you may want to write custom query to resolve model binding in specific routes. Even though there are `resolveRouteBinding` method in `Model` class and explicit route parameter binding, But both ways are system-wide and you cannot write custom query for specific routes.
Consider writing a route which is responsible to restore a trashed model.
```php
public function restore(User $user)
{
    $user->restore();
}
```
```php
Route::post('users/{user}/restore', [UsersController::class, 'restore']);
```
Implicit route binding cannot find user equivalent model because it's deleted. You may change `resolveRouteBinding` method in `App\Models\User` class. But then all other routes will be affected which is not good.

This PR provides custom model binding resolver for each route parameters.

To define custom method that should be used to resolve model you can use resolver method this way:
```php
class User extends Model
{
    public function resolveActiveUsers($value, $field = null)
    {
        return $this->active()->where($field ?? $this->getRouteKeyName(), $value)->first();
    }
}

Route::get('/users/{user}', [UsersController::class, 'accept'])
    ->resolve('user', 'resolveActiveUsers');
```
Or using Closure function (It is not compatible with route caching yet):
```php
Route::get('/users/{user}', [UsersController::class, 'accept'])
    ->resolve('user', function ($user, $field) {
        return User::query()->approved()->findOrFail($user);
    });
```
To resolve trashed models you can use:
```php
Route::get('/users/{user}/restore', [UsersController::class, 'restore'])
    ->resolveWithTrashed('user');
```