### PR TITLE
[8.x] Don't iterate over all collection in Collection::firstOrFail

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1146,13 +1146,15 @@ class Collection implements ArrayAccess, Enumerable
             ? $this->operatorForWhere(...func_get_args())
             : $key;
 
-        $items = $this->when($filter)->filter($filter);
+        $placeholder = new stdClass();
 
-        if ($items->isEmpty()) {
+        $item = $this->first($filter, $placeholder);
+
+        if ($item === $placeholder) {
             throw new ItemNotFoundException;
         }
 
-        return $items->first();
+        return $item;
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -242,6 +242,28 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testFirstOrFailStopsIteratingAtFirstMatch($collection)
+    {
+        $data = new $collection([
+            function () {
+                return false;
+            },
+            function () {
+                return true;
+            },
+            function () {
+                throw new Exception();
+            },
+        ]);
+
+        $this->assertNotNull($data->firstOrFail(function ($callback) {
+            return $callback();
+        }));
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testFirstWhere($collection)
     {
         $data = new $collection([


### PR DESCRIPTION
`Illuminate\Support\Collection::firstOrFail` actually iterates over every items of the collection, even if this is not needed.

This PR changes the implementation to stop iterating on first match, if exists.
