### PR TITLE
[8.x] Use `Fluent` instead of `array` on `Rule::when()`

### DIFF
--- a/src/Illuminate/Validation/ConditionalRules.php
+++ b/src/Illuminate/Validation/ConditionalRules.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Validation;
 
+use Illuminate\Support\Fluent;
+
 class ConditionalRules
 {
     /**
@@ -40,7 +42,7 @@ class ConditionalRules
     public function passes(array $data = [])
     {
         return is_callable($this->condition)
-                    ? call_user_func($this->condition, $data)
+                    ? call_user_func($this->condition, new Fluent($data))
                     : $this->condition;
     }
 

--- a/tests/Validation/ValidationRuleParserTest.php
+++ b/tests/Validation/ValidationRuleParserTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Validation;
 
+use Illuminate\Support\Fluent;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\ValidationRuleParser;
 use PHPUnit\Framework\TestCase;
@@ -16,7 +17,7 @@ class ValidationRuleParserTest extends TestCase
             'password' => Rule::when(true, 'required|min:2'),
             'username' => ['required', Rule::when(true, ['min:2'])],
             'address' => ['required', Rule::when(false, ['min:2'])],
-            'city' => ['required', Rule::when(function (array $input) {
+            'city' => ['required', Rule::when(function (Fluent $input) {
                 return true;
             }, ['min:2'])],
         ]);


### PR DESCRIPTION
Consistent with `Illuminate\Validation\Validator::sometimes()`

https://github.com/laravel/framework/blob/59b674a31492dae75c1407cd3f14b03c80ca145e/src/Illuminate/Validation/Validator.php#L1115-L1126

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>