### PR TITLE
[9.x] Lazy load queue commands

### DIFF
--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -681,7 +681,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerQueueMonitorCommand()
     {
-        $this->app->singleton('command.queue.monitor', function ($app) {
+        $this->app->singleton(QueueMonitorCommand::class, function ($app) {
             return new QueueMonitorCommand($app['queue'], $app['events']);
         });
     }
@@ -705,7 +705,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerQueuePruneFailedJobsCommand()
     {
-        $this->app->singleton('command.queue.prune-failed-jobs', function () {
+        $this->app->singleton(QueuePruneFailedJobsCommand::class, function () {
             return new QueuePruneFailedJobsCommand;
         });
     }

--- a/src/Illuminate/Queue/Console/MonitorCommand.php
+++ b/src/Illuminate/Queue/Console/MonitorCommand.php
@@ -20,6 +20,15 @@ class MonitorCommand extends Command
                        {--max=1000 : The maximum number of jobs that can be on the queue before an event is dispatched}';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'queue:monitor';
+
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Queue/Console/PruneFailedJobsCommand.php
+++ b/src/Illuminate/Queue/Console/PruneFailedJobsCommand.php
@@ -17,6 +17,15 @@ class PruneFailedJobsCommand extends Command
                 {--hours=24 : The number of hours to retain failed jobs data}';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'queue:prune-failed';
+
+    /**
      * The console command description.
      *
      * @var string


### PR DESCRIPTION
This PR registers new queue commands with class names and add ```$defaultName``` static property.

Two new queue commands were added to the framework: ```queue:prune-failed``` (#37696) and ```queue:monitor``` (#38168). Upon merging to master, the commands were not adjusted to take advantage of command lazy loading introduced in #34925.