### PR TITLE
[8.x] Add support to convert string to a sentence

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -676,6 +676,17 @@ class Str
     }
 
     /**
+     * Convert the given string to a sentence.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    public static function sentence($value)
+    {
+        return str_replace('_', ' ', static::snake($value));
+    }
+
+    /**
      * Get the singular form of an English word.
      *
      * @param  string  $value

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -555,6 +555,16 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Convert the given string to a sentence.
+     *
+     * @return static
+     */
+    public function sentence()
+    {
+        return new static(Str::sentence($this->value));
+    }
+
+    /**
      * Begin a string with a single instance of a given value.
      *
      * @param  string  $prefix

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -395,6 +395,16 @@ class SupportStrTest extends TestCase
         $this->assertSame('Foobar', Str::remove(['f', '|'], 'Foo|bar'));
     }
 
+    public function testSentence()
+    {
+        $this->assertSame('it converts to sentence case', Str::sentence('ItConvertsToSentenceCase'));
+        $this->assertSame('it preserves hyphenated-words', Str::sentence('it preserves hyphenated-words'));
+        $this->assertSame('it converts to sentence case', Str::sentence('it_converts_to_sentence_case'));
+        $this->assertSame('it converts to sentence case', Str::sentence('itConvertsToSentenceCase'));
+        $this->assertSame('it converts to sentence case', Str::sentence('itConverts toSentenceCase'));
+        $this->assertSame('laravel php framework', Str::sentence('Laravel    Php      Framework   '));
+    }
+
     public function testSnake()
     {
         $this->assertSame('laravel_p_h_p_framework', Str::snake('LaravelPHPFramework'));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -538,6 +538,16 @@ class SupportStringableTest extends TestCase
         $this->assertSame('Foobar', (string) $this->stringable('Foo|bar')->remove(['f', '|']));
     }
 
+    public function testSentence()
+    {
+        $this->assertSame('it converts to sentence case', (string) $this->stringable('ItConvertsToSentenceCase')->sentence());
+        $this->assertSame('it preserves hyphenated-words', (string) $this->stringable('it preserves hyphenated-words')->sentence());
+        $this->assertSame('it converts to sentence case', (string) $this->stringable('it_converts_to_sentence_case')->sentence());
+        $this->assertSame('it converts to sentence case', (string) $this->stringable('itConvertsToSentenceCase')->sentence());
+        $this->assertSame('it converts to sentence case', (string) $this->stringable('itConverts toSentenceCase')->sentence());
+        $this->assertSame('laravel php framework', (string) $this->stringable('Laravel    Php      Framework   ')->sentence());
+    }
+
     public function testSnake()
     {
         $this->assertSame('laravel_p_h_p_framework', (string) $this->stringable('LaravelPHPFramework')->snake());


### PR DESCRIPTION
I was watching replay of @jasonmccreary Building the PHPUnit to Pest Converter (https://www.youtube.com/watch?v=afdCgl_Rq5E) and found myself thinking: It would help if only there was a way to convert a string to a sentence . 

This PR adds `sentence()` to `Illuminate\Support\Str` and `Illuminate\Support\Stringable` allowing for the following to be possible:

```PHP
use Illuminate\Support\Str;

Str::sentence('ItConvertsToSentenceCase'); //it converts to sentence case
(string) Str::of('it converts to sentence case')->sentence(); //it converts to sentence case
```