### PR TITLE
[8.x] Simplify Application.php

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -638,7 +638,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function registerConfiguredProviders()
     {
-        $providers = Collection::make($this->config['app.providers'])
+        $providers = Collection::make($this->make('config')->get('app.providers'))
                         ->partition(function ($provider) {
                             return strpos($provider, 'Illuminate\\') === 0;
                         });


### PR DESCRIPTION
Using nested magic methods makes understanding laravel really cumbersome.
In this case, someone may wonder where this property `config` is coming from.
Here we call `__get` then `offsetGet` to eventually call `make` on the container.

Being explicit is more readable and does not execute slower.
This PR is based on the questions my students asked me.
