### PR TITLE
[9.x] Add command caching (deferred/lazy resolving of commands) for faster command loading, reduced memory

### DIFF
--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -80,6 +80,8 @@ class Application extends SymfonyApplication implements ApplicationContract
 
         $this->events->dispatch(new ArtisanStarting($this));
 
+        $this->setContainerCommandLoader();
+
         $this->bootstrap();
     }
 

--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -57,7 +57,7 @@ class Application extends SymfonyApplication implements ApplicationContract
     /**
      * The lazy command loader.
      *
-     * @var \Illuminate\Console\ContainerCommandLoader
+     * @var \Symfony\Component\Console\CommandLoader\CommandLoaderInterface
      */
     protected $commandLoader;
 

--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -54,11 +54,11 @@ class Application extends SymfonyApplication implements ApplicationContract
     protected static $bootstrappers = [];
 
     /**
-     * A map of command names to classes.
+     * The lazy command loader.
      *
-     * @var array
+     * @var \Illuminate\Console\ContainerCommandLoader
      */
-    protected $commandMap = [];
+    protected $commandLoader;
 
     /**
      * Create a new Artisan console application.
@@ -265,8 +265,8 @@ class Application extends SymfonyApplication implements ApplicationContract
      */
     public function resolve($command)
     {
-        if (class_exists($command) && ($commandName = $command::getDefaultName())) {
-            $this->commandMap[$commandName] = $command;
+        if (class_exists($command) && $this->commandLoader) {
+            $this->commandLoader->add($command);
 
             return null;
         }
@@ -298,7 +298,7 @@ class Application extends SymfonyApplication implements ApplicationContract
      */
     public function setContainerCommandLoader()
     {
-        $this->setCommandLoader(new ContainerCommandLoader($this->laravel, $this->commandMap));
+        $this->setCommandLoader($this->commandLoader = new ContainerCommandLoader($this->laravel));
 
         return $this;
     }

--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -55,6 +55,13 @@ class Application extends SymfonyApplication implements ApplicationContract
     protected static $bootstrappers = [];
 
     /**
+     * Indicates whether the console application has booted.
+     *
+     * @var bool
+     */
+    protected $booted = false;
+
+    /**
      * The lazy command loader.
      *
      * @var \Symfony\Component\Console\CommandLoader\CommandLoaderInterface
@@ -81,8 +88,6 @@ class Application extends SymfonyApplication implements ApplicationContract
         $this->events->dispatch(new ArtisanStarting($this));
 
         $this->setContainerCommandLoader();
-
-        $this->bootstrap();
     }
 
     /**
@@ -154,13 +159,21 @@ class Application extends SymfonyApplication implements ApplicationContract
     /**
      * Bootstrap the console application.
      *
-     * @return void
+     * @return $this
      */
-    protected function bootstrap()
+    public function bootstrap()
     {
+        if ($this->booted) {
+            return $this;
+        }
+
         foreach (static::$bootstrappers as $bootstrapper) {
             $bootstrapper($this);
         }
+
+        $this->booted = true;
+
+        return $this;
     }
 
     /**
@@ -297,7 +310,7 @@ class Application extends SymfonyApplication implements ApplicationContract
     /**
      * Add deferred commands list.
      *
-     * @param array $commands
+     * @param array $commands   Must be keyed by command name e.g. ['migrate' => MigrateCommand::class]
      * @return $this
      */
     public function addDeferredCommands(array $commands)

--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -295,6 +295,19 @@ class Application extends SymfonyApplication implements ApplicationContract
     }
 
     /**
+     * Add deferred commands list.
+     *
+     * @param array $commands
+     * @return $this
+     */
+    public function addDeferredCommands(array $commands)
+    {
+        $this->commandLoader->merge($commands);
+
+        return $this;
+    }
+
+    /**
      * Set the container command loader for lazy resolution.
      *
      * @param \Symfony\Component\Console\CommandLoader\CommandLoaderInterface|null
@@ -309,6 +322,16 @@ class Application extends SymfonyApplication implements ApplicationContract
         $this->setCommandLoader($this->commandLoader = $loader);
 
         return $this;
+    }
+
+    /**
+     * Get the deferred console commander loader.
+     *
+     * @return \Symfony\Component\Console\CommandLoader\CommandLoaderInterface
+     */
+    public function getCommandLoader()
+    {
+        return $this->commandLoader;
     }
 
     /**

--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -12,6 +12,7 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\ProcessUtils;
 use Symfony\Component\Console\Application as SymfonyApplication;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
+use Symfony\Component\Console\CommandLoader\CommandLoaderInterface;
 use Symfony\Component\Console\Exception\CommandNotFoundException;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -265,7 +266,7 @@ class Application extends SymfonyApplication implements ApplicationContract
      */
     public function resolve($command)
     {
-        if (class_exists($command) && $this->commandLoader) {
+        if ($this->commandLoader && $this->commandLoader->accepts($command)) {
             $this->commandLoader->add($command);
 
             return null;
@@ -294,11 +295,16 @@ class Application extends SymfonyApplication implements ApplicationContract
     /**
      * Set the container command loader for lazy resolution.
      *
+     * @param \Symfony\Component\Console\CommandLoader\CommandLoaderInterface|null
      * @return $this
      */
-    public function setContainerCommandLoader()
+    public function setContainerCommandLoader(CommandLoaderInterface $loader = null)
     {
-        $this->setCommandLoader($this->commandLoader = new ContainerCommandLoader($this->laravel));
+        if (is_null($loader)) {
+            $loader = new ContainerCommandLoader($this->laravel);
+        }
+
+        $this->setCommandLoader($this->commandLoader = $loader);
 
         return $this;
     }

--- a/src/Illuminate/Console/ContainerCommandLoader.php
+++ b/src/Illuminate/Console/ContainerCommandLoader.php
@@ -17,23 +17,32 @@ class ContainerCommandLoader implements CommandLoaderInterface
     protected $container;
 
     /**
-     * A map of command names to classes.
+     * A list of class names.
      *
      * @var array
      */
-    protected $commandMap;
+    protected $classes = [];
 
     /**
      * Create a new command loader instance.
      *
      * @param  \Psr\Container\ContainerInterface  $container
-     * @param  array  $commandMap
      * @return void
      */
-    public function __construct(ContainerInterface $container, array $commandMap)
+    public function __construct(ContainerInterface $container)
     {
         $this->container = $container;
-        $this->commandMap = $commandMap;
+    }
+
+    /**
+     * Add class to the loader.
+     *
+     * @param string $name
+     * @return void
+     */
+    public function add(string $name)
+    {
+        $this->classes[] = $name;
     }
 
     /**
@@ -50,7 +59,7 @@ class ContainerCommandLoader implements CommandLoaderInterface
             throw new CommandNotFoundException(sprintf('Command "%s" does not exist.', $name));
         }
 
-        return $this->container->get($this->commandMap[$name]);
+        return $this->container->get($name);
     }
 
     /**
@@ -61,7 +70,7 @@ class ContainerCommandLoader implements CommandLoaderInterface
      */
     public function has(string $name): bool
     {
-        return $name && isset($this->commandMap[$name]);
+        return in_array($name, $this->classes);
     }
 
     /**
@@ -71,6 +80,12 @@ class ContainerCommandLoader implements CommandLoaderInterface
      */
     public function getNames(): array
     {
-        return array_keys($this->commandMap);
+        $names = [];
+
+        foreach ($this->classes as $class) {
+            $names[] = $class::getDefaultName();
+        }
+
+        return $names;
     }
 }

--- a/src/Illuminate/Console/ContainerCommandLoader.php
+++ b/src/Illuminate/Console/ContainerCommandLoader.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Console;
 
+use InvalidArgumentException;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\CommandLoader\CommandLoaderInterface;
@@ -35,13 +36,30 @@ class ContainerCommandLoader implements CommandLoaderInterface
     }
 
     /**
+     * Determine if the class is accepted by the command loader.
+     *
+     * @param string $class
+     * @return bool
+     */
+    public function accepts(string $class): bool
+    {
+        return class_exists($class);
+    }
+
+    /**
      * Add class to the loader.
      *
      * @param string $name
      * @return void
+     *
+     * @throws \InvalidArgumentException
      */
     public function add(string $name)
     {
+        if (! $this->accepts($name)) {
+            throw new InvalidArgumentException(sprintf('Command "%s" was not accepted by the command loader.', $name));
+        }
+
         $this->classes[] = $name;
     }
 

--- a/src/Illuminate/Console/ContainerCommandLoader.php
+++ b/src/Illuminate/Console/ContainerCommandLoader.php
@@ -36,13 +36,28 @@ class ContainerCommandLoader implements CommandLoaderInterface
     }
 
     /**
-     * Determine if the command is accepted by the command loader.
+     * Merge the command map list
+     * 
+     * @param array $commandMap
+     * @return void
+     */
+    public function merge(array $commandMap)
+    {
+        $this->commandMap = array_merge($this->commandMap, $commandMap);
+    }
+
+    /**
+     * Determine if the command is accepted by the cmand loader.
      *
      * @param string $name
      * @return bool
      */
     public function accepts(string $name): bool
     {
+        if (in_array($name, $this->commandMap)) {
+            return true;
+        }
+
         return class_exists($name) && ! is_null($name::getDefaultName());
     }
 
@@ -56,6 +71,10 @@ class ContainerCommandLoader implements CommandLoaderInterface
      */
     public function add(string $name)
     {
+        if (in_array($name, $this->commandMap)) {
+            return;
+        }
+
         if (! $this->accepts($name)) {
             throw new InvalidArgumentException(sprintf('Command "%s" was not accepted by the command loader.', $name));
         }
@@ -99,5 +118,15 @@ class ContainerCommandLoader implements CommandLoaderInterface
     public function getNames(): array
     {
         return array_keys($this->commandMap);
+    }
+
+    /**
+     * Get the full list of commands.
+     *
+     * @return array
+     */
+    public function all(): array
+    {
+        return $this->commandMap;
     }
 }

--- a/src/Illuminate/Console/ContainerCommandLoader.php
+++ b/src/Illuminate/Console/ContainerCommandLoader.php
@@ -18,11 +18,11 @@ class ContainerCommandLoader implements CommandLoaderInterface
     protected $container;
 
     /**
-     * A list of class names.
+     * A map of command names to classes.
      *
      * @var array
      */
-    protected $classes = [];
+    protected $commandMap = [];
 
     /**
      * Create a new command loader instance.
@@ -36,14 +36,14 @@ class ContainerCommandLoader implements CommandLoaderInterface
     }
 
     /**
-     * Determine if the class is accepted by the command loader.
+     * Determine if the command is accepted by the command loader.
      *
-     * @param string $class
+     * @param string $name
      * @return bool
      */
-    public function accepts(string $class): bool
+    public function accepts(string $name): bool
     {
-        return class_exists($class);
+        return class_exists($name) && ! is_null($name::getDefaultName());
     }
 
     /**
@@ -60,7 +60,7 @@ class ContainerCommandLoader implements CommandLoaderInterface
             throw new InvalidArgumentException(sprintf('Command "%s" was not accepted by the command loader.', $name));
         }
 
-        $this->classes[] = $name;
+        $this->commandMap[$name::getDefaultName()] = $name;
     }
 
     /**
@@ -77,7 +77,7 @@ class ContainerCommandLoader implements CommandLoaderInterface
             throw new CommandNotFoundException(sprintf('Command "%s" does not exist.', $name));
         }
 
-        return $this->container->get($name);
+        return $this->container->get($this->commandMap[$name]);
     }
 
     /**
@@ -88,7 +88,7 @@ class ContainerCommandLoader implements CommandLoaderInterface
      */
     public function has(string $name): bool
     {
-        return in_array($name, $this->classes);
+        return isset($this->commandMap[$name]);
     }
 
     /**
@@ -98,12 +98,6 @@ class ContainerCommandLoader implements CommandLoaderInterface
      */
     public function getNames(): array
     {
-        $names = [];
-
-        foreach ($this->classes as $class) {
-            $names[] = $class::getDefaultName();
-        }
-
-        return $names;
+        return array_keys($this->commandMap);
     }
 }

