### PR TITLE
[5.1] fix:Undefined property: stdClass::$column_name for run mysql 8.0.25

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ composer.lock
 .php_cs.cache
 .DS_Store
 Thumbs.db
+.idea/

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -39,7 +39,7 @@ class MySqlGrammar extends Grammar
      */
     public function compileColumnExists()
     {
-        return 'select column_name from information_schema.columns where table_schema = ? and table_name = ?';
+        return 'select column_name as `column_name` from information_schema.columns where table_schema = ? and table_name = ?';
     }
 
     /**


### PR DESCRIPTION
My Laravel Project Version is v5.1.46,Recently I need to use MySQL 8.0.25 version,But there are some anomalies,The error message is as follows:
ErrorException in MySqlProcessor.php line 18:
Undefined property: stdClass::$column_name
When you read the column_name attribute in lowercase, you will be told that the column_name attribute does not exist. When you read the column_name attribute in lowercase, you will be told that the column_name attribute does not exist.
Code path:src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
Function as follows:
`/**
     * Compile the query to determine the list of columns.
     *
     * @return string
     */
    public function compileColumnExists()
    {
        return 'select column_name from information_schema.columns where table_schema = ? and table_name = ?';
    }`
In MySQL 8.0.25, column_name is returned in uppercase, so alias as `column_name` is needed.
This issue has been fixed in Laravel High version and now requests the authorities to merge the PR and release a new version v5.1.47.
Thank you very much!
