### PR TITLE
[8.x] Add Concat() Method in Query Builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -81,6 +81,13 @@ class Builder
     public $columns;
 
     /**
+     * The data that should be transformed with concat method.
+     *
+     * @var array
+     */
+    public $concat;
+
+    /**
      * Indicates if the query returns distinct results.
      *
      * Occasionally contains the columns that should be distinct.
@@ -2713,6 +2720,23 @@ class Builder
     public function doesntExistOr(Closure $callback)
     {
         return $this->doesntExist() ? true : $callback();
+    }
+
+
+    /**
+     * Retrieve the concatenated data with CONCAT method .
+     *
+     * @param  array  $columns
+     * @param  string  $as
+     * @param  string  $separator
+     * @return $this
+     */
+
+    public function concat($columns, $as, $separator = '')
+    {
+        $this->concat = compact('columns', 'as', 'separator');
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -140,7 +140,14 @@ class Grammar extends BaseGrammar
             $select = 'select ';
         }
 
-        return $select.$this->columnize($columns);
+        if ($query->concat){
+            $concatColumns = $this->columnize($query->concat['columns']);
+            $column = $this->columnize($columns). ", CONCAT_WS('{$query->concat['separator']}', $concatColumns) as {$query->concat['as']}";
+        } else {
+            $column = $this->columnize($columns);
+        }
+
+        return $select.$column;
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1373,6 +1373,21 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertSame('select * from "users" having "last_login_date" between ? and ? or user_foo < user_bar', $builder->toSql());
     }
 
+    public function testConcat()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->concat(['first_name', 'last_name'], 'full_name');
+        $this->assertSame('select *, CONCAT_WS(\'\', "first_name", "last_name") as full_name from "users"', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->concat(['first_name', 'last_name'], 'full_name', ' ');
+        $this->assertSame('select *, CONCAT_WS(\' \', "first_name", "last_name") as full_name from "users"', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->select(['first_name', 'last_name'])->from('users')->concat(['first_name', 'last_name'], 'full_name');
+        $this->assertSame('select "first_name", "last_name", CONCAT_WS(\'\', "first_name", "last_name") as full_name from "users"', $builder->toSql());
+    }
+
     public function testLimitsAndOffsets()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
There are 2 methods in SQL called CONCAT and CONCAT_WS that allow us to concat columns data in a table.
For example, we have a table for users which has two columns called 'first_name' and 'last_name', with this method which has been added we will be able to access a value that is concatenated.
```php
User::concat(['first_name', 'last_name'], 'full_name', '-')->first(); // we will access to $user->full_name
```
Or another example:

```php
User::concat(['country', 'city', 'street'], 'address', ',')->first(); // we will access to $user->address
```