### PR TITLE
[8.x] Logs deprecations instead of treating them as exceptions

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,6 +6,7 @@
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
+         convertDeprecationsToExceptions="false"
          processIsolation="false"
          stopOnError="false"
          stopOnFailure="false"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,7 +6,6 @@
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
-         convertDeprecationsToExceptions="false"
          processIsolation="false"
          stopOnError="false"
          stopOnFailure="false"

--- a/tests/Foundation/Bootstrap/HandleExceptionsTest.php
+++ b/tests/Foundation/Bootstrap/HandleExceptionsTest.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Bootstrap;
+
+use ErrorException;
+use Illuminate\Config\Repository as Config;
+use Illuminate\Container\Container;
+use Illuminate\Foundation\Bootstrap\HandleExceptions;
+use Illuminate\Log\LogManager;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+class HandleExceptionsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $this->container = Container::setInstance(new Container);
+
+        $this->config = new Config();
+
+        $this->container->singleton('config', function () {
+            return $this->config;
+        });
+
+        $this->handleExceptions = new HandleExceptions();
+
+        with(new ReflectionClass($this->handleExceptions), function ($reflection) {
+            $reflection->getProperty('app')->setValue(
+                $this->handleExceptions,
+                $this->container
+            );
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        Container::setInstance(null);
+    }
+
+    public function testPhpDeprecations()
+    {
+        $logger = m::mock(LogManager::class);
+        $this->container->instance(LogManager::class, $logger);
+        $logger->shouldReceive('channel')->with('deprecations')->andReturnSelf();
+        $logger->shouldReceive('warning')->with(sprintf('%s in %s on line %s',
+            'str_contains(): Passing null to parameter #2 ($needle) of type string is deprecated',
+            '/home/user/laravel/routes/web.php',
+            17
+        ));
+
+        $this->handleExceptions->handleError(
+            E_DEPRECATED,
+            'str_contains(): Passing null to parameter #2 ($needle) of type string is deprecated',
+            '/home/user/laravel/routes/web.php',
+            17
+        );
+    }
+
+    public function testUserDeprecations()
+    {
+        $logger = m::mock(LogManager::class);
+        $this->container->instance(LogManager::class, $logger);
+        $logger->shouldReceive('channel')->with('deprecations')->andReturnSelf();
+        $logger->shouldReceive('warning')->with(sprintf('%s in %s on line %s',
+            'str_contains(): Passing null to parameter #2 ($needle) of type string is deprecated',
+            '/home/user/laravel/routes/web.php',
+            17
+        ));
+
+        $this->handleExceptions->handleError(
+            E_USER_DEPRECATED,
+            'str_contains(): Passing null to parameter #2 ($needle) of type string is deprecated',
+            '/home/user/laravel/routes/web.php',
+            17
+        );
+    }
+
+    public function testErrors()
+    {
+        $logger = m::mock(LogManager::class);
+        $this->container->instance(LogManager::class, $logger);
+        $logger->shouldNotReceive('channel');
+        $logger->shouldNotReceive('warning');
+
+        $this->expectException(ErrorException::class);
+        $this->expectExceptionMessage('Something went wrong');
+
+        $this->handleExceptions->handleError(
+            E_ERROR,
+            'Something went wrong',
+            '/home/user/laravel/src/Providers/AppServiceProvider.php',
+            17
+        );
+    }
+
+    public function testEnsuresDeprecationsDriver()
+    {
+        $logger = m::mock(LogManager::class);
+        $this->container->instance(LogManager::class, $logger);
+        $logger->shouldReceive('channel')->andReturnSelf();
+        $logger->shouldReceive('warning');
+
+        $this->config->set('logging.channels.stack', [
+            'driver' => 'stack',
+            'channels' => ['single'],
+            'ignore_exceptions' => false,
+        ]);
+        $this->config->set('logging.deprecations', 'stack');
+
+        $this->handleExceptions->handleError(
+            E_USER_DEPRECATED,
+            'str_contains(): Passing null to parameter #2 ($needle) of type string is deprecated',
+            '/home/user/laravel/routes/web.php',
+            17
+        );
+
+        $this->assertEquals(
+            [
+                'driver' => 'stack',
+                'channels' => ['single'],
+                'ignore_exceptions' => false,
+            ],
+            $this->config->get('logging.channels.deprecations')
+        );
+    }
+
+    public function testEnsuresNullDeprecationsDriver()
+    {
+        $logger = m::mock(LogManager::class);
+        $this->container->instance(LogManager::class, $logger);
+        $logger->shouldReceive('channel')->andReturnSelf();
+        $logger->shouldReceive('warning');
+
+        $this->config->set('logging.channels.null', [
+            'driver' => 'monolog',
+            'handler' => NullHandler::class,
+        ]);
+
+        $this->handleExceptions->handleError(
+            E_USER_DEPRECATED,
+            'str_contains(): Passing null to parameter #2 ($needle) of type string is deprecated',
+            '/home/user/laravel/routes/web.php',
+            17
+        );
+
+        $this->assertEquals(
+            NullHandler::class,
+            $this->config->get('logging.channels.deprecations.handler')
+        );
+    }
+
+    public function testNoDeprecationsDriverIfNoDeprecationsHereSend()
+    {
+        $this->assertEquals(null, $this->config->get('logging.deprecations'));
+        $this->assertEquals(null, $this->config->get('logging.channels.deprecations'));
+    }
+
+    public function testIgnoreDeprecationIfLoggerUnresolvable()
+    {
+        $this->handleExceptions->handleError(
+            E_DEPRECATED,
+            'str_contains(): Passing null to parameter #2 ($needle) of type string is deprecated',
+            '/home/user/laravel/routes/web.php',
+            17
+        );
+    }
+}

