### PR TITLE
[8.x] Add Failover Swift Transport driver

### DIFF
--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -351,6 +351,7 @@ class MailManager implements FactoryContract
     protected function createFailoverTransport(array $config)
     {
         $transports = [];
+
         foreach ($config['mailers'] as $name) {
             $config = $this->getConfig($name);
 
@@ -358,9 +359,9 @@ class MailManager implements FactoryContract
                 throw new InvalidArgumentException("Mailer [{$name}] is not defined.");
             }
 
-            // Here we will check if the "driver" key exists and if it does we will set
-            // transport configuration parameter in order to  provide "BC" for any
-            // Laravel <= 6.x style mail configuration files.
+            // Now, we will check if the "driver" key exists and if it does we will set
+            // the transport configuration parameter in order to offer compatibility
+            // with any Laravel <= 6.x application style mail configuration files.
             $transports[] = $this->app['config']['mail.driver']
                 ? $this->createTransport(array_merge($config, ['transport' => $name]))
                 : $this->createTransport($config);

--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -18,10 +18,10 @@ use Postmark\ThrowExceptionOnFailurePlugin;
 use Postmark\Transport as PostmarkTransport;
 use Psr\Log\LoggerInterface;
 use Swift_DependencyContainer;
+use Swift_FailoverTransport as FailoverTransport;
 use Swift_Mailer;
 use Swift_SendmailTransport as SendmailTransport;
 use Swift_SmtpTransport as SmtpTransport;
-use Swift_FailoverTransport as FailoverTransport;
 
 /**
  * @mixin \Illuminate\Mail\Mailer
@@ -365,6 +365,7 @@ class MailManager implements FactoryContract
                 ? $this->createTransport(array_merge($config, ['transport' => $name]))
                 : $this->createTransport($config);
         }
+
         return new FailoverTransport($transports);
     }
 

--- a/tests/Mail/MailFailoverTransportTest.php
+++ b/tests/Mail/MailFailoverTransportTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Illuminate\Tests\Mail;
+
+use Illuminate\Mail\Transport\ArrayTransport;
+use Orchestra\Testbench\TestCase;
+
+class MailFailoverTransportTest extends TestCase
+{
+    public function testGetFailoverTransportWithConfiguredTransports()
+    {
+        $this->app['config']->set('mail.default', 'failover');
+
+        $this->app['config']->set('mail.mailers', [
+            'failover' => [
+                'transport' => 'failover',
+                'mailers' => [
+                    'sendmail',
+                    'array',
+                ],
+            ],
+
+            'sendmail' => [
+                'transport' => 'sendmail',
+                'path' => '/usr/sbin/sendmail -bs',
+            ],
+
+            'array' => [
+                'transport' => 'array',
+            ],
+        ]);
+
+        $transport = app('mailer')->getSwiftMailer()->getTransport();
+        $this->assertInstanceOf(\Swift_FailoverTransport::class, $transport);
+
+        $transports = $transport->getTransports();
+        $this->assertCount(2, $transports);
+        $this->assertInstanceOf(\Swift_SendmailTransport::class, $transports[0]);
+        $this->assertEquals('/usr/sbin/sendmail -bs', $transports[0]->getCommand());
+        $this->assertInstanceOf(ArrayTransport::class, $transports[1]);
+    }
+
+    public function testGetFailoverTransportWithLaravel6StyleMailConfiguration()
+    {
+        $this->app['config']->set('mail.driver', 'failover');
+
+        $this->app['config']->set('mail.mailers', [
+            'sendmail',
+            'array',
+        ]);
+
+        $this->app['config']->set('mail.sendmail', '/usr/sbin/sendmail -bs');
+
+        $transport = app('mailer')->getSwiftMailer()->getTransport();
+        $this->assertInstanceOf(\Swift_FailoverTransport::class, $transport);
+
+        $transports = $transport->getTransports();
+        $this->assertCount(2, $transports);
+        $this->assertInstanceOf(\Swift_SendmailTransport::class, $transports[0]);
+        $this->assertEquals('/usr/sbin/sendmail -bs', $transports[0]->getCommand());
+        $this->assertInstanceOf(ArrayTransport::class, $transports[1]);
+    }
+}


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Sometimes mailgun is not available in our area. The most recent one in the EU was on Aug 2 for ~2 hours and the one before that was on May 29 for ~5 hours (https://status.mailgun.com/). In each cases our clients might lost users by not getting immediate emails. With a "failover" mail transport we could fallback to a different transport driver in the future and help our clients not to lose users.

`Swift_FailoverTransport` is already battle tested and I was able to provide backward compatibility for "Laravel <= 6.x style mail configuration files".

This feature was requested in 2014 but it was rejected with a comment "No plans to implement this currently.". #3374

My original plan was to develop a provider (https://github.com/coding-socks/laravel-mail-failover) but the whole logic is so simple that in my opinion this could be added to the core library. If you disagree I can still release my lib on packagist.