### PR TITLE
[8.x] Add missing method signature in docblock

### DIFF
--- a/src/Illuminate/Support/Facades/Bus.php
+++ b/src/Illuminate/Support/Facades/Bus.php
@@ -24,6 +24,7 @@ use Illuminate\Support\Testing\Fakes\BusFake;
  * @method static void assertDispatchedAfterResponseTimes(string $command, int $times = 1)
  * @method static void assertNotDispatchedAfterResponse(string|\Closure $command, callable $callback = null)
  * @method static void assertBatched(callable $callback)
+ * @method static void assertChained(array $expectedChain)
  *
  * @see \Illuminate\Contracts\Bus\Dispatcher
  */


### PR DESCRIPTION
Add missing method signature in docblock.
