### PR TITLE
[8.x] Adds Pipable trait

### DIFF
--- a/src/Illuminate/Pipeline/Pipable.php
+++ b/src/Illuminate/Pipeline/Pipable.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Illuminate\Pipeline;
+
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Support\Facades\Facade;
+use Throwable;
+
+trait Pipable
+{
+    /**
+     * @param  array|string|callable  $pipe
+     * @param  string  $via
+     * @param  \Illuminate\Contracts\Container\Container|null  $container
+     *
+     * @return $this
+     */
+    public function pipe($pipe, $via = 'handle', ?Container $container = null)
+    {
+        return new class($this, $pipe, $via, $container)
+        {
+            /**
+             * The container implementation.
+             *
+             * @var \Illuminate\Contracts\Container\Container
+             */
+            private $container;
+
+            /**
+             * The pipable object.
+             *
+             * @var object
+             */
+            private $pipable;
+
+            /**
+             * The array of pipes.
+             *
+             * @var array|string
+             */
+            private $pipes;
+
+            /**
+             * The method to call on the pipes.
+             *
+             * @var string
+             */
+            private $via;
+
+            public function __construct($pipable, $pipes, $via, ?Container $container)
+            {
+                $this->pipable = $pipable;
+                $this->pipes = $pipes;
+                $this->via = $via;
+                $this->container = $container ?: Facade::getFacadeApplication();
+            }
+
+            public function __call($method, $params)
+            {
+                $pipeline = new Pipeline($this->container);
+
+                $core = (function ($params) use ($method) {
+                    try {
+                        return $this->$method(...$params);
+                    } catch (Throwable $e) {
+                        return $e;
+                    }
+                })->bindTo($this->pipable, $this->pipable);
+
+                $result = $pipeline->via($this->via)->send($params)->through($this->pipes)->then($core);
+
+                if ($result instanceof Throwable) {
+                    throw $result;
+                }
+
+                return $result;
+            }
+        };
+    }
+}

--- a/tests/Pipeline/PipableTest.php
+++ b/tests/Pipeline/PipableTest.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Illuminate\Tests\Pipeline;
+
+use Exception;
+use Illuminate\Container\Container;
+use Illuminate\Pipeline\Pipable;
+use PHPUnit\Framework\TestCase;
+
+class PipableTest extends TestCase
+{
+    public function testBasicPipable()
+    {
+        $calc = new PipableCalculator();
+
+        $pipes = [
+            ToIntParamsPipe::class,
+            new ToStringResultPipe(),
+        ];
+
+        $strFive = $calc->pipe($pipes, 'handle', new Container)->add('3', '2');
+
+        $this->assertEquals('5', $strFive);
+        $this->assertIsString($strFive);
+    }
+
+    public function testPrivateMethodsCanBePiped()
+    {
+        $calc = new SecretiveCalculator();
+
+        $this->assertEquals(2, $calc->iPipeToPrivate());
+    }
+
+    public function testAlternativeMethodsAsPipes()
+    {
+        $calc = new PipableCalculator();
+
+        $pipes = [
+            ToIntParamsPipe::class,
+            new ToStringResultPipe(),
+        ];
+
+        $strFive = $calc->pipe($pipes, 'alternative_handler', new Container)->add('100', '100');
+
+        $this->assertEquals('3', $strFive);
+        $this->assertIsString($strFive);
+    }
+
+    public function testItExecutesPipesInCaseOfException()
+    {
+        $value = (new FailyPipable())->pipe(MyPipe::class, 'handle', new Container)->faily();
+
+        $this->assertInstanceOf(Exception::class, MyPipe::$resp);
+        $this->assertEquals('Oh My God', $value);
+    }
+}
+
+class PipableCalculator
+{
+    use Pipable;
+
+    public function add($num1, $num2): int
+    {
+        if (is_int($num1) && is_int($num2)) {
+            return $num1 + $num2;
+        }
+
+        return 0;
+    }
+}
+
+class SecretiveCalculator
+{
+    use Pipable;
+
+    private function privateAdd(int $num1, int $num2): int
+    {
+        return $num1 + $num2;
+    }
+
+    public function iPipeToPrivate()
+    {
+        return $this->pipe(ToIntParamsPipe::class, 'handle', new Container)->privateAdd('1', '1');
+    }
+}
+
+class FailyPipable
+{
+    use Pipable;
+
+    public function faily()
+    {
+        throw new Exception('Oh My God');
+    }
+}
+
+class ToIntParamsPipe
+{
+    public function handle($data, $next)
+    {
+        $data[0] = (int) $data[0];
+        $data[1] = (int) $data[1];
+
+        return $next($data);
+    }
+
+    public function alternative_handler($data, $next)
+    {
+        $data = [1, 1];
+
+        return $next($data);
+    }
+}
+
+class ToStringResultPipe
+{
+    public function handle($data, $next)
+    {
+        return (string) $next($data);
+    }
+
+    public function alternative_handler($data, $next)
+    {
+        return (string) ($next($data) + 1);
+    }
+}
+
+class MyPipe
+{
+    public static $resp;
+
+    public function handle($data, $next)
+    {
+        $result = $next($data);
+        self::$resp = $result;
+
+        return $result->getMessage();
+    }
+}


### PR DESCRIPTION
This PR adds the "Pipable" trait, which allows decorating methods calls at the "call site", allowing to refactor christmas tree code into a method chain.

- This is a simplified version of the [laravel-middlewarize](https://github.com/imanghafoori1/laravel-middlewarize) package.
Support for static method can also be added as the package has if this was accepted.

Example usages:
```php
$obj->pipe('retry:3')->fetchData();
```
```php
$response = $this->pipe('throttler:3')->login();
```

-------------------------

Before:
```php
$ttl = \DateInterval::createFromDateString('6 seconds');

return Cache::remember("user_$id", $ttl, function () use ($id) {
    $repo = new UserRepo();

    return $repo->find($id);
});
```

After:
```php
$repo = new UserRepo();   // The UserRepo uses Pipable trait.

$user = $repo->pipe("cacher:user_$id,6 seconds")->find(1);
```

In this example, the point is that the `Cacher` pipe class does not know anything about the `UserRepo` or what is being cached. So it can be defined once (in a package or somewhere else) and be used everywhere. So nice pipes can be shared as laravel packages.

```php
class Cacher
{
    public function handle($data, $next, $key, $ttl)
    {
        $ttl = \DateInterval::createFromDateString($ttl);

        return Cache::remember($key, $ttl, function () use ($next, $data) {
            return $next($data);
        });
    }
}
```
We also bind:
```php
app()->singleton(Cacher::class, 'cacher');
```
