### PR TITLE
Translations for the Password Rule

### DIFF
--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -279,19 +279,19 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
         $value = (string) $value;
 
         if ($this->mixedCase && ! preg_match('/(\p{Ll}+.*\p{Lu})|(\p{Lu}+.*\p{Ll})/u', $value)) {
-            $this->fail('The :attribute must contain at least one uppercase and one lowercase letter.');
+            $this->fail(__('validation.password_mixedcase'));
         }
 
         if ($this->letters && ! preg_match('/\pL/u', $value)) {
-            $this->fail('The :attribute must contain at least one letter.');
+            $this->fail(__('validation.password_letters'));
         }
 
         if ($this->symbols && ! preg_match('/\p{Z}|\p{S}|\p{P}/u', $value)) {
-            $this->fail('The :attribute must contain at least one symbol.');
+            $this->fail(__('validation.password_symbols'));
         }
 
         if ($this->numbers && ! preg_match('/\pN/u', $value)) {
-            $this->fail('The :attribute must contain at least one number.');
+            $this->fail(__('validation.password_numbers'));
         }
 
         if (! empty($this->messages)) {
@@ -302,9 +302,7 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
             'value' => $value,
             'threshold' => $this->compromisedThreshold,
         ])) {
-            return $this->fail(
-                'The given :attribute has appeared in a data leak. Please choose a different :attribute.'
-            );
+            return $this->fail(__('validation.password_compromised'));
         }
 
         return true;


### PR DESCRIPTION
I have a multi-language application and could not find a way to replace the Password rule failed messages with translations.

In this PR, the code is moving these error messages to the lang\en-us\validation.php file inside the Laravel application, which allows proper use of translations.