### PR TITLE
Have RedisBroadcast return a BroadcastException

### DIFF
--- a/src/Illuminate/Contracts/Broadcasting/Broadcaster.php
+++ b/src/Illuminate/Contracts/Broadcasting/Broadcaster.php
@@ -28,6 +28,8 @@ interface Broadcaster
      * @param  string  $event
      * @param  array  $payload
      * @return void
+     *
+     * @throws \Illuminate\Broadcasting\BroadcastException
      */
     public function broadcast(array $channels, $event, array $payload = []);
 }


### PR DESCRIPTION
Since there is a BroadcastException already used on the PusherBroadcast class, makes sense that RedisBroadcast also throw the same exception.