### PR TITLE
[8.x] Adds dynamic properties to `AnonymousNotifiable`

### DIFF
--- a/src/Illuminate/Notifications/AnonymousNotifiable.php
+++ b/src/Illuminate/Notifications/AnonymousNotifiable.php
@@ -18,23 +18,6 @@ class AnonymousNotifiable extends Fluent
     public $routes = [];
 
     /**
-     * Adds dynamic properties to the instance.
-     *
-     * @param  \Illuminate\Contracts\Support\Arrayable|array  $attributes
-     * @return $this
-     */
-    public function with($attributes)
-    {
-        if ($attributes instanceof Arrayable) {
-            $attributes = $attributes->toArray();
-        }
-
-        $this->attributes = array_merge($this->attributes, $attributes);
-
-        return $this;
-    }
-
-    /**
      * Add routing information to the target.
      *
      * @param  string  $channel
@@ -53,6 +36,23 @@ class AnonymousNotifiable extends Fluent
 
         return $this;
     }
+
+    /**
+     * Add dynamic properties to the instance.
+     *
+     * @param  \Illuminate\Contracts\Support\Arrayable|array  $attributes
+     * @return $this
+     */
+    public function with($attributes)
+    {
+        if ($attributes instanceof Arrayable) {
+            $attributes = $attributes->toArray();
+        }
+
+        $this->attributes = array_merge($this->attributes, $attributes);
+
+        return $this;
+    }    
 
     /**
      * Send the given notification.

--- a/src/Illuminate/Notifications/AnonymousNotifiable.php
+++ b/src/Illuminate/Notifications/AnonymousNotifiable.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Notifications;
 
+use BadMethodCallException;
 use Illuminate\Contracts\Notifications\Dispatcher;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Fluent;
@@ -20,7 +21,6 @@ class AnonymousNotifiable extends Fluent
      * Adds dynamic properties to the instance.
      *
      * @param  \Illuminate\Contracts\Support\Arrayable|array  $attributes
-     *
      * @return $this
      */
     public function with($attributes)
@@ -95,5 +95,19 @@ class AnonymousNotifiable extends Fluent
     public function getKey()
     {
         //
+    }
+
+    /**
+     * Disable dynamic calls to set a parameter value.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return void
+     */
+    public function __call($method, $parameters)
+    {
+        throw new BadMethodCallException(sprintf(
+            'Call to undefined method %s::%s()', static::class, $method
+        ));
     }
 }

--- a/src/Illuminate/Notifications/AnonymousNotifiable.php
+++ b/src/Illuminate/Notifications/AnonymousNotifiable.php
@@ -3,9 +3,11 @@
 namespace Illuminate\Notifications;
 
 use Illuminate\Contracts\Notifications\Dispatcher;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Fluent;
 use InvalidArgumentException;
 
