### PR TITLE
[9.x] Bug fix: Use correct parameters to send email through SES via SesV2Client

### DIFF
--- a/src/Illuminate/Mail/Transport/SesTransport.php
+++ b/src/Illuminate/Mail/Transport/SesTransport.php
@@ -45,8 +45,8 @@ class SesTransport extends Transport
             array_merge(
                 $this->options, [
                     'FromEmailAddress' => key($message->getSender() ?: $message->getFrom()),
-                    'RawMessage' => [
-                        'Data' => $message->toString(),
+                    'Content' => [
+                        'Raw' => ['Data' => $message->toString()],
                     ],
                 ]
             )

--- a/src/Illuminate/Mail/Transport/SesTransport.php
+++ b/src/Illuminate/Mail/Transport/SesTransport.php
@@ -44,7 +44,6 @@ class SesTransport extends Transport
         $result = $this->ses->sendEmail(
             array_merge(
                 $this->options, [
-                    'FromEmailAddress' => key($message->getSender() ?: $message->getFrom()),
                     'Content' => [
                         'Raw' => ['Data' => $message->toString()],
                     ],

--- a/tests/Mail/MailSesTransportTest.php
+++ b/tests/Mail/MailSesTransportTest.php
@@ -59,7 +59,6 @@ class MailSesTransportTest extends TestCase
         $client->expects($this->once())
             ->method('sendEmail')
             ->with($this->equalTo([
-                'FromEmailAddress' => 'myself@example.com',
                 'Content' => [
                     'Raw' => ['Data' => (string) $message],
                 ],

--- a/tests/Mail/MailSesTransportTest.php
+++ b/tests/Mail/MailSesTransportTest.php
@@ -60,7 +60,9 @@ class MailSesTransportTest extends TestCase
             ->method('sendEmail')
             ->with($this->equalTo([
                 'FromEmailAddress' => 'myself@example.com',
-                'RawMessage' => ['Data' => (string) $message],
+                'Content' => [
+                    'Raw' => ['Data' => (string) $message],
+                ],
             ]))
             ->willReturn($sendRawEmailMock);
 


### PR DESCRIPTION
The parameters and tests were updated to use the correct array keys needed for the newer SES client.

**This PR does 2 things:**

1. Uses the correct parameters to send a raw email 😅
2. Removes the `FromEmailAddress` parameter (explanation below)