### PR TITLE
```->asAjax()``` helper method for tests

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -92,6 +92,18 @@ trait MakesHttpRequests
     }
 
     /**
+     * Sets a header to simulate an ajax request
+     *
+     * @return $this
+     */
+    public function asAjax()
+    {
+        $this->withHeader('X-Requested-With', 'XMLHttpRequest');
+
+        return $this;
+    }
+
+    /**
      * Add an authorization token for the request.
      *
      * @param  string  $token

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -92,7 +92,7 @@ trait MakesHttpRequests
     }
 
     /**
-     * Sets a header to simulate an ajax request
+     * Sets a header to simulate an ajax request.
      *
      * @return $this
      */

--- a/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
+++ b/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
@@ -26,6 +26,12 @@ class MakesHttpRequestsTest extends TestCase
         $this->assertSame('Basic foobar', $this->defaultHeaders['Authorization']);
     }
 
+    public function testAsAjaxSetsXRequestedWithHeader()
+    {
+        $this->asAjax();
+        $this->assertSame('XMLHttpRequest', $this->defaultHeaders['X-Requested-With']);
+    }
+
     public function testWithoutAndWithMiddleware()
     {
         $this->assertFalse($this->app->has('middleware.disable'));


### PR DESCRIPTION
This PR adds a simple helper method for automated tests which will allow developers to simulate an ajax request.

Currently, this is possible by adding the XRequestedWith header manually using the ->withHeader method. This PR gives this a clearer syntax, and makes it consistent with the current $request->ajax(); that is used within the application.
