### PR TITLE
[8.x] Fix edge case causing a BadMethodCallExceptions to be thrown when using loadMissing()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -201,7 +201,7 @@ class Collection extends BaseCollection implements QueueableCollection
                 $path[count($segments) - 1][end($segments)] = $value;
             }
 
-            $this->loadMissingRelation($this, $path);
+            $this->loadMissingRelation($this->whereNotNull(), $path);
         }
 
         return $this;
@@ -225,14 +225,14 @@ class Collection extends BaseCollection implements QueueableCollection
         }
 
         $models->filter(function ($model) use ($name) {
-            return ! is_null($model) && ! $model->relationLoaded($name);
+            return ! $model->relationLoaded($name);
         })->load($relation);
 
         if (empty($path)) {
             return;
         }
 
-        $models = $models->pluck($name);
+        $models = $models->pluck($name)->whereNotNull();
 
         if ($models->first() instanceof BaseCollection) {
             $models = $models->collapse();

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -201,7 +201,7 @@ class Collection extends BaseCollection implements QueueableCollection
                 $path[count($segments) - 1][end($segments)] = $value;
             }
 
-            $this->loadMissingRelation($this->whereNotNull(), $path);
+            $this->loadMissingRelation($this, $path);
         }
 
         return $this;
@@ -225,7 +225,7 @@ class Collection extends BaseCollection implements QueueableCollection
         }
 
         $models->filter(function ($model) use ($name) {
-            return ! $model->relationLoaded($name);
+            return ! is_null($model) && ! $model->relationLoaded($name);
         })->load($relation);
 
         if (empty($path)) {


### PR DESCRIPTION
Sometimes when relations are loaded, a collection of `null` and `BaseCollection`s is returned. When this happens, the `->first() instanceof BaseCollection` check can be false, as the first value can be null, in which case `->collapse()` is incorrectly skipped.

There have been a few PRs more properly describing this issue, but these have been closed rather than merged:
#32043
#32053 (Comment by nal-chris on 18 Mar describes it pretty well)

I've chosen non-descriptive names for a few relations, feel free to suggest something more concrete (though these serve their purpose).

I've removed an `! is_null()` check and added an additional `->whereNotNull()` on the initial call to prevent redundant null checks for every recursively executed `loadMissingRelation()`.


(PS. This is my first ever PR to Laravel, so assume I ~~am an idiot~~ don't really know a lot about contributing to Laravel)