### PR TITLE
[8.x] Fix previous column for cursor pagination

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -305,7 +305,11 @@ trait BuildsQueries
         if (! is_null($cursor)) {
             $addCursorConditions = function (self $builder, $previousColumn, $i) use (&$addCursorConditions, $cursor, $orders) {
                 if (! is_null($previousColumn)) {
-                    $builder->where($previousColumn, '=', $cursor->parameter($previousColumn));
+                    $builder->where(
+                        $this->getOriginalColumnNameForCursorPagination($this, $previousColumn),
+                        '=',
+                        $cursor->parameter($previousColumn)
+                    );
                 }
 
                 $builder->where(function (self $builder) use ($addCursorConditions, $cursor, $orders, $i) {


### PR DESCRIPTION
This fixes an issue where the newly added previous column in cursor pagination wasn't yet resolved to check for a select alias to retrieve its original column name.

Fixes #38138
