### PR TITLE
[8.x] Fix route cache issue

### DIFF
--- a/src/Illuminate/Routing/AbstractRouteCollection.php
+++ b/src/Illuminate/Routing/AbstractRouteCollection.php
@@ -133,6 +133,16 @@ abstract class AbstractRouteCollection implements Countable, IteratorAggregate, 
     {
         $compiled = $this->dumper()->getCompiledRoutes();
 
+        // Here we manually override if a static url has many routes with different methods
+        foreach ($compiled[1] as $url => $routesData) {
+            for ($i = count($routesData) - 1; $i !== 0; $i--) {
+                $methods = $routesData[$i][2];
+                for ($j = $i - 1; $j !== -1; $j--) {
+                    $compiled[1][$url][$j][2] = array_diff_key($routesData[$j][2], $methods);
+                }
+            }
+        }
+
         $attributes = [];
 
         foreach ($this->getRoutes() as $route) {

--- a/tests/Integration/Routing/RouteCachingTest.php
+++ b/tests/Integration/Routing/RouteCachingTest.php
@@ -20,7 +20,7 @@ class RouteCachingTest extends TestCase
 
         $this->post('/foo/1')->assertRedirect('/foo/1/bar');
         $this->get('/foo/1/bar')->assertSee('Redirect response');
-        $this->get('/foo/1')->assertRedirect('/foo/1/bar');
+        $this->get('/foo/1')->assertSee('GET response');
     }
 
     protected function routes(string $file)


### PR DESCRIPTION
The root cause of this problem is that when the routes are cached we use "symfony matcher" to match a route based on request data and when the routes are not cached we use "Laravel matcher". So the implementations of the ->match( method are very different and they behave differently when there are two candidate routes to choose from.
1- Illuminate\Routing\CompiledRouteCollection@match
2- Illuminate\Routing\RouteCollection@match

More generally, we should be able to survive a case like below:
```
Route::any('/things', fn() => '3');
Route::match(['get', 'post'],'/things', fn() => '2');
Route::match(['post'],'/things', fn() => '1');
```

In this solution, we eliminate the possibility of picking up the wrong route (by symfony matcher) by manually removing the methods which are considered to be "overridden"

So in this case what we store in cache for the first route definition does not include post, get, head and only includes put, patch, delete, options
The same principle applies to the second route.

- Let me mention that the loops only affect the fully "static" URLs. I mean URLs like: /{slug}/something is not changed by the loop.
- The code added below does not execute on each and every request, it only runs once when the `route:cache` command is run, so does not hinder performance at all.