--- a/tests/Foundation/Bootstrap/HandleExceptionsTest.php
+++ b/tests/Foundation/Bootstrap/HandleExceptionsTest.php
@@ -26,7 +26,9 @@ class HandleExceptionsTest extends TestCase
         $this->handleExceptions = new HandleExceptions();
 
         with(new ReflectionClass($this->handleExceptions), function ($reflection) {
-            $reflection->getProperty('app')->setValue(
+            $property = tap($reflection->getProperty('app'))->setAccessible(true);
+
+            $property->setValue(
                 $this->handleExceptions,
                 $this->container
             );


### PR DESCRIPTION
This pull request changes the way Laravel's exception handler treats PHP deprecations.

Until today, Laravel always turn `E_DEPRECATION` or `E_USER_DEPRECATION` level errors into exceptions. In other words, if we were to use `str_contains('', null)` in PHP 8.1, Laravel would convert that deprecation into an Error Exception that gets reported on the Exception Handler, and rendered on the browser.

This pull request - just like Symfony - proposes that we start to ignore PHP deprecations and userland deprecations. Meaning that deprecations like `str_contains('', null)` in PHP 8.1 would not cause the program to stop. So, by default, if this pull request gets merged, no error exceptions appear on the browser or on the logger.

This pull request also introduces a new `deprecations` log channel that can be configured by the user. This channel, uses the `null` driver by default,  yet the user can configure a real driver like so:

```php
<?php

return [

    /*
    |--------------------------------------------------------------------------
    | Default Log Channel
    |--------------------------------------------------------------------------
    |
    | This option defines the default log channel that gets used when writing
    | messages to the logs. The name specified in this option should match
    | one of the channels defined in the "channels" configuration array.
    |
    */

    'default' => env('LOG_CHANNEL', 'stack'),

    /*
    |--------------------------------------------------------------------------
    | Deprecations Log Channel
    |--------------------------------------------------------------------------
    |
    | Lorem ipsum dolor sit amet, consectetur adipiscing elit. Eiuro,
    | adridens, iniquum, hac quidem de re; Nihil enim hoc differt.
    | Quodsi ipsam honestatem undique pertectam atque absolutam.
    |
    */

    'deprecations' => env('LOG_DEPRECATIONS_CHANNEL', 'stack'),

    // ..
]
```

Of course, this pull request also configures PHPUnit differently, using the `convertDeprecationsToExceptions` flag so deprecations don't get treated as exceptions on tests.

If this pull request gets merged, changes will be necessary on:

- [ ] Laravel Skeleton: `config/logging.php`, bump framework version, and phpunit version.
- [ ] Lumen Framework: Copy/Past the code of this pull request
- [ ] Lumen Skeleton: `config/logging.php`, bump framework version, and phpunit version.