### PR TITLE
[8.x] Add route:count command

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteCountCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteCountCommand.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Routing\Router;
+use Illuminate\Support\Str;
+use Symfony\Component\Console\Input\InputOption;
+
+class RouteCountCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'route:count';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Count all registered routes';
+
+    /**
+     * The router instance.
+     *
+     * @var \Illuminate\Routing\Router
+     */
+    protected $router;
+
+    /**
+     * Create a new route command instance.
+     *
+     * @param  \Illuminate\Routing\Router  $router
+     * @return void
+     */
+    public function __construct(Router $router)
+    {
+        parent::__construct();
+
+        $this->router = $router;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        if (empty($this->router->getRoutes())) {
+            return $this->error("Your application doesn't have any routes.");
+        }
+
+        if (! $count = $this->countRoutes()) {
+            return $this->error("Your application doesn't have any routes matching the given criteria.");
+        }
+
+        $this->info($count.' routes');
+    }
+
+    /**
+     * Count how many routes there are.
+     *
+     * @return array
+     */
+    protected function countRoutes()
+    {
+        return collect($this->router->getRoutes())->filter(function ($route) {
+            return $this->filterRoute([
+                'method' => implode('|', $route->methods()),
+                'uri' => $route->uri(),
+                'name' => $route->getName(),
+                ]);
+        })->count();
+    }
+
+    /**
+     * Filter the route by URI and / or name.
+     *
+     * @param  array  $route
+     * @return array|null
+     */
+    protected function filterRoute(array $route)
+    {
+        if (($this->option('name') && ! Str::contains($route['name'], $this->option('name'))) ||
+             $this->option('path') && ! Str::contains($route['uri'], $this->option('path')) ||
+             $this->option('method') && ! Str::contains($route['method'], strtoupper($this->option('method')))) {
+            return;
+        }
+
+        if ($this->option('except-path')) {
+            foreach (explode(',', $this->option('except-path')) as $path) {
+                if (Str::contains($route['uri'], $path)) {
+                    return;
+                }
+            }
+        }
+
+        return $route;
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['method', null, InputOption::VALUE_OPTIONAL, 'Filter the routes by method'],
+            ['name', null, InputOption::VALUE_OPTIONAL, 'Filter the routes by name'],
+            ['path', null, InputOption::VALUE_OPTIONAL, 'Only show routes matching the given path pattern'],
+            ['except-path', null, InputOption::VALUE_OPTIONAL, 'Do not display the routes matching the given path pattern'],
+        ];
+    }
+}

--- a/src/Illuminate/Foundation/Console/RouteCountCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteCountCommand.php
@@ -73,7 +73,7 @@ class RouteCountCommand extends Command
                 'method' => implode('|', $route->methods()),
                 'uri' => $route->uri(),
                 'name' => $route->getName(),
-                ]);
+            ]);
         })->count();
     }
 

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -943,7 +943,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
     protected function registerRouteCountCommand()
     {
         $this->app->singleton('command.route.count', function ($app) {
-            return new RouteCountCommand($app['files']);
+            return new RouteCountCommand($app['router']);
         });
     }
 

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -50,6 +50,7 @@ use Illuminate\Foundation\Console\RequestMakeCommand;
 use Illuminate\Foundation\Console\ResourceMakeCommand;
 use Illuminate\Foundation\Console\RouteCacheCommand;
 use Illuminate\Foundation\Console\RouteClearCommand;
+use Illuminate\Foundation\Console\RouteCountCommand;
 use Illuminate\Foundation\Console\RouteListCommand;
 use Illuminate\Foundation\Console\RuleMakeCommand;
 use Illuminate\Foundation\Console\ServeCommand;
@@ -121,6 +122,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'QueueWork' => 'command.queue.work',
         'RouteCache' => 'command.route.cache',
         'RouteClear' => 'command.route.clear',
+        'RouteCount' => 'command.route.count',
         'RouteList' => 'command.route.list',
         'SchemaDump' => 'command.schema.dump',
         'Seed' => 'command.seed',
@@ -929,6 +931,19 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
     {
         $this->app->singleton('command.route.clear', function ($app) {
             return new RouteClearCommand($app['files']);
+        });
+    }
+    
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerRouteCountCommand()
+    {
+        $this->app->singleton('command.route.count', function ($app) {
+            return new RouteCountCommand($app['files']);
         });
     }
 

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -933,7 +933,6 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
             return new RouteClearCommand($app['files']);
         });
     }
-    
 
     /**
      * Register the command.


### PR DESCRIPTION
While working on enterprise-level Laravel projects that have hundreds of registered routes, throughout dozens of route files, I often find myself wanting to know how many routes a new feature has created/removed. Similarly, I have often wanted to know how many routes match filter criteria. This command will count all registered routes and like the `route:list` command, this `route:count` command allows filtering via:
- name
- uri
- method


**Example commands are:**
```
route:count
route:count --name=shop
route:count --path=shop/shoes
route:count --method=post
route:count --path-except=shop/shoes
```

Output is in the format `x routes` e.g. `265 routes`