### PR TITLE
[8.x] Added whereMin and whereMax filters to Collections

### DIFF
--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -423,20 +423,20 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function whereInstanceOf($type);
 
     /**
-     * Get the item where the key/callback has the minimum value.
+     * Get the item where the given key has the minimum value.
      *
-     * @param  callable|string  $callback
-     * @return mixed
+     * @param  string  $key
+     * @return static
      */
-    public function whereMin($callback);
+    public function whereMin($key);
 
     /**
-     * Get the item where the key/callback has the maximum value.
+     * Get the item where the given key has the maximum value.
      *
-     * @param  callable|string  $callback
-     * @return mixed
+     * @param  string  $key
+     * @return static
      */
-    public function whereMax($callback);
+    public function whereMax($key);
 
     /**
      * Get the first item from the enumerable passing the given truth test.

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -423,6 +423,22 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function whereInstanceOf($type);
 
     /**
+     * Get the item where the key/callback has the minimum value.
+     *
+     * @param  callable|string  $callback
+     * @return mixed
+     */
+    public function whereMin($callback);
+
+    /**
+     * Get the item where the key/callback has the maximum value.
+     *
+     * @param  callable|string  $callback
+     * @return mixed
+     */
+    public function whereMax($callback);
+
+    /**
      * Get the first item from the enumerable passing the given truth test.
      *
      * @param  callable|null  $callback

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -692,6 +692,28 @@ trait EnumeratesValues
     }
 
     /**
+     * Get the item where the key/callback has the minimum value.
+     *
+     * @param  callable|string  $callback
+     * @return mixed
+     */
+    public function whereMin($callback)
+    {
+        return $this->sortBy($callback)->first();
+    }
+
+    /**
+     * Get the item where the key/callback has the maximum value.
+     *
+     * @param  callable|string  $callback
+     * @return mixed
+     */
+    public function whereMax($callback)
+    {
+        return $this->sortByDesc($callback)->first();
+    }
+
+    /**
      * Pass the collection to the given callback and return the result.
      *
      * @param  callable  $callback

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -692,25 +692,25 @@ trait EnumeratesValues
     }
 
     /**
-     * Get the item where the key/callback has the minimum value.
+     * Get the item where the given key has the minimum value.
      *
-     * @param  callable|string  $callback
-     * @return mixed
+     * @param  string  $key
+     * @return static
      */
-    public function whereMin($callback)
+    public function whereMin($key)
     {
-        return $this->sortBy($callback)->first();
+        return $this->where($key, $this->min($key));
     }
 
     /**
-     * Get the item where the key/callback has the maximum value.
+     * Get the item where the given key has the maximum value.
      *
-     * @param  callable|string  $callback
-     * @return mixed
+     * @param  string  $key
+     * @return static
      */
-    public function whereMax($callback)
+    public function whereMax($key)
     {
-        return $this->sortByDesc($callback)->first();
+        return $this->where($key, $this->max($key));
     }
 
     /**


### PR DESCRIPTION
This pull request adds two new methods in the `Illuminate\Collections\Enumerable` interface along with their implementation in the `Illuminate\Collections\Traits\EnumeratesValues` trait. It does not break any existing features and passes all tests.

## `whereMin($key)`
This method returns the items of the collection for which the key value is the minimum.

## `whereMax($key)`
This method returns the items of the collection for which the key value is the maximum.

# Use cases
```php
$items = collect([
    ['name' => 'Item 1',  'price' => 100],
    ['name' => 'Item 2',  'price' => 50],
    ['name' => 'Item 3',  'price' => 100],
    ['name' => 'Item 4',  'price' => 75],
]);
```
```php
$items->whereMax('price'); 

/* Returns the items with the highest price.
[
    ['name' => 'Item 1',  'price' => 100],
    ['name' => 'Item 3',  'price' => 100]
] */
```
```php
$items->whereMin('price'); 

/* Returns the items with the lowest price.
[
    ['name' => 'Item 2',  'price' => 50
] */
```
