### PR TITLE
[8.x] Add pluckMany() method to Collections

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -645,7 +645,7 @@ class Collection implements ArrayAccess, Enumerable
             }
 
             if ($item instanceof ArrayAccess) {
-                return (object) collect($keys)->mapWithKeys(function ($key) use ($item) {
+                return collect($keys)->mapWithKeys(function ($key) use ($item) {
                     return [$key => $item[$key]];
                 })->toArray();
             }

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -636,7 +636,7 @@ class Collection implements ArrayAccess, Enumerable
     public function pluckMany($keys)
     {
         return $this->map(function ($item) use ($keys) {
-            if ($item instanceof self) {
+            if ($item instanceof self || $item instanceof LazyCollection) {
                 return $item->only($keys);
             }
 

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -628,6 +628,33 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
+     * Get the values of several given keys.
+     *
+     * @param  array   $keys
+     * @return static
+     */
+    public function pluckMany($keys)
+    {
+        return $this->map(function ($item) use ($keys) {
+            if ($item instanceof self) {
+                return $item->only($keys);
+            }
+
+            if (is_array($item)) {
+                return Arr::only($item, $keys);
+            }
+
+            if ($item instanceof ArrayAccess) {
+                return (object) collect($keys)->mapWithKeys(function ($key) use ($item) {
+                    return [$key => $item[$key]];
+                })->toArray();
+            }
+
+            return (object) Arr::only(get_object_vars($item), $keys);
+        });
+    }
+
+    /**
      * Run a map over each of the items.
      *
      * @param  callable  $callback

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -661,7 +661,7 @@ class LazyCollection implements Enumerable
             }
 
             if ($item instanceof ArrayAccess) {
-                return (object) collect($keys)->mapWithKeys(function ($key) use ($item) {
+                return collect($keys)->mapWithKeys(function ($key) use ($item) {
                     return [$key => $item[$key]];
                 })->toArray();
             }

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -652,7 +652,7 @@ class LazyCollection implements Enumerable
     public function pluckMany($keys)
     {
         return $this->map(function ($item) use ($keys) {
-            if ($item instanceof self) {
+            if ($item instanceof self || $item instanceof Collection) {
                 return $item->only($keys);
             }
 

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Support;
 
+use ArrayAccess;
 use ArrayIterator;
 use Closure;
 use DateTimeInterface;
@@ -639,6 +640,33 @@ class LazyCollection implements Enumerable
                     yield $itemKey => $itemValue;
                 }
             }
+        });
+    }
+
+    /**
+     * Get the values of several given keys.
+     *
+     * @param  array   $keys
+     * @return static
+     */
+    public function pluckMany($keys)
+    {
+        return $this->map(function ($item) use ($keys) {
+            if ($item instanceof self) {
+                return $item->only($keys);
+            }
+
+            if (is_array($item)) {
+                return Arr::only($item, $keys);
+            }
+
+            if ($item instanceof ArrayAccess) {
+                return (object) collect($keys)->mapWithKeys(function ($key) use ($item) {
+                    return [$key => $item[$key]];
+                })->toArray();
+            }
+
+            return (object) Arr::only(get_object_vars($item), $keys);
         });
     }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2089,9 +2089,9 @@ class SupportCollectionTest extends TestCase
         ]);
 
         $this->assertEquals([
-                (object) ['name' => 'matt', 'hobby' => 'coding'],
-                ['name' => 'tomo', 'hobby' => 'cooking'],
-            ],
+            (object) ['name' => 'matt', 'hobby' => 'coding'],
+            ['name' => 'tomo', 'hobby' => 'cooking'],
+        ],
             $data->pluckMany(['name', 'hobby'])->all()
         );
     }
@@ -2107,9 +2107,9 @@ class SupportCollectionTest extends TestCase
         ]);
 
         $this->assertEquals([
-                ['name' => 'marco', 'hobby' => 'drinking'],
-                ['name' => 'belle', 'hobby' => 'cross-stitch'],
-            ],
+            ['name' => 'marco', 'hobby' => 'drinking'],
+            ['name' => 'belle', 'hobby' => 'cross-stitch'],
+        ],
             $data->pluckMany(['name', 'hobby'])->all()
         );
     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -9,7 +9,6 @@ use CachingIterator;
 use Exception;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\ItemNotFoundException;

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -9,6 +9,7 @@ use CachingIterator;
 use Exception;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\ItemNotFoundException;
