### PR TITLE
[8.x] Remove `mapWithKeys` from HTTP Client `headers()` methods

### DIFF
--- a/src/Illuminate/Http/Client/Request.php
+++ b/src/Illuminate/Http/Client/Request.php
@@ -120,9 +120,7 @@ class Request implements ArrayAccess
      */
     public function headers()
     {
-        return collect($this->request->getHeaders())->mapWithKeys(function ($values, $header) {
-            return [$header => $values];
-        })->all();
+        return $this->request->getHeaders();
     }
 
     /**

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -107,9 +107,7 @@ class Response implements ArrayAccess
      */
     public function headers()
     {
-        return collect($this->response->getHeaders())->mapWithKeys(function ($v, $k) {
-            return [$k => $v];
-        })->all();
+        return $this->response->getHeaders();
     }
 
     /**


### PR DESCRIPTION
These  `headers()` methods have been this way since the initial port of ZTTP in 65b8d50d5b92d5c24dd4696168ad25f37c2a0c2a. The `getHeaders()` method in the PSR-7 Request and Response objects already return the headers as `string[][]`, so this `mapWithKeys` usage is essentially a no-op.

I didn't feel the need to add any specific tests for this, as the `header()` method is used internally in `hasHeader()`, which is tested directly or indirectly 21 times in `HttpClientTest`, sufficient to show that the expected header array is the same as it was before.