### PR TITLE
[8.x] Create helper class In eloquent to making new functions to avoid the repetition of the code 

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -8,6 +8,7 @@ use Exception;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Concerns\BuildsQueries;
 use Illuminate\Database\Concerns\ExplainsQueries;
+use Illuminate\Database\Eloquent\Helpers\Helper;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Builder as QueryBuilder;
@@ -263,7 +264,7 @@ class Builder
      */
     public function where($column, $operator = null, $value = null, $boolean = 'and')
     {
-        if ($column instanceof Closure && is_null($operator)) {
+        if (Helper::is_closure($column) && is_null($operator)) {
             $column($query = $this->model->newQueryWithoutRelationships());
 
             $this->query->addNestedWhereQuery($query->getQuery(), $boolean);

--- a/src/Illuminate/Database/Eloquent/Helpers/Helper.php
+++ b/src/Illuminate/Database/Eloquent/Helpers/Helper.php
@@ -1,0 +1,23 @@
+<?php
+namespace Illuminate\Database\Eloquent\Helpers;
+use Closure;
+
+/**
+ * Class Helper
+ *
+ * The purpose of this class is create a helper functions to prevent the repetition of the code
+ * Every function should achieve the ( single responsibility ) principle
+ */
+class Helper {
+
+    /**
+     * Check if it's a closure or not
+     *
+     * @param $var
+     * @return bool
+     */
+    public static function is_closure($var): bool
+    {
+        return $var instanceof Closure;
+    }
+}

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Concerns\BuildsQueries;
 use Illuminate\Database\Concerns\ExplainsQueries;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Database\Eloquent\Helpers\Helper;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Grammars\Grammar;
 use Illuminate\Database\Query\Processors\Processor;
@@ -704,7 +705,7 @@ class Builder
         // If the columns is actually a Closure instance, we will assume the developer
         // wants to begin a nested where statement which is wrapped in parenthesis.
         // We'll add that Closure to the query then return back out immediately.
-        if ($column instanceof Closure && is_null($operator)) {
+        if (Helper::is_closure($column) && is_null($operator)) {
             return $this->whereNested($column, $boolean);
         }
 

--- a/src/Illuminate/Validation/Rules/DatabaseRule.php
+++ b/src/Illuminate/Validation/Rules/DatabaseRule.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Validation\Rules;
 
 use Closure;
+use Illuminate\Database\Eloquent\Helpers\Helper;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
 
@@ -90,7 +91,7 @@ trait DatabaseRule
             return $this->whereIn($column, $value);
         }
 
-        if ($column instanceof Closure) {
+        if (Helper::is_closure($column)) {
             return $this->using($column);
         }
 


### PR DESCRIPTION
**Description: **

The purpose of creating a Helper class In eloquent is to create new helper functions to avoid the repetition of the code.
I created the first function called is_closure, I realized the same line is repeated in the 3 files so I created this function and replaced the repeated code with the name of the function with following the best practice as I can ( single responsibility principle (method) - convention name)