### PR TITLE
[8.x] Ability to return the default value of a request whenHas and whenFilled methods

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -111,24 +111,18 @@ trait InteractsWithInput
      * Apply the callback if the request contains the given input item key.
      *
      * @param  string  $key
-     * @param  callable|null  $callback
+     * @param  callable  $callback
      * @param  callable|null  $default
      * @return $this|mixed
      */
-    public function whenHas($key, callable $callback = null, callable $default = null)
+    public function whenHas($key, callable $callback, callable $default = null)
     {
-        $value = data_get($this->all(), $key);
-
         if ($this->has($key)) {
-            if ($callback) {
-                return $callback($value);
-            }
-
-            return $value;
+            return $callback(data_get($this->all(), $key)) ?: $this;
         }
 
         if ($default) {
-            return $default($value);
+            return $default();
         }
 
         return $this;
@@ -195,24 +189,18 @@ trait InteractsWithInput
      * Apply the callback if the request contains a non-empty value for the given input item key.
      *
      * @param  string  $key
-     * @param  callable|null  $callback
+     * @param  callable  $callback
      * @param  callable|null  $default
      * @return $this|mixed
      */
-    public function whenFilled($key, callable $callback = null, callable $default = null)
+    public function whenFilled($key, callable $callback, callable $default = null)
     {
-        $value = data_get($this->all(), $key);
-
         if ($this->filled($key)) {
-            if ($callback) {
-                return $callback($value);
-            }
-
-            return $value;
+            return $callback(data_get($this->all(), $key)) ?: $this;
         }
 
         if ($default) {
-            return $default($value);
+            return $default();
         }
 
         return $this;

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -111,13 +111,24 @@ trait InteractsWithInput
      * Apply the callback if the request contains the given input item key.
      *
      * @param  string  $key
-     * @param  callable  $callback
+     * @param  callable|null  $callback
+     * @param  callable|null  $default
      * @return $this|mixed
      */
-    public function whenHas($key, callable $callback)
+    public function whenHas($key, callable $callback = null, callable $default = null)
     {
+        $value = data_get($this->all(), $key);
+
         if ($this->has($key)) {
-            return $callback(data_get($this->all(), $key)) ?: $this;
+            if ($callback) {
+                return $callback($value);
+            }
+
+            return $value;
+        }
+
+        if ($default) {
+            return $default($value);
         }
 
         return $this;
@@ -184,13 +195,24 @@ trait InteractsWithInput
      * Apply the callback if the request contains a non-empty value for the given input item key.
      *
      * @param  string  $key
-     * @param  callable  $callback
+     * @param  callable|null  $callback
+     * @param  callable|null  $default
      * @return $this|mixed
      */
-    public function whenFilled($key, callable $callback)
+    public function whenFilled($key, callable $callback = null, callable $default = null)
     {
+        $value = data_get($this->all(), $key);
+
         if ($this->filled($key)) {
-            return $callback(data_get($this->all(), $key)) ?: $this;
+            if ($callback) {
+                return $callback($value);
+            }
+
+            return $value;
+        }
+
+        if ($default) {
+            return $default($value);
         }
 
         return $this;

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -304,7 +304,7 @@ class HttpRequestTest extends TestCase
     {
         $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => '', 'city' => null]);
 
-        $name = $age = $city = $foo = false;
+        $name = $age = $city = $foo = $bar = false;
 
         $request->whenHas('name', function ($value) use (&$name) {
             $name = $value;
@@ -322,17 +322,30 @@ class HttpRequestTest extends TestCase
             $foo = 'test';
         });
 
+        $request->whenHas('bar', function () use (&$bar) {
+            $bar = 'test';
+        }, function () use (&$bar) {
+            $bar = true;
+        });
+
+        $baz = $request->whenHas('foobar', function () use (&$foo) {
+            $foo = 'test';
+        });
+
         $this->assertSame('Taylor', $name);
         $this->assertSame('', $age);
         $this->assertNull($city);
         $this->assertFalse($foo);
+        $this->assertTrue($bar);
+        $this->assertSame('', $request->whenHas('age'));
+        $this->assertInstanceOf(Request::class, $baz);
     }
 
     public function testWhenFilledMethod()
     {
         $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => '', 'city' => null]);
 
-        $name = $age = $city = $foo = false;
+        $name = $age = $city = $foo = $bar = false;
 
         $request->whenFilled('name', function ($value) use (&$name) {
             $name = $value;
@@ -350,10 +363,24 @@ class HttpRequestTest extends TestCase
             $foo = 'test';
         });
 
+        $request->whenFilled('bar', function () use (&$bar) {
+            $bar = 'test';
+        }, function () use (&$bar) {
+            $bar = true;
+        });
+
+        $baz = $request->whenFilled('foobar', function () use (&$foo) {
+            $foo = 'test';
+        });
+
         $this->assertSame('Taylor', $name);
         $this->assertFalse($age);
         $this->assertFalse($city);
         $this->assertFalse($foo);
+        $this->assertTrue($bar);
+        $this->assertSame('Taylor', $request->whenFilled('name'));
+        $this->assertInstanceOf(Request::class, $request->whenFilled('age'));
+        $this->assertInstanceOf(Request::class, $baz);
     }
 
     public function testMissingMethod()

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -328,17 +328,11 @@ class HttpRequestTest extends TestCase
             $bar = true;
         });
 
-        $baz = $request->whenHas('foobar', function () use (&$foo) {
-            $foo = 'test';
-        });
-
         $this->assertSame('Taylor', $name);
         $this->assertSame('', $age);
         $this->assertNull($city);
         $this->assertFalse($foo);
         $this->assertTrue($bar);
-        $this->assertSame('', $request->whenHas('age'));
-        $this->assertInstanceOf(Request::class, $baz);
     }
 
     public function testWhenFilledMethod()
@@ -369,18 +363,11 @@ class HttpRequestTest extends TestCase
             $bar = true;
         });
 
-        $baz = $request->whenFilled('foobar', function () use (&$foo) {
-            $foo = 'test';
-        });
-
         $this->assertSame('Taylor', $name);
         $this->assertFalse($age);
         $this->assertFalse($city);
         $this->assertFalse($foo);
         $this->assertTrue($bar);
-        $this->assertSame('Taylor', $request->whenFilled('name'));
-        $this->assertInstanceOf(Request::class, $request->whenFilled('age'));
-        $this->assertInstanceOf(Request::class, $baz);
     }
 
     public function testMissingMethod()


### PR DESCRIPTION
Many times I needed to return the default value using one of the `whenHas` or `whenFilled` methods, but I could not which was annoying because such a great method was practically useless in some cases.

The solution taken from the collection, we have there for example the `whenEmpty` method, which takes a paramter that returns the default value.

Let's see how this is used in collections:

```php
$collection->whenEmpty(function ($collection) {
    return $collection->push('Adam');
}, function ($collection) {
    return $collection->push('Taylor');
});
```

In the same way now it would be possible to obtain in the request object:

```php
$request->whenHas('name', function ($name) {
    return $name;
}, function () {
    return 'some default value';
});
```

If we do not pass the default value, we will get an instance of the request class, which is the same as before the changes I made.

If I was the only person who needed this solution, then PR is to close.

I also added tests and I hope that I considered each case, I tried to test the introduced code so that it does not force changes on existing solutions.