### PR TITLE
[8.x] Widen Batch::add($jobs) parameter type

### DIFF
--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -156,7 +156,7 @@ class Batch implements Arrayable, JsonSerializable
     /**
      * Add additional jobs to the batch.
      *
-     * @param  \Illuminate\Support\Collection|array  $jobs
+     * @param  \Illuminate\Support\Enumerable|array  $jobs
      * @return self
      */
     public function add($jobs)


### PR DESCRIPTION
This PR widens the accepted type of `Batch::add($jobs)` to allow all enumerables (e.g. `LazyCollection`), instead of only `Collection`.

The first line of this method converts whatever `$jobs` is to a regular collection (via wrapping, which explicitly checks for the `Enumerable` interface).