### PR TITLE
[8.x] Clear config after dumping auto-loaded files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -79,6 +79,7 @@
     },
     "require-dev": {
         "aws/aws-sdk-php": "^3.155",
+        "composer/composer": "^1.0|^2.0",
         "doctrine/dbal": "^2.6|^3.0",
         "filp/whoops": "^2.8",
         "guzzlehttp/guzzle": "^6.5.5|^7.0.1",

--- a/composer.json
+++ b/composer.json
@@ -79,7 +79,6 @@
     },
     "require-dev": {
         "aws/aws-sdk-php": "^3.155",
-        "composer/composer": "^1.0|^2.0",
         "doctrine/dbal": "^2.6|^3.0",
         "filp/whoops": "^2.8",
         "guzzlehttp/guzzle": "^6.5.5|^7.0.1",

--- a/src/Illuminate/Foundation/ComposerScripts.php
+++ b/src/Illuminate/Foundation/ComposerScripts.php
@@ -56,7 +56,7 @@ class ComposerScripts
 
         if (is_file($configPath = $laravel->getCachedConfigPath())) {
             @unlink($configPath);
-        }        
+        }
 
         if (is_file($servicesPath = $laravel->getCachedServicesPath())) {
             @unlink($servicesPath);

--- a/src/Illuminate/Foundation/ComposerScripts.php
+++ b/src/Illuminate/Foundation/ComposerScripts.php
@@ -61,5 +61,9 @@ class ComposerScripts
         if (is_file($packagesPath = $laravel->getCachedPackagesPath())) {
             @unlink($packagesPath);
         }
+
+        if (is_file($configPath = $laravel->getCachedConfigPath())) {
+            @unlink($configPath);
+        }
     }
 }

--- a/src/Illuminate/Foundation/ComposerScripts.php
+++ b/src/Illuminate/Foundation/ComposerScripts.php
@@ -54,16 +54,16 @@ class ComposerScripts
     {
         $laravel = new Application(getcwd());
 
+        if (is_file($configPath = $laravel->getCachedConfigPath())) {
+            @unlink($configPath);
+        }        
+
         if (is_file($servicesPath = $laravel->getCachedServicesPath())) {
             @unlink($servicesPath);
         }
 
         if (is_file($packagesPath = $laravel->getCachedPackagesPath())) {
             @unlink($packagesPath);
-        }
-
-        if (is_file($configPath = $laravel->getCachedConfigPath())) {
-            @unlink($configPath);
         }
     }
 }


### PR DESCRIPTION
I can't remember the amount of times I debugged issues where people were seeing problems with their app due to them not clearing their config cache after installing new packages. Usually caching config files locally isn't very useful yet it still happens a lot. By clearing config cache after installing new packages we can prevent them from running into these issues.

Also added `composer/composer` as a `dev` dependency since it's used in the `ComposerScripts` class.