### PR TITLE
[8.x] Add missing docblock for withContext and withoutContext

### DIFF
--- a/src/Illuminate/Support/Facades/Log.php
+++ b/src/Illuminate/Support/Facades/Log.php
@@ -5,6 +5,8 @@ namespace Illuminate\Support\Facades;
 /**
  * @method static \Psr\Log\LoggerInterface channel(string $channel = null)
  * @method static \Psr\Log\LoggerInterface stack(array $channels, string $channel = null)
+ * @method static \Illuminate\Log\Logger withContext(array $context = [])
+ * @method static \Illuminate\Log\Logger withoutContext()
  * @method static void alert(string $message, array $context = [])
  * @method static void critical(string $message, array $context = [])
  * @method static void debug(string $message, array $context = [])


### PR DESCRIPTION
This pull request adds the missing documentation for the `withContext` and `withoutContext` methods on the `Log` facade.