### PR TITLE
[8.x] Add ability to throw a custom validation exception

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1358,7 +1358,7 @@ class Validator implements ValidatorContract
      *
      * @param  string  $exception
      * @return void
-     * 
+     *
      * @throws InvalidArgumentException
      */
     public function setException($exception)
@@ -1368,7 +1368,7 @@ class Validator implements ValidatorContract
                 sprintf('Exception [%s] is invalid. It must extend [%s].', $exception, ValidationException::class)
             );
         }
-        
+
         $this->exception = $exception;
     }
 

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -15,6 +15,7 @@ use Illuminate\Support\Fluent;
 use Illuminate\Support\MessageBag;
 use Illuminate\Support\Str;
 use Illuminate\Support\ValidatedInput;
+use InvalidArgumentException;
 use RuntimeException;
 use stdClass;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
@@ -276,6 +277,13 @@ class Validator implements ValidatorContract
     protected $dotPlaceholder;
 
     /**
+     * The exception to throw upon failure.
+     *
+     * @var string
+     */
+    protected $exception = ValidationException::class;
+
+    /**
      * Create a new Validator instance.
      *
      * @param  \Illuminate\Contracts\Translation\Translator  $translator
@@ -475,9 +483,7 @@ class Validator implements ValidatorContract
      */
     public function validate()
     {
-        if ($this->fails()) {
-            throw new ValidationException($this);
-        }
+        throw_if($this->fails(), $this->exception, $this);
 
         return $this->validated();
     }
@@ -520,9 +526,7 @@ class Validator implements ValidatorContract
      */
     public function validated()
     {
-        if ($this->invalid()) {
-            throw new ValidationException($this);
-        }
+        throw_if($this->invalid(), $this->exception, $this);
 
         $results = [];
 
@@ -1373,6 +1377,25 @@ class Validator implements ValidatorContract
     public function setPresenceVerifier(PresenceVerifierInterface $presenceVerifier)
     {
         $this->presenceVerifier = $presenceVerifier;
+    }
+
+    /**
+     * Set the exception to throw upon failed validation.
+     *
+     * @param  string  $exception
+     * @return void
+     * 
+     * @throws InvalidArgumentException
+     */
+    public function setException($exception)
+    {
+        if (! is_a($exception, ValidationException::class, true)) {
+            throw new InvalidArgumentException(
+                sprintf('Exception [%s] is invalid. It must extend [%s].', $exception, ValidationException::class)
+            );
+        }
+        
+        $this->exception = $exception;
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -633,7 +633,7 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['name' => ''], ['name' => 'required']);
 
-        $exception = new class ($v) extends ValidationException {};
+        $exception = new class($v) extends ValidationException {};
         $v->setException($exception);
 
         try {

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -634,7 +634,7 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['name' => ''], ['name' => 'required']);
 
         $exception = new class ($v) extends ValidationException {};
-        
+
         $v->setException($exception);
 
         try {

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -627,6 +627,35 @@ class ValidationValidatorTest extends TestCase
         $this->assertSame('english is required!', $v->messages()->first('lang.en'));
     }
 
+    public function testCustomException()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+
+        $v = new Validator($trans, ['name' => ''], ['name' => 'required']);
+
+        $exception = new class ($v) extends ValidationException {};
+        
+        $v->setException($exception);
+
+        try {
+            $v->validate();
+        } catch (ValidationException $e) {
+            $this->assertSame($exception, $e);
+        }
+    }
+
+    public function testCustomExceptionMustExtendValidationException()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+
+        $v = new Validator($trans, [], []);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Exception [RuntimeException] is invalid. It must extend [Illuminate\Validation\ValidationException].');
+
+        $v->setException(\RuntimeException::class);
+    }
+
     public function testValidationDotCustomDotAnythingCanBeTranslated()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

## Description

This PR adds the ability to set a custom validation exception for manually created `Validator` instances via a `setException()` method.

The custom validation exception **must** extend the current `ValidationException`.

## Purpose

This is super helpful for customizing the `ValidationException` with extra functionality that an application may need for specific validator instances.

The only other way of doing this right now (to my knowledge) is to extend the validator factory and modify the methods that throw the validation exceptions.

## Example

```php
class AppValidationException extends \Illuminate\Validation\ValidationException {}

// Somewhere in the application...

$validator = Validator::make($data, $rules, $messages);

$validator->setException(AppValidationException::class);

$validator->validate();
```

## Notes

Let me know if you'd like anything adjusted or modified. No hard feelings on closure ❤️ 

Thanks for your time!