### PR TITLE
[8.x] Support job middleware on queued listeners

### DIFF
--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -557,6 +557,13 @@ class Dispatcher implements DispatcherContract
                     ? $listener->viaQueue()
                     : $listener->queue ?? null;
 
+        $job->through(
+            array_merge(
+                method_exists($listener, 'middleware') ? $listener->middleware() : [],
+                $listener->middleware ?? []
+            )
+        );
+
         isset($listener->delay)
                     ? $connection->laterOn($queue, $listener->delay, $job)
                     : $connection->pushOn($queue, $job);


### PR DESCRIPTION
Middleware is already supported on jobs, notifications, and mailables. It would be useful to also support it on queued listeners.
