### PR TITLE
[8.x] Fix return type PHPDoc of the cursorPaginate method

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -332,7 +332,7 @@ trait BuildsQueries
      * @param  int  $perPage
      * @param  \Illuminate\Pagination\Cursor  $cursor
      * @param  array  $options
-     * @return \Illuminate\Pagination\Paginator
+     * @return \Illuminate\Pagination\CursorPaginator
      */
     protected function cursorPaginator($items, $perPage, $cursor, $options)
     {

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2407,7 +2407,7 @@ class Builder
      * @param  array  $columns
      * @param  string  $cursorName
      * @param  string|null  $cursor
-     * @return \Illuminate\Contracts\Pagination\Paginator
+     * @return \Illuminate\Contracts\Pagination\CursorPaginator
      * @throws \Illuminate\Pagination\CursorPaginationException
      */
     public function cursorPaginate($perPage = 15, $columns = ['*'], $cursorName = 'cursor', $cursor = null)


### PR DESCRIPTION
The return type of `Illuminate\Database\Query\Builder::cursorPaginate` should be `\Illuminate\Contracts\Pagination\CursorPaginator`, but its wrote as `\Illuminate\Contracts\Pagination\Paginator` in PHPDoc.

This should lead to wrong intellisense in editors, for example, the following code triggers an undefined method error, but its completely right:

```
$paginator = CharacterDetails::whereCount(0)->orderBy('id')->cursorPaginate(100);
$paginator->nextCursor();
```

This PR changes the PHPDoc of `Illuminate\Database\Query\Builder::cursorPaginate` and `Illuminate\Database\Concerns\BuildsQueries::cursorPaginator` to make intellisense of cursorPaginate() work.