### PR TITLE
Add truncateMiddle string method.

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -812,6 +812,20 @@ class Str
     }
 
     /**
+     * Replaces the middle of a string with another string.
+     *
+     * @param  $string
+     * @param  string  $replace
+     * @param  int  $maxChars
+     *
+     * @return array|string|string[]
+     */
+    public static function truncateMiddle($string, $maxChars = 16, $replace = '...')
+    {
+        return substr_replace($string, $replace, $maxChars/2, strlen($string) - $maxChars);
+    }
+
+    /**
      * Make a string's first character uppercase.
      *
      * @param  string  $string

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -575,6 +575,13 @@ class SupportStrTest extends TestCase
         $this->assertSame('aaaaa', Str::repeat('a', 5));
         $this->assertSame('', Str::repeat('', 5));
     }
+
+    public function testTruncateMiddle()
+    {
+        $this->assertSame('ba4d9...8bb3e', Str::truncateMiddle('ba4d95a2-94d8-4ce5-a4a4-a0621aa8bb3e', 10));
+        $this->assertSame('ba4d9---8bb3e', Str::truncateMiddle('ba4d95a2-94d8-4ce5-a4a4-a0621aa8bb3e', 10, '---'));
+        $this->assertSame('the quic...lazy dog', Str::truncateMiddle('the quick brown fox jumps over the lazy dog'));
+    }
 }
 
 class StringableObjectStub


### PR DESCRIPTION
I wasn't sure if this was actually available and I couldn't find it in the documentation.

This PR adds `Str::truncateMiddle()`, a small string helper that replaces the middle of a string with another string.

My use case came from needing to display a UUID in a table, but it was overkill to display the whole thing since it was just for quick reference.

Therefore this was the implementation:

```php
Str::truncateMiddle('ba4d95a2-94d8-4ce5-a4a4-a0621aa8bb3e', 10);
```

Yields:

```
ba4d9...8bb3e
```

The third parameter is the replacement string if you wanted to change that:

```php
Str::truncateMiddle('ba4d95a2-94d8-4ce5-a4a4-a0621aa8bb3e', 10, '---');
// ba4d9---8bb3e
```

I was going to add `Str::substrReplace()` as well but I figured it was overkill since it added no extra functionality. 