### PR TITLE
[8.x] Adds closure based maintenance mode handling

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
+++ b/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
@@ -28,7 +28,7 @@ class PreventRequestsDuringMaintenance
     /**
      * Create a new middleware instance.
      *
-     * @param \Illuminate\Contracts\Foundation\Application $app
+     * @param  \Illuminate\Contracts\Foundation\Application  $app
      * @return void
      */
     public function __construct(Application $app)

--- a/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
+++ b/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
@@ -129,7 +129,7 @@ class PreventRequestsDuringMaintenance
     /**
      * Determine if there is a maintenance mode handler that returns true for the given request.
      *
-     * @param \Illuminate\Http\Request $request
+     * @param  \Illuminate\Http\Request  $request
      * @return bool
      */
     protected function hasTruthyHandler(Request $request)

--- a/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
+++ b/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
@@ -14,7 +14,7 @@ class PreventRequestsDuringMaintenance
     /**
      * The application implementation.
      *
-     * @var Application
+     * @var \Illuminate\Contracts\Foundation\Application
      */
     protected $app;
 
@@ -28,7 +28,7 @@ class PreventRequestsDuringMaintenance
     /**
      * Create a new middleware instance.
      *
-     * @param Application $app
+     * @param \Illuminate\Contracts\Foundation\Application $app
      * @return void
      */
     public function __construct(Application $app)
