### PR TITLE
[8.x] Adding `lang_path` helper function

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -791,6 +791,19 @@ if (! function_exists('storage_path')) {
     }
 }
 
+if (! function_exists('lang_path')) {
+    /**
+     * Get the path to the language folder.
+     *
+     * @param  string  $path
+     * @return string
+     */
+    function lang_path($path = '')
+    {
+        return app('path.lang').($path ? DIRECTORY_SEPARATOR.$path : $path);
+    }
+}
+
 if (! function_exists('today')) {
     /**
      * Create a new Carbon instance for the current date.

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -483,6 +483,20 @@ if (! function_exists('logger')) {
     }
 }
 
+
+if (! function_exists('lang_path')) {
+    /**
+     * Get the path to the language folder.
+     *
+     * @param  string  $path
+     * @return string
+     */
+    function lang_path($path = '')
+    {
+        return app('path.lang').($path ? DIRECTORY_SEPARATOR.$path : $path);
+    }
+}
+
 if (! function_exists('logs')) {
     /**
      * Get a log driver instance.
@@ -788,19 +802,6 @@ if (! function_exists('storage_path')) {
     function storage_path($path = '')
     {
         return app('path.storage').($path ? DIRECTORY_SEPARATOR.$path : $path);
-    }
-}
-
-if (! function_exists('lang_path')) {
-    /**
-     * Get the path to the language folder.
-     *
-     * @param  string  $path
-     * @return string
-     */
-    function lang_path($path = '')
-    {
-        return app('path.lang').($path ? DIRECTORY_SEPARATOR.$path : $path);
     }
 }
 

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -483,7 +483,6 @@ if (! function_exists('logger')) {
     }
 }
 
-
 if (! function_exists('lang_path')) {
     /**
      * Get the path to the language folder.


### PR DESCRIPTION
Based on the PR #36044 the framework will look for the **lang** directory in both the "**resources**" directory and at the **top level**.

Adding a new helper function **lang_path** to get the current path to the language folder. 

```php
$langPath = lang_path(); // PROJECT_DIR/resources/lang or PROJECT_DIR/lang

$langPath = lang_path('es'); // PROJECT_DIR/resources/lang/es or PROJECT_DIR/lang/es

$langPath = lang_path('en'); // PROJECT_DIR/resources/lang/en or PROJECT_DIR/lang/en
```

Using a custom directory. Don't have to figure it out where is the **lang** directory.

```php
// Set the language file directory.
app()->useLangPath(resource_path('language'));
```

```php
$langPath = lang_path(); // PROJECT_DIR/resources/language

$langPath = lang_path('es'); // PROJECT_DIR/resources/language/es

$langPath = lang_path('en'); // PROJECT_DIR/resources/language/en
```