### PR TITLE
[8.x] Reflash session on Route::redirect()

### DIFF
--- a/src/Illuminate/Routing/RedirectController.php
+++ b/src/Illuminate/Routing/RedirectController.php
@@ -38,6 +38,10 @@ class RedirectController extends Controller
         if (! Str::startsWith($destination, '/') && Str::startsWith($url, '/')) {
             $url = Str::after($url, '/');
         }
+        
+        if($request->hasSession()) {
+            $request->session()->reflash();
+        }
 
         return new RedirectResponse($url, $status);
     }

--- a/src/Illuminate/Routing/RedirectController.php
+++ b/src/Illuminate/Routing/RedirectController.php
@@ -38,7 +38,7 @@ class RedirectController extends Controller
         if (! Str::startsWith($destination, '/') && Str::startsWith($url, '/')) {
             $url = Str::after($url, '/');
         }
-        
+
         if ($request->hasSession()) {
             $request->session()->reflash();
         }

--- a/src/Illuminate/Routing/RedirectController.php
+++ b/src/Illuminate/Routing/RedirectController.php
@@ -39,7 +39,7 @@ class RedirectController extends Controller
             $url = Str::after($url, '/');
         }
         
-        if($request->hasSession()) {
+        if ($request->hasSession()) {
             $request->session()->reflash();
         }
 


### PR DESCRIPTION
Checks if request has a session and then reflashes it before redirecting when using a redirect route (`Route::redirect(...)`). 

This is useful to keep/forward flash messages when there is a double redirect:

- Change profile redirects to `/`
- `/` is a redirect route to `/dashboard`

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
