### PR TITLE
Support nested JSON language files

### DIFF
--- a/src/Illuminate/Translation/FileLoader.php
+++ b/src/Illuminate/Translation/FileLoader.php
@@ -4,6 +4,7 @@ namespace Illuminate\Translation;
 
 use Illuminate\Contracts\Translation\Loader;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Arr;
 use RuntimeException;
 
 class FileLoader implements Loader
@@ -145,7 +146,9 @@ class FileLoader implements Loader
                         throw new RuntimeException("Translation file [{$full}] contains an invalid JSON structure.");
                     }
 
-                    $output = array_merge($output, $decoded);
+                    $flattened = Arr::dot($decoded);
+
+                    $output = array_merge($output, $flattened);
                 }
 
                 return $output;


### PR DESCRIPTION
While namespaced language files (e.g. `resources/lang/en/acme.php`) already supported nested keys (e.g. `acme.path.to.key`), JSON language files (e.g. `resources/lang/en.json`) have been expected to be "only one level deep", and therefore nested keys in JSON language files have effectively been ignored so far.

By flattening the loaded JSON language files (e.g. `{"acme":{"key":"foo"}}` becomes `{"acme.key":"foo"}`), we make nested keys in JSON language files work as expected.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
