### PR TITLE
[8.x] Fix `$expectedListener` in docblock

### DIFF
--- a/src/Illuminate/Support/Facades/Event.php
+++ b/src/Illuminate/Support/Facades/Event.php
@@ -17,7 +17,7 @@ use Illuminate\Support\Testing\Fakes\EventFake;
  * @method static void assertDispatchedTimes(string $event, int $times = 1)
  * @method static void assertNotDispatched(string|\Closure $event, callable|int $callback = null)
  * @method static void assertNothingDispatched()
- * @method static void assertListening(string $expectedEvent, string expectedListener)
+ * @method static void assertListening(string $expectedEvent, string $expectedListener)
  * @method static void flush(string $event)
  * @method static void forget(string $event)
  * @method static void forgetPushed()


### PR DESCRIPTION
I noticed the docblock was misformed when using the ide-helper package in a project.