### PR TITLE
[8.x] Add qualifyColumns method to Model class

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1518,6 +1518,17 @@ class Builder
     }
 
     /**
+     * Qualify the column's lists name by the model's table.
+     *
+     * @param  array|mixed  $columns
+     * @return array
+     */
+    public function qualifyColumns($columns)
+    {
+        return $this->model->qualifyColumns($columns);
+    }
+
+    /**
      * Get the given macro by name.
      *
      * @param  string  $name

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1520,7 +1520,7 @@ class Builder
     /**
      * Qualify the column's lists name by the model's table.
      *
-     * @param  array|mixed  $columns
+     * @param  array|\Illuminate\Database\Query\Expression  $columns
      * @return array
      */
     public function qualifyColumns($columns)

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -440,11 +440,11 @@ abstract class Model implements Arrayable, ArrayAccess, HasBroadcastChannel, Jso
      * @param  array|mixed  $columns
      * @return array
      */
-    public function qualifyColumns($columns) 
+    public function qualifyColumns($columns)
     {
         $columns = is_array($columns) ? $columns : func_get_args();
         $qualifiedArray = [];
-        foreach($columns as $column) {
+        foreach ($columns as $column) {
             $qualifiedArray[] = $this->qualifyColumn($column);
         }
         return $qualifiedArray;

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -443,13 +443,11 @@ abstract class Model implements Arrayable, ArrayAccess, HasBroadcastChannel, Jso
     public function qualifyColumns($columns)
     {
         $columns = is_array($columns) ? $columns : func_get_args();
-        
         $qualifiedArray = [];
 
         foreach ($columns as $column) {
             $qualifiedArray[] = $this->qualifyColumn($column);
-        }
-        
+        }   
         return $qualifiedArray;
     }
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -437,12 +437,11 @@ abstract class Model implements Arrayable, ArrayAccess, HasBroadcastChannel, Jso
     /**
      * Qualify the column's lists name by the model's table.
      *
-     * @param  array|mixed  $columns
+     * @param  array  $columns
      * @return array
      */
     public function qualifyColumns($columns)
     {
-        $columns = is_array($columns) ? $columns : func_get_args();
         $qualifiedArray = [];
 
         foreach ($columns as $column) {

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -443,7 +443,9 @@ abstract class Model implements Arrayable, ArrayAccess, HasBroadcastChannel, Jso
     public function qualifyColumns($columns)
     {
         $columns = is_array($columns) ? $columns : func_get_args();
+        
         $qualifiedArray = [];
+
         foreach ($columns as $column) {
             $qualifiedArray[] = $this->qualifyColumn($column);
         }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -448,6 +448,7 @@ abstract class Model implements Arrayable, ArrayAccess, HasBroadcastChannel, Jso
         foreach ($columns as $column) {
             $qualifiedArray[] = $this->qualifyColumn($column);
         }   
+        
         return $qualifiedArray;
     }
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -435,6 +435,20 @@ abstract class Model implements Arrayable, ArrayAccess, HasBroadcastChannel, Jso
     }
 
     /**
+     * Qualify the column's lists name by the model's table.
+     *
+     * @param  array|mixed  $columns
+     * @return array
+     */
+    public function qualifyColumns(...$columns) {
+        $qualifiedArray = [];
+        foreach($columns as $column) {
+            $qualifiedArray[] = $this->qualifyColumn($column);
+        }
+        return $qualifiedArray;
+    }
+
+    /**
      * Create a new instance of the given model.
      *
      * @param  array  $attributes

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -440,7 +440,8 @@ abstract class Model implements Arrayable, ArrayAccess, HasBroadcastChannel, Jso
      * @param  array|mixed  $columns
      * @return array
      */
-    public function qualifyColumns(...$columns) {
+    public function qualifyColumns(...$columns) 
+    {
         $qualifiedArray = [];
         foreach($columns as $column) {
             $qualifiedArray[] = $this->qualifyColumn($column);

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -447,6 +447,7 @@ abstract class Model implements Arrayable, ArrayAccess, HasBroadcastChannel, Jso
         foreach ($columns as $column) {
             $qualifiedArray[] = $this->qualifyColumn($column);
         }
+        
         return $qualifiedArray;
     }
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -440,8 +440,9 @@ abstract class Model implements Arrayable, ArrayAccess, HasBroadcastChannel, Jso
      * @param  array|mixed  $columns
      * @return array
      */
-    public function qualifyColumns(...$columns) 
+    public function qualifyColumns($columns) 
     {
+        $columns = is_array($columns) ? $columns : func_get_args();
         $qualifiedArray = [];
         foreach($columns as $column) {
             $qualifiedArray[] = $this->qualifyColumn($column);

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -447,8 +447,8 @@ abstract class Model implements Arrayable, ArrayAccess, HasBroadcastChannel, Jso
 
         foreach ($columns as $column) {
             $qualifiedArray[] = $this->qualifyColumn($column);
-        }   
-        
+        }
+
         return $qualifiedArray;
     }
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -203,8 +203,8 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $builder->setModel(new EloquentModelStub);
 
-        $this->assertSame(['stub.column', 'stub.column2', 'stub.column3'], $builder->qualifyColumn('column', 'column2', 'column3'));
-        $this->assertSame(['stub.column', 'stub.column2', 'stub.column3'], $builder->qualifyColumn(...['column', 'column2', 'column3']));
+        $this->assertSame(['stub.column', 'stub.column2', 'stub.column3'], $builder->qualifyColumns('column', 'column2', 'column3'));
+        $this->assertSame(['stub.column', 'stub.column2', 'stub.column3'], $builder->qualifyColumns(...['column', 'column2', 'column3']));
     }
 
     public function testGetMethodLoadsModelsAndHydratesEagerRelations()

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -203,7 +203,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $builder->setModel(new EloquentModelStub);
 
-        $this->assertEquals(['stub.column', 'stub.name'], $builder->qualifyColumns('column', 'name'));
+        $this->assertEquals(['stub.column', 'stub.name'], $builder->qualifyColumns(['column', 'name']));
     }
 
     public function testGetMethodLoadsModelsAndHydratesEagerRelations()

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -203,8 +203,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $builder->setModel(new EloquentModelStub);
 
-        $this->assertEquals(['stub.column', 'stub.column2', 'stub.column3'], $builder->qualifyColumns('column', 'column2', 'column3'));
-        $this->assertEquals(['stub.column', 'stub.column2', 'stub.column3'], $builder->qualifyColumns(['column', 'column2', 'column3']));
+        $this->assertEquals(['stub.column'], $builder->qualifyColumns('column'));
     }
 
     public function testGetMethodLoadsModelsAndHydratesEagerRelations()

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -203,7 +203,6 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $builder->setModel(new EloquentModelStub);
 
-        $this->assertEquals(['stub.column', 'stub.name'], $builder->qualifyColumns('column', 'name'));
         $this->assertEquals(['stub.column', 'stub.name'], $builder->qualifyColumns(['column', 'name']));
     }
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -196,6 +196,17 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertSame('stub.column', $builder->qualifyColumn('column'));
     }
 
