### PR TITLE
[8.x] Add exception message to `assertRedirect`

### DIFF
--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -637,6 +637,22 @@ class TestResponseTest extends TestCase
         $response->assertStatus(200);
     }
 
+    public function testAssertRedirect()
+    {
+        $statusCode = 500;
+
+        $this->expectException(AssertionFailedError::class);
+
+        $this->expectExceptionMessage("Response status code [{$statusCode}] is not a redirect status code.");
+
+        $baseResponse = tap(new Response, function ($response) use ($statusCode) {
+            $response->setStatusCode($statusCode);
+        });
+
+        $response = TestResponse::fromBaseResponse($baseResponse);
+        $response->assertRedirect();
+    }
+
     public function testAssertHeader()
     {
         $this->expectException(AssertionFailedError::class);


### PR DESCRIPTION
In addition to #38025.

Often when working with POST requests, `assertRedirect` is used to test the given response.

This PR adds the logged exception message, similar to the `assertStatus` methods, to `assertRedirect` and `assertRedirectToSignedRoute` to improve DX while testing.