### PR TITLE
[8.x] Add a phpunit comparator for models

### DIFF
--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -8,6 +8,7 @@ use Illuminate\Support\AggregateServiceProvider;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Testing\LoggedExceptionCollection;
 use Illuminate\Testing\ParallelTestingServiceProvider;
+use Illuminate\Testing\TestingServiceProvider;
 use Illuminate\Validation\ValidationException;
 
 class FoundationServiceProvider extends AggregateServiceProvider
@@ -20,6 +21,7 @@ class FoundationServiceProvider extends AggregateServiceProvider
     protected $providers = [
         FormRequestServiceProvider::class,
         ParallelTestingServiceProvider::class,
+        TestingServiceProvider::class,
     ];
 
     /**

--- a/src/Illuminate/Testing/Comparators/ModelComparator.php
+++ b/src/Illuminate/Testing/Comparators/ModelComparator.php
@@ -23,11 +23,11 @@ class ModelComparator extends Comparator
     /**
      * Asserts that expected and actual are the same model.
      *
-     * @param \Illuminate\Database\Eloquent\Model $expected
-     * @param \Illuminate\Database\Eloquent\Model $actual
-     * @param float $delta
-     * @param bool $canonicalize
-     * @param bool $ignoreCase
+     * @param  \Illuminate\Database\Eloquent\Model  $expected
+     * @param  \Illuminate\Database\Eloquent\Model  $actual
+     * @param  float  $delta
+     * @param  bool  $canonicalize
+     * @param  bool  $ignoreCase
      * @return void
      */
     public function assertEquals($expected, $actual, $delta = 0.0, $canonicalize = false, $ignoreCase = false): void

--- a/src/Illuminate/Testing/Comparators/ModelComparator.php
+++ b/src/Illuminate/Testing/Comparators/ModelComparator.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Illuminate\Testing\Comparators;
+
+use Illuminate\Database\Eloquent\Model;
+use SebastianBergmann\Comparator\Comparator;
+use SebastianBergmann\Comparator\ComparisonFailure;
+
+class ModelComparator extends Comparator
+{
+    public function accepts($expected, $actual): bool
+    {
+        return $expected instanceof Model && $actual instanceof Model;
+    }
+
+    /**
+     * @param Model $expected
+     * @param Model $actual
+     */
+    public function assertEquals($expected, $actual, $delta = 0.0, $canonicalize = false, $ignoreCase = false): void
+    {
+        if (! $expected->is($actual)) {
+            throw new ComparisonFailure(
+                $expected,
+                $actual,
+                "{$expected->getMorphClass()}::{$expected->getKey()}",
+                "{$actual->getMorphClass()}::{$actual->getKey()}",
+            );
+        }
+    }
+}

