### PR TITLE
[8.x] Use type hints in cast.stub to match interface

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/cast.stub
+++ b/src/Illuminate/Foundation/Console/stubs/cast.stub
@@ -15,7 +15,7 @@ class {{ class }} implements CastsAttributes
      * @param  array  $attributes
      * @return mixed
      */
-    public function get($model, $key, $value, $attributes)
+    public function get($model, string $key, $value, array $attributes)
     {
         return $value;
     }
@@ -29,7 +29,7 @@ class {{ class }} implements CastsAttributes
      * @param  array  $attributes
      * @return mixed
      */
-    public function set($model, $key, $value, $attributes)
+    public function set($model, string $key, $value, array $attributes)
     {
         return $value;
     }


### PR DESCRIPTION
The `CastsAttributes` [interface](https://github.com/laravel/framework/blob/8.x/src/Illuminate/Contracts/Database/Eloquent/CastsAttributes.php) uses type hints for the params `$key` and `$attributes`.

This PR adds the same type hints to the `cast.stub`.