### PR TITLE
[8.x] New flag --requests -R to make:controller and make:model Commands

### DIFF
--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -133,6 +133,7 @@ class ModelMakeCommand extends GeneratorCommand
             'name' => "{$controller}Controller",
             '--model' => $this->option('resource') || $this->option('api') ? $modelName : null,
             '--api' => $this->option('api'),
+            '--requests' => $this->option('requests'),
         ]));
     }
 
@@ -205,6 +206,7 @@ class ModelMakeCommand extends GeneratorCommand
             ['pivot', 'p', InputOption::VALUE_NONE, 'Indicates if the generated model should be a custom intermediate table model'],
             ['resource', 'r', InputOption::VALUE_NONE, 'Indicates if the generated controller should be a resource controller'],
             ['api', null, InputOption::VALUE_NONE, 'Indicates if the generated controller should be an API controller'],
+            ['requests', 'R', InputOption::VALUE_NONE, 'Create a new FormRequest class and use it in resource controller'],
         ];
     }
 }

--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -216,7 +216,7 @@ class ControllerMakeCommand extends GeneratorCommand
 
         $namespacedRequests = $namespace.'\\'.$storeRequestClass.';';
         if ($storeRequestClass != $updateRequestClass) {
-            $namespacedRequests .= PHP_EOL."use ".$namespace.'\\'.$updateRequestClass.';';
+            $namespacedRequests .= PHP_EOL.'use '.$namespace.'\\'.$updateRequestClass.';';
         }
 
         return array_merge($replace, [

--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -248,7 +248,7 @@ class ControllerMakeCommand extends GeneratorCommand
             ['model', 'm', InputOption::VALUE_OPTIONAL, 'Generate a resource controller for the given model.'],
             ['parent', 'p', InputOption::VALUE_OPTIONAL, 'Generate a nested resource controller class.'],
             ['resource', 'r', InputOption::VALUE_NONE, 'Generate a resource controller class.'],
-            ['requests', null, InputOption::VALUE_NONE, 'Generate FormRequest classes for store and update.'],
+            ['requests', 'R', InputOption::VALUE_NONE, 'Generate FormRequest classes for store and update.'],
         ];
     }
 }

--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -193,7 +193,7 @@ class ControllerMakeCommand extends GeneratorCommand
     /**
      * Build the model replacement values.
      *
-     * @param  array   $replace
+     * @param  array  $replace
      * @param  string  $modelClass
      * @return array
      */
@@ -203,27 +203,27 @@ class ControllerMakeCommand extends GeneratorCommand
         $namespace = 'Illuminate\\Http';
 
         if ($this->option('requests')) {
-            $storeRequestClass = 'Store' . class_basename($modelClass) . 'Request';
+            $storeRequestClass = 'Store'.class_basename($modelClass).'Request';
             $this->call('make:request', [
                 'name' => $storeRequestClass,
             ]);
-            $updateRequestClass = 'Update' . class_basename($modelClass) . 'Request';
+            $updateRequestClass = 'Update'.class_basename($modelClass).'Request';
             $this->call('make:request', [
                 'name' => $updateRequestClass,
             ]);
             $namespace = 'App\\Http\\Requests';
         }
         if ($this->option('request')) {
-            $storeRequestClass = $updateRequestClass = class_basename($modelClass) . 'Request';
+            $storeRequestClass = $updateRequestClass = class_basename($modelClass).'Request';
             $this->call('make:request', [
-                'name' => $storeRequestClass
+                'name' => $storeRequestClass,
             ]);
             $namespace = 'App\\Http\\Requests';
         }
 
