### PR TITLE
[8.x] Remove the 'migrate:rollback' command in DatabaseMigrations trait

### DIFF
--- a/src/Illuminate/Foundation/Testing/DatabaseMigrations.php
+++ b/src/Illuminate/Foundation/Testing/DatabaseMigrations.php
@@ -7,7 +7,7 @@ use Illuminate\Contracts\Console\Kernel;
 trait DatabaseMigrations
 {
     /**
-     * Define hooks to migrate the database before and after each test.
+     * Re-migrate the database before each test.
      *
      * @return void
      */
@@ -16,11 +16,5 @@ trait DatabaseMigrations
         $this->artisan('migrate:fresh');
 
         $this->app[Kernel::class]->setArtisan(null);
-
-        $this->beforeApplicationDestroyed(function () {
-            $this->artisan('migrate:rollback');
-
-            RefreshDatabaseState::$migrated = false;
-        });
     }
 }


### PR DESCRIPTION
because the trait now calls the 'migrate:fresh' (since 2017) which drops all tables in the beginning, the rollback is redundant, isn't it?

should save some execution time which is precious especially during dusk tests
