### PR TITLE
[8.x] Improve batch assertions

### DIFF
--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -465,4 +465,14 @@ class Batch implements Arrayable, JsonSerializable
     {
         return $this->toArray();
     }
+
+    /**
+     * Return the repository implementation.
+     *
+     * @var \Illuminate\Bus\BatchRepository
+     */
+    public function repository()
+    {
+        return $this->repository;
+    }
 }

--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -465,14 +465,4 @@ class Batch implements Arrayable, JsonSerializable
     {
         return $this->toArray();
     }
-
-    /**
-     * Return the repository implementation.
-     *
-     * @var \Illuminate\Bus\BatchRepository
-     */
-    public function repository()
-    {
-        return $this->repository;
-    }
 }

--- a/src/Illuminate/Support/Testing/Fakes/BatchFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BatchFake.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Illuminate\Support\Testing\Fakes;
+
+use Illuminate\Bus\Batch;
+use Illuminate\Support\Arr;
+
+class BatchFake extends Batch
+{
+    /**
+     * The fake bus instance.
+     *
+     * @var \Illuminate\Support\Testing\Fakes\BusFake
+     */
+    protected $bus;
+
+    /**
+     * Add additional jobs to the batch.
+     *
+     * @param  \Illuminate\Support\Collection|array  $jobs
+     * @return self
+     */
+    public function add($jobs)
+    {
+        $jobs = Arr::wrap($jobs);
+
+        $this->totalJobs += count($jobs);
+        $this->pendingJobs += count($jobs);
+        $this->finishedAt = null;
+
+        return $this->bus->recordBatch($this);
+    }
+
+    /**
+     * Set the fake bus instance.
+     *
+     * @param  \Illuminate\Support\Testing\Fakes\BusFake  $bus
+     */
+    public function setBus(BusFake $bus)
+    {
+        $this->bus = $bus;
+    }
+}

--- a/src/Illuminate/Support/Testing/Fakes/BatchRepositoryFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BatchRepositoryFake.php
@@ -4,7 +4,6 @@ namespace Illuminate\Support\Testing\Fakes;
 
 use Carbon\CarbonImmutable;
 use Closure;
-use Illuminate\Bus\Batch;
 use Illuminate\Bus\BatchRepository;
 use Illuminate\Bus\PendingBatch;
 use Illuminate\Bus\UpdatedBatchJobCounts;
@@ -39,25 +38,27 @@ class BatchRepositoryFake implements BatchRepository
     /**
      * Store a new pending batch.
      *
-     * @param  \Illuminate\Bus\PendingBatch  $batch
-     * @return \Illuminate\Bus\Batch
+     * @param  \Illuminate\Bus\PendingBatch  $pendingBatch
+     * @return \Illuminate\Support\Testing\Fakes\BatchFake
      */
-    public function store(PendingBatch $batch)
+    public function store(PendingBatch $pendingBatch)
     {
-        return new Batch(
+        return tap(new BatchFake(
             new QueueFake(Facade::getFacadeApplication()),
             $this,
             (string) Str::orderedUuid(),
-            $batch->name,
-            count($batch->jobs),
-            count($batch->jobs),
+            $pendingBatch->name,
+            count($pendingBatch->jobs),
+            count($pendingBatch->jobs),
             0,
             [],
-            $batch->options,
+            $pendingBatch->options,
             CarbonImmutable::now(),
             null,
             null
-        );
+        ), function (BatchFake $batch) use ($pendingBatch) {
+            $batch->setBus($pendingBatch->bus());
+        });
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Support\Testing\Fakes;
 
 use Closure;
+use Illuminate\Bus\Batch;
 use Illuminate\Bus\PendingBatch;
 use Illuminate\Contracts\Bus\QueueingDispatcher;
 use Illuminate\Support\Arr;
@@ -637,13 +638,33 @@ class BusFake implements QueueingDispatcher
      * Record the fake pending batch dispatch.
      *
      * @param  \Illuminate\Bus\PendingBatch $pendingBatch
-     * @return \Illuminate\Bus\Batch
+     * @return \Illuminate\Support\Testing\Fakes\BatchFake
      */
     public function recordPendingBatch(PendingBatch $pendingBatch)
     {
-        $this->batches[] = $pendingBatch;
+        $batchFake = (new BatchRepositoryFake)->store($pendingBatch);
 
-        return (new BatchRepositoryFake)->store($pendingBatch);
+        $this->batches[$batchFake->id] = $pendingBatch;
+
+        return $batchFake;
+    }
+
+    /**
+     * Record the fake batch add.
+     *
+     * @param  \Illuminate\Support\Testing\Fakes\BatchFake $batchFake
+     * @return \Illuminate\Support\Testing\Fakes\BatchFake
+     */
+    public function recordBatch(BatchFake $batchFake)
+    {
+        /** @var \Illuminate\Bus\PendingBatch $batch */
+        foreach ($this->batches as $key => $batch) {
+            if ($key === $batchFake->id) {
+                $this->batches[$key] = $batchFake;
+            }
+        }
+
+        return $batchFake;
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/PendingBatchFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/PendingBatchFake.php
@@ -30,10 +30,20 @@ class PendingBatchFake extends PendingBatch
     /**
      * Dispatch the batch.
      *
-     * @return \Illuminate\Bus\Batch
+     * @return \Illuminate\Support\Testing\Fakes\BatchFake
      */
     public function dispatch()
     {
         return $this->bus->recordPendingBatch($this);
+    }
+
+    /**
+     * Return the fake bus instance.
+     *
+     * @var \Illuminate\Support\Testing\Fakes\BusFake
+     */
+    public function bus()
+    {
+        return $this->bus;
     }
 }


### PR DESCRIPTION
This PR improves batch assertion by also allowing to assert additional jobs were added to batches. Take, for example, the following test:

```php
use App\Jobs\FooJob;
use Illuminate\Bus\PendingBatch;
use Illuminate\Support\Facades\Bus;

Bus::fake();

$batch = Bus::batch([])->dispatch();

$batch->add(new FooJob());

Bus::assertBatched(function (PendingBatch $batch) {
    return $batch->jobs->count() === 1;
});
```

With the changes in this PR you can do:

```php
use App\Jobs\FooJob;
use Illuminate\Bus\PendingBatch;
use Illuminate\Support\Facades\Bus;

Bus::fake();

$batch = Bus::batch([])->dispatch();

$batch->add(new FooJob());

Bus::assertBatched(function ($batch) {
    $count = $batch instanceof PendingBatch
        ? $batch->jobs->count()
        : $batch->totalJobs;
    
    return $count === 1;
});
```

Which will check if the batch is a pending one or an instance of `Illuminate\Bus\Batch` (in this case `Illuminate\Support\Testing\Fakes\BatchFake`) and thus derive the total job count. 

I wish I could have solved it without having to add the new getter methods on the `Batch` and `BatchFake` classes but I don't see another way. It's also a bit cumbersome that you can't type-hint `PendingBatch` anymore in the assertion but it more closely reflects the actual situation where there's no PendingBatch anymore but a real Batch instance.

Fixes https://github.com/laravel/framework/issues/36590