### PR TITLE
[8.x] Add InteractsWithGate trait to help developers test authorization policies

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithGate.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithGate.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Illuminate\Foundation\Testing\Concerns;
+
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Foundation\Testing\ExpectedPermission;
+use Illuminate\Support\Facades\Gate;
+
+trait InteractsWithGate
+{
+    /**
+     * Indicates if the hooks have been registered.
+     *
+     * @var bool
+     */
+    private $hasRegisteredGateHooks = false;
+
+    /**
+     * Collection of expected permissions.
+     *
+     * @var \Illuminate\Support\Collection
+     */
+    private $expectedPermissions;
+
+    /**
+     * Set the expectation for the given ability and allows access.
+     *
+     * @param  string  $ability
+     * @param  mixed  ...$arguments
+     * @return \Illuminate\Foundation\Testing\ExpectedPermission
+     */
+    public function shouldAllow($ability, ...$arguments)
+    {
+        return $this->setExpectedPermission(true, auth()->user(), $ability, $arguments);
+    }
+
+    /**
+     * Set the expectation for the given ability and denies access.
+     *
+     * @param  string  $ability
+     * @param  mixed  ...$arguments
+     * @return \Illuminate\Foundation\Testing\ExpectedPermission
+     */
+    public function shouldDeny($ability, ...$arguments)
+    {
+        return $this->setExpectedPermission(false, auth()->user(), $ability, $arguments);
+    }
+
+    /**
+     * Add an expected permission to the list of expected permissions.
+     *
+     * @param  bool  $result
+     * @param  Authenticatable  $user
+     * @param  string  $ability
+     * @param  array  $arguments
+     * @return \Illuminate\Foundation\Testing\ExpectedPermission
+     */
+    private function setExpectedPermission($result, $user, $ability, array $arguments)
+    {
+        $this->registerGateHooks();
+
+        return tap(new ExpectedPermission($result, $user, $ability, $arguments), function ($permission) {
+            $this->expectedPermissions->prepend($permission);
+        });
+    }
+
+    /**
+     * Register the gate hooks and expectations. Also initializes the expected permissions collection.
+     *
+     * @return void
+     */
+    private function registerGateHooks()
+    {
+        if ($this->hasRegisteredGateHooks) {
+            return;
+        }
+
+        $this->expectedPermissions = collect();
+
+        Gate::before(function ($user = null, $ability, $arguments) {
+            if ($permission = $this->expectedPermission($user, $ability, $arguments)) {
+                return $permission->expectedResult();
+            }
+
+            return null;
+        });
+
+        $this->beforeApplicationDestroyed(function () {
+            $unmatched = $this->expectedPermissions->reject(function ($permision) {
+                return $permision->wasMatched();
+            })->map(function ($permission) {
+                return $permission->ability();
+            });
+
+            if ($unmatched->isNotEmpty()) {
+                $this->fail(sprintf('The expected ability or policiy checks were not called: %s', $unmatched->join(', ')));
+            }
+        });
+
+        $this->hasRegisteredGateHooks = true;
+    }
+
+    /**
+     * Gets the expected permission from the list of expected permissions.
+     *
+     * @param  Authenticatable  $user
+     * @param  string  $ability
+     * @param  array  $arguments
+     * @return \Illuminate\Foundation\Testing\ExpectedPermission|null
+     */
+    private function expectedPermission($user, $ability, $arguments)
+    {
+        return $this->expectedPermissions->first(function (ExpectedPermission $permission) use ($user, $ability, $arguments) {
+            return $permission->matches($user, $ability, $arguments);
+        });
+    }
+}

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithGate.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithGate.php
@@ -29,7 +29,7 @@ trait InteractsWithGate
      * @param  mixed  ...$arguments
      * @return \Illuminate\Foundation\Testing\ExpectedPermission
      */
-    public function shouldAllow($ability, ...$arguments)
+    protected function shouldAllow($ability, ...$arguments)
     {
         return $this->setExpectedPermission(true, auth()->user(), $ability, $arguments);
     }
