### PR TITLE
[8.x] Fix PHPDocs of query builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -407,7 +407,7 @@ class Builder
     /**
      * Force the query to only return distinct results.
      *
-     * @param  mixed  $distinct,...
+     * @param  mixed  ...$distinct
      * @return $this
      */
     public function distinct()


### PR DESCRIPTION
A followup patch for this one: https://github.com/laravel/framework/pull/38045.

Using native PHP syntax for variadic variables: https://www.php.net/manual/en/functions.arguments.php#functions.variable-arg-list.