### PR TITLE
[8.x] Add Validator::excludeArrays() to exclude array keys that aren't included in the validation rules

### DIFF
--- a/src/Illuminate/Validation/Factory.php
+++ b/src/Illuminate/Validation/Factory.php
@@ -67,18 +67,18 @@ class Factory implements FactoryContract
     protected $fallbackMessages = [];
 
     /**
+     * Indicates that unvalidated array keys should be excluded, even if the parent array was validated.
+     *
+     * @var bool
+     */
+    protected $excludeUnvalidatedArrayKeys;
+
+    /**
      * The Validator resolver instance.
      *
      * @var \Closure
      */
     protected $resolver;
-
-    /**
-     * Indicates that array values should be excluded.
-     *
-     * @var bool
-     */
-    protected $excludeArrays;
 
     /**
      * Create a new Validator factory instance.
@@ -122,7 +122,7 @@ class Factory implements FactoryContract
             $validator->setContainer($this->container);
         }
 
-        $validator->excludeArrays = $this->excludeArrays;
+        $validator->excludeUnvalidatedArrayKeys = $this->excludeUnvalidatedArrayKeys;
 
         $this->addExtensions($validator);
 
@@ -249,6 +249,16 @@ class Factory implements FactoryContract
     }
 
     /**
+     * Indicate that unvalidated array keys should be excluded, even if the parent array was validated.
+     *
+     * @return void
+     */
+    public function excludeUnvalidatedArrayKeys()
+    {
+        $this->excludeUnvalidatedArrayKeys = true;
+    }
+
+    /**
      * Set the Validator instance resolver.
      *
      * @param  \Closure  $resolver
@@ -257,16 +267,6 @@ class Factory implements FactoryContract
     public function resolver(Closure $resolver)
     {
         $this->resolver = $resolver;
-    }
-
-    /**
-     * Indicates that array values should be excluded.
-     *
-     * @return void
-     */
-    public function excludeArrays()
-    {
-        $this->excludeArrays = true;
     }
 
     /**

--- a/src/Illuminate/Validation/Factory.php
+++ b/src/Illuminate/Validation/Factory.php
@@ -74,6 +74,13 @@ class Factory implements FactoryContract
     protected $resolver;
 
     /**
+     * Indicates that array values should be excluded.
+     *
+     * @var bool
+     */
+    protected $excludeArrays;
+
+    /**
      * Create a new Validator factory instance.
      *
      * @param  \Illuminate\Contracts\Translation\Translator  $translator
@@ -114,6 +121,8 @@ class Factory implements FactoryContract
         if (! is_null($this->container)) {
             $validator->setContainer($this->container);
         }
+
+        $validator->excludeArrays = $this->excludeArrays;
 
         $this->addExtensions($validator);
 
@@ -248,6 +257,16 @@ class Factory implements FactoryContract
     public function resolver(Closure $resolver)
     {
         $this->resolver = $resolver;
+    }
+
+    /**
+     * Indicates that array values should be excluded.
+     *
+     * @return void
+     */
+    public function excludeArrays()
+    {
+        $this->excludeArrays = true;
     }
 
     /**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -518,7 +518,7 @@ class Validator implements ValidatorContract
         foreach ($this->getRules() as $key => $rules) {
             if ($this->excludeArrays &&
                 in_array('array', $rules) &&
-                ! empty(preg_grep('/^'.$key.'\.*/', array_keys($this->implicitAttributes)))) {
+                ! empty(preg_grep('/^'.preg_quote($key, '/').'\.*/', array_keys($this->implicitAttributes)))) {
                 continue;
             }
 

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -157,6 +157,13 @@ class Validator implements ValidatorContract
     protected $stopOnFirstFailure = false;
 
     /**
+     * Indicates that array values should be excluded.
+     *
+     * @var bool
+     */
+    public $excludeArrays = false;
+
+    /**
      * All of the custom validator extensions.
      *
      * @var array
@@ -508,7 +515,13 @@ class Validator implements ValidatorContract
 
         $missingValue = new stdClass;
 
-        foreach (array_keys($this->getRules()) as $key) {
+        foreach ($this->getRules() as $key => $rules) {
+            if ($this->excludeArrays &&
+                in_array('array', $rules) &&
+                ! empty(preg_grep('/^'.$key.'\.*/', array_keys($this->implicitAttributes)))) {
+                continue;
+            }
+
             $value = data_get($this->getData(), $key, $missingValue);
 
             if ($value !== $missingValue) {

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -157,11 +157,11 @@ class Validator implements ValidatorContract
     protected $stopOnFirstFailure = false;
 
     /**
-     * Indicates that array values should be excluded.
+     * Indicates that unvalidated array keys should be excluded, even if the parent array was validated.
      *
      * @var bool
      */
-    public $excludeArrays = false;
+    public $excludeUnvalidatedArrayKeys = false;
 
     /**
      * All of the custom validator extensions.
@@ -516,7 +516,7 @@ class Validator implements ValidatorContract
         $missingValue = new stdClass;
 
         foreach ($this->getRules() as $key => $rules) {
-            if ($this->excludeArrays &&
+            if ($this->excludeUnvalidatedArrayKeys &&
                 in_array('array', $rules) &&
                 ! empty(preg_grep('/^'.preg_quote($key, '/').'\.*/', array_keys($this->implicitAttributes)))) {
                 continue;

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -6191,6 +6191,15 @@ class ValidationValidatorTest extends TestCase
         $validator->excludeUnvalidatedArrayKeys = true;
         $this->assertTrue($validator->passes());
         $this->assertSame(['users' => ['admins' => [['name' => 'mohamed']]]], $validator->validated());
+
+        $validator = new Validator(
+            $this->getIlluminateArrayTranslator(),
+            ['users' => [1, 2, 3]],
+            ['users' => 'array|max:10']
+        );
+        $validator->excludeUnvalidatedArrayKeys = true;
+        $this->assertTrue($validator->passes());
+        $this->assertSame(['users' => [1, 2, 3]], $validator->validated());
     }
 
     public function testExcludeUnless()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -6146,6 +6146,44 @@ class ValidationValidatorTest extends TestCase
         $this->assertSame($expectedMessages, $validator->messages()->toArray());
     }
 
