### PR TITLE
[9.x] Make BuildsQueries::tap consistent with other versions of tap

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -422,10 +422,12 @@ trait BuildsQueries
      * Pass the query to a given callback.
      *
      * @param  callable  $callback
-     * @return $this|mixed
+     * @return $this
      */
     public function tap($callback)
     {
-        return $this->when(true, $callback);
+        $callback($this);
+
+        return $this;
     }
 }


### PR DESCRIPTION
As previously mentioned on #38343 and #38353.

This PR makes `BuildsQueries::tap()` consistent with `EnumeratesValues::tap()` and `tap()`, meaning it will always return `$this` after executing the given callback. This change should not be breaking unless the developer was relying on undocumented behaviour (prior to #38353).