### PR TITLE
[8.x] Use 'many' to reduce the number of requests when setting tag ids

### DIFF
--- a/src/Illuminate/Cache/TagSet.php
+++ b/src/Illuminate/Cache/TagSet.php
@@ -102,8 +102,7 @@ class TagSet
     protected function resetTags($tagIds)
     {
         $result = [];
-        foreach ($tagIds as $tagId)
-        {
+        foreach ($tagIds as $tagId) {
             if ($this->store->forever($tagId, $id = str_replace('.', '', uniqid('', true)))) {
                 $result[$tagId] = $id;
             }

--- a/src/Illuminate/Cache/TagSet.php
+++ b/src/Illuminate/Cache/TagSet.php
@@ -72,8 +72,44 @@ class TagSet
      * @return array
      */
     protected function tagIds()
+    {   
+        return $this->fillTagIds($this->store->many(array_map([$this, 'tagKey'], $this->names)));
+    }
+
+    protected function fillTagIds($tagIds)
     {
-        return array_map([$this, 'tagId'], $this->names);
+        $missingTagIds = $this->getMissingTagIds($tagIds);
+
+        if (!count($missingTagIds) || !($setTagIds = $this->resetTags($missingTagIds))) {
+            return $tagIds;
+        }
+
+        return array_merge($tagIds, $setTagIds);
+    }
+
+    protected function getMissingTagIds($tagIds)
+    {
+        $missingTagIds = [];
+        foreach($tagIds as $key => $value) {
+            if (is_null($value)) {
+                $missingTagIds[] = $key;
+            }
+        }
+
+        return $missingTagIds;
+    }
+
+    protected function resetTags($tagIds)
+    {
+        $result = [];
+        foreach($tagIds as $tagId)
+        {
+            if ($this->store->forever($tagId, $id = str_replace('.', '', uniqid('', true)))) {
+                $result[$tagId] = $id;
+            }
+        }
+
+        return $result;
     }
 
     /**

--- a/src/Illuminate/Cache/TagSet.php
+++ b/src/Illuminate/Cache/TagSet.php
@@ -73,21 +73,16 @@ class TagSet
      */
     protected function tagIds()
     {
-        return $this->fillTagIds($this->store->many(array_map([$this, 'tagKey'], $this->names)));
+        return $this->setMissingTagIds($this->store->many(array_map([$this, 'tagKey'], $this->names)));
     }
 
-    protected function fillTagIds($tagIds)
-    {
-        $missingTagIds = $this->getMissingTagIds($tagIds);
-
-        if (! count($missingTagIds) || ! ($setTagIds = $this->resetTags($missingTagIds))) {
-            return $tagIds;
-        }
-
-        return array_merge($tagIds, $setTagIds);
-    }
-
-    protected function getMissingTagIds($tagIds)
+    /**
+     * Finds and sets missing tag ids
+     * 
+     * @param array $tagIds
+     * @return array  
+     */
+    protected function setMissingTagIds($tagIds)
     {
         $missingTagIds = [];
         foreach ($tagIds as $key => $value) {
@@ -96,9 +91,16 @@ class TagSet
             }
         }
 
-        return $missingTagIds;
+        if (! count($missingTagIds) || ! ($setTagIds = $this->resetTags($missingTagIds))) {
+            return $tagIds;
+        }
+
+        return array_merge($tagIds, $setTagIds);
     }
 
+    /**
+     * Resets multiple tags and once and returns the new identifier.
+     */
     protected function resetTags($tagIds)
     {
         $result = [];

--- a/src/Illuminate/Cache/TagSet.php
+++ b/src/Illuminate/Cache/TagSet.php
@@ -72,7 +72,7 @@ class TagSet
      * @return array
      */
     protected function tagIds()
-    {   
+    {
         return $this->fillTagIds($this->store->many(array_map([$this, 'tagKey'], $this->names)));
     }
 
@@ -80,7 +80,7 @@ class TagSet
     {
         $missingTagIds = $this->getMissingTagIds($tagIds);
 
-        if (!count($missingTagIds) || !($setTagIds = $this->resetTags($missingTagIds))) {
+        if (! count($missingTagIds) || ! ($setTagIds = $this->resetTags($missingTagIds))) {
             return $tagIds;
         }
 
@@ -90,7 +90,7 @@ class TagSet
     protected function getMissingTagIds($tagIds)
     {
         $missingTagIds = [];
-        foreach($tagIds as $key => $value) {
+        foreach ($tagIds as $key => $value) {
             if (is_null($value)) {
                 $missingTagIds[] = $key;
             }
@@ -102,7 +102,7 @@ class TagSet
     protected function resetTags($tagIds)
     {
         $result = [];
-        foreach($tagIds as $tagId)
+        foreach ($tagIds as $tagId)
         {
             if ($this->store->forever($tagId, $id = str_replace('.', '', uniqid('', true)))) {
                 $result[$tagId] = $id;

--- a/src/Illuminate/Cache/TagSet.php
+++ b/src/Illuminate/Cache/TagSet.php
@@ -78,9 +78,9 @@ class TagSet
 
     /**
      * Finds and sets missing tag ids
-     * 
+     *
      * @param array $tagIds
-     * @return array  
+     * @return array
      */
     protected function setMissingTagIds($tagIds)
     {

--- a/src/Illuminate/Cache/TagSet.php
+++ b/src/Illuminate/Cache/TagSet.php
@@ -77,7 +77,7 @@ class TagSet
     }
 
     /**
-     * Finds and sets missing tag ids
+     * Finds and sets missing tag ids.
      *
      * @param array $tagIds
      * @return array


### PR DESCRIPTION
Instead of calling `get` for each tag ID this switches to a `many` call. For the RedisStore it'll use `mget` instead of multiple `get` calls and reduce cache requests.

If this is a change you want to commit we can also consider:

* Adding in a RedisTagSet that'll override resetTags to do that in one call instead of multiple
* Changing RedisTaggedCache::pushKeys to be a LuaScript instead of multiple sadd calls
 
I've been working on both, but haven't written tests and didn't want to continue until I understood the desire for any of this to be in the framework.