### PR TITLE
[8.x] `firstOrCreate` and `firstOrNew` should merge attributes correctly

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -465,7 +465,7 @@ class Builder
             return $instance;
         }
 
-        return $this->newModelInstance($attributes + $values);
+        return $this->newModelInstance(array_merge($attributes, $values));
     }
 
     /**
@@ -481,7 +481,7 @@ class Builder
             return $instance;
         }
 
-        return tap($this->newModelInstance($attributes + $values), function ($instance) {
+        return tap($this->newModelInstance(array_merge($attributes, $values)), function ($instance) {
             $instance->save();
         });
     }

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -214,7 +214,7 @@ abstract class HasOneOrMany extends Relation
     public function firstOrNew(array $attributes = [], array $values = [])
     {
         if (is_null($instance = $this->where($attributes)->first())) {
-            $instance = $this->related->newInstance($attributes + $values);
+            $instance = $this->related->newInstance(array_merge($attributes, $values));
 
             $this->setForeignAttributesForCreate($instance);
         }
@@ -232,7 +232,7 @@ abstract class HasOneOrMany extends Relation
     public function firstOrCreate(array $attributes = [], array $values = [])
     {
         if (is_null($instance = $this->where($attributes)->first())) {
-            $instance = $this->create($attributes + $values);
+            $instance = $this->create(array_merge($attributes, $values));
         }
 
         return $instance;

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -401,6 +401,16 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertInstanceOf(CursorPaginator::class, $models);
     }
 
+    public function testFirstOrNew()
+    {
+        $user1 = EloquentTestUser::firstOrNew(
+            ['name' => 'Dries Vints'],
+            ['name' => 'Nuno Maduro']
+        );
+
+        $this->assertSame('Nuno Maduro', $user1->name);
+    }
+
     public function testFirstOrCreate()
     {
         $user1 = EloquentTestUser::firstOrCreate(['email' => 'taylorotwell@gmail.com']);
@@ -425,6 +435,13 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertNotEquals($user3->id, $user1->id);
         $this->assertSame('abigailotwell@gmail.com', $user3->email);
         $this->assertSame('Abigail Otwell', $user3->name);
+
+        $user4 = EloquentTestUser::firstOrCreate(
+            ['name' => 'Dries Vints'],
+            ['name' => 'Nuno Maduro']
+        );
+
+        $this->assertSame('Nuno Maduro', $user4->name);
     }
 
     public function testUpdateOrCreate()

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -695,6 +695,36 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertCount(1, $models);
     }
 
+    public function testFirstOrNewOnHasOneRelationShip()
+    {
+        $user1 = EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);
+        $post1 = $user1->post()->firstOrNew(['name' => 'First Post'], ['name' => 'New Post']);
+
+        $this->assertSame('New Post', $post1->name);
+
+        $user2 = EloquentTestUser::create(['email' => 'abigailotwell@gmail.com']);
+        $post = $user2->post()->create(['name' => 'First Post']);
+        $post2 = $user2->post()->firstOrNew(['name' => 'First Post'], ['name' => 'New Post']);
+
+        $this->assertSame('First Post', $post2->name);
+        $this->assertSame($post->id, $post2->id);
+    }
+
+    public function testFirstOrCreateOnHasOneRelationShip()
+    {
+        $user1 = EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);
+        $post1 = $user1->post()->firstOrCreate(['name' => 'First Post'], ['name' => 'New Post']);
+
+        $this->assertSame('New Post', $post1->name);
+
+        $user2 = EloquentTestUser::create(['email' => 'abigailotwell@gmail.com']);
+        $post = $user2->post()->create(['name' => 'First Post']);
+        $post2 = $user2->post()->firstOrCreate(['name' => 'First Post'], ['name' => 'New Post']);
+
+        $this->assertSame('First Post', $post2->name);
+        $this->assertSame($post->id, $post2->id);
+    }
+
     public function testHasOnSelfReferencingBelongsToManyRelationship()
     {
         $user = EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -438,7 +438,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         $user4 = EloquentTestUser::firstOrCreate(
             ['name' => 'Dries Vints'],
-            ['name' => 'Nuno Maduro']
+            ['name' => 'Nuno Maduro', 'email' => 'nuno@laravel.com']
         );
 
         $this->assertSame('Nuno Maduro', $user4->name);


### PR DESCRIPTION
Not sure if this is a bug, but at the same time, it seems like it doesn't work as you'd expect, so thought I'd create this PR for some feedback.

I guess you could argue this is not the correct use case for the `firstOrNew()` method, e.g. why check for an existing value, then change that value to something new. Either way, it was still unexpected.

Consider the following example...

```php
$company = Company::firstOrNew(
	['name' => 'Does not exist'],
	['name' => 'New Company'],
);

dd($company);

```

### Current Output
```
=> App\Models\Company {
    name: "Does not exist",
}
```

### Expected Output?
```
=> App\Models\Company {
    name: "New Company",
}
```

Same "bug" exists with `firstOrCreate()`

More details here https://github.com/laravel/framework/discussions/38303

// ping @Sirfrummel