### PR TITLE
[8.x] Show a pretty diff for `assertExactJson()`

### DIFF
--- a/src/Illuminate/Testing/AssertableJsonString.php
+++ b/src/Illuminate/Testing/AssertableJsonString.php
@@ -96,7 +96,10 @@ class AssertableJsonString implements ArrayAccess, Countable
 
         $expected = $this->reorderAssocKeys($data);
 
-        PHPUnit::assertEquals(json_encode($expected), json_encode($actual));
+        PHPUnit::assertEquals(
+            json_encode($expected, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES),
+            json_encode($actual, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)
+        );
 
         return $this;
     }


### PR DESCRIPTION
When using `assertExactJson()` with a large payload, it can be *incredibly* difficult to compare the "expected" and "actual" values to see what caused the failure.

This PR pretty-prints the JSON before asserting, which allows PHPUnit to show the specific lines that didn't match, with a few lines of context.

**Before**
![image](https://user-images.githubusercontent.com/4977161/131934711-7ac4d89e-6cb2-42b1-aaea-5468b8d7e490.png)

**After**
![image](https://user-images.githubusercontent.com/4977161/131934904-47de040b-ac89-43b9-9ca7-b485a5f9483a.png)

I couldn't find a way to test this new behaviour which didn't just seem to be testing PHPUnit itself.