### PR TITLE
Fix null search parameter

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -74,7 +74,7 @@ class Str
      */
     public static function afterLast($subject, $search)
     {
-        if ($search === '') {
+        if ((string) $search === '') {
             return $subject;
         }
 
@@ -108,7 +108,7 @@ class Str
      */
     public static function before($subject, $search)
     {
-        if ($search === '') {
+        if ((string) $search === '') {
             return $subject;
         }
 
@@ -126,7 +126,7 @@ class Str
      */
     public static function beforeLast($subject, $search)
     {
-        if ($search === '') {
+        if ((string) $search === '') {
             return $subject;
         }
 
@@ -149,7 +149,7 @@ class Str
      */
     public static function between($subject, $from, $to)
     {
-        if ($from === '' || $to === '') {
+        if ((string) $from === '' || (string) $to === '') {
             return $subject;
         }
 
@@ -586,7 +586,7 @@ class Str
      */
     public static function replaceFirst($search, $replace, $subject)
     {
-        if ($search === '') {
+        if ((string) $search === '') {
             return $subject;
         }
 
@@ -609,7 +609,7 @@ class Str
      */
     public static function replaceLast($search, $replace, $subject)
     {
-        if ($search === '') {
+        if ((string) $search === '') {
             return $subject;
         }
 


### PR DESCRIPTION
Str::between('foo bar foo', null, 'foo')
or 
Str::between('foo bar foo', 'foo', null)
return 
ErrorException
explode(): Empty delimiter

This PR corrects this and returns the full term, as indicated in the logic

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
