### PR TITLE
[8.x] Allow request input to be retrieved as a collection

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -304,7 +304,7 @@ trait InteractsWithInput
      */
     public function collect($key = null)
     {
-        return collect($this->input($key, []));
+        return collect($this->input($key));
     }
 
     /**

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -297,6 +297,17 @@ trait InteractsWithInput
     }
 
     /**
+     * Retrieve input from the request as a collection.
+     *
+     * @param  string|null $key
+     * @return \Illuminate\Support\Collection
+     */
+    public function collect($key = null)
+    {
+        return collect($this->input($key, []));
+    }
+
+    /**
      * Get a subset containing the provided keys with values from the input data.
      *
      * @param  array|mixed  $keys

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -299,7 +299,7 @@ trait InteractsWithInput
     /**
      * Retrieve input from the request as a collection.
      *
-     * @param  string|null $key
+     * @param  string|null  $key
      * @return \Illuminate\Support\Collection
      */
     public function collect($key = null)

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Routing\Route;
 use Illuminate\Session\Store;
+use Illuminate\Support\Collection;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
@@ -500,6 +501,26 @@ class HttpRequestTest extends TestCase
         $this->assertFalse($request->boolean('unchecked'));
         $this->assertFalse($request->boolean('with_trashed'));
         $this->assertFalse($request->boolean('some_undefined_key'));
+    }
+
+    public function testCollectMethod()
+    {
+        $request = Request::create('/', 'GET', ['users' => [1, 2, 3]]);
+
+        $this->assertInstanceOf(Collection::class, $request->collect('users'));
+        $this->assertTrue($request->collect('developers')->isEmpty());
+        $this->assertEquals([1, 2, 3], $request->collect('users')->all());
+        $this->assertEquals(['users' => [1, 2, 3]], $request->collect()->all());
+
+        $request = Request::create('/', 'GET', ['text-payload']);
+        $this->assertEquals(['text-payload'], $request->collect()->all());
+
+        $request = Request::create('/', 'GET', ['email' => 'test@example.com']);
+        $this->assertEquals(['test@example.com'], $request->collect('email')->all());
+
+        $request = Request::create('/', 'GET', []);
+        $this->assertInstanceOf(Collection::class, $request->collect());
+        $this->assertTrue($request->collect()->isEmpty());
     }
 
     public function testArrayAccess()


### PR DESCRIPTION
## Description
This PR adds the ability to retrieve input from an incoming request as a collection. In our codebase, I have noticed that we are commonly retrieving input from the request, defaulting it to an empty array and passing it to the `collect` helper. If a key is not given it will return all of the request's input as a collection. If a key is not found, it will default the input to `[]` and return an empty collection.

### Before

```php
collect($request->input('users', []))->each(function ($user) {
    // ...
});
```

### After

If approved, it would allow for a straight forward shortcut to retrieve the requested input / input key as a collection:

```php
$request->collect('users')->each(function ($user) {
    // ...
});
```

Thanks!