### PR TITLE
[8.x] Added ability to cancel notifications immediately prior to sending

### DIFF
--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -162,7 +162,6 @@ class NotificationSender
      */
     protected function shouldSendNotification($notifiable, $notification, $channel)
     {
-
         if (method_exists($notification, 'shouldBeSent') && ($notification->shouldBeSent($notifiable, $channel) !== true)) {
             return false;
         }

--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -162,6 +162,11 @@ class NotificationSender
      */
     protected function shouldSendNotification($notifiable, $notification, $channel)
     {
+
+        if (method_exists($notification, 'shouldBeSent') && ($notification->shouldBeSent($notifiable, $channel) !== true)) {
+            return false;
+        }
+
         return $this->events->until(
             new NotificationSending($notifiable, $notification, $channel)
         ) !== false;

--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -162,7 +162,8 @@ class NotificationSender
      */
     protected function shouldSendNotification($notifiable, $notification, $channel)
     {
-        if (method_exists($notification, 'shouldBeSent') && ($notification->shouldBeSent($notifiable, $channel) !== true)) {
+        if (method_exists($notification, 'shouldSend') &&
+            $notification->shouldSend($notifiable, $channel) === false) {
             return false;
         }
 

--- a/tests/Notifications/NotificationChannelManagerTest.php
+++ b/tests/Notifications/NotificationChannelManagerTest.php
@@ -146,7 +146,7 @@ class NotificationChannelManagerTestCancelledNotification extends Notification
         return $this->line('test')->action('Text', 'url');
     }
 
-    public function shouldBeSent($notifiable, $channel)
+    public function shouldSend($notifiable, $channel)
     {
         return false;
     }
@@ -164,7 +164,7 @@ class NotificationChannelManagerTestNotCancelledNotification extends Notificatio
         return $this->line('test')->action('Text', 'url');
     }
 
-    public function shouldBeSent($notifiable, $channel)
+    public function shouldSend($notifiable, $channel)
     {
         return true;
     }

--- a/tests/Notifications/NotificationChannelManagerTest.php
+++ b/tests/Notifications/NotificationChannelManagerTest.php
@@ -58,6 +58,37 @@ class NotificationChannelManagerTest extends TestCase
         $manager->send([new NotificationChannelManagerTestNotifiable], new NotificationChannelManagerTestNotificationWithTwoChannels);
     }
 
+    public function testNotificationNotSentWhenCancelled()
+    {
+        $container = new Container;
+        $container->instance('config', ['app.name' => 'Name', 'app.logo' => 'Logo']);
+        $container->instance(Bus::class, $bus = m::mock());
+        $container->instance(Dispatcher::class, $events = m::mock());
+        Container::setInstance($container);
+        $manager = m::mock(ChannelManager::class.'[driver]', [$container]);
+        $events->shouldReceive('until')->with(m::type(NotificationSending::class))->andReturn(true);
+        $manager->shouldNotReceive('driver');
+        $events->shouldNotReceive('dispatch');
+
+        $manager->send([new NotificationChannelManagerTestNotifiable], new NotificationChannelManagerTestCancelledNotification);
+    }
+
+    public function testNotificationSentWhenNotCancelled()
+    {
+        $container = new Container;
+        $container->instance('config', ['app.name' => 'Name', 'app.logo' => 'Logo']);
+        $container->instance(Bus::class, $bus = m::mock());
+        $container->instance(Dispatcher::class, $events = m::mock());
+        Container::setInstance($container);
+        $manager = m::mock(ChannelManager::class.'[driver]', [$container]);
+        $events->shouldReceive('until')->with(m::type(NotificationSending::class))->andReturn(true);
+        $manager->shouldReceive('driver')->once()->andReturn($driver = m::mock());
+        $driver->shouldReceive('send')->once();
+        $events->shouldReceive('dispatch')->once()->with(m::type(NotificationSent::class));
+
+        $manager->send([new NotificationChannelManagerTestNotifiable], new NotificationChannelManagerTestNotCancelledNotification);
+    }
+
     public function testNotificationCanBeQueued()
     {
         $container = new Container;
@@ -100,6 +131,42 @@ class NotificationChannelManagerTestNotificationWithTwoChannels extends Notifica
     public function message()
     {
         return $this->line('test')->action('Text', 'url');
+    }
+}
+
+class NotificationChannelManagerTestCancelledNotification extends Notification
+{
+    public function via()
+    {
+        return ['test'];
+    }
+
+    public function message()
+    {
+        return $this->line('test')->action('Text', 'url');
+    }
+
+    public function shouldBeSent($notifiable, $channel)
+    {
+        return false;
+    }
+}
+
+class NotificationChannelManagerTestNotCancelledNotification extends Notification
+{
+    public function via()
+    {
+        return ['test'];
+    }
+
+    public function message()
+    {
+        return $this->line('test')->action('Text', 'url');
+    }
+
+    public function shouldBeSent($notifiable, $channel)
+    {
+        return true;
     }
 }
 


### PR DESCRIPTION
This PR makes it easier to cancel notifications immediately prior to sending, without having to register custom event listeners or create job classes.

**Use case**

Queued or delayed notifications make it possible that data changes between the notification being queued and its job being processed. Sometimes the up-to-date data is no longer compatible with the kind of notification being sent, for example a "DispatchConfirmation" email on an order that has since been cancelled.

Currently the primary way to prevent notifications being dispatched with stale information is to register a custom event listener, listen for the `NotificationSending` event, and attempt to call user-defined methods on the notification class in order to determine if the notification should be sent or not. Alternatively, a Job can be queued which synchronously dispatches a notification after the current state is checked.

This PR just simplifies this process by checking for the existance of a `shouldBeSent()` method on the notification and cancelling sending if the method returns anything but `true`.

**Non-breaking changes**

The `NotificationSending` event is still dispatched, so applications using the technique described above will not be affected.