### PR TITLE
[9.x] Refactor whereKeyNot to reuse code from whereKey

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -179,6 +179,7 @@ class Builder implements BuilderContract
      * Add a where clause on the primary key to the query.
      *
      * @param  mixed  $id
+     * @param  bool   $negation
      * @return $this
      */
     public function whereKey($id, $negation = false)

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -181,14 +181,21 @@ class Builder implements BuilderContract
      * @param  mixed  $id
      * @return $this
      */
-    public function whereKey($id)
+    public function whereKey($id, $negation = false)
     {
         if ($id instanceof Model) {
             $id = $id->getKey();
         }
 
         if (is_array($id) || $id instanceof Arrayable) {
-            $this->query->whereIn($this->model->getQualifiedKeyName(), $id);
+            $this->query->{
+                ! $negation
+                ? 'whereIn'
+                : 'whereNotIn'
+            }(
+                $this->model->getQualifiedKeyName(),
+                $id
+            );
 
             return $this;
         }
@@ -197,7 +204,11 @@ class Builder implements BuilderContract
             $id = (string) $id;
         }
 
-        return $this->where($this->model->getQualifiedKeyName(), '=', $id);
+        return $this->where(
+            $this->model->getQualifiedKeyName(),
+            ! $negation ? '=' : '!=',
+            $id
+        );
     }
 
     /**
@@ -208,21 +219,7 @@ class Builder implements BuilderContract
      */
     public function whereKeyNot($id)
     {
-        if ($id instanceof Model) {
-            $id = $id->getKey();
-        }
-
-        if (is_array($id) || $id instanceof Arrayable) {
-            $this->query->whereNotIn($this->model->getQualifiedKeyName(), $id);
-
-            return $this;
-        }
-
-        if ($id !== null && $this->model->getKeyType() === 'string') {
-            $id = (string) $id;
-        }
-
-        return $this->where($this->model->getQualifiedKeyName(), '!=', $id);
+        return $this->whereKey($id, true);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -179,10 +179,10 @@ class Builder implements BuilderContract
      * Add a where clause on the primary key to the query.
      *
      * @param  mixed  $id
-     * @param  bool   $negation
+     * @param  bool   $reverse
      * @return $this
      */
-    public function whereKey($id, $negation = false)
+    public function whereKey($id, $reverse = false)
     {
         if ($id instanceof Model) {
             $id = $id->getKey();
@@ -190,7 +190,7 @@ class Builder implements BuilderContract
 
         if (is_array($id) || $id instanceof Arrayable) {
             $this->query->{
-                ! $negation
+                ! $reverse
                 ? 'whereIn'
                 : 'whereNotIn'
             }(
@@ -207,7 +207,7 @@ class Builder implements BuilderContract
 
         return $this->where(
             $this->model->getQualifiedKeyName(),
-            ! $negation ? '=' : '!=',
+            ! $reverse ? '=' : '!=',
             $id
         );
     }


### PR DESCRIPTION
While digging into Eloquent Builder I noticed a bit of code duplication, so briefly refactored it.
I think these ternaries won't make much impact while the code is a bit cleaner.