@@ -41,7 +41,7 @@ trait InteractsWithGate
      * @param  mixed  ...$arguments
      * @return \Illuminate\Foundation\Testing\ExpectedPermission
      */
-    public function shouldDeny($ability, ...$arguments)
+    protected function shouldDeny($ability, ...$arguments)
     {
         return $this->setExpectedPermission(false, auth()->user(), $ability, $arguments);
     }

--- a/src/Illuminate/Foundation/Testing/ExpectedPermission.php
+++ b/src/Illuminate/Foundation/Testing/ExpectedPermission.php
@@ -1,0 +1,222 @@
+<?php
+
+namespace Illuminate\Foundation\Testing;
+
+use Illuminate\Auth\Access\Response;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Database\Eloquent\Model;
+
+class ExpectedPermission
+{
+    /**
+     * @var bool
+     */
+    protected $result;
+
+    /**
+     * The user associated to the expected permission.
+     *
+     * @var \Illuminate\Contracts\Auth\Authenticatable
+     */
+    protected $user;
+
+    /**
+     * Specifies if the permission should be expected for a guest user.
+     *
+     * @var bool
+     */
+    protected $guest = false;
+
+    /**
+     * The ability associated to the expected permission.
+     *
+     * @var string
+     */
+    protected $ability;
+
+    /**
+     * The arguments associated to the expected permission.
+     *
+     * @var \Illuminate\Support\Collection
+     */
+    protected $arguments;
+
+    /**
+     * The response message that will be returned as part of a Gate inspection response.
+     *
+     * @var string|null
+     */
+    protected $message = null;
+
+    /**
+     * The response code that will be returned as part of a Gate inspection response.
+     *
+     * @var string|null
+     */
+    protected $code = null;
+
+    /**
+     * The times the expected permission has been matched.
+     *
+     * @var int
+     */
+    protected $matches = 0;
+
+    /**
+     * ExpectedPermission constructor.
+     *
+     * @param  bool  $result
+     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
+     * @param  string  $ability
+     * @param  array  $arguments
+     * @return void
+     */
+    public function __construct($result, $user, $ability, $arguments)
+    {
+        $this->result = $result;
+        $this->user = $user;
+        $this->ability = $ability;
+        $this->arguments = collect($arguments);
+    }
+
+    /**
+     * Set the expectation for a specific user.
+     *
+     * @param  Authenticatable  $user
+     * @return static
+     */
+    public function forUser(Authenticatable $user)
+    {
+        $this->user = $user;
+
+        return $this;
+    }
+
+    /**
+     * Set the expectation for a guest user.
+     *
+     * @return static
+     */
+    public function forGuest()
+    {
+        $this->guest = true;
+
+        return $this;
+    }
+
+    /**
+     * Add a message for the allowed or denied response.
+     *
+     * @param  string  $message
+     * @param  string|null  $code
+     * @return static
+     */
+    public function withMessage(string $message, string $code = null)
+    {
+        $this->message = $message;
+        $this->code = $code;
+
+        return $this;
+    }
+
+    /**
+     * Checks if the permission matches the expected user, ability and arguments.
+     *
+     * @param  \Illuminate\Contracts\Auth\Authenticatable $expectedUser
+     * @param  string  $expectedAbility
+     * @param  array  $expectedArguments
+     * @return bool
+     */
+    public function matches($expectedUser, $expectedAbility, $expectedArguments)
+    {
+        $matched = $this->ability === $expectedAbility
+            && $this->matchesUser($expectedUser)
+            && $this->matchesAllArguments($expectedArguments);
+
+        if ($matched) {
+            $this->matches += 1;
+        }
+
+        return $matched;
+    }
+
+    /**
+     * Checks if the given user matches the expectation of this permission.
+     *
+     * @param  \Illuminate\Contracts\Auth\Authenticatable|null  $expectedUser
+     * @return bool
+     */
+    protected function matchesUser($expectedUser)
+    {
+        if ($expectedUser === null) {
+            return $this->guest;
+        }
+
+        return $this->matchesArgument($this->user, $expectedUser);
+    }
+
+    /**
+     * Checks if the permission arguments match the expected arguments.
+     *
+     * @param  array  $expectedArguments
+     * @return bool
+     */
+    protected function matchesAllArguments(array $expectedArguments)
+    {
+        return $this->arguments->zip($expectedArguments)->every(function ($actualAndExpected) {
+            [$actual, $expected] = $actualAndExpected;
+
+            return $this->matchesArgument($actual, $expected);
+        });
+    }
+
+    /**
+     * Check if 2 arguments match. This will use the 'is' helper if both arguments are Eloquent models.
+     *
+     * @param  mixed  $actual
+     * @param  mixed  $expected
+     * @return bool
+     */
+    protected function matchesArgument($actual, $expected)
+    {
+        if ($actual instanceof Model && $expected instanceof Model) {
+            return $expected->is($actual);
+        }
+
+        return $actual === $expected;
+    }
+
+    /**
+     * Returns the ability string.
+     *
+     * @return string
+     */
+    public function ability()
+    {
+        return $this->ability;
+    }
+
+    /**
+     * Returns the expected result.
+     *
+     * @return bool|\Illuminate\Auth\Access\Response
+     */
+    public function expectedResult()
+    {
+        if ($this->message != null || $this->code != null) {
+            return new Response($this->result, $this->message, $this->code);
+        }
+
+        return $this->result;
+    }
+
+    /**
+     * Returns true if the permission was matched one or more times, false otherwise.
+     *
+     * @return bool
+     */
+    public function wasMatched()
+    {
+        return $this->matches > 0;
+    }
+}

