### PR TITLE
[8.x] Added assertRedirectContains

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -278,6 +278,25 @@ EOF;
     }
 
     /**
+     * Assert whether the response is redirecting to a given URI that matches the pattern.
+     *
+     * @param  string  $regex
+     * @return $this
+     */
+    public function assertRedirectRegex($regex)
+    {
+        PHPUnit::assertTrue(
+            $this->isRedirect(), 'Response status code ['.$this->getStatusCode().'] is not a redirect status code.'
+        );
+
+        PHPUnit::assertMatchesRegularExpression(
+            $regex, $this->headers->get('Location')
+        );
+
+        return $this;
+    }
+
+    /**
      * Assert whether the response is redirecting to a given signed route.
      *
      * @param  string|null  $name

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -278,19 +278,19 @@ EOF;
     }
 
     /**
-     * Assert whether the response is redirecting to a given URI that matches the pattern.
+     * Assert whether the response is redirecting to a URI that contains the given URI.
      *
-     * @param  string  $regex
+     * @param  string  $uri
      * @return $this
      */
-    public function assertRedirectRegex($regex)
+    public function assertRedirectContains($uri)
     {
         PHPUnit::assertTrue(
             $this->isRedirect(), 'Response status code ['.$this->getStatusCode().'] is not a redirect status code.'
         );
 
-        PHPUnit::assertMatchesRegularExpression(
-            $regex, $this->headers->get('Location')
+        PHPUnit::assertStringContainsString(
+            $uri, $this->headers->get('Location')
         );
 
         return $this;

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -1528,6 +1528,19 @@ class TestResponseTest extends TestCase
         $response->assertCookieMissing('cookie-name');
     }
 
+    public function testAssertRedirectRegex()
+    {
+        $response = TestResponse::fromBaseResponse(
+            (new Response('', 302))->withHeaders(['Location' => 'https://url.com'])
+        );
+
+        $response->assertRedirectRegex('/url\.com/');
+
+        $this->expectException(ExpectationFailedException::class);
+
+        $response->assertRedirectRegex('/url\.net/');
+    }
+
     private function makeMockResponse($content)
     {
         $baseResponse = tap(new Response, function ($response) use ($content) {

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -1528,17 +1528,17 @@ class TestResponseTest extends TestCase
         $response->assertCookieMissing('cookie-name');
     }
 
-    public function testAssertRedirectRegex()
+    public function testAssertRedirectContains()
     {
         $response = TestResponse::fromBaseResponse(
             (new Response('', 302))->withHeaders(['Location' => 'https://url.com'])
         );
 
-        $response->assertRedirectRegex('/url\.com/');
+        $response->assertRedirectContains('url.com');
 
         $this->expectException(ExpectationFailedException::class);
 
-        $response->assertRedirectRegex('/url\.net/');
+        $response->assertRedirectContains('url.net');
     }
 
     private function makeMockResponse($content)


### PR DESCRIPTION
This adds the ability to call `assertRedirectContains()` on the `TestResponse`. For example when using Cashier, one might use `return Auth::user()->redirectToBillingPortal();` which redirects to a url like `https://billing.stripe.com/session/_KOsvPyL7ZaTxYiyD8sHhfm4ZK6ewPJ8`. 

This is continuation from #39189 

## Before

```php
$response = $this->get(route('checkout']))->assertRedirect();

$this->assertStringContainsString('https://checkout.stripe.com/', $response->headers->get('Location'));
```

## After

```php
$this->get(route('checkout']))
    ->assertRedirectContains('checkout.stripe.com');
```