### PR TITLE
[8.x] Revert mocking

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
@@ -78,24 +78,6 @@ trait InteractsWithContainer
     }
 
     /**
-     * Register an instance of an object as a singleton in the container.
-     *
-     * @param  string  $abstract
-     * @param  \Mockery\MockInterface  $instance
-     * @return \Mockery\MockInterface
-     */
-    protected function singletonInstance($abstract, $instance)
-    {
-        $abstract = $this->app->getAlias($abstract);
-
-        $this->app->singleton($abstract, function () use ($instance) {
-            return $instance;
-        });
-
-        return $instance;
-    }
-
-    /**
      * Register an empty handler for Laravel Mix in the container.
      *
      * @return $this

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
@@ -50,7 +50,7 @@ trait InteractsWithContainer
      */
     protected function mock($abstract, Closure $mock = null)
     {
-        return $this->singletonInstance($abstract, Mockery::mock(...array_filter(func_get_args())));
+        return $this->instance($abstract, Mockery::mock(...array_filter(func_get_args())));
     }
 
     /**
@@ -62,7 +62,7 @@ trait InteractsWithContainer
      */
     protected function partialMock($abstract, Closure $mock = null)
     {
-        return $this->singletonInstance($abstract, Mockery::mock(...array_filter(func_get_args()))->makePartial());
+        return $this->instance($abstract, Mockery::mock(...array_filter(func_get_args()))->makePartial());
     }
 
     /**
@@ -74,7 +74,7 @@ trait InteractsWithContainer
      */
     protected function spy($abstract, Closure $mock = null)
     {
-        return $this->singletonInstance($abstract, Mockery::spy(...array_filter(func_get_args())));
+        return $this->instance($abstract, Mockery::spy(...array_filter(func_get_args())));
     }
 
     /**

--- a/tests/Foundation/Testing/Concerns/InteractsWithContainerTest.php
+++ b/tests/Foundation/Testing/Concerns/InteractsWithContainerTest.php
@@ -3,8 +3,6 @@
 namespace Illuminate\Tests\Foundation\Testing\Concerns;
 
 use Illuminate\Foundation\Mix;
-use Illuminate\Http\Request;
-use Mockery\MockInterface;
 use Orchestra\Testbench\TestCase;
 use stdClass;
 
@@ -28,25 +26,5 @@ class InteractsWithContainerTest extends TestCase
 
         $this->assertSame($handler, resolve(Mix::class));
         $this->assertSame($this, $instance);
-    }
-
-    public function testSingletonBoundInstancesCanBeResolved()
-    {
-        $this->singletonInstance('foo', 'bar');
-
-        $this->assertEquals('bar', $this->app->make('foo'));
-        $this->assertEquals('bar', $this->app->make('foo', ['with' => 'params']));
-    }
-
-    public function testSingletonRebindsAlias()
-    {
-        $this->app->instance('request', Request::create('/example'));
-
-        $this->mock(Request::class, function (MockInterface $mock) {
-            //
-        });
-
-        $this->assertInstanceOf(MockInterface::class, resolve(Request::class));
-        $this->assertInstanceOf(MockInterface::class, resolve('request'));
     }
 }


### PR DESCRIPTION
This PR reverts the changes made to the mocking methods in tests which is currently breaking existing test suites. Caused by https://github.com/laravel/framework/pull/37746

This will re-introduce https://github.com/laravel/framework/issues/37706 for which we can send in a different solution maybe.

Fixes https://github.com/laravel/framework/issues/37789