### PR TITLE
[8.x] Adds `mask()` to `Str` helper

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -395,6 +395,25 @@ class Str
     }
 
     /**
+     * Masks a matching string with a repeated character.
+     *
+     * @param  string  $haystack
+     * @param  string|array  $needle
+     * @param  string  $mask
+     * @return string
+     */
+    public static function mask($haystack, $needle, $mask = '*')
+    {
+        if (is_array($needle)) {
+            $needle = self::substr($haystack, $needle[0], $needle[1] ?? null);
+        }
+
+        return static::replace(
+            $needle, static::repeat($mask[0] ?? '*', static::length($needle)), $haystack
+        );
+    }
+
+    /**
      * Get the string matching the given pattern.
      *
      * @param  string  $pattern

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -405,10 +405,10 @@ class Str
     public static function mask($haystack, $needle, $mask = '*')
     {
         if (is_array($needle)) {
-            $needle = self::substr($haystack, $needle[0], $needle[1] ?? null);
+            $needle = self::substr($haystack, ...$needle);
         }
 
-        return static::replace(
+        return static::replaceFirst(
             $needle, static::repeat($mask[0] ?? '*', static::length($needle)), $haystack
         );
     }

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -343,6 +343,18 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Masks a matching string with a repeated character.
+     *
+     * @param  string|array  $needle
+     * @param  string  $mask
+     * @return static
+     */
+    public function mask($needle, $mask = '*')
+    {
+        return new static(Str::mask($this->value, $needle, $mask));
+    }
+
+    /**
      * Get the string matching the given pattern.
      *
      * @param  string  $pattern

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -574,9 +574,11 @@ class SupportStrTest extends TestCase
         $this->assertSame('My name is !!!!!!!!', Str::mask($subject, 'a secret', '!X'));
         $this->assertSame('My name is ********', Str::mask($subject, 'a secret', ''));
         $this->assertSame('My name is a secret', Str::mask($subject, 'not found'));
+        $this->assertSame('I did ****** and secret', Str::mask('I did secret and secret', 'secret'));
 
         $this->assertSame('My name is ********', Str::mask($subject, [11]));
         $this->assertSame('My **** is a secret', Str::mask($subject, [3, 4]));
+        $this->assertSame('******* is a secret', Str::mask($subject, [0, -12]));
     }
 
     public function testRepeat()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -566,6 +566,19 @@ class SupportStrTest extends TestCase
         $this->assertSame("<h1>hello world</h1>\n", Str::markdown('# hello world'));
     }
 
+    public function testMask()
+    {
+        $subject = 'My name is a secret';
+
+        $this->assertSame('My name is ********', Str::mask($subject, 'a secret'));
+        $this->assertSame('My name is !!!!!!!!', Str::mask($subject, 'a secret', '!X'));
+        $this->assertSame('My name is ********', Str::mask($subject, 'a secret', ''));
+        $this->assertSame('My name is a secret', Str::mask($subject, 'not found'));
+
+        $this->assertSame('My name is ********', Str::mask($subject, [11]));
+        $this->assertSame('My **** is a secret', Str::mask($subject, [3, 4]));
+    }
+
     public function testRepeat()
     {
         $this->assertSame('aaaaa', Str::repeat('a', 5));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -666,13 +666,28 @@ class SupportStringableTest extends TestCase
         };
 
         $this->assertInstanceOf(Stringable::class, $this->stringable('foo')->pipe($callback));
-        $this->assertSame('bar', (string) $this->stringable('foo')->pipe($callback));
+        $this->assertSame('bar', (string)  $this->stringable('foo')->pipe($callback));
     }
 
     public function testMarkdown()
     {
         $this->assertEquals("<p><em>hello world</em></p>\n", $this->stringable('*hello world*')->markdown());
         $this->assertEquals("<h1>hello world</h1>\n", $this->stringable('# hello world')->markdown());
+    }
+
+    public function testMask()
+    {
+        $subject = 'My name is a secret';
+
+        $this->assertSame('My name is ********', (string) $this->stringable($subject)->mask('a secret'));
+        $this->assertSame('My name is !!!!!!!!', (string) $this->stringable($subject)->mask('a secret', '!X'));
+        $this->assertSame('My name is ********', (string) $this->stringable($subject)->mask('a secret', ''));
+        $this->assertSame('My name is a secret', (string) $this->stringable($subject)->mask('not found'));
+        $this->assertSame('I did ****** and secret', (string) $this->stringable('I did secret and secret')->mask('secret'));
+
+        $this->assertSame('My name is ********', (string) $this->stringable($subject)->mask([11]));
+        $this->assertSame('My **** is a secret', (string) $this->stringable($subject)->mask([3, 4]));
+        $this->assertSame('******* is a secret', (string) $this->stringable($subject)->mask([0, -12]));
     }
 
     public function testRepeat()


### PR DESCRIPTION
## What?

Allows to mask a string with repeating characters (much like `Str::replace()`). The repeating character is configurable, but is `*` by default.

```php
$subject = 'My name is John Doe';

// Before:
Str::replaceFirst('John Doe', '********', $subject);

// After:
Str::mask($subject, 'John Doe'); // "My name is *******"
```

The main difference is that it can work without knowing the contents, but the length. By giving it an start and end as an array, it becomes a shrotcut to `Str::substr()`. 

For example, we can use it to mask part of the email of a given user.

```php
$subject = 'my.private.address@gmail.com';

// Before:
Str::replace(Str::substr($subject, 0, -13), Str::repeat('*', 13), $subject);

// After:
Str::mask($subject, [0, -13]); // "****************ss@gmail.com"
```

## How?

Behind it uses `Str::replace()`. It locates the position of the needle in the string, and replaces it with a new string, made of repeating a character by the same needle length.

When issuing an array instead of a string for a needle, it will be used to pass it as `Str::substr()` arguments.

## BC?

None, it's merely an additive PR.

## Notes

This only replaces the **first occurrence**. For replacing ALL occurrences, `Str::replace()` should be used instead as it requires to know the contents to replace in the first place.