### PR TITLE
[8.x] Dont recompile view if lastModified is same as cache file

### DIFF
--- a/src/Illuminate/View/Compilers/Compiler.php
+++ b/src/Illuminate/View/Compilers/Compiler.php
@@ -68,7 +68,7 @@ abstract class Compiler
             return true;
         }
 
-        return $this->files->lastModified($path) >=
+        return $this->files->lastModified($path) >
                $this->files->lastModified($compiled);
     }
 


### PR DESCRIPTION
This small change fixes an issue i encountered when running laravel via serverless framework on aws lambda.

https://github.com/brefphp/laravel-bridge/blob/master/src/BrefServiceProvider.php#L65
I dont like the above workaround, because it forces blade templates to be recompiled every time, which defeats the purpose of caching.

But when including the storage (or any other) directory in the serverless.zip, i noticed that all dates in the zip file were set to 01-01-1980
This was not a bug, but a feature to create reproducible builds/zip files:
https://github.com/serverless/serverless/blob/master/lib/plugins/package/lib/zipService.js#L95

When searching i found some PR's that touched the subject:
https://github.com/laravel/framework/pull/13938#issuecomment-230329250
https://github.com/laravel/framework/pull/31206

I believe this PR could fix all these edge cases, without drastically changing the caching behaviour.