### PR TITLE
[8.x] Adds ResponseReceived events to async requests of HTTP Client

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -707,7 +707,10 @@ class PendingRequest
     {
         return $this->promise = $this->sendRequest($method, $url, $options)
             ->then(function (MessageInterface $message) {
-                return $this->populateResponse(new Response($message));
+                return tap(new Response($message), function ($response) {
+                    $this->populateResponse($response);
+                    $this->dispatchResponseReceivedEvent($response);
+                });
             })
             ->otherwise(function (TransferException $e) {
                 return $e instanceof RequestException ? $this->populateResponse(new Response($e->getResponse())) : $e;


### PR DESCRIPTION
this is a follow-up to https://github.com/laravel/framework/pull/37572, so that the event "ResponseReceived" is also sent during async requests