### PR TITLE
[8.x] Fix overriding presence verifier connection by null

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1346,7 +1346,7 @@ class Validator implements ValidatorContract
             throw new RuntimeException('Presence verifier has not been set.');
         }
 
-        if ($this->presenceVerifier instanceof DatabasePresenceVerifierInterface) {
+        if (! is_null($connection) && $this->presenceVerifier instanceof DatabasePresenceVerifierInterface) {
             $this->presenceVerifier->setConnection($connection);
         }
 

--- a/tests/Validation/ValidationDatabasePresenceVerifierTest.php
+++ b/tests/Validation/ValidationDatabasePresenceVerifierTest.php
@@ -4,7 +4,10 @@ namespace Illuminate\Tests\Validation;
 
 use Closure;
 use Illuminate\Database\ConnectionResolverInterface;
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
 use Illuminate\Validation\DatabasePresenceVerifier;
+use Illuminate\Validation\Validator;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use stdClass;
@@ -59,5 +62,39 @@ class ValidationDatabasePresenceVerifierTest extends TestCase
         $builder->shouldReceive('count')->once()->andReturn(100);
 
         $this->assertEquals(100, $verifier->getCount('table', 'column', 'value', null, null, $extra));
+    }
+
+    public function testSetPresenceVerifierOnValidator()
+    {
+        $verifier = new DatabasePresenceVerifier($db = m::mock(ConnectionResolverInterface::class));
+        $verifier->setConnection('connection');
+
+        $validator = new Validator(new Translator(new ArrayLoader, 'en'), [], []);
+        $validator->setPresenceVerifier($verifier);
+
+        $db->shouldReceive('connection')->once()->with('connection')->andReturn($conn = m::mock(stdClass::class));
+        $conn->shouldReceive('table')->once()->with('table')->andReturn($builder = m::mock(stdClass::class));
+        $builder->shouldReceive('useWritePdo')->once()->andReturn($builder);
+        $builder->shouldReceive('where')->with('column', '=', 'value')->andReturn($builder);
+        $builder->shouldReceive('count')->once()->andReturn(100);
+
+        $this->assertTrue($validator->validateExists('column', 'value', ['table']));
+    }
+
+    public function testSetPresenceVerifierOnValidatorWithSpecifiedConnection()
+    {
+        $verifier = new DatabasePresenceVerifier($db = m::mock(ConnectionResolverInterface::class));
+        $verifier->setConnection('connection');
+
+        $validator = new Validator(new Translator(new ArrayLoader, 'en'), [], []);
+        $validator->setPresenceVerifier($verifier);
+
+        $db->shouldReceive('connection')->once()->with('mysql')->andReturn($conn = m::mock(stdClass::class));
+        $conn->shouldReceive('table')->once()->with('table')->andReturn($builder = m::mock(stdClass::class));
+        $builder->shouldReceive('useWritePdo')->once()->andReturn($builder);
+        $builder->shouldReceive('where')->with('column', '=', 'value')->andReturn($builder);
+        $builder->shouldReceive('count')->once()->andReturn(100);
+
+        $this->assertTrue($validator->validateExists('column', 'value', ['mysql.table']));
     }
 }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2652,7 +2652,7 @@ class ValidationValidatorTest extends TestCase
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['email' => 'foo'], ['email' => 'Unique:users']);
         $mock = m::mock(DatabasePresenceVerifierInterface::class);
-        $mock->shouldReceive('setConnection')->once()->with(null);
+        $mock->shouldReceive('setConnection')->never();
         $mock->shouldReceive('getCount')->once()->with('users', 'email', 'foo', null, null, [])->andReturn(0);
         $v->setPresenceVerifier($mock);
         $this->assertTrue($v->passes());
@@ -2666,28 +2666,28 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['email' => 'foo'], ['email' => 'Unique:users,email_addr,1']);
         $mock = m::mock(DatabasePresenceVerifierInterface::class);
-        $mock->shouldReceive('setConnection')->once()->with(null);
+        $mock->shouldReceive('setConnection')->never();
         $mock->shouldReceive('getCount')->once()->with('users', 'email_addr', 'foo', '1', 'id', [])->andReturn(1);
         $v->setPresenceVerifier($mock);
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['email' => 'foo'], ['email' => 'Unique:users,email_addr,1,id_col']);
         $mock = m::mock(DatabasePresenceVerifierInterface::class);
-        $mock->shouldReceive('setConnection')->once()->with(null);
+        $mock->shouldReceive('setConnection')->never();
         $mock->shouldReceive('getCount')->once()->with('users', 'email_addr', 'foo', '1', 'id_col', [])->andReturn(2);
         $v->setPresenceVerifier($mock);
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['users' => [['id' => 1, 'email' => 'foo']]], ['users.*.email' => 'Unique:users,email,[users.*.id]']);
         $mock = m::mock(DatabasePresenceVerifierInterface::class);
-        $mock->shouldReceive('setConnection')->once()->with(null);
+        $mock->shouldReceive('setConnection')->never();
         $mock->shouldReceive('getCount')->once()->with('users', 'email', 'foo', '1', 'id', [])->andReturn(1);
         $v->setPresenceVerifier($mock);
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['email' => 'foo'], ['email' => 'Unique:users,email_addr,NULL,id_col,foo,bar']);
         $mock = m::mock(DatabasePresenceVerifierInterface::class);
