### PR TITLE
[8.x] Mail empty address handling

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -619,7 +619,7 @@ class Mailable implements MailableContract, Renderable
     protected function setAddress($address, $name = null, $property = 'to')
     {
         if (empty($address)) {
-            $address = [];
+            return $this;
         }
 
         foreach ($this->addressesToArray($address, $name) as $recipient) {

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -621,6 +621,7 @@ class Mailable implements MailableContract, Renderable
         if (empty($address)) {
             $address = [];
         }
+
         foreach ($this->addressesToArray($address, $name) as $recipient) {
             $recipient = $this->normalizeRecipient($recipient);
 

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -618,6 +618,9 @@ class Mailable implements MailableContract, Renderable
      */
     protected function setAddress($address, $name = null, $property = 'to')
     {
+        if (empty($address)) {
+            $address = [];
+        }
         foreach ($this->addressesToArray($address, $name) as $recipient) {
             $recipient = $this->normalizeRecipient($recipient);
 
@@ -679,6 +682,10 @@ class Mailable implements MailableContract, Renderable
      */
     protected function hasRecipient($address, $name = null, $property = 'to')
     {
+        if (empty($address)) {
+            return false;
+        }
+
         $expected = $this->normalizeRecipient(
             $this->addressesToArray($address, $name)[0]
         );

--- a/tests/Mail/MailMailableTest.php
+++ b/tests/Mail/MailMailableTest.php
@@ -52,6 +52,17 @@ class MailMailableTest extends TestCase
         ], $mailable->to);
         $this->assertTrue($mailable->hasTo(new MailableTestUserStub));
         $this->assertTrue($mailable->hasTo('taylor@laravel.com'));
+
+        $mailable = new WelcomeMailableStub;
+        $mailable->to('');
+        $this->assertFalse($mailable->hasTo(new MailableTestUserStub));
+        $this->assertFalse($mailable->hasTo(''));
+
+        $mailable = new WelcomeMailableStub;
+        $mailable->to(null);
+        $this->assertFalse($mailable->hasTo(new MailableTestUserStub));
+        $this->assertFalse($mailable->hasTo(null));
+
     }
 
     public function testMailableSetsCcRecipientsCorrectly()
@@ -108,6 +119,16 @@ class MailMailableTest extends TestCase
         ], $mailable->cc);
         $this->assertTrue($mailable->hasCc('taylor@laravel.com'));
         $this->assertTrue($mailable->hasCc('not-taylor@laravel.com'));
+
+        $mailable = new WelcomeMailableStub;
+        $mailable->cc('');
+        $this->assertFalse($mailable->hasCc(new MailableTestUserStub));
+        $this->assertFalse($mailable->hasCc(''));
+
+        $mailable = new WelcomeMailableStub;
+        $mailable->cc(null);
+        $this->assertFalse($mailable->hasCc(new MailableTestUserStub));
+        $this->assertFalse($mailable->hasCc(null));
     }
 
     public function testMailableSetsBccRecipientsCorrectly()
@@ -164,6 +185,16 @@ class MailMailableTest extends TestCase
         ], $mailable->bcc);
         $this->assertTrue($mailable->hasBcc('taylor@laravel.com'));
         $this->assertTrue($mailable->hasBcc('not-taylor@laravel.com'));
+
+        $mailable = new WelcomeMailableStub;
+        $mailable->bcc('');
+        $this->assertFalse($mailable->hasBcc(new MailableTestUserStub));
+        $this->assertFalse($mailable->hasBcc(''));
+
+        $mailable = new WelcomeMailableStub;
+        $mailable->bcc(null);
+        $this->assertFalse($mailable->hasBcc(new MailableTestUserStub));
+        $this->assertFalse($mailable->hasBcc(null));
     }
 
     public function testMailableSetsReplyToCorrectly()
@@ -211,6 +242,17 @@ class MailMailableTest extends TestCase
         ], $mailable->replyTo);
         $this->assertTrue($mailable->hasReplyTo(new MailableTestUserStub));
         $this->assertTrue($mailable->hasReplyTo('taylor@laravel.com'));
+
+        $mailable = new WelcomeMailableStub;
+        $mailable->replyTo('');
+        $this->assertFalse($mailable->hasReplyTo(new MailableTestUserStub));
+        $this->assertFalse($mailable->hasReplyTo(''));
+
+        $mailable = new WelcomeMailableStub;
+        $mailable->replyTo(null);
+        $this->assertFalse($mailable->hasReplyTo(new MailableTestUserStub));
+        $this->assertFalse($mailable->hasReplyTo(null));
+
     }
 
     public function testItIgnoresDuplicatedRawAttachments()

--- a/tests/Mail/MailMailableTest.php
+++ b/tests/Mail/MailMailableTest.php
@@ -255,6 +255,63 @@ class MailMailableTest extends TestCase
 
     }
 
