### PR TITLE
Add route `whereIn` regex registration method

### DIFF
--- a/src/Illuminate/Routing/CreatesRegularExpressionRouteConstraints.php
+++ b/src/Illuminate/Routing/CreatesRegularExpressionRouteConstraints.php
@@ -31,8 +31,8 @@ trait CreatesRegularExpressionRouteConstraints
     /**
      * Specify that the given route parameters are contained within the given array.
      *
-     * @param $parameters
-     * @param array $values
+     * @param  array|string  $parameters
+     * @param  array  $values
      * @return $this
      */
     public function whereIn($parameters, $values = [])

--- a/src/Illuminate/Routing/CreatesRegularExpressionRouteConstraints.php
+++ b/src/Illuminate/Routing/CreatesRegularExpressionRouteConstraints.php
@@ -29,6 +29,18 @@ trait CreatesRegularExpressionRouteConstraints
     }
 
     /**
+     * Specify that the given route parameters are contained within the given array.
+     *
+     * @param $parameters
+     * @param array $values
+     * @return $this
+     */
+    public function whereIn($parameters, $values = [])
+    {
+        return $this->assignExpressionToParameters($parameters, implode('|', $values));
+    }
+
+    /**
      * Specify that the given route parameters must be numeric.
      *
      * @param  array|string  $parameters

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -660,6 +660,18 @@ class RouteRegistrarTest extends TestCase
         }
     }
 
+    public function testWhereInRegistration()
+    {
+        $wheres = ['foo' => 'one|two|three'];
+
+        $this->router->get('/{foo}')->whereIn(['foo'], ['one', 'two', 'three']);
+
+        /** @var \Illuminate\Routing\Route $route */
+        foreach ($this->router->getRoutes() as $route) {
+            $this->assertEquals($wheres, $route->wheres);
+        }
+    }
+
     public function testCanSetRouteName()
     {
         $this->router->as('users.index')->get('users', function () {


### PR DESCRIPTION
This PR adds a whereIn regex registration method to check if the route parameters are contained within a given array.

Usage example:

```php
Route::get('statuses/{type}')->whereIn('type', ['one', 'two', 'three']);
```
This will make sure `type` is equal to one of the values in the array.