### PR TITLE
[8.x] Fix event discovery with custom application paths

### DIFF
--- a/src/Illuminate/Foundation/Events/DiscoverEvents.php
+++ b/src/Illuminate/Foundation/Events/DiscoverEvents.php
@@ -92,8 +92,8 @@ class DiscoverEvents
         $psr4 = data_get($composer, 'autoload.psr-4');
 
         return str_replace(
-            [DIRECTORY_SEPARATOR, ucfirst(basename(app()->path())).'\\', ...str_replace('/', \DIRECTORY_SEPARATOR, array_values($psr4))],
-            ['\\', app()->getNamespace(), ...array_keys($psr4)],
+            array_merge([DIRECTORY_SEPARATOR, ucfirst(basename(app()->path())).'\\'], str_replace('/', \DIRECTORY_SEPARATOR, array_values($psr4))),
+            array_merge(['\\', app()->getNamespace()], array_keys($psr4)),
             ucfirst(Str::replaceLast('.php', '', $class))
         );
     }

--- a/src/Illuminate/Foundation/Events/DiscoverEvents.php
+++ b/src/Illuminate/Foundation/Events/DiscoverEvents.php
@@ -88,10 +88,12 @@ class DiscoverEvents
     protected static function classFromFile(SplFileInfo $file, $basePath)
     {
         $class = trim(Str::replaceFirst($basePath, '', $file->getRealPath()), DIRECTORY_SEPARATOR);
+        $composer = json_decode(file_get_contents(app()->basePath() . \DIRECTORY_SEPARATOR . 'composer.json'), true);
+        $psr4 = data_get($composer, 'autoload.psr-4');
 
         return str_replace(
-            [DIRECTORY_SEPARATOR, ucfirst(basename(app()->path())).'\\'],
-            ['\\', app()->getNamespace()],
+            [DIRECTORY_SEPARATOR, ucfirst(basename(app()->path())).'\\', ...str_replace('/', \DIRECTORY_SEPARATOR, array_values($psr4))],
+            ['\\', app()->getNamespace(), ...array_keys($psr4)],
             ucfirst(Str::replaceLast('.php', '', $class))
         );
     }

--- a/src/Illuminate/Foundation/Events/DiscoverEvents.php
+++ b/src/Illuminate/Foundation/Events/DiscoverEvents.php
@@ -91,10 +91,10 @@ class DiscoverEvents
         $composer = json_decode(file_get_contents(app()->basePath() . \DIRECTORY_SEPARATOR . 'composer.json'), true);
         $psr4 = data_get($composer, 'autoload.psr-4');
 
-        return str_replace(
+        return ucfirst(str_replace(
             array_merge([DIRECTORY_SEPARATOR, ucfirst(basename(app()->path())).'\\'], str_replace('/', \DIRECTORY_SEPARATOR, array_values($psr4))),
             array_merge(['\\', app()->getNamespace()], array_keys($psr4)),
-            ucfirst(Str::replaceLast('.php', '', $class))
-        );
+            Str::replaceLast('.php', '', $class)
+        ));
     }
 }

--- a/src/Illuminate/Foundation/Events/DiscoverEvents.php
+++ b/src/Illuminate/Foundation/Events/DiscoverEvents.php
@@ -88,11 +88,11 @@ class DiscoverEvents
     protected static function classFromFile(SplFileInfo $file, $basePath)
     {
         $class = trim(Str::replaceFirst($basePath, '', $file->getRealPath()), DIRECTORY_SEPARATOR);
-        $composer = json_decode(file_get_contents(app()->basePath() . \DIRECTORY_SEPARATOR . 'composer.json'), true);
+        $composer = json_decode(file_get_contents(app()->basePath().DIRECTORY_SEPARATOR.'composer.json'), true);
         $psr4 = data_get($composer, 'autoload.psr-4');
 
         return ucfirst(str_replace(
-            array_merge([DIRECTORY_SEPARATOR, ucfirst(basename(app()->path())).'\\'], str_replace('/', \DIRECTORY_SEPARATOR, array_values($psr4))),
+            array_merge([DIRECTORY_SEPARATOR, ucfirst(basename(app()->path())).'\\'], str_replace('/', DIRECTORY_SEPARATOR, array_values($psr4))),
             array_merge(['\\', app()->getNamespace()], array_keys($psr4)),
             Str::replaceLast('.php', '', $class)
         ));


### PR DESCRIPTION
This PR fixes an issue that was occurring when a listener's namespace was different from its path in the file system. Specifically, `classFromFile` could infer a wrong FQCN.

For instance, if I have a `src/App/Listeners/LoginSuccessful.php` listener, the inferred FQCN would be `Src\App\Listeners\LoginSuccessful` instead of `App\Listeners\LoginSuccessful` (with the first uppercase, too). 

This issue is fixed by using `composer.json`'s PSR-4 definition to replace a path by its associated namespace. 