### PR TITLE
Fix case insensitive relation binding.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -652,6 +652,26 @@ class Builder
     }
 
     /**
+     * Checks if method with case sensitive name exists on model.
+     *
+     * @param  string  $name
+     * @return boolean
+     */
+    public function existsCaseSensitiveMethod($name) {
+        if (!$model = $this->getModel()) {
+            return false;
+        }
+
+        if (!$instance = $model->newInstance()) {
+            return false;
+        }
+
+        $classMethods = get_class_methods($instance);
+
+        return false !== array_search($name, $classMethods, true);
+    }
+
+    /**
      * Get the relation instance for the given relation name.
      *
      * @param  string  $name
@@ -663,11 +683,11 @@ class Builder
         // not have to remove these where clauses manually which gets really hacky
         // and error prone. We don't want constraints because we add eager ones.
         $relation = Relation::noConstraints(function () use ($name) {
-            try {
-                return $this->getModel()->newInstance()->$name();
-            } catch (BadMethodCallException $e) {
+            if (!$this->existsCaseSensitiveMethod($name)) {
                 throw RelationNotFoundException::make($this->getModel(), $name);
             }
+
+            return $this->getModel()->newInstance()->$name();
         });
 
         $nested = $this->relationsNestedUnder($name);

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Database\Eloquent;
 
-use BadMethodCallException;
 use Closure;
 use Exception;
 use Illuminate\Contracts\Support\Arrayable;
@@ -655,14 +654,15 @@ class Builder
      * Checks if method with case sensitive name exists on model.
      *
      * @param  string  $name
-     * @return boolean
+     * @return bool
      */
-    public function existsCaseSensitiveMethod($name) {
-        if (!$model = $this->getModel()) {
+    public function existsCaseSensitiveMethod($name)
+    {
+        if (! $model = $this->getModel()) {
             return false;
         }
 
-        if (!$instance = $model->newInstance()) {
+        if (! $instance = $model->newInstance()) {
             return false;
         }
 
@@ -683,7 +683,7 @@ class Builder
         // not have to remove these where clauses manually which gets really hacky
         // and error prone. We don't want constraints because we add eager ones.
         $relation = Relation::noConstraints(function () use ($name) {
-            if (!$this->existsCaseSensitiveMethod($name)) {
+            if (! $this->existsCaseSensitiveMethod($name)) {
                 throw RelationNotFoundException::make($this->getModel(), $name);
             }
 


### PR DESCRIPTION
Given:
ModelAlpha { };
ModelBeta { belongsTo -> modelAlpha() };

When:
During eager loading, via relation method which has name with wrong case.
`ModelBeta::with('mOdElaLpha')->get();`

Then:
1) We get 1 eager call to the database with all related IDs;
2) For each ID call database again.

Proposal:
Validate the relation method name before invoking it.
