### PR TITLE
[8.x] Add self to Conditionable docblock

### DIFF
--- a/src/Illuminate/Support/Traits/Conditionable.php
+++ b/src/Illuminate/Support/Traits/Conditionable.php
@@ -11,7 +11,7 @@ trait Conditionable
      * @param  callable  $callback
      * @param  callable|null  $default
      *
-     * @return mixed
+     * @return mixed|self
      */
     public function when($value, $callback, $default = null)
     {
@@ -31,7 +31,7 @@ trait Conditionable
      * @param  callable  $callback
      * @param  callable|null  $default
      *
-     * @return mixed
+     * @return mixed|self
      */
     public function unless($value, $callback, $default = null)
     {


### PR DESCRIPTION
Adding `self` to the docblock helps IDEs chain methods after running `when()` or `unless()` in your chain.

We could also drop `mixed` altogether since it doesn't make sense, having self right there.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
