### PR TITLE
More DB fixes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -79,7 +79,7 @@
     },
     "require-dev": {
         "aws/aws-sdk-php": "^3.189.0",
-        "doctrine/dbal": "^2.6|^3.0",
+        "doctrine/dbal": "^2.13.3|^3.1.2",
         "filp/whoops": "^2.8",
         "guzzlehttp/guzzle": "^6.5.5|^7.0.1",
         "league/flysystem-cached-adapter": "^1.0",
@@ -130,7 +130,7 @@
         "ext-redis": "Required to use the Redis cache and queue drivers (^4.0|^5.0).",
         "aws/aws-sdk-php": "Required to use the SQS queue driver, DynamoDb failed job storage and SES mail driver (^3.189.0).",
         "brianium/paratest": "Required to run tests in parallel (^6.0).",
-        "doctrine/dbal": "Required to rename columns and drop SQLite columns (^2.6|^3.0).",
+        "doctrine/dbal": "Required to rename columns and drop SQLite columns (^2.13.3|^3.1.2).",
         "filp/whoops": "Required for friendly error pages in development (^2.8).",
         "fakerphp/faker": "Required to use the eloquent factory builder (^1.9.1).",
         "guzzlehttp/guzzle": "Required to use the HTTP Client, Mailgun mail driver and the ping methods on schedules (^6.5.5|^7.0.1).",

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -35,7 +35,7 @@
         }
     },
     "suggest": {
-        "doctrine/dbal": "Required to rename columns and drop SQLite columns (^2.6|^3.0).",
+        "doctrine/dbal": "Required to rename columns and drop SQLite columns (^2.13.3|^3.1.2).",
         "fakerphp/faker": "Required to use the eloquent factory builder (^1.9.1).",
         "illuminate/console": "Required to use the database commands (^8.0).",
         "illuminate/events": "Required to use the observers with Eloquent (^8.0).",

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -135,7 +135,7 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $post->tagsWithCustomPivot()->attach($tag->id);
 
         $this->assertInstanceOf(PostTagPivot::class, $post->tagsWithCustomPivot[0]->pivot);
-        $this->assertSame('1507630210', $post->tagsWithCustomPivot[0]->pivot->getAttributes()['created_at']);
+        $this->assertEquals('1507630210', $post->tagsWithCustomPivot[0]->pivot->getAttributes()['created_at']);
 
         $this->assertInstanceOf(PostTagPivot::class, $post->tagsWithCustomPivotClass[0]->pivot);
         $this->assertSame('posts_tags', $post->tagsWithCustomPivotClass()->getTable());
@@ -229,8 +229,8 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         );
         foreach ($post->tagsWithCustomExtraPivot as $tag) {
             $this->assertSame('exclude', $tag->pivot->flag);
-            $this->assertSame('1507630210', $tag->pivot->getAttributes()['created_at']);
-            $this->assertSame('1507630220', $tag->pivot->getAttributes()['updated_at']); // +10 seconds
+            $this->assertEquals('1507630210', $tag->pivot->getAttributes()['created_at']);
+            $this->assertEquals('1507630220', $tag->pivot->getAttributes()['updated_at']); // +10 seconds
         }
     }
 

--- a/tests/Integration/Database/EloquentCollectionLoadCountTest.php
+++ b/tests/Integration/Database/EloquentCollectionLoadCountTest.php
@@ -52,9 +52,9 @@ class EloquentCollectionLoadCountTest extends DatabaseTestCase
         $posts->loadCount('comments');
 
         $this->assertCount(1, DB::getQueryLog());
-        $this->assertSame('2', $posts[0]->comments_count);
-        $this->assertSame('0', $posts[1]->comments_count);
-        $this->assertSame('2', $posts[0]->getOriginal('comments_count'));
+        $this->assertEquals('2', $posts[0]->comments_count);
+        $this->assertEquals('0', $posts[1]->comments_count);
+        $this->assertEquals('2', $posts[0]->getOriginal('comments_count'));
     }
 
     public function testLoadCountWithSameModels()
@@ -66,9 +66,9 @@ class EloquentCollectionLoadCountTest extends DatabaseTestCase
         $posts->loadCount('comments');
 
         $this->assertCount(1, DB::getQueryLog());
-        $this->assertSame('2', $posts[0]->comments_count);
-        $this->assertSame('0', $posts[1]->comments_count);
-        $this->assertSame('2', $posts[2]->comments_count);
+        $this->assertEquals('2', $posts[0]->comments_count);
+        $this->assertEquals('0', $posts[1]->comments_count);
+        $this->assertEquals('2', $posts[2]->comments_count);
     }
 
     public function testLoadCountOnDeletedModels()
@@ -80,8 +80,8 @@ class EloquentCollectionLoadCountTest extends DatabaseTestCase
         $posts->loadCount('comments');
 
         $this->assertCount(1, DB::getQueryLog());
-        $this->assertSame('2', $posts[0]->comments_count);
-        $this->assertSame('0', $posts[1]->comments_count);
+        $this->assertEquals('2', $posts[0]->comments_count);
+        $this->assertEquals('0', $posts[1]->comments_count);
     }
 
     public function testLoadCountWithArrayOfRelations()
