### PR TITLE
[8.x] Add possibility to output an sql inlining the bindings to the screen

### DIFF
--- a/src/Illuminate/Database/Concerns/ShowsQueries.php
+++ b/src/Illuminate/Database/Concerns/ShowsQueries.php
@@ -53,10 +53,11 @@ trait ShowsQueries
                     break;
                 default:
                     $value = with($query->getConnection(), function ($connection) use ($value) {
-                        return $connection->getPdo()->quote((string)$value);
+                        return $connection->getPdo()->quote((string) $value);
                     });
                     break;
             }
+
             return $value;
 
         }, $query->toSql());

--- a/src/Illuminate/Database/Concerns/ShowsQueries.php
+++ b/src/Illuminate/Database/Concerns/ShowsQueries.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Illuminate\Database\Concerns;
+
+trait ShowsQueries
+{
+    /**
+     * Shows the query
+     *
+     * @return $this
+     */
+    public function show($toScreen = false)
+    {
+        $sql = $this->toSql();
+
+        $bindings = $this->getBindings();
+
+        echo $this->combineSqlAndBindings($sql, $bindings);
+
+        return $this;
+    }
+
+    private function combineSqlAndBindings($sql, $bindings)
+    {
+        return vsprintf(str_replace('?', '%s', $sql), collect($bindings)->map(function ($binding) {
+            return is_numeric($binding) ? $binding : "'{$binding}'";
+        })->toArray());
+    }
+}
+

--- a/src/Illuminate/Database/Concerns/ShowsQueries.php
+++ b/src/Illuminate/Database/Concerns/ShowsQueries.php
@@ -7,7 +7,7 @@ trait ShowsQueries
     /**
      * Shows the query.
      *
-     * @param \Closure $callback
+     * @param  \Closure|null  $callback
      * @return mixed
      */
     public function show(\Closure $callback = null)

--- a/src/Illuminate/Database/Concerns/ShowsQueries.php
+++ b/src/Illuminate/Database/Concerns/ShowsQueries.php
@@ -27,4 +27,3 @@ trait ShowsQueries
         })->toArray());
     }
 }
-

--- a/src/Illuminate/Database/Concerns/ShowsQueries.php
+++ b/src/Illuminate/Database/Concerns/ShowsQueries.php
@@ -9,7 +9,7 @@ trait ShowsQueries
      *
      * @return $this
      */
