### PR TITLE
[9.x] Add default argument to filesystem path function

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -158,7 +158,7 @@ class FilesystemAdapter implements CloudFilesystemContract
      * @param  string  $path
      * @return string
      */
-    public function path($path)
+    public function path($path = '')
     {
         return $this->prefixer->prefixPath($path);
     }

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -114,6 +114,14 @@ class FilesystemAdapterTest extends TestCase
         $this->assertEquals($this->tempDir.DIRECTORY_SEPARATOR.'file.txt', $filesystemAdapter->path('file.txt'));
     }
 
+    public function testPathWithDefaultPathArgument()
+    {
+        $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter, [
+            'root' => $this->tempDir.DIRECTORY_SEPARATOR,
+        ]);
+        $this->assertEquals($this->tempDir.DIRECTORY_SEPARATOR, $filesystemAdapter->path());
+    }
+
     public function testGet()
     {
         $this->filesystem->write('file.txt', 'Hello World');


### PR DESCRIPTION
This is the same as #37981, but targeting the `master` branch because changing the method signature of the `path()` function is a breaking change. 

---

This PR adds a default parameter of an empty string to the `path($path)` function of the `FilesystemAdapter` class.

Currently, to get the root path of a file system:
```php
Storage::disk('local')->path('');
```

After this change, the empty string can be omitted:
```php
Storage::disk('local')->path();
```

A small change, but it definitely improves the readability of the code.