### PR TITLE
[8.x] Update the where() logic when only 1 parameter is passed

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -733,11 +733,18 @@ class Builder
             return $this->whereSub($column, $operator, $value, $boolean);
         }
 
-        // If the value is "null", we will just assume the developer wants to add a
-        // where null clause to the query. So, we will allow a short-cut here to
-        // that method for convenience so the developer doesn't have to check.
+        // If the value is "null", two scenarios are possible :
+        // 1 - either the developer passed two parameters where($column, null),
+        //     so he wants to add a where null clause to the query.
+        // 2- or the developer passed only one parameter where($column), and here we will assume the developer
+        //     wants to add a where column is true clause to the query. So, we will allow a short-cut here
+        //     to that method for convenience so the developer doesn't have to check.
         if (is_null($value)) {
-            return $this->whereNull($column, $boolean, $operator !== '=');
+            if (1 === func_num_args()) {
+                $value = 1;
+            } else {
+                return $this->whereNull($column, $boolean, $operator !== '=');
+            }
         }
 
         $type = 'Basic';


### PR DESCRIPTION
Hi everyone, this pull request enhances the readability of the `where()` method when only one argument is passed. The actual behavior of the method is, when some one pass only one parameter, it assumes that it is a where null clause. But i think this is not the obvious and first reflex. What do you think ?

### Before (without this PR ):
```php
User::where('active')->get();
```
```sql
select * from `users` where `active` is null
```
---
```php
DB::table('users')->where('admin')->get();
```
```sql
select * from `users` where `admin` is null
```

### After (by merging this PR ):
```php
User::where('active')->get();
```
```sql
select * from `users` where `active` = 1
```
---
```php
DB::table('users')->where('admin')->get();
```
```sql
select * from `users` where `admin` = 1
```




