### PR TITLE
[8.x] Add hasView check for the mysql language

### DIFF
--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -138,6 +138,21 @@ class Builder
     }
 
     /**
+     * Determine if the given view exists.
+     *
+     * @param  string  $view
+     * @return bool
+     */
+    public function hasView($view)
+    {
+        $view = $this->connection->getTablePrefix().$view;
+
+        return count($this->connection->selectFromWriteConnection(
+            $this->grammar->compileViewExists(), [$view]
+        )) > 0;
+    }
+
+    /**
      * Determine if the given table has a given column.
      *
      * @param  string  $table

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -68,6 +68,16 @@ class MySqlGrammar extends Grammar
     }
 
     /**
+     * Compile the query to determine the list of tables.
+     *
+     * @return string
+     */
+    public function compileViewExists()
+    {
+        return "select * from information_schema.tables where table_schema = ? and table_name = ? and table_type = 'VIEW'";
+    }
+
+    /**
      * Compile the query to determine the list of columns.
      *
      * @return string

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -76,6 +76,16 @@ class PostgresGrammar extends Grammar
     }
 
     /**
+     * Compile the query to determine if a view exists.
+     *
+     * @return string
+     */
+    public function compileViewExists()
+    {
+        return "select * from information_schema.tables where table_schema = ? and table_name = ? and table_type = 'VIEW'";
+    }
+
+    /**
      * Compile the query to determine the list of columns.
      *
      * @return string

--- a/src/Illuminate/Database/Schema/MySqlBuilder.php
+++ b/src/Illuminate/Database/Schema/MySqlBuilder.php
@@ -46,6 +46,21 @@ class MySqlBuilder extends Builder
     }
 
     /**
+     * Determine if the given view exists.
+     *
+     * @param  string  $view
+     * @return bool
+     */
+    public function hasView($view)
+    {
+        $view = $this->connection->getTablePrefix().$view;
+
+        return count($this->connection->select(
+            $this->grammar->compileViewExists(), [$this->connection->getDatabaseName(), $view]
+        )) > 0;
+    }
+
+    /**
      * Get the column listing for a given table.
      *
      * @param  string  $table

--- a/src/Illuminate/Database/Schema/PostgresBuilder.php
+++ b/src/Illuminate/Database/Schema/PostgresBuilder.php
@@ -48,6 +48,23 @@ class PostgresBuilder extends Builder
     }
 
     /**
+     * Determine if the given view exists.
+     *
+     * @param  string  $view
+     * @return bool
+     */
+    public function hasView($view)
+    {
+        [$schema, $view] = $this->parseSchemaAndTable($view);
+
+        $view = $this->connection->getTablePrefix().$view;
+
+        return count($this->connection->select(
+            $this->grammar->compileViewExists(), [$schema, $view]
+        )) > 0;
+    }
+
+    /**
      * Drop all tables from the database.
      *
      * @return void

--- a/src/Illuminate/Support/Facades/Schema.php
+++ b/src/Illuminate/Support/Facades/Schema.php
@@ -16,6 +16,7 @@ namespace Illuminate\Support\Facades;
  * @method static bool hasColumns(string $table, array $columns)
  * @method static bool dropColumns(string $table, array $columns)
  * @method static bool hasTable(string $table)
+ * @method static bool hasView(string $view)
  * @method static void defaultStringLength(int $length)
  * @method static void registerCustomDoctrineType(string $class, string $name, string $type)
  * @method static array getColumnListing(string $table)


### PR DESCRIPTION
I would like to add the `hasView` method to the MySql builder for checking the database for a view. Currently the `hasTable` limits the query to `TABLE_TYPE = 'BASE TABLE'` and that doesn't return the views since they are `TABLE_TYPE = 'VIEW'`