### PR TITLE
[8.x] Use lowercase OpenSSL cipher names

### DIFF
--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -30,10 +30,10 @@ class Encrypter implements EncrypterContract, StringEncrypter
      * @var array
      */
     private static $supportedCiphers = [
-        'AES-128-CBC' => ['size' => 16, 'aead' => false],
-        'AES-256-CBC' => ['size' => 32, 'aead' => false],
-        'AES-128-GCM' => ['size' => 16, 'aead' => true],
-        'AES-256-GCM' => ['size' => 32, 'aead' => true],
+        'aes-128-cbc' => ['size' => 16, 'aead' => false],
+        'aes-256-cbc' => ['size' => 32, 'aead' => false],
+        'aes-128-gcm' => ['size' => 16, 'aead' => true],
+        'aes-256-gcm' => ['size' => 32, 'aead' => true],
     ];
 
     /**
@@ -45,11 +45,11 @@ class Encrypter implements EncrypterContract, StringEncrypter
      *
      * @throws \RuntimeException
      */
-    public function __construct($key, $cipher = 'AES-128-CBC')
+    public function __construct($key, $cipher = 'aes-128-cbc')
     {
         $key = (string) $key;
 
-        if (! static::supported($key, $cipher)) {
+        if (! static::supported($key, strtolower($cipher))) {
             $ciphers = implode(', ', array_keys(self::$supportedCiphers));
 
             throw new RuntimeException("Unsupported cipher or incorrect key length. Supported ciphers are: {$ciphers}.");
@@ -83,7 +83,7 @@ class Encrypter implements EncrypterContract, StringEncrypter
      */
     public static function generateKey($cipher)
     {
-        return random_bytes(self::$supportedCiphers[$cipher]['size'] ?? 32);
+        return random_bytes(self::$supportedCiphers[strtolower($cipher)]['size'] ?? 32);
     }
 
     /**
@@ -97,18 +97,18 @@ class Encrypter implements EncrypterContract, StringEncrypter
      */
     public function encrypt($value, $serialize = true)
     {
-        $iv = random_bytes(openssl_cipher_iv_length($this->cipher));
+        $iv = random_bytes(openssl_cipher_iv_length(strtolower($this->cipher)));
 
         $tag = '';
 
-        $value = self::$supportedCiphers[$this->cipher]['aead']
+        $value = self::$supportedCiphers[strtolower($this->cipher)]['aead']
             ? \openssl_encrypt(
                 $serialize ? serialize($value) : $value,
-                $this->cipher, $this->key, 0, $iv, $tag
+                strtolower($this->cipher), $this->key, 0, $iv, $tag
             )
             : \openssl_encrypt(
                 $serialize ? serialize($value) : $value,
-                $this->cipher, $this->key, 0, $iv
+                strtolower($this->cipher), $this->key, 0, $iv
             );
 
         if ($value === false) {
@@ -118,7 +118,7 @@ class Encrypter implements EncrypterContract, StringEncrypter
         $iv = base64_encode($iv);
         $tag = base64_encode($tag);
 
-        $mac = self::$supportedCiphers[$this->cipher]['aead']
+        $mac = self::$supportedCiphers[strtolower($this->cipher)]['aead']
             ? '' // For AEAD-algoritms, the tag / MAC is returned by openssl_encrypt...
             : $this->hash($iv, $value);
 
@@ -165,7 +165,7 @@ class Encrypter implements EncrypterContract, StringEncrypter
         // we will then unserialize it and return it out to the caller. If we are
         // unable to decrypt this value we will throw out an exception message.
         $decrypted = \openssl_decrypt(
-            $payload['value'], $this->cipher, $this->key, 0, $iv, $tag
+            $payload['value'], strtolower($this->cipher), $this->key, 0, $iv, $tag
         );
 
         if ($decrypted === false) {
@@ -219,7 +219,7 @@ class Encrypter implements EncrypterContract, StringEncrypter
             throw new DecryptException('The payload is invalid.');
         }
 
-        if (! self::$supportedCiphers[$this->cipher]['aead'] && ! $this->validMac($payload)) {
+        if (! self::$supportedCiphers[strtolower($this->cipher)]['aead'] && ! $this->validMac($payload)) {
             throw new DecryptException('The MAC is invalid.');
         }
 
@@ -235,7 +235,7 @@ class Encrypter implements EncrypterContract, StringEncrypter
     protected function validPayload($payload)
     {
         return is_array($payload) && isset($payload['iv'], $payload['value'], $payload['mac']) &&
-            strlen(base64_decode($payload['iv'], true)) === openssl_cipher_iv_length($this->cipher);
+            strlen(base64_decode($payload['iv'], true)) === openssl_cipher_iv_length(strtolower($this->cipher));
     }
 
     /**

--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -56,6 +56,19 @@ class EncrypterTest extends TestCase
         $this->assertSame('foo', $e->decrypt($encrypted));
     }
 
+    public function testCipherNamesCanBeMixedCase()
+    {
+        $upper = new Encrypter(str_repeat('b', 16), 'AES-128-GCM');
+        $encrypted = $upper->encrypt('bar');
+        $this->assertNotSame('bar', $encrypted);
+
+        $lower = new Encrypter(str_repeat('b', 16), 'aes-128-gcm');
+        $this->assertSame('bar', $lower->decrypt($encrypted));
+
+        $mixed = new Encrypter(str_repeat('b', 16), 'aEs-128-GcM');
+        $this->assertSame('bar', $mixed->decrypt($encrypted));
+    }
+
     public function testThatAnAeadCipherIncludesTag()
     {
         $e = new Encrypter(str_repeat('b', 32), 'AES-256-GCM');
@@ -79,7 +92,7 @@ class EncrypterTest extends TestCase
     public function testDoNoAllowLongerKey()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unsupported cipher or incorrect key length. Supported ciphers are: AES-128-CBC, AES-256-CBC, AES-128-GCM, AES-256-GCM.');
+        $this->expectExceptionMessage('Unsupported cipher or incorrect key length. Supported ciphers are: aes-128-cbc, aes-256-cbc, aes-128-gcm, aes-256-gcm.');
 
         new Encrypter(str_repeat('z', 32));
     }
@@ -87,7 +100,7 @@ class EncrypterTest extends TestCase
     public function testWithBadKeyLength()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unsupported cipher or incorrect key length. Supported ciphers are: AES-128-CBC, AES-256-CBC, AES-128-GCM, AES-256-GCM.');
+        $this->expectExceptionMessage('Unsupported cipher or incorrect key length. Supported ciphers are: aes-128-cbc, aes-256-cbc, aes-128-gcm, aes-256-gcm.');
 
         new Encrypter(str_repeat('a', 5));
     }
@@ -95,15 +108,15 @@ class EncrypterTest extends TestCase
     public function testWithBadKeyLengthAlternativeCipher()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unsupported cipher or incorrect key length. Supported ciphers are: AES-128-CBC, AES-256-CBC, AES-128-GCM, AES-256-GCM.');
+        $this->expectExceptionMessage('Unsupported cipher or incorrect key length. Supported ciphers are: aes-128-cbc, aes-256-cbc, aes-128-gcm, aes-256-gcm.');
 
-        new Encrypter(str_repeat('a', 16), 'AES-256-CFB8');
+        new Encrypter(str_repeat('a', 16), 'AES-256-GCM');
     }
 
     public function testWithUnsupportedCipher()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unsupported cipher or incorrect key length. Supported ciphers are: AES-128-CBC, AES-256-CBC, AES-128-GCM, AES-256-GCM.');
+        $this->expectExceptionMessage('Unsupported cipher or incorrect key length. Supported ciphers are: aes-128-cbc, aes-256-cbc, aes-128-gcm, aes-256-gcm.');
 
         new Encrypter(str_repeat('c', 16), 'AES-256-CFB8');
     }


### PR DESCRIPTION
See https://github.com/laravel/framework/issues/38558 for the issue discussion leading up to this PR.

**Problem**
OpenSSL &lt; 1.1.0 doesn't recognize `AES-128-GCM` as a cipher name, but `aes-128-gcm` (i.e. lowercase) is valid. This is caused by the fact that OpenSSL previously maintained upper- and lowercase names for ciphers as aliases, and for GCM a different alias was used instead (`id-aes128-GCM`). More recent versions of OpenSSL perform case-insensitive matching.

Prior to this PR, all cipher names are referenced in uppercase in Laravel, causing `AES-128/256-GCM` to not work on php versions using OpenSSL &lt; 1.1.0. Assuming the following information is updated, this problem remains in PHP 8 (the requirement is OpenSSL &geq; 1.0.1): https://www.php.net/manual/en/openssl.requirements.php

The effect is that `AES-128/256-GCM` can't be used as the new default cipher in Laravel, which is unfortunate since it does provide some performance and theoretical security advantages over the CBC+MAC mode.

**Solution**
This PR instead passes lowercase strings to OpenSSL.

**Backwards compatibility**
The internal cipher name in `Encrypter.php` is untouched and `strtolower()` is only applied when being passed to OpenSSL. Also, uppercase strings are still supported in the config file and can be left unchanged. This keeps BC with any packages or extending code peeking at `config('app.cipher')` or `$encrypter->cipher`.

The other supported ciphers (only `AES-128/256-CBC`) has always used the lower- and uppercase names as aliases in OpenSSL, so there is no risk of lowercase CBC not working on older systems.

