### PR TITLE
[8.x] Adding support for using a different Redis DB in a Sentinel setup

### DIFF
--- a/src/Illuminate/Redis/RedisManager.php
+++ b/src/Illuminate/Redis/RedisManager.php
@@ -108,7 +108,7 @@ class RedisManager implements Factory
         if (isset($this->config[$name])) {
             return $this->connector()->connect(
                 $this->parseConnectionConfiguration($this->config[$name]),
-                $options
+                array_merge(Arr::except($options, 'parameters'), ['parameters' => Arr::get($options, 'parameters.'.$name, Arr::get($options, 'parameters', []))])
             );
         }
 

--- a/src/Illuminate/Redis/RedisManager.php
+++ b/src/Illuminate/Redis/RedisManager.php
@@ -8,6 +8,7 @@ use Illuminate\Redis\Connections\Connection;
 use Illuminate\Redis\Connectors\PhpRedisConnector;
 use Illuminate\Redis\Connectors\PredisConnector;
 use Illuminate\Support\ConfigurationUrlParser;
+use Illuminate\Support\Arr;
 use InvalidArgumentException;
 
 /**

--- a/tests/Redis/RedisConnectorTest.php
+++ b/tests/Redis/RedisConnectorTest.php
@@ -181,4 +181,30 @@ class RedisConnectorTest extends TestCase
         $this->assertEquals($username, $parameters->username);
         $this->assertEquals($password, $parameters->password);
     }
+    
+    public function testPredisConfigurationWithSentinel()
+    {
+        $host = env('REDIS_HOST', '127.0.0.1');
+        $port = env('REDIS_PORT', 6379);
+
+        $predis = new RedisManager(new Application, 'predis', [
+            'cluster' => false,
+            'options' => [
+                'replication' => 'sentinel',
+                'service' => 'mymaster',
+                'parameters' => [
+                    'default' => [
+                        'database' => 5,
+                    ]
+                ]
+            ],
+            'default' => [
+                "tcp://{$host}:{$port}",
+            ],
+        ]);
+
+        $predisClient = $predis->connection()->client();
+        $parameters = $predisClient->getConnection()->getSentinelConnection()->getParameters();
+        $this->assertEquals($host, $parameters->host);
+    }
 }


### PR DESCRIPTION
Following the Cache and Database documentation, it should be possible to create multiple cache stores from the Laravel database config.

This doest work if someone is using a Redis Sentinel configuration.

The host can be changed, but not the selected DB. This change won't break current configurations.

Current config:
```
    'redis' => [

        'client' => env('REDIS_CLIENT', 'phpredis'),

        'options' => [
            'replication' => 'sentinel',
            'service' => 'mymaster',
            'parameters'  => [
                    'password' => env('REDIS_PASSWORD', null),
                    'database' => env('REDIS_DATABASE', null),
            ],
        ],

        'default' => [
            'tcp://'.env('REDIS_HOST_1').':26379?timeout=0.100',
            'tcp://'.env('REDIS_HOST_2').':26379?timeout=0.100',
            'tcp://'.env('REDIS_HOST_3').':26379?timeout=0.100',
        ],

        'storetwo' => [
            'tcp://'.env('REDIS_HOST_1').':26379?timeout=0.100',
            'tcp://'.env('REDIS_HOST_2').':26379?timeout=0.100',
            'tcp://'.env('REDIS_HOST_3').':26379?timeout=0.100',
        ],
    ],
```

New config:

```
    'redis' => [

        'client' => env('REDIS_CLIENT', 'phpredis'),

        'options' => [
            'replication' => 'sentinel',
            'service' => 'mymaster',
            'parameters'  => [
                'default' => [
                    'password' => env('REDIS_PASSWORD', null),
                    'database' => env('REDIS_DATABASE', null),
                ],
                'storetwo' => [
                    'password' => env('REDIS_PASSWORD', null),
                    'database' => env('REDIS_DATABASE_TWO', null)
                ]
            ],
        ],

        'default' => [
            'tcp://'.env('REDIS_HOST_1').':26379?timeout=0.100',
            'tcp://'.env('REDIS_HOST_2').':26379?timeout=0.100',
            'tcp://'.env('REDIS_HOST_3').':26379?timeout=0.100',
        ],

        'storetwo' => [
            'tcp://'.env('REDIS_HOST_1').':26379?timeout=0.100',
            'tcp://'.env('REDIS_HOST_2').':26379?timeout=0.100',
            'tcp://'.env('REDIS_HOST_3').':26379?timeout=0.100',
        ],
    ],
```