### PR TITLE
Add default UUID column name

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1192,7 +1192,7 @@ class Blueprint
      * @param  string  $column
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function uuid($column)
+    public function uuid($column = 'uuid')
     {
         return $this->addColumn('uuid', $column);
     }


### PR DESCRIPTION
This PR updates the UUID Blueprint method to apply a default column name of 'uuid' in the absence of one provided.

In addition, this also matches the intuitive behavior of the `id` Blueprint method located within the same class.
