### PR TITLE
[6.x] Fix signed routes with `expires` parameter

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -328,6 +328,12 @@ class UrlGenerator implements UrlGeneratorContract
             );
         }
 
+        if (array_key_exists('expires', $parameters)) {
+            throw new InvalidArgumentException(
+                '"Expires" is a reserved parameter when generating signed routes. Please rename your route parameter.'
+            );
+        }
+
         if ($expiration) {
             $parameters = $parameters + ['expires' => $this->availableAt($expiration)];
         }

--- a/tests/Integration/Routing/UrlSigningTest.php
+++ b/tests/Integration/Routing/UrlSigningTest.php
@@ -39,6 +39,18 @@ class UrlSigningTest extends TestCase
         $this->assertSame('invalid', $this->get($url)->original);
     }
 
+    public function testTemporarySignedUrlsWithExpiresParameter()
+    {
+        Route::get('/foo/{id}', function (Request $request, $id) {
+            return $request->hasValidSignature() ? 'valid' : 'invalid';
+        })->name('foo');
+
+        Carbon::setTestNow(Carbon::create(2018, 1, 1));
+        $this->assertIsString($url = URL::temporarySignedRoute('foo', now()->addMinutes(5), ['id' => 1, 'expires' => 253402300799]));
+        Carbon::setTestNow(Carbon::create(2018, 1, 1)->addMinutes(10));
+        $this->assertSame('invalid', $this->get($url)->original);
+    }
+
     public function testSignedUrlWithUrlWithoutSignatureParameter()
     {
         Route::get('/foo/{id}', function (Request $request, $id) {

--- a/tests/Integration/Routing/UrlSigningTest.php
+++ b/tests/Integration/Routing/UrlSigningTest.php
@@ -8,6 +8,7 @@ use Illuminate\Routing\Middleware\ValidateSignature;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\URL;
+use InvalidArgumentException;
 use Orchestra\Testbench\TestCase;
 
 /**
@@ -41,14 +42,14 @@ class UrlSigningTest extends TestCase
 
     public function testTemporarySignedUrlsWithExpiresParameter()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('reserved');
+
         Route::get('/foo/{id}', function (Request $request, $id) {
             return $request->hasValidSignature() ? 'valid' : 'invalid';
         })->name('foo');
 
-        Carbon::setTestNow(Carbon::create(2018, 1, 1));
-        $this->assertIsString($url = URL::temporarySignedRoute('foo', now()->addMinutes(5), ['id' => 1, 'expires' => 253402300799]));
-        Carbon::setTestNow(Carbon::create(2018, 1, 1)->addMinutes(10));
-        $this->assertSame('invalid', $this->get($url)->original);
+        URL::temporarySignedRoute('foo', now()->addMinutes(5), ['id' => 1, 'expires' => 253402300799]);
     }
 
     public function testSignedUrlWithUrlWithoutSignatureParameter()

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -664,6 +664,27 @@ class RoutingUrlGeneratorTest extends TestCase
 
         Request::create($url->signedRoute('foo', ['signature' => 'bar']));
     }
+
+    public function testSignedUrlParameterCannotBeNamedExpires()
+    {
+        $url = new UrlGenerator(
+            $routes = new RouteCollection,
+            $request = Request::create('http://www.foo.com/')
+        );
+        $url->setKeyResolver(function () {
+            return 'secret';
+        });
+
+        $route = new Route(['GET'], 'foo/{expires}', ['as' => 'foo', function () {
+            //
+        }]);
+        $routes->add($route);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('reserved');
+
+        Request::create($url->signedRoute('foo', ['expires' => 253402300799]));
+    }
 }
 
 class RoutableInterfaceStub implements UrlRoutable


### PR DESCRIPTION
### What

This PR fixes a bug regarding signed route URLs allowing arbitrary expiration timestamps to be injected.

### Why

When the URL is created with a parameter named `expires`, it will produce unexpected results that could be abused. This affects both temporary and non-temporary signed URLs, and routes with or without an `expires` parameter.

### How

#### For example, a temporary signed route that should expire after 30 minutes, will not fail if we pass an `expires` parameter with a timestamp 30 days in the future:

```php
Route::get('unsubscribe/{id}', UnsubscribeController::class)
    ->name('unsubscribe')
    ->middleware('signed');

$in30minutes = now()->addMinutes(30); // 1627000475
$in30days = now()->addDays(30); // 1629590675

// https://example.com/unsubscribe/1?signature=...&expires=1629590675
$url = URL::temporarySignedRoute(
    name: 'unsubscribe',
    expiration: $in30minutes,
    parameters: ['user' => 1, 'expires' => $in30days->timestamp],
);

Carbon::setTestNow(now()->addMinutes(31));

$this->get($url)->assertForbidden(); // Response status code [200] is not a forbidden status code
```

This temporary signed URL uses the timestamp from the `parameters` instead of the `expiration` timestamp, so URL is considered valid even after 30 minutes have passed.

Similarly, if we pass `'expires' => 0`, the URL will never expire because the `signatureHasNotExpired()` will treat the `expires` query parameter as empty and will not compare it to the current timestamp.

Furthermore, when passing a non-empty array e.g. `'expires' => ['https://www.youtube.com/watch?v=dQw4w9WgXcQ']`, the URL will never be expired (arrays are always greater in comparison to numbers).

#### Another example with a signed route that should not expire, will fail if we pass and `expires` parameter with a timestamp in the past:

```php
Route::get('unsubscribe/{id}', UnsubscribeController::class)
    ->name('unsubscribe')
    ->middleware('signed');

$in30minutes = now()->addMinutes(30); // 1627000475

// https://example.com/unsubscribe/1?signature=...&expires=1627000475
$url = URL::signedRoute(
    name: 'unsubscribe',
    parameters: ['user' => 1, 'expires' => $in30minutes->timestamp],
);

Carbon::setTestNow(now()->addMinutes(31));

$this->get($url)->assertOk(); // Response status code [403] does not match expected 200 status code
```

This signed URL uses the timestamp from the `parameters` in the query string, and `signatureHasNotExpired()` will treat it as non-empty and expired after 30 minutes.

### Changes details

The fix is similar to https://github.com/laravel/framework/pull/30444: it will throw an exception when the `parameters` array contains a key named `expires`.

In the first commit I've only included a failing test that demonstrates the bug report, and the second commit includes the fix and more tests.