+    public function testMailableSetsFromCorrectly()
+    {
+        $mailable = new WelcomeMailableStub;
+        $mailable->from('taylor@laravel.com');
+        $this->assertEquals([['name' => null, 'address' => 'taylor@laravel.com']], $mailable->from);
+        $this->assertTrue($mailable->hasFrom('taylor@laravel.com'));
+
+        $mailable = new WelcomeMailableStub;
+        $mailable->from('taylor@laravel.com', 'Taylor Otwell');
+        $this->assertEquals([['name' => 'Taylor Otwell', 'address' => 'taylor@laravel.com']], $mailable->from);
+        $this->assertTrue($mailable->hasFrom('taylor@laravel.com', 'Taylor Otwell'));
+        $this->assertTrue($mailable->hasFrom('taylor@laravel.com'));
+
+        $mailable = new WelcomeMailableStub;
+        $mailable->from(['taylor@laravel.com']);
+        $this->assertEquals([['name' => null, 'address' => 'taylor@laravel.com']], $mailable->from);
+        $this->assertTrue($mailable->hasFrom('taylor@laravel.com'));
+        $this->assertFalse($mailable->hasFrom('taylor@laravel.com', 'Taylor Otwell'));
+
+        $mailable = new WelcomeMailableStub;
+        $mailable->from([['name' => 'Taylor Otwell', 'email' => 'taylor@laravel.com']]);
+        $this->assertEquals([['name' => 'Taylor Otwell', 'address' => 'taylor@laravel.com']], $mailable->from);
+        $this->assertTrue($mailable->hasFrom('taylor@laravel.com', 'Taylor Otwell'));
+        $this->assertTrue($mailable->hasFrom('taylor@laravel.com'));
+
+        $mailable = new WelcomeMailableStub;
+        $mailable->from(new MailableTestUserStub);
+        $this->assertEquals([['name' => 'Taylor Otwell', 'address' => 'taylor@laravel.com']], $mailable->from);
+        $this->assertTrue($mailable->hasFrom(new MailableTestUserStub));
+        $this->assertTrue($mailable->hasFrom('taylor@laravel.com'));
+
+        $mailable = new WelcomeMailableStub;
+        $mailable->from(collect([new MailableTestUserStub]));
+        $this->assertEquals([['name' => 'Taylor Otwell', 'address' => 'taylor@laravel.com']], $mailable->from);
+        $this->assertTrue($mailable->hasFrom(new MailableTestUserStub));
+        $this->assertTrue($mailable->hasFrom('taylor@laravel.com'));
+
+        $mailable = new WelcomeMailableStub;
+        $mailable->from(collect([new MailableTestUserStub, new MailableTestUserStub]));
+        $this->assertEquals([
+            ['name' => 'Taylor Otwell', 'address' => 'taylor@laravel.com'],
+            ['name' => 'Taylor Otwell', 'address' => 'taylor@laravel.com'],
+        ], $mailable->from);
+        $this->assertTrue($mailable->hasFrom(new MailableTestUserStub));
+        $this->assertTrue($mailable->hasFrom('taylor@laravel.com'));
+
+        $mailable = new WelcomeMailableStub;
+        $mailable->from('');
+        $this->assertFalse($mailable->hasFrom(new MailableTestUserStub));
+        $this->assertFalse($mailable->hasFrom(''));
+
+        $mailable = new WelcomeMailableStub;
+        $mailable->from(null);
+        $this->assertFalse($mailable->hasFrom(new MailableTestUserStub));
+        $this->assertFalse($mailable->hasFrom(null));
+    }
+
     public function testItIgnoresDuplicatedRawAttachments()
     {
         $mailable = new WelcomeMailableStub;

--- a/tests/Mail/MailMailableTest.php
+++ b/tests/Mail/MailMailableTest.php
@@ -53,16 +53,12 @@ class MailMailableTest extends TestCase
         $this->assertTrue($mailable->hasTo(new MailableTestUserStub));
         $this->assertTrue($mailable->hasTo('taylor@laravel.com'));
 
-        $mailable = new WelcomeMailableStub;
-        $mailable->to('');
-        $this->assertFalse($mailable->hasTo(new MailableTestUserStub));
-        $this->assertFalse($mailable->hasTo(''));
-
-        $mailable = new WelcomeMailableStub;
-        $mailable->to(null);
-        $this->assertFalse($mailable->hasTo(new MailableTestUserStub));
-        $this->assertFalse($mailable->hasTo(null));
-
+        foreach (['', null, [], false] as $address) {
+            $mailable = new WelcomeMailableStub;
+            $mailable->to($address);
+            $this->assertFalse($mailable->hasTo(new MailableTestUserStub));
+            $this->assertFalse($mailable->hasTo($address));
+        }
     }
 
     public function testMailableSetsCcRecipientsCorrectly()
@@ -120,15 +116,12 @@ class MailMailableTest extends TestCase
         $this->assertTrue($mailable->hasCc('taylor@laravel.com'));
         $this->assertTrue($mailable->hasCc('not-taylor@laravel.com'));
 
