### PR TITLE
[8,x] Share handler instead of client between requests in pool to ensure ResponseReceived events are dispatched in async HTTP Request

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -808,7 +808,7 @@ class PendingRequest
     }
 
     /**
-     * add handlers to the handler stack
+     * add handlers to the handler stack.
      *
      * @param  \GuzzleHttp\HandlerStack  $handlerStack
      * @return \GuzzleHttp\HandlerStack
@@ -1046,7 +1046,7 @@ class PendingRequest
     }
 
     /**
-     * set the handler function
+     * set the handler function.
      *
      * @param  callable  $handler
      * @return $this

--- a/src/Illuminate/Http/Client/Pool.php
+++ b/src/Illuminate/Http/Client/Pool.php
@@ -17,7 +17,7 @@ class Pool
     protected $factory;
 
     /**
-     * The handler function for Guzzle client
+     * The handler function for Guzzle client.
      *
      * @var callable
      */

--- a/src/Illuminate/Http/Client/Pool.php
+++ b/src/Illuminate/Http/Client/Pool.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Http\Client;
 
+use GuzzleHttp\Utils;
+
 /**
  * @mixin \Illuminate\Http\Client\Factory
  */
@@ -15,11 +17,11 @@ class Pool
     protected $factory;
 
     /**
-     * The client instance.
+     * The handler function for Guzzle client
      *
-     * @var \GuzzleHttp\Client
+     * @var callable
      */
-    protected $client;
+    protected $handler;
 
     /**
      * The pool of requests.
@@ -38,7 +40,7 @@ class Pool
     {
         $this->factory = $factory ?: new Factory();
 
-        $this->client = $this->factory->buildClient();
+        $this->handler = Utils::chooseHandler();
     }
 
     /**
@@ -59,7 +61,7 @@ class Pool
      */
     protected function asyncRequest()
     {
-        return $this->factory->setClient($this->client)->async();
+        return $this->factory->setHandler($this->handler)->async();
     }
 
     /**

--- a/src/Illuminate/Http/Client/Pool.php
+++ b/src/Illuminate/Http/Client/Pool.php
@@ -40,7 +40,11 @@ class Pool
     {
         $this->factory = $factory ?: new Factory();
 
-        $this->handler = Utils::chooseHandler();
+        if (method_exists(Utils::class, 'chooseHandler')) {
+            $this->handler = Utils::chooseHandler();
+        } else {
+            $this->handler = \GuzzleHttp\choose_handler();
+        }
     }
 
     /**

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -940,6 +940,28 @@ class HttpClientTest extends TestCase
         m::close();
     }
 
+    public function testTheRequestSendingAndResponseReceivedEventsAreFiredWhenARequestIsSentAsync()
+    {
+        $events = m::mock(Dispatcher::class);
+        $events->shouldReceive('dispatch')->times(5)->with(m::type(RequestSending::class));
+        $events->shouldReceive('dispatch')->times(5)->with(m::type(ResponseReceived::class));
+
+        $factory = new Factory($events);
+        $factory->fake();
+        $factory->pool(function (Pool $pool) {
+            return [
+                $pool->get('https://example.com'),
+                $pool->head('https://example.com'),
+                $pool->post('https://example.com'),
+                $pool->patch('https://example.com'),
+                $pool->delete('https://example.com'),
+            ];
+        });
+
+
+        m::close();
+    }
+
     public function testTheTransferStatsAreCalledSafelyWhenFakingTheRequest()
     {
         $this->factory->fake(['https://example.com' => ['world' => 'Hello world']]);

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -958,7 +958,6 @@ class HttpClientTest extends TestCase
             ];
         });
 
-
         m::close();
     }
 


### PR DESCRIPTION
Currently, ResponseReceived events is not dispatched in async HTTP Request

This is beacause PendingRequest::$request is not set and following if statement not passes.
https://github.com/laravel/framework/blob/3591526d86ae6269c29c097710657565984eb09d/src/Illuminate/Http/Client/PendingRequest.php#L994

PendingRequest::$request is set in the handler given to guzzle client.
All requests in Pool use shared Pool::$client and the handler in the Pool::$client set request to the PendingRequest instance which created in the initialization of Pool::$client
not each PendingRequest instances created in Pool::asyncRequest().

To fix this, each request share handler instead of client in this PR.