### PR TITLE
[8.x] Add --pretend option for model:prune command

### DIFF
--- a/src/Illuminate/Database/Console/PruneCommand.php
+++ b/src/Illuminate/Database/Console/PruneCommand.php
@@ -19,7 +19,8 @@ class PruneCommand extends Command
      */
     protected $signature = 'model:prune
                                 {--model=* : Class names of the models to be pruned}
-                                {--chunk=1000 : The number of models to retrieve per chunk of models to be deleted}';
+                                {--chunk=1000 : The number of models to retrieve per chunk of models to be deleted}
+                                {--pretend : Print the number of prunable records found instead of deleting them}';
 
     /**
      * The console command description.
@@ -41,6 +42,14 @@ class PruneCommand extends Command
         if ($models->isEmpty()) {
             $this->info('No prunable models found.');
 
+            return;
+        }
+        
+        if ($this->option('pretend')) {
+            $models->each(function ($model) {
+                $this->pretendToPrune($model);
+            });
+            
             return;
         }
 
@@ -103,5 +112,26 @@ class PruneCommand extends Command
         $uses = class_uses_recursive($model);
 
         return in_array(Prunable::class, $uses) || in_array(MassPrunable::class, $uses);
+    }
+
+    /**
+     * Report how many models will be pruned, instead of actually pruning them.
+     *
+     * @param  string  $model
+     * @return void
+     */
+    protected function pretendToPrune($model)
+    {
+        $instance = new $model;
+        $count = $instance->prunable()
+            ->when(in_array(SoftDeletes::class, class_uses_recursive(get_class($instance))), function ($query) {
+                $query->withTrashed();
+            })->count();
+
+        if ($count == 0) {
+            $this->info("No prunable [$model] records found.");
+        } else {
+            $this->info("{$count} [{$model}] records will be pruned.");
+        }
     }
 }

--- a/src/Illuminate/Database/Console/PruneCommand.php
+++ b/src/Illuminate/Database/Console/PruneCommand.php
@@ -44,12 +44,12 @@ class PruneCommand extends Command
 
             return;
         }
-        
+
         if ($this->option('pretend')) {
             $models->each(function ($model) {
                 $this->pretendToPrune($model);
             });
-            
+
             return;
         }
 

--- a/src/Illuminate/Database/Console/PruneCommand.php
+++ b/src/Illuminate/Database/Console/PruneCommand.php
@@ -20,7 +20,7 @@ class PruneCommand extends Command
     protected $signature = 'model:prune
                                 {--model=* : Class names of the models to be pruned}
                                 {--chunk=1000 : The number of models to retrieve per chunk of models to be deleted}
