### PR TITLE
[9.x] Add support for 4xx/5xx fallback error views

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -544,7 +544,7 @@ class Handler implements ExceptionHandlerContract
     {
         $this->registerErrorViewPaths();
 
-        if (view()->exists($view = $this->getHttpExceptionView($e))) {
+        if ($view = $this->getHttpExceptionView($e)) {
             return response()->view($view, [
                 'errors' => new ViewErrorBag,
                 'exception' => $e,
@@ -568,11 +568,23 @@ class Handler implements ExceptionHandlerContract
      * Get the view used to render HTTP exceptions.
      *
      * @param  \Symfony\Component\HttpKernel\Exception\HttpExceptionInterface  $e
-     * @return string
+     * @return string|null
      */
     protected function getHttpExceptionView(HttpExceptionInterface $e)
     {
-        return "errors::{$e->getStatusCode()}";
+        $view = 'errors::'.$e->getStatusCode();
+
+        if (view()->exists($view)) {
+            return $view;
+        }
+
+        $view = substr($view, 0, -2).'xx';
+
+        if (view()->exists($view)) {
+            return $view;
+        }
+
+        return null;
     }
 
     /**

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -8,6 +8,7 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\Routing\ResponseFactory as ResponseFactoryContract;
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Contracts\View\Factory;
+use Illuminate\Contracts\View\Factory as ViewFactory;
 use Illuminate\Database\RecordsNotFoundException;
 use Illuminate\Foundation\Exceptions\Handler;
 use Illuminate\Http\RedirectResponse;
@@ -284,6 +285,65 @@ class FoundationExceptionsHandlerTest extends TestCase
         $logger->shouldNotReceive('error');
 
         $this->handler->report(new RecordsNotFoundException);
+    }
+
+    public function testItReturnsSpecificErrorViewIfExists()
+    {
+        $viewFactory = m::mock(stdClass::class);
+        $viewFactory->shouldReceive('exists')->with('errors::502')->andReturn(true);
+
+        $this->container->singleton(ViewFactory::class, function () use ($viewFactory) {
+            return $viewFactory;
+        });
+
+        $handler = new class($this->container) extends Handler {
+            public function getErrorView($e)
+            {
+                return $this->getHttpExceptionView($e);
+            }
+        };
+
+        $this->assertSame('errors::502', $handler->getErrorView(new HttpException(502)));
+    }
+
+    public function testItReturnsFallbackErrorViewIfExists()
+    {
+        $viewFactory = m::mock(stdClass::class);
+        $viewFactory->shouldReceive('exists')->once()->with('errors::502')->andReturn(false);
+        $viewFactory->shouldReceive('exists')->once()->with('errors::5xx')->andReturn(true);
+
+        $this->container->singleton(ViewFactory::class, function () use ($viewFactory) {
+            return $viewFactory;
+        });
+
+        $handler = new class($this->container) extends Handler {
+            public function getErrorView($e)
+            {
+                return $this->getHttpExceptionView($e);
+            }
+        };
+
+        $this->assertSame('errors::5xx', $handler->getErrorView(new HttpException(502)));
+    }
+
+    public function testItReturnsNullIfNoErrorViewExists()
+    {
+        $viewFactory = m::mock(stdClass::class);
+        $viewFactory->shouldReceive('exists')->once()->with('errors::404')->andReturn(false);
+        $viewFactory->shouldReceive('exists')->once()->with('errors::4xx')->andReturn(false);
+
+        $this->container->singleton(ViewFactory::class, function () use ($viewFactory) {
+            return $viewFactory;
+        });
+
+        $handler = new class($this->container) extends Handler {
+            public function getErrorView($e)
+            {
+                return $this->getHttpExceptionView($e);
+            }
+        };
+
+        $this->assertNull($handler->getErrorView(new HttpException(404)));
     }
 }
 

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -296,7 +296,8 @@ class FoundationExceptionsHandlerTest extends TestCase
             return $viewFactory;
         });
 
-        $handler = new class($this->container) extends Handler {
+        $handler = new class($this->container) extends Handler
+        {
             public function getErrorView($e)
             {
                 return $this->getHttpExceptionView($e);
@@ -316,7 +317,8 @@ class FoundationExceptionsHandlerTest extends TestCase
             return $viewFactory;
         });
 
-        $handler = new class($this->container) extends Handler {
+        $handler = new class($this->container) extends Handler
+        {
             public function getErrorView($e)
             {
                 return $this->getHttpExceptionView($e);
@@ -336,7 +338,8 @@ class FoundationExceptionsHandlerTest extends TestCase
             return $viewFactory;
         });
 
-        $handler = new class($this->container) extends Handler {
+        $handler = new class($this->container) extends Handler
+        {
             public function getErrorView($e)
             {
                 return $this->getHttpExceptionView($e);


### PR DESCRIPTION
We can render a custom HTTP error page by creating view file for a specific status code (eg: `errors/404.blade.php`). This PR adds support for a fallback if the exact status code does not have a view: `errors/4xx.blade.php`

One of my projects has views defined for most status codes. Each view shows a helpful friendly message in Dutch. Yesterday my customer ran into a 405 error that did not have a view. This scary English error was displayed:
![image](https://user-images.githubusercontent.com/7202674/133977357-df21c307-f544-4ee8-a9a2-ae4bb008045b.png)

With this PR, I can create `errors/4xx.blade.php` and `errors/5xx.blade.php` views to ensure that I always render a helpful custom error page.

