### PR TITLE
[8.x] Update the `ParallelRunner` to allow for a custom `Runner` to be resolved

### DIFF
--- a/src/Illuminate/Testing/ParallelRunner.php
+++ b/src/Illuminate/Testing/ParallelRunner.php
@@ -22,7 +22,7 @@ class ParallelRunner implements RunnerInterface
     protected static $applicationResolver;
 
     /**
-     * The paratest runner resolver callback.
+     * The runner resolver callback.
      *
      * @var \Closure|null
      */

--- a/src/Illuminate/Testing/ParallelRunner.php
+++ b/src/Illuminate/Testing/ParallelRunner.php
@@ -22,6 +22,13 @@ class ParallelRunner implements RunnerInterface
     protected static $applicationResolver;
 
     /**
+     * The paratest runner resolver callback.
+     *
+     * @var \Closure|null
+     */
+    protected static $runnerResolver;
+
+    /**
      * The original test runner options.
      *
      * @var \ParaTest\Runners\PHPUnit\Options
@@ -57,7 +64,11 @@ class ParallelRunner implements RunnerInterface
             $output = new ParallelConsoleOutput($output);
         }
 
-        $this->runner = new WrapperRunner($options, $output);
+        $runnerResolver = static::$runnerResolver ?: function (Options $options, OutputInterface $output) {
+            return new WrapperRunner($options, $output);
+        };
+
+        $this->runner = call_user_func($runnerResolver, $options, $output);
     }
 
     /**
@@ -69,6 +80,17 @@ class ParallelRunner implements RunnerInterface
     public static function resolveApplicationUsing($resolver)
     {
         static::$applicationResolver = $resolver;
+    }
+
+    /**
+     * Set the application resolver callback.
+     *
+     * @param  \Closure|null  $resolver
+     * @return void
+     */
+    public static function resolveRunnerUsing($resolver)
+    {
+        static::$runnerResolver = $resolver;
     }
 
     /**

--- a/src/Illuminate/Testing/ParallelRunner.php
+++ b/src/Illuminate/Testing/ParallelRunner.php
@@ -83,7 +83,7 @@ class ParallelRunner implements RunnerInterface
     }
 
     /**
-     * Set the application resolver callback.
+     * Set the runner resolver callback.
      *
      * @param  \Closure|null  $resolver
      * @return void


### PR DESCRIPTION
Howdy all!

This PR comes on the back of a new requirement for `Collision`, in which we want the ability to define the Paratest `Runner` that should be used under the `ParallelRunner`.

This allows for the following syntax:

```php
\Illuminate\Testing\ParallelRunner::resolveRunnerUsing(fn($options, $output) => new CustomRunner($options, $output));
```

When a resolver is defined, the runner will be returned based on the provided resolver logic. When a resolver is not defined, the runner will be returned using the default `WrapperRunner` currently used.

Thanks for all the hard work and for continuing to maintain the framework.

Kind Regards,
Luke