### PR TITLE
[8.x] Accept closure for retry() sleep

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -216,7 +216,7 @@ if (! function_exists('retry')) {
      *
      * @param  int  $times
      * @param  callable  $callback
-     * @param  int  $sleepMilliseconds
+     * @param  int|\Closure  $sleepMilliseconds
      * @param  callable|null  $when
      * @return mixed
      *
@@ -238,7 +238,7 @@ if (! function_exists('retry')) {
             }
 
             if ($sleepMilliseconds) {
-                usleep($sleepMilliseconds * 1000);
+                usleep(value($sleepMilliseconds, $attempts) * 1000);
             }
 
             goto beginning;

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -555,6 +555,27 @@ class SupportHelpersTest extends TestCase
         $this->assertEqualsWithDelta(0.1, microtime(true) - $startTime, 0.02);
     }
 
+    public function testRetryWithPassingSleepCallback()
+    {
+        $startTime = microtime(true);
+
+        $attempts = retry(3, function ($attempts) {
+            if ($attempts > 2) {
+                return $attempts;
+            }
+
+            throw new RuntimeException;
+        }, function ($attempt) {
+            return $attempt * 100;
+        });
+
+        // Make sure we made three attempts
+        $this->assertEquals(3, $attempts);
+
+        // Make sure we waited 300ms for the first two attempts
+        $this->assertEqualsWithDelta(0.3, microtime(true) - $startTime, 0.02);
+    }
+
     public function testRetryWithPassingWhenCallback()
     {
         $startTime = microtime(true);


### PR DESCRIPTION
With this change the `retry()` helper will also accept a closure for the `$sleepMilliseconds` argument (instead of only an integer). This closure will receive the `$attempts` variable, allowing the user to change the delay based on the number of attempts. For example, waiting 100ms after the first attempt and 200ms after the second attempt, etc.