### PR TITLE
[8.x] Adds NullableIf rule

### DIFF
--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -8,8 +8,8 @@ use Illuminate\Validation\Rules\Dimensions;
 use Illuminate\Validation\Rules\Exists;
 use Illuminate\Validation\Rules\In;
 use Illuminate\Validation\Rules\NotIn;
-use Illuminate\Validation\Rules\RequiredIf;
 use Illuminate\Validation\Rules\NullableIf;
+use Illuminate\Validation\Rules\RequiredIf;
 use Illuminate\Validation\Rules\Unique;
 
 class Rule

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -9,6 +9,7 @@ use Illuminate\Validation\Rules\Exists;
 use Illuminate\Validation\Rules\In;
 use Illuminate\Validation\Rules\NotIn;
 use Illuminate\Validation\Rules\RequiredIf;
+use Illuminate\Validation\Rules\NullableIf;
 use Illuminate\Validation\Rules\Unique;
 
 class Rule
@@ -90,6 +91,17 @@ class Rule
     public static function requiredIf($callback)
     {
         return new RequiredIf($callback);
+    }
+
+    /**
+     * Get a nullable_if constraint builder instance.
+     *
+     * @param  callable|bool  $callback
+     * @return \Illuminate\Validation\Rules\NullableIf
+     */
+    public static function nullableIf($callback)
+    {
+        return new NullableIf($callback);
     }
 
     /**

--- a/src/Illuminate/Validation/Rules/NullableIf.php
+++ b/src/Illuminate/Validation/Rules/NullableIf.php
@@ -21,7 +21,7 @@ class NullableIf
      */
     public function __construct($condition)
     {
-        if (!is_string($condition)) {
+        if (! is_string($condition)) {
             $this->condition = $condition;
         } else {
             throw new InvalidArgumentException('The provided condition must be a callable or boolean.');

--- a/src/Illuminate/Validation/Rules/NullableIf.php
+++ b/src/Illuminate/Validation/Rules/NullableIf.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+use InvalidArgumentException;
+
+class NullableIf
+{
+    /**
+     * The condition that validates the attribute.
+     *
+     * @var callable|bool
+     */
+    public $condition;
+
+    /**
+     * Create a new required validation rule based on a condition.
+     *
+     * @param  callable|bool  $condition
+     * @return void
+     */
+    public function __construct($condition)
+    {
+        if (!is_string($condition)) {
+            $this->condition = $condition;
+        } else {
+            throw new InvalidArgumentException('The provided condition must be a callable or boolean.');
+        }
+    }
+
+    /**
+     * Convert the rule to a validation string.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        if (is_callable($this->condition)) {
+            return call_user_func($this->condition) ? 'nullable' : '';
+        }
+
+        return $this->condition ? 'nullable' : '';
+    }
+}

--- a/tests/Validation/ValidationNullableIfTest.php
+++ b/tests/Validation/ValidationNullableIfTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Illuminate\Validation\Rules\NullableIf;
+use PHPUnit\Framework\TestCase;
+
+class ValidationNullableIfTest extends TestCase
+{
+    public function testItCorrectlyFormatsAStringVersionOfTheRule()
+    {
+        $rule = new NullableIf(function () {
+            return true;
+        });
+
+        $this->assertSame('nullable', (string) $rule);
+
+        $rule = new NullableIf(function () {
+            return false;
+        });
+
+        $this->assertSame('', (string) $rule);
+
+        $rule = new NullableIf(true);
+
+        $this->assertSame('nullable', (string) $rule);
+
+        $rule = new NullableIf(false);
+
+        $this->assertSame('', (string) $rule);
+    }
+}


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

The scenario that lead me to add this rule was the following:

When updating a resource, a particular field could be `null` unless a certain condition was met. Here, `null` is not an ignored value, it should update the resource database field to `null`.

The way I achieved this was with a combination of `nullable` and `requiredIf` rules, but as a consequence, I needed to include the field in the request.

Having a `NullableIf` rule would allow this validation to be more effective and readable.
