### PR TITLE
[8.x] Update cipher tests

### DIFF
--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -161,6 +161,10 @@ class Encrypter implements EncrypterContract, StringEncrypter
 
         $tag = empty($payload['tag']) ? null : base64_decode($payload['tag']);
 
+        if (self::$supportedCiphers[$this->cipher]['aead'] && strlen($tag) !== 16) {
+            throw new DecryptException('Could not decrypt the data.');
+        }
+
         // Here we will decrypt the value. If we are able to successfully decrypt it
         // we will then unserialize it and return it out to the caller. If we are
         // unable to decrypt this value we will throw out an exception message.

--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -66,6 +66,34 @@ class EncrypterTest extends TestCase
         $this->assertNotEmpty($data->tag);
     }
 
+    public function testThatAnAeadTagMustBeProvidedInFullLength()
+    {
+        $e = new Encrypter(str_repeat('b', 32), 'AES-256-GCM');
+        $encrypted = $e->encrypt('foo');
+        $data = json_decode(base64_decode($encrypted));
+
+        $this->expectException(DecryptException::class);
+        $this->expectExceptionMessage('Could not decrypt the data.');
+
+        $data->tag = substr($data->tag, 0, 4);
+        $encrypted = base64_encode(json_encode($data));
+        $e->decrypt($encrypted);
+    }
+
+    public function testThatAnAeadTagCantBeModified()
+    {
+        $e = new Encrypter(str_repeat('b', 32), 'AES-256-GCM');
+        $encrypted = $e->encrypt('foo');
+        $data = json_decode(base64_decode($encrypted));
+
+        $this->expectException(DecryptException::class);
+        $this->expectExceptionMessage('Could not decrypt the data.');
+
+        $data->tag = 'A'.substr($data->tag, 1, 23);
+        $encrypted = base64_encode(json_encode($data));
+        $e->decrypt($encrypted);
+    }
+
     public function testThatANonAeadCipherIncludesMac()
     {
         $e = new Encrypter(str_repeat('b', 32), 'AES-256-CBC');


### PR DESCRIPTION
This PR adds two missing tests for the new GCM ciphers, and also clarifies the error message for an invalid tag.