### PR TITLE
Fix isFile method to be able to check remote files too.

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -492,7 +492,7 @@ class Filesystem
      */
     public function isFile($file)
     {
-        return is_file($file);
+        return file_get_contents($file, 0, null, 0, 1);
     }
 
     /**


### PR DESCRIPTION
This pull request change use of PHP is_file function that can't work with remote files to file_get_contents reading only first byte, so now we can check also if file exist on remote paths 
