### PR TITLE
[9.x] Chunk collections with callback

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1192,9 +1192,10 @@ class Collection implements ArrayAccess, Enumerable
      * Chunk the collection into chunks of the given size.
      *
      * @param  int  $size
+     * @param  callable|null  $callback
      * @return static<int, static<int, TValue>>
      */
-    public function chunk($size)
+    public function chunk($size, callable $callback = null)
     {
         if ($size <= 0) {
             return new static;
@@ -1206,7 +1207,15 @@ class Collection implements ArrayAccess, Enumerable
             $chunks[] = new static($chunk);
         }
 
-        return new static($chunks);
+        $chunked = new static($chunks);
+
+        if (! $callback) {
+            return $chunked;
+        }
+
+        return $chunked->map(function (Collection $items, $key) use ($callback) {
+            return $callback($items, $key);
+        });
     }
 
     /**

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -878,9 +878,10 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Chunk the collection into chunks of the given size.
      *
      * @param  int  $size
+     * @param  callable|null  $callback
      * @return static<int, static<int, TValue>>
      */
-    public function chunk($size);
+    public function chunk($size, callable $callback = null);
 
     /**
      * Chunk the collection into chunks with a callback.

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1102,15 +1102,16 @@ class LazyCollection implements Enumerable
      * Chunk the collection into chunks of the given size.
      *
      * @param  int  $size
+     * @param  callable|null  $callback
      * @return static
      */
-    public function chunk($size)
+    public function chunk($size, callable $callback = null)
     {
         if ($size <= 0) {
             return static::empty();
         }
 
-        return new static(function () use ($size) {
+        $chunked = new static(function () use ($size) {
             $iterator = $this->getIterator();
 
             while ($iterator->valid()) {
@@ -1134,6 +1135,14 @@ class LazyCollection implements Enumerable
 
                 $iterator->next();
             }
+        });
+
+        if (! $callback) {
+            return $chunked;
+        }
+
+        return $chunked->map(function (LazyCollection $chunk, $key) use ($callback) {
+            return $callback($chunk, $key);
         });
     }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1910,6 +1910,25 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testChunkWithCallback($collection)
+    {
+        $data = new $collection([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        $data = $data->chunk(3, function ($chunk) {
+            return $chunk->filter(function ($item) {
+                return $item != 1;
+            });
+        });
+
+        $this->assertInstanceOf($collection, $data);
+        $this->assertInstanceOf($collection, $data->first());
+        $this->assertCount(4, $data);
+        $this->assertEquals([1 => 2, 2 => 3], $data->first()->toArray());
+        $this->assertEquals([9 => 10], $data->get(3)->toArray());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testChunkWhenGivenZeroAsSize($collection)
     {
         $data = new $collection([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);


### PR DESCRIPTION
This is a follow up on #39065

This PR adds an optional callback to the chunk method on `Illuminate\Support\Collection` and `Illuminate\Support\LazyCollection` classes.
This allows to use a callback when chunking collections:

```php
$collection = new Collection([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);

$collection->chunk(5, function(Collection $items) {
    return $items->filter(function($item) use ($items) {
        return $item > 1;
    });
})
```

The code above returns a Collection of chunked collections, rejecting the value `1` in the first collection: 

```
Illuminate\Support\Collection {#284 ▼
  #items: array:2 [▼
    0 => Illuminate\Support\Collection {#285 ▼
      #items: array:4 [▼
        1 => 2
        2 => 3
        3 => 4
        4 => 5
      ]
    }
    1 => Illuminate\Support\Collection {#286 ▼
      #items: array:5 [▼
        5 => 6
        6 => 7
        7 => 8
        8 => 9
        9 => 10
      ]
    }
  ]
}
```


