### PR TITLE
[8.x] Where function on collections should be more clear when it comes to arrays

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -549,7 +549,7 @@ trait EnumeratesValues
     public function where($key, $operator = null, $value = null)
     {
         if (is_array($key)) {
-            throw new Exception("Arrays are not supported in this where clause.");
+            throw new Exception('Arrays are not supported in this where clause.');
         }
 
         return $this->filter($this->operatorForWhere(...func_get_args()));

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -548,6 +548,10 @@ trait EnumeratesValues
      */
     public function where($key, $operator = null, $value = null)
     {
+        if (is_array($key)) {
+            throw new Exception("Arrays are not supported in this where clause.");
+        }
+
         return $this->filter($this->operatorForWhere(...func_get_args()));
     }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -921,6 +921,10 @@ class SupportCollectionTest extends TestCase
             [['v' => 1], ['v' => 2]],
             $c->where('v')->values()->all()
         );
+
+        $this->expectException(Exception::class);
+        $c = new $collection([['v' => 1], ['v' => 2], ['v' => null]]);
+        $c->where(['v' => 1])->values()->all();
     }
 
     /**


### PR DESCRIPTION
I came across a case where some `where` functions differences were not clear.

```
$collectionAttributes = ProductAttribute::all();

$collectionWithoutArray = $collectionAttributes ->where('uuid', 1)->first();
$collectionWithArray = $collectionAttributes ->where(['uuid' => 1])->first();
$attributesWithoutArray = ProductAttribute::where('uuid', 1)->first();
$attributesWithArray = ProductAttribute::where(['uuid' => 1])->first();

return[
  'collection_without_array'     => empty($collectionWithoutArray),
  'collection_with_array'        => empty($collectionWithArray),
  'attributes_without_array' => empty($attributesWithoutArray),
  'attributes_with_array'    => empty($attributesWithArray)
];
```

I would have expected all these example calls to return an element but the second one (`collection_with_array`) doesn't. 

Simply because the collections `where` does not support arrays but the Eloquent one does even if it is with a single element. 

It is by design but it should be a bit more clear that they are not supported. 

**At the moment, this code was not fetching any results (by habit of writing Eloquent where with an array) but didn't throw or alert me I should not be using an array in a `where` from a collection. It would just never return anything because it views my array as the key to look for**.

I thought of simply adding a caveat in the documentation but it felt a bit more clean for the end user to be notified by the framework. 
