### PR TITLE
[8.x] Add `assertSeeHtml` tests

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -579,6 +579,28 @@ EOF;
     }
 
     /**
+     * Assert that the given HTML string or array of HTML strings are contained within the response text.
+     *
+     * @param  string|array  $value
+     * @return $this
+     */
+    public function assertSeeHtml($value)
+    {
+        return $this->assertSee($value, false);
+    }
+
+    /**
+     * Assert that the given HTML strings are contained within the response text.
+     *
+     * @param  array  $values
+     * @return $this
+     */
+    public function assertSeeHtmlInOrder(array $values)
+    {
+        return $this->assertSeeInOrder($values, false);
+    }
+
+    /**
      * Assert that the given string or array of strings are contained within the response text.
      *
      * @param  string|array  $value
@@ -634,6 +656,17 @@ EOF;
         }
 
         return $this;
+    }
+
+    /**
+     * Assert that the given HTML string or array of HTML strings are not contained within the response text.
+     *
+     * @param  string|array  $value
+     * @return $this
+     */
+    public function assertDontSeeHtml($value)
+    {
+        return $this->assertDontSee($value, false);
     }
 
     /**

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -186,6 +186,28 @@ class TestResponseTest extends TestCase
         $response->assertSee(['bar & baz', 'baz & qux']);
     }
 
+    public function testAssertSeeHtml()
+    {
+        $response = $this->makeMockResponse([
+            'render' => '<ul><li>foo</li><li>bar</li><li>baz</li><li>foo</li></ul>',
+        ]);
+
+        $response->assertSeeHtml('<li>foo</li>');
+        $response->assertSeeHtml(['<li>baz</li>', '<li>bar</li>']);
+    }
+
+    public function testAssertSeeHtmlCanFail()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $response = $this->makeMockResponse([
+            'render' => '<ul><li>foo</li><li>bar</li><li>baz</li><li>foo</li></ul>',
+        ]);
+
+        $response->assertSeeHtml('<p>foo</p>');
+        $response->assertSeeHtml(['<p>not</p>', 'found']);
+    }
+
     public function testAssertSeeInOrder()
     {
         $response = $this->makeMockResponse([
@@ -217,6 +239,29 @@ class TestResponseTest extends TestCase
         ]);
 
         $response->assertSeeInOrder(['foo', 'qux', 'bar', 'baz']);
+    }
+
+
+    public function testAssertSeeHtmlInOrder()
+    {
+        $response = $this->makeMockResponse([
+            'render' => '<ul><li>foo</li><li>bar</li><li>baz</li><li>foo</li></ul>',
+        ]);
+
+        $response->assertSeeHtmlInOrder(['<li>foo</li>', '<li>bar</li>', '<li>baz</li>']);
+
+        $response->assertSeeHtmlInOrder(['<li>foo</li>', '<li>bar</li>', '<li>baz</li>', '<li>foo</li>']);
+    }
+
+    public function testAssertSeeHtmlInOrderCanFail()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $response = $this->makeMockResponse([
+            'render' => '<ul><li>foo</li><li>bar</li><li>baz</li><li>foo</li></ul>',
+        ]);
+
+        $response->assertSeeHtmlInOrder(['<li>baz</li>', '<li>bar</li>', '<li>foo</li>']);
     }
 
     public function testAssertSeeText()

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -241,7 +241,6 @@ class TestResponseTest extends TestCase
         $response->assertSeeInOrder(['foo', 'qux', 'bar', 'baz']);
     }
 
-
     public function testAssertSeeHtmlInOrder()
     {
         $response = $this->makeMockResponse([


### PR DESCRIPTION
This adds a couple of convenient test helpers similar to Livewire’s `assertSeeHtml`/`assertDontSeeHtml`/`assertSeeHtmlInOrder` [test methods](https://laravel-livewire.com/docs/2.x/testing#all-testing-methods).

Before:

```php
$this
    ->get('/')
    ->assertSee('<title>' . config('app.name') . '</title>', false)
    ->assertSeeInOrder(
        [
            'foo',
            'bar',
            'baz',
        ],
        false
    )
    ->assertDontSee('<h1>' . config('app.name') . '</h1>', false);
```

After:

```php
$this
    ->get('/')
    ->assertSeeHtml('<title>' . config('app.name') . '</title>')
    ->assertSeeHtmlInOrder([
        'foo',
        'bar',
        'baz',
    ])
    ->assertDontSeeHtml('<h1>' . config('app.name') . '</h1>');
```