### PR TITLE
[8.x] Adding fluent array validation rule

### DIFF
--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -4,6 +4,7 @@ namespace Illuminate\Validation;
 
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Traits\Macroable;
+use Illuminate\Validation\Rules\ArrayRule;
 use Illuminate\Validation\Rules\Dimensions;
 use Illuminate\Validation\Rules\Exists;
 use Illuminate\Validation\Rules\In;
@@ -14,6 +15,16 @@ use Illuminate\Validation\Rules\Unique;
 class Rule
 {
     use Macroable;
+
+    /**
+     * Get an array constraint builder instance.
+     *
+     * @return \Illuminate\Validation\Rules\ArrayRule
+     */
+    public static function array()
+    {
+        return new ArrayRule();
+    }
 
     /**
      * Get a dimensions constraint builder instance.

--- a/src/Illuminate/Validation/Rules/ArrayRule.php
+++ b/src/Illuminate/Validation/Rules/ArrayRule.php
@@ -1,0 +1,293 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Contracts\Validation\ValidatorAwareRule;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Traits\Conditionable;
+
+class ArrayRule implements Rule, ValidatorAwareRule
+{
+    use Conditionable;
+
+    /**
+     * The validator performing the validation.
+     *
+     * @var \Illuminate\Contracts\Validation\Validator
+     */
+    protected $validator;
+
+    /**
+     * The rules the array keys must adhere to.
+     *
+     * @var array
+     */
+    protected $keyRules = [];
+
+    /**
+     * The only keys that may be present on the array.
+     *
+     * @var array
+     */
+    protected $keysIn = [];
+
+    /**
+     * The keys that may not be present on the array.
+     *
+     * @var array
+     */
+    protected $keysNotIn = [];
+
+    /**
+     * The minimum number of elements the array can have.
+     *
+     * @var int
+     */
+    protected $min;
+
+    /**
+     * The maximum number of elements the array can have.
+     *
+     * @var int
+     */
+    protected $max;
+
+    /**
+     * The number of elements the array must have.
+     *
+     * @var int
+     */
+    protected $size;
+
+    /**
+     * Indicates that unvalidated array keys should be excluded, even if the parent array was validated.
+     * Will use the default value from the validator if left unset.
+     *
+     * @var bool
+     */
+    public $excludeUnvalidatedArrayKeys;
+
+    /**
+     * The failure messages, if any.
+     *
+     * @var array
+     */
+    protected $messages = [];
+
+    /**
+     * Defines the rules against which the keys should be validated.
+     *
+     * @param  string|array|Rule|\Closure  $rules
+     * @return $this
+     */
+    public function keyRules($rules)
+    {
+        $this->keyRules = is_array($rules) ? $rules : func_get_args();
+
+        return $this;
+    }
+
+    /**
+     * Requires the keys to be in the given set.
+     *
+     * @param  string|array  $keys
+     * @return $this
+     */
+    public function keysIn($keys)
+    {
+        $this->keysNotIn = [];
+
+        $this->keysIn = is_array($keys) ? $keys : func_get_args();
+
+        return $this;
+    }
+
+    /**
+     * Requires the keys to be in the given set.
+     *
+     * @param  string|array  $keys
+     * @return $this
+     */
+    public function keysNotIn($keys)
+    {
+        $this->keysIn = [];
+
+        $this->keysNotIn = is_array($keys) ? $keys : func_get_args();
+
+        return $this;
+    }
+
+    /**
+     * Forces unvalidated array keys to be excluded from the validated array.
+     *
+     * @return $this
+     */
+    public function excludeUnvalidatedKeys()
+    {
+        $this->excludeUnvalidatedArrayKeys = true;
+
+        return $this;
+    }
+
+    /**
+     * Forces unvalidated array keys to be returned from the validated array.
+     *
+     * @return $this
+     */
+    public function includeUnvalidatedKeys()
+    {
+        $this->excludeUnvalidatedArrayKeys = false;
+
+        return $this;
+    }
+
+    /**
+     * The minimum number of elements the array can have.
+     *
+     * @param  int|null  $value
+     * @return $this
+     */
+    public function min(?int $value)
+    {
+        $this->min = $value;
+
+        return $this;
+    }
+
+    /**
+     * The maximum number of elements the array can have.
+     *
+     * @param  int|null  $value
+     * @return $this
+     */
+    public function max(?int $value)
+    {
+        $this->max = $value;
+
+        return $this;
+    }
+
+    /**
+     * The number of elements the array must have.
+     *
+     * @param  int|null  $value
+     * @return $this
+     */
+    public function size(?int $value)
+    {
+        $this->size = $value;
+
+        return $this;
+    }
+
+    /**
+     * Set the performing validator.
+     *
+     * @param  \Illuminate\Contracts\Validation\Validator  $validator
+     *
+     * @return $this
+     */
+    public function setValidator($validator)
+    {
+        $this->validator = $validator;
+
+        return $this;
+    }
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return  bool
+     */
+    public function passes($attribute, $value)
+    {
+        if (! is_array($value)) {
+            return $this->fail('validation.array');
+        }
+
+        $size = count($value);
+
+        if (isset($this->min) && $size < $this->min) {
+            $this->fail($this->translate('validation.min.array', ['min' => $this->min]));
+        }
+
+        if (isset($this->max) && $size > $this->max) {
+            $this->fail($this->translate('validation.max.array', ['max' => $this->max]));
+        }
+
+        if (isset($this->size) && $size !== $this->size) {
+            $this->fail($this->translate('validation.size.array', ['size' => $this->size]));
+        }
+
+        if (! empty($this->keysIn) && ! empty(array_diff_key($value, array_fill_keys($this->keysIn, '')))) {
+            $this->fail('validation.array');
+        }
+
+        if (! empty($this->keysNotIn) && ! empty(array_intersect_key($value, array_fill_keys($this->keysNotIn, '')))) {
+            $this->fail('validation.array');
+        }
+
+        if (! empty($this->keyRules)) {
+            $keys = array_keys($value);
+
+            $validator = Validator::make(
+                array_combine($keys, $keys),
+                array_fill_keys($keys, $this->keyRules),
+                [],
+                array_fill_keys($keys, $this->translate(":attribute key ':key'"))
+            );
+
+            if ($validator->fails()) {
+                $this->fail($validator->messages()->all());
+            }
+        }
+
+        if (! empty($this->messages)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return array
+     */
+    public function message()
+    {
+        return $this->messages;
+    }
+
+    /**
+     * Adds the given failures, and return false.
+     *
+     * @param  array|string  $messages
+     *
+     * @return bool
+     */
+    protected function fail($messages)
+    {
+        $messages = collect(Arr::wrap($messages))->map(function ($message) {
+            return $this->translate($message);
+        })->all();
+
+        $this->messages = array_merge($this->messages, $messages);
+
+        return false;
+    }
+
+    /**
+     * Translate a message.
+     *
+     * @return string
+     */
+    protected function translate($message, $replace = [])
+    {
+        return $this->validator->getTranslator()->get($message, $replace);
+    }
+}

--- a/tests/Validation/ValidationArrayRuleTest.php
+++ b/tests/Validation/ValidationArrayRuleTest.php
@@ -1,0 +1,526 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Illuminate\Container\Container;
+use Illuminate\Support\Facades\Facade;
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\ValidationServiceProvider;
+use Illuminate\Validation\Validator;
+use PHPUnit\Framework\TestCase;
+
+class ValidationArrayRuleTest extends TestCase
+{
+    public function testSimpleArray()
+    {
+        $rule = Rule::array();
+
+        /*
+         * FAIL: Passing string
+         */
+        $validator = $this->validator([
+            'my_array' => clone $rule,
+        ], [
+            'my_array' => 'abc',
+        ]);
+
+        $this->assertFailing($validator, [
+            'my_array' => [
+                'validation.array',
+            ],
+        ]);
+
+        /*
+         * FAIL: Passing number
+         */
+        $validator = $this->validator([
+            'my_array' => clone $rule,
+        ], [
+            'my_array' => 123,
+        ]);
+
+        $this->assertFailing($validator, [
+            'my_array' => [
+                'validation.array',
+            ],
+        ]);
+
+        /*
+         * FAIL: Passing null
+         */
+        $validator = $this->validator([
+            'my_array' => clone $rule,
+        ], [
+            'my_array' => null,
+        ]);
+
+        $this->assertFailing($validator, [
+            'my_array' => [
+                'validation.array',
+            ],
+        ]);
+
+        /*
+         * PASS: Passing sequential array
+         */
+        $validator = $this->validator([
+            'my_array' => clone $rule,
+        ], [
+            'my_array' => [
+                'foo',
+                'bar',
+            ],
+        ]);
+
+        $this->assertPassing($validator, [
+            'my_array' => [
+                'foo',
+                'bar',
+            ],
+        ]);
+
+        /*
+         * FAIL: Passing associative array
+         */
+        $validator = $this->validator([
+            'my_array' => clone $rule,
+        ], [
+            'my_array' => [
+                'foo' => '123',
+                'bar' => 456,
+            ],
+        ]);
+
+        $this->assertPassing($validator, [
+            'my_array' => [
+                'foo' => '123',
+                'bar' => 456,
+            ],
+        ]);
+    }
+
+    public function testMinMax()
+    {
+        $rule = Rule::array()->min(2)->max(4);
+
+        /*
+         * FAIL: Passing 1 element
+         */
+        $validator = $this->validator([
+            'my_array' => clone $rule,
+        ], [
+            'my_array' => [
+                'abc',
+            ],
+        ]);
+
+        $this->assertFailing($validator, [
+            'my_array' => [
+                'validation.min.array',
+            ],
+        ]);
+
+        /*
+         * PASS: Passing sequential array with 2 elements
+         */
+        $validator = $this->validator([
+            'my_array' => clone $rule,
+        ], [
+            'my_array' => [
+                'foo',
+                'bar',
+            ],
+        ]);
+
+        $this->assertPassing($validator, [
+            'my_array' => [
+                'foo',
+                'bar',
+            ],
+        ]);
+
+        /*
+         * PASS: Passing associative array with 4 elements
+         */
+        $validator = $this->validator([
+            'my_array' => clone $rule,
+        ], [
+            'my_array' => [
+                'foo' => '123',
+                'bar' => 456,
+                'abc' => '567',
+                'def' => 890,
+            ],
+        ]);
+
+        $this->assertPassing($validator, [
+            'my_array' => [
+                'foo' => '123',
+                'bar' => 456,
+                'abc' => '567',
+                'def' => 890,
+            ],
+        ]);
+
+        /*
+         * FAIL: Passing array with 5 elements
+         */
+        $validator = $this->validator([
+            'my_array' => clone $rule,
+        ], [
+            'my_array' => [
+                'foo' => '123',
+                'bar' => 456,
+                'third' => 3,
+                'fourth' => 4,
+                'fifth' => 'fail',
+            ],
+        ]);
+
+        $this->assertFailing($validator, [
+            'my_array' => [
+                'validation.max.array',
+            ],
+        ]);
+    }
+
+    public function testSize()
+    {
+        $rule = Rule::array()->size(3);
+
+        /*
+         * FAIL: Passing 2 element
+         */
+        $validator = $this->validator([
+            'my_array' => clone $rule,
+        ], [
+            'my_array' => [
+                'abc',
+                123,
+            ],
+        ]);
+
+        $this->assertFailing($validator, [
+            'my_array' => [
+                'validation.size.array',
+            ],
+        ]);
+
+        /*
+         * PASS: Passing sequential array with 3 elements
+         */
+        $validator = $this->validator([
+            'my_array' => clone $rule,
+        ], [
+            'my_array' => [
+                'foo',
+                'bar',
+                'pass',
+            ],
+        ]);
+
+        $this->assertPassing($validator, [
+            'my_array' => [
+                'foo',
+                'bar',
+                'pass',
+            ],
+        ]);
+
+        /*
+         * PASS: Passing associative array with 3 elements
+         */
+        $validator = $this->validator([
+            'my_array' => clone $rule,
+        ], [
+            'my_array' => [
+                'foo' => '123',
+                'bar' => 456,
+                'abc' => '567',
+            ],
+        ]);
+
+        $this->assertPassing($validator, [
+            'my_array' => [
+                'foo' => '123',
+                'bar' => 456,
+                'abc' => '567',
+            ],
+        ]);
+
+        /*
+         * FAIL: Passing array with 4 elements
+         */
+        $validator = $this->validator([
+            'my_array' => clone $rule,
+        ], [
+            'my_array' => [
+                'foo' => '123',
+                'bar' => 456,
+                'third' => 3,
+                'fourth' => 4,
+                'fifth' => 'fail',
+            ],
+        ]);
+
+        $this->assertFailing($validator, [
+            'my_array' => [
+                'validation.size.array',
+            ],
+        ]);
+    }
+
+    public function testKeyValidation()
+    {
+        $rule = Rule::array()->keyRules('string', 'size:3');
+
+        /*
+         * FAIL: Passing keys that are too long
+         */
+        $validator = $this->validator([
+            'my_array' => clone $rule,
+        ], [
+            'my_array' => [
+                'abcd' => 'bar',
+                'test' => 'foo',
+            ],
+        ]);
+
+        $this->assertFailing($validator, [
+            'my_array' => [
+                'validation.size.string',
+            ],
+        ]);
+
+        /*
+         * FAIL: Passing sequential array (numeric keys)
+         */
+        $validator = $this->validator([
+            'my_array' => clone $rule,
+        ], [
+            'my_array' => [
+                'foo',
+                'bar',
+            ],
+        ]);
+
+        $this->assertFailing($validator, [
+            'my_array' => [
+                'validation.string',
+                'validation.size.string',
+            ],
+        ]);
+
+        /*
+         * PASS: Passing associative array with 3-char keys
+         */
+        $validator = $this->validator([
+            'my_array' => clone $rule,
+        ], [
+            'my_array' => [
+                'foo' => 'bar',
+                'abc' => 'success',
+            ],
+        ]);
+
+        $this->assertPassing($validator, [
+            'my_array' => [
+                'foo' => 'bar',
+                'abc' => 'success',
+            ],
+        ]);
+    }
+
+    public function testExcludeUnvalidatedKeys()
+    {
+        $rule = Rule::array()->excludeUnvalidatedKeys();
+
+        /*
+         * PASS: Dropping unvalidated keys
+         */
+        $validator = $this->validator([
+            'my_array' => clone $rule,
+            'my_array.foo' => 'string',
+            'my_array.bar' => 'numeric',
+        ], [
+            'my_array' => [
+                'foo' => 'bar',
+                'bar' => 123,
+                'unvalidated' => 'missing',
+            ],
+        ]);
+
+        $this->assertPassing($validator, [
+            'my_array' => [
+                'foo' => 'bar',
+                'bar' => 123,
+            ],
+        ]);
+    }
+
+    public function testIncludeUnvalidatedKeys()
+    {
+        $rule = Rule::array()->includeUnvalidatedKeys();
+
+        /*
+         * PASS: Including unvalidated keys on my_array (with custom rule) and
+         *       dropping them on other_array using validator's default.
+         */
+        $validator = $this->validator([
+            'my_array' => clone $rule,
+            'my_array.foo' => 'string',
+            'my_array.bar' => 'numeric',
+            'other_array' => 'array',
+            'other_array.name' => 'string',
+        ], [
+            'my_array' => [
+                'foo' => 'bar',
+                'bar' => 123,
+                'unvalidated' => 'present',
+            ],
+            'other_array' => [
+                'name' => 'Laravel',
+                'unvalidated' => 'missing',
+            ],
+        ]);
+        $validator->excludeUnvalidatedArrayKeys = true;
+
+        $this->assertPassing($validator, [
+            'my_array' => [
+                'foo' => 'bar',
+                'bar' => 123,
+                'unvalidated' => 'present',
+            ],
+            'other_array' => [
+                'name' => 'Laravel',
+            ],
+        ]);
+    }
+
+    public function testKeysIn()
+    {
+        $rule = Rule::array()->keysIn('foo', 'bar');
+
+        /*
+         * FAIL: Array with unknown keys
+         */
+        $validator = $this->validator([
+            'my_array' => clone $rule,
+        ], [
+            'my_array' => [
+                'foo' => 'bar',
+                'bar' => 'foo',
+                'fail' => 'fail',
+            ],
+        ]);
+
+        $this->assertFailing($validator, [
+            'my_array' => [
+                'validation.array',
+            ],
+        ]);
+
+        /*
+         * PASS: Array with only known keys
+         */
+        $validator = $this->validator([
+            'my_array' => clone $rule,
+        ], [
+            'my_array' => [
+                'foo' => 'bar',
+                'bar' => 'foo',
+            ],
+        ]);
+
+        $this->assertPassing($validator, [
+            'my_array' => [
+                'foo' => 'bar',
+                'bar' => 'foo',
+            ],
+        ]);
+    }
+
+    public function testKeysNotIn()
+    {
+        $rule = Rule::array()->keysNotIn('fail');
+
+        /*
+         * FAIL: Array with forbidden keys
+         */
+        $validator = $this->validator([
+            'my_array' => clone $rule,
+        ], [
+            'my_array' => [
+                'foo' => 'bar',
+                'bar' => 'foo',
+                'fail' => 'fail',
+            ],
+        ]);
+
+        $this->assertFailing($validator, [
+            'my_array' => [
+                'validation.array',
+            ],
+        ]);
+
+        /*
+         * PASS: Array without forbidden keys
+         */
+        $validator = $this->validator([
+            'my_array' => clone $rule,
+        ], [
+            'my_array' => [
+                'foo' => 'bar',
+                'bar' => 'foo',
+            ],
+        ]);
+
+        $this->assertPassing($validator, [
+            'my_array' => [
+                'foo' => 'bar',
+                'bar' => 'foo',
+            ],
+        ]);
+    }
+
+    protected function assertPassing($validator, $values)
+    {
+        $this->assertTrue($validator->passes());
+        $this->assertEqualsCanonicalizing($values, $validator->validated());
+    }
+
+    protected function assertFailing($validator, $messages)
+    {
+        $this->assertFalse($validator->passes());
+        $this->assertEqualsCanonicalizing($messages, $validator->messages()->toArray());
+    }
+
+    protected function validator($rules, $data)
+    {
+        return new Validator(resolve('translator'), $data, $rules);
+    }
+
+    protected function setUp(): void
+    {
+        $container = Container::getInstance();
+
+        $container->bind('translator', function () {
+            return new Translator(new ArrayLoader, 'en');
+        });
+
+        Facade::setFacadeApplication($container);
+
+        (new ValidationServiceProvider($container))->register();
+    }
+
+    protected function tearDown(): void
+    {
+        Container::setInstance(null);
+
+        Facade::clearResolvedInstances();
+
+        Facade::setFacadeApplication(null);
+    }
+}


### PR DESCRIPTION
This PR creates a new rule helper for arrays. It combines the existing validation options that are available for arrays (`array`, `min`, `max`, `size`) into a fluent rule and adds additional functionality:
- ensuring keys are not present in the array (opposite of currently available `array:foo,bar`)
- including/excluding unvalidated array keys regardless of the global setting
- validating array keys according to normal validation rules

```php
use Illuminate\Validation\Rule;

/*
 * EXISTING FUNCTIONALITY
 */
 
// the same as adding the 'array' rule
Rule::array()

// the same as adding the 'array:foo,bar' rule
Rule::array()->keysIn('foo', 'bar') 
Rule::array()->keysIn(['foo', 'bar'])

// almost the same as applying excludeUnvalidatedArrayKeys on the validator
// different in that it only applies to the array under validation
Rule::array()->excludeUnvalidatedKeys()

// the same as adding `array|min:3|max:8`
Rule::array()->min(3)->max(8)

// the same as adding `array|size:5`
Rule::array()->size(5)

/*
 * NEW FUNCTIONALITY
 */
 
// forbid these keys from existing on the array
Rule::array()->keysNotIn('foo', 'bar') 
Rule::array()->keysNotIn(['foo', 'bar'])

// returns all keys regardless of the excludeUnvalidatedArrayKeys setting on the validator
Rule::array()->includeUnvalidatedKeys()

// validating array keys
Rule::array()->keyRules('string', 'uuid')
Rule::array()->keyRules(['string', Rule::exists('users', 'id')])
```

### `keysIn/NotIn(...)` considerations
If the `keysIn()` option is being used and the validator fails, it will fail with the `validation.array` message, because this is the current behaviour for the `array:foo,bar` rule. An alternative in this case would be making it an alias for `keyRules('in:foo,bar')` which would return a `validation.in` error message.

`keysIn()` and `keysNotIn()` cannot be used simultaneously, calling one would empty the other.

### `in-/excludeUnvalidatedKeys()`
The `includeUnvalidatedKeys` and `excludeUnvalidatedKeys` methods allow the user to change the excluding behaviour on a per-array basis instead of for the entire dataset under validation.

### `keyRules(...)`
This helper would allow the user to validate that the keys on the array match certain rules. For example, checking they're all UUIDs, whether they exist in a database, requiring size restrictions (as strings or numerals), date formats, etc. 

They will be validated using the Laravel validator, so theoretically all rules can be applied there, although practically some of them won't work for obvious reasons, e.g.: `array`, `confirmed`, `dimensions`, `distinct`, `exclude_*`, `file`, `filled`, `image`, `in_array`, `mimetypes`, `mimes`, `nullable`, `present`, `prohibited_*`, `required_*`, `same` (may have missed some). They're not explicitly forbidden but in my opinion the developer should apply common sense to what keys can and cannot be. 

### Open questions

1. Naming of the methods. I'm not particularly sold on the `keyRules` name but couldn't think of anything better.
2. The class implements the `Conditionable` trait, would it make sense for the `keysIn()`, `keysNotIn()` and `keyRules()` function to merge the newly passed values with the existing values? Should passing an empty array then empty the existing values?