### PR TITLE
Change order of parameters of `assertJsonPath` and `assertPath`

### DIFF
--- a/src/Illuminate/Testing/AssertableJsonString.php
+++ b/src/Illuminate/Testing/AssertableJsonString.php
@@ -213,11 +213,11 @@ class AssertableJsonString implements ArrayAccess, Countable
     /**
      * Assert that the expected value and type exists at the given path in the response.
      *
-     * @param  string  $path
      * @param  mixed  $expect
+     * @param  string  $path
      * @return $this
      */
-    public function assertPath($path, $expect)
+    public function assertPath($expect, $path)
     {
         PHPUnit::assertSame($expect, $this->json($path));
 

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -704,13 +704,13 @@ EOF;
     /**
      * Assert that the expected value and type exists at the given path in the response.
      *
-     * @param  string  $path
      * @param  mixed  $expect
+     * @param  string  $path
      * @return $this
      */
-    public function assertJsonPath($path, $expect)
+    public function assertJsonPath($expect, $path)
     {
-        $this->decodeResponseJson()->assertPath($path, $expect);
+        $this->decodeResponseJson()->assertPath($expect, $path);
 
         return $this;
     }


### PR DESCRIPTION
In this PR, I've changed the arrangement of parameters in these two methods `assertJsonPath` and `assertPath`.
Because in `assertJsonCount` the expected value parameter has come first, it would be better to have consistency between these three methods. Also, `assertSame` method in PHPUnit has put its expected value as the first parameter.