### PR TITLE
[8.x] Allow index.blade.php views for anonymous components

### DIFF
--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -272,6 +272,10 @@ class ComponentTagCompiler
             return $view;
         }
 
+        if ($viewFactory->exists($view = $this->guessViewName($component).'.index')) {
+            return $view;
+        }
+
         throw new InvalidArgumentException(
             "Unable to locate a class or view for component [{$component}]."
         );

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -249,6 +249,22 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
 '@endComponentClass##END-COMPONENT-CLASS##', trim($result));
     }
 
+    public function testClasslessComponentsWithIndexView()
+    {
+        $container = new Container;
+        $container->instance(Application::class, $app = Mockery::mock(Application::class));
+        $container->instance(Factory::class, $factory = Mockery::mock(Factory::class));
+        $app->shouldReceive('getNamespace')->andReturn('App\\');
+        $factory->shouldReceive('exists')->andReturn(false, true);
+        Container::setInstance($container);
+
+        $result = $this->compiler()->compileTags('<x-anonymous-component :name="\'Taylor\'" :age="31" wire:model="foo" />');
+
+        $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\View\AnonymousComponent', 'anonymous-component', ['view' => 'components.anonymous-component.index','data' => ['name' => 'Taylor','age' => 31,'wire:model' => 'foo']])
+<?php \$component->withAttributes(['name' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute('Taylor'),'age' => 31,'wire:model' => 'foo']); ?>\n".
+'@endComponentClass##END-COMPONENT-CLASS##', trim($result));
+    }
+
     public function testPackagesClasslessComponents()
     {
         $container = new Container;


### PR DESCRIPTION
For a hypothetical "accordion" anonymous Blade component system (a component with sub-components), I would love to use the following syntax:

```html
<x-accordion>
    <x-accordion.item>
        ...
```

This PR allows me to use `index.blade.php` as a default view for an anonymous component pointing to a folder.

Here would be the folder structure

* `components/accordion`
  * `index.blade.php`
  * `item.blade.php`

This expands on the convention of `index.html/php/js` inside folders.

Without this addition, I have to use redundant wrapper names like: `<x-accordion.accordion>`,  `<x-accordion.group>`, or have a file called `accordion.blade.php` at the same level as the `accordion` folder holding the sub-component views.

As far as breaking changes, because this addition is only run immediately before an error is thrown about not being able to find a view for a component, I don't see it causing any odd behavior for existing projects. I could have missed something though of course.

Thanks for your time and attention!