### PR TITLE
[9.x] BelongsToMany `firstOrCreate` and `firstOrNew` should merge attributes correctly

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -594,12 +594,13 @@ class BelongsToMany extends Relation
      * Get the first related model record matching the attributes or instantiate it.
      *
      * @param  array  $attributes
+     * @param  array  $values
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function firstOrNew(array $attributes = [])
+    public function firstOrNew(array $attributes = [], array $values = [])
     {
         if (is_null($instance = $this->related->where($attributes)->first())) {
-            $instance = $this->related->newInstance($attributes);
+            $instance = $this->related->newInstance(array_merge($attributes, $values));
         }
 
         return $instance;
@@ -617,7 +618,7 @@ class BelongsToMany extends Relation
     public function firstOrCreate(array $attributes = [], array $values = [], array $joining = [], $touch = true)
     {
         if (is_null($instance = $this->related->where($attributes)->first())) {
-            $instance = $this->create($attributes + $values, $joining, $touch);
+            $instance = $this->create(array_merge($attributes, $values), $joining, $touch);
         }
 
         return $instance;

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -439,6 +439,36 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $this->assertNotNull($new->id);
     }
 
+    public function testFirstOrNewMethodWithValues()
+    {
+        $post = Post::create(['title' => Str::random()]);
+        $tag = Tag::create(['name' => Str::random()]);
+        $post->tags()->attach(Tag::all());
+
+        $existing = $post->tags()->firstOrNew(
+            ['name' => $tag->name],
+            ['type' => 'featured']
+        );
+
+        $this->assertEquals($tag->id, $existing->id);
+        $this->assertNotEquals('foo', $existing->name);
+
+        $new = $post->tags()->firstOrNew(
+            ['name' => 'foo'],
+            ['type' => 'featured']
+        );
+
+        $this->assertSame('foo', $new->name);
+        $this->assertSame('featured', $new->type);
+
+        $new = $post->tags()->firstOrNew(
+            ['name' => 'foo'],
+            ['name' => 'bar']
+        );
+
+        $this->assertSame('bar', $new->name);
+    }
+
     public function testFirstOrCreateMethodWithValues()
     {
         $post = Post::create(['title' => Str::random()]);
@@ -460,6 +490,14 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
 
         $this->assertSame('foo', $new->name);
         $this->assertSame('featured', $new->type);
+        $this->assertNotNull($new->id);
+
+        $new = $post->tags()->firstOrCreate(
+            ['name' => 'qux'],
+            ['name' => 'bar']
+        );
+
+        $this->assertSame('bar', $new->name);
         $this->assertNotNull($new->id);
     }
 


### PR DESCRIPTION
This PR is related to #38346 but only targets the `9.0` branch as the `firstOrNew()` and `firstOrCreate()` methods on the `BelongsToMany` relationship were updated in `9.0` (#37337) to be functionally the same as the equivalent methods in `Builder` and `HasOneOrMany` classes.