### PR TITLE
[8.x] Support adding column "after" other new column

### DIFF
--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -504,6 +504,17 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertSame('alter table `users` add `name` varchar(255) not null after `foo`', $statements[0]);
     }
 
+    public function testAddingColumnAfterAnotherAddedColumn()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->timestamps();
+        $blueprint->foreignId('created_by')->after('created_at');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `created_at` timestamp null, add `created_by` bigint unsigned not null, add `updated_at` timestamp null', $statements[0]);
+    }
+
     public function testAddingMultipleColumnsAfterAnotherColumn()
     {
         $blueprint = new Blueprint('users');


### PR DESCRIPTION
Previously, new columns could only be added after existing columns, so
referencing a new column with the "after" modifier caused a MySQL error.

From now one, referencing a new column causes the column definition to
be inserted simply after the definition of the referenced column.

In particular, this allows us to create a new table with `timestamps()`,
and adding a `created_by` column after `created_at` at the same time.