### PR TITLE
Add everyXDays and everyXDaysAt scheduling frequency helpers

### DIFF
--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -283,6 +283,61 @@ trait ManagesFrequencies
     }
 
     /**
+     * Schedule the event to run every two days.
+     *
+     * @return $this
+     */
+    public function everyTwoDays()
+    {
+        return $this->everyXDays(2);
+    }
+
+    /**
+     * Schedule the event to run every five days.
+     *
+     * @return $this
+     */
+    public function everyFiveDays()
+    {
+        return $this->everyXDays(5);
+    }
+
+    /**
+     * Schedule the event to run every ten days.
+     *
+     * @return $this
+     */
+    public function everyTenDays()
+    {
+        return $this->everyXDays(10);
+    }
+
+    /**
+     * Schedule the event to run every X days.
+     *
+     * @param  int  $days
+     * @return $this
+     */
+    public function everyXDays($days)
+    {
+        return $this->everyXDaysAt($days);
+    }
+
+    /**
+     * Schedule the event to run every X days at a given time (10:00, 16:31, etc).
+     *
+     * @param  $days
+     * @param  string  $time
+     * @return $this
+     */
+    public function everyXDaysAt($days, $time = '0:0')
+    {
+        $this->dailyAt($time);
+
+        return $this->spliceIntoPosition(3, '*/'.$days);
+    }
+
+    /**
      * Schedule the event to run only on weekdays.
      *
      * @return $this

--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -62,6 +62,25 @@ class FrequencyTest extends TestCase
         $this->assertSame('5 3,15 * * *', $this->event->twiceDailyAt(3, 15, 5)->getExpression());
     }
 
+    public function testEveryXDays()
+    {
+        $this->assertSame('0 0 */2 * *', $this->event->everyTwoDays()->getExpression());
+        $this->assertSame('0 0 */5 * *', $this->event->everyFiveDays()->getExpression());
+        $this->assertSame('0 0 */10 * *', $this->event->everyTenDays()->getExpression());
+        $this->assertSame('0 0 */3 * *', $this->event->everyXDays(3)->getExpression());
+        $this->assertSame('0 0 */8 * *', $this->event->everyXDays(8)->getExpression());
+        $this->assertSame('0 0 */13 * *', $this->event->everyXDays(13)->getExpression());
+    }
+
+    public function testEveryXDaysAt()
+    {
+        $this->assertSame('10 13 */2 * *', $this->event->everyXDaysAt(2, '13:10')->getExpression());
+        $this->assertSame('50 9 */3 * *', $this->event->everyXDaysAt(3, '9:50')->getExpression());
+        $this->assertSame('31 16 */4 * *', $this->event->everyXDaysAt(4, '16:31')->getExpression());
+        $this->assertSame('43 15 */5 * *', $this->event->everyXDaysAt(5, '15:43')->getExpression());
+        $this->assertSame('6 6 */6 * *', $this->event->everyXDaysAt(6, '6:6')->getExpression());
+    }
+
     public function testWeekly()
     {
         $this->assertSame('0 0 * * 0', $this->event->weekly()->getExpression());


### PR DESCRIPTION
This PR adds some helpers for scheduling frequencies to run jobs every X days. With `everyXDays()` and `everyXDaysAt()` the following helpers are also added:

- `everyTwoDays()`
- `everyFiveDays()`
- `everyTenDays()`
