### PR TITLE
[8.x] Improve make:migration table name guesser to feel more "laravel like"

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/TableGuesser.php
+++ b/src/Illuminate/Database/Console/Migrations/TableGuesser.php
@@ -10,7 +10,7 @@ class TableGuesser
     ];
 
     const CHANGE_PATTERNS = [
-        '/^(?:patch)_(\w+)_table$/',
+        '/^(?:patch|change|update)_(\w+)_table$/',
         '/_(?:to|from|in)_(\w+)_table$/',
         '/_(?:to|from|in)_(\w+)$/',
     ];

--- a/src/Illuminate/Database/Console/Migrations/TableGuesser.php
+++ b/src/Illuminate/Database/Console/Migrations/TableGuesser.php
@@ -10,8 +10,9 @@ class TableGuesser
     ];
 
     const CHANGE_PATTERNS = [
-        '/_(to|from|in)_(\w+)_table$/',
-        '/_(to|from|in)_(\w+)$/',
+        '/^(?:patch)_(\w+)_table$/',
+        '/_(?:to|from|in)_(\w+)_table$/',
+        '/_(?:to|from|in)_(\w+)$/',
     ];
 
     /**
@@ -30,7 +31,7 @@ class TableGuesser
 
         foreach (self::CHANGE_PATTERNS as $pattern) {
             if (preg_match($pattern, $migration, $matches)) {
-                return [$matches[2], $create = false];
+                return [$matches[1], $create = false];
             }
         }
     }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

If you want to create a migration stub updating an table
```php
    public function up()
    {
        Schema::table('users', function (Blueprint $table) {
            //
        });
    }

    public function down()
    {
        Schema::table('users', function (Blueprint $table) {
            //
        });
    }
```

You would have to run one of these commands

```
php artisan make:migration create_users_table --table=users
php artisan make:migration whatever_to_users_table
php artisan make:migration whatever_in_users_table
```

This small change allows you to use one of these instead

```php
php artisan make:migration update_users_table
php artisan make:migration patch_users_table
php artisan make:migration change_users_table
``````

This feels more uniform with `make:migration create_users_table`. Also, this could be added to the [docs](https://laravel.com/docs/8.x/migrations#generating-migrations)