### PR TITLE
[8.x] Add withoutTrashed on Exists rule

### DIFF
--- a/src/Illuminate/Validation/Rules/Exists.php
+++ b/src/Illuminate/Validation/Rules/Exists.php
@@ -9,6 +9,19 @@ class Exists
     use Conditionable, DatabaseRule;
 
     /**
+     * Ignore soft deleted models during the unique check.
+     *
+     * @param  string  $deletedAtColumn
+     * @return $this
+     */
+    public function withoutTrashed($deletedAtColumn = 'deleted_at')
+    {
+        $this->whereNull($deletedAtColumn);
+
+        return $this;
+    }
+
+    /**
      * Convert the rule to a validation string.
      *
      * @return string

--- a/src/Illuminate/Validation/Rules/Exists.php
+++ b/src/Illuminate/Validation/Rules/Exists.php
@@ -9,7 +9,7 @@ class Exists
     use Conditionable, DatabaseRule;
 
     /**
-     * Ignore soft deleted models during the unique check.
+     * Ignore soft deleted models during the existence check.
      *
      * @param  string  $deletedAtColumn
      * @return $this

--- a/tests/Validation/ValidationExistsRuleTest.php
+++ b/tests/Validation/ValidationExistsRuleTest.php
@@ -173,6 +173,17 @@ class ValidationExistsRuleTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
+    public function testItIgnoresSoftDeletes()
+    {
+        $rule = new Exists('table');
+        $rule->withoutTrashed();
+        $this->assertSame('exists:table,NULL,deleted_at,"NULL"', (string) $rule);
+
+        $rule = new Exists('table');
+        $rule->withoutTrashed('softdeleted_at');
+        $this->assertSame('exists:table,NULL,softdeleted_at,"NULL"', (string) $rule);
+    }
+
     protected function createSchema()
     {
         $this->schema('default')->create('users', function ($table) {


### PR DESCRIPTION
Based on previous PR https://github.com/laravel/framework/pull/38124 we can also add `withoutTrashed` on exists rule

```
// Before
[
  'id'=> [
    Rule::exists('users')->whereNull('deleted_at'),
  ],
];

// After
[
  'id'=> [
    Rule::exists('users')->withoutTrashed(),
  ],
];
```
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
