### PR TITLE
[8.x] Implement TrustProxies middleware

### DIFF
--- a/src/Illuminate/Http/Middleware/TrustProxies.php
+++ b/src/Illuminate/Http/Middleware/TrustProxies.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Illuminate\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+abstract class TrustProxies
+{
+    /**
+     * The trusted proxies for the application.
+     *
+     * @var string|array|null
+     */
+    protected $proxies;
+
+    /**
+     * The proxy header mappings.
+     *
+     * @var int
+     */
+    protected $headers = Request::HEADER_X_FORWARDED_FOR | Request::HEADER_X_FORWARDED_HOST | Request::HEADER_X_FORWARDED_PORT | Request::HEADER_X_FORWARDED_PROTO | Request::HEADER_X_FORWARDED_AWS_ELB;
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     *
+     * @throws \Symfony\Component\HttpKernel\Exception\HttpException
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        $request::setTrustedProxies([], $this->getTrustedHeaderNames()); // Reset trusted proxies between requests
+
+        $this->setTrustedProxyIpAddresses($request);
+
+        return $next($request);
+    }
+
+    /**
+     * Sets the trusted proxies on the request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return void
+     */
+    protected function setTrustedProxyIpAddresses(Request $request)
+    {
+        $trustedIps = $this->proxies;
+
+        // Trust any IP address that calls us
+        // `**` for backwards compatibility, but is deprecated
+        if ($trustedIps === '*' || $trustedIps === '**') {
+            return $this->setTrustedProxyIpAddressesToTheCallingIp($request);
+        }
+
+        // Support IPs addresses separated by comma
+        $trustedIps = is_string($trustedIps) ? array_map('trim', explode(',', $trustedIps)) : $trustedIps;
+
+        // Only trust specific IP addresses
+        if (is_array($trustedIps)) {
+            return $this->setTrustedProxyIpAddressesToSpecificIps($request, $trustedIps);
+        }
+    }
+
+    /**
+     * Specify the IP addresses to trust explicitly.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  array  $trustedIps
+     * @return void
+     */
+    protected function setTrustedProxyIpAddressesToSpecificIps(Request $request, array $trustedIps)
+    {
+        $request->setTrustedProxies($trustedIps, $this->getTrustedHeaderNames());
+    }
+
+    /**
+     * Set the trusted proxy to be the IP address calling this servers.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return void
+     */
+    protected function setTrustedProxyIpAddressesToTheCallingIp(Request $request)
+    {
+        $request->setTrustedProxies([$request->server->get('REMOTE_ADDR')], $this->getTrustedHeaderNames());
+    }
+
+    /**
+     * Retrieve trusted header name(s), falling back to defaults if config not set.
+     *
+     * @return int A bit field of Request::HEADER_*, to set which headers to trust from your proxies.
+     */
+    protected function getTrustedHeaderNames()
+    {
+        switch ($this->headers) {
+            case 'HEADER_X_FORWARDED_AWS_ELB':
+            case Request::HEADER_X_FORWARDED_AWS_ELB:
+                return Request::HEADER_X_FORWARDED_AWS_ELB;
+                break;
+            case 'HEADER_FORWARDED':
+            case Request::HEADER_FORWARDED:
+                return Request::HEADER_FORWARDED;
+                break;
+            case 'HEADER_X_FORWARDED_FOR':
+            case Request::HEADER_X_FORWARDED_FOR:
+                return Request::HEADER_X_FORWARDED_FOR;
+                break;
+            case 'HEADER_X_FORWARDED_HOST':
+            case Request::HEADER_X_FORWARDED_HOST:
+                return Request::HEADER_X_FORWARDED_HOST;
+                break;
+            case 'HEADER_X_FORWARDED_PORT':
+            case Request::HEADER_X_FORWARDED_PORT:
+                return Request::HEADER_X_FORWARDED_PORT;
+                break;
+            case 'HEADER_X_FORWARDED_PROTO':
+            case Request::HEADER_X_FORWARDED_PROTO:
+                return Request::HEADER_X_FORWARDED_PROTO;
+                break;
+            default:
+                return Request::HEADER_X_FORWARDED_FOR | Request::HEADER_X_FORWARDED_HOST | Request::HEADER_X_FORWARDED_PORT | Request::HEADER_X_FORWARDED_PROTO | Request::HEADER_X_FORWARDED_AWS_ELB;
+        }
+
+        return $this->headers;
+    }
+}

