### PR TITLE
[8.x] Typed route parameters

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -833,6 +833,7 @@ class Route
 
         return tap(RouteUri::parse($uri), function ($uri) {
             $this->bindingFields = $uri->bindingFields;
+            $this->wheres = array_merge($this->wheres, $uri->wheres);
         })->uri;
     }
 

--- a/src/Illuminate/Routing/RouteUri.php
+++ b/src/Illuminate/Routing/RouteUri.php
@@ -64,7 +64,7 @@ class RouteUri
         $bindingFields = [];
         $wheres = [];
 
-        $uri = preg_replace_callback($pattern, function($match) use (&$bindingFields, &$wheres) {
+        $uri = preg_replace_callback($pattern, function ($match) use (&$bindingFields, &$wheres) {
             [$_, $type, $parameter, $field, $optional] = $match;
 
             if ('' !== $type) {

--- a/src/Illuminate/Routing/RouteUri.php
+++ b/src/Illuminate/Routing/RouteUri.php
@@ -9,7 +9,7 @@ class RouteUri
      *
      * @var array
      */
-    public static $typeExpressions = [
+    protected static $typeExpressions = [
         'int' => '[0-9]+',
         'alpha' => '[a-zA-Z]+',
         'alnum' => '[a-zA-Z0-9]+',
@@ -60,8 +60,6 @@ class RouteUri
     public static function parse($uri)
     {
         $pattern = '/{(?:'.static::typesPattern().'\s+)?(\w+)(?::(\w+))?(\??)}/';
-
-        preg_match_all($pattern, $uri, $matches);
 
         $bindingFields = [];
         $wheres = [];

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1221,6 +1221,20 @@ class Router implements BindingRegistrar, RegistrarContract
     }
 
     /**
+     * Add a named type and its associated regular expression.
+     *
+     * @param  string  $name
+     * @param  string  $expression
+     * @return $this
+     */
+    public function addParameterType($name, $expression)
+    {
+        RouteUri::addType($name, $expression);
+
+        return $this;
+    }
+
+    /**
      * Get or set the verbs used in the resource URIs.
      *
      * @param  array  $verbs

--- a/tests/Integration/Routing/CompiledRouteCollectionTest.php
+++ b/tests/Integration/Routing/CompiledRouteCollectionTest.php
@@ -347,6 +347,21 @@ class CompiledRouteCollectionTest extends TestCase
         $this->assertSame('foo', $routes->match(Request::create('/foo', 'GET'))->getName());
     }
 
+    public function testTypesAreCompiled()
+    {
+        $this->routeCollection->add(
+            $this->newRoute('GET', '/foo/{int foo}', ['uses' => 'FooController@index', 'as' => 'foo'])
+        );
+
+        $routes = $this->collection();
+
+        $this->assertSame('foo', $routes->match(Request::create('/foo/1', 'GET'))->getName());
+
+        $this->expectException(NotFoundHttpException::class);
+
+        $routes->match(Request::create('/foo/bar', 'GET'));
+    }
+
     public function testMatchingDynamicallyAddedRoutesTakePrecedenceOverFallbackRoutes()
     {
         $this->routeCollection->add($this->fallbackRoute(['uses' => 'FooController@index']));

--- a/tests/Routing/RouteUriTest.php
+++ b/tests/Routing/RouteUriTest.php
@@ -33,4 +33,36 @@ class RouteUriTest extends TestCase
         $this->assertSame('/foo/{bar}/baz/{qux?}/{test?}', $parsed->uri);
         $this->assertEquals(['qux' => 'slug', 'test' => 'id'], $parsed->bindingFields);
     }
+
+    public function testRouteUriTypesAreProperlyParsed()
+    {
+        $int = RouteUri::getExpressionForType('int');
+        $alpha = RouteUri::getExpressionForType('alpha');
+        $alnum = RouteUri::getExpressionForType('alnum');
+
+        $parsed = RouteUri::parse('/foo/{int bar}');
+        $this->assertSame('/foo/{bar}', $parsed->uri);
+        $this->assertEquals([], $parsed->bindingFields);
+        $this->assertEquals(['bar' => $int], $parsed->wheres);
+
+        $parsed = RouteUri::parse('/foo/{int bar:slug}');
+        $this->assertSame('/foo/{bar}', $parsed->uri);
+        $this->assertEquals(['bar' => 'slug'], $parsed->bindingFields);
+        $this->assertEquals(['bar' => $int], $parsed->wheres);
+
+        $parsed = RouteUri::parse('/foo/{int bar}/baz/{alpha qux:slug}');
+        $this->assertSame('/foo/{bar}/baz/{qux}', $parsed->uri);
+        $this->assertEquals(['qux' => 'slug'], $parsed->bindingFields);
+        $this->assertEquals(['bar' => $int, 'qux' => $alpha], $parsed->wheres);
+
+        $parsed = RouteUri::parse('/foo/{int bar}/baz/{alnum qux:slug?}');
+        $this->assertSame('/foo/{bar}/baz/{qux?}', $parsed->uri);
+        $this->assertEquals(['qux' => 'slug'], $parsed->bindingFields);
+        $this->assertEquals(['bar' => $int, 'qux' => $alnum], $parsed->wheres);
+
+        $parsed = RouteUri::parse('/foo/{int bar}/baz/{qux:slug?}/{alnum test:id?}');
+        $this->assertSame('/foo/{bar}/baz/{qux?}/{test?}', $parsed->uri);
+        $this->assertEquals(['qux' => 'slug', 'test' => 'id'], $parsed->bindingFields);
+        $this->assertEquals(['bar' => $int, 'test' => $alnum], $parsed->wheres);
+    }
 }

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -839,6 +839,32 @@ class RoutingRouteTest extends TestCase
         $this->assertFalse($route->matches($request));
     }
 
+    public function testTypedParametersProperlyFilter()
+    {
+        $route = new Route('GET', 'foo/{int bar}', null);
+        $this->assertTrue($route->matches(Request::create('foo/123')));
+        $this->assertFalse($route->matches(Request::create('foo/abc')));
+        $this->assertFalse($route->matches(Request::create('foo/123abc')));
+
+        $route = new Route('GET', 'foo/{alpha bar}', null);
+        $this->assertTrue($route->matches(Request::create('foo/abc')));
+        $this->assertFalse($route->matches(Request::create('foo/123')));
+        $this->assertFalse($route->matches(Request::create('foo/123abc')));
+
+        $route = new Route('GET', 'foo/{alnum bar}', null);
+        $this->assertTrue($route->matches(Request::create('foo/abc')));
+        $this->assertTrue($route->matches(Request::create('foo/123')));
+        $this->assertTrue($route->matches(Request::create('foo/123abc')));
+        $this->assertFalse($route->matches(Request::create('foo/+++')));
+
+        $route = new Route('GET', 'foo/{uuid bar}', null);
+        $this->assertTrue($route->matches(Request::create('foo/'.Str::uuid())));
+        $this->assertFalse($route->matches(Request::create('foo/abc')));
+        $this->assertFalse($route->matches(Request::create('foo/123')));
+        $this->assertFalse($route->matches(Request::create('foo/123abc')));
+        $this->assertFalse($route->matches(Request::create('foo/+++')));
+    }
+
     public function testRoutePrefixParameterParsing()
     {
         $route = new Route('GET', '/foo', ['prefix' => 'profiles/{user:username}/portfolios', 'uses' => function () {


### PR DESCRIPTION
This PR adds a new routing syntax:

```php
// Before
Route::get('events/{year}/{month}', CalendarMonthController::class))
  ->whereNumber('year')
  ->whereNumber('month');

// After
Route::get('events/{int year}/{int month}', CalendarMonthController::class));
```

As well as a way to register your own parameter "types":

```php
Route::addParameterType('month', '(0?[1-9]|1[0-2])');
Route::addParameterType('year', '2[0-9]{3}');

Route::get('events/{year yr}/{month mo}', CalendarMonthController::class));
```

You can mix and match with the other routing syntax as needed:

```php
// Will trigger a 404 before ever querying the database if passed an invalid UUID

Route::get('events/{uuid event:uuid}', EventController::class));
```

The backstory of this is that we run a bug bounty program, and are constantly hit with requests like:

```
GET /events/XfWya5t4'));select%20pg_sleep(27);%20--%20/6/-3
```

And while it's possible to add `where()` or `whereNumber()`/etc to each of those routes, it will at least double the length of our routes files. Adding "type hints" inline means that I can easily type my route parameters in the URL definition using a syntax that feels like the PHP type syntax.