### PR TITLE
[8.x] Inject the list of env vars that are passed on to the web server

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -33,7 +33,7 @@ class ServeCommand extends Command
 
     /**
      * The environment variables that are passed thru to the built-in PHP webserver.
-     * 
+     *
      * @var array
      */
     protected $passthruEnvVars;
@@ -42,7 +42,7 @@ class ServeCommand extends Command
      * Create a new serve command instance.
      *
      * @param  array  $passthruEnvVars
-     * 
+     *
      * @return void
      */
     public function __construct(array $passthruEnvVars = ['APP_ENV', 'LARAVEL_SAIL'])

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -42,7 +42,6 @@ class ServeCommand extends Command
      * Create a new serve command instance.
      *
      * @param  array  $passthruEnvVars
-     *
      * @return void
      */
     public function __construct(array $passthruEnvVars = ['APP_ENV', 'LARAVEL_SAIL', 'PHP_CLI_SERVER_WORKERS'])

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -32,6 +32,27 @@ class ServeCommand extends Command
     protected $portOffset = 0;
 
     /**
+     * The environment variables that are passed thru to the built-in PHP webserver.
+     * 
+     * @var array
+     */
+    protected $passthruEnvVars;
+
+    /**
+     * Create a new serve command instance.
+     *
+     * @param  array  $passthruEnvVars
+     * 
+     * @return void
+     */
+    public function __construct(array $passthruEnvVars = ['APP_ENV', 'LARAVEL_SAIL'])
+    {
+        parent::__construct();
+
+        $this->passthruEnvVars = $passthruEnvVars;
+    }
+
+    /**
      * Execute the console command.
      *
      * @return int
@@ -100,7 +121,7 @@ class ServeCommand extends Command
                 return [$key => $value];
             }
 
-            return in_array($key, ['APP_ENV', 'LARAVEL_SAIL'])
+            return in_array($key, $this->passthruEnvVars)
                     ? [$key => $value]
                     : [$key => false];
         })->all());


### PR DESCRIPTION
This is needed for when using a `.env` file but still need to provide environment variables to PHP or a PHP extension such as xdebug.

Currently, Laravel Sail won't work with xdebug if you provide the configuration thru the XDEBUG_MODE and XDEBUG_CONFIG environment variables because this command doesn't pass the variables onto the php web server. You are forced to provide the xdebug configuration in the php.ini file but that isn't convenient for being able to turn xdebug on/off and switch between modes.

I'm sure there are other use cases as well where being able to modify the list of variables that are passed on to the php webserver are useful, for instance this PR: https://github.com/laravel/framework/pull/38208