### PR TITLE
[8.x] Passthrough excluded uri's in maintenance mode

### DIFF
--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -2,10 +2,10 @@
 
 namespace Illuminate\Foundation\Console;
 
+use App\Http\Middleware\PreventRequestsDuringMaintenance;
 use Exception;
 use Illuminate\Console\Command;
 use Illuminate\Foundation\Exceptions\RegisterErrorViewPaths;
-use App\Http\Middleware\PreventRequestsDuringMaintenance;
 
 class DownCommand extends Command
 {

--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -70,7 +70,7 @@ class DownCommand extends Command
     protected function getDownFilePayload()
     {
         return [
-            'exclude' => $this->excludePaths(),
+            'except' => $this->exceptPaths(),
             'redirect' => $this->redirectPath(),
             'retry' => $this->getRetryTime(),
             'refresh' => $this->option('refresh'),
@@ -81,11 +81,11 @@ class DownCommand extends Command
     }
 
     /**
-     * Get the exclude paths to be placed in the "down" file.
+     * Get the except paths to be placed in the "down" file.
      *
      * @return array
      */
-    protected function excludePaths()
+    protected function exceptPaths()
     {
         return $this->laravel->make(PreventRequestsDuringMaintenance::class)->getExceptPaths();
     }

--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Console;
 use Exception;
 use Illuminate\Console\Command;
 use Illuminate\Foundation\Exceptions\RegisterErrorViewPaths;
+use App\Http\Middleware\PreventRequestsDuringMaintenance;
 
 class DownCommand extends Command
 {
@@ -69,6 +70,7 @@ class DownCommand extends Command
     protected function getDownFilePayload()
     {
         return [
+            'exclude' => $this->excludePaths(),
             'redirect' => $this->redirectPath(),
             'retry' => $this->getRetryTime(),
             'refresh' => $this->option('refresh'),
@@ -76,6 +78,16 @@ class DownCommand extends Command
             'status' => (int) $this->option('status', 503),
             'template' => $this->option('render') ? $this->prerenderView() : null,
         ];
+    }
+
+    /**
+     * Get the exclude paths to be placed in the "down" file.
+     *
+     * @return array
+     */
+    protected function excludePaths()
+    {
+        return $this->laravel->make(PreventRequestsDuringMaintenance::class)->getExceptPaths();
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -6,6 +6,7 @@ use App\Http\Middleware\PreventRequestsDuringMaintenance;
 use Exception;
 use Illuminate\Console\Command;
 use Illuminate\Foundation\Exceptions\RegisterErrorViewPaths;
+use Throwable;
 
 class DownCommand extends Command
 {
@@ -70,7 +71,7 @@ class DownCommand extends Command
     protected function getDownFilePayload()
     {
         return [
-            'except' => $this->exceptPaths(),
+            'except' => $this->excludedPaths(),
             'redirect' => $this->redirectPath(),
             'retry' => $this->getRetryTime(),
             'refresh' => $this->option('refresh'),
@@ -81,13 +82,17 @@ class DownCommand extends Command
     }
 
     /**
-     * Get the except paths to be placed in the "down" file.
+     * Get the paths that should be excluded from maintenance mode.
      *
      * @return array
      */
-    protected function exceptPaths()
+    protected function excludedPaths()
     {
-        return $this->laravel->make(PreventRequestsDuringMaintenance::class)->getExceptPaths();
+        try {
+            return $this->laravel->make(PreventRequestsDuringMaintenance::class)->getExcludedPaths();
+        } catch (Throwable $e) {
+            return [];
+        }
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/stubs/maintenance-mode.stub
+++ b/src/Illuminate/Foundation/Console/stubs/maintenance-mode.stub
@@ -13,7 +13,7 @@ if (! isset($data['template'])) {
     return;
 }
 
-// Allow framework to handle request if current uri is in the exclude list...
+// Allow framework to handle request if request URI is in the exclude list...
 if (isset($data['except'])) {
     $uri = parse_url($_SERVER['REQUEST_URI'])['path'];
 

--- a/src/Illuminate/Foundation/Console/stubs/maintenance-mode.stub
+++ b/src/Illuminate/Foundation/Console/stubs/maintenance-mode.stub
@@ -14,13 +14,23 @@ if (! isset($data['template'])) {
 }
 
 // Allow framework to handle request if current uri is in the exclude list...
-if (isset($data['exclude'])) {
-    $uri = trim(parse_url($_SERVER['REQUEST_URI'])['path'], '/');
+if (isset($data['except'])) {
+    $uri = parse_url($_SERVER['REQUEST_URI'])['path'];
 
-    foreach ((array) $data['exclude'] as $exclude) {
-        $exclude = trim($exclude, '/');
+    $uri = rawurldecode($uri !== '/' ? trim($uri, '/') : $uri);
 
-        if ($exclude === $uri) {
+    foreach ((array) $data['except'] as $except) {
+        $except = $except !== '/' ? trim($except, '/') : $except;
+
+        if ($except == $uri) {
+            return;
+        }
+
+        $except = preg_quote($except, '#');
+
+        $except = str_replace('\*', '.*', $except);
+
+        if (preg_match('#^'.$except.'\z#u', $uri) === 1) {
             return;
         }
     }

--- a/src/Illuminate/Foundation/Console/stubs/maintenance-mode.stub
+++ b/src/Illuminate/Foundation/Console/stubs/maintenance-mode.stub
@@ -13,6 +13,19 @@ if (! isset($data['template'])) {
     return;
 }
 
+// Allow framework to handle request if current uri is in the exclude list...
+if (isset($data['exclude'])) {
+    $uri = trim(parse_url($_SERVER['REQUEST_URI'])['path'], '/');
+
+    foreach ((array) $data['exclude'] as $exclude) {
+        $exclude = trim($exclude, '/');
+
+        if ($exclude === $uri) {
+            return;
+        }
+    }
+}
+
 // Allow framework to handle maintenance mode bypass route...
 if (isset($data['secret']) && $_SERVER['REQUEST_URI'] === '/'.$data['secret']) {
     return;

--- a/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
+++ b/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
@@ -155,11 +155,11 @@ class PreventRequestsDuringMaintenance
     }
 
     /**
-     * Get the URIs that should not be accessible while maintenance mode is enabled.
+     * Get the URIs that should be accessible even when maintenance mode is enabled.
      *
      * @return array
      */
-    public function getExceptPaths()
+    public function getExcludedPaths()
     {
         return $this->except;
     }

--- a/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
+++ b/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
@@ -153,4 +153,14 @@ class PreventRequestsDuringMaintenance
 
         return $headers;
     }
+
+    /**
+     * Get the URIs that should not be accessible while maintenance mode is enabled.
+     *
+     * @return array
+     */
+    public function getExceptPaths()
+    {
+        return $this->except;
+    }
 }


### PR DESCRIPTION
I'm not entirely sure about the `$this->laravel->make(PreventRequestsDuringMaintenance::class)` since it will require people to always have this class here and named like this.

Fixes https://github.com/laravel/framework/issues/38038