### PR TITLE
Add mail middleware

### DIFF
--- a/src/Illuminate/Contracts/Mail/Mailable.php
+++ b/src/Illuminate/Contracts/Mail/Mailable.php
@@ -73,4 +73,12 @@ interface Mailable
      * @return $this
      */
     public function mailer($mailer);
+
+    /**
+     * Specify the middleware the mail should be sent through.
+     *
+     * @param  array|object|string  $middleware
+     * @return $this
+     */
+    public function through($middleware);
 }

--- a/src/Illuminate/Mail/PendingMail.php
+++ b/src/Illuminate/Mail/PendingMail.php
@@ -5,6 +5,7 @@ namespace Illuminate\Mail;
 use Illuminate\Contracts\Mail\Mailable as MailableContract;
 use Illuminate\Contracts\Mail\Mailer as MailerContract;
 use Illuminate\Contracts\Translation\HasLocalePreference;
+use Illuminate\Support\Arr;
 
 class PendingMail
 {
@@ -42,6 +43,13 @@ class PendingMail
      * @var array
      */
     protected $bcc = [];
+
+    /**
+     * The middleware the mail should be sent through.
+     *
+     * @var array
+     */
+    public $middleware = [];
 
     /**
      * Create a new mailable mailer instance.
@@ -111,6 +119,19 @@ class PendingMail
     }
 
     /**
+     * Specify the middleware the mail should be sent through.
+     *
+     * @param  array|object|string  $middleware
+     * @return $this
+     */
+    public function through($middleware)
+    {
+        $this->middleware = Arr::wrap($middleware);
+
+        return $this;
+    }
+
+    /**
      * Send a new mailable message instance.
      *
      * @param  \Illuminate\Contracts\Mail\Mailable  $mailable
@@ -152,12 +173,16 @@ class PendingMail
      */
     protected function fill(MailableContract $mailable)
     {
-        return tap($mailable->to($this->to)
-            ->cc($this->cc)
-            ->bcc($this->bcc), function (MailableContract $mailable) {
+        return tap(
+            $mailable->to($this->to)
+                ->cc($this->cc)
+                ->bcc($this->bcc)
+                ->through($this->middleware),
+            function (MailableContract $mailable) {
                 if ($this->locale) {
                     $mailable->locale($this->locale);
                 }
-            });
+            }
+        );
     }
 }

--- a/tests/Mail/MailMiddlewareTest.php
+++ b/tests/Mail/MailMiddlewareTest.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Illuminate\Tests\Mail;
+
+use Closure;
+use Illuminate\Support\Facades\Mail;
+use Orchestra\Testbench\TestCase;
+
+class MailMiddlewareTest extends TestCase
+{
+    public function testMailableIsSentWhenMiddlewarePasses()
+    {
+        Mail::fake();
+
+        Mail::to('jeff@test.com')
+            ->through(PassingMailMiddleware::class)
+            ->send(new Mailable);
+
+        Mail::assertSent(Mailable::class);
+    }
+
+    public function testMailableIsQueuedWhenMiddlewarePasses()
+    {
+        Mail::fake();
+
+        Mail::to('jeff@test.com')
+            ->through(PassingMailMiddleware::class)
+            ->queue(new Mailable);
+
+        Mail::assertQueued(Mailable::class);
+    }
+
+    public function testMailableIsNotSentWhenMiddlewareFails()
+    {
+        Mail::fake();
+
+        Mail::to('jeff@test.com')
+            ->through(FailingMailMiddleware::class)
+            ->send(new Mailable);
+
+        Mail::assertNotSent(Mailable::class);
+    }
+
+    public function testMailableIsNotQueuedWhenMiddlewareFails()
+    {
+        Mail::fake();
+
+        Mail::to('jeff@test.com')
+            ->through(FailingMailMiddleware::class)
+            ->queue(new Mailable);
+
+        Mail::assertNotQueued(Mailable::class);
+    }
+
+    public function testMailableIsNotSentWhenOneOfTwoMiddlewareFails()
+    {
+        Mail::fake();
+
+        Mail::to('jeff@test.com')
+            ->through([PassingMailMiddleware::class, FailingMailMiddleware::class])
+            ->send(new Mailable);
+
+        Mail::assertNotSent(Mailable::class);
+    }
+
+    public function testMailableIsNotQueuedWhenOneOfTwoMiddlewareFails()
+    {
+        Mail::fake();
+
+        Mail::to('jeff@test.com')
+            ->through([PassingMailMiddleware::class, FailingMailMiddleware::class])
+            ->queue(new Mailable);
+
+        Mail::assertNotQueued(Mailable::class);
+    }
+
+    public function testMailableWithInvalidToIsNotSent()
+    {
+        Mail::fake();
+
+        Mail::to('')
+            ->through(EnsureRecipientIsValid::class)
+            ->send(new Mailable);
+
+        Mail::assertNotSent(Mailable::class);
+    }
+
+    public function testMailableWithSomeInvalidRecipientsCanBeModifiedInMiddleware()
+    {
+        Mail::fake();
+
+        Mail::to(['', 'jeff@test.com'])
+            ->through(EnsureRecipientIsValid::class)
+            ->send(new Mailable);
+
+        Mail::assertSent(Mailable::class, 1);
+    }
+}
+
+class EnsureRecipientIsValid
+{
+    public function handle(Mailable $mailable, Closure $next)
+    {
+        $mailable->to = collect($mailable->to)
+            ->filter(function ($recipient) {
+                return filter_var($recipient['address'], FILTER_VALIDATE_EMAIL) !== false;
+            })
+            ->values()
+            ->all();
+
+        return ! empty($mailable->to) && $next($mailable);
+    }
+}
+
+class PassingMailMiddleware
+{
+    public function handle(Mailable $mailable, Closure $next)
+    {
+        return $next($mailable);
+    }
+}
+
+class FailingMailMiddleware
+{
+    public function handle(Mailable $mailable, Closure $next)
+    {
+        //
+    }
+}
+
+class Mailable extends \Illuminate\Mail\Mailable
+{
+    public function build()
+    {
+        return $this->html('Hello');
+    }
+}


### PR DESCRIPTION
This PR adds the ability to define middleware on mailables the same way you can do on queued jobs. The benefits of having mail middleware is it allows you to move some of that decision making to a single place, and keeps consistency with other parts of Laravel.

This might need to target the next major version as it changes the `Mailable` interface.

This is still a work in progress PR (still need to tweak queued mails), but I am just wondering whether this has a place in the framework?