### PR TITLE
[8.x] Add beforeSuffix and afterPrefix methods to Strings and Fluent Strings

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -100,11 +100,11 @@ class Str
             return $subject;
         }
 
-        if (! Str::startsWith($subject, $prefix)) {
+        if (! static::startsWith($subject, $prefix)) {
             return $subject;
         }
 
-        return Str::substr($subject, Str::length($prefix));
+        return static::substr($subject, static::length($prefix));
     }
 
     /**
@@ -172,11 +172,11 @@ class Str
             return $subject;
         }
 
-        if (! Str::endsWith($subject, $suffix)) {
+        if (! static::endsWith($subject, $suffix)) {
             return $subject;
         }
 
-        return Str::substr($subject, 0, Str::length($subject) - Str::length($suffix));
+        return static::substr($subject, 0, static::length($subject) - static::length($suffix));
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -88,6 +88,26 @@ class Str
     }
 
     /**
+     * Get the portion of a string after the occurrence of a given prefix value.
+     *
+     * @param  string  $subject
+     * @param  string  $prefix
+     * @return string
+     */
+    public static function afterPrefix($subject, $prefix)
+    {
+        if ($prefix === '') {
+            return $subject;
+        }
+
+        if (! Str::startsWith($subject, $prefix)) {
+            return $subject;
+        }
+
+        return Str::substr($subject, Str::length($prefix));
+    }
+
+    /**
      * Transliterate a UTF-8 value to ASCII.
      *
      * @param  string  $value
@@ -137,6 +157,26 @@ class Str
         }
 
         return static::substr($subject, 0, $pos);
+    }
+
+    /**
+     * Get the portion of a string before the occurrence of a given suffix value.
+     *
+     * @param  string  $subject
+     * @param  string  $suffix
+     * @return string
+     */
+    public static function beforeSuffix($subject, $suffix)
+    {
+        if ($suffix === '') {
+            return $subject;
+        }
+
+        if (! Str::endsWith($subject, $suffix)) {
+            return $subject;
+        }
+
+        return Str::substr($subject, 0, Str::length($subject) - Str::length($suffix));
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -104,7 +104,7 @@ class Str
             return $subject;
         }
 
-        return static::substr($subject, static::length($prefix));
+        return static::after($subject, $prefix);
     }
 
     /**
@@ -176,7 +176,7 @@ class Str
             return $subject;
         }
 
-        return static::substr($subject, 0, static::length($subject) - static::length($suffix));
+        return static::beforeLast($subject, $suffix);
     }
 
     /**

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -54,6 +54,17 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Get the portion of a string after the occurrence of a given prefix value.
+     *
+     * @param  string  $prefix
+     * @return static
+     */
+    public function afterPrefix($prefix)
+    {
+        return new static(Str::afterPrefix($this->value, $prefix));
+    }
+
+    /**
      * Append the given values to the string.
      *
      * @param  array  $values
@@ -116,6 +127,17 @@ class Stringable implements JsonSerializable
     public function beforeLast($search)
     {
         return new static(Str::beforeLast($this->value, $search));
+    }
+
+    /**
+     * Get the portion of a string before the occurrence of a given suffix value.
+     *
+     * @param  string  $prefix
+     * @return static
+     */
+    public function beforeSuffix($prefix)
+    {
+        return new static(Str::beforeSuffix($this->value, $prefix));
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -143,6 +143,20 @@ class SupportStrTest extends TestCase
         $this->assertSame('yv2et', Str::beforeLast('yv2et2te', 2));
     }
 
+    public function testStrBeforeSuffix()
+    {
+        $this->assertSame('string', Str::beforeSuffix('string_suffix', '_suffix'));
+        $this->assertSame('string suffix zzz', Str::beforeSuffix('string suffix zzz', 'suffix'));
+        $this->assertSame('suffix xxx', Str::beforeSuffix('suffix xxx', 'suffix'));
+        $this->assertSame('suffix suffix', Str::beforeSuffix('suffix suffix suffix', ' suffix'));
+        $this->assertSame('accented suffix ', Str::beforeSuffix('accented suffix é', 'é'));
+        $this->assertSame('blank suffix', Str::beforeSuffix('blank suffix', ''));
+        $this->assertSame('numeric suffix ', Str::beforeSuffix('numeric suffix 012', '012'));
+        $this->assertSame('zero int suffix ', Str::beforeSuffix('zero int suffix 0', 0));
+        $this->assertSame('int suffix', Str::beforeSuffix('int suffix23', 23));
+        $this->assertSame('', Str::beforeSuffix('all', 'all'));
+    }
+
     public function testStrBetween()
     {
         $this->assertSame('abc', Str::between('abc', '', 'c'));
@@ -182,6 +196,20 @@ class SupportStrTest extends TestCase
         $this->assertSame('te', Str::afterLast('yv0et0te', 0));
         $this->assertSame('te', Str::afterLast('yv2et2te', 2));
         $this->assertSame('foo', Str::afterLast('----foo', '---'));
+    }
+
+    public function testStrAfterPrefix()
+    {
+        $this->assertSame('string', Str::afterPrefix('prefix_string', 'prefix_'));
+        $this->assertSame('string prefix zzz', Str::afterPrefix('string prefix zzz', 'prefix'));
+        $this->assertSame('last prefix', Str::afterPrefix('last prefix', 'prefix'));
+        $this->assertSame('prefix prefix', Str::afterPrefix('prefix prefix prefix', 'prefix '));
+        $this->assertSame(' accented prefix', Str::afterPrefix('é accented prefix', 'é'));
+        $this->assertSame('blank prefix', Str::afterPrefix('blank prefix', ''));
+        $this->assertSame(' numeric prefix', Str::afterPrefix('012 numeric prefix', '012'));
+        $this->assertSame(' zero int prefix', Str::afterPrefix('0 zero int prefix', 0));
+        $this->assertSame(' int prefix', Str::afterPrefix('23 int prefix', 23));
+        $this->assertSame('', Str::afterPrefix('all', 'all'));
     }
 
     public function testStrContains()

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -311,6 +311,20 @@ class SupportStringableTest extends TestCase
         $this->assertSame('yv2et', (string) $this->stringable('yv2et2te')->beforeLast(2));
     }
 
