### PR TITLE
[8.x] Make `FilesystemAdapter` macroable

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -11,6 +11,7 @@ use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
 use League\Flysystem\Adapter\Ftp;
 use League\Flysystem\Adapter\Local as LocalAdapter;
@@ -32,6 +33,10 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
  */
 class FilesystemAdapter implements CloudFilesystemContract
 {
+    use Macroable {
+        __call as macroCall;
+    }
+
     /**
      * The Flysystem filesystem implementation.
      *
@@ -784,6 +789,10 @@ class FilesystemAdapter implements CloudFilesystemContract
      */
     public function __call($method, array $parameters)
     {
+        if (static::hasMacro($method)) {
+            return $this->macroCall($method, $parameters);
+        }
+
         return $this->driver->{$method}(...array_values($parameters));
     }
 }

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -319,4 +319,16 @@ class FilesystemAdapterTest extends TestCase
             'uploaded file content'
         );
     }
+
+    public function testMacroable()
+    {
+        $this->filesystem->write('foo.txt', 'Hello World');
+
+        $filesystemAdapter = new FilesystemAdapter($this->filesystem);
+        $filesystemAdapter->macro('getFoo', function () {
+            return $this->get('foo.txt');
+        });
+
+        $this->assertSame('Hello World', $filesystemAdapter->getFoo());
+    }
 }


### PR DESCRIPTION
This PR makes the `\Illuminate\Filesystem\FilesystemAdapter` class macroable. This class is used by the `Storage` facade.

A simple use-case I have encountered is wanting a clean way to return the root path of a particular storage disk.
```php
Storage::macro('rootPath', function () {
    return $this->path('');
});

// ...

Storage::rootPath();
```

A slightly more complex use-case is a function to move files from one disk to another. This would be especially useful on Vapor, moving files from temporary storage (such as a dynamically generated spreadsheet or invoice) to a permanent s3 bucket (for a user to download).
```php
Storage::macro('moveToDisk', function (string $path, string $disk = null) {
    Storage::disk($disk)->put($path, $this->get($path));
    $this->delete($path);
});

// ...

Spreadsheet::create(Storage::path('spreadsheet.xlsx'))
    ->addRow([ /* ... */ ]);

Storage::moveToDisk('spreadsheet.xlsx', 's3');
```