### PR TITLE
[9.x] Fixes invalid PHPDoc syntax

### DIFF
--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -255,7 +255,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Execute a callback over each nested chunk of items.
      *
-     * @param  callable(...mixed): mixed  $callback
+     * @param  callable(mixed ...$args): mixed  $callback
      * @return static<TKey, TValue>
      */
     public function eachSpread(callable $callback);
@@ -606,7 +606,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      *
      * @template TMapSpreadValue
      *
-     * @param  callable(...mixed): TMapSpreadValue  $callback
+     * @param  callable(mixed ...$args): TMapSpreadValue  $callback
      * @return static<TKey, TMapSpreadValue>
      */
     public function mapSpread(callable $callback);

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -255,7 +255,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Execute a callback over each nested chunk of items.
      *
-     * @param  callable(mixed ...$args): mixed  $callback
+     * @param  callable  $callback
      * @return static<TKey, TValue>
      */
     public function eachSpread(callable $callback);
@@ -604,10 +604,8 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Run a map over each nested chunk of items.
      *
-     * @template TMapSpreadValue
-     *
-     * @param  callable(mixed ...$args): TMapSpreadValue  $callback
-     * @return static<TKey, TMapSpreadValue>
+     * @param  callable  $callback
+     * @return static<TKey, TValue>
      */
     public function mapSpread(callable $callback);
 


### PR DESCRIPTION
This PR fixes invalid PHPDoc syntax.

/cc @nunomaduro 