### PR TITLE
[8.x] Add support for both CommonMark 1.x and 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "doctrine/inflector": "^1.4|^2.0",
         "dragonmantank/cron-expression": "^3.0.2",
         "egulias/email-validator": "^2.1.10",
-        "league/commonmark": "^1.3",
+        "league/commonmark": "^1.3|^2.0",
         "league/flysystem": "^1.1",
         "monolog/monolog": "^2.0",
         "nesbot/carbon": "^2.31",

--- a/src/Illuminate/Mail/Markdown.php
+++ b/src/Illuminate/Mail/Markdown.php
@@ -6,7 +6,6 @@ use Illuminate\Contracts\View\Factory as ViewFactory;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
 use League\CommonMark\CommonMarkConverter;
-use League\CommonMark\Environment;
 use League\CommonMark\Extension\Table\TableExtension;
 use TijsVerkoyen\CssToInlineStyles\CssToInlineStyles;
 
@@ -104,15 +103,13 @@ class Markdown
      */
     public static function parse($text)
     {
-        $environment = Environment::createCommonMarkEnvironment();
-
-        $environment->addExtension(new TableExtension);
-
         $converter = new CommonMarkConverter([
             'allow_unsafe_links' => false,
-        ], $environment);
+        ]);
 
-        return new HtmlString($converter->convertToHtml($text));
+        $converter->getEnvironment()->addExtension(new TableExtension());
+
+        return new HtmlString((string) $converter->convertToHtml($text));
     }
 
     /**

--- a/src/Illuminate/Mail/composer.json
+++ b/src/Illuminate/Mail/composer.json
@@ -21,7 +21,7 @@
         "illuminate/contracts": "^8.0",
         "illuminate/macroable": "^8.0",
         "illuminate/support": "^8.0",
-        "league/commonmark": "^1.3",
+        "league/commonmark": "^1.3|^2.0",
         "psr/log": "^1.0",
         "swiftmailer/swiftmailer": "^6.0",
         "tijsverkoyen/css-to-inline-styles": "^2.2.2"

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -391,7 +391,7 @@ class Str
     {
         $converter = new GithubFlavoredMarkdownConverter($options);
 
-        return $converter->convertToHtml($string);
+        return (string) $converter->convertToHtml($string);
     }
 
     /**

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -42,7 +42,7 @@
     },
     "suggest": {
         "illuminate/filesystem": "Required to use the composer class (^8.0).",
-        "league/commonmark": "Required to use Str::markdown() and Stringable::markdown() (^1.3).",
+        "league/commonmark": "Required to use Str::markdown() and Stringable::markdown() (^1.3|^2.0).",
         "ramsey/uuid": "Required to use Str::uuid() (^4.0).",
         "symfony/process": "Required to use the composer class (^5.1.4).",
         "symfony/var-dumper": "Required to use the dd function (^5.1.4).",


### PR DESCRIPTION
This PR complements #37953 by allowing users of 8.x to install either major version of the CommonMark library.