### PR TITLE
[8.x] Feature: Environment conditional routes

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1209,6 +1209,19 @@ class Route
     }
 
     /**
+     * Set route to work on specific environment
+     *
+     * @param string|null $env
+     * @return $this
+     */
+    public function env(string $env = null)
+    {
+        $this->action['env'] = $env;
+
+        return $this;
+    }
+
+    /**
      * Dynamically access route parameters.
      *
      * @param  string  $key

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1209,19 +1209,6 @@ class Route
     }
 
     /**
-     * Set route to work on specific environment
-     *
-     * @param string|null $env
-     * @return $this
-     */
-    public function env(string $env = null)
-    {
-        $this->action['env'] = $env;
-
-        return $this;
-    }
-
-    /**
      * Dynamically access route parameters.
      *
      * @param  string  $key

--- a/src/Illuminate/Routing/RouteGroup.php
+++ b/src/Illuminate/Routing/RouteGroup.php
@@ -28,7 +28,7 @@ class RouteGroup
         ]);
 
         return array_merge_recursive(Arr::except(
-            $old, ['namespace', 'prefix', 'where', 'as']
+            $old, ['namespace', 'prefix', 'where', 'as', 'env']
         ), $new);
     }
 

--- a/src/Illuminate/Routing/RouteGroup.php
+++ b/src/Illuminate/Routing/RouteGroup.php
@@ -24,6 +24,7 @@ class RouteGroup
             'namespace' => static::formatNamespace($new, $old),
             'prefix' => static::formatPrefix($new, $old, $prependExistingPrefix),
             'where' => static::formatWhere($new, $old),
+            'env' => static::formatEnvironment($new,$old),
         ]);
 
         return array_merge_recursive(Arr::except(
@@ -97,5 +98,23 @@ class RouteGroup
         }
 
         return $new;
+    }
+
+    /**
+     * Format the "env" clause of the new group attributes
+     *
+     * @param  array $new
+     * @param  array $old
+     * @return mixed|null
+     */
+    protected static function formatEnvironment(array $new, array $old)
+    {
+        if (isset($new['env'])) {
+            return $new['env'];
+        } elseif (isset($old['env'])) {
+            return $old['env'];
+        }
+
+        return null;
     }
 }

--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -55,7 +55,7 @@ class RouteRegistrar
      * @var string[]
      */
     protected $allowedAttributes = [
-        'as', 'domain', 'middleware', 'name', 'namespace', 'prefix', 'where',
+        'as', 'domain', 'middleware', 'name', 'namespace', 'prefix', 'where', 'env'
     ];
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -452,7 +452,16 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     public function addRoute($methods, $uri, $action)
     {
-        return $this->routes->add($this->createRoute($methods, $uri, $action));
+        $route = $this->createRoute($methods, $uri, $action);
+        $currentEnv = env('APP_ENV', 'local');
+
+        // if the route env is not set or matches the APP_ENV, we will add the route
+        // to the underlying route collection
+        if (in_array($route->parameter('env', null), [null, $currentEnv])) {
+            return $this->routes->add($this->createRoute($methods, $uri, $action));
+        }
+
+        return null;
     }
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -457,8 +457,8 @@ class Router implements BindingRegistrar, RegistrarContract
 
         // if the route env is not set or matches the APP_ENV, we will add the route
         // to the underlying route collection
-        if (in_array($route->parameter('env', null), [null, $currentEnv])) {
-            return $this->routes->add($this->createRoute($methods, $uri, $action));
+        if (in_array($route->getAction('env', null), [null, $currentEnv])) {
+            return $this->routes->add($route);
         }
 
         return null;


### PR DESCRIPTION
We all have come to situation that we want some routes to work locally and some on production and some on both. I have added this little feature to determine a route to be working locally, on production or on both.

This route will be working locally only
```php
Route::group(['env' => 'local'], function(){
    Route::get("/will-work-locally-only", function(){ return "local";})
});
```

This route will be working on production only
```php
Route::group(['env' => 'prod'], function(){
    Route::get("/will-work-on-prod-only", function(){ return "production";})
});
```

This route will be working on both local and production
```php
// set env to null or don't define env 
Route::group(['env' =>  null], function(){
    Route::get("/will-work-on-both", function(){ return "production and local";})
});
```