### PR TITLE
[8.x] Register macros with Mail::fake() in tests

### DIFF
--- a/src/Illuminate/Macroable/Traits/Macroable.php
+++ b/src/Illuminate/Macroable/Traits/Macroable.php
@@ -29,6 +29,16 @@ trait Macroable
     }
 
     /**
+     * Return the macros registered for the class.
+     *
+     * @return array
+     */
+    public static function macros()
+    {
+        return static::$macros;
+    }
+
+    /**
      * Mix another object into the class.
      *
      * @param  object  $mixin

--- a/src/Illuminate/Support/Facades/Mail.php
+++ b/src/Illuminate/Support/Facades/Mail.php
@@ -40,7 +40,13 @@ class Mail extends Facade
      */
     public static function fake()
     {
+        $macros = static::mailer()->macros();
+
         static::swap($fake = new MailFake);
+
+        foreach ($macros as $name => $macro) {
+            static::macro($name, $macro);
+        }
 
         return $fake;
     }

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -8,12 +8,14 @@ use Illuminate\Contracts\Mail\Mailable;
 use Illuminate\Contracts\Mail\Mailer;
 use Illuminate\Contracts\Mail\MailQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Support\Traits\Macroable;
 use Illuminate\Support\Traits\ReflectsClosures;
 use PHPUnit\Framework\Assert as PHPUnit;
 
 class MailFake implements Factory, Mailer, MailQueue
 {
     use ReflectsClosures;
+    use Macroable;
 
     /**
      * The mailer currently being used to send a message.

--- a/tests/Testing/MailFakeTest.php
+++ b/tests/Testing/MailFakeTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Illuminate\Tests\Testing;
+
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Tests\Mail\MailableQueueableStub;
+use Orchestra\Testbench\TestCase;
+
+class MailFakeTest extends TestCase
+{
+    public function testMacrosAreCopiedToMailFake()
+    {
+        Mail::macro('myMacro', function ($param) {
+            return $this;
+        });
+
+        Mail::fake();
+
+        Mail::myMacro('hello')
+            ->to('test@example.com')
+            ->send(new MailableQueueableStub());
+
+        self::assertEquals(['myMacro'], array_keys(Mail::mailer()->macros()));
+    }
+}

--- a/tests/Testing/MailFakeTest.php
+++ b/tests/Testing/MailFakeTest.php
@@ -3,23 +3,20 @@
 namespace Illuminate\Tests\Testing;
 
 use Illuminate\Support\Facades\Mail;
-use Illuminate\Tests\Mail\MailableQueueableStub;
 use Orchestra\Testbench\TestCase;
 
 class MailFakeTest extends TestCase
 {
-    public function testMacrosAreCopiedToMailFake()
+    public function testMacrosCanBeUsedWithMailFake()
     {
-        Mail::macro('myMacro', function ($param) {
-            return $this;
+        Mail::macro('foo', function () {
+            return 'bar';
         });
 
         Mail::fake();
 
-        Mail::myMacro('hello')
-            ->to('test@example.com')
-            ->send(new MailableQueueableStub());
-
-        self::assertEquals(['myMacro'], array_keys(Mail::mailer()->macros()));
+        $this->assertSame(
+            'bar', Mail::foo()
+        );
     }
 }


### PR DESCRIPTION
Hi! This PR adds the functionality for macros to be re-registered for the `MailFake` class during tests.

I've added this because I have a macro that is registered for my `Mail` in the `AppServiceProvider`. But it seems that when I was trying to write a test that involved the macro being used, the test kept failing with the following message:

```
Error : Call to undefined method Illuminate\Support\Testing\Fakes\MailFake::myMacro()
```

With this PR, when we call `Mail::fake()`, any of the macros already registered for the `Mail` facade will be re-registered. Hopefully, this means that we can then write the rest of the test as normal to assert that an email was sent.

Apologies if I've approached this from a completely wrong angle and there's a better way to solve it :)