### PR TITLE
[9.x] Omit `render()` method in Blade Components

### DIFF
--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -55,7 +55,7 @@ abstract class Component
      */
     public function render()
     {
-        return view('components.' . $this->resolveViewName());
+        return view('components.'.$this->resolveViewName());
     }
 
     /**

--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -53,7 +53,20 @@ abstract class Component
      *
      * @return \Illuminate\Contracts\View\View|\Illuminate\Contracts\Support\Htmlable|\Closure|string
      */
-    abstract public function render();
+    public function render()
+    {
+        return view('components.' . $this->resolveViewName());
+    }
+
+    /**
+     * Get the view name relative to the components directory.
+     *
+     * @return string view
+     */
+    protected function resolveViewName()
+    {
+        return $this->componentName ?: Str::kebab(class_basename(get_class($this)));
+    }
 
     /**
      * Resolve the Blade view or view file that should be used when rendering the component.

--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -51,7 +51,7 @@ abstract class Component
     /**
      * Get the view / view contents that represent the component.
      *
-     * @return \Illuminate\Contracts\View\View|\Illuminate\Contracts\Support\Htmlable|\Closure|string
+     * @return \Illuminate\Contracts\View\View|\Illuminate\Contracts\View\Factory
      */
     public function render()
     {

--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -61,7 +61,7 @@ abstract class Component
     /**
      * Get the view name relative to the components directory.
      *
-     * @return string view
+     * @return string
      */
     protected function resolveViewName()
     {

--- a/tests/View/ComponentTest.php
+++ b/tests/View/ComponentTest.php
@@ -85,6 +85,16 @@ class ComponentTest extends TestCase
         $this->assertInstanceOf(Htmlable::class, $view);
         $this->assertSame('<p>Hello foo</p>', $view->toHtml());
     }
+
+    public function testViewWithMissingRenderMethodGetReturned()
+    {
+        $view = m::mock(View::class);
+        $this->viewFactory->shouldReceive('make')->once()->with('components.test-missing-render-component', [], [])->andReturn($view);
+
+        $component = new TestMissingRenderComponent();
+
+        $this->assertSame($view, $component->resolveView());
+    }
 }
 
 class TestInlineViewComponent extends Component
@@ -144,5 +154,15 @@ class TestHtmlableReturningViewComponent extends Component
     public function render()
     {
         return new HtmlString("<p>Hello {$this->title}</p>");
+    }
+}
+
+class TestMissingRenderComponent extends Component
+{
+    public $title;
+
+    public function __construct($title = 'foo')
+    {
+        $this->title = $title;
     }
 }


### PR DESCRIPTION
Currently, the `render()` method is required on a blade component. I would say 95% of the time I never change the `render()` method view on a rendered blade view component. In Livewire, you can omit the `render()` method and this PR accomplishes the same action.

Before:
```php
<?php

namespace App\View\Components;

use Illuminate\View\Component;

class Alert extends Component
{
    public function render()
    {
        return view('components.alert');
    }
}
```

After:
```php
<?php

namespace App\View\Components;

use Illuminate\View\Component;

class Alert extends Component
{
    //
}
```

This will automatically attempt to resolve a view located at `components.x` and also works on nested components. Users may continue to write their own `render()` methods for complex customization.

Other considerations - throw a good exception message when the blade view doesn't exist (making it clear we couldn't automatically resolve the view)?