### PR TITLE
[8.x] Adds the `valueOfFail()` Eloquent builder method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -571,6 +571,19 @@ class Builder
     }
 
     /**
+     * Get a single column's value from the first result of the query or throw an exception.
+     *
+     * @param  string|\Illuminate\Database\Query\Expression  $column
+     * @return mixed
+     *
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
+     */
+    public function valueOrFail($column)
+    {
+        return $this->firstOrFail([$column])->{Str::afterLast($column, '.')};
+    }
+
+    /**
      * Execute the query as a "select" statement.
      *
      * @param  array|string  $columns

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -248,7 +248,29 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
         $builder->shouldReceive('first')->with(['name'])->andReturn(null);
 
-        $this->assertNull($builder->value('name'));
+        $this->assertNull($builder->valueOrFail('name'));
+    }
+
+    public function testValueOrFailMethodWithModelNotFound()
+    {
+        $this->expectException(ModelNotFoundException::class);
+
+        $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
+        $mockModel = new stdClass;
+        $mockModel->name = 'foo';
+        $builder->shouldReceive('first')->with(['name'])->andReturn($mockModel);
+
+        $this->assertSame('foo', $builder->valueOrFail('name'));
+    }
+
+    public function testValueOrFailMethodWithModelFound()
+    {
+        $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
+        $mockModel = new stdClass;
+        $mockModel->name = 'foo';
+        $builder->shouldReceive('first')->with(['name'])->andReturn($mockModel);
+
+        $this->assertSame('foo', $builder->value('name'));
     }
 
     public function testChunkWithLastChunkComplete()


### PR DESCRIPTION
## What?

It's the same `value()` but it will fail miserably if the model is not found.

```php
// Before:
$votes = User::where('name', 'John')->value('votes');

abort_unless($votes, 404);

// Now:
$votes = User::where('name', 'John')->valueOrFail('votes');
```

This is miles better if model contains properties that can be `null`.

## How?

It just copy-pastes the `value()` method but instead uses `firstOrFail()` and removes the condition since the model is expected to exist.

## BC?

None, it's additive.

## Notes

- I decided to not include `valueOr()` since you can use `??` or `??=`, which are awesome.