### PR TITLE
[8.x] Adds `date` route binding for Carbon objects

### DIFF
--- a/src/Illuminate/Support/Carbon.php
+++ b/src/Illuminate/Support/Carbon.php
@@ -4,9 +4,8 @@ namespace Illuminate\Support;
 
 use Carbon\Carbon as BaseCarbon;
 use Carbon\CarbonImmutable as BaseCarbonImmutable;
-use Carbon\Exceptions\InvalidFormatException;
+use Carbon\Exceptions\Exception;
 use Illuminate\Contracts\Routing\UrlRoutable;
-use InvalidArgumentException;
 
 class Carbon extends BaseCarbon implements UrlRoutable
 {
@@ -42,7 +41,7 @@ class Carbon extends BaseCarbon implements UrlRoutable
     {
         try {
             return static::createFromFormat($field ?? '!Y-m-d', $value);
-        } catch (InvalidFormatException|InvalidArgumentException $e) {
+        } catch (Exception $e) {
             return null;
         }
     }

--- a/src/Illuminate/Support/Carbon.php
+++ b/src/Illuminate/Support/Carbon.php
@@ -4,7 +4,7 @@ namespace Illuminate\Support;
 
 use Carbon\Carbon as BaseCarbon;
 use Carbon\CarbonImmutable as BaseCarbonImmutable;
-use Carbon\Exceptions\Exception;
+use Carbon\Exceptions\InvalidArgumentException;
 use Illuminate\Contracts\Routing\UrlRoutable;
 
 class Carbon extends BaseCarbon implements UrlRoutable
@@ -41,7 +41,7 @@ class Carbon extends BaseCarbon implements UrlRoutable
     {
         try {
             return static::createFromFormat($field ?? '!Y-m-d', $value);
-        } catch (Exception $e) {
+        } catch (InvalidArgumentException $e) {
             return null;
         }
     }

--- a/src/Illuminate/Support/Carbon.php
+++ b/src/Illuminate/Support/Carbon.php
@@ -6,6 +6,7 @@ use Carbon\Carbon as BaseCarbon;
 use Carbon\CarbonImmutable as BaseCarbonImmutable;
 use Carbon\Exceptions\InvalidFormatException;
 use Illuminate\Contracts\Routing\UrlRoutable;
+use InvalidArgumentException;
 
 class Carbon extends BaseCarbon implements UrlRoutable
 {
@@ -41,7 +42,7 @@ class Carbon extends BaseCarbon implements UrlRoutable
     {
         try {
             return static::createFromFormat($field ?? '!Y-m-d', $value);
-        } catch (InvalidFormatException $e) {
+        } catch (InvalidFormatException|InvalidArgumentException $e) {
             return null;
         }
     }

--- a/src/Illuminate/Support/Carbon.php
+++ b/src/Illuminate/Support/Carbon.php
@@ -40,7 +40,7 @@ class Carbon extends BaseCarbon implements UrlRoutable
     public function resolveRouteBinding($value, $field = null)
     {
         try {
-            return static::createFromFormat($field ?? '!Y-m-d', $value)->setTime(0, 0);
+            return static::createFromFormat($field ?? '!Y-m-d', $value);
         } catch (InvalidFormatException $e) {
             return null;
         }

--- a/src/Illuminate/Support/Carbon.php
+++ b/src/Illuminate/Support/Carbon.php
@@ -4,8 +4,10 @@ namespace Illuminate\Support;
 
 use Carbon\Carbon as BaseCarbon;
 use Carbon\CarbonImmutable as BaseCarbonImmutable;
+use Carbon\Exceptions\InvalidFormatException;
+use Illuminate\Contracts\Routing\UrlRoutable;
 
-class Carbon extends BaseCarbon
+class Carbon extends BaseCarbon implements UrlRoutable
 {
     /**
      * {@inheritdoc}
@@ -14,5 +16,41 @@ class Carbon extends BaseCarbon
     {
         BaseCarbon::setTestNow($testNow);
         BaseCarbonImmutable::setTestNow($testNow);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRouteKey()
+    {
+        return 'date';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRouteKeyName()
+    {
+        return $this->getRouteKey();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function resolveRouteBinding($value, $field = null)
+    {
+        try {
+            return static::createFromFormat($field ?? '!Y-m-d', $value)->setTime(0, 0);
+        } catch (InvalidFormatException $e) {
+            return null;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function resolveChildRouteBinding($childType, $value, $field)
+    {
+        return null;
     }
 }

--- a/src/Illuminate/Support/Carbon.php
+++ b/src/Illuminate/Support/Carbon.php
@@ -4,8 +4,8 @@ namespace Illuminate\Support;
 
 use Carbon\Carbon as BaseCarbon;
 use Carbon\CarbonImmutable as BaseCarbonImmutable;
-use Carbon\Exceptions\InvalidArgumentException;
 use Illuminate\Contracts\Routing\UrlRoutable;
+use InvalidArgumentException;
 
 class Carbon extends BaseCarbon implements UrlRoutable
 {

--- a/tests/Support/SupportDateRouteBindingTest.php
+++ b/tests/Support/SupportDateRouteBindingTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use Illuminate\Routing\Middleware\SubstituteBindings;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Route;
+use Orchestra\Testbench\TestCase;
+
+/**
+ * @group integration
+ */
+class SupportDateRouteBindingTest extends TestCase
+{
+    public function testBindsDate()
+    {
+        Carbon::setTestNow(Carbon::createFromTimestamp(1436040000));
+
+        Route::get('/foo/{date}/bar', function (Carbon $date) {
+            return $date->toDateTimeString();
+        })->middleware(SubstituteBindings::class);
+
+        $this->assertSame('2015-07-04 00:00:00', $this->get('foo/2015-07-04/bar')->original);
+        $this->get('foo/invalid/bar')->assertNotFound();
+    }
+
+    public function testBindsFormattedDate()
+    {
+        $date = Carbon::createFromTimestamp(1436040000)->format('YmdHis');
+
+        Route::get('/foo/{date:YmdHis}/bar', function (Carbon $date) {
+            return $date->toDateTimeString();
+        })->middleware(SubstituteBindings::class);
+
+        $this->assertSame('2015-07-04 20:00:00', $this->get("foo/$date/bar")->original);
+        $this->get('foo/invalid/bar')->assertNotFound();
+    }
+}


### PR DESCRIPTION
## What?

Allows a route to receive an instance of Carbon based on a date. [Based on my package](https://github.com/DarkGhostHunter/Laradate).

    Route::get('articles/{date}')
    
    /articles/2015-07-04/

## How?

It implements the `UrlRoutable` to the `Illuminate\Support\Carbon`. The developer can receive the date as a Carbon instance based on the date of the parameter. By default, it uses the `!Y-m-d` format which sets time to start of day (hence, the "date" word).

```php
// /articles/2015-07-04

Route::get('/articles/{date}', function (Carbon $date) {
    // 2015-07-04 00:00:00
    return Articles::whereDay('published_at', $date)->paginate();
});
```

It supports a custom PHP format, giving full control to the developer. For example, we can use `u` to use a Unix timestamp.

```php
Route::get('/articles/{date:u}', function (Carbon $date) {
   // 1436040000
    return Articles::where('published_at', $date)->paginate();
});

// articles/1436040000
```

If the string doesn't follows the given format, the binding returns null, which results in a HTTP 404 automatically.

## Why?

- This avoids the shenanigans of [parsing a date via Regex in the route](https://laravel.com/docs/8.x/routing#parameters-regular-expression-constraints).
- Having to validate the date from the Request instance when is part of the URL.
- Having to use `parse` and catching the `InvalidFormatException` with an `abort()`.
- Stop hating myself.

## Shortcomings

- Since it's a date, it can be any place in time. Validation should be used if if strictly a user generated value.