### PR TITLE
[8.x] Add assertions for notifications sent on-demand

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -7,6 +7,7 @@ use Exception;
 use Illuminate\Contracts\Notifications\Dispatcher as NotificationDispatcher;
 use Illuminate\Contracts\Notifications\Factory as NotificationFactory;
 use Illuminate\Contracts\Translation\HasLocalePreference;
+use Illuminate\Notifications\AnonymousNotifiable;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
@@ -30,6 +31,20 @@ class NotificationFake implements NotificationDispatcher, NotificationFactory
      * @var string|null
      */
     public $locale;
+
+    /**
+     * Assert if a notification was sent on-demand based on a truth-test callback.
+     *
+     * @param  string|\Closure  $notification
+     * @param  callable|null  $callback
+     * @return void
+     *
+     * @throws \Exception
+     */
+    public function assertSentOnDemand($notification, $callback = null)
+    {
+        $this->assertSentTo(new AnonymousNotifiable, $notification, $callback);
+    }
 
     /**
      * Assert if a notification was sent based on a truth-test callback.
@@ -67,6 +82,18 @@ class NotificationFake implements NotificationDispatcher, NotificationFactory
             $this->sent($notifiable, $notification, $callback)->count() > 0,
             "The expected [{$notification}] notification was not sent."
         );
+    }
+
+    /**
+     * Assert if a notification was sent on-demand a number of times.
+     *
+     * @param  string  $notification
+     * @param  int  $times
+     * @return void
+     */
+    public function assertSentOnDemandTimes($notification, $times = 1)
+    {
+        return $this->assertSentToTimes(new AnonymousNotifiable, $notification, $times);
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Given that on-demand notifications are always sent to `Illuminate\Notifications\AnonymousNotifiable`, this new set assertions  remove the need to declare the `assertSentTo(new AnonymousNotifiable)` every single time, but most importantly, it better communicates the strategy used to send those notifications.