-    public function show($toScreen = false)
+    public function show()
     {
         $sql = $this->toSql();
 

--- a/src/Illuminate/Database/Concerns/ShowsQueries.php
+++ b/src/Illuminate/Database/Concerns/ShowsQueries.php
@@ -5,7 +5,7 @@ namespace Illuminate\Database\Concerns;
 trait ShowsQueries
 {
     /**
-     * Shows the query
+     * Shows the query.
      *
      * @return $this
      */

--- a/src/Illuminate/Database/Concerns/ShowsQueries.php
+++ b/src/Illuminate/Database/Concerns/ShowsQueries.php
@@ -39,7 +39,6 @@ trait ShowsQueries
         $bindings = $query->getConnection()->prepareBindings($query->getBindings());
 
         $sql = preg_replace_callback('/(?<!\?)\?(?!\?)/', function () use (&$bindings, $query) {
-
             $value = array_shift($bindings);
 
             switch ($value) {
@@ -59,7 +58,6 @@ trait ShowsQueries
             }
 
             return $value;
-
         }, $query->toSql());
 
         return $sql;

--- a/src/Illuminate/Database/Concerns/ShowsQueries.php
+++ b/src/Illuminate/Database/Concerns/ShowsQueries.php
@@ -7,19 +7,31 @@ trait ShowsQueries
     /**
      * Shows the query.
      *
-     * @return $this
+     * @param \Closure $callback
+     * @return mixed
      */
-    public function show()
+    public function show(\Closure $callback = null)
     {
         $sql = $this->toSql();
 
         $bindings = $this->getBindings();
 
-        echo $this->combineSqlAndBindings($sql, $bindings);
+        $sql = $this->combineSqlAndBindings($sql, $bindings);
+
+        if ($callback) {
+            $callback($sql);
+        } else {
+            echo $sql;
+        }
 
         return $this;
     }
 
+    /**
+     * @param $sql
+     * @param $bindings
+     * @return string
+     */
     private function combineSqlAndBindings($sql, $bindings)
     {
         return vsprintf(str_replace('?', '%s', $sql), collect($bindings)->map(function ($binding) {

--- a/src/Illuminate/Database/Concerns/ShowsQueries.php
+++ b/src/Illuminate/Database/Concerns/ShowsQueries.php
@@ -42,7 +42,7 @@ trait ShowsQueries
 
             $value = array_shift($bindings);
 
-            switch($value){
+            switch ($value) {
                 case null:
                     $value = 'null';
                     break;
@@ -52,7 +52,9 @@ trait ShowsQueries
                 case is_numeric($value):
                     break;
                 default:
-                    $value = with($query->getConnection(), fn ($connection) => $connection->getPdo()->quote((string) $value));
+                    $value = with($query->getConnection(), function ($connection) use ($value) {
+                        return $connection->getPdo()->quote((string)$value);
+                    });
                     break;
             }
             return $value;

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -8,6 +8,7 @@ use Exception;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Concerns\BuildsQueries;
 use Illuminate\Database\Concerns\ExplainsQueries;
+use Illuminate\Database\Concerns\ShowsQueries;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Builder as QueryBuilder;
@@ -26,7 +27,7 @@ use ReflectionMethod;
  */
 class Builder
 {
-    use Concerns\QueriesRelationships, ExplainsQueries, ForwardsCalls;
+    use Concerns\QueriesRelationships, ExplainsQueries, ForwardsCalls, ShowsQueries;
     use BuildsQueries {
         sole as baseSole;
     }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -7,6 +7,7 @@ use DateTimeInterface;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Concerns\BuildsQueries;
 use Illuminate\Database\Concerns\ExplainsQueries;
+use Illuminate\Database\Concerns\ShowsQueries;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Relations\Relation;
@@ -24,7 +25,7 @@ use RuntimeException;
 
 class Builder
 {
-    use BuildsQueries, ExplainsQueries, ForwardsCalls, Macroable {
+    use BuildsQueries, ExplainsQueries, ForwardsCalls, Macroable, ShowsQueries {
         __call as macroCall;
     }
 

--- a/tests/Database/ShowsQueriesTest.php
+++ b/tests/Database/ShowsQueriesTest.php
@@ -55,7 +55,7 @@ class ShowsQueriesTest extends TestCase
         $this->schema()->drop('products');
     }
 
-    public function testTheQuerieIshownByQueryBuilder()
+    public function testTheQueryIsShownByQueryBuilder()
     {
         ob_start();
         DB::table('products')->where('id', '=', 1)->show()->get();
@@ -65,7 +65,16 @@ class ShowsQueriesTest extends TestCase
         $this->assertEquals('select * from "products" where "id" = 1', $sql);
     }
 
-    public function testTheQuerieIshownByEloquentBuilder()
+    public function testTheQueryCallsItsCallback()
+    {
+        $callback = function(string $sql){
+            $this->assertEquals('select * from "products" where "id" = 1', $sql);
+        };
+
+        DB::table('products')->where('id', '=', 1)->show($callback)->get();
+    }
+
+    public function testTheQueryIsShownByEloquentBuilder()
     {
         ob_start();
         ProductTestContract::whereId(1)->show()->get();

--- a/tests/Database/ShowsQueriesTest.php
+++ b/tests/Database/ShowsQueriesTest.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group one-of-many
+ */
+class ShowsQueriesTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $db = new DB;
+
+        $db->addConnection([
+            'driver'   => 'sqlite',
+            'database' => ':memory:',
+        ]);
+
+        $db->bootEloquent();
+        $db->setAsGlobal();
+
+        $this->createSchema();
+    }
+
+    /**
+     * Setup the database schema.
+     *
+     * @return void
+     */
+    public function createSchema()
+    {
+        $this->schema()->create('products', function ($table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->string('category_id');
+        });
+
+        $this->schema()->create('categories', function ($table) {
+            $table->increments('id');
+            $table->string('name');
+        });
+
+    }
+
+    /**
+     * Tear down the database schema.
+     *
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        $this->schema()->drop('products');
+    }
+
+    public function testTheQuerieIshownByQueryBuilder()
+    {
+        ob_start();
+        DB::table('products')->where('id', '=', 1)->show()->get();
+        $sql = ob_get_contents();
+        ob_end_clean();
+
+        $this->assertEquals('select * from "products" where "id" = 1', $sql);
+
+    }
+
+    public function testTheQuerieIshownByEloquentBuilder()
+    {
+        ob_start();
+        ProductTestContract::whereId(1)->show()->get();
+        $sql = ob_get_contents();
+        ob_end_clean();
+
+        $this->assertEquals('select * from "products" where "id" = 1', $sql);
+
+        ob_start();
+        ProductTestContract::whereHas('category')->show();
+        $sql = ob_get_contents();
+        ob_end_clean();
+
+        $this->assertEquals('select * from "products" where exists (select * from "categories" where "products"."category_id" = "categories"."id")', $sql);
+    }
+
+    /**
+     * Get a database connection instance.
+     *
+     * @return \Illuminate\Database\Connection
+     */
+    protected function connection()
+    {
+        return Eloquent::getConnectionResolver()->connection();
+    }
+
+    /**
+     * Get a schema builder instance.
+     *
+     * @return \Illuminate\Database\Schema\Builder
+     */
+    protected function schema()
+    {
+        return $this->connection()->getSchemaBuilder();
+    }
+
+    private function doISeeTheSqlOnView(string $sql)
+    {
+
+        $view->assertSee($sql);
+    }
+
+}
+
+/**
+ * Eloquent Models...
+ */
+class ProductTestContract extends Eloquent
+{
+    protected $table   = 'products';
+    protected $guarded = [];
+
+    public function category()
+    {
+        return $this->belongsTo(CategoryTestContract::class);
+    }
+}
+
+class CategoryTestContract extends Eloquent
+{
+    protected $table   = 'categories';
+    protected $guarded = [];
+
+    public function category()
+    {
+        return $this->belongsTo(ProductTestContract::class);
+    }
+}

--- a/tests/Database/ShowsQueriesTest.php
+++ b/tests/Database/ShowsQueriesTest.php
@@ -67,7 +67,7 @@ class ShowsQueriesTest extends TestCase
 
     public function testTheQueryCallsItsCallback()
     {
-        $callback = function(string $sql){
+        $callback = function (string $sql){
             $this->assertEquals('select * from "products" where "id" = 1', $sql);
         };
 

--- a/tests/Database/ShowsQueriesTest.php
+++ b/tests/Database/ShowsQueriesTest.php
@@ -77,7 +77,7 @@ class ShowsQueriesTest extends TestCase
         $this->assertEquals('select * from "products" where "id" = 1', $sql);
 
         ob_start();
-        ProductTestContract::whereHas('category')->show();
+        ProductTestContract::whereHas('category')->show()->get();
         $sql = ob_get_contents();
         ob_end_clean();
 

--- a/tests/Database/ShowsQueriesTest.php
+++ b/tests/Database/ShowsQueriesTest.php
@@ -43,7 +43,6 @@ class ShowsQueriesTest extends TestCase
             $table->increments('id');
             $table->string('name');
         });
-
     }
 
     /**
@@ -64,7 +63,6 @@ class ShowsQueriesTest extends TestCase
         ob_end_clean();
 
         $this->assertEquals('select * from "products" where "id" = 1', $sql);
-
     }
 
     public function testTheQuerieIshownByEloquentBuilder()
@@ -104,12 +102,6 @@ class ShowsQueriesTest extends TestCase
         return $this->connection()->getSchemaBuilder();
     }
 
-    private function doISeeTheSqlOnView(string $sql)
-    {
-
-        $view->assertSee($sql);
-    }
-
 }
 
 /**
@@ -117,7 +109,7 @@ class ShowsQueriesTest extends TestCase
  */
 class ProductTestContract extends Eloquent
 {
-    protected $table   = 'products';
+    protected $table = 'products';
     protected $guarded = [];
 
     public function category()
@@ -128,7 +120,7 @@ class ProductTestContract extends Eloquent
 
 class CategoryTestContract extends Eloquent
 {
-    protected $table   = 'categories';
+    protected $table = 'categories';
     protected $guarded = [];
 
     public function category()

--- a/tests/Database/ShowsQueriesTest.php
+++ b/tests/Database/ShowsQueriesTest.php
@@ -101,7 +101,6 @@ class ShowsQueriesTest extends TestCase
     {
         return $this->connection()->getSchemaBuilder();
     }
-
 }
 
 /**

--- a/tests/Database/ShowsQueriesTest.php
+++ b/tests/Database/ShowsQueriesTest.php
@@ -67,7 +67,7 @@ class ShowsQueriesTest extends TestCase
 
     public function testTheQueryCallsItsCallback()
     {
-        $callback = function (string $sql){
+        $callback = function (string $sql) {
             $this->assertEquals('select * from "products" where "id" = 1', $sql);
         };
 


### PR DESCRIPTION
## What ? 

A trait added to the Eloquent Builder and Query Builder to make it possible to **echo** the current **sql with bindings** included on the builder

## Usage 

The **Query Builder**
```php
DB::table('products')->where('id', '=', 1)->show()->get();
```


The **Eloquent Builder**

```php
Product::whereHas('category')->show()->get();
```
@Jubeki gave some valuable feedback 👏  and I've added the possibilty to pass a callback if you don't want the echo output. So you can decide whatever you want to do with the sql statement.

```php 
$callback = function(string $sql){
     Log::info($sql);
};

DB::table('products')->where('id', '=', 1)->show($callback)->get();
```

## Why

We often want to **show the query ( including the filled in bindings )** that will run against our database server.  You can do that with many of the community driven profiling tools but they are mostly thrown in a container together with other sql statements.  So you have to start dig into the bunch of statements ran against your database.  I find myself writing a macro over and over again to have the possibility of this pull request , maybe it might be a nice addition to the framework itself.

## Thoughts 

I now did the **output** to the **screen** , that's a **choice** , **but** also a **doubt**.  I find it **must** **return** the **Builder** instance and not a string  ( because not wanting to break the chain ).  The **doubt** in it is that the **user gets no choice** ...It's always an output , and not a log entry.    **EDIT** after the feedback from @Jubeki i've made it possible to pass it a closure

Could extend it but might be too much complex for developers using it.  What's your opinion on that ?