-        $mock->shouldReceive('setConnection')->once()->with(null);
+        $mock->shouldReceive('setConnection')->never();
         $mock->shouldReceive('getCount')->once()->withArgs(function () {
             return func_get_args() === ['users', 'email_addr', 'foo', null, 'id_col', ['foo' => 'bar']];
         })->andReturn(2);
@@ -2702,7 +2702,7 @@ class ValidationValidatorTest extends TestCase
             '*.email' => 'unique:users', '*.type' => 'exists:user_types',
         ]);
         $mock = m::mock(DatabasePresenceVerifierInterface::class);
-        $mock->shouldReceive('setConnection')->twice()->with(null);
+        $mock->shouldReceive('setConnection')->never();
         $mock->shouldReceive('getCount')->with('users', 'email', 'foo', null, null, [])->andReturn(0);
         $mock->shouldReceive('getCount')->with('user_types', 'type', 'bar', null, null, [])->andReturn(1);
         $v->setPresenceVerifier($mock);
@@ -2717,7 +2717,7 @@ class ValidationValidatorTest extends TestCase
             '*.type' => (new Exists('user_types'))->where($closure),
         ]);
         $mock = m::mock(DatabasePresenceVerifierInterface::class);
-        $mock->shouldReceive('setConnection')->twice()->with(null);
+        $mock->shouldReceive('setConnection')->never();
         $mock->shouldReceive('getCount')->with('users', 'email', 'foo', null, 'id', [$closure])->andReturn(0);
         $mock->shouldReceive('getCount')->with('user_types', 'type', 'bar', null, null, [$closure])->andReturn(1);
         $v->setPresenceVerifier($mock);
@@ -2729,7 +2729,7 @@ class ValidationValidatorTest extends TestCase
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['email' => 'foo'], ['email' => 'Exists:users']);
         $mock = m::mock(DatabasePresenceVerifierInterface::class);
-        $mock->shouldReceive('setConnection')->once()->with(null);
+        $mock->shouldReceive('setConnection')->never();
         $mock->shouldReceive('getCount')->once()->with('users', 'email', 'foo', null, null, [])->andReturn(1);
         $v->setPresenceVerifier($mock);
         $this->assertTrue($v->passes());
@@ -2737,21 +2737,21 @@ class ValidationValidatorTest extends TestCase
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['email' => 'foo'], ['email' => 'Exists:users,email,account_id,1,name,taylor']);
         $mock = m::mock(DatabasePresenceVerifierInterface::class);
-        $mock->shouldReceive('setConnection')->once()->with(null);
+        $mock->shouldReceive('setConnection')->never();
         $mock->shouldReceive('getCount')->once()->with('users', 'email', 'foo', null, null, ['account_id' => 1, 'name' => 'taylor'])->andReturn(1);
         $v->setPresenceVerifier($mock);
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['email' => 'foo'], ['email' => 'Exists:users,email_addr']);
         $mock = m::mock(DatabasePresenceVerifierInterface::class);
-        $mock->shouldReceive('setConnection')->once()->with(null);
+        $mock->shouldReceive('setConnection')->never();
         $mock->shouldReceive('getCount')->once()->with('users', 'email_addr', 'foo', null, null, [])->andReturn(0);
         $v->setPresenceVerifier($mock);
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['email' => ['foo']], ['email' => 'Exists:users,email_addr']);
         $mock = m::mock(DatabasePresenceVerifierInterface::class);
-        $mock->shouldReceive('setConnection')->once()->with(null);
+        $mock->shouldReceive('setConnection')->never();
         $mock->shouldReceive('getMultiCount')->once()->with('users', 'email_addr', ['foo'], [])->andReturn(0);
         $v->setPresenceVerifier($mock);
         $this->assertFalse($v->passes());
@@ -2765,7 +2765,7 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['email' => ['foo', 'foo']], ['email' => 'exists:users,email_addr']);
         $mock = m::mock(DatabasePresenceVerifierInterface::class);
-        $mock->shouldReceive('setConnection')->once()->with(null);
+        $mock->shouldReceive('setConnection')->never();
         $mock->shouldReceive('getMultiCount')->once()->with('users', 'email_addr', ['foo', 'foo'], [])->andReturn(1);
         $v->setPresenceVerifier($mock);
         $this->assertTrue($v->passes());
@@ -2783,7 +2783,7 @@ class ValidationValidatorTest extends TestCase
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['id' => '1'], ['id' => 'Integer|Exists:users,id']);
         $mock = m::mock(DatabasePresenceVerifierInterface::class);
-        $mock->shouldReceive('setConnection')->once()->with(null);
+        $mock->shouldReceive('setConnection')->never();
         $mock->shouldReceive('getCount')->once()->with('users', 'id', '1', null, null, [])->andReturn(1);
         $v->setPresenceVerifier($mock);
         $this->assertTrue($v->passes());


### PR DESCRIPTION
Before this PR, when we did `$validator->setPresenceVerifier($verifier);` the verifier's connection was always overridden by null:

```
$verifier = App::make('validation.presence');
$verifier->setConnection('sqlite');
$validator = Validator::make($request->data, ['attribute' => 'exists:table,column']);
$validator->setPresenceVerifier($verifier);
$data = $validator->validate(); // queries to 'mysql.table' but we expected 'sqlite.table' to be used
```

This PR allows customizing validator connection by presence verifier as expected.