### PR TITLE
[8.x] Add generics to Illuminate\Support\Collection

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -10,6 +10,13 @@ use Illuminate\Support\Traits\EnumeratesValues;
 use Illuminate\Support\Traits\Macroable;
 use stdClass;
 
+/**
+ * @template TKey
+ * @template TValue
+ * @implements ArrayAccess<TKey, TValue>
+ * @implements Enumerable<TKey, TValue>
+ * @uses EnumeratesValues<TKey, TValue>
+ */
 class Collection implements ArrayAccess, Enumerable
 {
     use EnumeratesValues, Macroable;
@@ -17,7 +24,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * The items contained in the collection.
      *
-     * @var array
+     * @var array<TKey, TValue>
      */
     protected $items = [];
 
@@ -47,7 +54,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get all of the items in the collection.
      *
-     * @return array
+     * @return array<TKey, TValue>
      */
     public function all()
     {
@@ -67,8 +74,8 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get the average value of a given key.
      *
-     * @param  callable|string|null  $callback
-     * @return mixed
+     * @param  string|null|callback(TValue): float|int  $callback
+     * @return float|int
      */
     public function avg($callback = null)
     {
@@ -88,8 +95,8 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get the median of a given key.
      *
-     * @param  string|array|null  $key
-     * @return mixed
+     * @param  string|array<mixed>|null  $key
+     * @return TValue|int|float|null
      */
     public function median($key = null)
     {
@@ -118,7 +125,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get the mode of a given key.
      *
-     * @param  string|array|null  $key
+     * @param  string|array<mixed>|null  $key
      * @return array|null
      */
     public function mode($key = null)
@@ -157,9 +164,9 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Determine if an item exists in the collection.
      *
-     * @param  mixed  $key
-     * @param  mixed  $operator
-     * @param  mixed  $value
+     * @param  TKey|TValue|callable  $key
+     * @param  string|null  $operator
+     * @param  TValue|null  $value
      * @return bool
      */
     public function contains($key, $operator = null, $value = null)
@@ -320,7 +327,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get all items except for those with the specified keys.
      *
-     * @param  \Illuminate\Support\Collection|mixed  $keys
+     * @param  \Illuminate\Support\Collection<int, TKey>|TKey  $keys
      * @return static
      */
     public function except($keys)
@@ -354,7 +361,7 @@ class Collection implements ArrayAccess, Enumerable
      *
      * @param  callable|null  $callback
      * @param  mixed  $default
-     * @return mixed
+     * @return TValue|null
      */
     public function first(callable $callback = null, $default = null)
     {
@@ -385,8 +392,8 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Remove an item from the collection by key.
      *
-     * @param  string|array  $keys
-     * @return $this
+     * @param  TKey|array<TKey>  $keys
+     * @return static
      */
     public function forget($keys)
     {
@@ -402,7 +409,7 @@ class Collection implements ArrayAccess, Enumerable
      *
      * @param  mixed  $key
      * @param  mixed  $default
-     * @return mixed
+     * @return TValue|null
      */
     public function get($key, $default = null)
     {
@@ -487,7 +494,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Determine if an item exists in the collection by key.
      *
-     * @param  mixed  $key
+     * @param  TKey  $key
      * @return bool
      */
     public function has($key)
@@ -598,7 +605,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get the keys of the collection items.
      *
-     * @return static
+     * @return static<int, TKey>
      */
     public function keys()
     {
@@ -610,7 +617,7 @@ class Collection implements ArrayAccess, Enumerable
      *
      * @param  callable|null  $callback
      * @param  mixed  $default
-     * @return mixed
+     * @return TValue|null
      */
     public function last(callable $callback = null, $default = null)
     {
@@ -620,9 +627,9 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get the values of a given key.
      *
-     * @param  string|array|int|null  $value
-     * @param  string|null  $key
-     * @return static
+     * @param string|array<mixed> $value
+     * @param string|null $key
+     * @return static<mixed>
      */
     public function pluck($value, $key = null)
     {
@@ -632,8 +639,9 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Run a map over each of the items.
      *
-     * @param  callable  $callback
-     * @return static
+     * @template TReturn
+     * @param callable(TValue, TKey): TReturn $callback
+     * @return static<TKey, TReturn>
      */
     public function map(callable $callback)
     {
@@ -649,8 +657,10 @@ class Collection implements ArrayAccess, Enumerable
      *
      * The callback should return an associative array with a single key/value pair.
      *
-     * @param  callable  $callback
-     * @return static
+     * @template TReturnKey
+     * @template TReturnValue
+     * @param  callable(TValue, TKey): array<TReturnKey, TReturnValue>  $callback
+     * @return static<TReturnKey, TReturnValue>
      */
     public function mapToDictionary(callable $callback)
     {
@@ -677,9 +687,10 @@ class Collection implements ArrayAccess, Enumerable
      * Run an associative map over each of the items.
      *
      * The callback should return an associative array with a single key/value pair.
-     *
-     * @param  callable  $callback
-     * @return static
+     * @template TReturnKey
+     * @template TReturnValue
+     * @param  callable(TValue, TKey): array<TReturnKey, TReturnValue>  $callback
+     * @return static<TReturnKey, TReturnValue>
      */
     public function mapWithKeys(callable $callback)
     {
@@ -788,7 +799,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get and remove the last item from the collection.
      *
-     * @return mixed
+     * @return TValue|null
      */
     public function pop()
     {
@@ -812,8 +823,8 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Push one or more items onto the end of the collection.
      *
-     * @param  mixed  $values [optional]
-     * @return $this
+     * @param  array<TValue>|TValue $values [optional]
+     * @return static
      */
     public function push(...$values)
     {
@@ -846,7 +857,7 @@ class Collection implements ArrayAccess, Enumerable
      *
      * @param  mixed  $key
      * @param  mixed  $default
-     * @return mixed
+     * @return TValue|null
      */
     public function pull($key, $default = null)
     {
@@ -856,9 +867,9 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Put an item in the collection by key.
      *
-     * @param  mixed  $key
-     * @param  mixed  $value
-     * @return $this
+     * @param  TKey   $key
+     * @param  TValue $value
+     * @return static
      */
     public function put($key, $value)
     {
@@ -871,7 +882,7 @@ class Collection implements ArrayAccess, Enumerable
      * Get one or a specified number of items randomly from the collection.
      *
      * @param  int|null  $number
-     * @return static|mixed
+     * @return static|TValue
      *
      * @throws \InvalidArgumentException
      */
@@ -919,9 +930,9 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Search the collection for a given value and return the corresponding key if successful.
      *
-     * @param  mixed  $value
-     * @param  bool  $strict
-     * @return mixed
+     * @param mixed $value
+     * @param bool  $strict
+     * @return TKey|false
      */
     public function search($value, $strict = false)
     {
@@ -941,7 +952,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get and remove the first item from the collection.
      *
-     * @return mixed
+     * @return TValue|null
      */
     public function shift()
     {
@@ -989,7 +1000,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Skip items in the collection until the given condition is met.
      *
-     * @param  mixed  $value
+     * @param  TValue  $value
      * @return static
      */
     public function skipUntil($value)
@@ -1071,9 +1082,9 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get the first item in the collection, but only if exactly one item exists. Otherwise, throw an exception.
      *
-     * @param  mixed  $key
-     * @param  mixed  $operator
-     * @param  mixed  $value
+     * @param  TKey|TValue|null  $key
+     * @param  string|null  $operator
+     * @param  TValue|null  $value
      * @return mixed
      *
      * @throws \Illuminate\Collections\ItemNotFoundException
@@ -1320,7 +1331,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Take items in the collection until the given condition is met.
      *
-     * @param  mixed  $value
+     * @param  TValue  $value
      * @return static
      */
     public function takeUntil($value)
@@ -1342,8 +1353,9 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Transform each item in the collection using a callback.
      *
-     * @param  callable  $callback
-     * @return $this
+     * @template TReturn
+     * @param callable(TValue, TKey): TReturn $callback
+     * @return static<TKey, TReturn>
      */
     public function transform(callable $callback)
     {
@@ -1388,7 +1400,7 @@ class Collection implements ArrayAccess, Enumerable
      * Pad collection to the specified length with a value.
      *
      * @param  int  $size
-     * @param  mixed  $value
+     * @param  TValue  $value
      * @return static
      */
     public function pad($size, $value)
@@ -1399,7 +1411,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get an iterator for the items.
      *
-     * @return \ArrayIterator
+     * @return \ArrayIterator<TKey, TValue>
      */
     public function getIterator()
     {
@@ -1430,8 +1442,8 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Add an item to the collection.
      *
-     * @param  mixed  $item
-     * @return $this
+     * @param  TValue  $item
+     * @return static
      */
     public function add($item)
     {
@@ -1453,7 +1465,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Determine if an item exists at an offset.
      *
-     * @param  mixed  $key
+     * @param  TKey  $key
      * @return bool
      */
     public function offsetExists($key)
@@ -1464,8 +1476,8 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get an item at a given offset.
      *
-     * @param  mixed  $key
-     * @return mixed
+     * @param  TKey  $key
+     * @return TValue
      */
     public function offsetGet($key)
     {
@@ -1475,8 +1487,8 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Set the item at a given offset.
      *
-     * @param  mixed  $key
-     * @param  mixed  $value
+     * @param  TKey  $key
+     * @param  TValue  $value
      * @return void
      */
     public function offsetSet($key, $value)
@@ -1491,7 +1503,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Unset the item at a given offset.
      *
-     * @param  string  $key
+     * @param  TKey  $key
      * @return void
      */
     public function offsetUnset($key)

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -10,10 +10,6 @@ use Illuminate\Support\Traits\EnumeratesValues;
 use Illuminate\Support\Traits\Macroable;
 use stdClass;
 
-/**
- * @template K
- * @template V
- */
 class Collection implements ArrayAccess, Enumerable
 {
     use EnumeratesValues, Macroable;
@@ -21,14 +17,14 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * The items contained in the collection.
      *
-     * @var array<K, V>
+     * @var array
      */
     protected $items = [];
 
     /**
      * Create a new collection.
      *
-     * @param  mixed $items
+     * @param  mixed  $items
      * @return void
      */
     public function __construct($items = [])
@@ -51,7 +47,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get all of the items in the collection.
      *
-     * @return array<K, V>
+     * @return array
      */
     public function all()
     {
@@ -71,7 +67,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get the average value of a given key.
      *
-     * @param  callable|K|null  $callback
+     * @param  callable|string|null  $callback
      * @return mixed
      */
     public function avg($callback = null)
@@ -92,7 +88,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get the median of a given key.
      *
-     * @param  K|null  $key
+     * @param  string|array|null  $key
      * @return mixed
      */
     public function median($key = null)
@@ -122,7 +118,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get the mode of a given key.
      *
-     * @param  K|null  $key
+     * @param  string|array|null  $key
      * @return array|null
      */
     public function mode($key = null)
@@ -161,9 +157,9 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Determine if an item exists in the collection.
      *
-     * @param  K   $key
+     * @param  mixed  $key
      * @param  mixed  $operator
-     * @param  V $value
+     * @param  mixed  $value
      * @return bool
      */
     public function contains($key, $operator = null, $value = null)
@@ -324,7 +320,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get all items except for those with the specified keys.
      *
-     * @param  \Illuminate\Support\Collection<int,K>|mixed  $keys
+     * @param  \Illuminate\Support\Collection|mixed  $keys
      * @return static
      */
     public function except($keys)
@@ -358,7 +354,7 @@ class Collection implements ArrayAccess, Enumerable
      *
      * @param  callable|null  $callback
      * @param  mixed  $default
-     * @return T|null
+     * @return mixed
      */
     public function first(callable $callback = null, $default = null)
     {
@@ -389,7 +385,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Remove an item from the collection by key.
      *
-     * @param  K|array<K>  $keys
+     * @param  string|array  $keys
      * @return $this
      */
     public function forget($keys)
@@ -403,9 +399,10 @@ class Collection implements ArrayAccess, Enumerable
 
     /**
      * Get an item from the collection by key.
-     * @param  K   $key
-     * @param  V $default
-     * @return V
+     *
+     * @param  mixed  $key
+     * @param  mixed  $default
+     * @return mixed
      */
     public function get($key, $default = null)
     {
@@ -490,7 +487,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Determine if an item exists in the collection by key.
      *
-     * @param  K $key
+     * @param  mixed  $key
      * @return bool
      */
     public function has($key)
@@ -601,7 +598,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get the keys of the collection items.
      *
-     * @return static<int, K>
+     * @return static
      */
     public function keys()
     {
@@ -613,7 +610,7 @@ class Collection implements ArrayAccess, Enumerable
      *
      * @param  callable|null  $callback
      * @param  mixed  $default
-     * @return V|null
+     * @return mixed
      */
     public function last(callable $callback = null, $default = null)
     {
@@ -801,8 +798,8 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Push an item onto the beginning of the collection.
      *
-     * @param  V $value
-     * @param  K   $key
+     * @param  mixed  $value
+     * @param  mixed  $key
      * @return $this
      */
     public function prepend($value, $key = null)
@@ -815,7 +812,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Push one or more items onto the end of the collection.
      *
-     * @param  array<V>|V  $values [optional]
+     * @param  mixed  $values [optional]
      * @return $this
      */
     public function push(...$values)
@@ -847,9 +844,9 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get and remove an item from the collection.
      *
-     * @param  K  $key
-     * @param  V  $default
-     * @return V
+     * @param  mixed  $key
+     * @param  mixed  $default
+     * @return mixed
      */
     public function pull($key, $default = null)
     {
@@ -859,8 +856,8 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Put an item in the collection by key.
      *
-     * @param  K   $key
-     * @param  V $value
+     * @param  mixed  $key
+     * @param  mixed  $value
      * @return $this
      */
     public function put($key, $value)
@@ -874,7 +871,7 @@ class Collection implements ArrayAccess, Enumerable
      * Get one or a specified number of items randomly from the collection.
      *
      * @param  int|null  $number
-     * @return static|V
+     * @return static|mixed
      *
      * @throws \InvalidArgumentException
      */
@@ -912,7 +909,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Reverse items order.
      *
-     * @return static<K, V>
+     * @return static
      */
     public function reverse()
     {
@@ -922,8 +919,8 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Search the collection for a given value and return the corresponding key if successful.
      *
-     * @param  V $value
-     * @param  bool   $strict
+     * @param  mixed  $value
+     * @param  bool  $strict
      * @return mixed
      */
     public function search($value, $strict = false)
@@ -944,7 +941,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get and remove the first item from the collection.
      *
-     * @return V
+     * @return mixed
      */
     public function shift()
     {
@@ -955,7 +952,7 @@ class Collection implements ArrayAccess, Enumerable
      * Shuffle the items in the collection.
      *
      * @param  int|null  $seed
-     * @return static<K, V>
+     * @return static
      */
     public function shuffle($seed = null)
     {
@@ -967,7 +964,7 @@ class Collection implements ArrayAccess, Enumerable
      *
      * @param  int  $size
      * @param  int  $step
-     * @return static<K, V>
+     * @return static
      */
     public function sliding($size = 2, $step = 1)
     {
@@ -982,7 +979,7 @@ class Collection implements ArrayAccess, Enumerable
      * Skip the first {$count} items.
      *
      * @param  int  $count
-     * @return static<K, V>
+     * @return static
      */
     public function skip($count)
     {
@@ -992,8 +989,8 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Skip items in the collection until the given condition is met.
      *
-     * @param  V  $value
-     * @return static<K, V>
+     * @param  mixed  $value
+     * @return static
      */
     public function skipUntil($value)
     {
@@ -1003,8 +1000,8 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Skip items in the collection while the given condition is met.
      *
-     * @param  V  $value
-     * @return static<K, V>
+     * @param  mixed  $value
+     * @return static
      */
     public function skipWhile($value)
     {
@@ -1016,7 +1013,7 @@ class Collection implements ArrayAccess, Enumerable
      *
      * @param  int  $offset
      * @param  int|null  $length
-     * @return static<K, V>
+     * @return static
      */
     public function slice($offset, $length = null)
     {
@@ -1027,7 +1024,7 @@ class Collection implements ArrayAccess, Enumerable
      * Split a collection into a certain number of groups.
      *
      * @param  int  $numberOfGroups
-     * @return static<K, V>
+     * @return static
      */
     public function split($numberOfGroups)
     {
@@ -1064,7 +1061,7 @@ class Collection implements ArrayAccess, Enumerable
      * Split a collection into a certain number of groups, and fill the first groups completely.
      *
      * @param  int  $numberOfGroups
-     * @return static<K, V>
+     * @return static
      */
     public function splitIn($numberOfGroups)
     {
@@ -1074,10 +1071,10 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get the first item in the collection, but only if exactly one item exists. Otherwise, throw an exception.
      *
-     * @param  K   $key
+     * @param  mixed  $key
      * @param  mixed  $operator
      * @param  mixed  $value
-     * @return V
+     * @return mixed
      *
      * @throws \Illuminate\Collections\ItemNotFoundException
      * @throws \Illuminate\Collections\MultipleItemsFoundException
@@ -1105,7 +1102,7 @@ class Collection implements ArrayAccess, Enumerable
      * Chunk the collection into chunks of the given size.
      *
      * @param  int  $size
-     * @return static<K, V>
+     * @return static
      */
     public function chunk($size)
     {
@@ -1126,7 +1123,7 @@ class Collection implements ArrayAccess, Enumerable
      * Chunk the collection into chunks with a callback.
      *
      * @param  callable  $callback
-     * @return static<K, V>
+     * @return static
      */
     public function chunkWhile(callable $callback)
     {
@@ -1139,7 +1136,7 @@ class Collection implements ArrayAccess, Enumerable
      * Sort through each item with a callback.
      *
      * @param  callable|int|null  $callback
-     * @return static<K, V>
+     * @return static
      */
     public function sort($callback = null)
     {
@@ -1156,7 +1153,7 @@ class Collection implements ArrayAccess, Enumerable
      * Sort items in descending order.
      *
      * @param  int  $options
-     * @return static<K, V>
+     * @return static
      */
     public function sortDesc($options = SORT_REGULAR)
     {
@@ -1173,7 +1170,7 @@ class Collection implements ArrayAccess, Enumerable
      * @param  callable|array|string  $callback
      * @param  int  $options
      * @param  bool  $descending
-     * @return static<K, V>
+     * @return static
      */
     public function sortBy($callback, $options = SORT_REGULAR, $descending = false)
     {
@@ -1209,7 +1206,7 @@ class Collection implements ArrayAccess, Enumerable
      * Sort the collection using multiple comparisons.
      *
      * @param  array  $comparisons
-     * @return static<K, V>
+     * @return static
      */
     protected function sortByMany(array $comparisons = [])
     {
@@ -1254,7 +1251,7 @@ class Collection implements ArrayAccess, Enumerable
      *
      * @param  callable|string  $callback
      * @param  int  $options
-     * @return static<K, V>
+     * @return static
      */
     public function sortByDesc($callback, $options = SORT_REGULAR)
     {
@@ -1266,7 +1263,7 @@ class Collection implements ArrayAccess, Enumerable
      *
      * @param  int  $options
      * @param  bool  $descending
-     * @return static<K, V>
+     * @return static
      */
     public function sortKeys($options = SORT_REGULAR, $descending = false)
     {
@@ -1281,7 +1278,7 @@ class Collection implements ArrayAccess, Enumerable
      * Sort the collection keys in descending order.
      *
      * @param  int  $options
-     * @return static<K, V>
+     * @return static
      */
     public function sortKeysDesc($options = SORT_REGULAR)
     {
@@ -1294,7 +1291,7 @@ class Collection implements ArrayAccess, Enumerable
      * @param  int  $offset
      * @param  int|null  $length
      * @param  mixed  $replacement
-     * @return static<K, V>
+     * @return static
      */
     public function splice($offset, $length = null, $replacement = [])
     {
@@ -1309,7 +1306,7 @@ class Collection implements ArrayAccess, Enumerable
      * Take the first or last {$limit} items.
      *
      * @param  int  $limit
-     * @return static<K, V>
+     * @return static
      */
     public function take($limit)
     {
@@ -1323,8 +1320,8 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Take items in the collection until the given condition is met.
      *
-     * @param  V  $value
-     * @return static<K, V>
+     * @param  mixed  $value
+     * @return static
      */
     public function takeUntil($value)
     {
@@ -1334,8 +1331,8 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Take items in the collection while the given condition is met.
      *
-     * @param  V  $value
-     * @return static<K, V>
+     * @param  mixed  $value
+     * @return static
      */
     public function takeWhile($value)
     {
@@ -1358,7 +1355,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Reset the keys on the underlying array.
      *
-     * @return static<int, V>
+     * @return static
      */
     public function values()
     {
@@ -1391,8 +1388,8 @@ class Collection implements ArrayAccess, Enumerable
      * Pad collection to the specified length with a value.
      *
      * @param  int  $size
-     * @param  V  $value
-     * @return static<K, V>
+     * @param  mixed  $value
+     * @return static
      */
     public function pad($size, $value)
     {
@@ -1402,7 +1399,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get an iterator for the items.
      *
-     * @return \ArrayIterator<K, V>
+     * @return \ArrayIterator
      */
     public function getIterator()
     {
@@ -1433,7 +1430,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Add an item to the collection.
      *
-     * @param  V  $item
+     * @param  mixed  $item
      * @return $this
      */
     public function add($item)
@@ -1446,7 +1443,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get a base Support collection instance from this collection.
      *
-     * @return \Illuminate\Support\Collection<K, V>
+     * @return \Illuminate\Support\Collection
      */
     public function toBase()
     {
@@ -1456,7 +1453,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Determine if an item exists at an offset.
      *
-     * @param  K  $key
+     * @param  mixed  $key
      * @return bool
      */
     public function offsetExists($key)
@@ -1467,7 +1464,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get an item at a given offset.
      *
-     * @param  K  $key
+     * @param  mixed  $key
      * @return mixed
      */
     public function offsetGet($key)
@@ -1478,8 +1475,8 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Set the item at a given offset.
      *
-     * @param  K  $key
-     * @param  V  $value
+     * @param  mixed  $key
+     * @param  mixed  $value
      * @return void
      */
     public function offsetSet($key, $value)
@@ -1494,7 +1491,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Unset the item at a given offset.
      *
-     * @param  K  $key
+     * @param  string  $key
      * @return void
      */
     public function offsetUnset($key)

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -11,7 +11,8 @@ use Illuminate\Support\Traits\Macroable;
 use stdClass;
 
 /**
- * @template T
+ * @template TKey
+ * @template TValue
  */
 class Collection implements ArrayAccess, Enumerable
 {
@@ -20,7 +21,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * The items contained in the collection.
      *
-     * @var array<T>
+     * @var array<TKey, TValue>
      */
     protected $items = [];
 
@@ -50,7 +51,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get all of the items in the collection.
      *
-     * @return array<T>
+     * @return array<TKey, TValue>
      */
     public function all()
     {
@@ -70,7 +71,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get the average value of a given key.
      *
-     * @param  callable|string|null  $callback
+     * @param  callable|TKey|null  $callback
      * @return mixed
      */
     public function avg($callback = null)
@@ -91,7 +92,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get the median of a given key.
      *
-     * @param  string|array|null  $key
+     * @param  TKey|null  $key
      * @return mixed
      */
     public function median($key = null)
@@ -121,7 +122,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get the mode of a given key.
      *
-     * @param  string|array|null  $key
+     * @param  TKey|null  $key
      * @return array|null
      */
     public function mode($key = null)
@@ -160,9 +161,9 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Determine if an item exists in the collection.
      *
-     * @param  mixed  $key
+     * @param  TKey   $key
      * @param  mixed  $operator
-     * @param  mixed  $value
+     * @param  TValue $value
      * @return bool
      */
     public function contains($key, $operator = null, $value = null)
@@ -323,7 +324,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get all items except for those with the specified keys.
      *
-     * @param  \Illuminate\Support\Collection|mixed  $keys
+     * @param  \Illuminate\Support\Collection<int,TKey>|mixed  $keys
      * @return static
      */
     public function except($keys)
@@ -388,7 +389,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Remove an item from the collection by key.
      *
-     * @param  string|array  $keys
+     * @param  TKey|array<TKey>  $keys
      * @return $this
      */
     public function forget($keys)
@@ -402,10 +403,9 @@ class Collection implements ArrayAccess, Enumerable
 
     /**
      * Get an item from the collection by key.
-     * @template P
-     * @param  mixed  $key
-     * @param  P  $default
-     * @return T|P
+     * @param  TKey   $key
+     * @param  TValue $default
+     * @return TValue
      */
     public function get($key, $default = null)
     {
@@ -490,7 +490,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Determine if an item exists in the collection by key.
      *
-     * @param  mixed  $key
+     * @param  TKey $key
      * @return bool
      */
     public function has($key)
@@ -601,7 +601,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get the keys of the collection items.
      *
-     * @return static
+     * @return static<int, TKey>
      */
     public function keys()
     {
@@ -613,7 +613,7 @@ class Collection implements ArrayAccess, Enumerable
      *
      * @param  callable|null  $callback
      * @param  mixed  $default
-     * @return T|null
+     * @return TValue|null
      */
     public function last(callable $callback = null, $default = null)
     {
@@ -801,8 +801,8 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Push an item onto the beginning of the collection.
      *
-     * @param  mixed  $value
-     * @param  mixed  $key
+     * @param  TValue $value
+     * @param  TKey   $key
      * @return $this
      */
     public function prepend($value, $key = null)
@@ -815,7 +815,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Push one or more items onto the end of the collection.
      *
-     * @param  array<T>|T  $values [optional]
+     * @param  array<TValue>|TValue  $values [optional]
      * @return $this
      */
     public function push(...$values)
@@ -847,9 +847,9 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get and remove an item from the collection.
      *
-     * @param  mixed  $key
-     * @param  mixed  $default
-     * @return T
+     * @param  TKey  $key
+     * @param  TValue  $default
+     * @return TValue
      */
     public function pull($key, $default = null)
     {
@@ -859,8 +859,8 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Put an item in the collection by key.
      *
-     * @param  mixed $key
-     * @param  T  $value
+     * @param  TKey   $key
+     * @param  TValue $value
      * @return $this
      */
     public function put($key, $value)
@@ -874,7 +874,7 @@ class Collection implements ArrayAccess, Enumerable
      * Get one or a specified number of items randomly from the collection.
      *
      * @param  int|null  $number
-     * @return static|T
+     * @return static|TValue
      *
      * @throws \InvalidArgumentException
      */
@@ -912,7 +912,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Reverse items order.
      *
-     * @return static
+     * @return static<TKey, TValue>
      */
     public function reverse()
     {
@@ -922,8 +922,8 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Search the collection for a given value and return the corresponding key if successful.
      *
-     * @param  mixed  $value
-     * @param  bool  $strict
+     * @param  TValue $value
+     * @param  bool   $strict
      * @return mixed
      */
     public function search($value, $strict = false)
@@ -944,7 +944,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get and remove the first item from the collection.
      *
-     * @return T
+     * @return TValue
      */
     public function shift()
     {
@@ -955,7 +955,7 @@ class Collection implements ArrayAccess, Enumerable
      * Shuffle the items in the collection.
      *
      * @param  int|null  $seed
-     * @return static
+     * @return static<TKey, TValue>
      */
     public function shuffle($seed = null)
     {
@@ -967,7 +967,7 @@ class Collection implements ArrayAccess, Enumerable
      *
      * @param  int  $size
      * @param  int  $step
-     * @return static
+     * @return static<TKey, TValue>
      */
     public function sliding($size = 2, $step = 1)
     {
@@ -982,7 +982,7 @@ class Collection implements ArrayAccess, Enumerable
      * Skip the first {$count} items.
      *
      * @param  int  $count
-     * @return static
+     * @return static<TKey, TValue>
      */
     public function skip($count)
     {
@@ -992,8 +992,8 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Skip items in the collection until the given condition is met.
      *
-     * @param  T  $value
-     * @return static
+     * @param  TValue  $value
+     * @return static<TKey, TValue>
      */
     public function skipUntil($value)
     {
@@ -1003,8 +1003,8 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Skip items in the collection while the given condition is met.
      *
-     * @param  T  $value
-     * @return static
+     * @param  TValue  $value
+     * @return static<TKey, TValue>
      */
     public function skipWhile($value)
     {
@@ -1016,7 +1016,7 @@ class Collection implements ArrayAccess, Enumerable
      *
      * @param  int  $offset
      * @param  int|null  $length
-     * @return static
+     * @return static<TKey, TValue>
      */
     public function slice($offset, $length = null)
     {
@@ -1027,7 +1027,7 @@ class Collection implements ArrayAccess, Enumerable
      * Split a collection into a certain number of groups.
      *
      * @param  int  $numberOfGroups
-     * @return static
+     * @return static<TKey, TValue>
      */
     public function split($numberOfGroups)
     {
@@ -1064,7 +1064,7 @@ class Collection implements ArrayAccess, Enumerable
      * Split a collection into a certain number of groups, and fill the first groups completely.
      *
      * @param  int  $numberOfGroups
-     * @return static
+     * @return static<TKey, TValue>
      */
     public function splitIn($numberOfGroups)
     {
@@ -1074,10 +1074,10 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get the first item in the collection, but only if exactly one item exists. Otherwise, throw an exception.
      *
-     * @param  mixed  $key
+     * @param  TKey   $key
      * @param  mixed  $operator
      * @param  mixed  $value
-     * @return T
+     * @return TValue
      *
      * @throws \Illuminate\Collections\ItemNotFoundException
      * @throws \Illuminate\Collections\MultipleItemsFoundException
@@ -1105,7 +1105,7 @@ class Collection implements ArrayAccess, Enumerable
      * Chunk the collection into chunks of the given size.
      *
      * @param  int  $size
-     * @return static
+     * @return static<TKey, TValue>
      */
     public function chunk($size)
     {
@@ -1126,7 +1126,7 @@ class Collection implements ArrayAccess, Enumerable
      * Chunk the collection into chunks with a callback.
      *
      * @param  callable  $callback
-     * @return static
+     * @return static<TKey, TValue>
      */
     public function chunkWhile(callable $callback)
     {
@@ -1139,7 +1139,7 @@ class Collection implements ArrayAccess, Enumerable
      * Sort through each item with a callback.
      *
      * @param  callable|int|null  $callback
-     * @return static
+     * @return static<TKey, TValue>
      */
     public function sort($callback = null)
     {
@@ -1156,7 +1156,7 @@ class Collection implements ArrayAccess, Enumerable
      * Sort items in descending order.
      *
      * @param  int  $options
-     * @return static
+     * @return static<TKey, TValue>
      */
     public function sortDesc($options = SORT_REGULAR)
     {
@@ -1173,7 +1173,7 @@ class Collection implements ArrayAccess, Enumerable
      * @param  callable|array|string  $callback
      * @param  int  $options
      * @param  bool  $descending
-     * @return static
+     * @return static<TKey, TValue>
      */
     public function sortBy($callback, $options = SORT_REGULAR, $descending = false)
     {
@@ -1209,7 +1209,7 @@ class Collection implements ArrayAccess, Enumerable
      * Sort the collection using multiple comparisons.
      *
      * @param  array  $comparisons
-     * @return static
+     * @return static<TKey, TValue>
      */
     protected function sortByMany(array $comparisons = [])
     {
@@ -1254,7 +1254,7 @@ class Collection implements ArrayAccess, Enumerable
      *
      * @param  callable|string  $callback
      * @param  int  $options
-     * @return static
+     * @return static<TKey, TValue>
      */
     public function sortByDesc($callback, $options = SORT_REGULAR)
     {
@@ -1266,7 +1266,7 @@ class Collection implements ArrayAccess, Enumerable
      *
      * @param  int  $options
      * @param  bool  $descending
-     * @return static
+     * @return static<TKey, TValue>
      */
     public function sortKeys($options = SORT_REGULAR, $descending = false)
     {
@@ -1281,7 +1281,7 @@ class Collection implements ArrayAccess, Enumerable
      * Sort the collection keys in descending order.
      *
      * @param  int  $options
-     * @return static
+     * @return static<TKey, TValue>
      */
     public function sortKeysDesc($options = SORT_REGULAR)
     {
@@ -1294,7 +1294,7 @@ class Collection implements ArrayAccess, Enumerable
      * @param  int  $offset
      * @param  int|null  $length
      * @param  mixed  $replacement
-     * @return static
+     * @return static<TKey, TValue>
      */
     public function splice($offset, $length = null, $replacement = [])
     {
@@ -1309,7 +1309,7 @@ class Collection implements ArrayAccess, Enumerable
      * Take the first or last {$limit} items.
      *
      * @param  int  $limit
-     * @return static
+     * @return static<TKey, TValue>
      */
     public function take($limit)
     {
@@ -1323,8 +1323,8 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Take items in the collection until the given condition is met.
      *
-     * @param  T  $value
-     * @return static
+     * @param  TValue  $value
+     * @return static<TKey, TValue>
      */
     public function takeUntil($value)
     {
@@ -1334,8 +1334,8 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Take items in the collection while the given condition is met.
      *
-     * @param  T  $value
-     * @return static
+     * @param  TValue  $value
+     * @return static<TKey, TValue>
      */
     public function takeWhile($value)
     {
@@ -1358,7 +1358,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Reset the keys on the underlying array.
      *
-     * @return static
+     * @return static<int, TValue>
      */
     public function values()
     {
@@ -1391,8 +1391,8 @@ class Collection implements ArrayAccess, Enumerable
      * Pad collection to the specified length with a value.
      *
      * @param  int  $size
-     * @param  mixed  $value
-     * @return static
+     * @param  TValue  $value
+     * @return static<TKey, TValue>
      */
     public function pad($size, $value)
     {
@@ -1402,7 +1402,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get an iterator for the items.
      *
-     * @return \ArrayIterator<T>
+     * @return \ArrayIterator<TKey, TValue>
      */
     public function getIterator()
     {
@@ -1433,7 +1433,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Add an item to the collection.
      *
-     * @param  T  $item
+     * @param  TValue  $item
      * @return $this
      */
     public function add($item)
@@ -1446,7 +1446,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get a base Support collection instance from this collection.
      *
-     * @return \Illuminate\Support\Collection<T>
+     * @return \Illuminate\Support\Collection<TKey, TValue>
      */
     public function toBase()
     {
@@ -1456,7 +1456,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Determine if an item exists at an offset.
      *
-     * @param  mixed  $key
+     * @param  TKey  $key
      * @return bool
      */
     public function offsetExists($key)
@@ -1467,7 +1467,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get an item at a given offset.
      *
-     * @param  mixed  $key
+     * @param  TKey  $key
      * @return mixed
      */
     public function offsetGet($key)
@@ -1478,8 +1478,8 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Set the item at a given offset.
      *
-     * @param  mixed  $key
-     * @param  T  $value
+     * @param  TKey  $key
+     * @param  TValue  $value
      * @return void
      */
     public function offsetSet($key, $value)
@@ -1494,7 +1494,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Unset the item at a given offset.
      *
-     * @param  string  $key
+     * @param  TKey  $key
      * @return void
      */
     public function offsetUnset($key)

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -10,6 +10,9 @@ use Illuminate\Support\Traits\EnumeratesValues;
 use Illuminate\Support\Traits\Macroable;
 use stdClass;
 
+/**
+ * @template T
+ */
 class Collection implements ArrayAccess, Enumerable
 {
     use EnumeratesValues, Macroable;
@@ -17,14 +20,14 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * The items contained in the collection.
      *
-     * @var array
+     * @var array<T>
      */
     protected $items = [];
 
     /**
      * Create a new collection.
      *
-     * @param  mixed  $items
+     * @param  mixed $items
      * @return void
      */
     public function __construct($items = [])
@@ -47,7 +50,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get all of the items in the collection.
      *
-     * @return array
+     * @return array<T>
      */
     public function all()
     {
@@ -354,7 +357,7 @@ class Collection implements ArrayAccess, Enumerable
      *
      * @param  callable|null  $callback
      * @param  mixed  $default
-     * @return mixed
+     * @return T|null
      */
     public function first(callable $callback = null, $default = null)
     {
@@ -402,7 +405,7 @@ class Collection implements ArrayAccess, Enumerable
      *
      * @param  mixed  $key
      * @param  mixed  $default
-     * @return mixed
+     * @return T
      */
     public function get($key, $default = null)
     {
@@ -610,7 +613,7 @@ class Collection implements ArrayAccess, Enumerable
      *
      * @param  callable|null  $callback
      * @param  mixed  $default
-     * @return mixed
+     * @return T|null
      */
     public function last(callable $callback = null, $default = null)
     {
@@ -812,7 +815,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Push one or more items onto the end of the collection.
      *
-     * @param  mixed  $values [optional]
+     * @param  array<T>|T  $values [optional]
      * @return $this
      */
     public function push(...$values)
@@ -846,7 +849,7 @@ class Collection implements ArrayAccess, Enumerable
      *
      * @param  mixed  $key
      * @param  mixed  $default
-     * @return mixed
+     * @return T
      */
     public function pull($key, $default = null)
     {
@@ -856,8 +859,8 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Put an item in the collection by key.
      *
-     * @param  mixed  $key
-     * @param  mixed  $value
+     * @param  mixed $key
+     * @param  T  $value
      * @return $this
      */
     public function put($key, $value)
@@ -871,7 +874,7 @@ class Collection implements ArrayAccess, Enumerable
      * Get one or a specified number of items randomly from the collection.
      *
      * @param  int|null  $number
-     * @return static|mixed
+     * @return static|T
      *
      * @throws \InvalidArgumentException
      */
@@ -941,7 +944,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get and remove the first item from the collection.
      *
-     * @return mixed
+     * @return T
      */
     public function shift()
     {
@@ -989,7 +992,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Skip items in the collection until the given condition is met.
      *
-     * @param  mixed  $value
+     * @param  T  $value
      * @return static
      */
     public function skipUntil($value)
@@ -1000,7 +1003,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Skip items in the collection while the given condition is met.
      *
-     * @param  mixed  $value
+     * @param  T  $value
      * @return static
      */
     public function skipWhile($value)
@@ -1074,7 +1077,7 @@ class Collection implements ArrayAccess, Enumerable
      * @param  mixed  $key
      * @param  mixed  $operator
      * @param  mixed  $value
-     * @return mixed
+     * @return T
      *
      * @throws \Illuminate\Collections\ItemNotFoundException
      * @throws \Illuminate\Collections\MultipleItemsFoundException
@@ -1320,7 +1323,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Take items in the collection until the given condition is met.
      *
-     * @param  mixed  $value
+     * @param  T  $value
      * @return static
      */
     public function takeUntil($value)
@@ -1331,7 +1334,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Take items in the collection while the given condition is met.
      *
-     * @param  mixed  $value
+     * @param  T  $value
      * @return static
      */
     public function takeWhile($value)
@@ -1399,7 +1402,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get an iterator for the items.
      *
-     * @return \ArrayIterator
+     * @return \ArrayIterator<T>
      */
     public function getIterator()
     {
@@ -1430,7 +1433,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Add an item to the collection.
      *
-     * @param  mixed  $item
+     * @param  T  $item
      * @return $this
      */
     public function add($item)
@@ -1443,7 +1446,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get a base Support collection instance from this collection.
      *
-     * @return \Illuminate\Support\Collection
+     * @return \Illuminate\Support\Collection<T>
      */
     public function toBase()
     {
@@ -1476,7 +1479,7 @@ class Collection implements ArrayAccess, Enumerable
      * Set the item at a given offset.
      *
      * @param  mixed  $key
-     * @param  mixed  $value
+     * @param  T  $value
      * @return void
      */
     public function offsetSet($key, $value)

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -402,10 +402,10 @@ class Collection implements ArrayAccess, Enumerable
 
     /**
      * Get an item from the collection by key.
-     *
+     * @template P
      * @param  mixed  $key
-     * @param  mixed  $default
-     * @return T
+     * @param  P  $default
+     * @return T|P
      */
     public function get($key, $default = null)
     {

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -11,8 +11,8 @@ use Illuminate\Support\Traits\Macroable;
 use stdClass;
 
 /**
- * @template TKey
- * @template TValue
+ * @template K
+ * @template V
  */
 class Collection implements ArrayAccess, Enumerable
 {
@@ -21,7 +21,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * The items contained in the collection.
      *
-     * @var array<TKey, TValue>
+     * @var array<K, V>
      */
     protected $items = [];
 
@@ -51,7 +51,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get all of the items in the collection.
      *
-     * @return array<TKey, TValue>
+     * @return array<K, V>
      */
     public function all()
     {
@@ -71,7 +71,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get the average value of a given key.
      *
-     * @param  callable|TKey|null  $callback
+     * @param  callable|K|null  $callback
      * @return mixed
      */
     public function avg($callback = null)
@@ -92,7 +92,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get the median of a given key.
      *
-     * @param  TKey|null  $key
+     * @param  K|null  $key
      * @return mixed
      */
     public function median($key = null)
@@ -122,7 +122,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get the mode of a given key.
      *
-     * @param  TKey|null  $key
+     * @param  K|null  $key
      * @return array|null
      */
     public function mode($key = null)
@@ -161,9 +161,9 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Determine if an item exists in the collection.
      *
-     * @param  TKey   $key
+     * @param  K   $key
      * @param  mixed  $operator
-     * @param  TValue $value
+     * @param  V $value
      * @return bool
      */
     public function contains($key, $operator = null, $value = null)
@@ -324,7 +324,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get all items except for those with the specified keys.
      *
-     * @param  \Illuminate\Support\Collection<int,TKey>|mixed  $keys
+     * @param  \Illuminate\Support\Collection<int,K>|mixed  $keys
      * @return static
      */
     public function except($keys)
@@ -389,7 +389,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Remove an item from the collection by key.
      *
-     * @param  TKey|array<TKey>  $keys
+     * @param  K|array<K>  $keys
      * @return $this
      */
     public function forget($keys)
@@ -403,9 +403,9 @@ class Collection implements ArrayAccess, Enumerable
 
     /**
      * Get an item from the collection by key.
-     * @param  TKey   $key
-     * @param  TValue $default
-     * @return TValue
+     * @param  K   $key
+     * @param  V $default
+     * @return V
      */
     public function get($key, $default = null)
     {
@@ -490,7 +490,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Determine if an item exists in the collection by key.
      *
-     * @param  TKey $key
+     * @param  K $key
      * @return bool
      */
     public function has($key)
@@ -601,7 +601,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get the keys of the collection items.
      *
-     * @return static<int, TKey>
+     * @return static<int, K>
      */
     public function keys()
     {
@@ -613,7 +613,7 @@ class Collection implements ArrayAccess, Enumerable
      *
      * @param  callable|null  $callback
      * @param  mixed  $default
-     * @return TValue|null
+     * @return V|null
      */
     public function last(callable $callback = null, $default = null)
     {
@@ -801,8 +801,8 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Push an item onto the beginning of the collection.
      *
-     * @param  TValue $value
-     * @param  TKey   $key
+     * @param  V $value
+     * @param  K   $key
      * @return $this
      */
     public function prepend($value, $key = null)
@@ -815,7 +815,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Push one or more items onto the end of the collection.
      *
-     * @param  array<TValue>|TValue  $values [optional]
+     * @param  array<V>|V  $values [optional]
      * @return $this
      */
     public function push(...$values)
@@ -847,9 +847,9 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get and remove an item from the collection.
      *
-     * @param  TKey  $key
-     * @param  TValue  $default
-     * @return TValue
+     * @param  K  $key
+     * @param  V  $default
+     * @return V
      */
     public function pull($key, $default = null)
     {
@@ -859,8 +859,8 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Put an item in the collection by key.
      *
-     * @param  TKey   $key
-     * @param  TValue $value
+     * @param  K   $key
+     * @param  V $value
      * @return $this
      */
     public function put($key, $value)
@@ -874,7 +874,7 @@ class Collection implements ArrayAccess, Enumerable
      * Get one or a specified number of items randomly from the collection.
      *
      * @param  int|null  $number
-     * @return static|TValue
+     * @return static|V
      *
      * @throws \InvalidArgumentException
      */
@@ -912,7 +912,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Reverse items order.
      *
-     * @return static<TKey, TValue>
+     * @return static<K, V>
      */
     public function reverse()
     {
@@ -922,7 +922,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Search the collection for a given value and return the corresponding key if successful.
      *
-     * @param  TValue $value
+     * @param  V $value
      * @param  bool   $strict
      * @return mixed
      */
@@ -944,7 +944,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get and remove the first item from the collection.
      *
-     * @return TValue
+     * @return V
      */
     public function shift()
     {
@@ -955,7 +955,7 @@ class Collection implements ArrayAccess, Enumerable
      * Shuffle the items in the collection.
      *
      * @param  int|null  $seed
-     * @return static<TKey, TValue>
+     * @return static<K, V>
      */
     public function shuffle($seed = null)
     {
@@ -967,7 +967,7 @@ class Collection implements ArrayAccess, Enumerable
      *
      * @param  int  $size
      * @param  int  $step
-     * @return static<TKey, TValue>
+     * @return static<K, V>
      */
     public function sliding($size = 2, $step = 1)
     {
@@ -982,7 +982,7 @@ class Collection implements ArrayAccess, Enumerable
      * Skip the first {$count} items.
      *
      * @param  int  $count
-     * @return static<TKey, TValue>
+     * @return static<K, V>
      */
     public function skip($count)
     {
@@ -992,8 +992,8 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Skip items in the collection until the given condition is met.
      *
-     * @param  TValue  $value
-     * @return static<TKey, TValue>
+     * @param  V  $value
+     * @return static<K, V>
      */
     public function skipUntil($value)
     {
@@ -1003,8 +1003,8 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Skip items in the collection while the given condition is met.
      *
-     * @param  TValue  $value
-     * @return static<TKey, TValue>
+     * @param  V  $value
+     * @return static<K, V>
      */
     public function skipWhile($value)
     {
@@ -1016,7 +1016,7 @@ class Collection implements ArrayAccess, Enumerable
      *
      * @param  int  $offset
      * @param  int|null  $length
-     * @return static<TKey, TValue>
+     * @return static<K, V>
      */
     public function slice($offset, $length = null)
     {
@@ -1027,7 +1027,7 @@ class Collection implements ArrayAccess, Enumerable
      * Split a collection into a certain number of groups.
      *
      * @param  int  $numberOfGroups
-     * @return static<TKey, TValue>
+     * @return static<K, V>
      */
     public function split($numberOfGroups)
     {
@@ -1064,7 +1064,7 @@ class Collection implements ArrayAccess, Enumerable
      * Split a collection into a certain number of groups, and fill the first groups completely.
      *
      * @param  int  $numberOfGroups
-     * @return static<TKey, TValue>
+     * @return static<K, V>
      */
     public function splitIn($numberOfGroups)
     {
@@ -1074,10 +1074,10 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get the first item in the collection, but only if exactly one item exists. Otherwise, throw an exception.
      *
-     * @param  TKey   $key
+     * @param  K   $key
      * @param  mixed  $operator
      * @param  mixed  $value
-     * @return TValue
+     * @return V
      *
      * @throws \Illuminate\Collections\ItemNotFoundException
      * @throws \Illuminate\Collections\MultipleItemsFoundException
@@ -1105,7 +1105,7 @@ class Collection implements ArrayAccess, Enumerable
      * Chunk the collection into chunks of the given size.
      *
      * @param  int  $size
-     * @return static<TKey, TValue>
+     * @return static<K, V>
      */
     public function chunk($size)
     {
@@ -1126,7 +1126,7 @@ class Collection implements ArrayAccess, Enumerable
      * Chunk the collection into chunks with a callback.
      *
      * @param  callable  $callback
-     * @return static<TKey, TValue>
+     * @return static<K, V>
      */
     public function chunkWhile(callable $callback)
     {
@@ -1139,7 +1139,7 @@ class Collection implements ArrayAccess, Enumerable
      * Sort through each item with a callback.
      *
      * @param  callable|int|null  $callback
-     * @return static<TKey, TValue>
+     * @return static<K, V>
      */
     public function sort($callback = null)
     {
@@ -1156,7 +1156,7 @@ class Collection implements ArrayAccess, Enumerable
      * Sort items in descending order.
      *
      * @param  int  $options
-     * @return static<TKey, TValue>
+     * @return static<K, V>
      */
     public function sortDesc($options = SORT_REGULAR)
     {
@@ -1173,7 +1173,7 @@ class Collection implements ArrayAccess, Enumerable
      * @param  callable|array|string  $callback
      * @param  int  $options
      * @param  bool  $descending
-     * @return static<TKey, TValue>
+     * @return static<K, V>
      */
     public function sortBy($callback, $options = SORT_REGULAR, $descending = false)
     {
@@ -1209,7 +1209,7 @@ class Collection implements ArrayAccess, Enumerable
      * Sort the collection using multiple comparisons.
      *
      * @param  array  $comparisons
-     * @return static<TKey, TValue>
+     * @return static<K, V>
      */
     protected function sortByMany(array $comparisons = [])
     {
@@ -1254,7 +1254,7 @@ class Collection implements ArrayAccess, Enumerable
      *
      * @param  callable|string  $callback
      * @param  int  $options
-     * @return static<TKey, TValue>
+     * @return static<K, V>
      */
     public function sortByDesc($callback, $options = SORT_REGULAR)
     {
@@ -1266,7 +1266,7 @@ class Collection implements ArrayAccess, Enumerable
      *
      * @param  int  $options
      * @param  bool  $descending
-     * @return static<TKey, TValue>
+     * @return static<K, V>
      */
     public function sortKeys($options = SORT_REGULAR, $descending = false)
     {
@@ -1281,7 +1281,7 @@ class Collection implements ArrayAccess, Enumerable
      * Sort the collection keys in descending order.
      *
      * @param  int  $options
-     * @return static<TKey, TValue>
+     * @return static<K, V>
      */
     public function sortKeysDesc($options = SORT_REGULAR)
     {
@@ -1294,7 +1294,7 @@ class Collection implements ArrayAccess, Enumerable
      * @param  int  $offset
      * @param  int|null  $length
      * @param  mixed  $replacement
-     * @return static<TKey, TValue>
+     * @return static<K, V>
      */
     public function splice($offset, $length = null, $replacement = [])
     {
@@ -1309,7 +1309,7 @@ class Collection implements ArrayAccess, Enumerable
      * Take the first or last {$limit} items.
      *
      * @param  int  $limit
-     * @return static<TKey, TValue>
+     * @return static<K, V>
      */
     public function take($limit)
     {
@@ -1323,8 +1323,8 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Take items in the collection until the given condition is met.
      *
-     * @param  TValue  $value
-     * @return static<TKey, TValue>
+     * @param  V  $value
+     * @return static<K, V>
      */
     public function takeUntil($value)
     {
@@ -1334,8 +1334,8 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Take items in the collection while the given condition is met.
      *
-     * @param  TValue  $value
-     * @return static<TKey, TValue>
+     * @param  V  $value
+     * @return static<K, V>
      */
     public function takeWhile($value)
     {
@@ -1358,7 +1358,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Reset the keys on the underlying array.
      *
-     * @return static<int, TValue>
+     * @return static<int, V>
      */
     public function values()
     {
@@ -1391,8 +1391,8 @@ class Collection implements ArrayAccess, Enumerable
      * Pad collection to the specified length with a value.
      *
      * @param  int  $size
-     * @param  TValue  $value
-     * @return static<TKey, TValue>
+     * @param  V  $value
+     * @return static<K, V>
      */
     public function pad($size, $value)
     {
@@ -1402,7 +1402,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get an iterator for the items.
      *
-     * @return \ArrayIterator<TKey, TValue>
+     * @return \ArrayIterator<K, V>
      */
     public function getIterator()
     {
@@ -1433,7 +1433,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Add an item to the collection.
      *
-     * @param  TValue  $item
+     * @param  V  $item
      * @return $this
      */
     public function add($item)
@@ -1446,7 +1446,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get a base Support collection instance from this collection.
      *
-     * @return \Illuminate\Support\Collection<TKey, TValue>
+     * @return \Illuminate\Support\Collection<K, V>
      */
     public function toBase()
     {
@@ -1456,7 +1456,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Determine if an item exists at an offset.
      *
-     * @param  TKey  $key
+     * @param  K  $key
      * @return bool
      */
     public function offsetExists($key)
@@ -1467,7 +1467,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get an item at a given offset.
      *
-     * @param  TKey  $key
+     * @param  K  $key
      * @return mixed
      */
     public function offsetGet($key)
@@ -1478,8 +1478,8 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Set the item at a given offset.
      *
-     * @param  TKey  $key
-     * @param  TValue  $value
+     * @param  K  $key
+     * @param  V  $value
      * @return void
      */
     public function offsetSet($key, $value)
@@ -1494,7 +1494,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Unset the item at a given offset.
      *
-     * @param  TKey  $key
+     * @param  K  $key
      * @return void
      */
     public function offsetUnset($key)

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -8,6 +8,12 @@ use Illuminate\Contracts\Support\Jsonable;
 use IteratorAggregate;
 use JsonSerializable;
 
+/**
+ * @template TKey
+ * @template TValue
+ *
+ * @extends IteratorAggregate<TKey, TValue>
+ */
 interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, JsonSerializable
 {
     /**
@@ -244,7 +250,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Determine if all items pass the given truth test.
      *
-     * @param  string|callable  $key
+     * @param  string|callable(TValue, TKey): bool  $key
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return bool
@@ -468,17 +474,17 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Group an associative array by a field or using a callback.
      *
-     * @param  array|callable|string  $groupBy
-     * @param  bool  $preserveKeys
-     * @return static
+     * @param array<mixed>|string|callable(TValue, TKey): mixed $groupBy
+     * @param bool $preserveKeys
+     * @return static<static<mixed>>
      */
     public function groupBy($groupBy, $preserveKeys = false);
 
     /**
      * Key an associative array by a field or using a callback.
      *
-     * @param  callable|string  $keyBy
-     * @return static
+     * @param  string|callable(TValue, TKey): mixed  $keyBy
+     * @return static<TValue>
      */
     public function keyBy($keyBy);
 
@@ -575,8 +581,8 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      *
      * The callback should return an associative array with a single key/value pair.
      *
-     * @param  callable  $callback
-     * @return static
+     * @param  callable(TValue, TKey): array<mixed>  $callback
+     * @return static<array<mixed>>
      */
     public function mapToDictionary(callable $callback);
 
@@ -595,8 +601,8 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      *
      * The callback should return an associative array with a single key/value pair.
      *
-     * @param  callable  $callback
-     * @return static
+     * @param  callable(TValue, TKey): array<mixed> $callback  $callback
+     * @return static<mixed>
      */
     public function mapWithKeys(callable $callback);
 
@@ -611,8 +617,9 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Map the values into a new class.
      *
-     * @param  string  $class
-     * @return static
+     * @template TClass
+     * @param class-string<TClass> $class
+     * @return static<TClass>
      */
     public function mapInto($class);
 
@@ -693,10 +700,10 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Partition the collection into two arrays using the given callback or key.
      *
-     * @param  callable|string  $key
+     * @param  string|callable(TValue, TKey): bool  $key
      * @param  mixed  $operator
      * @param  mixed  $value
-     * @return static
+     * @return static<static>
      */
     public function partition($key, $operator = null, $value = null);
 
@@ -812,7 +819,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Chunk the collection into chunks of the given size.
      *
      * @param  int  $size
-     * @return static
+     * @return static<static>
      */
     public function chunk($size);
 
@@ -911,8 +918,8 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Pass the collection to the given callback and then return it.
      *
-     * @param  callable  $callback
-     * @return $this
+     * @param  callable(static): void  $callback
+     * @return static
      */
     public function tap(callable $callback);
 

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -18,6 +18,8 @@ use Symfony\Component\VarDumper\VarDumper;
 use Traversable;
 
 /**
+ * @template TKey
+ * @template TValue
  * @property-read HigherOrderCollectionProxy $average
  * @property-read HigherOrderCollectionProxy $avg
  * @property-read HigherOrderCollectionProxy $contains
@@ -127,9 +129,9 @@ trait EnumeratesValues
     /**
      * Create a new collection by invoking the callback a given amount of times.
      *
-     * @param  int  $number
-     * @param  callable|null  $callback
-     * @return static
+     * @param int $number
+     * @param null|callable(int, int): mixed $callback
+     * @return static<mixed>
      */
     public static function times($number, callable $callback = null)
     {
@@ -145,8 +147,8 @@ trait EnumeratesValues
     /**
      * Alias for the "avg" method.
      *
-     * @param  callable|string|null  $callback
-     * @return mixed
+     * @param  string|null|callback(TValue): float|int  $callback
+     * @return float|int
      */
     public function average($callback = null)
     {
@@ -226,8 +228,8 @@ trait EnumeratesValues
     /**
      * Execute a callback over each item.
      *
-     * @param  callable  $callback
-     * @return $this
+     * @param callable(TValue, TKey): (void|bool) $callable
+     * @return static<TValue>
      */
     public function each(callable $callback)
     {
@@ -306,8 +308,8 @@ trait EnumeratesValues
     /**
      * Run a map over each nested chunk of items.
      *
-     * @param  callable  $callback
-     * @return static
+     * @param callable $callback
+     * @return static<int, mixed>
      */
     public function mapSpread(callable $callback)
     {
@@ -323,8 +325,8 @@ trait EnumeratesValues
      *
      * The callback should return an associative array with a single key/value pair.
      *
-     * @param  callable  $callback
-     * @return static
+     * @param callable(TValue, TKey): array<mixed> $callback
+     * @return static<static<mixed>>
      */
     public function mapToGroups(callable $callback)
     {
@@ -336,8 +338,8 @@ trait EnumeratesValues
     /**
      * Map a collection and flatten the result by a single level.
      *
-     * @param  callable  $callback
-     * @return static
+     * @param callable(TValue, TKey): mixed $callback
+     * @return static<mixed>
      */
     public function flatMap(callable $callback)
     {


### PR DESCRIPTION
Many users of Laravel use static analysis these days, and one of the most requested missing features of PHP are generics.

I thought adding them to `Collection` would be a great place to start with adding this functionality.

I don't know if this is something for Laravel 8.x or later, but I would love for these kinds of changes to be added in the framework. Especially with the new PHPStorm update coming up that adds better support (https://blog.jetbrains.com/phpstorm/2021/07/phpstorm-2021-2-beta/)

Let me know what you think about this, and if this is something that is in line with the vision of the Laravel framework. I would absolutely love it :D 

**Edit**: The `@template` syntax is supported by PHPStan as well as Psalm. It is also supported in the new version of PHPstorm and seems to be the default until this is implemented in the language.