### PR TITLE
[8.x] Stop test suite making a live HTTP request to example.com

### DIFF
--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -36,6 +36,11 @@ class HttpClientTest extends TestCase
         $this->factory = new Factory;
     }
 
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
     public function testStubbedResponsesAreReturnedAfterFaking()
     {
         $this->factory->fake();
@@ -936,8 +941,6 @@ class HttpClientTest extends TestCase
         $factory->post('https://example.com');
         $factory->patch('https://example.com');
         $factory->delete('https://example.com');
-
-        m::close();
     }
 
     public function testTheRequestSendingAndResponseReceivedEventsAreFiredWhenARequestIsSentAsync()
@@ -957,8 +960,6 @@ class HttpClientTest extends TestCase
                 $pool->delete('https://example.com'),
             ];
         });
-
-        m::close();
     }
 
     public function testTheTransferStatsAreCalledSafelyWhenFakingTheRequest()
@@ -988,13 +989,12 @@ class HttpClientTest extends TestCase
         $events->shouldReceive('dispatch')->once()->with(m::type(ResponseReceived::class));
 
         $factory = new Factory($events);
+        $factory->fake(['example.com' => $factory->response('foo', 200)]);
 
         $client = $factory->timeout(10);
         $clonedClient = clone $client;
 
         $clonedClient->get('https://example.com');
-
-        m::close();
     }
 
     public function testRequestIsMacroable()


### PR DESCRIPTION
https://github.com/laravel/framework/pull/37596 introduced a test that's sending an actual HTTP request to https://example.com/ on every test run. Mock that request to remove this external dependency that can intermittently fail. Running Laravel's test suite locally today I had `testClonedClientsWorkSuccessfullyWithTheRequestObject()` fail because a connection to example.com failed.

Also move Mockery `m::close()` into PHPUnit's `tearDown()` lifecycle since failed test cases were causing registered mocks to leak into subsequent test cases.

---

Fun with test suites: try disconnecting your WiFi and running the whole lot locally. A couple Laravel tests that rely on external services:

* `ValidationValidatorTest@testValidateActiveUrl()`

  The `active_url` validation rule calls PHP global function `dns_get_record()`. It could be wrapped in a new container-bound class.
* `ValidationPasswordRuleTest@testUncompromised()` & `testMessagesOrder()`

  The new `Password@uncompromised()` rule option does bind `Illuminate\Contracts\Validation\UncompromisedVerifier` to the container so this is mock-ready. A test fake could be added here to stop calling api.pwnedpasswords.com although for a full-coverage integration test we may want to actually call the API as long as requests don't get rate limited.