### PR TITLE
feature: add assert resource method for tests

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -923,8 +923,6 @@ EOF;
      */
     public function assertResource(\Illuminate\Http\Resources\Json\JsonResource $resource)
     {
-        /** @var \Illuminate\Testing\TestResponse $this */
-
         $resourceContent = [
             'data' => json_decode($resource->toJson(), 1),
         ];

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -918,6 +918,9 @@ EOF;
         return $this->decodeResponseJson()->json($key);
     }
 
+    /**
+     * @throws \Throwable
+     */
     public function assertResource(\Illuminate\Http\Resources\Json\JsonResource $resource)
     {
         /** @var \Illuminate\Testing\TestResponse $this */

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -918,6 +918,21 @@ EOF;
         return $this->decodeResponseJson()->json($key);
     }
 
+    public function assertResource(\Illuminate\Http\Resources\Json\JsonResource $resource)
+    {
+        /** @var \Illuminate\Testing\TestResponse $this */
+
+        if ($resource->resource instanceof \Illuminate\Pagination\AbstractPaginator) {
+            return $this->decodeResponseJson()
+                ->assertSubset([
+                    'data' => json_decode($resource->toJson(), 1)
+                ]);
+        }
+
+        $resource = ['data' => json_decode($resource->toJson(), 1)];
+        return $this->assertExactJson($resource);
+    }
+
     /**
      * Assert that the response view equals the given value.
      *

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -922,15 +922,16 @@ EOF;
     {
         /** @var \Illuminate\Testing\TestResponse $this */
 
+        $resourceContent = [
+            'data' => json_decode($resource->toJson(), 1),
+        ];
+
         if ($resource->resource instanceof \Illuminate\Pagination\AbstractPaginator) {
             return $this->decodeResponseJson()
-                ->assertSubset([
-                    'data' => json_decode($resource->toJson(), 1)
-                ]);
+                ->assertSubset($resourceContent);
         }
 
-        $resource = ['data' => json_decode($resource->toJson(), 1)];
-        return $this->assertExactJson($resource);
+        return $this->assertExactJson($resourceContent);
     }
 
     /**


### PR DESCRIPTION
## How it add value

This PR adds the capability to test a resource against a response.

The idea comes from Laracon Summer 2021, in Colin DeCarlo's talk.

It adds the ability to test the whole response with a oneliner instead of replicating the complete response structure.

The main advantage of this assertion is when someone changes a resource structure (remove or change a key and/or a value) there would be no need to refactor all the tests that have assertions with a hard code structure.

## Usage

For a single model resource:

```php


```php
// create a user and a post that belongs to the user
$user = User::factory()->create();
$post = Post::factory()->for($user, 'author')->create();

// ACT - Create 
$response = $this->actingAs($user)->getJson(route('api.users.posts.show', $post));

$resource = PostResource::make($post->load('authors'));
$response->assertResource($resource);
```

It also works for collections and paginated collection resources:

```php

// create a user and a post that belongs to the user
$user = User::factory()->create();
$posts = Post::factory()->for($user, 'author')->count(10)->create();

// ACT - Create 
$response = $this->actingAs($user)->getJson(route('api.users.posts.show', $posts));

$resource = PostResource::make(Post::query()->with('authors')->paginate());
$response->assertResource($resource);

```

Hope it would be useful.

Thanks.
