### PR TITLE
[8.x] Blade component slot attributes

### DIFF
--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -437,7 +437,11 @@ class ComponentTagCompiler
                 $name = "'{$name}'";
             }
 
-            return " @slot({$name}) ";
+            $this->boundAttributes = [];
+
+            $attributes = $this->getAttributesFromAttributeString($matches['attributes']);
+
+            return " @slot({$name}, [".$this->attributesToString($attributes, $escapeBound = false).']) ';
         }, $value);
 
         return preg_replace('/<\/\s*x[\-\:]slot[^>]*>/', ' @endslot', $value);

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -441,7 +441,7 @@ class ComponentTagCompiler
 
             $attributes = $this->getAttributesFromAttributeString($matches['attributes']);
 
-            return " @slot({$name}, null, [".$this->attributesToString($attributes, $escapeBound = false).']) ';
+            return " @slot({$name}, null, [".$this->attributesToString($attributes).']) ';
         }, $value);
 
         return preg_replace('/<\/\s*x[\-\:]slot[^>]*>/', ' @endslot', $value);

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -441,7 +441,7 @@ class ComponentTagCompiler
 
             $attributes = $this->getAttributesFromAttributeString($matches['attributes']);
 
-            return " @slot({$name}, [".$this->attributesToString($attributes, $escapeBound = false).']) ';
+            return " @slot({$name}, null, [".$this->attributesToString($attributes, $escapeBound = false).']) ';
         }, $value);
 
         return preg_replace('/<\/\s*x[\-\:]slot[^>]*>/', ' @endslot', $value);

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -395,7 +395,42 @@ class ComponentTagCompiler
      */
     public function compileSlots(string $value)
     {
-        $value = preg_replace_callback('/<\s*x[\-\:]slot\s+(:?)name=(?<name>(\"[^\"]+\"|\\\'[^\\\']+\\\'|[^\s>]+))\s*>/', function ($matches) {
+        $pattern = "/
+            <
+                \s*
+                x[\-\:]slot
+                \s+
+                (:?)name=(?<name>(\"[^\"]+\"|\\\'[^\\\']+\\\'|[^\s>]+))
+                (?<attributes>
+                    (?:
+                        \s+
+                        (?:
+                            (?:
+                                \{\{\s*\\\$attributes(?:[^}]+?)?\s*\}\}
+                            )
+                            |
+                            (?:
+                                [\w\-:.@]+
+                                (
+                                    =
+                                    (?:
+                                        \\\"[^\\\"]*\\\"
+                                        |
+                                        \'[^\']*\'
+                                        |
+                                        [^\'\\\"=<>]+
+                                    )
+                                )?
+                            )
+                        )
+                    )*
+                    \s*
+                )
+                (?<![\/=\-])
+            >
+        /x";
+
+        $value = preg_replace_callback($pattern, function ($matches) {
             $name = $this->stripQuotes($matches['name']);
 
             if ($matches[1] !== ':') {

--- a/src/Illuminate/View/ComponentSlot.php
+++ b/src/Illuminate/View/ComponentSlot.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Illuminate\View;
+
+use Illuminate\Contracts\Support\Htmlable;
+
+class ComponentSlot implements Htmlable
+{
+    /**
+     * The slot attribute bag.
+     *
+     * @var \Illuminate\View\ComponentAttributeBag
+     */
+    public $attributes;
+
+    /**
+     * The slot contents.
+     *
+     * @var string
+     */
+    protected $contents;
+
+    /**
+     * Create a new slot instance.
+     *
+     * @param  string  $contents
+     * @param  array  $attributes
+     * @return void
+     */
+    public function __construct($contents = '', $attributes = [])
+    {
+        $this->contents = $contents;
+        $this->withAttributes($attributes);
+    }
+
+    /**
+     * Get the HTML string.
+     *
+     * @return string
+     */
+    public function toHtml()
+    {
+        return $this->contents;
+    }
+
+    /**
+     * Determine if the given slot is empty.
+     *
+     * @return bool
+     */
+    public function isEmpty()
+    {
+        return $this->contents === '';
+    }
+
+    /**
+     * Determine if the given slot is not empty.
+     *
+     * @return bool
+     */
+    public function isNotEmpty()
+    {
+        return ! $this->isEmpty();
+    }
+
+    /**
+     * Set the extra attributes that the slot should make available.
+     *
+     * @param  array  $attributes
+     * @return $this
+     */
+    public function withAttributes(array $attributes)
+    {
+        $this->attributes = new ComponentAttributeBag($attributes);
+
+        return $this;
+    }
+
+    /**
+     * Get the HTML string.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->toHtml();
+    }
+}

--- a/src/Illuminate/View/ComponentSlot.php
+++ b/src/Illuminate/View/ComponentSlot.php
@@ -30,37 +30,8 @@ class ComponentSlot implements Htmlable
     public function __construct($contents = '', $attributes = [])
     {
         $this->contents = $contents;
+
         $this->withAttributes($attributes);
-    }
-
-    /**
-     * Get the HTML string.
-     *
-     * @return string
-     */
-    public function toHtml()
-    {
-        return $this->contents;
-    }
-
-    /**
-     * Determine if the given slot is empty.
-     *
-     * @return bool
-     */
-    public function isEmpty()
-    {
-        return $this->contents === '';
-    }
-
-    /**
-     * Determine if the given slot is not empty.
-     *
-     * @return bool
-     */
-    public function isNotEmpty()
-    {
-        return ! $this->isEmpty();
     }
 
     /**
@@ -77,7 +48,37 @@ class ComponentSlot implements Htmlable
     }
 
     /**
-     * Get the HTML string.
+     * Get the slot's HTML string.
+     *
+     * @return string
+     */
+    public function toHtml()
+    {
+        return $this->contents;
+    }
+
+    /**
+     * Determine if the slot is empty.
+     *
+     * @return bool
+     */
+    public function isEmpty()
+    {
+        return $this->contents === '';
+    }
+
+    /**
+     * Determine if the slot is not empty.
+     *
+     * @return bool
+     */
+    public function isNotEmpty()
+    {
+        return ! $this->isEmpty();
+    }
+
+    /**
+     * Get the slot's HTML string.
      *
      * @return string
      */

--- a/src/Illuminate/View/Concerns/ManagesComponents.php
+++ b/src/Illuminate/View/Concerns/ManagesComponents.php
@@ -123,9 +123,9 @@ trait ManagesComponents
      * @param  string|null  $content
      * @return void
      */
-    public function slot($name, $attributes = [], $content = null)
+    public function slot($name, $content = null, $attributes = [])
     {
-        if (func_num_args() === 3) {
+        if ($content) {
             $this->slots[$this->currentComponent()][$name] = $content;
         } elseif (ob_start()) {
             $this->slots[$this->currentComponent()][$name] = '';

--- a/src/Illuminate/View/Concerns/ManagesComponents.php
+++ b/src/Illuminate/View/Concerns/ManagesComponents.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Arr;
 use Illuminate\Support\HtmlString;
+use Illuminate\View\ComponentSlot;
 use InvalidArgumentException;
 
 trait ManagesComponents
@@ -119,21 +120,20 @@ trait ManagesComponents
      * Start the slot rendering process.
      *
      * @param  string  $name
+     * @param  array  $attributes
      * @param  string|null  $content
      * @return void
      *
      * @throws \InvalidArgumentException
      */
-    public function slot($name, $content = null)
+    public function slot($name, $attributes = [], $content = null)
     {
-        if (func_num_args() > 2) {
-            throw new InvalidArgumentException('You passed too many arguments to the ['.$name.'] slot.');
-        } elseif (func_num_args() === 2) {
+        if (func_num_args() === 3) {
             $this->slots[$this->currentComponent()][$name] = $content;
         } elseif (ob_start()) {
             $this->slots[$this->currentComponent()][$name] = '';
 
-            $this->slotStack[$this->currentComponent()][] = $name;
+            $this->slotStack[$this->currentComponent()][] = [$name, $attributes];
         }
     }
 
@@ -150,7 +150,9 @@ trait ManagesComponents
             $this->slotStack[$this->currentComponent()]
         );
 
-        $this->slots[$this->currentComponent()][$currentSlot] = new HtmlString(trim(ob_get_clean()));
+        [$currentSlotName, $currentSlotAttributes] = $currentSlot;
+
+        $this->slots[$this->currentComponent()][$currentSlotName] = new ComponentSlot(trim(ob_get_clean()), $currentSlotAttributes);
     }
 
     /**

--- a/src/Illuminate/View/Concerns/ManagesComponents.php
+++ b/src/Illuminate/View/Concerns/ManagesComponents.php
@@ -7,7 +7,6 @@ use Illuminate\Contracts\View\View;
 use Illuminate\Support\Arr;
 use Illuminate\Support\HtmlString;
 use Illuminate\View\ComponentSlot;
-use InvalidArgumentException;
 
 trait ManagesComponents
 {
@@ -123,8 +122,6 @@ trait ManagesComponents
      * @param  array  $attributes
      * @param  string|null  $content
      * @return void
-     *
-     * @throws \InvalidArgumentException
      */
     public function slot($name, $attributes = [], $content = null)
     {

--- a/src/Illuminate/View/Concerns/ManagesComponents.php
+++ b/src/Illuminate/View/Concerns/ManagesComponents.php
@@ -119,8 +119,8 @@ trait ManagesComponents
      * Start the slot rendering process.
      *
      * @param  string  $name
-     * @param  array  $attributes
      * @param  string|null  $content
+     * @param  array  $attributes
      * @return void
      */
     public function slot($name, $content = null, $attributes = [])
@@ -147,9 +147,11 @@ trait ManagesComponents
             $this->slotStack[$this->currentComponent()]
         );
 
-        [$currentSlotName, $currentSlotAttributes] = $currentSlot;
+        [$currentName, $currentAttributes] = $currentSlot;
 
-        $this->slots[$this->currentComponent()][$currentSlotName] = new ComponentSlot(trim(ob_get_clean()), $currentSlotAttributes);
+        $this->slots[$this->currentComponent()][$currentName] = new ComponentSlot(
+            trim(ob_get_clean()), $currentAttributes
+        );
     }
 
     /**

--- a/src/Illuminate/View/DynamicComponent.php
+++ b/src/Illuminate/View/DynamicComponent.php
@@ -120,7 +120,7 @@ EOF;
     protected function compileSlots(array $slots)
     {
         return collect($slots)->map(function ($slot, $name) {
-            return $name === '__default' ? null : '<x-slot name="'.$name.'">{{ $'.$name.' }}</x-slot>';
+            return $name === '__default' ? null : '<x-slot name="'.$name.'" '.((string) $slot->attributes).'>{{ $'.$name.' }}</x-slot>';
         })->filter()->implode(PHP_EOL);
     }
 

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -34,6 +34,22 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $this->assertSame("@slot(\$foo, []) \n".' @endslot', trim($result));
     }
 
+    public function testSlotsWithAttributesCanBeCompiled()
+    {
+        $result = $this->compiler()->compileSlots('<x-slot name="foo" class="font-bold">
+</x-slot>');
+
+        $this->assertSame("@slot('foo', ['class' => 'font-bold']) \n".' @endslot', trim($result));
+    }
+
+    public function testSlotsWithDynamicAttributesCanBeCompiled()
+    {
+        $result = $this->compiler()->compileSlots('<x-slot name="foo" :class="$classes">
+</x-slot>');
+
+        $this->assertSame("@slot('foo', ['class' => \$classes]) \n".' @endslot', trim($result));
+    }
+
     public function testBasicComponentParsing()
     {
         $this->mockViewFactory();

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -47,7 +47,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = $this->compiler()->compileSlots('<x-slot name="foo" :class="$classes">
 </x-slot>');
 
-        $this->assertSame("@slot('foo', null, ['class' => \$classes]) \n".' @endslot', trim($result));
+        $this->assertSame("@slot('foo', null, ['class' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute(\$classes)]) \n".' @endslot', trim($result));
     }
 
     public function testBasicComponentParsing()

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -23,7 +23,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = $this->compiler()->compileSlots('<x-slot name="foo">
 </x-slot>');
 
-        $this->assertSame("@slot('foo') \n".' @endslot', trim($result));
+        $this->assertSame("@slot('foo', []) \n".' @endslot', trim($result));
     }
 
     public function testDynamicSlotsCanBeCompiled()
@@ -31,7 +31,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = $this->compiler()->compileSlots('<x-slot :name="$foo">
 </x-slot>');
 
-        $this->assertSame("@slot(\$foo) \n".' @endslot', trim($result));
+        $this->assertSame("@slot(\$foo, []) \n".' @endslot', trim($result));
     }
 
     public function testBasicComponentParsing()

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -23,7 +23,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = $this->compiler()->compileSlots('<x-slot name="foo">
 </x-slot>');
 
-        $this->assertSame("@slot('foo', []) \n".' @endslot', trim($result));
+        $this->assertSame("@slot('foo', null, []) \n".' @endslot', trim($result));
     }
 
     public function testDynamicSlotsCanBeCompiled()
@@ -31,7 +31,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = $this->compiler()->compileSlots('<x-slot :name="$foo">
 </x-slot>');
 
-        $this->assertSame("@slot(\$foo, []) \n".' @endslot', trim($result));
+        $this->assertSame("@slot(\$foo, null, []) \n".' @endslot', trim($result));
     }
 
     public function testSlotsWithAttributesCanBeCompiled()
@@ -39,7 +39,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = $this->compiler()->compileSlots('<x-slot name="foo" class="font-bold">
 </x-slot>');
 
-        $this->assertSame("@slot('foo', ['class' => 'font-bold']) \n".' @endslot', trim($result));
+        $this->assertSame("@slot('foo', null, ['class' => 'font-bold']) \n".' @endslot', trim($result));
     }
 
     public function testSlotsWithDynamicAttributesCanBeCompiled()
@@ -47,7 +47,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = $this->compiler()->compileSlots('<x-slot name="foo" :class="$classes">
 </x-slot>');
 
-        $this->assertSame("@slot('foo', ['class' => \$classes]) \n".' @endslot', trim($result));
+        $this->assertSame("@slot('foo', null, ['class' => \$classes]) \n".' @endslot', trim($result));
     }
 
     public function testBasicComponentParsing()

--- a/tests/View/Blade/BladeComponentsTest.php
+++ b/tests/View/Blade/BladeComponentsTest.php
@@ -44,7 +44,7 @@ class BladeComponentsTest extends AbstractBladeTestCase
 
     public function testSlotsAreCompiled()
     {
-        $this->assertSame('<?php $__env->slot(\'foo\', ["foo" => "bar"]); ?>', $this->compiler->compileString('@slot(\'foo\', ["foo" => "bar"])'));
+        $this->assertSame('<?php $__env->slot(\'foo\', null, ["foo" => "bar"]); ?>', $this->compiler->compileString('@slot(\'foo\', null, ["foo" => "bar"])'));
         $this->assertSame('<?php $__env->slot(\'foo\'); ?>', $this->compiler->compileString('@slot(\'foo\')'));
     }
 

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -355,7 +355,7 @@ class ViewFactoryTest extends TestCase
         $factory->getDispatcher()->shouldReceive('dispatch');
         $factory->startComponent('component', ['name' => 'Taylor']);
         $factory->slot('title');
-        $factory->slot('website', [], 'laravel.com');
+        $factory->slot('website', 'laravel.com', []);
         echo 'title<hr>';
         $factory->endSlot();
         echo 'component';
@@ -371,7 +371,7 @@ class ViewFactoryTest extends TestCase
         $factory->getDispatcher()->shouldReceive('dispatch');
         $factory->startComponent($factory->make('component'), ['name' => 'Taylor']);
         $factory->slot('title');
-        $factory->slot('website', [], 'laravel.com');
+        $factory->slot('website', 'laravel.com', []);
         echo 'title<hr>';
         $factory->endSlot();
         echo 'component';
@@ -392,7 +392,7 @@ class ViewFactoryTest extends TestCase
             return $factory->make('component');
         }, ['name' => 'Taylor']);
         $factory->slot('title');
-        $factory->slot('website', [], 'laravel.com');
+        $factory->slot('website', 'laravel.com', []);
         echo 'title<hr>';
         $factory->endSlot();
         echo 'component';

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -355,7 +355,7 @@ class ViewFactoryTest extends TestCase
         $factory->getDispatcher()->shouldReceive('dispatch');
         $factory->startComponent('component', ['name' => 'Taylor']);
         $factory->slot('title');
-        $factory->slot('website', 'laravel.com');
+        $factory->slot('website', [], 'laravel.com');
         echo 'title<hr>';
         $factory->endSlot();
         echo 'component';
@@ -371,7 +371,7 @@ class ViewFactoryTest extends TestCase
         $factory->getDispatcher()->shouldReceive('dispatch');
         $factory->startComponent($factory->make('component'), ['name' => 'Taylor']);
         $factory->slot('title');
-        $factory->slot('website', 'laravel.com');
+        $factory->slot('website', [], 'laravel.com');
         echo 'title<hr>';
         $factory->endSlot();
         echo 'component';
@@ -392,7 +392,7 @@ class ViewFactoryTest extends TestCase
             return $factory->make('component');
         }, ['name' => 'Taylor']);
         $factory->slot('title');
-        $factory->slot('website', 'laravel.com');
+        $factory->slot('website', [], 'laravel.com');
         echo 'title<hr>';
         $factory->endSlot();
         echo 'component';


### PR DESCRIPTION
This PR further enhances the power of Blade components by allowing slots to have their own attributes. 🚀 

Take this `card` component example:

```blade
@props([
    'heading',
    'footer',
])

<div {{ $attributes->class(['border']) }}>
    <h1 {{ $heading->attributes->class(['text-lg']) }}>
        {{ $heading }}
    </h1>

    {{ $slot }}

    <footer {{ $footer->attributes->class(['text-gray-700']) }}>
        {{ $footer }}
    </footer>
</div>
```

```blade
<x-card class="shadow-sm">
    <x-slot name="heading" class="font-bold">
        Heading
    </x-slot>

    Content

    <x-slot name="footer" class="text-sm">
        Footer
    </x-slot>
</x-card>
```

In this example, I am able to fully customise multiple areas of the Blade component, not just its outer container. By passing the `class` attribute to both slots, I can make the heading bold and the footer smaller without having to create another view just for this use case.

Let me know if you have any questions about this implementation, or you can see any areas that could be improved!