### PR TITLE
[8.x] Add unprocessable test response assertion

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -155,6 +155,16 @@ class TestResponse implements ArrayAccess
     }
 
     /**
+     * Assert that the response has a 422 status code.
+     *
+     * @return $this
+     */
+    public function assertUnprocessable()
+    {
+        return $this->assertStatus(422);
+    }
+
+    /**
      * Assert that the response has the given status code.
      *
      * @param  int  $status

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -472,6 +472,22 @@ class TestResponseTest extends TestCase
         $response->assertUnauthorized();
     }
 
+    public function testAssertUnprocessable()
+    {
+        $statusCode = 500;
+
+        $this->expectException(AssertionFailedError::class);
+
+        $this->expectExceptionMessage('Expected response status code');
+
+        $baseResponse = tap(new Response, function ($response) use ($statusCode) {
+            $response->setStatusCode($statusCode);
+        });
+
+        $response = TestResponse::fromBaseResponse($baseResponse);
+        $response->assertUnprocessable();
+    }
+
     public function testAssertNoContentAsserts204StatusCodeByDefault()
     {
         $statusCode = 500;


### PR DESCRIPTION
* Add assertUnprocessable method
* Add test

Proposes a new `->assertUnprocessable()` method on `TestResponse` to compliment the existing descriptive convenience methods.

I use `->assertOk()`, `->assertUnauthorized()`, `->assertForbidden()` & friends in tests because they read really clearly and benefit from showing up in my editor's tab autocomplete so there's a small quality of life enhancement.

Working on a complex project with a lot of validation I've been wishing there was an equivalent for `->assertStatus(422)` or the more human but long winded `->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY)`.

The addition is syntactic sugar and does not modify any existing methods so there are no breaking changes. 
