### PR TITLE
[8.x] Fix Factory hasMany method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -211,9 +211,9 @@ abstract class Factory
     public function createMany(iterable $records)
     {
         return new EloquentCollection(
-            array_map(function ($record) {
+            collect($records)->map(function ($record) {
                 return $this->state($record)->create();
-            }, $records)
+            })
         );
     }
 


### PR DESCRIPTION
At the moment this method accepts any iterable but can only work with arrays.

Fixes #38318
