### PR TITLE
Make the hashing check function more readable.

### DIFF
--- a/src/Illuminate/Contracts/Hashing/Hasher.php
+++ b/src/Illuminate/Contracts/Hashing/Hasher.php
@@ -32,6 +32,16 @@ interface Hasher
     public function check($value, $hashedValue, array $options = []);
 
     /**
+     * Check the given plain value against a hash.
+     *
+     * @param  string  $value
+     * @param  string  $hashedValue
+     * @param  array  $options
+     * @return bool
+     */
+    public function checkPlainAgainstHash($value, $hashedValue, array $options = []);
+
+    /**
      * Check if the given hash has been hashed using the given options.
      *
      * @param  string  $hashedValue

--- a/src/Illuminate/Hashing/AbstractHasher.php
+++ b/src/Illuminate/Hashing/AbstractHasher.php
@@ -23,6 +23,19 @@ abstract class AbstractHasher
      * @param  array  $options
      * @return bool
      */
+    public function checkPlainAgainstHash($value, $hashedValue, array $options = [])
+    {
+        return $this->check($value, $hashedValue, $options);
+    }
+
+    /**
+     * Check the given plain value against a hash.
+     *
+     * @param  string  $value
+     * @param  string  $hashedValue
+     * @param  array  $options
+     * @return bool
+     */
     public function check($value, $hashedValue, array $options = [])
     {
         if (strlen($hashedValue) === 0) {

--- a/src/Illuminate/Hashing/Argon2IdHasher.php
+++ b/src/Illuminate/Hashing/Argon2IdHasher.php
@@ -6,6 +6,22 @@ use RuntimeException;
 
 class Argon2IdHasher extends ArgonHasher
 {
+
+    /**
+     * Check the given plain value against a hash.
+     *
+     * @param  string  $value
+     * @param  string  $hashedValue
+     * @param  array  $options
+     * @return bool
+     *
+     * @throws \RuntimeException
+     */
+    public function checkPlainAgainstHash($value, $hashedValue, array $options = [])
+    {
+        return $this->check($value, $hashedValue, $options);
+    }
+
     /**
      * Check the given plain value against a hash.
      *

--- a/src/Illuminate/Hashing/Argon2IdHasher.php
+++ b/src/Illuminate/Hashing/Argon2IdHasher.php
@@ -6,7 +6,6 @@ use RuntimeException;
 
 class Argon2IdHasher extends ArgonHasher
 {
-
     /**
      * Check the given plain value against a hash.
      *

--- a/src/Illuminate/Hashing/ArgonHasher.php
+++ b/src/Illuminate/Hashing/ArgonHasher.php
@@ -93,6 +93,21 @@ class ArgonHasher extends AbstractHasher implements HasherContract
      *
      * @throws \RuntimeException
      */
+    public function checkPlainAgainstHash($value, $hashedValue, array $options = [])
+    {
+        return $this->check($value, $hashedValue, $options);
+    }
+
+    /**
+     * Check the given plain value against a hash.
+     *
+     * @param  string  $value
+     * @param  string  $hashedValue
+     * @param  array  $options
+     * @return bool
+     *
+     * @throws \RuntimeException
+     */
     public function check($value, $hashedValue, array $options = [])
     {
         if ($this->verifyAlgorithm && $this->info($hashedValue)['algoName'] !== 'argon2i') {

--- a/src/Illuminate/Hashing/BcryptHasher.php
+++ b/src/Illuminate/Hashing/BcryptHasher.php
@@ -65,6 +65,21 @@ class BcryptHasher extends AbstractHasher implements HasherContract
      *
      * @throws \RuntimeException
      */
+    public function checkPlainAgainstHash($value, $hashedValue, array $options = [])
+    {
+        return $this->check($value, $hashedValue, $options);
+    }
+
+    /**
+     * Check the given plain value against a hash.
+     *
+     * @param  string  $value
+     * @param  string  $hashedValue
+     * @param  array  $options
+     * @return bool
+     *
+     * @throws \RuntimeException
+     */
     public function check($value, $hashedValue, array $options = [])
     {
         if ($this->verifyAlgorithm && $this->info($hashedValue)['algoName'] !== 'bcrypt') {

--- a/src/Illuminate/Hashing/HashManager.php
+++ b/src/Illuminate/Hashing/HashManager.php
@@ -68,6 +68,19 @@ class HashManager extends Manager implements Hasher
      * @param  array  $options
      * @return bool
      */
+    public function checkPlainAgainstHash($value, $hashedValue, array $options = [])
+    {
+        return $this->check($value, $hashedValue, $options);
+    }
+
+    /**
+     * Check the given plain value against a hash.
+     *
+     * @param  string  $value
+     * @param  string  $hashedValue
+     * @param  array  $options
+     * @return bool
+     */
     public function check($value, $hashedValue, array $options = [])
     {
         return $this->driver()->check($value, $hashedValue, $options);


### PR DESCRIPTION
When using the Hash::check() function, one gets confused about how the arguments are ordered.

But a more descriptive function name will solve this.

This is just an additional function name that still calls the check function that everyone is currently using. This change doesn't replace the current function, so those using the current function will be okay.

Developers no more need to waste any time confirming the structure of the function arguments, it is already described in the name. 

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
