### PR TITLE
[9.x] PHP8 string functions for Str class

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -187,7 +187,7 @@ class Str
         }
 
         foreach ((array) $needles as $needle) {
-            if ($needle !== '' && mb_strpos($haystack, $needle) !== false) {
+            if ($needle !== '' && str_contains($haystack, $needle)) {
                 return true;
             }
         }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -763,7 +763,7 @@ class Str
     public static function startsWith($haystack, $needles)
     {
         foreach ((array) $needles as $needle) {
-            if ((string) $needle !== '' && strncmp($haystack, $needle, strlen($needle)) === 0) {
+            if ((string) $needle !== '' && str_starts_with($haystack, $needle)) {
                 return true;
             }
         }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -231,7 +231,7 @@ class Str
         foreach ((array) $needles as $needle) {
             if (
                 $needle !== '' && $needle !== null
-                && substr($haystack, -strlen($needle)) === (string) $needle
+                && str_ends_with($haystack, $needle)
             ) {
                 return true;
             }


### PR DESCRIPTION
Now that Laravel 9 is targeting PHP 8.0 as a minimum version we can use the new `str_contains()`, `str_starts_with()` and `str_ends_with()` functions internally in the `\Illuminate\Support\Str` class. 

Relates to previous request brought up in #35439
