### PR TITLE
[8.x] Add default parameter to the FilesystemAdapter path() function

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -127,7 +127,7 @@ class FilesystemAdapter implements CloudFilesystemContract
      * @param  string  $path
      * @return string
      */
-    public function path($path)
+    public function path($path = '')
     {
         $adapter = $this->driver->getAdapter();
 

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -104,6 +104,12 @@ class FilesystemAdapterTest extends TestCase
         $this->assertEquals($this->tempDir.DIRECTORY_SEPARATOR.'file.txt', $filesystemAdapter->path('file.txt'));
     }
 
+    public function testRootPath()
+    {
+        $filesystemAdapter = new FilesystemAdapter($this->filesystem);
+        $this->assertEquals($this->tempDir.DIRECTORY_SEPARATOR, $filesystemAdapter->path());
+    }
+
     public function testGet()
     {
         $this->filesystem->write('file.txt', 'Hello World');

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -104,7 +104,7 @@ class FilesystemAdapterTest extends TestCase
         $this->assertEquals($this->tempDir.DIRECTORY_SEPARATOR.'file.txt', $filesystemAdapter->path('file.txt'));
     }
 
-    public function testRootPath()
+    public function testPathWithDefaultPathParameter()
     {
         $filesystemAdapter = new FilesystemAdapter($this->filesystem);
         $this->assertEquals($this->tempDir.DIRECTORY_SEPARATOR, $filesystemAdapter->path());


### PR DESCRIPTION
This PR adds a default parameter of an empty string to the `path($path)` function of the `FilesystemAdapter` class.

Currently, to get the root path of a file system:
```php
Storage::disk('local')->path('');
```

After this change, the empty string can be omitted:
```php
Storage::disk('local')->path();
```

A small change, but it definitely improves the readability of the code.