### PR TITLE
[8.x] Add Missing Http\assertSentInOrder Docblock

### DIFF
--- a/src/Illuminate/Support/Facades/Http.php
+++ b/src/Illuminate/Support/Facades/Http.php
@@ -45,6 +45,7 @@ use Illuminate\Http\Client\Factory;
  * @method static \Illuminate\Http\Client\Response send(string $method, string $url, array $options = [])
  * @method static \Illuminate\Http\Client\ResponseSequence fakeSequence(string $urlPattern = '*')
  * @method static void assertSent(callable $callback)
+ * @method static void assertSentInOrder(array $callbacks)
  * @method static void assertNotSent(callable $callback)
  * @method static void assertNothingSent()
  * @method static void assertSentCount(int $count)


### PR DESCRIPTION
After digging into HttpClient today, I found out this (handy!) `assertSentInOrder` function was missing in the Docblock