### PR TITLE
[9.x] Dont recompile view if lastModified is same as cache file

### DIFF
--- a/src/Illuminate/View/Compilers/Compiler.php
+++ b/src/Illuminate/View/Compilers/Compiler.php
@@ -68,7 +68,7 @@ abstract class Compiler
             return true;
         }
 
-        return $this->files->lastModified($path) >=
+        return $this->files->lastModified($path) >
                $this->files->lastModified($compiled);
     }
 


### PR DESCRIPTION
as discussed in: https://github.com/laravel/framework/pull/38270#issuecomment-894835862

this change makes the code adhere to the comment above it:

> we will verify the last modification of the views **is less than** the modification times of the compiled views