### PR TITLE
[8.x] Solve the inconsistency of the with-and-without middleware

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1034,7 +1034,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
             $signedMiddleware
         );
 
-        $this->forgetSignedMiddleware($middleware, !$sign);
+        $this->forgetSignedMiddleware($middleware, ! $sign);
 
         return $this;
     }
@@ -1063,7 +1063,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
             $index = array_search($abstract, $signedMiddleware);
 
             if ($index !== false) {
-                if (!$sign) {
+                if (! $sign) {
                     unset($this[$abstract]);
                 }
 

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -138,6 +138,8 @@ trait MakesHttpRequests
         if (is_null($middleware)) {
             $this->app->instance('middleware.disable', true);
 
+            $this->app->forgetSignedMiddleware();
+
             return $this;
         }
 
@@ -149,6 +151,8 @@ trait MakesHttpRequests
                     return $next($request);
                 }
             });
+
+            $this->app->pushSignedMiddleware($middleware, false);
         }
 
         return $this;
@@ -165,11 +169,13 @@ trait MakesHttpRequests
         if (is_null($middleware)) {
             unset($this->app['middleware.disable']);
 
+            $this->app->forgetSignedMiddleware(null, false);
+
             return $this;
         }
 
         foreach ((array) $middleware as $abstract) {
-            unset($this->app[$abstract]);
+            $this->app->pushSignedMiddleware($abstract);
         }
 
         return $this;

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -685,7 +685,11 @@ class Router implements BindingRegistrar, RegistrarContract
         $shouldSkipMiddleware = $this->container->bound('middleware.disable') &&
                                 $this->container->make('middleware.disable') === true;
 
-        $middleware = $shouldSkipMiddleware ? [] : $this->gatherRouteMiddleware($route);
+        $routeMiddleware = $this->gatherRouteMiddleware($route);
+
+        $middleware = $shouldSkipMiddleware
+            ? $this->container->getSignedMiddleware(true, $routeMiddleware)
+            : $routeMiddleware;
 
         return (new Pipeline($this->container))
                         ->send($request)

--- a/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
+++ b/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
@@ -33,9 +33,11 @@ class MakesHttpRequestsTest extends TestCase
         $this->withoutMiddleware();
         $this->assertTrue($this->app->has('middleware.disable'));
         $this->assertTrue($this->app->make('middleware.disable'));
+        $this->assertSame([], $this->app->make('middleware.required'));
 
         $this->withMiddleware();
         $this->assertFalse($this->app->has('middleware.disable'));
+        $this->assertSame([], $this->app->make('middleware.ignored'));
     }
 
     public function testWithoutAndWithMiddlewareWithParameter()
@@ -56,6 +58,14 @@ class MakesHttpRequestsTest extends TestCase
             'foo',
             $this->app->make(MyMiddleware::class)->handle('foo', $next)
         );
+        $this->assertContains(
+            MyMiddleware::class,
+            $this->app->make('middleware.ignored')
+        );
+        $this->assertNotContains(
+            MyMiddleware::class,
+            $this->app->make('middleware.required')
+        );
 
         $this->withMiddleware(MyMiddleware::class);
         $this->assertFalse($this->app->has(MyMiddleware::class));
@@ -63,6 +73,65 @@ class MakesHttpRequestsTest extends TestCase
             'fooWithMiddleware',
             $this->app->make(MyMiddleware::class)->handle('foo', $next)
         );
+        $this->assertContains(
+            MyMiddleware::class,
+            $this->app->make('middleware.required')
+        );
+        $this->assertNotContains(
+            MyMiddleware::class,
+            $this->app->make('middleware.ignored')
+        );
+    }
+
+    public function testWithoutAndWithMiddlewareWithAndWithoutParameter()
+    {
+        $next = function ($request) {
+            return $request;
+        };
+
+        $this->assertFalse($this->app->has(MyMiddleware::class));
+        $this->assertSame(
+            'fooWithMiddleware',
+            $this->app->make(MyMiddleware::class)->handle('foo', $next)
+        );
+
+        $this->withoutMiddleware();
+        $this->assertTrue($this->app->has('middleware.disable'));
+        $this->assertTrue($this->app->make('middleware.disable'));
+        $this->assertSame([], $this->app->make('middleware.required'));
+
+        $this->withMiddleware(MyMiddleware::class);
+        $this->assertSame(
+            'fooWithMiddleware',
+            $this->app->make(MyMiddleware::class)->handle('foo', $next)
+        );
+        $this->assertContains(
+            MyMiddleware::class,
+            $this->app->make('middleware.required')
+        );
+
+        $this->withoutMiddleware(MyMiddleware::class);
+        $this->assertTrue($this->app->has(MyMiddleware::class));
+        $this->assertSame(
+            'foo',
+            $this->app->make(MyMiddleware::class)->handle('foo', $next)
+        );
+        $this->assertContains(
+            MyMiddleware::class,
+            $this->app->make('middleware.ignored')
+        );
+        $this->assertNotContains(
+            MyMiddleware::class,
+            $this->app->make('middleware.required')
+        );
+
+        $this->withMiddleware();
+        $this->assertSame(
+            'fooWithMiddleware',
+            $this->app->make(MyMiddleware::class)->handle('foo', $next)
+        );
+        $this->assertFalse($this->app->has('middleware.disable'));
+        $this->assertSame([], $this->app->make('middleware.ignored'));
     }
 
     public function testWithCookieSetCookie()


### PR DESCRIPTION
This PR solved the inconsistency of the `withMiddleware` and `withoutMiddleware` in the following of this issue #24680 .

The first problem was related to running one or two middlewares (e.g. `withMiddleware(['foo', 'bar'])`) after disabling them using `withMiddleware()` [without parameter]. It was not working.

The second problem was related to enabling all middlewares using `withMiddleware()` [without parameter] after disabling them explicitly (e.g. `withoutMiddleware(['foo', 'bar'])`).  This one was not working, also.

For more clarification:
```php
//1. All middlewares disabled here.
$this->withoutMiddleware();

//2. Only include the foo & bar middlewares. This was NOT working before this PR.
$this->withMiddleware(['foo', 'bar']);

//3. Disable the bar middleware. It was OK.
$this->withoutMiddleware('bar');

//4. Enable all middlewares including bar middleware. Before this PR, the bar middleware was NOT included.
$this->withMiddleware();
```

Also, the test for above example included in the second commit.