### PR TITLE
[9.x] serialize selected model attributes on the queue job

### DIFF
--- a/src/Illuminate/Contracts/Database/ModelIdentifier.php
+++ b/src/Illuminate/Contracts/Database/ModelIdentifier.php
@@ -35,19 +35,28 @@ class ModelIdentifier
     public $connection;
 
     /**
+     * The model selected attributes.
+     *
+     * @var array
+     */
+    public $attributes;
+
+    /**
      * Create a new model identifier.
      *
      * @param  string  $class
      * @param  mixed  $id
      * @param  array  $relations
      * @param  mixed  $connection
+     * @param  array $attributes
      * @return void
      */
-    public function __construct($class, $id, array $relations, $connection)
+    public function __construct($class, $id, array $relations, $connection, array $attributes = ["*"])
     {
         $this->id = $id;
         $this->class = $class;
         $this->relations = $relations;
         $this->connection = $connection;
+        $this->attributes = $attributes;
     }
 }

--- a/src/Illuminate/Contracts/Database/ModelIdentifier.php
+++ b/src/Illuminate/Contracts/Database/ModelIdentifier.php
@@ -51,7 +51,7 @@ class ModelIdentifier
      * @param  array $attributes
      * @return void
      */
-    public function __construct($class, $id, array $relations, $connection, array $attributes = ["*"])
+    public function __construct($class, $id, array $relations, $connection, array $attributes = ['*'])
     {
         $this->id = $id;
         $this->class = $class;

--- a/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
+++ b/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
@@ -27,7 +27,7 @@ trait SerializesAndRestoresModelIdentifiers
                 $value->getQueueableIds(),
                 $model ? $this->getQueueableRelations($model) : [],
                 $value->getQueueableConnection(),
-                $model ? $this->getModelAttributes($model) : ["*"]
+                $model ? $this->getModelAttributes($model) : ['*']
             );
         }
 
@@ -128,7 +128,7 @@ trait SerializesAndRestoresModelIdentifiers
     {
         $attributes = array_keys($model->getAttributes());
 
-        return !empty($attributes) ? $attributes : ["*"];
+        return !empty($attributes) ? $attributes : ['*'];
     }
 
     /**
@@ -140,7 +140,7 @@ trait SerializesAndRestoresModelIdentifiers
      */
     protected function getRelationAttributesString($model, $relation)
     {
-        if (str_contains($relation, ".")) {
+        if (str_contains($relation, '.')) {
             return $relation;
         }
 
@@ -148,7 +148,7 @@ trait SerializesAndRestoresModelIdentifiers
 
         $attributes = $this->getModelAttributes($relationModel);
 
-        $relation = $relation . ":" . implode(",", $attributes);
+        $relation = $relation.':'.implode(',', $attributes);
 
         unset($attributes, $relationModel);
 

--- a/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
+++ b/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
@@ -20,11 +20,14 @@ trait SerializesAndRestoresModelIdentifiers
     protected function getSerializedPropertyValue($value)
     {
         if ($value instanceof QueueableCollection) {
+            $model = $value->first();
+
             return new ModelIdentifier(
                 $value->getQueueableClass(),
                 $value->getQueueableIds(),
-                $value->getQueueableRelations(),
-                $value->getQueueableConnection()
+                $model ? $this->getQueueableRelations($model) : [],
+                $value->getQueueableConnection(),
+                $model ? $this->getModelAttributes($model) : ["*"]
             );
         }
 
@@ -32,8 +35,9 @@ trait SerializesAndRestoresModelIdentifiers
             return new ModelIdentifier(
                 get_class($value),
                 $value->getQueueableId(),
-                $value->getQueueableRelations(),
-                $value->getQueueableConnection()
+                $this->getQueueableRelations($value),
+                $value->getQueueableConnection(),
+                $this->getModelAttributes($value)
             );
         }
 
@@ -71,7 +75,7 @@ trait SerializesAndRestoresModelIdentifiers
 
         $collection = $this->getQueryForModelRestoration(
             (new $value->class)->setConnection($value->connection), $value->id
-        )->useWritePdo()->get();
+        )->useWritePdo()->get($value->attributes);
 
         if (is_a($value->class, Pivot::class, true) ||
             in_array(AsPivot::class, class_uses($value->class))) {
@@ -99,7 +103,7 @@ trait SerializesAndRestoresModelIdentifiers
     {
         return $this->getQueryForModelRestoration(
             (new $value->class)->setConnection($value->connection), $value->id
-        )->useWritePdo()->firstOrFail()->load($value->relations ?? []);
+        )->useWritePdo()->firstOrFail($value->attributes)->load($value->relations ?? []);
     }
 
     /**
@@ -112,5 +116,59 @@ trait SerializesAndRestoresModelIdentifiers
     protected function getQueryForModelRestoration($model, $ids)
     {
         return $model->newQueryForRestoration($ids);
+    }
+
+    /**
+     * Get the model selected attributes.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model $model
+     * @return array
+     */
+    protected function getModelAttributes($model)
+    {
+        $attributes = array_keys($model->getAttributes());
+
+        return !empty($attributes) ? $attributes : ["*"];
+    }
+
+    /**
+     * Get the relation with it's selected attributes as string.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model $model
+     * @param  string $relation
+     * @return string
+     */
+    protected function getRelationAttributesString($model, $relation)
+    {
+        if (str_contains($relation, ".")) {
+            return $relation;
+        }
+
+        $relationModel = $model->getRelationValue($relation)->first();
+
+        $attributes = $this->getModelAttributes($relationModel);
+
+        $relation = $relation . ":" . implode(",", $attributes);
+
+        unset($attributes, $relationModel);
+
+        return $relation;
+    }
+
+    /**
+     * Get the queuebale relations.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model $value
+     * @return array
+     */
+    protected function getQueueableRelations($value)
+    {
+        $relations = [];
+
+        foreach ($value->getQueueableRelations() as $relation) {
+            $relations[] = $this->getRelationAttributesString($value, $relation);
+        }
+
+        return $relations;
     }
 }

