### PR TITLE
[8.x] Store artifacts for builds

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,6 +85,14 @@ jobs:
           AWS_ACCESS_KEY_ID: random_key
           AWS_SECRET_ACCESS_KEY: random_secret
 
+      - name: Store artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: logs
+          path: |
+            vendor/orchestra/testbench-core/laravel/storage/logs
+            !vendor/**/.gitignore
+
   windows_tests:
     runs-on: windows-latest
 
@@ -137,3 +145,12 @@ jobs:
 
       - name: Execute tests
         run: vendor/bin/phpunit --verbose
+          AWS_SECRET_ACCESS_KEY: random_secret
+
+      - name: Store artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: logs
+          path: |
+            vendor/orchestra/testbench-core/laravel/storage/logs
+            !vendor/**/.gitignore


### PR DESCRIPTION
This PR stores artifacts for builds so that logs from testbench are available after builds. This can come in handy when debugging build failures.
