### PR TITLE
[8.x] Adds ULID unique identifier support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
         "psr/container": "^1.0",
         "psr/simple-cache": "^1.0",
         "ramsey/uuid": "^4.0",
+        "robinvdvleuten/ulid": "^5.0",
         "swiftmailer/swiftmailer": "^6.0",
         "symfony/console": "^5.1.4",
         "symfony/error-handler": "^5.1.4",

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1212,6 +1212,31 @@ class Blueprint
     }
 
     /**
+     * Create a new ulid column on the table.
+     *
+     * @param  string  $column
+     * @return \Illuminate\Database\Schema\ColumnDefinition
+     */
+    public function ulid($column)
+    {
+        return $this->addColumn('ulid', $column);
+    }
+
+    /**
+     * Create a new ULID column on the table with a foreign key constraint.
+     *
+     * @param  string  $column
+     * @return \Illuminate\Database\Schema\ForeignIdColumnDefinition
+     */
+    public function foreignUlid($column)
+    {
+        return $this->addColumnDefinition(new ForeignIdColumnDefinition($this, [
+            'type' => 'ulid',
+            'name' => $column,
+        ]));
+    }
+
+    /**
      * Create a new IP address column on the table.
      *
      * @param  string  $column
@@ -1437,6 +1462,38 @@ class Blueprint
         $this->string("{$name}_type")->nullable();
 
         $this->uuid("{$name}_id")->nullable();
+
+        $this->index(["{$name}_type", "{$name}_id"], $indexName);
+    }
+
+    /**
+     * Add the proper columns for a polymorphic table using ULIDs.
+     *
+     * @param  string  $name
+     * @param  string|null  $indexName
+     * @return void
+     */
+    public function ulidMorphs($name, $indexName = null)
+    {
+        $this->string("{$name}_type");
+
+        $this->ulid("{$name}_id");
+
+        $this->index(["{$name}_type", "{$name}_id"], $indexName);
+    }
+
+    /**
+     * Add nullable columns for a polymorphic table using ULIDs.
+     *
+     * @param  string  $name
+     * @param  string|null  $indexName
+     * @return void
+     */
+    public function nullableUlidMorphs($name, $indexName = null)
+    {
+        $this->string("{$name}_type")->nullable();
+
+        $this->ulid("{$name}_id")->nullable();
 
         $this->index(["{$name}_type", "{$name}_id"], $indexName);
     }

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -804,6 +804,17 @@ class MySqlGrammar extends Grammar
     }
 
     /**
+     * Create the column definition for a ulid type.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+    protected function typeUlid(Fluent $column)
+    {
+        return 'char(26)';
+    }
+
+    /**
      * Create the column definition for an IP address type.
      *
      * @param  \Illuminate\Support\Fluent  $column

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -813,6 +813,17 @@ class PostgresGrammar extends Grammar
     }
 
     /**
+     * Create the column definition for a uuid type.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+    protected function typeUlid(Fluent $column)
+    {
+        return 'char(26)';
+    }
+
+    /**
      * Create the column definition for an IP address type.
      *
      * @param  \Illuminate\Support\Fluent  $column

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -726,6 +726,17 @@ class SQLiteGrammar extends Grammar
     }
 
     /**
+     * Create the column definition for a ulid type.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+    protected function typeUlid(Fluent $column)
+    {
+        return 'varchar';
+    }
+
+    /**
      * Create the column definition for an IP address type.
      *
      * @param  \Illuminate\Support\Fluent  $column

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -719,7 +719,7 @@ class SqlServerGrammar extends Grammar
      */
     protected function typeUlid(Fluent $column)
     {
-        return 'nvarchar(26)';
+        return 'nchar(26)';
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -712,6 +712,17 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
+     * Create the column definition for a ulid type.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+    protected function typeUlid(Fluent $column)
+    {
+        return 'nvarchar(26)';
+    }
+
+    /**
      * Create the column definition for an IP address type.
      *
      * @param  \Illuminate\Support\Fluent  $column

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -8,6 +8,7 @@ use Ramsey\Uuid\Codec\TimestampFirstCombCodec;
 use Ramsey\Uuid\Generator\CombGenerator;
 use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidFactory;
+use Ulid\Ulid;
 use voku\helper\ASCII;
 
 class Str
@@ -885,5 +886,19 @@ class Str
     public static function createUuidsNormally()
     {
         static::$uuidFactory = null;
+    }
+
+    /**
+     * Generate a ULID.
+     *
+     * @param  bool  $lowercase
+     * @param  string|null  $dateTime
+     * @return \Ulid\Ulid
+     */
+    public static function ulid(bool $lowercase = false, string $dateTime = null)
+    {
+        return $dateTime
+            ? Ulid::fromTimestamp(Carbon::parse($dateTime)->getTimestampMs(), $lowercase)
+            : Ulid::generate($lowercase);
     }
 }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -891,14 +891,14 @@ class Str
     /**
      * Generate a ULID.
      *
-     * @param  bool  $lowercase
-     * @param  string|null  $dateTime
+     * @param bool $lowercase
+     * @param \DateTimeInterface|null $dateTime
      * @return \Ulid\Ulid
      */
