### PR TITLE
[8.x] Adds `--pest` option when using the `make:test` artisan command

### DIFF
--- a/src/Illuminate/Foundation/Console/TestMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/TestMakeCommand.php
@@ -39,8 +39,8 @@ class TestMakeCommand extends GeneratorCommand
         $suffix = $this->option('unit') ? '.unit.stub' : '.stub';
 
         return $this->option('pest')
-            ? $this->resolveStubPath('/stubs/pest' . $suffix)
-            : $this->resolveStubPath('/stubs/test' . $suffix);
+            ? $this->resolveStubPath('/stubs/pest'.$suffix)
+            : $this->resolveStubPath('/stubs/test'.$suffix);
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/TestMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/TestMakeCommand.php
@@ -36,9 +36,11 @@ class TestMakeCommand extends GeneratorCommand
      */
     protected function getStub()
     {
-        return $this->option('unit')
-                    ? $this->resolveStubPath('/stubs/test.unit.stub')
-                    : $this->resolveStubPath('/stubs/test.stub');
+        $suffix = $this->option('unit') ? '.unit.stub' : '.stub';
+
+        return $this->option('pest')
+            ? $this->resolveStubPath('/stubs/pest' . $suffix)
+            : $this->resolveStubPath('/stubs/test' . $suffix);
     }
 
     /**
@@ -101,6 +103,7 @@ class TestMakeCommand extends GeneratorCommand
     {
         return [
             ['unit', 'u', InputOption::VALUE_NONE, 'Create a unit test.'],
+            ['pest', 'p', InputOption::VALUE_NONE, 'Create a Pest test.'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/stubs/pest.stub
+++ b/src/Illuminate/Foundation/Console/stubs/pest.stub
@@ -1,0 +1,7 @@
+<?php
+
+test('example', function () {
+    $response = $this->get('/');
+
+    $response->assertStatus(200);
+});

--- a/src/Illuminate/Foundation/Console/stubs/pest.unit.stub
+++ b/src/Illuminate/Foundation/Console/stubs/pest.unit.stub
@@ -1,0 +1,5 @@
+<?php
+
+test('example', function () {
+    expect(true)->toBeTrue();
+});


### PR DESCRIPTION
Howdy!

This PR adds support for Pest PHP when generating tests by adding a `--pest` option to the `php artisan make:test` command. To support this, two new stubs have been added, one for Pest feature tests and the other for Pest unit tests. These match the functionality of the existing PhpUnit tests, but are written in Pest (obviously).

This addition to the framework allows Pest to feel more "at home" as a citizen in Laravel as its popularity continues to grow.

Thanks for all your hard work.

Kind Regards,
Luke