### PR TITLE
[8.x] Allow passing when callback to Http client retry method

### DIFF
--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -25,7 +25,7 @@ use PHPUnit\Framework\Assert as PHPUnit;
  * @method \Illuminate\Http\Client\PendingRequest contentType(string $contentType)
  * @method \Illuminate\Http\Client\PendingRequest dd()
  * @method \Illuminate\Http\Client\PendingRequest dump()
- * @method \Illuminate\Http\Client\PendingRequest retry(int $times, int $sleep = 0)
+ * @method \Illuminate\Http\Client\PendingRequest retry(int $times, int $sleep = 0, ?callable $when = null)
  * @method \Illuminate\Http\Client\PendingRequest sink(string|resource $to)
  * @method \Illuminate\Http\Client\PendingRequest stub(callable $callback)
  * @method \Illuminate\Http\Client\PendingRequest timeout(int $seconds)

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -99,7 +99,7 @@ class PendingRequest
     protected $retryDelay = 100;
 
     /**
-     * A callback to determine if the request should be retried
+     * A callback to determine if the request should be retried.
      *
      * @var callable|null
      */

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -99,6 +99,13 @@ class PendingRequest
     protected $retryDelay = 100;
 
     /**
+     * A callback to determine if the request should be retried
+     *
+     * @var callable|null
+     */
+    protected $retryWhenCallback = null;
+
+    /**
      * The callbacks that should execute before the request is sent.
      *
      * @var \Illuminate\Support\Collection
@@ -441,12 +448,14 @@ class PendingRequest
      *
      * @param  int  $times
      * @param  int  $sleep
+     * @param  callable|null  $when
      * @return $this
      */
-    public function retry(int $times, int $sleep = 0)
+    public function retry(int $times, int $sleep = 0, $when = null)
     {
         $this->tries = $times;
         $this->retryDelay = $sleep;
+        $this->retryWhenCallback = $when;
 
         return $this;
     }
@@ -679,7 +688,7 @@ class PendingRequest
 
                 throw new ConnectionException($e->getMessage(), 0, $e);
             }
-        }, $this->retryDelay ?? 100);
+        }, $this->retryDelay ?? 100, $this->retryWhenCallback);
     }
 
     /**

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -99,7 +99,7 @@ class PendingRequest
     protected $retryDelay = 100;
 
     /**
-     * A callback to determine if the request should be retried.
+     * The callback that will determine if the request should be retried.
      *
      * @var callable|null
      */

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -451,7 +451,7 @@ class PendingRequest
      * @param  callable|null  $when
      * @return $this
      */
-    public function retry(int $times, int $sleep = 0, $when = null)
+    public function retry(int $times, int $sleep = 0, ?callable $when = null)
     {
         $this->tries = $times;
         $this->retryDelay = $sleep;

--- a/src/Illuminate/Support/Facades/Http.php
+++ b/src/Illuminate/Support/Facades/Http.php
@@ -20,7 +20,7 @@ use Illuminate\Http\Client\Factory;
  * @method static \Illuminate\Http\Client\PendingRequest contentType(string $contentType)
  * @method static \Illuminate\Http\Client\PendingRequest dd()
  * @method static \Illuminate\Http\Client\PendingRequest dump()
- * @method static \Illuminate\Http\Client\PendingRequest retry(int $times, int $sleep = 0)
+ * @method static \Illuminate\Http\Client\PendingRequest retry(int $times, int $sleep = 0, ?callable $when = null)
  * @method static \Illuminate\Http\Client\PendingRequest sink(string|resource $to)
  * @method static \Illuminate\Http\Client\PendingRequest stub(callable $callback)
  * @method static \Illuminate\Http\Client\PendingRequest timeout(int $seconds)


### PR DESCRIPTION
**TL;DR**
A little papercut I have, this adds support for passing a `$when` callback to the `Http::retry()` method which is already supported by the `retry` helper that is used to handle the Http client retries. There are no existing tests for `Http::retry()` so this PR does not contain any.

**When Callback already exists in the retry helper**
I have just noticed whilst writing this that the `$when` callback isn't actually documented on the `retry` helper docs (https://laravel.com/docs/8.x/helpers#method-retry). It is a very useful feature where you can decide whether to continue retrying or to throw the current exception by returning a `boolean` from the callback:

```php
$response = retry(
    3, // <-- Max tries
    fn () => SomeThrowableAction::make()->execute(), // <-- Code to execute
    400, // <-- Delay between attempts
    fn ($e) => $e instanceof SomeRetryException, // <-- The when callback
 );
```

**Use with Http client**
This PR adds the `$when` support to the Http client, which can be useful if as seen in the example you only want to retry when it gets a connection failure:

```php
$response = \Http::retry(
    3,
    400,
    fn ($e) => $e instanceof ConnectionException, // <-- Added when callback support
 )->get(...);
```