### PR TITLE
[8.x] - fix for custom date castable and database value formatting

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1219,7 +1219,18 @@ trait HasAttributes
      */
     protected function isDateCastable($key)
     {
-        return $this->hasCast($key, ['date', 'custom_datetime', 'datetime', 'immutable_date', 'immutable_custom_datetime', 'immutable_datetime']);
+        return $this->hasCast($key, ['date', 'datetime', 'immutable_date', 'immutable_datetime']);
+    }
+
+    /**
+     * Determine whether a value is Date / DateTime custom-castable for inbound manipulation.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    protected function isDateCastableWithCustomFormat($key)
+    {
+        return $this->hasCast($key, ['custom_datetime', 'immutable_custom_datetime']);
     }
 
     /**
@@ -1645,7 +1656,7 @@ trait HasAttributes
             return true;
         } elseif (is_null($attribute)) {
             return false;
-        } elseif ($this->isDateAttribute($key)) {
+        } elseif ($this->isDateAttribute($key) || $this->isDateCastableWithCustomFormat($key)) {
             return $this->fromDateTime($attribute) ===
                 $this->fromDateTime($original);
         } elseif ($this->hasCast($key, ['object', 'collection'])) {

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1219,7 +1219,7 @@ trait HasAttributes
      */
     protected function isDateCastable($key)
     {
-        return $this->hasCast($key, ['date', 'datetime', 'immutable_date', 'immutable_datetime']);
+        return $this->hasCast($key, ['date', 'custom_datetime', 'datetime', 'immutable_date', 'immutable_custom_datetime', 'immutable_datetime']);
     }
 
     /**

--- a/tests/Integration/Database/EloquentModelDateCastingTest.php
+++ b/tests/Integration/Database/EloquentModelDateCastingTest.php
@@ -2,10 +2,10 @@
 
 namespace Illuminate\Tests\Integration\Database\EloquentModelDateCastingTest;
 
+use Carbon\Carbon;
 use Carbon\CarbonImmutable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 

--- a/tests/Integration/Database/EloquentModelDateCastingTest.php
+++ b/tests/Integration/Database/EloquentModelDateCastingTest.php
@@ -49,22 +49,22 @@ class EloquentModelDateCastingTest extends DatabaseTestCase
         });
 
         $user = TestModel1::create([
-            'date_field' => new Carbon('2019-10'),
-            'datetime_field' => new Carbon('2019-10-01 10:15:20'),
-            'immutable_date_field' => new CarbonImmutable('2019-10-01'),
-            'immutable_datetime_field' => new CarbonImmutable('2019-10-01 10:15'),
+            'date_field' => '2019-10',
+            'datetime_field' => '2019-10-01 10:15:20',
+            'immutable_date_field' => '2019-10-01',
+            'immutable_datetime_field' => '2019-10-01 10:15',
         ]);
 
-        $this->assertSame(['2019-10-01 00:00:00', '2019-10-01 10:15:20', '2019-10-01 00:00:00', '2019-10-01 10:15:00'], $bindings);
+        $this->assertSame(['2019-10', '2019-10-01 10:15:20', '2019-10-01', '2019-10-01 10:15'], $bindings);
     }
 
     public function testDatesFormattedArrayAndJson()
     {
         $user = TestModel1::create([
-            'date_field' => new Carbon('2019-10'),
-            'datetime_field' => new Carbon('2019-10-01 10:15:20'),
-            'immutable_date_field' => new CarbonImmutable('2019-10-01'),
-            'immutable_datetime_field' => new CarbonImmutable('2019-10-01 10:15'),
+            'date_field' => '2019-10',
+            'datetime_field' => '2019-10-01 10:15:20',
+            'immutable_date_field' => '2019-10-01',
+            'immutable_datetime_field' => '2019-10-01 10:15',
         ]);
 
         $expected = [

--- a/tests/Integration/Database/EloquentModelDateCastingTest.php
+++ b/tests/Integration/Database/EloquentModelDateCastingTest.php
@@ -49,10 +49,10 @@ class EloquentModelDateCastingTest extends DatabaseTestCase
         });
 
         $user = TestModel1::create([
-            'date_field' => '2019-10',
-            'datetime_field' => new CarbonImmutable('2019-10-01 10:15:20'),
+            'date_field' => new Carbon('2019-10'),
+            'datetime_field' => new Carbon('2019-10-01 10:15:20'),
             'immutable_date_field' => new CarbonImmutable('2019-10-01'),
-            'immutable_datetime_field' => '2019-10-01 10:15',
+            'immutable_datetime_field' => new CarbonImmutable('2019-10-01 10:15'),
         ]);
 
         $this->assertSame(['2019-10-01 00:00:00', '2019-10-01 10:15:20', '2019-10-01 00:00:00', '2019-10-01 10:15:00'], $bindings);

--- a/tests/Integration/Database/EloquentModelDateCastingTest.php
+++ b/tests/Integration/Database/EloquentModelDateCastingTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Database\EloquentModelDateCastingTest;
 
+use Carbon\CarbonImmutable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Carbon;
@@ -21,6 +22,8 @@ class EloquentModelDateCastingTest extends DatabaseTestCase
             $table->increments('id');
             $table->date('date_field')->nullable();
             $table->datetime('datetime_field')->nullable();
+            $table->date('immutable_date_field')->nullable();
+            $table->datetime('immutable_datetime_field')->nullable();
         });
     }
 
@@ -36,6 +39,67 @@ class EloquentModelDateCastingTest extends DatabaseTestCase
         $this->assertInstanceOf(Carbon::class, $user->date_field);
         $this->assertInstanceOf(Carbon::class, $user->datetime_field);
     }
+
+    public function testDatesFormattedAttributeBindings()
+    {
+        $bindings = [];
+
+        $this->app->make('db')->listen(static function ($query) use (&$bindings) {
+            $bindings = $query->bindings;
+        });
+
+        $user = TestModel1::create([
+            'date_field' => '2019-10',
+            'datetime_field' => new CarbonImmutable('2019-10-01 10:15:20'),
+            'immutable_date_field' => new CarbonImmutable('2019-10-01'),
+            'immutable_datetime_field' => '2019-10-01 10:15',
+        ]);
+
+        $this->assertSame(['2019-10', '2019-10-01 10:15:20', '2019-10-01 00:00:00', '2019-10-01 10:15'], $bindings);
+    }
+
+
+    public function testCustomDateCastsAreComparedAsDatesForCarbonInstances()
+    {
+        /** @var TestModel1 */
+        $user = TestModel1::create([
+            'date_field' => '2019-10-01',
+            'datetime_field' => '2019-10-01 10:15:20',
+            'immutable_date_field' => '2019-10-01',
+            'immutable_datetime_field' => '2019-10-01 10:15:20',
+        ]);
+
+        $user->date_field = new Carbon('2019-10-01');
+        $user->datetime_field = new Carbon('2019-10-01 10:15:20');
+        $user->immutable_date_field = new CarbonImmutable('2019-10-01');
+        $user->immutable_datetime_field = new CarbonImmutable('2019-10-01 10:15:20');
+
+        $this->assertArrayNotHasKey('date_field', $user->getDirty());
+        $this->assertArrayNotHasKey('datetime_field', $user->getDirty());
+        $this->assertArrayNotHasKey('immutable_date_field', $user->getDirty());
+        $this->assertArrayNotHasKey('immutable_datetime_field', $user->getDirty());
+    }
+
+    public function testCustomDateCastsAreComparedAsDatesForStringValues()
+    {
+        /** @var TestModel1 */
+        $user = TestModel1::create([
+            'date_field' => '2019-10-01',
+            'datetime_field' => '2019-10-01 10:15:20',
+            'immutable_date_field' => '2019-10-01',
+            'immutable_datetime_field' => '2019-10-01 10:15:20',
+        ]);
+
+        $user->date_field = '2019-10-01';
+        $user->datetime_field = '2019-10-01 10:15:20';
+        $user->immutable_date_field = '2019-10-01';
+        $user->immutable_datetime_field = '2019-10-01 10:15:20';
+
+        $this->assertArrayNotHasKey('date_field', $user->getDirty());
+        $this->assertArrayNotHasKey('datetime_field', $user->getDirty());
+        $this->assertArrayNotHasKey('immutable_date_field', $user->getDirty());
+        $this->assertArrayNotHasKey('immutable_datetime_field', $user->getDirty());
+    }
 }
 
 class TestModel1 extends Model
