### PR TITLE
[8.x] Prevent race condition when decoding maintenance data

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/maintenance-mode.stub
+++ b/src/Illuminate/Foundation/Console/stubs/maintenance-mode.stub
@@ -6,7 +6,11 @@ if (! file_exists($down = __DIR__.'/down')) {
 }
 
 // Decode the "down" file's JSON...
-$data = json_decode(file_get_contents($down), true);
+try {
+    $data = json_decode(file_get_contents($down), true);
+} catch (\Exception $e) {
+    return;
+}
 
 // Allow framework to handle request if no prerendered template...
 if (! isset($data['template'])) {


### PR DESCRIPTION
A race condition exists when exiting maintenance mode that can cause a user to see an unexpected error. This PR does not add or affect any existing functionality.