### PR TITLE
[8.x] Fix code locating Bearer token in InteractsWithInput

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -54,7 +54,7 @@ trait InteractsWithInput
     {
         $header = $this->header('Authorization', '');
 
-        $position = strrpos($header, 'Bearer');
+        $position = strrpos($header, 'Bearer ');
 
         if ($position !== false) {
             $header = substr($header, $position + 7);

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -718,8 +718,8 @@ class HttpRequestTest extends TestCase
 
     public function testBearerTokenMethod()
     {
-        $request = Request::create('/', 'GET', [], [], [], ['HTTP_AUTHORIZATION' => 'Bearer foo']);
-        $this->assertSame('foo', $request->bearerToken());
+        $request = Request::create('/', 'GET', [], [], [], ['HTTP_AUTHORIZATION' => 'Bearer fooBearerbar']);
+        $this->assertSame('fooBearerbar', $request->bearerToken());
 
         $request = Request::create('/', 'GET', [], [], [], ['HTTP_AUTHORIZATION' => 'Basic foo, Bearer bar']);
         $this->assertSame('bar', $request->bearerToken());


### PR DESCRIPTION
The code currently only looks for the `Bearer` string when locating the Bearer token. However, since the token is base64-encoded, it is possible that the *encoded* token can also contain the string `Bearer` which actually bit me once in tests.

The correct behavior is to look for the string `Bearer ` with a trailing space. Spaces cannot be part of the token (see https://datatracker.ietf.org/doc/html/rfc6750#section-2.1).
The code already correctly splits the string after 7 characters, assuming that a trailing space is present.

This is a small fix for https://github.com/laravel/framework/pull/38426 which introduced this regression. Before, the code checked the trailing space.