### PR TITLE
[8.x] Eloquent firstOrForbidden method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -518,6 +518,24 @@ class Builder
     }
 
     /**
+     * Execute the query and get the first result or throw an 403 forbidden exception.
+     *
+     * @param  array  $columns
+     * @param  string  $message
+     * @return \Illuminate\Database\Eloquent\Model|static
+     *
+     * @throws \Illuminate\Database\Eloquent\ModelForbiddenException
+     */
+    public function firstOrForbidden($columns = ['*'], $message = null)
+    {
+        if (! is_null($model = $this->first($columns))) {
+            return $model;
+        }
+
+        throw new ModelForbiddenException($message);
+    }
+
+    /**
      * Execute the query and get the first result or call a callback.
      *
      * @param  \Closure|array  $columns

--- a/src/Illuminate/Database/Eloquent/ModelForbiddenException.php
+++ b/src/Illuminate/Database/Eloquent/ModelForbiddenException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Illuminate\Database\Eloquent;
+
+use Exception;
+use Throwable;
+
+class ModelForbiddenException extends Exception
+{
+    public function __construct($message = null, $code = null, Throwable $previous = null)
+    {
+        parent::__construct($message ?? 'This action is unauthorized.', 0, $previous);
+
+        $this->code = $code ?: 0;
+    }
+}

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Debug\ExceptionHandler as ExceptionHandlerContract;
 use Illuminate\Contracts\Support\Responsable;
+use Illuminate\Database\Eloquent\ModelForbiddenException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\MultipleRecordsFoundException;
 use Illuminate\Database\RecordsNotFoundException;
@@ -90,6 +91,7 @@ class Handler implements ExceptionHandlerContract
         HttpException::class,
         HttpResponseException::class,
         ModelNotFoundException::class,
+        ModelForbiddenException::class,
         MultipleRecordsFoundException::class,
         RecordsNotFoundException::class,
         SuspiciousOperationException::class,
@@ -383,6 +385,8 @@ class Handler implements ExceptionHandlerContract
     {
         if ($e instanceof ModelNotFoundException) {
             $e = new NotFoundHttpException($e->getMessage(), $e);
+        } elseif ($e instanceof ModelForbiddenException) {
+            $e = new AccessDeniedHttpException($e->getMessage(), $e);
         } elseif ($e instanceof AuthorizationException) {
             $e = new AccessDeniedHttpException($e->getMessage(), $e);
         } elseif ($e instanceof TokenMismatchException) {

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -9,6 +9,7 @@ use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\ModelForbiddenException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\Eloquent\RelationNotFoundException;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -151,6 +152,16 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->setModel($this->getMockModel());
         $builder->shouldReceive('first')->with(['column'])->andReturn(null);
         $builder->firstOrFail(['column']);
+    }
+
+    public function testFirstOrForbiddenMethodThrowsModelForbiddenException()
+    {
+        $this->expectException(ModelForbiddenException::class);
+
+        $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
+        $builder->setModel($this->getMockModel());
+        $builder->shouldReceive('first')->with(['column'])->andReturn(null);
+        $builder->firstOrForbidden(['column']);
     }
 
     public function testFindWithMany()


### PR DESCRIPTION
Especially in API-based projects, when user-specific record access is requested, `firstOrFail()` is used generally. And it is necessary to respond to this request with a 404 status code. In fact, the status code should be 403 when the request owner does not have the permission to access the record.

There are many ways to send 403 status, but I think `firstOrForbidden()` would be the ideal way in this case.