### PR TITLE
[8.x] Corrected the PHPDoc description for pluck()

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2577,7 +2577,7 @@ class Builder
     }
 
     /**
-     * Get an array with the values of a given column.
+     * Get a Collection Instance with the values of a given column.
      *
      * @param  string  $column
      * @param  string|null  $key

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2577,7 +2577,7 @@ class Builder
     }
 
     /**
-     * Get a Collection Instance with the values of a given column.
+     * Get a Collection instance with the values of a given column.
      *
      * @param  string  $column
      * @param  string|null  $key

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2577,7 +2577,7 @@ class Builder
     }
 
     /**
-     * Get a Collection instance with the values of a given column.
+     * Get a collection instance containing the values of a given column.
      *
      * @param  string  $column
      * @param  string|null  $key


### PR DESCRIPTION
Although the return type was correct, the description mentioned that an array will be returned but in practice, pluck returns a collection. Does not affect functionality.
