### PR TITLE
[8.0] Developer friendly message if no Prunable Models found

### DIFF
--- a/src/Illuminate/Database/Console/PruneCommand.php
+++ b/src/Illuminate/Database/Console/PruneCommand.php
@@ -36,11 +36,19 @@ class PruneCommand extends Command
      */
     public function handle(Dispatcher $events)
     {
+        $models = $this->models();
+
+        if ($models->isEmpty()) {
+            $this->info('No prunable Models found.');
+
+            return;
+        }
+
         $events->listen(ModelsPruned::class, function ($event) {
             $this->info("{$event->count} [{$event->model}] records have been pruned.");
         });
 
-        $this->models()->each(function ($model) {
+        $models->each(function ($model) {
             $instance = new $model;
 
             $chunkSize = property_exists($instance, 'prunableChunkSize')

--- a/src/Illuminate/Database/Console/PruneCommand.php
+++ b/src/Illuminate/Database/Console/PruneCommand.php
@@ -39,7 +39,7 @@ class PruneCommand extends Command
         $models = $this->models();
 
         if ($models->isEmpty()) {
-            $this->info('No prunable Models found.');
+            $this->info('No prunable models found.');
 
             return;
         }


### PR DESCRIPTION
Display a developer friendly message when no prunable Models (not records) are found.

Usually, when a command returns no output, I presume it has errored. Hopefully this will help alleviate that problem.