### PR TITLE
[8.x] Remove unnecessary double MAC for AEAD ciphers

### DIFF
--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -56,10 +56,30 @@ class EncrypterTest extends TestCase
         $this->assertSame('foo', $e->decrypt($encrypted));
     }
 
+    public function testThatAnAeadCipherIncludesTag()
+    {
+        $e = new Encrypter(str_repeat('b', 32), 'AES-256-GCM');
+        $encrypted = $e->encrypt('foo');
+        $data = json_decode(base64_decode($encrypted));
+
+        $this->assertEmpty($data->mac);
+        $this->assertNotEmpty($data->tag);
+    }
+
+    public function testThatANonAeadCipherIncludesMac()
+    {
+        $e = new Encrypter(str_repeat('b', 32), 'AES-256-CBC');
+        $encrypted = $e->encrypt('foo');
+        $data = json_decode(base64_decode($encrypted));
+
+        $this->assertEmpty($data->tag);
+        $this->assertNotEmpty($data->mac);
+    }
+
     public function testDoNoAllowLongerKey()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('The only supported ciphers are AES-128-CBC, AES-256-CBC, AES-128-GCM, and AES-256-GCM with the correct key lengths.');
+        $this->expectExceptionMessage('Unsupported cipher or incorrect key length. Supported ciphers are: AES-128-CBC, AES-256-CBC, AES-128-GCM, AES-256-GCM.');
 
         new Encrypter(str_repeat('z', 32));
     }
@@ -67,7 +87,7 @@ class EncrypterTest extends TestCase
     public function testWithBadKeyLength()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('The only supported ciphers are AES-128-CBC, AES-256-CBC, AES-128-GCM, and AES-256-GCM with the correct key lengths.');
+        $this->expectExceptionMessage('Unsupported cipher or incorrect key length. Supported ciphers are: AES-128-CBC, AES-256-CBC, AES-128-GCM, AES-256-GCM.');
 
         new Encrypter(str_repeat('a', 5));
     }
@@ -75,7 +95,7 @@ class EncrypterTest extends TestCase
     public function testWithBadKeyLengthAlternativeCipher()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('The only supported ciphers are AES-128-CBC, AES-256-CBC, AES-128-GCM, and AES-256-GCM with the correct key lengths.');
+        $this->expectExceptionMessage('Unsupported cipher or incorrect key length. Supported ciphers are: AES-128-CBC, AES-256-CBC, AES-128-GCM, AES-256-GCM.');
 
         new Encrypter(str_repeat('a', 16), 'AES-256-CFB8');
     }
@@ -83,7 +103,7 @@ class EncrypterTest extends TestCase
     public function testWithUnsupportedCipher()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('The only supported ciphers are AES-128-CBC, AES-256-CBC, AES-128-GCM, and AES-256-GCM with the correct key lengths.');
+        $this->expectExceptionMessage('Unsupported cipher or incorrect key length. Supported ciphers are: AES-128-CBC, AES-256-CBC, AES-128-GCM, AES-256-GCM.');
 
         new Encrypter(str_repeat('c', 16), 'AES-256-CFB8');
     }


### PR DESCRIPTION
This PR does two things:
 1. It resolves a small bug in the `generateKey` method (wrong result for `AES-128-GCM`, see comment in code below).
 2. It removes the unnecessary `hmac` computation for AEAD ciphers, improving performance and reducing encrypted data amount.

These two problems were introduced recently when support for GCM ciphers was added, in https://github.com/laravel/framework/pull/38190

GCM is a so called _Authenticated Encryption_ scheme (AEAD), which means that a Message Authentication Code (`mac`) is included in the algorithm and handled by `openssl_encrypt/openssl_decrypt`. This is called `tag` in the code, and serves the exact same purpose as the `mac` that is also present from before (and necessary in the CBC-case, which is not natively authenticated).

This PR removes the HMAC computation in the GCM case, since the `tag` already ensures data integrity (before decryption is attempted). This simplifies the code (very important for cryptographic implementations), improves performance and reduces the amount of data stored/transmitted. As an example, the XSRF and session id cookies are reduced by around 25 % (but the reduction for larger data is of course much smaller).

The changes are backwards compatible with https://github.com/laravel/framework/pull/38190, and of course with any data stored before that. In fact, the only change to the decryption part is skipping the MAC validation in the case of an AEAD-cipher being used.

This was actually all done correctly in a 2017 PR by bukka, https://github.com/laravel/framework/pull/21963, but that was never merged. I did use that PR as inspiration for this, but I tried to keep the changes to a minimum to increase chances of merging. One larger change is generalizing the list of supported ciphers, and adding the AEAD support as a property. This should simplify the process of adding additional ciphers in the future, and simplified other parts of the code.
