### PR TITLE
[8.x] Fix Relation::enforceMorphMap() default argument value

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -411,7 +411,7 @@ abstract class Relation
      * @param  bool  $merge
      * @return array
      */
-    public static function enforceMorphMap(array $map, $merge = true)
+    public static function enforceMorphMap(array $map = null, $merge = true)
     {
         static::requireMorphMap();
 


### PR DESCRIPTION
Add a default value to `$map` argument in `Relation::enforceMorphMap()` to match the type hint and be consistent with `Relation::morphMap()`.

