### PR TITLE
[8.x] Add throwIf method in Client Response

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -283,7 +283,7 @@ class Response implements ArrayAccess
     }
 
     /**
-     * Throw an exception if  the condition evaulates to true.
+     * Throw a server/client error exception if the condition evaulates to true.
      *
      * @return $this
      * @param  bool  $condition

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -286,7 +286,7 @@ class Response implements ArrayAccess
      * Throw an exception if  the condition evaulates to true.
      *
      * @return $this
-     * @param bool $condition
+     * @param  bool $condition
      * @throws \Illuminate\Http\Client\RequestException
      */
     public function throwIf($condition)

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -286,7 +286,7 @@ class Response implements ArrayAccess
      * Throw an exception if  the condition evaulates to true.
      *
      * @return $this
-     * @param  bool $condition
+     * @param  bool  $condition
      * @throws \Illuminate\Http\Client\RequestException
      */
     public function throwIf($condition)

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -283,6 +283,22 @@ class Response implements ArrayAccess
     }
 
     /**
+     * Throw an exception if  the condition evaulates to true.
+     *
+     * @return $this
+     * @param bool $condition
+     * @throws \Illuminate\Http\Client\RequestException
+     */
+    public function throwIf($condition)
+    {
+        if ($condition) {
+            return $this->throw();
+        }
+
+        return $this;
+    }
+
+    /**
      * Determine if the given offset exists.
      *
      * @param  string  $offset

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -283,19 +283,16 @@ class Response implements ArrayAccess
     }
 
     /**
-     * Throw a server/client error exception if the condition evaulates to true.
+     * Throw an exception if a server or client error occurred and the given condition evaluates to true.
      *
-     * @return $this
      * @param  bool  $condition
+     * @return $this
+     *
      * @throws \Illuminate\Http\Client\RequestException
      */
     public function throwIf($condition)
     {
-        if ($condition) {
-            return $this->throw();
-        }
-
-        return $this;
+        return $condition ? $this->throw() : $this;
     }
 
     /**


### PR DESCRIPTION
The `throw` method throws an exception if a server/client error occurs.

But there is no way to tell the `throw` to throw an exception if something evaluates to `true`.

For example:
```php
->json()
->throw(App::isProduction); // This is not possible
```

The `throwIf` method throws an exception only if the condition evaluates to true:
```php
->json()
->throwIf(App::isProduction);
```

Now, we can easily inspect the error message, during development, since no exception will be thrown.

