### PR TITLE
[8.x] Add queryable values in wheres

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -752,6 +752,17 @@ class Builder
             }
         }
 
+        // If the value is queryable instance, we will assume the developer wants
+        // to run a subquery and then compare the result of that subquery with
+        // the given value that was provided to the method.
+        if ($this->isQueryable($value)) {
+            [$sub, $bindings] = $this->createSub($value);
+
+            $value = new Expression('('.$sub.')');
+
+            $this->addBinding($bindings, 'where');
+        }
+
         // Now that we are working with just a simple query we can put the elements
         // in our array and add the query binding to our array of bindings that
         // will be bound to each SQL statements when it is finally executed.

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -4105,6 +4105,21 @@ SQL;
         $this->assertEquals([1], $builder->getBindings());
     }
 
+    public function testWhereWithQueryableValue()
+    {
+        $builder = $this->getBuilder();
+
+        $sub = $this->getBuilder();
+
+        $builder->select('*')
+            ->from('users')
+            ->where('role', '=', 'member')
+            ->where('email_verified_at', '>', $sub->select('created_at')->from('votes')->latest()->where('value', 1)->limit(1));
+
+        $this->assertSame('select * from "users" where "role" = ? and "email_verified_at" > (select "created_at" from "votes" where "value" = ? order by "created_at" desc limit 1)', $builder->toSql());
+        $this->assertEquals(['member', 1], $builder->getBindings());
+    }
+
     public function testFromSub()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
This PR adds the ability to add "Queryable" values on where queries.

When using the `whereIn` method on the query builder, it's super handy, that we can use expressions like the following:

```php
User::query()->whereIn('id', Post::query()->select('user_id')->published())->get();
```

The problem is, currently we can't use this approach on other types of where queries, however sometimes that would be very helpful:

```php
// Before
Proposal::query()->whereHas(
    'votes',
     static function (Builder $query): Builder {
           return $query->rejected();
      },
      '<=',
     DB::raw('('.User::query()->verified()->whereRaw("`role` = 'member'")->selectRaw("floor(count(*) / 2)")->toSql().')')
);

// After
Proposal::query()->whereHas(
    'votes',
     static function (Builder $query): Builder {
           return $query->rejected();
      },
      '<=',
      User::query()->verified()->role('member')->selectRaw("floor(count(*) / 2)")
);
```
Normally this works with all the wheres. Also, the "subquery" bindings are merged into the main query.

I've tested in MySQL 8+ and SQLite with real data, worked fine.

In my opinion this is not a BC, but if you consider as one, I gladly resubmit to 9.x.