### PR TITLE
[8.x] Do not perform a restore if the model is not deleted

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -106,7 +106,7 @@ trait SoftDeletes
      * @return bool
      */
     public function restore()
-    {        
+    {
         if (! $this->trashed()) {
             return true;
         }

--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -103,10 +103,14 @@ trait SoftDeletes
     /**
      * Restore a soft-deleted model instance.
      *
-     * @return bool|null
+     * @return bool
      */
     public function restore()
-    {
+    {        
+        if (! $this->trashed()) {
+            return true;
+        }
+
         // If the restoring event does not return false, we will proceed with this
         // restore operation. Otherwise, we bail out so the developer will stop
         // the restore totally. We will clear the deleted timestamp and save.


### PR DESCRIPTION
We don't need to perform an update when a model is already not deleted.

I believe it should return a `true` immediately without firing any restore events; what do you think?

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
