### PR TITLE
[6.x] Add new lost connection message to `DetectsLostConnections` for Vapor

### DIFF
--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -55,6 +55,7 @@ trait DetectsLostConnections
             'SQLSTATE[08006] [7] could not connect to server: Connection refused Is the server running on host',
             'SQLSTATE[HY000]: General error: 7 SSL SYSCALL error: No route to host',
             'The client was disconnected by the server because of inactivity. See wait_timeout and interactive_timeout for configuring this behavior.',
+            'SQLSTATE[08006] [7] could not translate host name',
         ]);
     }
 }


### PR DESCRIPTION
Vapor with serverless PostgreSQL threw this:

`SQLSTATE[08006] [7] could not translate host name "xxx.eu-central-1.rds.amazonaws.com" to address: Try again (SQL: select * from "personal_access_tokens" where "personal_access_tokens"."id" = 1 limit 1)`

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
