### PR TITLE
Adding support for using a different Redis DB in a Sentinel setup

### DIFF
--- a/src/Illuminate/Redis/RedisManager.php
+++ b/src/Illuminate/Redis/RedisManager.php
@@ -108,7 +108,7 @@ class RedisManager implements Factory
         if (isset($this->config[$name])) {
             return $this->connector()->connect(
                 $this->parseConnectionConfiguration($this->config[$name]),
-                $options
+                array_merge(Arr::except($options, 'parameters'), ['parameters' => Arr::get($options, 'parameters.'.$name, Arr::get($options, 'parameters', []))])
             );
         }
 


### PR DESCRIPTION
Following the Cache and Database documentation, it should be possible to create multiple cache stores from the Laravel database config.

This doest work if someone is using a Redis Sentinel configuration.

The host can be changed, but not the selected DB. This change won't break current configurations.

Current config:
```
    'redis' => [

        'client' => env('REDIS_CLIENT', 'phpredis'),

        'options' => [
            'replication' => 'sentinel',
            'service' => 'mymaster',
            'parameters'  => [
                    'password' => env('REDIS_PASSWORD', null),
                    'database' => env('REDIS_DATABASE', null),
            ],
        ],

        'default' => [
            'tcp://'.env('REDIS_HOST_1').':26379?timeout=0.100',
            'tcp://'.env('REDIS_HOST_2').':26379?timeout=0.100',
            'tcp://'.env('REDIS_HOST_3').':26379?timeout=0.100',
        ],

        'storetwo' => [
            'tcp://'.env('REDIS_HOST_1').':26379?timeout=0.100',
            'tcp://'.env('REDIS_HOST_2').':26379?timeout=0.100',
            'tcp://'.env('REDIS_HOST_3').':26379?timeout=0.100',
        ],
    ],
```

New config:

```
    'redis' => [

        'client' => env('REDIS_CLIENT', 'phpredis'),

        'options' => [
            'replication' => 'sentinel',
            'service' => 'mymaster',
            'parameters'  => [
                'default' => [
                    'password' => env('REDIS_PASSWORD', null),
                    'database' => env('REDIS_DATABASE', null),
                ],
                'storetwo' => [
                    'password' => env('REDIS_PASSWORD', null),
                    'database' => env('REDIS_DATABASE_TWO', null)
                ]
            ],
        ],

        'default' => [
            'tcp://'.env('REDIS_HOST_1').':26379?timeout=0.100',
            'tcp://'.env('REDIS_HOST_2').':26379?timeout=0.100',
            'tcp://'.env('REDIS_HOST_3').':26379?timeout=0.100',
        ],

        'storetwo' => [
            'tcp://'.env('REDIS_HOST_1').':26379?timeout=0.100',
            'tcp://'.env('REDIS_HOST_2').':26379?timeout=0.100',
            'tcp://'.env('REDIS_HOST_3').':26379?timeout=0.100',
        ],
    ],
```