### PR TITLE
[9.x] Dump specific key of the response in tests

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1349,9 +1349,10 @@ EOF;
     /**
      * Dump the content from the response.
      *
+     * @param  string|null  $key
      * @return $this
      */
-    public function dump()
+    public function dump($key = null)
     {
         $content = $this->getContent();
 
@@ -1361,7 +1362,11 @@ EOF;
             $content = $json;
         }
 
-        dump($content);
+        if (! is_null($key)) {
+            dump(data_get($content, $key));
+        } else {
+            dump($content);
+        }
 
         return $this;
     }


### PR DESCRIPTION
There are cases while debugging where you'd want to only dump specific key from the response you just made. This is a simple addition to be able to selectively dump parts of the response. 

An example would be getting the `data` key from an api-resource response. That's a very simplistic example (since you basically only save the pagination stuff) but when dumping a huge response, the dumped data are hard to read and with this change we can select the part we need.