### PR TITLE
[8.x] Adds Str helper for encoding to URL Query

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -826,7 +826,7 @@ class Str
      */
     public static function urlQuery($string)
     {
-        return urlencode(static::lower($string));
+        return urlencode(trim($string));
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -819,6 +819,28 @@ class Str
     }
 
     /**
+     * Encodes the string to a URL-query-safe string.
+     *
+     * @param  $string
+     * @return string
+     */
+    public static function urlQuery($string)
+    {
+        return urlencode(static::lower($string));
+    }
+
+    /**
+     * Encodes the string to a URL-path-safe string.
+     *
+     * @param  $string
+     * @return string
+     */
+    public static function urlPath($string)
+    {
+        return rawurlencode(static::lower($string));
+    }
+
+    /**
      * Get the number of words a string contains.
      *
      * @param  string  $string

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -830,17 +830,6 @@ class Str
     }
 
     /**
-     * Encodes the string to a URL-path-safe string.
-     *
-     * @param  $string
-     * @return string
-     */
-    public static function urlPath($string)
-    {
-        return rawurlencode(static::lower($string));
-    }
-
-    /**
      * Get the number of words a string contains.
      *
      * @param  string  $string

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -708,16 +708,6 @@ class Stringable implements JsonSerializable
     }
 
     /**
-     * Encodes the string to a URL-path-safe string.
-     *
-     * @return static
-     */
-    public function urlPath()
-    {
-        return new static(Str::urlPath($this->value));
-    }
-
-    /**
      * Encodes the string to a URL-query-safe string.
      *
      * @return static

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -708,6 +708,26 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Encodes the string to a URL-path-safe string.
+     *
+     * @return static
+     */
+    public function urlPath()
+    {
+        return new static(Str::urlPath($this->value));
+    }
+
+    /**
+     * Encodes the string to a URL-query-safe string.
+     *
+     * @return static
+     */
+    public function urlQuery()
+    {
+        return new static(Str::urlQuery($this->value));
+    }
+
+    /**
      * Execute the given callback if the string is empty.
      *
      * @param  callable  $callback

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -491,14 +491,6 @@ class SupportStrTest extends TestCase
         $this->assertSame('Мама мыла раму', Str::ucfirst('мама мыла раму'));
     }
 
-    public function testUrlPath()
-    {
-        $this->assertSame('laravel', Str::urlPath('Laravel'));
-        $this->assertSame('this%20sign%20%22%3D%22%20is%20%2F%20cool%21', Str::urlPath('This sign "=" is / cool!'));
-        $this->assertSame('%D0%BC%D0%B0%D0%BC%D0%B0', Str::urlPath('мама'));
-        $this->assertSame('%D0%BC%D0%B0%D0%BC%D0%B0%20%D0%BC%D1%8B%D0%BB%D0%B0%20%D1%80%D0%B0%D0%BC%D1%83', Str::urlPath('мама мыла раму'));
-    }
-
     public function testUrlQuery()
     {
         $this->assertSame('laravel', Str::urlQuery('Laravel'));

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -491,6 +491,22 @@ class SupportStrTest extends TestCase
         $this->assertSame('Мама мыла раму', Str::ucfirst('мама мыла раму'));
     }
 
+    public function testUrlPath()
+    {
+        $this->assertSame('laravel', Str::urlPath('Laravel'));
+        $this->assertSame('this%20sign%20%22%3D%22%20is%20%2F%20cool%21', Str::urlPath('This sign "=" is / cool!'));
+        $this->assertSame('%D0%BC%D0%B0%D0%BC%D0%B0', Str::urlPath('мама'));
+        $this->assertSame('%D0%BC%D0%B0%D0%BC%D0%B0%20%D0%BC%D1%8B%D0%BB%D0%B0%20%D1%80%D0%B0%D0%BC%D1%83', Str::urlPath('мама мыла раму'));
+    }
+
+    public function testUrlQuery()
+    {
+        $this->assertSame('laravel', Str::urlQuery('Laravel'));
+        $this->assertSame('this+sign+%22%3D%22+is+%2F+cool%21', Str::urlQuery('This sign "=" is / cool!'));
+        $this->assertSame('%D0%BC%D0%B0%D0%BC%D0%B0', Str::urlQuery('мама'));
+        $this->assertSame('%D0%BC%D0%B0%D0%BC%D0%B0+%D0%BC%D1%8B%D0%BB%D0%B0+%D1%80%D0%B0%D0%BC%D1%83', Str::urlQuery('мама мыла раму'));
+    }
+
     public function testUuid()
     {
         if (\PHP_VERSION_ID >= 80100) {

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -493,8 +493,9 @@ class SupportStrTest extends TestCase
 
     public function testUrlQuery()
     {
-        $this->assertSame('laravel', Str::urlQuery('Laravel'));
-        $this->assertSame('this+sign+%22%3D%22+is+%2F+cool%21', Str::urlQuery('This sign "=" is / cool!'));
+        $this->assertSame('Laravel', Str::urlQuery('Laravel'));
+        $this->assertSame('Laravel', Str::urlQuery(" Laravel \n"));
+        $this->assertSame('This+sign+%22%3D%22+is+%2F+cool%21', Str::urlQuery('This sign "=" is / cool!'));
         $this->assertSame('%D0%BC%D0%B0%D0%BC%D0%B0', Str::urlQuery('мама'));
         $this->assertSame('%D0%BC%D0%B0%D0%BC%D0%B0+%D0%BC%D1%8B%D0%BB%D0%B0+%D1%80%D0%B0%D0%BC%D1%83', Str::urlQuery('мама мыла раму'));
     }

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -91,6 +91,22 @@ class SupportStringableTest extends TestCase
         $this->assertSame(' foo', (string) $this->stringable(' foo ')->rtrim());
     }
 
+    public function testUrlPath()
+    {
+        $this->assertSame('laravel', (string) $this->stringable('Laravel')->urlPath());
+        $this->assertSame('this%20sign%20%22%3D%22%20is%20%2F%20cool%21', (string) $this->stringable('This sign "=" is / cool!')->urlPath());
+        $this->assertSame('%D0%BC%D0%B0%D0%BC%D0%B0', (string) $this->stringable('мама')->urlPath());
+        $this->assertSame('%D0%BC%D0%B0%D0%BC%D0%B0%20%D0%BC%D1%8B%D0%BB%D0%B0%20%D1%80%D0%B0%D0%BC%D1%83', (string) $this->stringable('мама мыла раму')->urlPath());
+    }
+
+    public function testUrlQuery()
+    {
+        $this->assertSame('laravel', (string) $this->stringable('Laravel')->urlQuery());
+        $this->assertSame('this+sign+%22%3D%22+is+%2F+cool%21', (string) $this->stringable('This sign "=" is / cool!')->urlQuery());
+        $this->assertSame('%D0%BC%D0%B0%D0%BC%D0%B0', (string) $this->stringable('мама')->urlQuery());
+        $this->assertSame('%D0%BC%D0%B0%D0%BC%D0%B0+%D0%BC%D1%8B%D0%BB%D0%B0+%D1%80%D0%B0%D0%BC%D1%83', (string) $this->stringable('мама мыла раму')->urlQuery());
+    }
+
     public function testCanBeLimitedByWords()
     {
         $this->assertSame('Taylor...', (string) $this->stringable('Taylor Otwell')->words(1));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -93,8 +93,9 @@ class SupportStringableTest extends TestCase
 
     public function testUrlQuery()
     {
-        $this->assertSame('laravel', (string) $this->stringable('Laravel')->urlQuery());
-        $this->assertSame('this+sign+%22%3D%22+is+%2F+cool%21', (string) $this->stringable('This sign "=" is / cool!')->urlQuery());
+        $this->assertSame('Laravel', (string) $this->stringable('Laravel')->urlQuery());
+        $this->assertSame('Laravel', (string) $this->stringable(" Laravel \n")->urlQuery());
+        $this->assertSame('This+sign+%22%3D%22+is+%2F+cool%21', (string) $this->stringable('This sign "=" is / cool!')->urlQuery());
         $this->assertSame('%D0%BC%D0%B0%D0%BC%D0%B0', (string) $this->stringable('мама')->urlQuery());
         $this->assertSame('%D0%BC%D0%B0%D0%BC%D0%B0+%D0%BC%D1%8B%D0%BB%D0%B0+%D1%80%D0%B0%D0%BC%D1%83', (string) $this->stringable('мама мыла раму')->urlQuery());
     }

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -91,14 +91,6 @@ class SupportStringableTest extends TestCase
         $this->assertSame(' foo', (string) $this->stringable(' foo ')->rtrim());
     }
 
-    public function testUrlPath()
-    {
-        $this->assertSame('laravel', (string) $this->stringable('Laravel')->urlPath());
-        $this->assertSame('this%20sign%20%22%3D%22%20is%20%2F%20cool%21', (string) $this->stringable('This sign "=" is / cool!')->urlPath());
-        $this->assertSame('%D0%BC%D0%B0%D0%BC%D0%B0', (string) $this->stringable('мама')->urlPath());
-        $this->assertSame('%D0%BC%D0%B0%D0%BC%D0%B0%20%D0%BC%D1%8B%D0%BB%D0%B0%20%D1%80%D0%B0%D0%BC%D1%83', (string) $this->stringable('мама мыла раму')->urlPath());
-    }
-
     public function testUrlQuery()
     {
         $this->assertSame('laravel', (string) $this->stringable('Laravel')->urlQuery());


### PR DESCRIPTION
## What?

This allows to encode strings to URL query strings. 

```php
use Illuminate\Support\Str;

$query = Str::urlQuery('This sign "=" is / cool!') // This+sign+%22%3D%22+is+%2F+cool%21

return redirect()->to('https://myapp.com/?check=' . $query);
```

## Why?

Because sometimes you have to deal with query strings from users in a simple way.

## BC?

None, it's additive.

## Notes?

Well, you may have a point using `urlencode(Str::lower($string))` but I think `urlQuery()` is more descriptive.