### PR TITLE
[8.x] Fix display of validation errors occurred when asserting status

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -81,9 +81,10 @@ class TestResponse implements ArrayAccess
      */
     public function assertSuccessful()
     {
-        $message = $this->statusMessageWithDetails('>=200, <300', $this->getStatusCode());
-
-        PHPUnit::assertTrue($this->isSuccessful(), $message);
+        PHPUnit::assertTrue(
+            $this->isSuccessful(),
+            $this->statusMessageWithDetails('>=200, <300', $this->getStatusCode())
+        );
 
         return $this;
     }
@@ -161,9 +162,7 @@ class TestResponse implements ArrayAccess
      */
     public function assertStatus($status)
     {
-        $actual = $this->getStatusCode();
-
-        $message = $this->statusMessageWithDetails($status, $actual);
+        $message = $this->statusMessageWithDetails($status, $actual = $this->getStatusCode());
 
         PHPUnit::assertSame($actual, $status, $message);
 
@@ -171,7 +170,7 @@ class TestResponse implements ArrayAccess
     }
 
     /**
-     * Get an assertion message for a status assertion containing extra details where available.
+     * Get an assertion message for a status assertion containing extra details when available.
      *
      * @param  string|int  $expected
      * @param  string|int  $actual
@@ -180,12 +179,14 @@ class TestResponse implements ArrayAccess
     protected function statusMessageWithDetails($expected, $actual)
     {
         $lastException = $this->exceptions->last();
+
         if ($lastException) {
             return $this->statusMessageWithException($expected, $actual, $lastException);
         }
 
         if ($this->baseResponse instanceof RedirectResponse) {
             $session = $this->baseResponse->getSession();
+
             if (! is_null($session) && $session->has('errors')) {
                 return $this->statusMessageWithErrors($expected, $actual, $session->get('errors')->all());
             }
@@ -193,6 +194,7 @@ class TestResponse implements ArrayAccess
 
         if ($this->baseResponse->headers->get('Content-Type') === 'application/json') {
             $json = $this->json();
+
             if (isset($json['errors'])) {
                 return $this->statusMessageWithErrors($expected, $actual, $json);
             }
@@ -246,6 +248,7 @@ Expected response status code [$expected] but received $actual.
 The following errors occurred during the request:
 
 $errors
+
 EOF;
     }
 

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -227,7 +227,7 @@ EOF;
     }
 
     /**
-     * Get an assertion message for a status assertion that contained errors
+     * Get an assertion message for a status assertion that contained errors.
      *
      * @param  string|int  $expected
      * @param  string|int  $actual

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -7,6 +7,7 @@ use Closure;
 use Illuminate\Contracts\View\View;
 use Illuminate\Cookie\CookieValuePrefix;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
@@ -80,11 +81,7 @@ class TestResponse implements ArrayAccess
      */
     public function assertSuccessful()
     {
-        $lastException = $this->exceptions->last();
-
-        $message = isset($lastException)
-                    ? $this->statusMessageWithException('>=200, <300', $this->getStatusCode(), $lastException)
-                    : 'Response status code ['.$this->getStatusCode().'] is not a successful status code.';
+        $message = $this->statusMessageWithDetails('>=200, <300', $this->getStatusCode());
 
         PHPUnit::assertTrue($this->isSuccessful(), $message);
 
@@ -166,17 +163,42 @@ class TestResponse implements ArrayAccess
     {
         $actual = $this->getStatusCode();
 
-        $lastException = $actual !== $status && in_array($actual, [422, 500])
-                    ? $this->exceptions->last()
-                    : null;
-
-        $message = isset($lastException)
-                    ? $this->statusMessageWithException($status, $actual, $lastException)
-                    : "Expected status code [{$status}] but received {$actual}.";
+        $message = $this->statusMessageWithDetails($status, $actual);
 
         PHPUnit::assertSame($actual, $status, $message);
 
         return $this;
+    }
+
+    /**
+     * Get an assertion message for a status assertion containing extra details where available.
+     *
+     * @param  string|int  $expected
+     * @param  string|int  $actual
+     * @return string
+     */
+    protected function statusMessageWithDetails($expected, $actual)
+    {
+        $lastException = $this->exceptions->last();
+        if ($lastException) {
+            return $this->statusMessageWithException($expected, $actual, $lastException);
+        }
+
+        if ($this->baseResponse instanceof RedirectResponse) {
+            $session = $this->baseResponse->getSession();
+            if ($session->has('errors')) {
+                return $this->statusMessageWithErrors($expected, $actual, $session->get('errors')->all());
+            }
+        }
+
+        if ($this->baseResponse->headers->get('Content-Type') === 'application/json') {
+            $json = $this->json();
+            if (isset($json['errors'])) {
+                return $this->statusMessageWithErrors($expected, $actual, $json);
+            }
+        }
+
+        return "Expected status code [{$expected}] but received {$actual}.";
     }
 
     /**
@@ -205,23 +227,23 @@ EOF;
     }
 
     /**
-     * Get an assertion message for a status assertion that has an unexpected validation exception.
+     * Get an assertion message for a status assertion that contained errors
      *
      * @param  string|int  $expected
      * @param  string|int  $actual
-     * @param  \Illuminate\Validation\ValidationException $exception;
+     * @param  array $errors;
      * @return string
      */
-    protected function statusMessageWithValidationErrors($expected, $actual, $exception)
+    protected function statusMessageWithErrors($expected, $actual, $errors)
     {
         $errors = $this->baseResponse->headers->get('Content-Type') === 'application/json'
-            ? json_encode($exception->errors(), JSON_PRETTY_PRINT)
-            : implode(PHP_EOL, Arr::flatten($exception->errors()));
+            ? json_encode($errors, JSON_PRETTY_PRINT)
+            : implode(PHP_EOL, Arr::flatten($errors));
 
         return <<<EOF
 Expected response status code [$expected] but received $actual.
 
-The following validation errors occurred during the request:
+The following errors occurred during the request:
 
 $errors
 EOF;

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -186,7 +186,7 @@ class TestResponse implements ArrayAccess
 
         if ($this->baseResponse instanceof RedirectResponse) {
             $session = $this->baseResponse->getSession();
-            if ($session->has('errors')) {
+            if (! is_null($session) && $session->has('errors')) {
                 return $this->statusMessageWithErrors($expected, $actual, $session->get('errors')->all());
             }
         }

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -198,7 +198,7 @@ class TestResponse implements ArrayAccess
             }
         }
 
-        return "Expected status code [{$expected}] but received {$actual}.";
+        return "Expected response status code [{$expected}] but received {$actual}.";
     }
 
     /**

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -590,7 +590,7 @@ class TestResponseTest extends TestCase
                 'errors' => [
                     'first_name' => 'The first name field is required.',
                     'last_name' => 'The last name field is required.',
-                ]
+                ],
             ],
             $statusCode
         );

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -397,7 +397,7 @@ class TestResponseTest extends TestCase
 
         $this->expectException(AssertionFailedError::class);
 
-        $this->expectExceptionMessage('Expected status code');
+        $this->expectExceptionMessage('Expected response status code');
 
         $baseResponse = tap(new Response, function ($response) use ($statusCode) {
             $response->setStatusCode($statusCode);
@@ -413,7 +413,7 @@ class TestResponseTest extends TestCase
 
         $this->expectException(AssertionFailedError::class);
 
-        $this->expectExceptionMessage('Expected status code');
+        $this->expectExceptionMessage('Expected response status code');
 
         $baseResponse = tap(new Response, function ($response) use ($statusCode) {
             $response->setStatusCode($statusCode);
@@ -428,7 +428,7 @@ class TestResponseTest extends TestCase
         $statusCode = 500;
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Expected status code');
+        $this->expectExceptionMessage('Expected response status code');
 
         $baseResponse = tap(new Response, function ($response) use ($statusCode) {
             $response->setStatusCode($statusCode);
@@ -444,7 +444,7 @@ class TestResponseTest extends TestCase
 
         $this->expectException(AssertionFailedError::class);
 
-        $this->expectExceptionMessage('Expected status code');
+        $this->expectExceptionMessage('Expected response status code');
 
         $baseResponse = tap(new Response, function ($response) use ($statusCode) {
             $response->setStatusCode($statusCode);
@@ -460,7 +460,7 @@ class TestResponseTest extends TestCase
 
         $this->expectException(AssertionFailedError::class);
 
-        $this->expectExceptionMessage('Expected status code');
+        $this->expectExceptionMessage('Expected response status code');
 
         $baseResponse = tap(new Response, function ($response) use ($statusCode) {
             $response->setStatusCode($statusCode);
@@ -476,7 +476,7 @@ class TestResponseTest extends TestCase
 
         $this->expectException(AssertionFailedError::class);
 
-        $this->expectExceptionMessage('Expected status code');
+        $this->expectExceptionMessage('Expected response status code');
 
         $baseResponse = tap(new Response, function ($response) use ($statusCode) {
             $response->setStatusCode($statusCode);
@@ -493,7 +493,7 @@ class TestResponseTest extends TestCase
 
         $this->expectException(AssertionFailedError::class);
 
-        $this->expectExceptionMessage('Expected status code');
+        $this->expectExceptionMessage('Expected response status code');
 
         $baseResponse = tap(new Response, function ($response) use ($statusCode) {
             $response->setStatusCode($statusCode);
@@ -525,7 +525,7 @@ class TestResponseTest extends TestCase
 
         $this->expectException(AssertionFailedError::class);
 
-        $this->expectExceptionMessage('Expected status code');
+        $this->expectExceptionMessage('Expected response status code');
 
         $baseResponse = tap(new Response, function ($response) use ($statusCode) {
             $response->setStatusCode($statusCode);

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -554,7 +554,7 @@ class TestResponseTest extends TestCase
         $response->assertStatus($expectedStatusCode);
     }
 
-    public function testAssertStatusShowsValidationErrorsOnUnexpected422()
+    public function testAssertStatusShowsErrorsOnUnexpectedErrorRedirect()
     {
         $statusCode = 302;
         $expectedStatusCode = 200;
@@ -575,7 +575,7 @@ class TestResponseTest extends TestCase
         $response->assertStatus($expectedStatusCode);
     }
 
-    public function testAssertStatusShowsJsonValidationErrorsOnUnexpected422()
+    public function testAssertStatusShowsJsonErrorsOnUnexpected422()
     {
         $statusCode = 422;
         $expectedStatusCode = 200;


### PR DESCRIPTION
As discovered by @paulredmond, the display of unexpected validation errors introduced in #38046 doesn't actually work in practice because a `ValidationException` is not reported by the exception handler. Paul's diagnosis can be found [here](https://github.com/laravel/framework/pull/38046#issuecomment-883765981). Thankfully this doesn't actually break any existing behaviour.

This PR fixes the issue by also showing errors from a redirect response with session errors (i.e. a non-JSON validation response) and errors in JSON response content, instead of only looking at reported exceptions.

I have learned my lesson and tested this in a new `laravel/laravel` project.

**Errors in redirect response session:**

![image](https://user-images.githubusercontent.com/4977161/126420124-c2c13023-40fe-4348-9e6c-dc44fb95e9d6.png)

**Errors in response JSON content:**

![image](https://user-images.githubusercontent.com/4977161/126420250-445f0187-a4b3-42ff-8db7-b776dd0aa63d.png)

The behaviour is slightly different than before because `assertStatus()` no longer only displays errors for unexpected 500 and 422 responses, and instead just displays any reported exceptions, session errors, or JSON errors when the status is not as asserted. This also makes `assertStatus()` behave the same as `assertSuccessful()`.

I also took the opportunity to standardise the messaging of "Expected response status code" which in some instances was just "Expected status code".