### PR TITLE
[8.x] Improve pretend run Doctrine failure message

### DIFF
--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -427,7 +427,7 @@ class Migrator
         } catch (SchemaException $e) {
             $name = get_class($migration);
 
-            $this->note("<info>{$name}:</info> failed to dump queries. Most likely, this is due to changing database columns using Doctrine, which isn't supported while pretending to run migrations.");
+            $this->note("<info>{$name}:</info> failed to dump queries. This may be due to changing database columns using Doctrine, which is not supported while pretending to run migrations.");
         }
     }
 

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Migrations;
 
+use Doctrine\DBAL\Schema\SchemaException;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
 use Illuminate\Database\Events\MigrationEnded;
@@ -411,16 +412,22 @@ class Migrator
      */
     protected function pretendToRun($migration, $method)
     {
-        foreach ($this->getQueries($migration, $method) as $query) {
+        try {
+            foreach ($this->getQueries($migration, $method) as $query) {
+                $name = get_class($migration);
+
+                $reflectionClass = new ReflectionClass($migration);
+
+                if ($reflectionClass->isAnonymous()) {
+                    $name = $this->getMigrationName($reflectionClass->getFileName());
+                }
+
+                $this->note("<info>{$name}:</info> {$query['query']}");
+            }
+        } catch (SchemaException $e) {
             $name = get_class($migration);
 
-            $reflectionClass = new ReflectionClass($migration);
-
-            if ($reflectionClass->isAnonymous()) {
-                $name = $this->getMigrationName($reflectionClass->getFileName());
-            }
-
-            $this->note("<info>{$name}:</info> {$query['query']}");
+            $this->note("<info>{$name}:</info> failed to dump queries. Most likely, this is due to changing database columns using Doctrine, which isn't supported while pretending to run migrations.");
         }
     }
 


### PR DESCRIPTION
This PR adds a failure message when trying to pretend queries in a migration while a `->change()` call is present. This isn't supported and atm leads to an exception. Catching this exception and providing a clear message will improve usabilty.

I don't think there's a real solution to the underlying issue so this is the least we can do atm.

Fixes https://github.com/laravel/framework/issues/36629