### PR TITLE
[8.x] Convert middleware to array when outputting as JSON

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -156,7 +156,7 @@ class RouteListCommand extends Command
     protected function displayRoutes(array $routes)
     {
         if ($this->option('json')) {
-            $this->line(json_encode(array_values($routes)));
+            $this->line($this->asJson($routes));
 
             return;
         }
@@ -251,6 +251,23 @@ class RouteListCommand extends Command
         }
 
         return array_map('strtolower', $results);
+    }
+
+    /**
+     * Output the routes as JSON.
+     *
+     * @return string
+     */
+    protected function asJson(array $routes)
+    {
+        return collect($routes)
+            ->map(function ($route) {
+                $route['middleware'] = empty($route['middleware']) ? [] : explode("\n", $route['middleware']);
+
+                return $route;
+            })
+            ->values()
+            ->toJson();
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -254,8 +254,9 @@ class RouteListCommand extends Command
     }
 
     /**
-     * Output the routes as JSON.
+     * Convert the given routes to JSON.
      *
+     * @param  array  $routes
      * @return string
      */
     protected function asJson(array $routes)


### PR DESCRIPTION
When using the `--json` option, middleware is currently being output as a delimited string. Previously the delimiter was a comma, in #32993 it was changed to a newline.

Since the goal of the JSON option is to provide a programmatic output, this delimited string can be improved. This change maps the middleware string into an array. It does so in an extracted method which makes it more readable and easier to map additional values in the future.

While technically a breaking change, I'm submitting this as a "bug fix" as the delimited string created a poor experience. Especially as newlines. However, feel free to retarget to 9.x. 👍 