### PR TITLE
[8.x] Add optional params to FormRequest validated method

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -73,6 +73,13 @@ class FormRequest extends Request implements ValidatesWhenResolved
     protected $validator;
 
     /**
+     * Request data that passed validation
+     *
+     * @var array
+     */
+    protected $validatedData;
+
+    /**
      * Get the validator instance for the request.
      *
      * @return \Illuminate\Contracts\Validation\Validator
@@ -188,11 +195,19 @@ class FormRequest extends Request implements ValidatesWhenResolved
     /**
      * Get the validated data from the request.
      *
-     * @return array
+     * @param  string|null  $key
+     * @param  mixed|null  $default
+     * @return  mixed
+     *
+     * @throws \Illuminate\Validation\ValidationException
      */
-    public function validated()
+    public function validated(string $key = null, $default = null)
     {
-        return $this->validator->validated();
+        if (!$this->validatedData) {
+            $this->validatedData = $this->validator->validated();
+        }
+
+        return data_get($this->validatedData, $key, $default);
     }
 
     /**

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -73,7 +73,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
     protected $validator;
 
     /**
-     * Request data that passed validation
+     * Request data that passed validation.
      *
      * @var array
      */
@@ -203,7 +203,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
      */
     public function validated(string $key = null, $default = null)
     {
-        if (!$this->validatedData) {
+        if (! $this->validatedData) {
             $this->validatedData = $this->validator->validated();
         }
 

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -115,6 +115,25 @@ class FoundationFormRequestTest extends TestCase
         $this->assertEquals(['name' => 'Adam'], $request->all());
     }
 
+    public function testValidatedMethodReturnsSingleValidatedDataField()
+    {
+        $request = $this->createRequest(['name' => 'specified']);
+
+        $request->validateResolved();
+
+        $this->assertSame('specified', $request->validated('name'));
+    }
+
+    public function testValidatedMethodReturnsNullWhenFieldIsNotValidated()
+    {
+        $request = $this->createRequest(['name' => 'specified', 'with' => 'extras']);
+
+        $request->validateResolved();
+
+        $this->assertSame('extras', $request->input('with'));
+        $this->assertNull($request->validated('with'));
+    }
+
     /**
      * Catch the given exception thrown from the executor, and return it.
      *


### PR DESCRIPTION
Adds optional params to FormRequest `validated()` method, so developer can access validated data in cleaner, more readable way. 

Before:
```php
$data = $request->validated()
$email = $data['email']
$role = $data['role'] ?? UserRole::GUEST
```

After:
```php
$email = $request->validated('email')
$role = $request->validated('role', UserRole::GUEST)
```

Method signature is the same as `$request->input($key, $default)` so there is no learning curve ~~and it is fully backwards compatible~~. It is also much faster than `$request->input('key')`, about 2-3x faster in my tests, performing similarly to `$request->get('key')`.
