### PR TITLE
[8.x] Added "MessageGroupId" to SQS Queue if queue is a fifo.

### DIFF
--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -112,13 +112,13 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     {
         $args = [
             'QueueUrl' => $this->getQueue($queue),
-            'MessageBody' => $payload, 
+            'MessageBody' => $payload,
         ];
 
         /** Add MessageGroupId to a Fifo SQS Queue */
         if (\strpos($queue, '.fifo')) {
             $args = \array_merge($args, [
-                'MessageGroupId' => md5($queue)
+                'MessageGroupId' => md5($queue),
             ]);
         }
 
@@ -152,7 +152,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
                 /** Add MessageGroupId to a Fifo SQS Queue */
                 if (\strpos($queue, '.fifo')) {
                     $args = \array_merge($args, [
-                        'MessageGroupId' => md5($queue)
+                        'MessageGroupId' => md5($queue),
                     ]);
                 }
 


### PR DESCRIPTION
I tested Amazon SQS "FIFO" queues and the response said that the "MessageGroupId" parameter was missing from the request for "sendMessage", so I added a condition, if the queue name contains ".fifo" in the name, I enter the "MessageGroupId" parameter with an MD5 encryption of the Queue name.