### PR TITLE
[8.x] Use a file system object to require files

### DIFF
--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -127,7 +127,7 @@ abstract class ServiceProvider
             $config = $this->app->make('config');
 
             $config->set($key, array_merge(
-                require $path, $config->get($key, [])
+                $this->app->make('files')->getRequire($path), $config->get($key, [])
             ));
         }
     }
@@ -141,7 +141,7 @@ abstract class ServiceProvider
     protected function loadRoutesFrom($path)
     {
         if (! ($this->app instanceof CachesRoutes && $this->app->routesAreCached())) {
-            require $path;
+            $this->app->make('files')->getRequire($path);
         }
     }
 


### PR DESCRIPTION
Currently, laravel provides a lot of nice helpers like: `app()->configPath()` and a lot more so that the structures of the customized applications remain understandable for a package developer. (No need to hard code `app()->basePath('config')` and just hope it will work.)

This is fine but it still leaves to way to know which paths are brought in from the service provider as `routes` and `config` files.

Practically a code analyzer package (like the laravel-microscope) needs to have a comprehensive list of all the route and config files to be able to scan and analyze them.
But currently, there is no way reliable way of seamlessly swapping the `loadRoutesFrom` and `mergeConfigFrom` implementations to know what is passed to them.

But if laravel starts to use `files` binding, a package developer can swap out the `files` binding to replace it with a "spy" version of it and know where are the route and config paths really reside.

- Performance hit:
In production, if the route and config files get cached, this change will have zero hits on performance and will not execute at all.

- Backward compatibility:
1- In case of a wrong path, PHP require produces a fatal E_COMPILE_ERROR level error, but this one throws an exception.
2- It introduces two new variables in the required files: `$__path` and `$__data` which may affect a function like: `get_defined_vars();`