### PR TITLE
[6.x] Prevent Cache::tags(..)->get() from performing a write operation

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -96,14 +96,14 @@ class Repository implements ArrayAccess, CacheContract
 
         $itemKey = $this->itemKey($key, true);
 
-        if (!is_null($itemKey)) {
+        if (! is_null($itemKey)) {
             $value = $this->store->get($itemKey);
         }
 
         // If we could not find the cache value, we will fire the missed event and get
         // the default value for this cache value. This default could be a callback
         // so we will execute the value function which will resolve it if needed.
-        if (!isset($value) || is_null($value)) {
+        if (! isset($value) || is_null($value)) {
             $this->event(new CacheMissed($key));
 
             $value = value($default);

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -94,12 +94,16 @@ class Repository implements ArrayAccess, CacheContract
             return $this->many($key);
         }
 
-        $value = $this->store->get($this->itemKey($key));
+        $itemKey = $this->itemKey($key, true);
+
+        if (!is_null($itemKey)) {
+            $value = $this->store->get($itemKey);
+        }
 
         // If we could not find the cache value, we will fire the missed event and get
         // the default value for this cache value. This default could be a callback
         // so we will execute the value function which will resolve it if needed.
-        if (is_null($value)) {
+        if (!isset($value) || is_null($value)) {
             $this->event(new CacheMissed($key));
 
             $value = value($default);
@@ -494,9 +498,10 @@ class Repository implements ArrayAccess, CacheContract
      * Format the key for a cache item.
      *
      * @param  string  $key
+     * @param  bool    $readOnly
      * @return string
      */
-    protected function itemKey($key)
+    protected function itemKey($key, $readOnly = false)
     {
         return $key;
     }

--- a/src/Illuminate/Cache/TagSet.php
+++ b/src/Illuminate/Cache/TagSet.php
@@ -59,11 +59,12 @@ class TagSet
     /**
      * Get a unique namespace that changes when any of the tags are flushed.
      *
+     * @param  bool   $readOnly
      * @return string
      */
-    public function getNamespace()
+    public function getNamespace($readOnly = false)
     {
-        return implode('|', $this->tagIds());
+        return implode('|', $this->tagIds($readOnly));
     }
 
     /**
@@ -71,19 +72,24 @@ class TagSet
      *
      * @return array
      */
-    protected function tagIds()
+    protected function tagIds($readOnly)
     {
-        return array_map([$this, 'tagId'], $this->names);
+        return array_map([$this, 'tagId'], $this->names, array_fill(0, count($this->names), $readOnly));
     }
 
     /**
      * Get the unique tag identifier for a given tag.
      *
      * @param  string  $name
+     * @param  bool    $readOnly
      * @return string
      */
-    public function tagId($name)
+    public function tagId($name, $readOnly)
     {
+        if ($readOnly) {
+            return $this->store->get($this->tagKey($name));
+        }
+
         return $this->store->get($this->tagKey($name)) ?: $this->resetTag($name);
     }
 

--- a/src/Illuminate/Cache/TaggedCache.php
+++ b/src/Illuminate/Cache/TaggedCache.php
@@ -86,20 +86,21 @@ class TaggedCache extends Repository
     /**
      * {@inheritdoc}
      */
-    protected function itemKey($key)
+    protected function itemKey($key, $readOnly = false)
     {
-        return $this->taggedItemKey($key);
+        return $this->taggedItemKey($key, $readOnly);
     }
 
     /**
      * Get a fully qualified key for a tagged item.
      *
      * @param  string  $key
+     * @param  bool    $readOnly
      * @return string
      */
-    public function taggedItemKey($key)
+    public function taggedItemKey($key, $readOnly)
     {
-        return sha1($this->tags->getNamespace()).':'.$key;
+        return sha1($this->tags->getNamespace($readOnly)).':'.$key;
     }
 
     /**


### PR DESCRIPTION
Current functionality breaks with master/replica setups in Redis.

When you perform a `get` operation we try to get redis namespace for the tags. If the namespace doesn't exist then we try to write the namespace. This throws an exception because the replicas are read-only.