### PR TITLE
[9.x] Uses generic collections on `Eloquent\Model::class`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -88,7 +88,7 @@
         "mockery/mockery": "^1.4.3",
         "orchestra/testbench-core": "^7.0",
         "pda/pheanstalk": "^4.0",
-        "phpstan/phpstan": "^0.12.94",
+        "phpstan/phpstan": "dev-master",
         "phpunit/phpunit": "^9.4",
         "predis/predis": "^1.1.2",
         "symfony/cache": "^6.0"

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -16,6 +16,9 @@ use Illuminate\Support\Traits\Conditionable;
 use InvalidArgumentException;
 use RuntimeException;
 
+/**
+ * @template TModel of \Illuminate\Database\Eloquent\Model
+ */
 trait BuildsQueries
 {
     use Conditionable;
@@ -63,9 +66,11 @@ trait BuildsQueries
     /**
      * Run a map over each item while chunking.
      *
-     * @param  callable  $callback
+     * @template TChunkMapValue
+     *
+     * @param  callable(TModel): TChunkMapValue  $callback
      * @param  int  $count
-     * @return \Illuminate\Support\Collection
+     * @return \Illuminate\Support\Collection<int, TChunkMapValue>
      */
     public function chunkMap(callable $callback, $count = 1000)
     {

--- a/src/Illuminate/Database/Concerns/ExplainsQueries.php
+++ b/src/Illuminate/Database/Concerns/ExplainsQueries.php
@@ -9,7 +9,7 @@ trait ExplainsQueries
     /**
      * Explains the query.
      *
-     * @return \Illuminate\Support\Collection
+     * @return \Illuminate\Support\Collection<int, object>
      */
     public function explain()
     {

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -23,10 +23,15 @@ use ReflectionClass;
 use ReflectionMethod;
 
 /**
+ * @template TModel of \Illuminate\Database\Eloquent\Model
+ *
  * @property-read HigherOrderBuilderProxy $orWhere
  */
 class Builder implements BuilderContract
 {
+    /**
+     * @use \Illuminate\Database\Concerns\BuildsQueries<TModel>
+     */
     use BuildsQueries, DecoratesQueryBuilder, ExplainsQueries, ForwardsCalls, QueriesRelationships {
         BuildsQueries::sole as baseSole;
     }
@@ -316,7 +321,7 @@ class Builder implements BuilderContract
      * Create a collection of models from plain arrays.
      *
      * @param  array  $items
-     * @return \Illuminate\Database\Eloquent\Collection
+     * @return \Illuminate\Database\Eloquent\Collection<int, TModel>
      */
     public function hydrate(array $items)
     {
@@ -338,7 +343,7 @@ class Builder implements BuilderContract
      *
      * @param  string  $query
      * @param  array  $bindings
-     * @return \Illuminate\Database\Eloquent\Collection
+     * @return \Illuminate\Database\Eloquent\Collection<int, TModel>
      */
     public function fromQuery($query, $bindings = [])
     {
@@ -352,7 +357,7 @@ class Builder implements BuilderContract
      *
      * @param  mixed  $id
      * @param  array  $columns
-     * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection|static[]|static|null
+     * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection<int, TModel>|static[]|static|null
      */
     public function find($id, $columns = ['*'])
     {
@@ -368,7 +373,7 @@ class Builder implements BuilderContract
      *
      * @param  \Illuminate\Contracts\Support\Arrayable|array  $ids
      * @param  array  $columns
-     * @return \Illuminate\Database\Eloquent\Collection
+     * @return \Illuminate\Database\Eloquent\Collection<int, TModel>
      */
     public function findMany($ids, $columns = ['*'])
     {
@@ -386,7 +391,7 @@ class Builder implements BuilderContract
      *
      * @param  mixed  $id
      * @param  array  $columns
-     * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection|static|static[]
+     * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection<int,TModel>|static|static[]
      *
      * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
      */
@@ -547,7 +552,7 @@ class Builder implements BuilderContract
      * Execute the query as a "select" statement.
      *
      * @param  array|string  $columns
-     * @return \Illuminate\Database\Eloquent\Collection|static[]
+     * @return \Illuminate\Database\Eloquent\Collection<int, TModel>|static[]
      */
     public function get($columns = ['*'])
     {
@@ -718,7 +723,7 @@ class Builder implements BuilderContract
      *
      * @param  string|\Illuminate\Database\Query\Expression  $column
      * @param  string|null  $key
-     * @return \Illuminate\Support\Collection
+     * @return \Illuminate\Support\Collection<int, mixed>
      */
     public function pluck($column, $key = null)
     {

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -22,6 +22,9 @@ use Illuminate\Support\Traits\ForwardsCalls;
 use JsonSerializable;
 use LogicException;
 
+/**
+ * @mixin \Illuminate\Database\Eloquent\Builder<static>
+ */
 abstract class Model implements Arrayable, ArrayAccess, HasBroadcastChannel, Jsonable, JsonSerializable, QueueableEntity, UrlRoutable
 {
     use Concerns\HasAttributes,
@@ -498,7 +501,7 @@ abstract class Model implements Arrayable, ArrayAccess, HasBroadcastChannel, Jso
      * Begin querying the model on a given connection.
      *
      * @param  string|null  $connection
-     * @return \Illuminate\Database\Eloquent\Builder
+     * @return \Illuminate\Database\Eloquent\Builder<static>
      */
     public static function on($connection = null)
     {
@@ -539,7 +542,7 @@ abstract class Model implements Arrayable, ArrayAccess, HasBroadcastChannel, Jso
      * Begin querying a model with eager loading.
      *
      * @param  array|string  $relations
-     * @return \Illuminate\Database\Eloquent\Builder
+     * @return \Illuminate\Database\Eloquent\Builder<static>
      */
     public static function with($relations)
     {
@@ -992,7 +995,7 @@ abstract class Model implements Arrayable, ArrayAccess, HasBroadcastChannel, Jso
     /**
      * Perform a model update operation.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  \Illuminate\Database\Eloquent\Builder<static>  $query
      * @return bool
      */
     protected function performUpdate(Builder $query)
@@ -1030,8 +1033,8 @@ abstract class Model implements Arrayable, ArrayAccess, HasBroadcastChannel, Jso
     /**
      * Set the keys for a select query.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder  $query
-     * @return \Illuminate\Database\Eloquent\Builder
+     * @param  \Illuminate\Database\Eloquent\Builder<static>  $query
+     * @return \Illuminate\Database\Eloquent\Builder<static>
      */
     protected function setKeysForSelectQuery($query)
     {
@@ -1053,8 +1056,8 @@ abstract class Model implements Arrayable, ArrayAccess, HasBroadcastChannel, Jso
     /**
      * Set the keys for a save update query.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder  $query
-     * @return \Illuminate\Database\Eloquent\Builder
+     * @param  \Illuminate\Database\Eloquent\Builder<static>  $query
+     * @return \Illuminate\Database\Eloquent\Builder<static>
      */
     protected function setKeysForSaveQuery($query)
     {
@@ -1076,7 +1079,7 @@ abstract class Model implements Arrayable, ArrayAccess, HasBroadcastChannel, Jso
     /**
      * Perform a model insert operation.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  \Illuminate\Database\Eloquent\Builder<static>  $query
      * @return bool
      */
     protected function performInsert(Builder $query)
@@ -1127,7 +1130,7 @@ abstract class Model implements Arrayable, ArrayAccess, HasBroadcastChannel, Jso
     /**
      * Insert the given attributes and set the ID on the model.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  \Illuminate\Database\Eloquent\Builder<static>  $query
      * @param  array  $attributes
      * @return void
      */
@@ -1141,7 +1144,7 @@ abstract class Model implements Arrayable, ArrayAccess, HasBroadcastChannel, Jso
     /**
      * Destroy the models for the given IDs.
      *
-     * @param  \Illuminate\Support\Collection|array|int|string  $ids
+     * @param  \Illuminate\Support\Collection<array-key, mixed>|array|int|string  $ids
      * @return int
      */
     public static function destroy($ids)
@@ -1244,7 +1247,7 @@ abstract class Model implements Arrayable, ArrayAccess, HasBroadcastChannel, Jso
     /**
      * Begin querying the model.
      *
-     * @return \Illuminate\Database\Eloquent\Builder
+     * @return \Illuminate\Database\Eloquent\Builder<static>
      */
     public static function query()
     {
@@ -1254,7 +1257,7 @@ abstract class Model implements Arrayable, ArrayAccess, HasBroadcastChannel, Jso
     /**
      * Get a new query builder for the model's table.
      *
-     * @return \Illuminate\Database\Eloquent\Builder
+     * @return \Illuminate\Database\Eloquent\Builder<static>
      */
     public function newQuery()
     {
@@ -1264,7 +1267,7 @@ abstract class Model implements Arrayable, ArrayAccess, HasBroadcastChannel, Jso
     /**
      * Get a new query builder that doesn't have any global scopes or eager loading.
      *
-     * @return \Illuminate\Database\Eloquent\Builder|static
+     * @return \Illuminate\Database\Eloquent\Builder<static>
      */
     public function newModelQuery()
     {
@@ -1276,7 +1279,7 @@ abstract class Model implements Arrayable, ArrayAccess, HasBroadcastChannel, Jso
     /**
      * Get a new query builder with no relationships loaded.
      *
-     * @return \Illuminate\Database\Eloquent\Builder
+     * @return \Illuminate\Database\Eloquent\Builder<static>
      */
     public function newQueryWithoutRelationships()
     {
@@ -1286,8 +1289,8 @@ abstract class Model implements Arrayable, ArrayAccess, HasBroadcastChannel, Jso
     /**
      * Register the global scopes for this builder instance.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder  $builder
-     * @return \Illuminate\Database\Eloquent\Builder
+     * @param  \Illuminate\Database\Eloquent\Builder<static>  $builder
+     * @return \Illuminate\Database\Eloquent\Builder<static>
      */
     public function registerGlobalScopes($builder)
     {
@@ -1301,7 +1304,7 @@ abstract class Model implements Arrayable, ArrayAccess, HasBroadcastChannel, Jso
     /**
      * Get a new query builder that doesn't have any global scopes.
      *
-     * @return \Illuminate\Database\Eloquent\Builder|static
+     * @return \Illuminate\Database\Eloquent\Builder<static>
      */
     public function newQueryWithoutScopes()
     {
@@ -1314,7 +1317,7 @@ abstract class Model implements Arrayable, ArrayAccess, HasBroadcastChannel, Jso
      * Get a new query instance without a given scope.
      *
      * @param  \Illuminate\Database\Eloquent\Scope|string  $scope
-     * @return \Illuminate\Database\Eloquent\Builder
+     * @return \Illuminate\Database\Eloquent\Builder<static>
      */
     public function newQueryWithoutScope($scope)
     {
@@ -1325,7 +1328,7 @@ abstract class Model implements Arrayable, ArrayAccess, HasBroadcastChannel, Jso
      * Get a new query to restore one or more models by their queueable IDs.
      *
      * @param  array|int  $ids
-     * @return \Illuminate\Database\Eloquent\Builder
+     * @return \Illuminate\Database\Eloquent\Builder<static>
      */
     public function newQueryForRestoration($ids)
     {
@@ -1338,7 +1341,7 @@ abstract class Model implements Arrayable, ArrayAccess, HasBroadcastChannel, Jso
      * Create a new Eloquent query builder for the model.
      *
      * @param  \Illuminate\Database\Query\Builder  $query
-     * @return \Illuminate\Database\Eloquent\Builder|static
+     * @return \Illuminate\Database\Eloquent\Builder<static>
      */
     public function newEloquentBuilder($query)
     {
@@ -1358,8 +1361,11 @@ abstract class Model implements Arrayable, ArrayAccess, HasBroadcastChannel, Jso
     /**
      * Create a new Eloquent Collection instance.
      *
-     * @param  array  $models
-     * @return \Illuminate\Database\Eloquent\Collection
+     * @template TNewCollectionKey as array-key
+     * @template TNewCollectionValue
+     *
+     * @param  array<TNewCollectionKey, TNewCollectionValue>  $models
+     * @return \Illuminate\Database\Eloquent\Collection<TNewCollectionKey, TNewCollectionValue>
      */
     public function newCollection(array $models = [])
     {

--- a/types/Database/Eloquent/Model.php
+++ b/types/Database/Eloquent/Model.php
@@ -1,0 +1,62 @@
+<?php
+
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use function PHPStan\Testing\assertType;
+
+class User extends Authenticatable
+{
+}
+
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', User::all());
+
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', User::newCollection([new User]));
+
+assertType('Illuminate\Database\Eloquent\Builder<User>', User::on());
+
+assertType('Illuminate\Database\Eloquent\Builder<User>', User::with('string'));
+
+assertType('int', User::destroy(collect([1]));
+
+assertType('Illuminate\Database\Eloquent\Builder<User>', User::query());
+
+assertType('Illuminate\Database\Eloquent\Builder<User>', User::newQuery());
+
+assertType('Illuminate\Database\Eloquent\Builder<User>', User::newQueryWithoutRelationships());
+
+assertType('Illuminate\Database\Eloquent\Builder<User>', User::registerGlobalScopes(function ($builder) {
+    // ..
+}));
+
+assertType('Illuminate\Database\Eloquent\Builder<User>', User::newQueryWithoutScopes());
+
+assertType('Illuminate\Database\Eloquent\Builder<User>', User::newQueryWithoutScope('string'));
+
+assertType('Illuminate\Database\Eloquent\Builder<User>', User::newQueryForRestoration(2));
+
+assertType('Illuminate\Database\Eloquent\Builder<User>', User::newEloquentBuilder(function ($builder) {
+    // ..
+}));
+
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', User::hydrate([[
+    'string' => 'string'
+]]));
+
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', User::fromQuery('string'));
+
+// assertType('Illuminate\Database\Eloquent\Collection<int, User>|User|null', User::find(1));
+
+assertType('Illuminate\Database\Eloquent\Collection<int, User>',  User::findMany([1]));
+
+// assertType('Illuminate\Database\Eloquent\Collection<int, User>|User', User::findOrFail(1));
+
+// assertType('Illuminate\Database\Eloquent\Collection<int, User>',  User::get());
+
+assertType('Illuminate\Support\Collection<int, mixed>',  User::pluck('string'));
+
+assertType('Illuminate\Support\Collection<int, string>',  User::chunkMap(function ($user) {
+    // assertType('User', $user);
+
+    return 'string';
+}));
+
+


### PR DESCRIPTION
**Note: this pull request is waiting for a PHPStan release**

This pull request makes `Eloquent\Model::class` to use generic collections (https://github.com/laravel/framework/pull/38538). In other words, the goal is simply search for `Collection`, and add the information - regarding generics - to those annotations.  Of course, the benefit is, at some point, have auto-completion/static analysis support on code like:

```php
$users = User::where('active', 1)
    ->orderBy('name')
    ->take(10);

$users->first()->userMethod();
```

Also, in the process, and thanks the `@mixin` annotation on the `Eloquent\Model::class`, without the IDE Helper, PHPStorm is able to understand a little bit more of the Model Builder class:

<img width="404" alt="Screenshot 2021-08-27 at 19 14 31" src="https://user-images.githubusercontent.com/5457236/131171274-7fb610c7-cc47-427c-9550-f3dab2b014e6.png">

Finally, at this point, is worth waiting for having PHPStorm understand generics before moving forward. If we go deeper on eloquent  - as we did with collections (fully type arguments, etc ) - we actually take the risk of losing some auto-completion.