### PR TITLE
[8.x] Check in the tests if there's a transaction still not closed

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -159,7 +159,7 @@ abstract class TestCase extends BaseTestCase
             foreach ($database->getConnections() as $connection) {
                 $transaction_level = $connection->transactionLevel();
                 if ($transaction_level !== 0) {
-                    throw new \DomainException("Invalid transaction level: ".$transaction_level);
+                    throw new \DomainException('Invalid transaction level: '.$transaction_level);
                 }
             }
 

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -150,10 +150,20 @@ abstract class TestCase extends BaseTestCase
      * @return void
      *
      * @throws \Mockery\Exception\InvalidCountException
+     * @throws \DomainException
      */
     protected function tearDown(): void
     {
         if ($this->app) {
+            
+            $database = $this->app->make('db');
+            foreach ($database->getConnections() as $connection) {
+                $transaction_level = $connection->transactionLevel();
+                if ($transaction_level !== 0) {
+                    throw new \DomainException("Invalid transaction level: ". $transaction_level);
+                }
+            }
+
             $this->callBeforeApplicationDestroyedCallbacks();
 
             ParallelTesting::callTearDownTestCaseCallbacks($this);

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -155,12 +155,11 @@ abstract class TestCase extends BaseTestCase
     protected function tearDown(): void
     {
         if ($this->app) {
-            
             $database = $this->app->make('db');
             foreach ($database->getConnections() as $connection) {
                 $transaction_level = $connection->transactionLevel();
                 if ($transaction_level !== 0) {
-                    throw new \DomainException("Invalid transaction level: ". $transaction_level);
+                    throw new \DomainException("Invalid transaction level: ".$transaction_level);
                 }
             }
 

--- a/tests/Testing/PendingTransactionTesting.php
+++ b/tests/Testing/PendingTransactionTesting.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Illuminate\Tests\Testing;
+
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Foundation\Testing\TestCase;
+use Orchestra\Testbench\Concerns\CreatesApplication;
+
+class PendingTransactionTesting extends TestCase
+{
+    use CreatesApplication;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->app['config']->set('database.default', 'testing');    
+    }
+
+    public function testItThrowsAnExceptionIfPendingTransaction()
+    {
+        \DB::beginTransaction();
+    }
+
+    public function testItDoesntThrowAnExceptionIfTransactionClosed()
+    {
+        \DB::beginTransaction();
+        \DB::beginTransaction();
+        \DB::rollback();
+        \DB::rollback();
+    }
+}

--- a/tests/Testing/PendingTransactionTesting.php
+++ b/tests/Testing/PendingTransactionTesting.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Tests\Testing;
 
-use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Foundation\Testing\TestCase;
 use Orchestra\Testbench\Concerns\CreatesApplication;
 
@@ -13,7 +12,7 @@ class PendingTransactionTesting extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        $this->app['config']->set('database.default', 'testing');    
+        $this->app['config']->set('database.default', 'testing');
     }
 
     public function testItThrowsAnExceptionIfPendingTransaction()

--- a/tests/Testing/PendingTransactionTestingTest.php
+++ b/tests/Testing/PendingTransactionTestingTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Illuminate\Tests\Testing;
+
+use Illuminate\Tests\Testing\PendingTransactionTesting;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestSuite;
+
+class PendingTransactionTestingTest extends TestCase
+{
+    public function testItThrowsAnExceptionIfPendingTransaction()
+    {
+        $test = new TestSuite();
+        $test->addTestSuite(PendingTransactionTesting::class);
+        $result = $test->run();
+
+        $this->assertCount(1, $result->errors());
+        $this->assertSame("DomainException: Invalid transaction level: 1", trim($result->errors()[0]->getExceptionAsString()));
+    }
+}

--- a/tests/Testing/PendingTransactionTestingTest.php
+++ b/tests/Testing/PendingTransactionTestingTest.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Tests\Testing;
 
-use Illuminate\Tests\Testing\PendingTransactionTesting;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\TestSuite;
 
@@ -15,6 +14,6 @@ class PendingTransactionTestingTest extends TestCase
         $result = $test->run();
 
         $this->assertCount(1, $result->errors());
-        $this->assertSame("DomainException: Invalid transaction level: 1", trim($result->errors()[0]->getExceptionAsString()));
+        $this->assertSame('DomainException: Invalid transaction level: 1', trim($result->errors()[0]->getExceptionAsString()));
     }
 }


### PR DESCRIPTION
This PR tries to solve a common error in coding, where a transaction is left open inside a class/request, checking after every test if the transaction level is zero.

It's something I always add in my own projects and I think it'd be useful for the framework itself.

Thanks.