### PR TITLE
[8.x] Add an option to allow generating inbound casts

### DIFF
--- a/src/Illuminate/Foundation/Console/CastMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/CastMakeCommand.php
@@ -34,6 +34,10 @@ class CastMakeCommand extends GeneratorCommand
      */
     protected function getStub()
     {
+        if ($this->option('inbound')) {
+            return $this->resolveStubPath('/stubs/cast-inbound.stub');
+        }
+
         return $this->resolveStubPath('/stubs/cast.stub');
     }
 

--- a/src/Illuminate/Foundation/Console/stubs/cast-inbound.stub
+++ b/src/Illuminate/Foundation/Console/stubs/cast-inbound.stub
@@ -1,0 +1,22 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Contracts\Database\Eloquent\CastsInboundAttributes;
+
+class {{ class }} implements CastsInboundAttributes
+{
+    /**
+     * Prepare the given value for storage.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  array  $attributes
+     * @return mixed
+     */
+    public function set($model, string $key, $value, array $attributes)
+    {
+        return $value;
+    }
+}


### PR DESCRIPTION
This PR adds a new option `--inbound` to the make cast command to allow generating [inbound cast](https://laravel.com/docs/8.x/eloquent-mutators#inbound-casting) objects.