### PR TITLE
[9.x] Queue commands

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1146,7 +1146,7 @@ class Collection implements ArrayAccess, Enumerable
             ? $this->operatorForWhere(...func_get_args())
             : $key;
 
-        $items = $this->when($filter)->filter($filter);
+        $items = $this->unless($filter == null)->filter($filter);
 
         if ($items->isEmpty()) {
             throw new ItemNotFoundException;

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1091,7 +1091,7 @@ class LazyCollection implements Enumerable
             : $key;
 
         return $this
-            ->when($filter)
+            ->unless($filter == null)
             ->filter($filter)
             ->take(1)
             ->collect()

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -731,9 +731,7 @@ trait HasRelationships
             return array_search(static::class, $morphMap, true);
         }
 
-        return Relation::$useTableNamesForMorphMap
-                    ? $this->getTable()
-                    : static::class;
+        return static::class;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -51,13 +51,6 @@ abstract class Relation
     protected static $constraints = true;
 
     /**
-     * Indicates that table names should be used when determining morph classes.
-     *
-     * @var bool
-     */
-    public static $useTableNamesForMorphMap = false;
-
-    /**
      * An array to map class names to their morph names in the database.
      *
      * @var array
@@ -381,16 +374,6 @@ abstract class Relation
                     && in_array($model->getKeyType(), ['int', 'integer'])
                         ? 'whereIntegerInRaw'
                         : 'whereIn';
-    }
-
-    /**
-     * Indicate that the table names should be used when determining morphed class names.
-     *
-     * @return void
-     */
-    public static function morphUsingTableNames()
-    {
-        static::$useTableNamesForMorphMap = true;
     }
 
     /**

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -681,7 +681,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerQueueMonitorCommand()
     {
-        $this->app->singleton('command.queue.monitor', function ($app) {
+        $this->app->singleton(QueueMonitorCommand::class, function ($app) {
             return new QueueMonitorCommand($app['queue'], $app['events']);
         });
     }
@@ -705,7 +705,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerQueuePruneFailedJobsCommand()
     {
-        $this->app->singleton('command.queue.prune-failed-jobs', function () {
+        $this->app->singleton(QueuePruneFailedJobsCommand::class, function () {
             return new QueuePruneFailedJobsCommand;
         });
     }

--- a/src/Illuminate/Queue/Console/MonitorCommand.php
+++ b/src/Illuminate/Queue/Console/MonitorCommand.php
@@ -20,6 +20,15 @@ class MonitorCommand extends Command
                        {--max=1000 : The maximum number of jobs that can be on the queue before an event is dispatched}';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'queue:monitor';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Queue/Console/PruneFailedJobsCommand.php
+++ b/src/Illuminate/Queue/Console/PruneFailedJobsCommand.php
@@ -17,6 +17,15 @@ class PruneFailedJobsCommand extends Command
                 {--hours=24 : The number of hours to retain failed jobs data}';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'queue:prune-failed';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Validation/ConditionalRules.php
+++ b/src/Illuminate/Validation/ConditionalRules.php
@@ -21,16 +21,25 @@ class ConditionalRules
     protected $rules;
 
     /**
+     * The rules to be added to the attribute if the condition fails.
+     *
+     * @var array|string
+     */
+    protected $defaultRules;
+
+    /**
      * Create a new conditional rules instance.
      *
      * @param  callable|bool  $condition
      * @param  array|string  $rules
+     * @param  array|string  $defaultRules
      * @return void
      */
-    public function __construct($condition, $rules)
+    public function __construct($condition, $rules, $defaultRules = [])
     {
         $this->condition = $condition;
         $this->rules = $rules;
+        $this->defaultRules = $defaultRules;
     }
 
     /**
@@ -54,5 +63,15 @@ class ConditionalRules
     public function rules()
     {
         return is_string($this->rules) ? explode('|', $this->rules) : $this->rules;
+    }
+
+    /**
+     * Get the default rules.
+     *
+     * @return array
+     */
+    public function defaultRules()
+    {
+        return is_string($this->defaultRules) ? explode('|', $this->defaultRules) : $this->defaultRules;
     }
 }

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -20,11 +20,12 @@ class Rule
      *
      * @param  callable|bool  $condition
      * @param  array|string  $rules
