### PR TITLE
[8.x] Add hasAny() Method to Collections

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -502,6 +502,29 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
+     * Determine if any of the keys exist in the collection.
+     *
+     * @param  mixed  $key
+     * @return bool
+     */
+    public function hasAny($key)
+    {
+        if ($this->isEmpty()) {
+            return false;
+        }
+
+        $keys = is_array($key) ? $key : func_get_args();
+
+        foreach ($keys as $value) {
+            if ($this->has($value)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Concatenate values of a given key as a string.
      *
      * @param  string  $value

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -513,6 +513,25 @@ class LazyCollection implements Enumerable
     }
 
     /**
+     * Determine if any of the keys exist in the collection.
+     *
+     * @param  mixed  $key
+     * @return bool
+     */
+    public function hasAny($key)
+    {
+        $keys = array_flip(is_array($key) ? $key : func_get_args());
+
+        foreach ($this as $key => $value) {
+            if (array_key_exists($key, $keys)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Concatenate values of a given key as a string.
      *
      * @param  string  $value

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2081,6 +2081,20 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testHasAny($collection)
+    {
+        $data = new $collection(['id' => 1, 'first' => 'Hello', 'second' => 'World']);
+
+        $this->assertTrue($data->hasAny('first'));
+        $this->assertFalse($data->hasAny('third'));
+        $this->assertTrue($data->hasAny(['first', 'second']));
+        $this->assertTrue($data->hasAny(['first', 'fourth']));
+        $this->assertFalse($data->hasAny(['third', 'fourth']));
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testImplode($collection)
     {
         $data = new $collection([['name' => 'taylor', 'email' => 'foo'], ['name' => 'dayle', 'email' => 'bar']]);

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -470,6 +470,17 @@ class SupportLazyCollectionIsLazyTest extends TestCase
         });
     }
 
+    public function testHasAnyIsLazy()
+    {
+        $this->assertEnumerates(5, function ($collection) {
+            $collection->hasAny(4);
+        });
+
+        $this->assertEnumerates(2, function ($collection) {
+            $collection->hasAny([1, 4]);
+        });
+    }
+
     public function testImplodeEnumeratesOnce()
     {
         $this->assertEnumeratesOnce(function ($collection) {

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -468,6 +468,10 @@ class SupportLazyCollectionIsLazyTest extends TestCase
         $this->assertEnumerates(5, function ($collection) {
             $collection->has(4);
         });
+
+        $this->assertEnumeratesOnce(function ($collection) {
+            $collection->has('non-existent');
+        });
     }
 
     public function testHasAnyIsLazy()
@@ -478,6 +482,10 @@ class SupportLazyCollectionIsLazyTest extends TestCase
 
         $this->assertEnumerates(2, function ($collection) {
             $collection->hasAny([1, 4]);
+        });
+
+        $this->assertEnumeratesOnce(function ($collection) {
+            $collection->hasAny(['non', 'existent']);
         });
     }
 


### PR DESCRIPTION
This PR adds support for a `hasAny()` method to collections. A similar method already exists as an array helper, in the MessageBag class and in the InteractsWithInput class. Since it already exists in all of those places, I think it makes sense to add it to the Collection classes for full parity.

This example would return true:

```
collect(['first' => 'Hello', 'second' => 'World'])->hasAny(['first', 'fourth']);
```

While this would return false:

```
collect(['first' => 'Hello', 'second' => 'World'])->hasAny(['third', 'fourth']);
```