### PR TITLE
[8.x] Trim Japan space full width character "　"

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
+++ b/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
@@ -53,7 +53,7 @@ class TrimStrings extends TransformsRequest
             return $value;
         }
 
-        return is_string($value) ? trim($value) : $value;
+        return is_string($value) ? trim($value, " \t\n\r\0\x0B　") : $value;
     }
 
     /**

--- a/tests/Foundation/Http/Middleware/TrimStringsTest.php
+++ b/tests/Foundation/Http/Middleware/TrimStringsTest.php
@@ -17,6 +17,7 @@ class TrimStringsTest extends TestCase
             'xyz' => '  456  ',
             'foo' => '  789  ',
             'bar' => '  010  ',
+            'fizz' => ' 　 socola 　 ',
         ]);
         $symfonyRequest->server->set('REQUEST_METHOD', 'GET');
         $request = Request::createFromBase($symfonyRequest);
@@ -26,6 +27,7 @@ class TrimStringsTest extends TestCase
             $this->assertSame('456', $request->get('xyz'));
             $this->assertSame('  789  ', $request->get('foo'));
             $this->assertSame('  010  ', $request->get('bar'));
+            $this->assertSame('socola', $request->get('fizz'));
         });
     }
 }


### PR DESCRIPTION
I use Japan language. It has space full with "　".
when I type into input with only space full with "　"  and submit, middleware TrimStrings cant trim It and required validate rule will not work correct.

I had modify middleware TrimStrings and create test case for It. Please help to verify It.

![image](https://user-images.githubusercontent.com/18243451/124760705-34747f00-df5b-11eb-93de-33c3f9dab1c6.png)


![image](https://user-images.githubusercontent.com/18243451/124760652-27f02680-df5b-11eb-9bae-748d6944ae9b.png)

@taylorotwell 

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
