### PR TITLE
[8.x] Track a loop variable for sequence and pass it with count to closure

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Sequence.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Sequence.php
@@ -16,21 +16,14 @@ class Sequence
      *
      * @var int
      */
-    protected $count;
+    public $count;
 
     /**
-     * The current index of the sequence.
+     * The current index of the sequence iteration.
      *
      * @var int
      */
-    protected $index = 0;
-
-    /**
-     * The current loop of the sequence.
-     *
-     * @var int
-     */
-    protected $loop = 0;
+    public $index = 0;
 
     /**
      * Create a new sequence instance.
@@ -51,10 +44,8 @@ class Sequence
      */
     public function __invoke()
     {
-        $this->index = $this->loop % $this->count;
-
-        return tap(value($this->sequence[$this->index], $this->loop, $this->count), function () {
-            $this->loop = $this->loop + 1;
+        return tap(value($this->sequence[$this->index % $this->count], $this), function () {
+            $this->index = $this->index + 1;
         });
     }
 }

--- a/src/Illuminate/Database/Eloquent/Factories/Sequence.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Sequence.php
@@ -26,6 +26,13 @@ class Sequence
     protected $index = 0;
 
     /**
+     * The current loop of the sequence.
+     *
+     * @var int
+     */
+    protected $loop = 0;
+
+    /**
      * Create a new sequence instance.
      *
      * @param  array  $sequence
@@ -44,12 +51,10 @@ class Sequence
      */
     public function __invoke()
     {
-        if ($this->index >= $this->count) {
-            $this->index = 0;
-        }
+        $this->index = $this->loop % $this->count;
 
-        return tap(value($this->sequence[$this->index]), function () {
-            $this->index = $this->index + 1;
+        return tap(value($this->sequence[$this->index], $this->loop, $this->count), function () {
+            $this->loop = $this->loop + 1;
         });
     }
 }

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -404,6 +404,13 @@ class DatabaseEloquentFactoryTest extends TestCase
         $this->assertCount(2, $user->roles->filter(function ($role) {
             return $role->pivot->admin === 'N';
         }));
+
+        $users = FactoryTestUserFactory::times(2)->sequence(function ($sequence) {
+            return ['name' => 'index: ' . $sequence->index];
+        })->create();
+
+        $this->assertSame('index: 0', $users[0]->name);
+        $this->assertSame('index: 1', $users[1]->name);
     }
 
     public function test_resolve_nested_model_factories()

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -406,7 +406,7 @@ class DatabaseEloquentFactoryTest extends TestCase
         }));
 
         $users = FactoryTestUserFactory::times(2)->sequence(function ($sequence) {
-            return ['name' => 'index: ' . $sequence->index];
+            return ['name' => 'index: '.$sequence->index];
         })->create();
 
         $this->assertSame('index: 0', $users[0]->name);


### PR DESCRIPTION
I have a use case where I would like to know the loop count in a sequence, so I thought that others might like the ability too.

All this does is track a loop variable similar to foreach to use with % to get the index. Then it passes it to the closure.

```php
Model::factory()->count(5)
    ->sequence(fn($loop, $count) => ['sort' => $loop * 100])
    ->create();
```

`$loop` & `$count` is optional, and people would only declare if needed.  I almost did not pass `$count`, but there are times that we do a random number in the `count` method, so there is a slight use case.

This is a re-mix of #37753 in a way to be backward compatible, as @driesvints suggested.

Thanks for considering & I hope that you see value in it.

Thanks so much for all the work that you put into Laravel!

