### PR TITLE
Add translate tip

### DIFF
--- a/src/Illuminate/Routing/Middleware/ThrottleRequests.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequests.php
@@ -197,7 +197,7 @@ class ThrottleRequests
 
         return is_callable($responseCallback)
                     ? new HttpResponseException($responseCallback($request, $headers))
-                    : new ThrottleRequestsException('Too Many Attempts.', null, $headers);
+                    : new ThrottleRequestsException(__('Too Many Attempts.'), null, $headers);
     }
 
     /**


### PR DESCRIPTION
As we know, users of the laravel framework are not only native English speakers, and its Throttle Request is a good middleware when develop APIs. 
However, when its reached the limit, it's `tip message` is not well.
**Too Many Attempts**
As a not English native user, everytime we want to translate the tip message to our tongue language, we have to create another Middleware to extend `Throttle Request` and rewrite `buildException` function, to modify the tip message **Too Many Attempts**. 
Or catch 429 ecption code to modify return message.
I mean its really unnecessary, we already have a good language package https://github.com/Laravel-Lang/lang 
![image](https://user-images.githubusercontent.com/37573610/124385446-3b578380-dd08-11eb-87ba-9331728aa3b9.png)

And its already translated `Too Many Attempts` message, but we can't use it cause the `buildException` returns string as message, not a translation function helper message.

I'm not a native English speaker also, hope you can understand I mean, and consider about it, thanks.