### PR TITLE
[8.x] Add `insertBetweenEach()` collection method

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -522,6 +522,19 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
+     * Insert a value between each item in the collection.
+     * 
+     * For example: ['a', 'b', 'c'] with 'x' becomes ['a', 'x', 'b', 'x', 'c'].
+     *
+     * @param  string  $value
+     * @return static
+     */
+    public function insertBetweenEach($value)
+    {
+        return new static($this->flatMap(fn ($item) => [$item, $value])->slice(0, -1));
+    }
+
+    /**
      * Intersect the collection with the given items.
      *
      * @param  mixed  $items

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -536,6 +536,19 @@ class LazyCollection implements Enumerable
     }
 
     /**
+     * Insert a value between each item in the collection.
+     * 
+     * For example: ['a', 'b', 'c'] with 'x' becomes ['a', 'x', 'b', 'x', 'c'].
+     *
+     * @param  string  $value
+     * @return static
+     */
+    public function insertBetweenEach($value)
+    {
+        return new static($this->flatMap(fn ($item) => [$item, $value])->slice(0, -1));
+    }
+
+    /**
      * Intersect the collection with the given items by key.
      *
      * @param  mixed  $items

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -4672,6 +4672,18 @@ class SupportCollectionTest extends TestCase
     }
 
     /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testInsertBetweenEach($collection)
+    {
+        $fruits = $collection::make(['banana', 'mango', 'watermelon']);
+        $this->assertSame(['banana', 'apple', 'mango', 'apple', 'watermelon'], $fruits->insertBetweenEach('apple')->all());
+
+        $fruits = $collection::make(['lemon', 'mango', 'banana', 'watermelon']);
+        $this->assertSame(['lemon', 'kiwi', 'mango', 'kiwi', 'banana', 'kiwi', 'watermelon'], $fruits->insertBetweenEach('kiwi')->all());
+    }
+
+    /**
      * Provides each collection class, respectively.
      *
      * @return array


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Hello,

I added the `insertBetweenEach()` collection method.

This method allows you to insert an item into a collection between each existing item.

For example:

```php 
collect(['a', 'b', 'c'])->insertBetweenEach('x'); // ['a', 'x', 'b', 'x', 'c']
```

This can replace this code:

```php
collect(['a', 'b', 'c'])->flatMap(function ($item) {
   return [$item, 'x'];   
})->slice(0, -1); // ['a', 'x', 'b', 'x', 'c']
```

I'm not really sure about the name of the method, but I couldn't think of anything better.

Thanks! Jeroen