### PR TITLE
[8.x] Add context to subsequent logs.

### DIFF
--- a/src/Illuminate/Log/Logger.php
+++ b/src/Illuminate/Log/Logger.php
@@ -169,27 +169,6 @@ class Logger implements LoggerInterface
     }
 
     /**
-     * Adds context to all future logs.
-     *
-     * @param array $context
-     * @return void
-     */
-    public function addContextToLogs($context = [])
-    {
-        $this->context = array_merge([], $this->context, $context);
-    }
-
-    /**
-     * Clears any set context from future logs.
-     *
-     * @return void
-     */
-    public function clearContext()
-    {
-        $this->context = [];
-    }
-
-    /**
      * Write a message to the log.
      *
      * @param  string  $level
@@ -199,11 +178,37 @@ class Logger implements LoggerInterface
      */
     protected function writeLog($level, $message, $context)
     {
-        $context = array_merge([], $this->context, $context);
-
-        $this->logger->{$level}($message = $this->formatMessage($message), $context);
+        $this->logger->{$level}(
+            $message = $this->formatMessage($message),
+            $context = array_merge($this->context, $context)
+        );
 
         $this->fireLogEvent($level, $message, $context);
+    }
+
+    /**
+     * Add context to all future logs.
+     *
+     * @param  array  $context
+     * @return $this
+     */
+    public function withContext(array $context = [])
+    {
+        $this->context = array_merge($this->context, $context);
+
+        return $this;
+    }
+
+    /**
+     * Flush the existing context array.
+     *
+     * @return $this
+     */
+    public function withoutContext()
+    {
+        $this->context = [];
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Log/Logger.php
+++ b/src/Illuminate/Log/Logger.php
@@ -27,6 +27,13 @@ class Logger implements LoggerInterface
     protected $dispatcher;
 
     /**
+     * Any context to be added to logs.
+     *
+     * @var array
+     */
+    protected $context = [];
+
+    /**
      * Create a new log writer instance.
      *
      * @param  \Psr\Log\LoggerInterface  $logger
@@ -162,6 +169,27 @@ class Logger implements LoggerInterface
     }
 
     /**
+     * Adds context to all future logs.
+     *
+     * @param array $context
+     * @return void
+     */
+    public function addContextToLogs($context = [])
+    {
+        $this->context = array_merge([], $this->context, $context);
+    }
+
+    /**
+     * Clears any set context from future logs.
+     *
+     * @return void
+     */
+    public function clearContext()
+    {
+        $this->context = [];
+    }
+
+    /**
      * Write a message to the log.
      *
      * @param  string  $level
@@ -171,6 +199,8 @@ class Logger implements LoggerInterface
      */
     protected function writeLog($level, $message, $context)
     {
+        $context = array_merge([], $this->context, $context);
+
         $this->logger->{$level}($message = $this->formatMessage($message), $context);
 
         $this->fireLogEvent($level, $message, $context);

--- a/tests/Log/LogLoggerTest.php
+++ b/tests/Log/LogLoggerTest.php
@@ -29,7 +29,7 @@ class LogLoggerTest extends TestCase
     public function testContextIsAddedToAllSubsequentLogs()
     {
         $writer = new Logger($monolog = m::mock(Monolog::class));
-        $writer->addContextToLogs(['bar' => 'baz']);
+        $writer->withContext(['bar' => 'baz']);
 
         $monolog->shouldReceive('error')->once()->with('foo', ['bar' => 'baz']);
 

--- a/tests/Log/LogLoggerTest.php
+++ b/tests/Log/LogLoggerTest.php
@@ -26,6 +26,16 @@ class LogLoggerTest extends TestCase
         $writer->error('foo');
     }
 
+    public function testContextIsAddedToAllSubsequentLogs()
+    {
+        $writer = new Logger($monolog = m::mock(Monolog::class));
+        $writer->addContextToLogs(['bar' => 'baz']);
+
+        $monolog->shouldReceive('error')->once()->with('foo', ['bar' => 'baz']);
+
+        $writer->error('foo');
+    }
+
     public function testLoggerFiresEventsDispatcher()
     {
         $writer = new Logger($monolog = m::mock(Monolog::class), $events = new Dispatcher);


### PR DESCRIPTION
**Description:**
This adds the ability to add `context` to all future logs along with the ability to clear that context if desired. 

**Use case:**
A good example of this of how this might be used in middleware, lets say you wanted to bind a `uuid` to every request:

```php
/**
 * Handle an incoming request.
 *
 * @param  \Illuminate\Http\Request  $request
 * @param  \Closure  $next
 * @return mixed
 */
public function handle(Request $request, Closure $next)
{
    $requestId = Str::uuid();

    Log::withContext(['request-id' => $requestId]);

    $response = $next($request);

    $response->header('request-id', $requestId);

    return $response;
}
```
Then when parsing logs one would be able to trace all logs pertaining to a specific request with ease. Another example where this would be very useful would be something like adding an authenticated user to the context that would be tied to all following logs.