### PR TITLE
[8.x] Allow Remember Me cookie time to be overriden

### DIFF
--- a/src/Illuminate/Auth/AuthManager.php
+++ b/src/Illuminate/Auth/AuthManager.php
@@ -139,7 +139,7 @@ class AuthManager implements FactoryContract
             $guard->setRequest($this->app->refresh('request', $guard, 'setRequest'));
         }
 
-        if(isset($config['rememberMeTokenDuration'])){
+        if (isset($config['rememberMeTokenDuration'])) {
             $guard->setRememberMeTokenDuration($config['rememberMeTokenDuration']);
         }
 

--- a/src/Illuminate/Auth/AuthManager.php
+++ b/src/Illuminate/Auth/AuthManager.php
@@ -139,8 +139,8 @@ class AuthManager implements FactoryContract
             $guard->setRequest($this->app->refresh('request', $guard, 'setRequest'));
         }
 
-        if (isset($config['rememberMeTokenDuration'])) {
-            $guard->setRememberMeTokenDuration($config['rememberMeTokenDuration']);
+        if (isset($config['remember'])) {
+            $guard->setRememberDuration($config['remember']);
         }
 
         return $guard;

--- a/src/Illuminate/Auth/AuthManager.php
+++ b/src/Illuminate/Auth/AuthManager.php
@@ -139,6 +139,10 @@ class AuthManager implements FactoryContract
             $guard->setRequest($this->app->refresh('request', $guard, 'setRequest'));
         }
 
+        if(isset($config['rememberMeTokenDuration'])){
+            $guard->setRememberMeTokenDuration($config['rememberMeTokenDuration']);
+        }
+
         return $guard;
     }
 

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -56,7 +56,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     /**
      * The duration that "remember me" token should last for.
      *
-     * @var null
+     * @var int
      */
     protected $rememberMeTokenDuration = 2628000;
 

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -58,7 +58,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      *
      * @var null
      */
