### PR TITLE
[8.x] Remove ksort in pool results that modifies intended original order

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -624,8 +624,6 @@ class PendingRequest
             $results[$key] = $item instanceof static ? $item->getPromise()->wait() : $item->wait();
         }
 
-        ksort($results);
-
         return $results;
     }
 


### PR DESCRIPTION
Bug Report: https://github.com/laravel/framework/issues/37774