### PR TITLE
[8.x] Eager Loaded Pseudo Relationships

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -649,7 +649,7 @@ class Builder
         // Then we will "back up" the existing where conditions on the query so we can
         // add our eager constraints. Then we will merge the wheres that were on the
         // query back to it in order that any where conditions might be specified.
-        $relation = $this->getRelation($name, $alias ?? null);
+        $relation = $this->getRelation($name);
 
         $relation->addEagerConstraints($models);
 
@@ -668,10 +668,9 @@ class Builder
      * Get the relation instance for the given relation name.
      *
      * @param  string  $name
-     * @param  string|null  $alias
      * @return \Illuminate\Database\Eloquent\Relations\Relation
      */
-    public function getRelation($name, $alias = null)
+    public function getRelation($name)
     {
         // We want to run a relationship query without any constrains so that we will
         // not have to remove these where clauses manually which gets really hacky
@@ -684,7 +683,7 @@ class Builder
             }
         });
 
-        $nested = $this->relationsNestedUnder($name, $alias ?? $name);
+        $nested = $this->relationsNestedUnder($name);
 
         // If there are nested relationships set on the query, we will put those onto
         // the query instances so that they can be handled after this relationship

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -577,10 +577,21 @@ class Builder
      */
     protected function eagerLoadRelation(array $models, $name, Closure $constraints)
     {
-        // First we will "back up" the existing where conditions on the query so we can
+        // First we will determine if the name has been aliased using an "as" clause on the name
+        // and if it has we will extract the actual relationship name and the desired name of
+        // the resulting column. This allows multiple instances on the same relationship name.
+        $segments = explode(' ', $name);
+
+        unset($alias);
+
+        if (count($segments) === 3 && Str::lower($segments[1]) === 'as') {
+            [$name, $alias] = [$segments[0], $segments[2]];
+        }
+
+        // Then we will "back up" the existing where conditions on the query so we can
         // add our eager constraints. Then we will merge the wheres that were on the
         // query back to it in order that any where conditions might be specified.
-        $relation = $this->getRelation($name);
+        $relation = $this->getRelation($name, $alias ?? null);
 
         $relation->addEagerConstraints($models);
 
@@ -590,8 +601,8 @@ class Builder
         // using the relationship instance. Then we just return the finished arrays
         // of models which have been eagerly hydrated and are readied for return.
         return $relation->match(
-            $relation->initRelation($models, $name),
-            $relation->getEager(), $name
+            $relation->initRelation($models, $alias ?? $name),
+            $relation->getEager(), $alias ?? $name
         );
     }
 
@@ -599,9 +610,10 @@ class Builder
      * Get the relation instance for the given relation name.
      *
      * @param  string  $name
+     * @param  string|null  $alias
      * @return \Illuminate\Database\Eloquent\Relations\Relation
      */
-    public function getRelation($name)
+    public function getRelation($name, $alias = null)
     {
         // We want to run a relationship query without any constrains so that we will
         // not have to remove these where clauses manually which gets really hacky
@@ -614,7 +626,7 @@ class Builder
             }
         });
 
-        $nested = $this->relationsNestedUnder($name);
+        $nested = $this->relationsNestedUnder($name, $alias ?? $name);
 
         // If there are nested relationships set on the query, we will put those onto
         // the query instances so that they can be handled after this relationship

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -510,7 +510,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $relation->shouldReceive('initRelation')->once()->with(['models'], 'orders')->andReturn(['models']);
         $relation->shouldReceive('getEager')->once()->andReturn(['results']);
         $relation->shouldReceive('match')->once()->with(['models'], ['results'], 'orders')->andReturn(['models.matched']);
-        $builder->shouldReceive('getRelation')->once()->with('orders')->andReturn($relation);
+        $builder->shouldReceive('getRelation')->once()->with('orders', null)->andReturn($relation);
         $results = $builder->eagerLoadRelations(['models']);
 
         $this->assertEquals(['models.matched'], $results);

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -633,7 +633,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $relation->shouldReceive('initRelation')->once()->with(['models'], 'orders')->andReturn(['models']);
         $relation->shouldReceive('getEager')->once()->andReturn(['results']);
         $relation->shouldReceive('match')->once()->with(['models'], ['results'], 'orders')->andReturn(['models.matched']);
