### PR TITLE
[6.x] Eager load pivot relations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -817,10 +817,17 @@ class BelongsToMany extends Relation
         // To hydrate the pivot relationship, we will just gather the pivot attributes
         // and create a new Pivot model, which is basically a dynamic model that we
         // will set the attributes, table, and connections on it so it will work.
+        $pivots = [];
         foreach ($models as $model) {
-            $model->setRelation($this->accessor, $this->newExistingPivot(
+            $pivots[] = $pivot = $this->newExistingPivot(
                 $this->migratePivotAttributes($model)
-            ));
+            );
+            $model->setRelation($this->accessor, $pivot);
+        }
+
+        if (count($pivots) > 0) {
+            $query = $pivots[0]->newQuery();
+            $query->eagerLoadRelations($pivots);
         }
     }
 


### PR DESCRIPTION
This allows you to use `protected $with = [];` on custom pivot models.

Since Pivot classes _are_ `Model` classes we're just adding in this missing bit of functionality.