### PR TITLE
[8.x] Add insertAt Collection method

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -522,8 +522,7 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
-     * Inserts value at given key of collection
-     * and returns the updated collection.
+     * Inserts value at given offset of collection
      *
      * @param  int  $offset
      * @param  mixed  $value

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -522,7 +522,7 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
-     * Inserts value at given offset of collection
+     * Inserts value at given offset of collection.
      *
      * @param  int  $offset
      * @param  mixed  $value

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -522,6 +522,22 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
+     * Inserts value at given key of collection
+     * and returns the updated collection.
+     *
+     * @param  int  $offset
+     * @param  mixed  $value
+     *
+     * @return $this
+     */
+    public function insertAt($offset, $value)
+    {
+        $this->splice($offset, 0, [$value]);
+
+        return $this;
+    }
+
+    /**
      * Intersect the collection with the given items.
      *
      * @param  mixed  $items

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -531,9 +531,7 @@ class Collection implements ArrayAccess, Enumerable
      */
     public function insertAt($offset, $value)
     {
-        $this->splice($offset, 0, [$value]);
-
-        return $this;
+        return $this->splice($offset, 0, [$value]);
     }
 
     /**

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -525,20 +525,6 @@ class LazyCollection implements Enumerable
     }
 
     /**
-     * Inserts value at given key of collection
-     * and returns the updated collection.
-     *
-     * @param  int  $offset
-     * @param  mixed  $value
-     *
-     * @return $this
-     */
-    public function insertAt($offset, $value)
-    {
-        return $this->passthru('insertAt', func_get_args());
-    }
-
-    /**
      * Intersect the collection with the given items.
      *
      * @param  mixed  $items

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -525,6 +525,20 @@ class LazyCollection implements Enumerable
     }
 
     /**
+     * Inserts value at given key of collection
+     * and returns the updated collection.
+     *
+     * @param  int  $offset
+     * @param  mixed  $value
+     *
+     * @return $this
+     */
+    public function insertAt($offset, $value)
+    {
+        return $this->passthru('insertAt', func_get_args());
+    }
+
+    /**
      * Intersect the collection with the given items.
      *
      * @param  mixed  $items

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1994,6 +1994,16 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testInsertAt($collection)
+    {
+        $data = new $collection(['taylor', 'jeffrey', 'adam']);
+        $data = $data->insertAt(2, 'matt');
+        $this->assertEquals(['taylor', 'jeffrey', 'matt', 'adam'], $data->all());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testTake($collection)
     {
         $data = new $collection(['taylor', 'dayle', 'shawn']);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1996,9 +1996,21 @@ class SupportCollectionTest extends TestCase
      */
     public function testInsertAt($collection)
     {
-        $data = new $collection(['taylor', 'jeffrey', 'adam']);
+        $data = new $collection(['taylor', 'jess', 'adam']);
         $data = $data->insertAt(2, 'matt');
-        $this->assertEquals(['taylor', 'jeffrey', 'matt', 'adam'], $data->all());
+        $this->assertEquals(['taylor', 'jess', 'matt', 'adam'], $data->all());
+
+        $data = new $collection(['taylor', 'jess', 'adam']);
+        $data = $data->insertAt(-1, 'sara');
+        $this->assertEquals(['taylor', 'jess', 'sara', 'adam'], $data->all());
+
+        $data = new $collection(['taylor', 'jess', 'adam']);
+        $data = $data->insertAt(1, 'diana');
+        $this->assertEquals(['taylor', 'diana', 'jess', 'adam'], $data->all());
+
+        $data = new $collection(['taylor', 'jess', 'adam']);
+        $data = $data->insertAt(0, null);
+        $this->assertEquals([null, 'taylor', 'jess', 'adam'], $data->all());
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1991,25 +1991,22 @@ class SupportCollectionTest extends TestCase
         $this->assertSame('taylor,dayle', $data->implode(','));
     }
 
-    /**
-     * @dataProvider collectionClassProvider
-     */
-    public function testInsertAt($collection)
+    public function testInsertAt()
     {
-        $data = new $collection(['taylor', 'jess', 'adam']);
-        $data = $data->insertAt(2, 'matt');
+        $data = new Collection(['taylor', 'jess', 'adam']);
+        $data->insertAt(2, 'matt');
         $this->assertEquals(['taylor', 'jess', 'matt', 'adam'], $data->all());
 
-        $data = new $collection(['taylor', 'jess', 'adam']);
-        $data = $data->insertAt(-1, 'sara');
+        $data = new Collection(['taylor', 'jess', 'adam']);
+        $data->insertAt(-1, 'sara');
         $this->assertEquals(['taylor', 'jess', 'sara', 'adam'], $data->all());
 
-        $data = new $collection(['taylor', 'jess', 'adam']);
-        $data = $data->insertAt(1, 'diana');
+        $data = new Collection(['taylor', 'jess', 'adam']);
+        $data->insertAt(1, 'diana');
         $this->assertEquals(['taylor', 'diana', 'jess', 'adam'], $data->all());
 
-        $data = new $collection(['taylor', 'jess', 'adam']);
-        $data = $data->insertAt(0, null);
+        $data = new Collection(['taylor', 'jess', 'adam']);
+        $data->insertAt(0, null);
         $this->assertEquals([null, 'taylor', 'jess', 'adam'], $data->all());
     }
 


### PR DESCRIPTION
### Purpose 
On a number of occasions I have found the need to insert an item at a specific position in a Collection. While it's not terribly difficult to do so by using the already available [`splice` Collection method](https://laravel.com/docs/8.x/collections#method-splice) along with a `0` length value, it can hurt the readability __a bit__ IMO. This PR adds an `insertAt` method that is essentially just a convenience wrapper around `splice` to allow for the insertion of an item at a specific position in the collection. Below is a quick before and after to demonstrate the enhanced readability:

**Before** 
```
        $data = new Collection(['foo', 'baz']);
        $data->splice(1, 0, 'bar');
        // $data->all() => ['foo', 'bar', 'baz'] 
```
**With `insertAt` method**
```
       $data = new $collection(['taylor', 'jess', 'adam']);
       $data->insertAt(1, 'bar');
       // $data->all() => ['foo', 'bar', 'baz'] 
```

### Passing tests
I added a new test `testInsertAt` with several assertions in the `SupportCollectionTest` to confirm the method behaves as expected. 