### PR TITLE
[8.x] Constraint psr/log version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "nesbot/carbon": "^2.31",
         "opis/closure": "^3.6",
         "psr/container": "^1.0",
+        "psr/log": "^1.0 || ^2.0",
         "psr/simple-cache": "^1.0",
         "ramsey/uuid": "^4.0",
         "swiftmailer/swiftmailer": "^6.0",


### PR DESCRIPTION
`monolog/monolog` 2.3.4 now supports `psr/log` 3.0.0 which has `log(...): void;` while previous versions used: `log(...);` making `Illuminate\Log\LogManager` no longer compatible.

I think we should restrict this on Laravel < 9, then maybe enforce psr/log ^3 for Laravel >= 9 then add the `: void` return type also in `Illuminate\Log\LogManager`.

See #38852 for 9.x