### PR TITLE
[8.x] Add AssertableJson::each() method

### DIFF
--- a/src/Illuminate/Testing/Fluent/AssertableJson.php
+++ b/src/Illuminate/Testing/Fluent/AssertableJson.php
@@ -118,6 +118,32 @@ class AssertableJson implements Arrayable
     }
 
     /**
+     * Instantiate a new "scope" on each child element.
+     *
+     * @param  \Closure  $callback
+     * @return $this
+     */
+    public function each(Closure $callback): self
+    {
+        $props = $this->prop();
+
+        $path = $this->dotPath();
+
+        PHPUnit::assertNotEmpty($props, $path === ''
+            ? 'Cannot scope directly onto each element of the root level because it is empty.'
+            : sprintf('Cannot scope directly onto each element of property [%s] because it is empty.', $path)
+        );
+
+        foreach (array_keys($props) as $key) {
+            $this->interactsWith($key);
+
+            $this->scope($key, $callback);
+        }
+
+        return $this;
+    }
+
+    /**
      * Create a new instance from an array.
      *
      * @param  array  $data

--- a/tests/Testing/Fluent/AssertTest.php
+++ b/tests/Testing/Fluent/AssertTest.php
@@ -699,6 +699,64 @@ class AssertTest extends TestCase
         });
     }
 
+    public function testEachScope()
+    {
+        $assert = AssertableJson::fromArray([
+            'foo' => [
+                'key' => 'first',
+            ],
+            'bar' => [
+                'key' => 'second',
+            ],
+        ]);
+
+        $assert->each(function (AssertableJson $item) {
+            $item->whereType('key', 'string');
+        });
+    }
+
+    public function testEachScopeFailsWhenNoProps()
+    {
+        $assert = AssertableJson::fromArray([]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Cannot scope directly onto each element of the root level because it is empty.');
+
+        $assert->each(function (AssertableJson $item) {
+            //
+        });
+    }
+
+    public function testEachNestedScopeFailsWhenNoProps()
+    {
+        $assert = AssertableJson::fromArray([
+            'foo' => [],
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Cannot scope directly onto each element of property [foo] because it is empty.');
+
+        $assert->has('foo', function (AssertableJson $assert) {
+            $assert->each(function (AssertableJson $item) {
+                //
+            });
+        });
+    }
+
+    public function testEachScopeFailsWhenPropSingleValue()
+    {
+        $assert = AssertableJson::fromArray([
+            'foo' => 'bar',
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Property [foo] is not scopeable.');
+
+        $assert->each(function (AssertableJson $item) {
+            //
+        });
+    }
+
     public function testFailsWhenNotInteractingWithAllPropsInScope()
     {
         $assert = AssertableJson::fromArray([


### PR DESCRIPTION
This PR adds an `each()` method, similar to `first()` on the `\Illuminate\Testing\Fluent\AssertableJson` class to assert on each element of the current JSON.
This is helpful if you want to ensure that every object in the `data` key has the same structure for example. Or that each element has a `0 <= price <= 10` to test filter logic.

I'm not sure if that method should be added as abstract to `\Illuminate\Testing\Fluent\Concerns\Has` like the `first()` right now. If so I would assume that this is a breaking change and should be targeted to Laravel 9!?