@@ -39,11 +39,11 @@ class PreventRequestsDuringMaintenance
     /**
      * Handle an incoming request.
      *
-     * @param  Request  $request
-     * @param Closure $next
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
      * @return mixed
      *
-     * @throws HttpException
+     * @throws \Symfony\Component\HttpKernel\Exception\HttpException
      */
     public function handle($request, Closure $next)
     {
@@ -92,7 +92,7 @@ class PreventRequestsDuringMaintenance
     /**
      * Determine if the incoming request has a maintenance mode bypass cookie.
      *
-     * @param  Request  $request
+     * @param  \Illuminate\Http\Request  $request
      * @param  array  $data
      * @return bool
      */
@@ -109,7 +109,7 @@ class PreventRequestsDuringMaintenance
     /**
      * Determine if the request has a URI that should be accessible in maintenance mode.
      *
-     * @param  Request  $request
+     * @param  \Illuminate\Http\Request  $request
      * @return bool
      */
     protected function inExceptArray($request)
@@ -130,7 +130,7 @@ class PreventRequestsDuringMaintenance
     /**
      * Determine if there is a maintenance mode handler that returns true for the given request.
      *
-     * @param Request $request
+     * @param \Illuminate\Http\Request $request
      * @return bool
      */
     protected function hasTruthyHandler(Request $request)
@@ -147,7 +147,7 @@ class PreventRequestsDuringMaintenance
      * Redirect the user back to the root of the application with a maintenance mode bypass cookie.
      *
      * @param  string  $secret
-     * @return RedirectResponse
+     * @return \Illuminate\Http\RedirectResponse
      */
     protected function bypassResponse(string $secret)
     {

--- a/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
+++ b/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
@@ -5,7 +5,6 @@ namespace Illuminate\Foundation\Http\Middleware;
 use Closure;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Foundation\Http\MaintenanceModeBypassCookie;
-use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 

--- a/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
+++ b/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
@@ -135,8 +135,10 @@ class PreventRequestsDuringMaintenance
      */
     protected function hasTruthyHandler(Request $request)
     {
-        return !empty(array_filter(array_map(
-            function($callback) use ($request) { return $callback->__invoke($request); },
+        return ! empty(array_filter(array_map(
+            function ($callback) use ($request) {
+                return $callback->__invoke($request);
+            },
             $this->app['router']->getMaintenanceModeHandlers()
         )));
     }

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -115,6 +115,13 @@ class Router implements BindingRegistrar, RegistrarContract
     protected $groupStack = [];
 
     /**
+     * Callables used to determine whether or not a request should bypass maintenance mode.
+     *
+     * @var array<callable>
+     */
+    protected $maintenanceModeHandlers = [];
+
+    /**
      * All of the verbs supported by the router.
      *
      * @var string[]
@@ -1270,6 +1277,27 @@ class Router implements BindingRegistrar, RegistrarContract
             ->setContainer($this->container);
 
         $this->container->instance('routes', $this->routes);
+    }
+
+    /**
+     * Add a maintenance mode handler to the stack.
+     *
+     * @param callable $callback
+     * @return void
+     */
+    public function addMaintenanceModeHandler(callable $callback)
+    {
+        $this->maintenanceModeHandlers[] = $callback;
+    }
+
+    /**
+     * Returns any registered maintenance mode handlers.
+     *
+     * @return array<callable>
+     */
+    public function getMaintenanceModeHandlers()
+    {
+        return $this->maintenanceModeHandlers;
     }
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1282,7 +1282,7 @@ class Router implements BindingRegistrar, RegistrarContract
     /**
      * Add a maintenance mode handler to the stack.
      *
-     * @param callable $callback
+     * @param  callable  $callback
      * @return void
      */
     public function addMaintenanceModeHandler(callable $callback)

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -117,7 +117,7 @@ class Router implements BindingRegistrar, RegistrarContract
     /**
      * Callables used to determine whether or not a request should bypass maintenance mode.
      *
-     * @var array<callable>
+     * @var array
      */
     protected $maintenanceModeHandlers = [];
 
@@ -1293,7 +1293,7 @@ class Router implements BindingRegistrar, RegistrarContract
     /**
      * Returns any registered maintenance mode handlers.
      *
-     * @return array<callable>
+     * @return array
      */
     public function getMaintenanceModeHandlers()
     {

--- a/tests/Integration/Foundation/MaintenanceModeTest.php
+++ b/tests/Integration/Foundation/MaintenanceModeTest.php
@@ -150,7 +150,7 @@ class MaintenanceModeTest extends TestCase
 
     public function testCanAddClosureBasedExceptRoutes()
     {
-        $this->app['router']->addMaintenanceModeHandler(function(Request $request) {
+        $this->app['router']->addMaintenanceModeHandler(function (Request $request) {
             return $request->path() == 'foo';
         });
 
@@ -176,11 +176,11 @@ class MaintenanceModeTest extends TestCase
 
     public function testMultipleMaintenanceHandlersCanBeDefined()
     {
-        $this->app['router']->addMaintenanceModeHandler(function(Request $request) {
+        $this->app['router']->addMaintenanceModeHandler(function (Request $request) {
             return false;
         });
 
-        $this->app['router']->addMaintenanceModeHandler(function(Request $request) {
+        $this->app['router']->addMaintenanceModeHandler(function (Request $request) {
             return true;
         });
 
@@ -196,6 +196,4 @@ class MaintenanceModeTest extends TestCase
         $response = $this->get('/foo');
         $response->assertStatus(200);
     }
-
-
 }

--- a/tests/Integration/Foundation/MaintenanceModeTest.php
+++ b/tests/Integration/Foundation/MaintenanceModeTest.php
@@ -174,5 +174,28 @@ class MaintenanceModeTest extends TestCase
         $otherResponse->assertStatus(503);
     }
 
+    public function testMultipleMaintenanceHandlersCanBeDefined()
+    {
+        $this->app['router']->addMaintenanceModeHandler(function(Request $request) {
+            return false;
+        });
+
+        $this->app['router']->addMaintenanceModeHandler(function(Request $request) {
+            return true;
+        });
+
+        file_put_contents(storage_path('framework/down'), json_encode([
+            'retry' => 60,
+            'refresh' => 60,
+        ]));
+
+        Route::get('/foo', function () {
+            return 'Hello world';
+        })->middleware(PreventRequestsDuringMaintenance::class);
+
+        $response = $this->get('/foo');
+        $response->assertStatus(200);
+    }
+
 
 }


### PR DESCRIPTION
Hi guys!

A number of times now, I've been writing packages and wanted to allow certain routes through maintenance mode without the user having to add to the `$except` array in the middleware.

For example, imagine we have a simple callback URL from an OAuth API that lives outside of the session. Because it lives outside of the session, the user's maintenance cookie won't be applied. However, its annoying to have to make the user go edit that file as part of the installation step.

## Usage

To add a new handler to the stack, you can call the `addMaintenanceModeHandler` method on the `Router` singleton:

```php
$this->app['router']->addMaintenanceModeHandler(function(Request $request) {
    return $request->path() == '/auth/service/callback'; // This is now allowed to run in maintenance mode
});
```

If a truth-y value is returned, the request will be allowed through maintenance mode. If a false-y value is returned, the handler will defer to the next available handler in the array, or fail the request.

Thanks for all the hard work. Hope you're all having a great start to the week 👌

Kind Regards,
Luke