### PR TITLE
[8.x] Adds caching support to the Http Client

### DIFF
--- a/src/Illuminate/Cache/CacheServiceProvider.php
+++ b/src/Illuminate/Cache/CacheServiceProvider.php
@@ -2,7 +2,9 @@
 
 namespace Illuminate\Cache;
 
+use Illuminate\Contracts\Http\Client\CacheHandler as CacheHandlerContract;
 use Illuminate\Contracts\Support\DeferrableProvider;
+use Illuminate\Http\Client\CacheHandlers\CacheHandler;
 use Illuminate\Support\ServiceProvider;
 use Symfony\Component\Cache\Adapter\Psr16Adapter;
 
@@ -32,6 +34,10 @@ class CacheServiceProvider extends ServiceProvider implements DeferrableProvider
         });
 
         $this->app->singleton(RateLimiter::class);
+
+        $this->app->singleton(CacheHandlerContract::class, function ($app) {
+            return new CacheHandler($app['cache']->driver());
+        });
     }
 
     /**
@@ -42,7 +48,7 @@ class CacheServiceProvider extends ServiceProvider implements DeferrableProvider
     public function provides()
     {
         return [
-            'cache', 'cache.store', 'cache.psr6', 'memcached.connector', RateLimiter::class,
+            'cache', 'cache.store', 'cache.psr6', 'memcached.connector', RateLimiter::class, CacheHandlerContract::class,
         ];
     }
 }

--- a/src/Illuminate/Contracts/Http/Client/CacheHandler.php
+++ b/src/Illuminate/Contracts/Http/Client/CacheHandler.php
@@ -1,0 +1,34 @@
+<?php
+
+
+namespace Illuminate\Contracts\Http\Client;
+
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Http\Client\Response;
+
+interface CacheHandler
+{
+
+    /**
+     * Determine whether or not a cached response exists for the given request.
+     *
+     * @return bool
+     */
+    public function hasCachedResponse(Request $request);
+
+    /**
+     * Return the cached response for the given request.
+     *
+     * @return \Illuminate\Http\Client\Response|null $response
+     */
+    public function getCachedResponse(Request $request);
+
+    /**
+     * Cache the response if possible.
+     *
+     * @return bool
+     */
+    public function handleCaching(Request $request, Response $response);
+
+}

--- a/src/Illuminate/Http/Client/CacheHandlers/CacheHandler.php
+++ b/src/Illuminate/Http/Client/CacheHandlers/CacheHandler.php
@@ -1,0 +1,121 @@
+<?php
+
+
+namespace Illuminate\Http\Client\CacheHandlers;
+
+
+use BadMethodCallException;
+use Illuminate\Contracts\Cache\Repository;
+use Illuminate\Contracts\Http\Client\CacheHandler as CacheHandlerContract;
+use Illuminate\Http\Client\Request;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
+
+class CacheHandler implements CacheHandlerContract
+{
+    const CACHE_PREFIX = 'http-client::';
+
+    /**
+     * The cache to use when storing the response.
+     *
+     * @var Repository
+     */
+    protected $cache;
+
+    public function __construct(Repository $cache)
+    {
+        $this->cache = $cache;
+    }
+
+    /**
+     * Determine whether or not a cached response exists for the given request.
+     *
+     * @return bool
+     */
+    public function hasCachedResponse(Request $request)
+    {
+        return $this->cache->has($this->getCacheKey($request));
+    }
+
+    /**
+     * Retrieve the cache key to be used based on the given cache options.
+     *
+     * @return string
+     */
+    protected function getCacheKey(Request $request)
+    {
+        return static::CACHE_PREFIX
+            . $request->url()
+            . (($key = $request->cacheOptions()->getKey()) ? "::$key" : '');
+    }
+
+    /**
+     * Return the cached response for the given request.
+     *
+     * @return Response|null $response
+     */
+    public function getCachedResponse(Request $request)
+    {
+        return $this->cache->get($this->getCacheKey($request));
+    }
+
+    /**
+     * Cache the response if possible.
+     *
+     * @return bool
+     */
+    public function handleCaching(Request $request, Response $response)
+    {
+        return $this->canCache($request, $response)
+            ? $this->cache->put($this->getCacheKey($request), $response, $this->getCacheExpiry($request, $response))
+            : false;
+    }
+
+    /**
+     * Determine if a response is allowed to be cached.
+     *
+     * @return bool
+     *
+     * @throws \BadMethodCallException
+     */
+    protected function canCache(Request $request, Response $response)
+    {
+        $cacheControlHeader = $this->parseHeaderParts($response->header('Cache-Control'));
+
+        if ($cacheControlHeader->has('private') && !$request->cacheOptions()->getKey()) {
+            throw new BadMethodCallException('You cannot cache a request marked as private without providing a key.');
+        }
+
+        return $this->getCacheExpiry($request, $response) && !$cacheControlHeader->has('no-store');
+    }
+
+    /**
+     * Retrieve the time-to-live in seconds based on the given cache options or request headers.
+     *
+     * @return int|null
+     */
+    protected function getCacheExpiry(Request $request, Response $response)
+    {
+        $cacheControlItems = $this->parseHeaderParts($response->header('Cache-Control'));
+
+        return $request->cacheOptions()->getExpiry()
+            ?? $cacheControlItems->get('s-maxage')
+            ?? $cacheControlItems->get('max-age')
+            ?? (($date = $response->header('Expires')) ? Carbon::parse($date)->diffInRealSeconds() : null);
+    }
+
+    /**
+     * Parse a header into separated keys and values.
+     *
+     * @return Collection
+     */
+    protected function parseHeaderParts(string $header)
+    {
+        return collect(explode(',', $header))->mapWithKeys(function ($option) {
+            $data = explode('=', $option, 2);
+
+            return [$data[0] => $data[1] ?? true];
+        });
+    }
+}

