### PR TITLE
[8.x] Add singular syntactic sugar to wormhole

### DIFF
--- a/src/Illuminate/Foundation/Testing/Wormhole.php
+++ b/src/Illuminate/Foundation/Testing/Wormhole.php
@@ -30,11 +30,33 @@ class Wormhole
      * @param  callable|null  $callback
      * @return mixed
      */
+    public function millisecond($callback = null)
+    {
+        return $this->milliseconds($callback);
+    }
+
+    /**
+     * Travel forward the given number of milliseconds.
+     *
+     * @param  callable|null  $callback
+     * @return mixed
+     */
     public function milliseconds($callback = null)
     {
         Carbon::setTestNow(Carbon::now()->addMilliseconds($this->value));
 
         return $this->handleCallback($callback);
+    }
+
+    /**
+     * Travel forward the given number of seconds.
+     *
+     * @param  callable|null  $callback
+     * @return mixed
+     */
+    public function second($callback = null)
+    {
+        return $this->seconds($callback);
     }
 
     /**
@@ -69,11 +91,33 @@ class Wormhole
      * @param  callable|null  $callback
      * @return mixed
      */
+    public function hour($callback = null)
+    {
+        return $this->hours($callback);
+    }
+
+    /**
+     * Travel forward the given number of hours.
+     *
+     * @param  callable|null  $callback
+     * @return mixed
+     */
     public function hours($callback = null)
     {
         Carbon::setTestNow(Carbon::now()->addHours($this->value));
 
         return $this->handleCallback($callback);
+    }
+
+    /**
+     * Travel forward the given number of days.
+     *
+     * @param  callable|null  $callback
+     * @return mixed
+     */
+    public function day($callback = null)
+    {
+        return $this->days($callback);
     }
 
     /**
@@ -95,6 +139,17 @@ class Wormhole
      * @param  callable|null  $callback
      * @return mixed
      */
+    public function week($callback = null)
+    {
+        return $this->weeks($callback);
+    }
+
+    /**
+     * Travel forward the given number of weeks.
+     *
+     * @param  callable|null  $callback
+     * @return mixed
+     */
     public function weeks($callback = null)
     {
         Carbon::setTestNow(Carbon::now()->addWeeks($this->value));
@@ -108,11 +163,33 @@ class Wormhole
      * @param  callable|null  $callback
      * @return mixed
      */
+    public function month($callback = null)
+    {
+        return $this->months($callback);
+    }
+
+    /**
+     * Travel forward the given number of months.
+     *
+     * @param  callable|null  $callback
+     * @return mixed
+     */
     public function months($callback = null)
     {
         Carbon::setTestNow(Carbon::now()->addMonths($this->value));
 
         return $this->handleCallback($callback);
+    }
+
+    /**
+     * Travel forward the given number of years.
+     *
+     * @param  callable|null  $callback
+     * @return mixed
+     */
+    public function year($callback = null)
+    {
+        return $this->years($callback);
     }
 
     /**


### PR DESCRIPTION
This adds syntactic sugar to the `Wormhole` for when using singular values. I've found that a number of my tests only go back or forward 1 unit of time and so this reads better.

```php
// Before
$this->travel(1)->weeks();
$this->travel(-1)->weeks();

// After
$this->travel(1)->week();
$this->travel(-1)->week();
```

Each existing unit gets a singular alias that defers back to the original.

I've copied the docblocks as-is - if I updated them to say "Travel forward a single millisecond" it wouldn't be technically correct. But happy to amend as you see fit.