### PR TITLE
[9.x] Bind the encryption key object into the container

### DIFF
--- a/src/Illuminate/Cookie/Middleware/EncryptCookies.php
+++ b/src/Illuminate/Cookie/Middleware/EncryptCookies.php
@@ -6,6 +6,7 @@ use Closure;
 use Illuminate\Contracts\Encryption\DecryptException;
 use Illuminate\Contracts\Encryption\Encrypter as EncrypterContract;
 use Illuminate\Cookie\CookieValuePrefix;
+use Illuminate\Encryption\Key;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -18,6 +19,13 @@ class EncryptCookies
      * @var \Illuminate\Contracts\Encryption\Encrypter
      */
     protected $encrypter;
+
+    /**
+     * The key instance.
+     *
+     * @var \Illuminate\Encryption\Key
+     */
+    protected Key $key;
 
     /**
      * The names of the cookies that should not be encrypted.
@@ -37,11 +45,13 @@ class EncryptCookies
      * Create a new CookieGuard instance.
      *
      * @param  \Illuminate\Contracts\Encryption\Encrypter  $encrypter
+     * @param  \Illuminate\Encryption\Key  $key
      * @return void
      */
-    public function __construct(EncrypterContract $encrypter)
+    public function __construct(EncrypterContract $encrypter, Key $key)
     {
         $this->encrypter = $encrypter;
+        $this->key = $key;
     }
 
     /**
@@ -103,7 +113,7 @@ class EncryptCookies
     {
         return is_array($value)
                     ? $this->validateArray($key, $value)
-                    : CookieValuePrefix::validate($key, $value, $this->encrypter->getKey());
+                    : CookieValuePrefix::validate($key, $value, $this->key->getValue());
     }
 
     /**
@@ -177,7 +187,7 @@ class EncryptCookies
             $response->headers->setCookie($this->duplicate(
                 $cookie,
                 $this->encrypter->encrypt(
-                    CookieValuePrefix::create($cookie->getName(), $this->encrypter->getKey()).$cookie->getValue(),
+                    CookieValuePrefix::create($cookie->getName(), $this->key->getValue()).$cookie->getValue(),
                     static::serialized($cookie->getName())
                 )
             ));

--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -39,15 +39,15 @@ class Encrypter implements EncrypterContract, StringEncrypter
     /**
      * Create a new encrypter instance.
      *
-     * @param  string  $key
+     * @param  \Illuminate\Encryption\Key  $key
      * @param  string  $cipher
      * @return void
      *
      * @throws \RuntimeException
      */
-    public function __construct($key, $cipher = 'aes-128-cbc')
+    public function __construct(Key $key, string $cipher = 'aes-128-cbc')
     {
-        $key = (string) $key;
+        $key = $key->getValue();
 
         if (! static::supported($key, $cipher)) {
             $ciphers = implode(', ', array_keys(self::$supportedCiphers));
@@ -253,15 +253,5 @@ class Encrypter implements EncrypterContract, StringEncrypter
         return hash_equals(
             $this->hash($payload['iv'], $payload['value']), $payload['mac']
         );
-    }
-
-    /**
-     * Get the encryption key.
-     *
-     * @return string
-     */
-    public function getKey()
-    {
-        return $this->key;
     }
 }

--- a/src/Illuminate/Encryption/EncryptionServiceProvider.php
+++ b/src/Illuminate/Encryption/EncryptionServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Encryption;
 
+use Illuminate\Contracts\Container\Container;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
 use Opis\Closure\SerializableClosure;
@@ -15,8 +16,23 @@ class EncryptionServiceProvider extends ServiceProvider
      */
     public function register()
     {
+        $this->registerKey();
         $this->registerEncrypter();
         $this->registerOpisSecurityKey();
+    }
+
+    /**
+     * Register the key.
+     *
+     * @return void
+     */
+    protected function registerKey(): void
+    {
+        $this->app->singleton(Key::class, function (Container $container): Key {
+            $config = $container->make('config')->get('app');
+
+            return new Key($this->parseKey($config));
+        });
     }
 
     /**
@@ -26,10 +42,10 @@ class EncryptionServiceProvider extends ServiceProvider
      */
     protected function registerEncrypter()
     {
-        $this->app->singleton('encrypter', function ($app) {
+        $this->app->singleton('encrypter', function (Container $app) {
             $config = $app->make('config')->get('app');
 
-            return new Encrypter($this->parseKey($config), $config['cipher']);
+            return new Encrypter($app->make(Key::class), $config['cipher']);
         });
     }
 

--- a/src/Illuminate/Encryption/Key.php
+++ b/src/Illuminate/Encryption/Key.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Illuminate\Encryption;
+
+class Key
+{
+    /**
+     * Create a new Key instance.
+     *
+     * @param  string  $value
+     * @return void
+     */
+    public function __construct(private string $value)
+    {
+    }
+
+    /**
+     * Get the key value.
+     *
+     * @return string
+     */
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+}

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Testing\Concerns;
 
 use Illuminate\Contracts\Http\Kernel as HttpKernel;
 use Illuminate\Cookie\CookieValuePrefix;
+use Illuminate\Encryption\Key;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
 use Illuminate\Testing\LoggedExceptionCollection;
@@ -603,7 +604,7 @@ trait MakesHttpRequests
         }
 
         return collect($this->defaultCookies)->map(function ($value, $key) {
-            return encrypt(CookieValuePrefix::create($key, app('encrypter')->getKey()).$value, false);
+            return encrypt(CookieValuePrefix::create($key, app(Key::class)->getValue()).$value, false);
         })->merge($this->unencryptedCookies)->all();
     }
 