-    public static function ulid(bool $lowercase = false, string $dateTime = null)
+    public static function ulid(bool $lowercase = false, \DateTimeInterface $dateTime = null)
     {
         return $dateTime
-            ? Ulid::fromTimestamp(Carbon::parse($dateTime)->getTimestampMs(), $lowercase)
+            ? Ulid::fromTimestamp(strtotime($dateTime) * 1000, $lowercase)
             : Ulid::generate($lowercase);
     }
 }

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -1048,6 +1048,37 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         ], $statements);
     }
 
+    public function testAddingUlid()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->ulid('foo');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `foo` char(26) not null', $statements[0]);
+    }
+
+    public function testAddingForeignUlid()
+    {
+        $blueprint = new Blueprint('users');
+        $foreignUlid = $blueprint->foreignUlid('foo');
+        $blueprint->foreignUlid('company_id')->constrained();
+        $blueprint->foreignUlid('laravel_idea_id')->constrained();
+        $blueprint->foreignUlid('team_id')->references('id')->on('teams');
+        $blueprint->foreignUlid('team_column_id')->constrained('teams');
+
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertInstanceOf(ForeignIdColumnDefinition::class, $foreignUlid);
+        $this->assertSame([
+            'alter table `users` add `foo` char(26) not null, add `company_id` char(26) not null, add `laravel_idea_id` char(26) not null, add `team_id` char(26) not null, add `team_column_id` char(26) not null',
+            'alter table `users` add constraint `users_company_id_foreign` foreign key (`company_id`) references `companies` (`id`)',
+            'alter table `users` add constraint `users_laravel_idea_id_foreign` foreign key (`laravel_idea_id`) references `laravel_ideas` (`id`)',
+            'alter table `users` add constraint `users_team_id_foreign` foreign key (`team_id`) references `teams` (`id`)',
+            'alter table `users` add constraint `users_team_column_id_foreign` foreign key (`team_column_id`) references `teams` (`id`)',
+        ], $statements);
+    }
+
     public function testAddingIpAddress()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -799,6 +799,37 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         ], $statements);
     }
 
+    public function testAddingUlid()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->ulid('foo');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add column "foo" char(26) not null', $statements[0]);
+    }
+
+    public function testAddingForeignUlid()
+    {
+        $blueprint = new Blueprint('users');
+        $foreignUuid = $blueprint->foreignUlid('foo');
+        $blueprint->foreignUlid('company_id')->constrained();
+        $blueprint->foreignUlid('laravel_idea_id')->constrained();
+        $blueprint->foreignUlid('team_id')->references('id')->on('teams');
+        $blueprint->foreignUlid('team_column_id')->constrained('teams');
+
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertInstanceOf(ForeignIdColumnDefinition::class, $foreignUuid);
+        $this->assertSame([
+            'alter table "users" add column "foo" char(26) not null, add column "company_id" char(26) not null, add column "laravel_idea_id" char(26) not null, add column "team_id" char(26) not null, add column "team_column_id" char(26) not null',
+            'alter table "users" add constraint "users_company_id_foreign" foreign key ("company_id") references "companies" ("id")',
+            'alter table "users" add constraint "users_laravel_idea_id_foreign" foreign key ("laravel_idea_id") references "laravel_ideas" ("id")',
+            'alter table "users" add constraint "users_team_id_foreign" foreign key ("team_id") references "teams" ("id")',
+            'alter table "users" add constraint "users_team_column_id_foreign" foreign key ("team_column_id") references "teams" ("id")',
+        ], $statements);
+    }
+
     public function testAddingGeneratedAs()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -731,6 +731,37 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         ], $statements);
     }
 
+    public function testAddingUlid()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->ulid('foo');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add column "foo" varchar not null', $statements[0]);
+    }
+
+    public function testAddingForeignUlid()
+    {
+        $blueprint = new Blueprint('users');
+        $foreignUuid = $blueprint->foreignUlid('foo');
+        $blueprint->foreignUlid('company_id')->constrained();
+        $blueprint->foreignUlid('laravel_idea_id')->constrained();
+        $blueprint->foreignUlid('team_id')->references('id')->on('teams');
+        $blueprint->foreignUlid('team_column_id')->constrained('teams');
+
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertInstanceOf(ForeignIdColumnDefinition::class, $foreignUuid);
+        $this->assertSame([
+            'alter table "users" add column "foo" varchar not null',
+            'alter table "users" add column "company_id" varchar not null',
+            'alter table "users" add column "laravel_idea_id" varchar not null',
+            'alter table "users" add column "team_id" varchar not null',
+            'alter table "users" add column "team_column_id" varchar not null',
+        ], $statements);
+    }
+
     public function testAddingIpAddress()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -761,6 +761,37 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         ], $statements);
     }
 
