### PR TITLE
[8.x] Restore auto-complete functionality on `when` and `unless`

### DIFF
--- a/src/Illuminate/Support/Traits/Conditionable.php
+++ b/src/Illuminate/Support/Traits/Conditionable.php
@@ -10,8 +10,7 @@ trait Conditionable
      * @param  mixed  $value
      * @param  callable  $callback
      * @param  callable|null  $default
-     *
-     * @return mixed|$this
+     * @return $this|mixed
      */
     public function when($value, $callback, $default = null)
     {
@@ -30,8 +29,7 @@ trait Conditionable
      * @param  mixed  $value
      * @param  callable  $callback
      * @param  callable|null  $default
-     *
-     * @return mixed|$this
+     * @return $this|mixed
      */
     public function unless($value, $callback, $default = null)
     {

--- a/src/Illuminate/Support/Traits/Conditionable.php
+++ b/src/Illuminate/Support/Traits/Conditionable.php
@@ -11,7 +11,7 @@ trait Conditionable
      * @param  callable  $callback
      * @param  callable|null  $default
      *
-     * @return mixed
+     * @return $this
      */
     public function when($value, $callback, $default = null)
     {
@@ -31,7 +31,7 @@ trait Conditionable
      * @param  callable  $callback
      * @param  callable|null  $default
      *
-     * @return mixed
+     * @return $this
      */
     public function unless($value, $callback, $default = null)
     {

--- a/src/Illuminate/Support/Traits/Conditionable.php
+++ b/src/Illuminate/Support/Traits/Conditionable.php
@@ -11,7 +11,7 @@ trait Conditionable
      * @param  callable  $callback
      * @param  callable|null  $default
      *
-     * @return $this
+     * @return mixed|$this
      */
     public function when($value, $callback, $default = null)
     {
@@ -31,7 +31,7 @@ trait Conditionable
      * @param  callable  $callback
      * @param  callable|null  $default
      *
-     * @return $this
+     * @return mixed|$this
      */
     public function unless($value, $callback, $default = null)
     {


### PR DESCRIPTION
Looks like when the `Conditionable` trait was merged, we lost the ability to get autocompletion from PHPStorm when doing `$eloquent->newQuery()->when(...)->chain()->anotherChain()->get()` because of the `mixed` return type.

**I have not verified**, but as far as I remember the goal with a `Conditionable` trait was consistency across the framework, in which case they're likely returning `$this` for chain capabilities.