### PR TITLE
[8.x] Added support for GCM encryption

### DIFF
--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -108,7 +108,7 @@ class Encrypter implements EncrypterContract, StringEncrypter
         // Once we get the encrypted value we'll go ahead and base64_encode the input
         // vector and create the MAC for the encrypted value so we can then verify
         // its authenticity. Then, we'll JSON the data into the "payload" array.
-        $mac = $this->hash($iv = base64_encode($iv), $value, $tag = $tag ? base64_encode($tag) : null);
+        $mac = $this->hash($iv = base64_encode($iv), $value, $tag = $tag ? base64_encode($tag) : '');
 
         $json = json_encode(compact('iv', 'value', 'mac', 'tag'), JSON_UNESCAPED_SLASHES);
 

--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -234,7 +234,7 @@ class Encrypter implements EncrypterContract, StringEncrypter
     protected function validMac(array $payload)
     {
         return hash_equals(
-            $this->hash($payload['iv'], $payload['value'], $payload['tag']), $payload['mac']
+            $this->hash($payload['iv'], $payload['value'], $payload['tag'] ?? ''), $payload['mac']
         );
     }
 

--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -90,10 +90,16 @@ class Encrypter implements EncrypterContract, StringEncrypter
         // First we will encrypt the value using OpenSSL. After this is encrypted we
         // will proceed to calculating a MAC for the encrypted value so that this
         // value can be verified later as not having been changed by the users.
-        $value = \openssl_encrypt(
-            $serialize ? serialize($value) : $value,
-            $this->cipher, $this->key, 0, $iv, $tag
-        );
+        $value =
+            in_array($this->cipher, ['AES-128-GCM', 'AES-256-GCM']) ?
+                \openssl_encrypt(
+                    $serialize ? serialize($value) : $value,
+                    $this->cipher, $this->key, 0, $iv, $tag
+                ) :
+                \openssl_encrypt(
+                    $serialize ? serialize($value) : $value,
+                    $this->cipher, $this->key, 0, $iv
+                );
 
         if ($value === false) {
             throw new EncryptException('Could not encrypt the data.');

--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -85,7 +85,7 @@ class Encrypter implements EncrypterContract, StringEncrypter
     public function encrypt($value, $serialize = true)
     {
         $iv = random_bytes(openssl_cipher_iv_length($this->cipher));
-        $tag = "";
+        $tag = '';
 
         // First we will encrypt the value using OpenSSL. After this is encrypted we
         // will proceed to calculating a MAC for the encrypted value so that this

--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -41,7 +41,7 @@ class Encrypter implements EncrypterContract, StringEncrypter
             $this->key = $key;
             $this->cipher = $cipher;
         } else {
-            throw new RuntimeException('The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.');
+            throw new RuntimeException('The only supported ciphers are AES-128-CBC, AES-256-CBC, AES-128-GCM, and AES-256-GCM with the correct key lengths.');
         }
     }
 
@@ -57,7 +57,9 @@ class Encrypter implements EncrypterContract, StringEncrypter
         $length = mb_strlen($key, '8bit');
 
         return ($cipher === 'AES-128-CBC' && $length === 16) ||
-               ($cipher === 'AES-256-CBC' && $length === 32);
+            ($cipher === 'AES-256-CBC' && $length === 32) ||
+            ($cipher === 'AES-128-GCM' && $length === 16) ||
+            ($cipher === 'AES-256-GCM' && $length === 32);
     }
 
     /**
@@ -83,13 +85,14 @@ class Encrypter implements EncrypterContract, StringEncrypter
     public function encrypt($value, $serialize = true)
     {
         $iv = random_bytes(openssl_cipher_iv_length($this->cipher));
+        $tag = "";
 
         // First we will encrypt the value using OpenSSL. After this is encrypted we
         // will proceed to calculating a MAC for the encrypted value so that this
         // value can be verified later as not having been changed by the users.
         $value = \openssl_encrypt(
             $serialize ? serialize($value) : $value,
-            $this->cipher, $this->key, 0, $iv
+            $this->cipher, $this->key, 0, $iv, $tag
         );
 
         if ($value === false) {
@@ -99,9 +102,9 @@ class Encrypter implements EncrypterContract, StringEncrypter
         // Once we get the encrypted value we'll go ahead and base64_encode the input
         // vector and create the MAC for the encrypted value so we can then verify
         // its authenticity. Then, we'll JSON the data into the "payload" array.
-        $mac = $this->hash($iv = base64_encode($iv), $value);
+        $mac = $this->hash($iv = base64_encode($iv), $value, $tag = base64_encode($tag));
 
-        $json = json_encode(compact('iv', 'value', 'mac'), JSON_UNESCAPED_SLASHES);
+        $json = json_encode(compact('iv', 'value', 'mac', 'tag'), JSON_UNESCAPED_SLASHES);
 
         if (json_last_error() !== JSON_ERROR_NONE) {
             throw new EncryptException('Could not encrypt the data.');
@@ -137,12 +140,13 @@ class Encrypter implements EncrypterContract, StringEncrypter
         $payload = $this->getJsonPayload($payload);
 
         $iv = base64_decode($payload['iv']);
+        $tag = base64_decode($payload['tag']);
 
         // Here we will decrypt the value. If we are able to successfully decrypt it
         // we will then unserialize it and return it out to the caller. If we are
         // unable to decrypt this value we will throw out an exception message.
         $decrypted = \openssl_decrypt(
-            $payload['value'], $this->cipher, $this->key, 0, $iv
+            $payload['value'], $this->cipher, $this->key, 0, $iv, $tag
         );
 
         if ($decrypted === false) {
@@ -172,9 +176,9 @@ class Encrypter implements EncrypterContract, StringEncrypter
      * @param  mixed  $value
      * @return string
      */
