### PR TITLE
[8.x] Allow to make test assertions about queued listeners

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -257,7 +257,7 @@ class QueueFake extends QueueManager implements Queue
     protected function listeners($job)
     {
         return collect($this->jobs[CallQueuedListener::class] ?? [])
-            ->filter(function($data) use ($job) {
+            ->filter(function ($data) use ($job) {
                 return $data['job']->class == $job;
             });
     }

--- a/tests/Support/SupportTestingQueueFakeTest.php
+++ b/tests/Support/SupportTestingQueueFakeTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Support;
 
 use BadMethodCallException;
 use Illuminate\Bus\Queueable;
+use Illuminate\Events\CallQueuedListener;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Testing\Fakes\QueueFake;
 use PHPUnit\Framework\Constraint\ExceptionMessage;
@@ -39,6 +40,22 @@ class SupportTestingQueueFakeTest extends TestCase
         }
 
         $this->fake->push($this->job);
+
+        $this->fake->assertPushed(JobStub::class);
+    }
+
+    public function testAssertPushedWithQueuedListener()
+    {
+        $queuedListener = new CallQueuedListener(JobStub::class, 'handle', []);
+
+        try {
+            $this->fake->assertPushed(JobStub::class);
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('The expected [Illuminate\Tests\Support\JobStub] job was not pushed.'));
+        }
+
+        $this->fake->push($queuedListener);
 
         $this->fake->assertPushed(JobStub::class);
     }


### PR DESCRIPTION
Currently when we use QueueFake class, some jobs may go "undetected" because they are invocated through a special internal class CallQueuedListener. Consider this example:

```php
class EventServiceProvider extends ServiceProvider {
    protected $listen = [
        EventHappened::class => [
            TakeAction::class,
        ],
}

class TakeAction implements ShouldQueue {
    public $delay = 10;
}
```

Now in one of our integration tests, we want to make sure that this TakeAction listener was queued, so we rely on the Queue fake as the documentation recommends:

```php
class Tests extends TestCase {
    public test_action_was_queued()
    {
        Queue::fake(); 

        // Something happens here

        Queue::assertPushed(TakeAction::class);
    }
}
```

This test fails because TakeAction class was never put in a queue, at least not directly. Behind the scenes, Laravel framework queued a special internal class CallQueuedListener instead and the $class property on that object is TakeAction::class.

Now there is a workaround of course:

```php
class Tests extends TestCase {
    public test_action_was_queued()
    {
        Queue::fake(); 

        // Something happens here

        Queue::assertPushed(CallQueuedListener::class, function ($job) {
            return $job->class == TakeAction::class;
        });
    }
}
```

But it feels a bit wrong for a couple of reasons:

* As a product developer, I don't really want to know about the CallQueuedListener class - it's a part of the framework internals, not exactly a part of the public API. What if it changes one day? What if the class gets renamed or modified, will I have to edit all my tests?
* For me as a developer, there is no clarity when a job will be put in the queue as a "real" class or as a CallQueuedListener so when I write the tests, it's never instantly clear which format should I use (from the two shown above). 
* All my Job classes and all my Listener classes use the same ShouldQueue trait, so I kind of expect them to be supported in tests in a similar fashion

This PR only affects QueueFake and should have no backward compatibility issues. It extends QueueFake's job search to the CallQueuedListener objects – we will look inside of those objects as well and accept those matches. This will allow us to make assertions about queued jobs and listeners in the same way:

```php
class Tests extends TestCase {
    public test_action_was_queued()
    {
        Queue::fake(); 

        // Something happens here

        Queue::assertPushed(Job::class);
        Queue::assertPushed(Listener::class);
    }
}
```