--- a/src/Illuminate/Http/Client/CacheOptions.php
+++ b/src/Illuminate/Http/Client/CacheOptions.php
@@ -1,0 +1,104 @@
+<?php
+
+
+namespace Illuminate\Http\Client;
+
+use BadMethodCallException;
+use Carbon\CarbonInterface;
+use DateTime;
+use DateTimeInterface;
+
+/**
+ * @mixin PendingRequest
+ */
+class CacheOptions
+{
+    /**
+     * @var PendingRequest|null
+     */
+    protected $pendingRequest;
+
+    /**
+     * @var int|null
+     */
+    protected $ttl = null;
+
+    /**
+     * @var string|null
+     */
+    protected $key = null;
+
+    public function __construct(PendingRequest $pendingRequest = null)
+    {
+        $this->pendingRequest = $pendingRequest;
+    }
+
+    /**
+     * Set the expiration in seconds for the cached response.
+     *
+     * @return $this
+     */
+    public function for(int $ttl)
+    {
+        $this->ttl = $ttl;
+
+        return $this;
+    }
+
+    /**
+     * Set the expiration based on a date instance
+     *
+     * @return $this
+     */
+    public function until(CarbonInterface $date)
+    {
+        $this->ttl = $date->diffInRealSeconds();
+
+        return $this;
+    }
+
+    /**
+     * Set a unique key to cache with.
+     *
+     * @param string $key
+     */
+    public function by(string $key)
+    {
+        $this->key = $key;
+
+        return $this;
+    }
+
+    /**
+     * The unique key to cache the response by.
+     *
+     * @return string|null
+     */
+    public function getKey()
+    {
+        return $this->key;
+    }
+
+    /**
+     * The Time-to-live for the cached response.
+     *
+     * @return int|null
+     */
+    public function getExpiry()
+    {
+        return $this->ttl;
+    }
+
+    /**
+     * Provide the PendingRequest with our cache builder and return control to it.
+     */
+    public function __call($name, $arguments)
+    {
+        if (!$this->pendingRequest) {
+            throw new BadMethodCallException("$name is not an existing method and no pending request has been set.");
+        }
+
+        return call_user_func_array([$this->pendingRequest->withCacheOptions($this), $name], $arguments);
+    }
+
+}

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -7,6 +7,7 @@ use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7\Response as Psr7Response;
 use GuzzleHttp\TransferStats;
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Http\Client\CacheHandler;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use PHPUnit\Framework\Assert as PHPUnit;
@@ -40,6 +41,7 @@ use PHPUnit\Framework\Assert as PHPUnit;
  * @method \Illuminate\Http\Client\PendingRequest withUserAgent(string $userAgent)
  * @method \Illuminate\Http\Client\PendingRequest withoutRedirecting()
  * @method \Illuminate\Http\Client\PendingRequest withoutVerifying()
