### PR TITLE
[8.x] Adds parameter casting for cursor paginated items

### DIFF
--- a/src/Illuminate/Pagination/AbstractCursorPaginator.php
+++ b/src/Illuminate/Pagination/AbstractCursorPaginator.php
@@ -196,13 +196,30 @@ abstract class AbstractCursorPaginator implements Htmlable
             ->flip()
             ->map(function ($_, $parameterName) use ($item) {
                 if ($item instanceof ArrayAccess || is_array($item)) {
-                    return $item[$parameterName] ?? $item[Str::afterLast($parameterName, '.')];
+                    return $this->castParameter($item[$parameterName] ?? $item[Str::afterLast($parameterName, '.')]);
                 } elseif (is_object($item)) {
-                    return $item->{$parameterName} ?? $item->{Str::afterLast($parameterName, '.')};
+                    return $this->castParameter($item->{$parameterName} ?? $item->{Str::afterLast($parameterName, '.')});
                 }
 
                 throw new Exception('Only arrays and objects are supported when cursor paginating items.');
             })->toArray();
+    }
+
+    /**
+     * Casts the given item parameter. When the given parameter is an object and can
+     * be cast to a string, the stringified representation will be returned,
+     * otherwise the original parameter will be returned.
+     *
+     * @param  mixed  $parameter
+     * @return string
+     */
+    public function castParameter($parameter)
+    {
+        if (is_object($parameter) && method_exists($parameter, '__toString')) {
+            return (string) $parameter;
+        }
+
+        return $parameter;
     }
 
     /**


### PR DESCRIPTION
This fixes the problem when the primary-key (or other attributes) are
objects (e.g.: value-objects) and can be cast to a string using the
__toString method.

Before, the CursorPaginator would always return a pointer to the current
page instead of the next page because the parameter, which was an
object, could not be converted.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