--- a/src/Illuminate/Support/Facades/Crypt.php
+++ b/src/Illuminate/Support/Facades/Crypt.php
@@ -9,7 +9,6 @@ namespace Illuminate\Support\Facades;
  * @method static string encrypt(mixed $value, bool $serialize = true)
  * @method static string encryptString(string $value)
  * @method static string generateKey(string $cipher)
- * @method static string getKey()
  *
  * @see \Illuminate\Encryption\Encrypter
  */

--- a/tests/Integration/Http/Middleware/VerifyCsrfTokenExceptTest.php
+++ b/tests/Integration/Http/Middleware/VerifyCsrfTokenExceptTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Integration\Http\Middleware;
 
 use Illuminate\Encryption\Encrypter;
+use Illuminate\Encryption\Key;
 use Illuminate\Http\Request;
 use Orchestra\Testbench\TestCase;
 
@@ -15,7 +16,7 @@ class VerifyCsrfTokenExceptTest extends TestCase
     {
         parent::setUp();
 
-        $this->stub = new VerifyCsrfTokenExceptStub(app(), new Encrypter(Encrypter::generateKey('AES-128-CBC')));
+        $this->stub = new VerifyCsrfTokenExceptStub(app(), new Encrypter(new Key(Encrypter::generateKey('AES-128-CBC'))));
         $this->request = Request::create('http://example.com/foo/bar', 'POST');
     }
 
@@ -57,6 +58,6 @@ class VerifyCsrfTokenExceptTest extends TestCase
 
     private function assertNonMatchingExcept(array $except)
     {
-        return $this->assertMatchingExcept($except, false);
+        $this->assertMatchingExcept($except, false);
     }
 }

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\View\View;
 use Illuminate\Cookie\CookieValuePrefix;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Encryption\Encrypter;
+use Illuminate\Encryption\Key;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Response;
@@ -1467,14 +1468,15 @@ class TestResponseTest extends TestCase
     public function testAssertCookie()
     {
         $container = Container::getInstance();
-        $encrypter = new Encrypter(str_repeat('a', 16));
+        $key = new Key(str_repeat('a', 16));
+        $encrypter = new Encrypter($key);
         $container->singleton('encrypter', function () use ($encrypter) {
             return $encrypter;
         });
 
         $cookieName = 'cookie-name';
         $cookieValue = 'cookie-value';
-        $encryptedValue = $encrypter->encrypt(CookieValuePrefix::create($cookieName, $encrypter->getKey()).$cookieValue, false);
+        $encryptedValue = $encrypter->encrypt(CookieValuePrefix::create($cookieName, $key->getValue()).$cookieValue, false);
 
         $response = TestResponse::fromBaseResponse(
             (new Response)->withCookie(new Cookie($cookieName, $encryptedValue))
@@ -1544,7 +1546,8 @@ class TestResponseTest extends TestCase
     public function testGetEncryptedCookie()
     {
         $container = Container::getInstance();
-        $encrypter = new Encrypter(str_repeat('a', 16));
+        $key = new Key(str_repeat('a', 16));
+        $encrypter = new Encrypter($key);
         $container->singleton('encrypter', function () use ($encrypter) {
             return $encrypter;
         });
@@ -1552,7 +1555,7 @@ class TestResponseTest extends TestCase
         $cookieName = 'cookie-name';
         $cookieValue = 'cookie-value';
         $encryptedValue = $encrypter->encrypt(
-            CookieValuePrefix::create($cookieName, $encrypter->getKey()).$cookieValue, false
+            CookieValuePrefix::create($cookieName, $key->getValue()).$cookieValue, false
         );
 
         $response = TestResponse::fromBaseResponse(


### PR DESCRIPTION
The `\Illuminate\Cookie\Middleware\EncryptCookies` middleware calls the `getKey` method which is not on the encrypter contract. This leads to broken applications when the users of the framework create their own encrypter implementation.

This PR fixes this issue by making the key a value object that is bound into the container. By doing so anybody can typehint the `Key` class in their constructors and get the key that way now so there's no need to break the encrypter encapsulation with the `getKey` method.

A side bonus of doing this is that people no longer need to copy paste the logic from `\Illuminate\Encryption\EncryptionServiceProvider::parseKey` every time when they need to construct just the key.

There are only three very minor breaking changes here that won't affect 99% of the applications out there:

1. The first parameter in the encrypter constructor now takes a `Key` instance instead of a string
2. The `getKey` method on the encrypter has been removed. If the user needs the key they can just typehint it directly in the constructor instead of typehinting the Encrypter just to get the key.
3. The `\Illuminate\Cookie\Middleware\EncryptCookies` middleware constructor now gets the `Key` instance as the second parameter so if anyone overrode the constructor of that class in their app they will have to adjust it (but usually the only thing that changes in that class is the [$except array](https://github.com/laravel/laravel/blob/8.x/app/Http/Middleware/EncryptCookies.php#L14)).

Fixes https://github.com/laravel/framework/issues/38772