### PR TITLE
[8.x] Use expectNotToPerformAssertions.

### DIFF
--- a/tests/Events/EventsSubscriberTest.php
+++ b/tests/Events/EventsSubscriberTest.php
@@ -16,23 +16,25 @@ class EventsSubscriberTest extends TestCase
 
     public function testEventSubscribers()
     {
+        $this->expectNotToPerformAssertions();
+
         $d = new Dispatcher($container = m::mock(Container::class));
         $subs = m::mock(ExampleSubscriber::class);
         $subs->shouldReceive('subscribe')->once()->with($d);
         $container->shouldReceive('make')->once()->with(ExampleSubscriber::class)->andReturn($subs);
 
         $d->subscribe(ExampleSubscriber::class);
-        $this->assertTrue(true);
     }
 
     public function testEventSubscribeCanAcceptObject()
     {
+        $this->expectNotToPerformAssertions();
+
         $d = new Dispatcher;
         $subs = m::mock(ExampleSubscriber::class);
         $subs->shouldReceive('subscribe')->once()->with($d);
 
         $d->subscribe($subs);
-        $this->assertTrue(true);
     }
 
     public function testEventSubscribeCanReturnMappings()

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -17,6 +17,8 @@ class SchemaBuilderTest extends DatabaseTestCase
 {
     public function testDropAllTables()
     {
+        $this->expectNotToPerformAssertions();
+
         Schema::create('table', function (Blueprint $table) {
             $table->increments('id');
         });
@@ -26,19 +28,17 @@ class SchemaBuilderTest extends DatabaseTestCase
         Schema::create('table', function (Blueprint $table) {
             $table->increments('id');
         });
-
-        $this->assertTrue(true);
     }
 
     public function testDropAllViews()
     {
+        $this->expectNotToPerformAssertions();
+
         DB::statement('create view "view"("id") as select 1');
 
         Schema::dropAllViews();
 
         DB::statement('create view "view"("id") as select 1');
-
-        $this->assertTrue(true);
     }
 
     public function testRegisterCustomDoctrineType()

--- a/tests/Integration/Log/LoggingIntegrationTest.php
+++ b/tests/Integration/Log/LoggingIntegrationTest.php
@@ -9,8 +9,8 @@ class LoggingIntegrationTest extends TestCase
 {
     public function testLoggingCanBeRunWithoutEncounteringExceptions()
     {
-        Log::info('Hello World');
+        $this->expectNotToPerformAssertions();
 
-        $this->assertTrue(true);
+        Log::info('Hello World');
     }
 }

--- a/tests/Routing/ImplicitRouteBindingTest.php
+++ b/tests/Routing/ImplicitRouteBindingTest.php
@@ -12,6 +12,8 @@ class ImplicitRouteBindingTest extends TestCase
 {
     public function test_it_can_resolve_the_implicit_route_bindings_for_the_given_route()
     {
+        $this->expectNotToPerformAssertions();
+
         $action = ['uses' => function (ImplicitRouteBindingUser $user) {
             return $user;
         }];
@@ -24,8 +26,6 @@ class ImplicitRouteBindingTest extends TestCase
         $container = Container::getInstance();
 
         ImplicitRouteBinding::resolveForRoute($container, $route);
-
-        $this->assertTrue(true);
     }
 }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
There is no need to assert that `true` is `true`, when you can use `expectNotToPerformAssertions`.