### PR TITLE
[9.x] Remove ext-json from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
     ],
     "require": {
         "php": "^8.0",
-        "ext-json": "*",
         "ext-mbstring": "*",
         "ext-openssl": "*",
         "doctrine/inflector": "^2.0",


### PR DESCRIPTION
Laravel 9 will require PHP 8.0 which is always shipped with the json extension. We can therefor remove this requirement from the composer.json.

Source: https://php.watch/versions/8.0/ext-json