### PR TITLE
[8.x] UUID fixes for PHP 8.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,7 +76,6 @@ jobs:
           command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
 
       - name: Execute tests
-        continue-on-error: ${{ matrix.php > 8 }}
         run: vendor/bin/phpunit --verbose
         env:
           DB_PORT: ${{ job.services.mysql.ports[3306] }}

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "psr/container": "^1.0",
         "psr/log": "^1.0 || ^2.0",
         "psr/simple-cache": "^1.0",
-        "ramsey/uuid": "^4.0",
+        "ramsey/uuid": "^4.2.2",
         "swiftmailer/swiftmailer": "^6.0",
         "symfony/console": "^5.1.4",
         "symfony/error-handler": "^5.1.4",

--- a/src/Illuminate/Queue/composer.json
+++ b/src/Illuminate/Queue/composer.json
@@ -26,7 +26,7 @@
         "illuminate/support": "^8.0",
         "laravel/serializable-closure": "^1.0",
         "opis/closure": "^3.6",
-        "ramsey/uuid": "^4.0",
+        "ramsey/uuid": "^4.2.2",
         "symfony/process": "^5.1.4"
     },
     "autoload": {

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -43,7 +43,7 @@
     "suggest": {
         "illuminate/filesystem": "Required to use the composer class (^8.0).",
         "league/commonmark": "Required to use Str::markdown() and Stringable::markdown() (^1.3|^2.0.2).",
-        "ramsey/uuid": "Required to use Str::uuid() (^4.0).",
+        "ramsey/uuid": "Required to use Str::uuid() (^4.2.2).",
         "symfony/process": "Required to use the composer class (^5.1.4).",
         "symfony/var-dumper": "Required to use the dd function (^5.1.4).",
         "vlucas/phpdotenv": "Required to use the Env class and env helper (^5.2)."

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -25,10 +25,6 @@ class BusBatchTest extends TestCase
 {
     protected function setUp(): void
     {
-        if (\PHP_VERSION_ID >= 80100) {
-            $this->markTestSkipped('Test failing in PHP 8.1');
-        }
-
         $db = new DB;
 
         $db->addConnection([

--- a/tests/Integration/Notifications/SendingMailNotificationsTest.php
+++ b/tests/Integration/Notifications/SendingMailNotificationsTest.php
@@ -68,10 +68,6 @@ class SendingMailNotificationsTest extends TestCase
 
     protected function setUp(): void
     {
-        if (\PHP_VERSION_ID >= 80100) {
-            $this->markTestSkipped('Test failing in PHP 8.1');
-        }
-
         parent::setUp();
 
         Schema::create('users', function (Blueprint $table) {

--- a/tests/Integration/Notifications/SendingNotificationsViaAnonymousNotifiableTest.php
+++ b/tests/Integration/Notifications/SendingNotificationsViaAnonymousNotifiableTest.php
@@ -17,10 +17,6 @@ class SendingNotificationsViaAnonymousNotifiableTest extends TestCase
 
     protected function setUp(): void
     {
-        if (\PHP_VERSION_ID >= 80100) {
-            $this->markTestSkipped('Test failing in PHP 8.1');
-        }
-
         parent::setUp();
     }
 

--- a/tests/Integration/Notifications/SendingNotificationsWithLocaleTest.php
+++ b/tests/Integration/Notifications/SendingNotificationsWithLocaleTest.php
@@ -57,10 +57,6 @@ class SendingNotificationsWithLocaleTest extends TestCase
 
     protected function setUp(): void
     {
-        if (\PHP_VERSION_ID >= 80100) {
-            $this->markTestSkipped('Test failing in PHP 8.1');
-        }
-
         parent::setUp();
 
         Schema::create('users', function (Blueprint $table) {

--- a/tests/Integration/Queue/CustomPayloadTest.php
+++ b/tests/Integration/Queue/CustomPayloadTest.php
@@ -30,10 +30,6 @@ class CustomPayloadTest extends TestCase
      */
     public function test_custom_payload_gets_cleared_for_each_data_provider(string $websites)
     {
-        if (\PHP_VERSION_ID >= 80100) {
-            $this->markTestSkipped('Test failing in PHP 8.1');
-        }
-
         $dispatcher = $this->app->make(QueueingDispatcher::class);
 
         $dispatcher->dispatchToQueue(new MyJob);

--- a/tests/Integration/Queue/JobChainingTest.php
+++ b/tests/Integration/Queue/JobChainingTest.php
@@ -19,10 +19,6 @@ class JobChainingTest extends TestCase
 
     protected function setUp(): void
     {
-        if (\PHP_VERSION_ID >= 80100) {
-            $this->markTestSkipped('Test failing in PHP 8.1');
-        }
-
         parent::setUp();
     }
 

--- a/tests/Integration/Queue/JobDispatchingTest.php
+++ b/tests/Integration/Queue/JobDispatchingTest.php
@@ -24,10 +24,6 @@ class JobDispatchingTest extends TestCase
 
     public function testJobCanUseCustomMethodsAfterDispatch()
     {
-        if (\PHP_VERSION_ID >= 80100) {
-            $this->markTestSkipped('Test failing in PHP 8.1');
-        }
-
         Job::dispatch('test')->replaceValue('new-test');
 
         $this->assertTrue(Job::$ran);

--- a/tests/Integration/Queue/UniqueJobTest.php
+++ b/tests/Integration/Queue/UniqueJobTest.php
@@ -21,10 +21,6 @@ class UniqueJobTest extends TestCase
 {
     protected function setUp(): void
     {
-        if (\PHP_VERSION_ID >= 80100) {
-            $this->markTestSkipped('Test failing in PHP 8.1');
-        }
-
         parent::setUp();
     }
 

--- a/tests/Integration/Queue/WorkCommandTest.php
+++ b/tests/Integration/Queue/WorkCommandTest.php
@@ -16,10 +16,6 @@ class WorkCommandTest extends TestCase
 {
     protected function setUp(): void
     {
-        if (\PHP_VERSION_ID >= 80100) {
-            $this->markTestSkipped('Test failing in PHP 8.1');
-        }
-
         parent::setUp();
     }
 

--- a/tests/Integration/Validation/ValidatorTest.php
+++ b/tests/Integration/Validation/ValidatorTest.php
@@ -16,10 +16,6 @@ class ValidatorTest extends DatabaseTestCase
 {
     protected function setUp(): void
     {
-        if (\PHP_VERSION_ID >= 80100) {
-            $this->markTestSkipped('Test failing in PHP 8.1');
-        }
-
         parent::setUp();
 
         Schema::create('users', function (Blueprint $table) {

--- a/tests/Notifications/NotificationChannelManagerTest.php
+++ b/tests/Notifications/NotificationChannelManagerTest.php
@@ -20,10 +20,6 @@ class NotificationChannelManagerTest extends TestCase
 {
     protected function setUp(): void
     {
-        if (\PHP_VERSION_ID >= 80100) {
-            $this->markTestSkipped('Test failing in PHP 8.1');
-        }
-
         parent::setUp();
     }
 

--- a/tests/Notifications/NotificationSenderTest.php
+++ b/tests/Notifications/NotificationSenderTest.php
@@ -18,10 +18,6 @@ class NotificationSenderTest extends TestCase
 {
     protected function setUp(): void
     {
-        if (\PHP_VERSION_ID >= 80100) {
-            $this->markTestSkipped('Test failing in PHP 8.1');
-        }
-
         parent::setUp();
     }
 

--- a/tests/Queue/QueueBeanstalkdQueueTest.php
+++ b/tests/Queue/QueueBeanstalkdQueueTest.php
@@ -25,10 +25,6 @@ class QueueBeanstalkdQueueTest extends TestCase
 
     protected function setUp(): void
     {
-        if (\PHP_VERSION_ID >= 80100) {
-            $this->markTestSkipped('Test failing in PHP 8.1');
-        }
-
         parent::setUp();
     }
 

--- a/tests/Queue/QueueDatabaseQueueUnitTest.php
+++ b/tests/Queue/QueueDatabaseQueueUnitTest.php
@@ -16,10 +16,6 @@ class QueueDatabaseQueueUnitTest extends TestCase
 {
     protected function setUp(): void
     {
-        if (\PHP_VERSION_ID >= 80100) {
-            $this->markTestSkipped('Test failing in PHP 8.1');
-        }
-
         parent::setUp();
     }
 

--- a/tests/Queue/QueueRedisQueueTest.php
+++ b/tests/Queue/QueueRedisQueueTest.php
@@ -16,10 +16,6 @@ class QueueRedisQueueTest extends TestCase
 {
     protected function setUp(): void
     {
-        if (\PHP_VERSION_ID >= 80100) {
-            $this->markTestSkipped('Test failing in PHP 8.1');
-        }
-
         parent::setUp();
     }
 

--- a/tests/Queue/QueueSyncQueueTest.php
+++ b/tests/Queue/QueueSyncQueueTest.php
@@ -16,15 +16,6 @@ use PHPUnit\Framework\TestCase;
 
 class QueueSyncQueueTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        if (\PHP_VERSION_ID >= 80100) {
-            $this->markTestSkipped('Test failing in PHP 8.1');
-        }
-
-        parent::setUp();
-    }
-
     protected function tearDown(): void
     {
         m::close();

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -493,10 +493,6 @@ class SupportStrTest extends TestCase
 
     public function testUuid()
     {
-        if (\PHP_VERSION_ID >= 80100) {
-            $this->markTestSkipped('Test failing in PHP 8.1');
-        }
-
         $this->assertInstanceOf(UuidInterface::class, Str::uuid());
         $this->assertInstanceOf(UuidInterface::class, Str::orderedUuid());
     }

--- a/tests/Support/SupportTestingNotificationFakeTest.php
+++ b/tests/Support/SupportTestingNotificationFakeTest.php
@@ -31,10 +31,6 @@ class SupportTestingNotificationFakeTest extends TestCase
 
     protected function setUp(): void
     {
-        if (\PHP_VERSION_ID >= 80100) {
-            $this->markTestSkipped('Test failing in PHP 8.1');
-        }
-
         parent::setUp();
 
         $this->fake = new NotificationFake;


### PR DESCRIPTION
Before: 163 tests skipped on PHP 8.1 (not including the 10 skipped always on CI).
After: 62 tests skipped on PHP 8.1 (not including the 10 skipped always on CI).