### PR TITLE
[8.x] Determine if the given table has a given index in a given column(s)

### DIFF
--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -224,6 +224,7 @@ class Builder
                 return true;
             }
         }
+
         return false;
     }
 

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -209,7 +209,7 @@ class Builder
      * */
     public function hasIndex($table, $column, $indexName = null): bool
     {
-        if (is_null($indexName) && is_array($column)){
+        if (is_null($indexName) && is_array($column)) {
             throw new LogicException("For array of columns index name can't be null");
         }
         if (is_null($indexName)) {

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -209,10 +209,10 @@ class Builder
      * */
     public function hasIndex($table, $column, $indexName = null): bool
     {
-        if (is_null($indexName) && !is_array($column)) {
-            $indexName = $table . '_' . $column . '_index';
+        if (is_null($indexName)) {
+            $indexName = $table.'_'.$column.'_index';
         }
-        if (!is_array($column)) {
+        if ( ! is_array($column)) {
             $column = [$column];
         }
         $table = $this->connection->getTablePrefix() . $table;
@@ -220,7 +220,7 @@ class Builder
         $tableIndexes = $this->connection->getDoctrineSchemaManager()->listTableIndexes($table);
 
         foreach ($tableIndexes as $tableIndex) {
-            if ($tableIndex->getName() === $indexName && !count(array_diff($column, $tableIndex->getColumns()))) {
+            if ($tableIndex->getName() === $indexName && ! count(array_diff($column, $tableIndex->getColumns()))) {
                 return true;
             }
         }

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -228,6 +228,33 @@ class Builder
         return false;
     }
 
+    /*
+     * Determine if the given table has a given Foreign Key
+     * @param string $localTable
+     * @param string $localColumn
+     * @param string $foreignTable
+     * @param string $foreignColumn
+     * */
+    public function hasForeignKey(string $localTable, string $localColumn, string $foreignTable, string $foreignColumn) : bool
+    {
+        $localTable = $this->connection->getTablePrefix().$localTable;
+        $foreignTable = $this->connection->getTablePrefix().$foreignTable;
+
+        $foreignKeysTable = $this->connection->getDoctrineSchemaManager()->listTableForeignKeys($localTable);
+
+        foreach ($foreignKeysTable as $foreignKeyTable){
+            if (
+                in_array($localColumn,$foreignKeyTable->getLocalColumns())
+                && in_array($foreignColumn,$foreignKeyTable->getForeignColumns())
+                && $foreignKeyTable->getForeignTableName() === $foreignTable
+            ){
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     /**
      * Modify a table on the schema.
      *

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -235,19 +235,19 @@ class Builder
      * @param string $foreignTable
      * @param string $foreignColumn
      * */
-    public function hasForeignKey(string $localTable, string $localColumn, string $foreignTable, string $foreignColumn) : bool
+    public function hasForeignKey(string $localTable, string $localColumn, string $foreignTable, string $foreignColumn): bool
     {
         $localTable = $this->connection->getTablePrefix().$localTable;
         $foreignTable = $this->connection->getTablePrefix().$foreignTable;
 
         $foreignKeysTable = $this->connection->getDoctrineSchemaManager()->listTableForeignKeys($localTable);
 
-        foreach ($foreignKeysTable as $foreignKeyTable){
+        foreach ($foreignKeysTable as $foreignKeyTable) {
             if (
-                in_array($localColumn,$foreignKeyTable->getLocalColumns())
-                && in_array($foreignColumn,$foreignKeyTable->getForeignColumns())
+                in_array($localColumn, $foreignKeyTable->getLocalColumns())
+                && in_array($foreignColumn, $foreignKeyTable->getForeignColumns())
                 && $foreignKeyTable->getForeignTableName() === $foreignTable
-            ){
+            ) {
                 return true;
             }
         }

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -209,6 +209,9 @@ class Builder
      * */
     public function hasIndex($table, $column, $indexName = null): bool
     {
+        if (is_null($indexName) && is_array($column)){
+            throw new LogicException("For array of columns index name can't be null");
+        }
         if (is_null($indexName)) {
             $indexName = $table.'_'.$column.'_index';
         }

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -200,6 +200,33 @@ class Builder
         return $this->connection->getPostProcessor()->processColumnListing($results);
     }
 
+    /*
+     * Determine if the given table has a given index in given column(s).
+     * @param string $table
+     * @param string|array $column
+     * @param string|null $indexName
+     * @return bool
+     * */
+    public function hasIndex($table, $column, $indexName = null): bool
+    {
+        if (is_null($indexName) && !is_array($column)) {
+            $indexName = $table . '_' . $column . '_index';
+        }
+        if (!is_array($column)) {
+            $column = [$column];
+        }
+        $table = $this->connection->getTablePrefix() . $table;
+
+        $tableIndexes = $this->connection->getDoctrineSchemaManager()->listTableIndexes($table);
+
+        foreach ($tableIndexes as $tableIndex) {
+            if ($tableIndex->getName() === $indexName && !count(array_diff($column, $tableIndex->getColumns()))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     /**
      * Modify a table on the schema.
      *

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -212,10 +212,10 @@ class Builder
         if (is_null($indexName)) {
             $indexName = $table.'_'.$column.'_index';
         }
-        if ( ! is_array($column)) {
+        if (! is_array($column)) {
             $column = [$column];
         }
-        $table = $this->connection->getTablePrefix() . $table;
+        $table = $this->connection->getTablePrefix().$table;
 
         $tableIndexes = $this->connection->getDoctrineSchemaManager()->listTableIndexes($table);
 

--- a/src/Illuminate/Support/Facades/Schema.php
+++ b/src/Illuminate/Support/Facades/Schema.php
@@ -15,6 +15,7 @@ namespace Illuminate\Support\Facades;
  * @method static bool hasColumn(string $table, string $column)
  * @method static bool hasColumns(string $table, array $columns)
  * @method static bool hasIndex(string $table, $columns,string $indexName = null)
+ * @method static bool hasForeignKey(string $localTable, string $localColumn, string $foreignTable, string $foreignColumn)
  * @method static bool dropColumns(string $table, array $columns)
  * @method static bool hasTable(string $table)
  * @method static void defaultStringLength(int $length)

--- a/src/Illuminate/Support/Facades/Schema.php
+++ b/src/Illuminate/Support/Facades/Schema.php
@@ -14,6 +14,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Database\Schema\Builder table(string $table, \Closure $callback)
  * @method static bool hasColumn(string $table, string $column)
  * @method static bool hasColumns(string $table, array $columns)
+ * @method static bool hasIndex(string $table, $columns,string $indexName)
  * @method static bool dropColumns(string $table, array $columns)
  * @method static bool hasTable(string $table)
  * @method static void defaultStringLength(int $length)

--- a/src/Illuminate/Support/Facades/Schema.php
+++ b/src/Illuminate/Support/Facades/Schema.php
@@ -14,7 +14,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Database\Schema\Builder table(string $table, \Closure $callback)
  * @method static bool hasColumn(string $table, string $column)
  * @method static bool hasColumns(string $table, array $columns)
- * @method static bool hasIndex(string $table, $columns,string $indexName)
+ * @method static bool hasIndex(string $table, $columns,string $indexName = null)
  * @method static bool dropColumns(string $table, array $columns)
  * @method static bool hasTable(string $table)
  * @method static void defaultStringLength(int $length)

--- a/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
@@ -73,6 +73,24 @@ class DatabaseSchemaBuilderIntegrationTest extends TestCase
         $this->assertTrue($this->db->connection()->getSchemaBuilder()->hasColumn('table1', 'name'));
     }
 
+    public function testTableHasIndexTablePrefix()
+    {
+        $this->db->connection()->setTablePrefix('test_');
+
+        $this->schemaBuilder()->create('pandemic_table', function (Blueprint $table) {
+            $table->id();
+            $table->string('stay_home')->index();
+            $table->string('covid19');
+            $table->string('wear_mask');
+            $table->unique(['wear_mask','covid19']);
+        });
+        $this->assertTrue($this->schemaBuilder()->hasIndex('pandemic_table','id','primary'));
+        $this->assertTrue($this->schemaBuilder()->hasIndex('pandemic_table','stay_home'));
+        $this->assertTrue($this->schemaBuilder()->hasIndex('pandemic_table',['wear_mask','covid19'],'pandemic_table_wear_mask_covid19_unique'));
+        $this->assertFalse($this->schemaBuilder()->hasIndex('pandemic_table',['wear_mask']));
+        $this->assertFalse($this->schemaBuilder()->hasIndex('pandemic_table',['wear_mask'],'primary'));
+    }
+
     public function testHasColumnAndIndexWithPrefixIndexDisabled()
     {
         $this->db->addConnection([

--- a/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
@@ -93,7 +93,7 @@ class DatabaseSchemaBuilderIntegrationTest extends TestCase
                 'pandemic_table_wear_mask_covid19_unique'
             )
         );
-        $this->assertFalse($this->schemaBuilder()->hasIndex('pandemic_table', ['wear_mask']));
+        $this->assertFalse($this->schemaBuilder()->hasIndex('pandemic_table', 'wear_mask'));
         $this->assertFalse($this->schemaBuilder()->hasIndex('pandemic_table', ['wear_mask'], 'primary'));
     }
 

--- a/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
@@ -82,13 +82,19 @@ class DatabaseSchemaBuilderIntegrationTest extends TestCase
             $table->string('stay_home')->index();
             $table->string('covid19');
             $table->string('wear_mask');
-            $table->unique(['wear_mask','covid19']);
+            $table->unique(['wear_mask', 'covid19']);
         });
-        $this->assertTrue($this->schemaBuilder()->hasIndex('pandemic_table','id','primary'));
-        $this->assertTrue($this->schemaBuilder()->hasIndex('pandemic_table','stay_home'));
-        $this->assertTrue($this->schemaBuilder()->hasIndex('pandemic_table',['wear_mask','covid19'],'pandemic_table_wear_mask_covid19_unique'));
-        $this->assertFalse($this->schemaBuilder()->hasIndex('pandemic_table',['wear_mask']));
-        $this->assertFalse($this->schemaBuilder()->hasIndex('pandemic_table',['wear_mask'],'primary'));
+        $this->assertTrue($this->schemaBuilder()->hasIndex('pandemic_table', 'id', 'primary'));
+        $this->assertTrue($this->schemaBuilder()->hasIndex('pandemic_table', 'stay_home'));
+        $this->assertTrue(
+            $this->schemaBuilder()->hasIndex(
+                'pandemic_table',
+                ['wear_mask', 'covid19'],
+                'pandemic_table_wear_mask_covid19_unique'
+            )
+        );
+        $this->assertFalse($this->schemaBuilder()->hasIndex('pandemic_table', ['wear_mask']));
+        $this->assertFalse($this->schemaBuilder()->hasIndex('pandemic_table', ['wear_mask'], 'primary'));
     }
 
     public function testHasColumnAndIndexWithPrefixIndexDisabled()

--- a/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
@@ -118,10 +118,10 @@ class DatabaseSchemaBuilderIntegrationTest extends TestCase
             $table->foreignId('country_id')->references('id')->on('countries_table')->cascadeOnDelete();
             $table->foreignId('image_id')->references('image_id')->on('countries_table')->cascadeOnDelete();
         });
-        $this->assertTrue($this->schemaBuilder()->hasForeignKey('users_table','country_id','countries_table','id'));
-        $this->assertTrue($this->schemaBuilder()->hasForeignKey('users_table','image_id','countries_table','image_id'));
-        $this->assertFalse($this->schemaBuilder()->hasForeignKey('users_table','id','countries_table','image_id'));
-        $this->assertFalse($this->schemaBuilder()->hasForeignKey('users_table','image_id','images_table','id'));
+        $this->assertTrue($this->schemaBuilder()->hasForeignKey('users_table', 'country_id', 'countries_table', 'id'));
+        $this->assertTrue($this->schemaBuilder()->hasForeignKey('users_table', 'image_id', 'countries_table', 'image_id'));
+        $this->assertFalse($this->schemaBuilder()->hasForeignKey('users_table', 'id', 'countries_table', 'image_id'));
+        $this->assertFalse($this->schemaBuilder()->hasForeignKey('users_table', 'image_id', 'images_table', 'id'));
     }
 
     public function testTableHasForeignKeyWithoutTablePrefix()
@@ -144,10 +144,10 @@ class DatabaseSchemaBuilderIntegrationTest extends TestCase
             $table->foreignId('country_id')->references('id')->on('countries_table')->cascadeOnDelete();
             $table->foreignId('image_id')->references('image_id')->on('countries_table')->cascadeOnDelete();
         });
-        $this->assertTrue($this->schemaBuilder()->hasForeignKey('users_table','country_id','countries_table','id'));
-        $this->assertTrue($this->schemaBuilder()->hasForeignKey('users_table','image_id','countries_table','image_id'));
-        $this->assertFalse($this->schemaBuilder()->hasForeignKey('users_table','id','countries_table','image_id'));
-        $this->assertFalse($this->schemaBuilder()->hasForeignKey('users_table','image_id','images_table','id'));
+        $this->assertTrue($this->schemaBuilder()->hasForeignKey('users_table', 'country_id', 'countries_table', 'id'));
+        $this->assertTrue($this->schemaBuilder()->hasForeignKey('users_table', 'image_id', 'countries_table', 'image_id'));
+        $this->assertFalse($this->schemaBuilder()->hasForeignKey('users_table', 'id', 'countries_table', 'image_id'));
+        $this->assertFalse($this->schemaBuilder()->hasForeignKey('users_table', 'image_id', 'images_table', 'id'));
     }
 
     public function testHasColumnAndIndexWithPrefixIndexDisabled()

--- a/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
@@ -97,6 +97,59 @@ class DatabaseSchemaBuilderIntegrationTest extends TestCase
         $this->assertFalse($this->schemaBuilder()->hasIndex('pandemic_table', ['wear_mask'], 'primary'));
     }
 
+    public function testTableHasForeignKeyTablePrefix()
+    {
+        $this->db->connection()->setTablePrefix('test_');
+        // Images table
+        $this->schemaBuilder()->create('images_table', function (Blueprint $table) {
+            $table->id();
+            $table->string('image_name')->index();
+        });
+        // Countries table
+        $this->schemaBuilder()->create('countries_table', function (Blueprint $table) {
+            $table->id();
+            $table->string('country_name')->index();
+            $table->bigInteger('image_id');
+        });
+        // users table
+        $this->schemaBuilder()->create('users_table', function (Blueprint $table) {
+            $table->id();
+            $table->string('username')->index();
+            $table->foreignId('country_id')->references('id')->on('countries_table')->cascadeOnDelete();
+            $table->foreignId('image_id')->references('image_id')->on('countries_table')->cascadeOnDelete();
+        });
+        $this->assertTrue($this->schemaBuilder()->hasForeignKey('users_table','country_id','countries_table','id'));
+        $this->assertTrue($this->schemaBuilder()->hasForeignKey('users_table','image_id','countries_table','image_id'));
+        $this->assertFalse($this->schemaBuilder()->hasForeignKey('users_table','id','countries_table','image_id'));
+        $this->assertFalse($this->schemaBuilder()->hasForeignKey('users_table','image_id','images_table','id'));
+    }
+
+    public function testTableHasForeignKeyWithoutTablePrefix()
+    {
+        // Images table
+        $this->schemaBuilder()->create('images_table', function (Blueprint $table) {
+            $table->id();
+            $table->string('image_name')->index();
+        });
+        // Countries table
+        $this->schemaBuilder()->create('countries_table', function (Blueprint $table) {
+            $table->id();
+            $table->string('country_name')->index();
+            $table->bigInteger('image_id');
+        });
+        // users table
+        $this->schemaBuilder()->create('users_table', function (Blueprint $table) {
+            $table->id();
+            $table->string('username')->index();
+            $table->foreignId('country_id')->references('id')->on('countries_table')->cascadeOnDelete();
+            $table->foreignId('image_id')->references('image_id')->on('countries_table')->cascadeOnDelete();
+        });
+        $this->assertTrue($this->schemaBuilder()->hasForeignKey('users_table','country_id','countries_table','id'));
+        $this->assertTrue($this->schemaBuilder()->hasForeignKey('users_table','image_id','countries_table','image_id'));
+        $this->assertFalse($this->schemaBuilder()->hasForeignKey('users_table','id','countries_table','image_id'));
+        $this->assertFalse($this->schemaBuilder()->hasForeignKey('users_table','image_id','images_table','id'));
+    }
+
     public function testHasColumnAndIndexWithPrefixIndexDisabled()
     {
         $this->db->addConnection([


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This PR will let users check if the table has been indexed in a specific column 

`\Illuminate\Support\Facades\Schema::hasIndex('table_name','column_name','index_name')`
Or
will search for default index name `table_name_column_name_index`
`\Illuminate\Support\Facades\Schema::hasIndex('table_name','column_name')`

```
$this->schemaBuilder()->create('pandemic_table', function (Blueprint $table) {
            $table->id();
            $table->string('stay_home')->index();
            $table->string('covid19');
            $table->string('wear_mask');
            $table->unique(['wear_mask','covid19']);
        });
$this->assertTrue($this->schemaBuilder()->hasIndex('pandemic_table','id','primary'));
$this->assertTrue($this->schemaBuilder()->hasIndex('pandemic_table','stay_home'));
$this->assertTrue($this->schemaBuilder()->hasIndex('pandemic_table',['wear_mask','covid19'],'pandemic_table_wear_mask_covid19_unique'));
$this->assertFalse($this->schemaBuilder()->hasIndex('pandemic_table',['wear_mask']));
$this->assertFalse($this->schemaBuilder()->hasIndex('pandemic_table',['wear_mask'],'primary'));
```

Previous code which I used to handle this case

```
$keys = collect(DB::select(DB::raw('SHOW KEYS from table_name')));
if (!$keys->where('Key_name', 'Index_name')->first()) {
                        $table->string('column_name')->index()->change();
}
```

if If I want to check foreign keys

```
$foreignKeys = collect(
                    DB::select(
                        "SELECT *
FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE
WHERE TABLE_SCHEMA = 'da_name'
      AND REFERENCED_COLUMN_NAME IS NOT NULL;"
                    )
                );
```
again for loop and  if and else in the migration file 

Why do we need this,
Real case
If we have multiple apps working with a shared ( single) database every app didn't know what others do in the database so we need to check if 

- [x] If the table exists (which laravel have this feature)
- [x] if a column exists (which also laravel have this feature)
- [x] if column(s) have specific index (done in this PR)
- [x] If column linked to another table foreign key (done in this PR)

