### PR TITLE
[8.x] Fix assertPushedOn docblock

### DIFF
--- a/src/Illuminate/Support/Facades/Queue.php
+++ b/src/Illuminate/Support/Facades/Queue.php
@@ -19,7 +19,7 @@ use Illuminate\Support\Testing\Fakes\QueueFake;
  * @method static void assertNotPushed(string|\Closure $job, callable $callback = null)
  * @method static void assertNothingPushed()
  * @method static void assertPushed(string|\Closure $job, callable|int $callback = null)
- * @method static void assertPushedOn(string $queue, string|\Closure $job, callable|int $callback = null)
+ * @method static void assertPushedOn(string $queue, string|\Closure $job, callable $callback = null)
  * @method static void assertPushedWithChain(string $job, array $expectedChain = [], callable $callback = null)
  *
  * @see \Illuminate\Queue\QueueManager


### PR DESCRIPTION
Contrary to `assertPushed`, `assertPushedOn` doesn't accepts an integer for its callback.

Fixes https://github.com/laravel/framework/issues/38924