### PR TITLE
[8.x] Add bad request test response assertion

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -165,6 +165,16 @@ class TestResponse implements ArrayAccess
     }
 
     /**
+     * Assert that the response has a 400 Bad Request status code.
+     *
+     * @return $this
+     */
+    public function assertBadRequest()
+    {
+        return $this->assertStatus(400);
+    }
+
+    /**
      * Assert that the response has the given status code.
      *
      * @param  int  $status

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -488,6 +488,36 @@ class TestResponseTest extends TestCase
         $response->assertUnprocessable();
     }
 
+    public function testAssertBadRequestWhenNotBadRequest()
+    {
+        $statusCode = 500;
+
+        $this->expectException(AssertionFailedError::class);
+
+        $this->expectExceptionMessage('Expected response status code');
+
+        $baseResponse = tap(new Response, function ($response) use ($statusCode) {
+            $response->setStatusCode($statusCode);
+        });
+
+        $response = TestResponse::fromBaseResponse($baseResponse);
+        $response->assertBadRequest();
+    }
+
+    public function testAssertBadRequestWhenIsBadRequest()
+    {
+        $statusCode = 400;
+
+        $baseResponse = tap(new Response, function ($response) use ($statusCode) {
+            $response->setStatusCode($statusCode);
+        });
+
+        $response = TestResponse::fromBaseResponse($baseResponse);
+        $chainedResponse = $response->assertBadRequest();
+        // Ensure that we can chain the response and implicitly that we do _not_ throw an assertion error
+        $this->assertEquals($response, $chainedResponse);
+    }
+
     public function testAssertNoContentAsserts204StatusCodeByDefault()
     {
         $statusCode = 500;


### PR DESCRIPTION
Inspired by PR #38553.  A readability enhancement in the same manner.
Just like `assertOk`, `assertUnauthorized` and company this adds an
`assertBadRequest` to ensure that a [400 Bad Request](https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1) was sent
in the response.

The intention is to increase readability and add broader support to the
existing suite of response code assertions which are much easier to
understand.

This introduces no breaking changes since it does not modify any
existing methods.

Also introduced a test case for the assert error path and the path where
there is no assertion error.
