### PR TITLE
[8.x] Return Command::SUCCESS enum instead of 0 for clarity to newer devs

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/console.stub
+++ b/src/Illuminate/Foundation/Console/stubs/console.stub
@@ -37,6 +37,6 @@ class {{ class }} extends Command
      */
     public function handle()
     {
-        return 0;
+        return Command::SUCCESS;
     }
 }


### PR DESCRIPTION
This question seems to come up with newer devs and I saw this suggestion recently which I think could be useful as a default for the command stub.  Swapping the exit status of 0 for the actual command status enum which makes it a bit more clear to a new dev what it actually signifies.