### PR TITLE
[8.x] Add the option to add timestamps to command output

### DIFF
--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -5,6 +5,7 @@ namespace Illuminate\Console\Concerns;
 use Closure;
 use Illuminate\Console\OutputStyle;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
 use Symfony\Component\Console\Helper\Table;
@@ -48,6 +49,20 @@ trait InteractsWithIO
         'quiet' => OutputInterface::VERBOSITY_QUIET,
         'normal' => OutputInterface::VERBOSITY_NORMAL,
     ];
+
+    /**
+     * Whether to prepend output with a timestamp.
+     *
+     * @var bool
+     */
+    protected $timestamps = false;
+
+    /**
+     * The format to use when prepending any output with a timestamp.
+     *
+     * @var string
+     */
+    public $timestampFormat = 'Y-m-d H:i:s';
 
     /**
      * Determine if the given argument is present.
@@ -292,6 +307,10 @@ trait InteractsWithIO
      */
     public function line($string, $style = null, $verbosity = null)
     {
+        if ($this->timestamps) {
+            $string = Carbon::now()->format("[$this->timestampFormat] ").$string;
+        }
+
         $styled = $style ? "<$style>$string</$style>" : $string;
 
         $this->output->writeln($styled, $this->parseVerbosity($verbosity));
@@ -437,5 +456,27 @@ trait InteractsWithIO
     public function getOutput()
     {
         return $this->output;
+    }
+
+    /**
+     * Enable/disable timestamped output.
+     *
+     * @param bool $enabled
+     * @return void
+     */
+    public function setTimestamps($enabled = true)
+    {
+        $this->timestamps = $enabled;
+    }
+
+    /**
+     * Set the timestamp format.
+     *
+     * @param string $format
+     * @return void
+     */
+    public function setTimestampFormat($format)
+    {
+        $this->timestampFormat = $format;
     }
 }

--- a/tests/Console/CommandTest.php
+++ b/tests/Console/CommandTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Console;
 use Illuminate\Console\Application;
 use Illuminate\Console\Command;
 use Illuminate\Console\OutputStyle;
+use Illuminate\Support\Carbon;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -144,5 +145,42 @@ class CommandTest extends TestCase
         $command->setOutput($output);
 
         $command->choice('Select all that apply.', ['option-1', 'option-2', 'option-3'], null, null, true);
+    }
+
+    public function testTheOutputContainsATimestampWithTheDefaultFormat()
+    {
+        Carbon::setTestNow(
+            $testNow = Carbon::now()
+        );
+
+        $command = new Command;
+        $output = m::mock(OutputStyle::class);
+        $output->shouldReceive('writeln')->once()->withArgs(function (...$args) use ($command, $testNow) {
+            return $args[0] === '<info>['.$testNow->format($command->timestampFormat).'] foo</info>';
+        });
+
+        $command->setOutput($output);
+        $command->setTimestamps(true);
+
+        $command->info('foo');
+    }
+
+    public function testTheOutputContainsATimestampWithACustomFormat()
+    {
+        Carbon::setTestNow(
+            $testNow = Carbon::now()
+        );
+
+        $command = new Command;
+        $command->setTimestampFormat('Y-m-d');
+        $output = m::mock(OutputStyle::class);
+        $output->shouldReceive('writeln')->once()->withArgs(function (...$args) use ($command, $testNow) {
+            return $args[0] === '<info>['.$testNow->format($command->timestampFormat).'] foo</info>';
+        });
+
+        $command->setOutput($output);
+        $command->setTimestamps(true);
+
+        $command->info('foo');
     }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
In various projects I've had the need for timestamped output in commands (and seen similar [here](https://github.com/laravel/ideas/issues/2646)). This allows you to either set the `$timestamps` property on a command class, or call `$command->setTimestamps(true)` to enable timestamped output. E.g.

When timestamps are enabled:

```php
$this->info('foo')
```

Output:

```
[2021-07-02 09:10:00] foo
```

You can also customise the time format with the `$timeFormat` property (or the `setTimestampFormat` function), with a default of `Y-m-d H:i:s` 

Originally in #37884