### PR TITLE
[8.x] Revert PR #38552

### DIFF
--- a/src/Illuminate/Auth/Notifications/ResetPassword.php
+++ b/src/Illuminate/Auth/Notifications/ResetPassword.php
@@ -59,31 +59,20 @@ class ResetPassword extends Notification
      */
     public function toMail($notifiable)
     {
-        $url = $this->resetUrl($notifiable);
-
         if (static::$toMailCallback) {
-            return call_user_func(static::$toMailCallback, $notifiable, $this->token, $url);
+            return call_user_func(static::$toMailCallback, $notifiable, $this->token);
         }
 
-        return $this->buildMailMessage($url);
-    }
-
-    /**
-     * Get the password reset URL for the given notifiable.
-     *
-     * @param  mixed  $notifiable
-     * @return string
-     */
-    protected function resetUrl($notifiable)
-    {
         if (static::$createUrlCallback) {
-            return call_user_func(static::$createUrlCallback, $notifiable, $this->token);
+            $url = call_user_func(static::$createUrlCallback, $notifiable, $this->token);
         } else {
-            return url(route('password.reset', [
+            $url = url(route('password.reset', [
                 'token' => $this->token,
                 'email' => $notifiable->getEmailForPasswordReset(),
             ], false));
         }
+
+        return $this->buildMailMessage($url);
     }
 
     /**


### PR DESCRIPTION
This PR reverts #38552 because it's a breaking change. Any Laravel app that doesn't has a password reset route will see their app break.

See https://github.com/laravel/nova-issues/issues/3542 & the comments in https://github.com/laravel/framework/pull/38552