### PR TITLE
Adds `existingOrCreateOne()` method to factories so existing models may be used.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -256,7 +256,7 @@ abstract class Factory
         $query = $this->newModel()->newQuery();
 
         $attributes = array_merge(
-            array_map(function($resolver) {
+            array_map(function ($resolver) {
                 return $resolver();
             }, $this->parentResolvers()),
             $attributes

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -256,7 +256,9 @@ abstract class Factory
         $query = $this->newModel()->newQuery();
 
         $attributes = array_merge(
-            array_map(fn($resolver) => $resolver(), $this->parentResolvers()),
+            array_map(function($resolver) {
+                return $resolver();
+            }, $this->parentResolvers()),
             $attributes
         );
 
@@ -264,9 +266,9 @@ abstract class Factory
             $query = $query->where($attributes);
         }
 
-        return $query->inRandomOrder()->firstOr(
-            fn() => $this->createOne($attributes)
-        );
+        return $query->inRandomOrder()->firstOr(function () use ($attributes) {
+            return $this->createOne($attributes);
+        });
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -246,6 +246,30 @@ abstract class Factory
     }
 
     /**
+     * Get an existing model or create one.
+     *
+     * @param  array  $attributes
+     * @return \Illuminate\Database\Eloquent\Collection|\Illuminate\Database\Eloquent\Model
+     */
+    public function existingOrCreateOne($attributes = [])
+    {
+        $query = $this->newModel()->newQuery();
+
+        $attributes = array_merge(
+            array_map(fn($resolver) => $resolver(), $this->parentResolvers()),
+            $attributes
+        );
+
+        if (! empty($attributes)) {
+            $query = $query->where($attributes);
+        }
+
+        return $query->inRandomOrder()->firstOr(
+            fn() => $this->createOne($attributes)
+        );
+    }
+
+    /**
      * Create a callback that persists a model in the database when invoked.
      *
      * @param  array  $attributes

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -170,7 +170,7 @@ class DatabaseEloquentFactoryTest extends TestCase
 
         $post = FactoryTestPostFactory::new([
             'title' => 'Test Title',
-            'user_id' => FactoryTestUserFactory::new()->existingOrCreateOne()
+            'user_id' => FactoryTestUserFactory::new()->existingOrCreateOne(),
         ])->raw();
         $this->assertIsArray($post);
         $this->assertIsInt($post['user_id']);
@@ -186,7 +186,7 @@ class DatabaseEloquentFactoryTest extends TestCase
         $this->assertSame(1, FactoryTestUser::query()->count());
 
         $posts = FactoryTestPostFactory::new([
-            'user_id' => FactoryTestUserFactory::new()->existingOrCreateOne()
+            'user_id' => FactoryTestUserFactory::new()->existingOrCreateOne(),
         ])->count(4)->raw();
 
         foreach ($posts as $post) {


### PR DESCRIPTION
## Basic Functionality

This PR adds the ability to pull from an existing record in the database and fall back on creating one. The advantage to this is that you could execute your factories in an organized order from seeders and have your existing models re-used.

For example, having a factory like this:

```php
class PostFactory extends Factory
{
    protected $model = Post::class;

    public function definition()
    {
        return [
            'user_id' => UserFactory::new()->existingOrCreateOne(),
            'title' => $this->faker->name,
        ];
    }
}
```

Would allow you to seed like this:

```php

// UserSeeder.php
UserFactory::new()->count(10)->create();

// PostSeeder.php
PostFactory::new()->count(100)->create();

// DatabaseSeeder.php
$this->call([
    UserSeeder::class,
    PostSeeder::class
]);

```

While having the `PostSeeder` re-use the users that were previously seeded. This is useful in the context of a demo or development environment where fake data should be present in the database and logically related.

> **Note** that this also retains the ability to create the user when necessary so that you could also seed posts without previously seeding users (e.g., in the context of a PHPUnit test).

## Behavioral Notes

There are a few important behavioral things to note about this PR:

1. Passing attributes to the `existingOrCreateOne()` method will utilize those attributes when looking for an existing record, much like the `firstOrCreate()` method on the Eloquent query builder.
2. The `existingOrCreateOne()` method will respect a previous `for()` call. This means that if you are looking for a record that is related to a specific parent, it will also include that in its search for an existing record and ensure that if one does not exist it will get created and returned.

## Benefit

We have had to do this manually for several projects and ends up resulting in a lot of duplicate code. We have to setup the relationships to existing models in our seeders and then rely on them to handle the creation of their parents in our PHPUnit tests. I imagine other developers have run into this and will find the ability to define this in the `definition` without adding additional logic to their seeder useful.

This PR is not breaking as it is completely opt-in.