### PR TITLE
[8.x] Adds a simple `where` helper for querying relations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -359,8 +359,8 @@ trait QueriesRelationships
      */
     public function whereRelation($relation, $column, $operator = null, $value = null)
     {
-        return $this->whereHas($relation, function ($builder) use ($column, $operator, $value) {
-            $builder->where($column, $operator, $value);
+        return $this->whereHas($relation, function ($query) use ($column, $operator, $value) {
+            $query->where($column, $operator, $value);
         });
     }
 
@@ -375,8 +375,42 @@ trait QueriesRelationships
      */
     public function orWhereRelation($relation, $column, $operator = null, $value = null)
     {
-        return $this->orWhereHas($relation, function ($builder) use ($column, $operator, $value) {
-            $builder->where($column, $operator, $value);
+        return $this->orWhereHas($relation, function ($query) use ($column, $operator, $value) {
+            $query->where($column, $operator, $value);
+        });
+    }
+
+    /**
+     * Add a polymorphic relationship condition to the query with a where clause.
+     *
+     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation
+     * @param  string|array $types
+     * @param  \Closure|string|array|\Illuminate\Database\Query\Expression  $column
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return \Illuminate\Database\Eloquent\Builder|static
+     */
+    public function whereMorphRelation($relation, $types, $column, $operator = null, $value = null)
+    {
+        return $this->whereHasMorph($relation, $types, function ($query) use ($column, $operator, $value) {
+            $query->where($column, $operator, $value);
+        });
+    }
+
+    /**
+     * Add a polymorphic relationship condition to the query with an "or where" clause.
+     *
+     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation
+     * @param  string|array $types
+     * @param  \Closure|string|array|\Illuminate\Database\Query\Expression  $column
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return \Illuminate\Database\Eloquent\Builder|static
+     */
+    public function orWhereMorphRelation($relation, $types, $column, $operator = null, $value = null)
+    {
+        return $this->orWhereHasMorph($relation, $types, function ($query) use ($column, $operator, $value) {
+            $query->where($column, $operator, $value);
         });
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -349,6 +349,38 @@ trait QueriesRelationships
     }
 
     /**
+     * Add a basic where clause to a relationship query.
+     *
+     * @param  string  $relation
+     * @param  \Closure|string|array|\Illuminate\Database\Query\Expression  $column
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return \Illuminate\Database\Eloquent\Builder|static
+     */
+    public function whereRelation($relation, $column, $operator = null, $value = null)
+    {
+        return $this->whereHas($relation, function (Builder $builder) use ($column, $operator, $value) {
+            $builder->where($column, $operator, $value);
+        });
+    }
+
+    /**
+     * Add an "or where" clause to a relationship query.
+     *
+     * @param  string  $relation
+     * @param  \Closure|string|array|\Illuminate\Database\Query\Expression  $column
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return \Illuminate\Database\Eloquent\Builder|static
+     */
+    public function orWhereRelation($relation, $column, $operator = null, $value = null)
+    {
+        return $this->orWhereHas($relation, function (Builder $builder) use ($value, $operator, $column) {
+            $builder->where($column, $operator, $value);
+        });
+    }
+
+    /**
      * Add subselect queries to include an aggregate value for a relationship.
      *
      * @param  mixed  $relations

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -359,7 +359,7 @@ trait QueriesRelationships
      */
     public function whereRelation($relation, $column, $operator = null, $value = null)
     {
-        return $this->whereHas($relation, function (Builder $builder) use ($column, $operator, $value) {
+        return $this->whereHas($relation, function ($builder) use ($column, $operator, $value) {
             $builder->where($column, $operator, $value);
         });
     }
@@ -375,7 +375,7 @@ trait QueriesRelationships
      */
     public function orWhereRelation($relation, $column, $operator = null, $value = null)
     {
-        return $this->orWhereHas($relation, function (Builder $builder) use ($value, $operator, $column) {
+        return $this->orWhereHas($relation, function ($builder) use ($column, $operator, $value) {
             $builder->where($column, $operator, $value);
         });
     }

--- a/tests/Integration/Database/EloquentWhereHasTest.php
+++ b/tests/Integration/Database/EloquentWhereHasTest.php
@@ -41,6 +41,20 @@ class EloquentWhereHasTest extends DatabaseTestCase
         (new Comment)->commentable()->associate($post)->save();
     }
 
+    public function testWhereRelation()
+    {
+        $users = User::whereRelation('posts', 'public', true)->get();
+
+        $this->assertEquals([1], $users->pluck('id')->all());
+    }
+
+    public function testOrWhereRelation()
+    {
+        $users = User::whereRelation('posts', 'public', true)->orWhereRelation('posts', 'public', false)->get();
+
+        $this->assertEquals([1, 2], $users->pluck('id')->all());
+    }
+
     public function testWithCount()
     {
         $users = User::whereHas('posts', function ($query) {

--- a/tests/Integration/Database/EloquentWhereHasTest.php
+++ b/tests/Integration/Database/EloquentWhereHasTest.php
@@ -55,6 +55,22 @@ class EloquentWhereHasTest extends DatabaseTestCase
         $this->assertEquals([1, 2], $users->pluck('id')->all());
     }
 
+    public function testWhereMorphRelation()
+    {
+        $comments = Comment::whereMorphRelation('commentable', '*', 'public', true)->get();
+
+        $this->assertEquals([1], $comments->pluck('id')->all());
+    }
+
+    public function testOrWhereMorphRelation()
+    {
+        $comments = Comment::whereMorphRelation('commentable', '*', 'public', true)
+            ->orWhereMorphRelation('commentable', '*', 'public', false)
+            ->get();
+
+        $this->assertEquals([1, 2], $comments->pluck('id')->all());
+    }
+
     public function testWithCount()
     {
         $users = User::whereHas('posts', function ($query) {


### PR DESCRIPTION
## What?

This is sugar for `whereHas()` for simple `where` clauses.

```php
// Before:
User::whereHas('posts', function ($query) {
    $query->where('published_at', '>', now());
})->get();

// After
User::whereRelation('posts', 'published_at', '>', now())->get();
```

## How?

Basically creates the `whereRelation()` and `orWhereRelation()` helpers, and `whereMorphRelation()` and `orWhereMorphRelation()` for morph relations. Since these use the `where()` method underneath, you can do advanced things:

```php
Comment::whereMorphRelation('commentable', '*', [
    'is_public' => true,
    'is_vip' => false,
])->get();
```

## Why?

Removes code complexity by making the query more readable when dealing with simple `where` clauses over relations.

## Breaking Changes

None - it's merely and additive PR.