### PR TITLE
[8.x] Use correct type hint for AuthenticationException redirectTo

### DIFF
--- a/src/Illuminate/Auth/AuthenticationException.php
+++ b/src/Illuminate/Auth/AuthenticationException.php
@@ -16,7 +16,7 @@ class AuthenticationException extends Exception
     /**
      * The path the user should be redirected to.
      *
-     * @var string
+     * @var string|null
      */
     protected $redirectTo;
 
@@ -49,7 +49,7 @@ class AuthenticationException extends Exception
     /**
      * Get the path the user should be redirected to.
      *
-     * @return string
+     * @return string|null
      */
     public function redirectTo()
     {


### PR DESCRIPTION
Context: I was testing my middleware while suddenly PHPStan reported an error when asserting the result of `AuthenticationException::redirectTo()`:
```
Call to method PHPUnit\Framework\Assert::assertNull() with string will always evaluate to false.
```

This PR changes the return type hint for `AuthenticationException::redirectTo()` and `AuthenticationException::$redirectTo` to match the constructor.

Other code depending on this method supports `null`:
https://github.com/laravel/framework/blob/8.x/src/Illuminate/Foundation/Exceptions/Handler.php#L410

And of course the default `Authenticate` middleware also (sometimes) returns `null`:
https://github.com/laravel/laravel/blob/8.x/app/Http/Middleware/Authenticate.php#L15
