### PR TITLE
[8.x] Fix haveibeenpwnd failures

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,14 +85,6 @@ jobs:
           AWS_ACCESS_KEY_ID: random_key
           AWS_SECRET_ACCESS_KEY: random_secret
 
-      - name: Archive artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: logs
-          path: |
-            vendor/orchestra/testbench-core/laravel/storage/logs
-            !vendor/**/.gitignore
-
   windows_tests:
     runs-on: windows-latest
 
@@ -145,11 +137,3 @@ jobs:
 
       - name: Execute tests
         run: vendor/bin/phpunit --verbose
-
-      - name: Archive artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: logs
-          path: |
-            vendor/orchestra/testbench-core/laravel/storage/logs
-            !vendor/**/.gitignore

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,6 +85,14 @@ jobs:
           AWS_ACCESS_KEY_ID: random_key
           AWS_SECRET_ACCESS_KEY: random_secret
 
+      - name: Archive artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: logs
+          path: |
+            vendor/orchestra/testbench-core/laravel/storage/logs
+            !vendor/**/.gitignore
+
   windows_tests:
     runs-on: windows-latest
 
@@ -137,3 +145,11 @@ jobs:
 
       - name: Execute tests
         run: vendor/bin/phpunit --verbose
+
+      - name: Archive artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: logs
+          path: |
+            vendor/orchestra/testbench-core/laravel/storage/logs
+            !vendor/**/.gitignore

--- a/src/Illuminate/Validation/NotPwnedVerifier.php
+++ b/src/Illuminate/Validation/NotPwnedVerifier.php
@@ -89,7 +89,7 @@ class NotPwnedVerifier implements UncompromisedVerifier
             ])->timeout($this->timeout)->get(
                 'https://api.pwnedpasswords.com/range/'.$hashPrefix
             );
-        } catch (Exception $e) {
+        } catch (Exception $e) {dd($e);
             report($e);
         }
 

--- a/src/Illuminate/Validation/NotPwnedVerifier.php
+++ b/src/Illuminate/Validation/NotPwnedVerifier.php
@@ -89,7 +89,8 @@ class NotPwnedVerifier implements UncompromisedVerifier
             ])->timeout($this->timeout)->get(
                 'https://api.pwnedpasswords.com/range/'.$hashPrefix
             );
-        } catch (Exception $e) {dd($e);
+        } catch (Exception $e) {
+            dd($e);
             report($e);
         }
 

