### PR TITLE
[9.x] Tighten up PHP version constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^8.0.2",
+        "php": "~8.0.2|~8.1.0",
         "ext-mbstring": "*",
         "ext-openssl": "*",
         "doctrine/inflector": "^2.0",

--- a/src/Illuminate/Auth/composer.json
+++ b/src/Illuminate/Auth/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^8.0.2",
+        "php": "~8.0.2|~8.1.0",
         "illuminate/collections": "^9.0",
         "illuminate/contracts": "^9.0",
         "illuminate/http": "^9.0",

--- a/src/Illuminate/Broadcasting/composer.json
+++ b/src/Illuminate/Broadcasting/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^8.0.2",
+        "php": "~8.0.2|~8.1.0",
         "ext-json": "*",
         "psr/log": "^1.0",
         "illuminate/bus": "^9.0",

--- a/src/Illuminate/Bus/composer.json
+++ b/src/Illuminate/Bus/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^8.0.2",
+        "php": "~8.0.2|~8.1.0",
         "illuminate/collections": "^9.0",
         "illuminate/contracts": "^9.0",
         "illuminate/pipeline": "^9.0",

--- a/src/Illuminate/Cache/composer.json
+++ b/src/Illuminate/Cache/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^8.0.2",
+        "php": "~8.0.2|~8.1.0",
         "illuminate/collections": "^9.0",
         "illuminate/contracts": "^9.0",
         "illuminate/macroable": "^9.0",

--- a/src/Illuminate/Collections/composer.json
+++ b/src/Illuminate/Collections/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^8.0.2",
+        "php": "~8.0.2|~8.1.0",
         "illuminate/conditionable": "^9.0",
         "illuminate/contracts": "^9.0",
         "illuminate/macroable": "^9.0"

--- a/src/Illuminate/Config/composer.json
+++ b/src/Illuminate/Config/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^8.0.2",
+        "php": "~8.0.2|~8.1.0",
         "illuminate/collections": "^9.0",
         "illuminate/contracts": "^9.0"
     },

--- a/src/Illuminate/Console/composer.json
+++ b/src/Illuminate/Console/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^8.0.2",
+        "php": "~8.0.2|~8.1.0",
         "illuminate/collections": "^9.0",
         "illuminate/contracts": "^9.0",
         "illuminate/macroable": "^9.0",

--- a/src/Illuminate/Container/composer.json
+++ b/src/Illuminate/Container/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^8.0.2",
+        "php": "~8.0.2|~8.1.0",
         "illuminate/contracts": "^9.0",
         "psr/container": "^1.1.1|^2.0.1"
     },

--- a/src/Illuminate/Contracts/composer.json
+++ b/src/Illuminate/Contracts/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^8.0.2",
+        "php": "~8.0.2|~8.1.0",
         "psr/container": "^1.1.1|^2.0.1",
         "psr/simple-cache": "^1.0"
     },

--- a/src/Illuminate/Cookie/composer.json
+++ b/src/Illuminate/Cookie/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^8.0.2",
+        "php": "~8.0.2|~8.1.0",
         "illuminate/collections": "^9.0",
         "illuminate/contracts": "^9.0",
         "illuminate/macroable": "^9.0",

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^8.0.2",
+        "php": "~8.0.2|~8.1.0",
         "ext-json": "*",
         "illuminate/collections": "^9.0",
         "illuminate/container": "^9.0",

--- a/src/Illuminate/Encryption/composer.json
+++ b/src/Illuminate/Encryption/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^8.0.2",
+        "php": "~8.0.2|~8.1.0",
         "ext-json": "*",
         "ext-mbstring": "*",
         "ext-openssl": "*",

--- a/src/Illuminate/Events/composer.json
+++ b/src/Illuminate/Events/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^8.0.2",
+        "php": "~8.0.2|~8.1.0",
         "illuminate/bus": "^9.0",
         "illuminate/collections": "^9.0",
         "illuminate/container": "^9.0",

--- a/src/Illuminate/Filesystem/composer.json
+++ b/src/Illuminate/Filesystem/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^8.0.2",
+        "php": "~8.0.2|~8.1.0",
         "illuminate/collections": "^9.0",
         "illuminate/contracts": "^9.0",
         "illuminate/macroable": "^9.0",

--- a/src/Illuminate/Hashing/composer.json
+++ b/src/Illuminate/Hashing/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^8.0.2",
+        "php": "~8.0.2|~8.1.0",
         "illuminate/contracts": "^9.0",
         "illuminate/support": "^9.0"
     },

--- a/src/Illuminate/Http/composer.json
+++ b/src/Illuminate/Http/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^8.0.2",
+        "php": "~8.0.2|~8.1.0",
         "ext-json": "*",
         "illuminate/collections": "^9.0",
         "illuminate/macroable": "^9.0",

--- a/src/Illuminate/Log/composer.json
+++ b/src/Illuminate/Log/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^8.0.2",
+        "php": "~8.0.2|~8.1.0",
         "illuminate/contracts": "^9.0",
         "illuminate/support": "^9.0",
         "monolog/monolog": "^2.0"

