### PR TITLE
[8.x] `@class` Blade directive

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -642,7 +642,7 @@ class Arr
     }
 
     /**
-     * Conditionally merge classes from an array into a class list.
+     * Conditionally compile classes from an array into a class list.
      *
      * @param  array  $array
      * @return string

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -494,6 +494,17 @@ class Arr
     }
 
     /**
+     * Convert the array into a query string.
+     *
+     * @param  array  $array
+     * @return string
+     */
+    public static function query($array)
+    {
+        return http_build_query($array, '', '&', PHP_QUERY_RFC3986);
+    }
+
+    /**
      * Get one or a specified number of random values from an array.
      *
      * @param  array  $array
@@ -642,12 +653,12 @@ class Arr
     }
 
     /**
-     * Conditionally compile classes from an array into a class list.
+     * Conditionally compile classes from an array into a CSS class list.
      *
      * @param  array  $array
      * @return string
      */
-    public static function toClasses($array)
+    public static function toCssClasses($array)
     {
         $classList = static::wrap($array);
 
@@ -662,17 +673,6 @@ class Arr
         }
 
         return implode(' ', $classes);
-    }
-
-    /**
-     * Convert the array into a query string.
-     *
-     * @param  array  $array
-     * @return string
-     */
-    public static function query($array)
-    {
-        return http_build_query($array, '', '&', PHP_QUERY_RFC3986);
     }
 
     /**

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -642,6 +642,29 @@ class Arr
     }
 
     /**
+     * Conditionally merge classes from an array into a class list.
+     *
+     * @param  array  $array
+     * @return string
+     */
+    public static function toClasses($array)
+    {
+        $classList = static::wrap($array);
+
+        $classes = [];
+
+        foreach ($classList as $class => $constraint) {
+            if (is_numeric($class)) {
+                $classes[] = $constraint;
+            } elseif ($constraint) {
+                $classes[] = $class;
+            }
+        }
+
+        return implode(' ', $classes);
+    }
+
+    /**
      * Convert the array into a query string.
      *
      * @param  array  $array

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -10,6 +10,7 @@ use InvalidArgumentException;
 class BladeCompiler extends Compiler implements CompilerInterface
 {
     use Concerns\CompilesAuthorizations,
+        Concerns\CompilesClasses,
         Concerns\CompilesComments,
         Concerns\CompilesComponents,
         Concerns\CompilesConditionals,

--- a/src/Illuminate/View/Compilers/Concerns/CompilesClasses.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesClasses.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\View\Compilers\Concerns;
+
+trait CompilesClasses
+{
+    /**
+     * Compile the conditional class statement into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileClass($expression)
+    {
+        $expression = is_null($expression) ? '([])' : $expression;
+
+        return "class=\"<?php echo \Illuminate\Support\Arr::toClasses{$expression} ?>\"";
+    }
+}

--- a/src/Illuminate/View/Compilers/Concerns/CompilesClasses.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesClasses.php
@@ -14,6 +14,6 @@ trait CompilesClasses
     {
         $expression = is_null($expression) ? '([])' : $expression;
 
-        return "class=\"<?php echo \Illuminate\Support\Arr::toClasses{$expression} ?>\"";
+        return "class=\"<?php echo \Illuminate\Support\Arr::toCssClasses{$expression} ?>\"";
     }
 }

--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -183,17 +183,7 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
     {
         $classList = Arr::wrap($classList);
 
-        $classes = [];
-
-        foreach ($classList as $class => $constraint) {
-            if (is_numeric($class)) {
-                $classes[] = $constraint;
-            } elseif ($constraint) {
-                $classes[] = $class;
-            }
-        }
-
-        return $this->merge(['class' => implode(' ', $classes)]);
+        return $this->merge(['class' => Arr::toClasses($classList)]);
     }
 
     /**

--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -183,7 +183,7 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
     {
         $classList = Arr::wrap($classList);
 
-        return $this->merge(['class' => Arr::toClasses($classList)]);
+        return $this->merge(['class' => Arr::toCssClasses($classList)]);
     }
 
     /**

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -808,16 +808,16 @@ class SupportArrTest extends TestCase
         $this->assertEquals($expect, Arr::sortRecursive($array));
     }
 
-    public function testToClasses()
+    public function testToCssClasses()
     {
-        $classes = Arr::toClasses([
+        $classes = Arr::toCssClasses([
             'font-bold',
             'mt-4',
         ]);
 
         $this->assertEquals('font-bold mt-4', $classes);
 
-        $classes = Arr::toClasses([
+        $classes = Arr::toCssClasses([
             'font-bold',
             'mt-4',
             'ml-2' => true,

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -808,6 +808,25 @@ class SupportArrTest extends TestCase
         $this->assertEquals($expect, Arr::sortRecursive($array));
     }
 
+    public function testToClasses()
+    {
+        $classes = Arr::toClasses([
+            'font-bold',
+            'mt-4',
+        ]);
+
+        $this->assertEquals('font-bold mt-4', $classes);
+
+        $classes = Arr::toClasses([
+            'font-bold',
+            'mt-4',
+            'ml-2' => true,
+            'mr-2' => false,
+        ]);
+
+        $this->assertEquals('font-bold mt-4 ml-2', $classes);
+    }
+
     public function testWhere()
     {
         $array = [100, '200', 300, '400', 500];

--- a/tests/View/Blade/BladeClassTest.php
+++ b/tests/View/Blade/BladeClassTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Illuminate\Tests\View\Blade;
+
+class BladeClassTest extends AbstractBladeTestCase
+{
+    public function testClassesAreConditionallyCompiledFromArray()
+    {
+        $string = "<span @class(['font-bold', 'mt-4', 'ml-2' => true, 'mr-2' => false])></span>";
+        $expected = "<span class=\"<?php echo \Illuminate\Support\Arr::toClasses(['font-bold', 'mt-4', 'ml-2' => true, 'mr-2' => false]) ?>\"></span>";
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+}

--- a/tests/View/Blade/BladeClassTest.php
+++ b/tests/View/Blade/BladeClassTest.php
@@ -7,7 +7,7 @@ class BladeClassTest extends AbstractBladeTestCase
     public function testClassesAreConditionallyCompiledFromArray()
     {
         $string = "<span @class(['font-bold', 'mt-4', 'ml-2' => true, 'mr-2' => false])></span>";
-        $expected = "<span class=\"<?php echo \Illuminate\Support\Arr::toClasses(['font-bold', 'mt-4', 'ml-2' => true, 'mr-2' => false]) ?>\"></span>";
+        $expected = "<span class=\"<?php echo \Illuminate\Support\Arr::toCssClasses(['font-bold', 'mt-4', 'ml-2' => true, 'mr-2' => false]) ?>\"></span>";
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }


### PR DESCRIPTION
Hey! 👋 

Conditional class syntax for Blade component attribute bags has been available in Laravel since v8.27.0. It can be used to conditionally merge attributes into the bag based on Boolean expressions, like so:

```blade
<span {{ $attributes->class([
    'text-sm',
    'font-bold' => $active,
]) }}>
    Dashboard
</span>
```

In this example, the `font-bold` class would be merged into this class list when the component is `$active`.

I would like to expand the scope of this syntax one step further, and make it available in a `@class` Blade directive. Similar functionality can be found in many frontend frameworks, including [Vue.js](https://vuejs.org/v2/guide/class-and-style.html#Object-Syntax) and [Alpine.js](https://alpinejs.dev/directives/bind#class-object-syntax). This will allow Blade developers to use conditional classes on any HTML element, not just when merging them into the attribute bag. For example:

```blade
<div>
    <span @class([
        'text-sm',
        'font-bold' => $active,
    ])>
        Dashboard
    </span>

    <svg @class([
        'w-6 h-6',
        'text-indigo-600' => $active,
    ])>
        <path />
        <path />
        <path />
    </svg>
</div>
```

To keep this new directive DRY, I extracted the class array compilation logic into a new array helper, `Arr::toCssClasses()`. Let me know if there is a better place to put this logic!

### Alternative

Alternatively, I could remove the `@class` Blade directive and allow developers to use the raw `Arr::toCssClasses()` helper, like so:

```blade
<div>
    <span class="{{ Arr::toCssClasses([
        'text-sm',
        'font-bold' => $active,
    ]) }}">
        Dashboard
    </span>

    <svg class="{{ Arr::toCssClasses([
        'w-6 h-6',
        'text-indigo-600' => $active,
    ]) }}">
        <path />
        <path />
        <path />
    </svg>
</div>
```