### PR TITLE
[8.x] Allow shift() and pop() to take multiple items from a collection

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -803,7 +803,6 @@ class Collection implements ArrayAccess, Enumerable
         }
 
         return collect($results);
-
     }
 
     /**
@@ -967,7 +966,6 @@ class Collection implements ArrayAccess, Enumerable
         }
 
         return collect($results);
-
     }
 
     /**

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -790,9 +790,20 @@ class Collection implements ArrayAccess, Enumerable
      *
      * @return mixed
      */
-    public function pop()
+    public function pop($number = 1)
     {
-        return array_pop($this->items);
+        if ($number === 1) {
+            return array_pop($this->items);
+        }
+
+        $results = [];
+
+        foreach (range(1, $number) as $item) {
+            array_push($results, array_pop($this->items));
+        }
+
+        return collect($results);
+
     }
 
     /**
@@ -943,9 +954,20 @@ class Collection implements ArrayAccess, Enumerable
      *
      * @return mixed
      */
-    public function shift()
+    public function shift($number = 1)
     {
-        return array_shift($this->items);
+        if ($number === 1) {
+            return array_shift($this->items);
+        }
+
+        $results = [];
+
+        foreach (range(1, $number) as $item) {
+            array_push($results, array_shift($this->items));
+        }
+
+        return collect($results);
+
     }
 
     /**

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -788,6 +788,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get and remove the last item from the collection.
      *
+     * @param int $number
      * @return mixed
      */
     public function pop($number = 1)
@@ -951,6 +952,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get and remove the first item from the collection.
      *
+     * @param int $number
      * @return mixed
      */
     public function shift($number = 1)

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -786,23 +786,24 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
-     * Get and remove the last item from the collection.
+     * Get and remove the last N items from the collection.
      *
+     * @param  int  $count
      * @return mixed
      */
-    public function pop($number = 1)
+    public function pop($count = 1)
     {
-        if ($number === 1) {
+        if ($count === 1) {
             return array_pop($this->items);
         }
 
         $results = [];
 
-        foreach (range(1, $number) as $item) {
+        foreach (range(1, $count) as $item) {
             array_push($results, array_pop($this->items));
         }
 
-        return collect($results);
+        return new static($results);
     }
 
     /**
@@ -949,23 +950,24 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
-     * Get and remove the first item from the collection.
+     * Get and remove the first N items from the collection.
      *
+     * @param  int  $count
      * @return mixed
      */
-    public function shift($number = 1)
+    public function shift($count = 1)
     {
-        if ($number === 1) {
+        if ($count === 1) {
             return array_shift($this->items);
         }
 
         $results = [];
 
-        foreach (range(1, $number) as $item) {
+        foreach (range(1, $count) as $item) {
             array_push($results, array_shift($this->items));
         }
 
-        return collect($results);
+        return new static($results);
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -225,6 +225,14 @@ class SupportCollectionTest extends TestCase
         $this->assertSame('foo', $c->first());
     }
 
+    public function testPopReturnsAndRemovesLastXItemsInCollection()
+    {
+        $c = new Collection(['foo', 'bar', 'baz']);
+
+        $this->assertEquals(new Collection(['baz', 'bar']), $c->pop(2));
+        $this->assertSame('foo', $c->first());
+    }
+
     public function testShiftReturnsAndRemovesFirstItemInCollection()
     {
         $data = new Collection(['Taylor', 'Otwell']);
@@ -233,6 +241,14 @@ class SupportCollectionTest extends TestCase
         $this->assertSame('Otwell', $data->first());
         $this->assertSame('Otwell', $data->shift());
         $this->assertNull($data->first());
+    }
+
+    public function testShiftReturnsAndRemovesFirstXItemsInCollection()
+    {
+        $data = new Collection(['foo', 'bar', 'baz']);
+
+        $this->assertEquals(new Collection(['foo', 'bar']), $data->shift(2));
+        $this->assertSame('baz', $data->first());
     }
 
     /**


### PR DESCRIPTION
This pull request adds an optional numeric argument, defaulting to 1, to the pop() and shift() methods of the Collection class. This allows the user to shift or pop x items from a collection in one pass. This PR was inspired by the following situation.

I have a collection of 98 records that I need to divide as evenly as possible into 4 groups. So the group sizes would be 25, 25, 24, and 24. In order to do this, I have to jump through some hoops using take() and skip()...

```php
$groupSizes = [25, 25, 24, 24];
$skip = 0;

foreach ($groupSizes as $size) {
    $group = $collection->skip($skip)->take($size);
    $skip += $size;
   // Do something with the group
}
```

With this new argument, I have the option of simply doing

```php
$groupSizes = [25, 25, 24, 24];


foreach ($groupSizes as $size) {
    $group = $collection->shift($size);
    // Do something with the group
}
```

Because the default value for each of the methods is 1, they continue to work exactly as they did before.

### Alternatives

There are a couple other ways this problem could be solved. The first would be to create new methods for each. Something like popMany() and shiftMany(). Another would be to add an optional second parameter to take() that would remove the items returned from the original collection. 
