### PR TITLE
[8.x] Fix docblock for ContextualBindingBuilder Contract

### DIFF
--- a/src/Illuminate/Contracts/Container/ContextualBindingBuilder.php
+++ b/src/Illuminate/Contracts/Container/ContextualBindingBuilder.php
@@ -15,7 +15,7 @@ interface ContextualBindingBuilder
     /**
      * Define the implementation for the contextual binding.
      *
-     * @param  \Closure|string  $implementation
+     * @param  \Closure|string|array  $implementation
      * @return void
      */
     public function give($implementation);


### PR DESCRIPTION
The implementation of `ContextualBindingBuilder` supports passing arrays for the `$implementation` argument, but the contract is missing that data type in the docblock.

This results in an error when using Larastan:

```
 ------ ----------------------------------------------------------------- 
  Line   Providers/AppServiceProvider.php                                 
 ------ ----------------------------------------------------------------- 
  33     Parameter #1 $implementation of method                           
         Illuminate\Contracts\Container\ContextualBindingBuilder::give()  
         expects Closure|string, array given.                             
 ------ ----------------------------------------------------------------- 
```

I suggest we update the contract to support passing arrays as well.