### PR TITLE
String comparison

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -969,6 +969,10 @@ trait ValidatesAttributes
             return false;
         }
 
+        if ($this->isBothAsString($value, $comparedToValue)) {
+            return $value > $comparedToValue;
+        }
+
         return $this->getSize($attribute, $value) > $this->getSize($attribute, $comparedToValue);
     }
 
@@ -1002,6 +1006,10 @@ trait ValidatesAttributes
 
         if (! $this->isSameType($value, $comparedToValue)) {
             return false;
+        }
+
+        if ($this->isBothAsString($value, $comparedToValue)) {
+            return $value < $comparedToValue;
         }
 
         return $this->getSize($attribute, $value) < $this->getSize($attribute, $comparedToValue);
@@ -1039,6 +1047,10 @@ trait ValidatesAttributes
             return false;
         }
 
+        if ($this->isBothAsString($value, $comparedToValue)) {
+            return $value >= $comparedToValue;
+        }
+
         return $this->getSize($attribute, $value) >= $this->getSize($attribute, $comparedToValue);
     }
 
@@ -1072,6 +1084,10 @@ trait ValidatesAttributes
 
         if (! $this->isSameType($value, $comparedToValue)) {
             return false;
+        }
+
+        if ($this->isBothAsString($value, $comparedToValue)) {
+            return $value <= $comparedToValue;
         }
 
         return $this->getSize($attribute, $value) <= $this->getSize($attribute, $comparedToValue);
@@ -2061,6 +2077,18 @@ trait ValidatesAttributes
     protected function isSameType($first, $second)
     {
         return gettype($first) == gettype($second);
+    }
+
+    /**
+     * Check if the parameters are of the strings
+     *
+     * @param $first
+     * @param $second
+     * @return bool
+     */
+    protected function isBothAsString($first, $second): bool
+    {
+        return is_string($first) === is_string($second);
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -969,10 +969,6 @@ trait ValidatesAttributes
             return false;
         }
 
-        if ($this->isBothAsString($value, $comparedToValue)) {
-            return $value > $comparedToValue;
-        }
-
         return $this->getSize($attribute, $value) > $this->getSize($attribute, $comparedToValue);
     }
 
@@ -1006,10 +1002,6 @@ trait ValidatesAttributes
 
         if (! $this->isSameType($value, $comparedToValue)) {
             return false;
-        }
-
-        if ($this->isBothAsString($value, $comparedToValue)) {
-            return $value < $comparedToValue;
         }
 
         return $this->getSize($attribute, $value) < $this->getSize($attribute, $comparedToValue);
@@ -1047,7 +1039,7 @@ trait ValidatesAttributes
             return false;
         }
 
-        if ($this->isBothAsString($value, $comparedToValue)) {
+        if ($this->isBothAsString($value, $comparedToValue) && $this->isSameSize($value, $comparedToValue)) {
             return $value >= $comparedToValue;
         }
 
@@ -1086,7 +1078,7 @@ trait ValidatesAttributes
             return false;
         }
 
-        if ($this->isBothAsString($value, $comparedToValue)) {
+        if ($this->isBothAsString($value, $comparedToValue) && $this->isSameSize($value, $comparedToValue)) {
             return $value <= $comparedToValue;
         }
 
@@ -2088,7 +2080,12 @@ trait ValidatesAttributes
      */
     protected function isBothAsString($first, $second): bool
     {
-        return is_string($first) === is_string($second);
+        return is_string($first) && is_string($second);
+    }
+
+    protected function isSameSize($first, $second) : bool
+    {
+        return mb_strlen($first) === mb_strlen($second);
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -2078,12 +2078,19 @@ trait ValidatesAttributes
      * @param $second
      * @return bool
      */
-    protected function isBothAsString($first, $second): bool
+    protected function isBothAsString($first, $second)
     {
         return is_string($first) && is_string($second);
     }
 
-    protected function isSameSize($first, $second) : bool
+    /**
+     * Check that two string have the same size
+     *
+     * @param $first
+     * @param $second
+     * @return bool
+     */
+    protected function isSameSize($first, $second)
     {
         return mb_strlen($first) === mb_strlen($second);
     }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1745,6 +1745,9 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['lhs' => 'longer string', 'rhs' => 'string'], ['lhs' => 'gte:rhs']);
         $this->assertTrue($v->passes());
 
+        $v = new Validator($trans, ['lhs' => '1.1.2', 'rhs' => '1.1.1'], ['lhs' => 'gte:rhs']);
+        $this->assertTrue($v->passes());
+
         $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => [1, 'string']], ['lhs' => 'gte:rhs']);
         $this->assertTrue($v->fails());
 
@@ -1784,6 +1787,9 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->fails());
 
         $v = new Validator($trans, ['lhs' => 'longer string', 'rhs' => 'string'], ['lhs' => 'lte:rhs']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['lhs' => '1.2.1', 'rhs' => '1.1.1'], ['lhs' => 'lte:rhs']);
         $this->assertTrue($v->fails());
 
         $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => [1, 'string']], ['lhs' => 'lte:rhs']);


### PR DESCRIPTION
Faced such a problem as poor string comparison.
In our code we transfer the semantic version of applications to the backend and at the moment the comparison is not working correctly.
`
min_os => 'lte:max_os',
max_os => 'gte:min_os'
`

It works incorrectly because the comparison is based on the length of the string:
`$this->getSize($attribute, '1.2.1') \\ is 5`
and 
`$this->getSize($attribute, '1.1.1') \\ is 5 too`

and there and there strings of the same length and the condition is processed incorrectly

`return $this->getSize($attribute, '1.2.1) <= $this->getSize($attribute, '1.1.1'); // return true;`

By default, the PHP has the correct logic for comparing strings, so I added this edit

`return '1.2.1' <= '1.1.1'; // return false`

Same problem we have when trying to compare 'Blablabla' with 'Alablabla'.

Current code says that  `'Alablabla' >= 'Blablabla' is true`. My solution `'Alablabla' >= 'Blablabla' is false`