+     * @param  array|string  $defaultRules
      * @return \Illuminate\Validation\ConditionalRules
      */
-    public static function when($condition, $rules)
+    public static function when($condition, $rules, $defaultRules = [])
     {
-        return new ConditionalRules($condition, $rules);
+        return new ConditionalRules($condition, $rules, $defaultRules);
     }
 
     /**

--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -293,7 +293,7 @@ class ValidationRuleParser
             if ($attributeRules instanceof ConditionalRules) {
                 return [$attribute => $attributeRules->passes($data)
                                 ? $attributeRules->rules()
-                                : $attributeRules->defaultRules()];
+                                : $attributeRules->defaultRules(), ];
             }
 
             return [$attribute => collect($attributeRules)->map(function ($rule) use ($data) {

--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -291,7 +291,9 @@ class ValidationRuleParser
             }
 
             if ($attributeRules instanceof ConditionalRules) {
-                return [$attribute => $attributeRules->passes($data) ? $attributeRules->rules() : null];
+                return [$attribute => $attributeRules->passes($data)
+                                ? $attributeRules->rules()
+                                : $attributeRules->defaultRules()];
             }
 
             return [$attribute => collect($attributeRules)->map(function ($rule) use ($data) {
@@ -299,7 +301,7 @@ class ValidationRuleParser
                     return [$rule];
                 }
 
-                return $rule->passes($data) ? $rule->rules() : null;
+                return $rule->passes($data) ? $rule->rules() : $rule->defaultRules();
             })->filter()->flatten(1)->values()->all()];
         })->filter()->all();
     }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1217,16 +1217,6 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals(EloquentModelStub::class, $relation->getMorphClass());
     }
 
-    public function testMorphOneCreatesProperRelationWhenUsingTableNames()
-    {
-        Relation::morphUsingTableNames();
-        $model = new EloquentModelStub;
-        $this->addMockConnection($model);
-        $relation = $model->morphOne(EloquentModelSaveStub::class, 'morph');
-        $this->assertEquals('stub', $relation->getMorphClass());
-        Relation::$useTableNamesForMorphMap = false;
-    }
-
     public function testCorrectMorphClassIsReturned()
     {
         Relation::morphMap(['alias' => 'AnotherModel']);

--- a/tests/Validation/ValidationRuleParserTest.php
+++ b/tests/Validation/ValidationRuleParserTest.php
@@ -30,4 +30,23 @@ class ValidationRuleParserTest extends TestCase
             'city' => ['required', 'min:2'],
         ], $rules);
     }
+
+    public function test_conditional_rules_with_default()
+    {
+        $rules = ValidationRuleParser::filterConditionalRules([
+            'name' => Rule::when(true, ['required', 'min:2'], ['string', 'max:10']),
+            'email' => Rule::when(false, ['required', 'min:2'], ['string', 'max:10']),
+            'password' => Rule::when(false, 'required|min:2', 'string|max:10'),
+            'username' => ['required', Rule::when(true, ['min:2'], ['string', 'max:10'])],
+            'address' => ['required', Rule::when(false, ['min:2'], ['string', 'max:10'])],
+        ]);
+
+        $this->assertEquals([
+            'name' => ['required', 'min:2'],
+            'email' => ['string', 'max:10'],
+            'password' => ['string', 'max:10'],
+            'username' => ['required', 'min:2'],
+            'address' => ['required', 'string', 'max:10'],
+        ], $rules);
+    }
 }


### PR DESCRIPTION
This PR registers new queue commands with class names and add ```$defaultName``` static property.

Two new queue commands were added to the framework: ```queue:prune-failed``` (#37696) and ```queue:monitor``` (#38168). Upon merging to master, the commands were not adjusted to take advantage of command lazy loading introduced in #34925.