+    public function testQualifyColumns()
+    {
+        $builder = new Builder(m::mock(BaseBuilder::class));
+        $builder->shouldReceive('from')->with('stub');
+
+        $builder->setModel(new EloquentModelStub);
+
+        $this->assertSame(['stub.column', 'stub.column2', 'stub.column3'], $builder->qualifyColumn('column', 'column2', 'column3'));
+        $this->assertSame(['stub.column', 'stub.column2', 'stub.column3'], $builder->qualifyColumn(...['column', 'column2', 'column3']));
+    }
+
     public function testGetMethodLoadsModelsAndHydratesEagerRelations()
     {
         $builder = m::mock(Builder::class.'[getModels,eagerLoadRelations]', [$this->getMockQueryBuilder()]);

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -203,8 +203,8 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $builder->setModel(new EloquentModelStub);
 
-        $this->assertSame(['stub.column', 'stub.column2', 'stub.column3'], $builder->qualifyColumns('column', 'column2', 'column3'));
-        $this->assertSame(['stub.column', 'stub.column2', 'stub.column3'], $builder->qualifyColumns(['column', 'column2', 'column3']));
+        $this->assertEquals(['stub.column', 'stub.column2', 'stub.column3'], $builder->qualifyColumns('column', 'column2', 'column3'));
+        $this->assertEquals(['stub.column', 'stub.column2', 'stub.column3'], $builder->qualifyColumns(['column', 'column2', 'column3']));
     }
 
     public function testGetMethodLoadsModelsAndHydratesEagerRelations()

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -204,7 +204,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->setModel(new EloquentModelStub);
 
         $this->assertSame(['stub.column', 'stub.column2', 'stub.column3'], $builder->qualifyColumns('column', 'column2', 'column3'));
-        $this->assertSame(['stub.column', 'stub.column2', 'stub.column3'], $builder->qualifyColumns(...['column', 'column2', 'column3']));
+        $this->assertSame(['stub.column', 'stub.column2', 'stub.column3'], $builder->qualifyColumns(['column', 'column2', 'column3']));
     }
 
     public function testGetMethodLoadsModelsAndHydratesEagerRelations()

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -203,8 +203,8 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $builder->setModel(new EloquentModelStub);
 
-        $this->assertEquals(['stub.column', 'stub.name'], $builder->qualifyColumns(['column', 'name']));
         $this->assertEquals(['stub.column', 'stub.name'], $builder->qualifyColumns('column', 'name'));
+        $this->assertEquals(['stub.column', 'stub.name'], $builder->qualifyColumns(['column', 'name']));
     }
 
     public function testGetMethodLoadsModelsAndHydratesEagerRelations()

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -203,7 +203,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $builder->setModel(new EloquentModelStub);
 
-        $this->assertEquals(['stub.column'], $builder->qualifyColumns('column'));
+        $this->assertEquals(['stub.column', 'stub.name'], $builder->qualifyColumns('column', 'name'));
     }
 
     public function testGetMethodLoadsModelsAndHydratesEagerRelations()

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -204,6 +204,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->setModel(new EloquentModelStub);
 
         $this->assertEquals(['stub.column', 'stub.name'], $builder->qualifyColumns(['column', 'name']));
+        $this->assertEquals(['stub.column', 'stub.name'], $builder->qualifyColumns('column', 'name'));
     }
 
     public function testGetMethodLoadsModelsAndHydratesEagerRelations()


### PR DESCRIPTION
Hi All,
this is my first pull request, I hope all is right.
I would like to suggest to add a qualifyColumns (note the "s") method to the Model class in order to qualify multiple column at once, avoiding to call qualifyColum method multiple times.
I think this may help when we need to qualify multiple columns when using select method of Builder.

1) without qualifyColumns:

`
$query->select(
   $userModel->qualifyColumn('name'), 
   $userModel->qualifyColumn('surname'), 
   $userModel->qualifyColumn('address')
);
`

2) with qualifyColumns:

`
$query->select($userModel->qualifyColumns(['name', 'surname, 'address']));
`
