### PR TITLE
[8.x] Fix HasOneOfMany with callback issue

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/CanBeOneOfMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/CanBeOneOfMany.php
@@ -102,7 +102,9 @@ trait CanBeOneOfMany
 
             if (isset($previous)) {
                 $this->addOneOfManyJoinSubQuery($subQuery, $previous['subQuery'], $previous['column']);
-            } elseif (isset($closure)) {
+            }
+
+            if (isset($closure)) {
                 $closure($subQuery);
             }
 
@@ -186,7 +188,7 @@ trait CanBeOneOfMany
         }
 
         if (! is_null($column)) {
-            $subQuery->selectRaw($aggregate.'('.$subQuery->getQuery()->grammar->wrap($column).') as '.$subQuery->getQuery()->grammar->wrap($column));
+            $subQuery->selectRaw($aggregate.'('.$subQuery->getQuery()->grammar->wrap($column).') as '.$subQuery->getQuery()->grammar->wrap($column.'_aggregate'));
         }
 
         $this->addOneOfManySubQueryConstraints($subQuery, $groupBy, $column, $aggregate);
@@ -208,7 +210,7 @@ trait CanBeOneOfMany
             $subQuery->applyBeforeQueryCallbacks();
 
             $parent->joinSub($subQuery, $this->relationName, function ($join) use ($on) {
-                $join->on($this->qualifySubSelectColumn($on), '=', $this->qualifyRelatedColumn($on));
+                $join->on($this->qualifySubSelectColumn($on.'_aggregate'), '=', $this->qualifyRelatedColumn($on));
 
                 $this->addOneOfManyJoinSubQueryConstraints($join, $on);
             });

--- a/tests/Database/DatabaseEloquentHasOneOfManyTest.php
+++ b/tests/Database/DatabaseEloquentHasOneOfManyTest.php
@@ -50,6 +50,7 @@ class DatabaseEloquentHasOneOfManyTest extends TestCase
             $table->string('state');
             $table->string('type');
             $table->foreignId('user_id');