-        $mailable = new WelcomeMailableStub;
-        $mailable->cc('');
-        $this->assertFalse($mailable->hasCc(new MailableTestUserStub));
-        $this->assertFalse($mailable->hasCc(''));
-
-        $mailable = new WelcomeMailableStub;
-        $mailable->cc(null);
-        $this->assertFalse($mailable->hasCc(new MailableTestUserStub));
-        $this->assertFalse($mailable->hasCc(null));
+        foreach (['', null, [], false] as $address) {
+            $mailable = new WelcomeMailableStub;
+            $mailable->cc($address);
+            $this->assertFalse($mailable->hasCc(new MailableTestUserStub));
+            $this->assertFalse($mailable->hasCc($address));
+        }
     }
 
     public function testMailableSetsBccRecipientsCorrectly()
@@ -186,15 +179,12 @@ class MailMailableTest extends TestCase
         $this->assertTrue($mailable->hasBcc('taylor@laravel.com'));
         $this->assertTrue($mailable->hasBcc('not-taylor@laravel.com'));
 
-        $mailable = new WelcomeMailableStub;
-        $mailable->bcc('');
-        $this->assertFalse($mailable->hasBcc(new MailableTestUserStub));
-        $this->assertFalse($mailable->hasBcc(''));
-
-        $mailable = new WelcomeMailableStub;
-        $mailable->bcc(null);
-        $this->assertFalse($mailable->hasBcc(new MailableTestUserStub));
-        $this->assertFalse($mailable->hasBcc(null));
+        foreach (['', null, [], false] as $address) {
+            $mailable = new WelcomeMailableStub;
+            $mailable->bcc($address);
+            $this->assertFalse($mailable->hasBcc(new MailableTestUserStub));
+            $this->assertFalse($mailable->hasBcc($address));
+        }
     }
 
     public function testMailableSetsReplyToCorrectly()
@@ -243,16 +233,12 @@ class MailMailableTest extends TestCase
         $this->assertTrue($mailable->hasReplyTo(new MailableTestUserStub));
         $this->assertTrue($mailable->hasReplyTo('taylor@laravel.com'));
 
-        $mailable = new WelcomeMailableStub;
-        $mailable->replyTo('');
-        $this->assertFalse($mailable->hasReplyTo(new MailableTestUserStub));
-        $this->assertFalse($mailable->hasReplyTo(''));
-
-        $mailable = new WelcomeMailableStub;
-        $mailable->replyTo(null);
-        $this->assertFalse($mailable->hasReplyTo(new MailableTestUserStub));
-        $this->assertFalse($mailable->hasReplyTo(null));
-
+        foreach (['', null, [], false] as $address) {
+            $mailable = new WelcomeMailableStub;
+            $mailable->replyTo($address);
+            $this->assertFalse($mailable->hasReplyTo(new MailableTestUserStub));
+            $this->assertFalse($mailable->hasReplyTo($address));
+        }
     }
 
     public function testMailableSetsFromCorrectly()
@@ -301,15 +287,12 @@ class MailMailableTest extends TestCase
         $this->assertTrue($mailable->hasFrom(new MailableTestUserStub));
         $this->assertTrue($mailable->hasFrom('taylor@laravel.com'));
 
-        $mailable = new WelcomeMailableStub;
-        $mailable->from('');
-        $this->assertFalse($mailable->hasFrom(new MailableTestUserStub));
-        $this->assertFalse($mailable->hasFrom(''));
-
-        $mailable = new WelcomeMailableStub;
-        $mailable->from(null);
-        $this->assertFalse($mailable->hasFrom(new MailableTestUserStub));
-        $this->assertFalse($mailable->hasFrom(null));
+        foreach (['', null, [], false] as $address) {
+            $mailable = new WelcomeMailableStub;
+            $mailable->from($address);
+            $this->assertFalse($mailable->hasFrom(new MailableTestUserStub));
+            $this->assertFalse($mailable->hasFrom($address));
+        }
     }
 
     public function testItIgnoresDuplicatedRawAttachments()


### PR DESCRIPTION
This PR is a follow-up to [this discussion](https://github.com/laravel/framework/discussions/39024).

Short version: I have an _optional_ `bcc` address set in config that all emailed messages are sent to. It works fine if that value is set, but if it's not, then Laravel just crashes. This PR makes all mail addressing functions (`to`, `cc`, `bcc`, `replyTo`, `from`) handle empty addresses cleanly. In the existing Laravel code, this code will fail if `mail.bcc` is not set in config:

```php
Mail::to($user)
    ->bcc(config('mail.bcc'))
    ->send(new Message($user));
```

Error:
> Attempt to read property "email" on null

The two patches (to `setAddress()` and `hasRecipient()`) use `empty()` to check the `$address` parameter, so that all empty/falsy values are handled, including `false`, `[]`, `null` and `''`.

Alternatives to this patch are not immediately obvious, for example, this doesn't work:

    ->bcc(config('mail.bcc', []))

because the config will only fall through to the default if the config value is `null` (missing from .env altogether), not just empty (present, but without a value, as is common in `.env.example` files). This works, but it's ugly and annoying to have to do every time, and you should not need to know the internals of the mail class in order to do this safely:

    ->bcc(config('mail.bcc') ?: []))

I note that there are no tests for bad inputs, only good ones, so I have added tests for these bad cases, and they fail without this patch.

I also noticed that there are no tests at all for the `from()` and `hasFrom()` methods, so I added a full set of those in the same style.