### PR TITLE
[8.x] HasCorrectSignature UrlGenerator taking force scheme into account.

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -405,6 +405,10 @@ class UrlGenerator implements UrlGeneratorContract
     {
         $url = $absolute ? $request->url() : '/'.$request->path();
 
+        if ($this->forceScheme && $absolute) {
+            $url = preg_replace('/^.*:\/\//U', $this->forceScheme, $url);
+        }
+
         $queryString = ltrim(preg_replace('/(^|&)signature=[^&]+/', '', $request->server->get('QUERY_STRING')), '&');
 
         $signature = hash_hmac('sha256', rtrim($url.'?'.$queryString, '?'), call_user_func($this->keyResolver));


### PR DESCRIPTION
**Problem:**

If a signed route is generated by `URL::signedRoute()` or `URL::temporarySignedRoute()` it uses actual scheme (https or http).

However, validation method `hasCorrectSignature()` of `Illuminate\Routing\UrlGenerator` doeesn't consider forceScheme setting.

**Scenario:**

When using proxy balance loader, in `hasCorrectSignature()` scheme will be different from generated in `URL::signedRoute()` wich will lead to constand unauthorized error.

I suggest add forceScheme condition to `hasCorrectSignature()` method.