### PR TITLE
[8.x] Add `File::chmodExecutable` to make a file executable

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -257,7 +257,7 @@ class Filesystem
      *
      * @param  string  $path
      * @param  int|null  $mode
-     * @return mixed
+     * @return string|bool
      */
     public function chmod($path, $mode = null)
     {
@@ -266,6 +266,35 @@ class Filesystem
         }
 
         return substr(sprintf('%o', fileperms($path)), -4);
+    }
+
+    /**
+     * Make a file or directory executable.
+     *
+     * @param  string  $path
+     * @return string|bool
+     */
+    public function chmodExecutable($path)
+    {
+        $permissions = $this->chmod($path);
+        if ($permissions === false) {
+            return false;
+        }
+
+        for ($i = 1; $i < 4; $i++) {
+            $perm = (int) $permissions[$i];
+            if ($perm === 7) {
+                continue;
+            }
+
+            if ($perm % 2 === 0) {
+                $permissions[$i] = $perm + 1;
+            }
+        }
+
+        clearstatcache(true, $path);
+
+        return $this->chmod($path, octdec($permissions));
     }
 
     /**

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -163,6 +163,20 @@ class FilesystemTest extends TestCase
         $this->assertEquals($expectedPermissions, $filePermission);
     }
 
+    public function testSetChmodExecutable()
+    {
+        $path = self::$tempDir.'/file.txt';
+        file_put_contents($path, 'Hello World');
+
+        $files = new Filesystem;
+        $files->chmod($path, 0744);
+        $files->chmodExecutable($path);
+
+        $filePermission = substr(sprintf('%o', fileperms($path)), -4);
+        $expectedPermissions = DIRECTORY_SEPARATOR === '\\' ? '0666' : '0755';
+        $this->assertEquals($expectedPermissions, $filePermission);
+    }
+
     public function testDeleteRemovesFiles()
     {
         file_put_contents(self::$tempDir.'/file1.txt', 'Hello World');


### PR DESCRIPTION
`File::chmodExecutable` is an implementation of `chmod +x`.
A use case of this method is to enable the application to `chmod +x` a file when the file executable status is unknown.

```
if (!is_executable('myscript.sh')) {
    File::chmodExecutable('myscript.sh');
}

// Run myscript.sh
```

`File::chmodExecutable` will automatically read file existing permissions and add only execute permission.
|Before|After|
|---|---|
|744|755|
|622|733|

Thank you for review and your effort to maintain the framework!