### PR TITLE
[8.x] Add stopOnFirstFailure() Method to the Validator Interface

### DIFF
--- a/src/Illuminate/Contracts/Validation/Validator.php
+++ b/src/Illuminate/Contracts/Validation/Validator.php
@@ -62,4 +62,9 @@ interface Validator extends MessageProvider
      * @return \Illuminate\Support\MessageBag
      */
     public function errors();
+    /**
+     * Stops validation after encountering first error
+     * @return void
+     */
+    public function stopOnFirstFailure();
 }

--- a/src/Illuminate/Contracts/Validation/Validator.php
+++ b/src/Illuminate/Contracts/Validation/Validator.php
@@ -64,7 +64,7 @@ interface Validator extends MessageProvider
     public function errors();
     /**
      * Stops validation after encountering first error
-     * @return void
+     * 
      */
     public function stopOnFirstFailure();
 }


### PR DESCRIPTION
stopOnFirstFailure() method was not added to the Validator Interface making the code Editor to resolve that stopOnFirstFailure() method does not exist on validator instance. this results in the compiler flagging the whole Controller as containing an error.

This fix will allow the method to be detected as a child of the validator Class