### PR TITLE
[8.x] Add forwardDecoratedCallTo

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -478,13 +478,7 @@ abstract class Relation
             return $this->macroCall($method, $parameters);
         }
 
-        $result = $this->forwardCallTo($this->query, $method, $parameters);
-
-        if ($result === $this->query) {
-            return $this;
-        }
-
-        return $result;
+        return $this->forwardDecoratedCallTo($this->query, $method, $parameters);
     }
 
     /**

--- a/src/Illuminate/Support/Traits/ForwardsCalls.php
+++ b/src/Illuminate/Support/Traits/ForwardsCalls.php
@@ -44,7 +44,6 @@ trait ForwardsCalls
      * @param  mixed  $object
      * @param  string  $method
      * @param  array  $parameters
-     *
      * @return mixed
      *
      * @throws \BadMethodCallException

--- a/src/Illuminate/Support/Traits/ForwardsCalls.php
+++ b/src/Illuminate/Support/Traits/ForwardsCalls.php
@@ -38,6 +38,29 @@ trait ForwardsCalls
     }
 
     /**
+     * Forward a method call to the given object, returning $this if
+     * the forwarded call returned itself (was fluent).
+     *
+     * @param  mixed  $object
+     * @param  string  $method
+     * @param  array  $parameters
+     *
+     * @return mixed
+     *
+     * @throws \BadMethodCallException
+     */
+    protected function forwardDecoratedCallTo($object, $method, $parameters)
+    {
+        $result = $this->forwardCallTo($object, $method, $parameters);
+
+        if ($result === $object) {
+            return $this;
+        }
+
+        return $result;
+    }
+
+    /**
      * Throw a bad method call exception for the given method.
      *
      * @param  string  $method

--- a/src/Illuminate/Support/Traits/ForwardsCalls.php
+++ b/src/Illuminate/Support/Traits/ForwardsCalls.php
@@ -38,8 +38,7 @@ trait ForwardsCalls
     }
 
     /**
-     * Forward a method call to the given object, returning $this if
-     * the forwarded call returned itself (was fluent).
+     * Forward a method call to the given object, returning $this if the forwarded call returned itself.
      *
      * @param  mixed  $object
      * @param  string  $method


### PR DESCRIPTION
This PR adds an additional method to `ForwardsCalls` to allow for easy fluent calls to decorated objects. This pattern is used in the `Relation` class as well as in the `DecoratesQueryBuilder` trait that will be introduced in Laravel 9. Under the hood, this essentially performs:

```php
public function __call($method, $parameters)
{
  $result = $this->forwardCallTo($this->decorated, $method, $parameters);

  // If the underlying call was fluent, make this call fluent as well
  if ($result === $this->decorated) {
    return $this;
  }

  return $result;
}
```

This is a nice solution, because we continue to receive our proxy object until we make a call that isn't fluent on the underlying decorated object.

There are a handful of places that could be updated to use this new method. Because these are mild breaking changes, I'll introduce them in 9.x PR should this PR get merged. These are:

- `Illuminate\Events\NullDispatcher`
- `Illuminate\Http\Resources\DelegatesToResource`
- `Illuminate\Mail\Message`
- `Illuminate\Pagination\AbstractPaginator` and `AbstractCursorPaginator`

In each of these cases, I believe the expected behavior of any delegated fluent call would be to receive the proxy object, whereas right now you would receive the underlying object.

For example, in the case of `Illuminate\Mail\Message`:

```php
// Works because you happen to call from() first
$message->from('foo@bar.com')->addPart('hello', 'text/plain');

// Fails because you call from() second, and `addPart()` returned the underlying Swift_Message
$message->addPart('hello', 'text/plain')->from('foo@bar.com');
```