### PR TITLE
[8.x] eloquent get accepts multiple strings

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -593,6 +593,8 @@ class Builder
     {
         $builder = $this->applyScopes();
 
+        $columns = is_array($columns) ? $columns : func_get_args();
+
         // If we actually found models we will also eager load any relationships that
         // have been specified as needing to be eager loaded, which will solve the
         // n+1 query issue for the developers to avoid running a lot of queries.


### PR DESCRIPTION
now `get` method accepts array of strings or multiple strings just like `only` method in `Route`
i think thats more laravelish

```php
User::whereSomething('something')->get('id', 'title');
```