### PR TITLE
RuleToStringInterface introduced and added to all rules which support __toString()

### DIFF
--- a/src/Illuminate/Validation/Rules/Dimensions.php
+++ b/src/Illuminate/Validation/Rules/Dimensions.php
@@ -4,7 +4,7 @@ namespace Illuminate\Validation\Rules;
 
 use Illuminate\Support\Traits\Conditionable;
 
-class Dimensions
+class Dimensions implements RulesInterface
 {
     use Conditionable;
 

--- a/src/Illuminate/Validation/Rules/Dimensions.php
+++ b/src/Illuminate/Validation/Rules/Dimensions.php
@@ -4,7 +4,7 @@ namespace Illuminate\Validation\Rules;
 
 use Illuminate\Support\Traits\Conditionable;
 
-class Dimensions implements RulesInterface
+class Dimensions implements RuleToStringInterface
 {
     use Conditionable;
 

--- a/src/Illuminate/Validation/Rules/Exists.php
+++ b/src/Illuminate/Validation/Rules/Exists.php
@@ -4,7 +4,7 @@ namespace Illuminate\Validation\Rules;
 
 use Illuminate\Support\Traits\Conditionable;
 
-class Exists
+class Exists implements RulesInterface
 {
     use Conditionable, DatabaseRule;
 

--- a/src/Illuminate/Validation/Rules/Exists.php
+++ b/src/Illuminate/Validation/Rules/Exists.php
@@ -4,7 +4,7 @@ namespace Illuminate\Validation\Rules;
 
 use Illuminate\Support\Traits\Conditionable;
 
-class Exists implements RulesInterface
+class Exists implements RuleToStringInterface
 {
     use Conditionable, DatabaseRule;
 

--- a/src/Illuminate/Validation/Rules/In.php
+++ b/src/Illuminate/Validation/Rules/In.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Validation\Rules;
 
-class In implements RulesInterface
+class In implements RuleToStringInterface
 {
     /**
      * The name of the rule.

--- a/src/Illuminate/Validation/Rules/In.php
+++ b/src/Illuminate/Validation/Rules/In.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Validation\Rules;
 
-class In
+class In implements RulesInterface
 {
     /**
      * The name of the rule.

--- a/src/Illuminate/Validation/Rules/NotIn.php
+++ b/src/Illuminate/Validation/Rules/NotIn.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Validation\Rules;
 
-class NotIn implements RulesInterface
+class NotIn implements RuleToStringInterface
 {
     /**
      * The name of the rule.

--- a/src/Illuminate/Validation/Rules/NotIn.php
+++ b/src/Illuminate/Validation/Rules/NotIn.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Validation\Rules;
 
-class NotIn
+class NotIn implements RulesInterface
 {
     /**
      * The name of the rule.

--- a/src/Illuminate/Validation/Rules/RequiredIf.php
+++ b/src/Illuminate/Validation/Rules/RequiredIf.php
@@ -4,7 +4,7 @@ namespace Illuminate\Validation\Rules;
 
 use InvalidArgumentException;
 
-class RequiredIf implements RulesInterface
+class RequiredIf implements RuleToStringInterface
 {
     /**
      * The condition that validates the attribute.

--- a/src/Illuminate/Validation/Rules/RequiredIf.php
+++ b/src/Illuminate/Validation/Rules/RequiredIf.php
@@ -4,7 +4,7 @@ namespace Illuminate\Validation\Rules;
 
 use InvalidArgumentException;
 
-class RequiredIf
+class RequiredIf implements RulesInterface
 {
     /**
      * The condition that validates the attribute.

--- a/src/Illuminate/Validation/Rules/RuleToStringInterface.php
+++ b/src/Illuminate/Validation/Rules/RuleToStringInterface.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Validation\Rules;
 
-interface RulesInterface
+interface RuleToStringInterface
 {
     /**
      * Convert the rule to a validation string.

--- a/src/Illuminate/Validation/Rules/RulesInterface.php
+++ b/src/Illuminate/Validation/Rules/RulesInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+interface RulesInterface
+{
+    /**
+     * Convert the rule to a validation string.
+     *
+     * @return string
+     */
+    public function __toString();
+}

--- a/src/Illuminate/Validation/Rules/Unique.php
+++ b/src/Illuminate/Validation/Rules/Unique.php
@@ -5,7 +5,7 @@ namespace Illuminate\Validation\Rules;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Traits\Conditionable;
 
-class Unique
+class Unique implements RulesInterface
 {
     use Conditionable, DatabaseRule;
 

--- a/src/Illuminate/Validation/Rules/Unique.php
+++ b/src/Illuminate/Validation/Rules/Unique.php
@@ -5,7 +5,7 @@ namespace Illuminate\Validation\Rules;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Traits\Conditionable;
 
-class Unique implements RulesInterface
+class Unique implements RuleToStringInterface
 {
     use Conditionable, DatabaseRule;
 


### PR DESCRIPTION
The intention is to be able to convert rules reliably to strings  e.g.

``` php
/** @var RuleToStringInterface $rule */
foreach ($rules as $key => $rule) {
    $stringRules[$key] = $rule->__toString();
}
```
