### PR TITLE
[8.x] Add `deleteOrFail` to `Model`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1262,6 +1262,24 @@ abstract class Model implements Arrayable, ArrayAccess, HasBroadcastChannel, Jso
     }
 
     /**
+     * Delete the model from the database within a transaction.
+     *
+     * @return bool|null
+     *
+     * @throws \Throwable
+     */
+    public function deleteOrFail()
+    {
+        if (! $this->exists) {
+            return false;
+        }
+
+        return $this->getConnection()->transaction(function () {
+            return $this->delete();
+        });
+    }
+
+    /**
      * Force a hard delete on a soft deleted model.
      *
      * This method protects developers from running forceDelete when the trait is missing.


### PR DESCRIPTION
The `deleteOrFail()` method makes it more convenient to handle delete errors in destroy actions, as it is less verbose than checking the return value of `delete()`.

See also:
- `saveOrFail` - added in #11202
- `updateOrFail` - added in #38592