### PR TITLE
[9.x] Do not let SetCacheHeaders override the eTag.

### DIFF
--- a/src/Illuminate/Http/Middleware/SetCacheHeaders.php
+++ b/src/Illuminate/Http/Middleware/SetCacheHeaders.php
@@ -30,7 +30,7 @@ class SetCacheHeaders
         }
 
         if (isset($options['etag']) && $options['etag'] === true) {
-            $options['etag'] = md5($response->getContent());
+            $options['etag'] = $response->getEtag() ?? md5($response->getContent());
         }
 
         if (isset($options['last_modified'])) {

--- a/tests/Http/Middleware/CacheTest.php
+++ b/tests/Http/Middleware/CacheTest.php
@@ -63,6 +63,15 @@ class CacheTest extends TestCase
         $this->assertSame('max-age=100, public, s-maxage=200', $response->headers->get('Cache-Control'));
     }
 
+    public function testDoesNotOverrideEtag()
+    {
+        $response = (new Cache)->handle(new Request, function () {
+            return (new Response('some content'))->setEtag('XYZ');
+        }, 'etag');
+
+        $this->assertSame('"XYZ"', $response->getEtag());
+    }
+
     public function testIsNotModified()
     {
         $request = new Request;


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

In some cases, I want to have the possibility to set my own response `eTag`, based on other arguments than just the the response content.

If so, I do no want it to be overridden when using `SetCacheHeaders` middleware.
