### PR TITLE
[8.x] Change cache key column from unique to primary

### DIFF
--- a/src/Illuminate/Cache/Console/stubs/cache.stub
+++ b/src/Illuminate/Cache/Console/stubs/cache.stub
@@ -14,7 +14,7 @@ class CreateCacheTable extends Migration
     public function up()
     {
         Schema::create('cache', function (Blueprint $table) {
-            $table->string('key')->unique();
+            $table->string('key')->primary();
             $table->mediumText('value');
             $table->integer('expiration');
         });


### PR DESCRIPTION
I look at database structure mess in project i working on and i found database cache table without primary key.
You advice people for key value structure use unique key instead of primary, realy?