### PR TITLE
[8.x] Use lowercase cipher names, fixes test suite

### DIFF
--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -161,7 +161,7 @@ class Encrypter implements EncrypterContract, StringEncrypter
 
         $tag = empty($payload['tag']) ? null : base64_decode($payload['tag']);
 
-        if (self::$supportedCiphers[$this->cipher]['aead'] && strlen($tag) !== 16) {
+        if (self::$supportedCiphers[strtolower($this->cipher)]['aead'] && strlen($tag) !== 16) {
             throw new DecryptException('Could not decrypt the data.');
         }
 


### PR DESCRIPTION
I didn't manage to include this commit in the last PR, sorry about that! This should fix the test suite again.