### PR TITLE
[8.x] Expose the underlying output implementation for OutputStyle

### DIFF
--- a/src/Illuminate/Console/OutputStyle.php
+++ b/src/Illuminate/Console/OutputStyle.php
@@ -68,4 +68,14 @@ class OutputStyle extends SymfonyStyle
     {
         return $this->output->isDebug();
     }
+    
+    /**
+     * Get the underlying Symfony output implementation.
+     *
+     * @return \Symfony\Component\Console\Output\OutputInterface
+     */
+    public function getOutput()
+    {
+        return $this->output;
+    }
 }


### PR DESCRIPTION
As requested and discussed in laravel/ideas#2064, some symfony features (`appendRow` for tables, or [multi progress bar](https://symfony.com/doc/current/components/console/helpers/progressbar.html#displaying-multiple-progress-bars)) requires output implementation other than `BufferedOutput`. However, since laravel [hides the `$output`](https://github.com/laravel/framework/blob/4094d785269ce7849557b792f650fb278d48978e/src/Illuminate/Console/OutputStyle.php#L16), there is no way for users to do so unless rewrting everything related to console output.

There was an attemp (#31426) to support it but it broke many tests and got reverted finally (4094d785269ce7849557b792f650fb278d48978e), because that PR also changes the consturction method of `Table`.

So instead of rewriting related codes or forwarding/proxying the calls, this PR proposes to simply expose the `$output` by adding a getter to allow advanced users to implment those feature without rewriting the whole thing, and at the same time we don't have to worry about it breaks anything. 