--- a/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
+++ b/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
@@ -128,7 +128,7 @@ trait SerializesAndRestoresModelIdentifiers
     {
         $attributes = array_keys($model->getAttributes());
 
-        return !empty($attributes) ? $attributes : ['*'];
+        return ! empty($attributes) ? $attributes : ['*'];
     }
 
     /**

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -331,7 +331,7 @@ class ModelSerializationTest extends TestCase
         $serialized = serialize(new ModelSerializationParentAccessibleTestClass($user, $user, $user));
 
         $this->assertSame(
-            'O:78:"Illuminate\\Tests\\Integration\\Queue\\ModelSerializationParentAccessibleTestClass":2:{s:4:"user";O:45:"Illuminate\\Contracts\\Database\\ModelIdentifier":4:{s:5:"class";s:61:"Illuminate\\Tests\\Integration\\Queue\\ModelSerializationTestUser";s:2:"id";i:1;s:9:"relations";a:0:{}s:10:"connection";s:9:"testbench";}s:8:"'."\0".'*'."\0".'user2";O:45:"Illuminate\\Contracts\\Database\\ModelIdentifier":4:{s:5:"class";s:61:"Illuminate\\Tests\\Integration\\Queue\\ModelSerializationTestUser";s:2:"id";i:1;s:9:"relations";a:0:{}s:10:"connection";s:9:"testbench";}}', $serialized
+            'O:78:"Illuminate\\Tests\\Integration\\Queue\\ModelSerializationParentAccessibleTestClass":2:{s:4:"user";O:45:"Illuminate\\Contracts\\Database\\ModelIdentifier":5:{s:5:"class";s:61:"Illuminate\\Tests\\Integration\\Queue\\ModelSerializationTestUser";s:2:"id";i:1;s:9:"relations";a:0:{}s:10:"connection";s:9:"testbench";s:10:"attributes";a:2:{i:0;s:5:"email";i:1;s:2:"id";}}s:8:"'."\0".'*'."\0".'user2";O:45:"Illuminate\\Contracts\\Database\\ModelIdentifier":5:{s:5:"class";s:61:"Illuminate\\Tests\\Integration\\Queue\\ModelSerializationTestUser";s:2:"id";i:1;s:9:"relations";a:0:{}s:10:"connection";s:9:"testbench";s:10:"attributes";a:2:{i:0;s:5:"email";i:1;s:2:"id";}}}', $serialized
         );
     }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This PR adds support to respect selected columns in the model when serialize/unserialize in the queue.

Problem:
We have tables that have JSON columns that store huge data. and when we want to get any row we just pick the fields we want and send the model to the queue
```php
$store = Store::select('id','domain')->find(1);
FetchStoreProducts::dispatch($store);
```

the problem is when Queue unserialize that it will do the query as `select * from stores ...` instead of `select id, domain from stores ...`


So this PR would fix it to do queries as expected.