-                                {--pretend : Print the number of prunable records found instead of deleting them}';
+                                {--pretend : Display the number of prunable records found instead of deleting them}';
 
     /**
      * The console command description.
@@ -115,7 +115,7 @@ class PruneCommand extends Command
     }
 
     /**
-     * Report how many models will be pruned, instead of actually pruning them.
+     * Display how many models will be pruned.
      *
      * @param  string  $model
      * @return void
@@ -123,12 +123,13 @@ class PruneCommand extends Command
     protected function pretendToPrune($model)
     {
         $instance = new $model;
+
         $count = $instance->prunable()
             ->when(in_array(SoftDeletes::class, class_uses_recursive(get_class($instance))), function ($query) {
                 $query->withTrashed();
             })->count();
 
-        if ($count == 0) {
+        if ($count === 0) {
             $this->info("No prunable [$model] records found.");
         } else {
             $this->info("{$count} [{$model}] records will be pruned.");

--- a/tests/Database/PruneCommandTest.php
+++ b/tests/Database/PruneCommandTest.php
@@ -60,6 +60,20 @@ No prunable [Illuminate\Tests\Database\NonPrunableTestModel] records found.
 EOF, str_replace("\r", '', $output->fetch()));
     }
 
+    public function testPretendPrunableModelWithPrunableRecords()
+    {
+        $output = $this->artisan([
+            '--model' => PrunableTestModelWithPrunableRecords::class,
+            '--pretend' => true
+        ]);
+
+        $this->assertEquals(<<<'EOF'
+10 [Illuminate\Tests\Database\PrunableTestModelWithPrunableRecords] records will be pruned.
+20 [Illuminate\Tests\Database\PrunableTestModelWithPrunableRecords] records will be pruned.
+
+EOF, str_replace("\r", '', $output->fetch()));
+    }
+
     protected function artisan($arguments)
     {
         $input = new ArrayInput($arguments);

--- a/tests/Database/PruneCommandTest.php
+++ b/tests/Database/PruneCommandTest.php
@@ -4,12 +4,15 @@ namespace Illuminate\Tests\Database;
 
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Database\Console\PruneCommand;
 use Illuminate\Database\Eloquent\MassPrunable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Prunable;
 use Illuminate\Database\Events\ModelsPruned;
 use Illuminate\Events\Dispatcher;
+use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
@@ -60,18 +63,39 @@ No prunable [Illuminate\Tests\Database\NonPrunableTestModel] records found.
 EOF, str_replace("\r", '', $output->fetch()));
     }
 
-    public function testPretendPrunableModelWithPrunableRecords()
+    public function testTheCommandMayBePretended()
     {
+        $db = new DB;
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+        $db->setAsGlobal();
+        DB::connection('default')->getSchemaBuilder()->create('prunables', function ($table) {
+            $table->string('name')->nullable();
+            $table->string('value')->nullable();
+        });
+        DB::connection('default')->table('prunables')->insert([
+            ['name' => 'zain', 'value' => 1],
+            ['name' => 'patrice', 'value' => 2],
+            ['name' => 'amelia', 'value' => 3],
+            ['name' => 'stuart', 'value' => 4],
+            ['name' => 'bello', 'value' => 5],
+        ]);
+        $resolver = m::mock(ConnectionResolverInterface::class, ['connection' => $db->getConnection('default')]);
+        PrunableTestModelWithPrunableRecords::setConnectionResolver($resolver);
+
         $output = $this->artisan([
             '--model' => PrunableTestModelWithPrunableRecords::class,
             '--pretend' => true
         ]);
 
         $this->assertEquals(<<<'EOF'
-10 [Illuminate\Tests\Database\PrunableTestModelWithPrunableRecords] records will be pruned.
-20 [Illuminate\Tests\Database\PrunableTestModelWithPrunableRecords] records will be pruned.
+3 [Illuminate\Tests\Database\PrunableTestModelWithPrunableRecords] records will be pruned.
 
 EOF, str_replace("\r", '', $output->fetch()));
+
+        $this->assertEquals(5, PrunableTestModelWithPrunableRecords::count());
     }
 
     protected function artisan($arguments)
@@ -98,12 +122,20 @@ class PrunableTestModelWithPrunableRecords extends Model
 {
     use MassPrunable;
 
+    protected $table = 'prunables';
+    protected $connection = 'default';
+
     public function pruneAll()
     {
         event(new ModelsPruned(static::class, 10));
         event(new ModelsPruned(static::class, 20));
 
         return 20;
+    }
+
+    public function prunable()
+    {
+        return static::where('value', '>=', 3);
     }
 }
 

--- a/tests/Database/PruneCommandTest.php
+++ b/tests/Database/PruneCommandTest.php
@@ -87,7 +87,7 @@ EOF, str_replace("\r", '', $output->fetch()));
 
         $output = $this->artisan([
             '--model' => PrunableTestModelWithPrunableRecords::class,
-            '--pretend' => true
+            '--pretend' => true,
         ]);
 
         $this->assertEquals(<<<'EOF'


### PR DESCRIPTION
This PR adds a `--pretend` option to `model:prune`, similar to the one for `migrate`. As prune is a potentially destructive command (a typo in a query could wipe out the wrong half of your database!), it's helpful to have an extra way to "sanity check" before committing.

The `pretend` option will print the number of records matching the `prunable()` query.  (I considered printing out the query instead, as `migrate`'s does, but that might be less useful, since it won't take chunking into account and might produce an expensive query.)

If this PR is accepted, I'll go ahead to update the docs.