### PR TITLE
Add env_or_throw helper

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -133,6 +133,21 @@ if (! function_exists('env')) {
     }
 }
 
+if (! function_exists('env_or_throw')) {
+    /**
+     * Gets the value of an environment variable or throws if undefined.
+     *
+     * @param  string  $key
+     * @return mixed
+     */
+    function env_or_throw($key)
+    {
+        return Env::get($key, function () use ($key) {
+            throw new Exception("Missing require environment variable '{$key}'.");
+        });
+    }
+}
+
 if (! function_exists('filled')) {
     /**
      * Determine if a value is "filled".

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Support;
 
 use ArrayAccess;
+use Exception;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Env;
 use Illuminate\Support\Optional;
@@ -695,6 +696,14 @@ class SupportHelpersTest extends TestCase
 
         $_SERVER['foo'] = 'x"null"x'; // this should not be unquoted
         $this->assertSame('x"null"x', env('foo'));
+    }
+
+    public function testEnvOrThrow()
+    {
+        $_SERVER['foo'] = 'bar';
+        $this->assertSame('bar', env_or_throw('foo'));
+        $this->expectException(Exception::class);
+        env_or_throw('baz');
     }
 
     public function testGetFromSERVERFirst()


### PR DESCRIPTION
Adds a new helper method to get an environment variable or throw an exception if it is not defined.

* Supported by config:cache (exception is thrown at cache time if undefined, or caches value otherwise)
* No breaking changes

### Usecase
Often we add environment variables that are required for the application to run. As other developers pull in your code in can be easy to miss changes to the .env.example. This method provides a way to alert everyone that a required value is missing rather than harder-to-debug errors later on as the application runs.

### Notes
I had contemplated a name such as `env_required` but felt this name is more descriptive.
