### PR TITLE
[8.x] Make getCookie public so it can be directly used in tests

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -523,7 +523,7 @@ EOF;
      * @param  string  $cookieName
      * @return \Symfony\Component\HttpFoundation\Cookie|null
      */
-    protected function getCookie($cookieName)
+    public function getCookie($cookieName)
     {
         foreach ($this->headers->getCookies() as $cookie) {
             if ($cookie->getName() === $cookieName) {


### PR DESCRIPTION
## Summary
I've a use case for more specific checks on cookies than the current `assertCookie` provides, i.e. I need the cookie directly.

Since the `getCookie` contains exactly the boilerplate necessary to get one from the test response, I figured just making it public would make sense.

Thank you 🙏 