-    protected function hash($iv, $value)
+    protected function hash($iv, $value, $tag = '')
     {
-        return hash_hmac('sha256', $iv.$value, $this->key);
+        return hash_hmac('sha256', $tag.$iv.$value, $this->key);
     }
 
     /**
@@ -211,8 +215,8 @@ class Encrypter implements EncrypterContract, StringEncrypter
      */
     protected function validPayload($payload)
     {
-        return is_array($payload) && isset($payload['iv'], $payload['value'], $payload['mac']) &&
-               strlen(base64_decode($payload['iv'], true)) === openssl_cipher_iv_length($this->cipher);
+        return is_array($payload) && isset($payload['iv'], $payload['value'], $payload['mac'], $payload['tag']) &&
+            strlen(base64_decode($payload['iv'], true)) === openssl_cipher_iv_length($this->cipher);
     }
 
     /**
@@ -224,7 +228,7 @@ class Encrypter implements EncrypterContract, StringEncrypter
     protected function validMac(array $payload)
     {
         return hash_equals(
-            $this->hash($payload['iv'], $payload['value']), $payload['mac']
+            $this->hash($payload['iv'], $payload['value'], $payload['tag']), $payload['mac']
         );
     }
 

--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -45,12 +45,12 @@ class EncrypterTest extends TestCase
 
     public function testWithCustomCipher()
     {
-        $e = new Encrypter(str_repeat('b', 32), 'AES-256-CBC');
+        $e = new Encrypter(str_repeat('b', 32), 'AES-256-GCM');
         $encrypted = $e->encrypt('bar');
         $this->assertNotSame('bar', $encrypted);
         $this->assertSame('bar', $e->decrypt($encrypted));
 
-        $e = new Encrypter(random_bytes(32), 'AES-256-CBC');
+        $e = new Encrypter(random_bytes(32), 'AES-256-GCM');
         $encrypted = $e->encrypt('foo');
         $this->assertNotSame('foo', $encrypted);
         $this->assertSame('foo', $e->decrypt($encrypted));
@@ -59,7 +59,7 @@ class EncrypterTest extends TestCase
     public function testDoNoAllowLongerKey()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.');
+        $this->expectExceptionMessage('The only supported ciphers are AES-128-CBC, AES-256-CBC, AES-128-GCM, and AES-256-GCM with the correct key lengths.');
 
         new Encrypter(str_repeat('z', 32));
     }
@@ -67,7 +67,7 @@ class EncrypterTest extends TestCase
     public function testWithBadKeyLength()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.');
+        $this->expectExceptionMessage('The only supported ciphers are AES-128-CBC, AES-256-CBC, AES-128-GCM, and AES-256-GCM with the correct key lengths.');
 
         new Encrypter(str_repeat('a', 5));
     }
@@ -75,7 +75,7 @@ class EncrypterTest extends TestCase
     public function testWithBadKeyLengthAlternativeCipher()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.');
+        $this->expectExceptionMessage('The only supported ciphers are AES-128-CBC, AES-256-CBC, AES-128-GCM, and AES-256-GCM with the correct key lengths.');
 
         new Encrypter(str_repeat('a', 16), 'AES-256-CFB8');
     }
@@ -83,7 +83,7 @@ class EncrypterTest extends TestCase
     public function testWithUnsupportedCipher()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.');
+        $this->expectExceptionMessage('The only supported ciphers are AES-128-CBC, AES-256-CBC, AES-128-GCM, and AES-256-GCM with the correct key lengths.');
 
         new Encrypter(str_repeat('c', 16), 'AES-256-CFB8');
     }


### PR DESCRIPTION
This pull request adds support for 128-bit and 256-bit GCM encryption, which will allow Laravel developers to use this stronger encryption mode in their applications.

Galois/Counter Mode (GCM) encryption is a more secure and modern encryption cipher than CBC (which is currently default).  

The pull request does not change the default encryption mode and is fully backwards compatible.
