### PR TITLE
[8.x] Consume Blade Directive

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
@@ -171,7 +171,7 @@ trait CompilesComponents
     {
         return "<?php foreach ({$expression} as \$__key => \$__value) {
     \$__consumeVariable = is_string(\$__key) ? \$__key : \$__value;
-    \$\$__consumeVariable = is_string(\$__key) ? \$__env->componentDataItem(\$__key, \$__value) : \$__env->componentDataItem(\$__value);
+    \$\$__consumeVariable = is_string(\$__key) ? \$__env->getConsumableComponentData(\$__key, \$__value) : \$__env->getConsumableComponentData(\$__value);
 } ?>";
     }
 

--- a/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
@@ -162,6 +162,20 @@ trait CompilesComponents
     }
 
     /**
+     * Compile the consume statement into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileConsume($expression)
+    {
+        return "<?php foreach ({$expression} as \$__key => \$__value) {
+    \$__consumeVariable = is_string(\$__key) ? \$__key : \$__value;
+    \$\$__consumeVariable = is_string(\$__key) ? \$__env->componentDataItem(\$__key, \$__value) : \$__env->componentDataItem(\$__value);
+} ?>";
+    }
+
+    /**
      * Sanitize the given component attribute value.
      *
      * @param  mixed  $value

--- a/src/Illuminate/View/Concerns/ManagesComponents.php
+++ b/src/Illuminate/View/Concerns/ManagesComponents.php
@@ -116,6 +116,32 @@ trait ManagesComponents
     }
 
     /**
+     * Get an item from the component data that exists above the current component.
+     *
+     * @param  string  $key
+     * @param  mixed  $default
+     * @return mixed|null
+     */
+    public function componentDataItem($key, $default = null)
+    {
+        $currentComponent = count($this->componentStack);
+
+        if ($currentComponent === 0) {
+            return value($default);
+        }
+
+        for ($i = $currentComponent - 1; $i >= 0; $i--) {
+            $data = $this->componentData[$i] ?? [];
+
+            if (array_key_exists($key, $data)) {
+                return $data[$key];
+            }
+        }
+
+        return value($default);
+    }
+
+    /**
      * Start the slot rendering process.
      *
      * @param  string  $name

--- a/src/Illuminate/View/Concerns/ManagesComponents.php
+++ b/src/Illuminate/View/Concerns/ManagesComponents.php
@@ -122,7 +122,7 @@ trait ManagesComponents
      * @param  mixed  $default
      * @return mixed|null
      */
-    public function componentDataItem($key, $default = null)
+    public function getConsumableComponentData($key, $default = null)
     {
         $currentComponent = count($this->componentStack);
 


### PR DESCRIPTION
From an idea by @calebporzio ...

When building complex Blade components, it's hard / impossible to access data passed into the parent from children in the parent's slot.

For a concrete example of the problem (using a `x-menu` component):

**Usage**
```html
<x-menu color="blue">
    <x-menu.item>Foo</x-menu.item>
    <x-menu.item>Bar</x-menu.item>
    ...
</x-menu>
```

Notice we are passing in a "color" attribute to the parent component. Here's the parent component definition:

**x-menu**
```html
@props(['color' => 'black'])

<ul ...>
    {{ $slot }}
</ul>
```

Now this component has access to `$color`, but it doesn't actually need it. We need to access `$color` from each `menu-item` component:

**x-menu.item**
```html
<li class="bg-{{ $color }}-500">
    {{ $slot }}
</li>
```

Can now be done via `@consume` directive in the child... defaults are also supported if no consumable data with the given name can be found in the parent component stack...

**x-menu.item**
```html
@consume(['color', 'foo' => 'default'])

<li class="bg-{{ $color }}-500">
    {{ $slot }}
</li>
```