### PR TITLE
[8.x] Custom value translation in FormRequest

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -112,7 +112,8 @@ class FormRequest extends Request implements ValidatesWhenResolved
         return $factory->make(
             $this->validationData(), $this->container->call([$this, 'rules']),
             $this->messages(), $this->attributes()
-        )->stopOnFirstFailure($this->stopOnFirstFailure);
+        )->stopOnFirstFailure($this->stopOnFirstFailure)
+            ->addCustomValues($this->values());
     }
 
     /**
@@ -229,6 +230,16 @@ class FormRequest extends Request implements ValidatesWhenResolved
      * @return array
      */
     public function attributes()
+    {
+        return [];
+    }
+
+    /**
+     * Get custom values for validator errors.
+     *
+     * @return array
+     */
+    public function values()
     {
         return [];
     }


### PR DESCRIPTION
Unlike ``customAttributes`` there is no method to set ``customValues`` in FormRequest class.

According to [documentation](https://laravel.com/docs/8.x/validation#specifying-values-in-language-files) we can accomplish that by putting them in ``resources/lang/xx/validation.php``  but it might causes some overlaps specially when using short generic names for model's attributes (e.g ``type.0`` may have different meaning in payments and courses table)

Also I'd like to separate some of translations into dedicated language classes. (In some of my projects we provide admins with a panel to update these files dynamically)

**PaymentRequest.php**
```
public function attributes()
{
    return __('payments.attributes');
}

public function values()
{
    return __('payments.values');
}

public function messages()
{
    return __('payments.messages');
}
```