### PR TITLE
[8.x] Fix PHPDoc for query builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -407,7 +407,7 @@ class Builder
     /**
      * Force the query to only return distinct results.
      *
-     * @param mixed $distinct,...
+     * @param  mixed  $distinct,...
      * @return $this
      */
     public function distinct()

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -407,6 +407,7 @@ class Builder
     /**
      * Force the query to only return distinct results.
      *
+     * @param mixed $distinct,...
      * @return $this
      */
     public function distinct()


### PR DESCRIPTION
Current PHPDoc misses method parameters. Not really sure about the correct syntax though. I used the one I was able to find in the manual [here](https://manual.phpdoc.org/HTMLSmartyConverter/HandS/phpDocumentor/tutorial_tags.param.pkg.html).