### PR TITLE
[8.x] Only look for files ending with .php in model:prune

### DIFF
--- a/src/Illuminate/Database/Console/PruneCommand.php
+++ b/src/Illuminate/Database/Console/PruneCommand.php
@@ -87,7 +87,7 @@ class PruneCommand extends Command
             return collect($models);
         }
 
-        return collect((new Finder)->in(app_path('Models'))->files())
+        return collect((new Finder)->in(app_path('Models'))->files()->name('*.php'))
             ->map(function ($model) {
                 $namespace = $this->laravel->getNamespace();
 


### PR DESCRIPTION
Currently `php artisan model:prune` will take a look at all files in the model directory.
It will throw an error if you have a file other than a php file there (e.g. readme.md)

With this PR only php files will be looked at in `php artisan model:prune`

Fixes #38963.