### PR TITLE
[8.x] Add context recursively

### DIFF
--- a/src/Illuminate/Log/Logger.php
+++ b/src/Illuminate/Log/Logger.php
@@ -180,7 +180,7 @@ class Logger implements LoggerInterface
     {
         $this->logger->{$level}(
             $message = $this->formatMessage($message),
-            $context = array_merge($this->context, $context)
+            $context = array_merge_recursive($this->context, $context)
         );
 
         $this->fireLogEvent($level, $message, $context);
@@ -194,7 +194,7 @@ class Logger implements LoggerInterface
      */
     public function withContext(array $context = [])
     {
-        $this->context = array_merge($this->context, $context);
+        $this->context = array_merge_recursive($this->context, $context);
 
         return $this;
     }

--- a/tests/Log/LogLoggerTest.php
+++ b/tests/Log/LogLoggerTest.php
@@ -32,8 +32,15 @@ class LogLoggerTest extends TestCase
     {
         $writer = new Logger($monolog = m::mock(Monolog::class));
         $writer->withContext(['payload' => ['uuid' => 123]]);
+        $writer->withContext(['payload' => ['pod' => 'xyz']]);
 
-        $monolog->shouldReceive('error')->once()->with('foo', ['payload' => ['uuid' => 123, 'type' => 'cli']]);
+        $monolog->shouldReceive('error')->once()->with('foo', [
+            'payload' => [
+                'uuid' => 123,
+                'pod' => 'xyz',
+                'type' => 'cli',
+            ],
+        ]);
 
         $writer->error('foo', ['payload' => ['type' => 'cli']]);
     }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

It is a pretty common practice to group pieces of context into a main data group when logging.
It makes it easier to manage filters when using a logging solution, like loggly, papertrail, etc...

At the moment adding context does not allow to do it in a recursive manner.

This PR introduces this possibility.
