### PR TITLE
[8.x] Allows EmailValidator to be faked on testing

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -680,7 +680,7 @@ trait ValidatesAttributes
             ->values()
             ->all() ?: [new RFCValidation];
 
-        return (new EmailValidator)->isValid($value, new MultipleValidationWithAnd($validations));
+        return $this->container->make(EmailValidator::class)->isValid($value, new MultipleValidationWithAnd($validations));
     }
 
     /**


### PR DESCRIPTION
## What?

Makes the `EmailValidator` resolvable via the Container. This allows to fake it on testing to bypass proper email validation when using extensive rules (like DNS records).

```php
public function test_route(): void 
{
    $this->mock(EmailValidator::class)->allows('isValid')->andReturnTrue();

    $this->post('test-route', [
        'name' => 'John',
        'email' => 'test@email.com'
    ]);

    // ...
}
```

## Why?

This avoids having to fake the whole validator, meaning, all rules become numb, or over-complicating the validation procedure fake just becase the email is being validated truthfully.

## BC?

None, it only changes the line that creates an `EmailValidator` instance.

From:

```php
return (new EmailValidator)->isValid($value, new MultipleValidationWithAnd($validations));
```

To:

```php
return $this->container->make(EmailValidator::class)->isValid($value, new MultipleValidationWithAnd($validations));
```