### PR TITLE
[8.x] Declare that abort(), dd() and kill() never return

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3402,7 +3402,7 @@ class Builder
     /**
      * Die and dump the current SQL and bindings.
      *
-     * @return void
+     * @return never
      */
     public function dd()
     {

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1104,7 +1104,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      * @param  int  $code
      * @param  string  $message
      * @param  array  $headers
-     * @return void
+     * @return never
      *
      * @throws \Symfony\Component\HttpKernel\Exception\HttpException
      * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -28,7 +28,7 @@ if (! function_exists('abort')) {
      * @param  \Symfony\Component\HttpFoundation\Response|\Illuminate\Contracts\Support\Responsable|int  $code
      * @param  string  $message
      * @param  array  $headers
-     * @return void
+     * @return never
      *
      * @throws \Symfony\Component\HttpKernel\Exception\HttpException
      * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -726,7 +726,7 @@ class Worker
      * Kill the process.
      *
      * @param  int  $status
-     * @return void
+     * @return never
      */
     public function kill($status = 0)
     {

--- a/src/Illuminate/Support/Facades/App.php
+++ b/src/Illuminate/Support/Facades/App.php
@@ -36,7 +36,7 @@ namespace Illuminate\Support\Facades;
  * @method static string storagePath(string $path = '')
  * @method static string version()
  * @method static string|bool environment(string|array ...$environments)
- * @method static void abort(int $code, string $message = '', array $headers = [])
+ * @method static never abort(int $code, string $message = '', array $headers = [])
  * @method static void boot()
  * @method static void booted(callable $callback)
  * @method static void booting(callable $callback)

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -789,7 +789,7 @@ class Stringable implements JsonSerializable
     /**
      * Dump the string and end the script.
      *
-     * @return void
+     * @return never
      */
     public function dd()
     {


### PR DESCRIPTION
This helps static analyzers like PHPStan and Psalm in cases like the following:

```php
$user = User::find($user_id);

if (!$user) {
  abort(404);
}

// Without declaring `abort()` to @return never, Psalm reports a `PossiblyNullArgument` here:
processUser($user);

function processUser(User $user) {
  // ...
}
```