### PR TITLE
[8.x] Str::random with excluded chars & Str::randomAlpha.

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -546,7 +546,7 @@ class Str
      */
     public static function randomAlpha($length = 16)
     {
-        return static::random($length, range(0,9));
+        return static::random($length, range(0, 9));
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -513,21 +513,40 @@ class Str
      * Generate a more truly "random" alpha-numeric string.
      *
      * @param  int  $length
+     * @param  string|string[]  $excludeChars
      * @return string
      */
-    public static function random($length = 16)
+    public static function random($length = 16, $excludeChars = [])
     {
         $string = '';
+
+        $excludeChars = array_merge(
+            ['/', '+', '='],
+            is_string($excludeChars)
+                ? str_split($excludeChars)
+                : $excludeChars
+        );
 
         while (($len = strlen($string)) < $length) {
             $size = $length - $len;
 
             $bytes = random_bytes($size);
 
-            $string .= substr(str_replace(['/', '+', '='], '', base64_encode($bytes)), 0, $size);
+            $string .= substr(str_replace($excludeChars, '', base64_encode($bytes)), 0, $size);
         }
 
         return $string;
+    }
+
+    /**
+     * Generate a more truly "random" alpha string.
+     *
+     * @param  int  $length
+     * @return string
+     */
+    public static function randomAlpha($length = 16)
+    {
+        return static::random($length, range(0,9));
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -339,7 +339,8 @@ class SupportStrTest extends TestCase
     /**
      * @dataProvider excludedRandomChars
      */
-    public function testRandomWithExcludedChars($excludeChars) {
+    public function testRandomWithExcludedChars($excludeChars)
+    {
         $forPattern = is_array($excludeChars)
             ? implode('', $excludeChars)
             : $excludeChars;

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -336,6 +336,29 @@ class SupportStrTest extends TestCase
         $this->assertIsString(Str::random());
     }
 
+    /**
+     * @dataProvider excludedRandomChars
+     */
+    public function testRandomWithExcludedChars($excludeChars) {
+        $forPattern = is_array($excludeChars)
+            ? implode('', $excludeChars)
+            : $excludeChars;
+
+        $this->assertMatchesRegularExpression(
+            '/^[^'.$forPattern.']{100}$/',
+            Str::random(100, $excludeChars)
+        );
+    }
+
+    public function testRandomAlpha()
+    {
+        $this->assertEquals(16, strlen(Str::randomAlpha()));
+        $randomInteger = random_int(1, 100);
+        $this->assertEquals($randomInteger, strlen(Str::randomAlpha($randomInteger)));
+        $this->assertIsString(Str::randomAlpha());
+        $this->assertMatchesRegularExpression('/^[^0-9]{100}$/', Str::randomAlpha(100));
+    }
+
     public function testReplace()
     {
         $this->assertSame('foo bar laravel', Str::replace('baz', 'laravel', 'foo bar baz'));
@@ -570,6 +593,33 @@ class SupportStrTest extends TestCase
     {
         $this->assertSame('aaaaa', Str::repeat('a', 5));
         $this->assertSame('', Str::repeat('', 5));
+    }
+
+    public function excludedRandomChars()
+    {
+        $chars = array_map(
+            function ($item) {
+                return chr($item);
+            },
+            array_merge(
+                range(ord('0'), ord('9')),
+                range(ord('A'), ord('Z')),
+                range(ord('a'), ord('z'))
+            )
+        );
+
+        shuffle($chars);
+
+        return [
+            [array_splice($chars, 0, 10)],
+            [array_splice($chars, 0, 10)],
+            [array_splice($chars, 0, 10)],
+            [array_splice($chars, 0, 10)],
+            [array_splice($chars, 0, 10)],
+            [array_splice($chars, 0, 10)],
+            ['abcdefjhijklmnopqrstuvwxyz'],
+            ['0123456789'],
+        ];
     }
 }
 

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -345,7 +345,7 @@ class SupportStrTest extends TestCase
             ? implode('', $excludeChars)
             : $excludeChars;
 
-        $this->assertMatchesRegularExpression(
+        $this->assertRegExp(
             '/^[^'.$forPattern.']{100}$/',
             Str::random(100, $excludeChars)
         );
@@ -357,7 +357,7 @@ class SupportStrTest extends TestCase
         $randomInteger = random_int(1, 100);
         $this->assertEquals($randomInteger, strlen(Str::randomAlpha($randomInteger)));
         $this->assertIsString(Str::randomAlpha());
-        $this->assertMatchesRegularExpression('/^[^0-9]{100}$/', Str::randomAlpha(100));
+        $this->assertRegExp('/^[^0-9]{100}$/', Str::randomAlpha(100));
     }
 
     public function testReplace()


### PR DESCRIPTION
```php
Str::randomAlpha(16);   // returns random string with excluded numeric chars
 
Str::random(16, ['1', 'a', 'A']);   // returns random string with excluded  '1', 'a', 'A' chars
```

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
