### PR TITLE
[8.x] Handle Query Builder supported arrays

### DIFF
--- a/src/Illuminate/Testing/Constraints/HasInDatabase.php
+++ b/src/Illuminate/Testing/Constraints/HasInDatabase.php
@@ -78,10 +78,7 @@ class HasInDatabase extends Constraint
     {
         $query = $this->database->table($table);
 
-        $similarResults = $query->where(
-            array_key_first($this->data),
-            $this->data[array_key_first($this->data)]
-        )->limit($this->show)->get();
+        $similarResults = $query->where(array_slice($this->data, 0, 1, true))->limit($this->show)->get();
 
         if ($similarResults->isNotEmpty()) {
             $description = 'Found similar results: '.json_encode($similarResults, JSON_PRETTY_PRINT);


### PR DESCRIPTION
This is a backward-compatible change.

With this change you could do the following too:

```php
$this->assertDatabaseHas($tableName, [
    ['field_a', '=', 'value'],
    ['field_b', '<>', '']
]);
```

And keeps it backward-compatilble with:

```php
$this->assertDatabaseHas($tableName, [
    'field_a' => 'value_a',
    'field_a' => 'value_b'
]);
```