### PR TITLE
[8.x] Auto-resolve contracts in bindMethod

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -336,7 +336,7 @@ class Container implements ArrayAccess, ContainerContract
             foreach ($interfaceNames as $name) {
                 if (strpos($method[0], $name) !== false) {
                     $method[0] = get_class(
-                        $this->make($method[0])
+                        $this->resolve($method[0])
                     );
                 }
             }

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -328,17 +328,10 @@ class Container implements ArrayAccess, ContainerContract
     protected function parseBindMethod($method)
     {
         if (is_array($method)) {
-            $contractNames = [
-                'Interface',
-                'Contract',
-            ];
-
-            foreach ($contractNames as $name) {
-                if (strpos($method[0], $name) !== false) {
-                    $method[0] = get_class(
-                        $this->resolve($method[0])
-                    );
-                }
+            if (interface_exists($method[0])) {
+                $method[0] = get_class(
+                    $this->resolve($method[0])
+                );
             }
 
             return $method[0].'@'.$method[1];

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -333,6 +333,14 @@ class Container implements ArrayAccess, ContainerContract
                 'Contract',
             ];
 
+            foreach ($interfaceNames as $name) {
+                if (strpos($method[0], $name) !== false) {
+                    $method[0] = get_class(
+                        $this->make($method[0])
+                    );
+                }
+            }
+
             return $method[0].'@'.$method[1];
         }
 

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -328,12 +328,12 @@ class Container implements ArrayAccess, ContainerContract
     protected function parseBindMethod($method)
     {
         if (is_array($method)) {
-            $interfaceNames = [
+            $contractNames = [
                 'Interface',
                 'Contract',
             ];
 
-            foreach ($interfaceNames as $name) {
+            foreach ($contractNames as $name) {
                 if (strpos($method[0], $name) !== false) {
                     $method[0] = get_class(
                         $this->resolve($method[0])

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -328,6 +328,11 @@ class Container implements ArrayAccess, ContainerContract
     protected function parseBindMethod($method)
     {
         if (is_array($method)) {
+            $interfaceNames = [
+                'Interface',
+                'Contract',
+            ];
+
             return $method[0].'@'.$method[1];
         }
 

--- a/tests/Container/ContainerCallTest.php
+++ b/tests/Container/ContainerCallTest.php
@@ -109,6 +109,25 @@ class ContainerCallTest extends TestCase
         $this->assertEquals(['foo', 'bar'], $result);
     }
 
+    public function testBindMethodPassedInterface()
+    {
+        $container = new Container;
+        $container->bind(ContainerTestCallStubInterface::class, ContainerTestCallStub::class);
+        $container->bindMethod([ContainerTestCallStubInterface::class, 'unresolvable'], function ($stub) {
+            return $stub->unresolvable('foo', 'bar');
+        });
+        $result = $container->call(ContainerTestCallStubInterface::class.'@unresolvable');
+        $this->assertEquals(['foo', 'bar'], $result);
+
+        $container = new Container;
+        $container->bind(ContainerTestCallStubContract::class, ContainerTestCallStub::class);
+        $container->bindMethod([ContainerTestCallStubContract::class, 'unresolvable'], function ($stub) {
+            return $stub->unresolvable('foo', 'bar');
+        });
+        $result = $container->call(ContainerTestCallStubContract::class.'@unresolvable');
+        $this->assertEquals(['foo', 'bar'], $result);
+    }
+
     public function testClosureCallWithInjectedDependency()
     {
         $container = new Container;
@@ -208,7 +227,25 @@ class ContainerCallTest extends TestCase
     }
 }
 
-class ContainerTestCallStub
+interface ContainerTestCallStubInterface
+{
+    public function work();
+
+    public function inject(ContainerCallConcreteStub $stub, $default = 'taylor');
+
+    public function unresolvable($foo, $bar);
+}
+
+interface ContainerTestCallStubContract
+{
+    public function work();
+
+    public function inject(ContainerCallConcreteStub $stub, $default = 'taylor');
+
+    public function unresolvable($foo, $bar);
+}
+
+class ContainerTestCallStub implements ContainerTestCallStubInterface, ContainerTestCallStubContract
 {
     public function work()
     {

--- a/tests/Container/ContainerCallTest.php
+++ b/tests/Container/ContainerCallTest.php
@@ -112,14 +112,6 @@ class ContainerCallTest extends TestCase
     public function testBindMethodPassedAnInterface()
     {
         $container = new Container;
-        $container->bind(ContainerTestCallStubInterface::class, ContainerTestCallStub::class);
-        $container->bindMethod([ContainerTestCallStubInterface::class, 'unresolvable'], function ($stub) {
-            return $stub->unresolvable('foo', 'bar');
-        });
-        $result = $container->call(ContainerTestCallStubInterface::class.'@unresolvable');
-        $this->assertEquals(['foo', 'bar'], $result);
-
-        $container = new Container;
         $container->bind(ContainerTestCallStubContract::class, ContainerTestCallStub::class);
         $container->bindMethod([ContainerTestCallStubContract::class, 'unresolvable'], function ($stub) {
             return $stub->unresolvable('foo', 'bar');
@@ -227,15 +219,6 @@ class ContainerCallTest extends TestCase
     }
 }
 
-interface ContainerTestCallStubInterface
-{
-    public function work();
-
-    public function inject(ContainerCallConcreteStub $stub, $default = 'taylor');
-
-    public function unresolvable($foo, $bar);
-}
-
 interface ContainerTestCallStubContract
 {
     public function work();
@@ -245,7 +228,7 @@ interface ContainerTestCallStubContract
     public function unresolvable($foo, $bar);
 }
 
-class ContainerTestCallStub implements ContainerTestCallStubInterface, ContainerTestCallStubContract
+class ContainerTestCallStub implements ContainerTestCallStubContract
 {
     public function work()
     {

--- a/tests/Container/ContainerCallTest.php
+++ b/tests/Container/ContainerCallTest.php
@@ -109,7 +109,7 @@ class ContainerCallTest extends TestCase
         $this->assertEquals(['foo', 'bar'], $result);
     }
 
-    public function testBindMethodPassedInterface()
+    public function testBindMethodPassedAnInterface()
     {
         $container = new Container;
         $container->bind(ContainerTestCallStubInterface::class, ContainerTestCallStub::class);


### PR DESCRIPTION
### The problem
When you use bindMethod functionality relying on interfaces, you should always resolve the implementation bound to the service container to then pass it to the bindMethod as `::class`. It was quite annoying action:

![AutoResolvingInterfaces](https://user-images.githubusercontent.com/37669560/126083092-593771a3-7b2d-47a5-a5a5-f3052cd291d8.png)

You can now just pass the `::class` of your interface/contract, so it will automatically resolve the actual implementation for you.
 
