### PR TITLE
[8.x] Fixes `alreadyExists` on `ListenerMakeCommand`

### DIFF
--- a/src/Illuminate/Foundation/Console/EventMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/EventMakeCommand.php
@@ -35,8 +35,7 @@ class EventMakeCommand extends GeneratorCommand
      */
     protected function alreadyExists($rawName)
     {
-        return class_exists($rawName) ||
-               $this->files->exists($this->getPath($this->qualifyClass($rawName)));
+        return class_exists($rawName) || parent::alreadyExists($rawName);
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
@@ -82,7 +82,7 @@ class ListenerMakeCommand extends GeneratorCommand
      */
     protected function alreadyExists($rawName)
     {
-        return class_exists($rawName);
+        return class_exists($rawName) || parent::alreadyExists($rawName);
     }
 
     /**


### PR DESCRIPTION
This PR fixes the issue on the command `make:listener` as it is right now it overwrites the class event if the class already exist.

## Before:

![image](https://user-images.githubusercontent.com/823088/134967908-06d320cb-7339-45bf-b488-55d089d9669e.png)

## After 

![image](https://user-images.githubusercontent.com/823088/134968440-2db19224-3748-433c-b6fb-5e8958b64dd5.png)


Also on EventMakeCommand the `$this->files->exists($this->getPath($this->qualifyClass($rawName)))` is the same on the parent class so I changed to:

```php
return class_exists($rawName) || parent::alreadyExists($rawName);
```


Hope that helps,
Thanks,
Francisco