### PR TITLE
[9.x] Update firstOrFail logic

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1146,7 +1146,7 @@ class Collection implements ArrayAccess, Enumerable
             ? $this->operatorForWhere(...func_get_args())
             : $key;
 
-        $items = $this->when($filter)->filter($filter);
+        $items = $this->unless($filter == null)->filter($filter);
 
         if ($items->isEmpty()) {
             throw new ItemNotFoundException;

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1091,7 +1091,7 @@ class LazyCollection implements Enumerable
             : $key;
 
         return $this
-            ->when($filter)
+            ->unless($filter == null)
             ->filter($filter)
             ->take(1)
             ->collect()


### PR DESCRIPTION
PR #38420 Introduces ```firstOrFail``` on collection classes, which on version 8.x uses ```when``` for filtering. The logic was adjusted to use ```unless``` in #37667 and this PR align the code to also use ```unless```.