### PR TITLE
[8.x] Add `Str::headline()`

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -680,6 +680,27 @@ class Str
     }
 
     /**
+     * Convert the given string to title case for each word.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    public static function headline($value)
+    {
+        $parts = explode('_', static::replace(' ', '_', $value));
+
+        if (count($parts) > 1) {
+            $parts = array_map([static::class, 'title'], $parts);
+        }
+
+        $studly = static::studly(implode($parts));
+
+        $words = preg_split('/(?=[A-Z])/', $studly, -1, PREG_SPLIT_NO_EMPTY);
+
+        return implode(' ', $words);
+    }
+
+    /**
      * Get the singular form of an English word.
      *
      * @param  string  $value
@@ -778,19 +799,6 @@ class Str
         $value = ucwords(str_replace(['-', '_'], ' ', $value));
 
         return static::$studlyCache[$key] = str_replace(' ', '', $value);
-    }
-
-    /**
-     * Convert a value to studly caps case for each word.
-     *
-     * @param  string  $value
-     * @return string
-     */
-    public static function studlyWords($value)
-    {
-        $parts = preg_split('/(?=[A-Z])/', static::studly($value), -1, PREG_SPLIT_NO_EMPTY);
-
-        return implode(' ', $parts);
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -781,6 +781,19 @@ class Str
     }
 
     /**
+     * Convert a value to studly caps case for each word.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    public static function studlyWords($value)
+    {
+        $parts = preg_split('/(?=[A-Z])/', static::studly($value), -1, PREG_SPLIT_NO_EMPTY);
+
+        return implode(' ', $parts);
+    }
+
+    /**
      * Returns the portion of the string specified by the start and length parameters.
      *
      * @param  string  $string

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -651,6 +651,16 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Convert a value to studly caps case for each word.
+     *
+     * @return static
+     */
+    public function studlyWords()
+    {
+        return new static(Str::studlyWords($this->value));
+    }
+
+    /**
      * Returns the portion of the string specified by the start and length parameters.
      *
      * @param  int  $start

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -597,6 +597,16 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Convert the given string to title case for each word.
+     *
+     * @return static
+     */
+    public function headline()
+    {
+        return new static(Str::headline($this->value));
+    }
+
+    /**
      * Get the singular form of an English word.
      *
      * @return static
@@ -648,16 +658,6 @@ class Stringable implements JsonSerializable
     public function studly()
     {
         return new static(Str::studly($this->value));
-    }
-
-    /**
-     * Convert a value to studly caps case for each word.
-     *
-     * @return static
-     */
-    public function studlyWords()
-    {
-        return new static(Str::studlyWords($this->value));
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -35,6 +35,23 @@ class SupportStrTest extends TestCase
         $this->assertSame('Jefferson Costella', Str::title('jefFErson coSTella'));
     }
 
+    public function testStringHeadline()
+    {
+        $this->assertSame('Jefferson Costella', Str::headline('jefferson costella'));
+        $this->assertSame('Jefferson Costella', Str::headline('jefFErson coSTella'));
+        $this->assertSame('Jefferson Costella Uses Laravel', Str::headline('jefferson_costella uses_Laravel'));
+
+        $this->assertSame('Laravel P H P Framework', Str::headline('laravel_p_h_p_framework'));
+        $this->assertSame('Laravel Php Framework', Str::headline('laravel_php_framework'));
+        $this->assertSame('Laravel Ph P Framework', Str::headline('laravel-phP-framework'));
+        $this->assertSame('Laravel Php Framework', Str::headline('laravel  -_-  php   -_-   framework   '));
+
+        $this->assertSame('Foo Bar', Str::headline('fooBar'));
+        $this->assertSame('Foo Bar', Str::headline('foo_bar'));
+        $this->assertSame('Foo Bar Baz', Str::headline('foo-barBaz'));
+        $this->assertSame('Foo Bar Baz', Str::headline('foo-bar_baz'));
+    }
+
     public function testStringWithoutWordsDoesntProduceError()
     {
         $nbsp = chr(0xC2).chr(0xA0);
@@ -430,19 +447,6 @@ class SupportStrTest extends TestCase
         $this->assertSame('FooBar', Str::studly('foo_bar')); // test cache
         $this->assertSame('FooBarBaz', Str::studly('foo-barBaz'));
         $this->assertSame('FooBarBaz', Str::studly('foo-bar_baz'));
-    }
-
-    public function testStudlyWords()
-    {
-        $this->assertSame('Laravel P H P Framework', Str::studlyWords('laravel_p_h_p_framework'));
-        $this->assertSame('Laravel Php Framework', Str::studlyWords('laravel_php_framework'));
-        $this->assertSame('Laravel Ph P Framework', Str::studlyWords('laravel-phP-framework'));
-        $this->assertSame('Laravel Php Framework', Str::studlyWords('laravel  -_-  php   -_-   framework   '));
-
-        $this->assertSame('Foo Bar', Str::studlyWords('fooBar'));
-        $this->assertSame('Foo Bar', Str::studlyWords('foo_bar'));
-        $this->assertSame('Foo Bar Baz', Str::studlyWords('foo-barBaz'));
-        $this->assertSame('Foo Bar Baz', Str::studlyWords('foo-bar_baz'));
     }
 
     public function testMatch()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -432,6 +432,19 @@ class SupportStrTest extends TestCase
         $this->assertSame('FooBarBaz', Str::studly('foo-bar_baz'));
     }
 
