### PR TITLE
[8.x] Support a proxy URL for mix hot

### DIFF
--- a/src/Illuminate/Foundation/Mix.php
+++ b/src/Illuminate/Foundation/Mix.php
@@ -31,6 +31,11 @@ class Mix
 
         if (is_file(public_path($manifestDirectory.'/hot'))) {
             $url = rtrim(file_get_contents(public_path($manifestDirectory.'/hot')));
+            
+            $hot_proxy_url = app('config')->get('app.mix_hot_proxy_url');
+            if (! empty($hot_proxy_url)) {
+                return new HtmlString("{$hot_proxy_url}{$path}");
+            }
 
             if (Str::startsWith($url, ['http://', 'https://'])) {
                 return new HtmlString(Str::after($url, ':').$path);

--- a/src/Illuminate/Foundation/Mix.php
+++ b/src/Illuminate/Foundation/Mix.php
@@ -31,7 +31,7 @@ class Mix
 
         if (is_file(public_path($manifestDirectory.'/hot'))) {
             $url = rtrim(file_get_contents(public_path($manifestDirectory.'/hot')));
-            
+
             $hot_proxy_url = app('config')->get('app.mix_hot_proxy_url');
             if (! empty($hot_proxy_url)) {
                 return new HtmlString("{$hot_proxy_url}{$path}");


### PR DESCRIPTION
Detect new ENV variable; Useful if you're serving a local app with ngrok, to change the url that gets output if in hot mode.

My use case: shopify app being built, react front end.  Making live tweaks to the app and want to see them reflected inside the shopify interface.  Running on ngrok to make local dev possible. Was manually changing app url's back and forth, but this makes things *a lot* easier.  

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
