### PR TITLE
[8.x]Collection prevent null being added to resulting collection with pop and shift

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -965,6 +965,8 @@ class Collection implements ArrayAccess, Enumerable
 
         $results = [];
 
+        $count = $count > $this->count() ? $this->count() : $count;
+
         foreach (range(1, $count) as $item) {
             array_push($results, array_shift($this->items));
         }

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -799,6 +799,8 @@ class Collection implements ArrayAccess, Enumerable
 
         $results = [];
 
+        $count = $count > $this->count() ? $this->count() : $count;
+
         foreach (range(1, $count) as $item) {
             array_push($results, array_pop($this->items));
         }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -258,6 +258,13 @@ class SupportCollectionTest extends TestCase
         $this->assertSame('baz', $data->first());
     }
 
+    public function testShiftOnlyReturnsCollectionItemsWhenParamGreaterThanCollectionLength()
+    {
+        $c = new Collection(['foo', 'bar']);
+        $this->assertEquals(new Collection(['foo', 'bar']), $c->shift(3));
+        $this->assertEmpty($c);
+    }
+
     /**
      * @dataProvider collectionClassProvider
      */

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -233,6 +233,13 @@ class SupportCollectionTest extends TestCase
         $this->assertSame('foo', $c->first());
     }
 
+    public function testPopOnlyReturnsCollectionItemsWhenParamGreaterThanCollectionLength()
+    {
+        $c = new Collection(['foo', 'bar']);
+        $this->assertEquals(new Collection(['bar', 'foo']), $c->pop(3));
+        $this->assertEmpty($c);
+    }
+
     public function testShiftReturnsAndRemovesFirstItemInCollection()
     {
         $data = new Collection(['Taylor', 'Otwell']);


### PR DESCRIPTION

In [this PR](https://github.com/laravel/framework/pull/38093) the ability to pop and shift a specified number of items from a collection was added.
However, if the supplied parameter is outside the bounds of the collection `NULL` values are added to the end of the collection.

```
    $collect = collect([1, 2, 3 , 4]);

    $collect->shift(6);

    // collect([1, 2, 3, 4, NULL, NULL])
```

This PR adds checks to the parameter passed to the `pop` and `shift` methods and if out of bounds returns **only** the items in the collection. This is in line with the behaviour of `splice` and `take` which do not add null values if the parameter is out of bounds