### PR TITLE
Added ensureRootHasScheme function to UrlGenerator (Fix for Issue #37971)

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -546,7 +546,7 @@ class UrlGenerator implements UrlGeneratorContract
 
         $start = Str::startsWith($root, 'http://') ? 'http://' : 'https://';
 
-        return preg_replace('~' . $start . '~', $scheme, $root, 1);
+        return preg_replace('~'.$start.'~', $scheme, $root, 1);
     }
 
     /**
@@ -556,9 +556,9 @@ class UrlGenerator implements UrlGeneratorContract
      */
     protected function ensureRootHasScheme($root)
     {
-        $needsScheme = !Str::startsWith($root, 'http://') && !Str::startsWith($root, 'https://');
+        $needsScheme = ! Str::startsWith($root, 'http://') && ! Str::startsWith($root, 'https://');
 
-        return $needsScheme ? $this->request->getScheme() . '://' . $root : $root;
+        return $needsScheme ? $this->request->getScheme().'://'.$root : $root;
     }
 
     /**

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -542,9 +542,23 @@ class UrlGenerator implements UrlGeneratorContract
             $root = $this->cachedRoot;
         }
 
+        $root = $this->ensureRootHasScheme($root);
+
         $start = Str::startsWith($root, 'http://') ? 'http://' : 'https://';
 
-        return preg_replace('~'.$start.'~', $scheme, $root, 1);
+        return preg_replace('~' . $start . '~', $scheme, $root, 1);
+    }
+
+    /**
+     * Add scheme to root URL if none exists.
+     * @param $root
+     * @return string
+     */
+    protected function ensureRootHasScheme($root)
+    {
+        $needsScheme = !Str::startsWith($root, 'http://') && !Str::startsWith($root, 'https://');
+
+        return $needsScheme ? $this->request->getScheme() . '://' . $root : $root;
     }
 
     /**


### PR DESCRIPTION
This pull request adds a function that checks the root domain for 'https' and 'http' and applies the current request scheme if none is found. The current implementation does not check for or add a scheme when using the forceRootUrl function.


