### PR TITLE
[9.x] Use string based accessor for Schema facade

### DIFF
--- a/src/Illuminate/Database/DatabaseServiceProvider.php
+++ b/src/Illuminate/Database/DatabaseServiceProvider.php
@@ -72,6 +72,10 @@ class DatabaseServiceProvider extends ServiceProvider
             return $app['db']->connection();
         });
 
+        $this->app->bind('db.schema', function ($app) {
+            return $app['db']->connection()->getSchemaBuilder();
+        });
+
         $this->app->singleton('db.transactions', function ($app) {
             return new DatabaseTransactionsManager;
         });

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1304,6 +1304,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
             'cookie' => [\Illuminate\Cookie\CookieJar::class, \Illuminate\Contracts\Cookie\Factory::class, \Illuminate\Contracts\Cookie\QueueingFactory::class],
             'db' => [\Illuminate\Database\DatabaseManager::class, \Illuminate\Database\ConnectionResolverInterface::class],
             'db.connection' => [\Illuminate\Database\Connection::class, \Illuminate\Database\ConnectionInterface::class],
+            'db.schema' => [\Illuminate\Database\Schema\Builder::class],
             'encrypter' => [\Illuminate\Encryption\Encrypter::class, \Illuminate\Contracts\Encryption\Encrypter::class, \Illuminate\Contracts\Encryption\StringEncrypter::class],
             'events' => [\Illuminate\Events\Dispatcher::class, \Illuminate\Contracts\Events\Dispatcher::class],
             'files' => [\Illuminate\Filesystem\Filesystem::class],

--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -24,6 +24,13 @@ abstract class Facade
     protected static $resolvedInstance;
 
     /**
+     * Determine if the resolved facade should be cached.
+     *
+     * @var bool
+     */
+    protected static $cached = true;
+
+    /**
      * Run a Closure when the facade has been resolved.
      *
      * @param  \Closure  $callback
@@ -84,8 +91,8 @@ abstract class Facade
         $name = static::getFacadeAccessor();
 
         $mock = static::isMock()
-                    ? static::$resolvedInstance[$name]
-                    : static::createFreshMockInstance();
+            ? static::$resolvedInstance[$name]
+            : static::createFreshMockInstance();
 
         return $mock->shouldReceive(...func_get_args());
     }
@@ -197,21 +204,21 @@ abstract class Facade
     /**
      * Resolve the facade root instance from the container.
      *
-     * @param  object|string  $name
+     * @param  string  $name
      * @return mixed
      */
     protected static function resolveFacadeInstance($name)
     {
-        if (is_object($name)) {
-            return $name;
-        }
-
         if (isset(static::$resolvedInstance[$name])) {
             return static::$resolvedInstance[$name];
         }
-
+        dump(array_keys(static::$resolvedInstance));
         if (static::$app) {
-            return static::$resolvedInstance[$name] = static::$app[$name];
+            if (static::$cached) {
+                return static::$resolvedInstance[$name] = static::$app[$name];
+            }
+
+            return static::$app[$name];
         }
     }
 

--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -24,7 +24,7 @@ abstract class Facade
     protected static $resolvedInstance;
 
     /**
-     * Determine if the resolved facade should be cached.
+     * Determine if the resolved instance should be cached.
      *
      * @var bool
      */

--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -212,7 +212,7 @@ abstract class Facade
         if (isset(static::$resolvedInstance[$name])) {
             return static::$resolvedInstance[$name];
         }
-        dump(array_keys(static::$resolvedInstance));
+
         if (static::$app) {
             if (static::$cached) {
                 return static::$resolvedInstance[$name] = static::$app[$name];

--- a/src/Illuminate/Support/Facades/RateLimiter.php
+++ b/src/Illuminate/Support/Facades/RateLimiter.php
@@ -24,6 +24,6 @@ class RateLimiter extends Facade
      */
     protected static function getFacadeAccessor()
     {
-        return 'Illuminate\Cache\RateLimiter';
+        return \Illuminate\Cache\RateLimiter::class;
     }
 }

--- a/src/Illuminate/Support/Facades/Schema.php
+++ b/src/Illuminate/Support/Facades/Schema.php
@@ -25,6 +25,13 @@ namespace Illuminate\Support\Facades;
 class Schema extends Facade
 {
     /**
+     * Determine if the resolved facade should be cached.
+     *
+     * @var bool
+     */
+    protected static $cached = false;
+
+    /**
      * Get a schema builder instance for a connection.
      *
      * @param  string|null  $name
@@ -36,12 +43,12 @@ class Schema extends Facade
     }
 
     /**
-     * Get a schema builder instance for the default connection.
+     * Get the registered name of the component.
      *
-     * @return \Illuminate\Database\Schema\Builder
+     * @return string
      */
     protected static function getFacadeAccessor()
     {
-        return static::$app['db']->connection()->getSchemaBuilder();
+        return 'db.schema';
     }
 }

--- a/tests/Database/DatabaseMigratorIntegrationTest.php
+++ b/tests/Database/DatabaseMigratorIntegrationTest.php
@@ -41,6 +41,9 @@ class DatabaseMigratorIntegrationTest extends TestCase
 
         $container = new Container;
         $container->instance('db', $db->getDatabaseManager());
+        $container->bind('db.schema', function ($app) {
+            return $app['db']->connection()->getSchemaBuilder();
+        });
 
         Facade::setFacadeApplication($container);
 


### PR DESCRIPTION
This is a re-send of https://github.com/laravel/framework/pull/25512 but one that keeps in mind the issues which originated from it with https://github.com/laravel/framework/issues/27686

It moves the Schema facade to a string based accessor in the way facades were intended to work. This will make all facade accessors in Laravel string based which means we can remove any object checks. The way this PR solves the original issue from https://github.com/laravel/framework/issues/27686 is by adding a new `$cached` check to the facade class. If caching is turned off, a fresh instance is always retrieved from the container, just like the facade is currently doing. 

At the same time this PR solves https://github.com/laravel/framework/issues/37983. The facade mocking will disregard the caching check and will always register a mock with the facade and thus enable all capabilities like spying, etc. Swapping is also supported now on the Schema facade.

Basically this PR should resolve all prior issues. While technically this should be good to go to 8.x, because the facade root isn't returning an object anymore I opted to send this in to master for the next major release.

I'd very much appreciate if @stancl (tenancy) and @awjudd (OP of the spying issue) could try out this PR.