### PR TITLE
[9.x] Support calling BelongsToMany::firstOrNew/Create without parameters

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -596,7 +596,7 @@ class BelongsToMany extends Relation
      * @param  array  $attributes
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function firstOrNew(array $attributes)
+    public function firstOrNew(array $attributes = [])
     {
         if (is_null($instance = $this->related->where($attributes)->first())) {
             $instance = $this->related->newInstance($attributes);
@@ -614,7 +614,7 @@ class BelongsToMany extends Relation
      * @param  bool  $touch
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function firstOrCreate(array $attributes, array $values = [], array $joining = [], $touch = true)
+    public function firstOrCreate(array $attributes = [], array $values = [], array $joining = [], $touch = true)
     {
         if (is_null($instance = $this->related->where($attributes)->first())) {
             $instance = $this->create($attributes + $values, $joining, $touch);


### PR DESCRIPTION
This PR makes `BelongsToMany` consistent with `HasOneOrMany` and `Builder` (c.f. https://github.com/laravel/framework/pull/33334).