### PR TITLE
[9.x] Improves auto-completion on `Model::factory()`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/HasFactory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/HasFactory.php
@@ -9,7 +9,7 @@ trait HasFactory
      *
      * @param  callable|array|int|null  $count
      * @param  callable|array  $state
-     * @return \Illuminate\Database\Eloquent\Factories\Factory
+     * @return \Illuminate\Database\Eloquent\Factories\Factory<static>
      */
     public static function factory($count = null, $state = [])
     {
@@ -23,7 +23,7 @@ trait HasFactory
     /**
      * Create a new factory instance for the model.
      *
-     * @return \Illuminate\Database\Eloquent\Factories\Factory
+     * @return \Illuminate\Database\Eloquent\Factories\Factory<static>
      */
     protected static function newFactory()
     {

--- a/types/Autoload.php
+++ b/types/Autoload.php
@@ -1,0 +1,9 @@
+<?php
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+
+class User extends Authenticatable
+{
+    use HasFactory;
+}

--- a/types/Database/Eloquent/Collection.php
+++ b/types/Database/Eloquent/Collection.php
@@ -1,11 +1,6 @@
 <?php
 
-use Illuminate\Foundation\Auth\User as Authenticatable;
 use function PHPStan\Testing\assertType;
-
-class User extends Authenticatable
-{
-}
 
 $collection = User::all();
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection);

--- a/types/Database/Eloquent/Factories/Factory.php
+++ b/types/Database/Eloquent/Factories/Factory.php
@@ -1,12 +1,7 @@
 <?php
 
 use Illuminate\Database\Eloquent\Factories\Factory;
-use Illuminate\Foundation\Auth\User as Authenticatable;
 use function PHPStan\Testing\assertType;
-
-class User extends Authenticatable
-{
-}
 
 /**
  * @extends Illuminate\Database\Eloquent\Factories\Factory<User>

--- a/types/Database/Eloquent/Model.php
+++ b/types/Database/Eloquent/Model.php
@@ -1,0 +1,6 @@
+<?php
+
+use function PHPStan\Testing\assertType;
+
+$factory = User::factory();
+assertType('Illuminate\Database\Eloquent\Factories\Factory<User>', $factory);

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -1,13 +1,8 @@
 <?php
 
 use Illuminate\Contracts\Support\Arrayable;
-use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Support\Collection;
 use function PHPStan\Testing\assertType;
-
-class User extends Authenticatable
-{
-}
 
 $collection = collect([new User]);
 /** @var Arrayable<int, User> $arrayable */


### PR DESCRIPTION
This pull request makes the `HasFactories` leverage the work on https://github.com/laravel/framework/pull/39169.

Because PHPStorm does not support generic traits, `Team::factory()` returns an instance of `Factory<Team>` but not `TeamFactory`, allowing to get some level of native auto-completion like this:
<img width="389" alt="Screenshot 2021-10-12 at 14 39 22" src="https://user-images.githubusercontent.com/5457236/136967026-96c31296-79c7-41c6-a9e3-5ec32036dbe3.png">

