### PR TITLE
[8.x] @aware blade directive

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
@@ -162,12 +162,12 @@ trait CompilesComponents
     }
 
     /**
-     * Compile the consume statement into valid PHP.
+     * Compile the aware statement into valid PHP.
      *
      * @param  string  $expression
      * @return string
      */
-    protected function compileConsume($expression)
+    protected function compileAware($expression)
     {
         return "<?php foreach ({$expression} as \$__key => \$__value) {
     \$__consumeVariable = is_string(\$__key) ? \$__key : \$__value;

--- a/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
@@ -171,7 +171,7 @@ trait CompilesComponents
     {
         return "<?php foreach ({$expression} as \$__key => \$__value) {
     \$__consumeVariable = is_string(\$__key) ? \$__key : \$__value;
-    \$\$__consumeVariable = is_string(\$__key) ? \$__env->componentDataItem(\$__key, \$__value) : \$__env->componentDataItem(\$__value);
+    \$\$__consumeVariable = is_string(\$__key) ? \$__env->getConsumableComponentData(\$__key, \$__value) : \$__env->getConsumableComponentData(\$__value);
 } ?>";
     }
 

--- a/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
@@ -162,6 +162,20 @@ trait CompilesComponents
     }
 
     /**
+     * Compile the consume statement into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileConsume($expression)
+    {
+        return "<?php foreach ({$expression} as \$__key => \$__value) {
+    \$__consumeVariable = is_string(\$__key) ? \$__key : \$__value;
+    \$\$__consumeVariable = is_string(\$__key) ? \$__env->componentDataItem(\$__key, \$__value) : \$__env->componentDataItem(\$__value);
+} ?>";
+    }
+
+    /**
      * Sanitize the given component attribute value.
      *
      * @param  mixed  $value

--- a/src/Illuminate/View/Concerns/ManagesComponents.php
+++ b/src/Illuminate/View/Concerns/ManagesComponents.php
@@ -218,5 +218,6 @@ trait ManagesComponents
     {
         $this->componentStack = [];
         $this->componentData = [];
+        $this->activeRenderData = [];
     }
 }

--- a/src/Illuminate/View/Concerns/ManagesComponents.php
+++ b/src/Illuminate/View/Concerns/ManagesComponents.php
@@ -25,11 +25,11 @@ trait ManagesComponents
     protected $componentData = [];
 
     /**
-     * The data that is currently being rendered.
+     * The component data for the component that is currently being rendered.
      *
      * @var array
      */
-    protected $activeRenderData = [];
+    protected $currentComponentData = [];
 
     /**
      * The slot contents for the component.
@@ -90,9 +90,9 @@ trait ManagesComponents
 
         $data = $this->componentData();
 
-        $previousRenderData = $this->activeRenderData;
+        $previousComponentData = $this->currentComponentData;
 
-        $this->activeRenderData = array_merge($previousRenderData, $data);
+        $this->currentComponentData = array_merge($previousComponentData, $data);
 
         try {
             $view = value($view, $data);
@@ -105,7 +105,7 @@ trait ManagesComponents
                 return $this->make($view, $data)->render();
             }
         } finally {
-            $this->activeRenderData = $previousRenderData;
+            $this->currentComponentData = $previousComponentData;
         }
     }
 
@@ -139,8 +139,8 @@ trait ManagesComponents
      */
     public function getConsumableComponentData($key, $default = null)
     {
-        if (array_key_exists($key, $this->activeRenderData)) {
-            return $this->activeRenderData[$key];
+        if (array_key_exists($key, $this->currentComponentData)) {
+            return $this->currentComponentData[$key];
         }
 
         $currentComponent = count($this->componentStack);
@@ -218,6 +218,6 @@ trait ManagesComponents
     {
         $this->componentStack = [];
         $this->componentData = [];
-        $this->activeRenderData = [];
+        $this->currentComponentData = [];
     }
 }

--- a/src/Illuminate/View/Concerns/ManagesComponents.php
+++ b/src/Illuminate/View/Concerns/ManagesComponents.php
@@ -116,6 +116,32 @@ trait ManagesComponents
     }
 
     /**
+     * Get an item from the component data that exists above the current component.
+     *
+     * @param  string  $key
+     * @param  mixed  $default
+     * @return mixed|null
+     */
+    public function componentDataItem($key, $default = null)
+    {
+        $currentComponent = count($this->componentStack);
+
+        if ($currentComponent === 0) {
+            return value($default);
+        }
+
+        for ($i = $currentComponent - 1; $i >= 0; $i--) {
+            $data = $this->componentData[$i] ?? [];
+
+            if (array_key_exists($key, $data)) {
+                return $data[$key];
+            }
+        }
+
+        return value($default);
+    }
+
+    /**
      * Start the slot rendering process.
      *
      * @param  string  $name

--- a/src/Illuminate/View/Concerns/ManagesComponents.php
+++ b/src/Illuminate/View/Concerns/ManagesComponents.php
@@ -91,6 +91,7 @@ trait ManagesComponents
         $data = $this->componentData();
 
         $previousRenderData = $this->activeRenderData;
+
         $this->activeRenderData = array_merge($previousRenderData, $data);
 
         try {

--- a/src/Illuminate/View/Concerns/ManagesComponents.php
+++ b/src/Illuminate/View/Concerns/ManagesComponents.php
@@ -88,11 +88,10 @@ trait ManagesComponents
     {
         $view = array_pop($this->componentStack);
 
-        $data = $this->componentData();
-
-        $previousComponentData = $this->currentComponentData;
-
-        $this->currentComponentData = array_merge($previousComponentData, $data);
+        $this->currentComponentData = array_merge(
+            $previousComponentData = $this->currentComponentData,
+            $data = $this->componentData()
+        );
 
         try {
             $view = value($view, $data);

--- a/src/Illuminate/View/Concerns/ManagesComponents.php
+++ b/src/Illuminate/View/Concerns/ManagesComponents.php
@@ -122,7 +122,7 @@ trait ManagesComponents
      * @param  mixed  $default
      * @return mixed|null
      */
