### PR TITLE
[8.x] Add missing methods to App facade docblock

### DIFF
--- a/src/Illuminate/Support/Facades/App.php
+++ b/src/Illuminate/Support/Facades/App.php
@@ -11,6 +11,8 @@ namespace Illuminate\Support\Facades;
  * @method static bool configurationIsCached()
  * @method static bool hasBeenBootstrapped()
  * @method static bool isDownForMaintenance()
+ * @method static bool isLocal()
+ * @method static bool isProduction()
  * @method static bool routesAreCached()
  * @method static bool runningInConsole()
  * @method static bool runningUnitTests()


### PR DESCRIPTION
This PR adds two missing methods from the doc block of the App facade:
`isLocal()` and `isProduction()`

This makes IDE's better understand the facade.