### PR TITLE
[8.x] Fix null values for cursor pagination

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -349,7 +349,7 @@ trait BuildsQueries
     }
 
     /**
-     * Handle creating a where clause for when a cursor value is null
+     * Handle creating a where clause for when a cursor value is null.
      *
      * @param  string  $column
      * @param  \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder  $builder
@@ -360,7 +360,7 @@ trait BuildsQueries
     {
         $ascending = $direction === 'asc';
         if (! $builder->getGrammar()->nullsAreOrderedFirst()) {
-            $ascending = !$ascending;
+            $ascending = ! $ascending;
         }
         if ($ascending) {
             $builder->whereNotNull($column);

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -315,11 +315,18 @@ trait BuildsQueries
                 $builder->where(function (self $builder) use ($addCursorConditions, $cursor, $orders, $i) {
                     ['column' => $column, 'direction' => $direction] = $orders[$i];
 
-                    $builder->where(
-                        $this->getOriginalColumnNameForCursorPagination($this, $column),
-                        $direction === 'asc' ? '>' : '<',
-                        $cursor->parameter($column)
-                    );
+                    $param = $cursor->parameter($column);
+                    $originalColumn = $this->getOriginalColumnNameForCursorPagination($this, $column);
+
+                    if (is_null($param)) {
+                        $this->whereClauseForCursorNullValue($originalColumn, $builder, $direction);
+                    } else {
+                        $builder->where(
+                            $originalColumn,
+                            $direction === 'asc' ? '>' : '<',
+                            $param
+                        );
+                    }
 
                     if ($i < $orders->count() - 1) {
                         $builder->orWhere(function (self $builder) use ($addCursorConditions, $column, $i) {
@@ -339,6 +346,27 @@ trait BuildsQueries
             'cursorName' => $cursorName,
             'parameters' => $orders->pluck('column')->toArray(),
         ]);
+    }
+
+    /**
+     * Handle creating a where clause for when a cursor value is null
+     *
+     * @param  string  $column
+     * @param  \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder  $builder
+     * @param  string  $direction
+     * @return void
+     */
+    protected function whereClauseForCursorNullValue($column, $builder, $direction)
+    {
+        $ascending = $direction === 'asc';
+        if (! $builder->getGrammar()->nullsAreOrderedFirst()) {
+            $ascending = !$ascending;
+        }
+        if ($ascending) {
+            $builder->whereNotNull($column);
+        } else {
+            $builder->whereNull($column);
+        }
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -1284,4 +1284,15 @@ class Grammar extends BaseGrammar
     {
         return $this->operators;
     }
+
+    /**
+     * Nulls are ordered first when ordring in ascending order
+     *
+     * @return bool
+     */
+    public function nullsAreOrderedFirst()
+    {
+        return true;
+    }
+
 }

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -1286,7 +1286,7 @@ class Grammar extends BaseGrammar
     }
 
     /**
-     * Nulls are ordered first when ordring in ascending order
+     * Nulls are ordered first when ordring in ascending order.
      *
      * @return bool
      */
@@ -1294,5 +1294,4 @@ class Grammar extends BaseGrammar
     {
         return true;
     }
-
 }

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -411,7 +411,7 @@ class PostgresGrammar extends Grammar
     }
 
     /**
-     * Nulls are ordered first when ordring in ascending order
+     * Nulls are ordered first when ordring in ascending order.
      *
      * @return bool
      */
@@ -419,5 +419,4 @@ class PostgresGrammar extends Grammar
     {
         return false;
     }
-
 }

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -409,4 +409,15 @@ class PostgresGrammar extends Grammar
                         : "'$attribute'";
         }, $path);
     }
+
+    /**
+     * Nulls are ordered first when ordring in ascending order
+     *
+     * @return bool
+     */
+    public function nullsAreOrderedFirst()
+    {
+        return false;
+    }
+
 }


### PR DESCRIPTION
Allow using cursor with a column with null values.

Fixes https://github.com/laravel/framework/issues/38220