### PR TITLE
[8.x] Serialize selected model attributes on the queue job.

### DIFF
--- a/src/Illuminate/Contracts/Database/ModelIdentifier.php
+++ b/src/Illuminate/Contracts/Database/ModelIdentifier.php
@@ -35,19 +35,28 @@ class ModelIdentifier
     public $connection;
 
     /**
+     * The model selected attributes.
+     *
+     * @var array
+     */
+    public $attributes;
+
+    /**
      * Create a new model identifier.
      *
      * @param  string  $class
      * @param  mixed  $id
      * @param  array  $relations
      * @param  mixed  $connection
+     * @param  array $attributes
      * @return void
      */
-    public function __construct($class, $id, array $relations, $connection)
+    public function __construct($class, $id, array $relations, $connection, array $attributes = ["*"])
     {
         $this->id = $id;
         $this->class = $class;
         $this->relations = $relations;
         $this->connection = $connection;
+        $this->attributes = $attributes;
     }
 }

--- a/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
+++ b/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
@@ -126,7 +126,7 @@ trait SerializesAndRestoresModelIdentifiers
      */
     protected function getModelAttributes($model)
     {
-        return array_keys($model->getAttributes());
+        return array_keys($model->getOriginal());
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This PR adds support to respect selected columns in the model when serialize/unserialize in the queue.

Problem:
We have tables that have JSON columns that store huge data. and when we want to get any row we just pick the fields we want and send the model to the queue
```php
$store = Store::select('id','domain')->find(1);
FetchStoreProducts::dispatch($store);
```

the problem is when Queue unserialize that it will do the query as `select * from stores ...` instead of `select id, domain from stores ...`


So this PR would fix it to do queries as expected.