### PR TITLE
Update symfony mailer docblocks

### DIFF
--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -222,7 +222,7 @@ class MailManager implements FactoryContract
      * Create an instance of the Symfony Amazon SES Transport driver.
      *
      * @param  array  $config
-     * @return \Symfony\Component\Mailer\Transport\TransportInterface
+     * @return \Symfony\Component\Mailer\Bridge\Amazon\Transport\SesApiAsyncAwsTransport
      */
     protected function createSesTransport(array $config)
     {
@@ -260,7 +260,7 @@ class MailManager implements FactoryContract
      * Create an instance of the Symfony Mailgun Transport driver.
      *
      * @param  array  $config
-     * @return \Symfony\Component\Mailer\Transport\TransportInterface
+     * @return \Symfony\Component\Mailer\Bridge\Mailgun\Transport\MailgunApiTransport
      */
     protected function createMailgunTransport(array $config)
     {
@@ -282,7 +282,7 @@ class MailManager implements FactoryContract
      * Create an instance of the Symfony Postmark Transport driver.
      *
      * @param  array  $config
-     * @return \Symfony\Component\Mailer\Transport\TransportInterface
+     * @return \Symfony\Component\Mailer\Bridge\Postmark\Transport\PostmarkApiTransport
      */
     protected function createPostmarkTransport(array $config)
     {

--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -219,10 +219,10 @@ class MailManager implements FactoryContract
     }
 
     /**
-     * Create an instance of the Amazon SES Swift Transport driver.
+     * Create an instance of the Symfony Amazon SES Transport driver.
      *
      * @param  array  $config
-     * @return \Illuminate\Mail\Transport\SesTransport
+     * @return \Symfony\Component\Mailer\Transport\TransportInterface
      */
     protected function createSesTransport(array $config)
     {
@@ -257,7 +257,7 @@ class MailManager implements FactoryContract
     }
 
     /**
-     * Create an instance of the Mailgun Swift Transport driver.
+     * Create an instance of the Symfony Mailgun Transport driver.
      *
      * @param  array  $config
      * @return \Symfony\Component\Mailer\Transport\TransportInterface
@@ -279,10 +279,10 @@ class MailManager implements FactoryContract
     }
 
     /**
-     * Create an instance of the Postmark Swift Transport driver.
+     * Create an instance of the Symfony Postmark Transport driver.
      *
      * @param  array  $config
-     * @return \Swift_Transport
+     * @return \Symfony\Component\Mailer\Transport\TransportInterface
      */
     protected function createPostmarkTransport(array $config)
     {


### PR DESCRIPTION
This PR removes some old references to Swift_Mailer and replaces it with the Symfony Mailer equivalent.

Even though the Symfony's TransportFactories annotate TransportInterface as the return type, Some of Laravels docblocks have a specific return type annotated.

Example: 
`EsmtpTransportFactory` returns an Object of `TransportInterface` but in the Laravel DocBlocks the real class will be annotated, which is here `EsmtpTransport`

Therefor all `@return` annotations have the most specific class.