### PR TITLE
[8.x] Allow eloquent model type in be/actingAs

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithAuthentication.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithAuthentication.php
@@ -9,7 +9,7 @@ trait InteractsWithAuthentication
     /**
      * Set the currently logged in user for the application.
      *
-     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
+     * @param  \Illuminate\Contracts\Auth\Authenticatable|\Illuminate\Database\Eloquent\Model  $user
      * @param  string|null  $guard
      * @return $this
      */
@@ -21,7 +21,7 @@ trait InteractsWithAuthentication
     /**
      * Set the currently logged in user for the application.
      *
-     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
+     * @param  \Illuminate\Contracts\Auth\Authenticatable|\Illuminate\Database\Eloquent\Model  $user
      * @param  string|null  $guard
      * @return $this
      */


### PR DESCRIPTION
> The problem is method accepts Authenticatable trait while the actual `create` factory's method returns Collection or Eloquent Model, which causes IDE throwing the warning of incompatible types:

![authenticatable](https://user-images.githubusercontent.com/37669560/126073701-8ffa17ee-f91e-4619-be07-5f149779bc5b.png)

`This PR fixes the type consistency.`