### PR TITLE
Add isHidden and isVisible methods to Eloquent Models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HidesAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HidesAttributes.php
@@ -44,6 +44,17 @@ trait HidesAttributes
     }
 
     /**
+     * Check if the attribute is hidden.
+     *
+     * @param $attribute
+     * @return bool
+     */
+    public function isHidden($attribute)
+    {
+        return in_array($attribute, $this->hidden);
+    }
+
+    /**
      * Get the visible attributes for the model.
      *
      * @return array
@@ -64,6 +75,17 @@ trait HidesAttributes
         $this->visible = $visible;
 
         return $this;
+    }
+
+    /**
+     * Check if the attribute is visible.
+     *
+     * @param $attribute
+     * @return bool
+     */
+    public function isVisible($attribute)
+    {
+        return in_array($attribute, $this->visible);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -943,13 +943,30 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertArrayNotHasKey('age', $array);
     }
 
-    public function testVisible()
-    {
+    public function testCheckAttributeIsHidden() {
+        $model = new EloquentModelStub;
+
+        $model->setHidden(['name']);
+
+        $this->assertTrue($model->isHidden('name'));
+        $this->assertFalse($model->isHidden('age'));
+    }
+
+    public function testVisible()    {
         $model = new EloquentModelStub(['name' => 'foo', 'age' => 'bar', 'id' => 'baz']);
         $model->setVisible(['name', 'id']);
         $array = $model->toArray();
         $this->assertArrayHasKey('name', $array);
         $this->assertArrayNotHasKey('age', $array);
+    }
+
+    public function testCheckAttributeIsVisible() {
+        $model = new EloquentModelStub;
+
+        $model->setVisible(['name']);
+
+        $this->assertTrue($model->isVisible('name'));
+        $this->assertFalse($model->isVisible('age'));
     }
 
     public function testDynamicHidden()

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -943,7 +943,8 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertArrayNotHasKey('age', $array);
     }
 
-    public function testCheckAttributeIsHidden() {
+    public function testCheckAttributeIsHidden()
+    {
         $model = new EloquentModelStub;
 
         $model->setHidden(['name']);
@@ -952,7 +953,8 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertFalse($model->isHidden('age'));
     }
 
-    public function testVisible()    {
+    public function testVisible()
+    {
         $model = new EloquentModelStub(['name' => 'foo', 'age' => 'bar', 'id' => 'baz']);
         $model->setVisible(['name', 'id']);
         $array = $model->toArray();
@@ -960,7 +962,8 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertArrayNotHasKey('age', $array);
     }
 
-    public function testCheckAttributeIsVisible() {
+    public function testCheckAttributeIsVisible()
+    {
         $model = new EloquentModelStub;
 
         $model->setVisible(['name']);


### PR DESCRIPTION
A more convenient way to check if an ​attribute is visible/hidden:

```php
// before
in_array('name', $model->getVisible());
// or
$model->getVisible()['name'] ?? false;
// isset... whatever
```

A bit more Laravel style:

```php
$model->isVisible('name')
```

I have also considered naming this methods `isHiddenAttribute` since they seem like a method that could exist in some app models but since it would be overwritten, no problem at all but open to rename them.