### PR TITLE
[8.x] Fix null values with cursor pagination

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -315,11 +315,13 @@ trait BuildsQueries
                 $builder->where(function (self $builder) use ($addCursorConditions, $cursor, $orders, $i) {
                     ['column' => $column, 'direction' => $direction] = $orders[$i];
 
-                    $builder->where(
-                        $this->getOriginalColumnNameForCursorPagination($this, $column),
-                        $direction === 'asc' ? '>' : '<',
-                        $cursor->parameter($column)
-                    );
+                    if (! is_null($parameter = $cursor->parameter($column))) {
+                        $builder->where(
+                            $this->getOriginalColumnNameForCursorPagination($this, $column),
+                            $direction === 'asc' ? '>' : '<',
+                            $parameter
+                        );
+                    }
 
                     if ($i < $orders->count() - 1) {
                         $builder->orWhere(function (self $builder) use ($addCursorConditions, $column, $i) {


### PR DESCRIPTION
`null` values should be ignored when applying where conditions on cursor pagination.

Fixes https://github.com/laravel/framework/issues/38220