### PR TITLE
[8.x] Added onlyTrashed to routes as an addition to withTrashed

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1817,9 +1817,21 @@ abstract class Model implements Arrayable, ArrayAccess, HasBroadcastChannel, Jso
      * @param  string|null  $field
      * @return \Illuminate\Database\Eloquent\Model|null
      */
-    public function resolveSoftDeletableRouteBinding($value, $field = null)
+    public function resolveWithTrashedRouteBinding($value, $field = null)
     {
         return $this->where($field ?? $this->getRouteKeyName(), $value)->withTrashed()->first();
+    }
+
+    /**
+     * Retrieve the model for a bound value.
+     *
+     * @param  mixed  $value
+     * @param  string|null  $field
+     * @return \Illuminate\Database\Eloquent\Model|null
+     */
+    public function resolveOnlyTrashedRouteBinding($value, $field = null)
+    {
+        return $this->where($field ?? $this->getRouteKeyName(), $value)->onlyTrashed()->first();
     }
 
     /**
@@ -1843,9 +1855,22 @@ abstract class Model implements Arrayable, ArrayAccess, HasBroadcastChannel, Jso
      * @param  string|null  $field
      * @return \Illuminate\Database\Eloquent\Model|null
      */
-    public function resolveSoftDeletableChildRouteBinding($childType, $value, $field)
+    public function resolveWithTrashedChildRouteBinding($childType, $value, $field)
     {
         return $this->resolveChildRouteBindingQuery($childType, $value, $field)->withTrashed()->first();
+    }
+
+    /**
+     * Retrieve the child model for a bound value.
+     *
+     * @param  string  $childType
+     * @param  mixed  $value
+     * @param  string|null  $field
+     * @return \Illuminate\Database\Eloquent\Model|null
+     */
+    public function resolveOnlyTrashedChildRouteBinding($childType, $value, $field)
+    {
+        return $this->resolveChildRouteBindingQuery($childType, $value, $field)->onlyTrashed()->first();
     }
 
     /**

--- a/src/Illuminate/Routing/AbstractRouteCollection.php
+++ b/src/Illuminate/Routing/AbstractRouteCollection.php
@@ -146,7 +146,8 @@ abstract class AbstractRouteCollection implements Countable, IteratorAggregate, 
                 'bindingFields' => $route->bindingFields(),
                 'lockSeconds' => $route->locksFor(),
                 'waitSeconds' => $route->waitsFor(),
-                'withTrashed' => $route->allowsTrashedBindings(),
+                'withTrashed' => $route->allowsWithTrashedBindings(),
+                'onlyTrashed' => $route->allowsOnlyTrashedBindings(),
             ];
         }
 

--- a/src/Illuminate/Routing/ImplicitRouteBinding.php
+++ b/src/Illuminate/Routing/ImplicitRouteBinding.php
@@ -37,14 +37,23 @@ class ImplicitRouteBinding
 
             $parent = $route->parentOfParameter($parameterName);
 
-            $routeBindingMethod = $route->allowsTrashedBindings()
-                        ? 'resolveSoftDeletableRouteBinding'
-                        : 'resolveRouteBinding';
+            $routeBindingMethod = 'resolveRouteBinding';
+            if ($route->allowsWithTrashedBindings()) {
+                $routeBindingMethod = 'resolveWithTrashedRouteBinding';
+            }
+            if ($route->allowsOnlyTrashedBindings()) {
+                $routeBindingMethod = 'resolveOnlyTrashedRouteBinding';
+            }
 
             if ($parent instanceof UrlRoutable && in_array($parameterName, array_keys($route->bindingFields()))) {
-                $childRouteBindingMethod = $route->allowsTrashedBindings()
-                            ? 'resolveSoftDeletableChildRouteBinding'
-                            : 'resolveChildRouteBinding';
+                $childRouteBindingMethod = 'resolveChildRouteBinding';
+                if ($route->allowsWithTrashedBindings()) {
+                    $childRouteBindingMethod = 'resolveWithTrashedChildRouteBinding';
+                }
+                if ($route->allowsOnlyTrashedBindings())
+                {
+                    $childRouteBindingMethod = 'resolveOnlyTrashedChildRouteBinding';
+                }
 
                 if (! $model = $parent->{$childRouteBindingMethod}(
                     $parameterName, $parameterValue, $route->bindingFieldFor($parameterName)

--- a/src/Illuminate/Routing/ImplicitRouteBinding.php
+++ b/src/Illuminate/Routing/ImplicitRouteBinding.php
@@ -50,8 +50,7 @@ class ImplicitRouteBinding
                 if ($route->allowsWithTrashedBindings()) {
                     $childRouteBindingMethod = 'resolveWithTrashedChildRouteBinding';
                 }
-                if ($route->allowsOnlyTrashedBindings())
-                {
+                if ($route->allowsOnlyTrashedBindings()) {
                     $childRouteBindingMethod = 'resolveOnlyTrashedChildRouteBinding';
                 }
 

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -101,6 +101,13 @@ class Route
     protected $withTrashedBindings = false;
 
     /**
+     * Indicates "only trashed" models can be retrieved when resolving implicit model bindings for this route.
+     *
+     * @var bool
+     */
+    protected $onlyTrashedBindings = false;
+
+    /**
      * Indicates the maximum number of seconds the route should acquire a session lock for.
      *
      * @var int|null
@@ -584,9 +591,32 @@ class Route
      *
      * @return bool
      */
