### PR TITLE
[8.x] Support customizing pagination link

### DIFF
--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -102,6 +102,13 @@ abstract class AbstractPaginator implements Htmlable
     protected static $queryStringResolver;
 
     /**
+     * The url generator resolver callback.
+     *
+     * @var \Closure
+     */
+    protected static $urlGeneratorResolver;
+
+    /**
      * The view factory resolver callback.
      *
      * @var \Closure
@@ -178,6 +185,10 @@ abstract class AbstractPaginator implements Htmlable
 
         if (count($this->query) > 0) {
             $parameters = array_merge($this->query, $parameters);
+        }
+
+        if (isset(static::$urlGeneratorResolver)) {
+            return call_user_func(static::$urlGeneratorResolver, $this->path(), $parameters, $page, $this);
         }
 
         return $this->path()
@@ -536,6 +547,17 @@ abstract class AbstractPaginator implements Htmlable
     public static function queryStringResolver(Closure $resolver)
     {
         static::$queryStringResolver = $resolver;
+    }
+
+    /**
+     * Set the url generator resolver callback.
+     *
+     * @param Closure $resolver
+     * @return void
+     */
+    public static function urlGeneratorResolver(Closure $resolver)
+    {
+        static::$urlGeneratorResolver = $resolver;
     }
 
     /**

--- a/tests/Pagination/LengthAwarePaginatorTest.php
+++ b/tests/Pagination/LengthAwarePaginatorTest.php
@@ -121,7 +121,7 @@ class LengthAwarePaginatorTest extends TestCase
         $paginator->setPageName('/page');
 
         Paginator::urlGeneratorResolver(function ($path, $parameters, $page, AbstractPaginator $paginator) {
-            return $path . $paginator->getPageName() . $page;
+            return $path.$paginator->getPageName().$page;
         });
 
         $this->assertSame('http://website.com/test/page1', $paginator->previousPageUrl());

--- a/tests/Pagination/LengthAwarePaginatorTest.php
+++ b/tests/Pagination/LengthAwarePaginatorTest.php
@@ -2,7 +2,9 @@
 
 namespace Illuminate\Tests\Pagination;
 
+use Illuminate\Pagination\AbstractPaginator;
 use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Pagination\Paginator;
 use PHPUnit\Framework\TestCase;
 
 class LengthAwarePaginatorTest extends TestCase
@@ -105,6 +107,25 @@ class LengthAwarePaginatorTest extends TestCase
 
         $this->assertSame('http://website.com?key=value%20with%20spaces&foo=2',
                             $this->p->url($this->p->currentPage()));
+    }
+
+    public function testLengthAwarePaginatorCustomizeUrls()
+    {
+        $paginator = new LengthAwarePaginator(
+            ['item1', 'item2', 'item3', 'item4', 'item5', 'item6'],
+            6, 2, 2,
+            $this->options
+        );
+
+        $paginator->setPath('http://website.com/test');
+        $paginator->setPageName('/page');
+
+        Paginator::urlGeneratorResolver(function ($path, $parameters, $page, AbstractPaginator $paginator) {
+            return $path . $paginator->getPageName() . $page;
+        });
+
+        $this->assertSame('http://website.com/test/page1', $paginator->previousPageUrl());
+        $this->assertSame('http://website.com/test/page3', $paginator->nextPageUrl());
     }
 
     public function testItRetrievesThePaginatorOptions()


### PR DESCRIPTION
Now, when you need to be search engine friendly, we can customize pagination links at the logical controller layer:
```
use Illuminate\Pagination\Paginator;

$paginator = new LengthAwarePaginator(
    ['item1', 'item2', 'item3', 'item4', 'item5', 'item6'],
    6, 2, 2,
    $this->options
);

$paginator->setPath('http://website.com/test');
$paginator->setPageName('/page');

Paginator::urlGeneratorResolver(function ($path, $parameters, $page, AbstractPaginator $paginator) {
    return $path . $paginator->getPageName() . $page;
});

$paginator->previousPageUrl() // http://website.com/test/page1
$paginator->nextPageUrl() // http://website.com/test/page3
```