### PR TITLE
[8.x] Add nested relationships to whereRelation function

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -374,6 +374,7 @@ trait QueriesRelationships
             function($query) use ($relations, $column, $operator, $value) {
                 $query->whereHas($relations->first(), function ($query) use ($relations, $column, $operator, $value) {
                     $relations->shift();
+
                     $query->whereRelation($relations->implode('.'), $column, $operator, $value);
                 });
             }
@@ -403,6 +404,7 @@ trait QueriesRelationships
             function($query) use ($relations, $column, $operator, $value) {
                 $query->orWhereHas($relations->first(), function ($query) use ($relations, $column, $operator, $value) {
                     $relations->shift();
+
                     $query->orWhereRelation($relations->implode('.'), $column, $operator, $value);
                 });
             }

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -367,7 +367,7 @@ trait QueriesRelationships
         return $this->when(
             $relations->count() == 1,
             function($query) use ($relations, $column, $operator, $value) {
-                $query->whereHas($relations->first(), function ($query) use ($column,  $operator, $value) {
+                $query->whereHas($relations->first(), function ($query) use ($column, $operator, $value) {
                     $query->where($column, $operator, $value);
                 });
             },
@@ -396,7 +396,7 @@ trait QueriesRelationships
         return $this->when(
             $relations->count() == 1,
             function($query) use ($relations, $column, $operator, $value) {
-                $query->orWhereHas($relations->first(), function ($query) use ($column,  $operator, $value) {
+                $query->orWhereHas($relations->first(), function ($query) use ($column, $operator, $value) {
                     $query->where($column, $operator, $value);
                 });
             },

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -353,7 +353,6 @@ trait QueriesRelationships
 
     /**
      * Add a basic where clause to a relationship query.
-     * Relationship can be nested using dot notation.
      *
      * @param  string  $relation
      * @param  \Closure|string|array|\Illuminate\Database\Query\Expression  $column
@@ -364,6 +363,7 @@ trait QueriesRelationships
     public function whereRelation($relation, $column, $operator = null, $value = null)
     {
         $relations = collect(explode('.', $relation));
+
         return $this->when(
             $relations->count() == 1,
             function($query) use ($relations, $column, $operator, $value) {
@@ -382,7 +382,6 @@ trait QueriesRelationships
 
     /**
      * Add an "or where" clause to a relationship query.
-     * Relationship can be nested using dot notation.
      *
      * @param  string  $relation
      * @param  \Closure|string|array|\Illuminate\Database\Query\Expression  $column
@@ -393,6 +392,7 @@ trait QueriesRelationships
     public function orWhereRelation($relation, $column, $operator = null, $value = null)
     {
         $relations = collect(explode('.', $relation));
+        
         return $this->when(
             $relations->count() == 1,
             function($query) use ($relations, $column, $operator, $value) {


### PR DESCRIPTION
This PR added the possibility to use nested relationships when using 'whereRelation' Eloquent's function, using dot notation.
Also still works with not nested relationships, so it's not a breaking change.

## How it works
```php
// Before
Company::whereHas('teams', function($query) {
  $query->whereHas('users', function($query) {
      $query->whereHas('roles', function($query) {
          $query->where('name', 'admin');
      });
  });
})->get();

// After 💅🏻
Company::whereRelation('teams.users.roles', 'name', 'admin')->get();

// Also can be used as orWhereRelation
Company::where('public', true)->orWhereRelation('teams.users', 'id', auth()->id())->get();

// Still can use this function for not nested relationships
Company::whereRelation('teams', 'id', '1')->get();
```