### PR TITLE
[8.x] Notification assertions respect `shouldSend` method on notification

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -232,9 +232,24 @@ class NotificationFake implements NotificationDispatcher, NotificationFactory
                 $notification->id = Str::uuid()->toString();
             }
 
+            $notifiableChannels = $channels ?: $notification->via($notifiable);
+
+            if (method_exists($notification, 'shouldSend')) {
+                $notifiableChannels = array_filter(
+                    $notifiableChannels,
+                    function ($channel) use ($notification, $notifiable) {
+                        return $notification->shouldSend($notifiable, $channel) !== false;
+                    }
+                );
+
+                if (! count($notifiableChannels)) {
+                    continue;
+                }
+            }
+
             $this->notifications[get_class($notifiable)][$notifiable->getKey()][get_class($notification)][] = [
                 'notification' => $notification,
-                'channels' => $channels ?: $notification->via($notifiable),
+                'channels' => $notifiableChannels,
                 'notifiable' => $notifiable,
                 'locale' => $notification->locale ?? $this->locale ?? value(function () use ($notifiable) {
                     if ($notifiable instanceof HasLocalePreference) {

--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -242,7 +242,7 @@ class NotificationFake implements NotificationDispatcher, NotificationFactory
                     }
                 );
 
-                if (! count($notifiableChannels)) {
+                if (empty($notifiableChannels)) {
                     continue;
                 }
             }

--- a/tests/Support/SupportTestingNotificationFakeTest.php
+++ b/tests/Support/SupportTestingNotificationFakeTest.php
@@ -144,6 +144,15 @@ class SupportTestingNotificationFakeTest extends TestCase
             return $notifiable === $user && $locale === 'au';
         });
     }
+
+    public function testAssertSentToWhenNotifiableHasFalsyShouldSend()
+    {
+        $user = new LocalizedUserStub;
+
+        $this->fake->send($user, new NotificationWithFalsyShouldSendStub);
+
+        $this->fake->assertNotSentTo($user, NotificationWithFalsyShouldSendStub::class);
+    }
 }
 
 class NotificationStub extends Notification
@@ -151,6 +160,19 @@ class NotificationStub extends Notification
     public function via($notifiable)
     {
         return ['mail'];
+    }
+}
+
+class NotificationWithFalsyShouldSendStub extends Notification
+{
+    public function via($notifiable)
+    {
+        return ['mail'];
+    }
+
+    public function shouldSend($notifiable, $channel)
+    {
+        return false;
     }
 }
 


### PR DESCRIPTION
Support for notification's `shouldSend` method were added in PR #37930. This method allows users to add some logic to cancel sending notification based on given notifiable and channel.


#### Problem

However, testing methods `assertSentTo` and `assertNotSentTo` weren't aware about this feature and didn't behave as expected (reported here as well https://github.com/laravel/framework/issues/38909). 

For example, take this code:
```php
// somewhere in user's code
Notification::send($user, new SomeNotification);

// implementation
class SomeNotification extends Notification
{
    public function via($notifiable)
    {
        return ['mail'];
    }

    public function shouldSend($notifiable, $channel)
    {
        return false;
    }
}
```

Now, when testing whether notification hasn't been sent, we won't get expected assertion result:

```php
Notification::fake();

// some code triggering notification send

Notification::assertNotSentTo($user, SomeNotification::class); // will fail, but should pass
```

#### Solution

This PR adds support of `shouldSend` to notification's `assertSentTo` and `assertNotSentTo` methods. So now when `shouldSend` is presented on notification class and returns false for some notifiable,  `assertSentTo` and `assertNotSentTo` can be used to check that behavior.

Fixes #38909