+ * @method \Illuminate\Http\Client\CacheOptions cache()
  * @method array pool(callable $callback)
  * @method \Illuminate\Http\Client\Response delete(string $url, array $data = [])
  * @method \Illuminate\Http\Client\Response get(string $url, array|string|null $query = null)
@@ -63,6 +65,13 @@ class Factory
      * @var \Illuminate\Contracts\Events\Dispatcher|null
      */
     protected $dispatcher;
+
+    /**
+     * The cache handler implementation.
+     *
+     * @var \Illuminate\Contracts\Http\Client\CacheHandler|null
+     */
+    protected $cacheHandler;
 
     /**
      * The stub callables that will handle requests.
@@ -96,11 +105,13 @@ class Factory
      * Create a new factory instance.
      *
      * @param  \Illuminate\Contracts\Events\Dispatcher|null  $dispatcher
+     * @param  \Illuminate\Contracts\Http\Client\CacheHandler|null $cacheHandler
      * @return void
      */
-    public function __construct(Dispatcher $dispatcher = null)
+    public function __construct(Dispatcher $dispatcher = null, CacheHandler $cacheHandler = null)
     {
         $this->dispatcher = $dispatcher;
+        $this->cacheHandler = $cacheHandler;
 
         $this->stubCallbacks = collect();
     }
@@ -370,6 +381,16 @@ class Factory
     public function getDispatcher()
     {
         return $this->dispatcher;
+    }
+
+    /**
+     * Get the current cache handler implementation.
+     *
+     * @return \Illuminate\Contracts\Http\Client\CacheHandler|null
+     */
+    public function getCacheHandler()
+    {
+        return $this->cacheHandler;
     }
 
     /**

--- a/src/Illuminate/Http/Client/Request.php
+++ b/src/Illuminate/Http/Client/Request.php
@@ -27,6 +27,13 @@ class Request implements ArrayAccess
     protected $data;
 
     /**
+     * The requested caching options.
+     *
+     * @var CacheOptions|null
+     */
+    protected $cacheOptions;
+
+    /**
      * Create a new request instance.
      *
      * @param  \Psr\Http\Message\RequestInterface  $request
@@ -243,6 +250,29 @@ class Request implements ArrayAccess
     public function withData(array $data)
     {
         $this->data = $data;
+
+        return $this;
+    }
+
+    /**
+     * The requested caching options.
+     *
+     * @return CacheOptions|null
+     */
+    public function cacheOptions()
+    {
+        return $this->cacheOptions;
+    }
+
+    /**
+     * Set the desired cache options to use.
+     *
+     * @param \Illuminate\Http\Client\CacheOptions $cacheOptions
+     * @return $this
+     */
+    public function withCacheOptions($cacheOptions)
+    {
+        $this->cacheOptions = $cacheOptions;
 
         return $this;
     }

--- a/src/Illuminate/Support/Facades/Http.php
+++ b/src/Illuminate/Support/Facades/Http.php
@@ -35,6 +35,7 @@ use Illuminate\Http\Client\Factory;
  * @method static \Illuminate\Http\Client\PendingRequest withUserAgent(string $userAgent)
  * @method static \Illuminate\Http\Client\PendingRequest withoutRedirecting()
  * @method static \Illuminate\Http\Client\PendingRequest withoutVerifying()
+ * @method static \Illuminate\Http\Client\CacheOptions cache()
  * @method static array pool(callable $callback)
  * @method static \Illuminate\Http\Client\Response delete(string $url, array $data = [])
  * @method static \Illuminate\Http\Client\Response get(string $url, array|string|null $query = null)

