### PR TITLE
[8.x] Conditionally merge validation rules

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -278,5 +278,4 @@ class FormRequest extends Request implements ValidatesWhenResolved
     {
         return Rule::when($condition, $rules);
     }
-
 }

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Validation\ValidatesWhenResolved;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Redirector;
+use Illuminate\Validation\Rule;
 use Illuminate\Validation\ValidatesWhenResolvedTrait;
 use Illuminate\Validation\ValidationException;
 
@@ -253,4 +254,29 @@ class FormRequest extends Request implements ValidatesWhenResolved
 
         return $this;
     }
+
+    /**
+     * Merge rules based on a given condition.
+     *
+     * @param  callable|bool  $condition
+     * @param  callable|array  $rules
+     * @return \Illuminate\Validation\MergeRules
+     */
+    protected function mergeWhen($condition, $rules)
+    {
+        return Rule::mergeWhen($condition, $rules);
+    }
+
+    /**
+     * Create a new conditional rule set.
+     *
+     * @param  callable|bool  $condition
+     * @param  array|string  $rules
+     * @return \Illuminate\Validation\ConditionalRules
+     */
+    protected function when($condition, $rules)
+    {
+        return Rule::when($condition, $rules);
+    }
+
 }

--- a/src/Illuminate/Validation/MergeRules.php
+++ b/src/Illuminate/Validation/MergeRules.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Illuminate\Validation;
+
+class MergeRules
+{
+    /**
+     * The boolean condition indicating if the rules should be merged.
+     *
+     * @var callable|bool
+     */
+    protected $condition;
+
+    /**
+     * The rules to be added to be merged.
+     *
+     * @var callable|array
+     */
+    protected $rules;
+
+    /**
+     * Create a new conditional rules instance.
+     *
+     * @param  callable|bool  $condition
+     * @param  callable|array  $rules
+     * @return void
+     */
+    public function __construct($condition, $rules)
+    {
+        $this->condition = $condition;
+        $this->rules = $rules;
+    }
+
+    /**
+     * Determine if the conditional rules should be added.
+     *
+     * @param  array  $data
+     * @return bool
+     */
+    public function passes(array $data = [])
+    {
+        return is_callable($this->condition)
+                    ? call_user_func($this->condition, $data)
+                    : $this->condition;
+    }
+
+    /**
+     * Get the rules.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return is_callable($this->rules)
+                    ? call_user_func($this->rules)
+                    : $this->rules;
+    }
+}

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -28,6 +28,18 @@ class Rule
     }
 
     /**
+     * Merge rules based on a given condition.
+     *
+     * @param  callable|bool  $condition
+     * @param  callable|array  $rules
+     * @return MergeRules
+     */
+    public static function mergeWhen($condition, $rules)
+    {
+        return new MergeRules($condition, $rules);
+    }
+
+    /**
      * Get a dimensions constraint builder instance.
      *
      * @param  array  $constraints

--- a/tests/Validation/ValidationRuleParserTest.php
+++ b/tests/Validation/ValidationRuleParserTest.php
@@ -42,15 +42,23 @@ class ValidationRuleParserTest extends TestCase
                 'country' => 'required|string|size:2',
 
                 'airports.*' => [
-                    Rule::when(function($input) { return $input['country'] === 'US'; }, 'in:NYC'),
-                    Rule::when(function($input) { return $input['country'] === 'NL'; }, 'in:AMS'),
+                    Rule::when(function ($input) {
+                        return $input['country'] === 'US';
+                    }, 'in:NYC'),
+                    Rule::when(function ($input) {
+                        return $input['country'] === 'NL';
+                    }, 'in:AMS'),
                 ],
 
-                Rule::mergeWhen(function($input) { return $input['country'] === 'US'; }, [
+                Rule::mergeWhen(function ($input) {
+                    return $input['country'] === 'US';
+                }, [
                     'state' => 'required|size:2',
                 ]),
 
-                Rule::mergeWhen(function($input) { return $input['country'] === 'NL'; }, [
+                Rule::mergeWhen(function ($input) {
+                    return $input['country'] === 'NL';
+                }, [
                     'province' => 'required|size:2',
                 ]),
             ]),

--- a/tests/Validation/ValidationRuleParserTest.php
+++ b/tests/Validation/ValidationRuleParserTest.php
@@ -29,4 +29,52 @@ class ValidationRuleParserTest extends TestCase
             'city' => ['required', 'min:2'],
         ], $rules);
     }
+
+    public function testMergeRules()
+    {
+        $rules = [
+            'name' => 'required|string',
+            'city' => 'required|min:2',
+            'airports.*' => ['required', 'string'],
+
+            Rule::mergeWhen(true, [
+                'city' => 'string',
+                'country' => 'required|string|size:2',
+
+                'airports.*' => [
+                    Rule::when(function($input) { return $input['country'] === 'US'; }, 'in:NYC'),
+                    Rule::when(function($input) { return $input['country'] === 'NL'; }, 'in:AMS'),
+                ],
+
+                Rule::mergeWhen(function($input) { return $input['country'] === 'US'; }, [
+                    'state' => 'required|size:2',
+                ]),
+
+                Rule::mergeWhen(function($input) { return $input['country'] === 'NL'; }, [
+                    'province' => 'required|size:2',
+                ]),
+            ]),
+
+            Rule::mergeWhen(false, [
+                'notincluded' => ['required', 'size:2'],
+            ]),
+        ];
+
+        $data = [
+            'country' => 'US',
+            'airports' => ['NYC', 'AMS'],
+        ];
+
+        $response = (new ValidationRuleParser($data))
+            ->explode(ValidationRuleParser::filterConditionalRules($rules, $data));
+
+        $this->assertEquals([
+            'name' => ['required', 'string'],
+            'city' => ['required', 'min:2', 'string'],
+            'country' => ['required', 'string', 'size:2'],
+            'state' => ['required', 'size:2'],
+            'airports.0' => ['required', 'string', 'in:NYC'],
+            'airports.1' => ['required', 'string', 'in:NYC'],
+        ], $response->rules);
+    }
 }


### PR DESCRIPTION
Building upon the conditional rule support added in #38361, this PR adds support conditional rule merging through `Rule::mergeWhen(bool|callable $condition, array|callable $rules)`. Rules for attributes are merged, not overwritten, in the example below `state` would be validated to `string, size:2, in:NY,CA,TX`.

```php
request()->validate([
    'state' => 'string',
    'country' => ['required', 'size:2'],
    
    // Option 1: Directly as an array
    Rule::mergeWhen(fn($inputs) => $inputs['country'] === 'US', [
        'state' => ['size:2', Rule::in('NY', 'CA', 'TX', '...')],
        'zipcode' => ['integer', 'digits:5']
    ]),

    Rule::mergeWhen(fn($inputs) => $inputs['country'] === 'NL', [
        'state' => 'nullable',
        'zipcode' => ['string', 'regex:/^[A-Z]{4}\d{2}$/']
    ]),
    
    // Option 2: As a closure/callable
    Rule::mergeWhen(fn($inputs) => $inputs['country'] === 'US', fn() => [
        'state' => ['size:2', Rule::in('NY', 'CA', 'TX', '...')],
        'zipcode' => ['integer', 'digits:5'],
    ]),
]);
```