### PR TITLE
Add `hasTables` function

### DIFF
--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -136,6 +136,23 @@ class Builder
             $this->grammar->compileTableExists(), [$table]
         )) > 0;
     }
+    
+    /**
+     * Determine if the given tables are exists.
+     *
+     * @param  array  $tables
+     * @return bool
+     */
+    public function hasTables($tables)
+    {
+        foreach ($tables as $table) {
+            if(! $this->hasTable($table)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
 
     /**
      * Determine if the given table has a given column.


### PR DESCRIPTION
Sometimes we need to load the data in `AppServiceProvider` before the view has been rendered as the following code shows.

```PHP
$users = \App\Models\User::get();

\Illuminate\Support\Facades\View::share('users', $users);
```
So, what if the developer NOT migrates the database yet? An error will be triggered because the `users` table does NOT exist yet, Here we want to check if the table exists or NOT using `hasTable` function. So, what if we want to load data from many tables in the `AppServiceProvider` we will need to check the existence of all of them as the following code shows

```PHP
if(Schema::hasTable('users') && Schema::hasTable('cats') && ...) {
   // get all data from these tables here
}
```

The form of code here is NOT formatted well. So, `hasTables` function will be here for that reason.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
