### PR TITLE
Upsert: match on uniqueBy fields even if they contain null values [SQL Server]

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -397,7 +397,9 @@ class SqlServerGrammar extends Grammar
         $sql .= 'using (values '.$parameters.') '.$this->wrapTable('laravel_source').' ('.$columns.') ';
 
         $on = collect($uniqueBy)->map(function ($column) use ($query) {
-            return $this->wrap('laravel_source.'.$column).' = '.$this->wrap($query->from.'.'.$column);
+            $srcCol = $this->wrap('laravel_source.'.$column);
+            $targetCol = $this->wrap($query->from.'.'.$column);
+            return '('.$srcCol.' = '.$targetCol.' or ('.$srcCol.' is null and '.$targetCol.' is null))';
         })->implode(' and ');
 
         $sql .= 'on '.$on.' ';


### PR DESCRIPTION
When performing upserts withSQL Server, rows that should be updated are instead being inserted. This happens when one or more of the fields in `upsert()`'s `$uniqueBy` parameter are `null` in both a record passed to `$values` and a existing database row that matches that record.

For instance, given this table `tbl`:

| row1 | row2 | row3 |
| ------ | ------- | ------ |
| a | foo | 123 |
| b | NULL | 456 |

```php
$table = DB::table('tbl');
$table->upsert(
    [
        ['row1' => 'a', 'row2' => 'foo', 'row3' => 111],
        ['row1' => 'b', 'row2' => null, 'row3' => 222],
        ['row1' => 'c', 'row2' => 'baz', 'row3' => 333],
    ],
    ['row1', 'row2'],
    ['row1', 'row2', 'row3']
);
```

After running the above code, `tbl` will look like this:

| row1 | row2 | row3 |
| ------ | ------- | ------ |
| a | foo | 111 |
| b | NULL | 456 |
| b | NULL | 222 |
| c | baz | 333 |

But the expected result is this:

| row1 | row2 | row3 |
| ------ | ------- | ------ |
| a | foo | 111 |
| b | NULL | 222 |
| c | baz | 333 |

The changes in this PR resolve this issue, so that the code snippet above results in the expected database state.