### PR TITLE
[8.x] HTTP client: only allow a single User-Agent header

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -374,7 +374,9 @@ class PendingRequest
      */
     public function withUserAgent($userAgent)
     {
-        return $this->withHeaders(['User-Agent' => $userAgent]);
+        return tap($this, function ($request) use ($userAgent) {
+            return $this->options['headers']['User-Agent'] = trim($userAgent);
+        });
     }
 
     /**

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -295,6 +295,23 @@ class HttpClientTest extends TestCase
         });
     }
 
+    public function testItOnlySendsOneUserAgentHeader()
+    {
+        $this->factory->fake();
+
+        $this->factory->withUserAgent('Laravel')
+            ->withUserAgent('FooBar')
+            ->post('http://foo.com/json');
+
+        $this->factory->assertSent(function (Request $request) {
+            $userAgent = $request->header('User-Agent');
+
+            return $request->url() === 'http://foo.com/json' &&
+                count($userAgent) === 1 &&
+                $userAgent[0] === 'FooBar';
+        });
+    }
+
     public function testSequenceBuilder()
     {
         $this->factory->fake([


### PR DESCRIPTION
Currently, using this method appends the specified UserAgent string to the headers list. Calling this method twice will send a request with two User-Agent header lines. This is not accepted as valid by a lot of services.

[See also](https://github.com/laravel/framework/pull/34611#issuecomment-934233430).

This PR overrides the User-Agent header instead of appending it.