### PR TITLE
[8.x] Fix resource type in DocBlocks

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -181,7 +181,7 @@ class PendingRequest
     /**
      * Attach a raw body to the request.
      *
-     * @param  resource|string  $content
+     * @param  string  $content
      * @param  string  $contentType
      * @return $this
      */
@@ -220,7 +220,7 @@ class PendingRequest
      * Attach a file to the request.
      *
      * @param  string|array  $name
-     * @param  string  $contents
+     * @param  string|resource  $contents
      * @param  string|null  $filename
      * @param  array  $headers
      * @return $this


### PR DESCRIPTION
withBody shouldn't be able to add a resource type (see the DocBlock type on the property) while attach should allow a resource type for the content (see our docs).

Also see #38209