--- a/src/Illuminate/Testing/Comparators/ModelComparator.php
+++ b/src/Illuminate/Testing/Comparators/ModelComparator.php
@@ -8,14 +8,27 @@ use SebastianBergmann\Comparator\ComparisonFailure;
 
 class ModelComparator extends Comparator
 {
+    /**
+     * Checks if the two values are allowed to be compared with this comparator.
+     *
+     * @param  mixed  $expected
+     * @param  mixed  $actual
+     * @return bool
+     */
     public function accepts($expected, $actual): bool
     {
         return $expected instanceof Model && $actual instanceof Model;
     }
 
     /**
-     * @param Model $expected
-     * @param Model $actual
+     * Asserts that expected and actual are the same model.
+     *
+     * @param \Illuminate\Database\Eloquent\Model $expected
+     * @param \Illuminate\Database\Eloquent\Model $actual
+     * @param float $delta
+     * @param bool $canonicalize
+     * @param bool $ignoreCase
+     * @return void
      */
     public function assertEquals($expected, $actual, $delta = 0.0, $canonicalize = false, $ignoreCase = false): void
     {

--- a/src/Illuminate/Testing/TestingServiceProvider.php
+++ b/src/Illuminate/Testing/TestingServiceProvider.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Illuminate\Testing;
+
+use Illuminate\Contracts\Support\DeferrableProvider;
+use Illuminate\Support\ServiceProvider;
+use Illuminate\Testing\Comparators\ModelComparator;
+use SebastianBergmann\Comparator\Factory;
+
+class TestingServiceProvider extends ServiceProvider
+{
+    /**
+     * Register the service provider.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        $comparatorFactory = Factory::getInstance();
+        $comparatorFactory->register(new ModelComparator());
+    }
+}

--- a/src/Illuminate/Testing/TestingServiceProvider.php
+++ b/src/Illuminate/Testing/TestingServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Testing;
 
-use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Testing\Comparators\ModelComparator;
 use SebastianBergmann\Comparator\Factory;
@@ -14,7 +13,7 @@ class TestingServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    public function register()
+    public function register(): void
     {
         $comparatorFactory = Factory::getInstance();
         $comparatorFactory->register(new ModelComparator());

--- a/tests/Testing/Comparators/ModelComparatorTest.php
+++ b/tests/Testing/Comparators/ModelComparatorTest.php
@@ -74,6 +74,7 @@ class ModelComparatorTest extends TestCase
     }
 }
 
-class TestModel extends Model {
+class TestModel extends Model
+{
     protected $guarded = [];
 }

--- a/tests/Testing/Comparators/ModelComparatorTest.php
+++ b/tests/Testing/Comparators/ModelComparatorTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Illuminate\Tests\Testing\Comparators;
+
+use Illuminate\Database\Eloquent\Model;
+use Orchestra\Testbench\TestCase;
+
+class ModelComparatorTest extends TestCase
+{
+    public function testIsEqual()
+    {
+        $modelA = new TestModel([
+            'id' => 100,
+        ]);
+        $modelB = new TestModel([
+            'id' => 100,
+        ]);
+
+        $this->assertEquals($modelA, $modelB);
+    }
+
+    public function testIgnoresProperties()
+    {
+        $modelA = new TestModel([
+            'id' => 100,
+            'text' => 'good',
+        ]);
+        $modelB = new TestModel([
+            'id' => 100,
+            'text' => 'bad',
+        ]);
+
+        $this->assertEquals($modelA, $modelB);
+    }
+
+    public function testIsNotEqualIfDifferentKey()
+    {
+        $modelA = new TestModel([
+            'id' => 100,
+        ]);
+        $modelB = new TestModel([
+            'id' => 200,
+        ]);
+
+        $this->assertNotEquals($modelA, $modelB);
+    }
+
+    public function testIsNotEqualIfDifferentTable()
+    {
+        $modelA = new TestModel([
+            'id' => 100,
+        ]);
+        $modelA->setTable('table_a');
+        $modelB = new TestModel([
+            'id' => 100,
+        ]);
+        $modelB->setTable('table_b');
+
+        $this->assertNotEquals($modelA, $modelB);
+    }
+
+    public function testIsNotEqualIfDifferentConnection()
+    {
+        $modelA = new TestModel([
+            'id' => 100,
+        ]);
+        $modelA->setConnection('good');
+        $modelB = new TestModel([
+            'id' => 100,
+        ]);
+        $modelA->setConnection('bad');
+
+        $this->assertNotEquals($modelA, $modelB);
+    }
+}
+
+class TestModel extends Model {
+    protected $guarded = [];
+}


### PR DESCRIPTION
This PR adds a phpunit comparator for models.

The comparator compares the models based on the model `is` method.
Phpunit comparators are used for the methods `assertEquals` and `assertNotEquals`.  

I often encounter that I want to check if two models are the same, and then use the `assertEquals`, only to get an error about things not being identical. This is often caused by fields like the `wasRecentlyCreated` and so on.  
To get around this I normally write `assertTrue($model->is($otherModel))`.


This solution might be BC and should have been submitted to L9, as it changes the current `assertEquals` result, however submitting it to L8 because it uses the official `is` method which is used for comparing models. If you consider this a BC i'll submit to L9 instead 👍 


Another solution for this would be so instead of using the `is` method for comparison it uses the `getAttributes` arrays for comparison. 