### PR TITLE
[8.x] Add idempotent middleware

### DIFF
--- a/src/Illuminate/Foundation/Http/Exceptions/DuplicatedIdempotencyKeyException.php
+++ b/src/Illuminate/Foundation/Http/Exceptions/DuplicatedIdempotencyKeyException.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Illuminate\Foundation\Http\Exceptions;
+
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Throwable;
+
+class DuplicatedIdempotencyKeyException extends HttpException
+{
+    /**
+     * Create a new "duplicated idempotency key" exception instance.
+     *
+     * @param  string|null  $message
+     * @param  \Throwable|null  $previous
+     * @param  array  $headers
+     * @param  int  $code
+     * @return void
+     */
+    public function __construct($message = null, Throwable $previous = null, array $headers = [], $code = 0)
+    {
+        parent::__construct(422, $message, $previous, $headers, $code);
+    }
+}

--- a/src/Illuminate/Foundation/Http/Exceptions/IdempotencyKeyCharacterLimitException.php
+++ b/src/Illuminate/Foundation/Http/Exceptions/IdempotencyKeyCharacterLimitException.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Illuminate\Foundation\Http\Exceptions;
+
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Throwable;
+
+class IdempotencyKeyCharacterLimitException extends HttpException
+{
+    /**
+     * Create a new "idempotency key character limit" exception instance.
+     *
+     * @param  string|null  $message
+     * @param  \Throwable|null  $previous
+     * @param  array  $headers
+     * @param  int  $code
+     * @return void
+     */
+    public function __construct($message = null, Throwable $previous = null, array $headers = [], $code = 0)
+    {
+        parent::__construct(422, $message, $previous, $headers, $code);
+    }
+}

--- a/src/Illuminate/Foundation/Http/Exceptions/MissingIdempotencyKeyException.php
+++ b/src/Illuminate/Foundation/Http/Exceptions/MissingIdempotencyKeyException.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Foundation\Http\Exceptions;
 
-use Throwable;
 use Symfony\Component\HttpKernel\Exception\HttpException;
