### PR TITLE
[8.x] Dispatch events when maintenance mode is enabled and disabled

### DIFF
--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Console;
 use App\Http\Middleware\PreventRequestsDuringMaintenance;
 use Exception;
 use Illuminate\Console\Command;
+use Illuminate\Foundation\Events\MaintenanceModeEnabled;
 use Illuminate\Foundation\Exceptions\RegisterErrorViewPaths;
 use Throwable;
 
@@ -52,6 +53,8 @@ class DownCommand extends Command
                 storage_path('framework/maintenance.php'),
                 file_get_contents(__DIR__.'/stubs/maintenance-mode.stub')
             );
+
+            $this->laravel->get('events')->dispatch(MaintenanceModeEnabled::class);
 
             $this->comment('Application is now in maintenance mode.');
         } catch (Exception $e) {

--- a/src/Illuminate/Foundation/Console/UpCommand.php
+++ b/src/Illuminate/Foundation/Console/UpCommand.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Console;
 
 use Exception;
 use Illuminate\Console\Command;
+use Illuminate\Foundation\Events\MaintenanceModeDisabled;
 
 class UpCommand extends Command
 {
@@ -40,6 +41,8 @@ class UpCommand extends Command
             if (is_file(storage_path('framework/maintenance.php'))) {
                 unlink(storage_path('framework/maintenance.php'));
             }
+
+            $this->laravel->get('events')->dispatch(MaintenanceModeDisabled::class);
 
             $this->info('Application is now live.');
         } catch (Exception $e) {

--- a/src/Illuminate/Foundation/Events/MaintenanceModeDisabled.php
+++ b/src/Illuminate/Foundation/Events/MaintenanceModeDisabled.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Illuminate\Foundation\Events;
+
+class MaintenanceModeDisabled
+{
+    /**
+     * Create a new event instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+}

--- a/src/Illuminate/Foundation/Events/MaintenanceModeDisabled.php
+++ b/src/Illuminate/Foundation/Events/MaintenanceModeDisabled.php
@@ -4,13 +4,5 @@ namespace Illuminate\Foundation\Events;
 
 class MaintenanceModeDisabled
 {
-    /**
-     * Create a new event instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        //
-    }
+    //
 }

--- a/src/Illuminate/Foundation/Events/MaintenanceModeEnabled.php
+++ b/src/Illuminate/Foundation/Events/MaintenanceModeEnabled.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Illuminate\Foundation\Events;
+
+class MaintenanceModeEnabled
+{
+    /**
+     * Create a new event instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+}

--- a/src/Illuminate/Foundation/Events/MaintenanceModeEnabled.php
+++ b/src/Illuminate/Foundation/Events/MaintenanceModeEnabled.php
@@ -4,13 +4,5 @@ namespace Illuminate\Foundation\Events;
 
 class MaintenanceModeEnabled
 {
-    /**
-     * Create a new event instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        //
-    }
+    //
 }


### PR DESCRIPTION
This feature makes it easy to trigger actions when the application is put into, or taken out of, maintenance mode.

I found myself wanting this today when setting up monitoring with [OhDear](https://ohdear.app).
They have endpoints for `/start-maintenance` and `/end-maintenance` and will not send notifications about the site being down during this period.

If this PR is merged, I could listen for the events in my application and automatically ping my monitoring service when going in or out of maintenance mode. Or log it, or any action that users see fit.

-----

I tried to follow conventions, but if anything is in the wrong place, or should have better names; just comment and I'll fix it, or feel free to refactor and push changes. 

Thanks!