### PR TITLE
[8.x] Refresh all relations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -12,7 +12,6 @@ use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
-use Illuminate\Database\Eloquent\Relations\Concerns\AsPivot;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Support\Arr;
@@ -1463,9 +1462,8 @@ abstract class Model implements Arrayable, ArrayAccess, HasBroadcastChannel, Jso
             $this->setKeysForSelectQuery($this->newQueryWithoutScopes())->firstOrFail()->attributes
         );
 
-        $this->load(collect($this->relations)->reject(function ($relation) {
-            return $relation instanceof Pivot
-                || (is_object($relation) && in_array(AsPivot::class, class_uses_recursive($relation), true));
+        $this->load(collect($this->relations)->reject(function ($relation, $name) {
+            return ! method_exists($this, $name);
         })->keys()->all());
 
         $this->syncOriginal();


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Currently, when you call `refresh` it doesn't reload `morph` relations that extend `MorphPivot` class:
```php
    public function latestComment()
    {
        return $this->morphOne(Comment::class, 'commentable')->ofMany(['id' => 'max']);
    }
```

This PR will reduce the complexity of the previous check and simply check if the (relation) method exists. I created a test case and without this PR the last line would fail and still return 1:
![image](https://user-images.githubusercontent.com/5358638/123405070-c36fb780-d5a9-11eb-9fca-789c35849530.png)