+    public function testAddingUlid()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->ulid('foo');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add "foo" nchar(26) not null', $statements[0]);
+    }
+
+    public function testAddingForeignUlid()
+    {
+        $blueprint = new Blueprint('users');
+        $foreignId = $blueprint->foreignUlid('foo');
+        $blueprint->foreignUlid('company_id')->constrained();
+        $blueprint->foreignUlid('laravel_idea_id')->constrained();
+        $blueprint->foreignUlid('team_id')->references('id')->on('teams');
+        $blueprint->foreignUlid('team_column_id')->constrained('teams');
+
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertInstanceOf(ForeignIdColumnDefinition::class, $foreignId);
+        $this->assertSame([
+            'alter table "users" add "foo" nchar(26) not null, "company_id" nchar(26) not null, "laravel_idea_id" nchar(26) not null, "team_id" nchar(26) not null, "team_column_id" nchar(26) not null',
+            'alter table "users" add constraint "users_company_id_foreign" foreign key ("company_id") references "companies" ("id")',
+            'alter table "users" add constraint "users_laravel_idea_id_foreign" foreign key ("laravel_idea_id") references "laravel_ideas" ("id")',
+            'alter table "users" add constraint "users_team_id_foreign" foreign key ("team_id") references "teams" ("id")',
+            'alter table "users" add constraint "users_team_column_id_foreign" foreign key ("team_column_id") references "teams" ("id")',
+        ], $statements);
+    }
+
     public function testAddingIpAddress()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -2,9 +2,11 @@
 
 namespace Illuminate\Tests\Support;
 
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\UuidInterface;
+use Ulid\Ulid;
 
 class SupportStrTest extends TestCase
 {
@@ -495,6 +497,13 @@ class SupportStrTest extends TestCase
     {
         $this->assertInstanceOf(UuidInterface::class, Str::uuid());
         $this->assertInstanceOf(UuidInterface::class, Str::orderedUuid());
+    }
+
+    public function testUlid()
+    {
+        $this->assertInstanceOf(Ulid::class, Str::ulid());
+        $datetime = Carbon::now()->subHour();
+        $this->assertSame($datetime->getTimestamp() * 1000, Str::ulid(false, $datetime)->toTimestamp());
     }
 
     public function testAsciiNull()


### PR DESCRIPTION
This PR adds another unique identifier option to the framework beside uuid using `robinvdvleuten/ulid` package

# What is ULID?
ULID (Universally Unique Lexicographically Sortable Identifier) is a case-insensitive 26-character string consisting of 48-bit timestamp (10 characters) and 80-bit randomness (16 characters):
 01AN4Z07BY      79KA1307SR9X4MV3
```
|----------|    |----------------|
 Timestamp          Randomness
   48bits             80bits
```
We can use ULID as identifiers for labeling records while maintaining their time-series order with millisecond resolution. You can use ULID for providing chronologically sortable IDs in distributed systems. ULID doesn’t guarantee the ordering if ULIDs are generated within the same millisecond from multiple machines, but if you have a single coordinator, it’s possible to generate monotonically increasing ULIDs,

## Comparing to Uuid

UUID can be suboptimal for many use-cases because:

* It isn't the most character efficient way of encoding 128 bits of randomness
* UUID v1/v2 is impractical in many environments, as it requires access to a unique, stable MAC address
* UUID v3/v5 requires a unique seed and produces randomly distributed IDs, which can cause fragmentation in many data structures
* UUID v4 provides no other information than randomness which can cause fragmentation in many data structures

Instead, herein is proposed ULID:

```php
Str::ulid() // 01ARZ3NDEKTSV4RRFFQ69G5FAV
```

* 128-bit compatibility with UUID
* 1.21e+24 unique ULIDs per millisecond
* Lexicographically sortable!
* Canonically encoded as a 26 character string, as opposed to the 36 character UUID
* Uses Crockford's base32 for better efficiency and readability (5 bits per character)
* Case insensitive
* No special characters (URL safe)
* Monotonic sort order (correctly detects and handles the same millisecond)

# What this PR adds

* adds a new ulid() method to the Str support class

```php
// Default ulid generator with the current timestamp & uppercase string
Str::ulid(); // 01FDRXQ57VR4K4RASPT9NPAQC0
// Default ulid generator with the current timestamp & lowercase string
Str::ulid(true); // 01fdrxpmg9njp20z3km461fgax
// Default ulid generator with the given datetime & uppercase string
Str::ulid(false, Carbon::now()->subHour()) // 01FDRTD2K8Z664S24X606N14KD
```

* also added all needed methods for creating it's database fields like uuid

```php
Schema::create('foos', function (Blueprint $table) {
    $table->ulid('id')->primary(); // adds primary ulid column 
    $table->foreignUlid('user_id')->constrained()->cascadeOnDelete(); // adds ulid foreignkey
    $table->ulidMorphs('taggable'); // adds ulid morphs
    $table->nullableUlidMorphs('likeable'); // adds nullable ulid morphs
});
```
