### PR TITLE
[9.x] Database queries containing JSON paths support array index references

### DIFF
--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2883,6 +2883,29 @@ class DatabaseQueryBuilderTest extends TestCase
         ]);
     }
 
+    public function testMySqlUpdateWrappingJsonPathArrayIndex()
+    {
+        $grammar = new MySqlGrammar;
+        $processor = m::mock(Processor::class);
+
+        $connection = $this->createMock(ConnectionInterface::class);
+        $connection->expects($this->once())
+                    ->method('update')
+                    ->with(
+                        'update `users` set `options` = json_set(`options`, \'$[1]."2fa"\', false), `meta` = json_set(`meta`, \'$."tags"[0][2]\', ?) where `active` = ?',
+                        [
+                            'large',
+                            1,
+                        ]
+                    );
+
+        $builder = new Builder($connection, $grammar, $processor);
+        $builder->from('users')->where('active', 1)->update([
+            'options->[1]->2fa' => false,
+            'meta->tags[0][2]' => 'large',
+        ]);
+    }
+
     public function testMySqlUpdateWithJsonPreparesBindingsCorrectly()
     {
         $grammar = new MySqlGrammar;

--- a/tests/Integration/Database/DatabaseMySqlConnectionTest.php
+++ b/tests/Integration/Database/DatabaseMySqlConnectionTest.php
@@ -106,6 +106,26 @@ class DatabaseMySqlConnectionTest extends DatabaseMySqlTestCase
             'nested key exists and null' => [true, 'nested->value', ['nested' => ['value' => null]]],
             'nested key exists and "null"' => [false, 'nested->value', ['nested' => ['value' => 'null']]],
             'nested key exists and not null' => [false, 'nested->value', ['nested' => ['value' => false]]],
+            'array index not exists' => [false, '[0]', [1 => 'invalid']],
+            'array index exists and null' => [true, '[0]', [null]],
+            'array index exists and "null"' => [false, '[0]', ['null']],
+            'array index exists and not null' => [false, '[0]', [false]],
+            'nested array index not exists' => [false, 'nested[0]', ['nested' => [1 => 'nested->invalid']]],
+            'nested array index exists and null' => [true, 'nested->value[1]', ['nested' => ['value' => [0, null]]]],
+            'nested array index exists and "null"' => [false, 'nested->value[1]', ['nested' => ['value' => [0, 'null']]]],
+            'nested array index exists and not null' => [false, 'nested->value[1]', ['nested' => ['value' => [0, false]]]],
         ];
+    }
+
+    public function testJsonPathUpdate()
+    {
+        DB::table(self::TABLE)->insert([
+            [self::JSON_COL => '{"foo":["bar"]}'],
+            [self::JSON_COL => '{"foo":["baz"]}'],
+        ]);
+        $updatedCount = DB::table(self::TABLE)->where(self::JSON_COL.'->foo[0]', 'baz')->update([
+            self::JSON_COL.'->foo[0]' => 'updated',
+        ]);
+        $this->assertSame(1, $updatedCount);
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/laravel/framework/issues/26415

When running queries that update JSON paths including an array index, Laravel compiles an SQL statement that escapes the array index as part of a JSON object key.

e.g.,

Database column `owner`.`packages` row with JSON payload:

```json
[
    {
        "name":"laravel/dusk",
        "versions":["6.17.0", "6.16.0", "6.15.1", "6.15.0"]
    },
    {
        "name":"laravel/framework",
        "versions":["8.54.0", "8.53.1", "8.53.0"]
    }
]
```

```php
DB::table('owner')
    ->where('packages[1]->name', 'laravel/framework')
    ->update(['packages[1]->versions[0]' => '9.0.0']);
```

For MySQL this compiles to:

```sql
UPDATE `owner`
SET `packages` = JSON_SET(`packages`, $"[1]"."versions[0]", '9.0.0')
WHERE json_unquote(json_extract(`packages[1]`, '$."name"')) = 'laravel/framework';
```

Which would instead append to the above payload with a new nested JSON object key:

```json
{
    "0": {
        "name":"laravel/dusk",
        "versions":["6.17.0", "6.16.0", "6.15.1", "6.15.0"]
    },
    "1": {
        "name":"laravel/framework",
        "versions":["8.54.0", "8.53.1", "8.53.0"]
    },
    "[1]": {
        "versions[0]": "9.0.0"
    }
}
```

When escaping JSON path segments, avoid enclosing array dereference characters `[` and `]`:

```sql
UPDATE `owner`
SET `framework` = JSON_SET(`framework`, $[1]."versions"[0], '9.0.0')
WHERE json_unquote(json_extract(`packages[1]`, '$."name"')) = 'laravel/framework';
```

---

### Database documentation for JSON path support

Each of Laravel's supported database drivers use the same syntax for JSON path array indices.

* MySQL: https://dev.mysql.com/doc/refman/8.0/en/json.html#json-path-syntax
* MariaDB: https://mariadb.com/kb/en/jsonpath-expressions/
* PostgreSQL: https://www.postgresql.org/docs/12/functions-json.html#FUNCTIONS-SQLJSON-PATH
* SQLite: https://www.sqlite.org/json1.html (scroll down for examples as the prose is bad readin')
* SQL Server: https://docs.microsoft.com/en-us/sql/relational-databases/json/json-path-expressions-sql-server?view=sql-server-ver15

### JSON path features supported by database drivers

Database software | Identifier | Object key | Array index | Key asterisk | Array asterisk | Key match double-asterisk
------------------|-----------:|-----------:|------------:|-------------:|---------------:|-------------------------:
MySQL             |        [x] |        [x] |         [x] |          [x] |            [x] |                       [x]
MariaDB           |        [x] |        [x] |         [x] |          [x] |            [x] |                       [x]
PostgreSQL        |        [x] |        [x] |         [x] |              |            [x] |                          
SQLite            |        [x] |        [x] |         [x] |              |                |                          
SQL Server        |        [x] |        [x] |         [x] |              |                |                          

For the above features, Laravel supports the first three columns that all the database drivers implement. Segment-matching `*` / `**` characters partially supported by some drivers still require Laravel developers to use raw SQL.

### 9.x upgrade guide

In the low likelihood use case that applications use JSON column payload object key names ending in regex `\[.+\]`, databases will need to be updated to no longer use such characters.