### PR TITLE
add `hasSession`  method in the `ManagesLayouts`

### DIFF
--- a/src/Illuminate/View/Concerns/ManagesLayouts.php
+++ b/src/Illuminate/View/Concerns/ManagesLayouts.php
@@ -195,6 +195,17 @@ trait ManagesLayouts
     {
         return ! $this->hasSection($name);
     }
+    
+    /**
+     * Check if the session exists.
+     *
+     * @param  string  $name
+     * @return bool
+     */
+    public function hasSession($name)
+    {
+        return array_key_exists($name, request()->session()->all());
+    }
 
     /**
      * Get the contents of a section.


### PR DESCRIPTION
This PR adds more ease for checking if the given session name exists or NOT
