### PR TITLE
[9.x] Improves `Support\Collection` and `Database\Eloquent\Collection` type definitions

### DIFF
--- a/.github/workflows/types.yml
+++ b/.github/workflows/types.yml
@@ -1,0 +1,45 @@
+name: types
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  linux_tests:
+    runs-on: ubuntu-20.04
+
+    strategy:
+      fail-fast: true
+      matrix:
+        php: ['8.0']
+        stability: [prefer-lowest, prefer-stable]
+        include:
+          - php: '8.1'
+            flags: "--ignore-platform-req=php"
+            stability: prefer-stable
+
+    name: PHP ${{ matrix.php }} - ${{ matrix.stability }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          tools: composer:v2
+          coverage: none
+
+      - name: Install dependencies
+        uses: nick-invision/retry@v1
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress ${{ matrix.flags }}
+
+      - name: Execute type checking
+        continue-on-error: ${{ matrix.php > 8 }}
+        run: vendor/bin/phpstan

--- a/.github/workflows/types.yml
+++ b/.github/workflows/types.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: true
       matrix:
         php: ['8.0']
-        stability: [prefer-lowest, prefer-stable]
+        stability: [prefer-stable]
         include:
           - php: '8.1'
             flags: "--ignore-platform-req=php"

--- a/.github/workflows/types.yml
+++ b/.github/workflows/types.yml
@@ -14,13 +14,11 @@ jobs:
       fail-fast: true
       matrix:
         php: ['8.0']
-        stability: [prefer-stable]
         include:
           - php: '8.1'
             flags: "--ignore-platform-req=php"
-            stability: prefer-stable
 
-    name: PHP ${{ matrix.php }} - ${{ matrix.stability }}
+    name: PHP ${{ matrix.php }}
 
     steps:
       - name: Checkout code
@@ -38,7 +36,7 @@ jobs:
         with:
           timeout_minutes: 5
           max_attempts: 5
-          command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress ${{ matrix.flags }}
+          command: composer update --prefer-stable --prefer-dist --no-interaction --no-progress ${{ matrix.flags }}
 
       - name: Execute type checking
         continue-on-error: ${{ matrix.php > 8 }}

--- a/composer.json
+++ b/composer.json
@@ -88,6 +88,7 @@
         "mockery/mockery": "^1.4.3",
         "orchestra/testbench-core": "^7.0",
         "pda/pheanstalk": "^4.0",
+        "phpstan/phpstan": "^0.12.94",
         "phpunit/phpunit": "^9.4",
         "predis/predis": "^1.1.2",
         "symfony/cache": "^5.3"

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,4 @@
+parameters:
+  paths:
+    - types
+  level: max

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -400,7 +400,7 @@ class Collection implements ArrayAccess, Enumerable
      * @param  string|array  $keys
      * @return $this
      */
-    public function forget($keys)
+    public function forget($keys) // TODO
     {
         foreach ((array) $keys as $key) {
             $this->offsetUnset($key);
@@ -817,7 +817,7 @@ class Collection implements ArrayAccess, Enumerable
      * @param  int  $count
      * @return mixed
      */
-    public function pop($count = 1)
+    public function pop($count = 1) // TODO
     {
         if ($count === 1) {
             return array_pop($this->items);
@@ -845,7 +845,7 @@ class Collection implements ArrayAccess, Enumerable
      * @param  mixed  $key
      * @return $this
      */
-    public function prepend($value, $key = null)
+    public function prepend($value, $key = null) // TODO
     {
         $this->items = Arr::prepend($this->items, ...func_get_args());
 
@@ -858,7 +858,7 @@ class Collection implements ArrayAccess, Enumerable
      * @param  ...TValue  $values
      * @return $this
      */
-    public function push(...$values)
+    public function push(...$values) // TODO
     {
         foreach ($values as $value) {
             $this->items[] = $value;
@@ -891,7 +891,7 @@ class Collection implements ArrayAccess, Enumerable
      * @param  mixed  $default
      * @return mixed
      */
-    public function pull($key, $default = null)
+    public function pull($key, $default = null) // TODO
     {
         return Arr::pull($this->items, $key, $default);
     }
@@ -903,7 +903,7 @@ class Collection implements ArrayAccess, Enumerable
      * @param  mixed  $value
      * @return $this
      */
-    public function put($key, $value)
+    public function put($key, $value) // TODO
     {
         $this->offsetSet($key, $value);
 
@@ -987,7 +987,7 @@ class Collection implements ArrayAccess, Enumerable
      * @param  int  $count
      * @return mixed
      */
-    public function shift($count = 1)
+    public function shift($count = 1) // TODO
     {
         if ($count === 1) {
             return array_shift($this->items);
@@ -1026,7 +1026,7 @@ class Collection implements ArrayAccess, Enumerable
      * @param  int  $step
      * @return static
      */
-    public function sliding($size = 2, $step = 1)
+    public function sliding($size = 2, $step = 1) // TODO
     {
         $chunks = floor(($this->count() - $size) / $step) + 1;
 
@@ -1123,7 +1123,7 @@ class Collection implements ArrayAccess, Enumerable
      * @param  int  $numberOfGroups
      * @return static
      */
-    public function splitIn($numberOfGroups)
+    public function splitIn($numberOfGroups) // TODO
     {
         return $this->chunk(ceil($this->count() / $numberOfGroups));
     }
@@ -1378,7 +1378,7 @@ class Collection implements ArrayAccess, Enumerable
      * @param  mixed  $replacement
      * @return static
      */
-    public function splice($offset, $length = null, $replacement = [])
+    public function splice($offset, $length = null, $replacement = []) // TODO
     {
         if (func_num_args() === 1) {
             return new static(array_splice($this->items, $offset));
@@ -1430,7 +1430,7 @@ class Collection implements ArrayAccess, Enumerable
      * @param  callable  $callback
      * @return $this
      */
-    public function transform(callable $callback)
+    public function transform(callable $callback) // TODO
     {
         $this->items = $this->map($callback)->all();
 
@@ -1491,7 +1491,7 @@ class Collection implements ArrayAccess, Enumerable
      * @return \ArrayIterator
      */
     #[\ReturnTypeWillChange]
-    public function getIterator()
+    public function getIterator() // TODO
     {
         return new ArrayIterator($this->items);
     }
@@ -1524,7 +1524,7 @@ class Collection implements ArrayAccess, Enumerable
      * @param  mixed  $item
      * @return $this
      */
-    public function add($item)
+    public function add($item) // TODO
     {
         $this->items[] = $item;
 
@@ -1536,7 +1536,7 @@ class Collection implements ArrayAccess, Enumerable
      *
      * @return \Illuminate\Support\Collection
      */
-    public function toBase()
+    public function toBase() // TODO
     {
         return new self($this);
     }
@@ -1548,7 +1548,7 @@ class Collection implements ArrayAccess, Enumerable
      * @return bool
      */
     #[\ReturnTypeWillChange]
-    public function offsetExists($key)
+    public function offsetExists($key) // TODO
     {
         return isset($this->items[$key]);
     }
@@ -1560,7 +1560,7 @@ class Collection implements ArrayAccess, Enumerable
      * @return mixed
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet($key)
+    public function offsetGet($key) // TODO
     {
         return $this->items[$key];
     }
@@ -1573,7 +1573,7 @@ class Collection implements ArrayAccess, Enumerable
      * @return void
      */
     #[\ReturnTypeWillChange]
-    public function offsetSet($key, $value)
+    public function offsetSet($key, $value) // TODO
     {
         if (is_null($key)) {
             $this->items[] = $value;
@@ -1589,7 +1589,7 @@ class Collection implements ArrayAccess, Enumerable
      * @return void
      */
     #[\ReturnTypeWillChange]
-    public function offsetUnset($key)
+    public function offsetUnset($key) // TODO
     {
         unset($this->items[$key]);
     }

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -11,6 +11,7 @@ use stdClass;
 /**
  * @template TKey of array-key
  * @template TValue
+ *
  * @implements \ArrayAccess<TKey, TValue>
  * @implements \Illuminate\Support\Enumerable<TKey, TValue>
  */

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -397,10 +397,10 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Remove an item from the collection by key.
      *
-     * @param  string|array  $keys
+     * @param  TKey|array<array-key, TKey>  $keys
      * @return $this
      */
-    public function forget($keys) // TODO
+    public function forget($keys)
     {
         foreach ((array) $keys as $key) {
             $this->offsetUnset($key);
@@ -815,9 +815,9 @@ class Collection implements ArrayAccess, Enumerable
      * Get and remove the last N items from the collection.
      *
      * @param  int  $count
-     * @return mixed
+     * @return static<int, TValue>|TValue|null
      */
-    public function pop($count = 1) // TODO
+    public function pop($count = 1)
     {
         if ($count === 1) {
             return array_pop($this->items);
@@ -841,11 +841,11 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Push an item onto the beginning of the collection.
      *
-     * @param  mixed  $value
-     * @param  mixed  $key
+     * @param  TValue  $value
+     * @param  TKey  $key
      * @return $this
      */
-    public function prepend($value, $key = null) // TODO
+    public function prepend($value, $key = null)
     {
         $this->items = Arr::prepend($this->items, ...func_get_args());
 
@@ -858,7 +858,7 @@ class Collection implements ArrayAccess, Enumerable
      * @param  ...TValue  $values
      * @return $this
      */
-    public function push(...$values) // TODO
+    public function push(...$values)
     {
         foreach ($values as $value) {
             $this->items[] = $value;
@@ -887,11 +887,13 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get and remove an item from the collection.
      *
-     * @param  mixed  $key
-     * @param  mixed  $default
-     * @return mixed
+     * @template TPullDefault
+     *
+     * @param  TKey  $key
+     * @param  TPullDefault  $default
+     * @return TValue|TPullDefault
      */
-    public function pull($key, $default = null) // TODO
+    public function pull($key, $default = null)
     {
         return Arr::pull($this->items, $key, $default);
     }
@@ -899,11 +901,11 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Put an item in the collection by key.
      *
-     * @param  mixed  $key
-     * @param  mixed  $value
+     * @param  TKey  $key
+     * @param  TValue  $value
      * @return $this
      */
-    public function put($key, $value) // TODO
+    public function put($key, $value)
     {
         $this->offsetSet($key, $value);
 
@@ -962,7 +964,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Search the collection for a given value and return the corresponding key if successful.
      *
-     * @param  TValue|callable(TValue,TKey): bool  $value
+     * @param  TValue|(callable(TValue,TKey): bool)  $value
      * @param  bool  $strict
      * @return TKey|bool
      */
@@ -985,9 +987,9 @@ class Collection implements ArrayAccess, Enumerable
      * Get and remove the first N items from the collection.
      *
      * @param  int  $count
-     * @return mixed
+     * @return static<int, TValue>|TValue|null
      */
-    public function shift($count = 1) // TODO
+    public function shift($count = 1)
     {
         if ($count === 1) {
             return array_shift($this->items);
@@ -1024,9 +1026,9 @@ class Collection implements ArrayAccess, Enumerable
      *
      * @param  int  $size
      * @param  int  $step
-     * @return static
+     * @return static<int, static<TKey, TValue>>
      */
-    public function sliding($size = 2, $step = 1) // TODO
+    public function sliding($size = 2, $step = 1)
     {
         $chunks = floor(($this->count() - $size) / $step) + 1;
 
@@ -1084,7 +1086,7 @@ class Collection implements ArrayAccess, Enumerable
      * Split a collection into a certain number of groups.
      *
      * @param  int  $numberOfGroups
-     * @return static<int, static<int, TValue>>
+     * @return static<int, static<TKey, TValue>>
      */
     public function split($numberOfGroups)
     {
@@ -1121,9 +1123,9 @@ class Collection implements ArrayAccess, Enumerable
      * Split a collection into a certain number of groups, and fill the first groups completely.
      *
      * @param  int  $numberOfGroups
-     * @return static
+     * @return static<int, static<TKey, TValue>>
      */
-    public function splitIn($numberOfGroups) // TODO
+    public function splitIn($numberOfGroups)
     {
         return $this->chunk(ceil($this->count() / $numberOfGroups));
     }
@@ -1375,10 +1377,10 @@ class Collection implements ArrayAccess, Enumerable
      *
      * @param  int  $offset
      * @param  int|null  $length
-     * @param  mixed  $replacement
-     * @return static
+     * @param  array<array-key, TValue>  $replacement
+     * @return static<TKey, TValue>
      */
-    public function splice($offset, $length = null, $replacement = []) // TODO
+    public function splice($offset, $length = null, $replacement = [])
     {
         if (func_num_args() === 1) {
             return new static(array_splice($this->items, $offset));
@@ -1427,10 +1429,10 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Transform each item in the collection using a callback.
      *
-     * @param  callable  $callback
+     * @param  callable(TValue, TKey): TValue  $callback
      * @return $this
      */
-    public function transform(callable $callback) // TODO
+    public function transform(callable $callback)
     {
         $this->items = $this->map($callback)->all();
 
@@ -1488,10 +1490,10 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get an iterator for the items.
      *
-     * @return \ArrayIterator
+     * @return \ArrayIterator<TKey, TValue>
      */
     #[\ReturnTypeWillChange]
-    public function getIterator() // TODO
+    public function getIterator()
     {
         return new ArrayIterator($this->items);
     }
@@ -1521,10 +1523,10 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Add an item to the collection.
      *
-     * @param  mixed  $item
+     * @param  TValue  $item
      * @return $this
      */
-    public function add($item) // TODO
+    public function add($item)
     {
         $this->items[] = $item;
 
@@ -1534,9 +1536,9 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get a base Support collection instance from this collection.
      *
-     * @return \Illuminate\Support\Collection
+     * @return \Illuminate\Support\Collection<TKey, TValue>
      */
-    public function toBase() // TODO
+    public function toBase()
     {
         return new self($this);
     }
@@ -1544,11 +1546,11 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Determine if an item exists at an offset.
      *
-     * @param  mixed  $key
+     * @param  TKey  $key
      * @return bool
      */
     #[\ReturnTypeWillChange]
-    public function offsetExists($key) // TODO
+    public function offsetExists($key)
     {
         return isset($this->items[$key]);
     }
@@ -1556,11 +1558,11 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get an item at a given offset.
      *
-     * @param  mixed  $key
-     * @return mixed
+     * @param  TKey  $key
+     * @return TValue
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet($key) // TODO
+    public function offsetGet($key)
     {
         return $this->items[$key];
     }
@@ -1568,12 +1570,12 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Set the item at a given offset.
      *
-     * @param  mixed  $key
-     * @param  mixed  $value
+     * @param  TKey|null  $key
+     * @param  TValue  $value
      * @return void
      */
     #[\ReturnTypeWillChange]
-    public function offsetSet($key, $value) // TODO
+    public function offsetSet($key, $value)
     {
         if (is_null($key)) {
             $this->items[] = $value;
@@ -1585,11 +1587,11 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Unset the item at a given offset.
      *
-     * @param  string  $key
+     * @param  TKey  $key
      * @return void
      */
     #[\ReturnTypeWillChange]
-    public function offsetUnset($key) // TODO
+    public function offsetUnset($key)
     {
         unset($this->items[$key]);
     }

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -362,11 +362,11 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get the first item from the collection passing the given truth test.
      *
-     * @template TFirstDefaultValue
+     * @template TFirstDefault
      *
      * @param  (callable(TValue): bool)|null  $callback
-     * @param  TFirstDefaultValue  $default
-     * @return TValue|TFirstDefaultValue
+     * @param  TFirstDefault  $default
+     * @return TValue|TFirstDefault
      */
     public function first(callable $callback = null, $default = null)
     {

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Traits\Macroable;
 use stdClass;
 
 /**
- * @template TKey as array-key
+ * @template TKey of array-key
  * @template TValue
  * @implements \ArrayAccess<TKey, TValue>
  * @implements \Illuminate\Support\Enumerable<TKey, TValue>
@@ -226,8 +226,8 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get the items in the collection whose keys and values are not present in the given items.
      *
-     * @param  mixed  $items
-     * @return static
+     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
+     * @return static<TKey, TValue>
      */
     public function diffAssoc($items)
     {
@@ -237,9 +237,9 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get the items in the collection whose keys and values are not present in the given items, using the callback.
      *
-     * @param  mixed  $items
-     * @param  callable  $callback
-     * @return static
+     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
+     * @param  callable(TKey): int  $callback
+     * @return static<TKey, TValue>
      */
     public function diffAssocUsing($items, callable $callback)
     {
@@ -249,8 +249,8 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get the items in the collection whose keys are not present in the given items.
      *
-     * @param  mixed  $items
-     * @return static
+     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
+     * @return static<TKey, TValue>
      */
     public function diffKeys($items)
     {
@@ -260,9 +260,9 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get the items in the collection whose keys are not present in the given items, using the callback.
      *
-     * @param  mixed  $items
-     * @param  callable  $callback
-     * @return static
+     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
+     * @param  callable(TKey): int  $callback
+     * @return static<TKey, TValue>
      */
     public function diffKeysUsing($items, callable $callback)
     {
@@ -272,9 +272,9 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Retrieve duplicate items from the collection.
      *
-     * @param  callable|string|null  $callback
+     * @param  (callable(TValue): bool)|string|null  $callback
      * @param  bool  $strict
-     * @return static
+     * @return static<TKey, TValue>
      */
     public function duplicates($callback = null, $strict = false)
     {
@@ -300,8 +300,8 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Retrieve duplicate items from the collection using strict comparison.
      *
-     * @param  callable|string|null  $callback
-     * @return static
+     * @param  (callable(TValue): bool)|string|null  $callback
+     * @return static<TKey, TValue>
      */
     public function duplicatesStrict($callback = null)
     {
@@ -312,7 +312,7 @@ class Collection implements ArrayAccess, Enumerable
      * Get the comparison function to detect duplicates.
      *
      * @param  bool  $strict
-     * @return \Closure
+     * @return callable(TValue, TValue): bool
      */
     protected function duplicateComparator($strict)
     {
@@ -330,8 +330,8 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get all items except for those with the specified keys.
      *
-     * @param  \Illuminate\Support\Collection|mixed  $keys
-     * @return static
+     * @param  \Illuminate\Support\Enumerable<array-key, TKey>|array<array-key, TKey>  $keys
+     * @return static<TKey, TValue>
      */
     public function except($keys)
     {
@@ -347,8 +347,8 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Run a filter over each of the items.
      *
-     * @param  callable|null  $callback
-     * @return static
+     * @param (callable(TValue): bool)|null  $callback
+     * @return static<TKey, TValue>
      */
     public function filter(callable $callback = null)
     {
@@ -377,7 +377,7 @@ class Collection implements ArrayAccess, Enumerable
      * Get a flattened array of the items in the collection.
      *
      * @param  int  $depth
-     * @return static
+     * @return static<TKey, TValue>
      */
     public function flatten($depth = INF)
     {
@@ -387,7 +387,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Flip the items in the collection.
      *
-     * @return static
+     * @return static<TValue, TKey>
      */
     public function flip()
     {
@@ -430,9 +430,9 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Group an associative array by a field or using a callback.
      *
-     * @param  array|callable|string  $groupBy
+     * @param  (callable(TValue, TKey): array-key)|array|string  $groupBy
      * @param  bool  $preserveKeys
-     * @return static
+     * @return static<array-key, array<array-key, TValue>>
      */
     public function groupBy($groupBy, $preserveKeys = false)
     {
@@ -476,8 +476,8 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Key an associative array by a field or using a callback.
      *
-     * @param  callable|string  $keyBy
-     * @return static
+     * @param  (callable(TValue, TKey): array-key)|array|string  $keyBy
+     * @return static<array-key, array<array-key, TValue>>
      */
     public function keyBy($keyBy)
     {
@@ -501,7 +501,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Determine if an item exists in the collection by key.
      *
-     * @param  mixed  $key
+     * @param  TKey|array<array-key, TKey>  $key
      * @return bool
      */
     public function has($key)
@@ -538,8 +538,8 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Intersect the collection with the given items.
      *
-     * @param  mixed  $items
-     * @return static
+     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
+     * @return static<TKey, TValue>
      */
     public function intersect($items)
     {
@@ -549,8 +549,8 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Intersect the collection with the given items by key.
      *
-     * @param  mixed  $items
-     * @return static
+     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
+     * @return static<TKey, TValue>
      */
     public function intersectByKeys($items)
     {
@@ -612,7 +612,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get the keys of the collection items.
      *
-     * @return static
+     * @return static<int, TKey>
      */
     public function keys()
     {
@@ -622,9 +622,11 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get the last item from the collection.
      *
-     * @param  callable|null  $callback
-     * @param  mixed  $default
-     * @return mixed
+     * @template TLastDefault
+     *
+     * @param  (callable(TValue, TKey): bool)|null  $callback
+     * @param  TLastDefault  $default
+     * @return TValue|TLastDefault
      */
     public function last(callable $callback = null, $default = null)
     {
@@ -646,8 +648,10 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Run a map over each of the items.
      *
-     * @param  callable  $callback
-     * @return static
+     * @template TMapValue
+     *
+     * @param  callable(TValue, TKey): TMapValue  $callback
+     * @return static<TKey, TMapValue>
      */
     public function map(callable $callback)
     {
@@ -843,7 +847,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Push one or more items onto the end of the collection.
      *
-     * @param  mixed  $values [optional]
+     * @param  ...TValue  $values
      * @return $this
      */
     public function push(...$values)

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -8,21 +8,30 @@ use Illuminate\Support\Traits\EnumeratesValues;
 use Illuminate\Support\Traits\Macroable;
 use stdClass;
 
+/**
+ * @template TKey as array-key
+ * @template TValue
+ * @implements \ArrayAccess<TKey, TValue>
+ * @implements \Illuminate\Support\Enumerable<TKey, TValue>
+ */
 class Collection implements ArrayAccess, Enumerable
 {
+    /**
+     * @use \Illuminate\Support\Traits\EnumeratesValues<TKey, TValue>
+     */
     use EnumeratesValues, Macroable;
 
     /**
      * The items contained in the collection.
      *
-     * @var array
+     * @var array<TKey, TValue>
      */
     protected $items = [];
 
     /**
      * Create a new collection.
      *
-     * @param  mixed  $items
+     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>|null  $items
      * @return void
      */
     public function __construct($items = [])
@@ -35,7 +44,7 @@ class Collection implements ArrayAccess, Enumerable
      *
      * @param  int  $from
      * @param  int  $to
-     * @return static
+     * @return static<int, int>
      */
     public static function range($from, $to)
     {
@@ -45,7 +54,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get all of the items in the collection.
      *
-     * @return array
+     * @return array<TKey, TValue>
      */
     public function all()
     {
@@ -65,8 +74,8 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get the average value of a given key.
      *
-     * @param  callable|string|null  $callback
-     * @return mixed
+     * @param  (callable(TValue): float|int)|string|null  $callback
+     * @return float|int|null
      */
     public function avg($callback = null)
     {
@@ -86,8 +95,8 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get the median of a given key.
      *
-     * @param  string|array|null  $key
-     * @return mixed
+     * @param  string|array<array-key, string>|null  $key
+     * @return float|int|null
      */
     public function median($key = null)
     {
@@ -116,8 +125,8 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get the mode of a given key.
      *
-     * @param  string|array|null  $key
-     * @return array|null
+     * @param  string|array<array-key, string>|null  $key
+     * @return array<int, float|int>|null
      */
     public function mode($key = null)
     {
@@ -145,7 +154,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Collapse the collection of items into a single array.
      *
-     * @return static
+     * @return static<int, mixed>
      */
     public function collapse()
     {
@@ -155,9 +164,9 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Determine if an item exists in the collection.
      *
-     * @param  mixed  $key
-     * @param  mixed  $operator
-     * @param  mixed  $value
+     * @param  (callable(TValue): bool)|TValue|string  $key
+     * @param  TValue|string|null  $operator
+     * @param  TValue|null  $value
      * @return bool
      */
     public function contains($key, $operator = null, $value = null)
@@ -178,8 +187,11 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Cross join with the given lists, returning all possible permutations.
      *
-     * @param  mixed  ...$lists
-     * @return static
+     * @template TCrossJoinKey
+     * @template TCrossJoinValue
+     *
+     * @param  \Illuminate\Contracts\Support\Arrayable<TCrossJoinKey, TCrossJoinValue>|iterable<TCrossJoinKey, TCrossJoinValue>  ...$lists
+     * @return static<int, array<int, TValue|TCrossJoinValue>>
      */
     public function crossJoin(...$lists)
     {
@@ -191,8 +203,8 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get the items in the collection that are not present in the given items.
      *
-     * @param  mixed  $items
-     * @return static
+     * @param  \Illuminate\Contracts\Support\Arrayable<array-key, TValue>|iterable<array-key, TValue>  $items
+     * @return static<TKey, TValue>
      */
     public function diff($items)
     {
@@ -202,9 +214,9 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get the items in the collection that are not present in the given items, using the callback.
      *
-     * @param  mixed  $items
-     * @param  callable  $callback
-     * @return static
+     * @param  \Illuminate\Contracts\Support\Arrayable<array-key, TValue>|iterable<array-key, TValue>  $items
+     * @param  callable(TValue): int  $callback
+     * @return static<TKey, TValue>
      */
     public function diffUsing($items, callable $callback)
     {
@@ -350,9 +362,11 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get the first item from the collection passing the given truth test.
      *
-     * @param  callable|null  $callback
-     * @param  mixed  $default
-     * @return mixed
+     * @template TFirstDefaultValue
+     *
+     * @param  (callable(TValue): bool)|null  $callback
+     * @param  TFirstDefaultValue  $default
+     * @return TValue|TFirstDefaultValue
      */
     public function first(callable $callback = null, $default = null)
     {
@@ -398,9 +412,11 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get an item from the collection by key.
      *
-     * @param  mixed  $key
-     * @param  mixed  $default
-     * @return mixed
+     * @template TGetDefault
+     *
+     * @param  TKey  $key
+     * @param  TGetDefault  $default
+     * @return TValue|TGetDefault
      */
     public function get($key, $default = null)
     {

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -667,8 +667,11 @@ class Collection implements ArrayAccess, Enumerable
      *
      * The callback should return an associative array with a single key/value pair.
      *
-     * @param  callable  $callback
-     * @return static
+     * @template TMapToDictionaryKey of array-key
+     * @template TMapToDictionaryValue
+     *
+     * @param  callable(TValue, TKey): array<TMapToDictionaryKey, TMapToDictionaryValue>   $callback
+     * @return static<TMapToDictionaryKey, array<int, TMapToDictionaryValue>>
      */
     public function mapToDictionary(callable $callback)
     {
@@ -696,8 +699,11 @@ class Collection implements ArrayAccess, Enumerable
      *
      * The callback should return an associative array with a single key/value pair.
      *
-     * @param  callable  $callback
-     * @return static
+     * @template TMapWithKeysKey of array-key
+     * @template TMapWithKeysValue
+     *
+     * @param  callable(TValue, TKey): array<TMapWithKeysKey, TMapWithKeysValue>   $callback
+     * @return static<TMapWithKeysKey, TMapWithKeysValue>
      */
     public function mapWithKeys(callable $callback)
     {
@@ -717,8 +723,8 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Merge the collection with the given items.
      *
-     * @param  mixed  $items
-     * @return static
+     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue> $items
+     * @return static<TKey, TValue>
      */
     public function merge($items)
     {
@@ -728,8 +734,8 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Recursively merge the collection with the given items.
      *
-     * @param  mixed  $items
-     * @return static
+     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue> $items
+     * @return static<TKey, array<int, TValue>>
      */
     public function mergeRecursive($items)
     {
@@ -739,8 +745,10 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Create a collection by using this collection for keys and another for its values.
      *
-     * @param  mixed  $values
-     * @return static
+     * @template TCombineValue
+     *
+     * @param  \Illuminate\Contracts\Support\Arrayable<array-key, TCombineValue>|iterable<array-key, TCombineValue> $values
+     * @return static<TKey, TCombineValue>
      */
     public function combine($values)
     {
@@ -750,8 +758,8 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Union the collection with the given items.
      *
-     * @param  mixed  $items
-     * @return static
+     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue> $items
+     * @return static<TKey, TValue>
      */
     public function union($items)
     {
@@ -763,7 +771,7 @@ class Collection implements ArrayAccess, Enumerable
      *
      * @param  int  $step
      * @param  int  $offset
-     * @return static
+     * @return static<TKey, TValue>
      */
     public function nth($step, $offset = 0)
     {
@@ -785,8 +793,8 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get the items with the specified keys.
      *
-     * @param  mixed  $keys
-     * @return static
+     * @param  \Illuminate\Support\Enumerable<array-key, TKey>|array<array-key, TKey> $keys
+     * @return static<TKey, TValue>
      */
     public function only($keys)
     {
@@ -862,8 +870,8 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Push all of the given items onto the collection.
      *
-     * @param  iterable  $source
-     * @return static
+     * @param  iterable<array-key, TValue>  $source
+     * @return static<TKey, TValue>
      */
     public function concat($source)
     {
@@ -906,7 +914,7 @@ class Collection implements ArrayAccess, Enumerable
      * Get one or a specified number of items randomly from the collection.
      *
      * @param  int|null  $number
-     * @return static|mixed
+     * @return static<int, TValue>|TValue
      *
      * @throws \InvalidArgumentException
      */
@@ -922,8 +930,8 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Replace the collection items with the given items.
      *
-     * @param  mixed  $items
-     * @return static
+     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue> $items
+     * @return static<TKey, TValue>
      */
     public function replace($items)
     {

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -636,9 +636,9 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get the values of a given key.
      *
-     * @param  string|array|int|null  $value
+     * @param  string|array<int, string>  $value
      * @param  string|null  $key
-     * @return static
+     * @return static<int, mixed>
      */
     public function pluck($value, $key = null)
     {
@@ -941,8 +941,8 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Recursively replace the collection items with the given items.
      *
-     * @param  mixed  $items
-     * @return static
+     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
+     * @return static<TKey, TValue>
      */
     public function replaceRecursive($items)
     {
@@ -952,7 +952,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Reverse items order.
      *
-     * @return static
+     * @return static<TKey, TValue>
      */
     public function reverse()
     {
@@ -962,9 +962,9 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Search the collection for a given value and return the corresponding key if successful.
      *
-     * @param  mixed  $value
+     * @param  TValue|callable(TValue,TKey): bool  $value
      * @param  bool  $strict
-     * @return mixed
+     * @return TKey|bool
      */
     public function search($value, $strict = false)
     {
@@ -1012,7 +1012,7 @@ class Collection implements ArrayAccess, Enumerable
      * Shuffle the items in the collection.
      *
      * @param  int|null  $seed
-     * @return static
+     * @return static<TKey, TValue>
      */
     public function shuffle($seed = null)
     {
@@ -1039,7 +1039,7 @@ class Collection implements ArrayAccess, Enumerable
      * Skip the first {$count} items.
      *
      * @param  int  $count
-     * @return static
+     * @return static<TKey, TValue>
      */
     public function skip($count)
     {
@@ -1049,8 +1049,8 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Skip items in the collection until the given condition is met.
      *
-     * @param  mixed  $value
-     * @return static
+     * @param  TValue|callable(TValue,TKey): bool  $value
+     * @return static<TKey, TValue>
      */
     public function skipUntil($value)
     {
@@ -1060,8 +1060,8 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Skip items in the collection while the given condition is met.
      *
-     * @param  mixed  $value
-     * @return static
+     * @param  TValue|callable(TValue,TKey): bool  $value
+     * @return static<TKey, TValue>
      */
     public function skipWhile($value)
     {
@@ -1073,7 +1073,7 @@ class Collection implements ArrayAccess, Enumerable
      *
      * @param  int  $offset
      * @param  int|null  $length
-     * @return static
+     * @return static<TKey, TValue>
      */
     public function slice($offset, $length = null)
     {
@@ -1084,7 +1084,7 @@ class Collection implements ArrayAccess, Enumerable
      * Split a collection into a certain number of groups.
      *
      * @param  int  $numberOfGroups
-     * @return static
+     * @return static<int, static<int, TValue>>
      */
     public function split($numberOfGroups)
     {
@@ -1131,10 +1131,10 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get the first item in the collection, but only if exactly one item exists. Otherwise, throw an exception.
      *
-     * @param  mixed  $key
-     * @param  mixed  $operator
-     * @param  mixed  $value
-     * @return mixed
+     * @param  (callable(TValue, TKey): bool)|string  $key
+     * @param  TValue|string|null  $operator
+     * @param  TValue|null  $value
+     * @return TValue
      *
      * @throws \Illuminate\Support\ItemNotFoundException
      * @throws \Illuminate\Support\MultipleItemsFoundException
@@ -1187,7 +1187,7 @@ class Collection implements ArrayAccess, Enumerable
      * Chunk the collection into chunks of the given size.
      *
      * @param  int  $size
-     * @return static
+     * @return static<int, static<int, TValue>>
      */
     public function chunk($size)
     {
@@ -1207,8 +1207,8 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Chunk the collection into chunks with a callback.
      *
-     * @param  callable  $callback
-     * @return static
+     * @param  callable(TValue, TKey, static<int, TValue>): bool  $callback
+     * @return static<int, static<int, TValue>>
      */
     public function chunkWhile(callable $callback)
     {
@@ -1220,8 +1220,8 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Sort through each item with a callback.
      *
-     * @param  callable|int|null  $callback
-     * @return static
+     * @param  (callable(TValue, TValue): bool)|null|int  $callback
+     * @return static<TKey, TValue>
      */
     public function sort($callback = null)
     {
@@ -1238,7 +1238,7 @@ class Collection implements ArrayAccess, Enumerable
      * Sort items in descending order.
      *
      * @param  int  $options
-     * @return static
+     * @return static<TKey, TValue>
      */
     public function sortDesc($options = SORT_REGULAR)
     {
@@ -1252,10 +1252,10 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Sort the collection using the given callback.
      *
-     * @param  callable|array|string  $callback
+     * @param  (callable(TValue, TKey): mixed)|string  $callback
      * @param  int  $options
      * @param  bool  $descending
-     * @return static
+     * @return static<TKey, TValue>
      */
     public function sortBy($callback, $options = SORT_REGULAR, $descending = false)
     {
@@ -1334,9 +1334,9 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Sort the collection in descending order using the given callback.
      *
-     * @param  callable|string  $callback
+     * @param  (callable(TValue, TKey): mixed)|string  $callback
      * @param  int  $options
-     * @return static
+     * @return static<TKey, TValue>
      */
     public function sortByDesc($callback, $options = SORT_REGULAR)
     {
@@ -1348,7 +1348,7 @@ class Collection implements ArrayAccess, Enumerable
      *
      * @param  int  $options
      * @param  bool  $descending
-     * @return static
+     * @return static<TKey, TValue>
      */
     public function sortKeys($options = SORT_REGULAR, $descending = false)
     {
@@ -1363,7 +1363,7 @@ class Collection implements ArrayAccess, Enumerable
      * Sort the collection keys in descending order.
      *
      * @param  int  $options
-     * @return static
+     * @return static<TKey, TValue>
      */
     public function sortKeysDesc($options = SORT_REGULAR)
     {
@@ -1391,7 +1391,7 @@ class Collection implements ArrayAccess, Enumerable
      * Take the first or last {$limit} items.
      *
      * @param  int  $limit
-     * @return static
+     * @return static<TKey, TValue>
      */
     public function take($limit)
     {
@@ -1405,8 +1405,8 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Take items in the collection until the given condition is met.
      *
-     * @param  mixed  $value
-     * @return static
+     * @param  TValue|callable(TValue,TKey): bool  $value
+     * @return static<TKey, TValue>
      */
     public function takeUntil($value)
     {
@@ -1416,8 +1416,8 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Take items in the collection while the given condition is met.
      *
-     * @param  mixed  $value
-     * @return static
+     * @param  TValue|callable(TValue,TKey): bool  $value
+     * @return static<TKey, TValue>
      */
     public function takeWhile($value)
     {
@@ -1440,7 +1440,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Reset the keys on the underlying array.
      *
-     * @return static
+     * @return static<int, TValue>
      */
     public function values()
     {
@@ -1453,8 +1453,10 @@ class Collection implements ArrayAccess, Enumerable
      * e.g. new Collection([1, 2, 3])->zip([4, 5, 6]);
      *      => [[1, 4], [2, 5], [3, 6]]
      *
-     * @param  mixed  ...$items
-     * @return static
+     * @template TZipValue
+     *
+     * @param  \Illuminate\Contracts\Support\Arrayable<array-key, TZipValue>|iterable<array-key, TZipValue>  ...$items
+     * @return static<int, static<int, TValue|TZipValue>>
      */
     public function zip($items)
     {
@@ -1472,9 +1474,11 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Pad collection to the specified length with a value.
      *
+     * @template TPadValue
+     *
      * @param  int  $size
-     * @param  mixed  $value
-     * @return static
+     * @param  TPadValue  $value
+     * @return static<int, TValue|TPadValue>
      */
     public function pad($size, $value)
     {
@@ -1506,8 +1510,8 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Count the number of items in the collection by a field or using a callback.
      *
-     * @param  callable|string  $countBy
-     * @return static
+     * @param  (callable(TValue, TKey): mixed)|string|null  $countBy
+     * @return static<TValue, int>
      */
     public function countBy($countBy = null)
     {

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -166,8 +166,8 @@ class Collection implements ArrayAccess, Enumerable
      * Determine if an item exists in the collection.
      *
      * @param  (callable(TValue): bool)|TValue|string  $key
-     * @param  TValue|string|null  $operator
-     * @param  TValue|null  $value
+     * @param  mixed  $operator
+     * @param  mixed  $value
      * @return bool
      */
     public function contains($key, $operator = null, $value = null)
@@ -378,7 +378,7 @@ class Collection implements ArrayAccess, Enumerable
      * Get a flattened array of the items in the collection.
      *
      * @param  int  $depth
-     * @return static<TKey, TValue>
+     * @return static<int, mixed>
      */
     public function flatten($depth = INF)
     {
@@ -637,7 +637,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get the values of a given key.
      *
-     * @param  string|array<int, string>  $value
+     * @param  string|array<array-key, string>  $value
      * @param  string|null  $key
      * @return static<int, mixed>
      */
@@ -1135,8 +1135,8 @@ class Collection implements ArrayAccess, Enumerable
      * Get the first item in the collection, but only if exactly one item exists. Otherwise, throw an exception.
      *
      * @param  (callable(TValue, TKey): bool)|string  $key
-     * @param  TValue|string|null  $operator
-     * @param  TValue|null  $value
+     * @param  mixed  $operator
+     * @param  mixed  $value
      * @return TValue
      *
      * @throws \Illuminate\Support\ItemNotFoundException

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -477,6 +477,8 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Get an item from the collection by key.
      *
+     * @template TGetDefault
+     *
      * @param  TKey  $key
      * @param  TGetDefault  $default
      * @return TValue|TGetDefault

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -8,13 +8,22 @@ use Illuminate\Contracts\Support\Jsonable;
 use IteratorAggregate;
 use JsonSerializable;
 
+/**
+ * @template TKey as array-key
+ * @template TValue
+ * @extends \Illuminate\Contracts\Support\Arrayable<TKey, TValue>
+ * @extends \IteratorAggregate<TKey, TValue>
+ */
 interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, JsonSerializable
 {
     /**
      * Create a new collection instance if the value isn't one already.
      *
-     * @param  mixed  $items
-     * @return static
+     * @template TMakeKey as array-key
+     * @template TMakeValue
+     *
+     * @param  \Illuminate\Contracts\Support\Arrayable<TMakeKey, TMakeValue>|iterable<TMakeKey, TMakeValue>|null  $items
+     * @return static<TMakeKey, TMakeValue>
      */
     public static function make($items = []);
 
@@ -39,23 +48,29 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Wrap the given value in a collection if applicable.
      *
-     * @param  mixed  $value
-     * @return static
+     * @template TWrapKey as array-key
+     * @template TWrapValue
+     *
+     * @param  iterable<TWrapKey, TWrapValue>  $value
+     * @return static<TWrapKey, TWrapValue>
      */
     public static function wrap($value);
 
     /**
      * Get the underlying items from the given collection if applicable.
      *
-     * @param  array|static  $value
-     * @return array
+     * @template TUnwrapKey as array-key
+     * @template TUnwrapValue
+     *
+     * @param  array<TUnwrapKey, TUnwrapValue>|static<TUnwrapKey, TUnwrapValue>   $value
+     * @return array<TUnwrapKey, TUnwrapValue>
      */
     public static function unwrap($value);
 
     /**
      * Create a new instance with no items.
      *
-     * @return static
+     * @return static<TKey, TValue>
      */
     public static function empty();
 
@@ -69,40 +84,40 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Alias for the "avg" method.
      *
-     * @param  callable|string|null  $callback
-     * @return mixed
+     * @param  (callable(TValue): float|int)|string|null  $callback
+     * @return float|int|null
      */
     public function average($callback = null);
 
     /**
      * Get the median of a given key.
      *
-     * @param  string|array|null  $key
-     * @return mixed
+     * @param  string|array<array-key, string>|null  $key
+     * @return float|int|null
      */
     public function median($key = null);
 
     /**
      * Get the mode of a given key.
      *
-     * @param  string|array|null  $key
-     * @return array|null
+     * @param  string|array<array-key, string>|null  $key
+     * @return array<int, float|int>|null
      */
     public function mode($key = null);
 
     /**
      * Collapse the items into a single enumerable.
      *
-     * @return static
+     * @return static<int, mixed>
      */
     public function collapse();
 
     /**
      * Alias for the "contains" method.
      *
-     * @param  mixed  $key
-     * @param  mixed  $operator
-     * @param  mixed  $value
+     * @param  (callable(TValue): bool)|TValue|string  $key
+     * @param  TValue|string|null  $operator
+     * @param  TValue|null  $value
      * @return bool
      */
     public function some($key, $operator = null, $value = null);
@@ -110,8 +125,8 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Determine if an item exists, using strict comparison.
      *
-     * @param  mixed  $key
-     * @param  mixed  $value
+     * @param  (callable(TValue): bool)|TValue|string  $key
+     * @param  TValue|null  $value
      * @return bool
      */
     public function containsStrict($key, $value = null);
@@ -119,17 +134,17 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Get the average value of a given key.
      *
-     * @param  callable|string|null  $callback
-     * @return mixed
+     * @param  (callable(TValue): float|int)|string|null  $callback
+     * @return float|int|null
      */
     public function avg($callback = null);
 
     /**
      * Determine if an item exists in the enumerable.
      *
-     * @param  mixed  $key
-     * @param  mixed  $operator
-     * @param  mixed  $value
+     * @param  (callable(TValue): bool)|TValue|string  $key
+     * @param  TValue|string|null  $operator
+     * @param  TValue|null  $value
      * @return bool
      */
     public function contains($key, $operator = null, $value = null);
@@ -137,8 +152,11 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Cross join with the given lists, returning all possible permutations.
      *
-     * @param  mixed  ...$lists
-     * @return static
+     * @template TCrossJoinKey
+     * @template TCrossJoinValue
+     *
+     * @param  \Illuminate\Contracts\Support\Arrayable<TCrossJoinKey, TCrossJoinValue>|iterable<TCrossJoinKey, TCrossJoinValue>  ...$lists
+     * @return static<int, array<int, TValue|TCrossJoinValue>>
      */
     public function crossJoin(...$lists);
 
@@ -146,7 +164,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Dump the collection and end the script.
      *
      * @param  mixed  ...$args
-     * @return void
+     * @return never
      */
     public function dd(...$args);
 
@@ -160,17 +178,17 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Get the items that are not present in the given items.
      *
-     * @param  mixed  $items
-     * @return static
+     * @param  \Illuminate\Contracts\Support\Arrayable<array-key, TValue>|iterable<array-key, TValue>  $items
+     * @return static<TKey, TValue>
      */
     public function diff($items);
 
     /**
      * Get the items that are not present in the given items, using the callback.
      *
-     * @param  mixed  $items
-     * @param  callable  $callback
-     * @return static
+     * @param  \Illuminate\Contracts\Support\Arrayable<array-key, TValue>|iterable<array-key, TValue>  $items
+     * @param  callable(TValue): int  $callback
+     * @return static<TKey, TValue>
      */
     public function diffUsing($items, callable $callback);
 
@@ -459,9 +477,9 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Get an item from the collection by key.
      *
-     * @param  mixed  $key
-     * @param  mixed  $default
-     * @return mixed
+     * @param  TKey  $key
+     * @param  TGetDefault  $default
+     * @return TValue|TGetDefault
      */
     public function get($key, $default = null);
 

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -9,7 +9,7 @@ use IteratorAggregate;
 use JsonSerializable;
 
 /**
- * @template TKey as array-key
+ * @template TKey of array-key
  * @template TValue
  * @extends \Illuminate\Contracts\Support\Arrayable<TKey, TValue>
  * @extends \IteratorAggregate<TKey, TValue>
@@ -19,7 +19,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Create a new collection instance if the value isn't one already.
      *
-     * @template TMakeKey as array-key
+     * @template TMakeKey of array-key
      * @template TMakeValue
      *
      * @param  \Illuminate\Contracts\Support\Arrayable<TMakeKey, TMakeValue>|iterable<TMakeKey, TMakeValue>|null  $items
@@ -48,7 +48,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Wrap the given value in a collection if applicable.
      *
-     * @template TWrapKey as array-key
+     * @template TWrapKey of array-key
      * @template TWrapValue
      *
      * @param  iterable<TWrapKey, TWrapValue>  $value
@@ -59,7 +59,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Get the underlying items from the given collection if applicable.
      *
-     * @template TUnwrapKey as array-key
+     * @template TUnwrapKey of array-key
      * @template TUnwrapValue
      *
      * @param  array<TUnwrapKey, TUnwrapValue>|static<TUnwrapKey, TUnwrapValue>   $value
@@ -195,58 +195,58 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Get the items whose keys and values are not present in the given items.
      *
-     * @param  mixed  $items
-     * @return static
+     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
+     * @return static<TKey, TValue>
      */
     public function diffAssoc($items);
 
     /**
      * Get the items whose keys and values are not present in the given items, using the callback.
      *
-     * @param  mixed  $items
-     * @param  callable  $callback
-     * @return static
+     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
+     * @param  callable(TKey): int  $callback
+     * @return static<TKey, TValue>
      */
     public function diffAssocUsing($items, callable $callback);
 
     /**
      * Get the items whose keys are not present in the given items.
      *
-     * @param  mixed  $items
-     * @return static
+     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
+     * @return static<TKey, TValue>
      */
     public function diffKeys($items);
 
     /**
      * Get the items whose keys are not present in the given items, using the callback.
      *
-     * @param  mixed  $items
-     * @param  callable  $callback
-     * @return static
+     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
+     * @param  callable(TKey): int  $callback
+     * @return static<TKey, TValue>
      */
     public function diffKeysUsing($items, callable $callback);
 
     /**
      * Retrieve duplicate items.
      *
-     * @param  callable|string|null  $callback
+     * @param  (callable(TValue): bool)|string|null  $callback
      * @param  bool  $strict
-     * @return static
+     * @return static<TKey, TValue>
      */
     public function duplicates($callback = null, $strict = false);
 
     /**
      * Retrieve duplicate items using strict comparison.
      *
-     * @param  callable|string|null  $callback
-     * @return static
+     * @param  (callable(TValue): bool)|string|null  $callback
+     * @return static<TKey, TValue>
      */
     public function duplicatesStrict($callback = null);
 
     /**
      * Execute a callback over each item.
      *
-     * @param  callable  $callback
+     * @param  callable(TValue): mixed  $callback
      * @return $this
      */
     public function each(callable $callback);
@@ -254,17 +254,17 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Execute a callback over each nested chunk of items.
      *
-     * @param  callable  $callback
-     * @return static
+     * @param  callable(...mixed): mixed  $callback
+     * @return static<TKey, TValue>
      */
     public function eachSpread(callable $callback);
 
     /**
      * Determine if all items pass the given truth test.
      *
-     * @param  string|callable  $key
-     * @param  mixed  $operator
-     * @param  mixed  $value
+     * @param  (callable(TValue, TKey): bool)|TValue|string  $key
+     * @param  TValue|string|null  $operator
+     * @param  TValue|null  $value
      * @return bool
      */
     public function every($key, $operator = null, $value = null);
@@ -272,72 +272,84 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Get all items except for those with the specified keys.
      *
-     * @param  mixed  $keys
-     * @return static
+     * @param  \Illuminate\Support\Enumerable<array-key, TKey>|array<array-key, TKey>  $keys
+     * @return static<TKey, TValue>
      */
     public function except($keys);
 
     /**
      * Run a filter over each of the items.
      *
-     * @param  callable|null  $callback
-     * @return static
+     * @param (callable(TValue): bool)|null  $callback
+     * @return static<TKey, TValue>
      */
     public function filter(callable $callback = null);
 
     /**
      * Apply the callback if the given "value" is (or resolves to) truthy.
      *
+     * @template TWhenReturnType as null
+     *
      * @param  bool  $value
-     * @param  callable|null  $callback
-     * @param  callable|null  $default
-     * @return static|mixed
+     * @param  (callable($this): TWhenReturnType)|null  $callback
+     * @param  (callable($this): TWhenReturnType)|null  $default
+     * @return $this|TWhenReturnType
      */
     public function when($value, callable $callback = null, callable $default = null);
 
     /**
      * Apply the callback if the collection is empty.
      *
-     * @param  callable  $callback
-     * @param  callable|null  $default
-     * @return static|mixed
+     * @template TWhenEmptyReturnType
+     *
+     * @param  (callable($this): TWhenEmptyReturnType)  $callback
+     * @param  (callable($this): TWhenEmptyReturnType)|null  $default
+     * @return $this|TWhenEmptyReturnType
      */
     public function whenEmpty(callable $callback, callable $default = null);
 
     /**
      * Apply the callback if the collection is not empty.
      *
-     * @param  callable  $callback
-     * @param  callable|null  $default
-     * @return static|mixed
+     * @template TWhenNotEmptyReturnType
+     *
+     * @param  callable($this): TWhenNotEmptyReturnType  $callback
+     * @param  (callable($this): TWhenNotEmptyReturnType)|null  $default
+     * @return $this|TWhenNotEmptyReturnType
      */
     public function whenNotEmpty(callable $callback, callable $default = null);
 
     /**
      * Apply the callback if the given "value" is (or resolves to) truthy.
      *
+     * @template TWhenReturnType
+     *
      * @param  bool  $value
-     * @param  callable  $callback
-     * @param  callable|null  $default
-     * @return static|mixed
+     * @param  (callable($this): TUnlessReturnType)  $callback
+     * @param  (callable($this): TUnlessReturnType)|null  $default
+     * @return $this|TUnlessReturnType
      */
     public function unless($value, callable $callback, callable $default = null);
 
     /**
      * Apply the callback unless the collection is empty.
      *
-     * @param  callable  $callback
-     * @param  callable|null  $default
-     * @return static|mixed
+     * @template TUnlessEmptyReturnType
+     *
+     * @param  callable($this): TUnlessEmptyReturnType  $callback
+     * @param  (callable($this): TUnlessEmptyReturnType)|null  $default
+     * @return $this|TUnlessEmptyReturnType
      */
     public function unlessEmpty(callable $callback, callable $default = null);
 
     /**
      * Apply the callback unless the collection is not empty.
      *
-     * @param  callable  $callback
-     * @param  callable|null  $default
-     * @return static|mixed
+     * @template TUnlessNotEmptyReturnType
+     *
+     * @param  callable($this): TUnlessNotEmptyReturnType  $callback
+     * @param  (callable($this): TUnlessNotEmptyReturnType)|null  $default
+     * @return $this|TUnlessNotEmptyReturnType
      */
     public function unlessNotEmpty(callable $callback, callable $default = null);
 
@@ -347,7 +359,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @param  string  $key
      * @param  mixed  $operator
      * @param  mixed  $value
-     * @return static
+     * @return static<TKey, TValue>
      */
     public function where($key, $operator = null, $value = null);
 
@@ -355,7 +367,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Filter items where the value for the given key is null.
      *
      * @param  string|null  $key
-     * @return static
+     * @return static<TKey, TValue>
      */
     public function whereNull($key = null);
 
@@ -363,7 +375,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Filter items where the value for the given key is not null.
      *
      * @param  string|null  $key
-     * @return static
+     * @return static<TKey, TValue>
      */
     public function whereNotNull($key = null);
 
@@ -372,7 +384,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      *
      * @param  string  $key
      * @param  mixed  $value
-     * @return static
+     * @return static<TKey, TValue>
      */
     public function whereStrict($key, $value);
 
@@ -380,9 +392,9 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Filter items by the given key value pair.
      *
      * @param  string  $key
-     * @param  mixed  $values
+     * @param  \Illuminate\Contracts\Support\Arrayable|iterable  $values
      * @param  bool  $strict
-     * @return static
+     * @return static<TKey, TValue>
      */
     public function whereIn($key, $values, $strict = false);
 
@@ -390,8 +402,8 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Filter items by the given key value pair using strict comparison.
      *
      * @param  string  $key
-     * @param  mixed  $values
-     * @return static
+     * @param  \Illuminate\Contracts\Support\Arrayable|iterable  $values
+     * @return static<TKey, TValue>
      */
     public function whereInStrict($key, $values);
 
@@ -399,8 +411,8 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Filter items such that the value of the given key is between the given values.
      *
      * @param  string  $key
-     * @param  array  $values
-     * @return static
+     * @param  \Illuminate\Contracts\Support\Arrayable|iterable  $values
+     * @return static<TKey, TValue>
      */
     public function whereBetween($key, $values);
 
@@ -408,8 +420,8 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Filter items such that the value of the given key is not between the given values.
      *
      * @param  string  $key
-     * @param  array  $values
-     * @return static
+     * @param  \Illuminate\Contracts\Support\Arrayable|iterable  $values
+     * @return static<TKey, TValue>
      */
     public function whereNotBetween($key, $values);
 
@@ -417,9 +429,9 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Filter items by the given key value pair.
      *
      * @param  string  $key
-     * @param  mixed  $values
+     * @param  \Illuminate\Contracts\Support\Arrayable|iterable  $values
      * @param  bool  $strict
-     * @return static
+     * @return static<TKey, TValue>
      */
     public function whereNotIn($key, $values, $strict = false);
 
@@ -427,25 +439,27 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Filter items by the given key value pair using strict comparison.
      *
      * @param  string  $key
-     * @param  mixed  $values
-     * @return static
+     * @param  \Illuminate\Contracts\Support\Arrayable|iterable  $values
+     * @return static<TKey, TValue>
      */
     public function whereNotInStrict($key, $values);
 
     /**
      * Filter the items, removing any items that don't match the given type(s).
      *
-     * @param  string|string[]  $type
-     * @return static
+     * @param  class-string|array<array-key, class-string>  $type
+     * @return static<TKey, TValue>
      */
     public function whereInstanceOf($type);
 
     /**
      * Get the first item from the enumerable passing the given truth test.
      *
-     * @param  callable|null  $callback
-     * @param  mixed  $default
-     * @return mixed
+     * @template TFirstDefault
+     *
+     * @param  (callable(TValue): bool)|null  $callback
+     * @param  TFirstDefault  $default
+     * @return TValue|TFirstDefault
      */
     public function first(callable $callback = null, $default = null);
 
@@ -455,7 +469,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @param  string  $key
      * @param  mixed  $operator
      * @param  mixed  $value
-     * @return mixed
+     * @return TValue|null
      */
     public function firstWhere($key, $operator = null, $value = null);
 
@@ -463,14 +477,14 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Get a flattened array of the items in the collection.
      *
      * @param  int  $depth
-     * @return static
+     * @return static<TKey, TValue>
      */
     public function flatten($depth = INF);
 
     /**
      * Flip the values with their keys.
      *
-     * @return static
+     * @return static<TValue, TKey>
      */
     public function flip();
 
@@ -488,24 +502,24 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Group an associative array by a field or using a callback.
      *
-     * @param  array|callable|string  $groupBy
+     * @param  (callable(TValue, TKey): array-key)|array|string  $groupBy
      * @param  bool  $preserveKeys
-     * @return static
+     * @return static<array-key, array<array-key, TValue>>
      */
     public function groupBy($groupBy, $preserveKeys = false);
 
     /**
      * Key an associative array by a field or using a callback.
      *
-     * @param  callable|string  $keyBy
-     * @return static
+     * @param  (callable(TValue, TKey): array-key)|array|string  $keyBy
+     * @return static<array-key, array<array-key, TValue>>
      */
     public function keyBy($keyBy);
 
     /**
      * Determine if an item exists in the collection by key.
      *
-     * @param  mixed  $key
+     * @param  TKey|array<array-key, TKey>  $key
      * @return bool
      */
     public function has($key);
@@ -522,16 +536,16 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Intersect the collection with the given items.
      *
-     * @param  mixed  $items
-     * @return static
+     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
+     * @return static<TKey, TValue>
      */
     public function intersect($items);
 
     /**
      * Intersect the collection with the given items by key.
      *
-     * @param  mixed  $items
-     * @return static
+     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
+     * @return static<TKey, TValue>
      */
     public function intersectByKeys($items);
 
@@ -561,24 +575,28 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Get the keys of the collection items.
      *
-     * @return static
+     * @return static<int, TKey>
      */
     public function keys();
 
     /**
      * Get the last item from the collection.
      *
-     * @param  callable|null  $callback
-     * @param  mixed  $default
-     * @return mixed
+     * @template TLastDefault
+     *
+     * @param  (callable(TValue, TKey): bool)|null  $callback
+     * @param  TLastDefault  $default
+     * @return TValue|TLastDefault
      */
     public function last(callable $callback = null, $default = null);
 
     /**
      * Run a map over each of the items.
      *
-     * @param  callable  $callback
-     * @return static
+     * @template TMapValue
+     *
+     * @param  callable(TValue, TKey): TMapValue  $callback
+     * @return static<TKey, TMapValue>
      */
     public function map(callable $callback);
 

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -116,9 +116,9 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Alias for the "contains" method.
      *
-     * @param  (callable(TValue): bool)|TValue|string  $key
-     * @param  TValue|string|null  $operator
-     * @param  TValue|null  $value
+     * @param  (callable(TValue, TKey): bool)|TValue|string  $key
+     * @param  mixed  $operator
+     * @param  mixed  $value
      * @return bool
      */
     public function some($key, $operator = null, $value = null);
@@ -143,9 +143,9 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Determine if an item exists in the enumerable.
      *
-     * @param  (callable(TValue): bool)|TValue|string  $key
-     * @param  TValue|string|null  $operator
-     * @param  TValue|null  $value
+     * @param  (callable(TValue, TKey): bool)|TValue|string  $key
+     * @param  mixed  $operator
+     * @param  mixed  $value
      * @return bool
      */
     public function contains($key, $operator = null, $value = null);
@@ -264,8 +264,8 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Determine if all items pass the given truth test.
      *
      * @param  (callable(TValue, TKey): bool)|TValue|string  $key
-     * @param  TValue|string|null  $operator
-     * @param  TValue|null  $value
+     * @param  mixed  $operator
+     * @param  mixed  $value
      * @return bool
      */
     public function every($key, $operator = null, $value = null);
@@ -746,8 +746,8 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Partition the collection into two arrays using the given callback or key.
      *
      * @param  (callable(TValue, TKey): bool)|TValue|string  $key
-     * @param  TValue|string|null  $operator
-     * @param  TValue|null  $value
+     * @param  mixed  $operator
+     * @param  mixed  $value
      * @return array<int, static<TKey, TValue>>
      */
     public function partition($key, $operator = null, $value = null);
@@ -867,8 +867,8 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Get the first item in the collection, but only if exactly one item exists. Otherwise, throw an exception.
      *
      * @param  (callable(TValue, TKey): bool)|string  $key
-     * @param  TValue|string|null  $operator
-     * @param  TValue|null  $value
+     * @param  mixed  $operator
+     * @param  mixed  $value
      * @return TValue
      *
      * @throws \Illuminate\Support\ItemNotFoundException
@@ -997,7 +997,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Get the values of a given key.
      *
-     * @param  string|array<int, string>  $value
+     * @param  string|array<array-key, string>  $value
      * @param  string|null  $key
      * @return static<int, mixed>
      */

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -792,24 +792,24 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Recursively replace the collection items with the given items.
      *
-     * @param  mixed  $items
-     * @return static
+     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
+     * @return static<TKey, TValue>
      */
     public function replaceRecursive($items);
 
     /**
      * Reverse items order.
      *
-     * @return static
+     * @return static<TKey, TValue>
      */
     public function reverse();
 
     /**
      * Search the collection for a given value and return the corresponding key if successful.
      *
-     * @param  mixed  $value
+     * @param  TValue|callable(TValue,TKey): bool  $value
      * @param  bool  $strict
-     * @return mixed
+     * @return TKey|bool
      */
     public function search($value, $strict = false);
 
@@ -817,7 +817,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Shuffle the items in the collection.
      *
      * @param  int|null  $seed
-     * @return static
+     * @return static<TKey, TValue>
      */
     public function shuffle($seed = null);
 
@@ -825,23 +825,23 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Skip the first {$count} items.
      *
      * @param  int  $count
-     * @return static
+     * @return static<TKey, TValue>
      */
     public function skip($count);
 
     /**
      * Skip items in the collection until the given condition is met.
      *
-     * @param  mixed  $value
-     * @return static
+     * @param  TValue|callable(TValue,TKey): bool  $value
+     * @return static<TKey, TValue>
      */
     public function skipUntil($value);
 
     /**
      * Skip items in the collection while the given condition is met.
      *
-     * @param  mixed  $value
-     * @return static
+     * @param  TValue|callable(TValue,TKey): bool  $value
+     * @return static<TKey, TValue>
      */
     public function skipWhile($value);
 
@@ -850,7 +850,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      *
      * @param  int  $offset
      * @param  int|null  $length
-     * @return static
+     * @return static<TKey, TValue>
      */
     public function slice($offset, $length = null);
 
@@ -858,17 +858,17 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Split a collection into a certain number of groups.
      *
      * @param  int  $numberOfGroups
-     * @return static
+     * @return static<int, static<int, TValue>>
      */
     public function split($numberOfGroups);
 
     /**
      * Get the first item in the collection, but only if exactly one item exists. Otherwise, throw an exception.
      *
-     * @param  mixed  $key
-     * @param  mixed  $operator
-     * @param  mixed  $value
-     * @return mixed
+     * @param  (callable(TValue, TKey): bool)|string  $key
+     * @param  TValue|string|null  $operator
+     * @param  TValue|null  $value
+     * @return TValue
      *
      * @throws \Illuminate\Support\ItemNotFoundException
      * @throws \Illuminate\Support\MultipleItemsFoundException
@@ -879,23 +879,23 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Chunk the collection into chunks of the given size.
      *
      * @param  int  $size
-     * @return static
+     * @return static<int, static<int, TValue>>
      */
     public function chunk($size);
 
     /**
      * Chunk the collection into chunks with a callback.
      *
-     * @param  callable  $callback
-     * @return static
+     * @param  callable(TValue, TKey, static<int, TValue>): bool  $callback
+     * @return static<int, static<int, TValue>>
      */
     public function chunkWhile(callable $callback);
 
     /**
      * Sort through each item with a callback.
      *
-     * @param  callable|null|int  $callback
-     * @return static
+     * @param  (callable(TValue, TValue): bool)|null|int  $callback
+     * @return static<TKey, TValue>
      */
     public function sort($callback = null);
 
@@ -903,26 +903,26 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Sort items in descending order.
      *
      * @param  int  $options
-     * @return static
+     * @return static<TKey, TValue>
      */
     public function sortDesc($options = SORT_REGULAR);
 
     /**
      * Sort the collection using the given callback.
      *
-     * @param  callable|string  $callback
+     * @param  (callable(TValue, TKey): mixed)|string  $callback
      * @param  int  $options
      * @param  bool  $descending
-     * @return static
+     * @return static<TKey, TValue>
      */
     public function sortBy($callback, $options = SORT_REGULAR, $descending = false);
 
     /**
      * Sort the collection in descending order using the given callback.
      *
-     * @param  callable|string  $callback
+     * @param  (callable(TValue, TKey): mixed)|string  $callback
      * @param  int  $options
-     * @return static
+     * @return static<TKey, TValue>
      */
     public function sortByDesc($callback, $options = SORT_REGULAR);
 
@@ -931,7 +931,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      *
      * @param  int  $options
      * @param  bool  $descending
-     * @return static
+     * @return static<TKey, TValue>
      */
     public function sortKeys($options = SORT_REGULAR, $descending = false);
 
@@ -939,14 +939,14 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Sort the collection keys in descending order.
      *
      * @param  int  $options
-     * @return static
+     * @return static<TKey, TValue>
      */
     public function sortKeysDesc($options = SORT_REGULAR);
 
     /**
      * Get the sum of the given values.
      *
-     * @param  callable|string|null  $callback
+     * @param  (callable(TValue): mixed)|string|null  $callback
      * @return mixed
      */
     public function sum($callback = null);
@@ -955,30 +955,30 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Take the first or last {$limit} items.
      *
      * @param  int  $limit
-     * @return static
+     * @return static<TKey, TValue>
      */
     public function take($limit);
 
     /**
      * Take items in the collection until the given condition is met.
      *
-     * @param  mixed  $value
-     * @return static
+     * @param  TValue|callable(TValue,TKey): bool  $value
+     * @return static<TKey, TValue>
      */
     public function takeUntil($value);
 
     /**
      * Take items in the collection while the given condition is met.
      *
-     * @param  mixed  $value
-     * @return static
+     * @param  TValue|callable(TValue,TKey): bool  $value
+     * @return static<TKey, TValue>
      */
     public function takeWhile($value);
 
     /**
      * Pass the collection to the given callback and then return it.
      *
-     * @param  callable  $callback
+     * @param  callable(TValue): mixed  $callback
      * @return $this
      */
     public function tap(callable $callback);
@@ -986,66 +986,70 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Pass the enumerable to the given callback and return the result.
      *
-     * @param  callable  $callback
-     * @return mixed
+     * @template TPipeReturnType
+     *
+     * @param  callable($this): TPipeReturnType  $callback
+     * @return TPipeReturnType
      */
     public function pipe(callable $callback);
 
     /**
      * Get the values of a given key.
      *
-     * @param  string|array  $value
+     * @param  string|array<int, string>  $value
      * @param  string|null  $key
-     * @return static
+     * @return static<int, mixed>
      */
     public function pluck($value, $key = null);
 
     /**
      * Create a collection of all elements that do not pass a given truth test.
      *
-     * @param  callable|mixed  $callback
-     * @return static
+     * @param  (callable(TValue): bool)|bool  $callback
+     * @return static<TKey, TValue>
      */
     public function reject($callback = true);
 
     /**
      * Return only unique items from the collection array.
      *
-     * @param  string|callable|null  $key
+     * @param  (callable(TValue, TKey): bool)|string|null  $key
      * @param  bool  $strict
-     * @return static
+     * @return static<TKey, TValue>
      */
     public function unique($key = null, $strict = false);
 
     /**
      * Return only unique items from the collection array using strict comparison.
      *
-     * @param  string|callable|null  $key
-     * @return static
+     * @param  (callable(TValue, TKey): bool)|string|null  $key
+     * @return static<TKey, TValue>
      */
     public function uniqueStrict($key = null);
 
     /**
      * Reset the keys on the underlying array.
      *
-     * @return static
+     * @return static<int, TValue>
      */
     public function values();
 
     /**
      * Pad collection to the specified length with a value.
      *
+     * @template TPadValue
+     *
      * @param  int  $size
-     * @param  mixed  $value
-     * @return static
+     * @param  TPadValue  $value
+     * @return static<int, TValue|TPadValue>
      */
     public function pad($size, $value);
 
     /**
      * Count the number of items in the collection using a given truth test.
      *
-     * @param  callable|null  $callback
-     * @return static
+     * @param  (callable(TValue, TKey): mixed)|string|null  $callback
+     * @return static<TValue, int>
      */
     public function countBy($callback = null);
 
@@ -1055,15 +1059,17 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * e.g. new Collection([1, 2, 3])->zip([4, 5, 6]);
      *      => [[1, 4], [2, 5], [3, 6]]
      *
-     * @param  mixed  ...$items
-     * @return static
+     * @template TZipValue
+     *
+     * @param  \Illuminate\Contracts\Support\Arrayable<array-key, TZipValue>|iterable<array-key, TZipValue>  ...$items
+     * @return static<int, static<int, TValue|TZipValue>>
      */
     public function zip($items);
 
     /**
      * Collect the values into a collection.
      *
-     * @return \Illuminate\Support\Collection
+     * @return \Illuminate\Support\Collection<TKey, TValue>
      */
     public function collect();
 

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -11,6 +11,7 @@ use JsonSerializable;
 /**
  * @template TKey of array-key
  * @template TValue
+ *
  * @extends \Illuminate\Contracts\Support\Arrayable<TKey, TValue>
  * @extends \IteratorAggregate<TKey, TValue>
  */

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -62,7 +62,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @template TUnwrapKey of array-key
      * @template TUnwrapValue
      *
-     * @param  array<TUnwrapKey, TUnwrapValue>|static<TUnwrapKey, TUnwrapValue>   $value
+     * @param  array<TUnwrapKey, TUnwrapValue>|static<TUnwrapKey, TUnwrapValue>  $value
      * @return array<TUnwrapKey, TUnwrapValue>
      */
     public static function unwrap($value);
@@ -280,7 +280,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Run a filter over each of the items.
      *
-     * @param (callable(TValue): bool)|null  $callback
+     * @param  (callable(TValue): bool)|null  $callback
      * @return static<TKey, TValue>
      */
     public function filter(callable $callback = null);
@@ -603,8 +603,10 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Run a map over each nested chunk of items.
      *
-     * @param  callable  $callback
-     * @return static
+     * @template TMapSpreadValue
+     *
+     * @param  callable(...mixed): TMapSpreadValue  $callback
+     * @return static<TKey, TMapSpreadValue>
      */
     public function mapSpread(callable $callback);
 
@@ -613,8 +615,11 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      *
      * The callback should return an associative array with a single key/value pair.
      *
-     * @param  callable  $callback
-     * @return static
+     * @template TMapToDictionaryKey of array-key
+     * @template TMapToDictionaryValue
+     *
+     * @param  callable(TValue, TKey): array<TMapToDictionaryKey, TMapToDictionaryValue>  $callback
+     * @return static<TMapToDictionaryKey, array<int, TMapToDictionaryValue>>
      */
     public function mapToDictionary(callable $callback);
 
@@ -623,8 +628,11 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      *
      * The callback should return an associative array with a single key/value pair.
      *
-     * @param  callable  $callback
-     * @return static
+     * @template TMapToGroupsKey of array-key
+     * @template TMapToGroupsValue
+     *
+     * @param  callable(TValue, TKey): array<TMapToGroupsKey, TMapToGroupsValue>  $callback
+     * @return static<TMapToGroupsKey, static<int, TMapToGroupsValue>>
      */
     public function mapToGroups(callable $callback);
 
@@ -633,72 +641,77 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      *
      * The callback should return an associative array with a single key/value pair.
      *
-     * @param  callable  $callback
-     * @return static
+     * @template TMapWithKeysKey of array-key
+     * @template TMapWithKeysValue
+     *
+     * @param  callable(TValue, TKey): array<TMapWithKeysKey, TMapWithKeysValue>  $callback
+     * @return static<TMapWithKeysKey, TMapWithKeysValue>
      */
     public function mapWithKeys(callable $callback);
 
     /**
      * Map a collection and flatten the result by a single level.
      *
-     * @param  callable  $callback
-     * @return static
+     * @param  callable(TValue, TKey): mixed  $callback
+     * @return static<int, mixed>
      */
     public function flatMap(callable $callback);
 
     /**
      * Map the values into a new class.
      *
-     * @param  string  $class
-     * @return static
+     * @param  class-string $class
+     * @return static<TKey, mixed>
      */
     public function mapInto($class);
 
     /**
      * Merge the collection with the given items.
      *
-     * @param  mixed  $items
-     * @return static
+     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
+     * @return static<TKey, TValue>
      */
     public function merge($items);
 
     /**
      * Recursively merge the collection with the given items.
      *
-     * @param  mixed  $items
-     * @return static
+     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
+     * @return static<TKey, array<int, TValue>>
      */
     public function mergeRecursive($items);
 
     /**
      * Create a collection by using this collection for keys and another for its values.
      *
-     * @param  mixed  $values
-     * @return static
+     * @template TCombineValue
+     *
+     * @param  \Illuminate\Contracts\Support\Arrayable<array-key, TCombineValue>|iterable<array-key, TCombineValue>  $values
+     * @return static<TKey, TCombineValue>
      */
     public function combine($values);
 
     /**
      * Union the collection with the given items.
      *
-     * @param  mixed  $items
-     * @return static
+     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
+     * @return static<TKey, TValue>
      */
     public function union($items);
 
     /**
      * Get the min value of a given key.
      *
-     * @param  callable|string|null  $callback
-     * @return mixed
+     * @param  (callable(TValue):mixed)|string|null  $callback
+     * @return TValue
      */
     public function min($callback = null);
 
     /**
      * Get the max value of a given key.
      *
-     * @param  callable|string|null  $callback
-     * @return mixed
+     * @param  (callable(TValue):mixed)|string|null  $callback
+     * @return TValue
      */
     public function max($callback = null);
 
@@ -707,15 +720,15 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      *
      * @param  int  $step
      * @param  int  $offset
-     * @return static
+     * @return static<TKey, TValue>
      */
     public function nth($step, $offset = 0);
 
     /**
      * Get the items with the specified keys.
      *
-     * @param  mixed  $keys
-     * @return static
+     * @param  \Illuminate\Support\Enumerable<array-key, TKey>|array<array-key, TKey>  $keys
+     * @return static<TKey, TValue>
      */
     public function only($keys);
 
@@ -724,25 +737,25 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      *
      * @param  int  $page
      * @param  int  $perPage
-     * @return static
+     * @return static<TKey, TValue>
      */
     public function forPage($page, $perPage);
 
     /**
      * Partition the collection into two arrays using the given callback or key.
      *
-     * @param  callable|string  $key
-     * @param  mixed  $operator
-     * @param  mixed  $value
-     * @return static
+     * @param  (callable(TValue, TKey): bool)|TValue|string  $key
+     * @param  TValue|string|null  $operator
+     * @param  TValue|null  $value
+     * @return array<int, static<TKey, TValue>>
      */
     public function partition($key, $operator = null, $value = null);
 
     /**
      * Push all of the given items onto the collection.
      *
-     * @param  iterable  $source
-     * @return static
+     * @param  iterable<array-key, TValue>  $source
+     * @return static<TKey, TValue>
      */
     public function concat($source);
 
@@ -750,7 +763,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Get one or a specified number of items randomly from the collection.
      *
      * @param  int|null  $number
-     * @return static|mixed
+     * @return static<int, TValue>|TValue
      *
      * @throws \InvalidArgumentException
      */
@@ -759,17 +772,20 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Reduce the collection to a single value.
      *
-     * @param  callable  $callback
-     * @param  mixed  $initial
-     * @return mixed
+     * @template TReduceInitial
+     * @template TReduceReturnType
+     *
+     * @param  callable(TReduceInitial|TReduceReturnType, TValue): TReduceReturnType  $callback
+     * @param  TReduceInitial  $initial
+     * @return TReduceReturnType
      */
     public function reduce(callable $callback, $initial = null);
 
     /**
      * Replace the collection items with the given items.
      *
-     * @param  mixed  $items
-     * @return static
+     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
+     * @return static<TKey, TValue>
      */
     public function replace($items);
 

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -858,7 +858,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Split a collection into a certain number of groups.
      *
      * @param  int  $numberOfGroups
-     * @return static<int, static<int, TValue>>
+     * @return static<int, static<TKey, TValue>>
      */
     public function split($numberOfGroups);
 

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -43,6 +43,8 @@ use Traversable;
  * @property-read HigherOrderCollectionProxy $unless
  * @property-read HigherOrderCollectionProxy $until
  * @property-read HigherOrderCollectionProxy $when
+ * @template TKey as array-key
+ * @template TValue
  */
 trait EnumeratesValues
 {
@@ -51,7 +53,7 @@ trait EnumeratesValues
     /**
      * The methods that can be proxied.
      *
-     * @var string[]
+     * @var array<int, string>
      */
     protected static $proxies = [
         'average',
@@ -86,8 +88,11 @@ trait EnumeratesValues
     /**
      * Create a new collection instance if the value isn't one already.
      *
-     * @param  mixed  $items
-     * @return static
+     * @template TMakeKey as array-key
+     * @template TMakeValue
+     *
+     * @param  \Illuminate\Contracts\Support\Arrayable<TMakeKey, TMakeValue>|iterable<TMakeKey, TMakeValue>|null  $items
+     * @return static<TMakeKey, TMakeValue>
      */
     public static function make($items = [])
     {
@@ -97,8 +102,11 @@ trait EnumeratesValues
     /**
      * Wrap the given value in a collection if applicable.
      *
-     * @param  mixed  $value
-     * @return static
+     * @template TWrapKey as array-key
+     * @template TWrapValue
+     *
+     * @param  iterable<TWrapKey, TWrapValue>  $value
+     * @return static<TWrapKey, TWrapValue>
      */
     public static function wrap($value)
     {
@@ -110,8 +118,11 @@ trait EnumeratesValues
     /**
      * Get the underlying items from the given collection if applicable.
      *
-     * @param  array|static  $value
-     * @return array
+     * @template TUnwrapKey as array-key
+     * @template TUnwrapValue
+     *
+     * @param  array<TUnwrapKey, TUnwrapValue>|static<TUnwrapKey, TUnwrapValue>   $value
+     * @return array<TUnwrapKey, TUnwrapValue>
      */
     public static function unwrap($value)
     {
@@ -121,7 +132,7 @@ trait EnumeratesValues
     /**
      * Create a new instance with no items.
      *
-     * @return static
+     * @return static<TKey, TValue>
      */
     public static function empty()
     {
@@ -131,9 +142,11 @@ trait EnumeratesValues
     /**
      * Create a new collection by invoking the callback a given amount of times.
      *
+     * @template TTimesValue
+     *
      * @param  int  $number
-     * @param  callable|null  $callback
-     * @return static
+     * @param  (callable(int): TTimesValue)|null  $callback
+     * @return static<int, TTimesValue>
      */
     public static function times($number, callable $callback = null)
     {
@@ -149,8 +162,8 @@ trait EnumeratesValues
     /**
      * Alias for the "avg" method.
      *
-     * @param  callable|string|null  $callback
-     * @return mixed
+     * @param  (callable(TValue): float|int)|string|null  $callback
+     * @return float|int|null
      */
     public function average($callback = null)
     {
@@ -160,9 +173,9 @@ trait EnumeratesValues
     /**
      * Alias for the "contains" method.
      *
-     * @param  mixed  $key
-     * @param  mixed  $operator
-     * @param  mixed  $value
+     * @param  (callable(TValue): bool)|TValue|string  $key
+     * @param  TValue|string|null  $operator
+     * @param  TValue|null  $value
      * @return bool
      */
     public function some($key, $operator = null, $value = null)
@@ -173,8 +186,8 @@ trait EnumeratesValues
     /**
      * Determine if an item exists, using strict comparison.
      *
-     * @param  mixed  $key
-     * @param  mixed  $value
+     * @param  (callable(TValue): bool)|TValue|string  $key
+     * @param  TValue|null  $value
      * @return bool
      */
     public function containsStrict($key, $value = null)
@@ -202,7 +215,7 @@ trait EnumeratesValues
      * Dump the items and end the script.
      *
      * @param  mixed  ...$args
-     * @return void
+     * @return never
      */
     public function dd(...$args)
     {
@@ -230,7 +243,7 @@ trait EnumeratesValues
     /**
      * Execute a callback over each item.
      *
-     * @param  callable  $callback
+     * @param  callable(TValue): mixed  $callback
      * @return $this
      */
     public function each(callable $callback)
@@ -788,7 +801,7 @@ trait EnumeratesValues
     /**
      * Get the collection of items as a plain array.
      *
-     * @return array
+     * @return array<TKey, TValue>
      */
     public function toArray()
     {

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -704,7 +704,7 @@ trait EnumeratesValues
     /**
      * Pass the collection into a new class.
      *
-     * @param  string  $class
+     * @param  string-class  $class
      * @return mixed
      */
     public function pipeInto($class)
@@ -736,9 +736,12 @@ trait EnumeratesValues
     /**
      * Reduce an associative collection to a single value.
      *
-     * @param  callable  $callback
-     * @param  mixed  $initial
-     * @return mixed
+     * @template TReduceWithKeysInitial
+     * @template TReduceWithKeysReturnType
+     *
+     * @param  callable(TReduceWithKeysInitial|TReduceWithKeysReturnType, TValue): TReduceWithKeysReturnType $callback
+     * @param  TReduceWithKeysInitial $initial
+     * @return TReduceWithKeysReturnType
      */
     public function reduceWithKeys(callable $callback, $initial = null)
     {
@@ -821,7 +824,7 @@ trait EnumeratesValues
     /**
      * Get the collection of items as a plain array.
      *
-     * @return array<TKey, TValue>
+     * @return array<TKey, mixed>
      */
     public function toArray()
     {
@@ -833,7 +836,7 @@ trait EnumeratesValues
     /**
      * Convert the object into something JSON serializable.
      *
-     * @return array
+     * @return array<TKey, mixed>
      */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -174,9 +174,9 @@ trait EnumeratesValues
     /**
      * Alias for the "contains" method.
      *
-     * @param  (callable(TValue): bool)|TValue|string  $key
-     * @param  TValue|string|null  $operator
-     * @param  TValue|null  $value
+     * @param  (callable(TValue, TKey): bool)|TValue|string  $key
+     * @param  mixed  $operator
+     * @param  mixed  $value
      * @return bool
      */
     public function some($key, $operator = null, $value = null)
@@ -277,8 +277,8 @@ trait EnumeratesValues
      * Determine if all items pass the given truth test.
      *
      * @param  (callable(TValue, TKey): bool)|TValue|string  $key
-     * @param  TValue|string|null  $operator
-     * @param  TValue|null  $value
+     * @param  mixed  $operator
+     * @param  mixed  $value
      * @return bool
      */
     public function every($key, $operator = null, $value = null)

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -16,6 +16,9 @@ use Symfony\Component\VarDumper\VarDumper;
 use Traversable;
 
 /**
+ * @template TKey of array-key
+ * @template TValue
+ *
  * @property-read HigherOrderCollectionProxy $average
  * @property-read HigherOrderCollectionProxy $avg
  * @property-read HigherOrderCollectionProxy $contains
@@ -43,8 +46,6 @@ use Traversable;
  * @property-read HigherOrderCollectionProxy $unless
  * @property-read HigherOrderCollectionProxy $until
  * @property-read HigherOrderCollectionProxy $when
- * @template TKey of array-key
- * @template TValue
  */
 trait EnumeratesValues
 {

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -43,7 +43,7 @@ use Traversable;
  * @property-read HigherOrderCollectionProxy $unless
  * @property-read HigherOrderCollectionProxy $until
  * @property-read HigherOrderCollectionProxy $when
- * @template TKey as array-key
+ * @template TKey of array-key
  * @template TValue
  */
 trait EnumeratesValues
@@ -88,7 +88,7 @@ trait EnumeratesValues
     /**
      * Create a new collection instance if the value isn't one already.
      *
-     * @template TMakeKey as array-key
+     * @template TMakeKey of array-key
      * @template TMakeValue
      *
      * @param  \Illuminate\Contracts\Support\Arrayable<TMakeKey, TMakeValue>|iterable<TMakeKey, TMakeValue>|null  $items
@@ -102,7 +102,7 @@ trait EnumeratesValues
     /**
      * Wrap the given value in a collection if applicable.
      *
-     * @template TWrapKey as array-key
+     * @template TWrapKey of array-key
      * @template TWrapValue
      *
      * @param  iterable<TWrapKey, TWrapValue>  $value
@@ -118,7 +118,7 @@ trait EnumeratesValues
     /**
      * Get the underlying items from the given collection if applicable.
      *
-     * @template TUnwrapKey as array-key
+     * @template TUnwrapKey of array-key
      * @template TUnwrapValue
      *
      * @param  array<TUnwrapKey, TUnwrapValue>|static<TUnwrapKey, TUnwrapValue>   $value
@@ -260,8 +260,8 @@ trait EnumeratesValues
     /**
      * Execute a callback over each nested chunk of items.
      *
-     * @param  callable  $callback
-     * @return static
+     * @param  callable(...mixed): mixed  $callback
+     * @return static<TKey, TValue>
      */
     public function eachSpread(callable $callback)
     {
@@ -275,9 +275,9 @@ trait EnumeratesValues
     /**
      * Determine if all items pass the given truth test.
      *
-     * @param  string|callable  $key
-     * @param  mixed  $operator
-     * @param  mixed  $value
+     * @param  (callable(TValue, TKey): bool)|TValue|string  $key
+     * @param  TValue|string|null  $operator
+     * @param  TValue|null  $value
      * @return bool
      */
     public function every($key, $operator = null, $value = null)
@@ -303,7 +303,7 @@ trait EnumeratesValues
      * @param  string  $key
      * @param  mixed  $operator
      * @param  mixed  $value
-     * @return mixed
+     * @return TValue|null
      */
     public function firstWhere($key, $operator = null, $value = null)
     {
@@ -474,9 +474,11 @@ trait EnumeratesValues
     /**
      * Apply the callback if the collection is empty.
      *
-     * @param  callable  $callback
-     * @param  callable|null  $default
-     * @return static|mixed
+     * @template TWhenEmptyReturnType
+     *
+     * @param  (callable($this): TWhenEmptyReturnType)  $callback
+     * @param  (callable($this): TWhenEmptyReturnType)|null  $default
+     * @return $this|TWhenEmptyReturnType
      */
     public function whenEmpty(callable $callback, callable $default = null)
     {
@@ -486,9 +488,11 @@ trait EnumeratesValues
     /**
      * Apply the callback if the collection is not empty.
      *
-     * @param  callable  $callback
-     * @param  callable|null  $default
-     * @return static|mixed
+     * @template TWhenNotEmptyReturnType
+     *
+     * @param  callable($this): TWhenNotEmptyReturnType  $callback
+     * @param  (callable($this): TWhenNotEmptyReturnType)|null  $default
+     * @return $this|TWhenNotEmptyReturnType
      */
     public function whenNotEmpty(callable $callback, callable $default = null)
     {
@@ -498,9 +502,11 @@ trait EnumeratesValues
     /**
      * Apply the callback unless the collection is empty.
      *
-     * @param  callable  $callback
-     * @param  callable|null  $default
-     * @return static|mixed
+     * @template TUnlessEmptyReturnType
+     *
+     * @param  callable($this): TUnlessEmptyReturnType  $callback
+     * @param  (callable($this): TUnlessEmptyReturnType)|null  $default
+     * @return $this|TUnlessEmptyReturnType
      */
     public function unlessEmpty(callable $callback, callable $default = null)
     {
@@ -510,9 +516,11 @@ trait EnumeratesValues
     /**
      * Apply the callback unless the collection is not empty.
      *
-     * @param  callable  $callback
-     * @param  callable|null  $default
-     * @return static|mixed
+     * @template TUnlessNotEmptyReturnType
+     *
+     * @param  callable($this): TUnlessNotEmptyReturnType  $callback
+     * @param  (callable($this): TUnlessNotEmptyReturnType)|null  $default
+     * @return $this|TUnlessNotEmptyReturnType
      */
     public function unlessNotEmpty(callable $callback, callable $default = null)
     {
@@ -525,7 +533,7 @@ trait EnumeratesValues
      * @param  string  $key
      * @param  mixed  $operator
      * @param  mixed  $value
-     * @return static
+     * @return static<TKey, TValue>
      */
     public function where($key, $operator = null, $value = null)
     {
@@ -536,7 +544,7 @@ trait EnumeratesValues
      * Filter items where the value for the given key is null.
      *
      * @param  string|null  $key
-     * @return static
+     * @return static<TKey, TValue>
      */
     public function whereNull($key = null)
     {
@@ -547,7 +555,7 @@ trait EnumeratesValues
      * Filter items where the value for the given key is not null.
      *
      * @param  string|null  $key
-     * @return static
+     * @return static<TKey, TValue>
      */
     public function whereNotNull($key = null)
     {
@@ -559,7 +567,8 @@ trait EnumeratesValues
      *
      * @param  string  $key
      * @param  mixed  $value
-     * @return static
+     * @param  bool  $strict
+     * @return static<TKey, TValue>
      */
     public function whereStrict($key, $value)
     {
@@ -570,9 +579,9 @@ trait EnumeratesValues
      * Filter items by the given key value pair.
      *
      * @param  string  $key
-     * @param  mixed  $values
+     * @param  \Illuminate\Contracts\Support\Arrayable|iterable  $values
      * @param  bool  $strict
-     * @return static
+     * @return static<TKey, TValue>
      */
     public function whereIn($key, $values, $strict = false)
     {
@@ -587,8 +596,8 @@ trait EnumeratesValues
      * Filter items by the given key value pair using strict comparison.
      *
      * @param  string  $key
-     * @param  mixed  $values
-     * @return static
+     * @param  \Illuminate\Contracts\Support\Arrayable|iterable  $values
+     * @return static<TKey, TValue>
      */
     public function whereInStrict($key, $values)
     {
@@ -599,8 +608,8 @@ trait EnumeratesValues
      * Filter items such that the value of the given key is between the given values.
      *
      * @param  string  $key
-     * @param  array  $values
-     * @return static
+     * @param  \Illuminate\Contracts\Support\Arrayable|iterable  $values
+     * @return static<TKey, TValue>
      */
     public function whereBetween($key, $values)
     {
@@ -611,8 +620,8 @@ trait EnumeratesValues
      * Filter items such that the value of the given key is not between the given values.
      *
      * @param  string  $key
-     * @param  array  $values
-     * @return static
+     * @param  \Illuminate\Contracts\Support\Arrayable|iterable  $values
+     * @return static<TKey, TValue>
      */
     public function whereNotBetween($key, $values)
     {
@@ -625,9 +634,9 @@ trait EnumeratesValues
      * Filter items by the given key value pair.
      *
      * @param  string  $key
-     * @param  mixed  $values
+     * @param  \Illuminate\Contracts\Support\Arrayable|iterable  $values
      * @param  bool  $strict
-     * @return static
+     * @return static<TKey, TValue>
      */
     public function whereNotIn($key, $values, $strict = false)
     {
@@ -642,8 +651,8 @@ trait EnumeratesValues
      * Filter items by the given key value pair using strict comparison.
      *
      * @param  string  $key
-     * @param  mixed  $values
-     * @return static
+     * @param  \Illuminate\Contracts\Support\Arrayable|iterable  $values
+     * @return static<TKey, TValue>
      */
     public function whereNotInStrict($key, $values)
     {
@@ -653,8 +662,8 @@ trait EnumeratesValues
     /**
      * Filter the items, removing any items that don't match the given type(s).
      *
-     * @param  string|string[]  $type
-     * @return static
+     * @param  class-string|array<array-key, class-string>  $type
+     * @return static<TKey, TValue>
      */
     public function whereInstanceOf($type)
     {

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -462,7 +462,7 @@ trait EnumeratesValues
     /**
      * Get the sum of the given values.
      *
-     * @param  callable|string|null  $callback
+     * @param  (callable(TValue): mixed)|string|null  $callback
      * @return mixed
      */
     public function sum($callback = null)
@@ -690,8 +690,10 @@ trait EnumeratesValues
     /**
      * Pass the collection to the given callback and return the result.
      *
-     * @param  callable  $callback
-     * @return mixed
+     * @template TPipeReturnType
+     *
+     * @param  callable($this): TPipeReturnType  $callback
+     * @return TPipeReturnType
      */
     public function pipe(callable $callback)
     {
@@ -745,8 +747,8 @@ trait EnumeratesValues
     /**
      * Create a collection of all elements that do not pass a given truth test.
      *
-     * @param  callable|mixed  $callback
-     * @return static
+     * @param  (callable(TValue): bool)|bool  $callback
+     * @return static<TKey, TValue>
      */
     public function reject($callback = true)
     {
@@ -762,7 +764,7 @@ trait EnumeratesValues
     /**
      * Pass the collection to the given callback and then return it.
      *
-     * @param  callable  $callback
+     * @param  callable(TValue): mixed  $callback
      * @return $this
      */
     public function tap(callable $callback)
@@ -775,9 +777,9 @@ trait EnumeratesValues
     /**
      * Return only unique items from the collection array.
      *
-     * @param  string|callable|null  $key
+     * @param  (callable(TValue, TKey): bool)|string|null  $key
      * @param  bool  $strict
-     * @return static
+     * @return static<TKey, TValue>
      */
     public function unique($key = null, $strict = false)
     {
@@ -797,8 +799,8 @@ trait EnumeratesValues
     /**
      * Return only unique items from the collection array using strict comparison.
      *
-     * @param  string|callable|null  $key
-     * @return static
+     * @param  (callable(TValue, TKey): bool)|string|null  $key
+     * @return static<TKey, TValue>
      */
     public function uniqueStrict($key = null)
     {
@@ -808,7 +810,7 @@ trait EnumeratesValues
     /**
      * Collect the values into a collection.
      *
-     * @return \Illuminate\Support\Collection
+     * @return \Illuminate\Support\Collection<TKey, TValue>
      */
     public function collect()
     {

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -323,8 +323,10 @@ trait EnumeratesValues
     /**
      * Run a map over each nested chunk of items.
      *
-     * @param  callable  $callback
-     * @return static
+     * @template TMapSpreadValue
+     *
+     * @param  callable(mixed): TMapSpreadValue  $callback
+     * @return static<TKey, TMapSpreadValue>
      */
     public function mapSpread(callable $callback)
     {
@@ -340,8 +342,11 @@ trait EnumeratesValues
      *
      * The callback should return an associative array with a single key/value pair.
      *
-     * @param  callable  $callback
-     * @return static
+     * @template TMapToGroupsKey of array-key
+     * @template TMapToGroupsValue
+     *
+     * @param  callable(TValue, TKey): array<TMapToGroupsKey, TMapToGroupsValue>   $callback
+     * @return static<TMapToGroupsKey, static<int, TMapToGroupsValue>>
      */
     public function mapToGroups(callable $callback)
     {
@@ -353,8 +358,8 @@ trait EnumeratesValues
     /**
      * Map a collection and flatten the result by a single level.
      *
-     * @param  callable  $callback
-     * @return static
+     * @param callable(TValue, TKey): mixed $callback
+     * @return static<int, mixed>
      */
     public function flatMap(callable $callback)
     {
@@ -364,8 +369,8 @@ trait EnumeratesValues
     /**
      * Map the values into a new class.
      *
-     * @param  string  $class
-     * @return static
+     * @param  class-string $class
+     * @return static<TKey, mixed>
      */
     public function mapInto($class)
     {
@@ -377,8 +382,8 @@ trait EnumeratesValues
     /**
      * Get the min value of a given key.
      *
-     * @param  callable|string|null  $callback
-     * @return mixed
+     * @param  (callable(TValue):mixed)|string|null  $callback
+     * @return TValue
      */
     public function min($callback = null)
     {
@@ -396,8 +401,8 @@ trait EnumeratesValues
     /**
      * Get the max value of a given key.
      *
-     * @param  callable|string|null  $callback
-     * @return mixed
+     * @param  (callable(TValue):mixed)|string|null  $callback
+     * @return TValue
      */
     public function max($callback = null)
     {
@@ -429,10 +434,10 @@ trait EnumeratesValues
     /**
      * Partition the collection into two arrays using the given callback or key.
      *
-     * @param  callable|string  $key
-     * @param  mixed  $operator
-     * @param  mixed  $value
-     * @return static
+     * @param  (callable(TValue, TKey): bool)|TValue|string  $key
+     * @param  TValue|string|null $operator
+     * @param  TValue|null $value
+     * @return array<int, static<TKey, TValue>>
      */
     public function partition($key, $operator = null, $value = null)
     {
@@ -707,9 +712,12 @@ trait EnumeratesValues
     /**
      * Reduce the collection to a single value.
      *
-     * @param  callable  $callback
-     * @param  mixed  $initial
-     * @return mixed
+     * @template TReduceInitial
+     * @template TReduceReturnType
+     *
+     * @param  callable(TReduceInitial|TReduceReturnType, TValue): TReduceReturnType $callback
+     * @param  TReduceInitial $initial
+     * @return TReduceReturnType
      */
     public function reduce(callable $callback, $initial = null)
     {

--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -7,8 +7,10 @@ if (! function_exists('collect')) {
     /**
      * Create a collection from the given value.
      *
-     * @param  mixed  $value
-     * @return \Illuminate\Support\Collection
+     * @template TKey as array-key
+     * @template TValue
+     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>|null  $value
+     * @return \Illuminate\Support\Collection<TKey, TValue>
      */
     function collect($value = null)
     {

--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -9,6 +9,7 @@ if (! function_exists('collect')) {
      *
      * @template TKey of array-key
      * @template TValue
+     * 
      * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>|null  $value
      * @return \Illuminate\Support\Collection<TKey, TValue>
      */

--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -9,7 +9,7 @@ if (! function_exists('collect')) {
      *
      * @template TKey of array-key
      * @template TValue
-     * 
+     *
      * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>|null  $value
      * @return \Illuminate\Support\Collection<TKey, TValue>
      */

--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -7,7 +7,7 @@ if (! function_exists('collect')) {
     /**
      * Create a collection from the given value.
      *
-     * @template TKey as array-key
+     * @template TKey of array-key
      * @template TValue
      * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>|null  $value
      * @return \Illuminate\Support\Collection<TKey, TValue>

--- a/src/Illuminate/Conditionable/Traits/Conditionable.php
+++ b/src/Illuminate/Conditionable/Traits/Conditionable.php
@@ -10,10 +10,12 @@ trait Conditionable
     /**
      * Apply the callback if the given "value" is (or resolves to) truthy.
      *
-     * @param  mixed  $value
-     * @param  callable|null  $callback
-     * @param  callable|null  $default
-     * @return $this|mixed
+     * @template TWhenReturnType
+     *
+     * @param  bool  $value
+     * @param  (callable($this): TWhenReturnType)|null  $callback
+     * @param  (callable($this): TWhenReturnType)|null  $default
+     * @return $this|TWhenReturnType
      */
     public function when($value, callable $callback = null, callable $default = null)
     {
@@ -35,10 +37,12 @@ trait Conditionable
     /**
      * Apply the callback if the given "value" is (or resolves to) falsy.
      *
-     * @param  mixed  $value
-     * @param  callable|null  $callback
-     * @param  callable|null  $default
-     * @return $this|mixed
+     * @template TUnlessReturnType
+     *
+     * @param  bool  $value
+     * @param  (callable($this): TUnlessReturnType)  $callback
+     * @param  (callable($this): TUnlessReturnType)|null  $default
+     * @return $this|TUnlessReturnType
      */
     public function unless($value, callable $callback = null, callable $default = null)
     {

--- a/src/Illuminate/Contracts/Queue/QueueableCollection.php
+++ b/src/Illuminate/Contracts/Queue/QueueableCollection.php
@@ -14,14 +14,14 @@ interface QueueableCollection
     /**
      * Get the identifiers for all of the entities.
      *
-     * @return array
+     * @return array<int, mixed>
      */
     public function getQueueableIds();
 
     /**
      * Get the relationships of the entities being queued.
      *
-     * @return array
+     * @return array<int, string>
      */
     public function getQueueableRelations();
 

--- a/src/Illuminate/Contracts/Support/Arrayable.php
+++ b/src/Illuminate/Contracts/Support/Arrayable.php
@@ -2,12 +2,16 @@
 
 namespace Illuminate\Contracts\Support;
 
+/**
+ * @template TKey as array-key
+ * @template TValue
+ */
 interface Arrayable
 {
     /**
      * Get the instance as an array.
      *
-     * @return array
+     * @return array<TKey, TValue>
      */
     public function toArray();
 }

--- a/src/Illuminate/Contracts/Support/Arrayable.php
+++ b/src/Illuminate/Contracts/Support/Arrayable.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Contracts\Support;
 
 /**
- * @template TKey as array-key
+ * @template TKey of array-key
  * @template TValue
  */
 interface Arrayable

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -74,7 +74,7 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Load a set of aggregations over relationship's column onto the collection.
      *
-     * @param  array<array-key, string>|string  $relations
+     * @param  array<array-key, (callable(\Illuminate\Database\Eloquent\Builder): mixed)|string>|string  $relations
      * @param  string  $column
      * @param  string|null  $function
      * @return $this
@@ -109,7 +109,7 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Load a set of relationship counts onto the collection.
      *
-     * @param  array<array-key, string>|string  $relations
+     * @param  array<array-key, (callable(\Illuminate\Database\Eloquent\Builder): mixed)|string>|string  $relations
      * @return $this
      */
     public function loadCount($relations)
@@ -120,7 +120,7 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Load a set of relationship's max column values onto the collection.
      *
-     * @param  array<array-key, string>|string  $relations
+     * @param  array<array-key, (callable(\Illuminate\Database\Eloquent\Builder): mixed)|string>|string  $relations
      * @param  string  $column
      * @return $this
      */
@@ -132,7 +132,7 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Load a set of relationship's min column values onto the collection.
      *
-     * @param  array<array-key, string>|string  $relations
+     * @param  array<array-key, (callable(\Illuminate\Database\Eloquent\Builder): mixed)|string>|string  $relations
      * @param  string  $column
      * @return $this
      */
@@ -144,7 +144,7 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Load a set of relationship's column summations onto the collection.
      *
-     * @param  array<array-key, string>|string  $relations
+     * @param  array<array-key, (callable(\Illuminate\Database\Eloquent\Builder): mixed)|string>|string  $relations
      * @param  string  $column
      * @return $this
      */
@@ -156,7 +156,7 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Load a set of relationship's average column values onto the collection.
      *
-     * @param  array<array-key, string>|string  $relations
+     * @param  array<array-key, (callable(\Illuminate\Database\Eloquent\Builder): mixed)|string>|string  $relations
      * @param  string  $column
      * @return $this
      */
@@ -168,7 +168,7 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Load a set of related existences onto the collection.
      *
-     * @param  array<array-key, string>|string  $relations
+     * @param  array<array-key, (callable(\Illuminate\Database\Eloquent\Builder): mixed)|string>|string  $relations
      * @return $this
      */
     public function loadExists($relations)
@@ -179,7 +179,7 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Load a set of relationships onto the collection if they are not already eager loaded.
      *
-     * @param  array<array-key, string>|string  $relations
+     * @param  array<array-key, (callable(\Illuminate\Database\Eloquent\Builder): mixed)|string>|string  $relations
      * @return $this
      */
     public function loadMissing($relations)
@@ -253,7 +253,7 @@ class Collection extends BaseCollection implements QueueableCollection
      * Load a set of relationships onto the mixed relationship collection.
      *
      * @param  string  $relation
-     * @param  array<array-key, string>  $relations
+     * @param  array<array-key, (callable(\Illuminate\Database\Eloquent\Builder): mixed)|string> $relations
      * @return $this
      */
     public function loadMorph($relation, $relations)
@@ -274,7 +274,7 @@ class Collection extends BaseCollection implements QueueableCollection
      * Load a set of relationship counts onto the mixed relationship collection.
      *
      * @param  string  $relation
-     * @param  array<array-key, string>  $relations
+     * @param  array<array-key, (callable(\Illuminate\Database\Eloquent\Builder): mixed)|string> $relations
      * @return $this
      */
     public function loadMorphCount($relation, $relations)

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -10,14 +10,22 @@ use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Support\Str;
 use LogicException;
 
+/**
+ * @template TKey of array-key
+ * @template TModel of \Illuminate\Database\Eloquent\Model
+ *
+ * @extends \Illuminate\Support\Collection<TKey, TModel>
+ */
 class Collection extends BaseCollection implements QueueableCollection
 {
     /**
      * Find a model in the collection by key.
      *
+     * @template TFindDefault
+     *
      * @param  mixed  $key
-     * @param  mixed  $default
-     * @return \Illuminate\Database\Eloquent\Model|static|null
+     * @param  TFindDefault  $default
+     * @return static<TKey|TModel>|TModel|TFindDefault
      */
     public function find($key, $default = null)
     {
@@ -45,7 +53,7 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Load a set of relationships onto the collection.
      *
-     * @param  array|string  $relations
+     * @param  array<array-key, string>|string  $relations
      * @return $this
      */
     public function load($relations)
@@ -66,9 +74,9 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Load a set of aggregations over relationship's column onto the collection.
      *
-     * @param  array|string  $relations
+     * @param  array<array-key, string>|string  $relations
      * @param  string  $column
-     * @param  string  $function
+     * @param  string|null  $function
      * @return $this
      */
     public function loadAggregate($relations, $column, $function = null)
@@ -101,7 +109,7 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Load a set of relationship counts onto the collection.
      *
-     * @param  array|string  $relations
+     * @param  array<array-key, string>|string  $relations
      * @return $this
      */
     public function loadCount($relations)
@@ -112,7 +120,7 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Load a set of relationship's max column values onto the collection.
      *
-     * @param  array|string  $relations
+     * @param  array<array-key, string>|string  $relations
      * @param  string  $column
      * @return $this
      */
@@ -124,7 +132,7 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Load a set of relationship's min column values onto the collection.
      *
-     * @param  array|string  $relations
+     * @param  array<array-key, string>|string  $relations
      * @param  string  $column
      * @return $this
      */
@@ -136,7 +144,7 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Load a set of relationship's column summations onto the collection.
      *
-     * @param  array|string  $relations
+     * @param  array<array-key, string>|string  $relations
      * @param  string  $column
      * @return $this
      */
@@ -148,7 +156,7 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Load a set of relationship's average column values onto the collection.
      *
-     * @param  array|string  $relations
+     * @param  array<array-key, string>|string  $relations
      * @param  string  $column
      * @return $this
      */
@@ -160,7 +168,7 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Load a set of related existences onto the collection.
      *
-     * @param  array|string  $relations
+     * @param  array<array-key, string>|string  $relations
      * @return $this
      */
     public function loadExists($relations)
@@ -171,7 +179,7 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Load a set of relationships onto the collection if they are not already eager loaded.
      *
-     * @param  array|string  $relations
+     * @param  array<array-key, string>|string  $relations
      * @return $this
      */
     public function loadMissing($relations)
@@ -245,7 +253,7 @@ class Collection extends BaseCollection implements QueueableCollection
      * Load a set of relationships onto the mixed relationship collection.
      *
      * @param  string  $relation
-     * @param  array  $relations
+     * @param  array<array-key, string>  $relations
      * @return $this
      */
     public function loadMorph($relation, $relations)
@@ -266,7 +274,7 @@ class Collection extends BaseCollection implements QueueableCollection
      * Load a set of relationship counts onto the mixed relationship collection.
      *
      * @param  string  $relation
-     * @param  array  $relations
+     * @param  array<array-key, string>  $relations
      * @return $this
      */
     public function loadMorphCount($relation, $relations)
@@ -286,7 +294,7 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Determine if a key exists in the collection.
      *
-     * @param  mixed  $key
+     * @param  (callable(TModel, TKey): bool)|TModel|string  $key
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return bool
@@ -311,7 +319,7 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Get the array of primary keys.
      *
-     * @return array
+     * @return array<int, mixed>
      */
     public function modelKeys()
     {
@@ -323,8 +331,8 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Merge the collection with the given items.
      *
-     * @param  \ArrayAccess|array  $items
-     * @return static
+     * @param  iterable<array-key, TModel>  $items
+     * @return static<TKey, TModel>
      */
     public function merge($items)
     {
@@ -340,8 +348,10 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Run a map over each of the items.
      *
-     * @param  callable  $callback
-     * @return \Illuminate\Support\Collection|static
+     * @template TMapValue
+     *
+     * @param  callable(TModel, TKey): TMapValue  $callback
+     * @return \Illuminate\Support\Collection<TKey, TMapValue>|static<TKey, TMapValue>
      */
     public function map(callable $callback)
     {
@@ -357,8 +367,11 @@ class Collection extends BaseCollection implements QueueableCollection
      *
      * The callback should return an associative array with a single key / value pair.
      *
-     * @param  callable  $callback
-     * @return \Illuminate\Support\Collection|static
+     * @template TMapWithKeysKey of array-key
+     * @template TMapWithKeysValue
+     *
+     * @param  callable(TModel, TKey): array<TMapWithKeysKey, TMapWithKeysValue>  $callback
+     * @return \Illuminate\Support\Collection<TMapWithKeysKey, TMapWithKeysValue>|static<TMapWithKeysKey, TMapWithKeysValue>
      */
     public function mapWithKeys(callable $callback)
     {
@@ -372,8 +385,8 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Reload a fresh model instance from the database for all the entities.
      *
-     * @param  array|string  $with
-     * @return static
+     * @param  array<array-key, string>|string  $with
+     * @return static<TKey, TModel>
      */
     public function fresh($with = [])
     {
@@ -400,8 +413,8 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Diff the collection with the given items.
      *
-     * @param  \ArrayAccess|array  $items
-     * @return static
+     * @param  iterable<array-key, TModel>  $items
+     * @return static<TKey, TModel>
      */
     public function diff($items)
     {
@@ -421,8 +434,8 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Intersect the collection with the given items.
      *
-     * @param  \ArrayAccess|array  $items
-     * @return static
+     * @param  iterable<array-key, TModel>  $items
+     * @return static<TKey, TModel>
      */
     public function intersect($items)
     {
@@ -446,9 +459,9 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Return only unique items from the collection.
      *
-     * @param  string|callable|null  $key
+     * @param  (callable(TModel, TKey): bool)|string|null  $key
      * @param  bool  $strict
-     * @return static
+     * @return static<int, TModel>
      */
     public function unique($key = null, $strict = false)
     {
@@ -462,8 +475,8 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Returns only the models from the collection with the specified keys.
      *
-     * @param  mixed  $keys
-     * @return static
+     * @param  array<array-key, mixed>|null  $keys
+     * @return static<int, TModel>
      */
     public function only($keys)
     {
@@ -479,8 +492,8 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Returns all models in the collection except the models with specified keys.
      *
-     * @param  mixed  $keys
-     * @return static
+     * @param  array<array-key, mixed>|null  $keys
+     * @return static<int, TModel>
      */
     public function except($keys)
     {
@@ -492,7 +505,7 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Make the given, typically visible, attributes hidden across the entire collection.
      *
-     * @param  array|string  $attributes
+     * @param  array<array-key, string>|string  $attributes
      * @return $this
      */
     public function makeHidden($attributes)
@@ -503,7 +516,7 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Make the given, typically hidden, attributes visible across the entire collection.
      *
-     * @param  array|string  $attributes
+     * @param  array<array-key, string>|string  $attributes
      * @return $this
      */
     public function makeVisible($attributes)
@@ -514,7 +527,7 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Append an attribute across the entire collection.
      *
-     * @param  array|string  $attributes
+     * @param  array<array-key, string>|string  $attributes
      * @return $this
      */
     public function append($attributes)
@@ -525,8 +538,8 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Get a dictionary keyed by primary keys.
      *
-     * @param  \ArrayAccess|array|null  $items
-     * @return array
+     * @param  iterable<array-key, TModel>|null  $items
+     * @return array<array-key, TModel>
      */
     public function getDictionary($items = null)
     {
@@ -548,9 +561,9 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Get an array with the values of a given key.
      *
-     * @param  string|array  $value
+     * @param  string|array<array-key, string>  $value
      * @param  string|null  $key
-     * @return \Illuminate\Support\Collection
+     * @return \Illuminate\Support\Collection<int, mixed>
      */
     public function pluck($value, $key = null)
     {
@@ -560,7 +573,7 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Get the keys of the collection items.
      *
-     * @return \Illuminate\Support\Collection
+     * @return \Illuminate\Support\Collection<int, TKey>
      */
     public function keys()
     {
@@ -570,8 +583,10 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Zip the collection together with one or more arrays.
      *
-     * @param  mixed  ...$items
-     * @return \Illuminate\Support\Collection
+     * @template TZipValue
+     *
+     * @param  \Illuminate\Contracts\Support\Arrayable<array-key, TZipValue>|iterable<array-key, TZipValue>  ...$items
+     * @return \Illuminate\Support\Collection<int, \Illuminate\Support\Collection<int, TModel|TZipValue>>
      */
     public function zip($items)
     {
@@ -581,7 +596,7 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Collapse the collection of items into a single array.
      *
-     * @return \Illuminate\Support\Collection
+     * @return \Illuminate\Support\Collection<int, mixed>
      */
     public function collapse()
     {
@@ -592,7 +607,7 @@ class Collection extends BaseCollection implements QueueableCollection
      * Get a flattened array of the items in the collection.
      *
      * @param  int  $depth
-     * @return \Illuminate\Support\Collection
+     * @return \Illuminate\Support\Collection<int, mixed>
      */
     public function flatten($depth = INF)
     {
@@ -602,7 +617,7 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Flip the items in the collection.
      *
-     * @return \Illuminate\Support\Collection
+     * @return \Illuminate\Support\Collection<TModel, TKey>
      */
     public function flip()
     {
@@ -612,9 +627,11 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Pad collection to the specified length with a value.
      *
+     * @template TPadValue
+     *
      * @param  int  $size
-     * @param  mixed  $value
-     * @return \Illuminate\Support\Collection
+     * @param  TPadValue  $value
+     * @return \Illuminate\Support\Collection<int, TModel|TPadValue>
      */
     public function pad($size, $value)
     {
@@ -625,7 +642,7 @@ class Collection extends BaseCollection implements QueueableCollection
      * Get the comparison function to detect duplicates.
      *
      * @param  bool  $strict
-     * @return \Closure
+     * @return callable(TValue, TValue): bool
      */
     protected function duplicateComparator($strict)
     {
@@ -661,7 +678,7 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Get the identifiers for all of the entities.
      *
-     * @return array
+     * @return array<int, mixed>
      */
     public function getQueueableIds()
     {
@@ -677,7 +694,7 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Get the relationships of the entities being queued.
      *
-     * @return array
+     * @return array<int, string>
      */
     public function getQueueableRelations()
     {

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -53,7 +53,7 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Load a set of relationships onto the collection.
      *
-     * @param  array<array-key, string>|string  $relations
+     * @param  array<array-key, (callable(\Illuminate\Database\Eloquent\Builder): mixed)|string>|string  $relations
      * @return $this
      */
     public function load($relations)

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -526,7 +526,7 @@ abstract class Model implements Arrayable, ArrayAccess, HasBroadcastChannel, Jso
      * Get all of the models from the database.
      *
      * @param  array|mixed  $columns
-     * @return \Illuminate\Database\Eloquent\Collection|static[]
+     * @return \Illuminate\Database\Eloquent\Collection<int, static>
      */
     public static function all($columns = ['*'])
     {

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -526,7 +526,7 @@ abstract class Model implements Arrayable, ArrayAccess, HasBroadcastChannel, Jso
      * Get all of the models from the database.
      *
      * @param  array|mixed  $columns
-     * @return \Illuminate\Database\Eloquent\Collection<int, static>
+     * @return \Illuminate\Database\Eloquent\Collection|static[]
      */
     public static function all($columns = ['*'])
     {

--- a/types/Database/Eloquent/Collection.php
+++ b/types/Database/Eloquent/Collection.php
@@ -22,31 +22,61 @@ assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->lo
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadAggregate('string', 'string'));
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadAggregate(['string'], 'string'));
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadAggregate(['string'], 'string', 'string'));
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadAggregate(['string' => function ($query) {
+    // assertType('\Illuminate\Database\Query\Builder', $query);
+}], 'string', 'string'));
 
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadCount('string'));
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadCount(['string']));
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadCount(['string' => function ($query) {
+    // assertType('\Illuminate\Database\Query\Builder', $query);
+}]));
 
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadMax('string', 'string'));
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadMax(['string'], 'string'));
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadMax(['string' => function ($query) {
+    // assertType('\Illuminate\Database\Query\Builder', $query);
+}], 'string'));
 
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadMin('string', 'string'));
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadMin(['string'], 'string'));
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadMin(['string' => function ($query) {
+    // assertType('\Illuminate\Database\Query\Builder', $query);
+}], 'string'));
 
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadSum('string', 'string'));
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadSum(['string'], 'string'));
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadSum(['string' => function ($query) {
+    // assertType('\Illuminate\Database\Query\Builder', $query);
+}], 'string'));
 
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadAvg('string', 'string'));
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadAvg(['string'], 'string'));
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadAvg(['string' => function ($query) {
+    // assertType('\Illuminate\Database\Query\Builder', $query);
+}], 'string'));
 
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadExists('string'));
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadExists(['string']));
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadExists(['string' => function ($query) {
+    // assertType('\Illuminate\Database\Query\Builder', $query);
+}]));
 
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadMissing('string'));
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadMissing(['string']));
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadMissing(['string' => function ($query) {
+    // assertType('\Illuminate\Database\Query\Builder', $query);
+}]));
 
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadMorph('string', ['string']));
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadMorph('string', ['string' => function ($query) {
+    // assertType('\Illuminate\Database\Query\Builder', $query);
+}]));
 
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadMorphCount('string', ['string']));
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadMorphCount('string', ['string' => function ($query) {
+    // assertType('\Illuminate\Database\Query\Builder', $query);
+}]));
 
 assertType('bool', $collection->contains(function ($user) {
     assertType('User', $user);

--- a/types/Database/Eloquent/Collection.php
+++ b/types/Database/Eloquent/Collection.php
@@ -1,0 +1,153 @@
+<?php
+
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use function PHPStan\Testing\assertType;
+
+class User extends Authenticatable
+{
+}
+
+$collection = User::all();
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection);
+
+assertType('Illuminate\Database\Eloquent\Collection<int, User>|User|null', $collection->find(1));
+assertType('Illuminate\Database\Eloquent\Collection<int, User>|string|User', $collection->find(1, 'string'));
+
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->load('string'));
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->load(['string']));
+
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadAggregate('string', 'string'));
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadAggregate(['string'], 'string'));
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadAggregate(['string'], 'string', 'string'));
+
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadCount('string'));
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadCount(['string']));
+
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadMax('string', 'string'));
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadMax(['string'], 'string'));
+
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadMin('string', 'string'));
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadMin(['string'], 'string'));
+
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadSum('string', 'string'));
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadSum(['string'], 'string'));
+
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadAvg('string', 'string'));
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadAvg(['string'], 'string'));
+
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadExists('string'));
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadExists(['string']));
+
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadMissing('string'));
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadMissing(['string']));
+
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadMorph('string', ['string']));
+
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadMorphCount('string', ['string']));
+
+assertType('bool', $collection->contains(function ($user) {
+    assertType('User', $user);
+
+    return true;
+}));
+assertType('bool', $collection->contains('string', '=', 'string'));
+
+assertType('array<int, mixed>', $collection->modelKeys());
+
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->merge($collection));
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->merge([new User]));
+
+assertType(
+    'Illuminate\Support\Collection<int, User>',
+    $collection->map(function ($user, $int) {
+        assertType('User', $user);
+        assertType('int', $int);
+
+        return new User;
+    })
+);
+
+assertType(
+    'Illuminate\Support\Collection<int, User>',
+    $collection->mapWithKeys(function ($user, $int) {
+        assertType('User', $user);
+        assertType('int', $int);
+
+        return [new User];
+    })
+);
+assertType(
+    'Illuminate\Support\Collection<string, User>',
+    $collection->mapWithKeys(function ($user, $int) {
+        return ['string' => new User];
+    })
+);
+
+assertType(
+    'Illuminate\Database\Eloquent\Collection<int, User>',
+    $collection->fresh()
+);
+assertType(
+    'Illuminate\Database\Eloquent\Collection<int, User>',
+    $collection->fresh('string')
+);
+assertType(
+    'Illuminate\Database\Eloquent\Collection<int, User>',
+    $collection->fresh(['string'])
+);
+
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->diff($collection));
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->diff([new User]));
+
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->intersect($collection));
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->intersect([new User]));
+
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->unique());
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->unique(function ($user, $int) {
+    assertType('User', $user);
+    assertType('int', $int);
+
+    return true;
+}));
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->unique('string'));
+
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->only(null));
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->only(['string']));
+
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->except(null));
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->except(['string']));
+
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->makeHidden('string'));
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->makeHidden(['string']));
+
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->makeVisible('string'));
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->makeVisible(['string']));
+
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->append('string'));
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->append(['string']));
+
+assertType('array<User>', $collection->getDictionary());
+assertType('array<User>', $collection->getDictionary($collection));
+assertType('array<User>', $collection->getDictionary([new User]));
+
+assertType('Illuminate\Support\Collection<int, mixed>', $collection->pluck('string'));
+assertType('Illuminate\Support\Collection<int, mixed>', $collection->pluck(['string']));
+
+assertType('Illuminate\Support\Collection<int, int>', $collection->keys());
+
+assertType('Illuminate\Support\Collection<int, Illuminate\Support\Collection<int, int|User>>', $collection->zip([1]));
+assertType('Illuminate\Support\Collection<int, Illuminate\Support\Collection<int, string|User>>', $collection->zip(['string']));
+
+assertType('Illuminate\Support\Collection<int, mixed>', $collection->collapse());
+
+assertType('Illuminate\Support\Collection<int, mixed>', $collection->flatten());
+assertType('Illuminate\Support\Collection<int, mixed>', $collection->flatten(4));
+
+assertType('Illuminate\Support\Collection<User, int>', $collection->flip());
+
+assertType('Illuminate\Support\Collection<int, int|User>', $collection->pad(2, 0));
+assertType('Illuminate\Support\Collection<int, string|User>', $collection->pad(2, 'string'));
+
+assertType('array<int, mixed>', $collection->getQueueableIds());
+
+assertType('array<int, string>', $collection->getQueueableRelations());

--- a/types/Database/Eloquent/Collection.php
+++ b/types/Database/Eloquent/Collection.php
@@ -15,6 +15,9 @@ assertType('Illuminate\Database\Eloquent\Collection<int, User>|string|User', $co
 
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->load('string'));
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->load(['string']));
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->load(['string' => function ($query) {
+    // assertType('\Illuminate\Database\Query\Builder', $query);
+}]));
 
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadAggregate('string', 'string'));
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->loadAggregate(['string'], 'string'));

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -9,7 +9,7 @@ class User extends Authenticatable
 {
 }
 
-$collection = Collection::make([new User]);
+$collection = collect([new User]);
 /** @var Arrayable<int, User> $arrayable */
 $arrayable = [];
 /** @var iterable<int, int> $iterable */

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -2,7 +2,6 @@
 
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Foundation\Auth\User as Authenticatable;
-use Illuminate\Support\Collection;
 use function PHPStan\Testing\assertType;
 
 class User extends Authenticatable

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -1,0 +1,158 @@
+<?php
+
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Support\Collection;
+use function PHPStan\Testing\assertType;
+
+class User extends Authenticatable
+{
+}
+
+$collection = Collection::make([new User]);
+/** @var Arrayable<int, User> $arrayable */
+$arrayable = [];
+/** @var iterable<int, int> $iterable */
+$iterable = [];
+/** @var Traversable<int, string>  $traversable */
+$traversable = [];
+
+assertType('Illuminate\Support\Collection<int, User>', $collection);
+
+foreach ($collection as $int => $user) {
+    assertType('int', $int);
+    assertType('User', $user);
+}
+
+assertType('Illuminate\Support\Collection<int, string>', collect(['string']));
+assertType('Illuminate\Support\Collection<string, User>', collect(['string' => new User]));
+assertType('Illuminate\Support\Collection<int, User>', collect($arrayable));
+assertType('Illuminate\Support\Collection<int, User>', collect($collection));
+assertType('Illuminate\Support\Collection<int, User>', collect($collection));
+assertType('Illuminate\Support\Collection<int, int>', collect($iterable));
+assertType('Illuminate\Support\Collection<int, string>', collect($traversable));
+
+assertType('Illuminate\Support\Collection<int, string>', $collection::make(['string']));
+assertType('Illuminate\Support\Collection<string, User>', $collection::make(['string' => new User]));
+assertType('Illuminate\Support\Collection<int, User>', $collection::make($arrayable));
+assertType('Illuminate\Support\Collection<int, User>', $collection::make($collection));
+assertType('Illuminate\Support\Collection<int, User>', $collection::make($collection));
+assertType('Illuminate\Support\Collection<int, int>', $collection::make($iterable));
+assertType('Illuminate\Support\Collection<int, string>', $collection::make($traversable));
+
+assertType('Illuminate\Support\Collection<int, User>', $collection::times(10, function ($int) {
+    // assertType('int', $int);
+
+    return new User;
+}));
+
+assertType('Illuminate\Support\Collection<int, User>', $collection->each(function ($user) {
+    assertType('User', $user);
+}));
+
+assertType('Illuminate\Support\Collection<int, int>', $collection->range(1, 100));
+
+assertType('Illuminate\Support\Collection<int, string>', $collection->wrap(['string']));
+assertType('Illuminate\Support\Collection<string, User>', $collection->wrap(['string' => new User]));
+
+assertType('array<int, string>', $collection->unwrap(['string']));
+assertType('array<int, User>', $collection->unwrap(
+    $collection
+));
+
+assertType('Illuminate\Support\Collection<int, User>', $collection::empty());
+
+assertType('float|int|null', $collection->average());
+assertType('float|int|null', $collection->average('string'));
+assertType('float|int|null', $collection->average(function ($user) {
+    assertType('User', $user);
+
+    return 1;
+}));
+assertType('float|int|null', $collection->average(function ($user) {
+    assertType('User', $user);
+
+    return 0.1;
+}));
+
+assertType('float|int|null', $collection->median());
+assertType('float|int|null', $collection->median('string'));
+assertType('float|int|null', $collection->median(['string']));
+
+assertType('array<int, float|int>|null', $collection->mode());
+assertType('array<int, float|int>|null', $collection->mode('string'));
+assertType('array<int, float|int>|null', $collection->mode(['string']));
+
+assertType('Illuminate\Support\Collection<int, mixed>', $collection->collapse());
+
+assertType('bool', $collection->some(function ($user) {
+    assertType('User', $user);
+
+    return true;
+}));
+assertType('bool', $collection::make(['string'])->some('string', '=', 'string'));
+
+assertType('bool', $collection->containsStrict(function ($user) {
+    assertType('User', $user);
+
+    return true;
+}));
+assertType('bool', $collection::make(['string'])->containsStrict('string', 'string'));
+
+assertType('float|int|null', $collection->avg());
+assertType('float|int|null', $collection->avg('string'));
+assertType('float|int|null', $collection->avg(function ($user) {
+    assertType('User', $user);
+
+    return 1;
+}));
+assertType('float|int|null', $collection->avg(function ($user) {
+    assertType('User', $user);
+
+    return 0.1;
+}));
+
+assertType('bool', $collection->contains(function ($user) {
+    assertType('User', $user);
+
+    return true;
+}));
+assertType('bool', $collection::make(['string'])->contains('string', '=', 'string'));
+
+assertType('Illuminate\Support\Collection<int, array<int, string|User>>', $collection->crossJoin($collection::make(['string'])));
+assertType('Illuminate\Support\Collection<int, array<int, int|User>>', $collection->crossJoin([1, 2]));
+
+assertType('Illuminate\Support\Collection<int, int>', $collection::make([3, 4])->diff([1, 2]));
+assertType('Illuminate\Support\Collection<int, string>', $collection::make(['string-1'])->diff(['string-2']));
+
+assertType('Illuminate\Support\Collection<int, int>', $collection::make([3, 4])->diffUsing([1, 2], function ($int) {
+    assertType('int', $int);
+
+    return -1;
+}));
+assertType('Illuminate\Support\Collection<int, string>', $collection::make(['string-1'])->diffUsing(['string-2'], function ($string) {
+    assertType('string', $string);
+
+    return -1;
+}));
+
+assertType('array<int, User>', $collection->all());
+
+assertType('User|null', $collection->get(0));
+assertType('string|User', $collection->get(0, 'string'));
+
+assertType('User|null', $collection->first());
+assertType('User|null', $collection->first(function ($user) {
+    assertType('User', $user);
+
+    return true;
+}));
+assertType('string|User', $collection->first(function ($user) {
+    assertType('User', $user);
+
+    return false;
+}, 'string'));
+
+assertType('array<int, User>', $collection->toArray());
+assertType('array<string, string>', collect(['string' => 'string'])->toArray());
+assertType('array<int, int>', collect([1, 2])->toArray());

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -13,7 +13,7 @@ $collection = collect([new User]);
 $arrayable = [];
 /** @var iterable<int, int> $iterable */
 $iterable = [];
-/** @var Traversable<int, string>  $traversable */
+/** @var Traversable<int, string> $traversable */
 $traversable = [];
 
 assertType('Illuminate\Support\Collection<int, User>', $collection);
@@ -42,6 +42,10 @@ assertType('Illuminate\Support\Collection<int, string>', $collection::make($trav
 assertType('Illuminate\Support\Collection<int, User>', $collection::times(10, function ($int) {
     // assertType('int', $int);
 
+    return new User;
+}));
+
+assertType('Illuminate\Support\Collection<int, User>', $collection::times(10, function () {
     return new User;
 }));
 
@@ -135,10 +139,226 @@ assertType('Illuminate\Support\Collection<int, string>', $collection::make(['str
     return -1;
 }));
 
-assertType('array<int, User>', $collection->all());
+assertType('Illuminate\Support\Collection<int, int>', $collection::make([3, 4])->diffAssoc([1, 2]));
+assertType('Illuminate\Support\Collection<string, string>', $collection::make(['string' => 'string'])->diffAssoc(['string' => 'string']));
 
-assertType('User|null', $collection->get(0));
-assertType('string|User', $collection->get(0, 'string'));
+assertType('Illuminate\Support\Collection<int, int>', $collection::make([3, 4])->diffAssocUsing([1, 2], function ($int) {
+    assertType('int', $int);
+
+    return -1;
+}));
+assertType('Illuminate\Support\Collection<int, string>', $collection::make(['string-1'])->diffAssocUsing(['string-2'], function ($int) {
+    assertType('int', $int);
+
+    return -1;
+}));
+
+assertType('Illuminate\Support\Collection<int, int>', $collection::make([3, 4])->diffKeys([1, 2]));
+assertType('Illuminate\Support\Collection<string, string>', $collection::make(['string' => 'string'])->diffKeys(['string' => 'string']));
+
+assertType('Illuminate\Support\Collection<int, int>', $collection::make([3, 4])->diffKeysUsing([1, 2], function ($int) {
+    assertType('int', $int);
+
+    return -1;
+}));
+assertType('Illuminate\Support\Collection<int, string>', $collection::make(['string-1'])->diffKeysUsing(['string-2'], function ($int) {
+    assertType('int', $int);
+
+    return -1;
+}));
+
+assertType('Illuminate\Support\Collection<string, string>', $collection::make(['string' => 'string'])
+    ->duplicates());
+assertType('Illuminate\Support\Collection<int, User>', $collection->duplicates('name', true));
+assertType('Illuminate\Support\Collection<int, int|string>', $collection::make([3, 'string'])
+    ->duplicates(function ($intOrString) {
+        assertType('int|string', $intOrString);
+
+        return true;
+    }));
+
+assertType('Illuminate\Support\Collection<string, string>', $collection::make(['string' => 'string'])
+    ->duplicatesStrict());
+assertType('Illuminate\Support\Collection<int, User>', $collection->duplicatesStrict('name'));
+assertType('Illuminate\Support\Collection<int, int|string>', $collection::make([3, 'string'])
+    ->duplicatesStrict(function ($intOrString) {
+        assertType('int|string', $intOrString);
+
+        return true;
+    }));
+
+assertType('Illuminate\Support\Collection<int, User>', $collection->each(function ($user) {
+    assertType('User', $user);
+
+    return null;
+}));
+assertType('Illuminate\Support\Collection<int, User>', $collection->each(function ($user) {
+    assertType('User', $user);
+}));
+
+assertType('Illuminate\Support\Collection<int, array(string)>', $collection::make([['string']])
+    ->eachSpread(function ($int, $string) {
+        // assertType('int', $int);
+        // assertType('int', $string);
+
+        return null;
+    }));
+assertType('Illuminate\Support\Collection<int, array(int, string)>', $collection::make([[1, 'string']])
+    ->eachSpread(function ($int, $string) {
+        // assertType('int', $int);
+        // assertType('int', $string);
+    }));
+
+assertType('bool', $collection->every(function ($user, $int) {
+    assertType('int', $int);
+    assertType('User', $user);
+
+    return true;
+}));
+assertType('bool', $collection::make(['string'])->every('string', '=', 'string'));
+
+assertType('Illuminate\Support\Collection<string, string>', $collection::make(['string' => 'string'])->except(['string']));
+assertType('Illuminate\Support\Collection<int, User>', $collection->except([1]));
+assertType('Illuminate\Support\Collection<int, string>', $collection::make(['string'])
+    ->except($collection->keys()->toArray()));
+
+assertType('Illuminate\Support\Collection<int, User>', $collection->filter());
+assertType('Illuminate\Support\Collection<int, User>', $collection->filter(function ($user) {
+    assertType('User', $user);
+
+    return true;
+}));
+
+assertType('Illuminate\Support\Collection<int, User>', $collection->filter());
+assertType('Illuminate\Support\Collection<int, User>', $collection->filter(function ($user) {
+    assertType('User', $user);
+
+    return true;
+}));
+
+assertType('bool|Illuminate\Support\Collection<int, User>', $collection->when(true, function ($collection) {
+    assertType('Illuminate\Support\Collection<int, User>', $collection);
+
+    return true;
+}));
+assertType('Illuminate\Support\Collection<int, User>|void', $collection->when(true, function ($collection) {
+    assertType('Illuminate\Support\Collection<int, User>', $collection);
+}));
+assertType('Illuminate\Support\Collection<int, User>|string', $collection->when(true, function ($collection) {
+    assertType('Illuminate\Support\Collection<int, User>', $collection);
+
+    return 'string';
+}));
+
+assertType('bool|Illuminate\Support\Collection<int, User>', $collection->whenEmpty(function ($collection) {
+    assertType('Illuminate\Support\Collection<int, User>', $collection);
+
+    return true;
+}));
+assertType('Illuminate\Support\Collection<int, User>|void', $collection->whenEmpty(function ($collection) {
+    assertType('Illuminate\Support\Collection<int, User>', $collection);
+}));
+assertType('Illuminate\Support\Collection<int, User>|string', $collection->whenEmpty(function ($collection) {
+    assertType('Illuminate\Support\Collection<int, User>', $collection);
+
+    return 'string';
+}));
+
+assertType('bool|Illuminate\Support\Collection<int, User>', $collection->whenNotEmpty(function ($collection) {
+    assertType('Illuminate\Support\Collection<int, User>', $collection);
+
+    return true;
+}));
+assertType('Illuminate\Support\Collection<int, User>|void', $collection->whenNotEmpty(function ($collection) {
+    assertType('Illuminate\Support\Collection<int, User>', $collection);
+}));
+assertType('Illuminate\Support\Collection<int, User>|string', $collection->whenNotEmpty(function ($collection) {
+    assertType('Illuminate\Support\Collection<int, User>', $collection);
+
+    return 'string';
+}));
+
+assertType('bool|Illuminate\Support\Collection<int, User>', $collection->unless(true, function ($collection) {
+    assertType('Illuminate\Support\Collection<int, User>', $collection);
+
+    return true;
+}));
+assertType('Illuminate\Support\Collection<int, User>|void', $collection->unless(true, function ($collection) {
+    assertType('Illuminate\Support\Collection<int, User>', $collection);
+}));
+assertType('Illuminate\Support\Collection<int, User>|string', $collection->unless(true, function ($collection) {
+    assertType('Illuminate\Support\Collection<int, User>', $collection);
+
+    return 'string';
+}));
+
+assertType('bool|Illuminate\Support\Collection<int, User>', $collection->unlessEmpty(function ($collection) {
+    assertType('Illuminate\Support\Collection<int, User>', $collection);
+
+    return true;
+}));
+assertType('Illuminate\Support\Collection<int, User>|void', $collection->unlessEmpty(function ($collection) {
+    assertType('Illuminate\Support\Collection<int, User>', $collection);
+}));
+assertType('Illuminate\Support\Collection<int, User>|string', $collection->unlessEmpty(function ($collection) {
+    assertType('Illuminate\Support\Collection<int, User>', $collection);
+
+    return 'string';
+}));
+
+assertType('bool|Illuminate\Support\Collection<int, User>', $collection->unlessNotEmpty(function ($collection) {
+    assertType('Illuminate\Support\Collection<int, User>', $collection);
+
+    return true;
+}));
+assertType('Illuminate\Support\Collection<int, User>|void', $collection->unlessNotEmpty(function ($collection) {
+    assertType('Illuminate\Support\Collection<int, User>', $collection);
+}));
+assertType('Illuminate\Support\Collection<int, User>|string', $collection->unlessNotEmpty(function ($collection) {
+    assertType('Illuminate\Support\Collection<int, User>', $collection);
+
+    return 'string';
+}));
+
+assertType("Illuminate\Support\Collection<int, array('string' => string)>", $collection::make([['string' => 'string']])
+    ->where('string'));
+assertType("Illuminate\Support\Collection<int, array('string' => string)>", $collection::make([['string' => 'string']])
+    ->where('string', '=', 'string'));
+assertType("Illuminate\Support\Collection<int, array('string' => string)>", $collection::make([['string' => 'string']])
+    ->where('string', 'string'));
+
+assertType('Illuminate\Support\Collection<int, User>', $collection->whereNull());
+assertType('Illuminate\Support\Collection<int, User>', $collection->whereNull('foo'));
+
+assertType('Illuminate\Support\Collection<int, User>', $collection->whereNotNull());
+assertType('Illuminate\Support\Collection<int, User>', $collection->whereNotNull('foo'));
+
+assertType("Illuminate\Support\Collection<int, array('string' => int)>", $collection::make([['string' => 2]])
+    ->whereStrict('string', 2));
+
+assertType("Illuminate\Support\Collection<int, array('string' => int)>", $collection::make([['string' => 2]])
+    ->whereIn('string', [2]));
+
+assertType("Illuminate\Support\Collection<int, array('string' => int)>", $collection::make([['string' => 2]])
+    ->whereInStrict('string', [2]));
+
+assertType("Illuminate\Support\Collection<int, array('string' => int)>", $collection::make([['string' => 2]])
+    ->whereBetween('string', [1, 3]));
+
+assertType("Illuminate\Support\Collection<int, array('string' => int)>", $collection::make([['string' => 2]])
+    ->whereNotBetween('string', [1, 3]));
+
+assertType("Illuminate\Support\Collection<int, array('string' => int)>", $collection::make([['string' => 2]])
+    ->whereNotIn('string', [2]));
+
+assertType("Illuminate\Support\Collection<int, array('string' => int)>", $collection::make([['string' => 2]])
+    ->whereNotInStrict('string', [2]));
+
+assertType('Illuminate\Support\Collection<int, int|User>', $collection::make([new User, 1])
+    ->whereInstanceOf(User::class));
+
+assertType('Illuminate\Support\Collection<int, int|User>', $collection::make([new User, 1])
+    ->whereInstanceOf([User::class, User::class]));
 
 assertType('User|null', $collection->first());
 assertType('User|null', $collection->first(function ($user) {
@@ -151,6 +371,73 @@ assertType('string|User', $collection->first(function ($user) {
 
     return false;
 }, 'string'));
+
+assertType('User|null', $collection->firstWhere('string', 'string'));
+assertType('User|null', $collection->firstWhere('string', 'string', 'string'));
+
+assertType('Illuminate\Support\Collection<string, int>', $collection::make(['string'])->flip());
+
+assertType('Illuminate\Support\Collection<(int|string), array<User>>', $collection->groupBy('name'));
+assertType('Illuminate\Support\Collection<(int|string), array<User>>', $collection->groupBy('name', true));
+assertType('Illuminate\Support\Collection<(int|string), array<User>>', $collection->groupBy(function ($user, $int) {
+    // assertType('User', $user);
+    // assertType('int', $int);
+
+    return 'foo';
+}));
+assertType('Illuminate\Support\Collection<(int|string), array<User>>', $collection->groupBy(function ($user) {
+    return 'foo';
+}));
+
+assertType('Illuminate\Support\Collection<(int|string), array<User>>', $collection->keyBy('name'));
+assertType('Illuminate\Support\Collection<(int|string), array<User>>', $collection->keyBy(function ($user, $int) {
+    // assertType('User', $user);
+    // assertType('int', $int);
+
+    return 'foo';
+}));
+
+assertType('bool', $collection->has(0));
+assertType('bool', $collection->has([0, 1]));
+
+assertType('Illuminate\Support\Collection<int, User>', $collection->intersect([new User]));
+
+assertType('Illuminate\Support\Collection<int, User>', $collection->intersectByKeys([new User]));
+
+assertType('Illuminate\Support\Collection<int, int>', $collection->keys());
+
+assertType('User|null', $collection->last());
+assertType('User|null', $collection->last(function ($user, $int) {
+    assertType('User', $user);
+    assertType('int', $int);
+
+    return true;
+}));
+assertType('string|User', $collection->last(function () {
+    return true;
+}, 'string'));
+
+assertType('Illuminate\Support\Collection<int, int>', $collection->map(function () {
+    return 1;
+}));
+assertType('Illuminate\Support\Collection<int, string>', $collection->map(function () {
+    return 'string';
+}));
+
+assertType('Illuminate\Support\Collection<int, string>', $collection::make(['string'])
+    ->map(function ($string, $int) {
+        assertType('string', $string);
+        assertType('int', $int);
+
+        return (string) $string;
+    }));
+
+assertType('Illuminate\Support\Collection<int, int>', $collection->make([1])->push(2));
+
+assertType('array<int, User>', $collection->all());
+
+assertType('User|null', $collection->get(0));
+assertType('string|User', $collection->get(0, 'string'));
 
 assertType('array<int, User>', $collection->toArray());
 assertType('array<string, string>', collect(['string' => 'string'])->toArray());

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -519,7 +519,6 @@ assertType('array<int, Illuminate\Support\Collection<int, User>>', $collection->
 
     return true;
 }));
-
 assertType('array<int, Illuminate\Support\Collection<int, string>>', $collection::make(['string'])->partition('string', '=', 'string'));
 assertType('array<int, Illuminate\Support\Collection<int, string>>', $collection::make(['string'])->partition('string', 'string'));
 assertType('array<int, Illuminate\Support\Collection<int, string>>', $collection::make(['string'])->partition('string', ));
@@ -538,7 +537,6 @@ assertType('int', $collection
         return 1;
     }));
 
-
 assertType('int', $collection
     ->reduce(function ($int, $user) {
         assertType('User', $user);
@@ -550,10 +548,203 @@ assertType('int', $collection
 assertType('Illuminate\Support\Collection<int, int>', $collection::make([1])->replace([1]));
 assertType('Illuminate\Support\Collection<int, User>', $collection->replace([new User]));
 
+assertType('Illuminate\Support\Collection<int, int>', $collection::make([1])->replaceRecursive([1]));
+assertType('Illuminate\Support\Collection<int, User>', $collection->replaceRecursive([new User]));
+
+assertType('Illuminate\Support\Collection<int, User>', $collection->reverse());
+
+assertType('int|bool', $collection->make([1])->search(2));
+assertType('string|bool', $collection->make(['string' => 'string'])->search('string'));
+assertType('int|bool', $collection->search(function ($user, $int) {
+    assertType('User', $user);
+    assertType('int', $int);
+
+    return true;
+}));
+
+assertType('Illuminate\Support\Collection<int, int>', $collection->make([1])->shuffle());
+assertType('Illuminate\Support\Collection<int, User>', $collection->shuffle());
+
+assertType('Illuminate\Support\Collection<int, int>', $collection->make([1])->skip(1));
+assertType('Illuminate\Support\Collection<int, User>', $collection->skip(1));
+
+assertType('Illuminate\Support\Collection<int, int>', $collection->make([1])->skipUntil(1));
+assertType('Illuminate\Support\Collection<int, User>', $collection->skipUntil(new User));
+assertType('Illuminate\Support\Collection<int, User>', $collection->skipUntil(function ($user, $int) {
+    assertType('User', $user);
+    assertType('int', $int);
+
+    return true;
+}));
+
+assertType('Illuminate\Support\Collection<int, int>', $collection->make([1])->skipWhile(1));
+assertType('Illuminate\Support\Collection<int, User>', $collection->skipWhile(new User));
+assertType('Illuminate\Support\Collection<int, User>', $collection->skipWhile(function ($user, $int) {
+    assertType('User', $user);
+    assertType('int', $int);
+
+    return true;
+}));
+
+assertType('Illuminate\Support\Collection<int, int>', $collection->make([1])->slice(1));
+assertType('Illuminate\Support\Collection<int, User>', $collection->slice(1, 2));
+
+assertType('Illuminate\Support\Collection<int, Illuminate\Support\Collection<int, User>>', $collection->split(3));
+assertType('Illuminate\Support\Collection<int, Illuminate\Support\Collection<int, int>>', $collection->make([1])->split(3));
+
+assertType('string', $collection->make(['string' => 'string'])->sole('string', 'string'));
+assertType('string', $collection->make(['string' => 'string'])->sole('string', '=', 'string'));
+assertType('User', $collection->sole(function ($user, $int) {
+    assertType('User', $user);
+    assertType('int', $int);
+
+    return true;
+}));
+
+assertType('Illuminate\Support\Collection<int, Illuminate\Support\Collection<int, string>>', $collection::make(['string'])->chunk(1));
+assertType('Illuminate\Support\Collection<int, Illuminate\Support\Collection<int, User>>', $collection->chunk(2));
+
+assertType('Illuminate\Support\Collection<int, Illuminate\Support\Collection<int, User>>', $collection->chunkWhile(function ($user, $int, $collection) {
+    assertType('User', $user);
+    assertType('int', $int);
+    assertType('Illuminate\Support\Collection<int, User>', $collection);
+
+    return true;
+}));
+
+assertType('Illuminate\Support\Collection<int, User>', $collection->sort(function ($userA, $userB) {
+    assertType('User', $userA);
+    assertType('User', $userB);
+
+    return true;
+}));
+assertType('Illuminate\Support\Collection<int, User>', $collection->sort());
+
+assertType('Illuminate\Support\Collection<int, User>', $collection->sortDesc());
+assertType('Illuminate\Support\Collection<int, User>', $collection->sortDesc(2));
+
+assertType('Illuminate\Support\Collection<int, User>', $collection->sortBy(function ($user, $int) {
+    assertType('User', $user);
+    assertType('int', $int);
+
+    return 1;
+}));
+assertType('Illuminate\Support\Collection<int, User>', $collection->sortBy('string'));
+assertType('Illuminate\Support\Collection<int, User>', $collection->sortBy('string', 1, false));
+
+assertType('Illuminate\Support\Collection<int, User>', $collection->sortByDesc(function ($user, $int) {
+    assertType('User', $user);
+    assertType('int', $int);
+
+    return 1;
+}));
+
+assertType('Illuminate\Support\Collection<int, int>', $collection->make([1])->sortKeys());
+assertType('Illuminate\Support\Collection<string, string>', $collection->make(['string' => 'string'])->sortKeys(1, true));
+
+assertType('Illuminate\Support\Collection<int, int>', $collection->make([1])->sortKeysDesc());
+assertType('Illuminate\Support\Collection<string, string>', $collection->make(['string' => 'string'])->sortKeysDesc(1));
+
+assertType('mixed', $collection->make([1])->sum('string'));
+assertType('mixed', $collection->make(['string'])->sum(function ($string) {
+    assertType('string', $string);
+
+    return 1;
+}));
+
+assertType('Illuminate\Support\Collection<int, int>', $collection->make([1])->take(1));
+assertType('Illuminate\Support\Collection<int, User>', $collection->take(1));
+
+assertType('Illuminate\Support\Collection<int, int>', $collection->make([1])->takeUntil(1));
+assertType('Illuminate\Support\Collection<int, User>', $collection->takeUntil(new User));
+assertType('Illuminate\Support\Collection<int, User>', $collection->takeUntil(function ($user, $int) {
+    assertType('User', $user);
+    assertType('int', $int);
+
+    return true;
+}));
+
+assertType('Illuminate\Support\Collection<int, int>', $collection->make([1])->takeWhile(1));
+assertType('Illuminate\Support\Collection<int, User>', $collection->takeWhile(new User));
+assertType('Illuminate\Support\Collection<int, User>', $collection->takeWhile(function ($user, $int) {
+    assertType('User', $user);
+    assertType('int', $int);
+
+    return true;
+}));
+
+assertType('Illuminate\Support\Collection<int, User>', $collection->tap(function ($user) {
+    assertType('User', $user);
+}));
+
+assertType('Illuminate\Support\Collection<int, int>', $collection->pipe(function ($collection) {
+    assertType('Illuminate\Support\Collection<int, User>', $collection);
+
+    return collect([1]);
+}));
+assertType('int', $collection->make([1])->pipe(function ($collection) {
+    assertType('Illuminate\Support\Collection<int, int>', $collection);
+
+    return 1;
+}));
+
+assertType('Illuminate\Support\Collection<int, mixed>', $collection->make(['string' => 'string'])->pluck('string'));
+assertType('Illuminate\Support\Collection<int, mixed>', $collection->make(['string' => 'string'])->pluck('string', 'string'));
+
+assertType('Illuminate\Support\Collection<int, User>', $collection->reject());
+assertType('Illuminate\Support\Collection<int, User>', $collection->reject(function ($user) {
+    assertType('User', $user);
+
+    return true;
+}));
+
+assertType('Illuminate\Support\Collection<int, User>', $collection->unique());
+assertType('Illuminate\Support\Collection<int, User>', $collection->unique(function ($user, $int) {
+    assertType('User', $user);
+    assertType('int', $int);
+
+    return true;
+}));
+assertType('Illuminate\Support\Collection<string, string>', $collection->make(['string' => 'string'])->unique(function ($stringA, $stringB) {
+    assertType('string', $stringA);
+    assertType('string', $stringA);
+
+    return false;
+}, true));
+
+assertType('Illuminate\Support\Collection<int, User>', $collection->uniqueStrict());
+assertType('Illuminate\Support\Collection<int, User>', $collection->uniqueStrict(function ($user, $int) {
+    assertType('User', $user);
+    assertType('int', $int);
+
+    return true;
+}));
+
+assertType('Illuminate\Support\Collection<int, User>', $collection->values());
+assertType('Illuminate\Support\Collection<int, string>', $collection::make(['string', 'string'])->values());
+assertType('Illuminate\Support\Collection<int, int|string>', $collection::make(['string', 1])->values());
+
+assertType('Illuminate\Support\Collection<int, int>', $collection->make([1])->pad(2, 0));
+assertType('Illuminate\Support\Collection<int, int|string>', $collection->make([1])->pad(2, 'string'));
+assertType('Illuminate\Support\Collection<int, int|User>', $collection->pad(2, 0));
+
+assertType('Illuminate\Support\Collection<int, int>', $collection->make([1])->countBy());
+assertType('Illuminate\Support\Collection<string, int>', $collection->make(['string' => 'string'])->countBy('string'));
+assertType('Illuminate\Support\Collection<string, int>', $collection->make(['string'])->countBy(function ($string, $int) {
+    assertType('string', $string);
+    assertType('int', $int);
+
+    return false;
+}));
+
+assertType('Illuminate\Support\Collection<int, Illuminate\Support\Collection<int, int|User>>', $collection->zip([1]));
+assertType('Illuminate\Support\Collection<int, Illuminate\Support\Collection<int, string|User>>', $collection->zip(['string']));
+assertType('Illuminate\Support\Collection<int, Illuminate\Support\Collection<int, string>>', $collection::make(['string' => 'string'])->zip(['string']));
+
+assertType('Illuminate\Support\Collection<int, User>', $collection->collect());
+assertType('Illuminate\Support\Collection<int, int>', $collection->make([1])->collect());
+
 assertType('Illuminate\Support\Collection<int, int>', $collection->make([1])->push(2));
-
-
-
 
 assertType('array<int, User>', $collection->all());
 

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -368,6 +368,9 @@ assertType('string|User', $collection->first(function ($user) {
     return false;
 }, 'string'));
 
+assertType('Illuminate\Support\Collection<int, mixed>', $collection->flatten());
+assertType('Illuminate\Support\Collection<int, mixed>', $collection::make(['string' => 'string'])->flatten(4));
+
 assertType('User|null', $collection->firstWhere('string', 'string'));
 assertType('User|null', $collection->firstWhere('string', 'string', 'string'));
 

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -767,7 +767,7 @@ assertType('string|User', $collection->pull(1, 'string'));
 
 assertType('Illuminate\Support\Collection<int, User>', $collection->put(1, new User));
 assertType('Illuminate\Support\Collection<string, string>', $collection::make([
-    'string-key-1' => 'string-value-1'
+    'string-key-1' => 'string-value-1',
 ])->put('string-key-2', 'string-value-2'));
 
 assertType('Illuminate\Support\Collection<int, User>|User|null', $collection->shift(1));
@@ -814,7 +814,9 @@ assertType('Illuminate\Support\Collection<int, User>', $collection->add(new User
  *
  * @extends \Illuminate\Support\Collection<TKey, TValue>
  */
-class CustomCollection extends Collection {}
+class CustomCollection extends Collection
+{
+}
 
 // assertType('CustomCollection<int, User>', CustomCollection::make([new User]));
 assertType('Illuminate\Support\Collection<int, User>', CustomCollection::make([new User])->toBase());

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -432,7 +432,128 @@ assertType('Illuminate\Support\Collection<int, string>', $collection::make(['str
         return (string) $string;
     }));
 
+assertType('Illuminate\Support\Collection<int, string>', $collection::make(['string'])
+    ->mapSpread(function () {
+        return 'string';
+    }));
+
+assertType('Illuminate\Support\Collection<int, int>', $collection::make(['string'])
+    ->mapSpread(function () {
+        return 1;
+    }));
+
+assertType('Illuminate\Support\Collection<string, array<int, int>>', $collection::make(['string', 'string'])
+    ->mapToDictionary(function ($stringValue, $stringKey) {
+        assertType('string', $stringValue);
+        assertType('int', $stringKey);
+
+        return ['string' => 1];
+    }));
+
+assertType('Illuminate\Support\Collection<string, Illuminate\Support\Collection<int, int>>', $collection::make(['string', 'string'])
+    ->mapToGroups(function ($stringValue, $stringKey) {
+        assertType('string', $stringValue);
+        assertType('int', $stringKey);
+
+        return ['string' => 1];
+    }));
+
+assertType('Illuminate\Support\Collection<string, int>', $collection::make(['string'])
+    ->mapWithKeys(function ($string, $int) {
+        assertType('string', $string);
+        assertType('int', $int);
+
+        return ['string' => 1];
+    }));
+
+assertType('Illuminate\Support\Collection<int, mixed>', $collection::make(['string'])
+    ->flatMap(function ($string, $int) {
+        assertType('string', $string);
+        assertType('int', $int);
+
+        return 1;
+    }));
+
+assertType('Illuminate\Support\Collection<int, mixed>', $collection->mapInto(User::class));
+
+assertType('Illuminate\Support\Collection<int, int>', $collection->make([1])->merge([2]));
+assertType('Illuminate\Support\Collection<int, string>', $collection->make(['string'])->merge(['string']));
+
+assertType('Illuminate\Support\Collection<int, array<int, int>>', $collection->make([1])->mergeRecursive([2]));
+assertType('Illuminate\Support\Collection<int, array<int, string>>', $collection->make(['string'])->mergeRecursive(['string']));
+
+assertType('Illuminate\Support\Collection<string, int>', $collection->make(['string' => 'string'])->combine([2]));
+assertType('Illuminate\Support\Collection<int, int>', $collection->make([1])->combine([1]));
+
+assertType('Illuminate\Support\Collection<int, int>', $collection->make([1])->union([1]));
+assertType('Illuminate\Support\Collection<string, string>', $collection->make(['string' => 'string'])->union(['string' => 'string']));
+
+assertType('int', $collection->make([1])->min());
+assertType('int', $collection->make([1])->min('string'));
+assertType('int', $collection->make([1])->min(function ($int) {
+    assertType('int', $int);
+
+    return 1;
+}));
+
+assertType('int', $collection->make([1])->max());
+assertType('int', $collection->make([1])->max('string'));
+assertType('int', $collection->make([1])->max(function ($int) {
+    assertType('int', $int);
+
+    return 1;
+}));
+
+assertType('Illuminate\Support\Collection<int, User>', $collection->nth(1, 2));
+
+assertType('Illuminate\Support\Collection<string, string>', $collection::make(['string' => 'string'])->only(['string']));
+assertType('Illuminate\Support\Collection<int, User>', $collection->only([1]));
+assertType('Illuminate\Support\Collection<int, string>', $collection::make(['string'])
+    ->only($collection->keys()->toArray()));
+
+assertType('Illuminate\Support\Collection<int, User>', $collection->forPage(1, 2));
+
+assertType('array<int, Illuminate\Support\Collection<int, User>>', $collection->partition(function ($user, $int) {
+    assertType('User', $user);
+    assertType('int', $int);
+
+    return true;
+}));
+
+assertType('array<int, Illuminate\Support\Collection<int, string>>', $collection::make(['string'])->partition('string', '=', 'string'));
+assertType('array<int, Illuminate\Support\Collection<int, string>>', $collection::make(['string'])->partition('string', 'string'));
+assertType('array<int, Illuminate\Support\Collection<int, string>>', $collection::make(['string'])->partition('string', ));
+
+assertType('Illuminate\Support\Collection<int, int>', $collection->make([1])->concat([2]));
+assertType('Illuminate\Support\Collection<int, string>', $collection->make(['string'])->concat(['string']));
+
+assertType('Illuminate\Support\Collection<int, int>|int', $collection->make([1])->random(2));
+assertType('Illuminate\Support\Collection<int, string>|string', $collection->make(['string'])->random());
+
+assertType('int', $collection
+    ->reduce(function ($null, $user) {
+        assertType('User', $user);
+        assertType('int|null', $null);
+
+        return 1;
+    }));
+
+
+assertType('int', $collection
+    ->reduce(function ($int, $user) {
+        assertType('User', $user);
+        assertType('int', $int);
+
+        return 1;
+    }, 0));
+
+assertType('Illuminate\Support\Collection<int, int>', $collection::make([1])->replace([1]));
+assertType('Illuminate\Support\Collection<int, User>', $collection->replace([new User]));
+
 assertType('Illuminate\Support\Collection<int, int>', $collection->make([1])->push(2));
+
+
+
 
 assertType('array<int, User>', $collection->all());
 

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -535,9 +535,23 @@ assertType('int', $collection
 
         return 1;
     }));
-
 assertType('int', $collection
     ->reduce(function ($int, $user) {
+        assertType('User', $user);
+        assertType('int', $int);
+
+        return 1;
+    }, 0));
+
+assertType('int', $collection
+    ->reduceWithKeys(function ($null, $user) {
+        assertType('User', $user);
+        assertType('int|null', $null);
+
+        return 1;
+    }));
+assertType('int', $collection
+    ->reduceWithKeys(function ($int, $user) {
         assertType('User', $user);
         assertType('int', $int);
 
@@ -687,6 +701,8 @@ assertType('int', $collection->make([1])->pipe(function ($collection) {
     return 1;
 }));
 
+assertType('mixed', $collection->pipeInto(User::class));
+
 assertType('Illuminate\Support\Collection<int, mixed>', $collection->make(['string' => 'string'])->pluck('string'));
 assertType('Illuminate\Support\Collection<int, mixed>', $collection->make(['string' => 'string'])->pluck('string', 'string'));
 
@@ -834,9 +850,9 @@ assertType('User', $collection[0] = new User);
 $collection->offsetUnset(0);
 unset($collection[0]);
 
-assertType('array<int, User>', $collection->toArray());
-assertType('array<string, string>', collect(['string' => 'string'])->toArray());
-assertType('array<int, int>', collect([1, 2])->toArray());
+assertType('array<int, mixed>', $collection->toArray());
+assertType('array<string, mixed>', collect(['string' => 'string'])->toArray());
+assertType('array<int, mixed>', collect([1, 2])->toArray());
 
 assertType('ArrayIterator<int, User>', $collection->getIterator());
 foreach ($collection as $int => $user) {

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Support\Collection;
 use function PHPStan\Testing\assertType;
 
 class User extends Authenticatable
@@ -17,11 +18,6 @@ $iterable = [];
 $traversable = [];
 
 assertType('Illuminate\Support\Collection<int, User>', $collection);
-
-foreach ($collection as $int => $user) {
-    assertType('int', $int);
-    assertType('User', $user);
-}
 
 assertType('Illuminate\Support\Collection<int, string>', collect(['string']));
 assertType('Illuminate\Support\Collection<string, User>', collect(['string' => new User]));
@@ -553,14 +549,14 @@ assertType('Illuminate\Support\Collection<int, User>', $collection->replaceRecur
 
 assertType('Illuminate\Support\Collection<int, User>', $collection->reverse());
 
-assertType('int|bool', $collection->make([1])->search(2));
-assertType('string|bool', $collection->make(['string' => 'string'])->search('string'));
-assertType('int|bool', $collection->search(function ($user, $int) {
-    assertType('User', $user);
-    assertType('int', $int);
-
-    return true;
-}));
+// assertType('int|bool', $collection->make([1])->search(2));
+// assertType('string|bool', $collection->make(['string' => 'string'])->search('string'));
+// assertType('int|bool', $collection->search(function ($user, $int) {
+//     assertType('User', $user);
+//    assertType('int', $int);
+//
+//    return true;
+// }));
 
 assertType('Illuminate\Support\Collection<int, int>', $collection->make([1])->shuffle());
 assertType('Illuminate\Support\Collection<int, User>', $collection->shuffle());
@@ -751,6 +747,94 @@ assertType('array<int, User>', $collection->all());
 assertType('User|null', $collection->get(0));
 assertType('string|User', $collection->get(0, 'string'));
 
+assertType('Illuminate\Support\Collection<int, User>', $collection->forget(1));
+assertType('Illuminate\Support\Collection<int, User>', $collection->forget([1, 2]));
+
+assertType('Illuminate\Support\Collection<int, User>|User|null', $collection->pop(1));
+assertType('Illuminate\Support\Collection<int, string>|string|null', $collection::make([
+    'string-key-1' => 'string-value-1',
+    'string-key-2' => 'string-value-2',
+])->pop(2));
+
+assertType('Illuminate\Support\Collection<int, int>', $collection->make([1])->prepend(2));
+assertType('Illuminate\Support\Collection<int, User>', $collection->prepend(new User, 2));
+
+assertType('Illuminate\Support\Collection<int, int>', $collection->make([1])->push(2));
+assertType('Illuminate\Support\Collection<int, User>', $collection->push(new User, new User));
+
+assertType('User|null', $collection->pull(1));
+assertType('string|User', $collection->pull(1, 'string'));
+
+assertType('Illuminate\Support\Collection<int, User>', $collection->put(1, new User));
+assertType('Illuminate\Support\Collection<string, string>', $collection::make([
+    'string-key-1' => 'string-value-1'
+])->put('string-key-2', 'string-value-2'));
+
+assertType('Illuminate\Support\Collection<int, User>|User|null', $collection->shift(1));
+assertType('Illuminate\Support\Collection<int, string>|string|null', $collection::make([
+    'string-key-1' => 'string-value-1',
+    'string-key-2' => 'string-value-2',
+])->shift(2));
+
+assertType(
+    'Illuminate\Support\Collection<int, Illuminate\Support\Collection<int, User>>',
+    $collection->sliding(2)
+);
+
+assertType(
+    'Illuminate\Support\Collection<int, Illuminate\Support\Collection<string, string>>',
+    $collection::make(['string' => 'string'])->sliding(2, 1)
+);
+
+assertType(
+    'Illuminate\Support\Collection<int, Illuminate\Support\Collection<int, User>>',
+    $collection->splitIn(2)
+);
+
+assertType(
+    'Illuminate\Support\Collection<int, Illuminate\Support\Collection<string, string>>',
+    $collection::make(['string' => 'string'])->splitIn(1)
+);
+
+assertType('Illuminate\Support\Collection<int, User>', $collection->splice(1));
+assertType('Illuminate\Support\Collection<int, User>', $collection->splice(1, 1, [new User]));
+
+assertType('Illuminate\Support\Collection<int, User>', $collection->transform(function ($user, $int) {
+    assertType('User', $user);
+    assertType('int', $int);
+
+    return new User;
+}));
+
+assertType('Illuminate\Support\Collection<int, User>', $collection->add(new User));
+
+/**
+ * @template TKey of array-key
+ * @template TValue
+ *
+ * @extends \Illuminate\Support\Collection<TKey, TValue>
+ */
+class CustomCollection extends Collection {}
+
+// assertType('CustomCollection<int, User>', CustomCollection::make([new User]));
+assertType('Illuminate\Support\Collection<int, User>', CustomCollection::make([new User])->toBase());
+
+assertType('bool', $collection->offsetExists(0));
+assertType('bool', isset($collection[0]));
+
+$collection->offsetSet(0, new User);
+$collection->offsetSet(null, new User);
+assertType('User', $collection[0] = new User);
+
+$collection->offsetUnset(0);
+unset($collection[0]);
+
 assertType('array<int, User>', $collection->toArray());
 assertType('array<string, string>', collect(['string' => 'string'])->toArray());
 assertType('array<int, int>', collect([1, 2])->toArray());
+
+assertType('ArrayIterator<int, User>', $collection->getIterator());
+foreach ($collection as $int => $user) {
+    assertType('int', $int);
+    assertType('User', $user);
+}


### PR DESCRIPTION
Following the discussion on https://github.com/laravel/framework/pull/38257, this pull request starts the work of introducing **serious strong type definitions** on Laravel core. What this pull request **include**:

1. GitHub action job that validates/tests the type definitions.
2. Improves type definitions of `Support\Collection` and `Database\Eloquent\Collection`.

![1](https://user-images.githubusercontent.com/5457236/130773476-cf038db4-ee59-419b-b349-363f095b4dc4.jpg)

![generics_laravel_collections-3](https://user-images.githubusercontent.com/5457236/151783350-ed301660-1e09-44c1-b549-85c6db3f078d.gif)

What this pull request **does not** include:
- Usage of this new type definitions on `Database\Eloquent`. In other words, `collect(['string' => 1])->flip()->all()` or `collect()->map()` is 100% static analyzable and understood by static analysis tools - PHPStorm + PHPStan + ~~[Psalm](https://github.com/vimeo/psalm/issues/6357)~~, but not yet `User::all()`.

As the next step, going to improve the type definitions of `Database\Eloquent`. That's only possible now because of the this work we did with collections.