### PR TITLE
[8.x] Add fullUrlWithoutQuery method to Request

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -132,7 +132,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
             ? $this->url().$question.Arr::query(array_merge($this->query(), $query))
             : $this->fullUrl().$question.Arr::query($query);
     }
-    
+
     /**
      * Get the full URL for the request without the given query string parameters.
      *

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -132,6 +132,23 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
             ? $this->url().$question.Arr::query(array_merge($this->query(), $query))
             : $this->fullUrl().$question.Arr::query($query);
     }
+    
+    /**
+     * Get the full URL for the request without the given query string parameters.
+     *
+     * @param  array|string  $query
+     * @return string
+     */
+    public function fullUrlWithoutQuery($keys)
+    {
+        $query = Arr::except($this->query(), $keys);
+
+        $question = $this->getBaseUrl().$this->getPathInfo() === '/' ? '/?' : '?';
+
+        return count($query) > 0
+            ? $this->url().$question.Arr::query($query)
+            : $this->url();
+    }
 
     /**
      * Get the current path info for the request.


### PR DESCRIPTION
It is quite easy to add query parameters to the current url using `request()->fullUrlWithQuery()` helper. This works really well when you want to add filters to the current url. But it isn't as easy to remove a parameter.

When the current URL is https://example.com/?color=red&shape=square&size=small
```
request()->fullUrlWithoutQuery('color');
// https://example.com/?shape=square&size=small

request()->fullUrlWithoutQuery(['color', 'size']);
// https://example.com/?shape=square
```