### PR TITLE
[8.x] urldecode X-XSRF-TOKEN before decrypting

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -154,7 +154,7 @@ class VerifyCsrfToken
 
         if (! $token && $header = $request->header('X-XSRF-TOKEN')) {
             try {
-                $token = CookieValuePrefix::remove($this->encrypter->decrypt($header, static::serialized()));
+                $token = CookieValuePrefix::remove($this->encrypter->decrypt(urldecode($header), static::serialized()));
             } catch (DecryptException $e) {
                 $token = '';
             }


### PR DESCRIPTION
When verifying CSRF with **XSRF-TOKEN** cookie, the given cookie is urlencoded so that some characters like 
`=` would be converted into `%3D`, hence when decrypting the X-XSRF-TOKEN header the DecryptException will be thrown, therefore, before decrypting this header we should decode it by urldecode PHP built-in function.

I'm submitting this PR to resolve the stated issue.