### PR TITLE
[8.x] add collation argument to query builder orderBy

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1962,11 +1962,12 @@ class Builder
      *
      * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Query\Expression|string  $column
      * @param  string  $direction
+     * @param  null|string $collation
      * @return $this
      *
      * @throws \InvalidArgumentException
      */
-    public function orderBy($column, $direction = 'asc')
+    public function orderBy($column, $direction = 'asc', $collation = null)
     {
         if ($this->isQueryable($column)) {
             [$query, $bindings] = $this->createSub($column);
@@ -1985,6 +1986,7 @@ class Builder
         $this->{$this->unions ? 'unionOrders' : 'orders'}[] = [
             'column' => $column,
             'direction' => $direction,
+            'collation' => $collation
         ];
 
         return $this;

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1986,7 +1986,7 @@ class Builder
         $this->{$this->unions ? 'unionOrders' : 'orders'}[] = [
             'column' => $column,
             'direction' => $direction,
-            'collation' => $collation
+            'collation' => $collation,
         ];
 
         return $this;

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -736,6 +736,7 @@ class Grammar extends BaseGrammar
     {
         return array_map(function ($order) {
             $collation = isset($order['collation']) ? ' collate '.$order['collation'] : '';
+
             return $order['sql'] ?? $this->wrap($order['column']).' '.$order['direction'].$collation;
         }, $orders);
     }

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -735,7 +735,8 @@ class Grammar extends BaseGrammar
     protected function compileOrdersToArray(Builder $query, $orders)
     {
         return array_map(function ($order) {
-            return $order['sql'] ?? $this->wrap($order['column']).' '.$order['direction'];
+            $collation = isset($order['collation']) ? ' collate '.$order['collation'] : '';
+            return $order['sql'] ?? $this->wrap($order['column']).' '.$order['direction'].$collation;
         }, $orders);
     }
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1173,6 +1173,9 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->orders = [];
         $this->assertSame('select * from "users"', $builder->toSql());
 
+        $builder->orderBy('email', 'asc', 'my_test_collation');
+        $this->assertSame('select * from "users" order by "email" asc collate my_test_collation', $builder->toSql());
+
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->orderBy('email')->orderByRaw('"age" ? desc', ['foo']);
         $this->assertSame('select * from "users" order by "email" asc, "age" ? desc', $builder->toSql());


### PR DESCRIPTION
This pull request makes it easier to add a collation to an order by clause in SQL generated by the query builder.

Background:
In internationalized web apps, users can typically select their language. Among the things that change based on the selected language are not only translated strings in the UI or date / time formats but also sorting order. Databases implement this via collations, it's possible to specify the collation not only when creating databases / tables but also for a single query.

So far, Laravel only allowed building queries with specified collation in an order by clause by using `orderByRaw()`. This is not great when you want to internationalize your project and have to switch from `orderBy()` to `orderByRaw()` throughout your code base.

Implementation:

This pull request adds an optional 3rd argument to `orderBy()` called `$collation`, defaulting to null. If it's null, no collation information is added to the generated SQL, making it fully backwards compatible.

If a collation information is given, `" collate " . $collation` is appended to the generated SQL.

This syntax works with all four supported database engines. The names of the available collations are different from database to database and version to version, but that's anyways up to the developer to specify the collation they want to use.

Tests:

The case that no collation information is given is already covered by the existing tests which compare generated SQL to fixed strings. There is one new test added ensuring that a collation string given in the `orderBy()` leads to the correct SQL.