### PR TITLE
[8.x] Implements whenExists on ConditionallyLoadsAttributes for cleaner syntax in resources

### DIFF
--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -162,6 +162,23 @@ trait ConditionallyLoadsAttributes
     }
 
     /**
+     * Retrieve an attribute when it's present.
+     * 
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  mixed  $default
+     * @return \Illuminate\Http\Resources\MissingValue|mixed
+     */
+    protected function whenExists($attribute, $value = null, $default = null)
+    {
+        if (property_exists($this->resource, $attribute)) {
+            return func_num_args() >= 2 ? value($value) : $this->resource->{$attribute};
+        }
+
+        return func_num_args() === 3 ? value($default) : new MissingValue;
+    }
+
+    /**
      * Retrieve a relationship if it has been loaded.
      *
      * @param  string  $relationship

--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -163,7 +163,7 @@ trait ConditionallyLoadsAttributes
 
     /**
      * Retrieve an attribute when it's present.
-     * 
+     *
      * @param  string  $attribute
      * @param  mixed  $value
      * @param  mixed  $default


### PR DESCRIPTION
This pull request adds the method ``whenExists`` to the ``ConditionallyLoadsAttributes`` trait. This allows for cleaner syntax when you, for example, would like to conditionally include a resource attribute only when it's present.

I came accross this use case when wanting to conditionally include counts if they were loaded (example: `UserResource::collection(User::query()->withCount('followers')->get())`.

The example below would only include the followers and following count in the response if it has been loaded. It allows for clean and Laravel-style syntax.
```php
class UserResource extends JsonResource
{

    /**
     * Transform the resource into an array.
     *
     * @param Request $request
     * @return array
     */
    public function toArray($request)
    {
        return [
            'id' => $this->id,
            'username' => $this->username,
            'email' => $this->email,
            'followers_count' => $this->whenExists('followers_count'),
            'following_count' => $this->whenExists('following_count'),
        ];
    }

}
```

Note:
I debated on whether to call the method ``whenPresent`` or ``whenExists``, but ultimately landed on the latter due to the ``property_exists`` function already setting a precedent. Of course up for changing this.

Thank you!