### PR TITLE
[8.x] Add twiceDailyAt schedule frequency

### DIFF
--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -263,9 +263,22 @@ trait ManagesFrequencies
      */
     public function twiceDaily($first = 1, $second = 13)
     {
+        return $this->twiceDailyAt($first, $second, 0);
+    }
+
+    /**
+     * Schedule the event to run twice daily at a given offset.
+     *
+     * @param  int  $first
+     * @param  int  $second
+     * @param  int  $offset
+     * @return $this
+     */
+    public function twiceDailyAt($first = 1, $second = 13, $offset = 0)
+    {
         $hours = $first.','.$second;
 
-        return $this->spliceIntoPosition(1, 0)
+        return $this->spliceIntoPosition(1, $offset)
                     ->spliceIntoPosition(2, $hours);
     }
 

--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -57,6 +57,11 @@ class FrequencyTest extends TestCase
         $this->assertSame('0 3,15 * * *', $this->event->twiceDaily(3, 15)->getExpression());
     }
 
+    public function testTwiceDailyAt()
+    {
+        $this->assertSame('5 3,15 * * *', $this->event->twiceDailyAt(3, 15, 5)->getExpression());
+    }
+
     public function testWeekly()
     {
         $this->assertSame('0 0 * * 0', $this->event->weekly()->getExpression());


### PR DESCRIPTION
Adds a new `twiceDailyAt` schedule frequency that allows setting the specific minutes past the hour to run at. Also refactors the original `twiceDaily` to avoid repeating code between both.