### PR TITLE
[8.x] Add multipleDialy() to ManagesFrequencies trait

### DIFF
--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -263,10 +263,7 @@ trait ManagesFrequencies
      */
     public function twiceDaily($first = 1, $second = 13)
     {
-        $hours = $first.','.$second;
-
-        return $this->spliceIntoPosition(1, 0)
-                    ->spliceIntoPosition(2, $hours);
+        return $this->multipleDialy([$first, $second]);
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -270,6 +270,22 @@ trait ManagesFrequencies
     }
 
     /**
+     * Schedule the event to run multiple times daily.
+     *
+     * @param  array  $hours
+     * @param  array  $minutes
+     * @return $this
+     */
+    public function multipleDialy($hours = [0], $minutes = [0])
+    {
+        $hours = implode(',', $hours);
+        $minutes = implode(',', $minutes);
+
+        return $this->spliceIntoPosition(2, $hours)
+                    ->spliceIntoPosition(1, $minutes);
+    }
+
+    /**
      * Schedule the event to run only on weekdays.
      *
      * @return $this

--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -60,7 +60,7 @@ class FrequencyTest extends TestCase
     public function testMultipleDialy()
     {
         $this->assertSame('0 8,16,20 * * *', $this->event->multipleDialy([8, 16, 20])->getExpression());
-        $this->assertSame('15,30,45 12,14,16 * * *', $this->event->multipleDialy([12,14,16], [15,30,45])->getExpression());
+        $this->assertSame('15,30,45 12,14,16 * * *', $this->event->multipleDialy([12, 14, 16], [15, 30, 45])->getExpression());
     }
 
     public function testWeekly()

--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -57,6 +57,12 @@ class FrequencyTest extends TestCase
         $this->assertSame('0 3,15 * * *', $this->event->twiceDaily(3, 15)->getExpression());
     }
 
+    public function testMultipleDialy()
+    {
+        $this->assertSame('0 8,16,20 * * *', $this->event->multipleDialy([8, 16, 20])->getExpression());
+        $this->assertSame('15,30,45 12,14,16 * * *', $this->event->multipleDialy([12,14,16], [15,30,45])->getExpression());
+    }
+
     public function testWeekly()
     {
         $this->assertSame('0 0 * * 0', $this->event->weekly()->getExpression());


### PR DESCRIPTION
Added `multipleDaily` method to execute a scheduled task multiple times in one day.

The method accepts 2 parameters as arrays (hours and minutes). It's useful if you have to run one task multiple times at day, as example: `08:00, 12:00, 16:00, 20:00`.

`twiceDialy` was modified returning the `multipleDaily` method.

## Usage

### 3 times at day in specific hours

At 12:00, 16:00, and 18:00
```php
multipleDaily([12, 16, 18]);
```

### 3 times at day in specific hours and every X minutes

At 15, 30, and 45 minutes past the hour, at 12:00, 16:00, and 18:00
```php
multipleDialy([12, 16, 18], [15, 30, 45]);
```