@@ -47,5 +111,7 @@ class TestModel1 extends Model
     public $casts = [
         'date_field' => 'date:Y-m',
         'datetime_field' => 'datetime:Y-m H:i',
+        'immutable_date_field' => 'date:Y-m',
+        'immutable_datetime_field' => 'datetime:Y-m H:i',
     ];
 }

--- a/tests/Integration/Database/EloquentModelDateCastingTest.php
+++ b/tests/Integration/Database/EloquentModelDateCastingTest.php
@@ -55,7 +55,7 @@ class EloquentModelDateCastingTest extends DatabaseTestCase
             'immutable_datetime_field' => '2019-10-01 10:15',
         ]);
 
-        $this->assertSame(['2019-10', '2019-10-01 10:15:20', '2019-10-01 00:00:00', '2019-10-01 10:15'], $bindings);
+        $this->assertSame(['2019-10-01 00:00:00', '2019-10-01 10:15:20', '2019-10-01 00:00:00', '2019-10-01 10:15:00'], $bindings);
     }
 
 

--- a/tests/Integration/Database/EloquentModelDateCastingTest.php
+++ b/tests/Integration/Database/EloquentModelDateCastingTest.php
@@ -58,6 +58,26 @@ class EloquentModelDateCastingTest extends DatabaseTestCase
         $this->assertSame(['2019-10-01 00:00:00', '2019-10-01 10:15:20', '2019-10-01 00:00:00', '2019-10-01 10:15:00'], $bindings);
     }
 
+    public function testDatesFormattedArrayAndJson()
+    {
+        $user = TestModel1::create([
+            'date_field' => new Carbon('2019-10'),
+            'datetime_field' => new Carbon('2019-10-01 10:15:20'),
+            'immutable_date_field' => new CarbonImmutable('2019-10-01'),
+            'immutable_datetime_field' => new CarbonImmutable('2019-10-01 10:15'),
+        ]);
+
+        $expected = [
+            'date_field' => '2019-10',
+            'datetime_field' => '2019-10 10:15',
+            'immutable_date_field' => '2019-10',
+            'immutable_datetime_field' => '2019-10 10:15',
+            'id' => 1,
+        ];
+
+        $this->assertSame($expected, $user->toArray());
+        $this->assertSame(json_encode($expected), $user->toJson());
+    }
 
     public function testCustomDateCastsAreComparedAsDatesForCarbonInstances()
     {


### PR DESCRIPTION
This is a followup to #38720 and #38828.

Instead of always treating `custom_datetime` and `immutable_custom_datetime` casts as `isDateCastable()`, this only checks them in the `originalIsEquivalent()` method.

This retains the old behavior for formatting values for the database, while incorporating a fix to ensure that custom (immutable) date casts are compared correctly, even if the Carbon instance is not identical.