### PR TITLE
[8.x] MorphTo casted type

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -6,13 +6,11 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Concerns\ComparesRelatedModels;
-use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithDictionary;
 use Illuminate\Database\Eloquent\Relations\Concerns\SupportsDefaultModels;
 
 class BelongsTo extends Relation
 {
     use ComparesRelatedModels,
-        InteractsWithDictionary,
         SupportsDefaultModels;
 
     /**
@@ -176,7 +174,7 @@ class BelongsTo extends Relation
         $dictionary = [];
 
         foreach ($results as $result) {
-            $attribute = $this->getDictionaryKey($result->getAttribute($owner));
+            $attribute = static::getDictionaryKey($result->getAttribute($owner));
 
             $dictionary[$attribute] = $result;
         }
@@ -185,7 +183,7 @@ class BelongsTo extends Relation
         // and match back onto their children using these keys of the dictionary and
         // the primary key of the children to map them onto the correct instances.
         foreach ($models as $model) {
-            $attribute = $this->getDictionaryKey($model->{$foreign});
+            $attribute = static::getDictionaryKey($model->{$foreign});
 
             if (isset($dictionary[$attribute])) {
                 $model->setRelation($relation, $dictionary[$attribute]);

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -8,14 +8,13 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\Eloquent\Relations\Concerns\AsPivot;
-use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithDictionary;
 use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithPivotTable;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 
 class BelongsToMany extends Relation
 {
-    use InteractsWithDictionary, InteractsWithPivotTable;
+    use InteractsWithPivotTable;
 
     /**
      * The intermediate table for the relation.
@@ -279,7 +278,7 @@ class BelongsToMany extends Relation
         // children back to their parent using the dictionary and the keys on the
         // the parent models. Then we will return the hydrated models back out.
         foreach ($models as $model) {
-            $key = $this->getDictionaryKey($model->{$this->parentKey});
+            $key = static::getDictionaryKey($model->{$this->parentKey});
 
             if (isset($dictionary[$key])) {
                 $model->setRelation(
@@ -305,7 +304,7 @@ class BelongsToMany extends Relation
         $dictionary = [];
 
         foreach ($results as $result) {
-            $value = $this->getDictionaryKey($result->{$this->accessor}->{$this->foreignPivotKey});
+            $value = static::getDictionaryKey($result->{$this->accessor}->{$this->foreignPivotKey});
 
             $dictionary[$value][] = $result;
         }

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithDictionary.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithDictionary.php
@@ -14,7 +14,7 @@ trait InteractsWithDictionary
      *
      * @throws \Doctrine\Instantiator\Exception\InvalidArgumentException
      */
-    protected function getDictionaryKey($attribute)
+    protected static function getDictionaryKey($attribute)
     {
         if (is_object($attribute)) {
             if (method_exists($attribute, '__toString')) {

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -7,13 +7,10 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
-use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithDictionary;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 class HasManyThrough extends Relation
 {
-    use InteractsWithDictionary;
-
     /**
      * The "through" parent model instance.
      *
@@ -196,7 +193,7 @@ class HasManyThrough extends Relation
         // link them up with their children using the keyed dictionary to make the
         // matching very convenient and easy work. Then we'll just return them.
         foreach ($models as $model) {
-            if (isset($dictionary[$key = $this->getDictionaryKey($model->getAttribute($this->localKey))])) {
+            if (isset($dictionary[$key = static::getDictionaryKey($model->getAttribute($this->localKey))])) {
                 $model->setRelation(
                     $relation, $this->related->newCollection($dictionary[$key])
                 );

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -5,12 +5,9 @@ namespace Illuminate\Database\Eloquent\Relations;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithDictionary;
 
 abstract class HasOneOrMany extends Relation
 {
-    use InteractsWithDictionary;
-
     /**
      * The foreign key of the parent model.
      *
@@ -146,7 +143,7 @@ abstract class HasOneOrMany extends Relation
         // link them up with their children using the keyed dictionary to make the
         // matching very convenient and easy work. Then we'll just return them.
         foreach ($models as $model) {
-            if (isset($dictionary[$key = $this->getDictionaryKey($model->getAttribute($this->localKey))])) {
+            if (isset($dictionary[$key = static::getDictionaryKey($model->getAttribute($this->localKey))])) {
                 $model->setRelation(
                     $relation, $this->getRelationValue($dictionary, $key, $type)
                 );
@@ -182,7 +179,7 @@ abstract class HasOneOrMany extends Relation
         $foreign = $this->getForeignKeyName();
 
         return $results->mapToDictionary(function ($result) use ($foreign) {
-            return [$this->getDictionaryKey($result->{$foreign}) => $result];
+            return [static::getDictionaryKey($result->{$foreign}) => $result];
         })->all();
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneThrough.php
@@ -4,12 +4,11 @@ namespace Illuminate\Database\Eloquent\Relations;
 
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithDictionary;
 use Illuminate\Database\Eloquent\Relations\Concerns\SupportsDefaultModels;
 
 class HasOneThrough extends HasManyThrough
 {
-    use InteractsWithDictionary, SupportsDefaultModels;
+    use SupportsDefaultModels;
 
     /**
      * Get the results of the relationship.
@@ -53,7 +52,7 @@ class HasOneThrough extends HasManyThrough
         // link them up with their children using the keyed dictionary to make the
         // matching very convenient and easy work. Then we'll just return them.
         foreach ($models as $model) {
-            if (isset($dictionary[$key = $this->getDictionaryKey($model->getAttribute($this->localKey))])) {
+            if (isset($dictionary[$key = static::getDictionaryKey($model->getAttribute($this->localKey))])) {
                 $value = $dictionary[$key];
                 $model->setRelation(
                     $relation, reset($value)

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -6,12 +6,9 @@ use BadMethodCallException;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithDictionary;
 
 class MorphTo extends BelongsTo
 {
-    use InteractsWithDictionary;
-
     /**
      * The type of the polymorphic relation.
      *
@@ -100,8 +97,8 @@ class MorphTo extends BelongsTo
     {
         foreach ($models as $model) {
             if ($model->{$this->morphType}) {
-                $morphTypeKey = $this->getDictionaryKey($model->{$this->morphType});
-                $foreignKeyKey = $this->getDictionaryKey($model->{$this->foreignKey});
+                $morphTypeKey = static::getDictionaryKey($model->{$this->morphType});
+                $foreignKeyKey = static::getDictionaryKey($model->{$this->foreignKey});
 
                 $this->dictionary[$morphTypeKey][$foreignKeyKey][] = $model;
             }
@@ -213,7 +210,7 @@ class MorphTo extends BelongsTo
     protected function matchToMorphParents($type, Collection $results)
     {
         foreach ($results as $result) {
-            $ownerKey = ! is_null($this->ownerKey) ? $this->getDictionaryKey($result->{$this->ownerKey}) : $result->getKey();
+            $ownerKey = ! is_null($this->ownerKey) ? static::getDictionaryKey($result->{$this->ownerKey}) : $result->getKey();
 
             if (isset($this->dictionary[$type][$ownerKey])) {
                 foreach ($this->dictionary[$type][$ownerKey] as $model) {

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithDictionary;
 use Illuminate\Database\MultipleRecordsFoundException;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Support\Arr;
@@ -18,7 +19,7 @@ use Illuminate\Support\Traits\Macroable;
  */
 abstract class Relation
 {
-    use ForwardsCalls, Macroable {
+    use ForwardsCalls, InteractsWithDictionary, Macroable {
         __call as macroCall;
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -463,7 +463,9 @@ abstract class Relation
      */
     public static function getMorphedModel($alias)
     {
-        return static::$morphMap[$alias] ?? null;
+        $dictionaryKey = static::getDictionaryKey($alias);
+
+        return static::$morphMap[$dictionaryKey] ?? null;
     }
 
     /**

--- a/tests/Database/RelationTest.php
+++ b/tests/Database/RelationTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Eloquent\Relations\Relation;
+use PHPUnit\Framework\TestCase;
+
+class RelationTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Relation::morphMap([
+            'test' => 'test_model',
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        Relation::morphMap([], false);
+    }
+
+    public function testGetMorphedModel()
+    {
+        self::assertEquals('test_model', Relation::getMorphedModel('test'));
+        self::assertEquals('test_model', Relation::getMorphedModel(new class
+        {
+            public function __toString()
+            {
+                return 'test';
+            }
+        }));
+    }
+}

--- a/tests/Integration/Database/DatabaseEloquentMorphToCastedAliasTest.php
+++ b/tests/Integration/Database/DatabaseEloquentMorphToCastedAliasTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database {
+
+    use Illuminate\Database\Eloquent\Relations\Relation;
+    use Illuminate\Database\Schema\Blueprint;
+    use Illuminate\Support\Facades\Schema;
+    use MorphTo\Test\TestAttachment;
+    use MorphTo\Test\TestImage;
+
+    /**
+     * @group integration
+     */
+    class DatabaseEloquentMorphToCastedAliasTest extends DatabaseTestCase
+    {
+        private $oldMap;
+
+        protected function setUp(): void
+        {
+            parent::setUp();
+            $this->oldMap = Relation::morphMap();
+            Relation::morphMap([
+                'image' => \MorphTo\Test\TestImage::class,
+            ]);
+            Schema::create('test_images', function (Blueprint $table) {
+                $table->increments('id');
+                $table->string('title');
+                $table->timestamps();
+            });
+
+            Schema::create('test_attachments', function (Blueprint $table) {
+                $table->increments('id');
+                $table->integer('content_id');
+                $table->string('content_type');
+                $table->timestamps();
+            });
+        }
+
+        protected function tearDown(): void
+        {
+            parent::tearDown();
+            Relation::morphMap($this->oldMap, false);
+        }
+
+        public function testCastedAlias()
+        {
+            $image = TestImage::create(['title' => 'Hello world']);
+            TestImage::create(['title' => 'Hello world2']);
+            TestAttachment::create(['content_type' => 'image', 'content_id' => $image->id]);
+
+            $fetchedUser = TestAttachment::query()->whereHas('content')->first();
+            self::assertEquals('Hello world', $fetchedUser->content->title);
+        }
+    }
+}
+
+namespace MorphTo\Test {
+
+    use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+    use Illuminate\Database\Eloquent\Model;
+
+    class TestCastedValue
+    {
+        private $value;
+
+        public function __construct($value)
+        {
+            $this->value = $value;
+        }
+
+        public function __toString()
+        {
+            return (string) $this->value;
+        }
+    }
+
+    class CastToObject implements CastsAttributes
+    {
+        public function get($model, string $key, $value, array $attributes)
+        {
+            return new TestCastedValue($value);
+        }
+
+        public function set($model, string $key, $value, array $attributes)
+        {
+            return (string) $value;
+        }
+    }
+
+    class TestImage extends Model
+    {
+        protected $guarded = [];
+    }
+
+    class TestAttachment extends Model
+    {
+        protected $guarded = [];
+
+        protected $casts = [
+            'content_type' => \MorphTo\Test\CastToObject::class,
+        ];
+
+        public function content()
+        {
+            return $this->morphTo();
+        }
+    }
+}


### PR DESCRIPTION
In some cases morph type can be casted to an object and in this cases it's unable to make whereHas('morph'). The PR fixes this
example:
```php
class TestCastedValue
{
    private $value;

    public function __construct($value)
    {
        $this->value = $value;
    }

    public function __toString()
    {
        return (string) $this->value;
    }
}

class CastToObject implements CastsAttributes
{
    public function get($model, string $key, $value, array $attributes)
    {
        return new TestCastedValue($value);
    }

    public function set($model, string $key, $value, array $attributes)
    {
        return (string) $value;
    }
}

class TestImage extends Model
{
    protected $guarded = [];
}

class TestAttachment extends Model
{
    protected $guarded = [];

    protected $casts = [
         'content_type' => CastToObject::class,
    ];

    public function content()
    {
        return $this->morphTo();
    }
}
```
Following invocation results to an Exception `Illegal offset type`
```php
TestAttachment::whereHas('content')->first()
```