### PR TITLE
[6.x] Remove hardcoded Carbon reference from scheduler event

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -10,7 +10,6 @@ use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Mail\Mailer;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Reflector;
 use Illuminate\Support\Traits\Macroable;
@@ -320,7 +319,7 @@ class Event
      */
     protected function expressionPasses()
     {
-        $date = Carbon::now();
+        $date = Date::now();
 
         if ($this->timezone) {
             $date->setTimezone($this->timezone);


### PR DESCRIPTION
This pull request changes the date that is used to check if a scheduled event is due to the `Date` facade. I ran into a problem where my tests are failing because my application uses a different date class (`CarbonImmutable`)

```php
class AppServiceProvider extends ServiceProvider
{
    public function boot(): void
    {
        Date::use(CarbonImmutable::class);
    }
}

class MyTest extends TestCase
{
    public function testScheduler(): void
    {
        Date::setTestNow('...');

        $myEvent = '...';
        $dueEvents = $this->app->make(Schedule::class)->dueEvents($this->app);

        // This next line fails, because Carbon::now() returns the actual date
        $this->assertTrue($dueEvents->contains($myEvent));
    }
}
```

The following test will always fail because the scheduler calls `Carbon` directly, which at this point does not have a test instance set (because `CarbonImmutable` is used)

This shouldn't introduce any breaking changes because:
- `illuminate/console` already requires `illuminate/support`
- The `\Illuminate\Console\Scheduling\Event` class already uses the `Date` facade everywhere except the line that was changed