### PR TITLE
[9.x] Strict mode for RedisStore: preserve type of numeric values

### DIFF
--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -199,7 +199,9 @@ class CacheManager implements FactoryContract
 
         $connection = $config['connection'] ?? 'default';
 
-        $store = new RedisStore($redis, $this->getPrefix($config), $connection);
+        $strict = $config['strict'] ?? true;
+
+        $store = new RedisStore($redis, $this->getPrefix($config), $connection, $strict);
 
         return $this->repository(
             $store->setLockConnection($config['lock_connection'] ?? $connection)

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -355,7 +355,7 @@ class RedisStore extends TaggableStore implements LockProvider
      */
     protected function unserialize($value)
     {
-        if ($this->strict && filter_var($value, FILTER_VALIDATE_INT)) {
+        if ($this->strict && filter_var($value, FILTER_VALIDATE_INT) !== false) {
             return (int) $value;
         }
 


### PR DESCRIPTION
In order to optimize memory consumption and make `RedisStore::increment()` and `RedisStore::decrement()` work using the built-in Redis `incrby` and `decrby` commands, numeric values are stored as their base 10 string representation. Sadly, it causes a type inconsistency issue. If we get a numeric string from Redis, we can't know if the original value was string or int/float. Currently Laraval returns all numeric values as string:
```php
Cache::put('k', 1);
dump(is_int(Cache::get('k'))); // Must be true, but it is false.
dump(is_string(Cache::get('k'))); // Must be false, but it is true. 
```
This PR tries to fix this type inconsistency by adding a "strict" mode option to Redis cache configuration, with the default value being true. It may be a breaking change. If the non-strict behavior is more appropriate for an existing application, strict should be set to false.

Alternative choices regarding backward compatibility and the default behavior:
1. Don't give any config option to disable the strict mode. Basically it was a bug to not preserve types, so why giving option to stick with the bug? Besides, other cache drivers don't have such option.
2. Make sure by default strict mode is disabled so it doesn't cause an extra pain during the major upgrade. In case you choose this option you may consider sending a PR to 8.x as well. But be aware of the optional parameter to the constructor of `RedisStore`.

Let me know if you prefer an alternative choice or the current PR. I can add some relevant tests later.

Note: `incrby` and `decrby` Redis commands doesn't work with float values. Also Redis doesn't store non-integer numbers in a compressed way.

Fixes #31345
