### PR TITLE
Add default method signatures to 'withValidator', 'authorize', and 'rules' in FormRequest class

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -91,9 +91,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
             $validator = $this->createDefaultValidator($factory);
         }
 
-        if (method_exists($this, 'withValidator')) {
-            $this->withValidator($validator);
-        }
+        $this->withValidator($validator);
 
         $this->setValidator($validator);
 
@@ -166,11 +164,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
      */
     protected function passesAuthorization()
     {
-        if (method_exists($this, 'authorize')) {
-            return $this->container->call([$this, 'authorize']);
-        }
-
-        return true;
+        return $this->container->call([$this, 'authorize']);
     }
 
     /**
@@ -213,6 +207,36 @@ class FormRequest extends Request implements ValidatesWhenResolved
     public function attributes()
     {
         return [];
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [];
+    }
+
+    /**
+     * Configure the validator instance.
+     *
+     * @param  \Illuminate\Validation\Validator  $validator
+     * @return void
+     */
+    public function withValidator(Validator $validator)
+    {
+    }
+
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Laravel papercut: many times when working with FormRequests, I find myself wondering the exact method signature for  `withValidator(...)` (`authorize()` and `rules()` too, while we are at it). IDE's are really good at pulling in the method signature for you if it is implemented in a parent class.

This PR adds default method signatures for those methods in the FormRequest class.

