### PR TITLE
[8.x] Add support for getting Model morphed alias

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -466,6 +466,17 @@ abstract class Relation
     }
 
     /**
+     * Get the alias associated with a given Model class name.
+     *
+     * @param  string  $model
+     * @return false|int|string
+     */
+    public static function getMorphedAlias($model)
+    {
+        return array_search($model, static::$morphMap);
+    }
+
+    /**
      * Handle dynamic method calls to the relationship.
      *
      * @param  string  $method

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -234,6 +234,16 @@ class DatabaseEloquentRelationTest extends TestCase
         Relation::morphMap([], false);
     }
 
+    public function testGettingAliasFromModelClassName()
+    {
+        Relation::morphMap(['user' => 'App\User']);
+
+        $this->assertEquals(
+            'user',
+            Relation::getMorphedAlias('App\User')
+        );
+    }
+
     public function testWithoutRelations()
     {
         $original = new EloquentNoTouchingModelStub;


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
### Rationale
Allows to get the the morphed alias from the model class name. This can be useful in many scenarios where one wants to manually query the database (or any other source) with the given alias. One for all is described in the example below:
```php
use Illuminate\Database\Eloquent\Relations\Relation;

Relation::morphMap([
    'children.a' => ChildrenA::class,
    'children.b' => ChildrenB::class,
]);

/** @property string $type */
abstract class Parent extends Model {
    protected $table = 'parent_table';
    public static function boot()
    {
        parent::boot();

        static::addGlobalScope(
            fn (Builder $query) => $query->where('type', Relation::getMorphedAlias(static::class))
        );
    }
}

class ChildrenA extends Parent {
}

class ChildrenB extends Parent {
}
```
### Considerations
It's in no way breaking existing features as it simply adds a new static method to the Relation class.

As return value for `getMorphedAlias` I picked `false|int|string` as the key can be `int|string`. About the `false` value, we can replace it with `null` for consistency with `getMorphedModel`.