### PR TITLE
Use helper data_get in retrieveItem (query, headers, cookies...)

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -474,7 +474,7 @@ trait InteractsWithInput
             return $this->$source->all();
         }
 
-        return $this->$source->get($key, $default);
+        return data_get($this->$source->all(), $key, $default);
     }
 
     /**


### PR DESCRIPTION
Now I can't use 'filters.0.name' with request->query() method, with this change I can access an item from an array or object using "dot" notation (data_get helper).

URL example: .../list?filters[0][name]=category&filters[0][value]=6

- Now $request->query('filters.0.name') returns NULL
- Now $request->input('filters.0.name') returns "category" (but i want to use query method only)
- With data_get (my change): $request->query('filters.0.name') returns "category"