### PR TITLE
[8.x] Add dd() and dump() to the Eloquent Model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -22,6 +22,7 @@ use Illuminate\Support\Traits\ForwardsCalls;
 use JsonSerializable;
 use LogicException;
 use ReturnTypeWillChange;
+use Symfony\Component\VarDumper\VarDumper;
 
 abstract class Model implements Arrayable, ArrayAccess, HasBroadcastChannel, Jsonable, JsonSerializable, QueueableEntity, UrlRoutable
 {
@@ -1881,6 +1882,30 @@ abstract class Model implements Arrayable, ArrayAccess, HasBroadcastChannel, Jso
     public function broadcastChannel()
     {
         return str_replace('\\', '.', get_class($this)).'.'.$this->getKey();
+    }
+
+    /**
+     * Dump the model and end the script.
+     *
+     * @return void
+     */
+    public function dd()
+    {
+        $this->dump();
+
+        exit(1);
+    }
+
+    /**
+     * Dump the model.
+     *
+     * @return $this
+     */
+    public function dump()
+    {
+        VarDumper::dump($this);
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
This PR adds `dd()` and `dump()` to the Eloquent Model.

```php
$user = User::first();

// Before
dump($user);
dd($user);

// After
$user->dump();
$user->dd();
```