--- a/src/Illuminate/Foundation/Console/CommandCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/CommandCacheCommand.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Artisan;
+
+class CommandCacheCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'command:cache';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a cache file for faster command loading';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        Artisan::cacheCommands();
+
+        $this->info('Commands cached successfully!');
+    }
+}

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -328,7 +328,6 @@ class Kernel implements KernelContract
     {
         if (is_null($this->artisan)) {
             $this->artisan = (new Artisan($this->app, $this->events, $this->app->version()))
-                                    ->setContainerCommandLoader()
                                     ->resolveCommands($this->commands);
         }
 

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -328,8 +328,8 @@ class Kernel implements KernelContract
     {
         if (is_null($this->artisan)) {
             $this->artisan = (new Artisan($this->app, $this->events, $this->app->version()))
-                                    ->resolveCommands($this->commands)
-                                    ->setContainerCommandLoader();
+                                    ->setContainerCommandLoader()
+                                    ->resolveCommands($this->commands);
         }
 
         return $this->artisan;

--- a/src/Illuminate/Foundation/Console/OptimizeCommand.php
+++ b/src/Illuminate/Foundation/Console/OptimizeCommand.php
@@ -38,6 +38,7 @@ class OptimizeCommand extends Command
     {
         $this->call('config:cache');
         $this->call('route:cache');
+        $this->call('command:cache');
 
         $this->info('Files cached successfully!');
     }

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -22,6 +22,7 @@ use Illuminate\Database\Console\WipeCommand;
 use Illuminate\Foundation\Console\CastMakeCommand;
 use Illuminate\Foundation\Console\ChannelMakeCommand;
 use Illuminate\Foundation\Console\ClearCompiledCommand;
+use Illuminate\Foundation\Console\CommandCacheCommand;
 use Illuminate\Foundation\Console\ComponentMakeCommand;
 use Illuminate\Foundation\Console\ConfigCacheCommand;
 use Illuminate\Foundation\Console\ConfigClearCommand;
@@ -95,6 +96,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'ClearCompiled' => ClearCompiledCommand::class,
         'ClearResets' => ClearResetsCommand::class,
         'ConfigCache' => ConfigCacheCommand::class,
+        'CommandCache' => CommandCacheCommand::class,
         'ConfigClear' => ConfigClearCommand::class,
         'Db' => DbCommand::class,
         'DbPrune' => PruneCommand::class,
@@ -317,6 +319,18 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
     {
         $this->app->singleton(ConfigClearCommand::class, function ($app) {
             return new ConfigClearCommand($app['files']);
+        });
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerCommandCacheCommand()
+    {
+        $this->app->singleton(CommandCacheCommand::class, function ($app) {
+            return new CommandCacheCommand;
         });
     }
 


### PR DESCRIPTION
This PR fully defers resolving of commands (originally not working prior to this commit) + adds additional caching layer so that command files are not hit on disk at all.

- [x] Defer resolving commands
- [x] Cache commands
- [x] Use cached commands, or register commands
- [ ] Refresh cached commands

Early testing yields around 17% memory reduction (2.5MB) on a base Laravel install without any user commands.

Results could be higher with larger apps with lots of commands.

This follows the same kind of principle behind config and route caching.

Related: #34873 