### PR TITLE
Added string comparison for correct check versions

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -969,6 +969,10 @@ trait ValidatesAttributes
             return false;
         }
 
+        if ($this->isBothAsString($value, $comparedToValue)) {
+            return $value > $comparedToValue;
+        }
+
         return $this->getSize($attribute, $value) > $this->getSize($attribute, $comparedToValue);
     }
 
@@ -1002,6 +1006,10 @@ trait ValidatesAttributes
 
         if (! $this->isSameType($value, $comparedToValue)) {
             return false;
+        }
+
+        if ($this->isBothAsString($value, $comparedToValue)) {
+            return $value < $comparedToValue;
         }
 
         return $this->getSize($attribute, $value) < $this->getSize($attribute, $comparedToValue);
@@ -1039,6 +1047,10 @@ trait ValidatesAttributes
             return false;
         }
 
+        if ($this->isBothAsString($value, $comparedToValue)) {
+            return $value >= $comparedToValue;
+        }
+
         return $this->getSize($attribute, $value) >= $this->getSize($attribute, $comparedToValue);
     }
 
@@ -1072,6 +1084,10 @@ trait ValidatesAttributes
 
         if (! $this->isSameType($value, $comparedToValue)) {
             return false;
+        }
+
+        if ($this->isBothAsString($value, $comparedToValue)) {
+            return $value <= $comparedToValue;
         }
 
         return $this->getSize($attribute, $value) <= $this->getSize($attribute, $comparedToValue);
@@ -2061,6 +2077,18 @@ trait ValidatesAttributes
     protected function isSameType($first, $second)
     {
         return gettype($first) == gettype($second);
+    }
+
+    /**
+     * Check if the parameters are of the strings
+     *
+     * @param $first
+     * @param $second
+     * @return bool
+     */
+    protected function isBothAsString($first, $second): bool
+    {
+        return is_string($first) === is_string($second);
     }
 
     /**


### PR DESCRIPTION
Faced such a problem as poor string comparison.
In our code we transfer the semantic version of applications to the backend and at the moment the comparison is not working correctly.
`
min_os => 'lte:max_os',
max_os => 'gte:min_os'
`

It works incorrectly because the comparison is based on the length of the string:
`$this->getSize($attribute, '1.2.1') \\ is 5`
and 
`$this->getSize($attribute, '1.1.1') \\ is 5 too`

and there and there strings of the same length and the condition is processed incorrectly

`return $this->getSize($attribute, '1.2.1) <= $this->getSize($attribute, '1.1.1'); // return true;`

By default, the PHP has the correct logic for comparing strings, so I added this edit

`return '1.2.1' <= '1.1.1'; // return false`

Same problem we have when trying to compare 'Blablabla' with 'Alablabla'.

Current code says that  `'Alablabla' >= 'Blablabla' is true`. My solution `'Alablabla' >= 'Blablabla' is false`