### PR TITLE
[8.x] Update ShouldBroadcast::broadcastOn docblock to return strings

### DIFF
--- a/src/Illuminate/Contracts/Broadcasting/ShouldBroadcast.php
+++ b/src/Illuminate/Contracts/Broadcasting/ShouldBroadcast.php
@@ -7,7 +7,7 @@ interface ShouldBroadcast
     /**
      * Get the channels the event should broadcast on.
      *
-     * @return \Illuminate\Broadcasting\Channel|\Illuminate\Broadcasting\Channel[]|string|string[]
+     * @return \Illuminate\Broadcasting\Channel|\Illuminate\Broadcasting\Channel[]|string[]|string
      */
     public function broadcastOn();
 }

--- a/src/Illuminate/Contracts/Broadcasting/ShouldBroadcast.php
+++ b/src/Illuminate/Contracts/Broadcasting/ShouldBroadcast.php
@@ -7,7 +7,7 @@ interface ShouldBroadcast
     /**
      * Get the channels the event should broadcast on.
      *
-     * @return \Illuminate\Broadcasting\Channel|\Illuminate\Broadcasting\Channel[]
+     * @return \Illuminate\Broadcasting\Channel|\Illuminate\Broadcasting\Channel[]|string|string[]
      */
     public function broadcastOn();
 }


### PR DESCRIPTION
The `broadcastOn` method may also return a string or an array of string. Without this change, Psalm complains about the return type and you're forced to wrap the string in `new Channel()` before returning.