### PR TITLE
[8.x] The controller can directly return the stdClass object

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -787,6 +787,7 @@ class Router implements BindingRegistrar, RegistrarContract
                     $response instanceof Jsonable ||
                     $response instanceof ArrayObject ||
                     $response instanceof JsonSerializable ||
+                    $response instanceof \stdClass ||
                     is_array($response))) {
             $response = new JsonResponse($response);
         } elseif (! $response instanceof SymfonyResponse) {

--- a/tests/Http/HttpJsonResponseTest.php
+++ b/tests/Http/HttpJsonResponseTest.php
@@ -30,6 +30,7 @@ class HttpJsonResponseTest extends TestCase
             'JsonSerializable data' => [new JsonResponseTestJsonSerializeObject],
             'Arrayable data' => [new JsonResponseTestArrayableObject],
             'Array data' => [['foo' => 'bar']],
+            'stdClass data' => [(object) ['foo' => 'bar']],
         ];
     }
 


### PR DESCRIPTION
`DB::table('users')->find(1)` returns an instance of `stdClass`, which is now allowed to return directly from the controller method.