### PR TITLE
[8.x] Add ignoreTrashed to Unique validation rule

### DIFF
--- a/src/Illuminate/Validation/Rules/Unique.php
+++ b/src/Illuminate/Validation/Rules/Unique.php
@@ -58,14 +58,14 @@ class Unique
     }
 
     /**
-     * Ignore trashed models during the unique check.
+     * Ignore soft deleted models during the unique check.
      *
-     * @param  string|null  $deletedAtColumn
+     * @param  string  $deletedAtColumn
      * @return $this
      */
-    public function ignoreTrashed($deletedAtColumn = null)
+    public function withoutTrashed($deletedAtColumn = 'deleted_at')
     {
-        $this->whereNull($deletedAtColumn ?? 'deleted_at');
+        $this->whereNull($deletedAtColumn);
 
         return $this;
     }

--- a/src/Illuminate/Validation/Rules/Unique.php
+++ b/src/Illuminate/Validation/Rules/Unique.php
@@ -56,7 +56,7 @@ class Unique
 
         return $this;
     }
-    
+
     /**
      * Ignore trashed models during the unique check.
      *

--- a/src/Illuminate/Validation/Rules/Unique.php
+++ b/src/Illuminate/Validation/Rules/Unique.php
@@ -56,6 +56,19 @@ class Unique
 
         return $this;
     }
+    
+    /**
+     * Ignore trashed models during the unique check.
+     *
+     * @param  string|null  $deletedAtColumn
+     * @return $this
+     */
+    public function ignoreTrashed($deletedAtColumn = null)
+    {
+        $this->whereNull($deletedAtColumn ?? 'deleted_at');
+
+        return $this;
+    }
 
     /**
      * Convert the rule to a validation string.


### PR DESCRIPTION
Hi all!

I find myself adding `whereNull('deleted_at')` to the `Rule::unique()` quite often when working with models which can be soft deleted. This PR will add a simple helper to the unique validation rule. 

Have a great day! 😄 

```php
// Before
[
  'email'=> [
    Rule::unique('users')->whereNull('deleted_at'),
  ],
];

// After
[
  'email'=> [
    Rule::unique('users')->ignoreTrashed(),
  ],
];
````