### PR TITLE
[8.x] Add `isAttached($id)` method to pivot trait

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -276,6 +276,28 @@ trait InteractsWithPivotTable
     }
 
     /**
+     * Check if a record is attached to the parent.
+     *
+     * @param  mixed  $id
+     * @return bool
+     */
+    public function isAttached($id)
+    {
+        $ids = $this->parseIds($id);
+        $idsCount = count($ids);
+
+        $query = $this
+            ->newPivotStatement()
+            ->where($this->foreignPivotKey, $this->parent->{$this->parentKey});
+
+        if ($idsCount === 1) {
+            return $query->where($this->relatedPivotKey, $ids)->exists();
+        }
+
+        return $query->whereIn($this->relatedPivotKey, $ids)->count() === $idsCount;
+    }
+
+    /**
      * Attach a model to the parent using a custom class.
      *
      * @param  mixed  $id

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -274,6 +274,31 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $this->assertEquals($tag8->name, $post->tags[7]->name);
     }
 
+    public function testIsAttachedMethod()
+    {
+        $post = Post::create(['title' => Str::random()]);
+        $post2 = Post::create(['title' => Str::random()]);
+
+        $tag = Tag::create(['name' => Str::random()]);
+        $tag2 = Tag::create(['name' => Str::random()]);
+        $tag3 = Tag::create(['name' => Str::random()]);
+
+        $post->tags()->attach($tag);
+        $post->tags()->attach($tag2);
+        $post2->tags()->attach($tag3);
+
+        $this->assertTrue($post->tags()->isAttached($tag));
+        $this->assertTrue($post->tags()->isAttached($tag2));
+        $this->assertTrue($post2->tags()->isAttached($tag3));
+
+        $this->assertTrue($post->tags()->isAttached($tag->id));
+        $this->assertTrue($post->tags()->isAttached([$tag->id, $tag2->id]));
+        $this->assertTrue($post->tags()->isAttached(new Collection([$tag, $tag2])));
+
+        $this->assertFalse($post->tags()->isAttached($tag3));
+        $this->assertFalse($post->tags()->isAttached([$tag, $tag2, $tag3]));
+    }
+
     public function testDetachMethod()
     {
         $post = Post::create(['title' => Str::random()]);


### PR DESCRIPTION
I recently noticed that in our apps (also on StackOverflow / Github repos) the following code was a pretty common way to check if a record was attached:

```php
$account->blocked()->wherePivot('blocked_id', $blockedProfile)->exists();
```

SQL output:

```sql
SELECT *
FROM   `accounts`
       INNER JOIN `blocked_profiles`
               ON `accounts`.`id` = `blocked_profiles`.`blocked_id`
WHERE  `blocked_profiles`.`account_id` = ?
       AND `blocked_profiles`.`blocked_id` = ?
       AND `accounts`.`deleted_at` IS NULL 
```

As you can see, this query is more complex than needed and could be optimised.

This PR adds a new method `isAttached($id)` to the `InteractsWithPivotTable` trait.

It is less verbose, optimised and could be convenient for people like me who tend to forget to check the SQL outputs when coding.

This method is pretty simple and works in a similar fashion as `attach()` and `detach()` thanks to `parseIds()`. Eg:

```php
$account->blocked()->isAttached(1); // id
$account->blocked()->isAttached([1, 2]); // array
$account->blocked()->isAttached($john); // model
$account->blocked()->isAttached(new Collection([$john, $jane])); // collection of models (Eloquent\Collection)
```

The following SQL outputs would be:

```sql
-- single record
select
  exists(
    select
      *
    from
      `blocked_profiles`
    where
      `account_id` = ?
      and `blocked_id` = ?
  ) as `exists`

-- multiple records
select
  count(*) as aggregate
from
  `blocked_profiles`
where
  `account_id` = 1
  and `blocked_id` in (1, 2)
```