### PR TITLE
[8.x] Add return type to console generation stub

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/console.stub
+++ b/src/Illuminate/Foundation/Console/stubs/console.stub
@@ -35,7 +35,7 @@ class {{ class }} extends Command
      *
      * @return int
      */
-    public function handle()
+    public function handle(): int
     {
         return 0;
     }


### PR DESCRIPTION
**benefit to end users**
This change strengthens the type safety of the generated code.

**reasons it does not break any existing features**
The return parameter "int" is compatible with PHP 7.3, 7.4 and PHP 8. It affects only new commands.

