### PR TITLE
[8.x] The port memcached must be accepted as a number

### DIFF
--- a/src/Illuminate/Cache/MemcachedConnector.php
+++ b/src/Illuminate/Cache/MemcachedConnector.php
@@ -27,7 +27,7 @@ class MemcachedConnector
             // servers we'll verify the connection is successful and return it back.
             foreach ($servers as $server) {
                 $memcached->addServer(
-                    $server['host'], $server['port'], $server['weight']
+                    $server['host'], (int) $server['port'], $server['weight']
                 );
             }
         }

--- a/src/Illuminate/Cache/MemcachedConnector.php
+++ b/src/Illuminate/Cache/MemcachedConnector.php
@@ -26,8 +26,11 @@ class MemcachedConnector
             // the server to the Memcached connection. Once we have added all of these
             // servers we'll verify the connection is successful and return it back.
             foreach ($servers as $server) {
+                if(!is_int($server['port'])){
+                    throw new InvalidArgumentException("Port must be a integer.");
+                }
                 $memcached->addServer(
-                    $server['host'], (int) $server['port'], $server['weight']
+                    $server['host'], $server['port'], $server['weight']
                 );
             }
         }

--- a/src/Illuminate/Cache/MemcachedConnector.php
+++ b/src/Illuminate/Cache/MemcachedConnector.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Cache;
 
 use Memcached;
+use InvalidArgumentException;
 
 class MemcachedConnector
 {


### PR DESCRIPTION
The port must be accepted as a number. Without this, the port is always returned from the config as a string
