### PR TITLE
Add @in and @notin blade directives

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -233,6 +233,48 @@ trait CompilesConditionals
     }
 
     /**
+     * Compile the if-in statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileIn($expression)
+    {
+        return "<?php if(in_array{$expression}): ?>";
+    }
+
+    /**
+     * Compile the end-in statements into valid PHP.
+     *
+     * @return string
+     */
+    protected function compileEndIn()
+    {
+        return '<?php endif; ?>';
+    }
+
+    /**
+     * Compile the if-notin statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileNotin($expression)
+    {
+        return "<?php if(! in_array{$expression}): ?>";
+    }
+
+    /**
+     * Compile the end-notin statements into valid PHP.
+     *
+     * @return string
+     */
+    protected function compileEndNotin()
+    {
+        return '<?php endif; ?>';
+    }
+
+    /**
      * Compile the switch statements into valid PHP.
      *
      * @param  string  $expression

--- a/tests/View/Blade/BladeIfInStatementsTest.php
+++ b/tests/View/Blade/BladeIfInStatementsTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Illuminate\Tests\View\Blade;
+
+class BladeIfInStatementsTest extends AbstractBladeTestCase
+{
+    public function testIfStatementsAreCompiled()
+    {
+        $string = '@in(2, [1, 2, 3])
+breeze
+@endin';
+        $expected = '<?php if(in_array(2, [1, 2, 3])): ?>
+breeze
+<?php endif; ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+}

--- a/tests/View/Blade/BladeIfNotinStatementsTest.php
+++ b/tests/View/Blade/BladeIfNotinStatementsTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Illuminate\Tests\View\Blade;
+
+class BladeIfNotinStatementsTest extends AbstractBladeTestCase
+{
+    public function testIfStatementsAreCompiled()
+    {
+        $string = '@notin(2, [1, 2, 3])
+breeze
+@endnotin';
+        $expected = '<?php if(! in_array(2, [1, 2, 3])): ?>
+breeze
+<?php endif; ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+}


### PR DESCRIPTION
Feature request for `@in` and `@notin` blade directives.
Equivalent to `@if(in_array(1, [1,2,3]))`.

An example scenario can be

```
<form method={{ $method }} ...>
    @notin($method, ['GET']) @csrf @notin

    @in($method, ['PUT', 'PATCH', 'DELETE'])
        @method($method)
    @endin
</form>
```