### PR TITLE
[8.x] Fix bug discarding input fields with empty validation rules

### DIFF
--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -292,8 +292,8 @@ class ValidationRuleParser
 
             if ($attributeRules instanceof ConditionalRules) {
                 return [$attribute => $attributeRules->passes($data)
-                                ? $attributeRules->rules()
-                                : $attributeRules->defaultRules(), ];
+                                ? array_filter($attributeRules->rules())
+                                : array_filter($attributeRules->defaultRules()), ];
             }
 
             return [$attribute => collect($attributeRules)->map(function ($rule) use ($data) {
@@ -303,6 +303,6 @@ class ValidationRuleParser
 
                 return $rule->passes($data) ? $rule->rules() : $rule->defaultRules();
             })->filter()->flatten(1)->values()->all()];
-        })->filter()->all();
+        })->all();
     }
 }

--- a/tests/Validation/ValidationRuleParserTest.php
+++ b/tests/Validation/ValidationRuleParserTest.php
@@ -24,10 +24,26 @@ class ValidationRuleParserTest extends TestCase
 
         $this->assertEquals([
             'name' => ['required', 'min:2'],
+            'email' => [],
             'password' => ['required', 'min:2'],
             'username' => ['required', 'min:2'],
             'address' => ['required'],
             'city' => ['required', 'min:2'],
+        ], $rules);
+    }
+
+    public function test_empty_rules_are_preserved()
+    {
+        $rules = ValidationRuleParser::filterConditionalRules([
+            'name' => [],
+            'email' => '',
+            'password' => Rule::when(true, 'required|min:2'),
+        ]);
+
+        $this->assertEquals([
+            'name' => [],
+            'email' => '',
+            'password' => ['required', 'min:2'],
         ], $rules);
     }
 
@@ -47,6 +63,21 @@ class ValidationRuleParserTest extends TestCase
             'password' => ['string', 'max:10'],
             'username' => ['required', 'min:2'],
             'address' => ['required', 'string', 'max:10'],
+        ], $rules);
+    }
+
+    public function test_empty_conditional_rules_are_preserved()
+    {
+        $rules = ValidationRuleParser::filterConditionalRules([
+            'name' => Rule::when(true, '', ['string', 'max:10']),
+            'email' => Rule::when(false, ['required', 'min:2'], []),
+            'password' => Rule::when(false, 'required|min:2', 'string|max:10'),
+        ]);
+
+        $this->assertEquals([
+            'name' => [],
+            'email' => [],
+            'password' => ['string', 'max:10'],
         ], $rules);
     }
 }


### PR DESCRIPTION
This PR fixes a breaking change that was introduced with conditional validation rules in v8.55.0.

Before the change in v8.55, if input fields were being validated with an empty list of validation rules, no validation would be performed but those fields would be included in the data returned from `$request->validated()`.

Now, fields with an empty list of validation rules (`[]` or `''`) are removed from the list of rules entirely, so matching input fields in the request are not included in `$request->validated()`.

**v8.54 and earlier:**

```php
validator([
    'name' => 'Jacob', // Input
], [
    'name' => '', // Rules
])->validated();

// ['name' => 'Jacob']
```

**v8.55 and later:**

```php
validator([
    'name' => 'Jacob', // Input
], [
    'name' => '', // Rules
])->validated();

// []
```

## Background

The conditional validation rules feature added in v8.55.0 runs `filter()` on the collection of validation rules so that conditional rules are not applied if the conditional is false.

This unintentionally introduced the side-effect that input data is excluded from the output of `validated()` for non-conditional rules with empty (`[]` or `''`) rules, and for conditional rules where the conditional is false. In the second case, if the only rule on a field is a conditional rule and the condition evaluates to be false, instead of just not running the conditional rules the field will be removed from `validated()` completely.

I'm not suggesting in this PR that the previous behaviour is or isn't _correct_ (I asked some colleagues about this and most actually agree that the new behaviour is better), but it seems like a breaking change, so I think it would be ideal to avoid making it in a minor release. At Tighten we've already seen multiple applications break as a result of this change.

The code change in this PR is very small and completely backwards-compatible—it just stops filtering out validation rules that are `[]` or `''`. If filtering these fields out is the preferred behaviour, it could easily be reintroduced in v9.

Fixes #38505.