### PR TITLE
[9.x] Add `ith` method to collection

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -479,7 +479,7 @@ class Collection implements ArrayAccess, Enumerable
      */
     public function ith(int $index)
     {
-        return $this->slice($index - 1, 1)->first();
+        return $this->slice($index, 1)->first();
     }
 
     /**

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -476,6 +476,9 @@ class Collection implements ArrayAccess, Enumerable
 
     /**
      * Get the i-th item from the collection.
+     *
+     * @param  int  $index
+     * @return TValue
      */
     public function ith(int $index)
     {

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -475,6 +475,14 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
+     * Get the i-th item from the collection.
+     */
+    public function ith(int $index)
+    {
+        return $this->slice($index - 1, 1)->first();
+    }
+
+    /**
      * Key an associative array by a field or using a callback.
      *
      * @param  (callable(TValue, TKey): array-key)|array|string  $keyBy

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -565,6 +565,14 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function isNotEmpty();
 
     /**
+     * Get the i-th item from the collection.
+     *
+     * @param  int  $index
+     * @return TValue
+     */
+    public function ith(int $index);
+
+    /**
      * Join all items from the collection using a string. The final items can use a separate glue string.
      *
      * @param  string  $glue

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -557,6 +557,24 @@ class LazyCollection implements Enumerable
     }
 
     /**
+     * Get the i-th item from the collection.
+     */
+    public function ith(int $index)
+    {
+        $position = 1;
+
+        foreach ($this as $item) {
+            if ($position === $index) {
+                return $item;
+            }
+
+            $position++;
+        }
+
+        return null;
+    }
+
+    /**
      * Determine if the collection contains a single item.
      *
      * @return bool

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -561,7 +561,7 @@ class LazyCollection implements Enumerable
      */
     public function ith(int $index)
     {
-        $position = 1;
+        $position = 0;
 
         foreach ($this as $item) {
             if ($position === $index) {

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -4861,7 +4861,7 @@ class SupportCollectionTest extends TestCase
             'd' => 'D',
         ]);
 
-        $this->assertSame('C', $data->ith(3));
+        $this->assertSame('C', $data->ith(2));
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -4850,6 +4850,21 @@ class SupportCollectionTest extends TestCase
     }
 
     /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testIth($collection)
+    {
+        $data = new $collection([
+            'a' => 'A',
+            'b' => 'B',
+            'c' => 'C',
+            'd' => 'D',
+        ]);
+
+        $this->assertSame('C', $data->ith(3));
+    }
+
+    /**
      * Provides each collection class, respectively.
      *
      * @return array


### PR DESCRIPTION
This adds a method to retrieve i-th element in the array. The other methods like `get($i)` and `[$i]` return the element by key, while this returns the i-th element in the *foreach* order similar to how `first()` returns the first element regardless of what key it has.

I've asked this on [SO](https://stackoverflow.com/questions/40444759/how-to-access-the-nth-item-in-a-laravel-collection) and it has gotten quite of views over the years, so it seems I've not the only one who needs such feature from time to time.

## Indexing

Why is this 1-indexed not 0-indexed? For semantic compatibility with `first()`. It felt to me that `->ith(1)` should return the same as `->first()`. 

I think that 0-indexed would be fine as well (or even better) if someone could suggest a good name that "makes sense" for a 0-indexed getter. Unfourtunately, `get` and `offsetGet` are already taken by access-by-key.

## Details

I tried out two other implementations for `Collection::ith` as well. Rekeying with `$this->values` and taking the i-th element was slightly faster for small arrays, but the execution time increased faster than for `slice` as the array grew. The same was true for `$this->items[$this->keys[$i]]`. Manually `foreach`ing until the desired element like done in `LazyCollection::ith` is very fast for small indices, but the execution time grew quicker than for `slice` and for indices above ~200 `slice` is the fastest option. (`array_slice` grows linearly as well, but the internal `for` cycle in C seems to have smaller overhead per iteration than `foreach` that's available for us in PHP).

I am sending this to the `master` branch because this might be breaking for some users who have a collection macro `ith` already.