-    public function allowsTrashedBindings()
+    public function allowsWithTrashedBindings()
     {
         return $this->withTrashedBindings;
+    }
+
+    /**
+     * Allow "only trashed" models to be retrieved when resolving implicit model bindings for this route.
+     *
+     * @param  bool  $onlyTrashed
+     * @return $this
+     */
+    public function onlyTrashed($onlyTrashed = true)
+    {
+        $this->onlyTrashedBindings = $onlyTrashed;
+
+        return $this;
+    }
+
+    /**
+     * Determines if the route allows "only trashed" models to be retrieved when resolving implicit model bindings.
+     *
+     * @return bool
+     */
+    public function allowsOnlyTrashedBindings()
+    {
+        return $this->onlyTrashedBindings;
     }
 
     /**

--- a/tests/Integration/Routing/ImplicitRouteBindingTest.php
+++ b/tests/Integration/Routing/ImplicitRouteBindingTest.php
@@ -131,6 +131,41 @@ PHP);
             'name' => $user->name,
         ]);
     }
+
+    public function testSoftDeletedModelsCanBeRetrievedUsingOnlyTrashedMethod()
+    {
+        $user = ImplicitBindingModel::create(['name' => 'Dries']);
+
+        $user->delete();
+
+        config(['app.key' => str_repeat('a', 32)]);
+
+        Route::post('/user/{user}', function (ImplicitBindingModel $user) {
+            return $user;
+        })->middleware(['web'])->onlyTrashed();
+
+        $response = $this->postJson("/user/{$user->id}");
+
+        $response->assertJson([
+            'id' => $user->id,
+            'name' => $user->name,
+        ]);
+    }
+
+    public function testNotSoftDeletedModelsCannotBeRetrievedUsingOnlyTrashedMethod()
+    {
+        $user = ImplicitBindingModel::create(['name' => 'Dries']);
+
+        config(['app.key' => str_repeat('a', 32)]);
+
+        Route::post('/user/{user}', function (ImplicitBindingModel $user) {
+            return $user;
+        })->middleware(['web'])->onlyTrashed();
+
+        $response = $this->postJson("/user/{$user->id}");
+
+        $response->assertStatus(404);
+    }
 }
 
 class ImplicitBindingModel extends Model


### PR DESCRIPTION
Added `onlyTrashed` to routes as an addition to [`withTrashed`](https://github.com/laravel/framework/pull/38348).

Usage:
```php
Route::post('/user/{user}', function (ImplicitBindingModel $user) {
    return $user;
})->middleware(['web'])->onlyTrashed();
```