### PR TITLE
[8.x] Switch to docker compose for test suite

### DIFF
--- a/bin/test.sh
+++ b/bin/test.sh
@@ -1,23 +1,4 @@
 #!/usr/bin/env bash
 
-docker-compose down -t 0 &> /dev/null
-docker-compose up -d
-
-echo "Waiting for services to boot   ..."
-
-if docker run -it --rm registry.gitlab.com/grahamcampbell/php:7.4-base -r "\$tries = 0; while (true) { try { \$tries++; if (\$tries > 30) { throw new RuntimeException('MySQL never became available'); } sleep(1); new PDO('mysql:host=docker.for.mac.localhost;dbname=forge', 'root', '', [PDO::ATTR_TIMEOUT => 3]); break; } catch (PDOException \$e) {} }"; then
-    if docker run -it -w /data -v ${PWD}:/data:delegated --entrypoint vendor/bin/phpunit \
-       --env CI=1 --env DB_HOST=docker.for.mac.localhost --env DB_USERNAME=root \
-       --env REDIS_HOST=docker.for.mac.localhost --env REDIS_PORT=6379 \
-       --env MEMCACHED_HOST=docker.for.mac.localhost --env MEMCACHED_PORT=11211 \
-       --rm registry.gitlab.com/grahamcampbell/php:7.4-base "$@"; then
-        docker-compose down -t 0
-    else
-        docker-compose down -t 0
-        exit 1
-    fi
-else
-    docker-compose logs
-    docker-compose down -t 0 &> /dev/null
-    exit 1
-fi
+docker compose up --renew-anon-volumes --exit-code-from test
+docker compose down -v

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     ports:
       - "11211:11211"
     restart: always
+    networks:
+      - laravel-framework
   mysql:
     image: mysql:5.7
     environment:
@@ -14,8 +16,49 @@ services:
     ports:
       - "3306:3306"
     restart: always
+    networks:
+      - laravel-framework
   redis:
     image: redis:5.0-alpine
+    command: redis-server --save ''
     ports:
       - "6379:6379"
     restart: always
+    networks:
+      - laravel-framework
+  dynamodb:
+    image: amazon/dynamodb-local:latest
+    ports:
+      - "8000:8000"
+    restart: always
+    networks:
+      - laravel-framework
+  test:
+    image: registry.gitlab.com/grahamcampbell/php:8.0-base
+    depends_on:
+      - memcached
+      - mysql
+      - redis
+      - dynamodb
+    entrypoint: vendor/bin/phpunit
+    working_dir: /data
+    volumes:
+      - ".:/data:rw,delegated"
+    environment:
+      CI: 1
+      DB_HOST: mysql
+      DB_USERNAME: root
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      MEMCACHED_HOST: memcached
+      MEMCACHED_PORT: 11211
+      DYNAMODB_CACHE_TABLE: laravel_dynamodb_test
+      DYNAMODB_ENDPOINT: "http://dynamodb:8000"
+      AWS_ACCESS_KEY_ID: random_key
+      AWS_SECRET_ACCESS_KEY: random_secret
+    networks:
+      - laravel-framework
+
+networks:
+  laravel-framework:
+    driver: "bridge"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
     networks:
       - laravel-framework
   test:
-    image: registry.gitlab.com/grahamcampbell/php:8.0-base
+    image: registry.gitlab.com/grahamcampbell/php:7.4-base
     depends_on:
       - memcached
       - mysql


### PR DESCRIPTION
This swaps out a bunch of `bin/test.sh` for native `docker compose` features like `--exit-code-from` and named networks. Running `test.sh` will start all the necessary services first, and then run the tests (due to the `depends_on` option). When the tests finish, it will automatically cause docker compose to exit with the same exit code as the tests.

I've also pulled over the dynamodb image from the existing Github workflow so that local test can run dynamodb as well.

![image](https://user-images.githubusercontent.com/21592/124842409-77cfed00-df5d-11eb-8414-c39043f1a24f.png)

There are a few tests that are failing locally on my machine whether I run the test suite using the existing `8.x` branch or with these changes. If anyone out there can successfully run the current `test.sh` script, I'd love to know what happens when you try this branch instead. Theoretically, the actual docker setup is the same—it's just configured in a simpler way.