### PR TITLE
[8.x] Fix eager loaded relationship overlays

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1294,7 +1294,7 @@ class Builder
     /**
      * Merge the relationships that should be eager loaded.
      *
-     * @param array $eagerLoad
+     * @param  array  $eagerLoad
      */
     protected function mergeEagerLoad($eagerLoad)
     {

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1286,9 +1286,27 @@ class Builder
             $eagerLoad = $this->parseWithRelations(is_string($relations) ? func_get_args() : $relations);
         }
 
-        $this->eagerLoad = array_merge($this->eagerLoad, $eagerLoad);
+        $this->mergeEagerLoad($eagerLoad);
 
         return $this;
+    }
+
+    /**
+     * Merge the relationships that should be eager loaded.
+     *
+     * @param array $eagerLoad
+     */
+    protected function mergeEagerLoad($eagerLoad)
+    {
+        foreach ($eagerLoad as $name => $constraints) {
+            // Already exists relationships?
+            if (isset($this->eagerLoad[$name])) {
+                // Ignore
+                unset($eagerLoad[$name]);
+            }
+        }
+
+        $this->eagerLoad = array_merge($this->eagerLoad, $eagerLoad);
     }
 
     /**


### PR DESCRIPTION
### Question

When you define the following eager loading relationship:

```
$eloquentModel
    ->with(
        'progresses',
        function (HasMany $builder) {
            $builder->select(['id', 'eloquent_model_id', 'workflow_id', 'admin_id'])
                ->orderBy('id');
        }
    )
    ->with('progresses.admin:id,name')
    ->with('progresses.workflow:id,name,admin_role_id')
    ->with('progresses.workflow.adminRole:id,name,slug');
```

The generated SQL will be as follows:

```sql
-- missing query field settings and sort settings
select * from `progresses` where `progresses`. `eloquent_model_id` in (1, 2, 3, 4, 5);

select `id`, `name` from `admin_users` where `admin_users`. `id` in (7, 10);

-- missing query field settings
select * from `workflows` where `workflows`. `id` in (1, 2, 3, 4);

select `id`, `name`, `slug` from `admin_roles` where `admin_roles`. `id` in (3, 4, 5);
```

The query condition restrictions for `progresses` and `workflow` will not take effect because the definitions are overridden later.

### Solution

When the correspondence has been defined eager to load rules, the later definitions are simply ignored.

The resulting sql will look like this:

```sql
select `id`, `eloquent_model_id`, `workflow_id`, `admin_id` from `progresses` where `progresses`. `eloquent_model_id` in (1, 2, 3, 4, 5) order by `id` asc;

select `id`, `name` from `admin_users` where `admin_users`. `id` in (7, 10);

select `id`, `name`, `admin_role_id` from `workflows` where `workflows`. `id` in (1, 2, 3, 4);

select `id`, `name`, `slug` from `admin_roles` where `admin_roles`. `id` in (3, 4, 5);
```

### Impact of the modification

The modification will not affect the user's previous usage habits, and will not affect users who have not defined detailed desire-loading rules, but will make it easier for users who want to define the desire-loading rules for each relationship in detail, and will be more intuitive to use with.