### PR TITLE
[8.x] Allow attributes on render or data method

### DIFF
--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -231,7 +231,7 @@ class ComponentTagCompiler
         }
 
         return "##BEGIN-COMPONENT-CLASS##@component('{$class}', '{$component}', [".$this->attributesToString($parameters, $escapeBound = false).'])
-<?php $component->withAttributes(['.$this->attributesToString($attributes->all(), $escapeAttributes = $class !== DynamicComponent::class).']); ?>';
+<?php $component->withAttributes(['.$this->attributesToString($attributes->all(), $escapeAttributes = $class !== DynamicComponent::class).']); $__env->startComponent($component->resolveView(), $component->data()); ?>';
     }
 
     /**

--- a/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
@@ -66,7 +66,6 @@ trait CompilesComponents
             '<?php $component = $__env->getContainer()->make('.Str::finish($component, '::class').', '.($data ?: '[]').'); ?>',
             '<?php $component->withName('.$alias.'); ?>',
             '<?php if ($component->shouldRender()): ?>',
-            '<?php $__env->startComponent($component->resolveView(), $component->data()); ?>',
         ]);
     }
 

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -57,9 +57,9 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = $this->compiler(['alert' => TestAlertComponent::class])->compileTags('<div><x-alert type="foo" limit="5" @click="foo" wire:click="changePlan(\'{{ $plan }}\')" required /><x-alert /></div>');
 
         $this->assertSame("<div>##BEGIN-COMPONENT-CLASS##@component('Illuminate\Tests\View\Blade\TestAlertComponent', 'alert', [])
-<?php \$component->withAttributes(['type' => 'foo','limit' => '5','@click' => 'foo','wire:click' => 'changePlan(\''.e(\$plan).'\')','required' => true]); ?>\n".
+<?php \$component->withAttributes(['type' => 'foo','limit' => '5','@click' => 'foo','wire:click' => 'changePlan(\''.e(\$plan).'\')','required' => true]); \$__env->startComponent(\$component->resolveView(), \$component->data()); ?>\n".
 "@endComponentClass##END-COMPONENT-CLASS####BEGIN-COMPONENT-CLASS##@component('Illuminate\Tests\View\Blade\TestAlertComponent', 'alert', [])
-<?php \$component->withAttributes([]); ?>\n".
+<?php \$component->withAttributes([]); \$__env->startComponent(\$component->resolveView(), \$component->data()); ?>\n".
 '@endComponentClass##END-COMPONENT-CLASS##</div>', trim($result));
     }
 
@@ -68,7 +68,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = $this->compiler(['alert' => TestAlertComponent::class])->compileTags('<div><x-alert type="" limit=\'\' @click="" required /></div>');
 
         $this->assertSame("<div>##BEGIN-COMPONENT-CLASS##@component('Illuminate\Tests\View\Blade\TestAlertComponent', 'alert', [])
-<?php \$component->withAttributes(['type' => '','limit' => '','@click' => '','required' => true]); ?>\n".
+<?php \$component->withAttributes(['type' => '','limit' => '','@click' => '','required' => true]); \$__env->startComponent(\$component->resolveView(), \$component->data()); ?>\n".
 '@endComponentClass##END-COMPONENT-CLASS##</div>', trim($result));
     }
 
@@ -77,7 +77,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = $this->compiler(['profile' => TestProfileComponent::class])->compileTags('<x-profile user-id="1"></x-profile>');
 
         $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\Tests\View\Blade\TestProfileComponent', 'profile', ['userId' => '1'])
-<?php \$component->withAttributes([]); ?> @endComponentClass##END-COMPONENT-CLASS##", trim($result));
+<?php \$component->withAttributes([]); \$__env->startComponent(\$component->resolveView(), \$component->data()); ?> @endComponentClass##END-COMPONENT-CLASS##", trim($result));
     }
 
     public function testColonData()
@@ -85,7 +85,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = $this->compiler(['profile' => TestProfileComponent::class])->compileTags('<x-profile :user-id="1"></x-profile>');
 
         $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\Tests\View\Blade\TestProfileComponent', 'profile', ['userId' => 1])
-<?php \$component->withAttributes([]); ?> @endComponentClass##END-COMPONENT-CLASS##", trim($result));
+<?php \$component->withAttributes([]); \$__env->startComponent(\$component->resolveView(), \$component->data()); ?> @endComponentClass##END-COMPONENT-CLASS##", trim($result));
     }
 
     public function testEscapedColonAttribute()
@@ -93,7 +93,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = $this->compiler(['profile' => TestProfileComponent::class])->compileTags('<x-profile :user-id="1" ::title="user.name"></x-profile>');
 
         $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\Tests\View\Blade\TestProfileComponent', 'profile', ['userId' => 1])
-<?php \$component->withAttributes([':title' => 'user.name']); ?> @endComponentClass##END-COMPONENT-CLASS##", trim($result));
+<?php \$component->withAttributes([':title' => 'user.name']); \$__env->startComponent(\$component->resolveView(), \$component->data()); ?> @endComponentClass##END-COMPONENT-CLASS##", trim($result));
     }
 
     public function testColonAttributesIsEscapedIfStrings()
@@ -101,7 +101,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = $this->compiler(['profile' => TestProfileComponent::class])->compileTags('<x-profile :src="\'foo\'"></x-profile>');
 
         $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\Tests\View\Blade\TestProfileComponent', 'profile', [])
-<?php \$component->withAttributes(['src' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute('foo')]); ?> @endComponentClass##END-COMPONENT-CLASS##", trim($result));
+<?php \$component->withAttributes(['src' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute('foo')]); \$__env->startComponent(\$component->resolveView(), \$component->data()); ?> @endComponentClass##END-COMPONENT-CLASS##", trim($result));
     }
 
     public function testColonNestedComponentParsing()
@@ -109,7 +109,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = $this->compiler(['foo:alert' => TestAlertComponent::class])->compileTags('<x-foo:alert></x-foo:alert>');
 
         $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\Tests\View\Blade\TestAlertComponent', 'foo:alert', [])
-<?php \$component->withAttributes([]); ?> @endComponentClass##END-COMPONENT-CLASS##", trim($result));
+<?php \$component->withAttributes([]); \$__env->startComponent(\$component->resolveView(), \$component->data()); ?> @endComponentClass##END-COMPONENT-CLASS##", trim($result));
     }
 
     public function testColonStartingNestedComponentParsing()
@@ -117,7 +117,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = $this->compiler(['foo:alert' => TestAlertComponent::class])->compileTags('<x:foo:alert></x-foo:alert>');
 
         $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\Tests\View\Blade\TestAlertComponent', 'foo:alert', [])
-<?php \$component->withAttributes([]); ?> @endComponentClass##END-COMPONENT-CLASS##", trim($result));
+<?php \$component->withAttributes([]); \$__env->startComponent(\$component->resolveView(), \$component->data()); ?> @endComponentClass##END-COMPONENT-CLASS##", trim($result));
     }
 
     public function testSelfClosingComponentsCanBeCompiled()
@@ -125,7 +125,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = $this->compiler(['alert' => TestAlertComponent::class])->compileTags('<div><x-alert/></div>');
 
         $this->assertSame("<div>##BEGIN-COMPONENT-CLASS##@component('Illuminate\Tests\View\Blade\TestAlertComponent', 'alert', [])
-<?php \$component->withAttributes([]); ?>\n".
+<?php \$component->withAttributes([]); \$__env->startComponent(\$component->resolveView(), \$component->data()); ?>\n".
 '@endComponentClass##END-COMPONENT-CLASS##</div>', trim($result));
     }
 
@@ -164,7 +164,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = $this->compiler(['alert' => TestAlertComponent::class])->compileTags('<x-alert class="bar" wire:model="foo" x-on:click="bar" @click="baz" />');
 
         $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\Tests\View\Blade\TestAlertComponent', 'alert', [])
-<?php \$component->withAttributes(['class' => 'bar','wire:model' => 'foo','x-on:click' => 'bar','@click' => 'baz']); ?>\n".
+<?php \$component->withAttributes(['class' => 'bar','wire:model' => 'foo','x-on:click' => 'bar','@click' => 'baz']); \$__env->startComponent(\$component->resolveView(), \$component->data()); ?>\n".
 '@endComponentClass##END-COMPONENT-CLASS##', trim($result));
     }
 
@@ -173,7 +173,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = $this->compiler(['alert' => TestAlertComponent::class])->compileTags('<x-alert title="foo" class="bar" wire:model="foo" />');
 
         $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\Tests\View\Blade\TestAlertComponent', 'alert', ['title' => 'foo'])
-<?php \$component->withAttributes(['class' => 'bar','wire:model' => 'foo']); ?>\n".
+<?php \$component->withAttributes(['class' => 'bar','wire:model' => 'foo']); \$__env->startComponent(\$component->resolveView(), \$component->data()); ?>\n".
 '@endComponentClass##END-COMPONENT-CLASS##', trim($result));
     }
 
@@ -183,7 +183,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = $this->compiler(['profile' => TestProfileComponent::class])->compileTags('<x-profile class="bar" {{ $attributes }} wire:model="foo"></x-profile>');
 
         $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\Tests\View\Blade\TestProfileComponent', 'profile', [])
-<?php \$component->withAttributes(['class' => 'bar','attributes' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute(\$attributes),'wire:model' => 'foo']); ?> @endComponentClass##END-COMPONENT-CLASS##", trim($result));
+<?php \$component->withAttributes(['class' => 'bar','attributes' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute(\$attributes),'wire:model' => 'foo']); \$__env->startComponent(\$component->resolveView(), \$component->data()); ?> @endComponentClass##END-COMPONENT-CLASS##", trim($result));
     }
 
     public function testSelfClosingComponentCanReceiveAttributeBag()
@@ -193,7 +193,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = $this->compiler(['alert' => TestAlertComponent::class])->compileTags('<div><x-alert title="foo" class="bar" {{ $attributes->merge([\'class\' => \'test\']) }} wire:model="foo" /></div>');
 
         $this->assertSame("<div>##BEGIN-COMPONENT-CLASS##@component('Illuminate\Tests\View\Blade\TestAlertComponent', 'alert', ['title' => 'foo'])
-<?php \$component->withAttributes(['class' => 'bar','attributes' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute(\$attributes->merge(['class' => 'test'])),'wire:model' => 'foo']); ?>\n".
+<?php \$component->withAttributes(['class' => 'bar','attributes' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute(\$attributes->merge(['class' => 'test'])),'wire:model' => 'foo']); \$__env->startComponent(\$component->resolveView(), \$component->data()); ?>\n".
             '@endComponentClass##END-COMPONENT-CLASS##</div>', trim($result));
     }
 
@@ -202,7 +202,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = $this->compiler(['profile' => TestProfileComponent::class])->compileTags('<x-profile></x-profile>Words');
 
         $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\Tests\View\Blade\TestProfileComponent', 'profile', [])
-<?php \$component->withAttributes([]); ?> @endComponentClass##END-COMPONENT-CLASS##Words", trim($result));
+<?php \$component->withAttributes([]); \$__env->startComponent(\$component->resolveView(), \$component->data()); ?> @endComponentClass##END-COMPONENT-CLASS##Words", trim($result));
     }
 
     public function testSelfClosingComponentsCanHaveAttachedWord()
@@ -210,7 +210,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = $this->compiler(['alert' => TestAlertComponent::class])->compileTags('<x-alert/>Words');
 
         $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\Tests\View\Blade\TestAlertComponent', 'alert', [])
-<?php \$component->withAttributes([]); ?>\n".
+<?php \$component->withAttributes([]); \$__env->startComponent(\$component->resolveView(), \$component->data()); ?>\n".
 '@endComponentClass##END-COMPONENT-CLASS##Words', trim($result));
     }
 
@@ -219,7 +219,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = $this->compiler(['alert' => TestAlertComponent::class])->compileTags('<x-alert :title="$title" class="bar" />');
 
         $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\Tests\View\Blade\TestAlertComponent', 'alert', ['title' => \$title])
-<?php \$component->withAttributes(['class' => 'bar']); ?>\n".
+<?php \$component->withAttributes(['class' => 'bar']); \$__env->startComponent(\$component->resolveView(), \$component->data()); ?>\n".
 '@endComponentClass##END-COMPONENT-CLASS##', trim($result));
     }
 
@@ -229,7 +229,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
 </x-alert>');
 
         $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\Tests\View\Blade\TestAlertComponent', 'alert', [])
-<?php \$component->withAttributes([]); ?>
+<?php \$component->withAttributes([]); \$__env->startComponent(\$component->resolveView(), \$component->data()); ?>
  @endComponentClass##END-COMPONENT-CLASS##", trim($result));
     }
 
@@ -245,7 +245,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = $this->compiler()->compileTags('<x-anonymous-component :name="\'Taylor\'" :age="31" wire:model="foo" />');
 
         $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\View\AnonymousComponent', 'anonymous-component', ['view' => 'components.anonymous-component','data' => ['name' => 'Taylor','age' => 31,'wire:model' => 'foo']])
-<?php \$component->withAttributes(['name' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute('Taylor'),'age' => 31,'wire:model' => 'foo']); ?>\n".
+<?php \$component->withAttributes(['name' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute('Taylor'),'age' => 31,'wire:model' => 'foo']); \$__env->startComponent(\$component->resolveView(), \$component->data()); ?>\n".
 '@endComponentClass##END-COMPONENT-CLASS##', trim($result));
     }
 
@@ -261,14 +261,13 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = $this->compiler()->compileTags('<x-package::anonymous-component :name="\'Taylor\'" :age="31" wire:model="foo" />');
 
         $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\View\AnonymousComponent', 'package::anonymous-component', ['view' => 'package::components.anonymous-component','data' => ['name' => 'Taylor','age' => 31,'wire:model' => 'foo']])
-<?php \$component->withAttributes(['name' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute('Taylor'),'age' => 31,'wire:model' => 'foo']); ?>\n".
+<?php \$component->withAttributes(['name' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute('Taylor'),'age' => 31,'wire:model' => 'foo']); \$__env->startComponent(\$component->resolveView(), \$component->data()); ?>\n".
 '@endComponentClass##END-COMPONENT-CLASS##', trim($result));
     }
 
     public function testAttributeSanitization()
     {
-        $class = new class
-        {
+        $class = new class {
             public function __toString()
             {
                 return '<hi>';

--- a/tests/View/Blade/BladeComponentsTest.php
+++ b/tests/View/Blade/BladeComponentsTest.php
@@ -15,8 +15,7 @@ class BladeComponentsTest extends AbstractBladeTestCase
         $this->assertSame('<?php if (isset($component)) { $__componentOriginal35bda42cbf6f9717b161c4f893644ac7a48b0d98 = $component; } ?>
 <?php $component = $__env->getContainer()->make(Test::class, ["foo" => "bar"]); ?>
 <?php $component->withName(\'test\'); ?>
-<?php if ($component->shouldRender()): ?>
-<?php $__env->startComponent($component->resolveView(), $component->data()); ?>', $this->compiler->compileString('@component(\'Test::class\', \'test\', ["foo" => "bar"])'));
+<?php if ($component->shouldRender()): ?>', $this->compiler->compileString('@component(\'Test::class\', \'test\', ["foo" => "bar"])'));
     }
 
     public function testEndComponentsAreCompiled()


### PR DESCRIPTION
 This pull request will allow the use of the component attributes in data or render method

I'm building complex blade components. I really need to access the component attributes before start the component.
Like example:
I want to share attributes as view variables in some components, so I need to access the blade attributes

```
MyComponent.php
...
protected $sharedAttributes = [
    'id',
    'name',
    'disabled' => false,
    'readonly' => false,
];

public function data()
{
    return array_merge(
        parent::data(),
        $this->extractSharedAttributes()
    );
}

protected function extractSharedAttributes(): array
{
    return collect($this->sharedAttributes)->mapWithKeys(function ($value, $key) {
        $attribute = is_numeric($key) ? $value : $key;
        $value = is_numeric($key) ? null : $value;

        return [$attribute => $this->attributes->get($attribute, $value)];
    })->toArray();
}
```

I know, the laravel has a way to do it, returning a callable function in the render method, will access the data, attributes, and slots, but using this way brokes some hosting, `file_exists(): File name is longer than the maximum allowed path length on this platform (4096):`
More info: https://github.com/PH7-Jack/wireui/issues/60

Another use case is access the component attributes in the render
```
MyComponent.php
...
public function render()
{
    //$this->attributes // do anything
  
    return view('my-view');
}
```

I think it will be helpful for multiples users