### PR TITLE
[8.x] New JobRetrying event dispatched

### DIFF
--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -5,7 +5,7 @@ namespace Illuminate\Queue\Console;
 use DateTimeInterface;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Encryption\Encrypter;
-use Illuminate\Queue\Events\JobRetrying;
+use Illuminate\Queue\Events\JobRetryRequested;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use RuntimeException;
@@ -42,7 +42,7 @@ class RetryCommand extends Command
             if (is_null($job)) {
                 $this->error("Unable to find failed job with ID [{$id}].");
             } else {
-                $this->laravel['events']->dispatch(new JobRetrying($job));
+                $this->laravel['events']->dispatch(new JobRetryRequested($job));
 
                 $this->retryJob($job);
 

--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -5,6 +5,7 @@ namespace Illuminate\Queue\Console;
 use DateTimeInterface;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Encryption\Encrypter;
+use Illuminate\Queue\Events\JobRetrying;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use RuntimeException;
@@ -41,6 +42,8 @@ class RetryCommand extends Command
             if (is_null($job)) {
                 $this->error("Unable to find failed job with ID [{$id}].");
             } else {
+                $this->laravel['events']->dispatch(new JobRetrying($job));
+
                 $this->retryJob($job);
 
                 $this->info("The failed job [{$id}] has been pushed back onto the queue!");

--- a/src/Illuminate/Queue/Events/JobRetryRequested.php
+++ b/src/Illuminate/Queue/Events/JobRetryRequested.php
@@ -2,17 +2,17 @@
 
 namespace Illuminate\Queue\Events;
 
-class JobRetrying
+class JobRetryRequested
 {
     /**
-     * The job retrying object.
+     * The job instance.
      *
      * @var \stdClass
      */
     public $job;
 
     /**
-     * The job payload.
+     * The decoded job payload.
      *
      * @var array|null
      */
@@ -34,7 +34,7 @@ class JobRetrying
      *
      * @return array
      */
-    public function payload(): array
+    public function payload()
     {
         if (is_null($this->payload)) {
             $this->payload = json_decode($this->job->payload, true);

--- a/src/Illuminate/Queue/Events/JobRetrying.php
+++ b/src/Illuminate/Queue/Events/JobRetrying.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Illuminate\Queue\Events;
+
+class JobRetrying
+{
+    /**
+     * The job retrying object
+     *
+     * @var \stdClass
+     */
+    public $job;
+
+    /**
+     * The job payload
+     *
+     * @var array|null
+     */
+    protected $payload = null;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  \stdClass   $job
+     * @return void
+     */
+    public function __construct($job)
+    {
+        $this->job = $job;
+    }
+
+    /**
+     * The job payload
+     *
+     * @return array
+     */
+    public function payload(): array
+    {
+        if (is_null($this->payload)) {
+            $this->payload = json_decode($this->job->payload, true);
+        }
+
+        return $this->payload;
+    }
+}

--- a/src/Illuminate/Queue/Events/JobRetrying.php
+++ b/src/Illuminate/Queue/Events/JobRetrying.php
@@ -5,14 +5,14 @@ namespace Illuminate\Queue\Events;
 class JobRetrying
 {
     /**
-     * The job retrying object
+     * The job retrying object.
      *
      * @var \stdClass
      */
     public $job;
 
     /**
-     * The job payload
+     * The job payload.
      *
      * @var array|null
      */
@@ -21,7 +21,7 @@ class JobRetrying
     /**
      * Create a new event instance.
      *
-     * @param  \stdClass   $job
+     * @param  \stdClass  $job
      * @return void
      */
     public function __construct($job)
@@ -30,7 +30,7 @@ class JobRetrying
     }
 
     /**
-     * The job payload
+     * The job payload.
      *
      * @return array
      */


### PR DESCRIPTION
The PR introduces the new event `JobRetrying`, dispatched calling the `queue:retry` command.

For example, it's a magic bullet for the models strictly related to a dynamic tenant connection. To learn more about it, see here: https://github.com/spatie/laravel-multitenancy/issues/259#issuecomment-925646752