### PR TITLE
[8.x] Remove PHPUnit\Util\InvalidArgumentHelper

### DIFF
--- a/src/Illuminate/Testing/Assert.php
+++ b/src/Illuminate/Testing/Assert.php
@@ -10,7 +10,6 @@ use PHPUnit\Framework\Constraint\FileExists;
 use PHPUnit\Framework\Constraint\LogicalNot;
 use PHPUnit\Framework\Constraint\RegularExpression;
 use PHPUnit\Framework\InvalidArgumentException;
-use PHPUnit\Util\InvalidArgumentHelper;
 
 /**
  * @internal This class is not meant to be used or overwritten outside the framework itself.
@@ -29,19 +28,11 @@ abstract class Assert extends PHPUnit
     public static function assertArraySubset($subset, $array, bool $checkForIdentity = false, string $msg = ''): void
     {
         if (! (is_array($subset) || $subset instanceof ArrayAccess)) {
-            if (class_exists(InvalidArgumentException::class)) {
-                throw InvalidArgumentException::create(1, 'array or ArrayAccess');
-            } else {
-                throw InvalidArgumentHelper::factory(1, 'array or ArrayAccess');
-            }
+            throw InvalidArgumentException::create(1, 'array or ArrayAccess');
         }
 
         if (! (is_array($array) || $array instanceof ArrayAccess)) {
-            if (class_exists(InvalidArgumentException::class)) {
-                throw InvalidArgumentException::create(2, 'array or ArrayAccess');
-            } else {
-                throw InvalidArgumentHelper::factory(2, 'array or ArrayAccess');
-            }
+            throw InvalidArgumentException::create(2, 'array or ArrayAccess');
         }
 
         $constraint = new ArraySubset($subset, $checkForIdentity);


### PR DESCRIPTION
Previously, when PHPUnit 7.x was supported alongside more recent versions of the tool, the `InvalidArgumentHelper` had to be used instead of an `InvalidArgumentException` when PHPUnit 7.x was installed.

Since Laravel 7.x, support for PHPUnit 7.x was dropped. And installing 8.x or 9.x was required.

Some of that old logic was left behind so I removed it, as it no longer serves its purpose.