### PR TITLE
[8.x] Bump AWS SDK

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -78,7 +78,7 @@
         "illuminate/view": "self.version"
     },
     "require-dev": {
-        "aws/aws-sdk-php": "^3.155",
+        "aws/aws-sdk-php": "^3.186.4",
         "doctrine/dbal": "^2.6|^3.0",
         "filp/whoops": "^2.8",
         "guzzlehttp/guzzle": "^6.5.5|^7.0.1",
@@ -128,7 +128,7 @@
         "ext-pcntl": "Required to use all features of the queue worker.",
         "ext-posix": "Required to use all features of the queue worker.",
         "ext-redis": "Required to use the Redis cache and queue drivers (^4.0|^5.0).",
-        "aws/aws-sdk-php": "Required to use the SQS queue driver, DynamoDb failed job storage and SES mail driver (^3.155).",
+        "aws/aws-sdk-php": "Required to use the SQS queue driver, DynamoDb failed job storage and SES mail driver (^3.186.4).",
         "brianium/paratest": "Required to run tests in parallel (^6.0).",
         "doctrine/dbal": "Required to rename columns and drop SQLite columns (^2.6|^3.0).",
         "filp/whoops": "Required for friendly error pages in development (^2.8).",

--- a/src/Illuminate/Mail/composer.json
+++ b/src/Illuminate/Mail/composer.json
@@ -37,7 +37,7 @@
         }
     },
     "suggest": {
-        "aws/aws-sdk-php": "Required to use the SES mail driver (^3.155).",
+        "aws/aws-sdk-php": "Required to use the SES mail driver (^3.186.4).",
         "guzzlehttp/guzzle": "Required to use the Mailgun mail driver (^6.5.5|^7.0.1).",
         "wildbit/swiftmailer-postmark": "Required to use Postmark mail driver (^3.0)."
     },

--- a/src/Illuminate/Queue/composer.json
+++ b/src/Illuminate/Queue/composer.json
@@ -41,7 +41,7 @@
     "suggest": {
         "ext-pcntl": "Required to use all features of the queue worker.",
         "ext-posix": "Required to use all features of the queue worker.",
-        "aws/aws-sdk-php": "Required to use the SQS queue driver and DynamoDb failed job storage (^3.155).",
+        "aws/aws-sdk-php": "Required to use the SQS queue driver and DynamoDb failed job storage (^3.186.4).",
         "illuminate/redis": "Required to use the Redis queue driver (^8.0).",
         "pda/pheanstalk": "Required to use the Beanstalk queue driver (^4.0)."
     },


### PR DESCRIPTION
This PR bumps the minimum AWS SDK version to v3.186.4 to accommodate for some PHP 8.1 fixes. 
