### PR TITLE
[8.x] Add `isStaging()` helper to Application class

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -585,6 +585,16 @@ class Application extends Container implements ApplicationContract, CachesConfig
     }
 
     /**
+     * Determine if the application is in the staging environment.
+     *
+     * @return bool
+     */
+    public function isStaging()
+    {
+        return $this['env'] === 'staging';
+    }
+
+    /**
      * Determine if the application is in the production environment.
      *
      * @return bool

--- a/src/Illuminate/Support/Facades/App.php
+++ b/src/Illuminate/Support/Facades/App.php
@@ -11,6 +11,7 @@ namespace Illuminate\Support\Facades;
  * @method static bool configurationIsCached()
  * @method static bool hasBeenBootstrapped()
  * @method static bool isDownForMaintenance()
+ * @method static bool isStaging()
  * @method static bool routesAreCached()
  * @method static bool runningInConsole()
  * @method static bool runningUnitTests()


### PR DESCRIPTION
This PR adds a `isStaging()` helper, similar to `isLocal()` and `isProduction()` to the Application class, and App facade.

Might have a conflict to resolve before merging if #39073 already has been accepted.