### PR TITLE
[8.x] Fix #38949

### DIFF
--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -268,6 +268,8 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
      */
     public function passes($attribute, $value)
     {
+        $this->messages = [];
+
         $validator = Validator::make($this->data, [
             $attribute => 'string|min:'.$this->min,
         ], $this->validator->customMessages, $this->validator->customAttributes);

--- a/tests/Validation/ValidationPasswordRuleTest.php
+++ b/tests/Validation/ValidationPasswordRuleTest.php
@@ -232,6 +232,29 @@ class ValidationPasswordRuleTest extends TestCase
         Password::defaults('required|password');
     }
 
+    public function testItPassesWithValidDataIfTheSameValidationRulesAreReused()
+    {
+        $rules = [
+            'password' => Password::default()
+        ];
+
+        $v = new Validator(
+            resolve('translator'),
+            ['password' => '1234'],
+            $rules
+        );
+
+        $this->assertFalse($v->passes());
+
+        $v1 = new Validator(
+            resolve('translator'),
+            ['password' => '12341234'],
+            $rules
+        );
+
+        $this->assertTrue($v1->passes());
+    }
+
     protected function passes($rule, $values)
     {
         $this->assertValidationRules($rule, $values, true, []);

--- a/tests/Validation/ValidationPasswordRuleTest.php
+++ b/tests/Validation/ValidationPasswordRuleTest.php
@@ -235,7 +235,7 @@ class ValidationPasswordRuleTest extends TestCase
     public function testItPassesWithValidDataIfTheSameValidationRulesAreReused()
     {
         $rules = [
-            'password' => Password::default()
+            'password' => Password::default(),
         ];
 
         $v = new Validator(


### PR DESCRIPTION
Hi,
This PR should fix #38949. I've added a test which fails without adding the following line
```diff
public function passes($attribute, $value)
{
+        $this->messages = [];
...
}
```
