### PR TITLE
[8.x] ErrorException: Undefined array key "exception"

### DIFF
--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -107,7 +107,7 @@ class FoundationServiceProvider extends AggregateServiceProvider
         );
 
         $this->app->make('events')->listen(MessageLogged::class, function ($event) {
-            if ($event->context['exception']) {
+            if (isset($event->context['exception'])) {
                 $this->app->make(LoggedExceptionCollection::class)
                         ->push($event->context['exception']);
             }


### PR DESCRIPTION
This pull request fixes the issue with calls to logging methods like `Log::info` in latest PHP, where non existing array keys are now an error. This happens, when no context is given, or `exception` is not set in context.
There is a line in FoundationServiceProvider.php
`if ($event->context['exception']) {`
which now fails, here should be an isset around it.
