### PR TITLE
[8.x] Adds XDEBUG_MODE and XDEBUG_CONFIG to the list of env vars that are passed on to the php web server

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -100,7 +100,7 @@ class ServeCommand extends Command
                 return [$key => $value];
             }
 
-            return in_array($key, ['APP_ENV', 'LARAVEL_SAIL', 'PHP_CLI_SERVER_WORKERS'])
+            return in_array($key, ['APP_ENV', 'LARAVEL_SAIL', 'PHP_CLI_SERVER_WORKERS', 'XDEBUG_MODE', 'XDEBUG_CONFIG'])
                     ? [$key => $value]
                     : [$key => false];
         })->all());


### PR DESCRIPTION
Alternative implementation for https://github.com/laravel/framework/pull/38211

---

This is needed for when using a .env file but still need to provide environment variables to PHP or a PHP extension such as xdebug.

Currently, Laravel Sail won't work with xdebug if you provide the configuration thru the XDEBUG_MODE and XDEBUG_CONFIG environment variables because this command doesn't pass the variables onto the php web server. You are forced to provide the xdebug configuration in the php.ini file but that isn't convenient for being able to turn xdebug on/off and switch between modes.

