### PR TITLE
[8.x] Update return type for tap

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -422,7 +422,7 @@ trait BuildsQueries
      * Pass the query to a given callback.
      *
      * @param  callable  $callback
-     * @return $this
+     * @return $this|mixed
      */
     public function tap($callback)
     {


### PR DESCRIPTION
`when` already has `$this|mixed` so this should be reflected in `tap` on `BuildsQueries`. If you look at the logic inside `when` you'll see that this is the correct return type as it's either the return value of the given callback or `$this`. A previous attempt was made here: https://github.com/laravel/framework/pull/32717

See a more thorough explanation here: https://github.com/laravel/framework/issues/38343
