### PR TITLE
[8.x] Show errors in config files (#39111)

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -628,7 +628,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function runningUnitTests()
     {
-        return $this['env'] === 'testing';
+        return $this->bound('env') ? $this['env'] === 'testing' : false;
     }
 
     /**


### PR DESCRIPTION
If there is a config error `env` is bound in application and runningUnitTests() fails. 
I added a check if `env` is bound and assume it is not a unit test as fallback.
With this fix, config errors are shown correctly for all files except `config/app.php`.

See also #39111 