+    public function testStudlyWords()
+    {
+        $this->assertSame('Laravel P H P Framework', Str::studlyWords('laravel_p_h_p_framework'));
+        $this->assertSame('Laravel Php Framework', Str::studlyWords('laravel_php_framework'));
+        $this->assertSame('Laravel Ph P Framework', Str::studlyWords('laravel-phP-framework'));
+        $this->assertSame('Laravel Php Framework', Str::studlyWords('laravel  -_-  php   -_-   framework   '));
+
+        $this->assertSame('Foo Bar', Str::studlyWords('fooBar'));
+        $this->assertSame('Foo Bar', Str::studlyWords('foo_bar'));
+        $this->assertSame('Foo Bar Baz', Str::studlyWords('foo-barBaz'));
+        $this->assertSame('Foo Bar Baz', Str::studlyWords('foo-bar_baz'));
+    }
+
     public function testMatch()
     {
         $this->assertSame('bar', Str::match('/bar/', 'foo bar'));

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -39,9 +39,11 @@ class SupportStrTest extends TestCase
     {
         $this->assertSame('Jefferson Costella', Str::headline('jefferson costella'));
         $this->assertSame('Jefferson Costella', Str::headline('jefFErson coSTella'));
-        $this->assertSame('Jefferson Costella Uses Laravel', Str::headline('jefferson_costella uses_Laravel'));
+        $this->assertSame('Jefferson Costella Uses Laravel', Str::headline('jefferson_costella uses-_Laravel'));
+        $this->assertSame('Jefferson Costella Uses Laravel', Str::headline('jefferson_costella uses__Laravel'));
 
         $this->assertSame('Laravel P H P Framework', Str::headline('laravel_p_h_p_framework'));
+        $this->assertSame('Laravel P H P Framework', Str::headline('laravel _p _h _p _framework'));
         $this->assertSame('Laravel Php Framework', Str::headline('laravel_php_framework'));
         $this->assertSame('Laravel Ph P Framework', Str::headline('laravel-phP-framework'));
         $this->assertSame('Laravel Php Framework', Str::headline('laravel  -_-  php   -_-   framework   '));


### PR DESCRIPTION
## Description

This PR adds a new `Stringable` method to convert a string to `Studly Words`.

## Purpose

- There is `studly()` but it concatenates words together
- There is `title()`, but it converts a series of words to `ucfirst` without separating words that are underscored, hyphenated, etc.

## Use Case

This is super useful for displaying "base-named" PHP classes to user interfaces as titles:

```php
// Displays: "Voice Recording Stored"
echo Str::studlyWords(
    class_basename(\App\Events\VoiceRecordingStored::class)
);
```

Or even taking slugs and converting them to a title:

```php
$slug = "using-laravel-with-redis";

// Displays: "Using Laravel With Redis"
echo Str::studlyWords($slug);
```

Thanks for your time! No hard feelings on closure ❤️ 