### PR TITLE
[8.x] Support shorter subscription syntax

### DIFF
--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -182,7 +182,13 @@ class Dispatcher implements DispatcherContract
 
         if (is_array($events)) {
             foreach ($events as $event => $listeners) {
-                foreach ($listeners as $listener) {
+                foreach (Arr::wrap($listeners) as $listener) {
+                    if (is_string($listener) && method_exists($subscriber, $listener)) {
+                        $this->listen($event, [get_class($subscriber), $listener]);
+
+                        continue;
+                    }
+
                     $this->listen($event, $listener);
                 }
             }


### PR DESCRIPTION
This PR allows you to return an array from the `subscribe` method (this was already supported) that has a shorter syntax for methods that exist on the subscriber itself:

```php
<?php

namespace App\Listeners;

use App\Events\SomeEvent;

class SomeEventSubscriber
{
    /**
     * Handle an event.
     */
    public function handleSomeEvent($event)
    {
        info('Handling some event...');
    }

    /**
     * Register the listeners for the subscriber.
     *
     * @param  \Illuminate\Events\Dispatcher  $events
     * @return void
     */
    public function subscribe($events)
    {
        return [
            SomeEvent::class => [
                'handleSomeEvent',
            ],
        ];

        // Or...

        return [
            SomeEvent::class => 'handleSomeEvent',
        ];
    }
}
```