### PR TITLE
[8.x] Added assertRedirectRegex

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -278,6 +278,25 @@ EOF;
     }
 
     /**
+     * Assert whether the response is redirecting to a given URI that matches the pattern.
+     *
+     * @param  string  $regex
+     * @return $this
+     */
+    public function assertRedirectRegex($regex)
+    {
+        PHPUnit::assertTrue(
+            $this->isRedirect(), 'Response status code ['.$this->getStatusCode().'] is not a redirect status code.'
+        );
+
+        PHPUnit::assertMatchesRegularExpression(
+            $regex, $this->headers->get('Location')
+        );
+
+        return $this;
+    }
+
+    /**
      * Assert whether the response is redirecting to a given signed route.
      *
      * @param  string|null  $name

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -1528,6 +1528,19 @@ class TestResponseTest extends TestCase
         $response->assertCookieMissing('cookie-name');
     }
 
+    public function testAssertRedirectRegex()
+    {
+        $response = TestResponse::fromBaseResponse(
+            (new Response('', 302))->withHeaders(['Location' => 'https://url.com'])
+        );
+
+        $response->assertRedirectRegex('/url\.com/');
+
+        $this->expectException(ExpectationFailedException::class);
+
+        $response->assertRedirectRegex('/url\.net/');
+    }
+
     private function makeMockResponse($content)
     {
         $baseResponse = tap(new Response, function ($response) use ($content) {


### PR DESCRIPTION
This adds the ability to call `assertRedirectRegex()` on the `TestResponse`. More fluent and readable 🤓

## Before

```php
$response = $this->get(route('checkout']))->assertRedirect();

$this->assertStringContainsString('https://checkout.stripe.com/', $response->headers->get('Location'));
```

## After

```php
$this->get(route('checkout']))
    ->assertRedirectRegex('/checkout\.stripe\.com/');
```