### PR TITLE
[8.x] Added method for converting number to representational words

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -4,12 +4,12 @@ namespace Illuminate\Support;
 
 use Illuminate\Support\Traits\Macroable;
 use League\CommonMark\GithubFlavoredMarkdownConverter;
+use NumberFormatter;
 use Ramsey\Uuid\Codec\TimestampFirstCombCodec;
 use Ramsey\Uuid\Generator\CombGenerator;
 use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidFactory;
 use voku\helper\ASCII;
-use NumberFormatter;
 
 class Str
 {

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -9,6 +9,7 @@ use Ramsey\Uuid\Generator\CombGenerator;
 use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidFactory;
 use voku\helper\ASCII;
+use NumberFormatter;
 
 class Str
 {
@@ -889,5 +890,21 @@ class Str
     public static function createUuidsNormally()
     {
         static::$uuidFactory = null;
+    }
+
+    /**
+     * Make a number parsed to words.
+     *
+     * @param  string  $value
+     * @param  string  $locale
+     * @return string
+     */
+    public static function numberToWords($value, $locale = 'en_us'): string
+    {
+        if (! is_numeric($value)) {
+            return false;
+        }
+
+        return numfmt_format(numfmt_create($locale, NumberFormatter::SPELLOUT), $value);
     }
 }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -902,7 +902,7 @@ class Str
     public static function numberToWords($value, $locale = 'en_us'): string
     {
         if (! is_numeric($value)) {
-            return false;
+            return $value;
         }
 
         return numfmt_format(numfmt_create($locale, NumberFormatter::SPELLOUT), $value);


### PR DESCRIPTION
* Method for converting number to representational words. Method accepts two parameters, one for number that should be converted and second for the language in which it should be shown. 
* This can be useful for bank systems or different contracts that people use where except numbers value is presented in words too.