### PR TITLE
Consume

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
@@ -63,10 +63,11 @@ trait CompilesComponents
     {
         return implode("\n", [
             '<?php if (isset($component)) { $__componentOriginal'.$hash.' = $component; } ?>',
+            '<?php if (isset($__componentData)) { $__env->withComponentConsumableData($__componentData); } ?>',
             '<?php $component = $__env->getContainer()->make('.Str::finish($component, '::class').', '.($data ?: '[]').'); ?>',
             '<?php $component->withName('.$alias.'); ?>',
             '<?php if ($component->shouldRender()): ?>',
-            '<?php $__env->startComponent($component->resolveView(), $component->data()); ?>',
+            '<?php $__env->startComponent($component->resolveView(), $__componentData = $component->data()); ?>',
         ]);
     }
 
@@ -159,6 +160,20 @@ trait CompilesComponents
     if (array_key_exists(\$__key, \$__defined_vars)) unset(\$\$__key);
 } ?>
 <?php unset(\$__defined_vars); ?>";
+    }
+
+    /**
+     * Compile the consume statement into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileConsume($expression)
+    {
+        return "<?php foreach ({$expression} as \$__key => \$__value) {
+    \$__consumeVariable = is_string(\$__key) ? \$__key : \$__value;
+    \$\$__consumeVariable = is_string(\$__key) ? \$__env->getConsumableComponentData(\$__key, \$__value) : \$__env->getConsumableComponentData(\$__value);
+} ?>";
     }
 
     /**

--- a/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
@@ -172,7 +172,9 @@ trait CompilesComponents
     {
         return "<?php foreach ({$expression} as \$__key => \$__value) {
     \$__consumeVariable = is_string(\$__key) ? \$__key : \$__value;
+    if (! array_key_exists(\$__consumeVariable, get_defined_vars())) {
     \$\$__consumeVariable = is_string(\$__key) ? \$__env->getConsumableComponentData(\$__key, \$__value) : \$__env->getConsumableComponentData(\$__value);
+    }
 } ?>";
     }
 

--- a/src/Illuminate/View/Concerns/ManagesComponents.php
+++ b/src/Illuminate/View/Concerns/ManagesComponents.php
@@ -25,6 +25,13 @@ trait ManagesComponents
     protected $componentData = [];
 
     /**
+     * The currently consumable component data.
+     *
+     * @var array
+     */
+    protected $consumableData = [];
+
+    /**
      * The slot contents for the component.
      *
      * @var array
@@ -116,6 +123,29 @@ trait ManagesComponents
     }
 
     /**
+     * Get an item from the component data that exists above the current component.
+     *
+     * @param  string|null  $key
+     * @param  mixed  $default
+     * @return mixed|null
+     */
+    public function getConsumableComponentData($key = null, $default = null)
+    {
+        return Arr::get($this->consumableData, $key, $default);
+    }
+
+    /**
+     * Merge additional component consumable data into the current consumable data array.
+     *
+     * @param  array  $data
+     * @return void
+     */
+    public function withComponentConsumableData(array $data)
+    {
+        $this->consumableData = array_merge($this->consumableData, $data);
+    }
+
+    /**
      * Start the slot rendering process.
      *
      * @param  string  $name
@@ -173,5 +203,6 @@ trait ManagesComponents
     {
         $this->componentStack = [];
         $this->componentData = [];
+        $this->consumableData = [];
     }
 }

--- a/tests/Integration/View/BladeTest.php
+++ b/tests/Integration/View/BladeTest.php
@@ -81,10 +81,10 @@ class BladeTest extends TestCase
         $view = View::make('consume')->render();
 
         $this->assertSame('<h1>Menu</h1>
-<div>Slot: 1, Color: blue</div>
-<div>Slot: 2, Color: blue</div>
-<div>Slot: 3, Color: blue</div>
-<div>Slot: 4, Color: orange</div>', trim($view));
+<div>Slot: 1, Color: blue, Default: foo</div>
+<div>Slot: 2, Color: blue, Default: foo</div>
+<div>Slot: 3, Color: blue, Default: foo</div>
+<div>Slot: 4, Color: orange, Default: foo</div>', trim($view));
     }
 
     protected function getEnvironmentSetUp($app)

--- a/tests/Integration/View/BladeTest.php
+++ b/tests/Integration/View/BladeTest.php
@@ -76,6 +76,17 @@ class BladeTest extends TestCase
         $this->assertSame('<input class="disabled-class" foo="bar" type="text" disabled />', trim($view));
     }
 
+    public function test_consumable_data()
+    {
+        $view = View::make('consume')->render();
+
+        $this->assertSame('<h1>Menu</h1>
+<div>Slot: 1, Color: blue</div>
+<div>Slot: 2, Color: blue</div>
+<div>Slot: 3, Color: blue</div>
+<div>Slot: 4, Color: orange</div>', trim($view));
+    }
+
     protected function getEnvironmentSetUp($app)
     {
         $app['config']->set('view.paths', [__DIR__.'/templates']);

--- a/tests/Integration/View/BladeTest.php
+++ b/tests/Integration/View/BladeTest.php
@@ -83,8 +83,9 @@ class BladeTest extends TestCase
         $this->assertSame('<h1>Menu</h1>
 <div>Slot: 1, Color: blue, Default: foo</div>
 <div>Slot: 2, Color: blue, Default: foo</div>
-<div>Slot: 3, Color: blue, Default: foo</div>
-<div>Slot: 4, Color: orange, Default: foo</div>', trim($view));
+<div>Slot: 3, Color: purple, Default: foo</div>
+<div>Slot: 4, Color: blue, Default: foo</div>
+<div>Slot: 5, Color: orange, Default: foo</div>', trim($view));
     }
 
     protected function getEnvironmentSetUp($app)

--- a/tests/Integration/View/templates/components/menu-item.blade.php
+++ b/tests/Integration/View/templates/components/menu-item.blade.php
@@ -1,0 +1,2 @@
+@consume(['color'])
+<div>Slot: {{ $slot }}, Color: {{ $color }}</div>

--- a/tests/Integration/View/templates/components/menu-item.blade.php
+++ b/tests/Integration/View/templates/components/menu-item.blade.php
@@ -1,2 +1,2 @@
-@consume(['color'])
-<div>Slot: {{ $slot }}, Color: {{ $color }}</div>
+@consume(['color', 'default' => 'foo'])
+<div>Slot: {{ $slot }}, Color: {{ $color }}, Default: {{ $default }}</div>

--- a/tests/Integration/View/templates/components/menu.blade.php
+++ b/tests/Integration/View/templates/components/menu.blade.php
@@ -1,0 +1,4 @@
+<h1>Menu</h1>
+{{ $slot }}
+<x-menu-item>3</x-menu-item>
+<x-menu-item color="orange">4</x-menu-item>

--- a/tests/Integration/View/templates/components/menu.blade.php
+++ b/tests/Integration/View/templates/components/menu.blade.php
@@ -1,4 +1,4 @@
 <h1>Menu</h1>
 {{ $slot }}
-<x-menu-item>3</x-menu-item>
-<x-menu-item color="orange">4</x-menu-item>
+<x-menu-item>4</x-menu-item>
+<x-menu-item color="orange">5</x-menu-item>

--- a/tests/Integration/View/templates/consume.blade.php
+++ b/tests/Integration/View/templates/consume.blade.php
@@ -1,4 +1,5 @@
 <x-menu color="blue">
 <x-menu-item>1</x-menu-item>
 <x-menu-item>2</x-menu-item>
+<x-menu-item color="purple">3</x-menu-item>
 </x-menu>

--- a/tests/Integration/View/templates/consume.blade.php
+++ b/tests/Integration/View/templates/consume.blade.php
@@ -1,0 +1,4 @@
+<x-menu color="blue">
+<x-menu-item>1</x-menu-item>
+<x-menu-item>2</x-menu-item>
+</x-menu>

--- a/tests/View/Blade/BladeComponentsTest.php
+++ b/tests/View/Blade/BladeComponentsTest.php
@@ -13,10 +13,11 @@ class BladeComponentsTest extends AbstractBladeTestCase
     public function testClassComponentsAreCompiled()
     {
         $this->assertSame('<?php if (isset($component)) { $__componentOriginal35bda42cbf6f9717b161c4f893644ac7a48b0d98 = $component; } ?>
+<?php if (isset($__componentData)) { $__env->withComponentConsumableData($__componentData); } ?>
 <?php $component = $__env->getContainer()->make(Test::class, ["foo" => "bar"]); ?>
 <?php $component->withName(\'test\'); ?>
 <?php if ($component->shouldRender()): ?>
-<?php $__env->startComponent($component->resolveView(), $component->data()); ?>', $this->compiler->compileString('@component(\'Test::class\', \'test\', ["foo" => "bar"])'));
+<?php $__env->startComponent($component->resolveView(), $__componentData = $component->data()); ?>', $this->compiler->compileString('@component(\'Test::class\', \'test\', ["foo" => "bar"])'));
     }
 
     public function testEndComponentsAreCompiled()


### PR DESCRIPTION
From an idea by @calebporzio ...

When building complex Blade components, it's hard / impossible to access data passed into the parent from children in the parent's slot.

For a concrete example of the problem (using a `x-menu` component):

**Usage**
```html
<x-menu color="blue">
    <x-menu.item>Foo</x-menu.item>
    <x-menu.item>Bar</x-menu.item>
    ...
</x-menu>
```

Notice we are passing in a "color" attribute to the parent component. Here's the parent component definition:

**x-menu**
```html
@props(['color' => 'black'])

<ul ...>
    {{ $slot }}
</ul>
```

Now this component has access to `$color`, but it doesn't actually need it. We need to access `$color` from each `menu-item` component:

**x-menu.item**
```html
<li class="bg-{{ $color }}-500">
    {{ $slot }}
</li>
```

Can now be done via `@consume` directive in the child... defaults are also supported if no consumable data with the given name can be found in the parent component stack...

**x-menu.item**
```html
@consume(['color', 'foo' => 'default'])

<li class="bg-{{ $color }}-500">
    {{ $slot }}
</li>
```