### PR TITLE
[8.x] Paginate with PerPage=-1 to load all items

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -780,11 +780,15 @@ class Builder
     {
         $page = $page ?: Paginator::resolveCurrentPage($pageName);
 
-        $perPage = $perPage ?: $this->model->getPerPage();
+        $total = $this->toBase()->getCountForPagination();
 
-        $results = ($total = $this->toBase()->getCountForPagination())
-                                    ? $this->forPage($page, $perPage)->get($columns)
-                                    : $this->model->newCollection();
+        $perPage = $perPage === -1
+            ? $total
+            : ($perPage ?: $this->model->getPerPage());
+
+        $results = $total
+            ? $this->forPage($page, $perPage)->get($columns)
+            : $this->model->newCollection();
 
         return $this->paginator($results, $total, $perPage, $page, [
             'path' => Paginator::resolveCurrentPath(),

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2366,6 +2366,8 @@ class Builder
 
         $total = $this->getCountForPagination();
 
+        $perPage = $perPage === -1 ? $total : $perPage;
+
         $results = $total ? $this->forPage($page, $perPage)->get($columns) : collect();
 
         return $this->paginator($results, $total, $perPage, $page, [

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -291,6 +291,22 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertInstanceOf(LengthAwarePaginator::class, $models);
     }
 
+    public function testPaginatedModelCollectionRetrievalWithMinusOnePerPage()
+    {
+        EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
+        EloquentTestUser::create(['id' => 2, 'email' => 'abigailotwell@gmail.com']);
+        EloquentTestUser::create(['id' => 3, 'email' => 'foo@gmail.com']);
+
+        Paginator::currentPageResolver(function () {
+            return 1;
+        });
+
+        $models = EloquentTestUser::oldest('id')->paginate(-1);
+
+        $this->assertCount(3, $models);
+        $this->assertInstanceOf(LengthAwarePaginator::class, $models);
+    }
+
     public function testCountForPaginationWithGrouping()
     {
         EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -3599,6 +3599,36 @@ SQL;
         ]), $result);
     }
 
+    public function testPaginateWithMinusOnePerPage()
+    {
+        $perPage = -1;
+        $pageName = 'page';
+        $page = 1;
+        $builder = $this->getMockQueryBuilder();
+        $path = 'http://foo.bar?page=1';
+
+        $results = collect([['test' => 'foo'], ['test' => 'bar']]);
+
+        $builder->shouldReceive('getCountForPagination')->once()->andReturn(2);
+        $builder->shouldReceive('forPage')->once()->with($page, 2)->andReturnSelf();
+        $builder->shouldReceive('get')->once()->andReturn($results);
+
+        Paginator::currentPageResolver(function () {
+            return 1;
+        });
+
+        Paginator::currentPathResolver(function () use ($path) {
+            return $path;
+        });
+
+        $result = $builder->paginate($perPage);
+
+        $this->assertEquals(new LengthAwarePaginator($results, 2, 2, $page, [
+            'path' => $path,
+            'pageName' => $pageName,
+        ]), $result);
+    }
+
     public function testPaginateWhenNoResults()
     {
         $perPage = 15;


### PR DESCRIPTION
This PR implements a feature to load all records using the `paginate` method for `Eloquent Builder` and `Query Builder`.

### How is it works:
```php
User::where(...)->paginate(-1);
```
---

### Where is the use case:
In some cases, the `per_page` argument is specified by users in the **front-end**.
e.g. the users specify each page contain 50, 100, or event **all rows**.
So they just need to send `per_page=-1` and it works without extra code.

---

### Why in the framework:
Because the `total` records calculated using `getCountForPagination` in the `paginate` method for both cases (`Eloquent & Query Builders`). It executes a query to get the `total` count and there is no need for another extra query. 


