### PR TITLE
[8.x] Aliasing on `with()` for eager loading

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -627,7 +627,7 @@ class Builder
         foreach ($this->eagerLoad as $name => $constraints) {
             $segments = explode(' ', $name);
 
-            if (count($segments) === 3 && Str::lower($segments[1] === 'as')) {
+            if (count($segments) === 3 && Str::lower($segments[1]) === 'as') {
                 [$name, $alias] = [$segments[0], $segments[2]];
             }
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -650,7 +650,7 @@ class DatabaseEloquentBuilderTest extends TestCase
             //
         };
         $builder->setEagerLoads(['foo' => $nop1, 'foo.bar' => $nop2]);
-        $builder->shouldAllowMockingProtectedMethods()->shouldReceive('eagerLoadRelation')->with(['models'], 'foo', $nop1)->andReturn(['foo']);
+        $builder->shouldAllowMockingProtectedMethods()->shouldReceive('eagerLoadRelation')->with(['models'], 'foo', $nop1, null)->andReturn(['foo']);
 
         $results = $builder->eagerLoadRelations(['models']);
         $this->assertEquals(['foo'], $results);

--- a/tests/Database/DatabaseEloquentPolymorphicRelationsIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentPolymorphicRelationsIntegrationTest.php
@@ -142,7 +142,7 @@ class DatabaseEloquentPolymorphicRelationsIntegrationTest extends TestCase
         $tag = EloquentManyToManyPolymorphicTestTag::create();
         $post->tags()->attach($tag->id);
 
-        $post = EloquentManyToManyPolymorphicTestPost::with(['tags as tags_alias' => function($query) use ($tag) {
+        $post = EloquentManyToManyPolymorphicTestPost::with(['tags as tags_alias' => function ($query) use ($tag) {
             $query->where('id', $tag->id);
         }])->whereId(1)->first();
         $tag = EloquentManyToManyPolymorphicTestTag::with('posts')->whereId(1)->first();

--- a/tests/Database/DatabaseEloquentPolymorphicRelationsIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentPolymorphicRelationsIntegrationTest.php
@@ -95,7 +95,7 @@ class DatabaseEloquentPolymorphicRelationsIntegrationTest extends TestCase
         $tag = EloquentManyToManyPolymorphicTestTag::create();
         $post->tags()->attach($tag->id);
 
-        $post = EloquentManyToManyPolymorphicTestPost::with('tags as tags_test')->whereId(1)->first();
+        $post = EloquentManyToManyPolymorphicTestPost::with('tags')->whereId(1)->first();
         $tag = EloquentManyToManyPolymorphicTestTag::with('posts')->whereId(1)->first();
 
         $this->assertTrue($post->relationLoaded('tags'));

--- a/tests/Database/DatabaseEloquentPolymorphicRelationsIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentPolymorphicRelationsIntegrationTest.php
@@ -136,6 +136,23 @@ class DatabaseEloquentPolymorphicRelationsIntegrationTest extends TestCase
         $this->assertEquals($post->id, $tag->posts->first()->id);
     }
 
+    public function testEagerLoadingAliasingRelationNameWithConstraints()
+    {
+        $post = EloquentManyToManyPolymorphicTestPost::create();
+        $tag = EloquentManyToManyPolymorphicTestTag::create();
+        $post->tags()->attach($tag->id);
+
+        $post = EloquentManyToManyPolymorphicTestPost::with(['tags as tags_alias' => function($query) use ($tag) {
+            $query->where('id', $tag->id);
+        }])->whereId(1)->first();
+        $tag = EloquentManyToManyPolymorphicTestTag::with('posts')->whereId(1)->first();
+
+        $this->assertTrue($post->relationLoaded('tags_alias'));
+        $this->assertTrue($tag->relationLoaded('posts'));
+        $this->assertEquals($tag->id, $post->tags_alias->first()->id);
+        $this->assertEquals($post->id, $tag->posts->first()->id);
+    }
+
     public function testChunkById()
     {
         $post = EloquentManyToManyPolymorphicTestPost::create();

--- a/tests/Database/DatabaseEloquentPolymorphicRelationsIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentPolymorphicRelationsIntegrationTest.php
@@ -95,12 +95,44 @@ class DatabaseEloquentPolymorphicRelationsIntegrationTest extends TestCase
         $tag = EloquentManyToManyPolymorphicTestTag::create();
         $post->tags()->attach($tag->id);
 
-        $post = EloquentManyToManyPolymorphicTestPost::with('tags')->whereId(1)->first();
+        $post = EloquentManyToManyPolymorphicTestPost::with('tags as tags_test')->whereId(1)->first();
         $tag = EloquentManyToManyPolymorphicTestTag::with('posts')->whereId(1)->first();
 
         $this->assertTrue($post->relationLoaded('tags'));
         $this->assertTrue($tag->relationLoaded('posts'));
         $this->assertEquals($tag->id, $post->tags->first()->id);
+        $this->assertEquals($post->id, $tag->posts->first()->id);
+    }
+
+    public function testEagerLoadingAliasingRelationName()
+    {
+        $post = EloquentManyToManyPolymorphicTestPost::create();
+        $tag = EloquentManyToManyPolymorphicTestTag::create();
+        $post->tags()->attach($tag->id);
+
+        $post = EloquentManyToManyPolymorphicTestPost::with('tags as tags_alias')->whereId(1)->first();
+        $tag = EloquentManyToManyPolymorphicTestTag::with('posts')->whereId(1)->first();
+
+        $this->assertTrue($post->relationLoaded('tags_alias'));
+        $this->assertTrue($tag->relationLoaded('posts'));
+        $this->assertEquals($tag->id, $post->tags_alias->first()->id);
+        $this->assertEquals($post->id, $tag->posts->first()->id);
+    }
+
+    public function testEagerLoadCanLoadSameRelationWithDifferentAliases()
+    {
+        $post = EloquentManyToManyPolymorphicTestPost::create();
+        $tag = EloquentManyToManyPolymorphicTestTag::create();
+        $post->tags()->attach($tag->id);
+
+        $post = EloquentManyToManyPolymorphicTestPost::with('tags as tags_alias', 'tags as second_tags')->whereId(1)->first();
+        $tag = EloquentManyToManyPolymorphicTestTag::with('posts')->whereId(1)->first();
+
+        $this->assertTrue($post->relationLoaded('tags_alias'));
+        $this->assertTrue($post->relationLoaded('second_tags'));
+        $this->assertTrue($tag->relationLoaded('posts'));
+        $this->assertEquals($tag->id, $post->tags_alias->first()->id);
+        $this->assertEquals($tag->id, $post->second_tags->first()->id);
         $this->assertEquals($post->id, $tag->posts->first()->id);
     }
 


### PR DESCRIPTION
## What?
This PR introduces the ability to alias eager loaded relations, as `withCount` method does. 

## Why?
This alias allows to eager load the same relationship multiple times in different context. This is particularly useful in cases where you have to load model relationships filtering based on different constraints, avoiding N+1 queries without defining aditional constrained relationships in the Model.
