### PR TITLE
[8.x] Check for incomplete class to prevent unexpected error when class cannot be loaded

### DIFF
--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -171,7 +171,7 @@ class RetryCommand extends Command
             throw new RuntimeException('Unable to extract job payload.');
         }
 
-        if (is_object($instance) && method_exists($instance, 'retryUntil')) {
+        if (is_object($instance) && !($instance instanceof \__PHP_Incomplete_Class) && method_exists($instance, 'retryUntil')) {
             $retryUntil = $instance->retryUntil();
 
             $payload['retryUntil'] = $retryUntil instanceof DateTimeInterface

--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -171,7 +171,7 @@ class RetryCommand extends Command
             throw new RuntimeException('Unable to extract job payload.');
         }
 
-        if (is_object($instance) && !($instance instanceof \__PHP_Incomplete_Class) && method_exists($instance, 'retryUntil')) {
+        if (is_object($instance) && ! ($instance instanceof \__PHP_Incomplete_Class) && method_exists($instance, 'retryUntil')) {
             $retryUntil = $instance->retryUntil();
 
             $payload['retryUntil'] = $retryUntil instanceof DateTimeInterface

--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -171,7 +171,7 @@ class RetryCommand extends Command
             throw new RuntimeException('Unable to extract job payload.');
         }
 
-        if (is_object($instance) && ! ($instance instanceof \__PHP_Incomplete_Class) && method_exists($instance, 'retryUntil')) {
+        if (is_object($instance) && ! $instance instanceof \__PHP_Incomplete_Class && method_exists($instance, 'retryUntil')) {
             $retryUntil = $instance->retryUntil();
 
             $payload['retryUntil'] = $retryUntil instanceof DateTimeInterface


### PR DESCRIPTION
Since PHP 7.2 [is_object](https://www.php.net/manual/en/function.is-object.php) returns true even when class could not be correctly instantiated.

Currently trying to retry jobs of unknown classes (e.g. the job was created by another system) is crashing with "method_exists(): The script tried to execute a method or access a property of an incomplete object."

The change is aiming to allow job retry functionality independent from availability of class in the current context.