### PR TITLE
[8.x] Fix api guard tests

### DIFF
--- a/tests/Integration/Auth/ApiAuthenticationWithEloquentTest.php
+++ b/tests/Integration/Auth/ApiAuthenticationWithEloquentTest.php
@@ -21,6 +21,12 @@ class ApiAuthenticationWithEloquentTest extends TestCase
         $app['config']->set('auth.defaults.guard', 'api');
         $app['config']->set('auth.providers.users.model', User::class);
 
+        $app['config']->set('auth.guards.api', [
+            'driver' => 'token',
+            'provider' => 'users',
+            'hash' => false,
+        ]);
+
         // Database configuration
         $app['config']->set('database.default', 'testbench');
 

--- a/tests/Integration/Foundation/Testing/Concerns/InteractsWithAuthenticationTest.php
+++ b/tests/Integration/Foundation/Testing/Concerns/InteractsWithAuthenticationTest.php
@@ -16,6 +16,12 @@ class InteractsWithAuthenticationTest extends TestCase
     {
         $app['config']->set('auth.providers.users.model', AuthenticationTestUser::class);
 
+        $app['config']->set('auth.guards.api', [
+            'driver' => 'token',
+            'provider' => 'users',
+            'hash' => false,
+        ]);
+
         $app['config']->set('database.default', 'testbench');
         $app['config']->set('database.connections.testbench', [
             'driver' => 'sqlite',


### PR DESCRIPTION
These tests will fail as soon as a new Testbench version is tagged because the api guard was removed from the skeleton. We'll need to explicitly re-add the api guard for these tests.
