### PR TITLE
[8.x] Add `Filesystem::replaceInFile` method

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -214,8 +214,8 @@ class Filesystem
     /**
      * Replace a given string within a given file.
      *
-     * @param  string  $search
-     * @param  string  $replace
+     * @param  array|string  $search
+     * @param  array|string  $replace
      * @param  string  $path
      * @return void
      */

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -212,6 +212,19 @@ class Filesystem
     }
 
     /**
+     * Replace a given string within a given file.
+     *
+     * @param  string  $search
+     * @param  string  $replace
+     * @param  string  $path
+     * @return void
+     */
+    public function replaceInFile($search, $replace, $path)
+    {
+        file_put_contents($path, str_replace($search, $replace, file_get_contents($path)));
+    }
+
+    /**
      * Prepend to a file.
      *
      * @param  string  $path

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -88,6 +88,17 @@ class FilesystemTest extends TestCase
         $this->assertStringEqualsFile($tempFile, 'Hello World');
     }
 
+    public function testReplaceInFileCorrectlyReplaces()
+    {
+        $tempFile = self::$tempDir.'/file.txt';
+
+        $filesystem = new Filesystem;
+
+        $filesystem->put($tempFile, 'Hello World');
+        $filesystem->replaceInFile('Hello World', 'Hello Taylor', $tempFile);
+        $this->assertStringEqualsFile($tempFile, 'Hello Taylor');
+    }
+
     public function testReplaceWhenUnixSymlinkExists()
     {
         if (windows_os()) {


### PR DESCRIPTION
This pull request introduces a new `Filesystem::replaceInFile($search, $replace, $path)` method. This method can be found in both Breeze and Jetstream and I've needed the same method too so it made sense to try and PR into the framework.