-        $namespacedRequests = $namespace . '\\' . $storeRequestClass . ';';
+        $namespacedRequests = $namespace.'\\'.$storeRequestClass.';';
         if ($storeRequestClass != $updateRequestClass) {
-            $namespacedRequests .= "\r\nuse " . $namespace . "\\" . $updateRequestClass . ";";
+            $namespacedRequests .= "\r\nuse ".$namespace."\\".$updateRequestClass . ";";
         }
 
         return array_merge($replace, [
@@ -231,10 +231,10 @@ class ControllerMakeCommand extends GeneratorCommand
             '{{storeRequest}}' => $storeRequestClass,
             '{{ updateRequest }}' => $updateRequestClass,
             '{{updateRequest}}' => $updateRequestClass,
-            '{{ namespacedStoreRequest }}' => $namespace . '\\' . $storeRequestClass,
-            '{{namespacedStoreRequest}}' => $namespace . '\\' . $storeRequestClass,
-            '{{ namespacedUpdateRequest }}' => $namespace . '\\' . $updateRequestClass,
-            '{{namespacedUpdateRequest}}' => $namespace . '\\' . $updateRequestClass,
+            '{{ namespacedStoreRequest }}' => $namespace.'\\'.$storeRequestClass,
+            '{{namespacedStoreRequest}}' => $namespace.'\\'.$storeRequestClass,
+            '{{ namespacedUpdateRequest }}' => $namespace.'\\'.$updateRequestClass,
+            '{{namespacedUpdateRequest}}' => $namespace.'\\'.$updateRequestClass,
             '{{ namespacedRequests }}' => $namespacedRequests,
             '{{namespacedRequests}}' => $namespacedRequests,
         ]);

--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -223,7 +223,7 @@ class ControllerMakeCommand extends GeneratorCommand
 
         $namespacedRequests = $namespace.'\\'.$storeRequestClass.';';
         if ($storeRequestClass != $updateRequestClass) {
-            $namespacedRequests .= "\r\nuse ".$namespace.'\\'.$updateRequestClass.';';
+            $namespacedRequests .= PHP_EOL."use ".$namespace.'\\'.$updateRequestClass.';';
         }
 
         return array_merge($replace, [

--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -223,7 +223,7 @@ class ControllerMakeCommand extends GeneratorCommand
 
         $namespacedRequests = $namespace.'\\'.$storeRequestClass.';';
         if ($storeRequestClass != $updateRequestClass) {
-            $namespacedRequests .= "\r\nuse ".$namespace.'\\'.$updateRequestClass . ';';
+            $namespacedRequests .= "\r\nuse ".$namespace.'\\'.$updateRequestClass.';';
         }
 
         return array_merge($replace, [

--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -213,13 +213,6 @@ class ControllerMakeCommand extends GeneratorCommand
             ]);
             $namespace = 'App\\Http\\Requests';
         }
-        if ($this->option('request')) {
-            $storeRequestClass = $updateRequestClass = class_basename($modelClass).'Request';
-            $this->call('make:request', [
-                'name' => $storeRequestClass,
-            ]);
-            $namespace = 'App\\Http\\Requests';
-        }
 
         $namespacedRequests = $namespace.'\\'.$storeRequestClass.';';
         if ($storeRequestClass != $updateRequestClass) {
@@ -255,7 +248,6 @@ class ControllerMakeCommand extends GeneratorCommand
             ['model', 'm', InputOption::VALUE_OPTIONAL, 'Generate a resource controller for the given model.'],
             ['parent', 'p', InputOption::VALUE_OPTIONAL, 'Generate a nested resource controller class.'],
             ['resource', 'r', InputOption::VALUE_NONE, 'Generate a resource controller class.'],
-            ['request', null, InputOption::VALUE_NONE, 'Generate a FormRequest class.'],
             ['requests', null, InputOption::VALUE_NONE, 'Generate FormRequest classes for store and update.'],
         ];
     }