@@ -93,10 +93,10 @@ class EloquentCollectionLoadCountTest extends DatabaseTestCase
         $posts->loadCount(['comments', 'likes']);
 
         $this->assertCount(1, DB::getQueryLog());
-        $this->assertSame('2', $posts[0]->comments_count);
-        $this->assertSame('1', $posts[0]->likes_count);
-        $this->assertSame('0', $posts[1]->comments_count);
-        $this->assertSame('0', $posts[1]->likes_count);
+        $this->assertEquals('2', $posts[0]->comments_count);
+        $this->assertEquals('1', $posts[0]->likes_count);
+        $this->assertEquals('0', $posts[1]->comments_count);
+        $this->assertEquals('0', $posts[1]->likes_count);
     }
 
     public function testLoadCountDoesNotOverrideAttributesWithDefaultValue()
@@ -107,7 +107,7 @@ class EloquentCollectionLoadCountTest extends DatabaseTestCase
         Collection::make([$post])->loadCount('comments');
 
         $this->assertSame(200, $post->some_default_value);
-        $this->assertSame('2', $post->comments_count);
+        $this->assertEquals('2', $post->comments_count);
     }
 }
 

--- a/tests/Integration/Database/EloquentPivotEventsTest.php
+++ b/tests/Integration/Database/EloquentPivotEventsTest.php
@@ -91,7 +91,7 @@ class EloquentPivotEventsTest extends DatabaseTestCase
 
         $project->collaborators()->updateExistingPivot($user->id, ['role' => 'Lead Developer']);
 
-        $this->assertSame(
+        $this->assertEquals(
             [
                 'user_id' => '1',
                 'project_id' => '1',

--- a/tests/Integration/Database/QueryBuilderTest.php
+++ b/tests/Integration/Database/QueryBuilderTest.php
@@ -36,7 +36,7 @@ class QueryBuilderTest extends DatabaseTestCase
     {
         $expected = ['id' => '1', 'title' => 'Foo Post'];
 
-        $this->assertSame($expected, (array) DB::table('posts')->where('title', 'Foo Post')->select('id', 'title')->sole());
+        $this->assertEquals($expected, (array) DB::table('posts')->where('title', 'Foo Post')->select('id', 'title')->sole());
     }
 
     public function testSoleFailsForMultipleRecords()
@@ -61,13 +61,13 @@ class QueryBuilderTest extends DatabaseTestCase
     {
         $expected = ['id' => '1', 'title' => 'Foo Post'];
 
-        $this->assertSame($expected, (array) DB::table('posts')->select('id', 'title')->first());
-        $this->assertSame($expected, (array) DB::table('posts')->select(['id', 'title'])->first());
+        $this->assertEquals($expected, (array) DB::table('posts')->select('id', 'title')->first());
+        $this->assertEquals($expected, (array) DB::table('posts')->select(['id', 'title'])->first());
     }
 
     public function testSelectReplacesExistingSelects()
     {
-        $this->assertSame(
+        $this->assertEquals(
             ['id' => '1', 'title' => 'Foo Post'],
             (array) DB::table('posts')->select('content')->select(['id', 'title'])->first()
         );
@@ -75,7 +75,7 @@ class QueryBuilderTest extends DatabaseTestCase
 
     public function testSelectWithSubQuery()
     {
-        $this->assertSame(
+        $this->assertEquals(
             ['id' => '1', 'title' => 'Foo Post', 'foo' => 'bar'],
             (array) DB::table('posts')->select(['id', 'title', 'foo' => function ($query) {
                 $query->select('bar');
@@ -87,14 +87,14 @@ class QueryBuilderTest extends DatabaseTestCase
     {
         $expected = ['id' => '1', 'title' => 'Foo Post', 'content' => 'Lorem Ipsum.'];
 
-        $this->assertSame($expected, (array) DB::table('posts')->select('id')->addSelect('title', 'content')->first());
-        $this->assertSame($expected, (array) DB::table('posts')->select('id')->addSelect(['title', 'content'])->first());
-        $this->assertSame($expected, (array) DB::table('posts')->addSelect(['id', 'title', 'content'])->first());
+        $this->assertEquals($expected, (array) DB::table('posts')->select('id')->addSelect('title', 'content')->first());
+        $this->assertEquals($expected, (array) DB::table('posts')->select('id')->addSelect(['title', 'content'])->first());
+        $this->assertEquals($expected, (array) DB::table('posts')->addSelect(['id', 'title', 'content'])->first());
     }
 
     public function testAddSelectWithSubQuery()
     {
-        $this->assertSame(
+        $this->assertEquals(
             ['id' => '1', 'title' => 'Foo Post', 'foo' => 'bar'],
             (array) DB::table('posts')->addSelect(['id', 'title', 'foo' => function ($query) {
                 $query->select('bar');


### PR DESCRIPTION
If we wanna merge the `php81-fixes` PR into 8.x, we'll need to either wait till doctrine do those new tags, or revert that part of these changes.