### PR TITLE
[8.x] Fix stringable docblock

### DIFF
--- a/src/Illuminate/Support/Facades/Blade.php
+++ b/src/Illuminate/Support/Facades/Blade.php
@@ -26,7 +26,7 @@ namespace Illuminate\Support\Facades;
  * @method static void withDoubleEncoding()
  * @method static void withoutComponentTags()
  * @method static void withoutDoubleEncoding()
- * @method static void stringable(string|callable $class, callable|null $handler)
+ * @method static void stringable(string|callable $class, callable|null $handler = null)
  *
  * @see \Illuminate\View\Compilers\BladeCompiler
  */


### PR DESCRIPTION
Add missing `null` default value on `Blade@stringable` façade docblock

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
