### PR TITLE
[8.x] Add missing "scoped" provider property

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -686,6 +686,12 @@ class Application extends Container implements ApplicationContract, CachesConfig
             }
         }
 
+        if (property_exists($provider, 'scoped')) {
+            foreach ($provider->scoped as $key => $value) {
+                $this->scoped($key, $value);
+            }
+        }
+
         $this->markAsRegistered($provider);
 
         // If the application has already booted, we will call this boot method on

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -78,6 +78,24 @@ class FoundationApplicationTest extends TestCase
         $this->assertSame($instance, $app->make(AbstractClass::class));
     }
 
+    public function testScopedAreCreatedWhenServiceProviderIsRegistered()
+    {
+        $app = new Application;
+        $app->register($provider = new class($app) extends ServiceProvider
+        {
+            public $scoped = [
+                AbstractClass::class => ConcreteClass::class,
+            ];
+        });
+
+        $this->assertArrayHasKey(get_class($provider), $app->getLoadedProviders());
+
+        $instance = $app->make(AbstractClass::class);
+
+        $this->assertInstanceOf(ConcreteClass::class, $instance);
+        $this->assertSame($instance, $app->make(AbstractClass::class));
+    }
+
     public function testServiceProvidersAreCorrectlyRegisteredWhenRegisterMethodIsNotFilled()
     {
         $provider = m::mock(ServiceProvider::class);

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -78,7 +78,7 @@ class FoundationApplicationTest extends TestCase
         $this->assertSame($instance, $app->make(AbstractClass::class));
     }
 
-    public function testScopedAreCreatedWhenServiceProviderIsRegistered()
+    public function testScopedInstancesAreCreatedWhenServiceProviderIsRegistered()
     {
         $app = new Application;
         $app->register($provider = new class($app) extends ServiceProvider


### PR DESCRIPTION
Added missing "scoped" provider property for those using Octane.