### PR TITLE
[8.x]  Fixed json validation check if there is encoded content

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -193,7 +193,7 @@ class TestResponse implements ArrayAccess
 
         if (
             $this->baseResponse->headers->get('Content-Type') === 'application/json'
-            && !$this->baseResponse->headers->has('content-encoding')
+            && ! $this->baseResponse->headers->has('content-encoding')
         ) {
             $json = $this->json();
 

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -193,7 +193,7 @@ class TestResponse implements ArrayAccess
 
         if (
             $this->baseResponse->headers->get('Content-Type') === 'application/json'
-            && ! $this->baseResponse->headers->has('content-encoding')
+            && ! $this->baseResponse->headers->has('Content-Encoding')
         ) {
             $json = $this->json();
 

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -191,7 +191,10 @@ class TestResponse implements ArrayAccess
             }
         }
 
-        if ($this->baseResponse->headers->get('Content-Type') === 'application/json') {
+        if (
+            $this->baseResponse->headers->get('Content-Type') === 'application/json'
+            && !$this->baseResponse->headers->has('content-encoding')
+        ) {
             $json = $this->json();
 
             if (isset($json['errors'])) {

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -559,8 +559,8 @@ class TestResponseTest extends TestCase
         $expectedStatusCode = 200;
 
         $baseResponse = tap(new Response, function ($response) {
-            $response->header('content-type', 'application/json');
-            $response->header('content-encoding', 'gzip');
+            $response->header('Content-Type', 'application/json');
+            $response->header('Content-Encoding', 'gzip');
             $response->setContent('b"x£½V*.I,)-V▓R╩¤V¬\x05\x00+ü\x059"');
         });
 

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -554,6 +554,19 @@ class TestResponseTest extends TestCase
         $response->assertStatus($expectedStatusCode);
     }
 
+    public function testAssertNotValidatedJsonForEncoding()
+    {
+        $expectedStatusCode = 200;
+
+        $baseResponse = tap(new Response, function ($response) {
+            $response->header('content-type', 'application/json');
+            $response->header('content-encoding', 'gzip');
+            $response->setContent('b"x£½V*.I,)-V▓R╩¤V¬\x05\x00+ü\x059"');
+        });
+
+        TestResponse::fromBaseResponse($baseResponse)->assertStatus($expectedStatusCode);
+    }
+
     public function testAssertStatusShowsErrorsOnUnexpectedErrorRedirect()
     {
         $statusCode = 302;


### PR DESCRIPTION
Hey, in recent commits #38046 #38088, JSON validation has been added when the `application/json` header is present, but this is not always required as the content can be encoded. This PR adds a check that will only check the content if it hasn't been encoded.