### PR TITLE
[8.x] Add stringable support for strip_tags()

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -568,7 +568,7 @@ class Stringable implements JsonSerializable
     /**
      * Strip HTML and PHP tags from the given string.
      *
-     * @param  string|array  $allowedTags
+     * @param  string  $allowedTags
      * @return static
      */
     public function stripTags($allowedTags = null)

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -568,12 +568,12 @@ class Stringable implements JsonSerializable
     /**
      * Strip HTML and PHP tags from the given string.
      *
-     * @param  string|array  $allowed_tags
+     * @param  string|array  $allowedTags
      * @return static
      */
-    public function stripTags($allowed_tags = null)
+    public function stripTags($allowedTags = null)
     {
-        return new static(strip_tags($this->value, $allowed_tags));
+        return new static(strip_tags($this->value, $allowedTags));
     }
 
     /**

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -566,6 +566,17 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Strip HTML and PHP tags from the given string.
+     *
+     * @param  string|array  $allowed_tags
+     * @return static
+     */
+    public function stripTags($allowed_tags = null)
+    {
+        return new static(strip_tags($this->value, $allowed_tags));
+    }
+
+    /**
      * Convert the given string to upper-case.
      *
      * @return static

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -686,7 +686,7 @@ class SupportStringableTest extends TestCase
         $this->assertEquals(2, $this->stringable('Hello, world!')->wordCount());
         $this->assertEquals(10, $this->stringable('Hi, this is my first contribution to the Laravel framework.')->wordCount());
     }
-    
+
     public function testStripTags()
     {
         $this->assertSame('beforeafter', (string) $this->stringable('before<br>after')->stripTags());

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -686,4 +686,12 @@ class SupportStringableTest extends TestCase
         $this->assertEquals(2, $this->stringable('Hello, world!')->wordCount());
         $this->assertEquals(10, $this->stringable('Hi, this is my first contribution to the Laravel framework.')->wordCount());
     }
+    
+    public function testStripTags()
+    {
+        $this->assertSame('beforeafter', (string) $this->stringable('before<br>after')->stripTags());
+        $this->assertSame('before<br>after', (string) $this->stringable('before<br>after')->stripTags('<br>'));
+        $this->assertSame('before<br>after', (string) $this->stringable('<strong>before</strong><br>after')->stripTags('<br>'));
+        $this->assertSame('<strong>before</strong><br>after', (string) $this->stringable('<strong>before</strong><br>after')->stripTags(['<br>', '<strong>']));
+    }
 }

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -692,6 +692,6 @@ class SupportStringableTest extends TestCase
         $this->assertSame('beforeafter', (string) $this->stringable('before<br>after')->stripTags());
         $this->assertSame('before<br>after', (string) $this->stringable('before<br>after')->stripTags('<br>'));
         $this->assertSame('before<br>after', (string) $this->stringable('<strong>before</strong><br>after')->stripTags('<br>'));
-        $this->assertSame('<strong>before</strong><br>after', (string) $this->stringable('<strong>before</strong><br>after')->stripTags(['<br>', '<strong>']));
+        $this->assertSame('<strong>before</strong><br>after', (string) $this->stringable('<strong>before</strong><br>after')->stripTags('<br><strong>'));
     }
 }


### PR DESCRIPTION
This PR adds the ability to use the PHP method `strip_tags()` as part of a fluent string chain, like this:

```
Str::of('<strong>before<strong><br />after')->stripTags();
```

P.S. The prior PR had failing tests because it attempted to support passing an array to `strip_tags`, which is only supported in PHP 7.4 and greater. That has been removed.