### PR TITLE
[8.x] Re-add update from support for PostgreSQL

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -20,6 +20,7 @@ use Illuminate\Support\Str;
 use Illuminate\Support\Traits\ForwardsCalls;
 use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
+use LogicException;
 use RuntimeException;
 
 class Builder
@@ -2997,6 +2998,27 @@ class Builder
 
         return $this->connection->update($sql, $this->cleanBindings(
             $this->grammar->prepareBindingsForUpdate($this->bindings, $values)
+        ));
+    }
+
+    /**
+     * UpdateFrom records in a PostgreSQL database.
+     *
+     * @param  array  $values
+     * @return int
+     */
+    public function updateFrom(array $values)
+    {
+        if (! method_exists($this->grammar, 'compileUpdateFrom')) {
+            throw new LogicException('This database engine does not support the updateFrom method.');
+        }
+
+        $this->applyBeforeQueryCallbacks();
+
+        $sql = $this->grammar->compileUpdateFrom($this, $values);
+
+        return $this->connection->update($sql, $this->cleanBindings(
+            $this->grammar->prepareBindingsForUpdateFrom($this->bindings, $values)
         ));
     }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3002,7 +3002,7 @@ class Builder
     }
 
     /**
-     * UpdateFrom records in a PostgreSQL database.
+     * Update records in a PostgreSQL database using the update from syntax.
      *
      * @param  array  $values
      * @return int

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -261,6 +261,114 @@ class PostgresGrammar extends Grammar
     }
 
     /**
+     * Compile an update from statement into SQL.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $values
+     * @return string
+     */
+    public function compileUpdateFrom(Builder $query, $values)
+    {
+        $table = $this->wrapTable($query->from);
+
+        // Each one of the columns in the update statements needs to be wrapped in the
+        // keyword identifiers, also a place-holder needs to be created for each of
+        // the values in the list of bindings so we can make the sets statements.
+        $columns = $this->compileUpdateColumns($query, $values);
+
+        $from = '';
+
+        if (isset($query->joins)) {
+            // When using Postgres, updates with joins list the joined tables in the from
+            // clause, which is different than other systems like MySQL. Here, we will
+            // compile out the tables that are joined and add them to a from clause.
+            $froms = collect($query->joins)->map(function ($join) {
+                return $this->wrapTable($join->table);
+            })->all();
+
+            if (count($froms) > 0) {
+                $from = ' from '.implode(', ', $froms);
+            }
+        }
+
+        $where = $this->compileUpdateWheres($query);
+
+        return trim("update {$table} set {$columns}{$from} {$where}");
+    }
+
+    /**
+     * Compile the additional where clauses for updates with joins.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @return string
+     */
+    protected function compileUpdateWheres(Builder $query)
+    {
+        $baseWheres = $this->compileWheres($query);
+
+        if (! isset($query->joins)) {
+            return $baseWheres;
+        }
+
+        // Once we compile the join constraints, we will either use them as the where
+        // clause or append them to the existing base where clauses. If we need to
+        // strip the leading boolean we will do so when using as the only where.
+        $joinWheres = $this->compileUpdateJoinWheres($query);
+
+        if (trim($baseWheres) == '') {
+            return 'where '.$this->removeLeadingBoolean($joinWheres);
+        }
+
+        return $baseWheres.' '.$joinWheres;
+    }
+
+    /**
+     * Compile the "join" clause where clauses for an update.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @return string
+     */
+    protected function compileUpdateJoinWheres(Builder $query)
+    {
+        $joinWheres = [];
+
+        // Here we will just loop through all of the join constraints and compile them
+        // all out then implode them. This should give us "where" like syntax after
+        // everything has been built and then we will join it to the real wheres.
+        foreach ($query->joins as $join) {
+            foreach ($join->wheres as $where) {
+                $method = "where{$where['type']}";
+
+                $joinWheres[] = $where['boolean'].' '.$this->$method($query, $where);
+            }
+        }
+
+        return implode(' ', $joinWheres);
+    }
+
+    /**
+     * Prepare the bindings for an update statement.
+     *
+     * @param  array  $bindings
+     * @param  array  $values
+     * @return array
+     */
+    public function prepareBindingsForUpdateFrom(array $bindings, array $values)
+    {
+        $values = collect($values)->map(function ($value, $column) {
+            return is_array($value) || ($this->isJsonSelector($column) && ! $this->isExpression($value))
+                ? json_encode($value)
+                : $value;
+        })->all();
+
+        $bindingsWithoutWhere = Arr::except($bindings, ['select', 'where']);
+
+        return array_values(
+            array_merge($values, $bindings['where'], Arr::flatten($bindingsWithoutWhere))
+        );
+    }
+
+    /**
      * Compile an update statement with joins or limit into SQL.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2458,10 +2458,10 @@ class DatabaseQueryBuilderTest extends TestCase
             ->join('orders', function ($join) {
                 $join->on('users.id', '=', 'orders.user_id')
                    ->where('users.id', '=', 1);
-           })->where('name', 'baz')
+            })->where('name', 'baz')
            ->updateFrom(['email' => 'foo', 'name' => 'bar']);
-       $this->assertEquals(1, $result);
-   }
+        $this->assertEquals(1, $result);
+    }
 
     public function testUpdateMethodRespectsRaw()
     {

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2437,6 +2437,32 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(1, $result);
     }
 
+    public function testUpdateFromMethodWithJoinsOnPostgres()
+    {
+        $builder = $this->getPostgresBuilder();
+        $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "email" = ?, "name" = ? from "orders" where "users"."id" = ? and "users"."id" = "orders"."user_id"', ['foo', 'bar', 1])->andReturn(1);
+        $result = $builder->from('users')->join('orders', 'users.id', '=', 'orders.user_id')->where('users.id', '=', 1)->updateFrom(['email' => 'foo', 'name' => 'bar']);
+        $this->assertEquals(1, $result);
+
+        $builder = $this->getPostgresBuilder();
+        $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "email" = ?, "name" = ? from "orders" where "users"."id" = "orders"."user_id" and "users"."id" = ?', ['foo', 'bar', 1])->andReturn(1);
+        $result = $builder->from('users')->join('orders', function ($join) {
+            $join->on('users.id', '=', 'orders.user_id')
+                ->where('users.id', '=', 1);
+        })->updateFrom(['email' => 'foo', 'name' => 'bar']);
+        $this->assertEquals(1, $result);
+
+        $builder = $this->getPostgresBuilder();
+        $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "email" = ?, "name" = ? from "orders" where "name" = ? and "users"."id" = "orders"."user_id" and "users"."id" = ?', ['foo', 'bar', 'baz', 1])->andReturn(1);
+        $result = $builder->from('users')
+            ->join('orders', function ($join) {
+                $join->on('users.id', '=', 'orders.user_id')
+                   ->where('users.id', '=', 1);
+           })->where('name', 'baz')
+           ->updateFrom(['email' => 'foo', 'name' => 'bar']);
+       $this->assertEquals(1, $result);
+   }
+
     public function testUpdateMethodRespectsRaw()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
This PR re-introduces "update ... from ..." support for the PostgreSQL grammar. Since there wasn't a good option or straight way to re-implement the behavior after the refactor in #29393 I opted to add a new dedicated `updateFrom` method specifically for the PostgreSQL grammar.

This implementation is a bit cumbersome and crude as people will need to specifically use `updateFrom` instead of `update` if they want the correct behavior. Ideally this would be done automatically.

I've tested this with the queries from #33265 and got them back working with this. I also re-added the original tests that were removed.

Before merging this I'd like to:

- Get a review from @staudenmeir
- Get feedback from people who reported #33265
- Maybe clean up the code in the PostgreSQL grammar

If we get feedback from someone who can think of a better way to solve this then gladly. Otherwise I think this is the only solution for the problem at hand.

Fixes #33265
