### PR TITLE
[8.x] Adds `attempt` method to Rate Limiter

### DIFF
--- a/src/Illuminate/Cache/RateLimiter.php
+++ b/src/Illuminate/Cache/RateLimiter.php
@@ -163,4 +163,26 @@ class RateLimiter
     {
         return max(0, $this->cache->get($key.':timer') - $this->currentTime());
     }
+
+    /**
+     * Attempts to execute a callback if it's available.
+     *
+     * @param  string  $key
+     * @param  int  $maxAttempts
+     * @param  \Closure  $callback
+     * @param  int  $decaySeconds
+     * @return bool
+     */
+    public function attempt($key, $maxAttempts, Closure $callback, $decaySeconds = 60)
+    {
+        if ($this->tooManyAttempts($key, $maxAttempts)) {
+            return false;
+        }
+
+        $callback();
+
+        $this->hit($key, $decaySeconds);
+
+        return true;
+    }
 }

--- a/src/Illuminate/Cache/RateLimiter.php
+++ b/src/Illuminate/Cache/RateLimiter.php
@@ -171,7 +171,7 @@ class RateLimiter
      * @param  int  $maxAttempts
      * @param  \Closure  $callback
      * @param  int  $decaySeconds
-     * @return bool
+     * @return mixed
      */
     public function attempt($key, $maxAttempts, Closure $callback, $decaySeconds = 60)
     {
@@ -179,10 +179,10 @@ class RateLimiter
             return false;
         }
 
-        $callback();
+        $result = $callback();
 
         $this->hit($key, $decaySeconds);
 
-        return true;
+        return $result ?? true;
     }
 }

--- a/src/Illuminate/Support/Facades/RateLimiter.php
+++ b/src/Illuminate/Support/Facades/RateLimiter.php
@@ -12,6 +12,7 @@ namespace Illuminate\Support\Facades;
  * @method static int retriesLeft($key, $maxAttempts)
  * @method static void clear($key)
  * @method static int availableIn($key)
+ * @method static bool attempt($key, $maxAttempts, \Closure $callback, $decaySeconds = 60)
  *
  * @see \Illuminate\Cache\RateLimiter
  */

--- a/tests/Cache/CacheRateLimiterTest.php
+++ b/tests/Cache/CacheRateLimiterTest.php
@@ -76,4 +76,34 @@ class CacheRateLimiterTest extends TestCase
         $this->assertTrue($rateLimiter->availableIn('key:timer') >= 0);
         $this->assertTrue($rateLimiter->availableIn('key:timer') >= 0);
     }
+
+    public function testAttemptsCallbackReturnsTrue()
+    {
+        $cache = m::mock(Cache::class);
+        $cache->shouldReceive('get')->once()->with('key', 0)->andReturn(0);
+        $cache->shouldReceive('add')->once()->with('key:timer', m::type('int'), 1);
+        $cache->shouldReceive('add')->once()->with('key', 0, 1)->andReturns(1);
+        $cache->shouldReceive('increment')->once()->with('key')->andReturn(1);
+
+        $executed = false;
+
+        $rateLimiter = new RateLimiter($cache);
+
+        $this->assertTrue($rateLimiter->attempt('key', 1, function() use (&$executed) { $executed = true; }, 1));
+        $this->assertTrue($executed);
+    }
+
+    public function testAttemptsCallbackReturnsFalse()
+    {
+        $cache = m::mock(Cache::class);
+        $cache->shouldReceive('get')->once()->with('key', 0)->andReturn(2);
+        $cache->shouldReceive('has')->once()->with('key:timer')->andReturn(true);
+
+        $executed = false;
+
+        $rateLimiter = new RateLimiter($cache);
+
+        $this->assertFalse($rateLimiter->attempt('key', 1, function() use (&$executed) { $executed = true; }, 1));
+        $this->assertFalse($executed);
+    }
 }

--- a/tests/Cache/CacheRateLimiterTest.php
+++ b/tests/Cache/CacheRateLimiterTest.php
@@ -89,7 +89,9 @@ class CacheRateLimiterTest extends TestCase
 
         $rateLimiter = new RateLimiter($cache);
 
-        $this->assertTrue($rateLimiter->attempt('key', 1, function() use (&$executed) { $executed = true; }, 1));
+        $this->assertTrue($rateLimiter->attempt('key', 1, function() use (&$executed) {
+            $executed = true;
+        }, 1));
         $this->assertTrue($executed);
     }
 
@@ -118,7 +120,9 @@ class CacheRateLimiterTest extends TestCase
 
         $rateLimiter = new RateLimiter($cache);
 
-        $this->assertFalse($rateLimiter->attempt('key', 1, function() use (&$executed) { $executed = true; }, 1));
+        $this->assertFalse($rateLimiter->attempt('key', 1, function() use (&$executed) {
+            $executed = true;
+        }, 1));
         $this->assertFalse($executed);
     }
 }

--- a/tests/Cache/CacheRateLimiterTest.php
+++ b/tests/Cache/CacheRateLimiterTest.php
@@ -93,6 +93,21 @@ class CacheRateLimiterTest extends TestCase
         $this->assertTrue($executed);
     }
 
+    public function testAttemptsCallbackReturnsCallbackReturn()
+    {
+        $cache = m::mock(Cache::class);
+        $cache->shouldReceive('get')->once()->with('key', 0)->andReturn(0);
+        $cache->shouldReceive('add')->once()->with('key:timer', m::type('int'), 1);
+        $cache->shouldReceive('add')->once()->with('key', 0, 1)->andReturns(1);
+        $cache->shouldReceive('increment')->once()->with('key')->andReturn(1);
+
+        $rateLimiter = new RateLimiter($cache);
+
+        $this->assertEquals('foo', $rateLimiter->attempt('key', 1, function() {
+            return 'foo';
+        }, 1));
+    }
+
     public function testAttemptsCallbackReturnsFalse()
     {
         $cache = m::mock(Cache::class);


### PR DESCRIPTION
## What?

You can use the `attempt()` from the Rate Limiter to execute a callback if available.

```php
use Illuminate\Support\Facades\RateLimiter;

RateLimiter::attempt('something', 5, function () {
    // ...
});
```

> Fourth argument, `decaySeconds`, is default to 60.

## How?

It just simply wraps the `tooManyAttempts()` and `hit()` in one call. Syntactic sugar for this:

```php
use Illuminate\Support\Facades\RateLimiter;

if (RateLimiter::tooManyAttempts('something', 5)) {
    return false
}

// Do something...

RateLimiter::hit('something', 60);

return true;
```

If the shortcut fails, `false` is returned. Otherwise, it returns result of the callback, or `true` if the result is `null`. THis allows the developer to programmatically proceed if the call wasn't executed.

```php
use Illuminate\Support\Facades\RateLimiter;

$executed = RateLimiter::attempt('something', 5, fn() => 'foo', 60 * 60);

if ($executed) {
    return "It returned $executed";
}
```

## Why?

- Simplifies effective Rate Limiter usage into one method easy to understand. (Should be documented too!)