### PR TITLE
[8.x] Filter input models based on isPrunable condition as well

### DIFF
--- a/src/Illuminate/Database/Console/PruneCommand.php
+++ b/src/Illuminate/Database/Console/PruneCommand.php
@@ -55,9 +55,7 @@ class PruneCommand extends Command
                             ? $instance->prunableChunkSize
                             : $this->option('chunk');
 
-            $total = $this->isPrunable($model)
-                        ? $instance->pruneAll($chunkSize)
-                        : 0;
+            $total = $instance->pruneAll($chunkSize);
 
             if ($total == 0) {
                 $this->info("No prunable [$model] records found.");
@@ -75,7 +73,10 @@ class PruneCommand extends Command
     protected function models()
     {
         if (! empty($models = $this->option('model'))) {
-            return collect($models);
+            return collect($models)
+                ->filter(function ($model) {
+                    return $this->isPrunable($model);
+                });
         }
 
         return collect((new Finder)->in(app_path('Models'))->files())

--- a/tests/Database/PruneCommandTest.php
+++ b/tests/Database/PruneCommandTest.php
@@ -10,7 +10,6 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Prunable;
 use Illuminate\Database\Events\ModelsPruned;
 use Illuminate\Events\Dispatcher;
-use Illuminate\Support\Facades\Artisan;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
@@ -67,7 +66,7 @@ EOF, str_replace("\r", '', $output->fetch()));
             '--model' => [
                 PrunableTestModelWithoutPrunableRecords::class, PrunableTestModelWithPrunableRecords::class,
                 NonPrunableTestModel::class,
-            ]
+            ],
         ]);
 
         $this->assertEquals(<<<'EOF'

--- a/tests/Database/PruneCommandTest.php
+++ b/tests/Database/PruneCommandTest.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Prunable;
 use Illuminate\Database\Events\ModelsPruned;
 use Illuminate\Events\Dispatcher;
+use Illuminate\Support\Facades\Artisan;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
@@ -55,7 +56,24 @@ EOF, str_replace("\r", '', $output->fetch()));
         $output = $this->artisan(['--model' => NonPrunableTestModel::class]);
 
         $this->assertEquals(<<<'EOF'
-No prunable [Illuminate\Tests\Database\NonPrunableTestModel] records found.
+No prunable models found.
+
+EOF, str_replace("\r", '', $output->fetch()));
+    }
+
+    public function testFilterNonPrunableFromInputModels()
+    {
+        $output = $this->artisan([
+            '--model' => [
+                PrunableTestModelWithoutPrunableRecords::class, PrunableTestModelWithPrunableRecords::class,
+                NonPrunableTestModel::class
+            ]
+        ]);
+
+        $this->assertEquals(<<<'EOF'
+No prunable [Illuminate\Tests\Database\PrunableTestModelWithoutPrunableRecords] records found.
+10 [Illuminate\Tests\Database\PrunableTestModelWithPrunableRecords] records have been pruned.
+20 [Illuminate\Tests\Database\PrunableTestModelWithPrunableRecords] records have been pruned.
 
 EOF, str_replace("\r", '', $output->fetch()));
     }

--- a/tests/Database/PruneCommandTest.php
+++ b/tests/Database/PruneCommandTest.php
@@ -66,7 +66,7 @@ EOF, str_replace("\r", '', $output->fetch()));
         $output = $this->artisan([
             '--model' => [
                 PrunableTestModelWithoutPrunableRecords::class, PrunableTestModelWithPrunableRecords::class,
-                NonPrunableTestModel::class
+                NonPrunableTestModel::class,
             ]
         ]);
 


### PR DESCRIPTION
1- Currently in situations where we do not get models from the command argument, we check if models are prunable twice.
2- Currently when an argument model is not prunable we get the following error:
```No prunable [Illuminate\Tests\Database\NonPrunableTestModel] records found.```
but it makes more sense this way:
```No prunable models found.```
3- It would be better if before executing following code, apply prunable filter just like how we do it in non-argument models.
```
$models->each(function ($model) {
            $instance = new $model;

            $chunkSize = property_exists($instance, 'prunableChunkSize')
                            ? $instance->prunableChunkSize
                            : $this->option('chunk');

            $total = $this->isPrunable($model)
                        ? $instance->pruneAll($chunkSize)
                        : 0;
            // ...
});
```

This PR will fix these 3 problems.