### PR TITLE
[8.x] Update InteractsWithInput.php

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -4,7 +4,6 @@ namespace Illuminate\Http\Concerns;
 
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
 use SplFileInfo;
 use stdClass;
 use Symfony\Component\VarDumper\VarDumper;
@@ -58,7 +57,8 @@ trait InteractsWithInput
         $pos = strrpos($header, 'Bearer');
         if ($pos !== false) {
             $header = substr($header, $pos + 7);
-            return str_contains($header, ',') ? strstr(',',$header, true) : $header;
+            
+            return str_contains($header, ',') ? strstr(',', $header, true) : $header;
         }
     }
 

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -59,7 +59,7 @@ trait InteractsWithInput
         if ($position !== false) {
             $header = substr($header, $position + 7);
 
-            return str_contains($header, ',') ? strstr(',', $header, true) : $header;
+            return strpos($header, ',') !== false ? strstr(',', $header, true) : $header;
         }
     }
 

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -54,9 +54,10 @@ trait InteractsWithInput
     {
         $header = $this->header('Authorization', '');
 
-        $pos = strrpos($header, 'Bearer');
-        if ($pos !== false) {
-            $header = substr($header, $pos + 7);
+        $position = strrpos($header, 'Bearer');
+
+        if ($position !== false) {
+            $header = substr($header, $position + 7);
 
             return str_contains($header, ',') ? strstr(',', $header, true) : $header;
         }

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -55,8 +55,10 @@ trait InteractsWithInput
     {
         $header = $this->header('Authorization', '');
 
-        if (Str::startsWith($header, 'Bearer ')) {
-            return Str::substr($header, 7);
+        $pos = strrpos($header, 'Bearer');
+        if ($pos !== false) {
+            $header = substr($header, $pos + 7);
+            return str_contains($header, ',') ? strstr(',',$header, true) : $header;
         }
     }
 

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -57,7 +57,7 @@ trait InteractsWithInput
         $pos = strrpos($header, 'Bearer');
         if ($pos !== false) {
             $header = substr($header, $pos + 7);
-            
+
             return str_contains($header, ',') ? strstr(',', $header, true) : $header;
         }
     }

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -695,6 +695,15 @@ class HttpRequestTest extends TestCase
         $this->assertSame('foo', $all['do-this'][0]);
     }
 
+    public function testBearerTokenMethod()
+    {
+        $request = Request::create('/', 'GET', [], [], [], ['HTTP_AUTHORIZATION' => 'Bearer foo']);
+        $this->assertSame('foo', $request->bearerToken());
+
+        $request = Request::create('/', 'GET', [], [], [], ['HTTP_AUTHORIZATION' => 'Basic foo, Bearer bar']);
+        $this->assertSame('bar', $request->bearerToken());
+    }
+
     public function testJSONMethod()
     {
         $payload = ['name' => 'taylor'];


### PR DESCRIPTION
Recently I came across some conditions that I needed to send both `Basic` and `Bearer` token. As we can send `Authorization: Basic X, Bearer Y` we need to change logic how to get token from the `Authorization` header.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
