### PR TITLE
[8.x] Compare custom date/immutable_date using date comparison

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1217,7 +1217,7 @@ trait HasAttributes
      */
     protected function isDateCastable($key)
     {
-        return $this->hasCast($key, ['date', 'datetime', 'immutable_date', 'immutable_datetime']);
+        return $this->hasCast($key, ['date', 'datetime', 'custom_datetime', 'immutable_date', 'immutable_datetime', 'immutable_custom_datetime']);
     }
 
     /**
@@ -1643,7 +1643,7 @@ trait HasAttributes
             return true;
         } elseif (is_null($attribute)) {
             return false;
-        } elseif ($this->isDateAttribute($key)) {
+        } elseif ($this->isDateAttribute($key) || $this->isDateCastable($key)) {
             return $this->fromDateTime($attribute) ===
                 $this->fromDateTime($original);
         } elseif ($this->hasCast($key, ['object', 'collection'])) {

--- a/tests/Integration/Database/EloquentModelDateCastingTest.php
+++ b/tests/Integration/Database/EloquentModelDateCastingTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Database\EloquentModelDateCastingTest;
 
+use Carbon\CarbonImmutable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Carbon;
@@ -21,6 +22,8 @@ class EloquentModelDateCastingTest extends DatabaseTestCase
             $table->increments('id');
             $table->date('date_field')->nullable();
             $table->datetime('datetime_field')->nullable();
+            $table->date('immutable_date_field')->nullable();
+            $table->datetime('immutable_datetime_field')->nullable();
         });
     }
 
@@ -36,6 +39,27 @@ class EloquentModelDateCastingTest extends DatabaseTestCase
         $this->assertInstanceOf(Carbon::class, $user->date_field);
         $this->assertInstanceOf(Carbon::class, $user->datetime_field);
     }
+
+    public function testCustomDateCastsAreComparedAsDates()
+    {
+        /** @var TestModel1 */
+        $user = TestModel1::create([
+            'date_field' => '2019-10-01',
+            'datetime_field' => '2019-10-01 10:15:20',
+            'immutable_date_field' => '2019-10-01',
+            'immutable_datetime_field' => '2019-10-01 10:15:20',
+        ]);
+
+        $user->date_field = new Carbon('2019-10-01');
+        $user->datetime_field = new Carbon('2019-10-01 10:15:20');
+        $user->immutable_date_field = new CarbonImmutable('2019-10-01');
+        $user->immutable_datetime_field = new CarbonImmutable('2019-10-01 10:15:20');
+
+        $this->assertArrayNotHasKey('date_field', $user->getDirty());
+        $this->assertArrayNotHasKey('datetime_field', $user->getDirty());
+        $this->assertArrayNotHasKey('immutable_date_field', $user->getDirty());
+        $this->assertArrayNotHasKey('immutable_datetime_field', $user->getDirty());
+    }
 }
 
 class TestModel1 extends Model
@@ -47,5 +71,7 @@ class TestModel1 extends Model
     public $casts = [
         'date_field' => 'date:Y-m',
         'datetime_field' => 'datetime:Y-m H:i',
+        'immutable_date_field' => 'date:Y-m',
+        'immutable_datetime_field' => 'datetime:Y-m H:i',
     ];
 }


### PR DESCRIPTION
### Description:

Model attributes cast as custom date(time) formats are incorrectly marked as dirty attributes when the value has not in fact changed.

I first noticed this happening as part of a Livewire controller, but it’s not limited to just Livewire.

### Steps To Reproduce:

See #38719 for some steps.

Most basic example:

https://github.com/macbookandrew/laravel-bug-report/blob/e44c1422b154b02bb59c2aedae3c9ce45798bc2d/tests/Feature/EventDateTest.php#L41

### Cause

The `HasAttributes` `originalIsEquivalent` method does not treat custom date/immutable_date attributes as date objects and does a strict comparison; if the Carbon instance has changed, it fails.

### Suggested solution

If an attribute `isDateCastable()` then compare them using `fromDateTime()` rather than creating new Carbon instances and comparing them.