### PR TITLE
[8.x] Pass null to custom cast set method when value is null

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -839,7 +839,7 @@ trait HasAttributes
                 function () {
                 },
                 $this->normalizeCastClassResponse($key, $caster->set(
-                    $this, $key, $this->{$key}, $this->attributes
+                    $this, $key, $value, $this->attributes
                 ))
             ));
         } else {

--- a/tests/Integration/Database/EloquentModelCustomCastingTest.php
+++ b/tests/Integration/Database/EloquentModelCustomCastingTest.php
@@ -1,0 +1,222 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Database\Schema\Blueprint;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group integration
+ */
+class EloquentModelCustomCastingTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $db = new DB;
+
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+
+        $db->bootEloquent();
+        $db->setAsGlobal();
+
+        $this->createSchema();
+    }
+
+    /**
+     * Setup the database schema.
+     *
+     * @return void
+     */
+    public function createSchema()
+    {
+        $this->schema()->create('casting_table', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('address_line_one');
+            $table->string('address_line_two');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Tear down the database schema.
+     *
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        $this->schema()->drop('casting_table');
+    }
+
+    /**
+     * Tests...
+     */
+    public function testSavingCastedAttributesToDatabase()
+    {
+        /** @var \Illuminate\Tests\Integration\Database\CustomCasts $model */
+        $model = CustomCasts::create([
+            'address' => new AddressModel('address_line_one_value', 'address_line_two_value'),
+        ]);
+
+        $this->assertSame('address_line_one_value', $model->getOriginal('address_line_one'));
+        $this->assertSame('address_line_one_value', $model->getAttribute('address_line_one'));
+
+        $this->assertSame('address_line_two_value', $model->getOriginal('address_line_two'));
+        $this->assertSame('address_line_two_value', $model->getAttribute('address_line_two'));
+
+        /** @var \Illuminate\Tests\Integration\Database\CustomCasts $another_model */
+        $another_model = CustomCasts::create([
+            'address_line_one' => 'address_line_one_value',
+            'address_line_two' => 'address_line_two_value',
+        ]);
+
+        $this->assertInstanceOf(AddressModel::class, $another_model->address);
+
+        $this->assertSame('address_line_one_value', $model->address->lineOne);
+        $this->assertSame('address_line_two_value', $model->address->lineTwo);
+    }
+
+    public function testInvalidArgumentExceptionOnInvalidValue()
+    {
+        /** @var \Illuminate\Tests\Integration\Database\CustomCasts $model */
+        $model = CustomCasts::create([
+            'address' => new AddressModel('address_line_one_value', 'address_line_two_value'),
+        ]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The given value is not an Address instance.');
+        $model->address = 'single_string';
+
+        // Ensure model values remain unchanged
+        $this->assertSame('address_line_one_value', $model->address->lineOne);
+        $this->assertSame('address_line_two_value', $model->address->lineTwo);
+    }
+
+    public function testInvalidArgumentExceptionOnNull()
+    {
+        /** @var \Illuminate\Tests\Integration\Database\CustomCasts $model */
+        $model = CustomCasts::create([
+            'address' => new AddressModel('address_line_one_value', 'address_line_two_value'),
+        ]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The given value is not an Address instance.');
+        $model->address = null;
+
+        // Ensure model values remain unchanged
+        $this->assertSame('address_line_one_value', $model->address->lineOne);
+        $this->assertSame('address_line_two_value', $model->address->lineTwo);
+    }
+
+    /**
+     * Get a database connection instance.
+     *
+     * @return \Illuminate\Database\Connection
+     */
+    protected function connection()
+    {
+        return Eloquent::getConnectionResolver()->connection();
+    }
+
+    /**
+     * Get a schema builder instance.
+     *
+     * @return \Illuminate\Database\Schema\Builder
+     */
+    protected function schema()
+    {
+        return $this->connection()->getSchemaBuilder();
+    }
+}
+
+/**
+ * Eloquent Casts...
+ */
+class Address implements CastsAttributes
+{
+    /**
+     * Cast the given value.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  array  $attributes
+     * @return AddressModel
+     */
+    public function get($model, $key, $value, $attributes)
+    {
+        return new AddressModel(
+            $attributes['address_line_one'],
+            $attributes['address_line_two'],
+        );
+    }
+
+    /**
+     * Prepare the given value for storage.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @param  AddressModel  $value
+     * @param  array  $attributes
+     * @return array
+     */
+    public function set($model, $key, $value, $attributes)
+    {
+        if (! $value instanceof AddressModel) {
+            throw new InvalidArgumentException('The given value is not an Address instance.');
+        }
+
+        return [
+            'address_line_one' => $value->lineOne,
+            'address_line_two' => $value->lineTwo,
+        ];
+    }
+}
+
+/**
+ * Eloquent Models...
+ */
+class CustomCasts extends Eloquent
+{
+    /**
+     * @var string
+     */
+    protected $table = 'casting_table';
+
+    /**
+     * @var string[]
+     */
+    protected $guarded = [];
+
+    /**
+     * @var array
+     */
+    protected $casts = [
+        'address' => Address::class,
+    ];
+}
+
+class AddressModel
+{
+    /**
+     * @var string
+     */
+    public $lineOne;
+
+    /**
+     * @var string
+     */
+    public $lineTwo;
+
+    public function __construct($address_line_one, $address_line_two)
+    {
+        $this->lineOne = $address_line_one;
+        $this->lineTwo = $address_line_two;
+    }
+}

--- a/tests/Integration/Database/EloquentModelCustomCastingTest.php
+++ b/tests/Integration/Database/EloquentModelCustomCastingTest.php
@@ -78,8 +78,8 @@ class EloquentModelCustomCastingTest extends TestCase
 
         $this->assertInstanceOf(AddressModel::class, $another_model->address);
 
-        $this->assertSame('address_line_one_value', $model->address->lineOne);
-        $this->assertSame('address_line_two_value', $model->address->lineTwo);
+        $this->assertSame('address_line_one_value', $another_model->address->lineOne);
+        $this->assertSame('address_line_two_value', $another_model->address->lineTwo);
     }
 
     public function testInvalidArgumentExceptionOnInvalidValue()

--- a/tests/Integration/Database/EloquentModelCustomCastingTest.php
+++ b/tests/Integration/Database/EloquentModelCustomCastingTest.php
@@ -138,7 +138,7 @@ class EloquentModelCustomCastingTest extends TestCase
 /**
  * Eloquent Casts...
  */
-class Address implements CastsAttributes
+class AddressCast implements CastsAttributes
 {
     /**
      * Cast the given value.
@@ -198,7 +198,7 @@ class CustomCasts extends Eloquent
      * @var array
      */
     protected $casts = [
-        'address' => Address::class,
+        'address' => AddressCast::class,
     ];
 }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

When using a custom cast class for casting attributes on a model, it is currently impossible to add custom behavior when the value set equals to `null`. This is due to the fact that in this case there is a manual catch that calls the setter with the current model value instead of the given `null` value.

By the looks of it, I think the purpose of this clause is to automatically set all attributes values provided by the class `set` method equal to `null`, which sounds reasonable but then again prevents users for adding custom behavior. It might be even better to remove the clause altogether (though this probably should be considered a breaking change), any feedback is appreciated!
