### PR TITLE
[8.x] Add `hasTables` function

### DIFF
--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -136,6 +136,23 @@ class Builder
             $this->grammar->compileTableExists(), [$table]
         )) > 0;
     }
+    
+   /**
+     * Determine if the given tables are exists.
+     *
+     * @param  array  $tables
+     * @return bool
+     */
+    public function hasTables(array $tables)
+    {
+        $tablesCount = 0;
+
+        foreach ($tables as $table) {
+           $tablesCount += $this->hasTable($table);
+        }
+
+        return count($tables) == $tablesCount ?? false;
+    }
 
     /**
      * Determine if the given table has a given column.

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -151,7 +151,7 @@ class Builder
            $tablesCount += $this->hasTable($table);
         }
 
-        return count($tables) == $tablesCount ?? false;
+        return count($tables) == $tablesCount;
     }
 
     /**


### PR DESCRIPTION
Sometimes we need to check the existence of lots of tables, and instead of using `and` operator between `hasTable` function, So we can refactor that using `hasTables`
