### PR TITLE
[8.x] Use actual countable interface on MessageBag

### DIFF
--- a/src/Illuminate/Contracts/Support/MessageBag.php
+++ b/src/Illuminate/Contracts/Support/MessageBag.php
@@ -2,7 +2,9 @@
 
 namespace Illuminate\Contracts\Support;
 
-interface MessageBag extends Arrayable
+use Countable;
+
+interface MessageBag extends Arrayable, Countable
 {
     /**
      * Get the keys present in the message bag.
@@ -97,11 +99,4 @@ interface MessageBag extends Arrayable
      * @return bool
      */
     public function isNotEmpty();
-
-    /**
-     * Get the number of messages in the container.
-     *
-     * @return int
-     */
-    public function count();
 }

--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -2,14 +2,13 @@
 
 namespace Illuminate\Support;
 
-use Countable;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\MessageBag as MessageBagContract;
 use Illuminate\Contracts\Support\MessageProvider;
 use JsonSerializable;
 
-class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, MessageBagContract, MessageProvider
+class MessageBag implements Arrayable, Jsonable, JsonSerializable, MessageBagContract, MessageProvider
 {
     /**
      * All of the registered messages.

--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -2,13 +2,12 @@
 
 namespace Illuminate\Support;
 
-use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\MessageBag as MessageBagContract;
 use Illuminate\Contracts\Support\MessageProvider;
 use JsonSerializable;
 
-class MessageBag implements Arrayable, Jsonable, JsonSerializable, MessageBagContract, MessageProvider
+class MessageBag implements Jsonable, JsonSerializable, MessageBagContract, MessageProvider
 {
     /**
      * All of the registered messages.


### PR DESCRIPTION
Instead of defining our own declaration of Countable, let's use the actual PHP interface. This is the only contract in Laravel that defines its own count method.

I've also removed the `Arrayable` interface from the `MessageBag` class because it's already defined through the `MessageBag` interface. 

Ideally, both `Arrayable` and `Countable` wouldn't exist on the `MessageBag` interface but only on the concrete implementation.
