### PR TITLE
[8.x] Added `prohibits` validation

### DIFF
--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -433,6 +433,20 @@ trait ReplacesAttributes
     }
 
     /**
+     * Replace all place-holders for the prohibited_with rule.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array  $parameters
+     * @return string
+     */
+    protected function replaceProhibits($message, $attribute, $rule, $parameters)
+    {
+        return str_replace(':other', implode(' / ', $this->getAttributeList($parameters)), $message);
+    }
+
+    /**
      * Replace all place-holders for the same rule.
      *
      * @param  string  $message

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1535,6 +1535,25 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate that other attributes do not exist when this attribute exists.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  mixed  $parameters
+     * @return bool
+     */
+    public function validateProhibits($attribute, $value, $parameters)
+    {
+        foreach ($parameters as $other) {
+            if (Arr::has($this->data, $other)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * Indicate that an attribute is excluded.
      *
      * @return bool

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1544,7 +1544,7 @@ trait ValidatesAttributes
      */
     public function validateProhibits($attribute, $value, $parameters)
     {
-        return !Arr::hasAny($this->data, $parameters);
+        return ! Arr::hasAny($this->data, $parameters);
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1544,13 +1544,7 @@ trait ValidatesAttributes
      */
     public function validateProhibits($attribute, $value, $parameters)
     {
-        foreach ($parameters as $other) {
-            if (Arr::has($this->data, $other)) {
-                return false;
-            }
-        }
-
-        return true;
+        return !Arr::hasAny($this->data, $parameters);
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1470,6 +1470,47 @@ class ValidationValidatorTest extends TestCase
         $this->assertSame('The last field is prohibited unless first is in taylor, jess.', $v->messages()->first('last'));
     }
 
+    public function testProhibits()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['email' => 'foo', 'emails' => ['foo']], ['email' => 'prohibits:emails']);
+        $this->assertTrue($v->fails());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['email' => 'foo', 'emails' => []], ['email' => 'prohibits:emails']);
+        $this->assertTrue($v->fails());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['email' => 'foo', 'emails' => ''], ['email' => 'prohibits:emails']);
+        $this->assertTrue($v->fails());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['email' => 'foo', 'emails' => null], ['email' => 'prohibits:emails']);
+        $this->assertTrue($v->fails());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['email' => 'foo', 'emails' => false], ['email' => 'prohibits:emails']);
+        $this->assertTrue($v->fails());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['email' => 'foo', 'emails' => ['foo']], ['email' => 'prohibits:email_address,emails']);
+        $this->assertTrue($v->fails());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['email' => 'foo'], ['email' => 'prohibits:emails']);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['email' => 'foo', 'other' => 'foo'], ['email' => 'prohibits:email_address,emails']);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines(['validation.prohibits' => 'The :attribute field prohibits :other being present.'], 'en');
+        $v = new Validator($trans, ['email' => 'foo', 'emails' => 'bar', 'email_address' => 'baz'], ['email' => 'prohibits:emails,email_address']);
+        $this->assertFalse($v->passes());
+        $this->assertSame('The email field prohibits emails / email address being present.', $v->messages()->first('email'));
+    }
+
     public function testFailedFileUploads()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
**NB:** I originally submitted this as `prohibited_with`, which was turned down because `with` would behave differently from `required_with`. I feel that changing the wording to `prohibits` resolves this issue without compromising on the functionality of this validation.

I've encountered a requirement in a few systems where two potential fields could be passed, but if one exists the other cannot exist. The `prohibited_if` validation allows you to counter this only if you know the potential values of the second field, so I've added `prohibits` as a way to create a simple `NAND` between fields.

The most recent example was working with the Facebook Business SDK, where a customer record could accept `email` or `emails`, but passing both fields causes an error (because it can't be resolved into a correct single value). With this validation, I could catch that earlier in the application and ensure that I'm not having to deal with API/SDK errors. For this example:

```php
Validator::validate([
    'email' => 'example@example.com', 
    'emails' => ['example@example.com', 'other.example@example.com']
], [
    'email' => 'prohibits:emails'
]);
```

You can also pass multiple fields for a situation where you have one field or multiple fields (e.g. passing a model ID as well as fields that can only be set on creation). In this case, if any of the listed `prohibits` fields exist, it will trigger a validation failure.

```php
Validator::validate([
    'post_id' => 1, 
    'created_by' => 2,
    'created_at' => '2020-07-16 20:54:22'
], [
    'post_id' => 'prohibits:created_by,created_at'
]);
```

Finally, this can be used with `required_without` to create a `XOR`, where one property _must_ be passed, but never both.

```php
Validator::validate([
    'email' => 'example@example.com', 
    'emails' => ['example@example.com', 'other.example@example.com']
], [
    'email' => ['prohibits:emails', 'required_without:emails']
]);
```

If you choose to merge, I will send PRs to `laravel/docs` and `laravel/laravel`.