--- a/src/Illuminate/Mail/composer.json
+++ b/src/Illuminate/Mail/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^8.0.2",
+        "php": "~8.0.2|~8.1.0",
         "ext-json": "*",
         "illuminate/collections": "^9.0",
         "illuminate/container": "^9.0",

--- a/src/Illuminate/Notifications/composer.json
+++ b/src/Illuminate/Notifications/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^8.0.2",
+        "php": "~8.0.2|~8.1.0",
         "illuminate/broadcasting": "^9.0",
         "illuminate/bus": "^9.0",
         "illuminate/collections": "^9.0",

--- a/src/Illuminate/Pagination/composer.json
+++ b/src/Illuminate/Pagination/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^8.0.2",
+        "php": "~8.0.2|~8.1.0",
         "ext-json": "*",
         "illuminate/collections": "^9.0",
         "illuminate/contracts": "^9.0",

--- a/src/Illuminate/Pipeline/composer.json
+++ b/src/Illuminate/Pipeline/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^8.0.2",
+        "php": "~8.0.2|~8.1.0",
         "illuminate/contracts": "^9.0",
         "illuminate/support": "^9.0"
     },

--- a/src/Illuminate/Queue/composer.json
+++ b/src/Illuminate/Queue/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^8.0.2",
+        "php": "~8.0.2|~8.1.0",
         "ext-json": "*",
         "illuminate/collections": "^9.0",
         "illuminate/console": "^9.0",

--- a/src/Illuminate/Redis/composer.json
+++ b/src/Illuminate/Redis/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^8.0.2",
+        "php": "~8.0.2|~8.1.0",
         "illuminate/collections": "^9.0",
         "illuminate/contracts": "^9.0",
         "illuminate/macroable": "^9.0",

--- a/src/Illuminate/Routing/composer.json
+++ b/src/Illuminate/Routing/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^8.0.2",
+        "php": "~8.0.2|~8.1.0",
         "ext-json": "*",
         "illuminate/collections": "^9.0",
         "illuminate/container": "^9.0",

--- a/src/Illuminate/Session/composer.json
+++ b/src/Illuminate/Session/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^8.0.2",
+        "php": "~8.0.2|~8.1.0",
         "ext-json": "*",
         "illuminate/collections": "^9.0",
         "illuminate/contracts": "^9.0",

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^8.0.2",
+        "php": "~8.0.2|~8.1.0",
         "ext-json": "*",
         "ext-mbstring": "*",
         "doctrine/inflector": "^2.0",

--- a/src/Illuminate/Testing/composer.json
+++ b/src/Illuminate/Testing/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^8.0.2",
+        "php": "~8.0.2|~8.1.0",
         "illuminate/collections": "^9.0",
         "illuminate/contracts": "^9.0",
         "illuminate/macroable": "^9.0",

--- a/src/Illuminate/Translation/composer.json
+++ b/src/Illuminate/Translation/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^8.0.2",
+        "php": "~8.0.2|~8.1.0",
         "ext-json": "*",
         "illuminate/collections": "^9.0",
         "illuminate/contracts": "^9.0",

--- a/src/Illuminate/Validation/composer.json
+++ b/src/Illuminate/Validation/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^8.0.2",
+        "php": "~8.0.2|~8.1.0",
         "ext-json": "*",
         "egulias/email-validator": "^3.1",
         "illuminate/collections": "^9.0",

--- a/src/Illuminate/View/composer.json
+++ b/src/Illuminate/View/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^8.0.2",
+        "php": "~8.0.2|~8.1.0",
         "ext-json": "*",
         "illuminate/collections": "^9.0",
         "illuminate/container": "^9.0",


### PR DESCRIPTION
This is an attempt to, starting from Laravel v9, tighten up PHP version constraints. Until this moment, we always treated the PHP requirement the way we treated most other libraries: as a SemVer constraint. However, PHP doesn't adopts semantic versioning and since there's breaking changes in each PHP minor release, we shouldn't be using the caret symbol `^` any longer to indicate PHP constraints.

By adopting a versioning constraint using the tilde `~`, we can reference specific PHP minor releases that Laravel supports. This way, it becomes more clear which PHP versions a Laravel release supports, as well as prevent people from installing Laravel on PHP versions it doesn't supports.

For example, it is technically possible that people can install Laravel v6 or v8 on PHP 8.2 should it ever be released because of the `^8.0` constraint. Even though third party dependencies might prevent this all together, the separate Illuminate components might still be able to be installed on newer PHP versions even though they might totally not support it. Some other well known PHP projects, like [PhpSpec](https://github.com/phpspec/phpspec/blob/main/composer.json#L25) have started to adopt this versioning scheme as well.

I contemplated of sending this in to 8.x which would still be fine I think. But it might be a good thing to start doing from a new major release. I'd like to start using this way of versioning PHP releases as well on our first party libraries, should this get accepted to the core.

Happy to receive any feedback about this.