### PR TITLE
[8.x] Get statusText from Response protected property

### DIFF
--- a/src/Illuminate/Http/ResponseTrait.php
+++ b/src/Illuminate/Http/ResponseTrait.php
@@ -31,13 +31,13 @@ trait ResponseTrait
     {
         return $this->getStatusCode();
     }
-    
+
     /**
      * Get the status text for the response.
      *
      * @return string
      */
-    public function getStatusText()
+    public function statusText()
     {
         return $this->statusText;
     }    

--- a/src/Illuminate/Http/ResponseTrait.php
+++ b/src/Illuminate/Http/ResponseTrait.php
@@ -31,6 +31,16 @@ trait ResponseTrait
     {
         return $this->getStatusCode();
     }
+    
+    /**
+     * Get the status text for the response.
+     *
+     * @return string
+     */
+    public function getStatusText()
+    {
+        return $this->statusText;
+    }    
 
     /**
      * Get the content of the response.

--- a/tests/Http/HttpResponseTest.php
+++ b/tests/Http/HttpResponseTest.php
@@ -117,7 +117,7 @@ class HttpResponseTest extends TestCase
     {
         $response = new Response('foo');
         $response->setStatusCode(404);
-        $this->assertSame('Not Found', $response->getStatusText());
+        $this->assertSame('Not Found', $response->statusText());
     }
     
     public function testOnlyInputOnRedirect()

--- a/tests/Http/HttpResponseTest.php
+++ b/tests/Http/HttpResponseTest.php
@@ -113,6 +113,13 @@ class HttpResponseTest extends TestCase
         $this->assertSame(404, $response->getStatusCode());
     }
 
+    public function testSetStatusCodeAndRetrieveStatusText()
+    {
+        $response = new Response('foo');
+        $response->setStatusCode(404);
+        $this->assertSame('Not Found', $response->getStatusText());
+    }
+    
     public function testOnlyInputOnRedirect()
     {
         $response = new RedirectResponse('foo.bar');


### PR DESCRIPTION
**Description:**
Currently you are able to get the `statusCode` and `content` from a response. Content returns back the entire HTML output in some cases. When you need to render a Custom Error Page in the Exceptions\Handler for generic status codes like 403, 404, etc. it is beneficial in some cases to return the `statusText` protected property.

**Use Case:**
Rendering a custom error page for production when using Inertia.js to avoid using the error modal behaviour meant for local development and not production, as per Inertia documentation. Passing through the `statusText` in addition to the `statusCode` allows for both pre-defined error text to pass through to the custom error page/component.

This should not break any existing features and only extends out `statusText` in the same way that `statusCode` is passed down.

![image](https://user-images.githubusercontent.com/18236969/123151702-993ac000-d418-11eb-99a4-5d3ac0db0612.png)
