### PR TITLE
[8.x] Adds `to_route` helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -804,6 +804,22 @@ if (! function_exists('today')) {
     }
 }
 
+if (! function_exists('to_route')) {
+    /**
+     * Create a new redirect response to a named route.
+     *
+     * @param  string  $route
+     * @param  mixed  $parameters
+     * @param  int  $status
+     * @param  array  $headers
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    function to_route($route, $parameters = [], $status = 302, $headers = [])
+    {
+        return redirect()->route($route, $parameters, $status, $headers);
+    }
+}
+
 if (! function_exists('trans')) {
     /**
      * Translate the given message.

--- a/tests/Integration/Routing/RouteRedirectTest.php
+++ b/tests/Integration/Routing/RouteRedirectTest.php
@@ -37,4 +37,29 @@ class RouteRedirectTest extends TestCase
             'route redirect with two optional replacements that switch position' => ['users/{user?}/{switch?}', 'members/{switch?}/{user?}', '/users/11/22', '/members/22/11'],
         ];
     }
+
+    public function testToRoute()
+    {
+        Route::get('to', function () {
+            // ..
+        })->name('to');
+
+        Route::get('from-301', function () {
+            return to_route('to', [], 301);
+        });
+
+        Route::get('from-302', function () {
+            return to_route('to');
+        });
+
+        $this->get('from-301')
+            ->assertRedirect('to')
+            ->assertStatus(301)
+            ->assertSee('Redirecting to');
+
+        $this->get('from-302')
+            ->assertRedirect('to')
+            ->assertStatus(302)
+            ->assertSee('Redirecting to');
+    }
 }


### PR DESCRIPTION
This pull request adds the `to_route` helper to Laravel's core. While this helper can be added to projects individually, I think it would be handy to have this available on the core. In addition, the function name `to_route` reads very well when combined with the keyword `return`. 💅🏻

```php
     // return redirect()->route('users.show', [$user]);
        return to_route('users.show', $user);
```

The original idea comes from [this tweet]( https://twitter.com/taylorotwell/status/1419666654225698816).