### PR TITLE
[8.x] Allow the Arr::has to check a dotted string key

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -334,7 +334,7 @@ class Arr
                 continue;
             }
 
-            foreach (explode('.', $key) as $segment) {
+            foreach (str_getcsv($key, ".", '"') as $segment) {
                 if (static::accessible($subKeyArray) && static::exists($subKeyArray, $segment)) {
                     $subKeyArray = $subKeyArray[$segment];
                 } else {

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -346,7 +346,6 @@ class Arr
         return true;
     }
 
-
     /**
      * Determine if any of the keys exist in an array using "dot" notation.
      *

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -334,7 +334,7 @@ class Arr
                 continue;
             }
 
-            foreach (str_getcsv($key, ".", '"') as $segment) {
+            foreach (str_getcsv($key, '.', '"') as $segment) {
                 if (static::accessible($subKeyArray) && static::exists($subKeyArray, $segment)) {
                     $subKeyArray = $subKeyArray[$segment];
                 } else {
@@ -345,6 +345,7 @@ class Arr
 
         return true;
     }
+
 
     /**
      * Determine if any of the keys exist in an array using "dot" notation.

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -394,7 +394,7 @@ class SupportArrTest extends TestCase
 
         $array = [
             'products' => [ 
-                'desk.0' => [ 'price' => 10 ] 
+                'desk.0' => ['price' => 10]
             ]
         ];
         $this->assertTrue(Arr::has($array, 'products."desk.0"'));

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -393,9 +393,10 @@ class SupportArrTest extends TestCase
         $this->assertFalse(Arr::has([], ['']));
 
         $array = [
-            'products' => [ 'desk.0' => [ 'price' => 10 ] ]
+            'products' => [ 
+                'desk.0' => [ 'price' => 10 ] 
+            ]
         ];
-        
         $this->assertTrue(Arr::has($array, 'products."desk.0"'));
         $this->assertTrue(Arr::has($array, 'products."desk.0".price'));
         $this->assertFalse(Arr::has($array, 'products.desk.0'));

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -394,8 +394,8 @@ class SupportArrTest extends TestCase
 
         $array = [
             'products' => [
-                'desk.0' => ['price' => 10]
-            ]
+                'desk.0' => ['price' => 10],
+            ],
         ];
         $this->assertTrue(Arr::has($array, 'products."desk.0"'));
         $this->assertTrue(Arr::has($array, 'products."desk.0".price'));

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -391,6 +391,14 @@ class SupportArrTest extends TestCase
         $this->assertFalse(Arr::has([''], ''));
         $this->assertFalse(Arr::has([], ''));
         $this->assertFalse(Arr::has([], ['']));
+
+        $array = [
+            'products' => [ 'desk.0' => [ 'price' => 10 ] ]
+        ];
+        
+        $this->assertTrue(Arr::has($array, 'products."desk.0"'));
+        $this->assertTrue(Arr::has($array, 'products."desk.0".price'));
+        $this->assertFalse(Arr::has($array, 'products.desk.0'));
     }
 
     public function testHasAnyMethod()

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -393,7 +393,7 @@ class SupportArrTest extends TestCase
         $this->assertFalse(Arr::has([], ['']));
 
         $array = [
-            'products' => [ 
+            'products' => [
                 'desk.0' => ['price' => 10]
             ]
         ];


### PR DESCRIPTION
## The context

When we want to check the existing keys inside an array using the  Arr::has method, it works perfectly. 
However, when we have a dotted key, the check does not work properly.

For example:
Consider this array
```php
$array = [
     'products' => [ 'desk.0' => [ 'price' => 10 ] ]
];

```
The key of the array is dotted (has a dot) and the check of "dotted.0" existing in the array will not work. 
We can find this kind of array in errors response when we validate an array 
```php
[
  "message" => "The given data was invalid."
  "errors" => [
    "photos.0" => [ "The photos.0 must be an image." ]
  ]
]

```

We have now a problem to unit test the existing keys because the has method of AssertableJson class use behind the scenes the Arr::has method.

## Solution

Instead of using the explode function, I changed to str_get_csv function by providing a quoted as delimiter so that if we have the has method to take account a dotted string, we will only have a wrap this string in a quoted

Example:
```php
$array = [
     'products' => [ 'desk.0' => [ 'price' => 10 ] ]
];

Arr::has($array, 'products."desk.0"') // true
Arr::has($array, 'products."desk.0".price') // true
Arr::has($array, 'products.desk.0') // false

```

