### PR TITLE
[8.x] added method to register singletons in tests

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
@@ -78,6 +78,22 @@ trait InteractsWithContainer
     }
 
     /**
+     * Register a singleton in the container.
+     *
+     * @param  string  $abstract
+     * @param  object  $instance
+     * @return object
+     */
+    protected function singleton($abstract, $instance)
+    {
+        $this->app->singleton($abstract, function () use ($instance) {
+            return $instance;
+        });
+
+        return $instance;
+    }
+
+    /**
      * Register an empty handler for Laravel Mix in the container.
      *
      * @return $this

--- a/tests/Foundation/Testing/Concerns/InteractsWithContainerTest.php
+++ b/tests/Foundation/Testing/Concerns/InteractsWithContainerTest.php
@@ -8,6 +8,14 @@ use stdClass;
 
 class InteractsWithContainerTest extends TestCase
 {
+    public function testSingletonResolvesAnInstance()
+    {
+        $this->singleton('foo', 'bar');
+
+        $this->assertEquals('bar', $this->app->make('foo'));
+        $this->assertEquals('bar', $this->app->make('foo', ['with' => 'params']));
+    }
+
     public function testWithoutMixBindsEmptyHandlerAndReturnsInstance()
     {
         $instance = $this->withoutMix();


### PR DESCRIPTION
Helps with #37706.

Mocked instances won't be resolved if some arguments are passed to the constructor, but they will if they are registered as singletons.

This PR adds a `singleton` method to the `InteractsWithContainer` trait to make that easier.