### PR TITLE
[8.x] Remove duplicated `updated_at` setting

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -89,8 +89,6 @@ trait SoftDeletes
 
         if ($this->timestamps && ! is_null($this->getUpdatedAtColumn())) {
             $this->{$this->getUpdatedAtColumn()} = $time;
-
-            $columns[$this->getUpdatedAtColumn()] = $this->fromDateTime($time);
         }
 
         $query->update($columns);

--- a/tests/Database/DatabaseSoftDeletingTraitTest.php
+++ b/tests/Database/DatabaseSoftDeletingTraitTest.php
@@ -23,11 +23,9 @@ class DatabaseSoftDeletingTraitTest extends TestCase
         $query->shouldReceive('where')->once()->with('id', '=', 1)->andReturn($query);
         $query->shouldReceive('update')->once()->with([
             'deleted_at' => 'date-time',
-            'updated_at' => 'date-time',
         ]);
         $model->shouldReceive('syncOriginalAttributes')->once()->with([
             'deleted_at',
-            'updated_at',
         ]);
         $model->delete();
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

There is no need to set the `$columns[$this->getUpdatedAtColumn()]` value when soft deleting, as `Illuminate\Database\Eloquent\Builder::update` already merges in the Updated At column.
