### PR TITLE
Support CTL+CLICK opening of newly created migrations from IDE Terminal

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -115,7 +115,7 @@ class MigrateMakeCommand extends BaseCommand
         }
         
         $file = $this->getMigrationPath().DIRECTORY_SEPARATOR.$file.'.php';
-
+        
         $this->line("<info>Created Migration:</info> {$file}");
     }
 

--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -113,6 +113,8 @@ class MigrateMakeCommand extends BaseCommand
         if (! $this->option('fullpath')) {
             $file = pathinfo($file, PATHINFO_FILENAME);
         }
+        
+        $file = $this->getMigrationPath() . DIRECTORY_SEPARATOR . $file . '.php';
 
         $this->line("<info>Created Migration:</info> {$file}");
     }

--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -114,7 +114,7 @@ class MigrateMakeCommand extends BaseCommand
             $file = pathinfo($file, PATHINFO_FILENAME);
         }
         
-        $file = $this->getMigrationPath() . DIRECTORY_SEPARATOR . $file . '.php';
+        $file = $this->getMigrationPath().DIRECTORY_SEPARATOR.$file.'.php';
 
         $this->line("<info>Created Migration:</info> {$file}");
     }


### PR DESCRIPTION
This PR just add full path and file extension to the `info` line shown after creating a migration.

This will allow for CTL+CLICK from your IDE's integrated terminal to open and edit the migration file directly.

This DOES NOT affect the way migrations are generated. Just outputs the full path to the console.
