### PR TITLE
[8.x] Fix return type of Event::fakeFor()

### DIFF
--- a/src/Illuminate/Support/Facades/Event.php
+++ b/src/Illuminate/Support/Facades/Event.php
@@ -50,7 +50,7 @@ class Event extends Facade
      *
      * @param  callable  $callable
      * @param  array  $eventsToFake
-     * @return callable
+     * @return mixed
      */
     public static function fakeFor(callable $callable, array $eventsToFake = [])
     {


### PR DESCRIPTION
Event::fakeFor() returns the result of $callable(), which can be anything.

Current return type triggers psalm's InvalidPropertyAssignmentValue for the example in https://laravel.com/docs/8.x/mocking#scoped-event-fakes.

