### PR TITLE
[8.x] Avoid notifications locale being null

### DIFF
--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -98,7 +98,10 @@ class NotificationSender
                 continue;
             }
 
-            $this->withLocale($this->preferredLocale($notifiable, $notification), function () use ($viaChannels, $notifiable, $original) {
+            $locale = $this->preferredLocale($notifiable, $notification);
+            $original->locale($locale);
+
+            $this->withLocale($locale, function () use ($viaChannels, $notifiable, $original) {
                 $notificationId = Str::uuid()->toString();
 
                 foreach ((array) $viaChannels as $channel) {


### PR DESCRIPTION
This fixes something that I few is very annoying when working with localized notifications, currently, whenever we use the `HasLocalePreference` on any notifiable class, we can only retrieve the locale via `app()->getLocale()` instead of `$this->locale`, for example:

https://laravel.com/docs/8.x/notifications#user-preferred-locales

```php
use Illuminate\Contracts\Translation\HasLocalePreference;

class User extends Model implements HasLocalePreference
{
    public function preferredLocale()
    {
        return $this->locale;
    }
}
```

```php
class SampleNotification extends Notification
{
    public function toArray(): array
    {
        return [
            'example1' => trans('notifications.example1', locale: app()->getLocale()),
            'example2' => trans('notifications.example2', locale: $this->locale) // this will be null,
        ];
    }
}
```

But when setting the locale manually on the notification, the following works as expected:

```php
$notifiable->notify((new SampleNotification())->locale('hue_BR'));
```

```php
class SampleNotification extends Notification
{
    public function toArray(): array
    {
        return [
            'example1' => trans('notifications.example1', locale: app()->getLocale()), // works as expected
            'example2' => trans('notifications.example2', locale: $this->locale) // works as expected,
        ];
    }
}
```

So what this PR is doing is `ALWAYS` setting the property `$locale` on the notifications in order to make the `$this->locale` more reliable 

This is not a breaking change.