### PR TITLE
[9.x] Update psr/log version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "nesbot/carbon": "^2.31",
         "opis/closure": "^3.6",
         "psr/container": "^1.1.1|^2.0.1",
+        "psr/log": "^3.0",
         "psr/simple-cache": "^1.0",
         "ramsey/uuid": "^4.0",
         "symfony/console": "^6.0",

--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -16,6 +16,7 @@ use Monolog\Handler\SyslogHandler;
 use Monolog\Handler\WhatFailureGroupHandler;
 use Monolog\Logger as Monolog;
 use Psr\Log\LoggerInterface;
+use Stringable;
 use Throwable;
 
 class LogManager implements LoggerInterface
@@ -521,7 +522,7 @@ class LogManager implements LoggerInterface
      * @param  array  $context
      * @return void
      */
-    public function emergency($message, array $context = [])
+    public function emergency(string|Stringable $message, array $context = []): void
     {
         $this->driver()->emergency($message, $context);
     }
@@ -536,7 +537,7 @@ class LogManager implements LoggerInterface
      * @param  array  $context
      * @return void
      */
-    public function alert($message, array $context = [])
+    public function alert(string|Stringable $message, array $context = []): void
     {
         $this->driver()->alert($message, $context);
     }
@@ -550,7 +551,7 @@ class LogManager implements LoggerInterface
      * @param  array  $context
      * @return void
      */
-    public function critical($message, array $context = [])
+    public function critical(string|Stringable $message, array $context = []): void
     {
         $this->driver()->critical($message, $context);
     }
@@ -563,7 +564,7 @@ class LogManager implements LoggerInterface
      * @param  array  $context
      * @return void
      */
-    public function error($message, array $context = [])
+    public function error(string|Stringable $message, array $context = []): void
     {
         $this->driver()->error($message, $context);
     }
@@ -578,7 +579,7 @@ class LogManager implements LoggerInterface
      * @param  array  $context
      * @return void
      */
-    public function warning($message, array $context = [])
+    public function warning(string|Stringable $message, array $context = []): void
     {
         $this->driver()->warning($message, $context);
     }
@@ -590,7 +591,7 @@ class LogManager implements LoggerInterface
      * @param  array  $context
      * @return void
      */
-    public function notice($message, array $context = [])
+    public function notice(string|Stringable $message, array $context = []): void
     {
         $this->driver()->notice($message, $context);
     }
@@ -604,7 +605,7 @@ class LogManager implements LoggerInterface
      * @param  array  $context
      * @return void
      */
-    public function info($message, array $context = [])
+    public function info(string|Stringable $message, array $context = []): void
     {
         $this->driver()->info($message, $context);
     }
@@ -616,7 +617,7 @@ class LogManager implements LoggerInterface
      * @param  array  $context
      * @return void
      */
-    public function debug($message, array $context = [])
+    public function debug(string|Stringable $message, array $context = []): void
     {
         $this->driver()->debug($message, $context);
     }
@@ -629,7 +630,7 @@ class LogManager implements LoggerInterface
      * @param  array  $context
      * @return void
      */
-    public function log($level, $message, array $context = [])
+    public function log($level, string|Stringable $message, array $context = []): void
     {
         $this->driver()->log($level, $message, $context);
     }

--- a/src/Illuminate/Log/Logger.php
+++ b/src/Illuminate/Log/Logger.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Log\Events\MessageLogged;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use Stringable;
 
 class Logger implements LoggerInterface
 {
@@ -53,7 +54,7 @@ class Logger implements LoggerInterface
      * @param  array  $context
      * @return void
      */
-    public function emergency($message, array $context = [])
+    public function emergency(string|Stringable $message, array $context = []): void
     {
         $this->writeLog(__FUNCTION__, $message, $context);
     }
@@ -65,7 +66,7 @@ class Logger implements LoggerInterface
      * @param  array  $context
      * @return void
      */
-    public function alert($message, array $context = [])
+    public function alert(string|Stringable $message, array $context = []): void
     {
         $this->writeLog(__FUNCTION__, $message, $context);
     }
@@ -77,7 +78,7 @@ class Logger implements LoggerInterface
      * @param  array  $context
      * @return void
      */
-    public function critical($message, array $context = [])
+    public function critical(string|Stringable $message, array $context = []): void
     {
         $this->writeLog(__FUNCTION__, $message, $context);
     }
@@ -89,7 +90,7 @@ class Logger implements LoggerInterface
      * @param  array  $context
      * @return void
      */
-    public function error($message, array $context = [])
+    public function error(string|Stringable $message, array $context = []): void
     {
         $this->writeLog(__FUNCTION__, $message, $context);
     }
@@ -101,7 +102,7 @@ class Logger implements LoggerInterface
      * @param  array  $context
      * @return void
      */
-    public function warning($message, array $context = [])
+    public function warning(string|Stringable $message, array $context = []): void
     {
         $this->writeLog(__FUNCTION__, $message, $context);
     }
@@ -113,7 +114,7 @@ class Logger implements LoggerInterface
      * @param  array  $context
      * @return void
      */
-    public function notice($message, array $context = [])
+    public function notice(string|Stringable $message, array $context = []): void
     {
         $this->writeLog(__FUNCTION__, $message, $context);
     }
@@ -125,7 +126,7 @@ class Logger implements LoggerInterface
      * @param  array  $context
      * @return void
      */
-    public function info($message, array $context = [])
+    public function info(string|Stringable $message, array $context = []): void
     {
         $this->writeLog(__FUNCTION__, $message, $context);
     }
@@ -137,7 +138,7 @@ class Logger implements LoggerInterface
      * @param  array  $context
      * @return void
      */
-    public function debug($message, array $context = [])
+    public function debug(string|Stringable $message, array $context = []): void
     {
         $this->writeLog(__FUNCTION__, $message, $context);
     }
@@ -150,7 +151,7 @@ class Logger implements LoggerInterface
      * @param  array  $context
      * @return void
      */
-    public function log($level, $message, array $context = [])
+    public function log($level, string|Stringable $message, array $context = []): void
     {
         $this->writeLog($level, $message, $context);
     }
@@ -163,7 +164,7 @@ class Logger implements LoggerInterface
      * @param  array  $context
      * @return void
      */
-    public function write($level, $message, array $context = [])
+    public function write($level, string|Stringable $message, array $context = []): void
     {
         $this->writeLog($level, $message, $context);
     }


### PR DESCRIPTION
`monolog/monolog` 2.3.4 now supports `psr/log` 3.0.0 which has `log(...): void;` while previous versions used: `log(...);` making `Illuminate\Log\LogManager` no longer compatible.

I think we should restrict this on Laravel < 9, then maybe enforce psr/log ^3 for Laravel >= 9 then add the `: void` return type also in `Illuminate\Log\LogManager`.

See #38851 for 8.x