### PR TITLE
[8.x] Add `set` method to collection

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -954,12 +954,12 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
-    * Updates items values using "dot" notation
-    *
-    * @param  string  $key
-    * @param  mixed  $value
-    * @return static
-    */
+     * Updates items values using "dot" notation
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return static
+     */
     public function set($key, $value)
     {
         return $this->map(function ($item) use ($key, $value) {

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -954,7 +954,7 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
-     * Updates items values using "dot" notation
+     * Updates items values using "dot" notation.
      *
      * @param  string  $key
      * @param  mixed  $value

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -954,6 +954,23 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
+    * Updates items values using "dot" notation
+    *
+    * @param  string  $key
+    * @param  mixed  $value
+    * @return static
+    */
+    public function set($key, $value)
+    {
+        return $this->map(function ($item) use ($key, $value) {
+            $actualValue = data_get($item, $key);
+            $newValue = is_callable($value) ? $value($actualValue, $item) : $value;
+
+            return data_set($item, $key, $newValue);
+        });
+    }
+
+    /**
      * Get and remove the first N items from the collection.
      *
      * @param  int  $count

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -362,6 +362,27 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(new Collection(['foo', 'bar', 'baz']), (new Collection(['foo', 'bar', 'baz']))->shift(6));
     }
 
+    public function testSet()
+    {
+        $data = new Collection([
+            ['foo' => 1, 'bar' => 10, 'a' => ['b' => 100]],
+            ['foo' => 2, 'bar' => 20, 'a' => ['b' => 200]],
+            ['foo' => 3, 'bar' => 30, 'a' => ['b' => 300]],
+        ]);
+
+        // Fixed value
+        $this->assertSame([5, 5, 5], $data->set('foo', 5)->pluck('foo')->all());
+
+        // Callback with one argument
+        $this->assertSame([2, 4, 6], $data->set('foo', fn ($foo) => $foo * 2)->pluck('foo')->all());
+
+        // Callback with two arguments
+        $this->assertSame([10, 40, 90], $data->set('foo', fn ($foo, $item) => $foo * $item['bar'])->pluck('foo')->all());
+
+        // Using "dot" notation
+        $this->assertSame([['b' => 5], ['b' => 5], ['b' => 5]], $data->set('a.b', 5)->pluck('a')->all());
+    }
+
     /**
      * @dataProvider collectionClassProvider
      */

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -374,10 +374,14 @@ class SupportCollectionTest extends TestCase
         $this->assertSame([5, 5, 5], $data->set('foo', 5)->pluck('foo')->all());
 
         // Callback with one argument
-        $this->assertSame([2, 4, 6], $data->set('foo', fn ($foo) => $foo * 2)->pluck('foo')->all());
+        $this->assertSame([2, 4, 6], $data->set('foo', function ($foo) {
+            return $foo * 2;
+        })->pluck('foo')->all());
 
         // Callback with two arguments
-        $this->assertSame([10, 40, 90], $data->set('foo', fn ($foo, $item) => $foo * $item['bar'])->pluck('foo')->all());
+        $this->assertSame([10, 40, 90], $data->set('foo', function ($foo, $item) {
+            return $foo * $item['bar'];
+        })->pluck('foo')->all());
 
         // Using "dot" notation
         $this->assertSame([['b' => 5], ['b' => 5], ['b' => 5]], $data->set('a.b', 5)->pluck('a')->all());


### PR DESCRIPTION
Adds a `set` method to the collection, which updates values in a collection of arrays or objects:

```php
$collection = collect([
    ['product' => 'Chair', 'quality' => 1, 'price' => 100],
    ['product' => 'Desk', 'quality' => 2, 'price' => 200],
    ['product' => 'Computer', 'quality' => 3, 'price' => 300],
])

$collection->set('price', 500);
// [[..., 'price' => 500], [..., 'price' => 500], [..., 'price' => 500]]

$collection->set('price', fn($price) => $price * 2);
// [[..., 'price' => 200], [..., 'price' => 400], [..., 'price' => 600]]

$collection->set('price', fn($price, $item) => $price * $item['quality']);
// [[..., 'price' => 100], [..., 'price' => 400], [..., 'price' => 900]]
```

# Examples

1. Consider that you have fetched a collection of models from an external API.

2. You want to update the price of this models and post back the result to the same API, batch updating the models.

3. Actually, you need to do the following to achieve this goal:

```php
$products = $api->fetchProducts();

$updated = collect($products)->map(function($product) {
    $product['price'] = $product['price'] * $product['quality'];

    return $product;
});

// OR: You can use the put method on each item, if you want to keep it in a single line
$updated = collect($products)->map(fn($p) => collect($p)->put('price', $p['price'] * $p['quality'])->all());

$api->updateProducts($products->all());
```

4. With the `set` method, it becomes much easier and cleaner:

```php
$products = $api->fetchProducts();

$updated = collect($products)->set('price', fn($price, $product) => $price * $product['quality']))->all();

$api->updateProducts($updated);
```

5. The proposed method also works with objects and "dot" notation

```php
$collection = User::all();
$collection->set('points', 500);

$collection = collect([
    ['foo' => ['bar' => 0]],
    ['foo' => ['bar' => 5]],
]);
$collection->set('foo.bar', 123);
```

6. One last example is to compute values from the items data:

```php
$people = collect([
    ['name' => 'Ricardo', 'age' => 33, 'country' => 'Brazil'],
    ['name' => 'Felipe', 'age' => 16, 'country' => 'Chile'],
    ['name' => 'John', 'age' => 45, 'country' => 'Canada'],
]);

$people
    ->set('is_adult', fn($v, $person) => $person['age'] > 18)
    ->set('is_brazilian', fn($v, $person) => $person['country'] === 'Brazil')
    ->set('phone', fn() => $faker->phoneNumber);
```

7. Other people trying to solve the same problem:

- https://stackoverflow.com/questions/49235338/laravel-insert-a-new-keyvalue-to-collection-in-child-array
- https://laracasts.com/discuss/channels/laravel/add-key-value-to-current-object-in-eloquent-collection