### PR TITLE
Make ArgonHasher aware of argon provider

### DIFF
--- a/src/Illuminate/Hashing/ArgonHasher.php
+++ b/src/Illuminate/Hashing/ArgonHasher.php
@@ -45,7 +45,7 @@ class ArgonHasher extends AbstractHasher implements HasherContract
     {
         $this->time = $options['time'] ?? $this->time;
         $this->memory = $options['memory'] ?? $this->memory;
-        $this->threads = $options['threads'] ?? $this->threads;
+        $this->threads = $this->threads($options);
         $this->verifyAlgorithm = $options['verify'] ?? $this->verifyAlgorithm;
     }
 
@@ -187,6 +187,10 @@ class ArgonHasher extends AbstractHasher implements HasherContract
      */
     protected function threads(array $options)
     {
+        if (defined('PASSWORD_ARGON2_PROVIDER') && PASSWORD_ARGON2_PROVIDER === 'sodium') {
+            return 1;
+        }
+
         return $options['threads'] ?? $this->threads;
     }
 }

--- a/tests/Hashing/HasherTest.php
+++ b/tests/Hashing/HasherTest.php
@@ -23,10 +23,6 @@ class HasherTest extends TestCase
 
     public function testBasicArgon2iHashing()
     {
-        if (\PHP_VERSION_ID >= 80100) {
-            $this->markTestSkipped('Test failing in PHP 8.1');
-        }
-
         if (! defined('PASSWORD_ARGON2I')) {
             $this->markTestSkipped('PHP not compiled with Argon2i hashing support.');
         }
@@ -42,10 +38,6 @@ class HasherTest extends TestCase
 
     public function testBasicArgon2idHashing()
     {
-        if (\PHP_VERSION_ID >= 80100) {
-            $this->markTestSkipped('Test failing in PHP 8.1');
-        }
-
         if (! defined('PASSWORD_ARGON2ID')) {
             $this->markTestSkipped('PHP not compiled with Argon2id hashing support.');
         }
@@ -64,10 +56,6 @@ class HasherTest extends TestCase
      */
     public function testBasicBcryptVerification()
     {
-        if (\PHP_VERSION_ID >= 80100) {
-            $this->markTestSkipped('Test failing in PHP 8.1');
-        }
-
         $this->expectException(RuntimeException::class);
 
         if (! defined('PASSWORD_ARGON2I')) {


### PR DESCRIPTION
If sodium provides the argon2 then threads must be 1, if "standard" (libargon2) is the provider it can be 1 or 2.
Not sure why this seems to only affect PHP 8.1 however as the behaviour seems to date back quite a bit.

https://github.com/php/php-src/blob/2a3760a2d12b1a4c5c0207386b6cae84e404ee7e/ext/sodium/sodium_pwhash.c#L197

Related to thread here: https://twitter.com/nikita_ppv/status/1443525930979401733

This could be a potential fix if there's not a more elegant solution "upstream" in php-src found.

At this point it appears there is no way to control or manually set the `PASSWORD_ARGON2_PROVIDER`. As when you use/load the sodium extension it (libsodium) takes over functionality of hashing argon2 from libargon2. This is not something you can control via php.ini at this time - so I think the choice is either:

1. Compile with sodium extension and use libsodium for hashing,
2. do NOT compile sodium extension and use libargon2 for argon2 hashing.