### PR TITLE
[8.x] Add connection to validator

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -45,6 +45,13 @@ class Validator implements ValidatorContract
     protected $presenceVerifier;
 
     /**
+     * The connection name for the validator.
+     *
+     * @var string|null
+     */
+    protected $connection;
+
+    /**
      * The failed validation rules.
      *
      * @var array
@@ -1333,6 +1340,19 @@ class Validator implements ValidatorContract
     }
 
     /**
+     * Set the connection associated with the validator.
+     *
+     * @param  string|null  $name
+     * @return $this
+     */
+    public function setConnection($name)
+    {
+        $this->connection = $name;
+
+        return $this;
+    }
+
+    /**
      * Get the Presence Verifier implementation.
      *
      * @param  string|null  $connection
@@ -1347,7 +1367,7 @@ class Validator implements ValidatorContract
         }
 
         if ($this->presenceVerifier instanceof DatabasePresenceVerifierInterface) {
-            $this->presenceVerifier->setConnection($connection);
+            $this->presenceVerifier->setConnection($connection ?? $this->connection);
         }
 
         return $this->presenceVerifier;

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2697,7 +2697,7 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['id' => '1', 'email' => 'foo', 'type' => 'bar'], [
             'id' => 'Unique:users',
             'email' => 'Unique:another_connection.users',
-            'type' => 'Unique:types'
+            'type' => 'Unique:types',
         ]);
         $v->setConnection('connection');
         $mock = m::mock(DatabasePresenceVerifierInterface::class);
@@ -2788,7 +2788,7 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['id' => '1', 'email' => 'foo', 'type' => 'bar'], [
             'id' => 'Exists:users',
             'email' => 'Exists:another_connection.users',
-            'type' => 'Exists:types'
+            'type' => 'Exists:types',
         ]);
         $v->setConnection('connection');
         $mock = m::mock(DatabasePresenceVerifierInterface::class);


### PR DESCRIPTION
Before this PR, it wasn't possible to customize the default connection of a validator. This PR adds `setConnection` method to the validator to specify the default connection to be used for the `exists` and `unique` rules' query.

Please note that, the database connection which is explicitly specified on the rule itself would have precedence as expected:

```php
$validator = Validator::make($request->data, [
    'state' => 'exists:states',          // uses 'sqlite.states'
    'email' => 'exists:connection.staff' // uses 'connection.staff'

]);
$validator->setConnection('sqlite');
```