### PR TITLE
[8.x] add `Str::betweenAll()`

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -157,6 +157,25 @@ class Str
     }
 
     /**
+     * Get an array containing all substrings that occur between two given values.
+     *
+     * @param  string  $subject
+     * @param  string  $from
+     * @param  string  $to
+     * @return array<string>
+     */
+    public static function betweenAll($subject, $from, $to)
+    {
+        if ($from === '' || $to === '') {
+            return [];
+        }
+
+        preg_match_all('/'.preg_quote($from).'(.*?)'.preg_quote($to).'/', $subject, $matches);
+
+        return $matches[1];
+    }
+
+    /**
      * Convert a value to camel case.
      *
      * @param  string  $value

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -131,6 +131,18 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Get an array containing all substrings that occur between two given values.
+     *
+     * @param  string  $from
+     * @param  string  $to
+     * @return array<string>
+     */
+    public function betweenAll($from, $to)
+    {
+        return Str::betweenAll($this->value, $from, $to);
+    }
+
+    /**
      * Convert a value to camel case.
      *
      * @return static

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -158,6 +158,39 @@ class SupportStrTest extends TestCase
         $this->assertSame('bar', Str::between('foobarbar', 'foo', 'bar'));
     }
 
+    public function providesForStrBetweenAll()
+    {
+        return [
+            ['abc]', '', ']', []],
+            ['[abc', '[', '', []],
+            ['abc', '[', ']', []],
+            ['[abc', '[', ']', []],
+            ['abc]', '[', ']', []],
+            ['a]b[c', '[', ']', []],
+            ['abc[def]', '[', ']', ['def']],
+            ['a[b]c[d]e', '[', ']', ['b', 'd']],
+            ['a[]c[]e[f]', '[', ']', ['', '', 'f']],
+            ['foobarbuzz foobaxbuzz', 'foo', 'buzz', ['bar', 'bax']],
+            ['[[[]][[[]]]', '[', ']', ['[[', '[[']],
+            ['[[[]][[[]]]', '[[', ']', ['[', '[']],
+            ['「你好」「美女」', '「', '」', ['你好', '美女']],
+            [<<<STR
+            Hello:
+
+            Follow your order with <a href="http://example.com/t&t">Track & Trace</a>
+
+            Or <a href="http://example.com/unsub">unsubscribe</a> forever.
+
+            STR, 'href="', '"', ['http://example.com/t&t', 'http://example.com/unsub']],
+        ];
+    }
+
+    /** @dataProvider providesForStrBetweenAll */
+    public function testStrBetweenAll($subject, $from, $to, $expected)
+    {
+        $this->assertSame($expected, Str::betweenAll($subject, $from, $to));
+    }
+
     public function testStrAfter()
     {
         $this->assertSame('nah', Str::after('hannah', 'han'));

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -174,7 +174,7 @@ class SupportStrTest extends TestCase
             ['[[[]][[[]]]', '[', ']', ['[[', '[[']],
             ['[[[]][[[]]]', '[[', ']', ['[', '[']],
             ['「你好」「美女」', '「', '」', ['你好', '美女']],
-            [<<<STR
+            [<<<'STR'
             Hello:
 
             Follow your order with <a href="http://example.com/t&t">Track & Trace</a>

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -326,6 +326,11 @@ class SupportStringableTest extends TestCase
         $this->assertSame('bar', (string) $this->stringable('foobarbar')->between('foo', 'bar'));
     }
 
+    public function testBetweenAll()
+    {
+        $this->assertSame(['a', 'b'], $this->stringable('[a] [b]')->betweenAll('[', ']'));
+    }
+
     public function testAfter()
     {
         $this->assertSame('nah', (string) $this->stringable('hannah')->after('han'));


### PR DESCRIPTION
This PR adds a `Str::betweenAll()` method:

```php
$string = <<<STR
Follow your order with <a href="http://example.com/t&t">Track & Trace</a>

Or <a href="http://example.com/unsub">unsubscribe</a> forever.
STR;

Str::betweenAll($string, 'href="', '"'); // ['http://example.com/t&t', 'http://example.com/unsub']
```

My use-case is that I want to visit the first link from an email in a Dusk test. I intercept the email, and have to get the first link. With this new method I can do so using `Str::betweenAll($email->body, 'href="', '"')[0]`.

This new method is similar to `Str::between()`:

```php
Str::between('[a]', '[', ']') // 'a'
Str::betweenAll('[a]', '[', ']') // ['a']

Str::between('[a] [b]', '[', ']') // 'a] [b'
Str::betweenAll('[a] [b]', '[', ']') // ['a', 'b']
```
