### PR TITLE
[8.x] Fix unvalidated array keys without implicit attributes

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -515,10 +515,12 @@ class Validator implements ValidatorContract
 
         $missingValue = new stdClass;
 
+        $attributes = array_merge(array_keys($this->implicitAttributes), array_keys($this->getRules()));
+
         foreach ($this->getRules() as $key => $rules) {
             if ($this->excludeUnvalidatedArrayKeys &&
                 in_array('array', $rules) &&
-                ! empty(preg_grep('/^'.preg_quote($key, '/').'\.*/', array_keys($this->implicitAttributes)))) {
+                ! empty(preg_grep('/^'.preg_quote($key, '/').'\.+/', $attributes))) {
                 continue;
             }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -6167,6 +6167,15 @@ class ValidationValidatorTest extends TestCase
 
         $validator = new Validator(
             $this->getIlluminateArrayTranslator(),
+            ['admin' => ['name' => 'Mohamed', 'location' => 'cairo'], 'users' => [['name' => 'Mohamed', 'location' => 'cairo']]],
+            ['admin' => 'array', 'admin.name' => 'string', 'users' => 'array', 'users.*.name' => 'string']
+        );
+        $validator->excludeUnvalidatedArrayKeys = true;
+        $this->assertTrue($validator->passes());
+        $this->assertSame(['admin' => ['name' => 'Mohamed'], 'users' => [['name' => 'Mohamed']]], $validator->validated());
+
+        $validator = new Validator(
+            $this->getIlluminateArrayTranslator(),
             ['users' => [['name' => 'Mohamed', 'location' => 'cairo']]],
             ['users' => 'array']
         );
@@ -6185,7 +6194,7 @@ class ValidationValidatorTest extends TestCase
 
         $validator = new Validator(
             $this->getIlluminateArrayTranslator(),
-            ['users' => ['admins' => [['name' => 'mohamed', 'job' => 'dev']]]],
+            ['users' => ['admins' => [['name' => 'mohamed', 'job' => 'dev']], 'unvalidated' => 'foobar']],
             ['users' => 'array', 'users.admins' => 'array', 'users.admins.*.name' => 'string']
         );
         $validator->excludeUnvalidatedArrayKeys = true;


### PR DESCRIPTION
This PR aims to fix an issue that occurs when, in combination with the `excludeUnvalidatedArrayKeys` option on the validator, the array under validation does not have any implicit attributes. For example `user.name` instead of `users.*.name`. 

This is fixed by also checking the keys present in `getRules()` instead of just the `$implicitAttributes`. As a result, the regex had to be altered slightly to check for the presence of at least one `.` following the attribute key. Otherwise it would not return anything when using just `array` without nested rules.

```php
Validator::make([
    'admin' => ['name' => 'Mohamed', 'location' => 'cairo'], 
    'users' => [['name' => 'Mohamed', 'location' => 'cairo']]
], [
    'admin' => 'array',
    'admin.name' => 'string',
    'users' => 'array',
    'users.*.name' => 'string'
]);
```

![image](https://user-images.githubusercontent.com/4411748/126048102-6bb182fe-c240-497c-92a7-2bf9ccd538cb.png)