### PR TITLE
Monolog 2.3.0+ produces  memory exhausted

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "egulias/email-validator": "^2.1.10",
         "league/commonmark": "^1.3|^2.0",
         "league/flysystem": "^1.1",
-        "monolog/monolog": "^2.0",
+        "monolog/monolog": "<2.3.0",
         "nesbot/carbon": "^2.31",
         "opis/closure": "^3.6",
         "psr/container": "^1.0",


### PR DESCRIPTION
Monolog 2.3.0+ produces `PHP Fatal error: Allowed memory size of 2147483648 bytes exhausted (tried to allocate 2147483647 bytes)`
https://github.com/Seldaek/monolog/issues/1577

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
