### PR TITLE
[8.x] Add mergeIfExists in Request

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -315,6 +315,25 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     }
 
     /**
+     * Merge new input into the current request's input array if the key already exists.
+     *
+     * @param  array  $input
+     * @return $this
+     */
+    public function mergeIfExists(array $input)
+    {
+        foreach ($input as $key => $value) {
+            if ($this->has($key)) {
+                $this->merge([
+                    $key => $value,
+                ]);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
      * Replace the input for the current request.
      *
      * @param  array  $input


### PR DESCRIPTION
This PR aims to provide a way to merge input if only the request fields are existing on the request. This prevents unwanted behavior of merging fields if the field does not actually exist on the request. 

Consider this example I encountered in my project. I want to format my birthdate on sql standard format with my local helper `sql_date()` and the code looks like this.

```
$request->merge([
  // if birthdate does not exist, it still merges the birthdate with null value
  'birthdate' => $request->birthdate ? sql_date($request->birthdate) : null, 
]);

$user = User::find($id);
$user->fill($request->all()); // this overwrite the birthdate with null which is unintended behavior
$user->save();
```

```
$request->mergeIfExists([
  // if birthdate does not exist, the birthdate field does not get merged
  'birthdate' => $request->birthdate ? sql_date($request->birthdate) : null, 
]);

$user = User::find($id);
$user->fill($request->all()); // birthdate is not overwritten
$user->save();
```

This can be done using macros but I think it will be beneficial to others so I tried a PR for this.