### PR TITLE
[9.x] Return empty array for nullable values in arrayed casts to keep consistent

### DIFF
--- a/src/Illuminate/Database/Eloquent/Casts/AsArrayObject.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsArrayObject.php
@@ -19,7 +19,7 @@ class AsArrayObject implements Castable
         {
             public function get($model, $key, $value, $attributes)
             {
-                return isset($attributes[$key]) ? new ArrayObject(json_decode($attributes[$key], true)) : null;
+                return isset($attributes[$key]) ? new ArrayObject(json_decode($attributes[$key], true)) : [];
             }
 
             public function set($model, $key, $value, $attributes)


### PR DESCRIPTION
I was a bit amazed to find out that the default value for array casts is null in case the field has a non-JSON value.

I think that as long as the cast is marked as `arrayed`, no matter the attribute existence or JSON-parseable value it has, it should return an empty array to be consistent about casting.

I consider this a breaking change since some developers might already check for null on them, and that'd break.