### PR TITLE
Custom foreign key basename

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1946,7 +1946,7 @@ abstract class Model implements Arrayable, ArrayAccess, HasBroadcastChannel, Jso
      */
     public function getForeignKey()
     {
-        if (isset($this->foreignKeyBaseName) && !empty($this->foreignKeyBaseName)){
+        if (isset($this->foreignKeyBaseName) && ! empty($this->foreignKeyBaseName)) {
             return $this->foreignKeyBaseName.'_'.$this->getKeyName();
         }
         return Str::snake(class_basename($this)).'_'.$this->getKeyName();

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -97,6 +97,13 @@ abstract class Model implements Arrayable, ArrayAccess, HasBroadcastChannel, Jso
     protected $perPage = 15;
 
     /**
+     * Set custom foreign Key basename.
+     *
+     * @var string
+     */
+    protected $foreignKeyBaseName;
+
+    /**
      * Indicates if the model exists.
      *
      * @var bool
@@ -1939,6 +1946,9 @@ abstract class Model implements Arrayable, ArrayAccess, HasBroadcastChannel, Jso
      */
     public function getForeignKey()
     {
+        if (isset($this->foreignKeyBaseName) && !empty($this->foreignKeyBaseName)){
+            return $this->foreignKeyBaseName.'_'.$this->getKeyName();
+        }
         return Str::snake(class_basename($this)).'_'.$this->getKeyName();
     }
 


### PR DESCRIPTION
**Custom foreign key base name** is useful when we need to **inherit** an app model class without specify for `foreign_key ` and `local_key` in base model class(parent class).
with this method we can write:
```
class StoreSearchResultView extends Store implements Searchable
{
    protected $connection = 'read-only';
    protected $table = 'stores';
    protected $foreignKeyBaseName = "store";
}
```