### PR TITLE
[8.x] Support union types on event discovery

### DIFF
--- a/src/Illuminate/Foundation/Events/DiscoverEvents.php
+++ b/src/Illuminate/Foundation/Events/DiscoverEvents.php
@@ -21,11 +21,23 @@ class DiscoverEvents
      */
     public static function within($listenerPath, $basePath)
     {
-        return collect(static::getListenerEvents(
+        $listeners = collect(static::getListenerEvents(
             (new Finder)->files()->in($listenerPath), $basePath
-        ))->mapToDictionary(function ($event, $listener) {
-            return [$event => $listener];
-        })->all();
+        ));
+
+        $discoveredEvents = [];
+
+        foreach ($listeners as $listener => $events) {
+            foreach ($events as $event) {
+                if (! isset($discoveredEvents[$event])) {
+                    $discoveredEvents[$event] = [];
+                }
+
+                $discoveredEvents[$event][] = $listener;
+            }
+        }
+
+        return $discoveredEvents;
     }
 
     /**
@@ -59,7 +71,7 @@ class DiscoverEvents
                 }
 
                 $listenerEvents[$listener->name.'@'.$method->name] =
-                                Reflector::getParameterClassName($method->getParameters()[0]);
+                                Reflector::getParameterClassNames($method->getParameters()[0]);
             }
         }
 

--- a/src/Illuminate/Support/Reflector.php
+++ b/src/Illuminate/Support/Reflector.php
@@ -70,19 +70,7 @@ class Reflector
             return;
         }
 
-        $name = $type->getName();
-
-        if (! is_null($class = $parameter->getDeclaringClass())) {
-            if ($name === 'self') {
-                return $class->getName();
-            }
-
-            if ($name === 'parent' && $parent = $class->getParentClass()) {
-                return $parent->getName();
-            }
-        }
-
-        return $name;
+        return static::getTypeName($parameter, $type);
     }
 
     /**
@@ -106,24 +94,34 @@ class Reflector
                 continue;
             }
 
-            $name = $listedType->getName();
-
-            if (! is_null($class = $parameter->getDeclaringClass())) {
-                if ($name === 'self') {
-                    $unionTypes[] = $class->getName();
-                    continue;
-                }
-
-                if ($name === 'parent' && $parent = $class->getParentClass()) {
-                    $unionTypes[] = $parent->getName();
-                    continue;
-                }
-            }
-
-            $unionTypes[] = $name;
+            $unionTypes[] = static::getTypeName($parameter, $listedType);
         }
 
         return $unionTypes;
+    }
+
+    /**
+     * Get the given type's class name.
+     *
+     * @param  \ReflectionParameter  $parameter
+     * @param  \ReflectionNamedType  $type
+     * @return string
+     */
+    protected static function getTypeName($parameter, $type)
+    {
+        $name = $type->getName();
+
+        if (! is_null($class = $parameter->getDeclaringClass())) {
+            if ($name === 'self') {
+                return $class->getName();
+            }
+
+            if ($name === 'parent' && $parent = $class->getParentClass()) {
+                return $parent->getName();
+            }
+        }
+
+        return $name;
     }
 
     /**

--- a/tests/Integration/Foundation/DiscoverEventsTest.php
+++ b/tests/Integration/Foundation/DiscoverEventsTest.php
@@ -8,6 +8,7 @@ use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\Events\Event
 use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\Listeners\AbstractListener;
 use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\Listeners\Listener;
 use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\Listeners\ListenerInterface;
+use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\Listeners\UnionListener;
 use Orchestra\Testbench\TestCase;
 
 class DiscoverEventsTest extends TestCase
@@ -15,6 +16,7 @@ class DiscoverEventsTest extends TestCase
     public function testEventsCanBeDiscovered()
     {
         class_alias(Listener::class, 'Tests\Integration\Foundation\Fixtures\EventDiscovery\Listeners\Listener');
+        class_alias(UnionListener::class, 'Tests\Integration\Foundation\Fixtures\EventDiscovery\Listeners\UnionListener');
         class_alias(AbstractListener::class, 'Tests\Integration\Foundation\Fixtures\EventDiscovery\Listeners\AbstractListener');
         class_alias(ListenerInterface::class, 'Tests\Integration\Foundation\Fixtures\EventDiscovery\Listeners\ListenerInterface');
 
@@ -24,9 +26,11 @@ class DiscoverEventsTest extends TestCase
             EventOne::class => [
                 Listener::class.'@handle',
                 Listener::class.'@handleEventOne',
+                UnionListener::class.'@handle',
             ],
             EventTwo::class => [
                 Listener::class.'@handleEventTwo',
+                UnionListener::class.'@handle',
             ],
         ], $events);
     }

--- a/tests/Integration/Foundation/DiscoverEventsTest.php
+++ b/tests/Integration/Foundation/DiscoverEventsTest.php
@@ -8,7 +8,7 @@ use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\Events\Event
 use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\Listeners\AbstractListener;
 use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\Listeners\Listener;
 use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\Listeners\ListenerInterface;
-use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\Listeners\UnionListener;
+use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\UnionListeners\UnionListener;
 use Orchestra\Testbench\TestCase;
 
 class DiscoverEventsTest extends TestCase
@@ -16,7 +16,6 @@ class DiscoverEventsTest extends TestCase
     public function testEventsCanBeDiscovered()
     {
         class_alias(Listener::class, 'Tests\Integration\Foundation\Fixtures\EventDiscovery\Listeners\Listener');
-        class_alias(UnionListener::class, 'Tests\Integration\Foundation\Fixtures\EventDiscovery\Listeners\UnionListener');
         class_alias(AbstractListener::class, 'Tests\Integration\Foundation\Fixtures\EventDiscovery\Listeners\AbstractListener');
         class_alias(ListenerInterface::class, 'Tests\Integration\Foundation\Fixtures\EventDiscovery\Listeners\ListenerInterface');
 
@@ -26,10 +25,28 @@ class DiscoverEventsTest extends TestCase
             EventOne::class => [
                 Listener::class.'@handle',
                 Listener::class.'@handleEventOne',
-                UnionListener::class.'@handle',
             ],
             EventTwo::class => [
                 Listener::class.'@handleEventTwo',
+            ],
+        ], $events);
+    }
+
+    public function testUnionEventsCanBeDiscovered()
+    {
+        if (version_compare(phpversion(), '8.0.0', '<')) {
+            $this->markTestSkipped('Test uses union types.');
+        }
+
+        class_alias(UnionListener::class, 'Tests\Integration\Foundation\Fixtures\EventDiscovery\UnionListeners\UnionListener');
+
+        $events = DiscoverEvents::within(__DIR__.'/Fixtures/EventDiscovery/UnionListeners', getcwd());
+
+        $this->assertEquals([
+            EventOne::class => [
+                UnionListener::class.'@handle',
+            ],
+            EventTwo::class => [
                 UnionListener::class.'@handle',
             ],
         ], $events);

--- a/tests/Integration/Foundation/Fixtures/EventDiscovery/Listeners/UnionListener.php
+++ b/tests/Integration/Foundation/Fixtures/EventDiscovery/Listeners/UnionListener.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\Listeners;
+
+use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\Events\EventOne;
+use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\Events\EventTwo;
+
+class UnionListener
+{
+    public function handle(EventOne|EventTwo $event)
+    {
+        //
+    }
+}

--- a/tests/Integration/Foundation/Fixtures/EventDiscovery/UnionListeners/UnionListener.php
+++ b/tests/Integration/Foundation/Fixtures/EventDiscovery/UnionListeners/UnionListener.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\Listeners;
+namespace Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\UnionListeners;
 
 use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\Events\EventOne;
 use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\Events\EventTwo;


### PR DESCRIPTION
[Event discovery](https://laravel.com/docs/8.x/events#event-discovery) currently does not properly discover events on listeners that use union types. This fixes that. 👍 

```php
/**
 * Handle the event.
 *
 * @param  SomeEvent  $event
 * @return void
 */
public function handle(SomeEvent|AnotherEvent $event)
{
    //
}
```
