### PR TITLE
[8.x] Prevent assertStatus() invalid JSON exception for valid JSON response content

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -192,10 +192,10 @@ class TestResponse implements ArrayAccess
         }
 
         if ($this->baseResponse->headers->get('Content-Type') === 'application/json') {
-            $json = $this->json();
+            $testJson = new AssertableJsonString($this->getContent());
 
-            if (isset($json['errors'])) {
-                return $this->statusMessageWithErrors($expected, $actual, $json);
+            if (isset($testJson['errors'])) {
+                return $this->statusMessageWithErrors($expected, $actual, $testJson->json());
             }
         }
 

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -599,6 +599,14 @@ class TestResponseTest extends TestCase
         $response->assertStatus($expectedStatusCode);
     }
 
+    public function testAssertStatusWhenJsonIsFalse()
+    {
+        $baseResponse = new Response('false', 200, ['Content-Type' => 'application/json']);
+
+        $response = TestResponse::fromBaseResponse($baseResponse);
+        $response->assertStatus(200);
+    }
+
     public function testAssertHeader()
     {
         $this->expectException(AssertionFailedError::class);

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -607,6 +607,18 @@ class TestResponseTest extends TestCase
         $response->assertStatus(200);
     }
 
+    public function testAssertStatusWhenJsonIsEncoded()
+    {
+        $baseResponse = tap(new Response, function ($response) {
+            $response->header('Content-Type', 'application/json');
+            $response->header('Content-Encoding', 'gzip');
+            $response->setContent('b"x£½V*.I,)-V▓R╩¤V¬\x05\x00+ü\x059"');
+        });
+
+        $response = TestResponse::fromBaseResponse($baseResponse);
+        $response->assertStatus(200);
+    }
+
     public function testAssertHeader()
     {
         $this->expectException(AssertionFailedError::class);


### PR DESCRIPTION
Fixes: https://github.com/laravel/framework/issues/38178
Replaces pull request: https://github.com/laravel/framework/pull/38189 (this pull request adds **tabuna**'s GZIP-encoding test case)

Test suite JSON validation message feedback added in v8.52.0 (https://github.com/laravel/framework/pull/38046 https://github.com/laravel/framework/pull/38088) is causing `assertStatus()` to throw "Invalid JSON was returned from the route" on some valid JSON responses. A few known cases:

1. JSON response is a boolean `false` and not a key/value payload (described in the linked issue):
    * status code: 200 HTTP OK
    * header: Content-Type: application/json
    * body: false
2. JSON response body is GZIP-encoded.

The new custom validation feedback must avoid the below error checking block intended for the `assertJson*()` methods that inspect key/value payloads:

https://github.com/laravel/framework/blob/7bd4e6dc547526d072374eb4846e31369987d66f/src/Illuminate/Testing/TestResponse.php#L851-L857

...since validation of a JSON payload is unrelated to the HTTP status code being asserted. Instead silently attempt to gather the JSON `'errors'` validation messages and fallback gracefully to the generic PHPUnit failure message.