### PR TITLE
[8.x] Fix PHPDocs for JSON resources

### DIFF
--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -109,7 +109,7 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
      * Transform the resource into an array.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return array
+     * @return array|\Illuminate\Contracts\Support\Arrayable|\JsonSerializable
      */
     public function toArray($request)
     {

--- a/src/Illuminate/Http/Resources/Json/ResourceCollection.php
+++ b/src/Illuminate/Http/Resources/Json/ResourceCollection.php
@@ -94,7 +94,7 @@ class ResourceCollection extends JsonResource implements Countable, IteratorAggr
      * Transform the resource into a JSON array.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return array
+     * @return array|\Illuminate\Contracts\Support\Arrayable|\JsonSerializable
      */
     public function toArray($request)
     {


### PR DESCRIPTION
The `resolve()` method which is the client of the `toArray()` method [expects](https://github.com/laravel/framework/blob/f7c14192fd2d78ab5abcfc9079b3d5961a264b0c/src/Illuminate/Http/Resources/Json/JsonResource.php#L87-L106) `array|Arrayable|JsonSerializable` return type, not strictly `array`.

With the current PHPDoc problems arise when we extend the resource class, return something that is `Arrayable|JsonSerializable` and add a proper PHPDoc to the child class. Static analysis tools report a problem: we have weakened the postconditions of the overridden method.