### PR TITLE
[9.x] Allow named arguments for Eloquent Builder creation and update methods

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -885,7 +885,7 @@ class Builder implements BuilderContract
      */
     public function update(array $values = [], ...$namedValues)
     {
-        $values  = array_merge($values, $namedValues);
+        $values = array_merge($values, $namedValues);
 
         return $this->toBase()->update($this->addUpdatedAtColumn($values));
     }

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -864,10 +864,13 @@ class Builder implements BuilderContract
      * Save a new model and return the instance. Allow mass-assignment.
      *
      * @param  array  $attributes
+     * @param  array ...$namedAttributes
      * @return \Illuminate\Database\Eloquent\Model|$this
      */
-    public function forceCreate(array $attributes)
+    public function forceCreate(array $attributes, ...$namedAttributes)
     {
+        $attributes = array_merge($attributes, $namedAttributes);
+
         return $this->model->unguarded(function () use ($attributes) {
             return $this->newModelInstance()->create($attributes);
         });
@@ -877,10 +880,13 @@ class Builder implements BuilderContract
      * Update records in the database.
      *
      * @param  array  $values
+     * @param  array  ...$namedValues
      * @return int
      */
-    public function update(array $values)
+    public function update(array $values = [], ...$namedValues)
     {
+        $values  = array_merge($values, $namedValues);
+
         return $this->toBase()->update($this->addUpdatedAtColumn($values));
     }
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -102,10 +102,13 @@ class Builder implements BuilderContract
      * Create and return an un-saved model instance.
      *
      * @param  array  $attributes
+     * @param  array $namedAttributes
      * @return \Illuminate\Database\Eloquent\Model|static
      */
-    public function make(array $attributes = [])
+    public function make(array $attributes = [], ...$namedAttributes)
     {
+        $attributes = array_merge($attributes, $namedAttributes);
+
         return $this->newModelInstance($attributes);
     }
 
@@ -430,10 +433,13 @@ class Builder implements BuilderContract
      *
      * @param  array  $attributes
      * @param  array  $values
+     * @param  array  ...$namedAttributes
      * @return \Illuminate\Database\Eloquent\Model|static
      */
-    public function firstOrNew(array $attributes = [], array $values = [])
+    public function firstOrNew(array $attributes = [], array $values = [], ...$namedAttributes)
     {
+        $attributes = array_merge($attributes, $namedAttributes);
+
         if (! is_null($instance = $this->where($attributes)->first())) {
             return $instance;
         }
@@ -446,10 +452,13 @@ class Builder implements BuilderContract
      *
      * @param  array  $attributes
      * @param  array  $values
+     * @param  array  ...$namedAttributes
      * @return \Illuminate\Database\Eloquent\Model|static
      */
-    public function firstOrCreate(array $attributes = [], array $values = [])
+    public function firstOrCreate(array $attributes = [], array $values = [], ...$namedAttributes)
     {
+        $attributes = array_merge($attributes, $namedAttributes);
+
         if (! is_null($instance = $this->where($attributes)->first())) {
             return $instance;
         }
@@ -464,10 +473,13 @@ class Builder implements BuilderContract
      *
      * @param  array  $attributes
      * @param  array  $values
+     * @param  array  $namedAttributes
      * @return \Illuminate\Database\Eloquent\Model|static
      */
-    public function updateOrCreate(array $attributes, array $values = [])
+    public function updateOrCreate(array $attributes = [], array $values = [], ...$namedAttributes)
     {
+        $attributes = array_merge($attributes, $namedAttributes);
+
         return tap($this->firstOrNew($attributes), function ($instance) use ($values) {
             $instance->fill($values)->save();
         });
@@ -836,10 +848,13 @@ class Builder implements BuilderContract
      * Save a new model and return the instance.
      *
      * @param  array  $attributes
+     * @param  array ...$namedAttributes
      * @return \Illuminate\Database\Eloquent\Model|$this
      */
-    public function create(array $attributes = [])
+    public function create(array $attributes = [], ...$namedAttributes)
     {
+        $attributes = array_merge($attributes, $namedAttributes);
+
         return tap($this->newModelInstance($attributes), function ($instance) {
             $instance->save();
         });

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -102,7 +102,7 @@ class Builder implements BuilderContract
      * Create and return an un-saved model instance.
      *
      * @param  array  $attributes
-     * @param  array $namedAttributes
+     * @param  array  ...$namedAttributes
      * @return \Illuminate\Database\Eloquent\Model|static
      */
     public function make(array $attributes = [], ...$namedAttributes)
@@ -473,7 +473,7 @@ class Builder implements BuilderContract
      *
      * @param  array  $attributes
      * @param  array  $values
-     * @param  array  $namedAttributes
+     * @param  array  ...$namedAttributes
      * @return \Illuminate\Database\Eloquent\Model|static
      */
     public function updateOrCreate(array $attributes = [], array $values = [], ...$namedAttributes)

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -840,10 +840,13 @@ abstract class Model implements Arrayable, ArrayAccess, HasBroadcastChannel, Jso
      *
      * @param  array  $attributes
      * @param  array  $options
+     * @return array  ...$namedAttributes
      * @return bool
      */
-    public function update(array $attributes = [], array $options = [])
+    public function update(array $attributes = [], array $options = [], ...$namedAttributes)
     {
+        $attributes = array_merge($attributes, $namedAttributes);
+
         if (! $this->exists) {
             return false;
         }
@@ -856,10 +859,13 @@ abstract class Model implements Arrayable, ArrayAccess, HasBroadcastChannel, Jso
      *
      * @param  array  $attributes
      * @param  array  $options
+     * @return array  ...$namedAttributes
      * @return bool
      */
-    public function updateQuietly(array $attributes = [], array $options = [])
+    public function updateQuietly(array $attributes = [], array $options = [], ...$namedAttributes)
     {
+        $attributes = array_merge($attributes, $namedAttributes);
+
         if (! $this->exists) {
             return false;
         }

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -595,10 +595,13 @@ class BelongsToMany extends Relation
      *
      * @param  array  $attributes
      * @param  array  $values
+     * @param  array  ...$namedAttributes
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function firstOrNew(array $attributes = [], array $values = [])
+    public function firstOrNew(array $attributes = [], array $values = [], ...$namedAttributes)
     {
+        $attributes = array_merge($attributes, $namedAttributes);
+
         if (is_null($instance = $this->related->where($attributes)->first())) {
             $instance = $this->related->newInstance(array_merge($attributes, $values));
         }
@@ -613,10 +616,13 @@ class BelongsToMany extends Relation
      * @param  array  $values
      * @param  array  $joining
      * @param  bool  $touch
+     * @param  array  ...$namedAttributes
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function firstOrCreate(array $attributes = [], array $values = [], array $joining = [], $touch = true)
+    public function firstOrCreate(array $attributes = [], array $values = [], array $joining = [], $touch = true, ...$namedAttributes)
     {
+        $attributes = array_merge($attributes, $namedAttributes);
+
         if (is_null($instance = $this->related->where($attributes)->first())) {
             $instance = $this->create(array_merge($attributes, $values), $joining, $touch);
         }
@@ -631,10 +637,13 @@ class BelongsToMany extends Relation
      * @param  array  $values
      * @param  array  $joining
      * @param  bool  $touch
+     * @param  array  ...$namedAttributes
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function updateOrCreate(array $attributes, array $values = [], array $joining = [], $touch = true)
+    public function updateOrCreate(array $attributes, array $values = [], array $joining = [], $touch = true, ...$namedAttributes)
     {
+        $attributes = array_merge($attributes, $namedAttributes);
+
         if (is_null($instance = $this->related->where($attributes)->first())) {
             return $this->create(array_merge($attributes, $values), $joining, $touch);
         }
@@ -1156,10 +1165,13 @@ class BelongsToMany extends Relation
      * @param  array  $attributes
      * @param  array  $joining
      * @param  bool  $touch
+     * @param  array ...$namedAttributes
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function create(array $attributes = [], array $joining = [], $touch = true)
+    public function create(array $attributes = [], array $joining = [], $touch = true, ...$namedAttributes)
     {
+        $attributes = array_merge($attributes, $namedAttributes);
+
         $instance = $this->related->newInstance($attributes);
 
         // Once we save the related model, we need to attach it to the base model via

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -196,10 +196,13 @@ trait InteractsWithPivotTable
      * @param  mixed  $id
      * @param  array  $attributes
      * @param  bool  $touch
+     * @param  array $namedAttributes
      * @return int
      */
-    public function updateExistingPivot($id, array $attributes, $touch = true)
+    public function updateExistingPivot($id, array $attributes, $touch = true, ...$namedAttributes)
     {
+        $attributes = array_merge($attributes, $namedAttributes);
+
         if ($this->using &&
             empty($this->pivotWheres) &&
             empty($this->pivotWhereIns) &&
@@ -256,10 +259,13 @@ trait InteractsWithPivotTable
      * @param  mixed  $id
      * @param  array  $attributes
      * @param  bool  $touch
+     * @param  array  ...$namedAttributes
      * @return void
      */
-    public function attach($id, array $attributes = [], $touch = true)
+    public function attach($id, array $attributes = [], $touch = true, ...$namedAttributes)
     {
+        $attributes = array_merge($attributes, $namedAttributes);
+
         if ($this->using) {
             $this->attachUsingCustomClass($id, $attributes);
         } else {
@@ -504,10 +510,13 @@ trait InteractsWithPivotTable
      *
      * @param  array  $attributes
      * @param  bool  $exists
+     * @param  array  ...$namedAttributes
      * @return \Illuminate\Database\Eloquent\Relations\Pivot
      */
-    public function newPivot(array $attributes = [], $exists = false)
+    public function newPivot(array $attributes = [], $exists = false, ...$namedAttributes)
     {
+        $attributes = array_merge($attributes, $namedAttributes);
+
         $pivot = $this->related->newPivot(
             $this->parent, $attributes, $this->table, $exists, $this->using
         );
@@ -519,10 +528,13 @@ trait InteractsWithPivotTable
      * Create a new existing pivot model instance.
      *
      * @param  array  $attributes
+     * @param  array  ...$namedAttributes
      * @return \Illuminate\Database\Eloquent\Relations\Pivot
      */
-    public function newExistingPivot(array $attributes = [])
+    public function newExistingPivot(array $attributes = [], ...$namedAttributes)
     {
+        $attributes = array_merge($attributes, $namedAttributes);
+
         return $this->newPivot($attributes, true);
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -230,10 +230,13 @@ class HasManyThrough extends Relation
      * Get the first related model record matching the attributes or instantiate it.
      *
      * @param  array  $attributes
+     * @param  array  ...$namedAttributes
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function firstOrNew(array $attributes)
+    public function firstOrNew(array $attributes = [], ...$namedAttributes)
     {
+        $attributes = array_merge($attributes, $namedAttributes);
+
         if (is_null($instance = $this->where($attributes)->first())) {
             $instance = $this->related->newInstance($attributes);
         }
@@ -246,10 +249,13 @@ class HasManyThrough extends Relation
      *
      * @param  array  $attributes
      * @param  array  $values
+     * @param  array  ...$namedAttributes
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function updateOrCreate(array $attributes, array $values = [])
+    public function updateOrCreate(array $attributes, array $values = [], ...$namedAttributes)
     {
+        $attributes = array_merge($attributes, $namedAttributes);
+
         $instance = $this->firstOrNew($attributes);
 
         $instance->fill($values)->save();

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -213,10 +213,13 @@ abstract class HasOneOrMany extends Relation
      *
      * @param  array  $attributes
      * @param  array  $values
+     * @param  array  ...$namedAttributes
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function firstOrNew(array $attributes = [], array $values = [])
+    public function firstOrNew(array $attributes = [], array $values = [], ...$namedAttributes)
     {
+        $attributes = array_merge($attributes, $namedAttributes);
+
         if (is_null($instance = $this->where($attributes)->first())) {
             $instance = $this->related->newInstance(array_merge($attributes, $values));
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -2,9 +2,10 @@
 
 namespace Illuminate\Database\Eloquent\Relations;
 
+use Illuminate\Support\Arr;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithDictionary;
 
 abstract class HasOneOrMany extends Relation
@@ -46,10 +47,13 @@ abstract class HasOneOrMany extends Relation
      * Create and return an un-saved instance of the related model.
      *
      * @param  array  $attributes
+     * @param  array  $namedAttributes
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function make(array $attributes = [])
+    public function make(array $attributes = [], ...$namedAttributes)
     {
+        $attributes = array_merge($attributes, $namedAttributes);
+
         return tap($this->related->newInstance($attributes), function ($instance) {
             $this->setForeignAttributesForCreate($instance);
         });
@@ -227,10 +231,13 @@ abstract class HasOneOrMany extends Relation
      *
      * @param  array  $attributes
      * @param  array  $values
+     * @param  array  ...$namedAttributes
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function firstOrCreate(array $attributes = [], array $values = [])
+    public function firstOrCreate(array $attributes = [], array $values = [], ...$namedAttributes)
     {
+        $attributes = array_merge($attributes, $namedAttributes);
+
         if (is_null($instance = $this->where($attributes)->first())) {
             $instance = $this->create(array_merge($attributes, $values));
         }
@@ -243,10 +250,13 @@ abstract class HasOneOrMany extends Relation
      *
      * @param  array  $attributes
      * @param  array  $values
+     * @param  array  ...$namedAttributes
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function updateOrCreate(array $attributes, array $values = [])
+    public function updateOrCreate(array $attributes = [], array $values = [], ...$namedAttributes)
     {
+        $attributes = array_merge($attributes, $namedAttributes);
+
         return tap($this->firstOrNew($attributes), function ($instance) use ($values) {
             $instance->fill($values);
 
@@ -286,10 +296,13 @@ abstract class HasOneOrMany extends Relation
      * Create a new instance of the related model.
      *
      * @param  array  $attributes
+     * @param  array  ...$namedAttributes
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function create(array $attributes = [])
+    public function create(array $attributes = [], ...$namedAttributes)
     {
+        $attributes = array_merge($attributes, $namedAttributes);
+
         return tap($this->related->newInstance($attributes), function ($instance) {
             $this->setForeignAttributesForCreate($instance);
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -2,10 +2,9 @@
 
 namespace Illuminate\Database\Eloquent\Relations;
 
-use Illuminate\Support\Arr;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithDictionary;
 
 abstract class HasOneOrMany extends Relation

--- a/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
@@ -145,9 +145,10 @@ class MorphToMany extends BelongsToMany
      *
      * @param  array  $attributes
      * @param  bool  $exists
+     * @param  array  ...$namedAttributes
      * @return \Illuminate\Database\Eloquent\Relations\Pivot
      */
-    public function newPivot(array $attributes = [], $exists = false)
+    public function newPivot(array $attributes = [], $exists = false, ...$namedAttributes)
     {
         $using = $this->using;
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1560,6 +1560,24 @@ class DatabaseEloquentBuilderTest extends TestCase
         Carbon::setTestNow(null);
     }
 
+    public function testUpdateWithNamedArguments()
+    {
+        Carbon::setTestNow($now = '2017-10-10 10:10:10');
+
+        $query = new BaseBuilder(m::mock(ConnectionInterface::class), new Grammar, m::mock(Processor::class));
+        $builder = new Builder($query);
+        $model = new EloquentBuilderTestStub;
+        $this->mockConnectionForModel($model, '');
+        $builder->setModel($model);
+        $builder->getConnection()->shouldReceive('update')->once()
+            ->with('update "table" set "foo" = ?, "table"."updated_at" = ?', ['bar', $now])->andReturn(1);
+
+        $result = $builder->update(foo: 'bar');
+        $this->assertEquals(1, $result);
+
+        Carbon::setTestNow(null);
+    }
+
     public function testUpdateWithTimestampValue()
     {
         $query = new BaseBuilder(m::mock(ConnectionInterface::class), new Grammar, m::mock(Processor::class));

--- a/tests/Database/DatabaseEloquentHasOneTest.php
+++ b/tests/Database/DatabaseEloquentHasOneTest.php
@@ -107,6 +107,17 @@ class DatabaseEloquentHasOneTest extends TestCase
         $this->assertEquals($instance, $relation->make(['name' => 'taylor']));
     }
 
+    public function testMakeMethodDoesNotSaveNewModelWithNamedAttributes()
+    {
+        $relation = $this->getRelation();
+        $instance = $this->getMockBuilder(Model::class)->onlyMethods(['save', 'newInstance', 'setAttribute'])->getMock();
+        $relation->getRelated()->shouldReceive('newInstance')->with(['name' => 'taylor'])->andReturn($instance);
+        $instance->expects($this->once())->method('setAttribute')->with('foreign_key', 1);
+        $instance->expects($this->never())->method('save');
+
+        $this->assertEquals($instance, $relation->make(name: 'taylor'));
+    }
+
     public function testSaveMethodSetsForeignKeyOnModel()
     {
         $relation = $this->getRelation();
@@ -127,6 +138,17 @@ class DatabaseEloquentHasOneTest extends TestCase
         $created->expects($this->once())->method('setAttribute')->with('foreign_key', 1);
 
         $this->assertEquals($created, $relation->create(['name' => 'taylor']));
+    }
+
+    public function testCreateMethodProperlyCreatesNewModelWithNamedAttributes()
+    {
+        $relation = $this->getRelation();
+        $created = $this->getMockBuilder(Model::class)->onlyMethods(['save', 'getKey', 'setAttribute'])->getMock();
+        $created->expects($this->once())->method('save')->willReturn(true);
+        $relation->getRelated()->shouldReceive('newInstance')->once()->with(['name' => 'taylor'])->andReturn($created);
+        $created->expects($this->once())->method('setAttribute')->with('foreign_key', 1);
+
+        $this->assertEquals($created, $relation->create(name: 'taylor'));
     }
 
     public function testRelationIsProperlyInitialized()

--- a/tests/Database/DatabaseEloquentMorphTest.php
+++ b/tests/Database/DatabaseEloquentMorphTest.php
@@ -188,6 +188,18 @@ class DatabaseEloquentMorphTest extends TestCase
         $this->assertInstanceOf(Model::class, $relation->firstOrCreate(['foo' => 'bar'], ['baz' => 'qux']));
     }
 
+    public function testFirstOrCreateMethodWithNamedArgumentsAndWithValuesFindsFirstModel()
+    {
+        $relation = $this->getOneRelation();
+        $relation->getQuery()->shouldReceive('where')->once()->with(['foo' => 'bar'])->andReturn($relation->getQuery());
+        $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn($model = m::mock(Model::class));
+        $relation->getRelated()->shouldReceive('newInstance')->never();
+        $model->shouldReceive('setAttribute')->never();
+        $model->shouldReceive('save')->never();
+
+        $this->assertInstanceOf(Model::class, $relation->firstOrCreate(foo: 'bar', values: ['baz' => 'qux']));
+    }
+
     public function testFirstOrCreateMethodCreatesNewMorphModel()
     {
         $relation = $this->getOneRelation();

--- a/tests/Database/DatabaseEloquentMorphToManyTest.php
+++ b/tests/Database/DatabaseEloquentMorphToManyTest.php
@@ -43,6 +43,19 @@ class DatabaseEloquentMorphToManyTest extends TestCase
         $relation->attach(2, ['foo' => 'bar']);
     }
 
+    public function testAttachInsertsPivotTableRecordWithnamedArguments()
+    {
+        $relation = $this->getMockBuilder(MorphToMany::class)->onlyMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
+        $query = m::mock(stdClass::class);
+        $query->shouldReceive('from')->once()->with('taggables')->andReturn($query);
+        $query->shouldReceive('insert')->once()->with([['taggable_id' => 1, 'taggable_type' => get_class($relation->getParent()), 'tag_id' => 2, 'foo' => 'bar']])->andReturn(true);
+        $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock(stdClass::class));
+        $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
+        $relation->expects($this->once())->method('touchIfTouching');
+
+        $relation->attach(2, foo: 'bar');
+    }
+
     public function testDetachRemovesPivotTableRecord()
     {
         $relation = $this->getMockBuilder(MorphToMany::class)->onlyMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();


### PR DESCRIPTION
As Laravel 9 is targeting PHP 8 we can make use of [named arguments](https://wiki.php.net/rfc/named_params).

One case where this would make sense in my opinion are the many Eloquent methods for creating and updating models:

- `make()`
- `create()`
- `forceCreate()`
- `update()`

And also where you can update or create models if they are missing, and optionally also fill them with some values while doing so:

- `firstOrNew()`
- `firstOrCreate()`
- `updateOrCreate()`

## Examples

This PR enables us to do the following:

```php
User::create(name: 'Alex', email: 'studnitz@hey.com');
```

The old way with passing an array as the first argument is still possible of course.

```php
User::create(['name' => 'Alex', 'email' => 'studnitz@hey.com']);
```

And you can even mix both approaches, in case of collisions the named arguments win.

```php
$u1 = User::create(['name' => 'Alex', email: 'studnitz@hey.com']);

$u2 = User::create(['name' => 'Not Alex'], name: 'Alex, email: 'studnitz@hey.com']);


$u1->name === $u2->name; // true
```

In the case of methods like `firstOrCreate($attributes, $values)` we have also to provide the `values` parameter as a named argument:


```php
User::firstOrCreate(name: 'Alex', values: ['email' => 'studnitz@hey.com']);

```

This also works for the same methods found on relationships like `hasOne()`, `hasMany()`, etc.

## Implementation details

The implementation of this is extremely simple. Each method gets an additional variadic function parameter `...$namedAttributes` which yields an associative array of the named arguments used in the function call.

```diff php
-    public function make(array $attributes = [])
+    public function make(array $attributes = [], ...$namedAttributes)
     {
+        $attributes = array_merge($attributes, $namedAttributes);

         return $this->newModelInstance($attributes);
     }
```

This means that when no named arguments are used the behavior should be the same one as before. Because of the fact that every existing argument is already named, some attribute fields cant be called with argument names like `attributes` or `values`. This should be no problem though because the positional array still works regardless.

## Tests

I've added integration and also mocking tests, if they are too much or too few, just tell me and I will try to fix it.

## Additional Notes

I have absolutely no idea if this is possible, but I think this could also enable smarter autocompletion hints when used in conjunction with something like `laravel-ide-helper`, where it could suggest attribute names as named parameters. But as I said that's just a theory, I don't know how the IDE helper works under the hood.