+    public function testBeforeSuffix()
+    {
+        $this->assertSame('string', (string) $this->stringable('string_suffix')->beforeSuffix('_suffix'));
+        $this->assertSame('string suffix zzz', (string) $this->stringable('string suffix zzz')->beforeSuffix('suffix'));
+        $this->assertSame('suffix xxx', (string) $this->stringable('suffix xxx')->beforeSuffix('suffix'));
+        $this->assertSame('suffix suffix', (string) $this->stringable('suffix suffix suffix')->beforeSuffix(' suffix'));
+        $this->assertSame('accented suffix ', (string) $this->stringable('accented suffix é')->beforeSuffix('é'));
+        $this->assertSame('blank suffix', (string) $this->stringable('blank suffix')->beforeSuffix(''));
+        $this->assertSame('numeric suffix ', (string) $this->stringable('numeric suffix 012')->beforeSuffix('012'));
+        $this->assertSame('zero int suffix ', (string) $this->stringable('zero int suffix 0')->beforeSuffix(0));
+        $this->assertSame('int suffix', (string) $this->stringable('int suffix23')->beforeSuffix(23));
+        $this->assertSame('', (string) $this->stringable('all')->beforeSuffix('all'));
+    }
+
     public function testBetween()
     {
         $this->assertSame('abc', (string) $this->stringable('abc')->between('', 'c'));
@@ -350,6 +364,20 @@ class SupportStringableTest extends TestCase
         $this->assertSame('te', (string) $this->stringable('yv0et0te')->afterLast(0));
         $this->assertSame('te', (string) $this->stringable('yv2et2te')->afterLast(2));
         $this->assertSame('foo', (string) $this->stringable('----foo')->afterLast('---'));
+    }
+
+    public function testStrAfterPrefix()
+    {
+        $this->assertSame('string', (string) $this->stringable('prefix_string')->afterPrefix('prefix_'));
+        $this->assertSame('string prefix zzz', (string) $this->stringable('string prefix zzz')->afterPrefix('prefix'));
+        $this->assertSame('last prefix', (string) $this->stringable('last prefix')->afterPrefix('prefix'));
+        $this->assertSame('prefix prefix', (string) $this->stringable('prefix prefix prefix')->afterPrefix('prefix '));
+        $this->assertSame(' accented prefix', (string) $this->stringable('é accented prefix')->afterPrefix('é'));
+        $this->assertSame('blank prefix', (string) $this->stringable('blank prefix')->afterPrefix(''));
+        $this->assertSame(' numeric prefix', (string) $this->stringable('012 numeric prefix')->afterPrefix('012'));
+        $this->assertSame(' zero int prefix', (string) $this->stringable('0 zero int prefix')->afterPrefix(0));
+        $this->assertSame(' int prefix', (string) $this->stringable('23 int prefix')->afterPrefix(23));
+        $this->assertSame('', (string) $this->stringable('all')->afterPrefix('all'));
     }
 
     public function testContains()


### PR DESCRIPTION
This PR adds new `afterPrefix` and `beforeSuffix` methods to both the Strings `Str` helper class and the `Stringable` fluent strings class.

Previously if you wished to strip a string of a prefix you would first need to determine if that prefix exists using `startsWidth` and then strip it using `after`.  Failing to check if the string started with your prefix could mean that you cut the string at another occurrence of that prefix.

Utilising `afterPrefix` and `beforeSuffix` I feel makes this process a lot more intuitive and expressive.

```
# Prefix stripping 
# BEFORE
if (Str::startsWith($string, $prefix)) {
    $string = (string) Str::after($string, $prefix);
}

# AFTER
$string = Str::afterPrefix($string, $prefix);


# Suffix stripping
# BEFORE
if (Str::endsWith($string, $suffix)) {
    $string = (string) Str::beforeLast($string, $suffix);
}

# AFTER
$string = Str::beforeSuffix($string, $suffix);

```

For the fluent interface I believe the only way you could achieve this functionality reliably would be to use `pipe()`.

```
$string = (string) Str::of($string)->afterPrefix($prefix);

$string = (string) Str::of($string)->beforeSuffix($suffix);
```

I have added tests for the new methods but please advise if you need me to do anything else. 

Thanks