### PR TITLE
[8.x] Fix and re-enable Doctrine DBAL test

### DIFF
--- a/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
@@ -43,35 +43,50 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
         Facade::setFacadeApplication(null);
     }
 
-    // public function testRenamingAndChangingColumnsWork()
-    // {
-    //     $this->db->connection()->getSchemaBuilder()->create('users', function ($table) {
-    //         $table->string('name');
-    //         $table->string('age');
-    //     });
+    public function testRenamingAndChangingColumnsWork()
+    {
+        $this->db->connection()->getSchemaBuilder()->create('users', function ($table) {
+            $table->string('name');
+            $table->string('age');
+        });
 
-    //     $blueprint = new Blueprint('users', function ($table) {
-    //         $table->renameColumn('name', 'first_name');
-    //         $table->integer('age')->change();
-    //     });
+        $blueprint = new Blueprint('users', function ($table) {
+            $table->renameColumn('name', 'first_name');
+            $table->integer('age')->change();
+        });
 
-    //     $queries = $blueprint->toSql($this->db->connection(), new SQLiteGrammar);
+        $queries = $blueprint->toSql($this->db->connection(), new SQLiteGrammar);
 
-    //     $expected = [
-    //         'CREATE TEMPORARY TABLE __temp__users AS SELECT name, age FROM users',
-    //         'DROP TABLE users',
-    //         'CREATE TABLE users (name VARCHAR(255) NOT NULL COLLATE BINARY, age INTEGER NOT NULL)',
-    //         'INSERT INTO users (name, age) SELECT name, age FROM __temp__users',
-    //         'DROP TABLE __temp__users',
-    //         'CREATE TEMPORARY TABLE __temp__users AS SELECT name, age FROM users',
-    //         'DROP TABLE users',
-    //         'CREATE TABLE users (age VARCHAR(255) NOT NULL COLLATE BINARY, first_name VARCHAR(255) NOT NULL)',
-    //         'INSERT INTO users (first_name, age) SELECT name, age FROM __temp__users',
-    //         'DROP TABLE __temp__users',
-    //     ];
+        // Expect one of the following two query sequences to be present...
+        $expected = [
+            [
+                'CREATE TEMPORARY TABLE __temp__users AS SELECT name, age FROM users',
+                'DROP TABLE users',
+                'CREATE TABLE users (name VARCHAR(255) NOT NULL COLLATE BINARY, age INTEGER NOT NULL)',
+                'INSERT INTO users (name, age) SELECT name, age FROM __temp__users',
+                'DROP TABLE __temp__users',
+                'CREATE TEMPORARY TABLE __temp__users AS SELECT name, age FROM users',
+                'DROP TABLE users',
+                'CREATE TABLE users (age VARCHAR(255) NOT NULL COLLATE BINARY, first_name VARCHAR(255) NOT NULL)',
+                'INSERT INTO users (first_name, age) SELECT name, age FROM __temp__users',
+                'DROP TABLE __temp__users',
+            ],
+            [
+                'CREATE TEMPORARY TABLE __temp__users AS SELECT name, age FROM users',
+                'DROP TABLE users',
+                'CREATE TABLE users (name VARCHAR(255) NOT NULL COLLATE BINARY, age INTEGER NOT NULL)',
+                'INSERT INTO users (name, age) SELECT name, age FROM __temp__users',
+                'DROP TABLE __temp__users',
+                'CREATE TEMPORARY TABLE __temp__users AS SELECT name, age FROM users',
+                'DROP TABLE users',
+                'CREATE TABLE users (first_name VARCHAR(255) NOT NULL, age VARCHAR(255) NOT NULL COLLATE BINARY)',
+                'INSERT INTO users (first_name, age) SELECT name, age FROM __temp__users',
+                'DROP TABLE __temp__users',
+            ],
+        ];
 
-    //     $this->assertEquals($expected, $queries);
-    // }
+        $this->assertTrue(in_array($queries, $expected));
+    }
 
     public function testChangingColumnWithCollationWorks()
     {


### PR DESCRIPTION
The simplest fix for a changing order of sequences of columns in Doctrine releases is to assert both sequences as valid. The generated SQL queries are both acceptable and valid.
