### PR TITLE
[8.x] Add ability to validate one of multiple date formats

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -431,11 +431,15 @@ trait ValidatesAttributes
             return false;
         }
 
-        $format = $parameters[0];
+        foreach ($parameters as $format) {
+            $date = DateTime::createFromFormat('!'.$format, $value);
 
-        $date = DateTime::createFromFormat('!'.$format, $value);
+            if ($date && $date->format($format) == $value) {
+                return true;
+            }
+        }
 
-        return $date && $date->format($format) == $value;
+        return false;
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -2049,7 +2049,6 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  string  $rule
-     *
      * @return void
      */
     protected function shouldBeNumeric($attribute, $rule)

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3733,6 +3733,12 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['x' => '2000-01-01 17:43:59'], ['x' => 'date_format:H:i:s']);
         $this->assertTrue($v->fails());
 
+        $v = new Validator($trans, ['x' => '2000-01-01 17:43:59'], ['x' => 'date_format:Y-m-d H:i:s,H:i:s']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => '17:43:59'], ['x' => 'date_format:Y-m-d H:i:s,H:i:s']);
+        $this->assertTrue($v->passes());
+
         $v = new Validator($trans, ['x' => '17:43:59'], ['x' => 'date_format:H:i:s']);
         $this->assertTrue($v->passes());
 


### PR DESCRIPTION
## Description

This PR adds the ability to provide multiple possible date formats to the `date_format` validation rule, allowing developers to use one request input for multiple possible date format types.

This PR validates that the input must match *one of* the possible formats.

## Use Case

I'm working on a system where a user can enter a date with a year, or without a year, to signify whether that date is recurring. The formats I'm requiring are `Y-m-d` (one time) or `m-d` (recurring).

Currently, I have to create my own validation rule, or use multiple inputs to handle the alternate date formats:

```php
public function rules()
{
    return [
        'date_one_time'  => 'date_format:Y-m-d',
        'date_recurring' => 'date_format:m-d',
    ];
}
```

This can be simplified with this PR:

```php
public function rules()
{
    return [
        'date' => 'date_format:Y-m-d,m-d',
    ];
}
```

Thanks so much for your time -- no hard feelings on closure! ❤️ 