@@ -2063,6 +2064,55 @@ class SupportCollectionTest extends TestCase
 
         $this->assertEquals(['taylor' => 'foo', 'dayle' => 'bar'], $data->pluck('email', 'name')->all());
         $this->assertEquals(['foo', 'bar'], $data->pluck('email')->all());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testPluckManyWithCollections($collection)
+    {
+        $data = new $collection([
+            collect(['id' => 1, 'name' => 'matt', 'hobby' => 'coding']),
+            collect(['id' => 2, 'name' => 'tomo', 'hobby' => 'cooking']),
+        ]);
+
+        $this->assertEquals($data->map->only(['name', 'hobby']), $data->pluckMany(['name', 'hobby']));
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testPluckManyWithArrayAndObjectValues($collection)
+    {
+        $data = new $collection([
+            (object) ['id' => 1, 'name' => 'matt', 'hobby' => 'coding'],
+            ['id' => 2, 'name' => 'tomo', 'hobby' => 'cooking'],
+        ]);
+
+        $this->assertEquals([
+                (object) ['name' => 'matt', 'hobby' => 'coding'],
+                ['name' => 'tomo', 'hobby' => 'cooking'],
+            ],
+            $data->pluckMany(['name', 'hobby'])->all()
+        );
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testPluckManyWithArrayAccessValues($collection)
+    {
+        $data = new $collection([
+            new TestArrayAccessImplementation(['id' => 1, 'name' => 'marco', 'hobby' => 'drinking']),
+            new TestArrayAccessImplementation(['id' => 2, 'name' => 'belle', 'hobby' => 'cross-stitch']),
+        ]);
+
+        $this->assertEquals([
+                (object) ['name' => 'marco', 'hobby' => 'drinking'],
+                (object) ['name' => 'belle', 'hobby' => 'cross-stitch'],
+            ],
+            $data->pluckMany(['name', 'hobby'])->all()
+        );
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2107,8 +2107,8 @@ class SupportCollectionTest extends TestCase
         ]);
 
         $this->assertEquals([
-                (object) ['name' => 'marco', 'hobby' => 'drinking'],
-                (object) ['name' => 'belle', 'hobby' => 'cross-stitch'],
+                ['name' => 'marco', 'hobby' => 'drinking'],
+                ['name' => 'belle', 'hobby' => 'cross-stitch'],
             ],
             $data->pluckMany(['name', 'hobby'])->all()
         );


### PR DESCRIPTION
Thanks for providing Laravel! I hope I can contribute something useful.

### Background
Laravel provides the pluck() method on Collections to retrieve one attribute/key from each item in a Collection. There is no convenient means however to pluck more than one attribute or key at a time.

The current means are for example `$collection->map->only(['name', 'email'])` (if the Collection only contains other Collections), or the below if the Collection only contains arrays.

```
$collection->map(function ($item) {
    return Arr::only($item, ['name', 'email']);
});
```

If the Collection contains objects that implement ArrayAccess, or Collections that contain mixed items, it only becomes more complicated.

I believe there is demand for a solution to this problem because retrieving subsets of data is a common task, and many people have searched for solutions as evidenced by this Stack Overflow with 156k views:
https://stackoverflow.com/questions/38412091/get-only-specific-attributes-with-from-laravel-collection

### Change
This change would introduce the pluckMany() method to pluck more than one key or attribute from a Collection at a time. It has the same behaviour as for example `$collection->map->only(['name', 'email'])` but it is agnostic to the type of items in the Collection (they can be Collections, arrays, implementations of ArrayAccess, objects, or any combination of these).

### Example usage
```
$collection = collect([
    ['id' => 1, 'name' => 'matt', 'hobby' => 'coding'],
    (object) ['id' => 2, 'name' => 'tomo', 'hobby' => 'cooking'],
    new ImplementsArrayAccess(['id' => 3, 'name' => 'marco', 'hobby' => 'drinking']),
    collect(['id' => 4, 'name' => 'belle', 'hobby' => 'cross-stitch']),
]);

$collection->pluckMany(['name', 'hobby']);

// returns a new Collection object:
// collect([
//     ['name' => 'matt', 'hobby' => 'coding'],
//     (object) ['name' => 'tomo', 'hobby' => 'cooking'],
//     ['name' => 'marco', 'hobby' => 'drinking'],
//     collect(['name' => 'belle', 'hobby' => 'cross-stitch']),
// ])
```

### Design decisions
* When an item implements ArrayAccess, it is converted into a plain array. I felt like this was the most intuitive behaviour because although it was an object, it ensures the interface to access its keys stays the same.

### Impact
There should be no impact on existing behaviour because it is an addition of a new method only.

Please let me know your thoughts or if there's anything you'd like me to change.