### PR TITLE
[8.x] Add assertNotSoftDeleted Method

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Testing\Constraints\CountInDatabase;
 use Illuminate\Testing\Constraints\HasInDatabase;
+use Illuminate\Testing\Constraints\NotSoftDeletedInDatabase;
 use Illuminate\Testing\Constraints\SoftDeletedInDatabase;
 use PHPUnit\Framework\Constraint\LogicalNot as ReverseConstraint;
 
@@ -103,6 +104,28 @@ trait InteractsWithDatabase
 
         $this->assertThat(
             $this->getTable($table), new SoftDeletedInDatabase($this->getConnection($connection), $data, $deletedAtColumn)
+        );
+
+        return $this;
+    }
+
+    /**
+     * Assert the given record has not been "soft deleted".
+     *
+     * @param  \Illuminate\Database\Eloquent\Model|string  $table
+     * @param  array  $data
+     * @param  string|null  $connection
+     * @param  string|null  $deletedAtColumn
+     * @return $this
+     */
+    protected function assertNotSoftDeleted($table, array $data = [], $connection = null, $deletedAtColumn = 'deleted_at')
+    {
+        if ($this->isSoftDeletableModel($table)) {
+            return $this->assertNotSoftDeleted($table->getTable(), [$table->getKeyName() => $table->getKey()], $table->getConnectionName(), $table->getDeletedAtColumn());
+        }
+
+        $this->assertThat(
+            $this->getTable($table), new NotSoftDeletedInDatabase($this->getConnection($connection), $data, $deletedAtColumn)
         );
 
         return $this;

--- a/src/Illuminate/Testing/Constraints/NotSoftDeletedInDatabase.php
+++ b/src/Illuminate/Testing/Constraints/NotSoftDeletedInDatabase.php
@@ -45,10 +45,8 @@ class NotSoftDeletedInDatabase extends Constraint
      */
     public function __construct(Connection $database, array $data, string $deletedAtColumn)
     {
-        $this->data = $data;
-
         $this->database = $database;
-
+        $this->data = $data;
         $this->deletedAtColumn = $deletedAtColumn;
     }
 
@@ -75,7 +73,7 @@ class NotSoftDeletedInDatabase extends Constraint
     public function failureDescription($table): string
     {
         return sprintf(
-            "any not soft deleted row in the table [%s] matches the attributes %s.\n\n%s",
+            "any existing row in the table [%s] matches the attributes %s.\n\n%s",
             $table, $this->toString(), $this->getAdditionalInfo($table)
         );
     }

--- a/src/Illuminate/Testing/Constraints/NotSoftDeletedInDatabase.php
+++ b/src/Illuminate/Testing/Constraints/NotSoftDeletedInDatabase.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Illuminate\Testing\Constraints;
+
+use Illuminate\Database\Connection;
+use PHPUnit\Framework\Constraint\Constraint;
+
+class NotSoftDeletedInDatabase extends Constraint
+{
+    /**
+     * Number of records that will be shown in the console in case of failure.
+     *
+     * @var int
+     */
+    protected $show = 3;
+
+    /**
+     * The database connection.
+     *
+     * @var \Illuminate\Database\Connection
+     */
+    protected $database;
+
+    /**
+     * The data that will be used to narrow the search in the database table.
+     *
+     * @var array
+     */
+    protected $data;
+
+    /**
+     * The name of the column that indicates soft deletion has occurred.
+     *
+     * @var string
+     */
+    protected $deletedAtColumn;
+
+    /**
+     * Create a new constraint instance.
+     *
+     * @param  \Illuminate\Database\Connection  $database
+     * @param  array  $data
+     * @param  string  $deletedAtColumn
+     * @return void
+     */
+    public function __construct(Connection $database, array $data, string $deletedAtColumn)
+    {
+        $this->data = $data;
+
+        $this->database = $database;
+
+        $this->deletedAtColumn = $deletedAtColumn;
+    }
+
+    /**
+     * Check if the data is found in the given table.
+     *
+     * @param  string  $table
+     * @return bool
+     */
+    public function matches($table): bool
+    {
+        return $this->database->table($table)
+                ->where($this->data)
+                ->whereNull($this->deletedAtColumn)
+                ->count() > 0;
+    }
+
+    /**
+     * Get the description of the failure.
+     *
+     * @param  string  $table
+     * @return string
+     */
+    public function failureDescription($table): string
+    {
+        return sprintf(
+            "any not soft deleted row in the table [%s] matches the attributes %s.\n\n%s",
+            $table, $this->toString(), $this->getAdditionalInfo($table)
+        );
+    }
+
+    /**
+     * Get additional info about the records found in the database table.
+     *
+     * @param  string  $table
+     * @return string
+     */
+    protected function getAdditionalInfo($table)
+    {
+        $query = $this->database->table($table);
+
+        $results = $query->limit($this->show)->get();
+
+        if ($results->isEmpty()) {
+            return 'The table is empty';
+        }
+
+        $description = 'Found: '.json_encode($results, JSON_PRETTY_PRINT);
+
+        if ($query->count() > $this->show) {
+            $description .= sprintf(' and %s others', $query->count() - $this->show);
+        }
+
+        return $description;
+    }
+
+    /**
+     * Get a string representation of the object.
+     *
+     * @return string
+     */
+    public function toString(): string
+    {
+        return json_encode($this->data);
+    }
+}

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -250,6 +250,60 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertSoftDeleted(new CustomProductStub($this->data));
     }
 
