### PR TITLE
[8.x] Provide psr/simple-cache-implementation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -91,7 +91,8 @@
         "symfony/cache": "^5.1.4"
     },
     "provide": {
-        "psr/container-implementation": "1.0"
+        "psr/container-implementation": "1.0",
+        "psr/simple-cache-implementation": "1.0"
     },
     "conflict": {
         "tightenco/collect": "<5.5.33"

--- a/src/Illuminate/Cache/composer.json
+++ b/src/Illuminate/Cache/composer.json
@@ -20,6 +20,9 @@
         "illuminate/macroable": "^8.0",
         "illuminate/support": "^8.0"
     },
+    "provide": {
+        "psr/simple-cache-implementation": "1.0"
+    },
     "autoload": {
         "psr-4": {
             "Illuminate\\Cache\\": ""


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

`Illuminate\Cache\Repository` implements PSR-16's `Psr\SimpleCache\CacheInterface` via the `Illuminate\Contracts\Cache\Repository` interface.

Let's declare that `illuminate/cache` and `laravel/framework` provide `psr/simple-cache-implementation` so that packages relying on `psr/simple-cache-implementation` for a PSR-16 cache can be installed in a Laravel project.

---

Context: I was trying to use the [Unleash](https://www.getunleash.io/) PHP client ([`unleash/client`](https://github.com/Unleash/unleash-client-php)) in a Laravel project. The client will fail to `composer install` in a Laravel project as it uses the presence of a package providing `psr/simple-cache-implementation` to ensure that a [PSR-16](https://www.php-fig.org/psr/psr-16/) cache is available. 

Since [Laravel's cache is already PSR-16 compliant](https://github.com/laravel/framework/pull/29610#issuecomment-522086296), it should provide the `psr/simple-cache-implementation` virtual package to allow PHP packages requiring a PSR-16 cache to be used in a Laravel project.