### PR TITLE
[8.x] Add `Request::collect()` method

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -4,6 +4,7 @@ namespace Illuminate\Http\Concerns;
 
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use SplFileInfo;
 use stdClass;
@@ -253,6 +254,17 @@ trait InteractsWithInput
         }
 
         return $results;
+    }
+
+    /**
+     * Get all of the input and files for the request as a collection.
+     *
+     * @param  array|mixed|null  $keys
+     * @return \Illuminate\Support\Collection
+     */
+    public function collect($keys = null)
+    {
+        return Collection::make($this->all($keys));
     }
 
     /**

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -533,6 +533,18 @@ class HttpRequestTest extends TestCase
         $this->assertEquals(['developer' => ['name' => 'Taylor', 'age' => null]], $request->all());
     }
 
+    public function testCollectMethod()
+    {
+        $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => null]);
+        $this->assertEquals(['name' => 'Taylor'], $request->collect('name', 'age', 'email')->all());
+
+        $request = Request::create('/', 'GET', ['developer' => ['name' => 'Taylor', 'age' => null]]);
+        $this->assertEquals(['developer' => ['name' => 'Taylor']], $request->collect('developer.name', 'developer.skills')->all());
+        $this->assertEquals(['developer' => ['age' => null]], $request->collect('developer.age')->all());
+        $this->assertEquals(['developer' => ['skills' => null]], $request->collect('developer.skills')->all());
+        $this->assertEquals(['developer' => ['name' => 'Taylor', 'age' => null]], $request->collect()->all());
+    }
+
     public function testKeysMethod()
     {
         $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => null]);


### PR DESCRIPTION
This pull request introduces a new `Request::collect` method on the `Illuminate\Http\Request` object.

This method behaves like `Request::all()`, but instead returns an instance of `Illuminate\Support\Collection` as opposed to a plain `array`.