### PR TITLE
[8.x] Add `toRawSql()` method on the query builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -98,6 +98,7 @@ class Builder
         'raw',
         'sum',
         'toSql',
+        'toRawSql',
     ];
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2307,7 +2307,7 @@ class Builder
      */
     public function toRawSql()
     {
-        return array_reduce($this->getBindings(), function($sql, $binding) {
+        return array_reduce($this->getBindings(), function ($sql, $binding) {
             return preg_replace('/\?/', is_numeric($binding) ? $binding : "'".$binding."'", $sql, 1);
         }, $this->toSql());
     }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2307,8 +2307,8 @@ class Builder
      */
     public function toRawSql()
     {
-        return array_reduce($this->getBindings(), function($sql, $binding){
-            return preg_replace('/\?/', is_numeric($binding) ? $binding : "'".$binding."'" , $sql, 1);
+        return array_reduce($this->getBindings(), function($sql, $binding) {
+            return preg_replace('/\?/', is_numeric($binding) ? $binding : "'".$binding."'", $sql, 1);
         }, $this->toSql());
     }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2301,6 +2301,18 @@ class Builder
     }
 
     /**
+     * Get the Raw SQL representation of the query.
+     *
+     * @return string
+     */
+    public function toRawSql()
+    {
+        return array_reduce($this->getBindings(), function($sql, $binding){
+            return preg_replace('/\?/', is_numeric($binding) ? $binding : "'".$binding."'" , $sql, 1);
+        }, $this->toSql());
+    }
+
+    /**
      * Execute a query for a single record by ID.
      *
      * @param  int|string  $id

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2308,7 +2308,7 @@ class Builder
     public function toRawSql()
     {
         return array_reduce($this->getBindings(), function ($sql, $binding) {
-            return preg_replace('/\?/', is_numeric($binding) ? $binding : "'".$binding."'", $sql, 1);
+            return preg_replace('/\?/', is_numeric($binding) ? $binding : $this->grammar->quoteString($binding), $sql, 1);
         }, $this->toSql());
     }
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1643,6 +1643,15 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertSame('select * from "users" where "email" = ?', $clone->toSql());
     }
 
+    public function testToRawSql()
+    {
+        $model = new EloquentBuilderTestModelParentStub;
+
+        $builder = $model->where('foo', 'bar')->where('baz', 1);
+
+        $this->assertSame('select * from "eloquent_builder_test_model_parent_stubs" where "foo" = \'bar\' and "baz" = 1', $builder->toRawSql());
+    }
+
     protected function mockConnectionForModel($model, $database)
     {
         $grammarClass = 'Illuminate\Database\Query\Grammars\\'.$database.'Grammar';


### PR DESCRIPTION
This feature came from the desire to debug queries by combining `toSql()` and `getBindings()` into a complete raw query string. This adds another helpful debugging method to the query builder and enables a user to easily copy a raw query directly into a database GUI without having to manually replace parameter bindings in the `toSql()` output.

## Usage
```php
Model::where('foo', 'bar')->where('baz', 1)->toRawSql()

// output
"select * from model where "foo" = 'bar' and "baz" = 1"
```

The method takes into consideration if a parameter is a string or integer and will wrap a string in single quotes accordingly.