### PR TITLE
[8.x] Change Collection's implode method's first parameter to be optional

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -527,11 +527,11 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Concatenate values of a given key as a string.
      *
-     * @param  string  $value
+     * @param  string|null  $value
      * @param  string|null  $glue
      * @return string
      */
-    public function implode($value, $glue = null)
+    public function implode($value = null, $glue = null)
     {
         $first = $this->first();
 

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -534,11 +534,11 @@ class LazyCollection implements Enumerable
     /**
      * Concatenate values of a given key as a string.
      *
-     * @param  string  $value
+     * @param  string|null  $value
      * @param  string|null  $glue
      * @return string
      */
-    public function implode($value, $glue = null)
+    public function implode($value = null, $glue = null)
     {
         return $this->collect()->implode(...func_get_args());
     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2102,6 +2102,7 @@ class SupportCollectionTest extends TestCase
         $this->assertSame('foo,bar', $data->implode('email', ','));
 
         $data = new $collection(['taylor', 'dayle']);
+        $this->assertSame('taylordayle', $data->implode());
         $this->assertSame('taylordayle', $data->implode(''));
         $this->assertSame('taylor,dayle', $data->implode(','));
 
@@ -2109,10 +2110,12 @@ class SupportCollectionTest extends TestCase
             ['name' => Str::of('taylor'), 'email' => Str::of('foo')],
             ['name' => Str::of('dayle'), 'email' => Str::of('bar')],
         ]);
+
         $this->assertSame('foobar', $data->implode('email'));
         $this->assertSame('foo,bar', $data->implode('email', ','));
 
         $data = new $collection([Str::of('taylor'), Str::of('dayle')]);
+        $this->assertSame('taylordayle', $data->implode());
         $this->assertSame('taylordayle', $data->implode(''));
         $this->assertSame('taylor,dayle', $data->implode(','));
     }


### PR DESCRIPTION
This Pull Request changes the Collection's implode method's first parameter `$value` to be optional. As the built-in php implode function's glue is also optional, I think this change makes sense as it will not be necessary to add an empty string to the collection implode's first parameter when someone wants to concatenate a simple list of strings.

`echo collect(['taylor', 'dayle'])->implode(); // taylordayle`

If the collection is a list of nested elements (arrays or objects) and no `$value` is passed, it will trigger a notice `Notice: Array to string conversion` (as `implode()` normally does this when passing a nested array).

`echo collect([['name' => 'taylor'], ['name'=>'dayle']])->implode(); // Notice: Array to string conversion`