--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -223,7 +223,7 @@ class ControllerMakeCommand extends GeneratorCommand
 
         $namespacedRequests = $namespace.'\\'.$storeRequestClass.';';
         if ($storeRequestClass != $updateRequestClass) {
-            $namespacedRequests .= "\r\nuse ".$namespace."\\".$updateRequestClass . ";";
+            $namespacedRequests .= "\r\nuse ".$namespace.'\\'.$updateRequestClass . ';';
         }
 
         return array_merge($replace, [

--- a/src/Illuminate/Routing/Console/stubs/controller.model.api.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.model.api.stub
@@ -4,7 +4,7 @@ namespace {{ namespace }};
 
 use {{ namespacedModel }};
 use {{ rootNamespace }}Http\Controllers\Controller;
-use Illuminate\Http\Request;
+use {{ namespacedRequests }}
 
 class {{ class }} extends Controller
 {
@@ -21,10 +21,10 @@ class {{ class }} extends Controller
     /**
      * Store a newly created resource in storage.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \{{ namespacedStoreRequest }}  $request
      * @return \Illuminate\Http\Response
      */
-    public function store(Request $request)
+    public function store({{ storeRequest }} $request)
     {
         //
     }
@@ -43,11 +43,11 @@ class {{ class }} extends Controller
     /**
      * Update the specified resource in storage.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \{{ namespacedUpdateRequest }}  $request
      * @param  \{{ namespacedModel }}  ${{ modelVariable }}
      * @return \Illuminate\Http\Response
      */
-    public function update(Request $request, {{ model }} ${{ modelVariable }})
+    public function update({{ updateRequest }} $request, {{ model }} ${{ modelVariable }})
     {
         //
     }

--- a/src/Illuminate/Routing/Console/stubs/controller.model.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.model.stub
@@ -4,7 +4,7 @@ namespace {{ namespace }};
 
 use {{ namespacedModel }};
 use {{ rootNamespace }}Http\Controllers\Controller;
-use Illuminate\Http\Request;
+use {{ namespacedRequests }}
 
 class {{ class }} extends Controller
 {
@@ -31,10 +31,10 @@ class {{ class }} extends Controller
     /**
      * Store a newly created resource in storage.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \{{ namespacedStoreRequest }}  $request
      * @return \Illuminate\Http\Response
      */
-    public function store(Request $request)
+    public function store({{ storeRequest }} $request)
     {
         //
     }
@@ -64,11 +64,11 @@ class {{ class }} extends Controller
     /**
      * Update the specified resource in storage.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \{{ namespacedUpdateRequest }}  $request
      * @param  \{{ namespacedModel }}  ${{ modelVariable }}
      * @return \Illuminate\Http\Response
      */
-    public function update(Request $request, {{ model }} ${{ modelVariable }})
+    public function update({{ updateRequest }} $request, {{ model }} ${{ modelVariable }})
     {
         //
     }


### PR DESCRIPTION
This PR adds a new flag to `php artisan make:controller` command, which creates FormRequest class and uses it immediately in the generated controller.

## Problem

How I personally use Resourceful Controllers with Form Requests:

1. `php artisan make:controller UserController --resource`
2. `php artisan make:request StoreUserRequest`
3. `php artisan make:request UpdateUserRequest`
4. Go to the `UserController` and manually replace `Illuminate\Http\Request` with those new FormRequest classes

Why couldn't we generate it all at once?

This problem resonated with my Twitter audience, with 180+ likes on [this Tweet](https://twitter.com/PovilasKorop/status/1444530282078613506).

- - - - -

## My Proposed Solution (updated October 7)

Now, when you run `php artisan make:controller UserController --resource --model=User --requests`, it will generate two FormRequest classes: `StoreUserRequest` and `UpdateUserRequest`, and will replace them in the Controller.

A short version of `--requests` flag is `-R`, not to mix with `-r` for resources.

It is done by reusing the `make:request` command and calling it with appropriate class name.

This functionality works __only__ together with `--model` flag, otherwise it would be impossible/hard to guess the name for the FormRequest classes.

Also, it works one "layer" above in the Model: `php artisan make:model Project -mcrR` would generate `StoreProjectRequest` and `UpdateProjectRequest`

- - - - - 

## Breaking changes

It shouldn't break any existing functionality, it's just a new flag. If that flag isn't used, it all falls back to the old default values. 

- - - - - 

Any other suggestions for improvement are welcome.