-class AnonymousNotifiable
+class AnonymousNotifiable extends Fluent
 {
     /**
      * All of the notification routing information.
@@ -13,6 +15,24 @@ class AnonymousNotifiable
      * @var array
      */
     public $routes = [];
+
+    /**
+     * Adds dynamic properties to the instance.
+     *
+     * @param  \Illuminate\Contracts\Support\Arrayable|array  $attributes
+     *
+     * @return $this
+     */
+    public function with($attributes)
+    {
+        if ($attributes instanceof Arrayable) {
+            $attributes = $attributes->toArray();
+        }
+
+        $this->attributes = array_merge($this->attributes, $attributes);
+
+        return $this;
+    }
 
     /**
      * Add routing information to the target.

--- a/tests/Integration/Notifications/SendingNotificationsViaAnonymousNotifiableTest.php
+++ b/tests/Integration/Notifications/SendingNotificationsViaAnonymousNotifiableTest.php
@@ -92,7 +92,6 @@ class AnotherTestCustomChannel
     }
 }
 
-
 class AnonymousTestNotificationWithProperties extends Notification
 {
     public function __construct($test)

--- a/tests/Integration/Notifications/SendingNotificationsViaAnonymousNotifiableTest.php
+++ b/tests/Integration/Notifications/SendingNotificationsViaAnonymousNotifiableTest.php
@@ -36,6 +36,13 @@ class SendingNotificationsViaAnonymousNotifiableTest extends TestCase
         ], $_SERVER['__notifiable.route']);
     }
 
+    public function testAnonymousNotifiableWithProperties()
+    {
+        NotificationFacade::route('testchannel', 'enzo')
+            ->with(['foo' => 'bar'])
+            ->notify(new AnonymousTestNotificationWithProperties($this));
+    }
+
     public function testFaking()
     {
         $fake = NotificationFacade::fake();
@@ -82,5 +89,21 @@ class AnotherTestCustomChannel
     public function send($notifiable, $notification)
     {
         $_SERVER['__notifiable.route'][] = $notifiable->routeNotificationFor('anothertestchannel');
+    }
+}
+
+
+class AnonymousTestNotificationWithProperties extends Notification
+{
+    public function __construct($test)
+    {
+        $this->test = $test;
+    }
+
+    public function via($notifiable)
+    {
+        $this->test->assertSame('bar', $notifiable->foo);
+
+        return [TestCustomChannel::class];
     }
 }

--- a/tests/Integration/Notifications/SendingNotificationsViaAnonymousNotifiableTest.php
+++ b/tests/Integration/Notifications/SendingNotificationsViaAnonymousNotifiableTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Notifications;
 
+use BadMethodCallException;
 use Illuminate\Notifications\AnonymousNotifiable;
 use Illuminate\Notifications\Notification;
 use Illuminate\Support\Facades\Notification as NotificationFacade;
@@ -41,6 +42,15 @@ class SendingNotificationsViaAnonymousNotifiableTest extends TestCase
         NotificationFacade::route('testchannel', 'enzo')
             ->with(['foo' => 'bar'])
             ->notify(new AnonymousTestNotificationWithProperties($this));
+    }
+
+    public function testAnonymouseNotifiableDoesntAllowSetCalls()
+    {
+        $this->expectException(BadMethodCallException::class);
+        $this->expectExceptionMessage('Call to undefined method Illuminate\Notifications\AnonymousNotifiable::foo()');
+
+        NotificationFacade::route('testchannel', 'enzo')
+            ->foo('bar');
     }
 
     public function testFaking()


### PR DESCRIPTION
## What?

Allows using dynamic properties like Eloquent Models to the `AnonymousNotifiable` (on demand notifications).

```php
use Illuminate\Support\Facades\Notification;
use App\Notifications\GuitarShipped;

Notification::route('mail', 'johnpetrucci@gmail.com')
    ->with(['name' => 'John', 'instrument' => 'guitar'])
    ->notify(new GuitarShipped('JP45'));
```

This solves the problem when a notification expects data from the notifiable, as the `AnonymousNotifiable` doesn't support gracefully chaining properties, as it difficult to manually set each of them. Worse case scenario: making another notification.

This way is totally safe to get injected data from the notifiable.

```php
public function toMail($notifiable)
{
    return (new MailMessage)->subject("Hey $notifiable->name, your guitar is on route!");
}
```

The `with()` method supports `Arrayable` objects, so you can use a whole Model if you feel lazy.

```php
use Illuminate\Support\Facades\Notification;
use App\Notifications\GuitarShipped;
use App\Models\Client;

$client = Client::find(477);

Notification::route('mail', 'johnpetrucci@gmail.com')
    ->with($client) // I would used `$client->only('name', 'instrument'), but you do you.
    ->notify(new GuitarShipped('JP45'));
```

## How?

I just slapped the `Fluent` helper into the `AnonymousNotifiable` and added the `with()` method to merge multiple attributes in one go.

## BC?

Please...

## Notes

1. The Notifications package requires the Support package, so there is no sin to use duck-tape `Fluent` in my opinion.
2. I didn't set `with()` into the Facade, so it still forces the developer to route first and merge properties later.
3. The other alternative I do is to clone the Model into the Notification, but feels very hacky to me.