### PR TITLE
Inform the application container about deferred providers before registering providers

### DIFF
--- a/src/Illuminate/Foundation/ProviderRepository.php
+++ b/src/Illuminate/Foundation/ProviderRepository.php
@@ -67,7 +67,7 @@ class ProviderRepository
         foreach ($manifest['when'] as $provider => $events) {
             $this->registerLoadEvents($provider, $events);
         }
-        
+
         // We will add the deferred services to the application so that they are able
         // to be resolved if necessary during the registration process of the eagerly
         // loaded providers.

--- a/src/Illuminate/Foundation/ProviderRepository.php
+++ b/src/Illuminate/Foundation/ProviderRepository.php
@@ -67,15 +67,18 @@ class ProviderRepository
         foreach ($manifest['when'] as $provider => $events) {
             $this->registerLoadEvents($provider, $events);
         }
+        
+        // We will add the deferred services to the application so that they are able
+        // to be resolved if necessary during the registration process of the eagerly
+        // loaded providers.
+        $this->app->addDeferredServices($manifest['deferred']);
 
         // We will go ahead and register all of the eagerly loaded providers with the
         // application so their services can be registered with the application as
-        // a provided service. Then we will set the deferred service list on it.
+        // a provided service.
         foreach ($manifest['eager'] as $provider) {
             $this->app->register($provider);
         }
-
-        $this->app->addDeferredServices($manifest['deferred']);
     }
 
     /**


### PR DESCRIPTION
This change informs the application container about the deferred providers before registering the eager loaded providers. This fixes the issue of the vague exception of "Facade root not set" when attempting to use a deferred service provider via a facade (such as Cache) during the registration process of eagerly loaded service providers. The application cannot resolve a deferred provider unless it knows it has been deferred, and this line is what informs it of the deferred providers.

This should be an entirely harmless change that will enable the use of already loaded deferred service providers (that a developer would assume could be used, like the Cache provider) during the registration process of eager loaded service providers.

I understand if this change won't be accepted, but if it won't be I would greatly appreciate learning more about what potential issues this could cause so that I can understand the service provider registration flow in more detail.