### PR TITLE
[8.x] Add `whereBelongsTo()` Eloquent builder method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -309,9 +309,9 @@ class Builder
     /**
      * Add a "BelongsTo" relationship where clause to the query.
      *
-     * @param \Illuminate\Database\Eloquent\Model $related
-     * @param string $relationship
-     * @param string $boolean
+     * @param  \Illuminate\Database\Eloquent\Model  $related
+     * @param  string $relationship
+     * @param  string $boolean
      * @return $this
      *
      * @throws \Exception

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -310,8 +310,8 @@ class Builder
      * Add a "BelongsTo" relationship where clause to the query.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $related
-     * @param  string $relationship
-     * @param  string $boolean
+     * @param  string  $relationship
+     * @param  string  $boolean
      * @return $this
      *
      * @throws \Exception

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -309,10 +309,12 @@ class Builder
     /**
      * Add a "BelongsTo" relationship where clause to the query.
      *
-     * @param  \Illuminate\Database\Eloquent\Model  $related
-     * @param  string  $relationship
-     * @param  string  $boolean
+     * @param \Illuminate\Database\Eloquent\Model $related
+     * @param string $relationship
+     * @param string $boolean
      * @return $this
+     *
+     * @throws \Exception
      */
     public function whereBelongsTo($related, $relationshipName = null, $boolean = 'and')
     {
@@ -321,12 +323,16 @@ class Builder
         }
 
         if (! $this->model->isRelation($relationshipName)) {
+            throw new Exception("Relationship [{$relationshipName}] does not exist on the Eloquent builder model.");
+
             return $this;
         }
 
         $relationship = $this->model->{$relationshipName}();
 
         if (! $relationship instanceof BelongsTo) {
+            throw new Exception("Relationship [{$relationshipName}] is not of type BelongsTo.");
+
             return $this;
         }
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -322,18 +322,14 @@ class Builder
             $relationshipName = Str::camel(class_basename(get_class($related)));
         }
 
