### PR TITLE
[8.x] Minor improvements to validation assertions API

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1073,7 +1073,7 @@ EOF;
      * @param  string  $responseKey
      * @return $this
      */
-    public function assertInvalid($errors,
+    public function assertInvalid($errors = null,
                                   $errorBag = 'default',
                                   $responseKey = 'errors')
     {
@@ -1092,7 +1092,7 @@ EOF;
                         PHP_EOL.PHP_EOL.json_encode($sessionErrors, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE).PHP_EOL
                 : 'Response does not have validation errors in the session.';
 
-        foreach ($errors as $key => $value) {
+        foreach (Arr::wrap($errors) as $key => $value) {
             PHPUnit::assertArrayHasKey(
                 (is_int($key)) ? $value : $key,
                 $sessionErrors,

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -947,7 +947,11 @@ class TestResponseTest extends TestCase
 
         $testResponse = TestResponse::fromBaseResponse(new Response);
 
+        $testResponse->assertValid('last_name');
         $testResponse->assertValid(['last_name']);
+
+        $testResponse->assertInvalid();
+        $testResponse->assertInvalid('first_name');
         $testResponse->assertInvalid(['first_name']);
         $testResponse->assertInvalid(['first_name' => 'required']);
         $testResponse->assertInvalid(['first_name' => 'character']);


### PR DESCRIPTION
This makes a couple of minor improvements to the new validation assertions API:

* `assertInvalid` can now take no error arguments (like `assertInvalid`) so you can generically assert that there are errors - `assertInvalid()`
* The errors are passed through `Arr::wrap` (like `assertValid`) so that you can just pass a single key - `assertInvalid('email')`