-        $builder->shouldReceive('getRelation')->once()->with('orders', null)->andReturn($relation);
+        $builder->shouldReceive('getRelation')->once()->with('orders')->andReturn($relation);
         $results = $builder->eagerLoadRelations(['models']);
 
         $this->assertEquals(['models.matched'], $results);

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -810,6 +810,58 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertSame('taylorotwell@gmail.com', $post->first()->user->email);
     }
 
+    public function testBasicEagerLoadingWithAlias()
+    {
+        $user = EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);
+        $user->posts()->create(['name' => 'First Post']);
+        $user->posts()->create(['name' => 'Second Post']);
+        $user = EloquentTestUser::with([
+            'posts' => function ($q) {
+            },
+            'posts AS posts2' => function ($q) {
+                $q->where('name', 'Second Post');
+            },
+        ])->where('email', 'taylorotwell@gmail.com')->first();
+
+        $this->assertSame('First Post', $user->posts->first()->name);
+        $this->assertSame('Second Post', $user->posts2->first()->name);
+    }
+
+    public function testNestedEagerLoadingWithAlias()
+    {
+        $user = EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);
+        $post = $user->posts()->create(['name' => 'First Post']);
+        $post2 = $user->posts()->create(['name' => 'Second Post']);
+        $post->childPosts()->create(['name' => 'Child Post', 'user_id' => $user->id]);
+        $post->childPosts()->create(['name' => 'Child Post2', 'user_id' => $user->id]);
+
+        $user = EloquentTestUser::with([
+            'posts as aliasPosts' => function ($q) {
+                $q->where('name', 'Second Post');
+            },
+            'posts.childPosts' => function ($q) {
+            },
+            'posts.childPosts AS aliasChildPosts' => function ($q) {
+                $q->where('name', 'Child Post2');
+            },
+
+        ])->where('email', 'taylorotwell@gmail.com')->first();
+
+        $this->assertNotNull($user->aliasPosts->first());
+        $this->assertFalse(property_exists($user->aliasPosts->first(), 'childPosts'));
+        $this->assertFalse(property_exists($user->aliasPosts->first(), 'aliasChildPosts'));
+        $this->assertSame('Second Post', $user->aliasPosts->first()->name);
+
+        $this->assertNotNull($user->posts->first());
+        $this->assertSame('First Post', $user->posts->first()->name);
+
+        $this->assertNotNull($user->posts->first()->childPosts->first());
+        $this->assertSame('Child Post', $user->posts->first()->childPosts->first()->name);
+
+        $this->assertNotNull($user->posts->first()->childPosts->first());
+        $this->assertSame('Child Post2', $user->posts->first()->aliasChildPosts->first()->name);
+    }
+
     public function testBasicNestedSelfReferencingHasManyEagerLoading()
     {
         $user = EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);


### PR DESCRIPTION
If it's considered a feature and 6.x [PR #37829](https://github.com/laravel/framework/pull/37829) is not merged, maybe 8.x does
Create pseudo relationship that can be eager loaded, example:
```php
$salesperson = Salesperson::select()
    ->with(['leads as openLeads'=> fn($q)=> $q->where('status', 'open')])
    ->with(['leads as completedLeads'=> fn($q)=> $q->where('status', 'completed')])
    ->with(['leads as completedLeadsWithSale'=> fn($q)=> $q->where('status','completed')->where('result','sale')])
    ->with(['leads as completedLeadsWithNoSale'=> fn($q)=> $q->where('status','completed')->where('result','no sale')])
    ->first();

$salesperson->openLeads;
$salesperson->completedLeads;
$salesperson->completedLeadsWithSale;
$salesperson->completedLeadsWithNoSale;
```
These "relationships" are then available on the models in the view:
```blade
@foreach($salespersons as $salesperson)
    <tr>
        <td>{{ $salesperson->name }}</td>
        <td>{{ count($salesperson->openLeads) }}</td>
        <td>{{ count($salesperson->completedLeads) }}</td>
        <td>{{ count($salesperson->completedLeadsWithNoSale) }}</td>
        <td>{{ count($salesperson->completedLeadsWithSale) }}</td>
        <td>{{ count($salesperson->completedLeadsWithSale) / count($salesperson->completedLeads) }}</td>
    </tr>
@endforeach
```
This PR allows us to define eager loaded pseudo relationships. The benefit to this is it avoids our N+1 issues, keeps the filtering and sorting in the database, and keeps the majority of the logic out of the view. Can be merged with 8.x without conflicts.
As `withCount` set a alias, `with` will replay the same behaivor, and also this supports nested eager relationships. Consistent with `withCount($relations)` this PR supports `as`,`AS`,`As`
https://github.com/laravel/framework/blob/09feffba0ba3ebff4a366f020519b34c3d2e101f/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php#L368-L378