--- a/src/Illuminate/Validation/NotPwnedVerifier.php
+++ b/src/Illuminate/Validation/NotPwnedVerifier.php
@@ -32,7 +32,7 @@ class NotPwnedVerifier implements UncompromisedVerifier
     public function __construct($factory, $timeout = null)
     {
         $this->factory = $factory;
-        $this->timeout = $timeout ?? 20;
+        $this->timeout = $timeout ?? 30;
     }
 
     /**

--- a/src/Illuminate/Validation/NotPwnedVerifier.php
+++ b/src/Illuminate/Validation/NotPwnedVerifier.php
@@ -90,7 +90,6 @@ class NotPwnedVerifier implements UncompromisedVerifier
                 'https://api.pwnedpasswords.com/range/'.$hashPrefix
             );
         } catch (Exception $e) {
-            dd($e);
             report($e);
         }
 

--- a/src/Illuminate/Validation/NotPwnedVerifier.php
+++ b/src/Illuminate/Validation/NotPwnedVerifier.php
@@ -32,7 +32,7 @@ class NotPwnedVerifier implements UncompromisedVerifier
     public function __construct($factory, $timeout = null)
     {
         $this->factory = $factory;
-        $this->timeout = $timeout ?? 10;
+        $this->timeout = $timeout ?? 20;
     }
 
     /**

--- a/tests/Validation/ValidationNotPwnedVerifierTest.php
+++ b/tests/Validation/ValidationNotPwnedVerifierTest.php
@@ -49,7 +49,7 @@ class ValidationNotPwnedVerifierTest extends TestCase
         $httpFactory
             ->shouldReceive('timeout')
             ->once()
-            ->with(20)
+            ->with(30)
             ->andReturn($httpFactory);
 
         $httpFactory->shouldReceive('get')
@@ -86,7 +86,7 @@ class ValidationNotPwnedVerifierTest extends TestCase
         $httpFactory
             ->shouldReceive('timeout')
             ->once()
-            ->with(20)
+            ->with(30)
             ->andReturn($httpFactory);
 
         $httpFactory->shouldReceive('get')

--- a/tests/Validation/ValidationNotPwnedVerifierTest.php
+++ b/tests/Validation/ValidationNotPwnedVerifierTest.php
@@ -105,40 +105,42 @@ class ValidationNotPwnedVerifierTest extends TestCase
         ]));
     }
 
-    // public function testDnsDown()
-    // {
-    //     $container = Container::getInstance();
-    //     $exception = new ConnectionException();
+    public function testDnsDown()
+    {
+        $container = Container::getInstance();
+        $exception = new ConnectionException();
 
-    //     $exceptionHandler = m::mock(ExceptionHandler::class);
-    //     $exceptionHandler->shouldReceive('report')->once()->with($exception);
-    //     $container->bind(ExceptionHandler::class, function () use ($exceptionHandler) {
-    //         return $exceptionHandler;
-    //     });
+        $exceptionHandler = m::mock(ExceptionHandler::class);
+        $exceptionHandler->shouldReceive('report')->once()->with($exception);
+        $container->bind(ExceptionHandler::class, function () use ($exceptionHandler) {
+            return $exceptionHandler;
+        });
 
-    //     $httpFactory = m::mock(HttpFactory::class);
+        $httpFactory = m::mock(HttpFactory::class);
 
-    //     $httpFactory
-    //         ->shouldReceive('withHeaders')
-    //         ->once()
-    //         ->with(['Add-Padding' => true])
-    //         ->andReturn($httpFactory);
+        $httpFactory
+            ->shouldReceive('withHeaders')
+            ->once()
+            ->with(['Add-Padding' => true])
+            ->andReturn($httpFactory);
 
-    //     $httpFactory
-    //         ->shouldReceive('timeout')
-    //         ->once()
-    //         ->with(20)
-    //         ->andReturn($httpFactory);
+        $httpFactory
+            ->shouldReceive('timeout')
+            ->once()
+            ->with(20)
+            ->andReturn($httpFactory);
 
-    //     $httpFactory
-    //         ->shouldReceive('get')
-    //         ->once()
-    //         ->andThrow($exception);
+        $httpFactory
+            ->shouldReceive('get')
+            ->once()
+            ->andThrow($exception);
 
-    //     $verifier = new NotPwnedVerifier($httpFactory);
-    //     $this->assertTrue($verifier->verify([
-    //         'value' => 123123123,
-    //         'threshold' => 0,
-    //     ]));
-    // }
+        $verifier = new NotPwnedVerifier($httpFactory);
+        $this->assertTrue($verifier->verify([
+            'value' => 123123123,
+            'threshold' => 0,
+        ]));
+
+        unset($container[ExceptionHandler::class]);
+    }
 }

--- a/tests/Validation/ValidationNotPwnedVerifierTest.php
+++ b/tests/Validation/ValidationNotPwnedVerifierTest.php
@@ -105,40 +105,40 @@ class ValidationNotPwnedVerifierTest extends TestCase
         ]));
     }
 
-    public function testDnsDown()
-    {
-        $container = Container::getInstance();
-        $exception = new ConnectionException();
+    // public function testDnsDown()
+    // {
+    //     $container = Container::getInstance();
+    //     $exception = new ConnectionException();
 
-        $exceptionHandler = m::mock(ExceptionHandler::class);
-        $exceptionHandler->shouldReceive('report')->once()->with($exception);
-        $container->bind(ExceptionHandler::class, function () use ($exceptionHandler) {
-            return $exceptionHandler;
-        });
+    //     $exceptionHandler = m::mock(ExceptionHandler::class);
+    //     $exceptionHandler->shouldReceive('report')->once()->with($exception);
+    //     $container->bind(ExceptionHandler::class, function () use ($exceptionHandler) {
+    //         return $exceptionHandler;
+    //     });
 
-        $httpFactory = m::mock(HttpFactory::class);
+    //     $httpFactory = m::mock(HttpFactory::class);
 
-        $httpFactory
-            ->shouldReceive('withHeaders')
-            ->once()
-            ->with(['Add-Padding' => true])
-            ->andReturn($httpFactory);
+    //     $httpFactory
+    //         ->shouldReceive('withHeaders')
+    //         ->once()
+    //         ->with(['Add-Padding' => true])
+    //         ->andReturn($httpFactory);
 
-        $httpFactory
-            ->shouldReceive('timeout')
-            ->once()
-            ->with(10)
-            ->andReturn($httpFactory);
+    //     $httpFactory
+    //         ->shouldReceive('timeout')
+    //         ->once()
+    //         ->with(10)
+    //         ->andReturn($httpFactory);
 
-        $httpFactory
-            ->shouldReceive('get')
-            ->once()
-            ->andThrow($exception);
+    //     $httpFactory
+    //         ->shouldReceive('get')
+    //         ->once()
+    //         ->andThrow($exception);
 
-        $verifier = new NotPwnedVerifier($httpFactory);
-        $this->assertTrue($verifier->verify([
-            'value' => 123123123,
-            'threshold' => 0,
-        ]));
-    }
+    //     $verifier = new NotPwnedVerifier($httpFactory);
+    //     $this->assertTrue($verifier->verify([
+    //         'value' => 123123123,
+    //         'threshold' => 0,
+    //     ]));
+    // }
 }

--- a/tests/Validation/ValidationNotPwnedVerifierTest.php
+++ b/tests/Validation/ValidationNotPwnedVerifierTest.php
@@ -127,7 +127,7 @@ class ValidationNotPwnedVerifierTest extends TestCase
         $httpFactory
             ->shouldReceive('timeout')
             ->once()
-            ->with(20)
+            ->with(30)
             ->andReturn($httpFactory);
 
         $httpFactory

--- a/tests/Validation/ValidationNotPwnedVerifierTest.php
+++ b/tests/Validation/ValidationNotPwnedVerifierTest.php
@@ -49,7 +49,7 @@ class ValidationNotPwnedVerifierTest extends TestCase
         $httpFactory
             ->shouldReceive('timeout')
             ->once()
-            ->with(10)
+            ->with(20)
             ->andReturn($httpFactory);
 
         $httpFactory->shouldReceive('get')
@@ -86,7 +86,7 @@ class ValidationNotPwnedVerifierTest extends TestCase
         $httpFactory
             ->shouldReceive('timeout')
             ->once()
-            ->with(10)
+            ->with(20)
             ->andReturn($httpFactory);
 
         $httpFactory->shouldReceive('get')
@@ -127,7 +127,7 @@ class ValidationNotPwnedVerifierTest extends TestCase
     //     $httpFactory
     //         ->shouldReceive('timeout')
     //         ->once()
-    //         ->with(10)
+    //         ->with(20)
     //         ->andReturn($httpFactory);
 
     //     $httpFactory


### PR DESCRIPTION
This PR bumps the default timeout for haveibeenpwnd API calls which caused our builds to randomly fail because of timeouts.

I've also included one fix to unbind the exception handler after a DNS test. It previously caused the handler to stay bound to the container and give false and unclear exceptions later on for subsequent failing tests.