### PR TITLE
[8.x][fix bug] when search from cross database relationship ,it comes to "Property [from] does not exist on the Eloquent builder instance."

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -371,8 +371,8 @@ class Builder
             $this->getConnection()->getDatabaseName()) {
             $databaseName = $query->getConnection()->getDatabaseName();
 
-            if (strpos($query->from, $databaseName) !== 0 && strpos($query->from, '.') === false) {
-                $query->from($databaseName.'.'.$query->from);
+            if (strpos($query->getQuery()->from, $databaseName) !== 0 && strpos($query->getQuery()->from, '.') === false) {
+                $query->getQuery()->from($databaseName.'.'.$query->getQuery()->from);
             }
         }
 


### PR DESCRIPTION
fix bug : Property [from] does not exist on the Eloquent builder instance.

when I search from cross database relationship ,it comes to this error.

```php
OauthRecord::whereHas('user', function (Builder $query) {
    $query->where('username', 'like', 'sparkinzy%');
})
```

> Error:  Property [from] does not exist on the Eloquent builder instance.
> Error:  Property [from] does not exist on the Eloquent builder instance.
> Error:  Property [from] does not exist on the Eloquent builder instance.

Model A:
```php
class OauthRecord extends Model
{

    protected $table = 'oauth_record';
    protected $connection = 'mysql-B'

    public function user()
    {
        $instance = new User();
        $instance->setTable('db_a.users');
        $query = $instance->newQuery();
        return new BelongsTo($query, $this, 'user_id', 'id',null);
    }

}
```

Model B 
```php
class User extends Model
{

    protected $table = 'users';
    protected $connection = 'mysql-A'

}
```

config/database.php
```php
return [
    'connections' => [
           'mysql-A' => [
                'driver' => 'mysql',
                'host' => '127.0.0.1',
                'port' => '3306',
                'database'=> 'db_a',

            ],
           'mysql-B' => [
                'driver' => 'mysql',
                'host' => '127.0.0.1',
                'port' => '3306',
                'database'=> 'db_b',

            ],

    ]
];
```