### PR TITLE
[8.x] Add values() method in request class

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -246,6 +246,17 @@ trait InteractsWithInput
     }
 
     /**
+     * Get the values for all of the input and files.
+     *
+     * @param  array|mixed|null  $keys
+     * @return array
+     */
+    public function values($keys = null)
+    {
+        return array_values($this->all(is_array($keys) ? $keys : func_get_args()));
+    }
+
+    /**
      * Get all of the input and files for the request.
      *
      * @param  array|mixed|null  $keys

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -248,7 +248,7 @@ trait InteractsWithInput
     /**
      * Get the values for all of the input and files.
      *
-     * @param  array|mixed|null  $keys
+     * @param  mixed  $keys
      * @return array
      */
     public function values($keys = null)
@@ -259,7 +259,7 @@ trait InteractsWithInput
     /**
      * Get all of the input and files for the request.
      *
-     * @param  array|mixed|null  $keys
+     * @param  mixed  $keys
      * @return array
      */
     public function all($keys = null)

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -589,6 +589,35 @@ class HttpRequestTest extends TestCase
         $this->assertEquals(['name', 'foo'], $request->keys());
     }
 
+    public function testValuesMethod()
+    {
+        $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => null]);
+        $this->assertEquals(['Taylor', null], $request->values());
+        $this->assertEquals(['Taylor'], $request->values('name'));
+        $this->assertEquals([null], $request->values('age'));
+        $this->assertEquals([null, 'Taylor'], $request->values('age', 'name'));
+
+        $files = [
+            'foo' => [
+                'size' => 500,
+                'name' => 'foo.jpg',
+                'tmp_name' => __FILE__,
+                'type' => 'blah',
+                'error' => null,
+            ],
+        ];
+        $request = Request::create('/', 'GET', [], [], $files);
+        $this->assertEquals([
+            $request->file('foo'),
+        ], $request->values());
+
+        $request = Request::create('/', 'GET', ['name' => 'Taylor'], [], $files);
+        $this->assertEquals([
+            'Taylor',
+            $request->file('foo'),
+        ], $request->values());
+    }
+
     public function testOnlyMethod()
     {
         $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => null]);


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

## Use case

When I have a FormRequest: 

```php
class LoginRequest extends FormRequest
{
    public function rules(): array
    {
        return [
            'username' => 'string|required',
            'password' => 'string|required',
        ];
    }
}
```

The following is usage in controller:

```php
public function __invoke(LoginRequest $request, Auth $auth)
{
    // Usage 1: Get all data and use array key to access
    $data = $reqeust->all();
    $auth->auth($data['username'], $data['password']);

    // Usage 2: Get specify data
    $auth->auth($reqeust->get('username'), $reqeust->get('password'));

    // NEW Usage: use values method
    [$username, $password] = $reqeust->values('username', 'password');
    $auth->auth($username, $password);
}
```

## Why?

It's more readable then using array key or get method to access:

```php
// Bad
$auth->auth($data['username'], $data['password']);
$auth->auth($reqeust->get('username'), $reqeust->get('password'));

// Good
$auth->auth($username, $password);
```

It's can improved a lot if the same variable is used many times.