### PR TITLE
[8.x] Add 'relationsRetrieved' model event

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -633,6 +633,12 @@ class Builder
             }
         }
 
+        foreach ($models as $model) {
+            if ($model instanceof Model) {
+                $model->fireModelEvent('relationsRetrieved');
+            }
+        }
+
         return $models;
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -166,7 +166,7 @@ trait HasEvents
      * @param  bool  $halt
      * @return mixed
      */
-    protected function fireModelEvent($event, $halt = true)
+    public function fireModelEvent($event, $halt = true)
     {
         if (! isset(static::$dispatcher)) {
             return true;

--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -96,7 +96,7 @@ trait HasEvents
     {
         return array_merge(
             [
-                'retrieved', 'creating', 'created', 'updating', 'updated',
+                'relationsRetrieved', 'retrieved', 'creating', 'created', 'updating', 'updated',
                 'saving', 'saved', 'restoring', 'restored', 'replicating',
                 'deleting', 'deleted', 'forceDeleted',
             ],
@@ -225,6 +225,17 @@ trait HasEvents
         }
 
         return $result;
+    }
+
+    /**
+     * Register a relationsRetrieved model event with the dispatcher.
+     *
+     * @param  \Closure|string  $callback
+     * @return void
+     */
+    public static function relationsRetrieved($callback)
+    {
+        static::registerModelEvent('relationsRetrieved', $callback);
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

I tried implementing my idea from #38705 which has been also an issue: #29658 and has been mentioned in the pull request that added the 'retrieved' event https://github.com/laravel/framework/pull/20852#issuecomment-406696499. 

# Why
There are situations we need to do things after relations are loaded. A use case I found myself using is conditionally appending an attribute. I don't know other ways other than returning null which isn't really great when you have a more complex site and of course the 'retrieved' event doesn't help as relations are not loaded by that point.

It makes developing applications easier because it basically allows us to better handle relations which I've seen are a huge part in Laravel applications. I tried before collecting permissions from every role to a nice list automatically, and it wasn't that great as I had to check if I already collected it and it just becomes a mess the more you do it. Having the ability to just do it automatically (when needed) with this feature helps in development.

It shouldn't break anything as it's only adding a feature which does nothing if you aren't using it.

```php
protected static function booted() {
    static::relationsRetrieved(function (Model $mod)
    {
        if ($mod->relationLoaded('tags')) {
            $mod->append('tag_ids');
        }
    });
}
```

# Need feedback
* I tried to choose a less generic event name to avoid the issue mentioned in the comment here https://github.com/laravel/framework/pull/20852#issuecomment-326100695 Not sure if it's relevant, the name could by anything so if anyone has a better suggestion.
* This change makes fireModelEvent in HasEvents trait public, I'm not sure if this was a necessary change and if anyone has a better idea of handling this that'd be great. I thought of making a single method to call this specifically, but haven't found such cases so I'm unsure if that's the right way of doing it.

And in general, if you think this idea isn't good, I'd love to hear the reason, I think and believe this will be beneficial and is crucial if you want to do operations with your relations after they are loaded (I could really not find any better solution, and it seems like something people did ask for).

And of course, I'd love to see this feature implemented regardless of the implementation, so if you think you can do this better I have no problem closing this pull request.