### PR TITLE
[8.x] Add Str::wrap

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -830,6 +830,18 @@ class Str
     }
 
     /**
+     * Wrap a string in given character(s)
+     *
+     * @param  string  $string
+     * @param  string  $characters
+     * @return string
+     */
+    public static function wrap($string, $characters)
+    {
+        return $characters . $string . $characters;
+    }
+
+    /**
      * Generate a UUID (version 4).
      *
      * @return \Ramsey\Uuid\UuidInterface

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -830,7 +830,7 @@ class Str
     }
 
     /**
-     * Wrap a string in given character(s)
+     * Wrap a string in given character(s).
      *
      * @param  string  $string
      * @param  string  $characters
@@ -838,7 +838,7 @@ class Str
      */
     public static function wrap($string, $characters)
     {
-        return $characters . $string . $characters;
+        return $characters.$string.$characters;
     }
 
     /**

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -733,7 +733,7 @@ class Stringable implements JsonSerializable
     }
 
     /**
-     * Wrap a string in given character(s)
+     * Wrap a string in given character(s).
      *
      * @param  string  $characters
      * @return static

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -733,6 +733,17 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Wrap a string in given character(s)
+     *
+     * @param  string  $characters
+     * @return static
+     */
+    public function wrap($characters)
+    {
+        return new static(Str::wrap($this->value, $characters));
+    }
+
+    /**
      * Limit the number of words in a string.
      *
      * @param  int  $words

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -528,6 +528,12 @@ class SupportStrTest extends TestCase
         $this->assertEquals(10, Str::wordCount('Hi, this is my first contribution to the Laravel framework.'));
     }
 
+    public function testWrap()
+    {
+        $this->assertEquals('"Some String"', Str::wrap('Some String', '"'));
+        $this->assertEquals('AABBCCJamesAABBCC', Str::wrap('James', 'AABBCC'));
+    }
+
     public function validUuidList()
     {
         return [

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Support;
 
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
 use PHPUnit\Framework\TestCase;
 
@@ -679,5 +680,11 @@ class SupportStringableTest extends TestCase
     {
         $this->assertEquals(2, $this->stringable('Hello, world!')->wordCount());
         $this->assertEquals(10, $this->stringable('Hi, this is my first contribution to the Laravel framework.')->wordCount());
+    }
+
+    public function testWrap()
+    {
+        $this->assertEquals('"Some String"', $this->stringable('Some String')->wrap('"'));
+        $this->assertEquals('AABBCCJamesAABBCC', $this->stringable('James')->wrap('AABBCC'));
     }
 }

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Tests\Support;
 
 use Illuminate\Support\Collection;
-use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
 use PHPUnit\Framework\TestCase;
 


### PR DESCRIPTION
I'm currently writing a CSV handler, and I wanted to use `Str::of` to wrap my column in double quotes. I came up with the following code which looks rather messy:

```php 
return Str::of($item)->append('"')->prepend('"');
```

The following PR would allow you to do the following instead:

```php 
return Str::of($item)->wrap('"');
//or
return Str::wrap($item, '"')
```

(If this gets merge, i'll send a PR over to the docs)