### PR TITLE
Fix running schedule:test on CallbackEvent

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleTestCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleTestCommand.php
@@ -33,7 +33,7 @@ class ScheduleTestCommand extends Command
         $commandNames = [];
 
         foreach ($commands as $command) {
-            $commandNames[] = $command->command;
+            $commandNames[] = $command->command ?? $command->getSummaryForDisplay();
         }
 
         $index = array_search($this->choice('Which command would you like to run?', $commandNames), $commandNames);


### PR DESCRIPTION
When running the `schedule:test` on a scheduler added with `CallbackEvent`

```php
$schedule->call(MyScheduleClass::class . '@__invoke')->everyTenMinutes()
```

It shows up the following way in the schedule command.
![image](https://user-images.githubusercontent.com/5870441/127150255-f05c29c2-19d5-4aec-a215-25dd470087b1.png)
However choosing one of the values results in the following
![image](https://user-images.githubusercontent.com/5870441/127150342-6394892f-f358-40ee-866f-3e582d659337.png)

To fix I added a fallback to `getSummaryForDisplay` if no `command` property. 

Which makes them show up the following way
![image](https://user-images.githubusercontent.com/5870441/127150635-a3d4ab5c-d7f7-433b-860c-e5b431bc24f7.png)
And I can now actually run them :+1:


A better solution could possibly be to add a new method which is responsible for generating the name for this, so it wouldn't need a fallback like this, however not sure if it is needed.
