### PR TITLE
[8.x] Loading route files by $routeFiles property on providers

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -914,6 +914,8 @@ class Application extends Container implements ApplicationContract, CachesConfig
             $this->call([$provider, 'boot']);
         }
 
+        $provider->bootRoutes();
+
         $provider->callBootedCallbacks();
     }
 

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -48,6 +48,13 @@ abstract class ServiceProvider
     public static $publishGroups = [];
 
     /**
+     * Route files to be loaded.
+     *
+     * @var string[]
+     */
+    protected $routeFiles = [];
+
+    /**
      * Create a new service provider instance.
      *
      * @param  \Illuminate\Contracts\Foundation\Application  $app
@@ -129,6 +136,18 @@ abstract class ServiceProvider
             $config->set($key, array_merge(
                 require $path, $config->get($key, [])
             ));
+        }
+    }
+
+    /**
+     * Load the route files on the provider instance.
+     *
+     * @return void
+     */
+    public function bootRoutes()
+    {
+        foreach ($this->routeFiles as $routeFile) {
+            $this->loadRoutesFrom($routeFile);
         }
     }
 


### PR DESCRIPTION
Basically, this PR allows users to mention a list of relative route files on the service provider class to be loaded. 
Instead of calling the `$this->loadRoutesFrom(...);`

- This list can also be manipulated from the `boot` method if needed.
```php
class MyServiceProvider extends ServiceProvider
{
    protected $routeFiles = [  __DIR__.'/my_route.php'  ];

```
The problem with calling `loadRoutesFrom` is that it is not very clear where is the best place to call it for everyone. boot? or register?

The other problem is that package developers can not know which route files are being loaded by `loadRoutesFrom`.

Currently, laravel provides a lot of nice helpers like: app()->configPath() and a lot more so that the structures of the customized applications remain understandable for a package developer. (No need to hard code app()->basePath('config') and just hope it will work.)
As a real-world example, a code analyzer package (like the laravel-microscope) needs to have a comprehensive list of all the route and config files to be able to scan and analyze them.
But currently, there is no way reliable way of seamlessly swapping the `loadRoutesFrom` and `mergeConfigFrom` implementations FROM A Package, in order to know what is passed to them.

This way package developers can know about route files even if they are dynamically appended to the list from the boot method.
