### PR TITLE
[8.x] Makes getMorphClass() static on Eloquent Models

### DIFF
--- a/src/Illuminate/Database/ClassMorphViolationException.php
+++ b/src/Illuminate/Database/ClassMorphViolationException.php
@@ -7,7 +7,7 @@ use RuntimeException;
 class ClassMorphViolationException extends RuntimeException
 {
     /**
-     * The name of the affected Eloquent model.
+     * The class name of the affected Eloquent model.
      *
      * @var string
      */
@@ -16,12 +16,10 @@ class ClassMorphViolationException extends RuntimeException
     /**
      * Create a new exception instance.
      *
-     * @param  object  $model
+     * @param  string  $class
      */
-    public function __construct($model)
+    public function __construct($class)
     {
-        $class = get_class($model);
-
         parent::__construct("No morph map defined for model [{$class}].");
 
         $this->model = $class;

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -873,4 +873,3 @@ trait HasRelationships
         return $this;
     }
 }
-v

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -724,7 +724,7 @@ trait HasRelationships
      *
      * @return string
      */
-    public function getMorphClass()
+    public static function getMorphClass()
     {
         $morphMap = Relation::morphMap();
 
@@ -733,7 +733,7 @@ trait HasRelationships
         }
 
         if (Relation::requiresMorphMap()) {
-            throw new ClassMorphViolationException($this);
+            throw new ClassMorphViolationException(static::class);
         }
 
         return static::class;
@@ -873,3 +873,4 @@ trait HasRelationships
         return $this;
     }
 }
+v


### PR DESCRIPTION
This PR simply makes the `getMorphClass()` available statically on Eloquent Models. This allows easier usage in form validations where the user gets to select a model type.

Usage:
`$morphName = MyModel::getMorphClass()`

The current `getMorphClass()` only uses the object once, for throwing an exception if no morph name was set. However, the exception immediately calls `get_class()` to get the class name again so we can just use `MyModel::static` to pass in the class name directly.

Example usage in Form Validation:

```php
public function rules2()
{
    return [
        'type' => [
            Rule::in([
                MyModel::getMorphClass(),
                SecondModel::getMorphClass(),
            ]),
        ],
    ];
}
```