### PR TITLE
[8.x] Change Visibility of the Markdown property in Mailable

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -77,7 +77,7 @@ class Mailable implements MailableContract, Renderable
      *
      * @var string
      */
-    protected $markdown;
+    public $markdown;
 
     /**
      * The HTML to use for the message.


### PR DESCRIPTION
I wanted to compare the output of a `mailable` against a stub, after some searching I found this as a solution: 

```php
Mail::assertSent(SomeMail::class, function (SomeMail $mail) {
    $mail = $mail->build();

    $this->assertStringEqualsFile(
        $this->removeTabsFromString(base_path('tests/Unit/Stubs/SomeMail.txt')),
        view($mail->view, $mail->buildViewData())
    );

    return true;
});
```

I wanted to do something similar for a markdown email, but I can't get access to this property as it's protected.