+use Throwable;
 
 class MissingIdempotencyKeyException extends HttpException
 {

--- a/src/Illuminate/Foundation/Http/Exceptions/MissingIdempotencyKeyException.php
+++ b/src/Illuminate/Foundation/Http/Exceptions/MissingIdempotencyKeyException.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Illuminate\Foundation\Http\Exceptions;
+
+use Throwable;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class MissingIdempotencyKeyException extends HttpException
+{
+    /**
+     * Create a new "idempotency key mismatch" exception instance.
+     *
+     * @param  string|null  $message
+     * @param  \Throwable|null  $previous
+     * @param  array  $headers
+     * @param  int  $code
+     * @return void
+     */
+    public function __construct($message = null, Throwable $previous = null, array $headers = [], $code = 0)
+    {
+        parent::__construct(400, $message, $previous, $headers, $code);
+    }
+}

--- a/src/Illuminate/Foundation/Http/Middleware/Idempotent.php
+++ b/src/Illuminate/Foundation/Http/Middleware/Idempotent.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Illuminate\Foundation\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Cache\Repository as CacheRepository;
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Foundation\Http\Exceptions\DuplicatedIdempotencyKeyException;
+use Illuminate\Foundation\Http\Exceptions\MissingIdempotencyKeyException;
+
+class Idempotent
+{
+    const PREFIX = "IDEMPOTENT_";
+
+    /**
+     * The application instance.
+     *
+     * @var \Illuminate\Contracts\Foundation\Application
+     */
+    protected $app;
+
+    /**
+     * The application cache repository.
+     *
+     * @var \Illuminate\Cache\Repository
+     */
+    protected $cache;
+
+    public function __construct(Application $app, CacheRepository $cache)
+    {
+        $this->app = $app;
+        $this->cache = $cache;
+    }
+
+    /**
+     * Determine if the HTTP request method is POST or PATCH & PUT.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return bool
+     */
+    protected function shouldSkip($request)
+    {
+        return !in_array($request->method(), ['POST', 'PATCH', 'PUT']);
+    }
+
+    public function handle(Request $request, Closure $next, $force = true)
+    {
+        if ($this->shouldSkip($request)) {
+            return $next($request);
+        }
+
+        $idempotencyKey = $request->input('_idempotency_key') ?: $request->header('Idempotency-Key');
+        $force = filter_var($force, FILTER_VALIDATE_BOOLEAN);
+
+        if (!$idempotencyKey && $force === true) {
+            throw new MissingIdempotencyKeyException();
+        }
+
+        $cacheKey = self::PREFIX.$idempotencyKey.$request->fingerprint();
+
+        $cachedResponse = $this->cache->get($cacheKey);
+
+        if ($cachedResponse) {
+            throw new DuplicatedIdempotencyKeyException();
+        }
+
+        $response = $next($request);
+
+        $statusCode = $response->getStatusCode();
+
+        if ($statusCode >= 200 && $statusCode < 300) {
+            $this->cache->set(
+                $cacheKey,
+                1,
+                86400
+            );
+        }
+
+        return $response;
+    }
+}

--- a/src/Illuminate/Foundation/Http/Middleware/Idempotent.php
+++ b/src/Illuminate/Foundation/Http/Middleware/Idempotent.php
@@ -45,7 +45,7 @@ class Idempotent
     }
 
     /**
-     * Get checksum of request payload
+     * Get checksum of request payload.
      *
      * @param  \Illuminate\Http\Request  $request
      * @return string
@@ -91,7 +91,7 @@ class Idempotent
         $response = $next($request);
         $encodedData = json_encode([
             'payload_checksum' => $payloadChecksum,
-            'response' => serialize($response)
+            'response' => serialize($response),
         ]);
 
         $this->cache->set(

--- a/src/Illuminate/Foundation/Http/Middleware/Idempotent.php
+++ b/src/Illuminate/Foundation/Http/Middleware/Idempotent.php
@@ -3,15 +3,15 @@
 namespace Illuminate\Foundation\Http\Middleware;
 
 use Closure;
-use Illuminate\Http\Request;
 use Illuminate\Cache\Repository as CacheRepository;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Foundation\Http\Exceptions\DuplicatedIdempotencyKeyException;
 use Illuminate\Foundation\Http\Exceptions\MissingIdempotencyKeyException;
+use Illuminate\Http\Request;
 
 class Idempotent
 {
-    const PREFIX = "IDEMPOTENT_";
+    const PREFIX = 'IDEMPOTENT_';
 
     /**
      * The application instance.
@@ -34,14 +34,25 @@ class Idempotent
     }
 
     /**
-     * Determine if the HTTP request method is POST or PATCH & PUT.
+     * Determine if the HTTP request method is HEAD or OPTIONS.
      *
      * @param  \Illuminate\Http\Request  $request
      * @return bool
      */
     protected function shouldSkip($request)
     {
-        return !in_array($request->method(), ['POST', 'PATCH', 'PUT']);
+        return in_array($request->method(), ['HEAD', 'OPTIONS']);
+    }
+
+    /**
+     * Get checksum of request payload
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return string
+     */
+    protected function checksumPayload($request)
+    {
+        return md5(json_encode($request->all()));
     }
 
     public function handle(Request $request, Closure $next, $force = true)
@@ -53,29 +64,41 @@ class Idempotent
         $idempotencyKey = $request->input('_idempotency_key') ?: $request->header('Idempotency-Key');
         $force = filter_var($force, FILTER_VALIDATE_BOOLEAN);
 
-        if (!$idempotencyKey && $force === true) {
+        // make it optional if request method is get
+        if ($request->method() === 'GET') {
+            $force = false;
+        }
+
+        if (! $idempotencyKey && $force === true) {
             throw new MissingIdempotencyKeyException();
         }
 
         $cacheKey = self::PREFIX.$idempotencyKey.$request->fingerprint();
 
         $cachedResponse = $this->cache->get($cacheKey);
+        $payloadChecksum = $this->checksumPayload($request);
 
         if ($cachedResponse) {
-            throw new DuplicatedIdempotencyKeyException();
+            $decodedValue = json_decode($cachedResponse);
+
+            if ($decodedValue->payload_checksum !== $payloadChecksum) {
+                throw new DuplicatedIdempotencyKeyException();
+            }
+
+            return unserialize($decodedValue->response);
         }
 
         $response = $next($request);
+        $encodedData = json_encode([
+            'payload_checksum' => $payloadChecksum,
+            'response' => serialize($response)
+        ]);
 
-        $statusCode = $response->getStatusCode();
-
-        if ($statusCode >= 200 && $statusCode < 300) {
-            $this->cache->set(
-                $cacheKey,
-                1,
-                86400
-            );
-        }
+        $this->cache->set(
+            $cacheKey,
+            $encodedData,
+            86400 //24h
+        );
 
         return $response;
     }

