### PR TITLE
[8.x] Password Validator should inherit custom error message and attribute

### DIFF
--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -270,7 +270,7 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
     {
         $validator = Validator::make($this->data, [
             $attribute => 'string|min:'.$this->min,
-        ]);
+        ], $this->validator->customMessages, $this->validator->customAttributes);
 
         if ($validator->fails()) {
             return $this->fail($validator->messages()->all());


### PR DESCRIPTION
A Form Request or Validator with a custom attribute and/or message for a password field are discarded in the Validator of the Password Rule and defaults are returned.

Example Form Request:

```php
...

public function rules()
{
    return [
        'password' => [
            Password::min(8),
        ],
    ];
}

public function attributes()
{
    return [
        'password' => 'alternative attribute',
    ];
}

public function messages()
{
    return [
        'password.min' => 'Demo for Pull Request :attribute',
    ];
}

...
```

It should return **'Demo for Pull Request: alternative attribute'** however, **'The password must be at least 8 characters.'** is returned.

Unless I'm mistaken, this should be an easy fix without any breaking changes.

Looking forward to any feedback and suggestions regarding this pull request.

Thanks!