-        if (! $this->model->isRelation($relationshipName)) {
-            $modelClass = get_class($this->model);
-
-            throw RelationNotFoundException::make($modelClass, $relationshipName);
+        try {
+            $relationship = $this->model->{$relationshipName}();
+        } catch (BadMethodCallException $exception) {
+            throw RelationNotFoundException::make($this->model, $relationshipName);
         }
 
-        $relationship = $this->model->{$relationshipName}();
-
         if (! $relationship instanceof BelongsTo) {
-            $modelClass = get_class($this->model);
-
-            throw RelationNotFoundException::make($modelClass, $relationshipName, BelongsTo::class);
+            throw RelationNotFoundException::make($this->model, $relationshipName, BelongsTo::class);
         }
 
         $this->where(

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -324,16 +324,12 @@ class Builder
 
         if (! $this->model->isRelation($relationshipName)) {
             throw new Exception("Relationship [{$relationshipName}] does not exist on the Eloquent builder model.");
-
-            return $this;
         }
 
         $relationship = $this->model->{$relationshipName}();
 
         if (! $relationship instanceof BelongsTo) {
             throw new Exception("Relationship [{$relationshipName}] is not of type BelongsTo.");
-
-            return $this;
         }
 
         $this->where(

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -8,6 +8,7 @@ use Exception;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Concerns\BuildsQueries;
 use Illuminate\Database\Concerns\ExplainsQueries;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Builder as QueryBuilder;
@@ -303,6 +304,40 @@ class Builder
         );
 
         return $this->where($column, $operator, $value, 'or');
+    }
+
+    /**
+     * Add a "BelongsTo" relationship where clause to the query.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $related
+     * @param  string  $relationship
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereBelongsTo($related, $relationshipName = null, $boolean = 'and')
+    {
+        if ($relationshipName === null) {
+            $relationshipName = Str::camel(class_basename(get_class($related)));
+        }
+
+        if (! $this->model->isRelation($relationshipName)) {
+            return $this;
+        }
+
+        $relationship = $this->model->{$relationshipName}();
+
+        if (! $relationship instanceof BelongsTo) {
+            return $this;
+        }
+
+        $this->where(
+            $relationship->getForeignKeyName(),
+            '=',
+            $related->getAttributeValue($relationship->getOwnerKeyName()),
+            $boolean,
+        );
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -323,13 +323,17 @@ class Builder
         }
 
         if (! $this->model->isRelation($relationshipName)) {
-            throw new Exception("Relationship [{$relationshipName}] does not exist on the Eloquent builder model.");
+            $modelClass = get_class($this->model);
+
+            throw RelationNotFoundException::make($modelClass, $relationshipName);
         }
 
         $relationship = $this->model->{$relationshipName}();
 
         if (! $relationship instanceof BelongsTo) {
-            throw new Exception("Relationship [{$relationshipName}] is not of type BelongsTo.");
+            $modelClass = get_class($this->model);
+
+            throw RelationNotFoundException::make($modelClass, $relationshipName, BelongsTo::class);
         }
 
         $this->where(

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -8,7 +8,6 @@ use Exception;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Concerns\BuildsQueries;
 use Illuminate\Database\Concerns\ExplainsQueries;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Builder as QueryBuilder;
@@ -304,42 +303,6 @@ class Builder
         );
 
         return $this->where($column, $operator, $value, 'or');
-    }
-
-    /**
-     * Add a "BelongsTo" relationship where clause to the query.
-     *
-     * @param  \Illuminate\Database\Eloquent\Model  $related
-     * @param  string  $relationship
-     * @param  string  $boolean
-     * @return $this
-     *
-     * @throws \Exception
-     */
-    public function whereBelongsTo($related, $relationshipName = null, $boolean = 'and')
-    {
-        if ($relationshipName === null) {
-            $relationshipName = Str::camel(class_basename($related));
-        }
-
-        try {
-            $relationship = $this->model->{$relationshipName}();
-        } catch (BadMethodCallException $exception) {
-            throw RelationNotFoundException::make($this->model, $relationshipName);
-        }
-
-        if (! $relationship instanceof BelongsTo) {
-            throw RelationNotFoundException::make($this->model, $relationshipName, BelongsTo::class);
-        }
-
-        $this->where(
-            $relationship->getForeignKeyName(),
-            '=',
-            $related->getAttributeValue($relationship->getOwnerKeyName()),
-            $boolean,
-        );
-
-        return $this;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -319,7 +319,7 @@ class Builder
     public function whereBelongsTo($related, $relationshipName = null, $boolean = 'and')
     {
         if ($relationshipName === null) {
-            $relationshipName = Str::camel(class_basename(get_class($related)));
+            $relationshipName = Str::camel(class_basename($related));
         }
 
         try {

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -459,6 +459,56 @@ trait QueriesRelationships
     }
 
     /**
+     * Add a "belongs to" relationship where clause to the query.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $related
+     * @param  string  $relationship
+     * @param  string  $boolean
+     * @return $this
+     *
+     * @throws \Exception
+     */
+    public function whereBelongsTo($related, $relationshipName = null, $boolean = 'and')
+    {
+        if ($relationshipName === null) {
+            $relationshipName = Str::camel(class_basename($related));
+        }
+
+        try {
+            $relationship = $this->model->{$relationshipName}();
+        } catch (BadMethodCallException $exception) {
+            throw RelationNotFoundException::make($this->model, $relationshipName);
+        }
+
+        if (! $relationship instanceof BelongsTo) {
+            throw RelationNotFoundException::make($this->model, $relationshipName, BelongsTo::class);
+        }
+
+        $this->where(
+            $relationship->getQualifiedForeignKeyName(),
+            '=',
+            $related->getAttributeValue($relationship->getOwnerKeyName()),
+            $boolean,
+        );
+
+        return $this;
+    }
+
+    /**
+     * Add an "BelongsTo" relationship with an "or where" clause to the query.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $related
+     * @param  string  $relationship
+     * @return $this
+     *
+     * @throws \Exception
+     */
+    public function orWhereBelongsTo($related, $relationshipName = null)
+    {
+        return $this->whereBelongsTo($related, $relationshipName, 'or');
+    }
+
+    /**
      * Add subselect queries to include an aggregate value for a relationship.
      *
      * @param  mixed  $relations
@@ -619,42 +669,6 @@ trait QueriesRelationships
     public function withExists($relation)
     {
         return $this->withAggregate($relation, '*', 'exists');
-    }
-
-    /**
-     * Add a "BelongsTo" relationship where clause to the query.
-     *
-     * @param  \Illuminate\Database\Eloquent\Model  $related
-     * @param  string  $relationship
-     * @param  string  $boolean
-     * @return $this
-     *
-     * @throws \Exception
-     */
-    public function whereBelongsTo($related, $relationshipName = null, $boolean = 'and')
-    {
-        if ($relationshipName === null) {
-            $relationshipName = Str::camel(class_basename($related));
-        }
-
-        try {
-            $relationship = $this->model->{$relationshipName}();
-        } catch (BadMethodCallException $exception) {
-            throw RelationNotFoundException::make($this->model, $relationshipName);
-        }
-
-        if (! $relationship instanceof BelongsTo) {
-            throw RelationNotFoundException::make($this->model, $relationshipName, BelongsTo::class);
-        }
-
-        $this->where(
-            $relationship->getQualifiedForeignKeyName(),
-            '=',
-            $related->getAttributeValue($relationship->getOwnerKeyName()),
-            $boolean,
-        );
-
-        return $this;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -648,7 +648,7 @@ trait QueriesRelationships
         }
 
         $this->where(
-            $relationship->getForeignKeyName(),
+            $relationship->getQualifiedForeignKeyName(),
             '=',
             $related->getAttributeValue($relationship->getOwnerKeyName()),
             $boolean,

--- a/src/Illuminate/Database/Eloquent/RelationNotFoundException.php
+++ b/src/Illuminate/Database/Eloquent/RelationNotFoundException.php
@@ -25,13 +25,18 @@ class RelationNotFoundException extends RuntimeException
      *
      * @param  object  $model
      * @param  string  $relation
+     * @param  string  $type
      * @return static
      */
-    public static function make($model, $relation)
+    public static function make($model, $relation, $type = null)
     {
         $class = get_class($model);
 
-        $instance = new static("Call to undefined relationship [{$relation}] on model [{$class}].");
+        $instance = new static(
+            $type === null ?
+                "Call to undefined relationship [{$relation}] on model [{$class}]." :
+                "Call to undefined relationship [{$relation}] on model [{$class}] of type [{$type}].",
+        );
 
         $instance->model = $class;
         $instance->relation = $relation;

--- a/src/Illuminate/Database/Eloquent/RelationNotFoundException.php
+++ b/src/Illuminate/Database/Eloquent/RelationNotFoundException.php
@@ -25,7 +25,7 @@ class RelationNotFoundException extends RuntimeException
      *
      * @param  object  $model
      * @param  string  $relation
-     * @param  string  $type
+     * @param  string|null  $type
      * @return static
      */
     public static function make($model, $relation, $type = null)
@@ -33,9 +33,9 @@ class RelationNotFoundException extends RuntimeException
         $class = get_class($model);
 
         $instance = new static(
-            $type === null ?
-                "Call to undefined relationship [{$relation}] on model [{$class}]." :
-                "Call to undefined relationship [{$relation}] on model [{$class}] of type [{$type}].",
+            is_null($type)
+                ? "Call to undefined relationship [{$relation}] on model [{$class}]."
+                : "Call to undefined relationship [{$relation}] on model [{$class}] of type [{$type}].",
         );
 
         $instance->model = $class;

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -923,6 +923,14 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->setModel($related);
         $builder->getQuery()->shouldReceive('where')->once()->with('parent_id', '=', 2, 'and');
 
+        $result = $builder->whereBelongsTo($parent);
+        $this->assertEquals($result, $builder);
+
+        $builder = $this->getBuilder();
+        $builder->shouldReceive('from')->with('eloquent_builder_test_where_belongs_to_stubs');
+        $builder->setModel($related);
+        $builder->getQuery()->shouldReceive('where')->once()->with('parent_id', '=', 2, 'and');
+
         $result = $builder->whereBelongsTo($parent, 'parent');
         $this->assertEquals($result, $builder);
     }

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Database;
 
 use BadMethodCallException;
 use Closure;
+use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Database\Eloquent\Builder;
@@ -904,6 +905,45 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->getQuery()->shouldReceive('where')->once()->with('foo', '@>', 'bar');
         $result = $builder->where('foo', '@>', 'bar');
         $this->assertEquals($result, $builder);
+    }
+
+    public function testWhereBelongsTo()
+    {
+        $db = new DB;
+
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+
+        $db->bootEloquent();
+        $db->setAsGlobal();
+
+        $schema = Model::getConnectionResolver()
+            ->connection()
+            ->getSchemaBuilder();
+
+        $schema->create('where_belongs_to_stubs', function ($table) {
+            $table->increments('id');
+            $table->integer('parent_id');
+        });
+
+        EloquentBuilderTestWhereBelongsToStub::query()->insert([
+            ['id' => 1, 'parent_id' => 2],
+            ['id' => 2, 'parent_id' => 1],
+        ]);
+
+        $related = EloquentBuilderTestWhereBelongsToStub::query()->find(1);
+
+        $model = new EloquentBuilderTestWhereBelongsToStub;
+
+        $query = $model->query()->whereBelongsTo($related);
+        $this->assertSame($query->toSql(), 'select * from "where_belongs_to_stubs" where "parent_id" = ?');
+
+        $query = $model->query()->whereBelongsTo($related, 'parent');
+        $this->assertSame($query->toSql(), 'select * from "where_belongs_to_stubs" where "parent_id" = ?');
+
+        $schema->drop('where_belongs_to_stubs');
     }
 
     public function testDeleteOverride()
@@ -1947,4 +1987,19 @@ class EloquentBuilderTestStubStringPrimaryKey extends Model
     protected $table = 'foo_table';
 
     protected $keyType = 'string';
+}
+
+class EloquentBuilderTestWhereBelongsToStub extends Model
+{
+    protected $table = 'where_belongs_to_stubs';
+
+    public function eloquentBuilderTestWhereBelongsToStub()
+    {
+        return $this->belongsTo(self::class, 'parent_id', 'id', 'parent');
+    }
+
+    public function parent()
+    {
+        return $this->belongsTo(self::class, 'parent_id', 'id', 'parent');
+    }
 }

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -921,7 +921,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->shouldReceive('from')->with('eloquent_builder_test_where_belongs_to_stubs');
         $builder->setModel($related);
-        $builder->getQuery()->shouldReceive('where')->once()->with('parent_id', '=', 2, 'and');
+        $builder->getQuery()->shouldReceive('where')->once()->with('eloquent_builder_test_where_belongs_to_stubs.parent_id', '=', 2, 'and');
 
         $result = $builder->whereBelongsTo($parent);
         $this->assertEquals($result, $builder);
@@ -929,7 +929,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->shouldReceive('from')->with('eloquent_builder_test_where_belongs_to_stubs');
         $builder->setModel($related);
-        $builder->getQuery()->shouldReceive('where')->once()->with('parent_id', '=', 2, 'and');
+        $builder->getQuery()->shouldReceive('where')->once()->with('eloquent_builder_test_where_belongs_to_stubs.parent_id', '=', 2, 'and');
 
         $result = $builder->whereBelongsTo($parent, 'parent');
         $this->assertEquals($result, $builder);


### PR DESCRIPTION
Hey 👋 

When retrieving `belongsTo` related records, you can usually use the inverse (`hasMany`) of the relationship, like so:

```php
$author->posts()
```

However, sometimes this is not possible, and you must filter an existing query by its parent record:

```php
$query->where('author_id', $author->id)
```

This works, but explicitly depends on the name of foreign key (`author_id`), and the name of the owner key (`id`) in most cases. This is a maintenance burden, as these key names can be changed inside the relationship method and will subsequently become outdated across your entire app.

This PR introduces a `whereBelongsTo()` method to the Eloquent builder. You may use it like so:

```php
$query->whereBelongsTo($author)
```

It will automatically retrieve the foreign key name from the relationship (`author`), and the correct owner key from the related model (`$author`).

By default, the name of the relationship is guessed based on the class of the related model. Sometimes, this is not appropriate. If the `$author` is an instance of `App\Models\User`, `whereBelongsTo()` will search for a `user()` relationship that does not exist. In this case, you may manually specify the relationship name:

```php
$query->whereBelongsTo($author, 'author')
```