### PR TITLE
[9.x] Skip guarding model attributes if the data passed is ValidatedData

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -869,7 +869,7 @@ class Builder implements BuilderContract
      */
     public function create($attributes = [])
     {
-        if ($attributes instanceof ValidatedData){
+        if ($attributes instanceof ValidatedData) {
             return $this->forceCreate($attributes->toArray());
         }
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -388,7 +388,7 @@ abstract class Model implements Arrayable, ArrayAccess, HasBroadcastChannel, Jso
      */
     public function fill($attributes)
     {
-        if ($attributes instanceof ValidatedData){
+        if ($attributes instanceof ValidatedData) {
             return $this->forceFill($attributes->toArray());
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -610,7 +610,7 @@ class BelongsToMany extends Relation
         return $this->related->newModelInstance(
             array_merge($rawAttributes, $rawValues),
             $this->shouldForceAttributes($attributes, $values)
-        );;
+        );
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -269,7 +269,9 @@ abstract class HasOneOrMany extends Relation
     public function updateOrCreate($attributes, $values = [])
     {
         return tap($this->firstOrNew($attributes), function ($instance) use ($values) {
-            $instance->fill($values)->save();
+            $instance->fill($values);
+
+            $instance->save();
         });
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database\Eloquent\Relations;
 
 use Closure;
 use Illuminate\Contracts\Database\Query\Builder as BuilderContract;
+use Illuminate\Contracts\Support\ValidatedData;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Concerns\DecoratesQueryBuilder;
@@ -432,6 +433,20 @@ abstract class Relation implements BuilderContract
     public static function getMorphedModel($alias)
     {
         return static::$morphMap[$alias] ?? null;
+    }
+
+    /**
+     * Determines if the passed attributes are validated data.
+     *
+     * @param  array|\Illuminate\Contracts\Support\ValidatedData  $attributes
+     * @param  array|\Illuminate\Contracts\Support\ValidatedData  $values
+     * @return bool
+     */
+    protected function shouldForceAttributes($attributes, $values = [])
+    {
+        return $attributes instanceof ValidatedData && $values instanceof ValidatedData ||
+            ($attributes instanceof ValidatedData && empty($values)) ||
+            ($values instanceof ValidatedData && empty($attributes));
     }
 
     /**

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -100,7 +100,9 @@ class DatabaseEloquentHasManyTest extends TestCase
         $relation = $this->getRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo'])->andReturn($relation->getQuery());
         $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn(null);
-        $model = $this->expectNewModel($relation, ['foo']);
+        $model = $this->getMockBuilder(Model::class)->onlyMethods(['setAttribute', 'save'])->getMock();
+        $relation->getRelated()->shouldReceive('newModelInstance')->with(['foo'], false)->andReturn($model);
+        $model->expects($this->once())->method('setAttribute')->with('foreign_key', 1);
 
         $this->assertEquals($model, $relation->firstOrNew(['foo']));
     }
@@ -110,7 +112,9 @@ class DatabaseEloquentHasManyTest extends TestCase
         $relation = $this->getRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo' => 'bar'])->andReturn($relation->getQuery());
         $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn(null);
-        $model = $this->expectNewModel($relation, ['foo' => 'bar', 'baz' => 'qux']);
+        $model = $this->getMockBuilder(Model::class)->onlyMethods(['setAttribute', 'save'])->getMock();
+        $relation->getRelated()->shouldReceive('newModelInstance')->with(['foo' => 'bar', 'baz' => 'qux'], false)->andReturn($model);
+        $model->expects($this->once())->method('setAttribute')->with('foreign_key', 1);
 
         $this->assertEquals($model, $relation->firstOrNew(['foo' => 'bar'], ['baz' => 'qux']));
     }
@@ -144,7 +148,9 @@ class DatabaseEloquentHasManyTest extends TestCase
         $relation = $this->getRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo'])->andReturn($relation->getQuery());
         $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn(null);
-        $model = $this->expectCreatedModel($relation, ['foo']);
+        $model = $this->getMockBuilder(Model::class)->onlyMethods(['setAttribute', 'save'])->getMock();
+        $relation->getRelated()->shouldReceive('newModelInstance')->with(['foo'], false)->andReturn($model);
+        $model->expects($this->once())->method('setAttribute')->with('foreign_key', 1);
 
         $this->assertEquals($model, $relation->firstOrCreate(['foo']));
     }
@@ -154,7 +160,9 @@ class DatabaseEloquentHasManyTest extends TestCase
         $relation = $this->getRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo' => 'bar'])->andReturn($relation->getQuery());
         $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn(null);
-        $model = $this->expectCreatedModel($relation, ['foo' => 'bar', 'baz' => 'qux']);
+        $model = $this->getMockBuilder(Model::class)->onlyMethods(['setAttribute', 'save'])->getMock();
+        $relation->getRelated()->shouldReceive('newModelInstance')->with(['foo' => 'bar', 'baz' => 'qux'], false)->andReturn($model);
+        $model->expects($this->once())->method('setAttribute')->with('foreign_key', 1);
 
         $this->assertEquals($model, $relation->firstOrCreate(['foo' => 'bar'], ['baz' => 'qux']));
     }
@@ -164,7 +172,7 @@ class DatabaseEloquentHasManyTest extends TestCase
         $relation = $this->getRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo'])->andReturn($relation->getQuery());
         $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn($model = m::mock(stdClass::class));
-        $relation->getRelated()->shouldReceive('newInstance')->never();
+        $relation->getRelated()->shouldReceive('newModelInstance')->never();
         $model->shouldReceive('fill')->once()->with(['bar']);
         $model->shouldReceive('save')->once();
 
@@ -176,7 +184,7 @@ class DatabaseEloquentHasManyTest extends TestCase
         $relation = $this->getRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo'])->andReturn($relation->getQuery());
         $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn(null);
-        $relation->getRelated()->shouldReceive('newInstance')->once()->with(['foo'])->andReturn($model = m::mock(Model::class));
+        $relation->getRelated()->shouldReceive('newModelInstance')->once()->with(['foo'], false)->andReturn($model = m::mock(Model::class));
         $model->shouldReceive('save')->once()->andReturn(true);
         $model->shouldReceive('fill')->once()->with(['bar']);
         $model->shouldReceive('setAttribute')->once()->with('foreign_key', 1);

--- a/tests/Database/DatabaseEloquentMorphTest.php
+++ b/tests/Database/DatabaseEloquentMorphTest.php
@@ -143,7 +143,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $relation = $this->getOneRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo'])->andReturn($relation->getQuery());
         $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn(null);
-        $relation->getRelated()->shouldReceive('newInstance')->once()->with(['foo'])->andReturn($model = m::mock(Model::class));
+        $relation->getRelated()->shouldReceive('newModelInstance')->once()->with(['foo'], false)->andReturn($model = m::mock(Model::class));
         $model->shouldReceive('setAttribute')->once()->with('morph_id', 1);
         $model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
         $model->shouldReceive('save')->never();
@@ -156,7 +156,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $relation = $this->getOneRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo' => 'bar'])->andReturn($relation->getQuery());
         $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn(null);
-        $relation->getRelated()->shouldReceive('newInstance')->once()->with(['foo' => 'bar', 'baz' => 'qux'])->andReturn($model = m::mock(Model::class));
+        $relation->getRelated()->shouldReceive('newModelInstance')->once()->with(['foo' => 'bar', 'baz' => 'qux'], false)->andReturn($model = m::mock(Model::class));
         $model->shouldReceive('setAttribute')->once()->with('morph_id', 1);
         $model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
         $model->shouldReceive('save')->never();
@@ -169,7 +169,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $relation = $this->getOneRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo'])->andReturn($relation->getQuery());
         $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn($model = m::mock(Model::class));
-        $relation->getRelated()->shouldReceive('newInstance')->never();
+        $relation->getRelated()->shouldReceive('newModelInstance')->never();
         $model->shouldReceive('setAttribute')->never();
         $model->shouldReceive('save')->never();
 
@@ -181,7 +181,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $relation = $this->getOneRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo' => 'bar'])->andReturn($relation->getQuery());
         $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn($model = m::mock(Model::class));
-        $relation->getRelated()->shouldReceive('newInstance')->never();
+        $relation->getRelated()->shouldReceive('newModelInstance')->never();
         $model->shouldReceive('setAttribute')->never();
         $model->shouldReceive('save')->never();
 
@@ -193,7 +193,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $relation = $this->getOneRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo'])->andReturn($relation->getQuery());
         $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn(null);
-        $relation->getRelated()->shouldReceive('newInstance')->once()->with(['foo'])->andReturn($model = m::mock(Model::class));
+        $relation->getRelated()->shouldReceive('newModelInstance')->once()->with(['foo'], false)->andReturn($model = m::mock(Model::class));
         $model->shouldReceive('setAttribute')->once()->with('morph_id', 1);
         $model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
         $model->shouldReceive('save')->once()->andReturn(true);
@@ -206,7 +206,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $relation = $this->getOneRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo' => 'bar'])->andReturn($relation->getQuery());
         $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn(null);
-        $relation->getRelated()->shouldReceive('newInstance')->once()->with(['foo' => 'bar', 'baz' => 'qux'])->andReturn($model = m::mock(Model::class));
+        $relation->getRelated()->shouldReceive('newModelInstance')->once()->with(['foo' => 'bar', 'baz' => 'qux'], false)->andReturn($model = m::mock(Model::class));
         $model->shouldReceive('setAttribute')->once()->with('morph_id', 1);
         $model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
         $model->shouldReceive('save')->once()->andReturn(true);
@@ -232,7 +232,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $relation = $this->getOneRelation();
         $relation->getQuery()->shouldReceive('where')->once()->with(['foo'])->andReturn($relation->getQuery());
         $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn(null);
-        $relation->getRelated()->shouldReceive('newInstance')->once()->with(['foo'])->andReturn($model = m::mock(Model::class));
+        $relation->getRelated()->shouldReceive('newModelInstance')->once()->with(['foo'], false)->andReturn($model = m::mock(Model::class));
         $model->shouldReceive('setAttribute')->once()->with('morph_id', 1);
         $model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
         $model->shouldReceive('save')->once()->andReturn(true);

--- a/tests/Integration/Database/EloquentModelValidatedDataTest.php
+++ b/tests/Integration/Database/EloquentModelValidatedDataTest.php
@@ -5,9 +5,7 @@ namespace Illuminate\Tests\Integration\Database;
 use Illuminate\Database\Eloquent\MassAssignmentException;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Support\Str;
 use Illuminate\Support\ValidatedInput;
 
 /**

--- a/tests/Integration/Database/EloquentModelValidatedDataTest.php
+++ b/tests/Integration/Database/EloquentModelValidatedDataTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Database\Eloquent\MassAssignmentException;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use Illuminate\Support\ValidatedInput;
+
+/**
+ * @group integration
+ */
+class EloquentModelValidatedDataTest extends DatabaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('test_model1', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name')->nullable();
+            $table->string('title')->nullable();
+        });
+    }
+
+    public function testCreatingModelsWithValidatedData()
+    {
+        $input = new ValidatedInput(['name' => 'Mohamed']);
+
+        $model = new EloquentModelValidatedDataTestModel($input);
+        $this->assertEquals('Mohamed', $model->name);
+
+        $model = EloquentModelValidatedDataTestModel::make($input);
+        $this->assertEquals('Mohamed', $model->name);
+
+        $model = EloquentModelValidatedDataTestModel::create($input);
+        $this->assertEquals('Mohamed', $model->name);
+
+        $model = EloquentModelValidatedDataTestModel::forceCreate($input);
+        $this->assertEquals('Mohamed', $model->name);
+    }
+
+    public function testFirstOrNewWithValidatedData()
+    {
+        $input = new ValidatedInput(['name' => 'Mohamed']);
+        $values = new ValidatedInput(['title' => 'Developer']);
+
+        $model = EloquentModelValidatedDataTestModel::firstOrNew($input);
+        $this->assertEquals('Mohamed', $model->name);
+
+        $model = EloquentModelValidatedDataTestModel::firstOrNew($input, $values);
+        $this->assertEquals('Mohamed', $model->name);
+        $this->assertEquals('Developer', $model->title);
+
+        $model = EloquentModelValidatedDataTestModel::firstOrNew([], $values);
+        $this->assertEquals('Developer', $model->title);
+    }
+
+    public function testFirstOrNewAppliesGuardingWhenNonValidatedDataIsPassed()
+    {
+        $this->expectException(MassAssignmentException::class);
+        $model = EloquentModelValidatedDataTestModel::firstOrNew(['name' => 'Mohamed']);
+    }
+
+    public function testFirstOrNewAppliesGuardingWhenSomeNonValidatedDataIsPassed()
+    {
+        $this->expectException(MassAssignmentException::class);
+        $model = EloquentModelValidatedDataTestModel::firstOrNew(
+            new ValidatedInput(['name' => 'Mohamed']),
+            ['title' => 'Dev']
+        );
+    }
+
+    public function testFirstOrCreateWithValidatedData()
+    {
+        $model = EloquentModelValidatedDataTestModel::firstOrCreate(new ValidatedInput(['name' => 'Mohamed']));
+        $this->assertEquals('Mohamed', $model->name);
+
+        $model = EloquentModelValidatedDataTestModel::firstOrCreate(new ValidatedInput(['name' => 'Zain']), new ValidatedInput(['title' => 'Developer']));
+        $this->assertEquals('Zain', $model->name);
+        $this->assertEquals('Developer', $model->title);
+    }
+
+    public function testUpdateOrCreateWithValidatedData()
+    {
+        $model = EloquentModelValidatedDataTestModel::updateOrCreate(new ValidatedInput(['name' => 'Mohamed']));
+        $this->assertEquals('Mohamed', $model->name);
+
+        $model = EloquentModelValidatedDataTestModel::updateOrCreate(new ValidatedInput(['name' => 'Zain']), new ValidatedInput(['title' => 'Developer']));
+        $this->assertEquals('Zain', $model->name);
+        $this->assertEquals('Developer', $model->title);
+    }
+
+    public function testAcceptingValidatedData()
+    {
+        $input = new ValidatedInput(['name' => 'Mohamed']);
+
+        $model = new EloquentModelValidatedDataTestModel();
+        $model->forceFill($input);
+        $this->assertEquals('Mohamed', $model->name);
+
+        $model = new EloquentModelValidatedDataTestModel();
+        $model->forceFill($input);
+        $model->save();
+        $model->update(new ValidatedInput(['name' => 'Zain']));
+        $this->assertEquals('Zain', $model->name);
+
+        $model = new EloquentModelValidatedDataTestModel();
+        $model->forceFill($input);
+        $model->save();
+        $model->updateQuietly(new ValidatedInput(['name' => 'Zain']));
+        $this->assertEquals('Zain', $model->name);
+    }
+}
+
+class EloquentModelValidatedDataTestModel extends Model
+{
+    public $table = 'test_model1';
+    public $timestamps = false;
+    protected $guarded = ['*'];
+}


### PR DESCRIPTION
This PR skips mass assignment protection if the data passed is an instance of `ValidatedData`.

It covers the following methods:

```php
Model::make();
Model::firstOrNew();
Model::firstOrCreate();
Model::updateOrCreate();
Model::create();
Model::forceCreate();
Model::fill();
Model::forceFill();
Model::update();
Model::updateQuietly();
```

Update:

Relationship methods (create, firstOrCreate, firstOrNew, updateOrCreate) will also accept `ValidatedData` data.