### PR TITLE
[8.x] Add explicit `@return` annotations in `{@inheritdoc}` from vendors and add some missing `#[\ReturnTypeWillChange]`

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -131,6 +131,8 @@ class Repository implements ArrayAccess, CacheContract
 
     /**
      * {@inheritdoc}
+     *
+     * @return iterable
      */
     public function getMultiple($keys, $default = null)
     {
@@ -219,6 +221,8 @@ class Repository implements ArrayAccess, CacheContract
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
     public function set($key, $value, $ttl = null)
     {
@@ -276,6 +280,8 @@ class Repository implements ArrayAccess, CacheContract
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
     public function setMultiple($values, $ttl = null)
     {
@@ -439,6 +445,8 @@ class Repository implements ArrayAccess, CacheContract
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
     public function delete($key)
     {
@@ -447,6 +455,8 @@ class Repository implements ArrayAccess, CacheContract
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
     public function deleteMultiple($keys)
     {
@@ -463,6 +473,8 @@ class Repository implements ArrayAccess, CacheContract
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
     public function clear()
     {

--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -76,6 +76,8 @@ class Application extends SymfonyApplication implements ApplicationContract
 
     /**
      * {@inheritdoc}
+     *
+     * @return int
      */
     public function run(InputInterface $input = null, OutputInterface $output = null)
     {

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -163,6 +163,8 @@ class Command extends SymfonyCommand
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
     public function isHidden()
     {
@@ -171,6 +173,8 @@ class Command extends SymfonyCommand
 
     /**
      * {@inheritdoc}
+     *
+     * @return static
      */
     public function setHidden(bool $hidden)
     {

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -187,7 +187,9 @@ class Container implements ArrayAccess, ContainerContract
     }
 
     /**
-     *  {@inheritdoc}
+     * {@inheritdoc}
+     *
+     * @return bool
      */
     public function has($id)
     {
@@ -693,7 +695,9 @@ class Container implements ArrayAccess, ContainerContract
     }
 
     /**
-     *  {@inheritdoc}
+     * {@inheritdoc}
+     *
+     * @return mixed
      */
     public function get($id)
     {

--- a/src/Illuminate/Container/Util.php
+++ b/src/Illuminate/Container/Util.php
@@ -53,7 +53,7 @@ class Util
         $type = $parameter->getType();
 
         if (! $type instanceof ReflectionNamedType || $type->isBuiltin()) {
-            return;
+            return null;
         }
 
         $name = $type->getName();

--- a/src/Illuminate/Database/DBAL/TimestampType.php
+++ b/src/Illuminate/Database/DBAL/TimestampType.php
@@ -10,6 +10,8 @@ class TimestampType extends Type
 {
     /**
      * {@inheritdoc}
+     *
+     * @return string
      */
     public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
     {
@@ -97,6 +99,8 @@ class TimestampType extends Type
 
     /**
      * {@inheritdoc}
+     *
+     * @return string
      */
     public function getName()
     {

--- a/src/Illuminate/Database/PDO/SqlServerDriver.php
+++ b/src/Illuminate/Database/PDO/SqlServerDriver.php
@@ -6,6 +6,9 @@ use Doctrine\DBAL\Driver\AbstractSQLServerDriver;
 
 class SqlServerDriver extends AbstractSQLServerDriver
 {
+    /**
+     * @return \Doctrine\DBAL\Driver\Connection
+     */
     public function connect(array $params)
     {
         return new SqlServerConnection(

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -958,6 +958,8 @@ class Application extends Container implements ApplicationContract, CachesConfig
 
     /**
      * {@inheritdoc}
+     *
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     public function handle(SymfonyRequest $request, int $type = self::MASTER_REQUEST, bool $catch = true)
     {

--- a/src/Illuminate/Http/JsonResponse.php
+++ b/src/Illuminate/Http/JsonResponse.php
@@ -34,6 +34,8 @@ class JsonResponse extends BaseJsonResponse
 
     /**
      * {@inheritdoc}
+     *
+     * @return static
      */
     public static function fromJsonString(?string $data = null, int $status = 200, array $headers = [])
     {
@@ -65,6 +67,8 @@ class JsonResponse extends BaseJsonResponse
 
     /**
      * {@inheritdoc}
+     *
+     * @return static
      */
     public function setData($data = [])
     {
@@ -109,6 +113,8 @@ class JsonResponse extends BaseJsonResponse
 
     /**
      * {@inheritdoc}
+     *
+     * @return static
      */
     public function setEncodingOptions($options)
     {

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -456,6 +456,8 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
 
     /**
      * {@inheritdoc}
+     *
+     * @return static
      */
     public function duplicate(array $query = null, array $request = null, array $attributes = null, array $cookies = null, array $files = null, array $server = null)
     {

--- a/src/Illuminate/Mail/Transport/ArrayTransport.php
+++ b/src/Illuminate/Mail/Transport/ArrayTransport.php
@@ -26,6 +26,8 @@ class ArrayTransport extends Transport
 
     /**
      * {@inheritdoc}
+     *
+     * @return int
      */
     public function send(Swift_Mime_SimpleMessage $message, &$failedRecipients = null)
     {

--- a/src/Illuminate/Mail/Transport/LogTransport.php
+++ b/src/Illuminate/Mail/Transport/LogTransport.php
@@ -28,6 +28,8 @@ class LogTransport extends Transport
 
     /**
      * {@inheritdoc}
+     *
+     * @return int
      */
     public function send(Swift_Mime_SimpleMessage $message, &$failedRecipients = null)
     {

--- a/src/Illuminate/Mail/Transport/MailgunTransport.php
+++ b/src/Illuminate/Mail/Transport/MailgunTransport.php
@@ -55,6 +55,8 @@ class MailgunTransport extends Transport
 
     /**
      * {@inheritdoc}
+     *
+     * @return int
      */
     public function send(Swift_Mime_SimpleMessage $message, &$failedRecipients = null)
     {

--- a/src/Illuminate/Mail/Transport/SesTransport.php
+++ b/src/Illuminate/Mail/Transport/SesTransport.php
@@ -36,6 +36,8 @@ class SesTransport extends Transport
 
     /**
      * {@inheritdoc}
+     *
+     * @return int
      */
     public function send(Swift_Mime_SimpleMessage $message, &$failedRecipients = null)
     {

--- a/src/Illuminate/Mail/Transport/Transport.php
+++ b/src/Illuminate/Mail/Transport/Transport.php
@@ -18,6 +18,8 @@ abstract class Transport implements Swift_Transport
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
     public function isStarted()
     {
@@ -42,6 +44,8 @@ abstract class Transport implements Swift_Transport
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
     public function ping()
     {

--- a/src/Illuminate/Session/ArraySessionHandler.php
+++ b/src/Illuminate/Session/ArraySessionHandler.php
@@ -36,6 +36,8 @@ class ArraySessionHandler implements SessionHandlerInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
     #[\ReturnTypeWillChange]
     public function open($savePath, $sessionName)
@@ -45,6 +47,8 @@ class ArraySessionHandler implements SessionHandlerInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
     #[\ReturnTypeWillChange]
     public function close()
@@ -54,6 +58,8 @@ class ArraySessionHandler implements SessionHandlerInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return string|false
      */
     #[\ReturnTypeWillChange]
     public function read($sessionId)
@@ -75,6 +81,8 @@ class ArraySessionHandler implements SessionHandlerInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
     #[\ReturnTypeWillChange]
     public function write($sessionId, $data)
@@ -89,6 +97,8 @@ class ArraySessionHandler implements SessionHandlerInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
     #[\ReturnTypeWillChange]
     public function destroy($sessionId)
@@ -102,6 +112,8 @@ class ArraySessionHandler implements SessionHandlerInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return int|false
      */
     #[\ReturnTypeWillChange]
     public function gc($lifetime)

--- a/src/Illuminate/Session/CacheBasedSessionHandler.php
+++ b/src/Illuminate/Session/CacheBasedSessionHandler.php
@@ -36,6 +36,8 @@ class CacheBasedSessionHandler implements SessionHandlerInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
     #[\ReturnTypeWillChange]
     public function open($savePath, $sessionName)
@@ -45,6 +47,8 @@ class CacheBasedSessionHandler implements SessionHandlerInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
     #[\ReturnTypeWillChange]
     public function close()
@@ -54,6 +58,8 @@ class CacheBasedSessionHandler implements SessionHandlerInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return string|false
      */
     #[\ReturnTypeWillChange]
     public function read($sessionId)
@@ -63,6 +69,8 @@ class CacheBasedSessionHandler implements SessionHandlerInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
     #[\ReturnTypeWillChange]
     public function write($sessionId, $data)
@@ -72,6 +80,8 @@ class CacheBasedSessionHandler implements SessionHandlerInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
     #[\ReturnTypeWillChange]
     public function destroy($sessionId)
@@ -81,6 +91,8 @@ class CacheBasedSessionHandler implements SessionHandlerInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return int|false
      */
     #[\ReturnTypeWillChange]
     public function gc($lifetime)

--- a/src/Illuminate/Session/CookieSessionHandler.php
+++ b/src/Illuminate/Session/CookieSessionHandler.php
@@ -47,6 +47,8 @@ class CookieSessionHandler implements SessionHandlerInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
     #[\ReturnTypeWillChange]
     public function open($savePath, $sessionName)
@@ -56,6 +58,8 @@ class CookieSessionHandler implements SessionHandlerInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
     #[\ReturnTypeWillChange]
     public function close()
@@ -65,6 +69,8 @@ class CookieSessionHandler implements SessionHandlerInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return string|false
      */
     #[\ReturnTypeWillChange]
     public function read($sessionId)
@@ -82,6 +88,8 @@ class CookieSessionHandler implements SessionHandlerInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
     #[\ReturnTypeWillChange]
     public function write($sessionId, $data)
@@ -96,6 +104,8 @@ class CookieSessionHandler implements SessionHandlerInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
     #[\ReturnTypeWillChange]
     public function destroy($sessionId)
@@ -107,6 +117,8 @@ class CookieSessionHandler implements SessionHandlerInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return int|false
      */
     #[\ReturnTypeWillChange]
     public function gc($lifetime)

--- a/src/Illuminate/Session/DatabaseSessionHandler.php
+++ b/src/Illuminate/Session/DatabaseSessionHandler.php
@@ -69,6 +69,8 @@ class DatabaseSessionHandler implements ExistenceAwareInterface, SessionHandlerI
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
     #[\ReturnTypeWillChange]
     public function open($savePath, $sessionName)
@@ -78,6 +80,8 @@ class DatabaseSessionHandler implements ExistenceAwareInterface, SessionHandlerI
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
     #[\ReturnTypeWillChange]
     public function close()
@@ -87,6 +91,8 @@ class DatabaseSessionHandler implements ExistenceAwareInterface, SessionHandlerI
 
     /**
      * {@inheritdoc}
+     *
+     * @return string|false
      */
     #[\ReturnTypeWillChange]
     public function read($sessionId)
@@ -122,6 +128,8 @@ class DatabaseSessionHandler implements ExistenceAwareInterface, SessionHandlerI
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
     #[\ReturnTypeWillChange]
     public function write($sessionId, $data)
@@ -257,6 +265,8 @@ class DatabaseSessionHandler implements ExistenceAwareInterface, SessionHandlerI
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
     #[\ReturnTypeWillChange]
     public function destroy($sessionId)
@@ -268,6 +278,8 @@ class DatabaseSessionHandler implements ExistenceAwareInterface, SessionHandlerI
 
     /**
      * {@inheritdoc}
+     *
+     * @return int|false
      */
     #[\ReturnTypeWillChange]
     public function gc($lifetime)

--- a/src/Illuminate/Session/FileSessionHandler.php
+++ b/src/Illuminate/Session/FileSessionHandler.php
@@ -47,6 +47,8 @@ class FileSessionHandler implements SessionHandlerInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
     #[\ReturnTypeWillChange]
     public function open($savePath, $sessionName)
@@ -56,6 +58,8 @@ class FileSessionHandler implements SessionHandlerInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
     #[\ReturnTypeWillChange]
     public function close()
@@ -65,6 +69,8 @@ class FileSessionHandler implements SessionHandlerInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return string|false
      */
     #[\ReturnTypeWillChange]
     public function read($sessionId)
@@ -80,6 +86,8 @@ class FileSessionHandler implements SessionHandlerInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
     #[\ReturnTypeWillChange]
     public function write($sessionId, $data)
@@ -91,6 +99,8 @@ class FileSessionHandler implements SessionHandlerInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
     #[\ReturnTypeWillChange]
     public function destroy($sessionId)
@@ -102,6 +112,8 @@ class FileSessionHandler implements SessionHandlerInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return int|false
      */
     #[\ReturnTypeWillChange]
     public function gc($lifetime)

--- a/src/Illuminate/Session/NullSessionHandler.php
+++ b/src/Illuminate/Session/NullSessionHandler.php
@@ -8,6 +8,8 @@ class NullSessionHandler implements SessionHandlerInterface
 {
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
     #[\ReturnTypeWillChange]
     public function open($savePath, $sessionName)
@@ -17,6 +19,8 @@ class NullSessionHandler implements SessionHandlerInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
     #[\ReturnTypeWillChange]
     public function close()
@@ -26,6 +30,8 @@ class NullSessionHandler implements SessionHandlerInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return string|false
      */
     #[\ReturnTypeWillChange]
     public function read($sessionId)
@@ -35,6 +41,8 @@ class NullSessionHandler implements SessionHandlerInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
     #[\ReturnTypeWillChange]
     public function write($sessionId, $data)
@@ -44,6 +52,8 @@ class NullSessionHandler implements SessionHandlerInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
     #[\ReturnTypeWillChange]
     public function destroy($sessionId)
@@ -53,6 +63,8 @@ class NullSessionHandler implements SessionHandlerInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return int|false
      */
     #[\ReturnTypeWillChange]
     public function gc($lifetime)

--- a/src/Illuminate/Translation/MessageSelector.php
+++ b/src/Illuminate/Translation/MessageSelector.php
@@ -61,7 +61,7 @@ class MessageSelector
         preg_match('/^[\{\[]([^\[\]\{\}]*)[\}\]](.*)/s', $part, $matches);
 
         if (count($matches) !== 3) {
-            return;
+            return null;
         }
 
         $condition = $matches[1];


### PR DESCRIPTION
This PR introduces an `@return` annotation in PHPDoc blocks that reference `{@inheritdoc}` from a vendor (i.e. no `Illuminate` root namespace). This removes the need to rely on external knowledge to get some understanding of the annotations.

Besides that, this also functions as an opt-out for the type deprecations triggered by Symfony as of 5.4. Their function is similar to the `#[\ReturnTypeWillChange]` attribute: tell static analysers that you know the return type of the parent can be converted to a real type at any release, but you don't want to add the real type yourself yet (I think you will probably add these in Laravel 9?).

The type patcher script also discovered <s>some missing `#[\ReturnTypeWillChange]` attributes (causing deprecations on PHP 8.1) and</s> 2 cases where `return;` was used in combination with a `null` return type. The latter produces a fatal error once the type is introduced (https://3v4l.org/bK7Vt)