### PR TITLE
[8.x] Add cache_locks table to stub

### DIFF
--- a/src/Illuminate/Cache/Console/stubs/cache.stub
+++ b/src/Illuminate/Cache/Console/stubs/cache.stub
@@ -18,6 +18,12 @@ class CreateCacheTable extends Migration
             $table->mediumText('value');
             $table->integer('expiration');
         });
+
+        Schema::create('cache_locks', function (Blueprint $table) {
+            $table->string('key')->primary();
+            $table->string('owner');
+            $table->integer('expiration');
+        });
     }
 
     /**
@@ -28,5 +34,6 @@ class CreateCacheTable extends Migration
     public function down()
     {
         Schema::dropIfExists('cache');
+        Schema::dropIfExists('cache_locks');
     }
 }


### PR DESCRIPTION
Modified migration stub to create required `cache_locks` table when using the artisan command `cache:table`