### PR TITLE
[8.x] Add exception as parameter to the missing() callbacks

### DIFF
--- a/src/Illuminate/Routing/Middleware/SubstituteBindings.php
+++ b/src/Illuminate/Routing/Middleware/SubstituteBindings.php
@@ -41,7 +41,11 @@ class SubstituteBindings
             $this->router->substituteImplicitBindings($route);
         } catch (ModelNotFoundException $exception) {
             if ($route->getMissing()) {
-                return $route->getMissing()($request);
+                $missing = $route->getMissing()($request, $exception);
+                
+                if ($missing) {
+                    return $missing;
+                }
             }
 
             throw $exception;

--- a/src/Illuminate/Routing/Middleware/SubstituteBindings.php
+++ b/src/Illuminate/Routing/Middleware/SubstituteBindings.php
@@ -41,10 +41,10 @@ class SubstituteBindings
             $this->router->substituteImplicitBindings($route);
         } catch (ModelNotFoundException $exception) {
             if ($route->getMissing()) {
-                $missing = $route->getMissing()($request, $exception);
+                $callbackResponse = $route->getMissing()($request, $exception);
                 
-                if ($missing) {
-                    return $missing;
+                if ($callbackResponse) {
+                    return $callbackResponse;
                 }
             }
 

--- a/src/Illuminate/Routing/Middleware/SubstituteBindings.php
+++ b/src/Illuminate/Routing/Middleware/SubstituteBindings.php
@@ -42,7 +42,7 @@ class SubstituteBindings
         } catch (ModelNotFoundException $exception) {
             if ($route->getMissing()) {
                 $callbackResponse = $route->getMissing()($request, $exception);
-                
+
                 if ($callbackResponse) {
                     return $callbackResponse;
                 }

--- a/src/Illuminate/Routing/Middleware/SubstituteBindings.php
+++ b/src/Illuminate/Routing/Middleware/SubstituteBindings.php
@@ -41,11 +41,7 @@ class SubstituteBindings
             $this->router->substituteImplicitBindings($route);
         } catch (ModelNotFoundException $exception) {
             if ($route->getMissing()) {
-                $callbackResponse = $route->getMissing()($request, $exception);
-
-                if ($callbackResponse) {
-                    return $callbackResponse;
-                }
+                return $route->getMissing()($request, $exception);
             }
 
             throw $exception;


### PR DESCRIPTION
This PR change the logic for the `missing()` method handling any implicitly bound route models not found - changes are:

1. Passing the `ModelNotFoundException` exception to the callback registered with the routes `missing()` 
2. And only return the result of the callback if this callback does actually return a non-null value.

Note that the `missing()` method was created in https://github.com/laravel/framework/pull/36035 and made available in Laravel v8.26.0.

## Motivation
The `missing()` method (documented [here](https://laravel.com/docs/master/routing#customizing-missing-model-behavior)) offers a great way to handle any missing implicitly bound models, but there might be cases where one would like to only handle some missing models differently - and that is now possible i with this PR.

Expanding on the original example from PR [#36035](https://github.com/laravel/framework/pull/36035):

```php
Route::get('/locations/{location:slug}/photos/{photo}', [LocationsController::class, 'show'])
    ->name('locations.view')
    ->missing(function ($request, $exception) {
        if ($exception->getModel() == 'App\Models\Location') {
            return Redirect::route('locations.index', null, 301); // Only redirect user if the location is not found
        }

        // For all other models simply render the ModelNotFoundException as we would normally do
    );
```
The example above will only redirect the user if the `slug` provided for the `Location` model is not found. If an invalid `photo` is provided a normal ModelNotFound exception would be thrown and handled normally.

A real world example could be when using teams and wanting a separate logic for dealing with an invalid team while still keeping the normal 404 for other parameters.

## Alternatives

An alternative approach could be to allow a second parameter for the `missing()` method which specifies exactly what route parameter to apply the closure for:

```php
Route::get('/locations/{location:slug}', [LocationsController::class, 'show'])
    ->name('locations.view')
    ->missing(fn($request) => Redirect::route('locations.index', null, 301), 'location'); // This callable will only be applied to the location parameter
```

I personally think this syntax is better, but unfortunately an approach like this would require the method [`getMissing()`](https://github.com/laravel/framework/blob/9581cd6feb5be3e21c5b32ef154431f63eae89a8/src/Illuminate/Routing/Route.php#L943) to return an array of callables which would be a breaking change.

Note that this PR does not stand in the way of implementing the alternative syntax above in a later version of Laravel.
