### PR TITLE
[8.x] Add where helpers for boolean and where not

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -687,6 +687,10 @@ class Builder
      */
     public function where($column, $operator = null, $value = null, $boolean = 'and')
     {
+        if (func_num_args() === 1 && is_string($column)) {
+            return $this->where($column, true, null, $boolean);
+        }
+
         // If the column is an array, we will assume it is an array of key-value pairs
         // and can add them each as a where clause. We will maintain the boolean we
         // received when the method was called and pass it into the nested where.
@@ -850,6 +854,34 @@ class Builder
         );
 
         return $this->where($column, $operator, $value, 'or');
+    }
+
+    /**
+     * Add a "where not" clause to the query.
+     *
+     * @param  string  $column
+     * @param  mixed|null  $value
+     * @return $this
+     */
+    public function whereNot($column, $value = null)
+    {
+        return func_num_args() === 1 && is_string($column)
+                    ? $this->where($column, false)
+                    : $this->where($column, '<>', $value);
+    }
+
+    /**
+     * Add an "or where not" clause to the query.
+     *
+     * @param  string  $column
+     * @param  mixed|null  $value
+     * @return $this
+     */
+    public function orWhereNot($column, $value = null)
+    {
+        return func_num_args() === 1 && is_string($column)
+                    ? $this->orWhere($column, false)
+                    : $this->orWhere($column, '<>', $value);
     }
 
     /**
@@ -1112,6 +1144,17 @@ class Builder
     public function whereNotNull($columns, $boolean = 'and')
     {
         return $this->whereNull($columns, $boolean, true);
+    }
+
+    /**
+     * Add a "where" clause to the query that ensures a given column's value is true.
+     *
+     * @param  string  $column
+     * @return $this
+     */
+    public function whereTrue($column)
+    {
+        return $this->where($column, true);
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -3128,6 +3128,27 @@ SQL;
         $this->assertSame('select * from "users" where "foo" is not null', $builder->toSql());
     }
 
+    public function testProvidingJustColumnNameAddsWhereTrueQuery()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('foo');
+        $this->assertSame('select * from "users" where "foo" = ?', $builder->toSql());
+        $this->assertSame([true], $builder->getBindings());
+    }
+
+    public function testWhereNot()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereNot('foo', 'Taylor');
+        $this->assertSame('select * from "users" where "foo" <> ?', $builder->toSql());
+        $this->assertSame(['Taylor'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereNot('foo');
+        $this->assertSame('select * from "users" where "foo" = ?', $builder->toSql());
+        $this->assertSame([false], $builder->getBindings());
+    }
+
     public function testDynamicWhere()
     {
         $method = 'whereFooBarAndBazOrQux';


### PR DESCRIPTION
This PR adds a few small convenience methods to the query builder courtesy of inspiration by @simensen...

First, passing **only** a column name to the query builder will now add a where clause ensuring that the value of the column is `true`:

```php
User::where('subscribed')->get();

// Equivalent...
User::where('subscribed', true)->get();
```

In addition, `whereNot` and `orWhereNot` methods have been added. Typically, this generate traditional `<>` clauses:

```php
User::whereNot('name', 'Taylor')->get();

// Equivalent...
User::where('name', '<>', 'Taylor')->get();
```

In addition, passing **only** a column name to this method will add a "where false" clause to the query:

```php
User::whereNot('subscribed')->get();

// Equivalent...
User::where('subscribed', false)->get();
```

Let me know what you think!