### PR TITLE
[8.x] Add the index to the JsonResource

### DIFF
--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -17,6 +17,13 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     use ConditionallyLoadsAttributes, DelegatesToResource;
 
     /**
+     * The resource index.
+     *
+     * @var int
+     */
+    protected static $index = 1;
+
+    /**
      * The resource instance.
      *
      * @var mixed
@@ -72,15 +79,33 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
      * Create a new anonymous resource collection.
      *
      * @param  mixed  $resource
+     * @param  int  $startIndex
      * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
      */
-    public static function collection($resource)
+    public static function collection($resource, $startIndex = 1)
     {
+        static::$index = $startIndex ?? 1;
+
         return tap(new AnonymousResourceCollection($resource, static::class), function ($collection) {
             if (property_exists(static::class, 'preserveKeys')) {
                 $collection->preserveKeys = (new static([]))->preserveKeys === true;
             }
         });
+    }
+
+    /**
+     * Return the current resource index and increment it by specified amount.
+     *
+     * @param  int  $increment
+     * @return int
+     */
+    protected static function index($increment = 1)
+    {
+        $index = static::$index;
+
+        static::$index += $increment;
+
+        return $index;
     }
 
     /**


### PR DESCRIPTION
This PR adds a **protected static** `index()` **method** to have access to the current item in the `toArray()` method.

For Example: 

```php
    public function toArray($request)
    {
        return [
            'index' => static::index(),
            'title' => $this->title,
            'content' => $this->content,
        ];
    }
```

It will reset automatically by calling `collection()` method.

```php
    $posts = Post::get();

    return PostResource::collection($posts); //The index reset to 1 by default
```

And also, has the initial value as second parameter to support `pagination` or etc:
```php
   $posts = Post::skip(10)->limit(10)->get();

    PostResource::collection($posts, 11);
```
  