### PR TITLE
[8.x] Remove unecessary @method doc

### DIFF
--- a/src/Illuminate/Support/Facades/Queue.php
+++ b/src/Illuminate/Support/Facades/Queue.php
@@ -21,7 +21,6 @@ use Illuminate\Support\Testing\Fakes\QueueFake;
  * @method static void assertPushed(string|\Closure $job, callable|int $callback = null)
  * @method static void assertPushedOn(string $queue, string|\Closure $job, callable|int $callback = null)
  * @method static void assertPushedWithChain(string $job, array $expectedChain = [], callable $callback = null)
- * @method static void popUsing(string $workerName, callable $callback)
  *
  * @see \Illuminate\Queue\QueueManager
  * @see \Illuminate\Queue\Queue


### PR DESCRIPTION
This PR removes the @method for `popUsing` in `Illuminate\Support\Facades\Queue` class. Since the method is defined in the class itself, it doesn't need to be present in the doc block.