### PR TITLE
[8.x] Display unexpected validation errors when asserting status

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -214,11 +214,9 @@ EOF;
      */
     protected function statusMessageWithValidationErrors($expected, $actual, $exception)
     {
-        if ($this->baseResponse->headers->get('Content-Type') === 'application/json') {
-            $errors = json_encode($exception->errors(), JSON_PRETTY_PRINT);
-        } else {
-            $errors = implode(PHP_EOL, Arr::flatten($exception->errors()));
-        }
+        $errors = $this->baseResponse->headers->get('Content-Type') === 'application/json'
+            ? json_encode($exception->errors(), JSON_PRETTY_PRINT)
+            : implode(PHP_EOL, Arr::flatten($exception->errors()));
 
         return <<<EOF
 Expected response status code [$expected] but received $actual.

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -16,6 +16,7 @@ use Illuminate\Support\Traits\Tappable;
 use Illuminate\Testing\Assert as PHPUnit;
 use Illuminate\Testing\Constraints\SeeInOrder;
 use Illuminate\Testing\Fluent\AssertableJson;
+use Illuminate\Validation\ValidationException;
 use LogicException;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
@@ -165,7 +166,7 @@ class TestResponse implements ArrayAccess
     {
         $actual = $this->getStatusCode();
 
-        $lastException = $actual === 500 && $status !== 500
+        $lastException = $actual !== $status && in_array($actual, [422, 500])
                     ? $this->exceptions->last()
                     : null;
 
@@ -188,6 +189,10 @@ class TestResponse implements ArrayAccess
      */
     protected function statusMessageWithException($expected, $actual, $exception)
     {
+        if ($exception instanceof ValidationException) {
+            return $this->statusMessageWithValidationErrors($expected, $actual, $exception);
+        }
+
         $exception = (string) $exception;
 
         return <<<EOF
@@ -196,6 +201,23 @@ Expected response status code [$expected] but received $actual.
 The following exception occurred during the request:
 
 $exception
+EOF;
+    }
+
+    protected function statusMessageWithValidationErrors($expected, $actual, $exception)
+    {
+        if ($this->baseResponse->headers->get('Content-Type') === 'application/json') {
+            $errors = json_encode($exception->errors(), JSON_PRETTY_PRINT);
+        } else {
+            $errors = implode(PHP_EOL, Arr::flatten($exception->errors()));
+        }
+
+        return <<<EOF
+Expected response status code [$expected] but received $actual.
+
+The following validation errors occurred during the request:
+
+$errors
 EOF;
     }
 

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -204,6 +204,14 @@ $exception
 EOF;
     }
 
+    /**
+     * Get an assertion message for a status assertion that has an unexpected validation exception.
+     *
+     * @param  string|int  $expected
+     * @param  string|int  $actual
+     * @param  \Illuminate\Validation\ValidationException $exception;
+     * @return string
+     */
     protected function statusMessageWithValidationErrors($expected, $actual, $exception)
     {
         if ($this->baseResponse->headers->get('Content-Type') === 'application/json') {


### PR DESCRIPTION
This PR expands on #38025 to also show any unexpected validation errors that occurred when asserting a status code other than 422.

Currently the only way to see the validation errors is by dumping the response, running the test again, and then removing the dump. With this PR, the unexpected validation errors will be displayed straight away.

If the response being asserted against is JSON, the validation errors will be also be displayed as JSON. Otherwise the errors will be displayed as a simple list.