### PR TITLE
[8.x] MySQL json_search support

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1656,6 +1656,73 @@ class Builder
     }
 
     /**
+     * Add a "where JSON search/find" clause to the query.
+     *
+     * @param  string  $column
+     * @param  mixed  $value
+     * @param  string  $one_or_all
+     * @param  string  $escape_char
+     * @param  string  $boolean
+     * @param  bool  $not
+     * @return $this
+     */
+    public function whereJsonFinds($column, $value = null, $one_or_all = 'one', $escape_char = null, $boolean = 'and', $not = false)
+    {
+        $type = 'JsonFinds';
+
+        $this->wheres[] = compact('type', 'column', 'value', 'one_or_all', 'escape_char', 'boolean', 'not');
+
+        if (! $value instanceof Expression) {
+            $this->addBinding($this->flattenValue($value));
+        }
+
+        return $this;
+    }
+
+    /**
+     * Add an "or where JSON search/find" clause to the query.
+     *
+     * @param  string  $column
+     * @param  mixed  $value
+     * @param  string  $one_or_all
+     * @param  string  $escape_char
+     * @return $this
+     */
+    public function orWhereJsonFinds($column, $value, $one_or_all = 'one', $escape_char = null)
+    {
+        return $this->whereJsonFinds($column, $value, $one_or_all, $escape_char, 'or');
+    }
+
+    /**
+     * Add a "where JSON not search/find" clause to the query.
+     *
+     * @param  string  $column
+     * @param  mixed  $value
+     * @param  string  $one_or_all
+     * @param  string  $escape_char
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereJsonDoesntFind($column, $value, $one_or_all = 'one', $escape_char = null, $boolean = 'and')
+    {
+        return $this->whereJsonFinds($column, $value, $one_or_all, $escape_char, $boolean, true);
+    }
+
+    /**
+     * Add an "or where JSON not search/find" clause to the query.
+     *
+     * @param  string  $column
+     * @param  mixed  $value
+     * @param  string  $one_or_all
+     * @param  string  $escape_char
+     * @return $this
+     */
+    public function orWhereJsonDoesntFind($column, $value, $one_or_all = 'one', $escape_char = null)
+    {
+        return $this->whereJsonDoesntFind($column, $value, $one_or_all, $escape_char, 'or');
+    }
+
+    /**
      * Add a "where JSON contains" clause to the query.
      *
      * @param  string  $column

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -560,6 +560,38 @@ class Grammar extends BaseGrammar
     }
 
     /**
+     * Compile a "where JSON search/find" clause.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereJsonFinds(Builder $query, $where)
+    {
+        $not = $where['not'] ? 'not ' : '';
+
+        return $not.$this->compileJsonFinds(
+            $where['column'], $this->parameter($where['value']), $where['one_or_all'], $where['escape_char']
+        );
+    }
+
+    /**
+     * Compile a "JSON search/find" statement into SQL.
+     *
+     * @param  string  $column
+     * @param  string  $value
+     * @param  string  $one_or_all
+     * @param  string  $escape_char
+     * @return string
+     *
+     * @throws \RuntimeException
+     */
+    protected function compileJsonFinds($column, $value, $one_or_all, $escape_char)
+    {
+        throw new RuntimeException('This database engine does not support JSON search operations.');
+    }
+
+    /**
      * Compile a "where JSON contains" clause.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -63,6 +63,23 @@ class MySqlGrammar extends Grammar
     }
 
     /**
+     * Compile a "JSON search/find" statement into SQL.
+     *
+     * @param  string  $column
+     * @param  string  $value
+     * @param  string  $one_or_all
+     * @param  string  $escape_char
+     * @return string
+     */
+    protected function compileJsonFinds($column, $value, $one_or_all, $escape_char)
+    {
+        [$field, $path] = $this->wrapJsonFieldAndPath($column);
+        $escape_char = $escape_char === null ? 'NULL' : "'$escape_char'";
+
+        return 'json_search('.$field.', \''.$one_or_all.'\', '.$value.', '.$escape_char.$path.') != \'NULL\'';
+    }
+
+    /**
      * Compile a "JSON contains" statement into SQL.
      *
      * @param  string  $column


### PR DESCRIPTION
This PR requests adds `whereJsonFinds`, `orWhereJsonFinds`, `whereJsonDoesntFind`, `orWhereJsonDoesntFind` to ease json_search queries.

Let's take as an example the following model's table where the `name` column is localized using a json datatype.
| name | country |
|-|-|
|{"en": "New York", "es": "Nueva York"}|'US'|
|{"en": "York", "es": "Jamón"}|'GB'|
|{"en": "New Glasgow", "es": "Nuevo Glasgow"}|'CA'|
|{"en": "Newark", "es": "Newark"}|'US'|

With this new helper functions we could easily retrieve all the records whose name (in any language) match a query string.
Example:
```php
City::whereJsonFinds('name', 'York');
// {"name": {"en": "York", "es": "Jamón"}, "country": "GB"}
```  
or even
```php
City::where('country', 'US')->whereJsonFinds('name', 'Ne%');
// {"name": {"en": "New York", "es": "Nueva York"}, "country": "US"}
// {"name": {"en": "Newark", "es": "Newark"}, "country": "US"}
```  