### PR TITLE
[8.x] Fix casting to string on PHP 8.1

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -252,6 +252,7 @@ class Str
     public static function is($pattern, $value)
     {
         $patterns = Arr::wrap($pattern);
+
         $value = (string) $value;
 
         if (empty($patterns)) {

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -252,12 +252,15 @@ class Str
     public static function is($pattern, $value)
     {
         $patterns = Arr::wrap($pattern);
+        $value = (string) $value;
 
         if (empty($patterns)) {
             return false;
         }
 
         foreach ($patterns as $pattern) {
+            $pattern = (string) $pattern;
+
             // If the given value is an exact match we can of course return true right
             // from the beginning. Otherwise, we will translate asterisks and do an
             // actual pattern match against the two strings to see if they match.

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -272,6 +272,8 @@ class SupportStrTest extends TestCase
 
         // empty patterns
         $this->assertFalse(Str::is([], 'test'));
+        $this->assertFalse(Str::is([null], 0));
+        $this->assertTrue(Str::is([null], null));
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -272,6 +272,8 @@ class SupportStrTest extends TestCase
 
         // empty patterns
         $this->assertFalse(Str::is([], 'test'));
+
+        $this->assertFalse(Str::is('', 0));
         $this->assertFalse(Str::is([null], 0));
         $this->assertTrue(Str::is([null], null));
     }


### PR DESCRIPTION
Adopt the same tests from https://github.com/laravel/framework/pull/34670 to fix null passing to `Str::is` for PHP 8.1