### PR TITLE
Add MessageStreamId to Postmark Transport again

### DIFF
--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -288,10 +288,17 @@ class MailManager implements FactoryContract
     {
         $factory = new PostmarkTransportFactory();
 
+        $options = isset($config['message_stream_id'])
+                    ? ['message_stream' => $config['message_stream_id']]
+                    : [];
+
         return $factory->create(new Dsn(
             'postmark+api',
             'default',
-            $config['token'] ?? $this->app['config']->get('services.postmark.token')
+            $config['token'] ?? $this->app['config']->get('services.postmark.token'),
+            null,
+            null,
+            $options
         ));
     }
 


### PR DESCRIPTION
The Message Stream Id was removed from the code because Symfony Postmark Mailer didn't support it at that time.
Now symfony/symfony#42941 (by @driesvints) was merged into  Symfony 6.0 and we can therefor add support for it again.
