### PR TITLE
Fix `date_format:timestamp` has error when passing correct timestamp format 

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -410,6 +410,10 @@ trait ValidatesAttributes
 
         $format = $parameters[0];
 
+        if ($format == 'timestamp') {
+            $format = 'U';
+        }
+
         $date = DateTime::createFromFormat('!'.$format, $value);
 
         return $date && $date->format($format) == $value;

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3645,6 +3645,12 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['x' => '17:43'], ['x' => 'date_format:H:i']);
         $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => '1325376000'], ['x' => 'date_format:timestamp']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => '2000-01-01 17:43:59'], ['x' => 'date_format:timestamp']);
+        $this->assertTrue($v->fails());
     }
 
     public function testDateEquals()


### PR DESCRIPTION
This PR resolve timestamp format checking problem.
```
    $request->validate([
        'foo' => 'date_format:timestamp',
    ]);
```
When correct timestamp send this validation can not recognized truth format of value.