### PR TITLE
[8.x] Add Case-sensitivity flag on Str::contains() & Str::containsAll()

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -176,12 +176,19 @@ class Str
      *
      * @param  string  $haystack
      * @param  string|string[]  $needles
+     * @param  bool  $caseSensitive
      * @return bool
      */
-    public static function contains($haystack, $needles)
+    public static function contains($haystack, $needles, $caseSensitive = true)
     {
+        $position = function ($needle) use ($haystack, $caseSensitive) {
+            return $caseSensitive
+                ? mb_strpos($haystack, $needle)
+                : mb_stripos($haystack, $needle);
+        };
+
         foreach ((array) $needles as $needle) {
-            if ($needle !== '' && mb_strpos($haystack, $needle) !== false) {
+            if ($needle !== '' && $position($needle) !== false) {
                 return true;
             }
         }
@@ -194,12 +201,13 @@ class Str
      *
      * @param  string  $haystack
      * @param  string[]  $needles
+     * @param  bool  $caseSensitive
      * @return bool
      */
-    public static function containsAll($haystack, array $needles)
+    public static function containsAll($haystack, array $needles, $caseSensitive = true)
     {
         foreach ($needles as $needle) {
-            if (! static::contains($haystack, $needle)) {
+            if (! static::contains($haystack, $needle, $caseSensitive)) {
                 return false;
             }
         }

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -144,22 +144,24 @@ class Stringable implements JsonSerializable
      * Determine if a given string contains a given substring.
      *
      * @param  string|array  $needles
+     * @param  bool  $caseSensitive
      * @return bool
      */
-    public function contains($needles)
+    public function contains($needles, $caseSensitive = true)
     {
-        return Str::contains($this->value, $needles);
+        return Str::contains($this->value, $needles, $caseSensitive);
     }
 
     /**
      * Determine if a given string contains all array values.
      *
      * @param  array  $needles
+     * @param  bool  $caseSensitive
      * @return bool
      */
-    public function containsAll(array $needles)
+    public function containsAll(array $needles, $caseSensitive = true)
     {
-        return Str::containsAll($this->value, $needles);
+        return Str::containsAll($this->value, $needles, $caseSensitive);
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -187,10 +187,16 @@ class SupportStrTest extends TestCase
     public function testStrContains()
     {
         $this->assertTrue(Str::contains('taylor', 'ylo'));
+        $this->assertTrue(Str::contains('taYlor', 'yLo', false));
         $this->assertTrue(Str::contains('taylor', 'taylor'));
+        $this->assertTrue(Str::contains('Taylor', 'TAYLOR', false));
         $this->assertTrue(Str::contains('taylor', ['ylo']));
+        $this->assertTrue(Str::contains('taYlor', ['yLo'], false));
         $this->assertTrue(Str::contains('taylor', ['xxx', 'ylo']));
+        $this->assertTrue(Str::contains('Taylor', ['xxx', 'yLo'], false));
         $this->assertFalse(Str::contains('taylor', 'xxx'));
+        $this->assertFalse(Str::contains('taylor', 'Taylor'));
+        $this->assertFalse(Str::contains('taylor', 'xxx', false));
         $this->assertFalse(Str::contains('taylor', ['xxx']));
         $this->assertFalse(Str::contains('taylor', ''));
         $this->assertFalse(Str::contains('', ''));
@@ -199,8 +205,10 @@ class SupportStrTest extends TestCase
     public function testStrContainsAll()
     {
         $this->assertTrue(Str::containsAll('taylor otwell', ['taylor', 'otwell']));
+        $this->assertTrue(Str::containsAll('Taylor Otwell', ['taYlor', 'otWell'], false));
         $this->assertTrue(Str::containsAll('taylor otwell', ['taylor']));
         $this->assertFalse(Str::containsAll('taylor otwell', ['taylor', 'xxx']));
+        $this->assertFalse(Str::containsAll('taylor otwell', ['taylor', 'xxx'], false));
     }
 
     public function testParseCallback()

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -355,10 +355,15 @@ class SupportStringableTest extends TestCase
     public function testContains()
     {
         $this->assertTrue($this->stringable('taylor')->contains('ylo'));
+        $this->assertTrue($this->stringable('taYlor')->contains('yLo', false));
         $this->assertTrue($this->stringable('taylor')->contains('taylor'));
+        $this->assertTrue($this->stringable('Taylor')->contains('TAYLOR', false));
         $this->assertTrue($this->stringable('taylor')->contains(['ylo']));
+        $this->assertTrue($this->stringable('taYlor')->contains(['yLo'], false));
         $this->assertTrue($this->stringable('taylor')->contains(['xxx', 'ylo']));
+        $this->assertTrue($this->stringable('Taylor')->contains(['xxx', 'yLo'], false));
         $this->assertFalse($this->stringable('taylor')->contains('xxx'));
+        $this->assertFalse($this->stringable('taylor')->contains('xxx', false));
         $this->assertFalse($this->stringable('taylor')->contains(['xxx']));
         $this->assertFalse($this->stringable('taylor')->contains(''));
     }
@@ -366,8 +371,10 @@ class SupportStringableTest extends TestCase
     public function testContainsAll()
     {
         $this->assertTrue($this->stringable('taylor otwell')->containsAll(['taylor', 'otwell']));
+        $this->assertTrue($this->stringable('Taylor Otwell')->containsAll(['taYlor', 'otWell'], false));
         $this->assertTrue($this->stringable('taylor otwell')->containsAll(['taylor']));
         $this->assertFalse($this->stringable('taylor otwell')->containsAll(['taylor', 'xxx']));
+        $this->assertFalse($this->stringable('taylor otwell')->containsAll(['taylor', 'xxx'], false));
     }
 
     public function testParseCallback()


### PR DESCRIPTION
### What:
Update `Str.php` to add a third argument to `Str::contains()` & `Str::containsAll()` for case sensitivity (true by default). Passing false will cause the method to ignore case. `Stringable.php` updated to match these new additions.

### Why:
I have come across situations in which I would like to confirm some string contains certain triggers/words, but I allow the use of caseless or strict comparison. Adding this new flag reduces the overhead of my implementations of either lowercasing the string first, or writing my own macro to implement caseless in `Str::contains()`.

I also noticed that `Str::remove()` has the case sensitive flag, so adding this to `contains|containsAll` with the default of `true` has no backwards compatibility issues.

### Examples
```php
Str::contains('Taylor', 'taylor'); //false
Str::contains('Taylor', 'taylor', false); //true
Str::containsAll('Taylor Otwell', ['taylor', 'otwell']); //false
Str::containsAll('Taylor Otwell', ['taylor', 'otwell'], false); //true
Str::of('Taylor')->contains('tay'); //false
Str::of('Taylor')->contains('tay', false); //true
```

