### PR TITLE
[8.x] Fix `getDirty` method when using class castables (e.g. `As(Encrypted)ArrayObject`/`As(Encrypted)Collection`)

### DIFF
--- a/src/Illuminate/Database/Eloquent/Casts/AsArrayObject.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsArrayObject.php
@@ -19,7 +19,7 @@ class AsArrayObject implements Castable
         {
             public function get($model, $key, $value, $attributes)
             {
-                return isset($attributes[$key]) ? new ArrayObject(json_decode($attributes[$key], true)) : null;
+                return $value ? new ArrayObject(json_decode($value, true)) : null;
             }
 
             public function set($model, $key, $value, $attributes)

--- a/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
@@ -20,7 +20,7 @@ class AsCollection implements Castable
         {
             public function get($model, $key, $value, $attributes)
             {
-                return isset($attributes[$key]) ? new Collection(json_decode($attributes[$key], true)) : null;
+                return $value ? new Collection(json_decode($value, true)) : null;
             }
 
             public function set($model, $key, $value, $attributes)

--- a/src/Illuminate/Database/Eloquent/Casts/AsEncryptedArrayObject.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEncryptedArrayObject.php
@@ -20,7 +20,7 @@ class AsEncryptedArrayObject implements Castable
         {
             public function get($model, $key, $value, $attributes)
             {
-                return new ArrayObject(json_decode(Crypt::decryptString($attributes[$key]), true));
+                return new ArrayObject(json_decode(Crypt::decryptString($value), true));
             }
 
             public function set($model, $key, $value, $attributes)

--- a/src/Illuminate/Database/Eloquent/Casts/AsEncryptedCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEncryptedCollection.php
@@ -21,7 +21,7 @@ class AsEncryptedCollection implements Castable
         {
             public function get($model, $key, $value, $attributes)
             {
-                return new Collection(json_decode(Crypt::decryptString($attributes[$key]), true));
+                return new Collection(json_decode(Crypt::decryptString($value), true));
             }
 
             public function set($model, $key, $value, $attributes)

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1658,6 +1658,16 @@ trait HasAttributes
         } elseif ($this->hasCast($key, static::$primitiveCastTypes)) {
             return $this->castAttribute($key, $attribute) ===
                 $this->castAttribute($key, $original);
+        } elseif ($this->isClassCastable($key)) {
+            $caster = $this->resolveCasterClass($key);
+            $original = $this->normalizeCastClassResponse($key, $caster->set(
+                $this,
+                $key,
+                $this->castAttribute($key, $original),
+                $this->attributes
+            ));
+
+            return $attribute === $original[$key];
         }
 
         return is_numeric($attribute) && is_numeric($original)

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1659,8 +1659,7 @@ trait HasAttributes
             return $this->castAttribute($key, $attribute) ===
                 $this->castAttribute($key, $original);
         } elseif ($this->isClassCastable($key)) {
-            $caster = $this->resolveCasterClass($key);
-            $original = $this->normalizeCastClassResponse($key, $caster->set(
+            $original = $this->normalizeCastClassResponse($key, $this->resolveCasterClass($key)->set(
                 $this,
                 $key,
                 $this->castAttribute($key, $original),

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1659,10 +1659,12 @@ trait HasAttributes
             return $this->castAttribute($key, $attribute) ===
                 $this->castAttribute($key, $original);
         } elseif ($this->isClassCastable($key)) {
-            $original = $this->normalizeCastClassResponse($key, $this->resolveCasterClass($key)->set(
+            $caster = $this->resolveCasterClass($key);
+
+            $original = $this->normalizeCastClassResponse($key, $caster->set(
                 $this,
                 $key,
-                $this->castAttribute($key, $original),
+                $caster instanceof CastsInboundAttributes ? $original : $caster->get($this, $key, $original, $this->attributes),
                 $this->attributes
             ));
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Database;
 
+use ArrayObject;
 use DateTime;
 use DateTimeImmutable;
 use DateTimeInterface;
@@ -163,6 +164,9 @@ class DatabaseEloquentModelTest extends TestCase
             'arrayobjectAttribute' => '{"foo": "bar"}',
         ]);
         $model->syncOriginal();
+
+        $this->assertInstanceOf(ArrayObject::class, $model->arrayobjectAttribute);
+        $this->assertFalse($model->isDirty());
 
         $model->arrayobjectAttribute = ['foo' => 'bar'];
         $this->assertFalse($model->isDirty());

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -166,13 +166,13 @@ class DatabaseEloquentModelTest extends TestCase
         $model->syncOriginal();
 
         $this->assertInstanceOf(ArrayObject::class, $model->arrayobjectAttribute);
-        $this->assertFalse($model->isDirty());
+        $this->assertFalse($model->isDirty('arrayobjectAttribute'));
 
         $model->arrayobjectAttribute = ['foo' => 'bar'];
-        $this->assertFalse($model->isDirty());
+        $this->assertFalse($model->isDirty('arrayobjectAttribute'));
 
         $model->arrayobjectAttribute = ['foo' => 'baz'];
-        $this->assertTrue($model->isDirty());
+        $this->assertTrue($model->isDirty('arrayobjectAttribute'));
     }
 
     public function testCleanAttributes()

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Connection;
 use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Casts\AsArrayObject;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\JsonEncodingException;
 use Illuminate\Database\Eloquent\MassAssignmentException;
@@ -153,6 +154,21 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertFalse($model->isDirty());
         $this->assertFalse($model->isDirty('objectAttribute'));
         $this->assertFalse($model->isDirty('collectionAttribute'));
+    }
+
+    public function testDirtyOnCastedArrayObject()
+    {
+        $model = new EloquentModelCastingStub;
+        $model->setRawAttributes([
+            'arrayobjectAttribute' => '{"foo": "bar"}',
+        ]);
+        $model->syncOriginal();
+
+        $model->arrayobjectAttribute = ['foo' => 'bar'];
+        $this->assertFalse($model->isDirty());
+
+        $model->arrayobjectAttribute = ['foo' => 'baz'];
+        $this->assertTrue($model->isDirty());
     }
 
     public function testCleanAttributes()
@@ -2570,6 +2586,7 @@ class EloquentModelCastingStub extends Model
         'dateAttribute' => 'date',
         'datetimeAttribute' => 'datetime',
         'timestampAttribute' => 'timestamp',
+        'arrayobjectAttribute' => AsArrayObject::class,
     ];
 
     public function jsonAttributeValue()


### PR DESCRIPTION
### What is the issue?

In MySQL, a JSON column adds spaces between the JSON keys and the JSON values, even when you explicitly try to save it without spaces.
```
// If you try to save this in a MySQL json column:
{"foo":"bar"}
// Then MySQL will save it like this:
{"foo": "bar"}
```

This causes an issue when using the `AsArrayObject` casting class on a JSON attribute. Currently, the `originalIsEquivalent` method (used by `getDirty` method) does nothing special when an attribute uses a class castable. This means that it will do a strict string comparison between the original and the new value, which will result in a `false` because of the spaces in the original value. This causes a lot of unnecessary update queries because Eloquent thinks a model contains changes.

```php
'{"foo": "bar"}' !== '{"foo":"bar"}'
```

### How to fix it?

To fix this, we need to cast the original attribute using the class castable before comparing the two values. This casting is done in the `originalIsEquivalent` method itself. It does not use the `castAttribute` because that causes issues with the `classCastCache` (which caches only based key instead of key-value combination).

I also updated the `get` methods of the `As(Encrypted)ArrayObject` and `As(Encrypted)Collection` casts. The `get` method currently uses the value in the `$attributes` array, while it should use the provided `$value`.
