### PR TITLE
[9.x] Add explode() to Collection

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -537,6 +537,25 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
+     * Explode collection's values base on the separators.
+     *
+     * @param  string|array<string>  $separators
+     * @return static<int, string>
+     */
+    public function explode($separators)
+    {
+        $separators = array_values(array_filter(is_array($separators) ? $separators : [$separators]));
+
+        if (isset($separators[0])) {
+            return $this->reduce(function ($result, $item) use ($separators) {
+                return $result->push(...explode($separators[0], str_replace($separators, $separators[0], $item)));
+            }, new static());
+        }
+
+        return new static($this->all());
+    }
+
+    /**
      * Intersect the collection with the given items.
      *
      * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -539,16 +539,19 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Explode collection's values base on the separators.
      *
-     * @param  string|array<string>  $separators
+     * @param  string|array<string>  $value
+     * @param  string|array<string>  $glue
      * @return static<int, string>
      */
-    public function explode($separators)
+    public function explode($value, $glue = null)
     {
-        $separators = array_values(array_filter(is_array($separators) ? $separators : [$separators]));
+        $separators = array_values(array_filter(is_array($separators = $glue ?? $value) ? $separators : [$separators]));
 
         if (isset($separators[0])) {
-            return $this->reduce(function ($result, $item) use ($separators) {
-                return $result->push(...explode($separators[0], str_replace($separators, $separators[0], $item)));
+            return $this->reduce(function ($result, $item) use ($value, $glue, $separators) {
+                $target = is_null($glue) ? $item : Arr::get($item, $value);
+
+                return $result->push(...explode($separators[0], str_replace($separators, $separators[0], $target)));
             }, new static());
         }
 

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -535,6 +535,14 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function implode($value, $glue = null);
 
     /**
+     * Explode collection's values base on the separators.
+     *
+     * @param  string|array<string>  $separators
+     * @return static<int, string>
+     */
+    public function explode($separators);
+
+    /**
      * Intersect the collection with the given items.
      *
      * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -537,10 +537,11 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Explode collection's values base on the separators.
      *
-     * @param  string|array<string>  $separators
+     * @param  string|array<string>  $value
+     * @param  string|array<string>  $glue
      * @return static<int, string>
      */
-    public function explode($separators);
+    public function explode($value, $glue = null);
 
     /**
      * Intersect the collection with the given items.

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -525,6 +525,29 @@ class LazyCollection implements Enumerable
     }
 
     /**
+     * Explode collection's values base on the separators.
+     *
+     * @param  string|array<string>  $separators
+     * @return static<int, string>
+     */
+    public function explode($separators)
+    {
+        return new static(function () use ($separators) {
+            $separators = array_values(array_filter(is_array($separators) ? $separators : [$separators]));
+
+            foreach ($this as $item) {
+                if (isset($separators[0])) {
+                    foreach (explode($separators[0], str_replace($separators, $separators[0], $item)) as $subItem) {
+                        yield $subItem;
+                    }
+                } else {
+                    yield $item;
+                }
+            }
+        });
+    }
+
+    /**
      * Intersect the collection with the given items.
      *
      * @param  mixed  $items

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -527,18 +527,20 @@ class LazyCollection implements Enumerable
     /**
      * Explode collection's values base on the separators.
      *
-     * @param  string|array<string>  $separators
+     * @param  string|array<string>  $value
+     * @param  string|array<string>  $glue
      * @return static<int, string>
      */
-    public function explode($separators)
+    public function explode($value, $glue = null)
     {
-        return new static(function () use ($separators) {
-            $separators = array_values(array_filter(is_array($separators) ? $separators : [$separators]));
+        return new static(function () use ($value, $glue) {
+            $separators = array_values(array_filter(is_array($separators = $glue ?? $value) ? $separators : [$separators]));
 
             foreach ($this as $item) {
                 if (isset($separators[0])) {
-                    foreach (explode($separators[0], str_replace($separators, $separators[0], $item)) as $subItem) {
-                        yield $subItem;
+                    $target = is_null($glue) ? $item : Arr::get($item, $value);
+                    foreach (explode($separators[0], str_replace($separators, $separators[0], $target)) as $subString) {
+                        yield $subString;
                     }
                 } else {
                     yield $item;

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2105,6 +2105,28 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testExplode($collection)
+    {
+        $data = new $collection('taylor,foo');
+        $this->assertSame(['taylor,foo'], $data->explode('')->all());
+        $this->assertSame(['taylor', 'foo'], $data->explode(',')->all());
+        $this->assertSame(['taylor', 'foo'], $data->explode(['', ','])->all());
+
+        $data = new $collection('taylor,foo;dayle,bar');
+        $this->assertSame(['taylor', 'foo', 'dayle', 'bar'], $data->explode([',', ';'])->all());
+        $this->assertSame(['taylor', 'foo', 'dayle', 'bar'], $data->explode(',')->explode(';')->all());
+
+        $data = new $collection(['taylor:foo', 'dayle|bar']);
+        $this->assertSame(['taylor', 'foo', 'dayle', 'bar'], $data->explode([':', '|'])->all());
+        $this->assertSame(['taylor', 'foo', 'dayle', 'bar'], $data->explode(':')->explode('|')->all());
+
+        $data = new $collection('taylor[a]foo[b][c]dayle[d]bar');
+        $this->assertSame(['taylor', 'foo', '', 'dayle', 'bar'], $data->explode(['[a]', '[b]', '[c]', '[d]'])->all());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testTake($collection)
     {
         $data = new $collection(['taylor', 'dayle', 'shawn']);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2122,6 +2122,12 @@ class SupportCollectionTest extends TestCase
 
         $data = new $collection('taylor[a]foo[b][c]dayle[d]bar');
         $this->assertSame(['taylor', 'foo', '', 'dayle', 'bar'], $data->explode(['[a]', '[b]', '[c]', '[d]'])->all());
+
+        $data = new $collection([['names' => 'taylor,foo'], ['names' => 'dayle,bar']]);
+        $this->assertSame(['taylor', 'foo', 'dayle', 'bar'], $data->explode('names', ',')->all());
+
+        $data = new $collection([['person' => ['names' => 'taylor,foo']], ['person' => ['names' => 'dayle;bar']]]);
+        $this->assertSame(['taylor', 'foo', 'dayle', 'bar'], $data->explode('person.names', [',', ';'])->all());
     }
 
     /**


### PR DESCRIPTION
Hi :-)

This pull request propose the addition of an `explode()` (echoing the presence of `implode()` method) to the Collection object.

This try to answer 2 cases I often see:

1- Need to generate Collection from exploded string, in code we see:
```
collect(explode(',', 'apple,pear'))->...
```

2- Need to generate Collection form list of literal lists:
```
collect(['apple,pear', 'banana,peach']))->map(fn($list) => explode(',', $list))->flatten(1)->...
```

With the new explode method we can have an efficient way to do:
```
collect('apple,pear')->explode(',')->...
// Generate ['apple', 'pear']

collect(['apple,pear', 'banana,peach']))->explode(',')->...
// Generate ['apple', 'pear', 'banana', 'peach']
```

It even support multi separators (which seem to be a pain every time...) as:
```
collect(['apple,pear', 'banana;peach']))->explode([',', ';'])->...
// Generate ['apple', 'pear', 'banana', 'peach']
```
