### PR TITLE
[8.x] Fix non-existing class in ServiceProvider

### DIFF
--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -7,7 +7,7 @@ use Illuminate\Console\Application as Artisan;
 use Illuminate\Contracts\Foundation\CachesConfiguration;
 use Illuminate\Contracts\Foundation\CachesRoutes;
 use Illuminate\Contracts\Support\DeferrableProvider;
-use Illuminate\Database\Eloquent\Factory as ModelFactory;
+use Illuminate\Database\Eloquent\Factories\Factory as ModelFactory;
 use Illuminate\View\Compilers\BladeCompiler;
 
 abstract class ServiceProvider


### PR DESCRIPTION
Fix non-existing class in `\Illuminate/Support/ServiceProvider`
Import `\Illuminate\Database\Eloquent\Factories\Factory `

This can probably make `\Illuminate\Support\ServiceProvider::loadFactoriesFrom` work as expected