### PR TITLE
[8.x] Allow mass inserting models without having to call 'toArray' on each model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -920,7 +920,7 @@ class Builder
         if (reset($values) instanceof Model) {
             $values = array_map(function (Model $value) {
                 $value = $value->toArray();
-                $this->addTimestampsToUpsertValues($value);
+                $this->addTimestampsToUpsertValues([$value]);
 
                 return $value;
             }, $values);

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -912,7 +912,7 @@ class Builder
     /**
      * Insert many models at once.
      *
-     * @param  Model[]|array $values
+     * @param  Model[]|array  $values
      * @return bool
      */
     public function insert(array $values = []): bool

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -910,15 +910,15 @@ class Builder
     }
 
     /**
-     * Insert many models at once
+     * Insert many models at once.
      *
-     * @param Model[]|array $values
+     * @param  Model[]|array $values
      * @return bool
      */
     public function insert(array $values = []): bool
     {
         if (reset($values) instanceof Model) {
-            $values = array_map(function(Model $value) {
+            $values = array_map(function (Model $value) {
                 $value = $value->toArray();
                 $this->addTimestampsToUpsertValues($value);
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -918,12 +918,15 @@ class Builder
     public function insert(array $values = []): bool
     {
         if (reset($values) instanceof Model) {
-            $values = array_map(static function(Model $value) {
-                return $value->toArray();
+            $values = array_map(function(Model $value) {
+                $value = $value->toArray();
+                $this->addTimestampsToUpsertValues($value);
+
+                return $value;
             }, $values);
         }
 
-        return $this->query->insert($values);
+        return $this->toBase()->insert($values);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -918,15 +918,12 @@ class Builder
     public function insert(array $values = []): bool
     {
         if (reset($values) instanceof Model) {
-            $values = array_map(function (Model $value) {
-                $value = $value->toArray();
-                $this->addTimestampsToUpsertValues([$value]);
-
-                return $value;
+            $values = array_map(static function (Model $model) {
+                return $model->toArray();
             }, $values);
         }
 
-        return $this->toBase()->insert($values);
+        return $this->toBase()->insert($this->addTimestampsToUpsertValues($values));
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -910,6 +910,23 @@ class Builder
     }
 
     /**
+     * Insert many models at once
+     *
+     * @param Model[]|array $values
+     * @return bool
+     */
+    public function insert(array $values = []): bool
+    {
+        if (reset($values) instanceof Model) {
+            $values = array_map(static function(Model $value) {
+                return $value->toArray();
+            }, $values);
+        }
+
+        return $this->query->insert($values);
+    }
+
+    /**
      * Insert new records or update the existing ones.
      *
      * @param  array  $values

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1717,6 +1717,36 @@ class DatabaseEloquentBuilderTest extends TestCase
         Carbon::setTestNow(null);
     }
 
+    public function testInsertWithAttributeArrays()
+    {
+        Carbon::setTestNow($now = '2017-10-10 10:10:10');
+
+        $query = m::mock(BaseBuilder::class);
+        $query->shouldReceive('from')->with('foo_table')->andReturn('foo_table');
+        $query->from = 'foo_table';
+
+        $builder = new Builder($query);
+        $model = new EloquentBuilderTestStubStringPrimaryKey;
+        $builder->setModel($model);
+
+        $query->shouldReceive('insert')->once()
+            ->with([
+                ['email' => 'foo', 'name' => 'bar'],
+                ['name' => 'bar2', 'email' => 'foo2'],
+            ])->andReturn(true);
+
+        $result = $builder->insert(
+            [
+                ['email' => 'foo', 'name' => 'bar'],
+                ['name' => 'bar2', 'email' => 'foo2']
+            ]
+        );
+
+        $this->assertEquals(2, $result);
+
+        Carbon::setTestNow(null);
+    }
+
     public function testUpsert()
     {
         Carbon::setTestNow($now = '2017-10-10 10:10:10');

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -8,7 +8,6 @@ use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Database\Eloquent\Concerns\HasTimestamps;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\Eloquent\RelationNotFoundException;
@@ -1708,7 +1707,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $result = $builder->insert(
             [
                 new EloquentBuilderTestStubStringPrimaryKey(['email' => 'foo', 'name' => 'bar']),
-                new EloquentBuilderTestStubStringPrimaryKey(['name' => 'bar2', 'email' => 'foo2'])
+                new EloquentBuilderTestStubStringPrimaryKey(['name' => 'bar2', 'email' => 'foo2']),
             ]
         );
 
@@ -1738,7 +1737,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $result = $builder->insert(
             [
                 ['email' => 'foo', 'name' => 'bar'],
-                ['name' => 'bar2', 'email' => 'foo2']
+                ['name' => 'bar2', 'email' => 'foo2'],
             ]
         );
 
@@ -2011,6 +2010,6 @@ class EloquentBuilderTestStubStringPrimaryKey extends Model
 
     protected $fillable = [
         'email',
-        'name'
+        'name',
     ];
 }


### PR DESCRIPTION
When inserting a lot of models, it may be benificial to batch them in order to decrease the number of queries executed. This is currently possible with the ::insert() method on the QueryBuilder in this way:
```
/** @var Model[] $models */
$models = [];
foreach (.....) {
    $models[] = new Model();
}

Model::insert(
    array_map(static function(Model $model){return $model->toArray()}, $models)
)
```

Calling `->toArray()` on each model is necessary as the query builder expects a nested array of attributes. This change allows the following syntax instead:

```
/** @var Model[] $models */
$models = [];
foreach (.....) {
    $models[] = new Model();
}

Model::insert($models)
```