### PR TITLE
[8.x] Fix signed routes

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -319,7 +319,7 @@ class UrlGenerator implements UrlGeneratorContract
     public function signedRoute($name, $parameters = [], $expiration = null, $absolute = true)
     {
         $this->ensureSignedRouteParametersAreNotReserved(
-            $parameters = $this->formatParameters($parameters)
+            $parameters = Arr::wrap($parameters)
         );
 
         if ($expiration) {

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Routing;
 
 use Illuminate\Contracts\Routing\UrlRoutable;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Exceptions\UrlGenerationException;
 use Illuminate\Routing\Route;
@@ -690,6 +691,28 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertFalse($url->hasValidSignature($request));
     }
 
+    public function testSignedUrlImplicitModelBinding()
+    {
+        $url = new UrlGenerator(
+            $routes = new RouteCollection,
+            $request = Request::create('http://www.foo.com/')
+        );
+        $url->setKeyResolver(function () {
+            return 'secret';
+        });
+
+        $route = new Route(['GET'], 'foo/{user:uuid}', ['as' => 'foo', function () {
+            //
+        }]);
+        $routes->add($route);
+
+        $user = new RoutingUrlGeneratorTestUser(['uuid' => '0231d4ac-e9e3-4452-a89a-4427cfb23c3e']);
+
+        $request = Request::create($url->signedRoute('foo', $user));
+
+        $this->assertTrue($url->hasValidSignature($request));
+    }
+
     public function testSignedRelativeUrl()
     {
         $url = new UrlGenerator(
@@ -791,4 +814,9 @@ class InvokableActionStub
     {
         return 'hello';
     }
+}
+
+class RoutingUrlGeneratorTestUser extends Model
+{
+    protected $fillable = ['uuid'];
 }


### PR DESCRIPTION
After merging https://github.com/laravel/framework/pull/38111 a new formatting commit was made (https://github.com/laravel/framework/commit/732c0e0f64b222e7fc7daef6553f8e99007bb32c). I suspect while merging 6.x into 8.x something went amis with resolving some conflicts and the 6.x formatting was adopted instead of the newer 8.x formatting: https://github.com/laravel/framework/commit/67428eb8bacd4103c771f3143edba28c34f5d7fb#diff-1c99b8c24a0f2a0d87cf056dffb3a4504825a2f7fb4fe55dbdfb5d86742f3c5aL321-R323

Fixes https://github.com/laravel/framework/issues/38248