### PR TITLE
[6.x] Fix edge case causing a BadMethodCallExceptions to be thrown when using loadMissing()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -159,7 +159,7 @@ class Collection extends BaseCollection implements QueueableCollection
             return;
         }
 
-        $models = $models->pluck($name);
+        $models = $models->pluck($name)->whereNotNull();
 
         if ($models->first() instanceof BaseCollection) {
             $models = $models->collapse();


### PR DESCRIPTION
Sometimes when relations are loaded, a collection of `null` and `BaseCollection`s is returned. When this happens, the `->first() instanceof BaseCollection` check can be false, as the first value can be null, in which case `->collapse()` is incorrectly skipped.

There have been a few PRs more properly describing this issue, but these have been closed rather than merged:
#32043
#32053 (Comment by nal-chris on 18 Mar describes it pretty well)

I've chosen non-descriptive names for a few relations, feel free to suggest something more concrete (though these serve their purpose).

This is a replacement for #37864, which targeted 8.x.