--- a/tests/Http/HttpClientCachingTest.php
+++ b/tests/Http/HttpClientCachingTest.php
@@ -1,0 +1,311 @@
+<?php
+
+
+namespace Illuminate\Tests\Http;
+
+
+use BadMethodCallException;
+use Carbon\Carbon;
+use Illuminate\Contracts\Cache\Repository;
+use Illuminate\Http\Client\CacheHandlers\CacheHandler;
+use Illuminate\Http\Client\CacheOptions;
+use Illuminate\Http\Client\Factory;
+use Illuminate\Http\Client\Request;
+use PHPUnit\Framework\TestCase;
+use Mockery as m;
+
+class HttpClientCachingTest extends TestCase
+{
+    /**
+     * @var Factory
+     */
+    protected $factory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->factory = new Factory;
+    }
+
+    public function testThatTheHttpClientCanConstructCacheObject()
+    {
+        $this->factory->fake(['*' => ['result' => 'hello world']]);
+
+        $response = $this->factory
+            ->cache()->for(60 * 60)->by('foobar')
+            ->get('http://foo.com/api');
+
+        $this->assertSame('hello world', $response->json()['result']);
+
+        $this->factory->assertSent(function(Request $request) {
+            return $request->cacheOptions()->getKey() == 'foobar'
+                && $request->cacheOptions()->getExpiry() == 60 * 60;
+        });
+    }
+
+    public function testTheCacheExpiryCanBeSetUsingDateInstances()
+    {
+        Carbon::setTestNow(Carbon::now());
+
+        $date = Carbon::now()->addDay();
+        $cacheOptions = (new CacheOptions())->until($date);
+
+        $this->assertEquals($date->diffInSeconds(), $cacheOptions->getExpiry());
+    }
+
+    public function testTheRequestHeaderCacheHandlerSetsTheCacheExpiryBasedOnMaxAge()
+    {
+        $cache = m::mock(Repository::class);
+        $cache->shouldReceive('get', 'has')->andReturn(null);
+        $cache->shouldReceive('put')
+            ->once()
+            ->withArgs(function($key, $value, $ttl) {
+                return $ttl == 120;
+            })
+            ->andReturnTrue();
+
+        $factory = new Factory(null, new CacheHandler($cache));
+
+        $factory->fake(['*' => $this->factory->response([], 200, ['Cache-Control' => 'max-age=120'])]);
+
+        $factory->cache()->get('http://foo.com/api');
+
+        m::close();
+    }
+
+    public function testTheSMaxAgeHeaderOverridesTheMaxAgeHeader()
+    {
+        $cache = m::mock(Repository::class);
+        $cache->shouldReceive('get', 'has')->andReturn(null);
+        $cache->shouldReceive('put')
+            ->once()
+            ->withArgs(function($key, $value, $ttl) {
+                return $ttl == 160;
+            })
+            ->andReturnTrue();
+
+        $factory = new Factory(null, new CacheHandler($cache));
+
+        $factory->fake(['*' => $this->factory->response([], 200, ['Cache-Control' => 'max-age=120,s-maxage=160'])]);
+
+        $factory->cache()->get('http://foo.com/api');
+
+        m::close();
+    }
+
+    public function testTheManualCacheTimeIsUsedOverAnyHeaderValue()
+    {
+        $cache = m::mock(Repository::class);
+        $cache->shouldReceive('get', 'has')->andReturn(null);
+        $cache->shouldReceive('put')
+            ->once()
+            ->withArgs(function($key, $value, $ttl) {
+                return $ttl == 600;
+            })
+            ->andReturnTrue();
+
+        $factory = new Factory(null, new CacheHandler($cache));
+
+        $factory->fake(['*' => $this->factory->response([], 200, ['Cache-Control' => 'max-age=120, s-maxage=160'])]);
+
+        $factory->cache()->for(600)->get('http://foo.com/api');
+
+        m::close();
+    }
+
+    public function testIfNoExpiryTimeIsDiscoverableItWontCacheTheResponse()
+    {
+        $cache = m::mock(Repository::class);
+        $cache->shouldReceive('get', 'has')->andReturn(null);
+        $cache->shouldNotReceive('put');
+
+        $factory = new Factory(null, new CacheHandler($cache));
+
+        $factory->fake(['*' => $this->factory->response([], 200, [])]);
+
+        $factory->cache()->get('http://foo.com/api');
+
+        m::close();
+    }
+
+    public function testIfTheExpiryIsZeroItIsNotCached()
+    {
+        $cache = m::mock(Repository::class);
+        $cache->shouldReceive('get', 'has')->andReturn(null);
+        $cache->shouldNotReceive('put');
+
+        $factory = new Factory(null, new CacheHandler($cache));
+
+        $factory->fake(['*' => $this->factory->response([], 200, ['Cache-Control' => 'max-age=0'])]);
+
+        $factory->cache()->get('http://foo.com/api'); // Uses max-age header
+        $factory->cache()->for(0)->get('http://foo.com/api'); // Uses manual setting
+
+        m::close();
+    }
+
+    public function testIfTheNoStoreHeaderIsOnTheResponseItWontBeCached()
+    {
+        $cache = m::mock(Repository::class);
+        $cache->shouldReceive('get', 'has')->andReturn(null);
+        $cache->shouldNotReceive('put');
+
+        $factory = new Factory(null, new CacheHandler($cache));
+
+        $factory->fake(['*' => $this->factory->response([], 200, ['Cache-Control' => 'no-store'])]);
+
+        $factory->cache()->for(60)->get('http://foo.com/api');
+
+        m::close();
+    }
+
+    public function testTheCacheJustUsesTheUrlAsTheUniqueKeyIfNoKeyIsSpecified()
+    {
+        $cache = m::mock(Repository::class);
+        $cache->shouldReceive('get', 'has')->andReturn(null);
+        $cache->shouldReceive('put')
+            ->once()
+            ->withArgs(function($key, $value, $ttl) {
+                return $key == CacheHandler::CACHE_PREFIX . 'http://foo.com/api';
+            })
+            ->andReturnTrue();
+
+        $factory = new Factory(null, new CacheHandler($cache));
+
+        $factory->fake(['*' => $this->factory->response([], 200, ['Cache-Control' => 'max-age=120'])]);
+
+        $factory->cache()->get('http://foo.com/api');
+
+        m::close();
+    }
+
+    public function testTheCacheAppendsTheKeyIfSpecifiedToTheUrl()
+    {
+        $cache = m::mock(Repository::class);
+        $cache->shouldReceive('get', 'has')->andReturn(null);
+        $cache->shouldReceive('put')
+            ->once()
+            ->withArgs(function($key, $value, $ttl) {
+                return $key == CacheHandler::CACHE_PREFIX . 'http://foo.com/api::123';
+            })
+            ->andReturnTrue();
+
+        $factory = new Factory(null, new CacheHandler($cache));
+
+        $factory->fake(['*' => $this->factory->response([], 200, ['Cache-Control' => 'max-age=120'])]);
+
+        $factory->cache()->by('123')->get('http://foo.com/api');
+
+        m::close();
+    }
+
+    public function testTheExpiresHeaderIsUsedIfNoCacheControlMaxAgeIsAvailable()
+    {
+        Carbon::setTestNow(now());
+
+        $cache = m::mock(Repository::class);
+        $cache->shouldReceive('get', 'has')->andReturn(null);
+        $cache->shouldReceive('put')
+            ->once()
+            ->withArgs(function($key, $value, $ttl) {
+                return $ttl == 120;
+            })
+            ->andReturnTrue();
+
+        $factory = new Factory(null, new CacheHandler($cache));
+
+        $factory->fake(['*' => $this->factory->response([], 200, ['Expires' => Carbon::now()->addSeconds(120)->format('D, d M Y H:i:s T')])]);
+
+        $factory->cache()->get('http://foo.com/api');
+
+        m::close();
+    }
+
+    public function testTheExpiresHeaderIsNotUsedIfMaxAgeIsPresent()
+    {
+        Carbon::setTestNow(now());
+
+        $cache = m::mock(Repository::class);
+        $cache->shouldReceive('get', 'has')->andReturn(null);
+        $cache->shouldReceive('put')
+            ->once()
+            ->withArgs(function($key, $value, $ttl) {
+                return $ttl == 10;
+            })
+            ->andReturnTrue();
+
+        $factory = new Factory(null, new CacheHandler($cache));
+
+        $factory->fake(['*' => $this->factory->response([], 200, [
+            'Expires' => Carbon::now()->addSeconds(120)->format('D, d M Y H:i:s T'),
+            'Cache-Control' => 'max-age=10'
+        ])]);
+
+        $factory->cache()->get('http://foo.com/api');
+
+        m::close();
+    }
+
+    public function testACachedVersionOfTheResponseIsRetrievedWhenACacheableResponseIsRequestedAgain()
+    {
+        $cache = m::mock(Repository::class);
+        $cache->shouldReceive('put')->once()->andReturnTrue();
+        $cache->shouldReceive('has')->times(4)->andReturn(false, false, true, true);
+        $cache->shouldReceive('get')
+            ->once()
+            ->with(CacheHandler::CACHE_PREFIX . 'http://foo.com/api')
+            ->andReturn($this->factory->response(['response' => 'foo']));
+
+        $factory = new Factory(null, new CacheHandler($cache));
+
+        $factory->fake(['*' => $factory->response(['response' => 'bar'])]);
+
+        $factory->cache()->for(60)->get('http://foo.com/api');
+        $response = $factory->cache()->get('http://foo.com/api');
+
+        $this->assertSame('{"response":"foo"}', $response->body());
+
+        m::close();
+    }
+
+    public function testAnItemIsNotReCachedIfItAlreadyExists()
+    {
+        $cache = m::mock(Repository::class);
+        $cache->shouldReceive('has')->twice()->andReturn(false, true);
+        $cache->shouldNotReceive('put');
+
+        $factory = new Factory(null, new CacheHandler($cache));
+
+        $factory->fake(['*' => $factory->response(['response' => 'bar'])]);
+
+        $factory->cache()->for(60)->get('http://foo.com/api');
+
+        m::close();
+    }
+
+    public function testAnExceptionIsThrownIfAKeyIsNotSetOnAPrivateCache()
+    {
+        $this->expectException(BadMethodCallException::class);
+
+        $factory = new Factory(null, new CacheHandler(m::mock(Repository::class)));
+        $factory->fake(['*' => $factory->response(null, 200, ['Cache-Control' => 'private, max-age=3600'])]);
+
+        $factory->cache()->get('http://foo.com/api');
+
+        m::close();
+    }
+
+    public function testIfAKeyIsProvidedForAPrivateResponseTheResponseIsSuccessfullyCached()
+    {
+        $cache = m::mock(Repository::class);
+        $cache->shouldReceive('has')->twice()->andReturn(false, true);
+        $cache->shouldNotReceive('put');
+
+        $factory = new Factory(null, new CacheHandler($cache));
+        $factory->fake(['*' => $factory->response(null, 200, ['Cache-Control' => 'private, max-age=3600'])]);
+
+        $factory->cache()->by('foobar')->get('http://foo.com/api');
+    }
+
+}

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -967,6 +967,7 @@ class HttpClientTest extends TestCase
         $events->shouldReceive('dispatch')->once()->with(m::type(ResponseReceived::class));
 
         $factory = new Factory($events);
