### PR TITLE
[8.x] use mysql method found_rows() for paginate

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -140,6 +140,10 @@ class Grammar extends BaseGrammar
             $select = 'select ';
         }
 
+        if ($query->foundRowsCallable !== null) {
+            $select = preg_replace('/select /', 'select sql_calc_found_rows ', $select, 1);
+        }
+
         return $select.$this->columnize($columns);
     }
 


### PR DESCRIPTION
[https://dev.mysql.com/doc/refman/8.0/en/information-functions.html#function_found-rows](https://dev.mysql.com/doc/refman/8.0/en/information-functions.html#function_found-rows)

When paging, there is no need to perform two queries, which can improve performance.

![微信截图_20210729145052](https://user-images.githubusercontent.com/20262949/127446034-63544ad3-c688-4b64-b2d7-e35438a0f82e.png)
