### PR TITLE
[8.x] Fixes bug when trying to `make:listener` of an already existing listener

### DIFF
--- a/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
@@ -75,17 +75,6 @@ class ListenerMakeCommand extends GeneratorCommand
     }
 
     /**
-     * Determine if the class already exists.
-     *
-     * @param  string  $rawName
-     * @return bool
-     */
-    protected function alreadyExists($rawName)
-    {
-        return class_exists($rawName);
-    }
-
-    /**
      * Get the default namespace for the class.
      *
      * @param  string  $rootNamespace


### PR DESCRIPTION
This PR fixes an issue when trying to create a listener that already exists, right now if creating a listener with the name of a class that already exists it overwrites it.

Looks like  the `alreadyExists` method on the parent class `GeneratorCommand.php` does the trick for this one, so no need for the alreadyExists on this class.