--- a/src/Illuminate/Foundation/Http/Middleware/Idempotent.php
+++ b/src/Illuminate/Foundation/Http/Middleware/Idempotent.php
@@ -6,6 +6,7 @@ use Closure;
 use Illuminate\Cache\Repository as CacheRepository;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Foundation\Http\Exceptions\DuplicatedIdempotencyKeyException;
+use Illuminate\Foundation\Http\Exceptions\IdempotencyKeyCharacterLimitException;
 use Illuminate\Foundation\Http\Exceptions\MissingIdempotencyKeyException;
 use Illuminate\Http\Request;
 
@@ -71,6 +72,10 @@ class Idempotent
 
         if (! $idempotencyKey && $force === true) {
             throw new MissingIdempotencyKeyException();
+        }
+
+        if (strlen($idempotencyKey) > 38) {
+            throw new IdempotencyKeyCharacterLimitException();
         }
 
         $cacheKey = self::PREFIX.$idempotencyKey.$request->fingerprint();

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -316,6 +316,18 @@ if (! function_exists('cookie')) {
     }
 }
 
+if (! function_exists('idempotency_key_field')) {
+    /**
+     * Generate a Idempotency Key form field.
+     *
+     * @return \Illuminate\Support\HtmlString
+     */
+    function idempotency_key_field()
+    {
+        return new HtmlString('<input type="hidden" name="_idempotency_key" value="'.Str::uuid().'">');
+    }
+}
+
 if (! function_exists('csrf_field')) {
     /**
      * Generate a CSRF token form field.

--- a/tests/Foundation/Http/Middleware/IdempotentRequestTest.php
+++ b/tests/Foundation/Http/Middleware/IdempotentRequestTest.php
@@ -97,4 +97,24 @@ class IdempotentRequestTest extends TestbenchTestCase
 
         $response->assertStatus(400);
     }
+
+    public function testCharacterLimitIdempotencyKey()
+    {
+        Route::post('/', function () {
+            return request()->name;
+        })->middleware(Idempotent::class);
+
+        $response = $this->post(
+            '/',
+            [
+                'name' => 'laravel',
+            ],
+            [
+                'Accept' => 'application/json',
+                'Idempotency-Key' => Str::random(39)
+            ]
+        );
+
+        $response->assertStatus(422);
+    }
 }

--- a/tests/Foundation/Http/Middleware/IdempotentRequestTest.php
+++ b/tests/Foundation/Http/Middleware/IdempotentRequestTest.php
@@ -2,9 +2,9 @@
 
 namespace Illuminate\Tests\Foundation\Http\Middleware;
 
-use Illuminate\Support\Str;
-use Illuminate\Support\Facades\Route;
 use Illuminate\Foundation\Http\Middleware\Idempotent;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Str;
 use Orchestra\Testbench\TestCase as TestbenchTestCase;
 
 class IdempotentRequestTest extends TestbenchTestCase
@@ -18,11 +18,11 @@ class IdempotentRequestTest extends TestbenchTestCase
         $response = $this->post(
             '/',
             [
-                'name' => 'laravel'
+                'name' => 'laravel',
             ],
             [
                 'Accept' => 'application/json',
-                'Idempotency-Key' => Str::uuid()
+                'Idempotency-Key' => Str::uuid(),
             ]
         );
 
@@ -41,11 +41,11 @@ class IdempotentRequestTest extends TestbenchTestCase
         $response = $this->post(
             '/',
             [
-                'name' => 'laravel'
+                'name' => 'laravel',
             ],
             [
                 'Accept' => 'application/json',
-                'Idempotency-Key' => $uuid
+                'Idempotency-Key' => $uuid,
             ]
         );
 
@@ -54,15 +54,29 @@ class IdempotentRequestTest extends TestbenchTestCase
         $response = $this->post(
             '/',
             [
-                'name' => 'laravel'
+                'name' => 'php',
             ],
             [
                 'Accept' => 'application/json',
-                'Idempotency-Key' => $uuid
+                'Idempotency-Key' => $uuid,
             ]
         );
 
         $response->assertStatus(422);
+
+        $response = $this->post(
+            '/',
+            [
+                'name' => 'laravel',
+            ],
+            [
+                'Accept' => 'application/json',
+                'Idempotency-Key' => $uuid,
+            ]
+        );
+
+        $this->assertSame('laravel', $response->content());
+        $response->assertStatus(200);
     }
 
     public function testEmptyIdempotencyKey()
@@ -74,7 +88,7 @@ class IdempotentRequestTest extends TestbenchTestCase
         $response = $this->post(
             '/',
             [
-                'name' => 'laravel'
+                'name' => 'laravel',
             ],
             [
                 'Accept' => 'application/json',

--- a/tests/Foundation/Http/Middleware/IdempotentRequestTest.php
+++ b/tests/Foundation/Http/Middleware/IdempotentRequestTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Http\Middleware;
+
+use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Foundation\Http\Middleware\Idempotent;
+use Orchestra\Testbench\TestCase as TestbenchTestCase;
+
+class IdempotentRequestTest extends TestbenchTestCase
+{
+    public function testValidIdempotentRoutes()
+    {
+        Route::post('/', function () {
+            return request()->name;
+        })->middleware(Idempotent::class);
+
+        $response = $this->post(
+            '/',
+            [
+                'name' => 'laravel'
+            ],
+            [
+                'Accept' => 'application/json',
+                'Idempotency-Key' => Str::uuid()
+            ]
+        );
+
+        $this->assertSame('laravel', $response->content());
+        $response->assertStatus(200);
+    }
+
+    public function testDuplicateIdempotentRoutes()
+    {
+        Route::post('/', function () {
+            return request()->name;
+        })->middleware(Idempotent::class);
+
+        $uuid = Str::uuid();
+
+        $response = $this->post(
+            '/',
+            [
+                'name' => 'laravel'
+            ],
+            [
+                'Accept' => 'application/json',
+                'Idempotency-Key' => $uuid
+            ]
+        );
+
+        $this->assertSame('laravel', $response->content());
+
+        $response = $this->post(
+            '/',
+            [
+                'name' => 'laravel'
+            ],
+            [
+                'Accept' => 'application/json',
+                'Idempotency-Key' => $uuid
+            ]
+        );
+
+        $response->assertStatus(422);
+    }
+
+    public function testEmptyIdempotencyKey()
+    {
+        Route::post('/', function () {
+            return request()->name;
+        })->middleware(Idempotent::class);
+
+        $response = $this->post(
+            '/',
+            [
+                'name' => 'laravel'
+            ],
+            [
+                'Accept' => 'application/json',
+            ]
+        );
+
+        $response->assertStatus(400);
+    }
+}

--- a/tests/Foundation/Http/Middleware/IdempotentRequestTest.php
+++ b/tests/Foundation/Http/Middleware/IdempotentRequestTest.php
@@ -111,7 +111,7 @@ class IdempotentRequestTest extends TestbenchTestCase
             ],
             [
                 'Accept' => 'application/json',
-                'Idempotency-Key' => Str::random(39)
+                'Idempotency-Key' => Str::random(39),
             ]
         );
 


### PR DESCRIPTION
Add idempotent middleware based on new submitted [ietf draft](https://datatracker.ietf.org/doc/html/draft-ietf-httpapi-idempotency-key-header-00) to prevent duplication.
based on ietf draft introduction:
Let's say a client of an HTTP API wants to create (or update) a resource using a "POST" method.  Since "POST" is NOT an idempotent method, calling it multiple times can result in duplication or wrong updates.  Consider a scenario where the client sent a "POST" request to the server, but it got a timeout.

### Responsibilities

**Client**
Clients of HTTP API requiring idempotency, SHOULD understand the idempotency related requirements as published by the server and use appropriate algorithm to generate idempotency keys.

For each request, client SHOULD
   *  Send a unique idempotency key in the HTTP "Idempotency-Key"
      request header field.

**Resource Server**
Resource server MUST publish idempotency related specification.  This specification MUST include expiration related policy if applicable. Server is responsible for managing the lifecycle of the idempotency key.

For each request, server SHOULD
   *  Identify idempotency key from the HTTP "Idempotency-Key" request
      header field.
   *  Generate idempotency fingerprint if required.
   *  Check for idempotency considering various scenarios.