+        $factory->fake(['*' => $factory->response()]);
 
         $client = $factory->timeout(10);
         $clonedClient = clone $client;


### PR DESCRIPTION
Hi all,

This PR adds support for caching to the Http Client. It *isn't* just syntactical sugar for 

```php
cache()->remember('key', 60, fn() => Http::get('example.com')
```
because it is smart enough to base expiry times on max-age and expiry headers in the response. 

## Usage

Adding caching to an endpoint is as simple as prepending the `cache` method to your http client call:

```php
Http::cache()->get('https://example.com/api/users')
```

If the response has a `s-maxage`, `max-age` or `Expires` header and is not `private`, the request will be cached for the number of seconds reported in those headers. If a user wants to have more control over the length of time the response is cached for, they can chain the `for` or `until` method onto `cache`:

```php
// Both of these examples will cache the response for one hour
Http::cache()->for(60 * 60)->get('https://example.com/api/users'); 
Http::cache()->until(now()->addHour())->get('https://example.com/api/users'); 
```

Setting the specific timeout will override any max-age headers from the response.

The user can also specify a key to cache the response using the `by` method. This is useful when the request is being made to an API for a specific user, for example:

```php
Http::cache()->by(Auth::user()->id)->get('https://example.com/api/users'); 
```

In the above example, each logged in user will have their own cached request, so no data can leak out to other users through the cache.

If the response headers indicate that the cache control is private, and a key has not been set, a `BadMethodCallException` will be thrown.

## Custom implementations

If a user requires a custom solution, they can implement their own `CacheHandler`. A Cache Handler has 3 methods: 

- `hasCachedResponse`: checks if a response is available for the given request 
- `getCachedResponse`: returns a cached response if possible 
- `handleCaching`: decide if a response can be cached and perform the caching if so

Once implemented, the user can bind their implementation in a service provider:

```php
$this->app->singleton(CacheHandler::class, fn() => new MyVeryOwnCacheHandler());
``` 

## Potential improvements

One potential improvement is looking for and implementing with Etag headers. I've not done so yet, because I wanted to get feedback on if we're heading in the right direction so far from the community, but if so it might be nice to have these in, with support for automated validation of cached resources.

Finally, just want to say a massive thank you. This is my largest contribution to the framework to date, and so I'm sure I've missed a few things. Really appreciate the time and hard work it takes to manage everything.

Kind Regards,
Luke