--- a/tests/Foundation/Testing/Concerns/InteractsWithGateTest.php
+++ b/tests/Foundation/Testing/Concerns/InteractsWithGateTest.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Testing\Concerns;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Auth\User;
+use Illuminate\Foundation\Testing\Concerns\InteractsWithAuthentication;
+use Illuminate\Foundation\Testing\Concerns\InteractsWithGate;
+use Illuminate\Support\Facades\Gate;
+use Orchestra\Testbench\TestCase;
+
+class InteractsWithGateTest extends TestCase
+{
+    use InteractsWithGate, InteractsWithAuthentication;
+
+    protected static $expectedFailMessage = null;
+
+    /** @test */
+    public function should_allow_access_to_an_ability()
+    {
+        $this->actingAs(new TestUser);
+
+        $this->assertFalse(Gate::allows('can-do-something'));
+
+        $this->shouldAllow('can-do-something');
+
+        $this->assertTrue(Gate::allows('can-do-something'));
+    }
+
+    /** @test */
+    public function should_deny_access_to_an_ability()
+    {
+        $this->actingAs(new TestUser);
+
+        $this->shouldAllow('can-do-something');
+
+        $this->assertTrue(Gate::allows('can-do-something'));
+
+        $this->shouldDeny('can-do-something');
+
+        $this->assertFalse(Gate::allows('can-do-something'));
+    }
+
+    /** @test */
+    public function should_allow_access_to_an_ability_for_a_specific_user()
+    {
+        $this->assertFalse(Gate::forUser(new TestUser)->allows('can-do-something'));
+
+        $this->shouldAllow('can-do-something')->forUser(new TestUser);
+
+        $this->assertTrue(Gate::forUser(new TestUser)->allows('can-do-something'));
+    }
+
+    /** @test */
+    public function should_deny_access_to_an_ability_for_a_specific_user()
+    {
+        $this->shouldAllow('can-do-something')->forUser(new TestUser);
+
+        $this->assertTrue(Gate::forUser(new TestUser)->allows('can-do-something'));
+
+        $this->shouldDeny('can-do-something')->forUser(new TestUser);
+
+        $this->assertFalse(Gate::forUser(new TestUser)->allows('can-do-something'));
+    }
+
+    /** @test */
+    public function should_allow_access_to_an_ability_for_a_guest_user()
+    {
+        $this->assertFalse(Gate::allows('can-do-something'));
+
+        $permission = $this->shouldAllow('can-do-something');
+
+        $this->assertFalse(Gate::allows('can-do-something'));
+
+        $permission->forGuest();
+
+        $this->assertTrue(Gate::allows('can-do-something'));
+    }
+
+    /** @test */
+    public function should_deny_access_to_an_ability_for_a_guest_user()
+    {
+        $this->shouldAllow('can-do-something')->forGuest();
+
+        $this->assertTrue(Gate::allows('can-do-something'));
+
+        $this->shouldDeny('can-do-something')->forGuest();
+
+        $this->assertFalse(Gate::allows('can-do-something'));
+    }
+
+    /** @test */
+    public function should_allow_access_to_a_policy()
+    {
+        $this->actingAs(new TestUser);
+
+        $this->assertFalse(Gate::allows('update', new TestModel(['id' => 5])));
+
+        $this->shouldAllow('update', new TestModel(['id' => 5]));
+
+        $this->assertTrue(Gate::allows('update', new TestModel(['id' => 5])));
+    }
+
+    /** @test */
+    public function should_deny_access_to_a_policy()
+    {
+        $this->actingAs(new TestUser);
+
+        $this->assertFalse(Gate::allows('update', new TestModel(['id' => 3])));
+
+        $this->shouldAllow('update', new TestModel(['id' => 3]));
+
+        $this->assertTrue(Gate::allows('update', new TestModel(['id' => 3])));
+    }
+
+    /** @test */
+    public function should_allow_access_to_a_policy_for_a_specific_user()
+    {
+        $this->assertFalse(Gate::forUser(new TestUser)->allows('delete', new TestModel(['id' => 7])));
+
+        $this->shouldAllow('delete', new TestModel(['id' => 7]))->forUser(new TestUser);
+
+        $this->assertTrue(Gate::forUser(new TestUser)->allows('delete', new TestModel(['id' => 7])));
+    }
+
+    /** @test */
+    public function should_deny_access_to_a_policy_for_a_specific_user()
+    {
+        $this->shouldAllow('delete', new TestModel(['id' => 7]))->forUser(new TestUser);
+
+        $this->assertTrue(Gate::forUser(new TestUser)->allows('delete', new TestModel(['id' => 7])));
+
+        $this->shouldDeny('delete', new TestModel(['id' => 7]))->forUser(new TestUser);
+
+        $this->assertFalse(Gate::forUser(new TestUser)->allows('delete', new TestModel(['id' => 7])));
+    }
+
+    /** @test */
+    public function expects_test_to_fail_if_the_permission_expectation_was_not_used()
+    {
+        static::$expectedFailMessage = 'The expected ability or policiy checks were not called: can-do-something';
+
+        $this->shouldAllow('can-do-something')->forUser(new TestUser);
+    }
+
+    /** @test */
+    public function can_set_a_message_when_denying_access_to_the_current_user()
+    {
+        $this->actingAs(new TestUser);
+
+        $this->shouldDeny('can-do-something')->withMessage('[Reason why you cannot do something]', '[Code:123]');
+
+        $response = Gate::inspect('can-do-something');
+
+        $this->assertSame('[Reason why you cannot do something]', $response->message());
+        $this->assertSame('[Code:123]', $response->code());
+    }
+
+    public static function fail(string $message = ''): void
+    {
+        if (static::$expectedFailMessage === $message) {
+            static::$expectedFailMessage = null;
+
+            return;
+        }
+
+        parent::fail($message);
+    }
+}
+
+class TestUser extends User
+{
+}
+
+class TestModel extends Model
+{
+    protected $guarded = [];
+}


### PR DESCRIPTION
This PR adds a trait developers can include to simplify the process of testing code that depend on authorization logic (Gate, abilities and policies).

Before:

```
Gate::shouldReceive('allows')->once()->with('ability', Mockery::on(function($actualModel) use ($expectedModel) {
    $this->assertTrue($expectedModel->is($actualModel));

    return true;
}))->andReturn(true);
```

Now:

```
use InteractsWithGate;
// ...

$this->shouldAllow('ability', $model);
```

- This trait is smart enough to know the models should be matched through the `is` helper and not with `==`.
- Test will fail if the permission was never used. To let developers know they forgot to check the ability in their codebase.
- Support passing message and code `$this->shouldDeny('ability')->withMessage('message', 'code')`
