### PR TITLE
[8.x] Lowercase cipher name in the Encrypter `supported` method

### DIFF
--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -49,7 +49,7 @@ class Encrypter implements EncrypterContract, StringEncrypter
     {
         $key = (string) $key;
 
-        if (! static::supported($key, strtolower($cipher))) {
+        if (! static::supported($key, $cipher)) {
             $ciphers = implode(', ', array_keys(self::$supportedCiphers));
 
             throw new RuntimeException("Unsupported cipher or incorrect key length. Supported ciphers are: {$ciphers}.");
@@ -68,11 +68,11 @@ class Encrypter implements EncrypterContract, StringEncrypter
      */
     public static function supported($key, $cipher)
     {
-        if (! isset(self::$supportedCiphers[$cipher])) {
+        if (! isset(self::$supportedCiphers[strtolower($cipher)])) {
             return false;
         }
 
-        return mb_strlen($key, '8bit') === self::$supportedCiphers[$cipher]['size'];
+        return mb_strlen($key, '8bit') === self::$supportedCiphers[strtolower($cipher)]['size'];
     }
 
     /**

--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -183,4 +183,13 @@ class EncrypterTest extends TestCase
         $modified_payload = base64_encode(json_encode($data));
         $e->decrypt($modified_payload);
     }
+
+    public function testSupportedMethodAcceptsAnyCasing()
+    {
+        $key = str_repeat('a', 16);
+
+        $this->assertTrue(Encrypter::supported($key, 'AES-128-GCM'));
+        $this->assertTrue(Encrypter::supported($key, 'aes-128-CBC'));
+        $this->assertTrue(Encrypter::supported($key, 'aes-128-cbc'));
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/38690

This ensure that the public `supported` method in `Encrypter.php` lowercases the cipher name before testing if the cipher is supported. The internal representation changed recently to lowercase (due to an OpenSSL bug, see https://github.com/laravel/framework/pull/38594) which affects direct outside calls to the supported method prior to this PR.

Thanks to @Sn0wCrack for pointing this out!