### PR TITLE
Fix nested Log::withContext

### DIFF
--- a/src/Illuminate/Log/Logger.php
+++ b/src/Illuminate/Log/Logger.php
@@ -180,7 +180,7 @@ class Logger implements LoggerInterface
     {
         $this->logger->{$level}(
             $message = $this->formatMessage($message),
-            $context = array_merge($this->context, $context)
+            $context = array_replace_recursive($this->context, $context)
         );
 
         $this->fireLogEvent($level, $message, $context);
@@ -194,7 +194,7 @@ class Logger implements LoggerInterface
      */
     public function withContext(array $context = [])
     {
-        $this->context = array_merge($this->context, $context);
+        $this->context = array_replace_recursive($this->context, $context);
 
         return $this;
     }

--- a/src/Illuminate/Log/Logger.php
+++ b/src/Illuminate/Log/Logger.php
@@ -212,6 +212,17 @@ class Logger implements LoggerInterface
     }
 
     /**
+     * Get current context.
+     *
+     * @param  array  $context  Will be merged into current result but not applied to future logs.
+     * @return $this
+     */
+    public function getContext(array $context = [])
+    {
+        return array_replace_recursive($this->context, $context);
+    }
+
+    /**
      * Register a new callback handler for when a log event is triggered.
      *
      * @param  \Closure  $callback

--- a/tests/Log/LogLoggerTest.php
+++ b/tests/Log/LogLoggerTest.php
@@ -57,6 +57,26 @@ class LogLoggerTest extends TestCase
         $writer->error('foo', ['bar' => ['baz' => 'quux']]);
     }
 
+    public function testRetrieveAndOverrideCurrentContext()
+    {
+        $writer = new Logger($monolog = m::mock(Monolog::class));
+        $writer->withContext(['bar' => ['baz' => 'qux', 'baz2' => 'qux2']]);
+
+        $this->assertEquals(['bar' => ['baz' => 'quux', 'baz2' => 'qux2']], $writer->getContext(['bar' => ['baz' => 'quux']]));
+    }
+
+    public function testRetrievingContextWithOverrideDoesNotApplyToSubsequentLogs()
+    {
+        $writer = new Logger($monolog = m::mock(Monolog::class));
+        $writer->withContext(['bar' => ['baz' => 'qux', 'baz2' => 'qux2']]);
+
+        $writer->getContext(['bar' => ['baz' => 'quux']]);
+
+        $monolog->shouldReceive('error')->once()->with('foo', ['bar' => ['baz' => 'qux', 'baz2' => 'qux2']]);
+
+        $writer->error('foo');
+    }
+
     public function testLoggerFiresEventsDispatcher()
     {
         $writer = new Logger($monolog = m::mock(Monolog::class), $events = new Dispatcher);

--- a/tests/Log/LogLoggerTest.php
+++ b/tests/Log/LogLoggerTest.php
@@ -36,6 +36,27 @@ class LogLoggerTest extends TestCase
         $writer->error('foo');
     }
 
+    public function testNestedContextOverrides()
+    {
+        $writer = new Logger($monolog = m::mock(Monolog::class));
+        $writer->withContext(['bar' => ['baz' => 'qux', 'baz2' => 'qux2']]);
+        $writer->withContext(['bar' => ['baz' => 'quux']]);
+
+        $monolog->shouldReceive('error')->once()->with('foo', ['bar' => ['baz' => 'quux', 'baz2' => 'qux2']]);
+
+        $writer->error('foo');
+    }
+
+    public function testNestedLocalContextOverrides()
+    {
+        $writer = new Logger($monolog = m::mock(Monolog::class));
+        $writer->withContext(['bar' => ['baz' => 'qux', 'baz2' => 'qux2']]);
+
+        $monolog->shouldReceive('error')->once()->with('foo', ['bar' => ['baz' => 'quux', 'baz2' => 'qux2']]);
+
+        $writer->error('foo', ['bar' => ['baz' => 'quux']]);
+    }
+
     public function testLoggerFiresEventsDispatcher()
     {
         $writer = new Logger($monolog = m::mock(Monolog::class), $events = new Dispatcher);


### PR DESCRIPTION
This builds on @chasenyc's recent log context PR: github.com/laravel/framework/pull/37847

We have a custom context service to handle this in our own application, and I was glad to see it added to the framework. But I have a couple changes to propose based on our experience.

**First**, log context doesn't have to be flat. Say you want to have a couple values nested under user and then only change one. The following is how that would play out with `array_merge()`, `array_merge_recursive()`, and `array_replace_recursive()`.

```php
// setup -- assume each example starts clean and then runs this first
Log::withContext(['user' => ['id' => 1, 'name' => 'me']]); // ['user' => ['id' => 1, 'name' => 'me']]


// with array_merge it loses the unchanged key
Log::withContext(['user' => ['id' => 2]]); // ['user' => ['id' => 2]]

// with array_merge_recursive it keeps the unchanged key but combines the changed one into an array
Log::withContext(['user' => ['id' => 2]]); // ['user' => ['id' => [1, 2], 'name' => 'me']]

// with array_replace_recursive it replaces only the item specified
Log::withContext(['user' => ['id' => 2]]); // ['user' => ['id' => 2, 'name' => 'me']]
```

So array_replace_recursive() is what we landed on, and is what I have included in this PR. The TL;DR on this is that you can now change an individual nested key in the log context.

**Second**, I added a `getContext()` to get what is currently in the Log context. If you pass in some local overriding context to this method it **will not** apply to the future logs, only the current method response. This is useful if you want to  use your Log context for another purpose. For example, you could pass this context to a feature flag provider. 