### PR TITLE
[8.x] Add `assertNothingDispatched` to Event Facade doc block

### DIFF
--- a/src/Illuminate/Support/Facades/Event.php
+++ b/src/Illuminate/Support/Facades/Event.php
@@ -16,6 +16,7 @@ use Illuminate\Support\Testing\Fakes\EventFake;
  * @method static void assertDispatched(string|\Closure $event, callable|int $callback = null)
  * @method static void assertDispatchedTimes(string $event, int $times = 1)
  * @method static void assertNotDispatched(string|\Closure $event, callable|int $callback = null)
+ * @method static void assertNothingDispatched()
  * @method static void assertListening(string $expectedEvent, string expectedListener)
  * @method static void flush(string $event)
  * @method static void forget(string $event)


### PR DESCRIPTION
This PR adds the `assertNothingDispatched` from EventFake class to the Event facade, in order to provide IDE auto completion.