### PR TITLE
[8.x] Add ability to publish specific stubs

### DIFF
--- a/src/Illuminate/Foundation/Console/StubPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/StubPublishCommand.php
@@ -72,7 +72,7 @@ class StubPublishCommand extends Command
             realpath(__DIR__.'/../../Routing/Console/stubs/middleware.stub') => $stubsPath.'/middleware.stub',
         ];
 
-        if ($stubs = $this->argument('stubs')) {
+        if ($this->hasArgument('stubs')) {
             $stubs = explode(',', $this->argument('stubs'));
 
             $files = array_filter($files, function ($file) use ($stubs) {

--- a/src/Illuminate/Foundation/Console/StubPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/StubPublishCommand.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Str;
 
 class StubPublishCommand extends Command
 {
@@ -12,14 +13,15 @@ class StubPublishCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'stub:publish {--force : Overwrite any existing files}';
+    protected $signature = 'stub:publish {stubs? : The stubs to publish}
+                            {--force : Overwrite any existing files}';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = 'Publish all stubs that are available for customization';
+    protected $description = 'Publish stubs that are available for customization';
 
     /**
      * Execute the console command.
@@ -69,6 +71,14 @@ class StubPublishCommand extends Command
             realpath(__DIR__.'/../../Routing/Console/stubs/controller.stub') => $stubsPath.'/controller.stub',
             realpath(__DIR__.'/../../Routing/Console/stubs/middleware.stub') => $stubsPath.'/middleware.stub',
         ];
+
+        if ($stubs = $this->argument('stubs')) {
+            $stubs = explode(',', $this->argument('stubs'));
+
+            $files = array_filter($files, function ($file) use ($stubs) {
+                return Str::contains(Str::afterLast($file, '/'), $stubs);
+            });
+        }
 
         foreach ($files as $from => $to) {
             if (! file_exists($to) || $this->option('force')) {


### PR DESCRIPTION
This PR adds the ability to publish one or more specific stubs with the `stub:publish` command.

We often need to publish one specific stub or a small subset of them, like the migration ones, but not everything else. The only way to do this right now is to publish all 30+ stubs and then delete all but the ones we want. Later, if we need to publish one or two more, we have to publish all of them again and then go back in and delete the ones we don't need again too.

This PR adds one optional argument to the `stub:publish` command that accepts a comma-separated list of stub patterns to publish. The 'patterns' are interpreted very simply, the command just checks if the stub filename contains that string.

**Examples**

`php artisan stub:publish migration` publishes:

```
migration.create.stub
migration.stub
migration.update.stub
```

`php artisan stub:publish model,test` publishes:

```
model.pivot.stub
model.stub
test.stub
test.unit.stub
```

`php artisan stub:publish controller.plain` publishes:

```
controller.plain.stub
```
