### PR TITLE
Add: Arr:undot() helper

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -122,6 +122,23 @@ class Arr
     }
 
     /**
+     * Expand an array using "dot" notation to a multi-dimensional associative array
+     *
+     * @param  iterable  $array
+     * @return array
+     */
+    public static function undot($array)
+    {
+        $results = [];
+
+        foreach ($array as $key => $value) {
+            static::set($results, $key, $value);
+        }
+
+        return $results;
+    }
+
+    /**
      * Get all of the given array except for a specified array of keys.
      *
      * @param  array  $array

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -122,7 +122,7 @@ class Arr
     }
 
     /**
-     * Expand an array using "dot" notation to a multi-dimensional associative array
+     * Expand an array using "dot" notation to a multi-dimensional associative array.
      *
      * @param  iterable  $array
      * @return array

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -124,8 +124,8 @@ class SupportArrTest extends TestCase
         $array = Arr::undot(['foo' => []]);
         $this->assertEquals(['foo' => []], $array);
 
-        $array = Arr::undot(['foo','bar']);
-        $this->assertEquals(['foo','bar'], $array);
+        $array = Arr::undot(['foo', 'bar']);
+        $this->assertEquals(['foo', 'bar'], $array);
 
         $array = Arr::undot(['foo.bar' => []]);
         $this->assertEquals(['foo' => ['bar' => []]], $array);
@@ -136,8 +136,8 @@ class SupportArrTest extends TestCase
         $array = Arr::undot(['name' => 'taylor', 'languages' => ['php' => true]]);
         $this->assertEquals(['name' => 'taylor', 'languages' => ['php' => true]], $array);
 
-        $array = Arr::undot(['foo.bar.baz' => ['boo' => ['bor','boz']]]);
-        $this->assertEquals(['foo' => ['bar' => ['baz' => ['boo' => ['bor','boz']]]]], $array);
+        $array = Arr::undot(['foo.bar.baz' => ['boo' => ['bor', 'boz']]]);
+        $this->assertEquals(['foo' => ['bar' => ['baz' => ['boo' => ['bor', 'boz']]]]], $array);
     }
 
     public function testExcept()

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -113,6 +113,33 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['name' => 'taylor', 'languages.php' => true], $array);
     }
 
+    public function testUnDot()
+    {
+        $array = Arr::undot(['foo.bar' => 'baz']);
+        $this->assertEquals(['foo' => ['bar' => 'baz']], $array);
+
+        $array = Arr::undot([]);
+        $this->assertEquals([], $array);
+
+        $array = Arr::undot(['foo' => []]);
+        $this->assertEquals(['foo' => []], $array);
+
+        $array = Arr::undot(['foo','bar']);
+        $this->assertEquals(['foo','bar'], $array);
+
+        $array = Arr::undot(['foo.bar' => []]);
+        $this->assertEquals(['foo' => ['bar' => []]], $array);
+
+        $array = Arr::undot(['name' => 'taylor', 'languages.php' => true]);
+        $this->assertEquals(['name' => 'taylor', 'languages' => ['php' => true]], $array);
+
+        $array = Arr::undot(['name' => 'taylor', 'languages' => ['php' => true]]);
+        $this->assertEquals(['name' => 'taylor', 'languages' => ['php' => true]], $array);
+
+        $array = Arr::undot(['foo.bar.baz' => ['boo' => ['bor','boz']]]);
+        $this->assertEquals(['foo' => ['bar' => ['baz' => ['boo' => ['bor','boz']]]]], $array);
+    }
+
     public function testExcept()
     {
         $array = ['name' => 'taylor', 'age' => 26];


### PR DESCRIPTION
This PR adds a new array helper method `Arr::undot`. 

A `Arr::dot` method exists for quite a while which converts an multidimensional array to an array with dot notation.

_Out-of-the-framework-box_ there isn't a method available for the opposite behaviour. 
This PR adds functionality to transform an array with dot notation to a multi-dimensional array. Although a macro can be set, it feels right to add it to core since the dot method is already present. 

Example usage:
```php 

Illuminate\Support\Arr::undot(['foo.bar' => 'baz']);

// Result: ['foo' => ['bar' => 'baz']]


```
