### PR TITLE
[9.x] Add missing giveConfig method in ContextualBindingBuilder

### DIFF
--- a/src/Illuminate/Contracts/Container/ContextualBindingBuilder.php
+++ b/src/Illuminate/Contracts/Container/ContextualBindingBuilder.php
@@ -27,4 +27,13 @@ interface ContextualBindingBuilder
      * @return void
      */
     public function giveTagged($tag);
+
+    /**
+     * Specify the configuration item to bind as a primitive.
+     *
+     * @param  string  $key
+     * @param  ?string  $default
+     * @return void
+     */
+    public function giveConfig($key, $default = null);
 }


### PR DESCRIPTION
This PR adds the method `giveConfig` to the `ContextualBindingBuilder` contract. A similar PR, https://github.com/laravel/framework/pull/36361, was targeted at `8.x` and rejected because it would introduce a breaking change for any implementation implementing this contract. That's why this PR is targeted at `master` to make it available for the upcoming `9.x` release.

One of the reasons why I think this method should be part of the contract is that the `ContextualBindingBuilder` contract interface is declared as return type by the method `Container::when()`. When someone uses the "[Binding primitives](https://laravel.com/docs/8.x/container#binding-primitives)" example from the docs, where the existence of the `giveConfig` method is documented, they may encounter warnings from their IDE claiming that the method doesn't exists. 

In my opinion this is small fix that can prevent possible confusion and improves developer experience.