### PR TITLE
[8.x] Add support for disallowing class morphs

### DIFF
--- a/src/Illuminate/Database/ClassMorphViolationException.php
+++ b/src/Illuminate/Database/ClassMorphViolationException.php
@@ -22,7 +22,7 @@ class ClassMorphViolationException extends RuntimeException
     {
         $class = get_class($model);
 
-        parent::__construct("No morph map found for model [{$class}] while class morphs is disabled.");
+        parent::__construct("No morph map defined for model [{$class}].");
 
         $this->model = $class;
     }

--- a/src/Illuminate/Database/ClassMorphViolationException.php
+++ b/src/Illuminate/Database/ClassMorphViolationException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Illuminate\Database;
+
+use RuntimeException;
+
+class ClassMorphViolationException extends RuntimeException
+{
+    /**
+     * The name of the affected Eloquent model.
+     *
+     * @var string
+     */
+    public $model;
+
+    /**
+     * Create a new exception instance.
+     *
+     * @param  object  $model
+     */
+    public function __construct($model)
+    {
+        $class = get_class($model);
+
+        parent::__construct("No morph map found for model [{$class}] while class morphs is disabled.");
+
+        $this->model = $class;
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -54,13 +54,6 @@ trait HasRelationships
     protected static $relationResolvers = [];
 
     /**
-     * Prevents morph relationships without a morph map.
-     *
-     * @var bool
-     */
-    protected static $preventClassMorphs = false;
-
-    /**
      * Define a dynamic relation resolver.
      *
      * @param  string  $name
@@ -73,17 +66,6 @@ trait HasRelationships
             static::$relationResolvers,
             [static::class => [$name => $callback]]
         );
-    }
-
-    /**
-     * Prevent morphs to be used without a mapping.
-     *
-     * @param  bool  $prevent
-     * @return void
-     */
-    public static function preventClassMorphs($prevent = true)
-    {
-        self::$preventClassMorphs = $prevent;
     }
 
     /**
@@ -750,7 +732,7 @@ trait HasRelationships
             return array_search(static::class, $morphMap, true);
         }
 
-        if (self::$preventClassMorphs) {
+        if (Relation::requiresMorphMap()) {
             throw new ClassMorphViolationException($this);
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -58,6 +58,13 @@ abstract class Relation
     public static $morphMap = [];
 
     /**
+     * Prevents morph relationships without a morph map.
+     *
+     * @var bool
+     */
+    protected static $requireMorphMap = false;
+
+    /**
      * The count of self joins.
      *
      * @var int
@@ -374,6 +381,27 @@ abstract class Relation
                     && in_array($model->getKeyType(), ['int', 'integer'])
                         ? 'whereIntegerInRaw'
                         : 'whereIn';
+    }
+
+    /**
+     * Prevent polymorphic relationships from being used without model mappings.
+     *
+     * @param  bool  $requireMorphMap
+     * @return void
+     */
+    public static function requireMorphMap($requireMorphMap = true)
+    {
+        static::$requireMorphMap = $requireMorphMap;
+    }
+
+    /**
+     * Determine if polymorphic relationships require explicit model mapping.
+     *
+     * @return bool
+     */
+    public static function requiresMorphMap()
+    {
+        return static::$requireMorphMap;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -405,6 +405,20 @@ abstract class Relation
     }
 
     /**
+     * Define the morph map for polymorphic relations and require all morphed models to be explicitly mapped.
+     *
+     * @param  array|null  $map
+     * @param  bool  $merge
+     * @return array
+     */
+    public static function enforceMorphMap(array $map, $merge = true)
+    {
+        static::requireMorphMap();
+
+        return static::morphMap($map, $merge);
+    }
+
+    /**
      * Set or get the morph map for polymorphic relations.
      *
      * @param  array|null  $map

--- a/tests/Integration/Database/EloquentStrictMorphsTest.php
+++ b/tests/Integration/Database/EloquentStrictMorphsTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Database\ClassMorphViolationException;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Orchestra\Testbench\TestCase;
+
+class EloquentStrictMorphsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Model::preventClassMorphs();
+    }
+
+    public function testStrictModeThrowsAnExceptionOnClassMap()
+    {
+        $this->expectException(ClassMorphViolationException::class);
+
+        $model = TestModel::make();
+
+        $model->getMorphClass();
+    }
+
+    public function testStrictModeDoesNotThrowExceptionWhenMorphMap()
+    {
+        $model = TestModel::make();
+
+        Relation::morphMap([
+            'test' => TestModel::class,
+        ]);
+
+        $morphName = $model->getMorphClass();
+        $this->assertEquals('test', $morphName);
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        Relation::morphMap([], false);
+        Model::preventClassMorphs(false);
+    }
+}
+
+class TestModel extends Model
+{
+}

--- a/tests/Integration/Database/EloquentStrictMorphsTest.php
+++ b/tests/Integration/Database/EloquentStrictMorphsTest.php
@@ -37,6 +37,20 @@ class EloquentStrictMorphsTest extends TestCase
         $this->assertEquals('test', $morphName);
     }
 
+    public function testMapsCanBeEnforcedInOneMethod()
+    {
+        $model = TestModel::make();
+
+        Relation::requireMorphMap(false);
+
+        Relation::enforceMorphMap([
+            'test' => TestModel::class,
+        ]);
+
+        $morphName = $model->getMorphClass();
+        $this->assertEquals('test', $morphName);
+    }
+
     protected function tearDown(): void
     {
         parent::tearDown();

--- a/tests/Integration/Database/EloquentStrictMorphsTest.php
+++ b/tests/Integration/Database/EloquentStrictMorphsTest.php
@@ -13,7 +13,7 @@ class EloquentStrictMorphsTest extends TestCase
     {
         parent::setUp();
 
-        Model::preventClassMorphs();
+        Relation::requireMorphMap();
     }
 
     public function testStrictModeThrowsAnExceptionOnClassMap()
@@ -42,7 +42,7 @@ class EloquentStrictMorphsTest extends TestCase
         parent::tearDown();
 
         Relation::morphMap([], false);
-        Model::preventClassMorphs(false);
+        Relation::requireMorphMap(false);
     }
 }
 


### PR DESCRIPTION
This PR adds a new prevention flag to models. This flag is for disallowing morphs without a morph map on it. 

For enabling it simply do a
```php
Model::preventClassMorphs();
```

When a model does not have a morh map registered a `ClassMorphViolationException` will be thrown.

For preventing the exception, simply register the model in the morph map
```php
Relation::morphMap([
    'user' => User::class,
]);
```