### PR TITLE
[8.x] Adding support for multiple errors in the @error directive

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesErrors.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesErrors.php
@@ -18,22 +18,22 @@ trait CompilesErrors
         $hasMultipleErrors = Str::startsWith($expression, '[');
 
         $conditionFunc = $hasMultipleErrors ? 'hasAny' : 'has';
-        $condition = 'if ($__bag->' . $conditionFunc . '($__errorArgs[0])) :';
+        $condition = 'if ($__bag->'.$conditionFunc.'($__errorArgs[0])) :';
 
-        return '<?php $__errorArgs = [' . $expression . '];
+        return '<?php $__errorArgs = ['.$expression.'];
 $__bag = $errors->getBag($__errorArgs[1] ?? \'default\');
-' . $condition . '
+'.$condition.'
 if (isset($message)) { $__messageOriginal = $message; }
 if (isset($messages)) { $__messagesOriginal = $messages; }
-' . ($hasMultipleErrors
+'.($hasMultipleErrors
 
 ? '$messages = array_reduce($__errorArgs[0], function($carry, $__error) use($__bag) {
     $newline = $__bag->first($__error);
     if($newline) $carry[] = $newline;
     return $carry;
 }, []);
-$message = implode('. ', $messages); ?>'
-            
+$message = implode('.', $messages); ?>'
+
 : '$message = $__bag->first($__errorArgs[0]); ?>'
         );
     }

--- a/tests/View/Blade/BladeErrorTest.php
+++ b/tests/View/Blade/BladeErrorTest.php
@@ -66,7 +66,7 @@ $messages = array_reduce($__errorArgs[0], function($carry, $__error) use($__bag)
     if($newline) $carry[] = $newline;
     return $carry;
 }, []);
-$message = implode('. ', $messages); ?>
+$message = implode('.', $messages); ?>
     <span><?php echo e($message); ?></span>
 <?php unset($message, $messages);
 if (isset($__messageOriginal)) { $message = $__messageOriginal; }

--- a/tests/View/Blade/BladeErrorTest.php
+++ b/tests/View/Blade/BladeErrorTest.php
@@ -15,10 +15,12 @@ class BladeErrorTest extends AbstractBladeTestCase
 $__bag = $errors->getBag($__errorArgs[1] ?? \'default\');
 if ($__bag->has($__errorArgs[0])) :
 if (isset($message)) { $__messageOriginal = $message; }
+if (isset($messages)) { $__messagesOriginal = $messages; }
 $message = $__bag->first($__errorArgs[0]); ?>
     <span><?php echo e($message); ?></span>
-<?php unset($message);
+<?php unset($message, $messages);
 if (isset($__messageOriginal)) { $message = $__messageOriginal; }
+if (isset($__messagesOriginal)) { $messages = $__messagesOriginal; }
 endif;
 unset($__errorArgs, $__bag); ?>';
 
@@ -36,12 +38,42 @@ unset($__errorArgs, $__bag); ?>';
 $__bag = $errors->getBag($__errorArgs[1] ?? \'default\');
 if ($__bag->has($__errorArgs[0])) :
 if (isset($message)) { $__messageOriginal = $message; }
+if (isset($messages)) { $__messagesOriginal = $messages; }
 $message = $__bag->first($__errorArgs[0]); ?>
     <span><?php echo e($message); ?></span>
-<?php unset($message);
+<?php unset($message, $messages);
 if (isset($__messageOriginal)) { $message = $__messageOriginal; }
+if (isset($__messagesOriginal)) { $messages = $__messagesOriginal; }
 endif;
 unset($__errorArgs, $__bag); ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testErrorsArraysAreCompiled()
+    {
+        $string = '
+@error([\'email\', \'phone\'])
+    <span>{{ $message }}</span>
+@enderror';
+        $expected = '
+<?php $__errorArgs = [[\'email\', \'phone\']];
+$__bag = $errors->getBag($__errorArgs[1] ?? \'default\');
+if ($__bag->hasAny($__errorArgs[0])) :
+if (isset($message)) { $__messageOriginal = $message; }
+if (isset($messages)) { $__messagesOriginal = $messages; }
+$messages = array_reduce($__errorArgs[0], function($carry, $__error) use($__bag) {
+    $newline = $__bag->first($__error);
+    if($newline) $carry[] = $newline;
+    return $carry;
+}, []);
+$message = implode('. ', $messages); ?>
+    <span><?php echo e($message); ?></span>
+<?php unset($message, $messages);
+if (isset($__messageOriginal)) { $message = $__messageOriginal; }
+if (isset($__messagesOriginal)) { $messages = $__messagesOriginal; }
+endif;
+unset($__errorArgs, $__bag); ?>';
+
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 }


### PR DESCRIPTION
This change allows the first parameter of the `@error` directive to be an array of keys. Useful when we need to display multiple errors in a single block but not all of them (e.g. in a long form divided into sections, we might want to display each section's errors by themselves).

The change is backwards compatible because if the first parameter is not an array, the directive keeps its original behavior. However when the first parameter is an array, it checks if the error bag `hasAny` of the specified keys and builds the message accordingly.

I hesitated about the way of building the message to be displayed so if anyone has a better approach, please suggest it.

My current approach yields two variables :
- `$messages` is just an array containing all the received error's messages
- `$message` concatenates those messages in a single string and separates them by a point `.` I opted out of separating them by a break-line because it forces users to use insecure `{!! nl2br(e($message)) !!}` in order to display them and that's not ideal.

Those variables are set and unset in the same way that is used in the existing version of the directive.

I've added a test for this new behavior and updated the two already existing tests.

**Examples**
```blade
{{-- OLD (still working) behavior --}}
@error('name')
    <span>{{ $message }}</span>
@enderror
@error('email')
    <span>{{ $message }}</span>
@enderror
@error('phone')
    <span>{{ $message }}</span>
@enderror

{{-- NEW behavior --}}
@error(['name', 'email', 'phone'])
    <ul>
    @foreach($messages as $message)
        <li><span>{{ $message }}</span></li>
    @endforeach
    </ul>
@enderror

{{-- OR simply --}}
@error(['name', 'email', 'phone'])
    <span>{{ $message }}</span>
@enderror
```

PS: the usage of bags doesn't affect the behavior whatsoever.