### PR TITLE
[9.x] Drop CommonMark v1 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "doctrine/inflector": "^2.0",
         "dragonmantank/cron-expression": "^3.1",
         "egulias/email-validator": "^3.1",
-        "league/commonmark": "^1.3|^2.0",
+        "league/commonmark": "^2.0",
         "league/flysystem": "^2.0",
         "monolog/monolog": "^2.0",
         "nesbot/carbon": "^2.31",

--- a/src/Illuminate/Mail/Markdown.php
+++ b/src/Illuminate/Mail/Markdown.php
@@ -5,8 +5,10 @@ namespace Illuminate\Mail;
 use Illuminate\Contracts\View\Factory as ViewFactory;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
-use League\CommonMark\CommonMarkConverter;
+use League\CommonMark\Environment\Environment;
+use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
 use League\CommonMark\Extension\Table\TableExtension;
+use League\CommonMark\MarkdownConverter;
 use TijsVerkoyen\CssToInlineStyles\CssToInlineStyles;
 
 class Markdown
@@ -103,11 +105,14 @@ class Markdown
      */
     public static function parse($text)
     {
-        $converter = new CommonMarkConverter([
+        $environment = new Environment([
             'allow_unsafe_links' => false,
         ]);
 
-        $converter->getEnvironment()->addExtension(new TableExtension());
+        $environment->addExtension(new CommonMarkCoreExtension);
+        $environment->addExtension(new TableExtension);
+
+        $converter = new MarkdownConverter($environment);
 
         return new HtmlString((string) $converter->convertToHtml($text));
     }

--- a/src/Illuminate/Mail/composer.json
+++ b/src/Illuminate/Mail/composer.json
@@ -21,7 +21,7 @@
         "illuminate/contracts": "^9.0",
         "illuminate/macroable": "^9.0",
         "illuminate/support": "^9.0",
-        "league/commonmark": "^1.3|^2.0",
+        "league/commonmark": "^2.0",
         "psr/log": "^1.0",
         "swiftmailer/swiftmailer": "^6.2.7",
         "tijsverkoyen/css-to-inline-styles": "^2.2.2"

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -42,7 +42,7 @@
     },
     "suggest": {
         "illuminate/filesystem": "Required to use the composer class (^9.0).",
-        "league/commonmark": "Required to use Str::markdown() and Stringable::markdown() (^1.3|^2.0).",
+        "league/commonmark": "Required to use Str::markdown() and Stringable::markdown() (^2.0).",
         "ramsey/uuid": "Required to use Str::uuid() (^4.0).",
         "symfony/process": "Required to use the composer class (^5.3).",
         "symfony/var-dumper": "Required to use the dd function (^5.3).",


### PR DESCRIPTION
~The changes are straightforward but because of namespace changes to the `Environment` class we'll need to target v9. I think I can get CommonMark v2 working on 8.x but it'll require some nasty hacks. Feel free to let me know if you want to check into that.~

Drops CommonMark v1 support for Laravel v9