### PR TITLE
[8.x] Fix response factory type hints

### DIFF
--- a/src/Illuminate/Routing/ResponseFactory.php
+++ b/src/Illuminate/Routing/ResponseFactory.php
@@ -45,7 +45,7 @@ class ResponseFactory implements FactoryContract
     /**
      * Create a new response instance.
      *
-     * @param  string  $content
+     * @param  mixed  $content
      * @param  int  $status
      * @param  array  $headers
      * @return \Illuminate\Http\Response


### PR DESCRIPTION
The `$content` parameter of the `make()` method is passed straight to the constructor of the `Response` class which accepts `mixed`, not just `string`. This patch coordinates two method signatures.