### PR TITLE
Add array syntax to components class attribute just like the new @class directive

### DIFF
--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -553,7 +553,9 @@ class ComponentTagCompiler
         return collect($attributes)
                 ->map(function (string $value, string $attribute) use ($escapeBound) {
                     return $escapeBound && isset($this->boundAttributes[$attribute]) && $value !== 'true' && ! is_numeric($value)
-                                ? "'{$attribute}' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute({$value})"
+                                ? $attribute === 'class'
+                                    ? "'{$attribute}' => \Illuminate\Support\Arr::toCssClasses({$value})"
+                                    : "'{$attribute}' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute({$value})"
                                 : "'{$attribute}' => {$value}";
                 })
                 ->implode(',');

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -80,6 +80,14 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
 <?php \$component->withAttributes([':title' => 'user.name']); ?> @endComponentClass##END-COMPONENT-CLASS##", trim($result));
     }
 
+    public function testClassAttributeAcceptsArray()
+    {
+        $result = $this->compiler(['profile' => TestProfileComponent::class])->compileTags('<x-profile :class="[\'string\', \'include\' => true, \'exclude\' => false]" user-id="1"></x-profile>');
+
+        $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\Tests\View\Blade\TestProfileComponent', 'profile', ['userId' => '1'])
+<?php \$component->withAttributes(['class' => \Illuminate\Support\Arr::toCssClasses(['string', 'include' => true, 'exclude' => false])]); ?> @endComponentClass##END-COMPONENT-CLASS##", trim($result));
+    }
+
     public function testColonAttributesIsEscapedIfStrings()
     {
         $result = $this->compiler(['profile' => TestProfileComponent::class])->compileTags('<x-profile :src="\'foo\'"></x-profile>');


### PR DESCRIPTION
Hi!

I love the new `@class` directive so much, I added the array syntax to blade components as well.

Example:

```html
<x-alert :class="[
    'text-sm',
    'font-bold' => $active
]" />
```

Thank you for reviewing! Please let me know if any changes need to be made.