### PR TITLE
[8.x] Fix route groups with no prefix on PHP 8.1

### DIFF
--- a/src/Illuminate/Routing/RouteGroup.php
+++ b/src/Illuminate/Routing/RouteGroup.php
@@ -59,7 +59,7 @@ class RouteGroup
      */
     protected static function formatPrefix($new, $old, $prependExistingPrefix = true)
     {
-        $old = $old['prefix'] ?? null;
+        $old = $old['prefix'] ?? '';
 
         if ($prependExistingPrefix) {
             return isset($new['prefix']) ? trim($old, '/').'/'.trim($new['prefix'], '/') : $old;

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -250,6 +250,16 @@ class RouteRegistrarTest extends TestCase
         $this->assertSame('api.users', $this->getRoute()->getName());
     }
 
+    public function testRouteGroupingWithoutPrefix()
+    {
+        $this->router->group([], function ($router) {
+            $router->prefix('bar')->get('baz', ['as' => 'baz', function () {
+                return 'hello';
+            }]);
+        });
+        $this->seeResponse('hello', Request::create('bar/baz', 'GET'));
+    }
+
     public function testRegisteringNonApprovedAttributesThrows()
     {
         $this->expectException(BadMethodCallException::class);


### PR DESCRIPTION
In php 8.1 calling trim() on null values is deprecated and since my route collection have groups without a defined prefix, I get an error on this line of code.

Parsing in an empty string as opposed to null is the minimal change which solves the problem.