### PR TITLE
[8.x] Ensure alias is rebound when mocking items in the container

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
@@ -86,6 +86,8 @@ trait InteractsWithContainer
      */
     protected function singletonInstance($abstract, $instance)
     {
+        $abstract = $this->app->getAlias($abstract);
+
         $this->app->singleton($abstract, function () use ($instance) {
             return $instance;
         });

--- a/tests/Foundation/Testing/Concerns/InteractsWithContainerTest.php
+++ b/tests/Foundation/Testing/Concerns/InteractsWithContainerTest.php
@@ -2,7 +2,9 @@
 
 namespace Illuminate\Tests\Foundation\Testing\Concerns;
 
+use Illuminate\Http\Request;
 use Illuminate\Foundation\Mix;
+use Mockery\MockInterface;
 use Orchestra\Testbench\TestCase;
 use stdClass;
 
@@ -34,5 +36,17 @@ class InteractsWithContainerTest extends TestCase
 
         $this->assertEquals('bar', $this->app->make('foo'));
         $this->assertEquals('bar', $this->app->make('foo', ['with' => 'params']));
+    }
+
+    public function testSingletonRebindsAlias()
+    {
+        $this->app->instance('request', Request::create('/example'));
+
+        $this->mock(Request::class, function (MockInterface $mock) {
+
+        });
+
+        $this->assertInstanceOf(MockInterface::class, resolve(Request::class));
+        $this->assertInstanceOf(MockInterface::class, resolve('request'));
     }
 }

--- a/tests/Foundation/Testing/Concerns/InteractsWithContainerTest.php
+++ b/tests/Foundation/Testing/Concerns/InteractsWithContainerTest.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Tests\Foundation\Testing\Concerns;
 
-use Illuminate\Http\Request;
 use Illuminate\Foundation\Mix;
+use Illuminate\Http\Request;
 use Mockery\MockInterface;
 use Orchestra\Testbench\TestCase;
 use stdClass;
@@ -43,7 +43,7 @@ class InteractsWithContainerTest extends TestCase
         $this->app->instance('request', Request::create('/example'));
 
         $this->mock(Request::class, function (MockInterface $mock) {
-
+            //
         });
 
         $this->assertInstanceOf(MockInterface::class, resolve(Request::class));


### PR DESCRIPTION
Closes #37789.