### PR TITLE
[8.x] Add prohibitedIf validation rule

### DIFF
--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -8,8 +8,8 @@ use Illuminate\Validation\Rules\Dimensions;
 use Illuminate\Validation\Rules\Exists;
 use Illuminate\Validation\Rules\In;
 use Illuminate\Validation\Rules\NotIn;
-use Illuminate\Validation\Rules\RequiredIf;
 use Illuminate\Validation\Rules\ProhibitedIf;
+use Illuminate\Validation\Rules\RequiredIf;
 use Illuminate\Validation\Rules\Unique;
 
 class Rule

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -9,6 +9,7 @@ use Illuminate\Validation\Rules\Exists;
 use Illuminate\Validation\Rules\In;
 use Illuminate\Validation\Rules\NotIn;
 use Illuminate\Validation\Rules\RequiredIf;
+use Illuminate\Validation\Rules\ProhibitedIf;
 use Illuminate\Validation\Rules\Unique;
 
 class Rule
@@ -90,6 +91,17 @@ class Rule
     public static function requiredIf($callback)
     {
         return new RequiredIf($callback);
+    }
+
+    /**
+     * Get a prohibited_if constraint builder instance.
+     *
+     * @param  callable|bool  $callback
+     * @return \Illuminate\Validation\Rules\ProhibitedIf
+     */
+    public static function prohibitedIf($callback)
+    {
+        return new ProhibitedIf($callback);
     }
 
     /**

--- a/src/Illuminate/Validation/Rules/ProhibitedIf.php
+++ b/src/Illuminate/Validation/Rules/ProhibitedIf.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+use InvalidArgumentException;
+
+class ProhibitedIf
+{
+    /**
+     * The condition that validates the attribute.
+     *
+     * @var callable|bool
+     */
+    public $condition;
+
+    /**
+     * Create a new prohibited validation rule based on a condition.
+     *
+     * @param  callable|bool  $condition
+     * @return void
+     */
+    public function __construct($condition)
+    {
+        if (! is_string($condition)) {
+            $this->condition = $condition;
+        } else {
+            throw new InvalidArgumentException('The provided condition must be a callable or boolean.');
+        }
+    }
+
+    /**
+     * Convert the rule to a validation string.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        if (is_callable($this->condition)) {
+            return call_user_func($this->condition) ? 'prohibited' : '';
+        }
+
+        return $this->condition ? 'prohibited' : '';
+    }
+}

--- a/tests/Validation/ValidationProhibitedIfTest.php
+++ b/tests/Validation/ValidationProhibitedIfTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Illuminate\Validation\Rules\ProhibitedIf;
+use PHPUnit\Framework\TestCase;
+
+class ValidationProhibitedIfTest extends TestCase
+{
+    public function testItClosureReturnsFormatsAStringVersionOfTheRule()
+    {
+        $rule = new ProhibitedIf(function () {
+            return true;
+        });
+
+        $this->assertSame('prohibited', (string) $rule);
+
+        $rule = new ProhibitedIf(function () {
+            return false;
+        });
+
+        $this->assertSame('', (string) $rule);
+
+        $rule = new ProhibitedIf(true);
+
+        $this->assertSame('prohibited', (string) $rule);
+
+        $rule = new ProhibitedIf(false);
+
+        $this->assertSame('', (string) $rule);
+    }
+
+    public function testItOnlyCallableAndBooleanAreAcceptableArgumentsOfTheRule()
+    {
+        $rule = new ProhibitedIf(false);
+
+        $rule = new ProhibitedIf(true);
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $rule = new ProhibitedIf('phpinfo');
+    }
+
+    public function testItReturnedRuleIsNotSerializable()
+    {
+        $this->expectException(\Exception::class);
+
+        $rule = serialize(new ProhibitedIf(function () {
+            return true;
+        }));
+    }
+}


### PR DESCRIPTION

I've found myself needing these validation rules on a few occasions, where `prohibited_if `and `prohibited_unless `don't quite go far enough.

so i added `Rule::prohibitedIf` that works just like `Rule::requiredIf` which gets callback or boolean then converts the condition to validation string 

For example, in bellow snippet the request gets rejected if the user is admin and request payload has role_id parameter
```php
use Illuminate\Support\Facades\Validator;
use Illuminate\Validation\Rule;

Validator::make($request->all(), [
    'role_id' => Rule::prohibitedIf($request->user()->is_admin),
]);

Validator::make($request->all(), [
    'role_id' => Rule::prohibitedIf(function () use ($request) {
        return $request->user()->is_admin;
    }),
]);
```

Not sure if this is a common enough use-case to go into the framework, but hopefully it helps others 🙂

If this gets merged, I will follow up with a PR to `laravel/docs` and the language file in `laravel/laravel`.

thanks for reviewing