### PR TITLE
[8.x] Add colon port support in serve host option.

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -138,7 +138,9 @@ class ServeCommand extends Command
      */
     protected function host()
     {
-        return $this->input->getOption('host');
+        list($host,) = $this->getHostAndPort();
+
+        return $host;
     }
 
     /**
@@ -148,9 +150,30 @@ class ServeCommand extends Command
      */
     protected function port()
     {
-        $port = $this->input->getOption('port') ?: 8000;
+        $port = $this->input->getOption('port');
+
+        if (is_null($port)) {
+            list(, $port) = $this->getHostAndPort();
+        }
+
+        $port = $port ?: 8000;
 
         return $port + $this->portOffset;
+    }
+
+    /**
+     * Get host and port from host option string.
+     *
+     * @return array
+     */
+    protected function getHostAndPort(): array
+    {
+        $hostParts = explode(':', $this->input->getOption('host'));
+
+        return [
+            $hostParts[0],
+            $hostParts[1] ?? null
+        ];
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -138,7 +138,7 @@ class ServeCommand extends Command
      */
     protected function host()
     {
-        list($host,) = $this->getHostAndPort();
+        [$host, ] = $this->getHostAndPort();
 
         return $host;
     }
@@ -153,7 +153,7 @@ class ServeCommand extends Command
         $port = $this->input->getOption('port');
 
         if (is_null($port)) {
-            list(, $port) = $this->getHostAndPort();
+            [, $port] = $this->getHostAndPort();
         }
 
         $port = $port ?: 8000;
@@ -172,7 +172,7 @@ class ServeCommand extends Command
 
         return [
             $hostParts[0],
-            $hostParts[1] ?? null
+            $hostParts[1] ?? null,
         ];
     }
 

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -162,11 +162,11 @@ class ServeCommand extends Command
     }
 
     /**
-     * Get host and port from host option string.
+     * Get the host and port from the host option string.
      *
      * @return array
      */
-    protected function getHostAndPort(): array
+    protected function getHostAndPort()
     {
         $hostParts = explode(':', $this->input->getOption('host'));
 


### PR DESCRIPTION
This PR add support to set port in `--host` option of `artisan server` command. This practice is pretty common in devops|sysadmins people. Please see example bellow:

`php artisan serve --host=localhost:8888`

In case `--port` option is provided then it will take precedence. For example bellow command will use port 8080 instead of 8888.
`php artisan serve --host=localhost:8888 --port=8080`