### PR TITLE
[8.x] Add gate policy callback

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -279,7 +279,7 @@ class Gate implements GateContract
      */
     public function check($abilities, $arguments = [])
     {
-        if(is_array($abilities) && class_exists($abilities[0])) {
+        if (is_array($abilities) && class_exists($abilities[0])) {
             $abilities = [$abilities];
         }
 
@@ -297,8 +297,8 @@ class Gate implements GateContract
      */
     public function any($abilities, $arguments = [])
     {
-        if(is_array($abilities[1])) {
-            $abilities = collect($abilities[1])->map(function($ability) use($abilities) {
+        if (is_array($abilities[1])) {
+            $abilities = collect($abilities[1])->map(function ($ability) use ($abilities) {
                 return [$abilities[0], $ability];
             })->all();
         }
@@ -566,17 +566,17 @@ class Gate implements GateContract
             return $callback;
         }
 
-        if(is_array($ability)) {
+        if (is_array($ability)) {
             [$class, $method] = $ability;
 
-            if($this->canBeCalledWithUser($user, $class, $method)) {
+            if ($this->canBeCalledWithUser($user, $class, $method)) {
                 return $this->getCallableFromCallback($class, $method);
             }
         }
 
-        if(class_exists($ability) &&
+        if (class_exists($ability) &&
             $this->canBeCalledWithUser($user, $ability, '__invoke')) {
-                return $this->getCallableFromCallback($ability);
+            return $this->getCallableFromCallback($ability);
         }
 
         if (isset($this->stringCallbacks[$ability])) {
@@ -600,13 +600,13 @@ class Gate implements GateContract
     /**
      * Get callable from class method.
      *
-     * @param  string $class
-     * @param  string $method
+     * @param  string  $class
+     * @param  string  $method
      * @return \Closure
      */
     protected function getCallableFromCallback($class, $method = '__invoke')
     {
-        return function(...$params) use ($class, $method) {
+        return function (...$params) use ($class, $method) {
             return app($class)->{$method}(...$params);
         };
     }

--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -556,6 +556,19 @@ class Gate implements GateContract
             return $callback;
         }
 
+        if(is_array($ability)) {
+            [$class, $method] = $ability;
+
+            if($this->canBeCalledWithUser($user, $class, $method)) {
+                return $this->getCallableFromCallback($class, $method);
+            }
+        }
+
+        if(class_exists($ability) &&
+            $this->canBeCalledWithUser($user, $ability, '__invoke')) {
+                return $this->getCallableFromCallback($ability);
+        }
+
         if (isset($this->stringCallbacks[$ability])) {
             [$class, $method] = Str::parseCallback($this->stringCallbacks[$ability]);
 
@@ -571,6 +584,20 @@ class Gate implements GateContract
 
         return function () {
             //
+        };
+    }
+
+    /**
+     * Get callable from class method.
+     *
+     * @param  string $class
+     * @param  string $method
+     * @return \Closure
+     */
+    protected function getCallableFromCallback($class, $method = '__invoke')
+    {
+        return function(...$params) use ($class, $method) {
+            return app($class)->{$method}(...$params);
         };
     }
 

--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -279,6 +279,10 @@ class Gate implements GateContract
      */
     public function check($abilities, $arguments = [])
     {
+        if(is_array($abilities) && class_exists($abilities[0])) {
+            $abilities = [$abilities];
+        }
+
         return collect($abilities)->every(function ($ability) use ($arguments) {
             return $this->inspect($ability, $arguments)->allowed();
         });
@@ -293,6 +297,12 @@ class Gate implements GateContract
      */
     public function any($abilities, $arguments = [])
     {
+        if(is_array($abilities[1])) {
+            $abilities = collect($abilities[1])->map(function($ability) use($abilities) {
+                return [$abilities[0], $ability];
+            })->all();
+        }
+
         return collect($abilities)->contains(function ($ability) use ($arguments) {
             return $this->check($ability, $arguments);
         });

--- a/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
+++ b/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
@@ -53,7 +53,7 @@ trait AuthorizesRequests
             return [$ability, $arguments];
         }
 
-        if(is_array($ability)) {
+        if (is_array($ability)) {
             return [$ability, $arguments];
         }
 

--- a/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
+++ b/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
@@ -53,6 +53,10 @@ trait AuthorizesRequests
             return [$ability, $arguments];
         }
 
+        if(is_array($ability)) {
+            return [$ability, $arguments];
+        }
+
         $method = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 3)[2]['function'];
 
         return [$this->normalizeGuessedAbilityName($method), $ability];

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -767,8 +767,6 @@ class AuthAccessGateTest extends TestCase
 
         $this->assertFalse($response->denied());
         $this->assertTrue($response->allowed());
-
-
     }
 
     public function testInspectPolicyCallbackInvoke()

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -767,6 +767,8 @@ class AuthAccessGateTest extends TestCase
 
         $this->assertFalse($response->denied());
         $this->assertTrue($response->allowed());
+
+
     }
 
     public function testInspectPolicyCallbackInvoke()
@@ -777,6 +779,26 @@ class AuthAccessGateTest extends TestCase
 
         $this->assertFalse($response->denied());
         $this->assertTrue($response->allowed());
+    }
+
+    public function testCheckUsingPolicyCallback()
+    {
+        $gate = $this->getBasicGate();
+
+        $this->assertTrue($gate->check(
+            [AccessGateTestPolicyWithAllPermissions::class, 'edit'],
+            new AccessGateTestDummy)
+        );
+    }
+
+    public function testAnyUsingPolicyCallback()
+    {
+        $gate = $this->getBasicGate();
+
+        $this->assertTrue($gate->any(
+            [AccessGateTestPolicyWithAllPermissions::class, ['edit', 'update']],
+            new AccessGateTestDummy)
+        );
     }
 
     /**

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -759,6 +759,26 @@ class AuthAccessGateTest extends TestCase
         $this->assertFalse($gate->check(['edit', 'update'], new AccessGateTestDummy));
     }
 
+    public function testInspectPolicyCallback()
+    {
+        $gate = $this->getBasicGate();
+
+        $response = $gate->inspect([AccessGateTestPolicyWithAllPermissions::class, 'edit'], new AccessGateTestDummy);
+
+        $this->assertFalse($response->denied());
+        $this->assertTrue($response->allowed());
+    }
+
+    public function testInspectPolicyCallbackInvoke()
+    {
+        $gate = $this->getBasicGate();
+
+        $response = $gate->inspect(AccessGateTestGuestInvokableClass::class, new AccessGateTestDummy);
+
+        $this->assertFalse($response->denied());
+        $this->assertTrue($response->allowed());
+    }
+
     /**
      * @dataProvider hasAbilitiesTestDataProvider
      *

--- a/tests/Foundation/FoundationAuthorizesRequestsTraitTest.php
+++ b/tests/Foundation/FoundationAuthorizesRequestsTraitTest.php
@@ -17,6 +17,18 @@ class FoundationAuthorizesRequestsTraitTest extends TestCase
         Container::setInstance(null);
     }
 
+    public function testCallableGateCheck()
+    {
+        unset($_SERVER['_test.authorizes.trait']);
+
+        $gate = $this->getBasicGate();
+
+        $response = (new FoundationTestAuthorizeTraitClass)->authorize([FoundationAuthorizesRequestTestPolicy::class, 'create']);
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertTrue($_SERVER['_test.authorizes.trait.policy']);
+    }
+
     public function testBasicGateCheck()
     {
         unset($_SERVER['_test.authorizes.trait']);


### PR DESCRIPTION
This pr adds the ability to pass policy callbacks to the gate.

### Usage

```php
Gate::inspect([PostPolicy::class, 'update'], $post)->authorize();
Gate::inspect(InvokablePolicy::class)->authorize();
Gate::check([PostPolicy:class, 'update'], $post);
Gate::any([PostPolicy::class, ['update', 'edit']], $post);
```

### Why This Is Usefull

- This allows navigating to the namespace of the policy from where it is used.
- Different policies can be used for the same model.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
