### PR TITLE
[8.x] Make `PendingMail` `Conditionable`

### DIFF
--- a/src/Illuminate/Mail/PendingMail.php
+++ b/src/Illuminate/Mail/PendingMail.php
@@ -5,9 +5,12 @@ namespace Illuminate\Mail;
 use Illuminate\Contracts\Mail\Mailable as MailableContract;
 use Illuminate\Contracts\Mail\Mailer as MailerContract;
 use Illuminate\Contracts\Translation\HasLocalePreference;
+use Illuminate\Support\Traits\Conditionable;
 
 class PendingMail
 {
+    use Conditionable;
+
     /**
      * The mailer instance.
      *


### PR DESCRIPTION
This pull request adds the `Conditionable` trait to the `PendingMail` object.

This will let you use `when()` and `unless()` methods whilst configuring an email before calling `send()`, `queue()`, etc.