### PR TITLE
[8.x] Fix: don't wrap database with dots

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -1171,6 +1171,15 @@ class Grammar extends BaseGrammar
             return $this->wrapJsonSelector($value);
         }
 
+        // If a database from another connection is passed and it contains dots.
+        $segments = explode('`.', $value);
+
+        if (count($segments) === 2) {
+            $database = $segments[0];
+
+            return $database.'`.'.$this->wrapSegments(explode('.', $segments[1]));
+        }
+
         return $this->wrapSegments(explode('.', $value));
     }
 


### PR DESCRIPTION
Hello,

We have a use case with 2 separate databases. The particularity is that our databases have the name of the website (eg: www.laravel.com). The wrap function is called to parse columns, and behaves well with a dotless database.

When we make this query :
```php
$model->join('`www.laravel.com`.users.email', '`www.laravel.com`.users.email', '=', '`model`.email', 'left');
 ```
 
 We have this error : 
 ```
 Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '.`users`.`domain` where (```www`.`laravel`.`com```.`users' at line 1
 ```
 
 This pull request checks that a database is not passed and does not apply the wrapSegments on the first part.