### PR TITLE
[8.x] Fix flaky cipher tag test

### DIFF
--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -102,7 +102,7 @@ class EncrypterTest extends TestCase
         $this->expectException(DecryptException::class);
         $this->expectExceptionMessage('Could not decrypt the data.');
 
-        $data->tag = 'A'.substr($data->tag, 1, 23);
+        $data->tag[0] = $data->tag[0] === 'A' ? 'B' : 'A';
         $encrypted = base64_encode(json_encode($data));
         $e->decrypt($encrypted);
     }


### PR DESCRIPTION
There was a 1/64 chance of random failure in the test to check that a cipher tag can't be modified. This ensure the first character of the (base64-encoded) tag always changes.
