### PR TITLE
[8.x] Fix route cache priority bug #37639

### DIFF
--- a/src/Illuminate/Routing/AbstractRouteCollection.php
+++ b/src/Illuminate/Routing/AbstractRouteCollection.php
@@ -171,7 +171,7 @@ abstract class AbstractRouteCollection implements Countable, IteratorAggregate, 
     {
         $symfonyRoutes = new SymfonyRouteCollection;
 
-        $routes = $this->getRoutes();
+        $routes = array_reverse($this->getRoutes());
 
         foreach ($routes as $route) {
             if (! $route->isFallback) {


### PR DESCRIPTION
This PR fixes https://github.com/laravel/framework/issues/37639

I do not know whether symfony component has a bug or it should work as it does now.
currently, it matches the first case it finds, and no override happens there. As I deduced. (maybe I am wrong)

So
1- one way is to reverse the collection before getting cached. (As this PR suggests)
2- Or reverse the to reverse it after the cache file gets read and then pass it to symfony. (As shown in the snapshot below)

![image](https://user-images.githubusercontent.com/6961695/126487013-5ba5b4c0-acd4-468b-a9f6-47cd8272fee8.png)
If the symfony compiled matcher is performing wrong the bug should be fixed there.

I did not have time to really battle test this solution, so I wonder if anybody can find a side effect or something. (Help wanted)
