### PR TITLE
Fix issue when key isn't a string

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -175,7 +175,7 @@ trait HasAttributes
     protected function addDateAttributesToArray(array $attributes)
     {
         foreach ($this->getDates() as $key) {
-            if (! isset($attributes[$key])) {
+            if (! is_string($key) || ! isset($attributes[$key])) {
                 continue;
             }
 


### PR DESCRIPTION
I have faced an error that model named Date was taken as date attribute and this function tried to parse it.

