### PR TITLE
[8.x] Add `merge()` function to `ValidatedInput`

### DIFF
--- a/src/Illuminate/Support/ValidatedInput.php
+++ b/src/Illuminate/Support/ValidatedInput.php
@@ -69,16 +69,14 @@ class ValidatedInput implements ValidatedData
     }
 
     /**
-     * Merge the input with the given items.
+     * Merge the validated input with the given array of additional data.
      *
-     * @param array $items
-     * @return $this
+     * @param  array  $items
+     * @return static
      */
     public function merge(array $items)
     {
-        $this->input = array_merge($this->input, $items);
-
-        return $this;
+        return new static(array_merge($this->input, $items));
     }
 
     /**

--- a/src/Illuminate/Support/ValidatedInput.php
+++ b/src/Illuminate/Support/ValidatedInput.php
@@ -69,6 +69,19 @@ class ValidatedInput implements ValidatedData
     }
 
     /**
+     * Merge the input with the given items.
+     *
+     * @param array $items
+     * @return $this
+     */
+    public function merge(array $items)
+    {
+        array_merge($this->input, $items);
+
+        return $this;
+    }
+
+    /**
      * Get the input as a collection.
      *
      * @return \Illuminate\Support\Collection

--- a/src/Illuminate/Support/ValidatedInput.php
+++ b/src/Illuminate/Support/ValidatedInput.php
@@ -76,7 +76,7 @@ class ValidatedInput implements ValidatedData
      */
     public function merge(array $items)
     {
-        array_merge($this->input, $items);
+        $this->input = array_merge($this->input, $items);
 
         return $this;
     }

--- a/tests/Support/ValidatedInputTest.php
+++ b/tests/Support/ValidatedInputTest.php
@@ -22,7 +22,7 @@ class ValidatedInputTest extends TestCase
     {
         $input = new ValidatedInput(['name' => 'Taylor']);
 
-        $input->merge(['votes' => 100]);
+        $input = $input->merge(['votes' => 100]);
 
         $this->assertEquals('Taylor', $input->name);
         $this->assertEquals('Taylor', $input['name']);

--- a/tests/Support/ValidatedInputTest.php
+++ b/tests/Support/ValidatedInputTest.php
@@ -17,4 +17,17 @@ class ValidatedInputTest extends TestCase
         $this->assertEquals(['name' => 'Taylor'], $input->except(['votes']));
         $this->assertEquals(['name' => 'Taylor', 'votes' => 100], $input->all());
     }
+
+    public function test_can_merge_items()
+    {
+        $input = new ValidatedInput(['name' => 'Taylor']);
+        
+        $input->merge(['votes' => 100]);
+
+        $this->assertEquals('Taylor', $input->name);
+        $this->assertEquals('Taylor', $input['name']);
+        $this->assertEquals(['name' => 'Taylor'], $input->only(['name']));
+        $this->assertEquals(['name' => 'Taylor'], $input->except(['votes']));
+        $this->assertEquals(['name' => 'Taylor', 'votes' => 100], $input->all());
+    }
 }

--- a/tests/Support/ValidatedInputTest.php
+++ b/tests/Support/ValidatedInputTest.php
@@ -21,7 +21,7 @@ class ValidatedInputTest extends TestCase
     public function test_can_merge_items()
     {
         $input = new ValidatedInput(['name' => 'Taylor']);
-        
+
         $input->merge(['votes' => 100]);
 
         $this->assertEquals('Taylor', $input->name);


### PR DESCRIPTION
This PR will add the ability to merge items to validated inputs. As an example 

```php
    $validator = Validator::make(['name' => 'Taylor'], ['name' => 'required']);

    $validator->safe()->merge(['role' => 'Admin']);

    User::create($validator->safe()->all());
```
Previously you can't do this when using Form Request, you can't merge any data to the returned data from `validated()`.