### PR TITLE
[8.x] Change Arr::toCssClasses to Arr::conditionallyToString to be more abstract

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -653,26 +653,26 @@ class Arr
     }
 
     /**
-     * Conditionally compile classes from an array into a CSS class list.
+     * Conditionally compile values from an array into a string.
      *
      * @param  array  $array
      * @return string
      */
-    public static function toCssClasses($array)
+    public static function conditionallyToString($array, $separator = ' ')
     {
-        $classList = static::wrap($array);
+        $array = static::wrap($array);
 
-        $classes = [];
+        $values = [];
 
-        foreach ($classList as $class => $constraint) {
-            if (is_numeric($class)) {
-                $classes[] = $constraint;
-            } elseif ($constraint) {
-                $classes[] = $class;
+        foreach ($array as $key => $value) {
+            if (is_numeric($key)) {
+                $values[] = $value;
+            } elseif ($value) {
+                $values[] = $key;
             }
         }
 
-        return implode(' ', $classes);
+        return implode($separator, $values);
     }
 
     /**

--- a/src/Illuminate/View/Compilers/Concerns/CompilesClasses.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesClasses.php
@@ -14,6 +14,6 @@ trait CompilesClasses
     {
         $expression = is_null($expression) ? '([])' : $expression;
 
-        return "class=\"<?php echo \Illuminate\Support\Arr::toCssClasses{$expression} ?>\"";
+        return "class=\"<?php echo \Illuminate\Support\Arr::conditionallyToString{$expression} ?>\"";
     }
 }

--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -183,7 +183,7 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
     {
         $classList = Arr::wrap($classList);
 
-        return $this->merge(['class' => Arr::toCssClasses($classList)]);
+        return $this->merge(['class' => Arr::conditionallyToString($classList)]);
     }
 
     /**

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -826,7 +826,25 @@ class SupportArrTest extends TestCase
 
         $this->assertEquals('font-bold mt-4 ml-2', $classes);
 
-        $classes = Arr::conditionallyToString([
+        $values = Arr::conditionallyToString([
+            'Taylor',
+            'John',
+            'Sponge Bob' => false,
+            'Dave' => true,
+        ], ',');
+
+        $this->assertEquals('Taylor,John,Dave', $values);
+
+        $values = Arr::conditionallyToString([
+            'Taylor',
+            'John',
+            'Sponge Bob' => false,
+            'Dave' => true,
+        ], ', ');
+
+        $this->assertEquals('Taylor, John, Dave', $values);
+
+        $slugParts = Arr::conditionallyToString([
             'we',
             'do',
             'not' => false,
@@ -838,7 +856,7 @@ class SupportArrTest extends TestCase
             'like'
         ], '-');
 
-        $this->assertEquals('we-do-want-to-build-something-slug-like', $classes);
+        $this->assertEquals('we-do-want-to-build-something-slug-like', $slugParts);
     }
 
     public function testWhere()

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -853,7 +853,7 @@ class SupportArrTest extends TestCase
             'build',
             'something' => true,
             'slug',
-            'like'
+            'like',
         ], '-');
 
         $this->assertEquals('we-do-want-to-build-something-slug-like', $slugParts);

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -808,16 +808,16 @@ class SupportArrTest extends TestCase
         $this->assertEquals($expect, Arr::sortRecursive($array));
     }
 
-    public function testToCssClasses()
+    public function testConditionallyToString()
     {
-        $classes = Arr::toCssClasses([
+        $classes = Arr::conditionallyToString([
             'font-bold',
             'mt-4',
         ]);
 
         $this->assertEquals('font-bold mt-4', $classes);
 
-        $classes = Arr::toCssClasses([
+        $classes = Arr::conditionallyToString([
             'font-bold',
             'mt-4',
             'ml-2' => true,
@@ -825,6 +825,20 @@ class SupportArrTest extends TestCase
         ]);
 
         $this->assertEquals('font-bold mt-4 ml-2', $classes);
+
+        $classes = Arr::conditionallyToString([
+            'we',
+            'do',
+            'not' => false,
+            'want',
+            'to' => true,
+            'build',
+            'something' => true,
+            'slug',
+            'like'
+        ], '-');
+
+        $this->assertEquals('we-do-want-to-build-something-slug-like', $classes);
     }
 
     public function testWhere()

--- a/tests/View/Blade/BladeClassTest.php
+++ b/tests/View/Blade/BladeClassTest.php
@@ -7,7 +7,7 @@ class BladeClassTest extends AbstractBladeTestCase
     public function testClassesAreConditionallyCompiledFromArray()
     {
         $string = "<span @class(['font-bold', 'mt-4', 'ml-2' => true, 'mr-2' => false])></span>";
-        $expected = "<span class=\"<?php echo \Illuminate\Support\Arr::toCssClasses(['font-bold', 'mt-4', 'ml-2' => true, 'mr-2' => false]) ?>\"></span>";
+        $expected = "<span class=\"<?php echo \Illuminate\Support\Arr::conditionallyToString(['font-bold', 'mt-4', 'ml-2' => true, 'mr-2' => false]) ?>\"></span>";
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }


### PR DESCRIPTION
The functionality introduced with https://github.com/laravel/framework/pull/38016 is very useful. Thanks @danharrin! I might be a little late with this because it already got merged, and it's also maybe a little pedantic, but I still would like to try to make a point.

From my point of view the introduced array helper is too specific to a special situation. I see several use cased for the same functionality. If the framework starts to add helpers for each specific case, I could get bloated quite fast.

What does the array helper function actually do? It conditionally creates a string from a given array.

Hence, I would like to propose to change `Arr::toCssClasses` to `Arr::conditionallyToString` and add a little extra flexibility with the newly added parameter `$separator`.

## Changes

**Before:**
```php
public static function toCssClasses($array)
    {
        $classList = static::wrap($array);

        $classes = [];

        foreach ($classList as $class => $constraint) {
            if (is_numeric($class)) {
                $classes[] = $constraint;
            } elseif ($constraint) {
                $classes[] = $class;
            }
        }

        return implode(' ', $classes);
    }
```

**After:**
```php
public static function conditionallyToString($array, $separator = ' ')
    {
        $array = static::wrap($array);

        $values = [];

        foreach ($array as $key => $value) {
            if (is_numeric($key)) {
                $values[] = $value;
            } elseif ($value) {
                $values[] = $key;
            }
        }

        return implode($separator, $values);
    }
```

## Benefit
Function is re-usable to conditionally create any kind of string from an array. 

Let's say I want to create a `-` separated string from an array. I can use:

```php 
$classes = Arr::conditionallyToString([
            'we',
            'do',
            'not' => false,
            'want',
            'to' => true,
            'build',
            'something' => true,
            'slug',
            'like'
        ], '-');

        // result: 'we-do-want-to-build-something-slug-like
```

Or I want to have a `,` separated list of people attending to an event:

```php
        $values = Arr::conditionallyToString([
            'Taylor',
            'John',
            'Sponge Bob' => false,
            'Dave' => true,
        ], ', ');

        // result: Taylor, John, Dave'
```

## Breaking change or not?
Technically this is a breaking change, because the new function just got merged and released. One could argue that no one is using the new function now. 

In worst case there could be a non documented alias from `Arr::toCssClasses` to the more abstract `Arr::conditionallyToString`. This would not bloat the framework less in the specific case, but would enable developers to use a properly named function for teir own purpose.

## Notes
1. Blade stuff is changed to the new function name
2. Tests are changed to the new function name and a cases for the new `$separator` parameter got added.
3. This pull request requires changes in the newly added documentation items (https://github.com/laravel/docs/pull/7194) 
4. For better comparability I did not yet move the function to be in alphabetical order in `Arr::class`. Happy to do that in case the PR is considered to be merged
