### PR TITLE
[8.x] Fix the inconsistency in the In validation

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1101,14 +1101,12 @@ trait ValidatesAttributes
     {
         if (is_array($value) && $this->hasRule($attribute, 'Array')) {
             foreach ($value as $element) {
-                if (is_array($element)) {
+                if (!in_array($element, $parameters, true) || is_array($element)) {
                     return false;
                 }
             }
-
-            return count(array_diff($value, $parameters)) === 0;
+            return true;
         }
-
         return ! is_array($value) && in_array((string) $value, $parameters);
     }
 

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1105,8 +1105,7 @@ trait ValidatesAttributes
                     return false;
                 }
             }
-
-        } elseif(! in_array($value, $parameters, true)) {
+        } elseif (! in_array($value, $parameters, true)) {
             return false;
         }
 

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1101,7 +1101,7 @@ trait ValidatesAttributes
     {
         if (is_array($value) && $this->hasRule($attribute, 'Array')) {
             foreach ($value as $element) {
-                if (!in_array($element, $parameters, true) || is_array($element)) {
+                if (! in_array($element, $parameters, true) || is_array($element)) {
                     return false;
                 }
             }

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1105,6 +1105,7 @@ trait ValidatesAttributes
                     return false;
                 }
             }
+
         } elseif(! in_array($value, $parameters, true)) {
             return false;
         }

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1105,11 +1105,11 @@ trait ValidatesAttributes
                     return false;
                 }
             }
-
-            return true;
+        } elseif(! in_array($value, $parameters, true)) {
+            return false;
         }
 
-        return ! is_array($value) && in_array((string) $value, $parameters);
+        return true;
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1105,9 +1105,11 @@ trait ValidatesAttributes
                     return false;
                 }
             }
+
             return true;
         }
-        return ! is_array($value) && in_array((string) $value, $parameters);
+
+        return !is_array($value) && in_array((string) $value, $parameters);
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1109,7 +1109,7 @@ trait ValidatesAttributes
             return true;
         }
 
-        return !is_array($value) && in_array((string) $value, $parameters);
+        return ! is_array($value) && in_array((string) $value, $parameters);
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2569,7 +2569,6 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['name' => 'foo'], ['name' => 'In:bar,baz']);
         $this->assertFalse($v->passes());
 
-        $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['name' => 0], ['name' => 'In:bar,baz']);
         $this->assertFalse($v->passes());
 
@@ -2595,6 +2594,33 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['name' => ['foo', []]], ['name' => 'Array|In:foo,bar']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['name' => 0], ['name' => 'In:bar,baz']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['name' => 1], ['name' => 'In:true']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['name' => true], ['name' => 'In:true']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['name' => false], ['name' => 'In:false']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['name' => false], ['name' => 'In:0']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['name' => 'true'], ['name' => 'In:true']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['name' => 'false'], ['name' => 'In:false']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['name' => '1'], ['name' => 'In:true']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['name' => '0'], ['name' => 'In:false']);
         $this->assertFalse($v->passes());
     }
 


### PR DESCRIPTION
### Description

This is a pull request to fix the issue concerning [#38378](https://github.com/laravel/framework/issues/38378) regarding @eitheds issue.

### Solution

We used array_diff() to compare arrays inside the validation, by enabling the strict method on the in_array() method we avoid the confusion of booleans with 1s, and give the In rule a single task. 1s shouldn't be confused with a true, as we are looping over the entire array and not looking at the key value.

