### PR TITLE
[8.x] Http Client check if it's an absolute URL

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -648,7 +648,7 @@ class PendingRequest
      */
     public function send(string $method, string $url, array $options = [])
     {
-        if (!$this->isAbsoluteUrl($url)) {
+        if (! $this->isAbsoluteUrl($url)) {
             $url = ltrim(rtrim($this->baseUrl, '/').'/'.ltrim($url, '/'), '/');
         }
 
@@ -694,7 +694,7 @@ class PendingRequest
     }
 
     /**
-     * Determines whether the specified URL is absolute
+     * Determines whether the specified URL is absolute.
      *
      * @param  string  $url
      * @return bool

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -714,6 +714,28 @@ class HttpClientTest extends TestCase
         $this->factory->assertSentInOrder($exampleUrls);
     }
 
+    public function testUrlIsAbsolute()
+    {
+        $this->factory->fake();
+
+        $this->factory->baseUrl('http://example.com/1')->get('http://example.com/2');
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://example.com/2';
+        });
+    }
+
+    public function testUrlIsRelative()
+    {
+        $this->factory->fake();
+
+        $this->factory->baseUrl('http://example.com')->get('1');
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://example.com/1';
+        });
+    }
+
     public function testWrongNumberOfRequestsThrowAssertionFailed()
     {
         $this->factory->fake();

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -725,7 +725,7 @@ class HttpClientTest extends TestCase
         });
     }
 
-    public function testUrlIsRelative()
+    public function testBaseUrl()
     {
         $this->factory->fake();
 


### PR DESCRIPTION
This PR adds the functionality to use an absolute url inside the `send` method of `Illuminate\Http\Client\PendingRequest` class even when a `baseUrl` has been provided.

Before the PR the example below would have failed
```php
$response = Http::baseUrl('http://example.com/1')
        ->get('http://example.com/2');
```

Now this will call the `http://example.com/2` URL because its an absolute URL instead of merging it with the base URL.

This functionality is useful when you are dealing with API's, sometimes they may return an absolute URL that you might want to use it to send another request, with the same `Illuminate\Http\Client\PendingRequest` instance but this URL now will be absolute instead of a relative one and if there is a base URL setted with the current implementation the request URL will look something like this `http://example.com/1/http://example.com/2` and the request will fail.

The addition does not modify any existing functionality so there are no breaking changes.