### PR TITLE
[9.x] Improve name of the Hash check function

### DIFF
--- a/src/Illuminate/Contracts/Hashing/Hasher.php
+++ b/src/Illuminate/Contracts/Hashing/Hasher.php
@@ -32,6 +32,16 @@ interface Hasher
     public function check($value, $hashedValue, array $options = []);
 
     /**
+     * Check the given plain value against a hash.
+     *
+     * @param  string  $value
+     * @param  string  $hashedValue
+     * @param  array  $options
+     * @return bool
+     */
+    public function checkPlainAgainstHash($value, $hashedValue, array $options = []);
+
+    /**
      * Check if the given hash has been hashed using the given options.
      *
      * @param  string  $hashedValue

--- a/src/Illuminate/Hashing/AbstractHasher.php
+++ b/src/Illuminate/Hashing/AbstractHasher.php
@@ -23,6 +23,19 @@ abstract class AbstractHasher
      * @param  array  $options
      * @return bool
      */
+    public function checkPlainAgainstHash($value, $hashedValue, array $options = [])
+    {
+        return $this->check($value, $hashedValue, $options);
+    }
+
+    /**
+     * Check the given plain value against a hash.
+     *
+     * @param  string  $value
+     * @param  string  $hashedValue
+     * @param  array  $options
+     * @return bool
+     */
     public function check($value, $hashedValue, array $options = [])
     {
         if (strlen($hashedValue) === 0) {

--- a/src/Illuminate/Hashing/Argon2IdHasher.php
+++ b/src/Illuminate/Hashing/Argon2IdHasher.php
@@ -6,6 +6,22 @@ use RuntimeException;
 
 class Argon2IdHasher extends ArgonHasher
 {
+
+    /**
+     * Check the given plain value against a hash.
+     *
+     * @param  string  $value
+     * @param  string  $hashedValue
+     * @param  array  $options
+     * @return bool
+     *
+     * @throws \RuntimeException
+     */
+    public function checkPlainAgainstHash($value, $hashedValue, array $options = [])
+    {
+        return $this->check($value, $hashedValue, $options);
+    }
+
     /**
      * Check the given plain value against a hash.
      *

--- a/src/Illuminate/Hashing/Argon2IdHasher.php
+++ b/src/Illuminate/Hashing/Argon2IdHasher.php
@@ -6,7 +6,6 @@ use RuntimeException;
 
 class Argon2IdHasher extends ArgonHasher
 {
-
     /**
      * Check the given plain value against a hash.
      *

--- a/src/Illuminate/Hashing/ArgonHasher.php
+++ b/src/Illuminate/Hashing/ArgonHasher.php
@@ -93,6 +93,21 @@ class ArgonHasher extends AbstractHasher implements HasherContract
      *
      * @throws \RuntimeException
      */
+    public function checkPlainAgainstHash($value, $hashedValue, array $options = [])
+    {
+        return $this->check($value, $hashedValue, $options);
+    }
+
+    /**
+     * Check the given plain value against a hash.
+     *
+     * @param  string  $value
+     * @param  string  $hashedValue
+     * @param  array  $options
+     * @return bool
+     *
+     * @throws \RuntimeException
+     */
     public function check($value, $hashedValue, array $options = [])
     {
         if ($this->verifyAlgorithm && $this->info($hashedValue)['algoName'] !== 'argon2i') {

--- a/src/Illuminate/Hashing/BcryptHasher.php
+++ b/src/Illuminate/Hashing/BcryptHasher.php
@@ -65,6 +65,21 @@ class BcryptHasher extends AbstractHasher implements HasherContract
      *
      * @throws \RuntimeException
      */
+    public function checkPlainAgainstHash($value, $hashedValue, array $options = [])
+    {
+        return $this->check($value, $hashedValue, $options);
+    }
+
+    /**
+     * Check the given plain value against a hash.
+     *
+     * @param  string  $value
+     * @param  string  $hashedValue
+     * @param  array  $options
+     * @return bool
+     *
+     * @throws \RuntimeException
+     */
     public function check($value, $hashedValue, array $options = [])
     {
         if ($this->verifyAlgorithm && $this->info($hashedValue)['algoName'] !== 'bcrypt') {

--- a/src/Illuminate/Hashing/HashManager.php
+++ b/src/Illuminate/Hashing/HashManager.php
@@ -68,6 +68,19 @@ class HashManager extends Manager implements Hasher
      * @param  array  $options
      * @return bool
      */
+    public function checkPlainAgainstHash($value, $hashedValue, array $options = [])
+    {
+        return $this->check($value, $hashedValue, $options);
+    }
+
+    /**
+     * Check the given plain value against a hash.
+     *
+     * @param  string  $value
+     * @param  string  $hashedValue
+     * @param  array  $options
+     * @return bool
+     */
     public function check($value, $hashedValue, array $options = [])
     {
         return $this->driver()->check($value, $hashedValue, $options);

--- a/tests/Hashing/HasherTest.php
+++ b/tests/Hashing/HasherTest.php
@@ -5,17 +5,25 @@ namespace Illuminate\Tests\Hashing;
 use Illuminate\Hashing\Argon2IdHasher;
 use Illuminate\Hashing\ArgonHasher;
 use Illuminate\Hashing\BcryptHasher;
+use Illuminate\Support\Str;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
 class HasherTest extends TestCase
 {
+    private string $randomValueToHash;
+
+    private function __construct()
+    {
+        $this->randomValueToHash = Str::random(rand(6, 12));
+    }
+
     public function testBasicBcryptHashing()
     {
         $hasher = new BcryptHasher;
-        $value = $hasher->make('password');
-        $this->assertNotSame('password', $value);
-        $this->assertTrue($hasher->check('password', $value));
+        $value = $hasher->make($this->randomValueToHash);
+        $this->assertNotSame($this->randomValueToHash, $value);
+        $this->assertTrue($hasher->check($this->randomValueToHash, $value));
         $this->assertFalse($hasher->needsRehash($value));
         $this->assertTrue($hasher->needsRehash($value, ['rounds' => 1]));
         $this->assertSame('bcrypt', password_get_info($value)['algoName']);
@@ -28,9 +36,9 @@ class HasherTest extends TestCase
         }
 
         $hasher = new ArgonHasher;
-        $value = $hasher->make('password');
-        $this->assertNotSame('password', $value);
-        $this->assertTrue($hasher->check('password', $value));
+        $value = $hasher->make($this->randomValueToHash);
+        $this->assertNotSame($this->randomValueToHash, $value);
+        $this->assertTrue($hasher->check($this->randomValueToHash, $value));
         $this->assertFalse($hasher->needsRehash($value));
         $this->assertTrue($hasher->needsRehash($value, ['threads' => 1]));
         $this->assertSame('argon2i', password_get_info($value)['algoName']);
@@ -43,9 +51,9 @@ class HasherTest extends TestCase
         }
 
         $hasher = new Argon2IdHasher;
-        $value = $hasher->make('password');
-        $this->assertNotSame('password', $value);
-        $this->assertTrue($hasher->check('password', $value));
+        $value = $hasher->make($this->randomValueToHash);
+        $this->assertNotSame($this->randomValueToHash, $value);
+        $this->assertTrue($hasher->check($this->randomValueToHash, $value));
         $this->assertFalse($hasher->needsRehash($value));
         $this->assertTrue($hasher->needsRehash($value, ['threads' => 1]));
         $this->assertSame('argon2id', password_get_info($value)['algoName']);
@@ -63,8 +71,8 @@ class HasherTest extends TestCase
         }
 
         $argonHasher = new ArgonHasher(['verify' => true]);
-        $argonHashed = $argonHasher->make('password');
-        (new BcryptHasher(['verify' => true]))->check('password', $argonHashed);
+        $argonHashed = $argonHasher->make($this->randomValueToHash);
+        (new BcryptHasher(['verify' => true]))->check($this->randomValueToHash, $argonHashed);
     }
 
     /**
@@ -75,8 +83,8 @@ class HasherTest extends TestCase
         $this->expectException(RuntimeException::class);
 
         $bcryptHasher = new BcryptHasher(['verify' => true]);
-        $bcryptHashed = $bcryptHasher->make('password');
-        (new ArgonHasher(['verify' => true]))->check('password', $bcryptHashed);
+        $bcryptHashed = $bcryptHasher->make($this->randomValueToHash);
+        (new ArgonHasher(['verify' => true]))->check($this->randomValueToHash, $bcryptHashed);
     }
 
     /**
@@ -87,7 +95,7 @@ class HasherTest extends TestCase
         $this->expectException(RuntimeException::class);
 
         $bcryptHasher = new BcryptHasher(['verify' => true]);
-        $bcryptHashed = $bcryptHasher->make('password');
-        (new Argon2IdHasher(['verify' => true]))->check('password', $bcryptHashed);
+        $bcryptHashed = $bcryptHasher->make($this->randomValueToHash);
+        (new Argon2IdHasher(['verify' => true]))->check($this->randomValueToHash, $bcryptHashed);
     }
 }


### PR DESCRIPTION
When using the Hash::check() function, one gets confused about how the arguments are ordered.

But a more descriptive function name will solve this.

This is just an additional function name that still calls the check function that everyone is currently using. This change doesn't replace the current function, so those using the current function will be okay.

Developers no more need to waste any time confirming the structure of the function arguments, it is already described in the name.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
