### PR TITLE
[9.x] Only throws BroadcastException on all drivers

### DIFF
--- a/src/Illuminate/Broadcasting/Broadcasters/AblyBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/AblyBroadcaster.php
@@ -4,6 +4,7 @@ namespace Illuminate\Broadcasting\Broadcasters;
 
 use Ably\AblyRest;
 use Ably\Exceptions\AblyException;
+use Illuminate\Broadcasting\BroadcastException;
 use Illuminate\Support\Str;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
@@ -128,7 +129,7 @@ class AblyBroadcaster extends Broadcaster
                 $this->ably->channels->get($channel)->publish($event, $payload);
             }
         } catch (AblyException $e) {
-            throw new BrodcastException(
+            throw new BroadcastException(
                 sprintf('Ably error: %s', $e->getMessage())
             );
         }

--- a/src/Illuminate/Broadcasting/Broadcasters/AblyBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/AblyBroadcaster.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Broadcasting\Broadcasters;
 
 use Ably\AblyRest;
+use Ably\Exceptions\AblyException;
 use Illuminate\Support\Str;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
@@ -117,11 +118,19 @@ class AblyBroadcaster extends Broadcaster
      * @param  string  $event
      * @param  array  $payload
      * @return void
+     *
+     * @throws \Illuminate\Broadcasting\BroadcastException
      */
     public function broadcast(array $channels, $event, array $payload = [])
     {
-        foreach ($this->formatChannels($channels) as $channel) {
-            $this->ably->channels->get($channel)->publish($event, $payload);
+        try {
+            foreach ($this->formatChannels($channels) as $channel) {
+                $this->ably->channels->get($channel)->publish($event, $payload);
+            }
+        } catch (AblyException $e) {
+            throw new BrodcastException(
+                sprintf('Ably error: %s', $e->getMessage())
+            );
         }
     }
 

--- a/src/Illuminate/Contracts/Broadcasting/Broadcaster.php
+++ b/src/Illuminate/Contracts/Broadcasting/Broadcaster.php
@@ -28,6 +28,8 @@ interface Broadcaster
      * @param  string  $event
      * @param  array  $payload
      * @return void
+     *
+     * @throws \Illuminate\Broadcasting\BroadcastException
      */
     public function broadcast(array $channels, $event, array $payload = []);
 }


### PR DESCRIPTION
Based on what is done in the `PusherBroadcaster` this PR makes Redis and Ably also return `BroadcastException` as well.

This is a continuation from my previous pull request #38860.

Thanks for reviewing it.