### PR TITLE
[9.x] Add `hasUser` method to Guard contract

### DIFF
--- a/src/Illuminate/Contracts/Auth/Guard.php
+++ b/src/Illuminate/Contracts/Auth/Guard.php
@@ -47,4 +47,11 @@ interface Guard
      * @return void
      */
     public function setUser(Authenticatable $user);
+
+    /**
+     * Determine if the guard has a user instance.
+     *
+     * @return bool
+     */
+    public function hasUser();
 }

--- a/src/Illuminate/Contracts/Auth/Guard.php
+++ b/src/Illuminate/Contracts/Auth/Guard.php
@@ -41,17 +41,17 @@ interface Guard
     public function validate(array $credentials = []);
 
     /**
+     * Determine if the guard has a user instance.
+     *
+     * @return bool
+     */
+    public function hasUser();
+
+    /**
      * Set the current user.
      *
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @return void
      */
     public function setUser(Authenticatable $user);
-
-    /**
-     * Determine if the guard has a user instance.
-     *
-     * @return bool
-     */
-    public function hasUser();
 }


### PR DESCRIPTION
The following PR by @TBlindaruk has been previously rejected at v5.8.

- https://github.com/laravel/framework/pull/25629 

However, we are now at a new stage with many changes, such as introducing Contract on Query Builder implementation. I decided that it would be ready to resubmit this PR now. **It is useful in some situations that knowing whether `user()` causes side effects in advance.**

Note that we don't have to add `setProvider()` and `getProvider()` because they are mainly for internal use.


### Breaking Changes

- All custom `Guard` without `GuardHelpers` should explicitly implement `hasUser()` from now on.
  - Most `Guard` implementation which uses property caching should return `! is_null($this->user)`
  - `Guard` without any caches should always return `false`