### PR TITLE
[8.x] Make $validator->sometimes() item aware to be able to work with nested arrays

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1127,7 +1127,7 @@ class Validator implements ValidatorContract
         // We need the last part of the attribute to access the parent data
         // later on. This enables us to validate 'user.*.contact' based on
         // another value in the parent (e.g. user.*.type). If the attribute
-        // looks like 'user.*.contact' it returns '.value', otherwise false.
+        // looks like 'user.*.contact' it returns '.contact', otherwise false.
         // In case of false, we don't substr() in the following if() and use
         // the full attribute.
         $attributeEnd = strrchr($attribute, '.');

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1109,7 +1109,7 @@ class Validator implements ValidatorContract
             $response = (new ValidationRuleParser($this->data))->explode([$key => $rules]);
 
             foreach ($response->rules as $ruleKey => $ruleValue) {
-                if ($callback($payload, $this->dataForSometimesIteration($ruleKey, !Str::endsWith($key, '.*')))) {
+                if ($callback($payload, $this->dataForSometimesIteration($ruleKey, ! Str::endsWith($key, '.*')))) {
                     $this->addRules([$ruleKey => $ruleValue]);
                 }
             }

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1106,27 +1106,21 @@ class Validator implements ValidatorContract
     {
         $payload = new Fluent($this->data);
 
-        foreach ((array) $attribute as $attributeEntry) {
+        foreach ((array) $attribute as $key) {
 
-            if (Str::contains($attributeEntry, ['*'])) {
+            if (Str::contains($key, ['*']) && !Str::endsWith($key, '*')) {
 
-                if (Str::endsWith($attributeEntry, '*')) {
-                    throw new InvalidArgumentException("The attribute [{$attributeEntry}] can not end with '*'.");
-                }
-
-                $dataGetTarget = str_replace(strrchr($attributeEntry, "."), '', $attributeEntry);
+                $dataGetTarget = str_replace(strrchr($key, "."), '', $key);
 
                 foreach ((array)data_get($this->data, $dataGetTarget) as $index => $item) {
                     if ($callback($payload, new Fluent($item))) {
-                        $response = (new ValidationRuleParser($this->data))->explode([$attributeEntry => $rules]);
-                        $this->addRules([$response->implicitAttributes[$attributeEntry][$index] => $rules]);
+                        $response = (new ValidationRuleParser($this->data))->explode([$key => $rules]);
+                        $this->addRules([$response->implicitAttributes[$key][$index] => $rules]);
                     }
                 }
 
             } elseif ($callback($payload)) {
-                foreach ((array)$attributeEntry as $key) {
-                    $this->addRules([$key => $rules]);
-                }
+                $this->addRules([$key => $rules]);
             }
         }
 

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1106,7 +1106,6 @@ class Validator implements ValidatorContract
         $payload = new Fluent($this->data);
 
         foreach ((array) $attribute as $key) {
-
             $response = (new ValidationRuleParser($this->data))->explode([$key => $rules]);
 
             foreach ($response->rules as $ruleKey => $ruleValue) {

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1109,7 +1109,7 @@ class Validator implements ValidatorContract
             $response = (new ValidationRuleParser($this->data))->explode([$key => $rules]);
 
             foreach ($response->rules as $ruleKey => $ruleValue) {
-                if ($callback($payload, $this->dataForSometimesIteration($ruleKey))) {
+                if ($callback($payload, $this->dataForSometimesIteration($ruleKey, !Str::endsWith($key, '.*')))) {
                     $this->addRules([$ruleKey => $ruleValue]);
                 }
             }
@@ -1124,17 +1124,17 @@ class Validator implements ValidatorContract
      * @param  string  $attribute
      * @return \Illuminate\Support\Fluent|array|mixed
      */
-    private function dataForSometimesIteration(string $attribute)
+    private function dataForSometimesIteration(string $attribute, $removeLastSegmentOfAttribute)
     {
         $lastSegmentOfAttribute = strrchr($attribute, '.');
 
-        $attribute = $lastSegmentOfAttribute
+        $attribute = $lastSegmentOfAttribute && $removeLastSegmentOfAttribute
                     ? Str::replaceLast($lastSegmentOfAttribute, '', $attribute)
                     : $attribute;
 
         return is_array($data = data_get($this->data, $attribute))
-                    ? new Fluent($data)
-                    : $data;
+            ? new Fluent($data)
+            : $data;
     }
 
     /**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1106,14 +1106,11 @@ class Validator implements ValidatorContract
         $payload = new Fluent($this->data);
 
         foreach ((array) $attribute as $key) {
-
             if (Str::contains($key, ['*'])) {
+                $dataGetTarget = str_replace(strrchr($key, '.'), '', $key);
 
-                $dataGetTarget = str_replace(strrchr($key, "."), '', $key);
-
-                foreach ((array)data_get($this->data, $dataGetTarget) as $index => $item) {
+                foreach ((array) data_get($this->data, $dataGetTarget) as $index => $item) {
                     if ($callback($payload, new Fluent($item))) {
-
                         $response = (new ValidationRuleParser($this->data))->explode([$key => $rules]);
 
                         // If the $attribute given to the sometimes() method ends with a wildcard,

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4127,6 +4127,76 @@ class ValidationValidatorTest extends TestCase
             return is_null($i['foo'][0]['title']);
         });
         $this->assertEquals(['foo.0.name' => ['Required', 'String']], $v->getRules());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['first' => [['type' => 'url'], ['type' => 'string']]], ['first.0.value' => ['Required'], 'first.1.value' => ['Required']]);
+        $v->sometimes('first.*.value', 'url', function ($i, $item) {
+            return $item->type !== 'url';
+        });
+        $this->assertEquals(['first.0.value' => ['Required'], 'first.1.value' => ['Required', 'url']], $v->getRules());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['first' => [[ 'type' => 'string']]], ['first.0.value' => ['Required']]);
+        $v->sometimes('first.*.value', 'String', function ($i, $item) {
+            return $item->type === 'string';
+        });
+        $this->assertEquals(['first.0.value' => ['Required', 'String']], $v->getRules());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['first' => [['type' => 'string']]], ['first.0.value' => ['Required']]);
+        $v->sometimes('first.*.value', 'email:rfc,dns', function ($i, $item) {
+            return $item->type === 'email';
+        });
+        $this->assertEquals(['first.0.value' => ['Required']], $v->getRules());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['first' => [['type' => 'string']]], ['first.0.value' => ['Required']]);
+        $v->sometimes('first.*.value', 'String', function ($i, $item) {
+            return $item->type !== 'email';
+        });
+        $this->assertEquals(['first.0.value' => ['Required', 'String']], $v->getRules());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['first' => [['type' => 'email',], ['type' => null]]], ['first.0.value' => ['Required'], 'first.1.value' => ['Required', 'String']]);
+        $v->sometimes( 'first.*.value', 'email:rfc,dns', function ($i, $item) {
+            return $item->type === 'email';
+        });
+        $this->assertEquals(['first.0.value' => ['Required', 'email:rfc,dns'], 'first.1.value' => ['Required', 'String']], $v->getRules());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['first' => [['type' => 'email'],['type' => 'email'],['type' => 'string']]], ['first.2.value' => ['Required']]);
+        $v->sometimes('first.*.value', 'email:rfc,dns', function ($i, $item) {
+            return $item->type === 'email';
+        });
+        $this->assertEquals(['first.0.value' => ['email:rfc,dns'], 'first.1.value' => ['email:rfc,dns'], 'first.2.value' => ['Required']], $v->getRules());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['first' => [[ 'type' => 'email'], ['type' => 'string']]], ['first.0.value' => ['Required'], 'first.1.value' => ['Required']]);
+        $v->sometimes('first.*.value', 'email:rfc,dns', function ($i, $item) {
+            return $item->type === 'email';
+        });
+        $this->assertEquals(['first.0.value' => ['Required', 'email:rfc,dns'], 'first.1.value' => ['Required']], $v->getRules());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['first' => ['second' => [['type' => 'email']]]], ['first.second.0.value' => ['Required'], 'first.second.1.value' => ['Required']]);
+        $v->sometimes('first.second.*.value', 'email:rfc,dns', function ($i, $item) {
+            return $item->type === 'email';
+        });
+        $this->assertEquals(['first.second.0.value' => ['Required', 'email:rfc,dns'], 'first.second.1.value' => ['Required']], $v->getRules());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['first' => ['second' => ['third' => [['type' => 'email'], ['type' => 'string']]]]], ['first.second.third.0.value' => ['Required'], 'first.second.third.1.value' => ['Required']]);
+        $v->sometimes('first.second.third.*.value', 'email:rfc,dns', function ($i, $item) {
+            return $item->type === 'email';
+        });
+        $this->assertEquals(['first.second.third.0.value' => ['Required', 'email:rfc,dns'], 'first.second.third.1.value' => ['Required']], $v->getRules());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['first' => ['second' => ['third' => [['type' => 'email'], ['type' => 'string']]]]], ['first.second.third.0.value' => ['Required'], 'first.second.third.0.email' => ['Required'], 'first.second.third.1.value' => ['Required']]);
+        $v->sometimes(['first.second.third.*.value', 'first.second.third.*.email'], 'email:rfc,dns', function ($i, $item) {
+            return $item->type === 'email';
+        });
+        $this->assertEquals(['first.second.third.0.value' => ['Required', 'email:rfc,dns'], 'first.second.third.0.email' => ['Required', 'email:rfc,dns'],'first.second.third.1.value' => ['Required']], $v->getRules());
     }
 
     public function testCustomValidators()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4197,6 +4197,13 @@ class ValidationValidatorTest extends TestCase
             return $item->type === 'email';
         });
         $this->assertEquals(['first.second.third.0.value' => ['Required', 'email:rfc,dns'], 'first.second.third.0.email' => ['Required', 'email:rfc,dns'],'first.second.third.1.value' => ['Required']], $v->getRules());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['first' => ['second' => ['third' => [['type' => 'email'], ['type' => 'string']]]]], ['first.second.third' => ['Required'], 'first.second.third.0.value' => ['Required'], 'first.second.third.0.email' => ['Required'], 'first.second.third.1.value' => ['Required']]);
+        $v->sometimes(['first.second.*'], 'Array', function ($i) {
+            return true;
+        });
+        $this->assertEquals(['first.second.third' => ['Required', 'Array'], 'first.second.third.0.value' => ['Required'], 'first.second.third.0.email' => ['Required'], 'first.second.third.1.value' => ['Required']], $v->getRules());
     }
 
     public function testCustomValidators()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4157,7 +4157,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals(['first.0.value' => ['Required', 'String']], $v->getRules());
 
         $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, ['first' => [['type' => 'email',], ['type' => null]]], ['first.0.value' => ['Required'], 'first.1.value' => ['Required', 'String']]);
+        $v = new Validator($trans, ['first' => [['type' => 'email'], ['type' => null]]], ['first.0.value' => ['Required'], 'first.1.value' => ['Required', 'String']]);
         $v->sometimes( 'first.*.value', 'email:rfc,dns', function ($i, $item) {
             return $item->type === 'email';
         });

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4136,7 +4136,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals(['first.0.value' => ['Required'], 'first.1.value' => ['Required', 'url']], $v->getRules());
 
         $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, ['first' => [[ 'type' => 'string']]], ['first.0.value' => ['Required']]);
+        $v = new Validator($trans, ['first' => [['type' => 'string']]], ['first.0.value' => ['Required']]);
         $v->sometimes('first.*.value', 'String', function ($i, $item) {
             return $item->type === 'string';
         });
@@ -4158,20 +4158,20 @@ class ValidationValidatorTest extends TestCase
 
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['first' => [['type' => 'email'], ['type' => null]]], ['first.0.value' => ['Required'], 'first.1.value' => ['Required', 'String']]);
-        $v->sometimes( 'first.*.value', 'email:rfc,dns', function ($i, $item) {
+        $v->sometimes('first.*.value', 'email:rfc,dns', function ($i, $item) {
             return $item->type === 'email';
         });
         $this->assertEquals(['first.0.value' => ['Required', 'email:rfc,dns'], 'first.1.value' => ['Required', 'String']], $v->getRules());
 
         $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, ['first' => [['type' => 'email'],['type' => 'email'],['type' => 'string']]], ['first.2.value' => ['Required']]);
+        $v = new Validator($trans, ['first' => [['type' => 'email'], ['type' => 'email'], ['type' => 'string']]], ['first.2.value' => ['Required']]);
         $v->sometimes('first.*.value', 'email:rfc,dns', function ($i, $item) {
             return $item->type === 'email';
         });
         $this->assertEquals(['first.0.value' => ['email:rfc,dns'], 'first.1.value' => ['email:rfc,dns'], 'first.2.value' => ['Required']], $v->getRules());
 
         $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, ['first' => [[ 'type' => 'email'], ['type' => 'string']]], ['first.0.value' => ['Required'], 'first.1.value' => ['Required']]);
+        $v = new Validator($trans, ['first' => [['type' => 'email'], ['type' => 'string']]], ['first.0.value' => ['Required'], 'first.1.value' => ['Required']]);
         $v->sometimes('first.*.value', 'email:rfc,dns', function ($i, $item) {
             return $item->type === 'email';
         });
@@ -4196,7 +4196,7 @@ class ValidationValidatorTest extends TestCase
         $v->sometimes(['first.second.third.*.value', 'first.second.third.*.email'], 'email:rfc,dns', function ($i, $item) {
             return $item->type === 'email';
         });
-        $this->assertEquals(['first.second.third.0.value' => ['Required', 'email:rfc,dns'], 'first.second.third.0.email' => ['Required', 'email:rfc,dns'],'first.second.third.1.value' => ['Required']], $v->getRules());
+        $this->assertEquals(['first.second.third.0.value' => ['Required', 'email:rfc,dns'], 'first.second.third.0.email' => ['Required', 'email:rfc,dns'], 'first.second.third.1.value' => ['Required']], $v->getRules());
 
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['first' => ['second' => ['third' => [['type' => 'email'], ['type' => 'string']]]]], ['first.second.third' => ['Required'], 'first.second.third.0.value' => ['Required'], 'first.second.third.0.email' => ['Required'], 'first.second.third.1.value' => ['Required'], 'first.second.third2.1.value' => ['Required']]);

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4199,11 +4199,11 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals(['first.second.third.0.value' => ['Required', 'email:rfc,dns'], 'first.second.third.0.email' => ['Required', 'email:rfc,dns'],'first.second.third.1.value' => ['Required']], $v->getRules());
 
         $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, ['first' => ['second' => ['third' => [['type' => 'email'], ['type' => 'string']]]]], ['first.second.third' => ['Required'], 'first.second.third.0.value' => ['Required'], 'first.second.third.0.email' => ['Required'], 'first.second.third.1.value' => ['Required']]);
+        $v = new Validator($trans, ['first' => ['second' => ['third' => [['type' => 'email'], ['type' => 'string']]]]], ['first.second.third' => ['Required'], 'first.second.third.0.value' => ['Required'], 'first.second.third.0.email' => ['Required'], 'first.second.third.1.value' => ['Required'], 'first.second.third2.1.value' => ['Required']]);
         $v->sometimes(['first.second.*'], 'Array', function ($i) {
             return true;
         });
-        $this->assertEquals(['first.second.third' => ['Required', 'Array'], 'first.second.third.0.value' => ['Required'], 'first.second.third.0.email' => ['Required'], 'first.second.third.1.value' => ['Required']], $v->getRules());
+        $this->assertEquals(['first.second.third' => ['Required', 'Array'], 'first.second.third.0.value' => ['Required'], 'first.second.third.0.email' => ['Required'], 'first.second.third.1.value' => ['Required'], 'first.second.third2.1.value' => ['Required']], $v->getRules());
     }
 
     public function testCustomValidators()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4143,7 +4143,7 @@ class ValidationValidatorTest extends TestCase
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['users' => null], ['users.*.name'=> 'required|string']);
         $v->sometimes(['users'], 'array', function ($i, $item) {
-            return !!$item;
+            return (bool) $item;
         });
         $this->assertEquals([], $v->getRules());
 
@@ -4159,7 +4159,7 @@ class ValidationValidatorTest extends TestCase
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['company' => ['users' => null]], ['company'=> 'required', 'company.users.*.name'=> 'required|string']);
         $v->sometimes(['company.users'], 'array', function ($i, $item) {
-            return !!$item->users;
+            return (bool) $item->users;
         });
         $this->assertEquals(['company' => ['required']], $v->getRules());
 
@@ -4282,7 +4282,7 @@ class ValidationValidatorTest extends TestCase
         $v->sometimes('value', 'email', function ($i) {
             return $i->type === 'email';
         });
-        $this->assertEquals(['name' => ['required'], 'type' => ['required'], 'value' => ['required', 'email'],], $v->getRules());
+        $this->assertEquals(['name' => ['required'], 'type' => ['required'], 'value' => ['required', 'email']], $v->getRules());
 
         // ['value'] -> standard true case with array, the INPUT based condition does match and the optional validation is added
         $trans = $this->getIlluminateArrayTranslator();
@@ -4290,7 +4290,7 @@ class ValidationValidatorTest extends TestCase
         $v->sometimes(['value'], 'email', function ($i, $item) {
             return $i->type === 'email';
         });
-        $this->assertEquals(['name' => ['required'], 'type' => ['required'], 'value' => ['required', 'email'],], $v->getRules());
+        $this->assertEquals(['name' => ['required'], 'type' => ['required'], 'value' => ['required', 'email']], $v->getRules());
 
         // ['email'] -> if value is set, it will be validated as string
         $trans = $this->getIlluminateArrayTranslator();
@@ -4298,7 +4298,7 @@ class ValidationValidatorTest extends TestCase
         $v->sometimes(['email'], 'email', function ($i, $item) {
             return $item;
         });
-        $this->assertEquals(['email' => ['required', 'email'],], $v->getRules());
+        $this->assertEquals(['email' => ['required', 'email']], $v->getRules());
     }
 
     public function testCustomValidators()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4167,7 +4167,7 @@ class ValidationValidatorTest extends TestCase
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['company' => ['users' => [['name' => 'Taylor'], ['name' => 'Abigail']]]], ['company.users.*.name'=> 'required|string']);
         $v->sometimes(['company.*'], 'array', function ($i, $item) {
-            return $item->users !== null;
+            return $item !== null;
         });
         $this->assertEquals(['company.users' => ['array'], 'company.users.0.name' => ['required', 'string'], 'company.users.1.name' => ['required', 'string']], $v->getRules());
 
@@ -4175,15 +4175,15 @@ class ValidationValidatorTest extends TestCase
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['company' => ['users' => null]], ['company'=> 'required', 'company.users.*.name'=> 'required|string']);
         $v->sometimes(['company.*'], 'array', function ($i, $item) {
-            return $item->users;
+            return (bool) $item;
         });
         $this->assertEquals(['company' => ['required']], $v->getRules());
 
         // ['users.*'] -> all nested array items in users must be validated as array
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['users' => [['name' => 'Taylor'], ['name' => 'Abigail']]], ['users.*.name'=> 'required|string']);
-        $v->sometimes(['users.*'], 'array', function ($item) {
-            return true;
+        $v->sometimes(['users.*'], 'array', function ($i, $item) {
+            return (bool) $item;
         });
         $this->assertEquals(['users.0' => ['array'], 'users.1' => ['array'], 'users.0.name' => ['required', 'string'], 'users.1.name' => ['required', 'string']], $v->getRules());
 
@@ -4304,7 +4304,7 @@ class ValidationValidatorTest extends TestCase
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['attendee' => ['name' => 'Taylor', 'title' => 'Creator of Laravel', 'type' => 'Developer']], ['attendee.*'=> 'string']);
         $v->sometimes(['attendee.*'], 'required', function ($i, $item) {
-            return (bool) $item->name;
+            return (bool) $item;
         });
         $this->assertEquals(['attendee.name' => ['string', 'required'], 'attendee.title' => ['string', 'required'], 'attendee.type' => ['string', 'required']], $v->getRules());
     }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4299,6 +4299,14 @@ class ValidationValidatorTest extends TestCase
             return $item;
         });
         $this->assertEquals(['email' => ['required', 'email']], $v->getRules());
+
+        // ['attendee.*'] -> if attendee name is set, all other fields will be required as well
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['attendee' => ['name' => 'Taylor', 'title' => 'Creator of Laravel', 'type' => 'Developer']], ['attendee.*'=> 'string']);
+        $v->sometimes(['attendee.*'], 'required', function ($i, $item) {
+            return (bool) $item->name;
+        });
+        $this->assertEquals(['attendee.name' => ['string', 'required'], 'attendee.title' => ['string', 'required'], 'attendee.type' => ['string', 'required']], $v->getRules());
     }
 
     public function testCustomValidators()


### PR DESCRIPTION
#38385 got closed by @taylorotwell with the comment below. 
> I don't think I would want an entirely different method here.

So here I am with another try. Hope it's better now and has a chance to get merged. :-) 

## Problem
It is not possible to use `$validator->sometimes()` with nested arrays (e.g. in`withValidator($validator)` of a `FormRequest` class). Given a request like this:

```php
public function rules(): array
    {
        return [
            "channels"    => "required|array",
            "channels.*.type"  => "required|string|min:3",
            "channels.*.value" => "required|string|distinct|min:3",
            "channels.*.description"  => "nullable|string|min:3|max:80",
        ];
    }
```

The `value` can be an url, email or nullable – **depending on an other field**. So it must be possible to validate it as such, without knowing the key. `$validator->sometimes()` is not aware of the current item/index. Also the new `Rule::when()` does not support it. Hence, currently there is no flexible way to to apply specifc rules for nested arrays, to archieve someting like this without tons of `foreach` or a custom validator:

```php
$validator->sometimes('channels.*.value', 'email:rfc,dns', function($input, $item) {
  return $item->type === 'email';
});

$validator->sometimes('channels.*.value', 'url', function($input, $item) {
  return $item->type !== 'email';
});

$validator->sometimes('channels.*.value', 'nullable', function($input, $item) {
  return $item->type === null;
});
```

## Benefits for users
No need to create custom validators, traits or to use tons if `foreach`. Because `sometimes()` is aware of the item data, users can directly access it in beside of the already existing`$input` data.

## Non breaking
This PR adds new functionality without affecting the previous behavior. All tests are still passing and new tests got added. Since there is an (optional) second parameter passed to the callback and the item data is accessable from a `Fluent` object, it's worth to add this to the documentation (keen to do it if the PR gets accepted)