### PR TITLE
[6.x] Error out when detecting incompatible DBAL version

### DIFF
--- a/src/Illuminate/Database/MySqlConnection.php
+++ b/src/Illuminate/Database/MySqlConnection.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Query\Grammars\MySqlGrammar as QueryGrammar;
 use Illuminate\Database\Query\Processors\MySqlProcessor;
 use Illuminate\Database\Schema\Grammars\MySqlGrammar as SchemaGrammar;
 use Illuminate\Database\Schema\MySqlBuilder;
+use LogicException;
 
 class MySqlConnection extends Connection
 {
@@ -61,6 +62,12 @@ class MySqlConnection extends Connection
      */
     protected function getDoctrineDriver()
     {
+        if (! class_exists(DoctrineDriver::class)) {
+            throw new LogicException(
+                'Laravel v6 is only compatible with doctrine/dbal 2, in order to use this feature you must require the package "doctrine/dbal:^2.6".'
+            );
+        }
+
         return new DoctrineDriver;
     }
 }

--- a/src/Illuminate/Database/PostgresConnection.php
+++ b/src/Illuminate/Database/PostgresConnection.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Query\Grammars\PostgresGrammar as QueryGrammar;
 use Illuminate\Database\Query\Processors\PostgresProcessor;
 use Illuminate\Database\Schema\Grammars\PostgresGrammar as SchemaGrammar;
 use Illuminate\Database\Schema\PostgresBuilder;
+use LogicException;
 
 class PostgresConnection extends Connection
 {
@@ -61,6 +62,12 @@ class PostgresConnection extends Connection
      */
     protected function getDoctrineDriver()
     {
+        if (! class_exists(DoctrineDriver::class)) {
+            throw new LogicException(
+                'Laravel v6 is only compatible with doctrine/dbal 2, in order to use this feature you must require the package "doctrine/dbal:^2.6".'
+            );
+        }
+
         return new DoctrineDriver;
     }
 }

--- a/src/Illuminate/Database/SQLiteConnection.php
+++ b/src/Illuminate/Database/SQLiteConnection.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Query\Grammars\SQLiteGrammar as QueryGrammar;
 use Illuminate\Database\Query\Processors\SQLiteProcessor;
 use Illuminate\Database\Schema\Grammars\SQLiteGrammar as SchemaGrammar;
 use Illuminate\Database\Schema\SQLiteBuilder;
+use LogicException;
 
 class SQLiteConnection extends Connection
 {
@@ -85,6 +86,12 @@ class SQLiteConnection extends Connection
      */
     protected function getDoctrineDriver()
     {
+        if (! class_exists(DoctrineDriver::class)) {
+            throw new LogicException(
+                'Laravel v6 is only compatible with doctrine/dbal 2, in order to use this feature you must require the package "doctrine/dbal:^2.6".'
+            );
+        }
+
         return new DoctrineDriver;
     }
 

--- a/src/Illuminate/Database/SqlServerConnection.php
+++ b/src/Illuminate/Database/SqlServerConnection.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Query\Grammars\SqlServerGrammar as QueryGrammar;
 use Illuminate\Database\Query\Processors\SqlServerProcessor;
 use Illuminate\Database\Schema\Grammars\SqlServerGrammar as SchemaGrammar;
 use Illuminate\Database\Schema\SqlServerBuilder;
+use LogicException;
 use Throwable;
 
 class SqlServerConnection extends Connection
@@ -108,6 +109,12 @@ class SqlServerConnection extends Connection
      */
     protected function getDoctrineDriver()
     {
+        if (! class_exists(DoctrineDriver::class)) {
+            throw new LogicException(
+                'Laravel v6 is only compatible with doctrine/dbal 2, in order to use this feature you must require the package "doctrine/dbal:^2.6".'
+            );
+        }
+
         return new DoctrineDriver;
     }
 }


### PR DESCRIPTION
`doctrine/dbal` is an optional dependency of `laravel/framework`, and v3 of
the DBAL has been released recently, but obviously, Laravel 6 was never
meant to be compatible with that version.
Users still using Laravel 6 and updating their dependencies get confused
and file invalid reports on the DBAL, see for instance
https://github.com/doctrine/dbal/issues/4439
or
https://github.com/doctrine/dbal/issues/4757

Fixes #24271
