### PR TITLE
[8.x] Add `reduceMany` to Collections

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -752,7 +752,7 @@ trait EnumeratesValues
      * @param  mixed  ...$initial
      * @return array
      *
-     * @throws UnexpectedValueException
+     * @throws \UnexpectedValueException
      */
     public function reduceMany(callable $callback, ...$initial)
     {

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -15,6 +15,7 @@ use Illuminate\Support\HigherOrderWhenProxy;
 use JsonSerializable;
 use Symfony\Component\VarDumper\VarDumper;
 use Traversable;
+use UnexpectedValueException;
 
 /**
  * @property-read HigherOrderCollectionProxy $average
@@ -739,6 +740,33 @@ trait EnumeratesValues
 
         foreach ($this as $key => $value) {
             $result = $callback($result, $value, $key);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Reduce the collection to multiple aggregate values.
+     *
+     * @param  callable  $callback
+     * @param  mixed  ...$initial
+     * @return array
+     *
+     * @throws UnexpectedValueException
+     */
+    public function reduceMany(callable $callback, ...$initial)
+    {
+        $result = $initial;
+
+        foreach ($this as $key => $value) {
+            $result = call_user_func_array($callback, array_merge($result, [$value, $key]));
+
+            if (! is_array($result)) {
+                throw new UnexpectedValueException(sprintf(
+                    "%s::reduceMany expects reducer to return an array, but got a '%s' instead.",
+                    class_basename(static::class), gettype($result)
+                ));
+            }
         }
 
         return $result;

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -22,6 +22,7 @@ use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use stdClass;
 use Symfony\Component\VarDumper\VarDumper;
+use UnexpectedValueException;
 
 class SupportCollectionTest extends TestCase
 {
@@ -3900,6 +3901,39 @@ class SupportCollectionTest extends TestCase
         $this->assertSame('foobarbazqux', $data->reduceWithKeys(function ($carry, $element, $key) {
             return $carry .= $key.$element;
         }));
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testReduceMany($collection)
+    {
+        $data = new $collection([-1, 0, 1, 2, 3, 4, 5]);
+
+        [$sum, $max, $min] = $data->reduceMany(function($sum, $max, $min, $value) {
+            $sum += $value;
+            $max = max($max, $value);
+            $min = min($min, $value);
+            return [$sum, $max, $min];
+        }, 0, PHP_INT_MIN, PHP_INT_MAX);
+
+        $this->assertEquals(14, $sum);
+        $this->assertEquals(5, $max);
+        $this->assertEquals(-1, $min);
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testReduceManyThrowsAnExceptionIfReducerDoesNotReturnAnArray($collection)
+    {
+        $data = new $collection([1]);
+
+        $this->expectException(UnexpectedValueException::class);
+
+        $data->reduceMany(function () {
+            return false;
+        }, null);
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3910,7 +3910,7 @@ class SupportCollectionTest extends TestCase
     {
         $data = new $collection([-1, 0, 1, 2, 3, 4, 5]);
 
-        [$sum, $max, $min] = $data->reduceMany(function($sum, $max, $min, $value) {
+        [$sum, $max, $min] = $data->reduceMany(function ($sum, $max, $min, $value) {
             $sum += $value;
             $max = max($max, $value);
             $min = min($min, $value);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3914,6 +3914,7 @@ class SupportCollectionTest extends TestCase
             $sum += $value;
             $max = max($max, $value);
             $min = min($min, $value);
+
             return [$sum, $max, $min];
         }, 0, PHP_INT_MIN, PHP_INT_MAX);
 


### PR DESCRIPTION
Sometimes you need to compute multiple aggregate values from a collection. In many cases, it's fine to perform separate operations, but in cases where these values are interdependent, or there's a material performance cost to iterating the collection multiple times, this is not ideal.

This PR introduces a `reduceMany` operation that behaves exactly like `reduce` but allows for carrying as many values as needed. Rather than using the simplest example (see the added tests for this case), here's a slightly more complicated "real-world" example:

```php
// Figure out how many images we can send to our image processor, given a fixed
// number of "credits" available (where each image may require more than 1 credit)
[$credits_remaining, $batch] = Image::unprocessed()->get()
    ->reduceMany(function($credits_remaining, $batch, $image) {
        if ($credits_remaining && $credits_remaining >= $image->creditsNecessary()) {
            $batch->push($image);
            $credits_remaining -= $image->creditsNecessary();
        }
        
        return [$credits_remaining, $batch];
    }, ImageProcessor::creditsAvailable(), collect());

ImageProcessor::processImages($batch);

if ($credits_remaining < 100) {
    Log::alert("Only $credits_remaining image processing credits remaining!");
}
```

([See this Twitter thread](https://twitter.com/DCoulbourne/status/1443693263559577609) for another real-world use-case).

In the end, the API is exactly the same as `reduce` except that you can pass in more `$initial` values and receive a corresponding number of `$carry` values before the `$value` and `$key`. The only other difference is that you must return an array in your reducer that corresponds to the number of values you're reducing.

I've intentionally left this method off the `Enumerable` interface for backwards-compatibility reasons. If this PR gets merged, I would suggest adding it to the interface in `9.x` and possibly updating the signature of `reduce` to behave the same way (which would be backwards compatible but change the interface and thus affect anyone who has a custom implementation).