### PR TITLE
[8.x] Add support for using morph maps in model serialization

### DIFF
--- a/src/Illuminate/Contracts/Database/ModelIdentifier.php
+++ b/src/Illuminate/Contracts/Database/ModelIdentifier.php
@@ -2,12 +2,15 @@
 
 namespace Illuminate\Contracts\Database;
 
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Relation;
+
 class ModelIdentifier
 {
     /**
      * The class name of the model.
      *
-     * @var string
+     * @var string|null
      */
     public $class;
 
@@ -37,7 +40,7 @@ class ModelIdentifier
     /**
      * Create a new model identifier.
      *
-     * @param  string  $class
+     * @param  string|null  $class
      * @param  mixed  $id
      * @param  array  $relations
      * @param  mixed  $connection
@@ -49,5 +52,13 @@ class ModelIdentifier
         $this->class = $class;
         $this->relations = $relations;
         $this->connection = $connection;
+    }
+
+    /**
+     * @return class-string<Model>|null
+     */
+    public function getClass(): ?string
+    {
+        return Relation::getMorphedModel($this->class) ?? $this->class;
     }
 }

--- a/src/Illuminate/Contracts/Queue/QueueableEntity.php
+++ b/src/Illuminate/Contracts/Queue/QueueableEntity.php
@@ -4,6 +4,8 @@ namespace Illuminate\Contracts\Queue;
 
 interface QueueableEntity
 {
+    public function getQueueableClass();
+
     /**
      * Get the queueable identity for the entity.
      *

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -647,13 +647,18 @@ class Collection extends BaseCollection implements QueueableCollection
             return;
         }
 
-        $class = get_class($this->first());
+        $first = $this->first();
+        $class = get_class($first);
 
         $this->each(function ($model) use ($class) {
             if (get_class($model) !== $class) {
                 throw new LogicException('Queueing collections with multiple model types is not supported.');
             }
         });
+
+        if ($first instanceof QueueableEntity) {
+            return $first->getQueueableClass();
+        }
 
         return $class;
     }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1780,6 +1780,11 @@ abstract class Model implements Arrayable, ArrayAccess, HasBroadcastChannel, Jso
         return $this->getKey();
     }
 
+    public function getQueueableClass()
+    {
+        return $this->getMorphClass();
+    }
+
     /**
      * Get the queueable relationships for the entity.
      *

--- a/tests/Integration/Queue/ModelSerializationMorphTest.php
+++ b/tests/Integration/Queue/ModelSerializationMorphTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Queue;
+
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Relations\Relation;
+
+/**
+ * @group integration
+ */
+class ModelSerializationMorphTest extends ModelSerializationTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Relation::morphMap([
+            'modelBoot' => ModelBootTestWithTraitInitialization::class,
+            'testUser' => ModelSerializationTestUser::class,
+            'customerUser' => ModelSerializationTestCustomUser::class,
+            'order' => Order::class,
+            'line' => Line::class,
+            'product' => Product::class,
+            'user' => User::class,
+            'role' => Role::class,
+            'roleUser' => RoleUser::class,
+        ]);
+    }
+
+    public function testItCanUnserializeWithMorphs()
+    {
+        $user = ModelSerializationTestUser::create([
+            'email' => 'nuno@laravel.com',
+        ]);
+
+        $serialized = serialize(new ModelSerializationTestClass($user));
+
+        $unSerialized = unserialize($serialized);
+
+        $this->assertSame('nuno@laravel.com', $unSerialized->user->email);
+    }
+
+    public function test_model_serialization_structure()
+    {
+        $user = ModelSerializationTestUser::create([
+            'email' => 'nuno@laravel.com',
+        ]);
+
+        $serialized = serialize(new CollectionSerializationTestClass($user));
+
+        $this->assertSame(
+            'O:67:"Illuminate\Tests\Integration\Queue\CollectionSerializationTestClass":1:{s:5:"users";O:45:"Illuminate\Contracts\Database\ModelIdentifier":4:{s:5:"class";s:8:"testUser";s:2:"id";i:1;s:9:"relations";a:0:{}s:10:"connection";s:9:"testbench";}}',
+            $serialized
+        );
+    }
+
+    public function test_model_serialization_collection_structure()
+    {
+        $user = ModelSerializationTestUser::create([
+            'email' => 'nuno@laravel.com',
+        ]);
+
+        $serialized = serialize(new CollectionSerializationTestClass(new Collection([$user, $user])));
+
+        $this->assertSame(
+            'O:67:"Illuminate\Tests\Integration\Queue\CollectionSerializationTestClass":1:{s:5:"users";O:45:"Illuminate\Contracts\Database\ModelIdentifier":4:{s:5:"class";s:8:"testUser";s:2:"id";a:2:{i:0;i:1;i:1;i:1;}s:9:"relations";a:0:{}s:10:"connection";s:9:"testbench";}}',
+            $serialized
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        Relation::morphMap([], false);
+    }
+}

--- a/tests/Queue/QueueSyncQueueTest.php
+++ b/tests/Queue/QueueSyncQueueTest.php
@@ -95,6 +95,11 @@ class SyncQueueTestEntity implements QueueableEntity
     {
         //
     }
+
+    public function getQueueableClass()
+    {
+        //
+    }
 }
 
 class SyncQueueTestHandler


### PR DESCRIPTION
This PR adds support for morph maps inside model serialization.

This means when a model is serialized by the `\Illuminate\Queue\SerializesModels`, it will use morph maps for it. 


# Why?
The reason for this is when having serialized models by the FQCN, we cannot rename/move the class before none of the models are serialized anymore.  
By using the morph map for serialization, it allows us to move the class, as long as we don't change the morph mapping.  

# Problems
This only solves half of the issue with serialization, as we are still serializing FQCNs, just not model FQCN's. For example, in the job queue, a job will still be serialized by the FQCN.  
A potential follow-up on this PR would be a new mapping for serialization only.  
In this map you could register any class which you want to have custom serialization on. However the reason that this PR does not try to tackle that part is that Laravel's serialization trait is called `SerializesModels` and by extending it to all classes we are going out of the scope of the trait's name. That's why I suggest that solving this issue for other classes belongs in a follow-up pr.


Another potential problem (which I see as an advantage) is the solution proposed here will trigger `ClassMorphViolationException` if morph map is required while trying to serialize a model. At least this is something to take note of. 

Third and last, using the morph maps in serialization might be confusing for some, as it might not be clear that changing a setting related to morphs impacts the serialization. 