### PR TITLE
Support step argument for Collection::range method

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -37,11 +37,12 @@ class Collection implements ArrayAccess, Enumerable
      *
      * @param  int  $from
      * @param  int  $to
+     * @param  int  $step
      * @return static
      */
-    public static function range($from, $to)
+    public static function range($from, $to, $step = 1)
     {
-        return new static(range($from, $to));
+        return new static(range($from, $to, $step));
     }
 
     /**

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -32,9 +32,10 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      *
      * @param  int  $from
      * @param  int  $to
+     * @param  int  $step
      * @return static
      */
-    public static function range($from, $to);
+    public static function range($from, $to, $step = 1);
 
     /**
      * Wrap the given value in a collection if applicable.

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -43,17 +43,18 @@ class LazyCollection implements Enumerable
      *
      * @param  int  $from
      * @param  int  $to
+     * @param  int  $step
      * @return static
      */
-    public static function range($from, $to)
+    public static function range($from, $to, $step = 1)
     {
-        return new static(function () use ($from, $to) {
+        return new static(function () use ($from, $to, $step) {
             if ($from <= $to) {
-                for (; $from <= $to; $from++) {
+                for (; $from <= $to; $from += $step) {
                     yield $from;
                 }
             } else {
-                for (; $from >= $to; $from--) {
+                for (; $from >= $to; $from -= $step) {
                     yield $from;
                 }
             }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2388,6 +2388,7 @@ class SupportCollectionTest extends TestCase
     }
 
     /**
+     * @group range
      * @dataProvider collectionClassProvider
      */
     public function testRangeMethod($collection)
@@ -2420,6 +2421,21 @@ class SupportCollectionTest extends TestCase
         $this->assertSame(
             [-2, -3, -4],
             $collection::range(-2, -4)->all()
+        );
+
+        $this->assertSame(
+            [0, 2, 4, 6, 8, 10],
+            $collection::range(0, 10, 2)->all()
+        );
+
+        $this->assertSame(
+            [-5, -3, -1, 1, 3, 5],
+            $collection::range(-5, 5, 2)->all()
+        );
+
+        $this->assertSame(
+            [0, 5],
+            $collection::range(0, 5, 5)->all()
         );
     }
 


### PR DESCRIPTION
The `Collection::range()` method uses the default PHP `range()` method, but with no way of adding the step amount. This PR exposes that argument, with the same default as before.