### PR TITLE
[9.x] Allow withDefault to return null on relations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/SupportsDefaultModels.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/SupportsDefaultModels.php
@@ -51,7 +51,7 @@ trait SupportsDefaultModels
         $instance = $this->newRelatedInstanceFor($parent);
 
         if (is_callable($this->withDefault)) {
-            return call_user_func($this->withDefault, $instance, $parent) ?: $instance;
+            return call_user_func($this->withDefault, $instance, $parent);
         }
 
         if (is_array($this->withDefault)) {

--- a/tests/Database/DatabaseEloquentBelongsToTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToTest.php
@@ -38,6 +38,8 @@ class DatabaseEloquentBelongsToTest extends TestCase
     {
         $relation = $this->getRelation()->withDefault(function ($newModel) {
             $newModel->username = 'taylor';
+
+            return $newModel;
         });
 
         $this->builder->shouldReceive('first')->once()->andReturnNull();
@@ -49,6 +51,21 @@ class DatabaseEloquentBelongsToTest extends TestCase
         $this->assertSame($newModel, $relation->getResults());
 
         $this->assertSame('taylor', $newModel->username);
+    }
+
+    public function testBelongsToWithDynamicDefaultThatReturnsNull()
+    {
+        $relation = $this->getRelation()->withDefault(function ($newModel) {
+            return null;
+        });
+
+        $this->builder->shouldReceive('first')->once()->andReturnNull();
+
+        $newModel = new EloquentBelongsToModelStub();
+
+        $this->related->shouldReceive('newInstance')->once()->andReturn($newModel);
+
+        $this->assertNull($relation->getResults());
     }
 
     public function testBelongsToWithArrayDefault()

--- a/tests/Database/DatabaseEloquentHasOneTest.php
+++ b/tests/Database/DatabaseEloquentHasOneTest.php
@@ -43,6 +43,8 @@ class DatabaseEloquentHasOneTest extends TestCase
     {
         $relation = $this->getRelation()->withDefault(function ($newModel) {
             $newModel->username = 'taylor';
+
+            return $newModel;
         });
 
         $this->builder->shouldReceive('first')->once()->andReturnNull();
@@ -62,6 +64,8 @@ class DatabaseEloquentHasOneTest extends TestCase
     {
         $relation = $this->getRelation()->withDefault(function ($newModel, $parentModel) {
             $newModel->username = $parentModel->username;
+
+            return $newModel;
         });
 
         $this->builder->shouldReceive('first')->once()->andReturnNull();

--- a/tests/Database/DatabaseEloquentMorphToTest.php
+++ b/tests/Database/DatabaseEloquentMorphToTest.php
@@ -70,6 +70,8 @@ class DatabaseEloquentMorphToTest extends TestCase
     {
         $relation = $this->getRelation()->withDefault(function ($newModel) {
             $newModel->username = 'taylor';
+
+            return $newModel;
         });
 
         $this->builder->shouldReceive('first')->once()->andReturnNull();


### PR DESCRIPTION
Currently you are not able to override the `withDefault` method with a callable and have it return `null`

This means scenarios where you want to **optionally** return a default value is not possible.

E.g. in the below, you want to optionally return a model default but ONLY if the member was deleted.

```php
public function createdBy()
{
	return $this->belongsTo(Member::class, 'created_by')->withDefault(function($blankMember, $note) {
		$deletedLog = MemberRepository::make()->findDeletedLog($note->created_by);

		if (! $deletedLog) {
			return null; // Laravel will currently ignore this and just create a new member model instance.
		}

		$blankMember->username = $deletedLog->username;

		return $blankMember;
	});
}
```

**This would be a breaking change.** But it's more intuitive behaviour and allows complete control over what value `withDefault` will use. The code change to support this would be minimal.

**Before**

```php
public function user()
{
    return $this->belongsTo(User::class)->withDefault(function ($user, $post) {
        $user->name = 'Guest Author';
    });
}
```

**After**
```php
public function user()
{
    return $this->belongsTo(User::class)->withDefault(function ($user, $post) {
        $user->name = 'Guest Author';

        return $user; // Make sure to return a value
    });
}
```