### PR TITLE
[8.x] Allow for named arguments via dispatchable trait

### DIFF
--- a/src/Illuminate/Foundation/Bus/Dispatchable.php
+++ b/src/Illuminate/Foundation/Bus/Dispatchable.php
@@ -12,9 +12,9 @@ trait Dispatchable
      *
      * @return \Illuminate\Foundation\Bus\PendingDispatch
      */
-    public static function dispatch()
+    public static function dispatch(...$arguments)
     {
-        return new PendingDispatch(new static(...func_get_args()));
+        return new PendingDispatch(new static(...$arguments));
     }
 
     /**
@@ -52,9 +52,9 @@ trait Dispatchable
      *
      * @return mixed
      */
-    public static function dispatchSync()
+    public static function dispatchSync(...$arguments)
     {
-        return app(Dispatcher::class)->dispatchSync(new static(...func_get_args()));
+        return app(Dispatcher::class)->dispatchSync(new static(...$arguments));
     }
 
     /**
@@ -64,9 +64,9 @@ trait Dispatchable
      *
      * @deprecated Will be removed in a future Laravel version.
      */
-    public static function dispatchNow()
+    public static function dispatchNow(...$arguments)
     {
-        return app(Dispatcher::class)->dispatchNow(new static(...func_get_args()));
+        return app(Dispatcher::class)->dispatchNow(new static(...$arguments));
     }
 
     /**
@@ -74,9 +74,9 @@ trait Dispatchable
      *
      * @return mixed
      */
-    public static function dispatchAfterResponse()
+    public static function dispatchAfterResponse(...$arguments)
     {
-        return app(Dispatcher::class)->dispatchAfterResponse(new static(...func_get_args()));
+        return app(Dispatcher::class)->dispatchAfterResponse(new static(...$arguments));
     }
 
     /**


### PR DESCRIPTION
I've had a situation where it would be nice to use named arguments in dispatching a job to the queue as it allows me to leave out arguments:

```php
RegisterResponse::dispatch(
    uuid: $uuid,
    question: $request->question,
    answer: $request->answer,
    referer: $request->input('referer', $request->headers->get('referer'))
);
```

Unfortunately this will now work as `dispatch`, `dispatchSync` and `dispatchAfterRequest` don't receive any arguments.

Obviously it's easy enough to go about this a different way:

```php
dispatch(new RegisterResponse(
    question: $request->question,
    answer: $request->answer,
));
```

Are there any consequences to these simple changes that I'm not foreseeing?