### PR TITLE
[9.x] Prevent calling count() on LazyCollection in Blade loops

### DIFF
--- a/src/Illuminate/View/Concerns/ManagesLoops.php
+++ b/src/Illuminate/View/Concerns/ManagesLoops.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\View\Concerns;
 
-use Countable;
 use Illuminate\Support\Arr;
+use Illuminate\Support\LazyCollection;
 
 trait ManagesLoops
 {
@@ -22,7 +22,8 @@ trait ManagesLoops
      */
     public function addLoop($data)
     {
-        $length = is_array($data) || $data instanceof Countable ? count($data) : null;
+        $length = is_countable($data) && ! $data instanceof LazyCollection
+            ? count($data) : null;
 
         $parent = Arr::last($this->loopsStack);
 

--- a/src/Illuminate/View/Concerns/ManagesLoops.php
+++ b/src/Illuminate/View/Concerns/ManagesLoops.php
@@ -23,7 +23,8 @@ trait ManagesLoops
     public function addLoop($data)
     {
         $length = is_countable($data) && ! $data instanceof LazyCollection
-            ? count($data) : null;
+                            ? count($data) 
+                            : null;
 
         $parent = Arr::last($this->loopsStack);
 

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -11,6 +11,7 @@ use Illuminate\Contracts\View\View as ViewContract;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\HtmlString;
+use Illuminate\Support\LazyCollection;
 use Illuminate\View\Compilers\CompilerInterface;
 use Illuminate\View\Engines\CompilerEngine;
 use Illuminate\View\Engines\EngineResolver;
@@ -685,6 +686,30 @@ class ViewFactoryTest extends TestCase
         $factory = $this->getFactory();
 
         $factory->addLoop('');
+
+        $expectedLoop = [
+            'iteration' => 0,
+            'index' => 0,
+            'remaining' => null,
+            'count' => null,
+            'first' => true,
+            'last' => null,
+            'odd' => false,
+            'even' => true,
+            'depth' => 1,
+            'parent' => null,
+        ];
+
+        $this->assertEquals([$expectedLoop], $factory->getLoopStack());
+    }
+
+    public function testAddingLazyCollection()
+    {
+        $factory = $this->getFactory();
+
+        $factory->addLoop(new LazyCollection(function () {
+            $this->fail('LazyCollection\'s generator should not have been called');
+        }));
 
         $expectedLoop = [
             'iteration' => 0,


### PR DESCRIPTION
As described in #39003, looping over a `LazyCollection` using `@foreach` in Blade causes the entire collection's iterator to be unwound. This causes duplicate queries and unnecessary model hydration when using lazy collections with Eloquent (because everything would be loaded into memory – twice).

This change skips calling `count()` on lazy collections, which preserves its 'laziness' until actually looping over the items.

This PR could be considered a breaking change (therefore targeted towards 9.x), because certain information on [the loop variable](https://laravel.com/docs/8.x/blade#the-loop-variable) is lost. `$loop->remaining`, `$loop->count`, and `$loop->last` will be `null` after this change when looping over a lazy collection. If one would want to keep this behaviour, calling `->collect()` on the lazy collection would mimic that.