### PR TITLE
[8.x] Add stringable support for isUuid

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -259,6 +259,16 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Determine if a given string is a valid UUID.
+     *
+     * @return bool
+     */
+    public function isUuid()
+    {
+        return Str::isUuid($this->value);
+    }
+
+    /**
      * Determine if the given string is empty.
      *
      * @return bool

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -31,6 +31,12 @@ class SupportStringableTest extends TestCase
         $this->assertFalse($this->stringable('ù')->isAscii());
     }
 
+    public function testIsUuid()
+    {
+        $this->assertTrue($this->stringable('2cdc7039-65a6-4ac7-8e5d-d554a98e7b15')->isUuid());
+        $this->assertFalse($this->stringable('2cdc7039-65a6-4ac7-8e5d-d554a98')->isUuid());
+    }
+
     public function testIsEmpty()
     {
         $this->assertTrue($this->stringable('')->isEmpty());


### PR DESCRIPTION
This adds stringable support for the `isUuid()` method.

Before:

```php
$this->assertTrue(
    Str::isUuid(Str::of($filename)->after('-')->before('.'))
);
```

After:

```php
$this->assertTrue(
    Str::of($filename)->after('-')->before('.')->isUuid()
);
```