### PR TITLE
Unauthenticated message

### DIFF
--- a/src/Illuminate/Auth/Middleware/Authenticate.php
+++ b/src/Illuminate/Auth/Middleware/Authenticate.php
@@ -80,7 +80,7 @@ class Authenticate implements AuthenticatesRequests
     protected function unauthenticated($request, array $guards)
     {
         throw new AuthenticationException(
-            'Unauthenticated.', $guards, $this->redirectTo($request)
+            __('Unauthenticated.'), $guards, $this->redirectTo($request)
         );
     }
 


### PR DESCRIPTION
Allow _"Unauthenticated."_ message to be translated via `app/resources/lang/{language}.json`.