### PR TITLE
[8.x] ofMany to decide relationship name when it is null

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/CanBeOneOfMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/CanBeOneOfMany.php
@@ -137,7 +137,7 @@ trait CanBeOneOfMany
     {
         return $this->ofMany(collect(Arr::wrap($column))->mapWithKeys(function ($column) {
             return [$column => 'MAX'];
-        })->all(), 'MAX', $relation ?: $this->guessRelationship());
+        })->all(), 'MAX', $relation);
     }
 
     /**
@@ -152,7 +152,7 @@ trait CanBeOneOfMany
     {
         return $this->ofMany(collect(Arr::wrap($column))->mapWithKeys(function ($column) {
             return [$column => 'MIN'];
-        })->all(), 'MIN', $relation ?: $this->guessRelationship());
+        })->all(), 'MIN', $relation);
     }
 
     /**


### PR DESCRIPTION
I was able to replicate similar issue as #37402 when using using `latestOfMany` or `oldestOfMany` (working fine with `ofMany`)

So this pr appends "_of_many" to the one of many join alias when the relation name is the same as the table name. (similar to #37411)

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
