### PR TITLE
[8.x] Update "Security Fixes until" date in Security Policy

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -6,7 +6,7 @@
 
 Version | Security Fixes Until
 --- | ---
-8 | September 8th, 2021
+8 | July 3rd, 2022
 7 | March 3rd, 2021
 6 (LTS) | September 3rd, 2022
 5.8	| February 26th, 2020


### PR DESCRIPTION
Laravel 8 was released in September 2020 and Security Fixes for Laravel 7 went until March which means 6 months after the initial release.

Laravel 9 will be released in January 2022 and if there are again 6 months of security fixes it should be until July 2022 for Laravel 8.

Could also be an error in the year and it should be `September 8th 2022` instead of `September 8th 2021`