### PR TITLE
[8.x] Adds policy option to make:model

### DIFF
--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -45,6 +45,7 @@ class ModelMakeCommand extends GeneratorCommand
             $this->input->setOption('seed', true);
             $this->input->setOption('migration', true);
             $this->input->setOption('controller', true);
+            $this->input->setOption('policy', true);
             $this->input->setOption('resource', true);
         }
 
@@ -58,6 +59,10 @@ class ModelMakeCommand extends GeneratorCommand
 
         if ($this->option('seed')) {
             $this->createSeeder();
+        }
+
+        if ($this->option('policy')) {
+            $this->createPolicy();
         }
 
         if ($this->option('controller') || $this->option('resource') || $this->option('api')) {
@@ -110,6 +115,20 @@ class ModelMakeCommand extends GeneratorCommand
 
         $this->call('make:seeder', [
             'name' => "{$seeder}Seeder",
+        ]);
+    }
+
+    /**
+     * Create a policy file for the model.
+     *
+     * @return void
+     */
+    protected function createPolicy()
+    {
+        $policy = Str::studly(class_basename($this->argument('name')));
+
+        $this->call('make:policy', [
+            'name' => "{$policy}Policy"
         ]);
     }
 
@@ -175,11 +194,12 @@ class ModelMakeCommand extends GeneratorCommand
     protected function getOptions()
     {
         return [
-            ['all', 'a', InputOption::VALUE_NONE, 'Generate a migration, seeder, factory, and resource controller for the model'],
+            ['all', 'a', InputOption::VALUE_NONE, 'Generate a migration, seeder, factory, policy, and resource controller for the model'],
             ['controller', 'c', InputOption::VALUE_NONE, 'Create a new controller for the model'],
             ['factory', 'f', InputOption::VALUE_NONE, 'Create a new factory for the model'],
             ['force', null, InputOption::VALUE_NONE, 'Create the class even if the model already exists'],
             ['migration', 'm', InputOption::VALUE_NONE, 'Create a new migration file for the model'],
+            ['policy', null, InputOption::VALUE_NONE, 'Create a new policy file for the model'],
             ['seed', 's', InputOption::VALUE_NONE, 'Create a new seeder file for the model'],
             ['pivot', 'p', InputOption::VALUE_NONE, 'Indicates if the generated model should be a custom intermediate table model'],
             ['resource', 'r', InputOption::VALUE_NONE, 'Indicates if the generated controller should be a resource controller'],

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -128,7 +128,7 @@ class ModelMakeCommand extends GeneratorCommand
         $policy = Str::studly(class_basename($this->argument('name')));
 
         $this->call('make:policy', [
-            'name' => "{$policy}Policy"
+            'name' => "{$policy}Policy",
         ]);
     }
 

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -129,6 +129,7 @@ class ModelMakeCommand extends GeneratorCommand
 
         $this->call('make:policy', [
             'name' => "{$policy}Policy",
+            '--model' => $this->qualifyClass($this->getNameInput()),
         ]);
     }
 


### PR DESCRIPTION
When creating a model using the `artisan make:model` command, there is no option to create a Policy at the same time. This change adds the `--policy` option to the `make:model` command, and includes it in the `--all` option as well.

This is purely for convenience and has no far-reaching impacts for users.