### PR TITLE
[8.x] Add --force flag to test maker command

### DIFF
--- a/src/Illuminate/Foundation/Console/TestMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/TestMakeCommand.php
@@ -101,7 +101,7 @@ class TestMakeCommand extends GeneratorCommand
     {
         return [
             ['unit', 'u', InputOption::VALUE_NONE, 'Create a unit test.'],
-            ['force', 'f', InputOption::VALUE_NONE, 'Create the test even if the test already exists']
+            ['force', 'f', InputOption::VALUE_NONE, 'Create the test even if the test already exists.']
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/TestMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/TestMakeCommand.php
@@ -101,6 +101,7 @@ class TestMakeCommand extends GeneratorCommand
     {
         return [
             ['unit', 'u', InputOption::VALUE_NONE, 'Create a unit test.'],
+            ['force', 'f', InputOption::VALUE_NONE, 'Create the test even if the test already exists']
         ];
     }
 }


### PR DESCRIPTION
We will be able to use `--force` flag to recreate the test if the test class already exists.