### PR TITLE
[8.x] Fix duplicated columns on select

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -403,6 +403,8 @@ class Builder
             }
         }
 
+        $this->columns = array_unique($this->columns);
+
         return $this;
     }
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -104,7 +104,7 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testAddingSelects()
     {
         $builder = $this->getBuilder();
-        $builder->select('foo')->addSelect('bar')->addSelect(['baz', 'boom'])->from('users');
+        $builder->select('foo')->addSelect('bar')->addSelect(['baz', 'boom'])->addSelect('foo')->from('users');
         $this->assertSame('select "foo", "bar", "baz", "boom" from "users"', $builder->toSql());
     }
 


### PR DESCRIPTION
## Description

Using `$query->addSelect('something')` multiple times introduces duplicated columns, causing `SQLSTATE[42S21]: Column already exists: 1060 Duplicate column name 'something'`.

## Steps to reproduce 

Execute the following query:

```php
// accounts() is a many-to-many relation, with an intermediate Eloquent Model
App\User::find(1)->accounts()->groupBy('accounts.id')->select('accounts.*')->paginate();
```

The resulting problematic SQL query will be:

```mysql
select count(*) as aggregate
from (select `accounts`.*,
             `accounts`.*,
             `membership`.`user_id`    as `pivot_user_id`,
             `membership`.`account_id` as `pivot_account_id`,
             `membership`.`id`         as `pivot_id`,
             `membership`.`created_at` as `pivot_created_at`,
             `membership`.`updated_at` as `pivot_updated_at`
      from `accounts`
               inner join `membership` on `accounts`.`id` = `membership`.`account_id`
      where `membership`.`user_id` = 1
      group by `accounts`.`id`) as `aggregate_table`
```

The second `accounts`.* is introduced by `paginate()` here:

https://github.com/laravel/framework/blob/361813c431adf7d0beb01c078197878fba1211b7/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php#L434-L447

Related to #34096 #34097