### PR TITLE
[8.x] Fix undefined array key in SqlServerGrammar when using orderByRaw

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -217,7 +217,7 @@ class SqlServerGrammar extends Grammar
         }
 
         return Arr::first($query->orders, function ($value) {
-            return $this->isExpression($value['column']);
+            return $this->isExpression($value['column'] ?? null);
         }, false) !== false;
     }
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1190,6 +1190,36 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([1, 1, 'news', 'opinion'], $builder->getBindings());
     }
 
+    public function testOrderBysSqlServer()
+    {
+        $builder = $this->getSqlServerBuilder();
+        $builder->select('*')->from('users')->orderBy('email')->orderBy('age', 'desc');
+        $this->assertSame('select * from [users] order by [email] asc, [age] desc', $builder->toSql());
+
+        $builder->orders = null;
+        $this->assertSame('select * from [users]', $builder->toSql());
+
+        $builder->orders = [];
+        $this->assertSame('select * from [users]', $builder->toSql());
+
+        $builder = $this->getSqlServerBuilder();
+        $builder->select('*')->from('users')->orderBy('email');
+        $this->assertSame('select * from [users] order by [email] asc', $builder->toSql());
+
+        $builder = $this->getSqlServerBuilder();
+        $builder->select('*')->from('users')->orderByDesc('name');
+        $this->assertSame('select * from [users] order by [name] desc', $builder->toSql());
+
+        $builder = $this->getSqlServerBuilder();
+        $builder->select('*')->from('users')->orderByRaw('[age] asc');
+        $this->assertSame('select * from [users] order by [age] asc', $builder->toSql());
+
+        $builder = $this->getSqlServerBuilder();
+        $builder->select('*')->from('users')->orderBy('email')->orderByRaw('[age] ? desc', ['foo']);
+        $this->assertSame('select * from [users] order by [email] asc, [age] ? desc', $builder->toSql());
+        $this->assertEquals(['foo'], $builder->getBindings());
+    }
+
     public function testReorder()
     {
         $builder = $this->getBuilder();

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1218,6 +1218,10 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('users')->orderBy('email')->orderByRaw('[age] ? desc', ['foo']);
         $this->assertSame('select * from [users] order by [email] asc, [age] ? desc', $builder->toSql());
         $this->assertEquals(['foo'], $builder->getBindings());
+
+        $builder = $this->getSqlServerBuilder();
+        $builder->select('*')->from('users')->skip(25)->take(10)->orderByRaw('[email] desc');
+        $this->assertSame('select * from (select *, row_number() over (order by [email] desc) as row_num from [users]) as temp_table where row_num between 26 and 35 order by row_num', $builder->toSql());
     }
 
     public function testReorder()


### PR DESCRIPTION
This PR fixes the exception

> ErrorException: Undefined array key \"column\" in /var/www/vendor/laravel/framework/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php:220

which is triggered when using `orderByRaw` after the latest changes to the `SqlServerGrammar`.

---

A bit of background (and please correct me if I'm wrong):

When using `Builder::orderBy($column, $direction)`, an `order` is added with keys `column` and `direction` (line 1986+):
https://github.com/laravel/framework/blob/855a919d08b45f93cb3cf709736528c3d1531884/src/Illuminate/Database/Query/Builder.php#L1970-L1992

When using `Builder::orderByRaw($sql)`, an `order` is added with keys `type` and `sql` (line 2051):
https://github.com/laravel/framework/blob/855a919d08b45f93cb3cf709736528c3d1531884/src/Illuminate/Database/Query/Builder.php#L2045-L2054

Because of this, the patched code currently fails with an exception.