### PR TITLE
[8.x] Add missing singular `minute()` call

### DIFF
--- a/src/Illuminate/Foundation/Testing/Wormhole.php
+++ b/src/Illuminate/Foundation/Testing/Wormhole.php
@@ -78,6 +78,17 @@ class Wormhole
      * @param  callable|null  $callback
      * @return mixed
      */
+    public function minute($callback = null)
+    {
+        return $this->minutes($callback);
+    }
+
+    /**
+     * Travel forward the given number of minutes.
+     *
+     * @param  callable|null  $callback
+     * @return mixed
+     */
     public function minutes($callback = null)
     {
         Carbon::setTestNow(Carbon::now()->addMinutes($this->value));


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

It looks like a `minute()` call was missed out from #38815, however I'm not entirely sure if this was intentional.

This works the same way as the existing singular calls for the other Wormhole methods:
```php
// Before
$this->travel(1)->minutes();
$this->travel(-1)->minutes();

// After
$this->travel(1)->minute();
$this->travel(-1)->minute();
```