### PR TITLE
[8.x] Allow the php web server to run multiple workers

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -100,7 +100,7 @@ class ServeCommand extends Command
                 return [$key => $value];
             }
 
-            return in_array($key, ['APP_ENV', 'LARAVEL_SAIL'])
+            return in_array($key, ['APP_ENV', 'LARAVEL_SAIL', 'PHP_CLI_SERVER_WORKERS'])
                     ? [$key => $value]
                     : [$key => false];
         })->all());


### PR DESCRIPTION
This change allows users to specify the ```PHP_CLI_SERVER_WORKERS``` in their ```.env``` file.

This in turn allows the ```sail up``` command to run multiple php "threads". All in all this means ajax/guzzle requests are no longer sequential.

Does not break or change any existing functionality. Only relevant for local development.
