### PR TITLE
[8.x] allow tests to utilise the null logger

### DIFF
--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -95,7 +95,7 @@ class LogManager implements LoggerInterface
      */
     public function driver($driver = null)
     {
-        return $this->get($driver ?? $this->getDefaultDriver());
+        return $this->get($this->parseDriver($driver));
     }
 
     /**
@@ -450,7 +450,7 @@ class LogManager implements LoggerInterface
     /**
      * Get the default log driver name.
      *
-     * @return string
+     * @return string|null
      */
     public function getDefaultDriver()
     {
@@ -490,11 +490,28 @@ class LogManager implements LoggerInterface
      */
     public function forgetChannel($driver = null)
     {
-        $driver = $driver ?? $this->getDefaultDriver();
+        $driver = $this->parseDriver($driver);
 
         if (isset($this->channels[$driver])) {
             unset($this->channels[$driver]);
         }
+    }
+
+    /**
+     * Parse the driver name.
+     *
+     * @param  string|null  $driver
+     * @return string|null
+     */
+    protected function parseDriver($driver)
+    {
+        $driver = $driver ?? $this->getDefaultDriver();
+
+        if ($this->app->runningUnitTests()) {
+            $driver = $driver ?? 'null';
+        }
+
+        return $driver;
     }
 
     /**


### PR DESCRIPTION
**Note:** maybe I'm way off here and don't know how to use the "null" logger - so maybe PEBKEC?

Currently, the "null" logger does not ever get utillised. It instead creates and writes to the emergency logger.

The issue being that when you set this in your env...

```sh
# file: .env.testing

LOG_CHANNEL=null

# or...

LOG_CHANNEL='null'

# or

LOG_CHANNEL="null"
```

It is interpreted as `null` not `"null"`. There is possibly a way to tell dot env to read this value as a string and I've tried to obvious ones, but didn't have any luck. I'm sure someone will jump in and tell me how, but I reckon a lot of people will have this set and it is triggering the emergency logger instead.

Steps to reproduce the issue...

```
composer create-project laravel/laravel example-repo
cd example-repo
php artisan key:generate
echo "LOG_CHANNEL=null" > .env.testing
echo "<?php

namespace Tests\Feature;

use Illuminate\Foundation\Testing\RefreshDatabase;
use Illuminate\Log\LogManager;
use Illuminate\Support\Facades\Log;
use Illuminate\Support\Facades\Route;
use Psr\Log\LoggerInterface;
use Tests\TestCase;

class ExampleTest extends TestCase
{
    /**
     * A basic test example.
     *
     * @return void
     */
    public function test_example()
    {
        Route::get('/test', function () {
            Log::info('test');
        });

        \$response = \$this->get('/test');

        \$response->assertStatus(200);
    }
}" > tests/Feature/ExampleTest.php
./vendor/bin/phpunit
cat storage/logs/laravel.log
```

Hopefully the test is okay. I kinda felt like it would be good to have it all co-located rather than splitting out to atomic tests 🤷‍♂️

I didn't feel comfortable making this impact anything other than unit tests. Maybe this should also happen in production...but on the other hand if this is null in prod you probably really do want it to write to the emergency logger as a safe default.