### PR TITLE
Name HTTP/419: HTTP_PAGE_EXPIRED

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -386,7 +386,7 @@ class Handler implements ExceptionHandlerContract
         } elseif ($e instanceof AuthorizationException) {
             $e = new AccessDeniedHttpException($e->getMessage(), $e);
         } elseif ($e instanceof TokenMismatchException) {
-            $e = new HttpException(419, $e->getMessage(), $e);
+            $e = new HttpException(Response::HTTP_PAGE_EXPIRED, $e->getMessage(), $e);
         } elseif ($e instanceof SuspiciousOperationException) {
             $e = new NotFoundHttpException('Bad hostname provided.', $e);
         } elseif ($e instanceof RecordsNotFoundException) {

--- a/src/Illuminate/Http/Response.php
+++ b/src/Illuminate/Http/Response.php
@@ -18,6 +18,8 @@ class Response extends SymfonyResponse
         Macroable::__call as macroCall;
     }
 
+    public const HTTP_PAGE_EXPIRED = 419;
+
     /**
      * Create a new HTTP response.
      *


### PR DESCRIPTION
Name HTTP/419 response, it is not included in Symfony as it is non-standard.
https://github.com/symfony/http-foundation/blob/e36c8e5502b4f3f0190c675f1c1f1248a64f04e5/Response.php#L65-L66

