### PR TITLE
[8.x] Add overwrite setting for eager loaded

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -115,6 +115,13 @@ class Builder
     protected $removedScopes = [];
 
     /**
+     * Overwrite eager loaded.
+     *
+     * @var bool
+     */
+    protected $overwriteEagerLoaded = true;
+
+    /**
      * Create a new Eloquent query builder instance.
      *
      * @param  \Illuminate\Database\Query\Builder  $query
@@ -1286,7 +1293,40 @@ class Builder
             $eagerLoad = $this->parseWithRelations(is_string($relations) ? func_get_args() : $relations);
         }
 
+        $this->mergeEagerLoad($eagerLoad);
+
+        return $this;
+    }
+
+    /**
+     * Merge the relationships that should be eager loaded.
+     *
+     * @param  array  $eagerLoad
+     */
+    protected function mergeEagerLoad($eagerLoad)
+    {
+        if (! $this->overwriteEagerLoaded) {
+            foreach ($eagerLoad as $name => $constraints) {
+                // Already exists relationships?
+                if (isset($this->eagerLoad[$name])) {
+                    // Ignore
+                    unset($eagerLoad[$name]);
+                }
+            }
+        }
+
         $this->eagerLoad = array_merge($this->eagerLoad, $eagerLoad);
+    }
+
+    /**
+     * Whether to allow overrides when merging relationships that should be eager loaded.
+     *
+     * @param  bool  $overwriteEagerLoaded
+     * @return $this
+     */
+    public function overwriteWith($overwriteEagerLoaded)
+    {
+        $this->overwriteEagerLoaded = $overwriteEagerLoaded;
 
         return $this;
     }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -387,6 +387,36 @@ class DatabaseEloquentModelTest extends TestCase
         $closure($builder);
     }
 
+    public function eagerLoadingOverwriteSetting()
+    {
+        return [[true], [false]];
+    }
+
+    /**
+     * @dataProvider eagerLoadingOverwriteSetting
+     */
+    public function testEagerLoadingWithOverwrite($overwrite)
+    {
+        $model = new EloquentModelWithoutRelationStub;
+        $instance = $model->newInstance()->newQuery()
+            ->with('foo:bar,baz')
+            ->overwriteWith($overwrite)
+            ->with('foo.yao');
+
+        $builder = m::mock(Builder::class);
+
+        if ($overwrite) {
+            $builder->shouldNotReceive('select');
+        } else {
+            $builder->shouldReceive('select')->once()->with(['bar', 'baz']);
+        }
+
+        $this->assertNotNull($instance->getEagerLoads()['foo']);
+        $this->assertNotNull($instance->getEagerLoads()['foo.yao']);
+        $closure = $instance->getEagerLoads()['foo'];
+        $closure($builder);
+    }
+
     public function testWithMethodCallsQueryBuilderCorrectlyWithArray()
     {
         $result = EloquentModelWithStub::with(['foo', 'bar']);


### PR DESCRIPTION
### Question

When you define the following eager loading relationship.

```php
$eloquentModel
    ->with(
        'progresses',
        function (HasMany $builder) {
            $builder->select(['id', 'eloquent_model_id', 'workflow_id', 'status', 'admin_id'])
                ->orderBy('id');
        }
    )
    ->with('progresses.admin:id,name')
    ->with('progresses.workflow:id,name')
    ->with('progresses.workflow.adminRole:id,name,slug');
```

The generated SQL will be as follows.

```sql
-- missing column settings and sort settings
select * from `progresses` where `progresses`. `eloquent_model_id` in (1, 2, 3, 4, 5);

select `id`, `name` from `admin_users` where `admin_users`. `id` in (7, 10);

-- missing column settings
select * from `workflows` where `workflows`. `id` in (1, 2, 3, 4);

select `id`, `name`, `slug` from `admin_roles` where `admin_roles`. `id` in (3, 4, 5);
```

The query condition restrictions for `progresses` and `workflow` will not take effect because the definitions are overridden later.

### Solution

Add a setting option that sets the later definitions to be directly ignored when the correspondence has been defined eager to load rules.

```php
$eloquentModel
    // Do not overwrite defined eager loaded relations
    ->overwriteWith(false)
    ->with(
        'progresses',
        function (HasMany $builder) {
            $builder->select(['id', 'eloquent_model_id', 'workflow_id', 'status', 'admin_id'])
                ->orderBy('id');
        }
    )
    ->with('progresses.admin:id,name')
    ->with('progresses.workflow:id,name')
    ->with('progresses.workflow.adminRole:id,name,slug');
```

The generated SQL will be as follows:

```sql
select `id`, `eloquent_model_id`, `workflow_id`, `admin_id` from `progresses` where `progresses`. `eloquent_model_id` in (1, 2, 3, 4, 5) order by `id` asc;

select `id`, `name` from `admin_users` where `admin_users`. `id` in (7, 10);

select `id`, `name`, `admin_role_id` from `workflows` where `workflows`. `id` in (1, 2, 3, 4);

select `id`, `name`, `slug` from `admin_roles` where `admin_roles`. `id` in (3, 4, 5);
```

### Impact of the modification

The modification will not affect the previous functionality, but will make it easier for users who want to define the eager loading rules for each relationship in detail.

ps: My English is not good, the above description is translated using translation software, please forgive me.

