### PR TITLE
[8.x] Option to use table names when morphing

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -731,7 +731,9 @@ trait HasRelationships
             return array_search(static::class, $morphMap, true);
         }
 
-        return static::class;
+        return Relation::$useClassBasenamesForMorphMap
+                    ? class_basename(static::class)
+                    : static::class;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -731,8 +731,8 @@ trait HasRelationships
             return array_search(static::class, $morphMap, true);
         }
 
-        return Relation::$useClassBasenamesForMorphMap
-                    ? class_basename(static::class)
+        return Relation::$useTableNamesForMorphMap
+                    ? $this->getTable()
                     : static::class;
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -51,6 +51,13 @@ abstract class Relation
     protected static $constraints = true;
 
     /**
+     * Indicates that class basenames should be used when determining morph classes.
+     *
+     * @var bool
+     */
+    public static $useClassBasenamesForMorphMap = false;
+
+    /**
      * An array to map class names to their morph names in the database.
      *
      * @var array
@@ -374,6 +381,16 @@ abstract class Relation
                     && in_array($model->getKeyType(), ['int', 'integer'])
                         ? 'whereIntegerInRaw'
                         : 'whereIn';
+    }
+
+    /**
+     * Indicate that the basename of classes should be used when determining morphed class names.
+     *
+     * @return void
+     */
+    public static function useClassBasenamesForMorphMap()
+    {
+        static::$useClassBasenamesForMorphMap = true;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -51,11 +51,11 @@ abstract class Relation
     protected static $constraints = true;
 
     /**
-     * Indicates that class basenames should be used when determining morph classes.
+     * Indicates that model table names should be used when determining morph classes.
      *
      * @var bool
      */
-    public static $useClassBasenamesForMorphMap = false;
+    public static $useTableNamesForMorphMap = false;
 
     /**
      * An array to map class names to their morph names in the database.
@@ -388,9 +388,9 @@ abstract class Relation
      *
      * @return void
      */
-    public static function useClassBasenamesForMorphMap()
+    public static function useTableNamesForMorphMap()
     {
-        static::$useClassBasenamesForMorphMap = true;
+        static::$useTableNamesForMorphMap = true;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -51,7 +51,7 @@ abstract class Relation
     protected static $constraints = true;
 
     /**
-     * Indicates that model table names should be used when determining morph classes.
+     * Indicates that table names should be used when determining morph classes.
      *
      * @var bool
      */
@@ -384,11 +384,11 @@ abstract class Relation
     }
 
     /**
-     * Indicate that the basename of classes should be used when determining morphed class names.
+     * Indicate that the table names should be used when determining morphed class names.
      *
      * @return void
      */
-    public static function useTableNamesForMorphMap()
+    public static function morphUsingTableNames()
     {
         static::$useTableNamesForMorphMap = true;
     }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1219,12 +1219,12 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testMorphOneCreatesProperRelationWhenUsingBasenames()
     {
-        Relation::useClassBasenamesForMorphMap();
+        Relation::useTableNamesForMorphMap();
         $model = new EloquentModelStub;
         $this->addMockConnection($model);
         $relation = $model->morphOne(EloquentModelSaveStub::class, 'morph');
-        $this->assertEquals('EloquentModelStub', $relation->getMorphClass());
-        Relation::$useClassBasenamesForMorphMap = false;
+        $this->assertEquals('stub', $relation->getMorphClass());
+        Relation::$useTableNamesForMorphMap = false;
     }
 
     public function testCorrectMorphClassIsReturned()

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1217,6 +1217,16 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals(EloquentModelStub::class, $relation->getMorphClass());
     }
 
+    public function testMorphOneCreatesProperRelationWhenUsingBasenames()
+    {
+        Relation::useClassBasenamesForMorphMap();
+        $model = new EloquentModelStub;
+        $this->addMockConnection($model);
+        $relation = $model->morphOne(EloquentModelSaveStub::class, 'morph');
+        $this->assertEquals('EloquentModelStub', $relation->getMorphClass());
+        Relation::$useClassBasenamesForMorphMap = false;
+    }
+
     public function testCorrectMorphClassIsReturned()
     {
         Relation::morphMap(['alias' => 'AnotherModel']);

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1217,9 +1217,9 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals(EloquentModelStub::class, $relation->getMorphClass());
     }
 
-    public function testMorphOneCreatesProperRelationWhenUsingBasenames()
+    public function testMorphOneCreatesProperRelationWhenUsingTableNames()
     {
-        Relation::useTableNamesForMorphMap();
+        Relation::morphUsingTableNames();
         $model = new EloquentModelStub;
         $this->addMockConnection($model);
         $relation = $model->morphOne(EloquentModelSaveStub::class, 'morph');


### PR DESCRIPTION
This PR introduces a new method to instruct Laravel to use table names instead of class names when storing records in polymorphic tables. Typically this method can be called in the `register` method of your `AppServiceProvider`:

```php
Relation::morphUsingTableNames();
```

Not much else to say about this one 😅 