### PR TITLE
[8.x] Added ability to set withTrashed on route groups

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -593,6 +593,11 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     protected function mergeGroupAttributesIntoRoute($route)
     {
+        if(!empty($this->groupStack[0]['withTrashed']) && $this->groupStack[0]['withTrashed'])
+        {
+            $route->withTrashed();
+        }
+
         $route->setAction($this->mergeWithLastGroup(
             $route->getAction(),
             $prependExistingPrefix = false

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -593,8 +593,7 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     protected function mergeGroupAttributesIntoRoute($route)
     {
-        if(!empty($this->groupStack[0]['withTrashed']) && $this->groupStack[0]['withTrashed'])
-        {
+        if (! empty($this->groupStack[0]['withTrashed']) && $this->groupStack[0]['withTrashed']) {
             $route->withTrashed();
         }
 

--- a/tests/Integration/Routing/ImplicitRouteBindingTest.php
+++ b/tests/Integration/Routing/ImplicitRouteBindingTest.php
@@ -148,6 +148,20 @@ PHP);
             Route::get('/{user}/edit', function (ImplicitBindingModel $user) {
                 return $user;
             });
+
+            Route::group(['prefix' => 'users'], function() {
+                Route::get('/{user}/edit', function (ImplicitBindingModel $user) {
+                    return $user;
+                });
+            });
+        });
+
+        Route::group(['prefix' => 'not-trashed'], function() {
+            Route::group(['prefix' => 'users', 'withTrashed' => true], function() {
+                Route::get('/{user}/edit', function (ImplicitBindingModel $user) {
+                    return $user;
+                });
+            });
         });
 
         $post_response = $this->postJson("/user/{$user->id}");
@@ -160,6 +174,20 @@ PHP);
         $edit_response = $this->getJson("/user/{$user->id}/edit");
 
         $edit_response->assertJson([
+            'id' => $user->id,
+            'name' => $user->name,
+        ]);
+
+        $nested_edit_response = $this->getJson("/user/users/{$user->id}/edit");
+
+        $nested_edit_response->assertJson([
+            'id' => $user->id,
+            'name' => $user->name,
+        ]);
+
+        $not_trashed_nested_edit_response = $this->getJson("/user/users/{$user->id}/edit");
+
+        $not_trashed_nested_edit_response->assertJson([
             'id' => $user->id,
             'name' => $user->name,
         ]);

--- a/tests/Integration/Routing/ImplicitRouteBindingTest.php
+++ b/tests/Integration/Routing/ImplicitRouteBindingTest.php
@@ -131,6 +131,39 @@ PHP);
             'name' => $user->name,
         ]);
     }
+
+    public function testSoftDeletedModelsCanBeRetrievedUsingWithTrashedMethodOnGroups()
+    {
+        $user = ImplicitBindingModel::create(['name' => 'Dries']);
+
+        $user->delete();
+
+        config(['app.key' => str_repeat('a', 32)]);
+
+        Route::group(['prefix' => 'user', 'middleware' => 'web', 'withTrashed' => true], function() {
+            Route::post('/{user}', function (ImplicitBindingModel $user) {
+                return $user;
+            });
+
+            Route::get('/{user}/edit', function (ImplicitBindingModel $user) {
+                return $user;
+            });
+        });
+
+        $post_response = $this->postJson("/user/{$user->id}");
+
+        $post_response->assertJson([
+            'id' => $user->id,
+            'name' => $user->name,
+        ]);
+
+        $edit_response = $this->getJson("/user/{$user->id}/edit");
+
+        $edit_response->assertJson([
+            'id' => $user->id,
+            'name' => $user->name,
+        ]);
+    }
 }
 
 class ImplicitBindingModel extends Model

--- a/tests/Integration/Routing/ImplicitRouteBindingTest.php
+++ b/tests/Integration/Routing/ImplicitRouteBindingTest.php
@@ -140,7 +140,7 @@ PHP);
 
         config(['app.key' => str_repeat('a', 32)]);
 
-        Route::group(['prefix' => 'user', 'middleware' => 'web', 'withTrashed' => true], function() {
+        Route::group(['prefix' => 'user', 'middleware' => 'web', 'withTrashed' => true], function () {
             Route::post('/{user}', function (ImplicitBindingModel $user) {
                 return $user;
             });
@@ -149,15 +149,15 @@ PHP);
                 return $user;
             });
 
-            Route::group(['prefix' => 'users'], function() {
+            Route::group(['prefix' => 'users'], function () {
                 Route::get('/{user}/edit', function (ImplicitBindingModel $user) {
                     return $user;
                 });
             });
         });
 
-        Route::group(['prefix' => 'not-trashed'], function() {
-            Route::group(['prefix' => 'users', 'withTrashed' => true], function() {
+        Route::group(['prefix' => 'not-trashed'], function () {
+            Route::group(['prefix' => 'users', 'withTrashed' => true], function () {
                 Route::get('/{user}/edit', function (ImplicitBindingModel $user) {
                     return $user;
                 });


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Recently the [`withTrashed`](https://github.com/laravel/framework/pull/#38348) method for routes was introduced. This function already helps quite a lot. But I have a project with one route group containing more than 50 "withTrashed" routes. To me repeating something so small over 50 times doesn't feel like the Laravel way of doing things. 

So instead of having to do:
```php
Route::group(['prefix' => 'trashed', 'as' => 'trashed.'], function() {
  Route::get('users/{user}', [User::class, 'show'])->name('users.show')->withTrashed();
  Route::get('projects/{project}', [Project::class, 'show'])->name('projects.show')->withTrashed();
  Route::get('invoices/{invoice}', [Invoice::class, 'show'])->name('invoices.show')->withTrashed();
  Route::get('members/{member}', [Member::class, 'show'])->name('members.show')->withTrashed();
});
```
You can now simply do:

```php
Route::group(['prefix' => 'trashed', 'as' => 'trashed.', 'withTrashed' => true], function() {
  Route::get('users/{user}', [User::class, 'show'])->name('users.show');
  Route::get('projects/{project}', [Project::class, 'show'])->name('projects.show');
  Route::get('invoices/{invoice}', [Invoice::class, 'show'])->name('invoices.show');
  Route::get('members/{member}', [Member::class, 'show'])->name('members.show');
});
```

Right now adding the `withTrashed` method to routes seems to be in the wrong spot. So please let me know of a better place so we can also remove the hardcoded `[0]`.