### PR TITLE
[8.x] Add `anonymous` option to `make:component` command

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -136,6 +136,11 @@ abstract class GeneratorCommand extends Command
             return false;
         }
 
+        // Don't create a class when generating an anonymous blade component
+        if ($this->type === 'Component' && $this->hasOption('anonymous') && $this->option('anonymous') === true) {
+            return false;
+        }
+
         $name = $this->qualifyClass($this->getNameInput());
 
         $path = $this->getPath($name);

--- a/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
@@ -145,6 +145,7 @@ class ComponentMakeCommand extends GeneratorCommand
         return [
             ['force', null, InputOption::VALUE_NONE, 'Create the class even if the component already exists'],
             ['inline', null, InputOption::VALUE_NONE, 'Create a component that renders an inline view'],
+            ['anonymous', null, InputOption::VALUE_NONE, 'Create an anonymous component'],
         ];
     }
 }


### PR DESCRIPTION
This PR allows the `make:component` command to make an [anonymous component](https://laravel.com/docs/8.x/blade#anonymous-components). 

Class-based and inline components can already be generated using this command, but not anonymous.

Adding the `--anonymous` option will simply generate the relevant view as usual, but will prevent the class being generated.