### PR TITLE
[8.x] Allow for closure reflection on all MailFake assertions

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -152,7 +152,7 @@ class MailFake implements Factory, Mailer, MailQueue
     /**
      * Determine if a mailable was not queued based on a truth-test callback.
      *
-     * @param  \Closure|string  $mailable
+     * @param  string|\Closure  $mailable
      * @param  callable|null  $callback
      * @return void
      */

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -45,9 +45,7 @@ class MailFake implements Factory, Mailer, MailQueue
      */
     public function assertSent($mailable, $callback = null)
     {
-        if ($mailable instanceof Closure) {
-            [$mailable, $callback] = [$this->firstClosureParameterType($mailable), $mailable];
-        }
+        [$mailable, $callback] = $this->prepareMailableAndCallback($mailable, $callback);
 
         if (is_numeric($callback)) {
             return $this->assertSentTimes($mailable, $callback);
@@ -85,12 +83,14 @@ class MailFake implements Factory, Mailer, MailQueue
     /**
      * Determine if a mailable was not sent based on a truth-test callback.
      *
-     * @param  string  $mailable
+     * @param  string|\Closure  $mailable
      * @param  callable|null  $callback
      * @return void
      */
     public function assertNotSent($mailable, $callback = null)
     {
+        [$mailable, $callback] = $this->prepareMailableAndCallback($mailable, $callback);
+
         PHPUnit::assertCount(
             0, $this->sent($mailable, $callback),
             "The unexpected [{$mailable}] mailable was sent."
@@ -120,9 +120,7 @@ class MailFake implements Factory, Mailer, MailQueue
      */
     public function assertQueued($mailable, $callback = null)
     {
-        if ($mailable instanceof Closure) {
-            [$mailable, $callback] = [$this->firstClosureParameterType($mailable), $mailable];
-        }
+        [$mailable, $callback] = $this->prepareMailableAndCallback($mailable, $callback);
 
         if (is_numeric($callback)) {
             return $this->assertQueuedTimes($mailable, $callback);
@@ -154,12 +152,14 @@ class MailFake implements Factory, Mailer, MailQueue
     /**
      * Determine if a mailable was not queued based on a truth-test callback.
      *
-     * @param  string  $mailable
+     * @param  \Closure|string  $mailable
      * @param  callable|null  $callback
      * @return void
      */
     public function assertNotQueued($mailable, $callback = null)
     {
+        [$mailable, $callback] = $this->prepareMailableAndCallback($mailable, $callback);
+
         PHPUnit::assertCount(
             0, $this->queued($mailable, $callback),
             "The unexpected [{$mailable}] mailable was queued."
@@ -183,12 +183,14 @@ class MailFake implements Factory, Mailer, MailQueue
     /**
      * Get all of the mailables matching a truth-test callback.
      *
-     * @param  string  $mailable
+     * @param  string|\Closure  $mailable
      * @param  callable|null  $callback
      * @return \Illuminate\Support\Collection
      */
     public function sent($mailable, $callback = null)
     {
+        [$mailable, $callback] = $this->prepareMailableAndCallback($mailable, $callback);
+
         if (! $this->hasSent($mailable)) {
             return collect();
         }
@@ -216,12 +218,14 @@ class MailFake implements Factory, Mailer, MailQueue
     /**
      * Get all of the queued mailables matching a truth-test callback.
      *
-     * @param  string  $mailable
+     * @param  string|\Closure  $mailable
      * @param  callable|null  $callback
      * @return \Illuminate\Support\Collection
      */
     public function queued($mailable, $callback = null)
     {
+        [$mailable, $callback] = $this->prepareMailableAndCallback($mailable, $callback);
+
         if (! $this->hasQueued($mailable)) {
             return collect();
         }
@@ -385,5 +389,21 @@ class MailFake implements Factory, Mailer, MailQueue
     public function failures()
     {
         return [];
+    }
+
+    /**
+     * Infer mailable class using reflection if a typehinted closure is passed to assertion.
+     *
+     * @param  string|\Closure  $mailable
+     * @param  callable|null $callback
+     * @return array
+     */
+    protected function prepareMailableAndCallback($mailable, $callback)
+    {
+        if ($mailable instanceof Closure) {
+            [$mailable, $callback] = [$this->firstClosureParameterType($mailable), $mailable];
+        }
+
+        return [$mailable, $callback];
     }
 }

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -401,7 +401,7 @@ class MailFake implements Factory, Mailer, MailQueue
     protected function prepareMailableAndCallback($mailable, $callback)
     {
         if ($mailable instanceof Closure) {
-            [$mailable, $callback] = [$this->firstClosureParameterType($mailable), $mailable];
+            return [$this->firstClosureParameterType($mailable), $mailable];
         }
 
         return [$mailable, $callback];

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -69,6 +69,22 @@ class SupportTestingMailFakeTest extends TestCase
         }
     }
 
+    public function testAssertNotSentWithClosure()
+    {
+        $callback = function (MailableStub $mail) {
+            return $mail->hasTo('taylor@laravel.com');
+        };
+
+        $this->fake->assertNotSent($callback);
+
+        $this->fake->to('taylor@laravel.com')->send($this->mailable);
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessageMatches('/The unexpected \['.preg_quote(MailableStub::class, '/').'\] mailable was sent./m');
+
+        $this->fake->assertNotSent($callback);
+    }
+
     public function testAssertSentTimes()
     {
         $this->fake->to('taylor@laravel.com')->send($this->mailable);


### PR DESCRIPTION
Right now, only the positive assertions on the `MailFake` class allow for passing a closure rather than a FQCN and a closure:

```php
// This works:
Mail::assertSent(fn(MyMailable $mail) => $mail->hasTo('foo@bar.com'));

// This doesn't:
Mail::assertNotSent(fn(MyMailable $mail) => $mail->hasTo('foo@bar.com'));

// Instead, right now you must do:
Mail::assertNotSent(MyMailable::class, fn(MyMailable $mail) => $mail->hasTo('foo@bar.com'));
```

This PR updates all the `MailFake` assertions to allow for the single closure API.