### PR TITLE
[9.x] Use the nullsafe operator rather than the optional() helper

### DIFF
--- a/src/Illuminate/Cache/DatabaseLock.php
+++ b/src/Illuminate/Cache/DatabaseLock.php
@@ -134,7 +134,7 @@ class DatabaseLock extends Lock
      */
     protected function getCurrentOwner()
     {
-        return optional($this->connection->table($this->table)->where('key', $this->name)->first())->owner;
+        return $this->connection->table($this->table)->where('key', $this->name)->first()?->owner;
     }
 
     /**

--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -48,7 +48,7 @@ trait ManagesTransactions
                 $this->transactions = max(0, $this->transactions - 1);
 
                 if ($this->transactions == 0) {
-                    optional($this->transactionsManager)->commit($this->getName());
+                    $this->transactionsManager?->commit($this->getName());
                 }
             } catch (Throwable $e) {
                 $this->handleCommitTransactionException(
@@ -83,7 +83,7 @@ trait ManagesTransactions
             $this->transactions > 1) {
             $this->transactions--;
 
-            optional($this->transactionsManager)->rollback(
+            $this->transactionsManager?->rollback(
                 $this->getName(), $this->transactions
             );
 
@@ -116,7 +116,7 @@ trait ManagesTransactions
 
         $this->transactions++;
 
-        optional($this->transactionsManager)->begin(
+        $this->transactionsManager?->begin(
             $this->getName(), $this->transactions
         );
 
@@ -194,7 +194,7 @@ trait ManagesTransactions
         $this->transactions = max(0, $this->transactions - 1);
 
         if ($this->transactions == 0) {
-            optional($this->transactionsManager)->commit($this->getName());
+            $this->transactionsManager?->commit($this->getName());
         }
 
         $this->fireConnectionEvent('committed');
@@ -258,7 +258,7 @@ trait ManagesTransactions
 
         $this->transactions = $toLevel;
 
-        optional($this->transactionsManager)->rollback(
+        $this->transactionsManager?->rollback(
             $this->getName(), $this->transactions
         );
 
@@ -297,7 +297,7 @@ trait ManagesTransactions
         if ($this->causedByLostConnection($e)) {
             $this->transactions = 0;
 
-            optional($this->transactionsManager)->rollback(
+            $this->transactionsManager?->rollback(
                 $this->getName(), $this->transactions
             );
         }

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -303,7 +303,7 @@ class Handler implements ExceptionHandlerContract
         try {
             return array_filter([
                 'userId' => Auth::id(),
-                // 'email' => optional(Auth::user())->email,
+                // 'email' => Auth::user()?->email,
             ]);
         } catch (Throwable $e) {
             return [];

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -893,7 +893,7 @@ class PendingRequest
                 $promise = $handler($request, $options);
 
                 return $promise->then(function ($response) use ($request, $options) {
-                    optional($this->factory)->recordRequestResponsePair(
+                    $this->factory?->recordRequestResponsePair(
                         (new Request($request))->withData($options['laravel_data']),
                         new Response($response)
                     );
@@ -1030,7 +1030,7 @@ class PendingRequest
      */
     protected function dispatchRequestSendingEvent()
     {
-        if ($dispatcher = optional($this->factory)->getDispatcher()) {
+        if ($dispatcher = $this->factory?->getDispatcher()) {
             $dispatcher->dispatch(new RequestSending($this->request));
         }
     }
@@ -1043,7 +1043,7 @@ class PendingRequest
      */
     protected function dispatchResponseReceivedEvent(Response $response)
     {
-        if (! ($dispatcher = optional($this->factory)->getDispatcher()) ||
+        if (! ($dispatcher = $this->factory?->getDispatcher()) ||
             ! $this->request) {
             return;
         }
@@ -1058,7 +1058,7 @@ class PendingRequest
      */
     protected function dispatchConnectionFailedEvent()
     {
-        if ($dispatcher = optional($this->factory)->getDispatcher()) {
+        if ($dispatcher = $this->factory?->getDispatcher()) {
             $dispatcher->dispatch(new ConnectionFailed($this->request));
         }
     }

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -127,7 +127,7 @@ class Response implements ArrayAccess
      */
     public function effectiveUri()
     {
-        return optional($this->transferStats)->getEffectiveUri();
+        return $this->transferStats?->getEffectiveUri();
     }
 
     /**
@@ -222,7 +222,7 @@ class Response implements ArrayAccess
      */
     public function handlerStats()
     {
-        return optional($this->transferStats)->getHandlerStats() ?? [];
+        return $this->transferStats?->getHandlerStats() ?? [];
     }
 
     /**

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -733,7 +733,7 @@ class UrlGenerator implements UrlGeneratorContract
         $this->cachedRoot = null;
         $this->cachedScheme = null;
 
-        tap(optional($this->routeGenerator)->defaultParameters ?: [], function ($defaults) {
+        tap($this->routeGenerator?->defaultParameters ?? [], function ($defaults) {
             $this->routeGenerator = null;
 
             if (! empty($defaults)) {

--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -95,7 +95,7 @@ class StartSession
 
             return $this->handleStatefulRequest($request, $session, $next);
         } finally {
-            optional($lock)->release();
+            $lock?->release();
         }
     }
 

--- a/src/Illuminate/View/AnonymousComponent.php
+++ b/src/Illuminate/View/AnonymousComponent.php
@@ -51,7 +51,7 @@ class AnonymousComponent extends Component
         $this->attributes = $this->attributes ?: $this->newAttributeBag();
 
         return array_merge(
-            optional($this->data['attributes'] ?? null)->getAttributes() ?: [],
+            ($this->data['attributes'] ?? null)?->getAttributes() ?: [],
             $this->attributes->getAttributes(),
             $this->data,
             ['attributes' => $this->attributes]


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR replaces usage of `optional()` with the newly introduced nullsafe operator (see [rfc](https://wiki.php.net/rfc/nullsafe_operator))

```diff
-optional($this->transferStats)->getEffectiveUri()
+$this->transferStats?->getEffectiveUri()
```

it **does not** remove the `optional` helper for BC purposes.