### PR TITLE
[8.x] Keep backward compatibility with custom ciphers

### DIFF
--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -83,7 +83,7 @@ class Encrypter implements EncrypterContract, StringEncrypter
      */
     public static function generateKey($cipher)
     {
-        return random_bytes(self::$supportedCiphers[$cipher]['size']);
+        return random_bytes(self::$supportedCiphers[$cipher]['size'] ?? 32);
     }
 
     /**


### PR DESCRIPTION
<!-- DO NOT THROW THIS AWAY -->
<!-- Fill out the FULL versions with patch versions -->

- Laravel Version: 8.56.0
- PHP Version: 8.0.0
- Database Driver & Version:

### Description:
Laravel 8.56 was released a few days ago and these changes in the Encryption library break custom ciphers - https://github.com/illuminate/encryption/compare/v8.55.0...v8.56.0#diff-4f830444085dd7aded928d1f4c746b2b2a3ced0c12e2788d4474e777e4b9113dL73

`php artisan key:generate` doesn't work if the usec cipher is **XSalsa20**

### Steps To Reproduce:
- change in `config/app` this line to `'cipher' => 'XSalsa20',`
- run `php artisan key:generate`
- (libsodium must be installed)

Fixes https://github.com/laravel/framework/issues/38555