### PR TITLE
[8.x] Prepend and append to the current chain

### DIFF
--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -192,7 +192,6 @@ trait Queueable
         return $this;
     }
 
-
     /**
      * Prepend jobs to the chain to be run if this job is successful.
      *

--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -222,7 +222,7 @@ trait Queueable
 
         return $this;
     }
-    
+
     /**
      * Serialize a job for queuing.
      *

--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -192,6 +192,38 @@ trait Queueable
         return $this;
     }
 
+
+    /**
+     * Prepend jobs to the chain to be run if this job is successful.
+     *
+     * @param array $chain
+     * @return $this
+     */
+    public function prependChain($chain)
+    {
+        $this->chained = collect($chain)->map(function ($job) {
+            return $this->serializeJob($job);
+        })->merge(collect($this->chained))->all();
+
+        return $this;
+    }
+
+    /**
+     * Append jobs to the chain to be run if this job is successful.
+     *
+     * @param array $chain
+     * @return $this
+     */
+    public function appendChain($chain)
+    {
+        $this->chained = collect($this->chained)
+            ->merge(collect($chain)->map(function ($job) {
+                return $this->serializeJob($job);
+            }))->all();
+
+        return $this;
+    }
+    
     /**
      * Serialize a job for queuing.
      *

--- a/tests/Integration/Queue/JobChainingTest.php
+++ b/tests/Integration/Queue/JobChainingTest.php
@@ -218,6 +218,36 @@ class JobChainingTest extends TestCase
         $this->assertNull(JobChainingTestThirdJob::$usedQueue);
         $this->assertNull(JobChainingTestThirdJob::$usedConnection);
     }
+
+    public function testChainPrepend()
+    {
+        $job = new JobChainingTestFirstJob();
+        $job->chain([
+            new JobChainingTestThirdJob()
+        ]);
+        $job->prependChain([
+            new JobChainingTestSecondJob()
+        ]);
+
+        $this->assertCount(2, $job->chained);
+        $this->assertInstanceOf(JobChainingTestSecondJob::class, unserialize($job->chained[0]));
+        $this->assertInstanceOf(JobChainingTestThirdJob::class, unserialize($job->chained[1]));
+    }
+
+    public function testChainAppend()
+    {
+        $job = new JobChainingTestFirstJob();
+        $job->chain([
+            new JobChainingTestSecondJob()
+        ]);
+        $job->appendChain([
+            new JobChainingTestThirdJob()
+        ]);
+
+        $this->assertCount(2, $job->chained);
+        $this->assertInstanceOf(JobChainingTestSecondJob::class, unserialize($job->chained[0]));
+        $this->assertInstanceOf(JobChainingTestThirdJob::class, unserialize($job->chained[1]));
+    }
 }
 
 class JobChainingTestFirstJob implements ShouldQueue

--- a/tests/Integration/Queue/JobChainingTest.php
+++ b/tests/Integration/Queue/JobChainingTest.php
@@ -223,10 +223,10 @@ class JobChainingTest extends TestCase
     {
         $job = new JobChainingTestFirstJob();
         $job->chain([
-            new JobChainingTestThirdJob()
+            new JobChainingTestThirdJob(),
         ]);
         $job->prependChain([
-            new JobChainingTestSecondJob()
+            new JobChainingTestSecondJob(),
         ]);
 
         $this->assertCount(2, $job->chained);
@@ -238,10 +238,10 @@ class JobChainingTest extends TestCase
     {
         $job = new JobChainingTestFirstJob();
         $job->chain([
-            new JobChainingTestSecondJob()
+            new JobChainingTestSecondJob(),
         ]);
         $job->appendChain([
-            new JobChainingTestThirdJob()
+            new JobChainingTestThirdJob(),
         ]);
 
         $this->assertCount(2, $job->chained);


### PR DESCRIPTION
This PR adds the ability to prepend and append jobs in the current chain.
The `chain()` method exists but that overrides the chain. 

With the scenario where you have three jobs where the second job is dispatched by the first Job and the third job needs to wait for the second job to complete. If you use the chain method the third job gets lost.

1. Job 1 - Dispatches Job 2
    1a. Job 2
2. Job 3 - Needs to wait for Job 2 to finish

When you chain Job 1 and 3 and call `chain()` in Job 1 to add Job 2, Job 3 gets deleted.

