### PR TITLE
[8.x] Return null for a job's backoff if the property or method also returns null

### DIFF
--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -185,7 +185,10 @@ abstract class Queue
      */
     public function getJobBackoff($job)
     {
-        if (! method_exists($job, 'backoff') && ! isset($job->backoff)) {
+        if (
+            (! method_exists($job, 'backoff') && ! isset($job->backoff))
+            || ($job->backoff ?? $job->backoff() === null)
+        ) {
             return;
         }
 


### PR DESCRIPTION
This issue fixes #38736 by checking if the property `backoff` or the method `backoff` on a job returns null, and if so, also returns null in Queue.php's `getJobBackoff`.

Because Mailable has a method named `backoff`, which returns `null` by default, the result of this method is currently used to create an imploded string. Because the result is `null`, a Collection is created containing only the element `null`, resulting in an empty string. This empty string is used as the parameter for backing off from the job if it has previously failed, thus ignoring any defaults set in the queue or worker config in the case of Mailables failing to send.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
