### PR TITLE
[8.x] Fix bug with incorrect cypher length

### DIFF
--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -70,7 +70,7 @@ class Encrypter implements EncrypterContract, StringEncrypter
      */
     public static function generateKey($cipher)
     {
-        return random_bytes($cipher === 'AES-128-CBC' ? 16 : 32);
+        return random_bytes(in_array($cipher, ['AES-128-CBC', 'AES-128-GCM']) ? 16 : 32);
     }
 
     /**


### PR DESCRIPTION
This fixes an issue where an incorrect cypher length was used for AES-128-GCM when generating a random key. Introduced in #38190
