### PR TITLE
[9.x] Split parameters when using regex constraints

### DIFF
--- a/src/Illuminate/Routing/RouteParameterBinder.php
+++ b/src/Illuminate/Routing/RouteParameterBinder.php
@@ -89,8 +89,18 @@ class RouteParameterBinder
 
         $parameters = array_intersect_key($matches, array_flip($parameterNames));
 
+        // Explode if there's multiple parameters
+        $parameters = array_map(function ($parameter) {
+            if (strpos($parameter, '/')) {
+                return explode('/', $parameter);
+            }
+
+            return $parameter;
+        }, $parameters);
+
         return array_filter($parameters, function ($value) {
-            return is_string($value) && strlen($value) > 0;
+            return (is_string($value) && strlen($value) > 0)
+                || is_array($value);
         });
     }
 


### PR DESCRIPTION
A small paper-cut that I've seen users ask about. The "solution" seems to be to explode the parameters by yourself. (See examples below)

Using this PR parameters containing `/` will be treated as multiple parameters and exploded into an array.

Assuming that the requested url is: `http://localhost/one/two`

**routes/web.php**

```php
Route::get('/{any}', TestController::class)->where('any', '.*');
```

**app/Http/TestController.php**

```php
class TestController
{
    public function __invoke($parameters)
    {
        dd($parameters); // Will dump ['one', 'two']
    }
}
```
[Example 1](https://stackoverflow.com/questions/31407827/how-to-declare-unlimited-parameters-in-laravel)
[Example 2](https://github.com/laravel/framework/issues/39#issuecomment-12243609)