### PR TITLE
[8.x] Make Filesystem createFlysystem method public

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -254,7 +254,7 @@ class FilesystemManager implements FactoryContract
      * @param  array  $config
      * @return \League\Flysystem\FilesystemInterface
      */
-    protected function createFlysystem(AdapterInterface $adapter, array $config)
+    public function createFlysystem(AdapterInterface $adapter, array $config)
     {
         $cache = Arr::pull($config, 'cache');
 


### PR DESCRIPTION
I'd like to make this public so it can be used with other Flysystem adapters when extending storage with custom filesystem.

e.g. I want to add cache support to GoogleStorageAdapter (which in my case is getting its config from Firebase)
```php
Storage::extend(
    'firebase',
    function (Application $app, array $config) {
        return $app->get('filesystem')->createFlysystem(
            new GoogleStorageAdapter(FirebaseStorage::getStorageClient(), FirebaseStorage::getBucket($config['bucket']), $config['prefix'], $config['endpoint']),
            $config
        );
    }
);
```
