### PR TITLE
[9.x] Manually populate POST request body with JSON data only when required

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -432,7 +432,9 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
 
         $newRequest->content = $request->content;
 
-        $newRequest->request = $newRequest->getInputSource();
+        if ($newRequest->isJson()) {
+            $newRequest->request = $newRequest->json();
+        }
 
         return $newRequest;
     }

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -993,7 +993,12 @@ class HttpRequestTest extends TestCase
         $request->fingerprint();
     }
 
-    public function testCreateFromBase()
+    /**
+     * Ensure JSON GET requests populate $request->request with the JSON content
+     *
+     * @link https://github.com/laravel/framework/pull/7052 Correctly fill the $request->request parameter bag on creation
+     */
+    public function testJsonRequestFillsRequestBodyParams()
     {
         $body = [
             'foo' => 'bar',
@@ -1009,6 +1014,24 @@ class HttpRequestTest extends TestCase
         $request = Request::createFromBase($base);
 
         $this->assertEquals($request->request->all(), $body);
+    }
+    
+    /** 
+     * Ensure non-JSON GET requests don't pollute $request->request with the GET parameters
+     *
+     * @link https://github.com/laravel/framework/pull/37921 Manually populate POST request body with JSON data only when required
+     */
+    public function testNonJsonRequestDoesntFillRequestBodyParams()
+    {
+        $params = ['foo' => 'bar'];
+        
+        $getRequest = Request::create('/', 'GET', $params, [], [], []);
+        $this->assertEquals($getRequest->request->all(), []);
+        $this->assertEquals($getRequest->query->all(), $params);
+        
+        $postRequest = Request::create('/', 'POST', $params, [], [], []);
+        $this->assertEquals($postRequest->request->all(), $params);
+        $this->assertEquals($postRequest->query->all(), []);
     }
 
     /**

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -1015,7 +1015,7 @@ class HttpRequestTest extends TestCase
 
         $this->assertEquals($request->request->all(), $body);
     }
-    
+
     /**
      * Ensure non-JSON GET requests don't pollute $request->request with the GET parameters.
      *

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -994,9 +994,9 @@ class HttpRequestTest extends TestCase
     }
 
     /**
-     * Ensure JSON GET requests populate $request->request with the JSON content
+     * Ensure JSON GET requests populate $request->request with the JSON content.
      *
-     * @link https://github.com/laravel/framework/pull/7052 Correctly fill the $request->request parameter bag on creation
+     * @link https://github.com/laravel/framework/pull/7052 Correctly fill the $request->request parameter bag on creation.
      */
     public function testJsonRequestFillsRequestBodyParams()
     {
@@ -1017,18 +1017,18 @@ class HttpRequestTest extends TestCase
     }
     
     /** 
-     * Ensure non-JSON GET requests don't pollute $request->request with the GET parameters
+     * Ensure non-JSON GET requests don't pollute $request->request with the GET parameters.
      *
-     * @link https://github.com/laravel/framework/pull/37921 Manually populate POST request body with JSON data only when required
+     * @link https://github.com/laravel/framework/pull/37921 Manually populate POST request body with JSON data only when required.
      */
     public function testNonJsonRequestDoesntFillRequestBodyParams()
     {
         $params = ['foo' => 'bar'];
-        
+
         $getRequest = Request::create('/', 'GET', $params, [], [], []);
         $this->assertEquals($getRequest->request->all(), []);
         $this->assertEquals($getRequest->query->all(), $params);
-        
+
         $postRequest = Request::create('/', 'POST', $params, [], [], []);
         $this->assertEquals($postRequest->request->all(), $params);
         $this->assertEquals($postRequest->query->all(), []);

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -1016,7 +1016,7 @@ class HttpRequestTest extends TestCase
         $this->assertEquals($request->request->all(), $body);
     }
     
-    /** 
+    /**
      * Ensure non-JSON GET requests don't pollute $request->request with the GET parameters.
      *
      * @link https://github.com/laravel/framework/pull/37921 Manually populate POST request body with JSON data only when required.


### PR DESCRIPTION
This fixes a 6 year old bug introduced in #7052 where GET requests would have GET data populated in the POST body property leading to issues around `Request::post()` and `$request->getParsedBody()` returning GET values when called on GET requests.

This is a resubmit of #17087 & #36708, and fixes #22805. Credit to @dan-har for the initial solution and @mixlion for updating it for >=6.x.

The original PR was meant to support POST requests where their `content-type` was set to `application/json` (instead of the typical `application/x-www-form-urlencoded`), but it introduced a subtle and dangerous bug because while `$request->getInputSource()` does return the JSON data for JSON requests, it also returns the GET data for GET requests. This commit solves the underlying issue without breaking compatibility with the original functionality.

This PR is submitted as a direct result from a security issue reported to me by users of @wintercms & @octobercms and was submitted after a discussion with @taylorotwell via email.

I request that this fix also be backported to 6.x @driesvints 