### PR TITLE
[9.x] Fix consistency of assertJsonPath to act like assertSame so that expected value be first parameter

### DIFF
--- a/src/Illuminate/Testing/AssertableJsonString.php
+++ b/src/Illuminate/Testing/AssertableJsonString.php
@@ -213,11 +213,11 @@ class AssertableJsonString implements ArrayAccess, Countable
     /**
      * Assert that the expected value and type exists at the given path in the response.
      *
-     * @param  string  $path
      * @param  mixed  $expect
+     * @param  string  $path
      * @return $this
      */
-    public function assertPath($path, $expect)
+    public function assertPath($expect, $path)
     {
         PHPUnit::assertSame($expect, $this->json($path));
 

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -704,13 +704,13 @@ EOF;
     /**
      * Assert that the expected value and type exists at the given path in the response.
      *
-     * @param  string  $path
      * @param  mixed  $expect
+     * @param  string  $path
      * @return $this
      */
-    public function assertJsonPath($path, $expect)
+    public function assertJsonPath($expect, $path)
     {
-        $this->decodeResponseJson()->assertPath($path, $expect);
+        $this->decodeResponseJson()->assertPath($expect, $path);
 
         return $this;
     }

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -765,33 +765,33 @@ class TestResponseTest extends TestCase
     {
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceStub));
 
-        $response->assertJsonPath('0.foo', 'foo 0');
+        $response->assertJsonPath('foo 0', '0.foo');
 
-        $response->assertJsonPath('0.foo', 'foo 0');
-        $response->assertJsonPath('0.bar', 'bar 0');
-        $response->assertJsonPath('0.foobar', 'foobar 0');
+        $response->assertJsonPath('foo 0', '0.foo');
+        $response->assertJsonPath('bar 0', '0.bar');
+        $response->assertJsonPath('foobar 0', '0.foobar');
 
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));
 
-        $response->assertJsonPath('foo', 'bar');
+        $response->assertJsonPath('bar', 'foo');
 
-        $response->assertJsonPath('foobar.foobar_foo', 'foo');
-        $response->assertJsonPath('foobar.foobar_bar', 'bar');
+        $response->assertJsonPath('foo', 'foobar.foobar_foo');
+        $response->assertJsonPath('bar', 'foobar.foobar_bar');
 
-        $response->assertJsonPath('foobar.foobar_foo', 'foo')->assertJsonPath('foobar.foobar_bar', 'bar');
+        $response->assertJsonPath( 'foo', 'foobar.foobar_foo')->assertJsonPath( 'bar','foobar.foobar_bar');
 
-        $response->assertJsonPath('bars', [
+        $response->assertJsonPath([
             ['bar' => 'foo 0', 'foo' => 'bar 0'],
             ['bar' => 'foo 1', 'foo' => 'bar 1'],
             ['bar' => 'foo 2', 'foo' => 'bar 2'],
-        ]);
-        $response->assertJsonPath('bars.0', ['bar' => 'foo 0', 'foo' => 'bar 0']);
+        ], 'bars');
+        $response->assertJsonPath(['bar' => 'foo 0', 'foo' => 'bar 0'],  'bars.0');
 
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceWithIntegersStub));
 
-        $response->assertJsonPath('0.id', 10);
-        $response->assertJsonPath('1.id', 20);
-        $response->assertJsonPath('2.id', 30);
+        $response->assertJsonPath(10, '0.id');
+        $response->assertJsonPath(20, '1.id');
+        $response->assertJsonPath(30, '2.id');
     }
 
     public function testAssertJsonPathCanFail()
@@ -801,7 +801,7 @@ class TestResponseTest extends TestCase
 
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceWithIntegersStub));
 
-        $response->assertJsonPath('0.id', '10');
+        $response->assertJsonPath('10', '0.id');
     }
 
     public function testAssertJsonFragment()

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -778,7 +778,7 @@ class TestResponseTest extends TestCase
         $response->assertJsonPath('foo', 'foobar.foobar_foo');
         $response->assertJsonPath('bar', 'foobar.foobar_bar');
 
-        $response->assertJsonPath('foo', 'foobar.foobar_foo')->assertJsonPath('bar','foobar.foobar_bar');
+        $response->assertJsonPath('foo', 'foobar.foobar_foo')->assertJsonPath('bar', 'foobar.foobar_bar');
 
         $response->assertJsonPath([
             ['bar' => 'foo 0', 'foo' => 'bar 0'],

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -778,14 +778,14 @@ class TestResponseTest extends TestCase
         $response->assertJsonPath('foo', 'foobar.foobar_foo');
         $response->assertJsonPath('bar', 'foobar.foobar_bar');
 
-        $response->assertJsonPath( 'foo', 'foobar.foobar_foo')->assertJsonPath( 'bar','foobar.foobar_bar');
+        $response->assertJsonPath('foo', 'foobar.foobar_foo')->assertJsonPath('bar','foobar.foobar_bar');
 
         $response->assertJsonPath([
             ['bar' => 'foo 0', 'foo' => 'bar 0'],
             ['bar' => 'foo 1', 'foo' => 'bar 1'],
             ['bar' => 'foo 2', 'foo' => 'bar 2'],
         ], 'bars');
-        $response->assertJsonPath(['bar' => 'foo 0', 'foo' => 'bar 0'],  'bars.0');
+        $response->assertJsonPath(['bar' => 'foo 0', 'foo' => 'bar 0'], 'bars.0');
 
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceWithIntegersStub));
 


### PR DESCRIPTION
This PR fix consistency of assertJsonPath to act like assertSame so that the expected value be the first parameter

```
// Take expected value first then the key
assertJsonCount($expected, $key)

// Take expected value first then the path
assertSame($expected, $path)

// So why we don't make assertJsonPath take expected as first parameters to be consistent 
assertJsonPath($expected, $path)`
```

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
