### PR TITLE
[8.x] Add mergeWhen method to request

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -332,6 +332,22 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     }
 
     /**
+     * Conditionally merge new input into the current request's input array.
+     *
+     * @param  callable|bool  $condition
+     * @param  array  $input
+     * @return $this
+     */
+    public function mergeWhen($condition, array $input)
+    {
+        $shouldMerge = is_callable($condition) ? call_user_func($condition) : $condition;
+
+        $this->getInputSource()->add($shouldMerge ? $input : []);
+
+        return $this;
+    }
+
+    /**
      * Replace the input for the current request.
      *
      * @param  array  $input

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -692,6 +692,19 @@ class HttpRequestTest extends TestCase
         $this->assertSame('Dayle', $request->input('buddy'));
     }
 
+    public function testMergeWhenMethod()
+    {
+        $request = Request::create('/', 'GET', ['name' => 'Taylor']);
+        $request->mergeWhen(true, ['buddy' => 'Dayle']);
+        $closure = function () {
+            return false;
+        };
+        $request->mergeWhen($closure, ['foo' => 'Bar']);
+        $this->assertSame('Taylor', $request->input('name'));
+        $this->assertSame('Dayle', $request->input('buddy'));
+        $this->assertNull($request->input('foo'));
+    }
+
     public function testReplaceMethod()
     {
         $request = Request::create('/', 'GET', ['name' => 'Taylor']);


### PR DESCRIPTION
laravel [v8.55.0](https://github.com/laravel/framework/releases/tag/v8.55.0) introduce support for conditional validation.  
basically this PR has same goal but for the request class.  
this will add `mergeWhen` method to the request class.

Q: why?  
A: it might be useful when we need a simple conditional logic to merge input to the request

consider this following scenario:


```php
// its a `create new task form` which has team_id field
// when user does not supply the team_id, the default should be their own team 

// before
public function store(Request $request) 
{
    if ($request->isNotFilled('team_id')) {
        $request->merge([
            'team_id' => Auth::user()->team_id,
            'foo' => 'bar', // anything...
        ]);
    }
    $request->validate([
        'team_id' => 'required|exists:teams,id',
        //...
    ]);
    //...
}

// after
public function store(Request $request) 
{
    $request->mergeWhen($request->isNotFilled('team_id'), [
        'team_id' => Auth::user()->team_id,
        'foo' => 'bar', // anything...
    ]);
    $request->validate([
        'team_id' => 'required|exists:teams,id',
        //...
    ]);
    //...
}
//...
```

this will save `4 spaces of identation` 😁️
feel free to accept or drop this PR 😇️