+    public function testAssertNotSoftDeletedInDatabaseFindsResults()
+    {
+        $builder = $this->mockCountBuilder(1);
+
+        $this->assertNotSoftDeleted($this->table, $this->data);
+    }
+
+    public function testAssertNotSoftDeletedSupportModelStrings()
+    {
+        $this->mockCountBuilder(1);
+
+        $this->assertNotSoftDeleted(ProductStub::class, $this->data);
+    }
+
+    public function testAssertNotSoftDeletedInDatabaseDoesNotFindResults()
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The table is empty.');
+
+        $builder = $this->mockCountBuilder(0);
+
+        $builder->shouldReceive('get')->andReturn(collect());
+
+        $this->assertNotSoftDeleted($this->table, $this->data);
+    }
+
+    public function testAssertNotSoftDeletedInDatabaseDoesNotFindModelResults()
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The table is empty.');
+
+        $this->data = ['id' => 1];
+
+        $builder = $this->mockCountBuilder(0);
+
+        $builder->shouldReceive('get')->andReturn(collect());
+
+        $this->assertNotSoftDeleted(new ProductStub($this->data));
+    }
+
+    public function testAssertNotSoftDeletedInDatabaseDoesNotFindModelWithCustomColumnResults()
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The table is empty.');
+
+        $this->data = ['id' => 1];
+
+        $builder = $this->mockCountBuilder(0, 'trashed_at');
+
+        $builder->shouldReceive('get')->andReturn(collect());
+
+        $this->assertNotSoftDeleted(new CustomProductStub($this->data));
+    }
+
     public function testAssertExistsPassesWhenFindsResults()
     {
         $this->data = ['id' => 1];
@@ -282,6 +336,8 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $builder->shouldReceive('where')->with($this->data)->andReturnSelf();
 
         $builder->shouldReceive('whereNotNull')->with($deletedAtColumn)->andReturnSelf();
+
+        $builder->shouldReceive('whereNull')->with($deletedAtColumn)->andReturnSelf();
 
         $builder->shouldReceive('count')->andReturn($countResult)->byDefault();
 

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -264,6 +264,18 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertNotSoftDeleted(ProductStub::class, $this->data);
     }
 
+    public function testAssertNotSoftDeletedOnlyFindsMatchingModels()
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('Failed asserting that any existing row');
+
+        $builder = $this->mockCountBuilder(0);
+
+        $builder->shouldReceive('get')->andReturn(collect(), collect(1));
+
+        $this->assertNotSoftDeleted(ProductStub::class, $this->data);
+    }
+
     public function testAssertNotSoftDeletedInDatabaseDoesNotFindResults()
     {
         $this->expectException(ExpectationFailedException::class);


### PR DESCRIPTION
This PR adds the capability to test if a model was not marked as soft deleted.

@themsaid suggested to contribute with this method, on yesterday laravel live stream.

Hope that helps.

Thanks.