### PR TITLE
[8.x] Facade spy issue on second call

### DIFF
--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -56,6 +56,8 @@ abstract class Facade
                 static::swap($spy);
             });
         }
+
+        return static::getFacadeRoot();
     }
 
     /**

--- a/tests/Support/SupportFacadeTest.php
+++ b/tests/Support/SupportFacadeTest.php
@@ -53,6 +53,16 @@ class SupportFacadeTest extends TestCase
         $spy->shouldHaveReceived('foo');
     }
 
+    public function testSpyReturnsAMockerySpyWhenItIsCalledASecondTime()
+    {
+        $app = new ApplicationStub;
+        $app->setAttributes(['foo' => new stdClass]);
+        FacadeStub::setFacadeApplication($app);
+
+        $this->assertInstanceOf(MockInterface::class, $spy = FacadeStub::spy());
+        $this->assertEquals($spy, FacadeStub::spy());
+    }
+
     public function testShouldReceiveCanBeCalledTwice()
     {
         $app = new ApplicationStub;


### PR DESCRIPTION
Right now, if you try to call the `spy` method twice on a facade, the first time you get the mocked object back but the second time you call it, you receive `null` instead of the previously created mock.  This makes it return the previously created mock instead of returning nothing.

This goes with the following issue: https://github.com/laravel/framework/issues/37975

