### PR TITLE
[8.x] Support setting default custom values for null attributes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -432,7 +432,7 @@ trait HasAttributes
      */
     protected function getAttributeFromArray($key)
     {
-        return $this->getRawAttributeFromArray($key) ?? $this->getDefaultAttribueValue($key);
+        return $this->getRawAttributeFromArray($key) ?? $this->getDefaultAttributeValue($key);
     }
 
     /**
@@ -441,7 +441,7 @@ trait HasAttributes
      * @param  string  $key
      * @return mixed
      */
-    protected function getDefaultAttribueValue($key)
+    protected function getDefaultAttributeValue($key)
     {
         return $this->defaultValues()[$key] ?? null;
     }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -432,7 +432,7 @@ trait HasAttributes
      */
     protected function getAttributeFromArray($key)
     {
-        return getRawAttributeFromArray($key) ?? getDefaultAttribueValue($key);
+        return $this->getRawAttributeFromArray($key) ?? $this->getDefaultAttribueValue($key);
     }
 
     /**
@@ -441,7 +441,8 @@ trait HasAttributes
      * @param  string  $key
      * @return mixed
      */
-    protected function getDefaultAttribueValue($key){
+    protected function getDefaultAttribueValue($key)
+    {
         return $this->defaultValues()[$key] ?? null;
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -415,12 +415,43 @@ trait HasAttributes
     }
 
     /**
-     * Get an attribute from the $attributes array.
+     * Default values to be used if an attribute value is null.
+     *
+     * @return array
+     */
+    public function defaultValues()
+    {
+        return [];
+    }
+
+    /**
+     * Get an attribute from the $attributes array or from the default values.
      *
      * @param  string  $key
      * @return mixed
      */
     protected function getAttributeFromArray($key)
+    {
+        return getRawAttributeFromArray($key) ?? getDefaultAttribueValue($key);
+    }
+
+    /**
+     * Get an attribute from the default values.
+     *
+     * @param  string  $key
+     * @return mixed
+     */
+    protected function getDefaultAttribueValue($key){
+        return $this->defaultValues()[$key] ?? null;
+    }
+
+    /**
+     * Get an attribute from the $attributes array.
+     *
+     * @param  string  $key
+     * @return mixed
+     */
+    protected function getRawAttributeFromArray($key)
     {
         return $this->getAttributes()[$key] ?? null;
     }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -2699,7 +2699,7 @@ class EloquentModelDefaultValues extends Model
     public function defaultValues()
     {
         return [
-            "name" => "taylor",
+            'name' => 'taylor',
         ];
     }
 }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -2696,7 +2696,8 @@ class EloquentModelWithUpdatedAtNull extends Model
 
 class EloquentModelDefaultValues extends Model
 {
-    public function defaultValues(){
+    public function defaultValues()
+    {
         return [
             "name" => "taylor",
         ];

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -2239,6 +2239,13 @@ class DatabaseEloquentModelTest extends TestCase
 
         $this->assertNull($user->name);
     }
+
+    public function testGetDefaultValues()
+    {
+        $model = new EloquentModelDefaultValues;
+        $model->setAttribute('name', null);
+        $this->assertSame('taylor', $model->name);
+    }
 }
 
 class EloquentTestObserverStub
@@ -2685,6 +2692,15 @@ class EloquentModelWithUpdatedAtNull extends Model
 {
     protected $table = 'stub';
     const UPDATED_AT = null;
+}
+
+class EloquentModelDefaultValues extends Model
+{
+    public function defaultValues(){
+        return [
+            "name" => "taylor",
+        ];
+    }
 }
 
 class UnsavedModel extends Model


### PR DESCRIPTION
This feature allows the user to set default values for nullable fields.
A user could use `$product->description ?? 'None'` or different attributes all over the blade files.
now instead they can define a default value
```php
public function defaultValues() {
    return [
        'description' => 'None',
    ];
}
```
and using  `$product->description` would return the description or `None` if it was null.
I created this on github online web editor because my pc has some problems right now so I wasn't able to test it but I am certain it should work so I appologize for that.
_also ignore the commit messages_