### PR TITLE
[8.x] Added check to key:generate

### DIFF
--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -92,8 +92,8 @@ class KeyGenerateCommand extends Command
     {
         $envContents = file_get_contents($this->laravel->environmentFilePath());
 
-        if(!preg_match($this->keyReplacementPattern(), $envContents)) {
-            throw new \RuntimeException($this->laravel->environmentFilePath() . " is missing APP_KEY");
+        if(! preg_match($this->keyReplacementPattern(), $envContents)) {
+            throw new \RuntimeException($this->laravel->environmentFilePath() . ' is missing APP_KEY');
         }
 
         file_put_contents($this->laravel->environmentFilePath(), preg_replace(

--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -92,8 +92,8 @@ class KeyGenerateCommand extends Command
     {
         $envContents = file_get_contents($this->laravel->environmentFilePath());
 
-        if(! preg_match($this->keyReplacementPattern(), $envContents)) {
-            throw new \RuntimeException($this->laravel->environmentFilePath() . ' is missing APP_KEY');
+        if (! preg_match($this->keyReplacementPattern(), $envContents)) {
+            throw new \RuntimeException($this->laravel->environmentFilePath().' is missing APP_KEY');
         }
 
         file_put_contents($this->laravel->environmentFilePath(), preg_replace(
@@ -102,7 +102,7 @@ class KeyGenerateCommand extends Command
             $envContents
         ));
     }
-    
+
     /**
      * Get a regex pattern that will match env APP_KEY with any random key.
      *

--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -90,13 +90,19 @@ class KeyGenerateCommand extends Command
      */
     protected function writeNewEnvironmentFileWith($key)
     {
+        $envContents = file_get_contents($this->laravel->environmentFilePath());
+
+        if(!preg_match($this->keyReplacementPattern(), $envContents)) {
+            throw new \RuntimeException($this->laravel->environmentFilePath() . " is missing APP_KEY");
+        }
+
         file_put_contents($this->laravel->environmentFilePath(), preg_replace(
             $this->keyReplacementPattern(),
             'APP_KEY='.$key,
-            file_get_contents($this->laravel->environmentFilePath())
+            $envContents
         ));
     }
-
+    
     /**
      * Get a regex pattern that will match env APP_KEY with any random key.
      *

--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -87,6 +87,9 @@ class KeyGenerateCommand extends Command
      *
      * @param  string  $key
      * @return void
+     * 
+     * @throws \RuntimeException
+     * 
      */
     protected function writeNewEnvironmentFileWith($key)
     {


### PR DESCRIPTION
The artisan command key:generate exits with a success message when APP_KEY is not set. This happens when there is no APP_KEY line in the envfile.

Instead it should throw a rather descriptive exteption.

I've added a simple check against the .env contents with the help of keyReplacementPattern(). This implements the idea from: https://github.com/laravel/framework/discussions/38186


```
RuntimeException

  /home/dezio/dev/laravel/.env is missing APP_KEY

  at vendor/laravel/framework/src/Illuminate/Foundation/Console/KeyGenerateCommand.php:96
     92▕     {
     93▕         $envContents = file_get_contents($this->laravel->environmentFilePath());
     94▕
     95▕         if(!preg_match($this->keyReplacementPattern(), $envContents)) {
     96▕             throw new \RuntimeException($this->laravel->environmentFilePath() . " is missing APP_KEY");
     97▕         }
     98▕
     99▕         file_put_contents($this->laravel->environmentFilePath(), preg_replace(
    100▕             $this->keyReplacementPattern(),

      +15 vendor frames
  16  artisan:37
      Illuminate\Foundation\Console\Kernel::handle(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
```