### PR TITLE
[8.x] Fix phpdoc - Factory::createMany/create/make() only return Collection and/or Model 

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -206,7 +206,7 @@ abstract class Factory
      * Create a collection of models and persist them to the database.
      *
      * @param  iterable  $records
-     * @return \Illuminate\Database\Eloquent\Collection|mixed
+     * @return \Illuminate\Database\Eloquent\Collection
      */
     public function createMany(iterable $records)
     {
@@ -222,7 +222,7 @@ abstract class Factory
      *
      * @param  array  $attributes
      * @param  \Illuminate\Database\Eloquent\Model|null  $parent
-     * @return \Illuminate\Database\Eloquent\Collection|\Illuminate\Database\Eloquent\Model|mixed
+     * @return \Illuminate\Database\Eloquent\Collection|\Illuminate\Database\Eloquent\Model
      */
     public function create($attributes = [], ?Model $parent = null)
     {
@@ -309,7 +309,7 @@ abstract class Factory
      *
      * @param  array  $attributes
      * @param  \Illuminate\Database\Eloquent\Model|null  $parent
-     * @return \Illuminate\Database\Eloquent\Collection|\Illuminate\Database\Eloquent\Model|mixed
+     * @return \Illuminate\Database\Eloquent\Collection|\Illuminate\Database\Eloquent\Model
      */
     public function make($attributes = [], ?Model $parent = null)
     {


### PR DESCRIPTION
Factory::createMany/create/make() are declared to possibly return other values (`mixed`) than `Collection` and `Model`, when in reality they don't ever seem to be.

I noticed this while adding Psalm support for the new Model::factory() syntax in Laravel 8 (see https://github.com/psalm/psalm-plugin-laravel/issues/155).