### PR TITLE
[8.x] Added assertRedirectToSignedRoute() method for testing responses

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -268,7 +268,7 @@ EOF;
     }
 
     /**
-     * Assert whether the response is redirecting to a given signed URI.
+     * Assert whether the response is redirecting to a given signed route.
      *
      * @param  string|null  $name
      * @param  mixed  $parameters
@@ -293,7 +293,7 @@ EOF;
         if (! is_null($name)) {
             $expectedUri = rtrim($request->fullUrlWithQuery([
                 'signature' => null,
-                'expires'   => null,
+                'expires' => null,
             ]), '?');
 
             PHPUnit::assertEquals(

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -270,11 +270,16 @@ EOF;
     /**
      * Assert whether the response is redirecting to a given signed URI.
      *
-     * @param  string|null  $uri
+     * @param  string|null  $name
+     * @param  mixed  $parameters
      * @return $this
      */
-    public function assertRedirectToSignedRoute($uri = null)
+    public function assertRedirectToSignedRoute($name = null, $parameters = [])
     {
+        if (! is_null($name)) {
+            $uri = route($name, $parameters);
+        }
+
         PHPUnit::assertTrue(
             $this->isRedirect(), 'Response status code ['.$this->getStatusCode().'] is not a redirect status code.'
         );
@@ -285,7 +290,7 @@ EOF;
             $request->hasValidSignature(), 'The response is not a redirect to a signed route.'
         );
 
-        if (! is_null($uri)) {
+        if (! is_null($name)) {
             $expectedUri = rtrim($request->fullUrlWithQuery([
                 'signature' => null,
                 'expires'   => null,

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -286,10 +286,10 @@ EOF;
         );
 
         if (! is_null($uri)) {
-            $expectedUri = $request->fullUrlWithQuery([
+            $expectedUri = rtrim($request->fullUrlWithQuery([
                 'signature' => null,
                 'expires'   => null,
-            ]);
+            ]), '?');
 
             PHPUnit::assertEquals(
                 app('url')->to($uri), $expectedUri

--- a/tests/Testing/AssertRedirectToSignedRouteTest.php
+++ b/tests/Testing/AssertRedirectToSignedRouteTest.php
@@ -65,7 +65,7 @@ class AssertRedirectToSignedRouteTest extends TestCase
         $this->router->get('test-route-with-extra-param', function () {
             return new RedirectResponse($this->urlGenerator->signedRoute('signed-route-with-param', [
                 'param' => 'foo',
-                'extra' => 'another'
+                'extra' => 'another',
             ]));
         });
 
@@ -75,7 +75,7 @@ class AssertRedirectToSignedRouteTest extends TestCase
         $this->get('test-route-with-extra-param')
             ->assertRedirectToSignedRoute('signed-route-with-param', [
                 'param' => 'foo',
-                'extra' => 'another'
+                'extra' => 'another',
             ]);
     }
 

--- a/tests/Testing/AssertRedirectToSignedRouteTest.php
+++ b/tests/Testing/AssertRedirectToSignedRouteTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Illuminate\Tests\Testing;
+
+use Illuminate\Contracts\Routing\Registrar;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Routing\UrlGenerator;
+use Orchestra\Testbench\TestCase;
+
+class AssertRedirectToSignedRouteTest extends TestCase
+{
+    /**
+     * @var \Illuminate\Contracts\Routing\Registrar
+     */
+    private $router;
+
+    /**
+     * @var \Illuminate\Routing\UrlGenerator
+     */
+    private $urlGenerator;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->router = $this->app->make(Registrar::class);
+
+        $this->router
+            ->get('signed-route')
+            ->name('signed-route');
+
+        $this->router
+            ->get('signed-route-with-param/{param}')
+            ->name('signed-route-with-param');
+
+        $this->urlGenerator = $this->app->make(UrlGenerator::class);
+    }
+
+    public function testAssertRedirectToSignedRouteWithoutRouteName()
+    {
+        $this->router->get('test-route', function () {
+            return new RedirectResponse($this->urlGenerator->signedRoute('signed-route'));
+        });
+
+        $this->get('test-route')
+            ->assertRedirectToSignedRoute();
+    }
+
+    public function testAssertRedirectToSignedRouteWithRouteName()
+    {
+        $this->router->get('test-route', function () {
+            return new RedirectResponse($this->urlGenerator->signedRoute('signed-route'));
+        });
+
+        $this->get('test-route')
+            ->assertRedirectToSignedRoute('signed-route');
+    }
+
+    public function testAssertRedirectToSignedRouteWithRouteNameAndParams()
+    {
+        $this->router->get('test-route', function () {
+            return new RedirectResponse($this->urlGenerator->signedRoute('signed-route-with-param', 'hello'));
+        });
+
+        $this->router->get('test-route-with-extra-param', function () {
+            return new RedirectResponse($this->urlGenerator->signedRoute('signed-route-with-param', [
+                'param' => 'foo',
+                'extra' => 'another'
+            ]));
+        });
+
+        $this->get('test-route')
+            ->assertRedirectToSignedRoute('signed-route-with-param', 'hello');
+
+        $this->get('test-route-with-extra-param')
+            ->assertRedirectToSignedRoute('signed-route-with-param', [
+                'param' => 'foo',
+                'extra' => 'another'
+            ]);
+    }
+
+    public function testAssertRedirectToSignedRouteWithRouteNameToTemporarySignedRoute()
+    {
+        $this->router->get('test-route', function () {
+            return new RedirectResponse($this->urlGenerator->temporarySignedRoute('signed-route', 60));
+        });
+
+        $this->get('test-route')
+            ->assertRedirectToSignedRoute('signed-route');
+    }
+}

--- a/tests/Testing/AssertRedirectToSignedRouteTest.php
+++ b/tests/Testing/AssertRedirectToSignedRouteTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Testing;
 use Illuminate\Contracts\Routing\Registrar;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Routing\UrlGenerator;
+use Illuminate\Support\Facades\Facade;
 use Orchestra\Testbench\TestCase;
 
 class AssertRedirectToSignedRouteTest extends TestCase
@@ -87,5 +88,12 @@ class AssertRedirectToSignedRouteTest extends TestCase
 
         $this->get('test-route')
             ->assertRedirectToSignedRoute('signed-route');
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+
+        Facade::setFacadeApplication(null);
     }
 }


### PR DESCRIPTION
Hey! This PR adds a new method called `assertRedirectToSignedRoute()` that works in an almost identical way to the `assertRedirect()` route. I might be approaching this from the wrong angle, but I've not found a clean way of testing signed URL redirects so far, so I thought this could be pretty useful.

Here's an example of a controller method that we could write the test for:

```php
class RandomController extends Controller
{
    public function __invoke()
    {
        // Do something...
        
        return redirect()->signedRoute('example.route', ['param' => 'hello']);
    }
}
```

For example's sake, I'll just say that the route name for the method above is `laravel.index`... Now in the test we could use:

```php
public function test_user_is_redirected_to_signed_route()
{
    // We could do this if we just want to check that we were redirected to a signed URL
    $this->get(route('laravel.index'))
        ->assertRedirectToSignedRoute();

    // We could do this if we just want to check the URL was correct
    $this->get(route('laravel.index'))
        ->assertRedirectToSignedRoute(route('example.route', ['param' => 'hello']));
}
```

I've been trying this with quite a few different types of signed URLs (non-expiring and temporary) and it seems to cover all of the use cases I've tried. But it's possible that I might have missed some edge cases maybe?

I've not written any test for this, but if it's something you think might be worth pulling in, I'd be happy to write some tests for it :smile: 