### PR TITLE
[8.x] Use Queue::setConnectionName() inside Dispatcher::queueHandler()

### DIFF
--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -549,7 +549,7 @@ class Dispatcher implements DispatcherContract
     {
         [$listener, $job] = $this->createListenerAndJob($class, $method, $arguments);
 
-        $connection = $this->resolveQueue()->connection(method_exists($listener, 'viaConnection')
+        $connection = $this->resolveQueue()->setConnectionName(method_exists($listener, 'viaConnection')
                     ? $listener->viaConnection()
                     : $listener->connection ?? null);
 

--- a/tests/Events/QueuedEventsTest.php
+++ b/tests/Events/QueuedEventsTest.php
@@ -23,7 +23,7 @@ class QueuedEventsTest extends TestCase
         $d = new Dispatcher;
         $queue = m::mock(Queue::class);
 
-        $queue->shouldReceive('connection')->once()->with(null)->andReturnSelf();
+        $queue->shouldReceive('setConnectionName')->once()->with(null)->andReturnSelf();
 
         $queue->shouldReceive('pushOn')->once()->with(null, m::type(CallQueuedListener::class));
 
@@ -72,7 +72,7 @@ class QueuedEventsTest extends TestCase
         $d = new Dispatcher;
         $queue = m::mock(Queue::class);
 
-        $queue->shouldReceive('connection')->once()->with('some_other_connection')->andReturnSelf();
+        $queue->shouldReceive('setConnectionName')->once()->with('some_other_connection')->andReturnSelf();
 
         $queue->shouldReceive('pushOn')->once()->with(null, m::type(CallQueuedListener::class));
 


### PR DESCRIPTION
The logic inside queueHandler() in Event\Dispatcher is to chain setting the queue connection after resolving it

```php
$this->resolveQueue()->connection(...)
```

By the docblock, resolveQueue() should return Contracts\Queue\Queue. However, the method ```connection()``` is not available in the contract. While the test wasn't complaining with the original logic, what I think should be called is ```setConnectionName()```.