### PR TITLE
[8.x] Add `assertExists` testing method

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -109,22 +109,33 @@ trait InteractsWithDatabase
     }
 
     /**
-     * Assert the given record exists in the database.
+     * Assert the given model exists in the database.
      *
-     * @param  \Illuminate\Database\Eloquent\Model|string  $table
-     * @param  array  $data
-     * @param  string|null  $connection
+     * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return $this
      */
-    protected function assertExists($table, array $data = [], $connection = null)
+    protected function assertModelExists($model)
     {
-        if ($table instanceof Model) {
-            return $this->assertDatabaseHas($table->getTable(), [$table->getKeyName() => $table->getKey()], $table->getConnectionName());
-        }
+        return $this->assertDatabaseHas(
+            $model->getTable(),
+            [$model->getKeyName() => $model->getKey()],
+            $model->getConnectionName()
+        );
+    }
 
-        $this->assertDatabaseHas($this->getTable($table), $data, $connection);
-
-        return $this;
+    /**
+     * Assert the given model does not exist in the database.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return $this
+     */
+    protected function assertModelMissing($model)
+    {
+        return $this->assertDatabaseMissing(
+            $model->getTable(),
+            [$model->getKeyName() => $model->getKey()],
+            $model->getConnectionName()
+        );
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -109,6 +109,25 @@ trait InteractsWithDatabase
     }
 
     /**
+     * Assert the given record exists in the database.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model|string  $table
+     * @param  array  $data
+     * @param  string|null  $connection
+     * @return $this
+     */
+    protected function assertExists($table, array $data = [], $connection = null)
+    {
+        if ($table instanceof Model) {
+            return $this->assertDatabaseHas($table->getTable(), [$table->getKeyName() => $table->getKey()], $table->getConnectionName());
+        }
+
+        $this->assertDatabaseHas($this->getTable($table), $data, $connection);
+
+        return $this;
+    }
+
+    /**
      * Determine if the argument is a soft deletable model.
      *
      * @param  mixed  $model

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -239,6 +239,40 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertSoftDeleted(new CustomProductStub($this->data));
     }
 
+    public function testAssertExistsPassesWhenFindsResults()
+    {
+        $this->data = ['id' => 1];
+
+        $builder = $this->mockCountBuilder(1);
+
+        $builder->shouldReceive('get')->andReturn(collect($this->data));
+
+        $this->assertExists(new ProductStub($this->data));
+    }
+
+    public function testAssertExistsSupportsModelStrings()
+    {
+        $this->data = ['id' => 1];
+
+        $builder = $this->mockCountBuilder(1);
+
+        $builder->shouldReceive('get')->andReturn(collect($this->data));
+
+        $this->assertExists(ProductStub::class, $this->data);
+    }
+
+    public function testAssertExistsFailsDoesNotFindResults()
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The table is empty.');
+
+        $builder = $this->mockCountBuilder(0);
+
+        $builder->shouldReceive('get')->andReturn(collect());
+
+        $this->assertExists($this->table, $this->data);
+    }
+
     public function testGetTableNameFromModel()
     {
         $this->assertEquals($this->table, $this->getTable(ProductStub::class));

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -172,6 +172,17 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertDeleted(new ProductStub($this->data));
     }
 
+    public function testAssertModelMissingPassesWhenDoesNotFindModelResults()
+    {
+        $this->data = ['id' => 1];
+
+        $builder = $this->mockCountBuilder(0);
+
+        $builder->shouldReceive('get')->andReturn(collect());
+
+        $this->assertModelMissing(new ProductStub($this->data));
+    }
+
     public function testAssertDeletedFailsWhenFindsModelResults()
     {
         $this->expectException(ExpectationFailedException::class);
@@ -247,30 +258,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
 
         $builder->shouldReceive('get')->andReturn(collect($this->data));
 
-        $this->assertExists(new ProductStub($this->data));
-    }
-
-    public function testAssertExistsSupportsModelStrings()
-    {
-        $this->data = ['id' => 1];
-
-        $builder = $this->mockCountBuilder(1);
-
-        $builder->shouldReceive('get')->andReturn(collect($this->data));
-
-        $this->assertExists(ProductStub::class, $this->data);
-    }
-
-    public function testAssertExistsFailsDoesNotFindResults()
-    {
-        $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('The table is empty.');
-
-        $builder = $this->mockCountBuilder(0);
-
-        $builder->shouldReceive('get')->andReturn(collect());
-
-        $this->assertExists($this->table, $this->data);
+        $this->assertModelExists(new ProductStub($this->data));
     }
 
     public function testGetTableNameFromModel()


### PR DESCRIPTION
This PR adds the `assertExists` method for use in testing.

This method aims to make checking whether a model exists in the database easier, much like `assertDeleted` did for `assertDatabaseMissing`.

With this method, the following:

```php
public function testProductIsNotDeleted(): void
{
    $product = Product::find(1);

    // ...

    $this->assertDatabaseHas('products', [
        'id' => $product->getKey(),
    ]);
}
```

Could be rewritten to:

```php
public function testProductIsNotDeleted(): void
{
    $product = Product::find(1);

    // ...

    $this->assertExists($product);
}
```