### PR TITLE
[8.x] Update TestResponse docblocks

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1025,7 +1025,7 @@ EOF;
     /**
      * Assert that the given keys do not have validation errors.
      *
-     * @param  array|null  $keys
+     * @param  string|array|null  $keys
      * @param  string  $errorBag
      * @param  string  $responseKey
      * @return $this
@@ -1068,7 +1068,7 @@ EOF;
     /**
      * Assert that the response has the given validation errors.
      *
-     * @param  array  $errors
+     * @param  string|array|null  $errors
      * @param  string  $errorBag
      * @param  string  $responseKey
      * @return $this


### PR DESCRIPTION
Follow up to #38422, appears I missed updating the docblocks.

I noticed other examples in this class always used `string|array` over `array|string` so I've done the same here, and added `null`.