+            $table->timestamps();
         });
 
         $this->schema()->create('prices', function ($table) {
@@ -389,6 +390,29 @@ class DatabaseEloquentHasOneOfManyTest extends TestCase
         $this->assertNotNull($user->latest_login_with_soft_deletes);
     }
 
+    public function testWithContraintNotInAggregate()
+    {
+        $user = HasOneOfManyTestUser::create();
+
+        $previousFoo = $user->states()->create([
+            'type' => 'foo',
+            'state' => 'bar',
+            'updated_at' => '2020-01-01 00:00:00',
+        ]);
+        $newFoo = $user->states()->create([
+            'type' => 'foo',
+            'state' => 'active',
+            'updated_at' => '2021-01-01 12:00:00',
+        ]);
+        $newBar = $user->states()->create([
+            'type' => 'bar',
+            'state' => 'active',
+            'updated_at' => '2021-01-01 12:00:00',
+        ]);
+
+        $this->assertSame($newFoo->id, $user->last_updated_foo_state->id);
+    }
+
     /**
      * Get a database connection instance.
      *
@@ -464,6 +488,16 @@ class HasOneOfManyTestUser extends Eloquent
         );
     }
 
+    public function last_updated_foo_state()
+    {
+        return $this->hasOne(HasOneOfManyTestState::class, 'user_id')->ofMany([
+            'updated_at' => 'max',
+            'id' => 'max',
+        ], function ($q) {
+            $q->where('type', 'foo');
+        });
+    }
+
     public function prices()
     {
         return $this->hasMany(HasOneOfManyTestPrice::class, 'user_id');
@@ -518,8 +552,8 @@ class HasOneOfManyTestState extends Eloquent
 {
     protected $table = 'states';
     protected $guarded = [];
-    public $timestamps = false;
-    protected $fillable = ['type', 'state'];
+    public $timestamps = true;
+    protected $fillable = ['type', 'state', 'updated_at'];
 }
 
 class HasOneOfManyTestPrice extends Eloquent

--- a/tests/Database/DatabaseEloquentHasOneOfManyTest.php
+++ b/tests/Database/DatabaseEloquentHasOneOfManyTest.php
@@ -107,7 +107,7 @@ class DatabaseEloquentHasOneOfManyTest extends TestCase
         $user = HasOneOfManyTestUser::create();
         $relation = $user->latest_login();
         $relation->addEagerConstraints([$user]);
-        $this->assertSame('select MAX("id") as "id", "logins"."user_id" from "logins" where "logins"."user_id" = ? and "logins"."user_id" is not null and "logins"."user_id" in (1) group by "logins"."user_id"', $relation->getOneOfManySubQuery()->toSql());
+        $this->assertSame('select MAX("id") as "id_aggregate", "logins"."user_id" from "logins" where "logins"."user_id" = ? and "logins"."user_id" is not null and "logins"."user_id" in (1) group by "logins"."user_id"', $relation->getOneOfManySubQuery()->toSql());
     }
 
     public function testQualifyingSubSelectColumn()

--- a/tests/Database/DatabaseEloquentMorphOneOfManyTest.php
+++ b/tests/Database/DatabaseEloquentMorphOneOfManyTest.php
@@ -61,7 +61,7 @@ class DatabaseEloquentMorphOneOfManyTest extends TestCase
         $product = MorphOneOfManyTestProduct::create();
         $relation = $product->current_state();
         $relation->addEagerConstraints([$product]);
-        $this->assertSame('select MAX("id") as "id", "states"."stateful_id", "states"."stateful_type" from "states" where "states"."stateful_id" = ? and "states"."stateful_id" is not null and "states"."stateful_type" = ? and "states"."stateful_id" in (1) and "states"."stateful_type" = ? group by "states"."stateful_id", "states"."stateful_type"', $relation->getOneOfManySubQuery()->toSql());
+        $this->assertSame('select MAX("id") as "id_aggregate", "states"."stateful_id", "states"."stateful_type" from "states" where "states"."stateful_id" = ? and "states"."stateful_id" is not null and "states"."stateful_type" = ? and "states"."stateful_id" in (1) and "states"."stateful_type" = ? group by "states"."stateful_id", "states"."stateful_type"', $relation->getOneOfManySubQuery()->toSql());
     }
 
     public function testReceivingModel()


### PR DESCRIPTION
I found some kind of unexpected behaviour when using `hasOne()->ofMany()` with a callback.

I did not find a solution yet but having a failing test is helpful if someone wants to fix this.

Having something like
```php
class User extends Model {

    public function last_updated_foo_state()
    {
        return $this->hasOne(HasOneOfManyTestState::class, 'user_id')->ofMany([
            'updated_at' => 'max',
            'id' => 'max',
        ], function ($q) {
            $q->where('type', 'foo');
        });
    }
}
```
and some States 
```php
$previousFoo = $user->states()->create([
    'type' => 'foo',
    'state' => 'bar',
    'updated_at' => '2020-01-01 00:00:00'
]);
$newFoo = $user->states()->create([
    'type' => 'foo',
    'state' => 'active',
    'updated_at' => '2021-01-01 12:00:00'
]);
$newBar = $user->states()->create([
    'type' => 'bar',
    'state' => 'active',
    'updated_at' => '2021-01-01 12:00:00'
]);
```
we expect `$user->last_updated_foo_state` to be `$newFoo`. Actually it is `$newBar`.

The problem comes from the query. Actually, the generated sql looks like 
```sql
select *
from "states"
inner join (
    select max("id") as "id", "states"."user_id"
    from "states"
    inner join (
        select max("updated_at") as "updated_at", "states"."user_id"
        from "states"
        where "type" = ?
        and "states"."user_id" = ?
        and "states"."user_id" is not null
        group by "states"."user_id"
    ) as "last_updated_foo_state"
    on "last_updated_foo_state"."updated_at" = "states"."updated_at"
    and "last_updated_foo_state"."user_id" = "states"."user_id"
    group by "states"."user_id"
) as "last_updated_foo_state"
on "last_updated_foo_state"."id" = "states"."id" 
and "last_updated_foo_state"."user_id" = "states"."user_id"
where "states"."user_id" = ?
and "states"."user_id" is not null
```
My guess is that the callback is only applied once in the deeper inner join but should be also applied in the other one.

```diff
select *
from "states"
inner join (
    select max("id") as "id", "states"."user_id"
    from "states"
    inner join (
        select max("updated_at") as "updated_at", "states"."user_id"
        from "states"
        where "type" = ?
        and "states"."user_id" = ?
        and "states"."user_id" is not null
        group by "states"."user_id"
    ) as "last_updated_foo_state"
    on "last_updated_foo_state"."updated_at" = "states"."updated_at"
    and "last_updated_foo_state"."user_id" = "states"."user_id"
+   where "type" = ?    
    group by "states"."user_id"
) as "last_updated_foo_state"
on "last_updated_foo_state"."id" = "states"."id" 
and "last_updated_foo_state"."user_id" = "states"."user_id"
where "states"."user_id" = ?
and "states"."user_id" is not null
```

This could be solved by changing  `CanBeOneOfMany::ofMany` with 
```diff
if (isset($previous)) {
                $this->addOneOfManyJoinSubQuery($subQuery, $previous['subQuery'], $previous['column']);
-} elseif(isset($closure)) {
+}
+
+if(isset($closure))
    $closure($subQuery);
}
```
but it comes with other problems. Some tests are failing (`testMultipleAggregates`, `testEagerLoadingWithMultipleAggregates`) with `General error: 1 ambiguous column name: published_at`.

It can be solved in userland with 
```diff
public function price()
{
    return $this->hasOne(HasOneOfManyTestPrice::class, 'user_id')->ofMany([
        'published_at' => 'max',
        'id' => 'max',
    ], function ($q) {
-        $q->where('published_at', '<', now());
+        $q->where('prices.published_at', '<', now());
    });
}
```
but I'm not sure it is the right move.

If someone has any idea how to fix this, I left everything here !