---------------
### Current Scenario
Imagine you have a Salesperson with many Leads. Leads have a status of "open" or "completed", and a result of "sale" or "no sale".

You are trying to build a dashboard that shows the `Salesperson's` metrics.
Salesperson | Open | Completed | No Sale | Sale | Close Rate
-- | -- | -- | -- | -- | --
Taylor | 15 | 20 | 15 | 5 | 25%
Mohammed | 7 | 6 | 1 | 5 | 83%
Dries | 12 | 15 | 5 | 10 | 66%

It is a simple 1:many relationship between the models.
```php
class Salesperson extends Model {
    public function leads() {
        return $this->hasMany(Lead::class);
    }
}
```
In your controller you fetch all the `Salesperson`s.
```php
class SalespersonController {
    public function index() {
        $salespersons = Salesperson::with('leads')->get();
    }
}
```
In your view you loop through the `Salesperson`s.
```blade
@foreach($salespersons as $salesperson)
  <tr>
    <td>{{ $salesperson->name }}</td>
    <td>{{ count($salesperson->leads()->where('status', 'open')->get()) }}</td>
    <td>{{ count($salesperson->leads()->where('status', 'completed')->get()) }}</td>
    <td>{{ count($salesperson->leads()->where('status', 'completed')->where('result', 'no sale')->get()) }}</td>
    <td>{{ count($salesperson->leads()->where('status', 'completed')->where('result', 'sale')->get()) }}</td>
    <td>{{ count($salesperson->leads()->where('status', 'completed')->where('result', 'sale')->get()) / count($salesperson->leads()->where('status', 'completed')->get()) }}</td>
  </tr>
@endforeach
```
Because we are calling -`>leads()` as a method and not a property (in order to tack on our additional conditions), this will result in new queries being run for each of these groupings, and we don't benefit from the eager loading we did in the controller.

There are 2 ways we could currently handle this. We could create additional constrained relationships in the Model:
```php
class Salesperson extends Model {
    public function leads() {
        return $this->hasMany(Lead::class);
    }
    public function openLeads() {
        return $this->hasMany(Lead::class)->where('status', 'open');
    }
    public function completedLeads()  {
        return $this->hasMany(Lead::class)->where('status', 'completed');
    }
    public function completedLeadsWithSale() {
        return $this->hasMany(Lead::class)->where('status', 'completed')->where('result', 'sale');
    }
    public function completedLeadsWithNoSale() {
        return $this->hasMany(Lead::class)->where('status', 'completed')->where('result', 'no sale');
    }
}
```
and then eager load these in the Controller:
```php
class SalespersonController {
    public function index() {
        $salespersons = Salesperson::select()
            ->with('leads')
            ->with('openLeads')
            ->with('completedLeads')
            ->with('completedLeadsWithSale')
            ->with('completedLeadsWithNoSale')
            ->get();
    }
}
```
This gets rid of our N+1, but the problem with this is it quickly becomes very verbose and unmanageable.

The other option is to filter in PHP (rather than the query) using the returned Collections. In our controller we revert to our simple eager load on the leads relationship:
```php
class SalespersonController {
    public function index() {
        $salespersons = Salesperson::with('leads')->get();
    }
}
```
and now in our view we use Collection methods to filter out our desired data:
```blade
@foreach($salespersons as $salesperson)
  <tr>
    <td>{{ $salesperson->name }}</td>
    <td>{{ count($salesperson->leads->where('status', 'open')) }}</td>
    <td>{{ count($salesperson->leads->where('status', 'completed')) }}</td>
    <td>{{ count($salesperson->leads->where('status', 'completed')->where('result', 'no sale')) }}</td>
    <td>{{ count($salesperson->leads->where('status', 'completed')->where('result', 'sale')) }}</td>
    <td>{{ count($salesperson->leads->where('status', 'completed')->where('result', 'sale')) / count($salesperson->leads()->where('status', 'completed')) }}</td>
  </tr>
@endforeach
```
This option benefits from the eager loading, so our query count is very low. However, there is a lot of "logic" in the view, which some people do not like. We also duplicate 2 conditions in our "Close Rate" column that we've already determined. Finally, this does offload the filtering and sorting to PHP rather than the database, which could be undesirable in some scenarios, possibly for performance reasons.