### PR TITLE
[8.x] Support conditional `URL::forceScheme` calls

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -624,13 +624,16 @@ class UrlGenerator implements UrlGeneratorContract
      * Force the scheme for URLs.
      *
      * @param  string|null  $scheme
+     * @param  bool  $condition
      * @return void
      */
-    public function forceScheme($scheme)
+    public function forceScheme($scheme, $condition = true)
     {
-        $this->cachedScheme = null;
+        if ($condition) {
+            $this->cachedScheme = null;
 
-        $this->forceScheme = $scheme ? $scheme.'://' : null;
+            $this->forceScheme = $scheme ? $scheme.'://' : null;
+        }
     }
 
     /**

--- a/src/Illuminate/Support/Facades/URL.php
+++ b/src/Illuminate/Support/Facades/URL.php
@@ -19,7 +19,7 @@ namespace Illuminate\Support\Facades;
  * @method static string temporarySignedRoute(string $name, \DateTimeInterface|\DateInterval|int $expiration, array $parameters = [], bool $absolute = true)
  * @method static string to(string $path, $extra = [], bool $secure = null)
  * @method static void defaults(array $defaults)
- * @method static void forceScheme(string $scheme)
+ * @method static void forceScheme(string $scheme, bool $condition = true)
  * @method static bool isValidUrl(string $path)
  *
  * @see \Illuminate\Routing\UrlGenerator


### PR DESCRIPTION
This pull requests adds a second parameter to the `UrlGenerate::forceScheme` method that will allow you to provide a `bool` or `Closure` callback to determine if the scheme should be forced.

_Inside of `AppServiceProvider::boot()`_

```php
URL::forceScheme('https', $this->app->environment('production'));
```

In this scenario, the scheme will only be forced in `production`. Inspiration for this came from `Model::preventLazyLoading` where you can provide a boolean and change when it is enabled without needing an `if` statement.