### PR TITLE
[8.x] Add a way to skip count check but check $callback at the same time for AssertableJson->has()

### DIFF
--- a/src/Illuminate/Testing/Fluent/Concerns/Has.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Has.php
@@ -65,11 +65,12 @@ trait Has
 
         if (! is_null($callback)) {
             return $this->has($key, function (self $scope) use ($length, $callback) {
-                return $scope->tap(function (self $scope) use ($length) {
-                    if (is_int($length)) {
-                        $scope->count($length);
-                    }
-                })
+                return $scope
+                    ->tap(function (self $scope) use ($length) {
+                        if (is_int($length)) {
+                            $scope->count($length);
+                        }
+                    })
                     ->first($callback)
                     ->etc();
             });

--- a/src/Illuminate/Testing/Fluent/Concerns/Has.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Has.php
@@ -63,9 +63,13 @@ trait Has
 
         $this->interactsWith($key);
 
-        if (is_int($length) && ! is_null($callback)) {
+        if (! is_null($callback)) {
             return $this->has($key, function (self $scope) use ($length, $callback) {
-                return $scope->count($length)
+                return $scope->tap(function (self $scope) use ($length) {
+                    if (is_int($length)) {
+                        $scope->count($length);
+                    }
+                })
                     ->first($callback)
                     ->etc();
             });

--- a/src/Illuminate/Testing/Fluent/Concerns/Has.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Has.php
@@ -67,7 +67,7 @@ trait Has
             return $this->has($key, function (self $scope) use ($length, $callback) {
                 return $scope
                     ->tap(function (self $scope) use ($length) {
-                        if (is_int($length)) {
+                        if (! is_null($length)) {
                             $scope->count($length);
                         }
                     })

--- a/tests/Testing/Fluent/AssertTest.php
+++ b/tests/Testing/Fluent/AssertTest.php
@@ -691,6 +691,22 @@ class AssertTest extends TestCase
         });
     }
 
+    public function testScopeShorthandFailsWhenSecondArgumentUnsupportedType()
+    {
+        $assert = AssertableJson::fromArray([
+            'bar' => [
+                ['key' => 'first'],
+                ['key' => 'second'],
+            ],
+        ]);
+
+        $this->expectException(TypeError::class);
+
+        $assert->has('bar', 'invalid', function (AssertableJson $item) {
+            $item->where('key', 'first');
+        });
+    }
+
     public function testFirstScope()
     {
         $assert = AssertableJson::fromArray([

--- a/tests/Testing/Fluent/AssertTest.php
+++ b/tests/Testing/Fluent/AssertTest.php
@@ -607,6 +607,24 @@ class AssertTest extends TestCase
         $this->assertTrue($called, 'The scoped query was never actually called.');
     }
 
+    public function testScopeShorthandWithoutCount()
+    {
+        $assert = AssertableJson::fromArray([
+            'bar' => [
+                ['key' => 'first'],
+                ['key' => 'second'],
+            ],
+        ]);
+
+        $called = false;
+        $assert->has('bar', null, function (AssertableJson $item) use (&$called) {
+            $item->where('key', 'first');
+            $called = true;
+        });
+
+        $this->assertTrue($called, 'The scoped query was never actually called.');
+    }
+
     public function testScopeShorthandFailsWhenAssertingZeroItems()
     {
         $assert = AssertableJson::fromArray([
@@ -637,6 +655,38 @@ class AssertTest extends TestCase
         $this->expectExceptionMessage('Property [bar] does not have the expected size.');
 
         $assert->has('bar', 1, function (AssertableJson $item) {
+            $item->where('key', 'first');
+        });
+    }
+
+    public function testScopeShorthandFailsWhenAssertingEmptyArray()
+    {
+        $assert = AssertableJson::fromArray([
+            'bar' => [],
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage(
+            'Cannot scope directly onto the first element of property [bar] because it is empty.'
+        );
+
+        $assert->has('bar', 0, function (AssertableJson $item) {
+            $item->where('key', 'first');
+        });
+    }
+
+    public function testScopeShorthandFailsWhenAssertingEmptyArrayWithoutCount()
+    {
+        $assert = AssertableJson::fromArray([
+            'bar' => [],
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage(
+            'Cannot scope directly onto the first element of property [bar] because it is empty.'
+        );
+
+        $assert->has('bar', null, function (AssertableJson $item) {
             $item->where('key', 'first');
         });
     }


### PR DESCRIPTION
# TL;DR
This PR introduces a feature to AssertableJson->has() to skip the count check but check the third argument $callable
(might be a bug?)

# Details

Currently the `->has()` method of `src/Illuminate/Testing/Fluent/AssertableJson.php` has a shorthand syntax where you can write:
```
$assert = AssertableJson::fromArray([
    'bar' => [
        ['key' => 'first'],
        ['key' => 'second'],
    ]
]);

$assert->has('bar', 2, function (AssertableJson $item) {
     $item->where('key', 'first');
})
```

instead of:

```
$assert = AssertableJson::fromArray([
    'bar' => [
        ['key' => 'first'],
        ['key' => 'second'],
    ]
]);

$assert
    ->has('bar', 2)
    ->has('bar.0', function (AssertableJson $item) {
        $item->where('key', 'first');
    });
```

but this syntax doesn't support where you don't want to assert the length but want to check the first item.
such as:
```
$assert = AssertableJson::fromArray([
    'bar' => [
        ['key' => 'WRONG KEY'],
        ['key' => 'second'],
    ]
]);

// you currently need to explicitly pass 2 as the second argument for this to work
$assert->has('bar', null, function (AssertableJson $item) {
    // never called!!
    $item->where('key', 'first');
})  // and passes!!
```
This PR removes the check of `$length` to get into the if clause to call `$callback` and instead dynamically decide whether to put `->count($length)` or not, enabling what's trying to be done above.
