### PR TITLE
[8.x] Enable dot access in TestResponse@viewData

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -990,7 +990,7 @@ EOF;
     {
         $this->ensureResponseHasView();
 
-        return $this->original->gatherData()[$key];
+        return Arr::get($this->original->gatherData(), $key);
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->


The benefit to devs is that in tests, sometimes you want to access a nested array and this makes it easier to access rather than having to pull it outside of the class.

 Normal array access still works as it did before so it shouldn't break anything existing.
