### PR TITLE
[8.x] Parameter interception in BindMethod

### DIFF
--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -70,9 +70,9 @@ class BoundMethod
     /**
      * Call a method that has been bound to the container.
      *
-     * @param \Illuminate\Container\Container  $container
-     * @param callable  $callback
-     * @param mixed  $default
+     * @param  \Illuminate\Container\Container  $container
+     * @param  callable  $callback
+     * @param  mixed  $default
      *
      * @return mixed
      * @throws \ReflectionException

--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -70,10 +70,12 @@ class BoundMethod
     /**
      * Call a method that has been bound to the container.
      *
-     * @param  \Illuminate\Container\Container  $container
-     * @param  callable  $callback
-     * @param  mixed  $default
+     * @param \Illuminate\Container\Container $container
+     * @param callable                        $callback
+     * @param mixed                           $default
+     *
      * @return mixed
+     * @throws \ReflectionException
      */
     protected static function callBoundMethod($container, $callback, $default)
     {
@@ -87,7 +89,13 @@ class BoundMethod
         $method = static::normalizeMethod($callback);
 
         if ($container->hasMethodBinding($method)) {
-            return $container->callMethodBinding($method, $callback[0]);
+            $reflectDefault = new ReflectionFunction($default);
+
+            return $container->callMethodBinding(
+                $method,
+                $callback[0],
+                $reflectDefault->getStaticVariables()['parameters']
+            );
         }
 
         return Util::unwrapIfClosure($default);

--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -73,7 +73,6 @@ class BoundMethod
      * @param  \Illuminate\Container\Container  $container
      * @param  callable  $callback
      * @param  mixed  $default
-     *
      * @return mixed
      * @throws \ReflectionException
      */

--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -70,9 +70,9 @@ class BoundMethod
     /**
      * Call a method that has been bound to the container.
      *
-     * @param \Illuminate\Container\Container $container
-     * @param callable                        $callback
-     * @param mixed                           $default
+     * @param \Illuminate\Container\Container  $container
+     * @param callable  $callback
+     * @param mixed  $default
      *
      * @return mixed
      * @throws \ReflectionException

--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -74,6 +74,7 @@ class BoundMethod
      * @param  callable  $callback
      * @param  mixed  $default
      * @return mixed
+     *
      * @throws \ReflectionException
      */
     protected static function callBoundMethod($container, $callback, $default)

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -339,11 +339,12 @@ class Container implements ArrayAccess, ContainerContract
      *
      * @param  string  $method
      * @param  mixed  $instance
+     * @param  array  $parameters
      * @return mixed
      */
-    public function callMethodBinding($method, $instance)
+    public function callMethodBinding($method, $instance, $parameters)
     {
-        return call_user_func($this->methodBindings[$method], $instance, $this);
+        return call_user_func($this->methodBindings[$method], $instance, $this, $parameters);
     }
 
     /**

--- a/tests/Container/ContainerCallTest.php
+++ b/tests/Container/ContainerCallTest.php
@@ -109,6 +109,23 @@ class ContainerCallTest extends TestCase
         $this->assertEquals(['foo', 'bar'], $result);
     }
 
+    public function testBindMethodWithCallParameters()
+    {
+        $container = new Container;
+        $container->bindMethod([ContainerTestCallStub::class, 'unresolvable'], function ($stub, $app, $params) {
+            return $params;
+        });
+        $result = $container->call([new ContainerTestCallStub, 'unresolvable'], ['param' => 'works']);
+        $this->assertEquals(['param' => 'works'], $result);
+
+        $container = new Container;
+        $container->bindMethod([ContainerTestCallStub::class, 'unresolvable'], function ($stub, $app, $params) {
+            return $params;
+        });
+        $result = $container->call(ContainerTestCallStub::class.'@unresolvable', ['param' => 'works']);
+        $this->assertEquals(['param' => 'works'], $result);
+    }
+
     public function testClosureCallWithInjectedDependency()
     {
         $container = new Container;


### PR DESCRIPTION
When we use `bindMethod`, we can only get the instance passed to call and the container itself as the second parameter. This PR makes it possible to intercept the parameters passed to the container calls. It lets developers decide what to do in `bindMethod`, based on the method input.

Actually, we can do this:
```
bindMethod(
    Service::class,
    'myMethod',
    fn ($service, $app) => $service->myMethod(100) + 1
);
```

It would be nice if we'll have:
```
bindMethod(
    Service::class,
    'myMethod',
    function ($service, $app, $params) {
        if ($params['myParam'] === 'myValue') {
            $service->doThis($params['myParam']);
        }
        
        return $service->default();
    }
);
```

I have created the package as syntax sugar to interact with the container calls, but this small thing stops the whole idea of conditional method bindings. Please, let me know if we can merge that or improve something if possible.