### PR TITLE
[8.x] Add ReturnTypeWillChange attribute

### DIFF
--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -11,6 +11,7 @@ use Illuminate\Queue\SerializableClosure;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use JsonSerializable;
+use ReturnTypeWillChange;
 use Throwable;
 
 class Batch implements Arrayable, JsonSerializable
@@ -459,6 +460,7 @@ class Batch implements Arrayable, JsonSerializable
      *
      * @return array
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->toArray();

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -13,6 +13,7 @@ use Illuminate\Support\Enumerable;
 use Illuminate\Support\HigherOrderCollectionProxy;
 use Illuminate\Support\HigherOrderWhenProxy;
 use JsonSerializable;
+use ReturnTypeWillChange;
 use Symfony\Component\VarDumper\VarDumper;
 use Traversable;
 
@@ -833,6 +834,7 @@ trait EnumeratesValues
      *
      * @return array
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return array_map(function ($value) {

--- a/src/Illuminate/Database/Eloquent/Casts/ArrayObject.php
+++ b/src/Illuminate/Database/Eloquent/Casts/ArrayObject.php
@@ -5,6 +5,7 @@ namespace Illuminate\Database\Eloquent\Casts;
 use ArrayObject as BaseArrayObject;
 use Illuminate\Contracts\Support\Arrayable;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 class ArrayObject extends BaseArrayObject implements Arrayable, JsonSerializable
 {
@@ -33,6 +34,7 @@ class ArrayObject extends BaseArrayObject implements Arrayable, JsonSerializable
      *
      * @return array
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->getArrayCopy();

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -21,6 +21,7 @@ use Illuminate\Support\Str;
 use Illuminate\Support\Traits\ForwardsCalls;
 use JsonSerializable;
 use LogicException;
+use ReturnTypeWillChange;
 
 abstract class Model implements Arrayable, ArrayAccess, HasBroadcastChannel, Jsonable, JsonSerializable, QueueableEntity, UrlRoutable
 {
@@ -1426,6 +1427,7 @@ abstract class Model implements Arrayable, ArrayAccess, HasBroadcastChannel, Jso
      *
      * @return array
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->toArray();

--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\JsonEncodingException;
 use Illuminate\Http\Resources\ConditionallyLoadsAttributes;
 use Illuminate\Http\Resources\DelegatesToResource;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRoutable
 {
@@ -226,6 +227,7 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
      *
      * @return array
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->resolve(Container::getInstance()->make('request'));

--- a/src/Illuminate/Pagination/CursorPaginator.php
+++ b/src/Illuminate/Pagination/CursorPaginator.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Support\Collection;
 use IteratorAggregate;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 class CursorPaginator extends AbstractCursorPaginator implements Arrayable, ArrayAccess, Countable, IteratorAggregate, Jsonable, JsonSerializable, PaginatorContract
 {
@@ -142,6 +143,7 @@ class CursorPaginator extends AbstractCursorPaginator implements Arrayable, Arra
      *
      * @return array
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->toArray();

--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Support\Collection;
 use IteratorAggregate;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 class LengthAwarePaginator extends AbstractPaginator implements Arrayable, ArrayAccess, Countable, IteratorAggregate, Jsonable, JsonSerializable, LengthAwarePaginatorContract
 {
@@ -213,6 +214,7 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
      *
      * @return array
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->toArray();

--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Support\Collection;
 use IteratorAggregate;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Countable, IteratorAggregate, Jsonable, JsonSerializable, PaginatorContract
 {
@@ -158,6 +159,7 @@ class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Cou
      *
      * @return array
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->toArray();

--- a/src/Illuminate/Session/ArraySessionHandler.php
+++ b/src/Illuminate/Session/ArraySessionHandler.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Session;
 
 use Illuminate\Support\InteractsWithTime;
+use ReturnTypeWillChange;
 use SessionHandlerInterface;
 
 class ArraySessionHandler implements SessionHandlerInterface
@@ -37,6 +38,7 @@ class ArraySessionHandler implements SessionHandlerInterface
     /**
      * {@inheritdoc}
      */
+    #[ReturnTypeWillChange]
     public function open($savePath, $sessionName)
     {
         return true;
@@ -45,6 +47,7 @@ class ArraySessionHandler implements SessionHandlerInterface
     /**
      * {@inheritdoc}
      */
+    #[ReturnTypeWillChange]
     public function close()
     {
         return true;
@@ -53,6 +56,7 @@ class ArraySessionHandler implements SessionHandlerInterface
     /**
      * {@inheritdoc}
      */
+    #[ReturnTypeWillChange]
     public function read($sessionId)
     {
         if (! isset($this->storage[$sessionId])) {
@@ -73,6 +77,7 @@ class ArraySessionHandler implements SessionHandlerInterface
     /**
      * {@inheritdoc}
      */
+    #[ReturnTypeWillChange]
     public function write($sessionId, $data)
     {
         $this->storage[$sessionId] = [
@@ -86,6 +91,7 @@ class ArraySessionHandler implements SessionHandlerInterface
     /**
      * {@inheritdoc}
      */
+    #[ReturnTypeWillChange]
     public function destroy($sessionId)
     {
         if (isset($this->storage[$sessionId])) {
@@ -98,6 +104,7 @@ class ArraySessionHandler implements SessionHandlerInterface
     /**
      * {@inheritdoc}
      */
+    #[ReturnTypeWillChange]
     public function gc($lifetime)
     {
         $expiration = $this->calculateExpiration($lifetime);

--- a/src/Illuminate/Session/NullSessionHandler.php
+++ b/src/Illuminate/Session/NullSessionHandler.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Session;
 
+use ReturnTypeWillChange;
 use SessionHandlerInterface;
 
 class NullSessionHandler implements SessionHandlerInterface
@@ -9,6 +10,7 @@ class NullSessionHandler implements SessionHandlerInterface
     /**
      * {@inheritdoc}
      */
+    #[ReturnTypeWillChange]
     public function open($savePath, $sessionName)
     {
         return true;
@@ -17,6 +19,7 @@ class NullSessionHandler implements SessionHandlerInterface
     /**
      * {@inheritdoc}
      */
+    #[ReturnTypeWillChange]
     public function close()
     {
         return true;
@@ -25,6 +28,7 @@ class NullSessionHandler implements SessionHandlerInterface
     /**
      * {@inheritdoc}
      */
+    #[ReturnTypeWillChange]
     public function read($sessionId)
     {
         return '';
@@ -33,6 +37,7 @@ class NullSessionHandler implements SessionHandlerInterface
     /**
      * {@inheritdoc}
      */
+    #[ReturnTypeWillChange]
     public function write($sessionId, $data)
     {
         return true;
@@ -41,6 +46,7 @@ class NullSessionHandler implements SessionHandlerInterface
     /**
      * {@inheritdoc}
      */
+    #[ReturnTypeWillChange]
     public function destroy($sessionId)
     {
         return true;
@@ -49,6 +55,7 @@ class NullSessionHandler implements SessionHandlerInterface
     /**
      * {@inheritdoc}
      */
+    #[ReturnTypeWillChange]
     public function gc($lifetime)
     {
         return true;

--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -6,6 +6,7 @@ use ArrayAccess;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 class Fluent implements Arrayable, ArrayAccess, Jsonable, JsonSerializable
 {
@@ -70,6 +71,7 @@ class Fluent implements Arrayable, ArrayAccess, Jsonable, JsonSerializable
      *
      * @return array
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->toArray();

--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\MessageBag as MessageBagContract;
 use Illuminate\Contracts\Support\MessageProvider;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, MessageBagContract, MessageProvider
 {
@@ -389,6 +390,7 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
      *
      * @return array
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->toArray();

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Support\Traits\Tappable;
 use JsonSerializable;
+use ReturnTypeWillChange;
 use Symfony\Component\VarDumper\VarDumper;
 
 class Stringable implements JsonSerializable
@@ -782,6 +783,7 @@ class Stringable implements JsonSerializable
      *
      * @return string
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->__toString();

--- a/tests/Database/DatabaseProcessorTest.php
+++ b/tests/Database/DatabaseProcessorTest.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Query\Processors\Processor;
 use Mockery as m;
 use PDO;
 use PHPUnit\Framework\TestCase;
+use ReturnTypeWillChange;
 
 class DatabaseProcessorTest extends TestCase
 {
@@ -38,7 +39,8 @@ class ProcessorTestPDOStub extends PDO
         //
     }
 
-    public function lastInsertId($sequence = null)
+    #[ReturnTypeWillChange]
+    public function lastInsertId(string $sequence = null)
     {
         //
     }

--- a/tests/Http/HttpJsonResponseTest.php
+++ b/tests/Http/HttpJsonResponseTest.php
@@ -124,7 +124,7 @@ class JsonResponseTestJsonableObject implements Jsonable
 
 class JsonResponseTestJsonSerializeObject implements JsonSerializable
 {
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return ['foo' => 'bar'];
     }

--- a/tests/Http/HttpResponseTest.php
+++ b/tests/Http/HttpResponseTest.php
@@ -245,7 +245,7 @@ class JsonableStub implements Jsonable
 
 class JsonSerializableStub implements JsonSerializable
 {
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return ['foo' => 'bar'];
     }

--- a/tests/Integration/Http/Fixtures/JsonSerializableResource.php
+++ b/tests/Integration/Http/Fixtures/JsonSerializableResource.php
@@ -13,7 +13,7 @@ class JsonSerializableResource implements JsonSerializable
         $this->resource = $resource;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'id' => $this->resource->id,

--- a/tests/Integration/Http/JsonResponseTest.php
+++ b/tests/Integration/Http/JsonResponseTest.php
@@ -19,7 +19,7 @@ class JsonResponseTest extends TestCase
         Route::get('/response', function () {
             return new JsonResponse(new class implements \JsonSerializable
             {
-                public function jsonSerialize()
+                public function jsonSerialize(): string
                 {
                     return "\xB1\x31";
                 }

--- a/tests/Integration/Http/ResponseTest.php
+++ b/tests/Integration/Http/ResponseTest.php
@@ -19,7 +19,7 @@ class ResponseTest extends TestCase
         Route::get('/response', function () {
             return (new Response())->setContent(new class implements \JsonSerializable
             {
-                public function jsonSerialize()
+                public function jsonSerialize(): string
                 {
                     return "\xB1\x31";
                 }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -4789,7 +4789,7 @@ class TestJsonableObject implements Jsonable
 
 class TestJsonSerializeObject implements JsonSerializable
 {
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return ['foo' => 'bar'];
     }
@@ -4797,7 +4797,7 @@ class TestJsonSerializeObject implements JsonSerializable
 
 class TestJsonSerializeWithScalarValueObject implements JsonSerializable
 {
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         return 'foo';
     }

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -1381,7 +1381,7 @@ class TestResponseTest extends TestCase
 
 class JsonSerializableMixedResourcesStub implements JsonSerializable
 {
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'foo' => 'bar',
@@ -1415,7 +1415,7 @@ class JsonSerializableMixedResourcesStub implements JsonSerializable
 
 class JsonSerializableSingleResourceStub implements JsonSerializable
 {
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             ['foo' => 'foo 0', 'bar' => 'bar 0', 'foobar' => 'foobar 0'],
@@ -1428,7 +1428,7 @@ class JsonSerializableSingleResourceStub implements JsonSerializable
 
 class JsonSerializableSingleResourceWithIntegersStub implements JsonSerializable
 {
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             ['id' => 10, 'foo' => 'bar'],


### PR DESCRIPTION
Return types were added to internal methods in PHP 8.1. To suppress deprecation warnings, the ReturnTypeWillChange attribute can be added to inherited methods with no return types defined. Thanks to the backward compatible syntax of attributes, this does not break anything for lower PHP versions.

RFC: https://wiki.php.net/rfc/internal_method_return_types