### PR TITLE
[8.x] Allow parallel testing without database creation

### DIFF
--- a/src/Illuminate/Testing/Concerns/TestDatabases.php
+++ b/src/Illuminate/Testing/Concerns/TestDatabases.php
@@ -46,7 +46,7 @@ trait TestDatabases
             ];
 
             if (Arr::hasAny($uses, $databaseTraits)) {
-                if (! ParallelTesting::option('skip_database_creation')) {
+                if (! ParallelTesting::option('without_databases')) {
                     $this->whenNotUsingInMemoryDatabase(function ($database) use ($uses) {
                         [$testDatabase, $created] = $this->ensureTestDatabaseExists($database);
 

--- a/src/Illuminate/Testing/Concerns/TestDatabases.php
+++ b/src/Illuminate/Testing/Concerns/TestDatabases.php
@@ -27,15 +27,13 @@ trait TestDatabases
     protected function bootTestDatabase()
     {
         ParallelTesting::setUpProcess(function () {
-            if (! ParallelTesting::option('skip_database_creation')) {
-                $this->whenNotUsingInMemoryDatabase(function ($database) {
-                    if (ParallelTesting::option('recreate_databases')) {
-                        Schema::dropDatabaseIfExists(
-                            $this->testDatabase($database)
-                        );
-                    }
-                });
-            }
+            $this->whenNotUsingInMemoryDatabase(function ($database) {
+                if (ParallelTesting::option('recreate_databases')) {
+                    Schema::dropDatabaseIfExists(
+                        $this->testDatabase($database)
+                    );
+                }
+            });
         });
 
         ParallelTesting::setUpTestCase(function ($testCase) {

--- a/tests/Testing/ParallelTestingTest.php
+++ b/tests/Testing/ParallelTestingTest.php
@@ -56,21 +56,21 @@ class ParallelTestingTest extends TestCase
         $parallelTesting = new ParallelTesting(Container::getInstance());
 
         $this->assertFalse($parallelTesting->option('recreate_databases'));
-        $this->assertFalse($parallelTesting->option('skip_database_creation'));
+        $this->assertFalse($parallelTesting->option('without_databases'));
 
         $parallelTesting->resolveOptionsUsing(function ($option) {
             return $option === 'recreate_databases';
         });
 
         $this->assertFalse($parallelTesting->option('recreate_caches'));
-        $this->assertFalse($parallelTesting->option('skip_database_creation'));
+        $this->assertFalse($parallelTesting->option('without_databases'));
         $this->assertTrue($parallelTesting->option('recreate_databases'));
 
         $parallelTesting->resolveOptionsUsing(function ($option) {
-            return $option === 'skip_database_creation';
+            return $option === 'without_databases';
         });
 
-        $this->assertTrue($parallelTesting->option('skip_database_creation'));
+        $this->assertTrue($parallelTesting->option('without_databases'));
     }
 
     public function testToken()

--- a/tests/Testing/ParallelTestingTest.php
+++ b/tests/Testing/ParallelTestingTest.php
@@ -56,13 +56,21 @@ class ParallelTestingTest extends TestCase
         $parallelTesting = new ParallelTesting(Container::getInstance());
 
         $this->assertFalse($parallelTesting->option('recreate_databases'));
+        $this->assertFalse($parallelTesting->option('skip_database_creation'));
 
         $parallelTesting->resolveOptionsUsing(function ($option) {
             return $option === 'recreate_databases';
         });
 
         $this->assertFalse($parallelTesting->option('recreate_caches'));
+        $this->assertFalse($parallelTesting->option('skip_database_creation'));
         $this->assertTrue($parallelTesting->option('recreate_databases'));
+
+        $parallelTesting->resolveOptionsUsing(function ($option) {
+            return $option === 'skip_database_creation';
+        });
+
+        $this->assertTrue($parallelTesting->option('skip_database_creation'));
     }
 
     public function testToken()


### PR DESCRIPTION
Adding the ability to bypass database creation in parallel tests completely.  

Allows parallel testing to move forward without a custom database setup for each parallel process.

Allows applications to do their own custom database setup without requiring database setup.
  - In our case, we run all migrations as part of our Docker setup.  
  - In cases where there is more than one MySQL DB per connection, this can be useful as the current system doesn't support creating multiple databases on the default connection. 