### PR TITLE
[8.x] Fix `queue:retry --range=1-10` not working when database-uuids failed driver is used

### DIFF
--- a/src/Illuminate/Queue/Failed/DatabaseUuidFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseUuidFailedJobProvider.php
@@ -90,7 +90,7 @@ class DatabaseUuidFailedJobProvider implements FailedJobProviderInterface, Pruna
      */
     public function find($id)
     {
-        if ($record = $this->getTable()->where('uuid', $id)->first()) {
+        if ($record = $this->getTable()->where('uuid', $id)->orWhere('id', $id)->first()) {
             $record->id = $record->uuid;
             unset($record->uuid);
         }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

When using the `database-uuids` as queue failed driver the `--range` option on the `queue:retry` command is not working. 

This is because the --range option only accepts numeric values but the find method on the `DatabaseUuidFailedJobProvider` is looking in the uuid column. 

With this PR it's possible to also use id's instead of only the uuid's. 

I don't know if this is something you would allow? 

I couldn't find any tests for the `queue:retry` command so i didn't add any new tests for this. 
