### PR TITLE
[8.x] Fix scheduler unique job

### DIFF
--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -9,6 +9,8 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\PendingClosureDispatch;
+use Illuminate\Foundation\Bus\PendingDispatch;
 use Illuminate\Queue\CallQueuedClosure;
 use Illuminate\Support\ProcessUtils;
 use Illuminate\Support\Str;
@@ -165,12 +167,12 @@ class Schedule
                 );
             }
 
-            $job = CallQueuedClosure::create($job);
+            $job = new PendingClosureDispatch(CallQueuedClosure::create($job));
+        } else {
+            $job = new PendingDispatch($job);
         }
 
-        $this->getDispatcher()->dispatch(
-            $job->onConnection($connection)->onQueue($queue)
-        );
+        $job->onConnection($connection)->onQueue($queue);
     }
 
     /**

--- a/tests/Integration/Console/UniqueJobSchedulingTest.php
+++ b/tests/Integration/Console/UniqueJobSchedulingTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Console;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Queue;
+use Orchestra\Testbench\TestCase;
+use Illuminate\Contracts\Cache\Repository as Cache;
+
+class UniqueJobSchedulingTest extends TestCase
+{
+    public function testJobsPushedToQueue()
+    {
+        Queue::fake();
+        $this->dispatch(
+            TestJob::class,
+            TestJob::class,
+            TestJob::class,
+            TestJob::class
+        );
+
+        Queue::assertPushed(TestJob::class, 4);
+    }
+
+    public function testUniqueJobsPushedToQueue()
+    {
+        Queue::fake();
+        $this->dispatch(
+            UniqueTestJob::class,
+            UniqueTestJob::class,
+            UniqueTestJob::class,
+            UniqueTestJob::class
+        );
+
+        Queue::assertPushed(UniqueTestJob::class, 1);
+    }
+
+    private function dispatch(...$jobs)
+    {
+        /** @var \Illuminate\Console\Scheduling\Schedule $scheduler */
+        $scheduler = $this->app->make(Schedule::class);
+        foreach ($jobs as $job) {
+            $scheduler->job($job)->name('')->everyMinute();
+        }
+        $events = $scheduler->events();
+        foreach ($events as $event) {
+            $event->run($this->app);
+        }
+    }
+}
+
+class TestJob implements ShouldQueue
+{
+    use InteractsWithQueue, Queueable, Dispatchable;
+}
+
+class UniqueTestJob extends TestJob implements ShouldBeUnique
+{
+}


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Hi maintainers

I discovered a bug where scheduling job that implemented ShouldBeUnique failed to enforce uniqueness. 

I have included test case and possible fix. 

Please review. 

Thanks