-    public function componentDataItem($key, $default = null)
+    public function getConsumableComponentData($key, $default = null)
     {
         $currentComponent = count($this->componentStack);
 

--- a/tests/Integration/View/BladeTest.php
+++ b/tests/Integration/View/BladeTest.php
@@ -76,6 +76,42 @@ class BladeTest extends TestCase
         $this->assertSame('<input class="disabled-class" foo="bar" type="text" disabled />', trim($view));
     }
 
+    public function test_consume_default()
+    {
+        $view = View::make('consume', ['mode' => 'defaults'])->render();
+
+        $this->assertSame('<ul>
+<li>slot=Inline child 1, color=red</li>
+<li>slot=Inline child 2, color=red</li>
+<li>slot=Default item 1, color=red</li>
+<li>slot=Default item 2, color=red</li>
+</ul>', trim($view));
+    }
+
+    public function test_consume_props()
+    {
+        $view = View::make('consume', ['mode' => 'props'])->render();
+
+        $this->assertSame('<ul>
+<li>slot=Inline child 1, color=pink</li>
+<li>slot=Inline child 2, color=pink</li>
+<li>slot=Default item 1, color=pink</li>
+<li>slot=Default item 2, color=pink</li>
+</ul>', trim($view));
+    }
+
+    public function test_consume_with_override()
+    {
+        $view = View::make('consume', ['mode' => 'override'])->render();
+
+        $this->assertSame('<ul>
+<li>slot=Inline child 1, color=pink</li>
+<li>slot=Inline child 2, color=pink</li>
+<li>slot=Default item 1, color=yellow</li>
+<li>slot=Default item 2, color=pink</li>
+</ul>', trim($view));
+    }
+
     protected function getEnvironmentSetUp($app)
     {
         $app['config']->set('view.paths', [__DIR__.'/templates']);

--- a/tests/Integration/View/BladeTest.php
+++ b/tests/Integration/View/BladeTest.php
@@ -76,28 +76,30 @@ class BladeTest extends TestCase
         $this->assertSame('<input class="disabled-class" foo="bar" type="text" disabled />', trim($view));
     }
 
-    public function test_consume_default()
+    public function test_consume_defaults()
     {
-        $view = View::make('consume', ['mode' => 'defaults'])->render();
+        $view = View::make('consume')->render();
 
-        $this->assertSame('<ul>
-<li>slot=Inline child 1, color=orange</li>
-<li>slot=Inline child 2, color=red</li>
-<li>slot=Default item 1, color=blue</li>
-<li>slot=Default item 2, color=red</li>
-</ul>', trim($view));
+        $this->assertSame('<h1>Menu</h1>
+<div>Slot: A, Color: orange, Default: foo</div>
+<div>Slot: B, Color: red, Default: foo</div>
+<div>Slot: C, Color: blue, Default: foo</div>
+<div>Slot: D, Color: red, Default: foo</div>
+<div>Slot: E, Color: red, Default: foo</div>
+<div>Slot: F, Color: yellow, Default: foo</div>', trim($view));
     }
 
-    public function test_consume_props()
+    public function test_consume_with_props()
     {
-        $view = View::make('consume', ['mode' => 'props'])->render();
+        $view = View::make('consume', ['color' => 'rebeccapurple'])->render();
 
-        $this->assertSame('<ul>
-<li>slot=Inline child 1, color=orange</li>
-<li>slot=Inline child 2, color=pink</li>
-<li>slot=Default item 1, color=blue</li>
-<li>slot=Default item 2, color=pink</li>
-</ul>', trim($view));
+        $this->assertSame('<h1>Menu</h1>
+<div>Slot: A, Color: orange, Default: foo</div>
+<div>Slot: B, Color: rebeccapurple, Default: foo</div>
+<div>Slot: C, Color: blue, Default: foo</div>
+<div>Slot: D, Color: rebeccapurple, Default: foo</div>
+<div>Slot: E, Color: rebeccapurple, Default: foo</div>
+<div>Slot: F, Color: yellow, Default: foo</div>', trim($view));
     }
 
     protected function getEnvironmentSetUp($app)

--- a/tests/Integration/View/BladeTest.php
+++ b/tests/Integration/View/BladeTest.php
@@ -81,9 +81,9 @@ class BladeTest extends TestCase
         $view = View::make('consume', ['mode' => 'defaults'])->render();
 
         $this->assertSame('<ul>
-<li>slot=Inline child 1, color=red</li>
+<li>slot=Inline child 1, color=orange</li>
 <li>slot=Inline child 2, color=red</li>
-<li>slot=Default item 1, color=red</li>
+<li>slot=Default item 1, color=blue</li>
 <li>slot=Default item 2, color=red</li>
 </ul>', trim($view));
     }
@@ -93,21 +93,9 @@ class BladeTest extends TestCase
         $view = View::make('consume', ['mode' => 'props'])->render();
 
         $this->assertSame('<ul>
-<li>slot=Inline child 1, color=pink</li>
+<li>slot=Inline child 1, color=orange</li>
 <li>slot=Inline child 2, color=pink</li>
-<li>slot=Default item 1, color=pink</li>
-<li>slot=Default item 2, color=pink</li>
-</ul>', trim($view));
-    }
-
-    public function test_consume_with_override()
-    {
-        $view = View::make('consume', ['mode' => 'override'])->render();
-
-        $this->assertSame('<ul>
-<li>slot=Inline child 1, color=pink</li>
-<li>slot=Inline child 2, color=pink</li>
-<li>slot=Default item 1, color=yellow</li>
+<li>slot=Default item 1, color=blue</li>
 <li>slot=Default item 2, color=pink</li>
 </ul>', trim($view));
     }

--- a/tests/Integration/View/templates/components/menu-item.blade.php
+++ b/tests/Integration/View/templates/components/menu-item.blade.php
@@ -1,2 +1,2 @@
-@consume(['color' => 'red', 'default' => 'foo'])
+@aware(['color' => 'red', 'default' => 'foo'])
 <div>Slot: {{ $slot }}, Color: {{ $color }}, Default: {{ $default }}</div>

--- a/tests/Integration/View/templates/components/menu-item.blade.php
+++ b/tests/Integration/View/templates/components/menu-item.blade.php
@@ -1,2 +1,2 @@
-@consume(['color' => 'red'])
-<li>slot={{ $slot }}, color={{ $color }}</li>
+@consume(['color' => 'red', 'default' => 'foo'])
+<div>Slot: {{ $slot }}, Color: {{ $color }}, Default: {{ $default }}</div>

--- a/tests/Integration/View/templates/components/menu-item.blade.php
+++ b/tests/Integration/View/templates/components/menu-item.blade.php
@@ -1,0 +1,2 @@
+@consume(['color' => 'red'])
+<li>slot={{ $slot }}, color={{ $color }}</li>

--- a/tests/Integration/View/templates/components/menu.blade.php
+++ b/tests/Integration/View/templates/components/menu.blade.php
@@ -1,6 +1,6 @@
 @props(['color'])
 <ul>
-<x-menu-item>Inline child 1</x-menu-item>
+<x-menu-item color="orange">Inline child 1</x-menu-item>
 <x-menu-item>Inline child 2</x-menu-item>
 {{ $slot }}
 </ul>

--- a/tests/Integration/View/templates/components/menu.blade.php
+++ b/tests/Integration/View/templates/components/menu.blade.php
@@ -1,6 +1,6 @@
-@props(['color'])
-<ul>
-<x-menu-item color="orange">Inline child 1</x-menu-item>
-<x-menu-item>Inline child 2</x-menu-item>
+<h1>Menu</h1>
+<x-menu-item color="orange">A</x-menu-item>
+<x-menu-item>B</x-menu-item>
 {{ $slot }}
-</ul>
+<x-menu-item>E</x-menu-item>
+<x-menu-item color="yellow">F</x-menu-item>

--- a/tests/Integration/View/templates/components/menu.blade.php
+++ b/tests/Integration/View/templates/components/menu.blade.php
@@ -1,0 +1,6 @@
+@props(['color'])
+<ul>
+<x-menu-item>Inline child 1</x-menu-item>
+<x-menu-item>Inline child 2</x-menu-item>
+{{ $slot }}
+</ul>

--- a/tests/Integration/View/templates/consume.blade.php
+++ b/tests/Integration/View/templates/consume.blade.php
@@ -1,15 +1,15 @@
-@if('defaults' === $mode)
+@isset($color)
 
-<x-menu>
-<x-menu-item color="blue">Default item 1</x-menu-item>
-<x-menu-item>Default item 2</x-menu-item>
+<x-menu :color="$color">
+<x-menu-item color="blue">C</x-menu-item>
+<x-menu-item>D</x-menu-item>
 </x-menu>
 
 @else
 
-<x-menu color="pink">
-<x-menu-item color="blue">Default item 1</x-menu-item>
-<x-menu-item>Default item 2</x-menu-item>
+<x-menu>
+<x-menu-item color="blue">C</x-menu-item>
+<x-menu-item>D</x-menu-item>
 </x-menu>
 
-@endif
+@endisset

--- a/tests/Integration/View/templates/consume.blade.php
+++ b/tests/Integration/View/templates/consume.blade.php
@@ -1,0 +1,22 @@
+@if('defaults' === $mode)
+
+<x-menu>
+<x-menu-item>Default item 1</x-menu-item>
+<x-menu-item>Default item 2</x-menu-item>
+</x-menu>
+
+@elseif('override')
+
+<x-menu color="pink">
+<x-menu-item color="yellow">Default item 1</x-menu-item>
+<x-menu-item>Default item 2</x-menu-item>
+</x-menu>
+
+@else
+
+<x-menu color="pink">
+<x-menu-item>Default item 1</x-menu-item>
+<x-menu-item>Default item 2</x-menu-item>
+</x-menu>
+
+@endif

--- a/tests/Integration/View/templates/consume.blade.php
+++ b/tests/Integration/View/templates/consume.blade.php
@@ -1,21 +1,14 @@
 @if('defaults' === $mode)
 
 <x-menu>
-<x-menu-item>Default item 1</x-menu-item>
-<x-menu-item>Default item 2</x-menu-item>
-</x-menu>
-
-@elseif('override')
-
-<x-menu color="pink">
-<x-menu-item color="yellow">Default item 1</x-menu-item>
+<x-menu-item color="blue">Default item 1</x-menu-item>
 <x-menu-item>Default item 2</x-menu-item>
 </x-menu>
 
 @else
 
 <x-menu color="pink">
-<x-menu-item>Default item 1</x-menu-item>
+<x-menu-item color="blue">Default item 1</x-menu-item>
 <x-menu-item>Default item 2</x-menu-item>
 </x-menu>
 


### PR DESCRIPTION
This is a re-submit of #39080 that makes the data from any components that are actively being rendered as well as parent components that haven't yet been rendered available to child components via the `@consume` directive:

```blade
{{-- menu.blade.php --}}
@props(['color'])
<ul>
  <x-menu-item color="orange">A</x-menu-item>
  <x-menu-item>B</x-menu-item>
  {{ $slot }}
</ul>

{{-- menu-item.blade.php --}}
@consume(['color' => 'red'])
<li>slot={{ $slot }}, color={{ $color }}</li>

{{-- Without setting color attribute, colors will be: orange, red, blue, red --}}
<x-menu>
  <x-menu-item color="blue">C</x-menu-item>
  <x-menu-item>D</x-menu-item>
</x-menu>

{{-- With setting color attribute, colors will be: orange, pink, blue, pink --}}
<x-menu color="pink">
  <x-menu-item color="blue">C</x-menu-item>
  <x-menu-item>D</x-menu-item>
</x-menu>
```