### PR TITLE
[8.x] Use lowercase for hmac hash algorithm

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/maintenance-mode.stub
+++ b/src/Illuminate/Foundation/Console/stubs/maintenance-mode.stub
@@ -48,7 +48,7 @@ if (isset($_COOKIE['laravel_maintenance']) && isset($data['secret'])) {
     if (is_array($payload) &&
         is_numeric($payload['expires_at'] ?? null) &&
         isset($payload['mac']) &&
-        hash_equals(hash_hmac('SHA256', $payload['expires_at'], $data['secret']), $payload['mac']) &&
+        hash_equals(hash_hmac('sha256', $payload['expires_at'], $data['secret']), $payload['mac']) &&
         (int) $payload['expires_at'] >= time()) {
         return;
     }

--- a/src/Illuminate/Foundation/Http/MaintenanceModeBypassCookie.php
+++ b/src/Illuminate/Foundation/Http/MaintenanceModeBypassCookie.php
@@ -19,7 +19,7 @@ class MaintenanceModeBypassCookie
 
         return new Cookie('laravel_maintenance', base64_encode(json_encode([
             'expires_at' => $expiresAt->getTimestamp(),
-            'mac' => hash_hmac('SHA256', $expiresAt->getTimestamp(), $key),
+            'mac' => hash_hmac('sha256', $expiresAt->getTimestamp(), $key),
         ])), $expiresAt);
     }
 
@@ -37,7 +37,7 @@ class MaintenanceModeBypassCookie
         return is_array($payload) &&
             is_numeric($payload['expires_at'] ?? null) &&
             isset($payload['mac']) &&
-            hash_equals(hash_hmac('SHA256', $payload['expires_at'], $key), $payload['mac']) &&
+            hash_equals(hash_hmac('sha256', $payload['expires_at'], $key), $payload['mac']) &&
             (int) $payload['expires_at'] >= Carbon::now()->getTimestamp();
     }
 }


### PR DESCRIPTION
This simply aligns the casing of the hashing algorithm name, since all other references to hashing functions use lowercase.

The php documentation doesn't specifically say which casing to use, but it refers to `hash_hmac_algos` which returns lowercase only. The current PHP source does perform a `tolower` of the provided string.