### PR TITLE
Added new whereDoesntHaveAny method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -192,9 +192,9 @@ trait QueriesRelationships
     public function whereDoesntHaveAny($relations, $boolean = 'and', $callback = null)
     {
         $closure = function ($q) use (&$closure, &$relations, $callback) {
-            // In order to nest "has", we need to add count relation constraints on the
-            // callback Closure. We'll do this by simply passing the Closure its own
-            // reference to itself so it calls itself recursively on each segment.
+            // Made use of the closure method used in hasNested()
+            // to loop over the relations and recursively call itself to exclude
+            // all passed relations
             count($relations) > 1
                 ? $q->whereDoesntHave(array_shift($relations), $closure)
                 : $q->has(array_shift($relations), '<', 1, 'and', $callback);

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -349,6 +349,18 @@ trait QueriesRelationships
     }
 
     /**
+     * @param array $relations
+     * @param Closure|null $callback
+     * @return \Illuminate\Database\Eloquent\Builder|static
+     */
+    public function whereDoesntHaveAny($relations, Closure $callback = null)
+    {
+        foreach ($relations as $relation) {
+            return $this->doesntHave($relation);
+        }
+    }
+
+    /**
      * Add a basic where clause to a relationship query.
      *
      * @param  string  $relation

--- a/tests/Integration/Database/EloquentWhereHasTest.php
+++ b/tests/Integration/Database/EloquentWhereHasTest.php
@@ -151,7 +151,7 @@ class Image extends Model
 {
     public $timestamps = false;
 
-    public function commentable()
+    public function imageable()
     {
         return $this->morphTo();
     }

--- a/tests/Integration/Database/EloquentWhereHasTest.php
+++ b/tests/Integration/Database/EloquentWhereHasTest.php
@@ -39,6 +39,8 @@ class EloquentWhereHasTest extends DatabaseTestCase
         $user = User::create();
         $post = tap((new Post(['public' => false]))->user()->associate($user))->save();
         (new Comment)->commentable()->associate($post)->save();
+
+        $post = tap((new Post(['public' => false])))->save();
     }
 
     public function testWhereRelation()
@@ -78,6 +80,13 @@ class EloquentWhereHasTest extends DatabaseTestCase
         })->get();
 
         $this->assertEquals([1], $users->pluck('id')->all());
+    }
+
+    public function testWhereDoesntHaveAny()
+    {
+        $post = Post::whereDoesntHaveAny(['comments', 'user'])->get();
+
+        $this->assertEquals([3], $post->pluck('id')->all());
     }
 }
 

--- a/tests/Integration/Database/EloquentWhereHasTest.php
+++ b/tests/Integration/Database/EloquentWhereHasTest.php
@@ -62,7 +62,7 @@ class EloquentWhereHasTest extends DatabaseTestCase
     {
         $users = User::whereRelation('posts', 'public', true)->orWhereRelation('posts', 'public', false)->get();
 
-        $this->assertEquals([1, 2], $users->pluck('id')->all());
+        $this->assertEquals([1, 2, 3], $users->pluck('id')->all());
     }
 
     public function testWhereMorphRelation()

--- a/tests/Integration/Database/EloquentWhereHasTest.php
+++ b/tests/Integration/Database/EloquentWhereHasTest.php
@@ -106,6 +106,11 @@ class Comment extends Model
     {
         return $this->morphTo();
     }
+
+    public function images()
+    {
+        return $this->morphMany(Image::class, 'imageable');
+    }
 }
 
 class Post extends Model


### PR DESCRIPTION
# What?

This is just a simple addition to the doesntHave method.

# How?

By adding a `whereDoesntHaveAny()` function that loops over the passed array of relations and returns all records that do not have the provided relations.

# Why?

If you wanted to retrieve records but exclude those with a set of relations you'd previously have to chain multiple `whereDoesntHave()` queries in order to remove all records with your undesired relations.

# Who?

I'm quite new to web development and have been a professional developer for 4 years and this is my first open source contribution.

I apologise in advance for anything i may have gotten wrong.