### PR TITLE
[8.x] Prevent the `belongsTo` relation eager load query execution when no FK to load

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -44,7 +44,7 @@ class BelongsTo extends Relation
     protected $relationName;
 
     /**
-     * Indication of that there are entities that can be eager loaded
+     * Indicates that there are entities that can be eager loaded
      *
      * @var bool
      */

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -44,7 +44,7 @@ class BelongsTo extends Relation
     protected $relationName;
 
     /**
-     * Indicates that there are entities that can be eager loaded
+     * Indicates that there are entities that can be eager loaded.
      *
      * @var bool
      */
@@ -115,7 +115,7 @@ class BelongsTo extends Relation
     {
         $eagerModelKeys = $this->getEagerModelKeys($models);
         $this->hasEagerModelKeys = $eagerModelKeys !== [];
-        if (!$this->hasEagerModelKeys) {
+        if (! $this->hasEagerModelKeys) {
             // There is nothing to load
             return;
         }
@@ -135,7 +135,7 @@ class BelongsTo extends Relation
      */
     public function getEager()
     {
-        if (!$this->hasEagerModelKeys) {
+        if (! $this->hasEagerModelKeys) {
             // There is nothing to load
             return new Collection();
         }

--- a/tests/Database/DatabaseEloquentBelongsToTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToTest.php
@@ -181,7 +181,7 @@ class DatabaseEloquentBelongsToTest extends TestCase
         $relation = $this->getRelation();
         $relation->getRelated()->shouldReceive('getKeyName')->andReturn('id');
         $relation->getRelated()->shouldReceive('getKeyType')->andReturn('int');
-        $relation->getQuery()->shouldReceive('whereIntegerInRaw')->once()->with('relation.id', m::mustBe([]));
+        $relation->getQuery()->shouldNotReceive('whereIntegerInRaw')->with('relation.id', m::mustBe([]));
         $models = [new MissingEloquentBelongsToModelStub, new MissingEloquentBelongsToModelStub];
         $relation->addEagerConstraints($models);
     }
@@ -189,7 +189,7 @@ class DatabaseEloquentBelongsToTest extends TestCase
     public function testDefaultEagerConstraintsWhenIncrementingAndNonIntKeyType()
     {
         $relation = $this->getRelation(null, 'string');
-        $relation->getQuery()->shouldReceive('whereIn')->once()->with('relation.id', m::mustBe([]));
+        $relation->getQuery()->shouldNotReceive('whereIn')->with('relation.id', m::mustBe([]));
         $models = [new MissingEloquentBelongsToModelStub, new MissingEloquentBelongsToModelStub];
         $relation->addEagerConstraints($models);
     }
@@ -199,7 +199,7 @@ class DatabaseEloquentBelongsToTest extends TestCase
         $relation = $this->getRelation();
         $relation->getRelated()->shouldReceive('getKeyName')->andReturn('id');
         $relation->getRelated()->shouldReceive('getKeyType')->andReturn('int');
-        $relation->getQuery()->shouldReceive('whereIntegerInRaw')->once()->with('relation.id', m::mustBe([]));
+        $relation->getQuery()->shouldNotReceive('whereIntegerInRaw')->with('relation.id', m::mustBe([]));
         $models = [new MissingEloquentBelongsToModelStub, new MissingEloquentBelongsToModelStub];
         $relation->addEagerConstraints($models);
     }

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -1004,6 +1004,31 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertSame('taylorotwell@gmail.com', $post->first()->user->email);
     }
 
+    public function testBasicBelongsToEagerLoading()
+    {
+        $user = EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);
+        $post = $user->posts()->create(['name' => 'First Post']);
+
+        $this->assertSame($user->id, $post->user_id);
+
+        $post->load('user');
+
+        $this->assertTrue($post->relationLoaded('user'));
+        $this->assertNotNull($post->user);
+        $this->assertSame($user->id, $post->user->id);
+
+        // Test eager loading when FK is null
+
+        DB::connection()->enableQueryLog();
+
+        $post = new EloquentTestPost();
+        $post->load('user');
+
+        // No queries should be executed, because FK is null
+        $queryLog = DB::connection()->getQueryLog();
+        $this->assertCount(0, $queryLog);
+    }
+
     public function testBasicNestedSelfReferencingHasManyEagerLoading()
     {
         $user = EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);


### PR DESCRIPTION
The `BelongsTo` relation eager loading should not perform database query when there is nothing to load (no FK to load)

Code to reproduce issue:
```php
DB::enableQueryLog();

$post = new EloquentTestPost();
$post->load('user');

dump(DB::getQueryLog());
> select * from "users" where 0 = 1
```

Minimal model definitions:
```php
class EloquentTestUser extends Eloquent
{
    protected $table = 'users';
    protected $casts = ['birthday' => 'datetime'];
    protected $guarded = [];

    public function posts()
    {
        return $this->hasMany(EloquentTestPost::class, 'user_id');
    }
}

class EloquentTestPost extends Eloquent
{
    protected $table = 'posts';
    protected $guarded = [];

    public function user()
    {
        return $this->belongsTo(EloquentTestUser::class, 'user_id');
    }
}
```