### PR TITLE
[8.x] Ignore trailing delimiter in cache.headers options string

### DIFF
--- a/src/Illuminate/Http/Middleware/SetCacheHeaders.php
+++ b/src/Illuminate/Http/Middleware/SetCacheHeaders.php
@@ -55,7 +55,7 @@ class SetCacheHeaders
      */
     protected function parseOptions($options)
     {
-        return collect(explode(';', $options))->mapWithKeys(function ($option) {
+        return collect(explode(';', rtrim($options, ';')))->mapWithKeys(function ($option) {
             $data = explode('=', $option, 2);
 
             return [$data[0] => $data[1] ?? true];

--- a/tests/Http/Middleware/CacheTest.php
+++ b/tests/Http/Middleware/CacheTest.php
@@ -104,4 +104,15 @@ class CacheTest extends TestCase
 
         $this->assertSame(Carbon::parse($birthdate)->timestamp, $response->getLastModified()->getTimestamp());
     }
+
+    public function testTrailingDelimiterIgnored()
+    {
+        $time = time();
+
+        $response = (new Cache)->handle(new Request, function () {
+            return new Response('some content');
+        }, "last_modified=$time;");
+
+        $this->assertSame($time, $response->getLastModified()->getTimestamp());
+    }
 }


### PR DESCRIPTION
I recently tripped up on the fact that an options string passed to `cache.headers` middleware expects semicolon delimiters but results in the following exception if there is a semicolon following the _last_ option:

```
InvalidArgumentException: Response does not support the following options: "".
```

It took me a couple of minutes including reading through the core code to realise what I'd done wrong. I think my confusion was caused by the fact semicolons may be used to terminate directive groups in HTTP header values and other string based options in Laravel e.g. validation rules use a comma delimiter. I made this mistake despite having just consulted the example in the docs. 

Therefore this patch proposes trimming the trailing semicolon if it exists so that `explode()` in `SetCacheHeaders::parseOptions()` does not result in an additional empty string causing the error.

There are no breaking changes as existing option strings will continue to work.

This would benefit other developers by preventing an easy mistake causing confusion / requiring a little debugging time. It also mirrors modern PHP syntax where trailing delimiters are ignored e.g. arrays / arguments.