### PR TITLE
[8.x] Adds Response authorization to Form Requests

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -170,17 +170,13 @@ class FormRequest extends Request implements ValidatesWhenResolved
     protected function passesAuthorization()
     {
         if (method_exists($this, 'authorize')) {
-            if (! $result = $this->container->call([$this, 'authorize'])) {
-                return $result;
-            }
-
-            if (is_string($result)) {
-                $result = Response::deny($result);
-            }
+            $result = $this->container->call([$this, 'authorize']));
 
             if ($result instanceof Response) {
                 $result->authorize();
             }
+            
+            return $result;
         }
 
         return true;

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Http;
 
 use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Auth\Access\Response;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Validation\Factory as ValidationFactory;
 use Illuminate\Contracts\Validation\ValidatesWhenResolved;
@@ -163,11 +164,23 @@ class FormRequest extends Request implements ValidatesWhenResolved
      * Determine if the request passes the authorization check.
      *
      * @return bool
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException
      */
     protected function passesAuthorization()
     {
         if (method_exists($this, 'authorize')) {
-            return $this->container->call([$this, 'authorize']);
+            if (!$result = $this->container->call([$this, 'authorize'])) {
+                return $result;
+            }
+
+            if (is_string($result)) {
+                $result = Response::deny($result);
+            }
+
+            if ($result instanceof Response) {
+                $result->authorize();
+            }
         }
 
         return true;

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -170,13 +170,9 @@ class FormRequest extends Request implements ValidatesWhenResolved
     protected function passesAuthorization()
     {
         if (method_exists($this, 'authorize')) {
-            $result = $this->container->call([$this, 'authorize']));
+            $result = $this->container->call([$this, 'authorize']);
 
-            if ($result instanceof Response) {
-                $result->authorize();
-            }
-            
-            return $result;
+            return $result instanceof Response ? $result->authorize() : $result;
         }
 
         return true;

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -170,7 +170,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
     protected function passesAuthorization()
     {
         if (method_exists($this, 'authorize')) {
-            if (!$result = $this->container->call([$this, 'authorize'])) {
+            if (! $result = $this->container->call([$this, 'authorize'])) {
                 return $result;
             }
 

--- a/src/Illuminate/Validation/ValidatesWhenResolvedTrait.php
+++ b/src/Illuminate/Validation/ValidatesWhenResolvedTrait.php
@@ -2,8 +2,6 @@
 
 namespace Illuminate\Validation;
 
-use Illuminate\Auth\Access\Response;
-
 /**
  * Provides default implementation of ValidatesWhenResolved contract.
  */

--- a/src/Illuminate/Validation/ValidatesWhenResolvedTrait.php
+++ b/src/Illuminate/Validation/ValidatesWhenResolvedTrait.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Validation;
 
+use Illuminate\Auth\Access\Response;
+
 /**
  * Provides default implementation of ValidatesWhenResolved contract.
  */

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -123,7 +123,6 @@ class FoundationFormRequestTest extends TestCase
         $this->createRequest([], FoundationTestFormRequestPassesWithResponseStub::class)->validateResolved();
     }
 
-
     public function testPrepareForValidationRunsBeforeValidation()
     {
         $this->createRequest([], FoundationTestFormRequestHooks::class)->validateResolved();

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -110,14 +110,6 @@ class FoundationFormRequestTest extends TestCase
         $this->createRequest([], FoundationTestFormRequestForbiddenWithResponseStub::class)->validateResolved();
     }
 
-    public function testValidateThrowsExceptionFromString()
-    {
-        $this->expectException(AuthorizationException::class);
-        $this->expectExceptionMessage('bar');
-
-        $this->createRequest([], FoundationTestFormRequestForbiddenWithMessageStub::class)->validateResolved();
-    }
-
     public function testValidateDoesntThrowExceptionFromResponseAllowed()
     {
         $this->createRequest([], FoundationTestFormRequestPassesWithResponseStub::class)->validateResolved();
@@ -350,14 +342,6 @@ class FoundationTestFormRequestForbiddenWithResponseStub extends FormRequest
     public function authorize()
     {
         return Response::deny('foo');
-    }
-}
-
-class FoundationTestFormRequestForbiddenWithMessageStub extends FormRequest
-{
-    public function authorize()
-    {
-        return 'bar';
     }
 }
 

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Foundation;
 
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Auth\Access\Response;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Translation\Translator;
 use Illuminate\Contracts\Validation\Factory as ValidationFactoryContract;
@@ -100,6 +101,28 @@ class FoundationFormRequestTest extends TestCase
 
         $this->createRequest([], FoundationTestFormRequestForbiddenStub::class)->validateResolved();
     }
+
+    public function testValidateThrowsExceptionFromAuthorizationResponse()
+    {
+        $this->expectException(AuthorizationException::class);
+        $this->expectExceptionMessage('foo');
+
+        $this->createRequest([], FoundationTestFormRequestForbiddenWithResponseStub::class)->validateResolved();
+    }
+
+    public function testValidateThrowsExceptionFromString()
+    {
+        $this->expectException(AuthorizationException::class);
+        $this->expectExceptionMessage('bar');
+
+        $this->createRequest([], FoundationTestFormRequestForbiddenWithMessageStub::class)->validateResolved();
+    }
+
+    public function testValidateDoesntThrowExceptionFromResponseAllowed()
+    {
+        $this->createRequest([], FoundationTestFormRequestPassesWithResponseStub::class)->validateResolved();
+    }
+
 
     public function testPrepareForValidationRunsBeforeValidation()
     {
@@ -320,5 +343,34 @@ class FoundationTestFormRequestHooks extends FormRequest
     public function passedValidation()
     {
         $this->replace(['name' => 'Adam']);
+    }
+}
+
+class FoundationTestFormRequestForbiddenWithResponseStub extends FormRequest
+{
+    public function authorize()
+    {
+        return Response::deny('foo');
+    }
+}
+
+class FoundationTestFormRequestForbiddenWithMessageStub extends FormRequest
+{
+    public function authorize()
+    {
+        return 'bar';
+    }
+}
+
+class FoundationTestFormRequestPassesWithResponseStub extends FormRequest
+{
+    public function rules()
+    {
+        return [];
+    }
+
+    public function authorize()
+    {
+        return Response::allow('baz');
     }
 }


### PR DESCRIPTION
## What?

Allows to use `Response` objects in the `authorize()` method of the Form Requests.

```php
use Illuminate\Foundation\Http\FormRequest;
use Illuminate\Auth\Access\Response;

class CreatePostFormRequest extends FormRequest
{
    public function authorize()
    {
        return Response::deny('You are too cool to post.');
    }
}
```

## Why?

Because otherwise you have to fallback to using the Gate or Policy manually, or authorize via Controller, which makes FormRequest authorization a moot point.

## How?

When the `passesAuthorization()` method of the FormRequest is called, it will do two additional checks if the response from the `authorize()` method is not falsy: if it's a Response instance, call `authorize()`.

## BC?

None, as the `authorize()` is meant to return a bool anyway as the PHPDoc states.