### PR TITLE
[8.x] Add default rules in conditional rules

### DIFF
--- a/src/Illuminate/Validation/ConditionalRules.php
+++ b/src/Illuminate/Validation/ConditionalRules.php
@@ -21,16 +21,25 @@ class ConditionalRules
     protected $rules;
 
     /**
+     * The rules to be added to the attribute if the condition fails.
+     *
+     * @var array|string
+     */
+    protected $default;
+
+    /**
      * Create a new conditional rules instance.
      *
      * @param  callable|bool  $condition
      * @param  array|string  $rules
+     * @param  array|string  $default
      * @return void
      */
-    public function __construct($condition, $rules)
+    public function __construct($condition, $rules, $default = [])
     {
         $this->condition = $condition;
         $this->rules = $rules;
+        $this->default = $default;
     }
 
     /**
@@ -54,5 +63,15 @@ class ConditionalRules
     public function rules()
     {
         return is_string($this->rules) ? explode('|', $this->rules) : $this->rules;
+    }
+
+    /**
+     * Get the default rules.
+     *
+     * @return array
+     */
+    public function default()
+    {
+        return is_string($this->default) ? explode('|', $this->default) : $this->default;
     }
 }

--- a/src/Illuminate/Validation/ConditionalRules.php
+++ b/src/Illuminate/Validation/ConditionalRules.php
@@ -25,21 +25,21 @@ class ConditionalRules
      *
      * @var array|string
      */
-    protected $default;
+    protected $defaultRules;
 
     /**
      * Create a new conditional rules instance.
      *
      * @param  callable|bool  $condition
      * @param  array|string  $rules
-     * @param  array|string  $default
+     * @param  array|string  $defaultRules
      * @return void
      */
-    public function __construct($condition, $rules, $default = [])
+    public function __construct($condition, $rules, $defaultRules = [])
     {
         $this->condition = $condition;
         $this->rules = $rules;
-        $this->default = $default;
+        $this->defaultRules = $defaultRules;
     }
 
     /**
@@ -70,8 +70,8 @@ class ConditionalRules
      *
      * @return array
      */
-    public function default()
+    public function defaultRules()
     {
-        return is_string($this->default) ? explode('|', $this->default) : $this->default;
+        return is_string($this->defaultRules) ? explode('|', $this->defaultRules) : $this->defaultRules;
     }
 }

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -20,12 +20,12 @@ class Rule
      *
      * @param  callable|bool  $condition
      * @param  array|string  $rules
-     * @param  array|string  $default
+     * @param  array|string  $defaultRules
      * @return \Illuminate\Validation\ConditionalRules
      */
-    public static function when($condition, $rules, $default = [])
+    public static function when($condition, $rules, $defaultRules = [])
     {
-        return new ConditionalRules($condition, $rules, $default);
+        return new ConditionalRules($condition, $rules, $defaultRules);
     }
 
     /**

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -20,11 +20,12 @@ class Rule
      *
      * @param  callable|bool  $condition
      * @param  array|string  $rules
+     * @param  array|string  $default
      * @return \Illuminate\Validation\ConditionalRules
      */
-    public static function when($condition, $rules)
+    public static function when($condition, $rules, $default = [])
     {
-        return new ConditionalRules($condition, $rules);
+        return new ConditionalRules($condition, $rules, $default);
     }
 
     /**

--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -291,7 +291,7 @@ class ValidationRuleParser
             }
 
             if ($attributeRules instanceof ConditionalRules) {
-                return [$attribute => $attributeRules->passes($data) ? $attributeRules->rules() : null];
+                return [$attribute => $attributeRules->passes($data) ? $attributeRules->rules() : $attributeRules->default()];
             }
 
             return [$attribute => collect($attributeRules)->map(function ($rule) use ($data) {
@@ -299,7 +299,7 @@ class ValidationRuleParser
                     return [$rule];
                 }
 
-                return $rule->passes($data) ? $rule->rules() : null;
+                return $rule->passes($data) ? $rule->rules() : $rule->default();
             })->filter()->flatten(1)->values()->all()];
         })->filter()->all();
     }

--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -291,7 +291,9 @@ class ValidationRuleParser
             }
 
             if ($attributeRules instanceof ConditionalRules) {
-                return [$attribute => $attributeRules->passes($data) ? $attributeRules->rules() : $attributeRules->default()];
+                return [$attribute => $attributeRules->passes($data)
+                                ? $attributeRules->rules()
+                                : $attributeRules->defaultRules()];
             }
 
             return [$attribute => collect($attributeRules)->map(function ($rule) use ($data) {
@@ -299,7 +301,7 @@ class ValidationRuleParser
                     return [$rule];
                 }
 
-                return $rule->passes($data) ? $rule->rules() : $rule->default();
+                return $rule->passes($data) ? $rule->rules() : $rule->defaultRules();
             })->filter()->flatten(1)->values()->all()];
         })->filter()->all();
     }

--- a/tests/Validation/ValidationRuleParserTest.php
+++ b/tests/Validation/ValidationRuleParserTest.php
@@ -30,4 +30,23 @@ class ValidationRuleParserTest extends TestCase
             'city' => ['required', 'min:2'],
         ], $rules);
     }
+
+    public function test_conditional_rules_with_default()
+    {
+        $rules = ValidationRuleParser::filterConditionalRules([
+            'name' => Rule::when(true, ['required', 'min:2'], ['string', 'max:10']),
+            'email' => Rule::when(false, ['required', 'min:2'], ['string', 'max:10']),
+            'password' => Rule::when(false, 'required|min:2', 'string|max:10'),
+            'username' => ['required', Rule::when(true, ['min:2'], ['string', 'max:10'])],
+            'address' => ['required', Rule::when(false, ['min:2'], ['string', 'max:10'])],
+        ]);
+
+        $this->assertEquals([
+            'name' => ['required', 'min:2'],
+            'email' => ['string', 'max:10'],
+            'password' => ['string', 'max:10'],
+            'username' => ['required', 'min:2'],
+            'address' => ['required', 'string', 'max:10'],
+        ], $rules);
+    }
 }


### PR DESCRIPTION
PR https://github.com/laravel/framework/pull/38361 introduced `ConditionalRules` to conditionally add rules to the validation.

Imagine a validation like : 
```php
public function rules()
{
    return [
        'email' => [
            Rule::when($this->someComplexTest(), ['required']),
            Rule::when(!$this->someComplexTest(), ['nullable']),
        ]
    ];
}
```
           
This PR adds the ability to define the behaviour when the condition is false.

```php
public function rules()
{
    return [
        'email' => [
            Rule::when($this->someComplexTest(), ['required'], ['nullable']),
        ]
    ];
}
```

This behavior already exists in collections, conditionable, ...