### PR TITLE
[8.x] Allow sync broadcast via method

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -112,7 +112,10 @@ class BroadcastManager implements FactoryContract
      */
     public function queue($event)
     {
-        if ($event instanceof ShouldBroadcastNow) {
+        if ($event instanceof ShouldBroadcastNow ||
+            (is_object($event) &&
+             method_exists($event, 'shouldBroadcastNow') &&
+             $event->shouldBroadcastNow())) {
             return $this->app->make(BusDispatcherContract::class)->dispatchNow(new BroadcastEvent(clone $event));
         }
 

--- a/src/Illuminate/Database/Eloquent/BroadcastableModelEventOccurred.php
+++ b/src/Illuminate/Database/Eloquent/BroadcastableModelEventOccurred.php
@@ -115,6 +115,17 @@ class BroadcastableModelEventOccurred implements ShouldBroadcast
     }
 
     /**
+     * Determine if the event should be broadcast synchronously.
+     *
+     * @return bool
+     */
+    public function shouldBroadcastNow()
+    {
+        return $this->event === 'deleted' &&
+               ! method_exists($this->model, 'bootSoftDeletes');
+    }
+
+    /**
      * Get the event name.
      *
      * @return string

--- a/src/Illuminate/Database/Eloquent/BroadcastsEvents.php
+++ b/src/Illuminate/Database/Eloquent/BroadcastsEvents.php
@@ -111,6 +111,10 @@ trait BroadcastsEvents
      */
     protected function broadcastIfBroadcastChannelsExistForEvent($instance, $event, $channels = null)
     {
+        if (! static::$isBroadcasting) {
+            return;
+        }
+
         if (! empty($this->broadcastOn($event)) || ! empty($channels)) {
             return broadcast($instance->onChannels(Arr::wrap($channels)));
         }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -167,6 +167,13 @@ abstract class Model implements Arrayable, ArrayAccess, HasBroadcastChannel, Jso
     protected static $lazyLoadingViolationCallback;
 
     /**
+     * Indicates if broadcasting is currently enabled.
+     *
+     * @var bool
+     */
+    protected static $isBroadcasting = true;
+
+    /**
      * The name of the "created at" column.
      *
      * @var string|null
@@ -375,6 +382,25 @@ abstract class Model implements Arrayable, ArrayAccess, HasBroadcastChannel, Jso
     public static function handleLazyLoadingViolationUsing(callable $callback)
     {
         static::$lazyLoadingViolationCallback = $callback;
+    }
+
+    /**
+     * Execute a callback without broadcasting any model events for all model types.
+     *
+     * @param  callable  $callback
+     * @return mixed
+     */
+    public static function withoutBroadcasting(callable $callback)
+    {
+        $isBroadcasting = static::$isBroadcasting;
+
+        static::$isBroadcasting = false;
+
+        try {
+            return $callback();
+        } finally {
+            static::$isBroadcasting = $isBroadcasting;
+        }
     }
 
     /**


### PR DESCRIPTION
Alternative to #38547

-----------------------------

Currently, model broadcasting fails on models that are deleted. The queued broadcast job will fail because the model no longer exists.

This tweaks the behavior to broadcast the model's primary key in the event's model property on a model deletion that is not a soft deleted model.

Assuming this isn't a breaking change as the behavior is pretty broken at the moment.