### PR TITLE
[9.x] Add $limit to latest() and oldest()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -282,12 +282,17 @@ class Builder implements BuilderContract
      * Add an "order by" clause for a timestamp to the query.
      *
      * @param  string|\Illuminate\Database\Query\Expression  $column
+     * @param  int  $limit
      * @return $this
      */
-    public function latest($column = null)
+    public function latest($column = null, $limit = null)
     {
         if (is_null($column)) {
             $column = $this->model->getCreatedAtColumn() ?? 'created_at';
+        }
+
+        if (! is_null($limit)) {
+            $this->query->limit($limit);
         }
 
         $this->query->latest($column);
@@ -299,12 +304,17 @@ class Builder implements BuilderContract
      * Add an "order by" clause for a timestamp to the query.
      *
      * @param  string|\Illuminate\Database\Query\Expression  $column
+     * @param  int  $limit
      * @return $this
      */
-    public function oldest($column = null)
+    public function oldest($column = null, $limit = null)
     {
         if (is_null($column)) {
             $column = $this->model->getCreatedAtColumn() ?? 'created_at';
+        }
+
+        if (! is_null($limit)) {
+            $this->query->limit($limit);
         }
 
         $this->query->oldest($column);


### PR DESCRIPTION
Adding `$limit` param to `Builder::latest()` and `Builder::oldest()` is just a shortcut but it'll be quite intuitive:

Instead of
```php
$query->latest('id')->take(5)->get();
```
we can just say
```php
$query->latest('id', 5)->get();
```
which translates to: "Get the latest five entries ordered by ID column"

# Alternatives
Instead of having to pass `null` for the first parameter or using named parameters, every time, we want to use only the second parameter, we could check for the data type to implement method overloading but I'm not sure if that is needed since users could use named parameters instead.

```php
   /**
     * Add an "order by" clause for a timestamp to the query.
     *
     * @param  string|\Illuminate\Database\Query\Expression  $column
     * @param  int $limit
     * @return $this
     */
    public function latest($column = null, $limit = null)
    {
        [$column, $limit] = $this->query->prepareValueAndOperator(
            func_get_args()
        );

        if (is_null($column)) {
            $column = $this->model->getCreatedAtColumn() ?? 'created_at';
        }

        if (!is_null($limit)) {
            $this->query->limit($limit);   
        }

        $this->query->latest($column);

        return $this;
    }

    /**
     * Add an "order by" clause for a timestamp to the query.
     *
     * @param  string|\Illuminate\Database\Query\Expression  $column
     * @param  int $limit
     * @return $this
     */
    public function oldest($column = null, $limit = null)
    {
        [$column, $limit] = $this->query->prepareValueAndOperator(
            func_get_args()
        );

        if (is_null($column)) {
            $column = $this->model->getCreatedAtColumn() ?? 'created_at';
        }

        if (!is_null($limit)) {
            $this->query->limit($limit);   
        }

        $this->query->oldest($column);

        return $this;
    }

    /**
     * Prepare the value and operator for a where clause.
     *
     * @param array  $params
     * @return array
     *
     * @throws \InvalidArgumentException
     */
    private function prepareOrderByLimitParameters(array $params)
    {
        if (count($params)) {
            return $params;
        }

        if (is_string($params[0]) {
            return [ $params[0], null ];
        } else if (is_numeric($params[0]) {
            return [ null, $params[0];
        }

        throw new InvalidArgumentException('Illegal column and limit combination.');
    }
```