### PR TITLE
[8.x] Allow api resource to not wrap when merging per resource

### DIFF
--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -6,6 +6,8 @@ use Illuminate\Support\Arr;
 
 trait ConditionallyLoadsAttributes
 {
+    protected $wrapOnMerge = true;
+
     /**
      * Filter the given data, removing any optional values.
      *
@@ -34,6 +36,10 @@ trait ConditionallyLoadsAttributes
 
             if ($value instanceof self && is_null($value->resource)) {
                 $data[$key] = null;
+            }
+
+            if ($value instanceof MergeValue && !$this->wrapOnMerge) {
+                $data[$key] = $value->data;
             }
         }
 

--- a/tests/Integration/Http/Fixtures/PostResourceWithNoMergeWrap.php
+++ b/tests/Integration/Http/Fixtures/PostResourceWithNoMergeWrap.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http\Fixtures;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class PostResourceWithNoMergeWrap extends JsonResource
+{
+    protected $wrapOnMerge = false;
+
+    public function toArray($request)
+    {
+        return [
+            'name' => $this->resource->name,
+            'preferences' => $this->mergeWhen(true, ['id' => '1', 'name' => 'shop all'])
+        ];
+    }
+}

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -19,6 +19,7 @@ use Illuminate\Tests\Integration\Http\Fixtures\Post;
 use Illuminate\Tests\Integration\Http\Fixtures\PostCollectionResource;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResource;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithExtraData;
+use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithNoMergeWrap;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalAppendedAttributes;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalData;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalMerging;
@@ -987,6 +988,24 @@ class ResourceTest extends TestCase
         $this->assertEquals([
             'name' => 'mohamed', 'location' => 'hurghada',
         ], $results);
+    }
+
+    public function testMergeIsNotWrapped()
+    {
+
+        $resource = new PostResourceWithNoMergeWrap(new Post(['name' => 'hello']));
+
+        $results = json_decode($resource->toResponse($this->app['request'])->getContent(), true);
+
+        $expected = [
+            'name' => 'hello',
+            'preferences' => [
+                'id' => '1',
+                'name' => 'shop all',
+            ],
+        ];
+
+        $this->assertEquals($expected, $results['data']);
     }
 
     public function testLeadingMergeKeyedValueIsMergedCorrectlyWhenFirstValueIsMissing()


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Currently, when merging your data is wrapped in `data` because of `MergeValue#data`, more info here:
https://github.com/laravel/framework/issues/21052

^, I tried doing the work around but then you end up with the key and null value, i dont want the key present at all when the merge constraint is false.

This PR allows a API resource to not wrap when merging.
