### PR TITLE
Make new created models and final.

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/model.pivot.stub
+++ b/src/Illuminate/Foundation/Console/stubs/model.pivot.stub
@@ -4,7 +4,7 @@ namespace {{ namespace }};
 
 use Illuminate\Database\Eloquent\Relations\Pivot;
 
-class {{ class }} extends Pivot
+final class {{ class }} extends Pivot
 {
     //
 }

--- a/src/Illuminate/Foundation/Console/stubs/model.stub
+++ b/src/Illuminate/Foundation/Console/stubs/model.stub
@@ -5,7 +5,7 @@ namespace {{ namespace }};
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
-class {{ class }} extends Model
+final class {{ class }} extends Model
 {
     use HasFactory;
 }


### PR DESCRIPTION
In most cases when a developer creates a class, that class is final. In less than 100% of cases nobody extends from a model.
I offer to have new created models as final. For the rest cases when developer really needs to extend from a model, he can remove the FINAL word. I think it's a bad idea for each time when we create a model to manually add FINAL word.

And I think the same thing can be done with Listeners, Migrations, Seeders