### PR TITLE
[9.x] Separate Bootable Trait

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,7 @@
     },
     "replace": {
         "illuminate/auth": "self.version",
+        "illuminate/bootable": "self.version",
         "illuminate/broadcasting": "self.version",
         "illuminate/bus": "self.version",
         "illuminate/cache": "self.version",
@@ -106,7 +107,11 @@
         ],
         "psr-4": {
             "Illuminate\\": "src/Illuminate/",
-            "Illuminate\\Support\\": ["src/Illuminate/Macroable/", "src/Illuminate/Collections/"]
+            "Illuminate\\Support\\": [
+                "src/Illuminate/Bootable/",
+                "src/Illuminate/Collections/",
+                "src/Illuminate/Macroable/"
+            ]
         }
     },
     "autoload-dev": {

--- a/src/Illuminate/Bootable/LICENSE.md
+++ b/src/Illuminate/Bootable/LICENSE.md
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) Taylor Otwell
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Illuminate/Bootable/Traits/HasBootableTraits.php
+++ b/src/Illuminate/Bootable/Traits/HasBootableTraits.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace Illuminate\Support\Traits;
+
+trait HasBootableTraits
+{
+    /**
+     * The array of booted instances.
+     *
+     * @var array
+     */
+    protected static $booted = [];
+
+    /**
+     * The array of trait initializers that will be called on each new instance.
+     *
+     * @var array
+     */
+    protected static $traitInitializers = [];
+
+    /**
+     * Create a new instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->bootIfNotBooted();
+
+        $this->initializeTraits();
+    }
+
+    /**
+     * Get the event method name.
+     *
+     * @return string
+     */
+    protected static function getBootEventMethod()
+    {
+        return static::$bootEventMethod ?? 'fireEvent';
+    }
+
+    /**
+     * Check if the instance needs to be booted and if so, do it.
+     *
+     * @return void
+     */
+    protected function bootIfNotBooted()
+    {
+        if (! isset(static::$booted[static::class])) {
+            static::$booted[static::class] = true;
+
+            $this->{static::getBootEventMethod()}('booting', false);
+
+            static::booting();
+            static::boot();
+            static::booted();
+
+            $this->{static::getBootEventMethod()}('booted', false);
+        }
+    }
+
+    /**
+     * Fire the given event for the instance.
+     *
+     * @param string $event
+     * @param bool   $halt
+     *
+     * @return mixed
+     */
+    protected function fireEvent($event, $halt = true)
+    {
+        //
+    }
+
+    /**
+     * Perform any actions required before the instance boots.
+     *
+     * @return void
+     */
+    protected static function booting()
+    {
+        //
+    }
+
+    /**
+     * Bootstrap the instance and its traits.
+     *
+     * @return void
+     */
+    protected static function boot()
+    {
+        static::bootTraits();
+    }
+
+    /**
+     * Boot all of the bootable traits on the instance.
+     *
+     * @return void
+     */
+    protected static function bootTraits()
+    {
+        $class = static::class;
+
+        $booted = [];
+
+        static::$traitInitializers[$class] = [];
+
+        foreach (class_uses_recursive($class) as $trait) {
+            $method = 'boot'.class_basename($trait);
+
+            if (method_exists($class, $method) && ! in_array($method, $booted)) {
+                forward_static_call([$class, $method]);
+
+                $booted[] = $method;
+            }
+
+            if (method_exists($class, $method = 'initialize'.class_basename($trait))) {
+                static::$traitInitializers[$class][] = $method;
+
+                static::$traitInitializers[$class] = array_unique(
+                    static::$traitInitializers[$class]
+                );
+            }
+        }
+    }
+
+    /**
+     * Perform any actions required after the instance boots.
+     *
+     * @return void
+     */
+    protected static function booted()
+    {
+        //
+    }
+
+    /**
+     * Initialize any initializable traits on the instance.
+     *
+     * @return void
+     */
+    protected function initializeTraits()
+    {
+        foreach (static::$traitInitializers[static::class] as $method) {
+            $this->{$method}();
+        }
+    }
+
+    protected static function clearBooted(): void
+    {
+        static::$booted = [];
+    }
+
+    /**
+     * When a instance is being unserialized, check if it needs to be booted.
+     *
+     * @return void
+     */
+    public function __wakeup()
+    {
+        $this->bootIfNotBooted();
+
+        $this->initializeTraits();
+    }
+}

--- a/src/Illuminate/Bootable/composer.json
+++ b/src/Illuminate/Bootable/composer.json
@@ -1,0 +1,34 @@
+{
+    "name": "illuminate/bootable",
+    "description": "The Illuminate Bootable package.",
+    "license": "MIT",
+    "homepage": "https://laravel.com",
+    "support": {
+        "issues": "https://github.com/laravel/framework/issues",
+        "source": "https://github.com/laravel/framework"
+    },
+    "authors": [
+        {
+            "name": "Taylor Otwell",
+            "email": "taylor@laravel.com"
+        }
+    ],
+    "require": {
+        "php": "^7.4|^8.0",
+        "illuminate/support": "^9.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Illuminate\\Support\\": ""
+        }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "9.x-dev"
+        }
+    },
+    "config": {
+        "sort-packages": true
+    },
+    "minimum-stability": "dev"
+}

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -20,6 +20,7 @@
         "illuminate/collections": "^9.0",
         "illuminate/container": "^9.0",
         "illuminate/contracts": "^9.0",
+        "illuminate/bootable": "^9.0",
         "illuminate/macroable": "^9.0",
         "illuminate/support": "^9.0",
         "symfony/console": "^5.3"


### PR DESCRIPTION
I propose to put it in a separate package for use not only in the model.

Usage:
```php
<?php

namespace App\Services;

use App\Traits\SomeTrait;
use Illuminate\Support\Traits\HasBootableTraits;

class ApiService
{
    use HasBootableTraits, SomeTrait;
}

class CrawlerService
{
    use HasBootableTraits {__construct as bootConstruct;}
    use SomeTrait;

    public function __construct()
    {
        $this->bootConstruct();

        // OR

        $this->bootIfNotBooted();

        $this->initializeTraits();
    }
}

```
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
