### PR TITLE
[8.x] Add removeBom method to Str

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -640,6 +640,23 @@ class Str
     }
 
     /**
+     * Remove BOM mark in the string
+     *
+     * @param  string  $value
+     * @return string
+     */
+    public static function removeBom($value)
+    {
+        $bomMark = "\xEF\xBB\xBF";
+
+        if (static::startsWith($value, $bomMark)) {
+            return static::replace($bomMark, '', $value);
+        }
+
+        return $value;
+    }
+
+    /**
      * Begin a string with a single instance of a given value.
      *
      * @param  string  $value

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -640,7 +640,7 @@ class Str
     }
 
     /**
-     * Remove BOM mark in the string
+     * Remove BOM mark in the string.
      *
      * @param  string  $value
      * @return string

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -479,6 +479,16 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Remove BOM mark in the string
+     *
+     * @return static
+     */
+    public function removeBom()
+    {
+        return new static(Str::removeBom($this->value));
+    }
+
+    /**
      * Repeat the string.
      *
      * @param  int  $times

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -479,7 +479,7 @@ class Stringable implements JsonSerializable
     }
 
     /**
-     * Remove BOM mark in the string
+     * Remove BOM mark in the string.
      *
      * @return static
      */

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -395,6 +395,13 @@ class SupportStrTest extends TestCase
         $this->assertSame('Foobar', Str::remove(['f', '|'], 'Foo|bar'));
     }
 
+    public function testRemoveBom()
+    {
+        $this->assertSame('foobar', Str::removeBom("\xef\xbb\xbffoobar"));
+        $this->assertSame('foobar', Str::removeBom("\xEF\xBB\xBFfoobar"));
+        $this->assertSame('foobar', Str::removeBom('foobar'));
+    }
+
     public function testSnake()
     {
         $this->assertSame('laravel_p_h_p_framework', Str::snake('LaravelPHPFramework'));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -538,6 +538,13 @@ class SupportStringableTest extends TestCase
         $this->assertSame('Foobar', (string) $this->stringable('Foo|bar')->remove(['f', '|']));
     }
 
+    public function testRemoveBom()
+    {
+        $this->assertSame('foobar', (string) $this->stringable("\xef\xbb\xbffoobar")->removeBom());
+        $this->assertSame('foobar', (string) $this->stringable("\xEF\xBB\xBFfoobar")->removeBom());
+        $this->assertSame('foobar', (string) $this->stringable('foobar')->removeBom());
+    }
+
     public function testSnake()
     {
         $this->assertSame('laravel_p_h_p_framework', (string) $this->stringable('LaravelPHPFramework')->snake());


### PR DESCRIPTION
This PR add `removeBom` to the [Str](https://github.com/Danil42Russia/framework/blob/8.x/src/Illuminate/Support/Str.php) helper

Now, if there is a BOM mark in the file, you can do this:
```php
use Illuminate\Support\Facades\Storage;

$content = Str::removeBom(Storage::get('file.json'));
$data = json_decode($content, true);
```