### PR TITLE
Add Session Token to SES Transport in symfony mailer again

### DIFF
--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -236,6 +236,10 @@ class MailManager implements FactoryContract
 
         $factory = new SesTransportFactory();
 
+        if (! isset($config['session_token']) && isset($config['token'])) {
+            $config['session_token'] = $config['token'];
+        }
+
         return $factory->create(new Dsn(
             'ses+api',
             'default',


### PR DESCRIPTION
symfony/symfony#42982 was merged into 5.4 of Symfony (still waiting to be merged into 6.0) which adds support for the temporary credentials of AWS.

Because in the ses section of the Laravel mail-config the session_token is named token we need to rename the config key while passing the options to the SES-Factory.

I also added a check to not overwrite `session_token` if that is already set for whatever reason.