### PR TITLE
[8.x] Use readable Symfony exit code constants

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/console.stub
+++ b/src/Illuminate/Foundation/Console/stubs/console.stub
@@ -37,6 +37,6 @@ class {{ class }} extends Command
      */
     public function handle()
     {
-        return 0;
+        return self::SUCCESS;
     }
 }


### PR DESCRIPTION
easier to understand what is being returned.

taken from this [tweet](https://twitter.com/mdavis1982/status/1419261210122465293/photo/1)