### PR TITLE
[8.x] Subset in request's collect

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -304,10 +304,11 @@ trait InteractsWithInput
      */
     public function collect($key = null)
     {
-        if (is_array($key))
+        if (is_array($key)) {
             return collect($this->only($key));
-        else
+        } else {
             return collect($this->input($key));
+        }
     }
 
     /**

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -304,11 +304,7 @@ trait InteractsWithInput
      */
     public function collect($key = null)
     {
-        if (is_array($key)) {
-            return collect($this->only($key));
-        } else {
-            return collect($this->input($key));
-        }
+        return collect(is_array($key) ? $this->only($key) : $this->input($key));
     }
 
     /**

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -299,12 +299,15 @@ trait InteractsWithInput
     /**
      * Retrieve input from the request as a collection.
      *
-     * @param  string|null  $key
+     * @param  array|string|null  $key
      * @return \Illuminate\Support\Collection
      */
     public function collect($key = null)
     {
-        return collect($this->input($key));
+        if (is_array($key))
+            return collect($this->only($key));
+        else
+            return collect($this->input($key));
     }
 
     /**

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -521,6 +521,13 @@ class HttpRequestTest extends TestCase
         $request = Request::create('/', 'GET', []);
         $this->assertInstanceOf(Collection::class, $request->collect());
         $this->assertTrue($request->collect()->isEmpty());
+
+        $request = Request::create('/', 'GET', ['users' => [1, 2, 3], 'roles' => [4, 5, 6]]);
+        $this->assertInstanceOf(Collection::class, $request->collect(['users']));
+        $this->assertTrue($request->collect(['developers'])->isEmpty());
+        $this->assertTrue($request->collect(['roles'])->isNotEmpty());
+        $this->assertEquals(['roles' => [4, 5, 6]], $request->collect(['roles'])->all());
+        $this->assertEquals(['users' => [1, 2, 3], 'roles' => [4, 5, 6]], $request->collect()->all());
     }
 
     public function testArrayAccess()

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -522,12 +522,14 @@ class HttpRequestTest extends TestCase
         $this->assertInstanceOf(Collection::class, $request->collect());
         $this->assertTrue($request->collect()->isEmpty());
 
-        $request = Request::create('/', 'GET', ['users' => [1, 2, 3], 'roles' => [4, 5, 6]]);
+        $request = Request::create('/', 'GET', ['users' => [1, 2, 3], 'roles' => [4, 5, 6], 'foo' => ['bar', 'baz'], 'email' => 'test@example.com']);
         $this->assertInstanceOf(Collection::class, $request->collect(['users']));
         $this->assertTrue($request->collect(['developers'])->isEmpty());
         $this->assertTrue($request->collect(['roles'])->isNotEmpty());
         $this->assertEquals(['roles' => [4, 5, 6]], $request->collect(['roles'])->all());
-        $this->assertEquals(['users' => [1, 2, 3], 'roles' => [4, 5, 6]], $request->collect()->all());
+        $this->assertEquals(['users' => [1, 2, 3], 'email' => 'test@example.com'], $request->collect(['users', 'email'])->all());
+        $this->assertEquals(collect(['roles' => [4, 5, 6], 'foo' => ['bar', 'baz']]), $request->collect(['roles', 'foo']));
+        $this->assertEquals(['users' => [1, 2, 3], 'roles' => [4, 5, 6], 'foo' => ['bar', 'baz'], 'email' => 'test@example.com'], $request->collect()->all());
     }
 
     public function testArrayAccess()


### PR DESCRIPTION
This adds the ability to get a subset in request collect function.

Before
--

```php
    public function collect($key = null)
    {
        return collect($this->input($key));
    }
```

After
--
```php
    public function collect($key = null)
    {
        if (is_array($key))
            return collect($this->only($key));
        else
            return collect($this->input($key));
    }
```

fix https://github.com/laravel/framework/issues/39190