### PR TITLE
[8.x] Make it easy to output an empty line on the CLI

### DIFF
--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -290,7 +290,7 @@ trait InteractsWithIO
      * @param  int|string|null  $verbosity
      * @return void
      */
-    public function line($string, $style = null, $verbosity = null)
+    public function line($string = '', $style = null, $verbosity = null)
     {
         $styled = $style ? "<$style>$string</$style>" : $string;
 


### PR DESCRIPTION
Right now, you can create an empty line on the CLI with:

```php
$this->line('');
```

This PR makes passing that empty string optional.

```php
$this->line();
```