### PR TITLE
[8.x] Update SchemaState Process to remove timeout

### DIFF
--- a/src/Illuminate/Database/Schema/SchemaState.php
+++ b/src/Illuminate/Database/Schema/SchemaState.php
@@ -58,7 +58,7 @@ abstract class SchemaState
         $this->files = $files ?: new Filesystem;
 
         $this->processFactory = $processFactory ?: function (...$arguments) {
-            return Process::fromShellCommandline(...$arguments);
+            return Process::fromShellCommandline(...$arguments)->setTimeout(null);
         };
 
         $this->handleOutputUsing(function () {


### PR DESCRIPTION
### Issue Description:
"Dumper" (pg_dump/ pg_restore) migrations can timeout on slow machines, or when dumps are fairly decent in size.

### Proposed Solution
Remove the timeout for long lived processes such as pg_restore.

Default timeout is 60s, Symphony Process docs: https://symfony.com/doc/current/components/process.html#process-timeout

I didn't include any tests as it doesn't seem like this would need it. I encounter the 60second timeout on a GitLab instance that runs tests. During times when the shared server is being utilized a lot, the duration of the pg_restore process can last longer than 60s. I hope the team considers including this suggestion.