### PR TITLE
[8.x] Support broadcasting deleted model events

### DIFF
--- a/src/Illuminate/Database/Eloquent/BroadcastsEvents.php
+++ b/src/Illuminate/Database/Eloquent/BroadcastsEvents.php
@@ -124,18 +124,24 @@ trait BroadcastsEvents
      */
     public function newBroadcastableModelEvent($event)
     {
-        return tap($this->newBroadcastableEvent($event), function ($event) {
-            $event->connection = property_exists($this, 'broadcastConnection')
+        return tap($this->newBroadcastableEvent($event), function ($instance) use ($event) {
+            $instance->connection = property_exists($this, 'broadcastConnection')
                             ? $this->broadcastConnection
                             : $this->broadcastConnection();
 
-            $event->queue = property_exists($this, 'broadcastQueue')
+            $instance->queue = property_exists($this, 'broadcastQueue')
                             ? $this->broadcastQueue
                             : $this->broadcastQueue();
 
-            $event->afterCommit = property_exists($this, 'broadcastAfterCommit')
+            $instance->afterCommit = property_exists($this, 'broadcastAfterCommit')
                             ? $this->broadcastAfterCommit
                             : $this->broadcastAfterCommit();
+
+            if (method_exists($this, 'broadcastAs')) {
+                $instance->broadcastableAs($this->broadcastAs($event) ?: null);
+            }
+
+            $instance->onDefaultChannels($this->broadcastOn($event) ?: []);
         });
     }
 

--- a/tests/Integration/Database/DatabaseEloquentBroadcastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentBroadcastingTest.php
@@ -48,6 +48,23 @@ class DatabaseEloquentBroadcastingTest extends DatabaseTestCase
         });
     }
 
+    public function testDeleteBroadcasting()
+    {
+        Event::fake([BroadcastableModelEventOccurred::class]);
+
+        $model = new TestEloquentBroadcastUser;
+        $model->name = 'Taylor';
+        $model->save();
+        $model = $model->fresh();
+        $model->delete();
+
+        Event::assertDispatched(function (BroadcastableModelEventOccurred $event) use ($model) {
+            return $event->model === $model->id
+                    && count($event->broadcastOn()) === 1
+                    && $event->broadcastOn()[0]->name == "private-Illuminate.Tests.Integration.Database.TestEloquentBroadcastUser.{$event->model}";
+        });
+    }
+
     public function testChannelRouteFormatting()
     {
         $model = new TestEloquentBroadcastUser;


### PR DESCRIPTION
Currently, model broadcasting fails on models that are deleted. The queued broadcast job will fail because the model no longer exists.

This tweaks the behavior to broadcast the model's primary key in the event's `model` property on a model deletion that is not a soft deleted model.

Assuming this isn't a breaking change as the behavior is pretty broken at the moment.