### PR TITLE
[8.x] Improve validation rule required_if failed message.

### DIFF
--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -363,11 +363,19 @@ trait ReplacesAttributes
      */
     protected function replaceRequiredIf($message, $attribute, $rule, $parameters)
     {
-        $parameters[1] = $this->getDisplayableValue($parameters[0], Arr::get($this->data, $parameters[0]));
+        $other = $this->getDisplayableAttribute($parameters[0]);
 
-        $parameters[0] = $this->getDisplayableAttribute($parameters[0]);
+        $displayable_values = array_map(function ($value) use ($parameters) {
+            if ($value === 'null') {
+                $value = null;
+            } elseif ($value === 'true' || $value === 'false') {
+                $value = Arr::get($this->data, $parameters[0]);
+            }
 
-        return str_replace([':other', ':value'], $parameters, $message);
+            return $this->getDisplayableValue($parameters[0], $value);
+        }, array_slice($parameters, 1));
+
+        return str_replace([':other', ':value'], [$other, count($displayable_values) > 1 ? implode(', ', array_slice($displayable_values, 0, -1)).' or '.$displayable_values[count($displayable_values) - 1] : $displayable_values[0]], $message);
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1225,7 +1225,7 @@ class ValidationValidatorTest extends TestCase
         $trans->addLines(['validation.required_if' => 'The :attribute field is required when :other is :value.'], 'en');
         $v = new Validator($trans, ['first' => 'dayle', 'last' => ''], ['last' => 'RequiredIf:first,taylor,dayle']);
         $this->assertFalse($v->passes());
-        $this->assertSame('The last field is required when first is dayle.', $v->messages()->first('last'));
+        $this->assertSame('The last field is required when first is taylor or dayle.', $v->messages()->first('last'));
 
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.required_if' => 'The :attribute field is required when :other is :value.'], 'en');


### PR DESCRIPTION
Validation rule `required_if` can accept multiple values, but error message contains only one value when `required_if` failed.

```
Validator::make(['first' => 'foo', 'last' => ''], ['last' => 'required_if:first,foo,bar,baz'])->errors()->all()

result is:

 [
     "The last field is required when first is foo.",
 ]

```
This PR change the error message to 'The last field is required when first is foo, bar or baz.'
