### PR TITLE
[8.x] Use console const as default returned value

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/console.stub
+++ b/src/Illuminate/Foundation/Console/stubs/console.stub
@@ -37,6 +37,6 @@ class {{ class }} extends Command
      */
     public function handle()
     {
-        return 0;
+        return self::SUCCESS;
     }
 }


### PR DESCRIPTION
This simple PR is based on [Matthew Davis' tweet](https://twitter.com/mdavis1982/status/1419261210122465293). Rather than returning `0` when generating a command, it's fairer to use class constants (`self::SUCCESS`, `self::FAILURE` and `self::INVALID`).

- https://tldp.org/LDP/abs/html/exitcodes.html