--- a/src/Illuminate/Http/Middleware/TrustProxies.php
+++ b/src/Illuminate/Http/Middleware/TrustProxies.php
@@ -32,7 +32,7 @@ class TrustProxies
      */
     public function handle(Request $request, Closure $next)
     {
-        $request::setTrustedProxies([], $this->getTrustedHeaderNames()); // Reset trusted proxies between requests
+        $request::setTrustedProxies([], $this->getTrustedHeaderNames());
 
         $this->setTrustedProxyIpAddresses($request);
 
@@ -49,16 +49,12 @@ class TrustProxies
     {
         $trustedIps = $this->proxies;
 
-        // Trust any IP address that calls us
-        // `**` for backwards compatibility, but is deprecated
         if ($trustedIps === '*' || $trustedIps === '**') {
             return $this->setTrustedProxyIpAddressesToTheCallingIp($request);
         }
 
-        // Support IPs addresses separated by comma
         $trustedIps = is_string($trustedIps) ? array_map('trim', explode(',', $trustedIps)) : $trustedIps;
 
-        // Only trust specific IP addresses
         if (is_array($trustedIps)) {
             return $this->setTrustedProxyIpAddressesToSpecificIps($request, $trustedIps);
         }

--- a/src/Illuminate/Http/Middleware/TrustProxies.php
+++ b/src/Illuminate/Http/Middleware/TrustProxies.php
@@ -5,7 +5,7 @@ namespace Illuminate\Http\Middleware;
 use Closure;
 use Illuminate\Http\Request;
 
-abstract class TrustProxies
+class TrustProxies
 {
     /**
      * The trusted proxies for the application.

--- a/tests/Http/Middleware/TrustProxiesTest.php
+++ b/tests/Http/Middleware/TrustProxiesTest.php
@@ -17,7 +17,7 @@ class TrustProxiesTest extends TestCase
 
     /**
      * Test that Symfony does indeed NOT trust X-Forwarded-*
-     * headers when not given trusted proxies
+     * headers when not given trusted proxies.
      *
      * This re-tests Symfony's Request class, but hopefully provides
      * some clarify to developers looking at the tests.
@@ -34,7 +34,7 @@ class TrustProxiesTest extends TestCase
 
     /**
      * Test that Symfony DOES indeed trust X-Forwarded-*
-     * headers when given trusted proxies
+     * headers when given trusted proxies.
      *
      * Again, this re-tests Symfony's Request class.
      */
@@ -51,7 +51,7 @@ class TrustProxiesTest extends TestCase
 
     /**
      * Test the next most typical usage of TrustedProxies:
-     * Trusted X-Forwarded-For header, wilcard for TrustedProxies
+     * Trusted X-Forwarded-For header, wilcard for TrustedProxies.
      */
     public function test_trusted_proxy_sets_trusted_proxies_with_wildcard()
     {
@@ -65,7 +65,7 @@ class TrustProxiesTest extends TestCase
 
     /**
      * Test the next most typical usage of TrustedProxies:
-     * Trusted X-Forwarded-For header, wilcard for TrustedProxies
+     * Trusted X-Forwarded-For header, wilcard for TrustedProxies.
      */
     public function test_trusted_proxy_sets_trusted_proxies_with_double_wildcard_for_backwards_compat()
     {
@@ -79,7 +79,7 @@ class TrustProxiesTest extends TestCase
 
     /**
      * Test the most typical usage of TrustProxies:
-     * Trusted X-Forwarded-For header
+     * Trusted X-Forwarded-For header.
      */
     public function test_trusted_proxy_sets_trusted_proxies()
     {
@@ -92,7 +92,7 @@ class TrustProxiesTest extends TestCase
     }
 
     /**
-     * Test X-Forwarded-For header with multiple IP addresses
+     * Test X-Forwarded-For header with multiple IP addresses.
      */
     public function test_get_client_ips()
     {
@@ -105,7 +105,7 @@ class TrustProxiesTest extends TestCase
             '192.0.2.2,192.0.2.199',
         ];
 
-        foreach($forwardedFor as $forwardedForHeader) {
+        foreach ($forwardedFor as $forwardedForHeader) {
             $request = $this->createProxiedRequest(['HTTP_X_FORWARDED_FOR' => $forwardedForHeader]);
 
             $trustedProxy->handle($request, function ($request) use ($forwardedForHeader) {
@@ -116,7 +116,7 @@ class TrustProxiesTest extends TestCase
     }
 
     /**
-     * Test X-Forwarded-For header with multiple IP addresses, with some of those being trusted
+     * Test X-Forwarded-For header with multiple IP addresses, with some of those being trusted.
      */
     public function test_get_client_ip_with_muliple_ip_addresses_some_of_which_are_trusted()
     {
@@ -129,7 +129,7 @@ class TrustProxiesTest extends TestCase
             '192.0.2.2,192.0.2.199',
         ];
 
-        foreach($forwardedFor as $forwardedForHeader) {
+        foreach ($forwardedFor as $forwardedForHeader) {
             $request = $this->createProxiedRequest(['HTTP_X_FORWARDED_FOR' => $forwardedForHeader]);
 
             $trustedProxy->handle($request, function ($request) use ($forwardedForHeader) {
@@ -139,7 +139,7 @@ class TrustProxiesTest extends TestCase
     }
 
     /**
-     * Test X-Forwarded-For header with multiple IP addresses, with * wildcard trusting of all proxies
+     * Test X-Forwarded-For header with multiple IP addresses, with * wildcard trusting of all proxies.
      */
     public function test_get_client_ip_with_muliple_ip_addresses_all_proxies_are_trusted()
     {
@@ -152,7 +152,7 @@ class TrustProxiesTest extends TestCase
             '99.99.99.99,192.0.2.199,192.0.2.2',
         ];
 
-        foreach($forwardedFor as $forwardedForHeader) {
+        foreach ($forwardedFor as $forwardedForHeader) {
             $request = $this->createProxiedRequest(['HTTP_X_FORWARDED_FOR' => $forwardedForHeader]);
 
             $trustedProxy->handle($request, function ($request) use ($forwardedForHeader) {

--- a/tests/Http/Middleware/TrustProxiesTest.php
+++ b/tests/Http/Middleware/TrustProxiesTest.php
@@ -1,0 +1,379 @@
+<?php
+
+namespace Illuminate\Tests\Http\Middleware;
+
+use Illuminate\Http\Middleware\TrustProxies;
+use Illuminate\Http\Request;
+use PHPUnit\Framework\TestCase;
+
+class TrustProxiesTest extends TestCase
+{
+    /**
+     * A list of all proxy headers.
+     *
+     * @var int
+     */
+    protected $headerAll = Request::HEADER_X_FORWARDED_FOR | Request::HEADER_X_FORWARDED_HOST | Request::HEADER_X_FORWARDED_PORT | Request::HEADER_X_FORWARDED_PROTO | Request::HEADER_X_FORWARDED_AWS_ELB;
+
+    /**
+     * Test that Symfony does indeed NOT trust X-Forwarded-*
+     * headers when not given trusted proxies
+     *
+     * This re-tests Symfony's Request class, but hopefully provides
+     * some clarify to developers looking at the tests.
+     */
+    public function test_request_does_not_trust()
+    {
+        $req = $this->createProxiedRequest();
+
+        $this->assertEquals('192.168.10.10', $req->getClientIp(), 'Assert untrusted proxy x-forwarded-for header not used');
+        $this->assertEquals('http', $req->getScheme(), 'Assert untrusted proxy x-forwarded-proto header not used');
+        $this->assertEquals('localhost', $req->getHost(), 'Assert untrusted proxy x-forwarded-host header not used');
+        $this->assertEquals(8888, $req->getPort(), 'Assert untrusted proxy x-forwarded-port header not used');
+    }
+
+    /**
+     * Test that Symfony DOES indeed trust X-Forwarded-*
+     * headers when given trusted proxies
+     *
+     * Again, this re-tests Symfony's Request class.
+     */
+    public function test_does_trust_trusted_proxy()
+    {
+        $req = $this->createProxiedRequest();
+        $req->setTrustedProxies(['192.168.10.10'], $this->headerAll);
+
+        $this->assertEquals('173.174.200.38', $req->getClientIp(), 'Assert trusted proxy x-forwarded-for header used');
+        $this->assertEquals('https', $req->getScheme(), 'Assert trusted proxy x-forwarded-proto header used');
+        $this->assertEquals('serversforhackers.com', $req->getHost(), 'Assert trusted proxy x-forwarded-host header used');
+        $this->assertEquals(443, $req->getPort(), 'Assert trusted proxy x-forwarded-port header used');
+    }
+
+    /**
+     * Test the next most typical usage of TrustedProxies:
+     * Trusted X-Forwarded-For header, wilcard for TrustedProxies
+     */
+    public function test_trusted_proxy_sets_trusted_proxies_with_wildcard()
+    {
+        $trustedProxy = $this->createTrustedProxy($this->headerAll, '*');
+        $request = $this->createProxiedRequest();
+
+        $trustedProxy->handle($request, function ($request) {
+            $this->assertEquals('173.174.200.38', $request->getClientIp(), 'Assert trusted proxy x-forwarded-for header used with wildcard proxy setting');
+        });
+    }
+
+    /**
+     * Test the next most typical usage of TrustedProxies:
+     * Trusted X-Forwarded-For header, wilcard for TrustedProxies
+     */
+    public function test_trusted_proxy_sets_trusted_proxies_with_double_wildcard_for_backwards_compat()
+    {
+        $trustedProxy = $this->createTrustedProxy($this->headerAll, '**');
+        $request = $this->createProxiedRequest();
+
+        $trustedProxy->handle($request, function ($request) {
+            $this->assertEquals('173.174.200.38', $request->getClientIp(), 'Assert trusted proxy x-forwarded-for header used with wildcard proxy setting');
+        });
+    }
+
+    /**
+     * Test the most typical usage of TrustProxies:
+     * Trusted X-Forwarded-For header
+     */
+    public function test_trusted_proxy_sets_trusted_proxies()
+    {
+        $trustedProxy = $this->createTrustedProxy($this->headerAll, ['192.168.10.10']);
+        $request = $this->createProxiedRequest();
+
+        $trustedProxy->handle($request, function ($request) {
+            $this->assertEquals('173.174.200.38', $request->getClientIp(), 'Assert trusted proxy x-forwarded-for header used');
+        });
+    }
+
+    /**
+     * Test X-Forwarded-For header with multiple IP addresses
+     */
+    public function test_get_client_ips()
+    {
+        $trustedProxy = $this->createTrustedProxy($this->headerAll, ['192.168.10.10']);
+
+        $forwardedFor = [
+            '192.0.2.2',
+            '192.0.2.2, 192.0.2.199',
+            '192.0.2.2, 192.0.2.199, 99.99.99.99',
+            '192.0.2.2,192.0.2.199',
+        ];
+
+        foreach($forwardedFor as $forwardedForHeader) {
+            $request = $this->createProxiedRequest(['HTTP_X_FORWARDED_FOR' => $forwardedForHeader]);
+
+            $trustedProxy->handle($request, function ($request) use ($forwardedForHeader) {
+                $ips = $request->getClientIps();
+                $this->assertEquals('192.0.2.2', end($ips), 'Assert sets the '.$forwardedForHeader);
+            });
+        }
+    }
+
+    /**
+     * Test X-Forwarded-For header with multiple IP addresses, with some of those being trusted
+     */
+    public function test_get_client_ip_with_muliple_ip_addresses_some_of_which_are_trusted()
+    {
+        $trustedProxy = $this->createTrustedProxy($this->headerAll, ['192.168.10.10', '192.0.2.199']);
+
+        $forwardedFor = [
+            '192.0.2.2',
+            '192.0.2.2, 192.0.2.199',
+            '99.99.99.99, 192.0.2.2, 192.0.2.199',
+            '192.0.2.2,192.0.2.199',
+        ];
+
+        foreach($forwardedFor as $forwardedForHeader) {
+            $request = $this->createProxiedRequest(['HTTP_X_FORWARDED_FOR' => $forwardedForHeader]);
+
+            $trustedProxy->handle($request, function ($request) use ($forwardedForHeader) {
+                $this->assertEquals('192.0.2.2', $request->getClientIp(), 'Assert sets the '.$forwardedForHeader);
+            });
+        }
+    }
+
+    /**
+     * Test X-Forwarded-For header with multiple IP addresses, with * wildcard trusting of all proxies
+     */
+    public function test_get_client_ip_with_muliple_ip_addresses_all_proxies_are_trusted()
+    {
+        $trustedProxy = $this->createTrustedProxy($this->headerAll, '*');
+
+        $forwardedFor = [
+            '192.0.2.2',
+            '192.0.2.199, 192.0.2.2',
+            '192.0.2.199,192.0.2.2',
+            '99.99.99.99,192.0.2.199,192.0.2.2',
+        ];
+
+        foreach($forwardedFor as $forwardedForHeader) {
+            $request = $this->createProxiedRequest(['HTTP_X_FORWARDED_FOR' => $forwardedForHeader]);
+
+            $trustedProxy->handle($request, function ($request) use ($forwardedForHeader) {
+                $this->assertEquals('192.0.2.2', $request->getClientIp(), 'Assert sets the '.$forwardedForHeader);
+            });
+        }
+    }
+
+    /**
+     * Test distrusting a header.
+     */
+    public function test_can_distrust_headers()
+    {
+        $trustedProxy = $this->createTrustedProxy(Request::HEADER_FORWARDED, ['192.168.10.10']);
+
+        $request = $this->createProxiedRequest([
+            'HTTP_FORWARDED' => 'for=173.174.200.40:443; proto=https; host=serversforhackers.com',
+            'HTTP_X_FORWARDED_FOR' => '173.174.200.38',
+            'HTTP_X_FORWARDED_HOST' => 'svrs4hkrs.com',
+            'HTTP_X_FORWARDED_PORT' => '80',
+            'HTTP_X_FORWARDED_PROTO' => 'http',
+        ]);
+
+        $trustedProxy->handle($request, function ($request) {
+            $this->assertEquals('173.174.200.40', $request->getClientIp(),
+                'Assert trusted proxy used forwarded header for IP');
+            $this->assertEquals('https', $request->getScheme(),
+                'Assert trusted proxy used forwarded header for scheme');
+            $this->assertEquals('serversforhackers.com', $request->getHost(),
+                'Assert trusted proxy used forwarded header for host');
+            $this->assertEquals(443, $request->getPort(), 'Assert trusted proxy used forwarded header for port');
+        });
+    }
+
+    /**
+     * Test that only the X-Forwarded-For header is trusted.
+     */
+    public function test_x_forwarded_for_header_only_trusted()
+    {
+        $trustedProxy = $this->createTrustedProxy(Request::HEADER_X_FORWARDED_FOR, '*');
+
+        $request = $this->createProxiedRequest();
+
+        $trustedProxy->handle($request, function ($request) {
+            $this->assertEquals('173.174.200.38', $request->getClientIp(),
+                'Assert trusted proxy used forwarded header for IP');
+            $this->assertEquals('http', $request->getScheme(),
+                'Assert trusted proxy did not use forwarded header for scheme');
+            $this->assertEquals('localhost', $request->getHost(),
+                'Assert trusted proxy did not use forwarded header for host');
+            $this->assertEquals(8888, $request->getPort(), 'Assert trusted proxy did not use forwarded header for port');
+        });
+    }
+
+    /**
+     * Test that only the X-Forwarded-Host header is trusted.
+     */
+    public function test_x_forwarded_host_header_only_trusted()
+    {
+        $trustedProxy = $this->createTrustedProxy(Request::HEADER_X_FORWARDED_HOST, '*');
+
+        $request = $this->createProxiedRequest(['HTTP_X_FORWARDED_HOST' => 'serversforhackers.com:8888']);
+
+        $trustedProxy->handle($request, function ($request) {
+            $this->assertEquals('192.168.10.10', $request->getClientIp(),
+                'Assert trusted proxy did not use forwarded header for IP');
+            $this->assertEquals('http', $request->getScheme(),
+                'Assert trusted proxy did not use forwarded header for scheme');
+            $this->assertEquals('serversforhackers.com', $request->getHost(),
+                'Assert trusted proxy used forwarded header for host');
+            $this->assertEquals(8888, $request->getPort(), 'Assert trusted proxy did not use forwarded header for port');
+        });
+    }
+
+    /**
+     * Test that only the X-Forwarded-Port header is trusted.
+     */
+    public function test_x_forwarded_port_header_only_trusted()
+    {
+        $trustedProxy = $this->createTrustedProxy(Request::HEADER_X_FORWARDED_PORT, '*');
+
+        $request = $this->createProxiedRequest();
+
+        $trustedProxy->handle($request, function ($request) {
+            $this->assertEquals('192.168.10.10', $request->getClientIp(),
+                'Assert trusted proxy did not use forwarded header for IP');
+            $this->assertEquals('http', $request->getScheme(),
+                'Assert trusted proxy did not use forwarded header for scheme');
+            $this->assertEquals('localhost', $request->getHost(),
+                'Assert trusted proxy did not use forwarded header for host');
+            $this->assertEquals(443, $request->getPort(), 'Assert trusted proxy used forwarded header for port');
+        });
+    }
+
+    /**
+     * Test that only the X-Forwarded-Proto header is trusted.
+     */
+    public function test_x_forwarded_proto_header_only_trusted()
+    {
+        $trustedProxy = $this->createTrustedProxy(Request::HEADER_X_FORWARDED_PROTO, '*');
+
+        $request = $this->createProxiedRequest();
+
+        $trustedProxy->handle($request, function ($request) {
+            $this->assertEquals('192.168.10.10', $request->getClientIp(),
+                'Assert trusted proxy did not use forwarded header for IP');
+            $this->assertEquals('https', $request->getScheme(),
+                'Assert trusted proxy used forwarded header for scheme');
+            $this->assertEquals('localhost', $request->getHost(),
+                'Assert trusted proxy did not use forwarded header for host');
+            $this->assertEquals(8888, $request->getPort(), 'Assert trusted proxy did not use forwarded header for port');
+        });
+    }
+
+    /**
+     * Test a combination of individual X-Forwarded-* headers are trusted.
+     */
+    public function test_x_forwarded_multiple_individual_headers_trusted()
+    {
+        $trustedProxy = $this->createTrustedProxy(
+            Request::HEADER_X_FORWARDED_FOR | Request::HEADER_X_FORWARDED_HOST |
+            Request::HEADER_X_FORWARDED_PORT | Request::HEADER_X_FORWARDED_PROTO,
+            '*'
+        );
+
+        $request = $this->createProxiedRequest();
+
+        $trustedProxy->handle($request, function ($request) {
+            $this->assertEquals('173.174.200.38', $request->getClientIp(),
+                'Assert trusted proxy used forwarded header for IP');
+            $this->assertEquals('https', $request->getScheme(),
+                'Assert trusted proxy used forwarded header for scheme');
+            $this->assertEquals('serversforhackers.com', $request->getHost(),
+                'Assert trusted proxy used forwarded header for host');
+            $this->assertEquals(443, $request->getPort(), 'Assert trusted proxy used forwarded header for port');
+        });
+    }
+
+    /**
+     * Test to ensure it's reading text-based configurations and converting it correctly.
+     */
+    public function test_is_reading_text_based_configurations()
+    {
+        $request = $this->createProxiedRequest();
+
+        // trust *all* "X-Forwarded-*" headers
+        $trustedProxy = $this->createTrustedProxy('HEADER_X_FORWARDED_ALL', '192.168.1.1, 192.168.1.2');
+        $trustedProxy->handle($request, function (Request $request) {
+            $this->assertEquals($request->getTrustedHeaderSet(), $this->headerAll,
+                'Assert trusted proxy used all "X-Forwarded-*" header');
+
+            $this->assertEquals($request->getTrustedProxies(), ['192.168.1.1', '192.168.1.2'],
+                'Assert trusted proxy using proxies as string separated by comma.');
+        });
+
+        // or, if your proxy instead uses the "Forwarded" header
+        $trustedProxy = $this->createTrustedProxy('HEADER_FORWARDED', '192.168.1.1, 192.168.1.2');
+        $trustedProxy->handle($request, function (Request $request) {
+            $this->assertEquals($request->getTrustedHeaderSet(), Request::HEADER_FORWARDED,
+                'Assert trusted proxy used forwarded header');
+
+            $this->assertEquals($request->getTrustedProxies(), ['192.168.1.1', '192.168.1.2'],
+                'Assert trusted proxy using proxies as string separated by comma.');
+        });
+
+        // or, if you're using AWS ELB
+        $trustedProxy = $this->createTrustedProxy('HEADER_X_FORWARDED_AWS_ELB', '192.168.1.1, 192.168.1.2');
+        $trustedProxy->handle($request, function (Request $request) {
+            $this->assertEquals($request->getTrustedHeaderSet(), Request::HEADER_X_FORWARDED_AWS_ELB,
+                'Assert trusted proxy used AWS ELB header');
+
+            $this->assertEquals($request->getTrustedProxies(), ['192.168.1.1', '192.168.1.2'],
+                'Assert trusted proxy using proxies as string separated by comma.');
+        });
+    }
+
+    /**
+     * Fake an HTTP request by generating a Symfony Request object.
+     *
+     * @param  array  $serverOverRides
+     * @return \Symfony\Component\HttpFoundation\Request
+     */
+    protected function createProxiedRequest($serverOverRides = [])
+    {
+        // Add some X-Forwarded headers and over-ride
+        // defaults, simulating a request made over a proxy
+        $serverOverRides = array_replace([
+            'HTTP_X_FORWARDED_FOR' => '173.174.200.38',         // X-Forwarded-For   -- getClientIp()
+            'HTTP_X_FORWARDED_HOST' => 'serversforhackers.com', // X-Forwarded-Host  -- getHosts()
+            'HTTP_X_FORWARDED_PORT' => '443',                   // X-Forwarded-Port  -- getPort()
+            'HTTP_X_FORWARDED_PROTO' => 'https',                // X-Forwarded-Proto -- getScheme() / isSecure()
+            'SERVER_PORT' => 8888,
+            'HTTP_HOST' => 'localhost',
+            'REMOTE_ADDR' => '192.168.10.10',
+        ], $serverOverRides);
+
+        // Create a fake request made over "http", one that we'd get over a proxy
+        // which is likely something like this:
+        $request = Request::create('http://localhost:8888/tag/proxy', 'GET', [], [], [], $serverOverRides, null);
+        // Need to make sure these haven't already been set
+        $request->setTrustedProxies([], $this->headerAll);
+
+        return $request;
+    }
+
+    /**
+     * Create an anonymous middleware class.
+     *
+     * @param  null|string|int  $trustedHeaders
+     * @param  null|array|string  $trustedProxies
+     * @return \Illuminate\Http\Middleware\TrustProxies
+     */
+    protected function createTrustedProxy($trustedHeaders, $trustedProxies)
+    {
+        return new class($trustedHeaders, $trustedProxies) extends TrustProxies
+        {
+            public function __construct($trustedHeaders, $trustedProxies)
+            {
+                $this->headers = $trustedHeaders;
+                $this->proxies = $trustedProxies;
+            }
+        };
+    }
+}


### PR DESCRIPTION
This PR ports the TrustedProxies package by Chris Fidao to Laravel. This will help us reduce one more external dependency we used to rely on.

In contrary to the original package, all configuration is done through overwriting properties. I'll send in an additional PR to `laravel/laravel` after this is merged and tagged.
