### PR TITLE
[8.x] Deprecate `reduceMany` in favor of `reduceSpread`

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -752,9 +752,25 @@ trait EnumeratesValues
      * @param  mixed  ...$initial
      * @return array
      *
+     * @deprecated Use "reduceSpread" instead
+     *
      * @throws \UnexpectedValueException
      */
     public function reduceMany(callable $callback, ...$initial)
+    {
+        return $this->reduceSpread($callback, ...$initial);
+    }
+
+    /**
+     * Reduce the collection to multiple aggregate values.
+     *
+     * @param  callable  $callback
+     * @param  mixed  ...$initial
+     * @return array
+     *
+     * @throws \UnexpectedValueException
+     */
+    public function reduceSpread(callable $callback, ...$initial)
     {
         $result = $initial;
 
@@ -770,20 +786,6 @@ trait EnumeratesValues
         }
 
         return $result;
-    }
-
-    /**
-     * Reduce the collection to multiple aggregate values.
-     *
-     * @param  callable  $callback
-     * @param  mixed  ...$initial
-     * @return array
-     *
-     * @throws \UnexpectedValueException
-     */
-    public function reduceSpread(callable $callback, ...$initial)
-    {
-        return $this->reduceMany($callback, ...$initial);
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3920,11 +3920,11 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
-    public function testReduceMany($collection)
+    public function testReduceSpread($collection)
     {
         $data = new $collection([-1, 0, 1, 2, 3, 4, 5]);
 
-        [$sum, $max, $min] = $data->reduceMany(function ($sum, $max, $min, $value) {
+        [$sum, $max, $min] = $data->reduceSpread(function ($sum, $max, $min, $value) {
             $sum += $value;
             $max = max($max, $value);
             $min = min($min, $value);
@@ -3940,13 +3940,13 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
-    public function testReduceManyThrowsAnExceptionIfReducerDoesNotReturnAnArray($collection)
+    public function testReduceSpreadThrowsAnExceptionIfReducerDoesNotReturnAnArray($collection)
     {
         $data = new $collection([1]);
 
         $this->expectException(UnexpectedValueException::class);
 
-        $data->reduceMany(function () {
+        $data->reduceSpread(function () {
             return false;
         }, null);
     }


### PR DESCRIPTION
1. Deprecate `reduceMany` in favor of `reduceSpread`.
2. Add tests ensuring it's actually lazy.