### PR TITLE
[8.x] Allow customisation of random string using regex parameter

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -513,9 +513,11 @@ class Str
      * Generate a more truly "random" alpha-numeric string.
      *
      * @param  int  $length
+     * @param  string  $regexPattern
+     *
      * @return string
      */
-    public static function random($length = 16)
+    public static function random($length = 16, $regexPattern='A-Za-z0-9')
     {
         $string = '';
 
@@ -524,7 +526,7 @@ class Str
 
             $bytes = random_bytes($size);
 
-            $string .= substr(str_replace(['/', '+', '='], '', base64_encode($bytes)), 0, $size);
+            $string .= substr(preg_replace('/[^'.$regexPattern.'\-]/', '', base64_encode($bytes)), 0, $size);
         }
 
         return $string;


### PR DESCRIPTION
An enhancement to the `Str::random()` function. 

I found a need today that I wanted a quick of generating multiple 4 character long unique strings, but they had to be `[A-Z]`. 

This allows you to put a custom regex parameter in to ensure that the returned strings match that regex. 

EG: 
```
Str::random(4, 'A-Z'); // Might return AURE
Str::random(4, 'A-Za-z'); // Might return AirT
```

I don't believe this will break anything as the original `str_replace` seems to do the same as what `A-Za-z0-9` would do. 

