### PR TITLE
[9.x] Add capability to Ignore Exceptions if Broadcast fails

### DIFF
--- a/src/Illuminate/Broadcasting/Broadcasters/AblyBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/AblyBroadcaster.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Broadcasting\Broadcasters;
 
 use Ably\AblyRest;
+use Ably\Exceptions\AblyException;
 use Illuminate\Support\Str;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
@@ -117,11 +118,19 @@ class AblyBroadcaster extends Broadcaster
      * @param  string  $event
      * @param  array  $payload
      * @return void
+     *
+     * @throws \Illuminate\Broadcasting\BroadcastException
      */
     public function broadcast(array $channels, $event, array $payload = [])
     {
-        foreach ($this->formatChannels($channels) as $channel) {
-            $this->ably->channels->get($channel)->publish($event, $payload);
+        try {
+            foreach ($this->formatChannels($channels) as $channel) {
+                $this->ably->channels->get($channel)->publish($event, $payload);
+            }
+        } catch (AblyException $e) {
+            throw new BrodcastException(
+                sprintf('Ably error: %s', $e->getMessage())
+            )
         }
     }
 

--- a/src/Illuminate/Contracts/Broadcasting/Broadcaster.php
+++ b/src/Illuminate/Contracts/Broadcasting/Broadcaster.php
@@ -28,6 +28,8 @@ interface Broadcaster
      * @param  string  $event
      * @param  array  $payload
      * @return void
+     *
+     * @throws \Illuminate\Broadcasting\BroadcastException
      */
     public function broadcast(array $channels, $event, array $payload = []);
 }


### PR DESCRIPTION
## Description

This PR normalizes all the Exceptions under the broadcast drivers, Ably, Pusher, Redis to return only a BroadcastException.

Also adds the capability to ignore exceptions in the case of the broadcast fails to send, I find myself having to add a way to ignore the broadcast exceptions to avoid the user to receive a 500 error.

### Proposal addition to the `broadcasting.php` config:

```
    /*
    |--------------------------------------------------------------------------
    | Ignore Exceptions
    |--------------------------------------------------------------------------
    |
    | Here you can set to ignore all the exceptions, in the case something
    | happens to your connection it will not throw an exception.
    |
    */

    'ignore_exceptions' => false,
```