### PR TITLE
[8.x] Add `shadow()` helpers

### DIFF
--- a/src/Illuminate/Support/HigherOrderShadowProxy.php
+++ b/src/Illuminate/Support/HigherOrderShadowProxy.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Illuminate\Support;
+
+class HigherOrderShadowProxy
+{
+    /**
+     * The target being tapped.
+     *
+     * @var object
+     */
+    public $target;
+
+    /**
+     * If the object should be returned instead.
+     *
+     * @var bool
+     */
+    protected $tap;
+
+    /**
+     * Create a new shadow proxy instance.
+     *
+     * @param  mixed  $target
+     * @param  bool  $tap
+     * @return void
+     */
+    public function __construct($target, $tap)
+    {
+        $this->target = $target;
+        $this->tap = $tap;
+    }
+
+    /**
+     * Dynamically pass a method call to the target if it exists.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     */
+    public function __call($method, $parameters)
+    {
+        $result = false;
+
+        if (method_exists($this->target, $method) ||
+            method_exists($this->target, 'hasMacro') && $this->target::hasMacro($method)) {
+            $result = $this->target->$method(...$parameters);
+        }
+
+        return $this->tap ? $this->target : $result;
+    }
+}

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -4,6 +4,7 @@ use Illuminate\Contracts\Support\DeferringDisplayableValue;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Env;
+use Illuminate\Support\HigherOrderShadowProxy;
 use Illuminate\Support\HigherOrderTapProxy;
 use Illuminate\Support\Optional;
 
@@ -243,6 +244,32 @@ if (! function_exists('retry')) {
 
             goto beginning;
         }
+    }
+}
+
+if (! function_exists('shadow')) {
+    /**
+     * Return the method or macro call result if it exists in the object.
+     *
+     * @param  object  $object
+     * @return mixed
+     */
+    function shadow($object)
+    {
+        return new HigherOrderShadowProxy($object, false);
+    }
+}
+
+if (!function_exists('shadow_tap')) {
+    /**
+     * Executes a method or macro call result if it exists, and returns the object.
+     *
+     * @param  object  $object
+     * @return mixed
+     */
+    function shadow_tap($object)
+    {
+        return new HigherOrderShadowProxy($object, true);
     }
 }
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -5,7 +5,9 @@ namespace Illuminate\Tests\Support;
 use ArrayAccess;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Env;
+use Illuminate\Support\Fluent;
 use Illuminate\Support\Optional;
+use Illuminate\Support\Traits\Macroable;
 use LogicException;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -351,6 +353,45 @@ class SupportHelpersTest extends TestCase
             SupportTestTraitThree::class => SupportTestTraitThree::class,
         ],
         class_uses_recursive(SupportTestClassThree::class));
+    }
+
+    public function testShadow()
+    {
+        $object = new Fluent(['foo' => 'bar']);
+
+        $this->assertSame('bar', shadow($object)->offsetGet('foo'));
+        $this->assertFalse(shadow($object)->invalid('foo'));
+
+        $macroable = new class extends Fluent {
+            use Macroable;
+        };
+
+        $macroable::macro('testMacro', function () {
+            return 'macro';
+        });
+
+        $this->assertSame('macro', shadow($macroable)->testMacro());
+        $this->assertFalse(shadow($macroable)->invalid('foo'));
+    }
+
+    public function testShadowTap()
+    {
+        $object = new Fluent(['foo' => 'bar']);
+
+        $this->assertSame($object, shadow_tap($object)->offsetSet('foo', 'baz'));
+        $this->assertSame('baz', $object->foo);
+
+        $macroable = new class extends Fluent {
+            use Macroable;
+            protected $attributes = ['foo' => 'bar'];
+        };
+
+        $macroable::macro('testMacro', function () {
+            return $this->attributes['baz'] = 'qux';
+        });
+
+        $this->assertSame($macroable, shadow_tap($macroable)->testMacro());
+        $this->assertSame('qux', $macroable->baz);
     }
 
     public function testTap()


### PR DESCRIPTION
## What?

Shadow call. Returns a method or macro call result on an object if it exists. If not, it returns `false`.

```php
 // Before
if (method_exists($object, 'render') || (method_exists($object, 'hasMacro') && $object::hasMacro('render')) {
    return $object->render($request);
}

return false;

// After
return shadow($object)->render();
```

It also comes with `shadow_tap` that combines both `shadow()` and `tap()` in one call. In other words, you can call a method if it exists, and chain it with anything else.

```php
 // Before
return tap($object, function ($object) {
    if (method_exists($object, 'before') || (method_exists($object, 'hasMacro') && $object::hasMacro('before')) {
        $object->before($request);
    }    
})->after();

// After
return shadow_tap($object)->before()->after();
```

## How?

It uses a `HigherOrderShadowProxy` behind the veil. It will execute the next method if it exists, and return the object if it's "tapped", or the result if it's not. Both `shadow()` and `shadow_tap()` use the same object.

## Why? 

This is basically a way to infest the code with `method_exists()` conditions, or do method checks inside the `tap()`. 

## Notes

The macro is checked calling directly `hasMacro`, not if the `Macroable` trait exists. This is because the user may be using a different Macro helper ([like Carbon does](https://carbon.nesbot.com/docs/#api-macro)).