+    public function testExcludingArrays()
+    {
+        $validator = new Validator(
+            $this->getIlluminateArrayTranslator(),
+            ['users' => [['name' => 'Mohamed', 'location' => 'cairo']]],
+            ['users' => 'array', 'users.*.name' => 'string']
+        );
+        $this->assertTrue($validator->passes());
+        $this->assertSame(['users' => [['name' => 'Mohamed', 'location' => 'cairo']]], $validator->validated());
+
+        $validator = new Validator(
+            $this->getIlluminateArrayTranslator(),
+            ['users' => [['name' => 'Mohamed', 'location' => 'cairo']]],
+            ['users' => 'array', 'users.*.name' => 'string']
+        );
+        $validator->excludeArrays = true;
+        $this->assertTrue($validator->passes());
+        $this->assertSame(['users' => [['name' => 'Mohamed']]], $validator->validated());
+
+        $validator = new Validator(
+            $this->getIlluminateArrayTranslator(),
+            ['users' => ['mohamed', 'zain']],
+            ['users' => 'array', 'users.*' => 'string']
+        );
+        $validator->excludeArrays = true;
+        $this->assertTrue($validator->passes());
+        $this->assertSame(['users' => ['mohamed', 'zain']], $validator->validated());
+
+        $validator = new Validator(
+            $this->getIlluminateArrayTranslator(),
+            ['users' => ['admins' => [['name' => 'mohamed', 'job' => 'dev']]]],
+            ['users' => 'array', 'users.admins' => 'array', 'users.admins.*.name' => 'string']
+        );
+        $validator->excludeArrays = true;
+        $this->assertTrue($validator->passes());
+        $this->assertSame(['users' => ['admins' => [['name' => 'mohamed']]]], $validator->validated());
+    }
+
     public function testExcludeUnless()
     {
         $validator = new Validator(

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -6161,7 +6161,7 @@ class ValidationValidatorTest extends TestCase
             ['users' => [['name' => 'Mohamed', 'location' => 'cairo']]],
             ['users' => 'array', 'users.*.name' => 'string']
         );
-        $validator->excludeArrays = true;
+        $validator->excludeUnvalidatedArrayKeys = true;
         $this->assertTrue($validator->passes());
         $this->assertSame(['users' => [['name' => 'Mohamed']]], $validator->validated());
 
@@ -6170,7 +6170,7 @@ class ValidationValidatorTest extends TestCase
             ['users' => [['name' => 'Mohamed', 'location' => 'cairo']]],
             ['users' => 'array']
         );
-        $validator->excludeArrays = true;
+        $validator->excludeUnvalidatedArrayKeys = true;
         $this->assertTrue($validator->passes());
         $this->assertSame(['users' => [['name' => 'Mohamed', 'location' => 'cairo']]], $validator->validated());
 
@@ -6179,7 +6179,7 @@ class ValidationValidatorTest extends TestCase
             ['users' => ['mohamed', 'zain']],
             ['users' => 'array', 'users.*' => 'string']
         );
-        $validator->excludeArrays = true;
+        $validator->excludeUnvalidatedArrayKeys = true;
         $this->assertTrue($validator->passes());
         $this->assertSame(['users' => ['mohamed', 'zain']], $validator->validated());
 
@@ -6188,7 +6188,7 @@ class ValidationValidatorTest extends TestCase
             ['users' => ['admins' => [['name' => 'mohamed', 'job' => 'dev']]]],
             ['users' => 'array', 'users.admins' => 'array', 'users.admins.*.name' => 'string']
         );
-        $validator->excludeArrays = true;
+        $validator->excludeUnvalidatedArrayKeys = true;
         $this->assertTrue($validator->passes());
         $this->assertSame(['users' => ['admins' => [['name' => 'mohamed']]]], $validator->validated());
     }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -6167,6 +6167,15 @@ class ValidationValidatorTest extends TestCase
 
         $validator = new Validator(
             $this->getIlluminateArrayTranslator(),
+            ['users' => [['name' => 'Mohamed', 'location' => 'cairo']]],
+            ['users' => 'array']
+        );
+        $validator->excludeArrays = true;
+        $this->assertTrue($validator->passes());
+        $this->assertSame(['users' => [['name' => 'Mohamed', 'location' => 'cairo']]], $validator->validated());
+
+        $validator = new Validator(
+            $this->getIlluminateArrayTranslator(),
             ['users' => ['mohamed', 'zain']],
             ['users' => 'array', 'users.*' => 'string']
         );


### PR DESCRIPTION
Given the following rules:

```php
return request()->validate([
    'users' => 'required|array',
    'users.*.name' => 'required',
]);
```

The validator will return the `users` attribute with all its children:

```
array:1 [▼
  "users" => array:1 [▼
    1 => array:2 [▼
      "name" => "mohamed"
      "job" => "dev"
    ]
  ]
]
```

You can see that the `job` key was returned even though it wasn't included in the validator rules.

This PR adds a new `Validator::excludeArrays()` that when added to a `boot` method of a service provider, will instruct the validator to exclude any array keys that weren't validated:

```
array:1 [▼
  "users" => array:1 [▼
    1 => array:1 [▼
      "name" => "mohamed"
    ]
  ]
]
```