### PR TITLE
[8.x] Allow model resources to define their own response class

### DIFF
--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -235,8 +235,7 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
      */
     protected function resolveResourceResponse(): ResourceResponse
     {
-        return tap($this->resourceResponse, function ($resourceResponse) {
-
+        return tap($this->resourceResponse ? new $this->resourceResponse($this) : null, function ($resourceResponse) {
             if (!$resourceResponse) {
                 $resourceResponse = $this->isResourcePaginated()
                     ? new PaginatedResourceResponse($this)

--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -233,21 +233,16 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     /**
      * @return ResourceResponse
      */
-    protected function resolveResourceResponse(): ResourceResponse
+    protected function resolveResourceResponse()
     {
-        return tap($this->resourceResponse ? new $this->resourceResponse($this) : null, function ($resourceResponse) {
-            if (!$resourceResponse) {
-                $resourceResponse = $this->isResourcePaginated()
-                    ? new PaginatedResourceResponse($this)
-                    : new ResourceResponse($this);
-            }
-
-            if (!$resourceResponse instanceof ResourceResponse) {
-                throw new \InvalidArgumentException('Resource resource must be a instance of ResourceResponse.');
-            }
-
-            return $resourceResponse;
-        });
+        if ($this->resourceResponse) {
+            $resourceResponse = new $this->resourceResponse($this);
+        } else {
+            $resourceResponse = $this->isResourcePaginated()
+                ? new PaginatedResourceResponse($this)
+                : new ResourceResponse($this);
+        }
+        return $resourceResponse;
     }
 
     /**

--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -236,13 +236,16 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     protected function resolveResourceResponse()
     {
         if ($this->resourceResponse) {
-            $resourceResponse = new $this->resourceResponse($this);
+            $resourceResponse = $this->resourceResponse;
         } else {
             $resourceResponse = $this->isResourcePaginated()
-                ? new PaginatedResourceResponse($this)
-                : new ResourceResponse($this);
+                ? PaginatedResourceResponse::class
+                : ResourceResponse::class;
         }
-        return $resourceResponse;
+
+        return Container::getInstance()->makeWith($resourceResponse, [
+            'resource' => $this,
+        ]);
     }
 
     /**

--- a/src/Illuminate/Http/Resources/Json/ResourceCollection.php
+++ b/src/Illuminate/Http/Resources/Json/ResourceCollection.php
@@ -114,7 +114,7 @@ class ResourceCollection extends JsonResource implements Countable, IteratorAggr
             $this->preparePaginatedResponse($request);
         }
 
-        $this->resolveResourceResponse()
+        return $this->resolveResourceResponse()
             ->toResponse($request);
     }
 

--- a/src/Illuminate/Http/Resources/Json/ResourceCollection.php
+++ b/src/Illuminate/Http/Resources/Json/ResourceCollection.php
@@ -110,18 +110,19 @@ class ResourceCollection extends JsonResource implements Countable, IteratorAggr
      */
     public function toResponse($request)
     {
-        if ($this->resource instanceof AbstractPaginator || $this->resource instanceof AbstractCursorPaginator) {
-            return $this->preparePaginatedResponse($request);
+        if ($this->isResourcePaginated()) {
+            $this->preparePaginatedResponse($request);
         }
 
-        return parent::toResponse($request);
+        $this->resolveResourceResponse()
+            ->toResponse($request);
     }
 
     /**
      * Create a paginate-aware HTTP response.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\JsonResponse
+     * @return void
      */
     protected function preparePaginatedResponse($request)
     {
@@ -130,7 +131,5 @@ class ResourceCollection extends JsonResource implements Countable, IteratorAggr
         } elseif (! is_null($this->queryParameters)) {
             $this->resource->appends($this->queryParameters);
         }
-
-        return (new PaginatedResourceResponse($this))->toResponse($request);
     }
 }

--- a/tests/Integration/Http/Fixtures/PostCollectionResourceWithCustomResponsable.php
+++ b/tests/Integration/Http/Fixtures/PostCollectionResourceWithCustomResponsable.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http\Fixtures;
+
+use Illuminate\Http\Resources\Json\ResourceCollection;
+
+class PostCollectionResourceWithCustomResponsable extends ResourceCollection
+{
+    public $collects = PostResource::class;
+
+    public $resourceResponse = PostResourcePaginatedResponse::class;
+
+    public function toArray($request)
+    {
+        return ['data' => $this->collection];
+    }
+}

--- a/tests/Integration/Http/Fixtures/PostResourcePaginatedResponse.php
+++ b/tests/Integration/Http/Fixtures/PostResourcePaginatedResponse.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Illuminate\Tests\Integration\Http\Fixtures;
+
+use Illuminate\Http\Resources\Json\PaginatedResourceResponse;
+use Illuminate\Pagination\AbstractCursorPaginator;
+
+class PostResourcePaginatedResponse extends PaginatedResourceResponse
+{
+    /**
+     * Add the pagination information to the response.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    protected function paginationInformation($request)
+    {
+        /** @var AbstractCursorPaginator $paginator */
+        $paginator = $this->resource;
+
+        return [
+            'cursor' => $paginator->cursor()->encode(),
+        ];
+    }
+}

--- a/tests/Integration/Http/Fixtures/PostResourceResponse.php
+++ b/tests/Integration/Http/Fixtures/PostResourceResponse.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+namespace Illuminate\Tests\Integration\Http\Fixtures;
+
+use Illuminate\Http\Resources\Json\ResourceResponse;
+
+class PostResourceResponse extends ResourceResponse
+{
+    public function calculateStatus()
+    {
+        return 200;
+    }
+}

--- a/tests/Integration/Http/Fixtures/PostResourceWithCustomResponsable.php
+++ b/tests/Integration/Http/Fixtures/PostResourceWithCustomResponsable.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http\Fixtures;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class PostResourceWithCustomResponsable extends JsonResource
+{
+    public $resourceResponse = PostResourceResponse::class;
+
+    public function toArray($request)
+    {
+        return ['id' => $this->id, 'title' => $this->title, 'custom' => true];
+    }
+
+    public function withResponse($request, $response)
+    {
+        $response->header('X-Resource', 'True');
+    }
+}

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -684,7 +684,7 @@ class ResourceTest extends TestCase
         ]);
     }
 
-    public function testResourceWithCustomResponsableClass()
+    public function testResourceWithCustomResponsable()
     {
         Route::get('/', function () {
                 $post = new Post(['id' => 5, 'title' => 'Test Title']);
@@ -696,7 +696,7 @@ class ResourceTest extends TestCase
         $response = $this->withoutExceptionHandling()->get(
             '/', ['Accept' => 'application/json']
         );
-
+        // the custom resource response is setup to always return 200 even when we freshly create a new model in the request.
         $response->assertStatus(200);
     }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

### Motivation:
We have strict API standards that we need to follow in our responses, for pagination; we need to return a single `cursor` value. I would like to create a base pagination resource response class that our application can use for all resources.

### Benefits:
This will give folks more flexibility while maintaining BC

Resource response to be resolved by the container, allowing folks to DI any other classes into their response class -- for example a custom cursor.