-    protected $rememberMeTokenDuration = null;
+    protected $rememberMeTokenDuration = 2628000;
 
     /**
      * The session used by the guard.
@@ -549,10 +549,6 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      */
     protected function getRememberMeTokenDuration()
     {
-        if($this->rememberMeTokenDuration === null){
-            return 2628000;
-        }
-
         return $this->rememberMeTokenDuration;
     }
 

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -54,6 +54,13 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     protected $viaRemember = false;
 
     /**
+     * The duration that "remember me" token should last for.
+     *
+     * @var null
+     */
+    protected $rememberMeTokenDuration = null;
+
+    /**
      * The session used by the guard.
      *
      * @var \Illuminate\Contracts\Session\Session
@@ -532,7 +539,34 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      */
     protected function createRecaller($value)
     {
-        return $this->getCookieJar()->forever($this->getRecallerName(), $value);
+        return $this->getCookieJar()->make($this->getRecallerName(), $value, $this->getRememberMeTokenDuration());
+    }
+
+    /**
+     * Returns how long the remember me token should last for.
+     *
+     * @return int
+     */
+    protected function getRememberMeTokenDuration()
+    {
+        if($this->rememberMeTokenDuration === null){
+            return 2628000;
+        }
+
+        return $this->rememberMeTokenDuration;
+    }
+
+    /**
+     * Allows you to set the how long the remember me token will last for.
+     *
+     * @param int  $minutes
+     * @return $this
+     */
+    public function setRememberMeTokenDuration($minutes)
+    {
+        $this->rememberMeTokenDuration = $minutes;
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -555,7 +555,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     /**
      * Allows you to set the how long the remember me token will last for.
      *
-     * @param int  $minutes
+     * @param  int  $minutes
      * @return $this
      */
     public function setRememberMeTokenDuration($minutes)

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -54,11 +54,11 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     protected $viaRemember = false;
 
     /**
-     * The duration that "remember me" token should last for.
+     * The number of minutes that the "remember me" cookie should be valid for.
      *
      * @var int
      */
-    protected $rememberMeTokenDuration = 2628000;
+    protected $rememberDuration = 2628000;
 
     /**
      * The session used by the guard.
@@ -539,30 +539,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      */
     protected function createRecaller($value)
     {
-        return $this->getCookieJar()->make($this->getRecallerName(), $value, $this->getRememberMeTokenDuration());
-    }
-
-    /**
-     * Returns how long the remember me token should last for.
-     *
-     * @return int
-     */
-    protected function getRememberMeTokenDuration()
-    {
-        return $this->rememberMeTokenDuration;
-    }
-
-    /**
-     * Allows you to set the how long the remember me token will last for.
-     *
-     * @param  int  $minutes
-     * @return $this
-     */
-    public function setRememberMeTokenDuration($minutes)
-    {
-        $this->rememberMeTokenDuration = $minutes;
-
-        return $this;
+        return $this->getCookieJar()->make($this->getRecallerName(), $value, $this->getRememberDuration());
     }
 
     /**
@@ -844,6 +821,29 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     public function viaRemember()
     {
         return $this->viaRemember;
+    }
+
+    /**
+     * Get the number of minutes the remember me cookie should be valid for.
+     *
+     * @return int
+     */
+    protected function getRememberDuration()
+    {
+        return $this->rememberDuration;
+    }
+
+    /**
+     * Set the number of minutes the remember me cookie should be valid for.
+     *
+     * @param  int  $minutes
+     * @return $this
+     */
+    public function setRememberDuration($minutes)
+    {
+        $this->rememberDuration = $minutes;
+
+        return $this;
     }
 
     /**

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -444,7 +444,7 @@ class AuthGuardTest extends TestCase
     {
         [$session, $provider, $request, $cookie] = $this->getMocks();
         $guard = new SessionGuard('default', $provider, $session, $request);
-        $guard->setRememberMeTokenDuration(5000);
+        $guard->setRememberDuration(5000);
         $guard->setCookieJar($cookie);
         $foreverCookie = new Cookie($guard->getRecallerName(), 'foo');
         $cookie->shouldReceive('make')->once()->with($guard->getRecallerName(), 'foo|recaller|bar', 5000)->andReturn($foreverCookie);

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -427,7 +427,27 @@ class AuthGuardTest extends TestCase
         $guard = new SessionGuard('default', $provider, $session, $request);
         $guard->setCookieJar($cookie);
         $foreverCookie = new Cookie($guard->getRecallerName(), 'foo');
-        $cookie->shouldReceive('forever')->once()->with($guard->getRecallerName(), 'foo|recaller|bar')->andReturn($foreverCookie);
+        $cookie->shouldReceive('make')->once()->with($guard->getRecallerName(), 'foo|recaller|bar', 2628000)->andReturn($foreverCookie);
+        $cookie->shouldReceive('queue')->once()->with($foreverCookie);
+        $guard->getSession()->shouldReceive('put')->once()->with($guard->getName(), 'foo');
+        $session->shouldReceive('migrate')->once();
+        $user = m::mock(Authenticatable::class);
+        $user->shouldReceive('getAuthIdentifier')->andReturn('foo');
+        $user->shouldReceive('getAuthPassword')->andReturn('bar');
+        $user->shouldReceive('getRememberToken')->andReturn('recaller');
+        $user->shouldReceive('setRememberToken')->never();
+        $provider->shouldReceive('updateRememberToken')->never();
+        $guard->login($user, true);
+    }
+
+    public function testLoginMethodQueuesCookieWhenRememberingAndAllowsOverride()
+    {
+        [$session, $provider, $request, $cookie] = $this->getMocks();
+        $guard = new SessionGuard('default', $provider, $session, $request);
+        $guard->setRememberMeTokenDuration(5000);
+        $guard->setCookieJar($cookie);
+        $foreverCookie = new Cookie($guard->getRecallerName(), 'foo');
+        $cookie->shouldReceive('make')->once()->with($guard->getRecallerName(), 'foo|recaller|bar', 5000)->andReturn($foreverCookie);
         $cookie->shouldReceive('queue')->once()->with($foreverCookie);
         $guard->getSession()->shouldReceive('put')->once()->with($guard->getName(), 'foo');
         $session->shouldReceive('migrate')->once();
@@ -446,7 +466,7 @@ class AuthGuardTest extends TestCase
         $guard = new SessionGuard('default', $provider, $session, $request);
         $guard->setCookieJar($cookie);
         $foreverCookie = new Cookie($guard->getRecallerName(), 'foo');
-        $cookie->shouldReceive('forever')->once()->andReturn($foreverCookie);
+        $cookie->shouldReceive('make')->once()->andReturn($foreverCookie);
         $cookie->shouldReceive('queue')->once()->with($foreverCookie);
         $guard->getSession()->shouldReceive('put')->once()->with($guard->getName(), 'foo');
         $session->shouldReceive('migrate')->once();


### PR DESCRIPTION
We want to restrict how long a remember-me token will exist for certain guards. For usual web users, we want to allow them to be logged in forever, but for staff members, we want to expire the remember me token after 30 days. 


With this PR, I've made it so you can add `rememberMeTokenDuration` to the guard in `config/auth.php`. If you do not provide this, it will maintain the same cookie expiration date which is 5 years.
