### PR TITLE
[8.x] Add `AssertableJson::hasEach()` method

### DIFF
--- a/src/Illuminate/Testing/Fluent/AssertableJson.php
+++ b/src/Illuminate/Testing/Fluent/AssertableJson.php
@@ -144,6 +144,29 @@ class AssertableJson implements Arrayable
     }
 
     /**
+     * Ensure that the given prop exists and has expected size.
+     *
+     * Optionally instantiate a new "scope" on each child element via callback.
+     *
+     * @param  string|int  $key
+     * @param  int|\Closure|null  $length
+     * @param  \Closure|null  $callback
+     * @return $this
+     */
+    public function hasEach($key, $length = null, Closure $callback = null): self
+    {
+        if (is_int($length) && ! is_null($callback)) {
+            return $this->has($key, function (self $scope) use ($length, $callback) {
+                return $scope->count($length)
+                    ->each($callback)
+                    ->etc();
+            });
+        }
+
+        return $this->has($key, $length, $callback);
+    }
+
+    /**
      * Create a new instance from an array.
      *
      * @param  array  $data

--- a/tests/Testing/Fluent/AssertTest.php
+++ b/tests/Testing/Fluent/AssertTest.php
@@ -757,6 +757,40 @@ class AssertTest extends TestCase
         });
     }
 
+    public function testHasEachScope()
+    {
+        $assert = AssertableJson::fromArray([
+            'foo' => [
+                'bar' => [
+                    'key' => 'first',
+                ],
+                'baz' => [
+                    'key' => 'second',
+                ],
+            ],
+        ]);
+
+        $assert->hasEach('foo', 2, function (AssertableJson $item) {
+            $item->whereType('key', 'string');
+        });
+    }
+
+    public function testHasEachWithoutScope()
+    {
+        $assert = AssertableJson::fromArray([
+            'foo' => [
+                'bar' => [
+                    'key' => 'first',
+                ],
+                'baz' => [
+                    'key' => 'second',
+                ],
+            ],
+        ]);
+
+        $assert->hasEach('foo', 2);
+    }
+
     public function testFailsWhenNotInteractingWithAllPropsInScope()
     {
         $assert = AssertableJson::fromArray([


### PR DESCRIPTION
Following #38684, this PR adds the `hasEach()` method, a version of `has()`, to `AssertableJson`.
When `$callback` and `$length` are provided, it instantiates a new scope on each child element, utilizing newly introduced `each()`.

I believe this is a fairly common use case when you want to assert the structure of an array of JSON objects returned with an API response.
The new method will reduce the complexity of such assertions.

Before:
```php
$response->assertJson(fn (AssertableJson $json) =>
    $json->count('articles', 20)
        ->has('articles', fn (AssertableJson $items) =>
            $items->each(fn (AssertableJson $item) =>
                $item->where('property', 'value')
            )
        )
);
```
After:
```php
$response->assertJson(fn (AssertableJson $json) =>
    $json->hasEach('articles', 20, fn (AssertableJson $item) =>
        $item->where('property', 'value')
    )
);
```

Method will work exactly the same as `has()` when `$callback` or `$length` are not provided.
Ideally I would want to alter the `has()` method or add scoping key to `each()`, but that would be a breaking change.

Similarly to mentored PR, I'm not quite sure whatever or not to add this method to `\Illuminate\Testing\Fluent\Concerns\Has`, so I didn't do that.