### PR TITLE
[8.x] Add assertListening To Comment Section For IDEs Autocomplete

### DIFF
--- a/src/Illuminate/Support/Facades/Event.php
+++ b/src/Illuminate/Support/Facades/Event.php
@@ -16,6 +16,7 @@ use Illuminate\Support\Testing\Fakes\EventFake;
  * @method static void assertDispatched(string|\Closure $event, callable|int $callback = null)
  * @method static void assertDispatchedTimes(string $event, int $times = 1)
  * @method static void assertNotDispatched(string|\Closure $event, callable|int $callback = null)
+ * @method static void assertListening(string $expectedEvent, string expectedListener)
  * @method static void flush(string $event)
  * @method static void forget(string $event)
  * @method static void forgetPushed()


### PR DESCRIPTION
Now we won't be able to use assertListening in IDEs autocomplete.
With this change, we will be able to use this method with autocomplete.