### PR TITLE
[8.x] Testing: Access component properties from the return value of $this->component()

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithViews.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithViews.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Testing\Concerns;
 use Illuminate\Support\Facades\View as ViewFacade;
 use Illuminate\Support\MessageBag;
 use Illuminate\Support\ViewErrorBag;
+use Illuminate\Testing\TestComponent;
 use Illuminate\Testing\TestView;
 use Illuminate\View\View;
 
@@ -33,13 +34,13 @@ trait InteractsWithViews
     {
         $tempDirectory = sys_get_temp_dir();
 
-        if (! in_array($tempDirectory, ViewFacade::getFinder()->getPaths())) {
+        if (!in_array($tempDirectory, ViewFacade::getFinder()->getPaths())) {
             ViewFacade::addLocation(sys_get_temp_dir());
         }
 
         $tempFileInfo = pathinfo(tempnam($tempDirectory, 'laravel-blade'));
 
-        $tempFile = $tempFileInfo['dirname'].'/'.$tempFileInfo['filename'].'.blade.php';
+        $tempFile = $tempFileInfo['dirname'] . '/' . $tempFileInfo['filename'] . '.blade.php';
 
         file_put_contents($tempFile, $template);
 
@@ -59,9 +60,11 @@ trait InteractsWithViews
 
         $view = value($component->resolveView(), $data);
 
-        return $view instanceof View
-                ? new TestView($view->with($component->data()))
-                : new TestView(view($view, $component->data()));
+        $view = $view instanceof View
+            ? $view->with($component->data())
+            : view($view, $component->data());
+
+        return (new TestComponent($component, $view));
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithViews.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithViews.php
@@ -40,7 +40,7 @@ trait InteractsWithViews
 
         $tempFileInfo = pathinfo(tempnam($tempDirectory, 'laravel-blade'));
 
-        $tempFile = $tempFileInfo['dirname'].'/'.$tempFileInfo['filename'] . '.blade.php';
+        $tempFile = $tempFileInfo['dirname'].'/'.$tempFileInfo['filename'].'.blade.php';
 
         file_put_contents($tempFile, $template);
 

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithViews.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithViews.php
@@ -34,13 +34,13 @@ trait InteractsWithViews
     {
         $tempDirectory = sys_get_temp_dir();
 
-        if (!in_array($tempDirectory, ViewFacade::getFinder()->getPaths())) {
+        if (! in_array($tempDirectory, ViewFacade::getFinder()->getPaths())) {
             ViewFacade::addLocation(sys_get_temp_dir());
         }
 
         $tempFileInfo = pathinfo(tempnam($tempDirectory, 'laravel-blade'));
 
-        $tempFile = $tempFileInfo['dirname'] . '/' . $tempFileInfo['filename'] . '.blade.php';
+        $tempFile = $tempFileInfo['dirname'].'/'.$tempFileInfo['filename'] . '.blade.php';
 
         file_put_contents($tempFile, $template);
 
@@ -64,7 +64,7 @@ trait InteractsWithViews
             ? $view->with($component->data())
             : view($view, $component->data());
 
-        return (new TestComponent($component, $view));
+        return new TestComponent($component, $view);
     }
 
     /**

--- a/src/Illuminate/Testing/TestComponent.php
+++ b/src/Illuminate/Testing/TestComponent.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Illuminate\Testing;
+
+use Illuminate\Testing\TestView;
+use Illuminate\View\Component;
+
+
+class TestComponent extends TestView
+{
+  /**
+   * The original view.
+   *
+   * @var \Illuminate\View\Component
+   */
+  protected $component;
+
+  /**
+   * The rendered view contents.
+   *
+   * @var string
+   */
+  protected $rendered;
+
+  /**
+   * Create a new test view instance.
+   *
+   * @param  \Illuminate\View\Component  $view
+   * @return void
+   */
+  public function __construct(Component $component, $view)
+  {
+    $this->component = $component;
+    $this->rendered = $view->render();
+  }
+
+  public function __get($attribute)
+  {
+    return $this->component->{$attribute};
+  }
+}

--- a/tests/Foundation/Testing/Concerns/InteractsWithViewsTest.php
+++ b/tests/Foundation/Testing/Concerns/InteractsWithViewsTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Foundation\Testing\Concerns;
 
 use Illuminate\Foundation\Testing\Concerns\InteractsWithViews;
+use Illuminate\View\Component;
 use Orchestra\Testbench\TestCase;
 
 class InteractsWithViewsTest extends TestCase
@@ -14,5 +15,20 @@ class InteractsWithViewsTest extends TestCase
         $string = (string) $this->blade('@if(true)test @endif');
 
         $this->assertEquals('test ', $string);
+    }
+
+    public function testComponentCanAccessPublicProperties()
+    {
+        $exampleComponent = new class extends Component
+        {
+            public $foo = 'bar';
+            public function render()
+            {
+                return '';
+            }
+        };
+        $component = $this->component(get_class($exampleComponent));
+
+        $this->assertEquals('bar', $component->foo);
     }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

The benefits for this pull-request would be that it's possible to access component attributes when using 
`$this->component()` in your test

Example:

```
$table = $this->component(Table::class, [ 'data' => ['foo','bar','baz','quz'] ]);

$string = $table->concatenated_data;

$this->assertEquals( 'foobarbazquz', $string );
```

It's not going to break any existing features because It's still possible to use the assertions from `TestView::class` since `TestComponent::class` it extends to that class...

I know that it's possible to use `$this->app->make($componentClass, $data);` to instantiate and access properties from a component but it does not have the assertions that `$this->component()` have.... 
if you want to access the component properties and use the assertions you need to do both...
also `$this->app->make($componentClass, $data);` is not documented.

I was looking to the test for the `TestView::class` but I didn't found any so I just added it into `InteractsWithViewsTest`

It's my first contribution, and I'm open to constructive criticism.
