### PR TITLE
[8.x] Remove redundant func_get_args() call

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -201,8 +201,8 @@ class Gate implements GateContract
             }
 
             return isset($method)
-                    ? $policy->{$method}(...func_get_args())
-                    : $policy(...func_get_args());
+                    ? $policy->{$method}(...$arguments)
+                    : $policy(...$arguments);
         };
     }
 


### PR DESCRIPTION
Removes the need to call `func_get_args()` again, since there is already a variable with the args.

