### PR TITLE
[8.x] Add multiline method to SimpleMessage

### DIFF
--- a/src/Illuminate/Notifications/Messages/SimpleMessage.php
+++ b/src/Illuminate/Notifications/Messages/SimpleMessage.php
@@ -158,6 +158,22 @@ class SimpleMessage
     }
 
     /**
+     * Adds multiple lines of text to the notification by splitting a given 
+     * string using a provided or default separator.
+     *
+     * @param  string  $string
+     * @return $this
+     */
+    public function multiline($string, $separator = '<br>')
+    {
+        foreach (explode($separator, $string) as $line) {
+            $this->with($line);
+        }
+
+        return $this;
+    }
+
+    /**
      * Add a line of text to the notification.
      *
      * @param  mixed  $line

--- a/src/Illuminate/Notifications/Messages/SimpleMessage.php
+++ b/src/Illuminate/Notifications/Messages/SimpleMessage.php
@@ -158,7 +158,7 @@ class SimpleMessage
     }
 
     /**
-     * Adds multiple lines of text to the notification by splitting a given 
+     * Adds multiple lines of text to the notification by splitting a given
      * string using a provided or default separator.
      *
      * @param  string  $string


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR adds a `multiline` method to the `SimpleMessage` class to provide an easy way to split long messages that may contain line breaks into multiple lines using a single method.


```php
public function toMail($notifiable)
{
	return (new MailMessage)
		->subject('Another notification')
		->multiline('A fairly long message (e.g pulled from database), <br> that might contain (HTML) line breaks.');
}
```

**Why this addition?**

- Assume some text body of a mail notification, contains `<br>` tags for any reason. These will be visible to the user by default, which doesn't look great.
- Using separate `->line()` calls may not be an option because you do not yet know the formatting of the message text.
- Using the `HtmlString` may not be an option as it may be incompatible with your MailService provider.

In this case, using a single method like `->multiline($message)` can be very helpful.