### PR TITLE
[8.x] RouteUri::parse refactor

### DIFF
--- a/src/Illuminate/Routing/RouteUri.php
+++ b/src/Illuminate/Routing/RouteUri.php
@@ -39,23 +39,17 @@ class RouteUri
      */
     public static function parse($uri)
     {
-        preg_match_all('/\{([\w\:]+?)\??\}/', $uri, $matches);
-
         $bindingFields = [];
 
-        foreach ($matches[0] as $match) {
-            if (strpos($match, ':') === false) {
-                continue;
+        $uri = preg_replace_callback('/{(\w+)(?::(\w+))?(\??)}/', function ($match) use (&$bindingFields) {
+            [$_, $parameter, $field, $optional] = $match;
+
+            if ('' !== $field) {
+                $bindingFields[$parameter] = $field;
             }
 
-            $segments = explode(':', trim($match, '{}?'));
-
-            $bindingFields[$segments[0]] = $segments[1];
-
-            $uri = strpos($match, '?') !== false
-                    ? str_replace($match, '{'.$segments[0].'?}', $uri)
-                    : str_replace($match, '{'.$segments[0].'}', $uri);
-        }
+            return '{'.$parameter.$optional.'}';
+        }, $uri);
 
         return new static($uri, $bindingFields);
     }


### PR DESCRIPTION
This is a minor update to the implementation of `RouteUri::parse`. While working on #38466 I noticed that the parsing implementation relies on a bunch of string manipulation calls that can all be removed in favor of a regular expression.

Before, the implementation relied on `preg_match_all`, `strpos`, `explode`, and `str_replace`. Now the implementation is a single `preg_replace_callback` call.

In addition to simplifying the code, this refactor comes with a very minor performance improvement:

| Implementation | Round 1 | Round 2 | Round 3 | Round 4 | Average |
|----------------|---------|---------|---------|---------|---------|
| Original       | 0.10446000099182 | 0.10478210449219 | 0.10441279411316 | 0.10260915756226 | 0.1040660143 |
| Updated       | 0.083888053894043 | 0.08670711517334 | 0.087214946746826 | 0.081969976425171 | 0.0849450231 |

**Result:** 18.37% faster

This benchmark was done by calling `RouteUri::parse('/foo/{bar}/baz/{qux:slug?}/{test:id?}')` 10,000 times and measured using `microtime()`.

Obviously the performance gain won't have any measurable impact, but it doesn't hurt!