### PR TITLE
[8.x] Adds randomNumberBetween method to Support Str class

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -535,6 +535,18 @@ class Str
     }
 
     /**
+     * Generate a "random" numeric string.
+     *
+     * @param  int  $min
+     * @param  int  $max
+     * @return string
+     */
+    public static function randomNumbers(int $min, int $max)
+    {
+        return strval(rand($min, $max));
+    }
+
+    /**
      * Repeat the given string.
      *
      * @param  string  $string

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -541,7 +541,7 @@ class Str
      * @param  int  $max
      * @return string
      */
-    public static function randomNumbers(int $min, int $max)
+    public static function randomNumberBetween(int $min, int $max)
     {
         return strval(rand($min, $max));
     }

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -340,12 +340,12 @@ class SupportStrTest extends TestCase
         $this->assertIsString(Str::random());
     }
 
-    public function testRandomNumbers()
+    public function testRandomNumberBetween()
     {
-        $this->assertGreaterThan(0, Str::randomNumbers(1, 16));
-        $this->assertLessThan(17, Str::randomNumbers(1, 16));
-        $this->assertIsString(Str::randomNumbers(1, 16));
-        $this->assertTrue(ctype_digit(Str::randomNumbers(1, 16)));
+        $this->assertGreaterThan(0, Str::randomNumberBetween(1, 16));
+        $this->assertLessThan(17, Str::randomNumberBetween(1, 16));
+        $this->assertIsString(Str::randomNumberBetween(1, 16));
+        $this->assertTrue(ctype_digit(Str::randomNumberBetween(1, 16)));
     }
 
     public function testReplace()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -340,6 +340,14 @@ class SupportStrTest extends TestCase
         $this->assertIsString(Str::random());
     }
 
+    public function testRandomNumbers()
+    {
+        $this->assertGreaterThan(0, Str::randomNumbers(1, 16));
+        $this->assertLessThan(17, Str::randomNumbers(1, 16));
+        $this->assertIsString(Str::randomNumbers(1, 16));
+        $this->assertTrue(ctype_digit(Str::randomNumbers(1, 16)));
+    }
+
     public function testReplace()
     {
         $this->assertSame('foo bar laravel', Str::replace('baz', 'laravel', 'foo bar baz'));


### PR DESCRIPTION
This PR adds a `randomNumberBetween` method to the Support Str class.

### Usage

```php
Str::randomNumberBetween(1, 16)
```

will return a random number (as a string) between the provided `int` parameters - `min` and `max`.

### Test Scenario

Useful in test scenarios, when you want to assert a given value will be a random string of numbers (but don't care which random numbers):

```php
$this->mock(Str::class, function($mock) {
    $mock
        ->shouldReceive('randomNumberBetween')
        ->andReturn('12345');
});
```