### PR TITLE
[8.x] Reduce memory usage of models and routes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1176,7 +1176,13 @@ trait HasAttributes
     public function getCasts()
     {
         if ($this->getIncrementing()) {
-            return array_merge([$this->getKeyName() => $this->getKeyType()], $this->casts);
+            $casts = $this->casts;
+
+            if (! isset($casts[$this->getKeyName()])) {
+                $casts[$this->getKeyName()] = $this->getKeyType();
+            }
+
+            return $casts;
         }
 
         return $this->casts;

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -161,13 +161,15 @@ class Route
     {
         $this->uri = $uri;
         $this->methods = (array) $methods;
-        $this->action = Arr::except($this->parseAction($action), ['prefix']);
+        $this->action = $this->parseAction($action);
+
+        unset($this->action['prefix']);
 
         if (in_array('GET', $this->methods) && ! in_array('HEAD', $this->methods)) {
             $this->methods[] = 'HEAD';
         }
 
-        $this->prefix(is_array($action) ? Arr::get($action, 'prefix') : '');
+        $this->prefix(is_array($action) ? $action['prefix'] ?? '' : '');
     }
 
     /**

--- a/src/Illuminate/Routing/RouteGroup.php
+++ b/src/Illuminate/Routing/RouteGroup.php
@@ -20,15 +20,14 @@ class RouteGroup
             unset($old['domain']);
         }
 
-        $new = array_merge(static::formatAs($new, $old), [
-            'namespace' => static::formatNamespace($new, $old),
-            'prefix' => static::formatPrefix($new, $old, $prependExistingPrefix),
-            'where' => static::formatWhere($new, $old),
-        ]);
+        $newAttributes = static::formatAs($new, $old);
+        $newAttributes['namespace'] = static::formatNamespace($new, $old);
+        $newAttributes['prefix'] = static::formatPrefix($new, $old, $prependExistingPrefix);
+        $newAttributes['where'] = static::formatWhere($new, $old);
 
-        return array_merge_recursive(Arr::except(
-            $old, ['namespace', 'prefix', 'where', 'as']
-        ), $new);
+        unset($old['namespace'], $old['prefix'], $old['where'], $old['as']);
+
+        return array_merge_recursive($old, $newAttributes);
     }
 
     /**
@@ -77,10 +76,13 @@ class RouteGroup
      */
     protected static function formatWhere($new, $old)
     {
-        return array_merge(
-            $old['where'] ?? [],
-            $new['where'] ?? []
-        );
+        $wheres = $old['where'] ?? [];
+
+        foreach ($new['where'] ?? [] as $key => $where) {
+            $wheres[$key] = $where;
+        }
+
+        return $wheres;
     }
 
     /**

--- a/src/Illuminate/Routing/RouteGroup.php
+++ b/src/Illuminate/Routing/RouteGroup.php
@@ -2,8 +2,6 @@
 
 namespace Illuminate\Routing;
 
-use Illuminate\Support\Arr;
-
 class RouteGroup
 {
     /**


### PR DESCRIPTION
This PR aims to limit the use of internal PHP function prone to memory consumption, like `array_merge()` and `explode()`.

The minor changes introduced by this PR apply to models and routes. While routes are (ideally) cached on production,
the environments that benefit the most from this route changes are local envs and testing environments running integration tests, as they need to reboot the application.

Below there are some profiling results that indicate the difference of memory consumption while running my test suite.
The results show an improvement of ~20%, however we need to consider the size of both application and test suite:
my app and test suite are relatively small, so a bigger improvement is expected in larger realities.

This picture shows the memory consumed by `array_merge()` before the changes of this PR. It also includes the memory consumption from `Dotenv` (I'll send a PR to the `Dotenv` repo to reduce it as well):

![merge_before](https://user-images.githubusercontent.com/5838106/123403341-06eb1580-d5ec-11eb-8304-7d43322fb383.png)

and this is the memory consumed by `array_merge()` after the changes:

![merge_after](https://user-images.githubusercontent.com/5838106/123403366-0c486000-d5ec-11eb-97dd-e611129e031b.png)

same for `explode()`:

![explode_before](https://user-images.githubusercontent.com/5838106/123403361-0bafc980-d5ec-11eb-974d-dd015956966b.png)

and this is after:

![explode_after](https://user-images.githubusercontent.com/5838106/123403355-0a7e9c80-d5ec-11eb-9f10-8fb6ae0d2cd2.png)

Side note: the calls to `Arr::get()` shown in the picture above come from the configuration repository, which needs dot-notation to read config values: `explode()` here cannot be avoided.

My take from this profiling: Bootstrapping Laravel is one of the most sensitive part as its operations are repeated
over and over, unless they are cached or the app is kept in memory (Octane ❤️). During this process is important to avoid as much as possible internal PHP functions that are expensive in terms of memory usage.