### PR TITLE
[8.x] Fix route cache issue

### DIFF
--- a/src/Illuminate/Routing/AbstractRouteCollection.php
+++ b/src/Illuminate/Routing/AbstractRouteCollection.php
@@ -133,6 +133,20 @@ abstract class AbstractRouteCollection implements Countable, IteratorAggregate, 
     {
         $compiled = $this->dumper()->getCompiledRoutes();
 
+        // Here we manually override if a static url has many routes with different methods
+        foreach ($compiled[1] as $url => $routesData) {
+            for ($i = count($routesData) - 1; $i !== 0; $i--) {
+                $methods = $routesData[$i][2];
+                $domain = $routesData[$i][1];
+                for ($j = $i - 1; $j !== -1; $j--) {
+                    // if they are defined for the same domain
+                    if ($compiled[1][$url][$j][1] === $domain) {
+                        $compiled[1][$url][$j][2] = array_diff_key($routesData[$j][2], $methods);
+                    }
+                }
+            }
+        }
+
         $attributes = [];
 
         foreach ($this->getRoutes() as $route) {

--- a/tests/Integration/Routing/Fixtures/conflicty_routes.php
+++ b/tests/Integration/Routing/Fixtures/conflicty_routes.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+Route::any('/url', function () {
+    return 'response from any';
+});
+
+Route::domain('territory')->match(['get', 'delete'], '/url', function () {
+    return 'I am alien (?_?)';
+});
+
+Route::match(['get', 'post'], '/url', function () {
+    return '2';
+});
+
+Route::match(['post'], '/url', function () {
+    return '1';
+});
+
+Route::get('/{slug}', function () {
+    return 'sluggish (-_-)zzz';
+});

--- a/tests/Integration/Routing/RouteCachingTest.php
+++ b/tests/Integration/Routing/RouteCachingTest.php
@@ -23,6 +23,19 @@ class RouteCachingTest extends TestCase
         $this->get('/foo/1')->assertSee('GET response');
     }
 
+    public function testDifferentMethodsForOneUrl()
+    {
+        $this->routes(__DIR__.'/Fixtures/conflicty_routes.php');
+
+        $this->delete('/url')->assertSee('response from any');
+        $this->patch('/url')->assertSee('response from any');
+
+        $this->get('/url')->assertSee('2');
+        $this->get('/_slug_')->assertSee('sluggish (-_-)zzz');
+
+        $this->post('/url')->assertSee('1');
+    }
+
     protected function routes(string $file)
     {
         $this->defineCacheRoutes(file_get_contents($file));

--- a/tests/Integration/Routing/RouteCachingTest.php
+++ b/tests/Integration/Routing/RouteCachingTest.php
@@ -20,7 +20,7 @@ class RouteCachingTest extends TestCase
 
         $this->post('/foo/1')->assertRedirect('/foo/1/bar');
         $this->get('/foo/1/bar')->assertSee('Redirect response');
-        $this->get('/foo/1')->assertRedirect('/foo/1/bar');
+        $this->get('/foo/1')->assertSee('GET response');
     }
 
     protected function routes(string $file)


### PR DESCRIPTION
This PR fixes: https://github.com/laravel/framework/issues/37639

The root cause of this problem is that when the routes are cached we use "symfony matcher" to match a route based on request data and when the routes are not cached we use "Laravel matcher". So the implementations of the ->match( method are very different and they behave differently when there are two candidate routes to choose from.
1- Illuminate\Routing\CompiledRouteCollection@match
2- Illuminate\Routing\RouteCollection@match

More generally, we should be able to survive a case like below (as demonstrated in the included tests):
```php
Route::any('/url', fn() => '3');
Route::match(['get', 'post'],'/url', fn() => '2');
Route::post('/url', fn() => '1');
```

In this solution, we eliminate the possibility of picking up the wrong route (by symfony matcher) by manually removing the methods which are considered to be "overridden" before storing them in the cache file.

So in this case what we store in cache for the first route (Route::any) definition does not include "post", "get", "head" and only includes "put", "patch", "delete", "options". 
The same principle applies to the second route, it would be stored as if it was defined like this: `Route::match(['get'],'/url', fn() => '2');` in the first place.

- Let me mention that the loops only affect the fully "static" URLs. I mean URLs like: /{slug}/something is not changed by the loop.
- The code added below does NOT execute on each and every request, it only runs once when the `route:cache` command is run, so does not hinder performance at all.