### PR TITLE
[8.x] Collection prevent null being added to resulting collection with pop and shift

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -965,6 +965,8 @@ class Collection implements ArrayAccess, Enumerable
 
         $results = [];
 
+        $count = $count > $this->count() ? $this->count() : $count;
+
         foreach (range(1, $count) as $item) {
             array_push($results, array_shift($this->items));
         }

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -795,7 +795,7 @@ class Collection implements ArrayAccess, Enumerable
     {
         if ($count < 1 || $this->count() === 0) {
             return null;
-        } 
+        }
 
         if ($count === 1) {
             return array_pop($this->items);

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -797,6 +797,8 @@ class Collection implements ArrayAccess, Enumerable
             return array_pop($this->items);
         }
 
+        $count = $count > $this->count() ? $this->count() : $count;
+
         $results = [];
 
         foreach (range(1, $count) as $item) {

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -793,12 +793,13 @@ class Collection implements ArrayAccess, Enumerable
      */
     public function pop($count = 1)
     {
-        if ($count < 1 || $this->count() === 0) {
-            return null;
-        }
 
         if ($count === 1) {
             return array_pop($this->items);
+        }
+
+        if ($count < 1 || $this->count() === 0) {
+            return new static([]);
         }
 
         $count = $count > $this->count() ? $this->count() : $count;
@@ -963,12 +964,12 @@ class Collection implements ArrayAccess, Enumerable
      */
     public function shift($count = 1)
     {
-        if ($count < 1 || $this->count() === 0) {
-            return null;
-        }
-
         if ($count === 1) {
             return array_shift($this->items);
+        }
+
+        if ($count < 1 || $this->count() === 0) {
+            return new static([]);
         }
 
         $results = [];

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -788,13 +788,12 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get and remove the last N items from the collection.
      *
-     * @param  int  $count
+     * @param  int|null  $count
      * @return mixed
      */
-    public function pop($count = 1)
+    public function pop($count = null)
     {
-
-        if ($count === 1) {
+        if (is_null($count)) {
             return array_pop($this->items);
         }
 
@@ -959,12 +958,12 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get and remove the first N items from the collection.
      *
-     * @param  int  $count
+     * @param  int|null  $count
      * @return mixed
      */
-    public function shift($count = 1)
+    public function shift($count = null)
     {
-        if ($count === 1) {
+        if (is_null($count)) {
             return array_shift($this->items);
         }
 

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -793,6 +793,10 @@ class Collection implements ArrayAccess, Enumerable
      */
     public function pop($count = 1)
     {
+        if ($count < 1 || $this->count() === 0) {
+            return null;
+        } 
+
         if ($count === 1) {
             return array_pop($this->items);
         }
@@ -959,6 +963,10 @@ class Collection implements ArrayAccess, Enumerable
      */
     public function shift($count = 1)
     {
+        if ($count < 1 || $this->count() === 0) {
+            return null;
+        }
+
         if ($count === 1) {
             return array_shift($this->items);
         }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -258,6 +258,13 @@ class SupportCollectionTest extends TestCase
         $this->assertSame('baz', $data->first());
     }
 
+    public function testShiftOnlyReturnsCollectionItemsWhenParamGreaterThanCollectionLength()
+    {
+        $c = new Collection(['foo', 'bar']);
+        $this->assertEquals(new Collection(['foo', 'bar']), $c->shift(3));
+        $this->assertEmpty($c);
+    }
+
     /**
      * @dataProvider collectionClassProvider
      */

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -248,10 +248,10 @@ class SupportCollectionTest extends TestCase
         $this->assertSame('foo', $c->first());
     }
 
-    public function testPopReturnsNullWhenNoItemsInCollection()
+    public function testPopReturnsNullWhenNoItemsInCollectionAndParamSupplied()
     {
         $c = new Collection([]);
-        $this->assertNull($c->pop());
+        $this->assertEquals(new Collection([]), $c->pop(2));
         $this->assertCount(0, $c);
     }
 
@@ -287,10 +287,10 @@ class SupportCollectionTest extends TestCase
         $this->assertCount(2, $c);
     }
 
-    public function testShiftReturnsNullWhenNoItemsInCollection()
+    public function testShiftReturnsNullWhenNoItemsInCollectionAndParamSupplied()
     {
         $c = new Collection([]);
-        $this->assertNull($c->shift());
+        $this->assertEquals(new Collection([]), $c->shift(2));
         $this->assertCount(0, $c);
     }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -240,6 +240,20 @@ class SupportCollectionTest extends TestCase
         $this->assertEmpty($c);
     }
 
+    public function testPopReturnsNullWhenParameterLessThanOne()
+    {
+        $c = new Collection(['foo', 'bar']);
+        $this->assertNull($c->pop(0));
+        $this->assertCount(2, $c);
+    }
+
+    public function testPopReturnsNullWhenNoItemsInCollection()
+    {
+        $c = new Collection([]);
+        $this->assertNull($c->pop());
+        $this->assertCount(0, $c);
+    }
+
     public function testShiftReturnsAndRemovesFirstItemInCollection()
     {
         $data = new Collection(['Taylor', 'Otwell']);
@@ -263,6 +277,20 @@ class SupportCollectionTest extends TestCase
         $c = new Collection(['foo', 'bar']);
         $this->assertEquals(new Collection(['foo', 'bar']), $c->shift(3));
         $this->assertEmpty($c);
+    }
+
+    public function testShiftReturnsNullWhenParameterLessThanOne()
+    {
+        $c = new Collection(['foo', 'bar']);
+        $this->assertNull($c->shift(0));
+        $this->assertCount(2, $c);
+    }
+
+    public function testShiftReturnsNullWhenNoItemsInCollection()
+    {
+        $c = new Collection([]);
+        $this->assertNull($c->shift());
+        $this->assertCount(0, $c);
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -233,6 +233,13 @@ class SupportCollectionTest extends TestCase
         $this->assertSame('foo', $c->first());
     }
 
+    public function testPopOnlyReturnsCollectionItemsWhenParamGreaterThanCollectionLength()
+    {
+        $c = new Collection(['foo', 'bar']);
+        $this->assertEquals(new Collection(['bar', 'foo']), $c->pop(3));
+        $this->assertEmpty($c);
+    }
+
     public function testShiftReturnsAndRemovesFirstItemInCollection()
     {
         $data = new Collection(['Taylor', 'Otwell']);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -240,11 +240,12 @@ class SupportCollectionTest extends TestCase
         $this->assertEmpty($c);
     }
 
-    public function testPopReturnsNullWhenParameterLessThanOne()
+    public function testPopReturnsEmptyCollectionWhenParameterLessThanOne()
     {
-        $c = new Collection(['foo', 'bar']);
-        $this->assertNull($c->pop(0));
-        $this->assertCount(2, $c);
+        $c = new Collection(['foo', 'bar', 'baz']);
+
+        $this->assertEquals(new Collection([]), $c->pop(0));
+        $this->assertSame('foo', $c->first());
     }
 
     public function testPopReturnsNullWhenNoItemsInCollection()
@@ -279,10 +280,10 @@ class SupportCollectionTest extends TestCase
         $this->assertEmpty($c);
     }
 
-    public function testShiftReturnsNullWhenParameterLessThanOne()
+    public function testShiftReturnsEmptyColeectionWhenParameterLessThanOne()
     {
         $c = new Collection(['foo', 'bar']);
-        $this->assertNull($c->shift(0));
+        $this->assertEquals(new Collection([]), $c->shift(0));
         $this->assertCount(2, $c);
     }
 


### PR DESCRIPTION
## ISSUE
In [this PR](https://github.com/laravel/framework/pull/38093) the ability to pop and shift a specified number of items from a collection was added.
However, if the supplied parameter is outside the bounds of the collection `NULL` values are added to the end of the collection.

```
    $collect = collect([1, 2, 3 , 4]);

    $collect->shift(6);

    // collect([1, 2, 3, 4, NULL, NULL])
```

this is also the same for negative parameters, and for when the collection is empty

## changes in this pr

This PR adds checks to the parameter passed to the `pop` and `shift` methods and if out of bounds returns **only** the items in the collection. This is in line with the behaviour of `splice` and `take` which do not add null values if the parameter is out of bounds.

return null when the collection is empty and a parameter is passed to the pop() or shift() function

return null when the parameter is less than 1
(throwing an IllegalArgumentException is also a possiblity)
