### PR TITLE
[8.x] Add assertNotAllowed to TestResponse

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -135,6 +135,14 @@ class TestResponse implements ArrayAccess
     }
 
     /**
+     * @return $this
+     */
+    public function assertNotAllowed()
+    {
+        return $this->assertStatus(405);
+    }
+
+    /**
      * Assert that the response has a forbidden status code.
      *
      * @return $this

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -440,6 +440,21 @@ class TestResponseTest extends TestCase
         $response->assertNotFound();
     }
 
+    public function testAssertNotAllowed()
+    {
+        $statusCode = 500;
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Expected response status code');
+
+        $baseResponse = tap(new Response, function ($response) use ($statusCode) {
+            $response->setStatusCode($statusCode);
+        });
+
+        $response = TestResponse::fromBaseResponse($baseResponse);
+        $response->assertNotAllowed();
+    }
+
     public function testAssertForbidden()
     {
         $statusCode = 500;


### PR DESCRIPTION
add a new shortcut function for testing the response status 405, if a method isnt allowed.