### PR TITLE
[8.x] Check whether the given url is absolute

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -648,7 +648,7 @@ class PendingRequest
      */
     public function send(string $method, string $url, array $options = [])
     {
-        if (!$this->isAbsoluteUrl($url)) {
+        if (! $this->isAbsoluteUrl($url)) {
             $url = ltrim(rtrim($this->baseUrl, '/').'/'.ltrim($url, '/'), '/');
         }
 
@@ -694,7 +694,7 @@ class PendingRequest
     }
 
     /**
-     * Determines whether the specified URL is absolute
+     * Determines whether the specified URL is absolute.
      *
      * @param  string  $url
      * @return bool


### PR DESCRIPTION
This PR adds the functionality to use an absolute url inside the `send` method of `Illuminate\Http\Client\PendingRequest` class even when a `baseUrl` has been provided.

Before the example below would have failed
```php
$response = Http::baseUrl('https://pokeapi.co/api/v2/pokemon/ditto')
        ->get('https://pokeapi.co/api/v2/ability/7/');
```

Now this will call the absolute url from the `get` method instead of merging it with the baseUrl and the request will succeed.

This logic comes from the [Axios HTTP Client](https://github.com/axios/axios).