### PR TITLE
[8.x] Fix aliasing with cursor pagination

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -354,8 +354,10 @@ trait BuildsQueries
 
         if (! is_null($columns)) {
             foreach ($columns as $column) {
-                if (stripos($column, ' as ') !== false) {
-                    [$original, $alias] = explode(' as ', $column);
+                if (($position = stripos($column, ' as ')) !== false) {
+                    $as = substr($column, $position, 4);
+
+                    [$original, $alias] = explode($as, $column);
 
                     if ($parameter === $alias) {
                         return $original;


### PR DESCRIPTION
This fixes an issue with capitalization of aliases in cursor pagination. Atm "as" was targetted so if anyone is using the equivalent "AS" instead, the aliases will be ignored. The new way of substrating the alias and exploding on that will fix this.
