### PR TITLE
[9.x] Sesv2client

### DIFF
--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Mail;
 
-use Aws\Ses\SesClient;
+use Aws\SesV2\SesV2Client;
 use Closure;
 use GuzzleHttp\Client as HttpClient;
 use Illuminate\Contracts\Mail\Factory as FactoryContract;
@@ -271,7 +271,7 @@ class MailManager implements FactoryContract
         $config = Arr::except($config, ['transport']);
 
         return new SesTransport(
-            new SesClient($this->addSesCredentials($config)),
+            new SesV2Client($this->addSesCredentials($config)),
             $config['options'] ?? []
         );
     }

--- a/src/Illuminate/Mail/Transport/SesTransport.php
+++ b/src/Illuminate/Mail/Transport/SesTransport.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Mail\Transport;
 
-use Aws\Ses\SesClient;
+use Aws\SesV2\SesV2Client;
 use Swift_Mime_SimpleMessage;
 
 class SesTransport extends Transport
@@ -10,7 +10,7 @@ class SesTransport extends Transport
     /**
      * The Amazon SES instance.
      *
-     * @var \Aws\Ses\SesClient
+     * @var \Aws\SesV2\SesV2Client
      */
     protected $ses;
 
@@ -24,11 +24,11 @@ class SesTransport extends Transport
     /**
      * Create a new SES transport instance.
      *
-     * @param  \Aws\Ses\SesClient  $ses
+     * @param  \Aws\SesV2\SesV2Client  $ses
      * @param  array  $options
      * @return void
      */
-    public function __construct(SesClient $ses, $options = [])
+    public function __construct(SesV2Client $ses, $options = [])
     {
         $this->ses = $ses;
         $this->options = $options;
@@ -41,10 +41,10 @@ class SesTransport extends Transport
     {
         $this->beforeSendPerformed($message);
 
-        $result = $this->ses->sendRawEmail(
+        $result = $this->ses->sendEmail(
             array_merge(
                 $this->options, [
-                    'Source' => key($message->getSender() ?: $message->getFrom()),
+                    'FromEmailAddress' => key($message->getSender() ?: $message->getFrom()),
                     'RawMessage' => [
                         'Data' => $message->toString(),
                     ],
@@ -65,7 +65,7 @@ class SesTransport extends Transport
     /**
      * Get the Amazon SES client for the SesTransport instance.
      *
-     * @return \Aws\Ses\SesClient
+     * @return \Aws\SesV2\SesV2Client
      */
     public function ses()
     {

--- a/tests/Mail/MailSesTransportTest.php
+++ b/tests/Mail/MailSesTransportTest.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Tests\Mail;
 
-use Aws\Ses\SesClient;
+use Aws\SesV2\SesV2Client;
 use Illuminate\Config\Repository;
 use Illuminate\Container\Container;
 use Illuminate\Mail\MailManager;
@@ -46,8 +46,8 @@ class MailSesTransportTest extends TestCase
         $message->setTo('me@example.com');
         $message->setBcc('you@example.com');
 
-        $client = $this->getMockBuilder(SesClient::class)
-            ->addMethods(['sendRawEmail'])
+        $client = $this->getMockBuilder(SesV2Client::class)
+            ->addMethods(['sendEmail'])
             ->disableOriginalConstructor()
             ->getMock();
         $transport = new SesTransport($client);
@@ -57,9 +57,9 @@ class MailSesTransportTest extends TestCase
         $messageId = Str::random(32);
         $sendRawEmailMock = new sendRawEmailMock($messageId);
         $client->expects($this->once())
-            ->method('sendRawEmail')
+            ->method('sendEmail')
             ->with($this->equalTo([
-                'Source' => 'myself@example.com',
+                'FromEmailAddress' => 'myself@example.com',
                 'RawMessage' => ['Data' => (string) $message],
             ]))
             ->willReturn($sendRawEmailMock);
@@ -83,7 +83,7 @@ class MailSesTransportTest extends TestCase
                             'region' => 'eu-west-1',
                             'options' => [
                                 'ConfigurationSetName' => 'Laravel',
-                                'Tags' => [
+                                'EmailTags' => [
                                     ['Name' => 'Laravel', 'Value' => 'Framework'],
                                 ],
                             ],
@@ -116,7 +116,7 @@ class MailSesTransportTest extends TestCase
 
         $this->assertSame([
             'ConfigurationSetName' => 'Laravel',
-            'Tags' => [
+            'EmailTags' => [
                 ['Name' => 'Laravel', 'Value' => 'Framework'],
             ],
         ], $transport->getOptions());


### PR DESCRIPTION
This PR updates the Mail [`SesTransport`](https://github.com/laravel/framework/blob/master/src/Illuminate/Mail/Transport/SesTransport.php) class to use the newer `Aws\SesV2\SesV2Client` class.

> S3 docs on the AWS PHP SDK's [`sendEmail()` method here](https://docs.aws.amazon.com/aws-sdk-php/v3/api/api-sesv2-2019-09-27.html#sendemail).
> 
> There is no `sendRawEmail()` method on the V2 client.

- [x] Update `Sestransport`
- [x] Update `MailManager`
- [x] Update Tests
- [x] Update documentation via https://github.com/laravel/docs/pull/7165

## Documentation / Configuration changes

Just a few notes on documentation updates so you can also see the changes in configuration.

The documentation to updates needed will be from https://laravel.com/docs/8.x/mail#ses-driver

```diff
-If you would like to define [additional options](https://docs.aws.amazon.com/aws-sdk-php/v3/api/api-email-2010-12-01.html#sendrawemail) that Laravel should pass to the AWS SDK's `SendRawEmail` method when sending an email, you may define an `options` array within your `ses` configuration:

+If you would like to define [additional options](https://docs.aws.amazon.com/aws-sdk-php/v3/api/api-sesv2-2019-09-27.html#sendemail) that Laravel should pass to the AWS SDK's `SendEmail` method when sending an email, you may define an `options` array within your `ses` configuration:
```

```diff
'ses' => [
    'key' => env('AWS_ACCESS_KEY_ID'),
    'secret' => env('AWS_SECRET_ACCESS_KEY'),
    'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
    'options' => [
        'ConfigurationSetName' => 'MyConfigurationSet',
-        'Tags' => [
+        'EmailTags' => [
            ['Name' => 'foo', 'Value' => 'bar'],
        ],
    ],
],
```