### PR TITLE
[8.x] Add firstAttribute method

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -360,6 +360,22 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
+     * Get an attribute from the first item from the collection passing the given truth test.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $defaultValue
+     * @param  callable|null  $callback
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public function firstAttribute(string $attribute, $defaultValue = null, callable $callback = null, $default = null)
+    {
+        $item = $this->first($callback, $default);
+
+        return $item ? $item->$attribute : $defaultValue;
+    }
+
+    /**
      * Get a flattened array of the items in the collection.
      *
      * @param  int  $depth


### PR DESCRIPTION
There are times when you need to retrieve an attribute from a collection item if it exists, and return a separate default value if it doesn't.

This would currently be done like this:

`$user = $users->where('name', 'Bob Smith')->first();`
`$age = $user ? $user->age : "Unknown";`

What I really want is to be able to do:
`$age = $users->where('name', 'Bob Smith')->first()->age ?? "Unknown";`

But of course this will throw an exception if Bob Smith doesn't exist.

This sugar method allows you to do:

`$age = $users->where('name', 'Bob Smith')->firstAttribute('age', 'Unknown');`

The existing `$default` param in `first()` would require you to create an empty model for this to work.

**Note:** with this implementation, you wouldn't know whether there was an item and its attribute value was equal to defaultValue, or whether there wasn't an item and you had received the defaultValue in return. You should use other methods to determine existence.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
