### PR TITLE
[8.x] Adds an `--install` option when using the `make:provider` command

### DIFF
--- a/src/Illuminate/Foundation/Console/ProviderMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ProviderMakeCommand.php
@@ -61,7 +61,7 @@ class ProviderMakeCommand extends GeneratorCommand
     {
         return tap(parent::handle(), function ($result) {
             if ($result !== false && $this->option('register')) {
-                $this->registerProvider('RouteServiceProvider');
+                $this->registerProvider();
             }
         });
     }
@@ -71,14 +71,14 @@ class ProviderMakeCommand extends GeneratorCommand
      *
      * @return void
      */
-    protected function registerProvider(string $after)
+    protected function registerProvider()
     {
         $appConfig = file_get_contents(config_path('app.php'));
 
         if (! Str::contains($appConfig, 'App\\Providers\\'.$this->getNameInput().'::class')) {
             file_put_contents(config_path('app.php'), str_replace(
-                'App\\Providers\\'.$after.'::class,',
-                'App\\Providers\\'.$after.'::class,'.PHP_EOL.'        App\\Providers\\'.$this->getNameInput().'::class,',
+                'App\\Providers\\RouteServiceProvider::class,',
+                'App\\Providers\\RouteServiceProvider::class,'.PHP_EOL.'        App\\Providers\\'.$this->getNameInput().'::class,',
                 $appConfig
             ));
         }

--- a/src/Illuminate/Foundation/Console/ProviderMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ProviderMakeCommand.php
@@ -59,12 +59,10 @@ class ProviderMakeCommand extends GeneratorCommand
      */
     public function handle()
     {
-        return tap(parent::handle(), function($result) {
-            if ($result === false || !$this->hasOption('register')) {
-                return;
+        return tap(parent::handle(), function ($result) {
+            if ($result !== false && $this->option('register')) {
+                $this->registerProvider();
             }
-
-            $this->registerProvider();
         });
     }
 

--- a/src/Illuminate/Foundation/Console/ProviderMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ProviderMakeCommand.php
@@ -60,7 +60,7 @@ class ProviderMakeCommand extends GeneratorCommand
     public function handle()
     {
         return tap(parent::handle(), function ($result) {
-            if ($result !== false && $this->option('register')) {
+            if ($result !== false && $this->option('install')) {
                 $this->registerProvider();
             }
         });
@@ -83,7 +83,7 @@ class ProviderMakeCommand extends GeneratorCommand
             ));
         }
 
-        $this->info($this->type.' registered successfully.');
+        $this->info($this->type.' installed successfully.');
     }
 
     /**
@@ -94,7 +94,7 @@ class ProviderMakeCommand extends GeneratorCommand
     protected function getOptions()
     {
         return [
-            ['register', 'r', InputOption::VALUE_NONE, 'Automatically register the created provider in your application'],
+            ['install', 'i', InputOption::VALUE_NONE, 'Automatically install the created provider in your application'],
         ];
     }
 }


### PR DESCRIPTION
Hi guys,

Hope you're all well.

This PR is a small QOL improvement when using the `php artisan make:provider` command. It allows you to specify an `--install` option (or `-i` for shorthand) that will automatically add an entry in your `config/app.php` file.

The logic for inserting this into the file is taken from Telescope's `InstallCommand`: https://github.com/laravel/telescope/blob/4.x/src/Console/InstallCommand.php, with some modifications to make it more generic.

## Usage

Usage is identical to before, but now you can add the register option if desired:

```bash
php artisan make:provider MyVeryOwnServiceProvider --install
# Or
php artisan make:provider MyVeryOwnServiceProvider -i
```

The provider will be inserted under the `RouteServiceProvider` that ships with Laravel.

Thanks for all your hard work 🥳

Kind Regards,
Luke