### PR TITLE
[8.x] Add `whenWhere` method to query builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1802,6 +1802,21 @@ class Builder
     }
 
     /**
+     * Add "where column" clauses to the query when values are truthy.
+     *
+     * @param  array  $columns
+     * @return $this
+     */
+    public function whenWhere(array $columns)
+    {
+        collect($columns)->map(fn ($value, $column) =>
+              $this->when($value, fn ($query) => $query->where($column, $value))
+        );
+
+        return $this;
+    }
+
+    /**
      * Add a single dynamic where clause statement to the query.
      *
      * @param  string  $segment

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1468,6 +1468,17 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals($expected, $query->toSql());
     }
 
+    public function testWhenWhere()
+    {
+        $model = new EloquentBuilderTestModelParentStub;
+        $columnValues = ['foo' => 'bar', 'baz' => 'qux'];
+
+        $builder = $model->whenWhere($columnValues);
+
+        $this->assertSame('select * from "eloquent_builder_test_model_parent_stubs" where "foo" = ? and "baz" = ?', $builder->toSql());
+        $this->assertEquals(['bar', 'qux'], $builder->getBindings());
+    }
+
     public function testLatestWithoutColumnWithCreatedAt()
     {
         $model = $this->getMockModel();


### PR DESCRIPTION
🤞🏽  This feature gives the option to limit the possibilities of writing duplicate conditional where query codes.

Redundant
```php
Model::when($user_id, fn ($q) => $q->where('user_id' $user_id)
  ->when($status, fn ($q) => $q->where('status' $status)
  ->when($type, fn ($q) => $q->where('type' $type)
  ->when($conversation_id, fn ($q) => $q->where('conversation_id' $conversation_id)
```
Better
```php
Model::whenWhere([
  'user_id'           => $user_id,
  'status'            => $status,
  'type'              => $type,
  'conversation_id'   => $conversation_id
])
```

I hope this feature will be useful for `artisans`.