### PR TITLE
[8.x] Stricter assertions for strings comparisons

### DIFF
--- a/tests/Cache/CacheRateLimiterTest.php
+++ b/tests/Cache/CacheRateLimiterTest.php
@@ -105,7 +105,7 @@ class CacheRateLimiterTest extends TestCase
 
         $rateLimiter = new RateLimiter($cache);
 
-        $this->assertEquals('foo', $rateLimiter->attempt('key', 1, function () {
+        $this->assertSame('foo', $rateLimiter->attempt('key', 1, function () {
             return 'foo';
         }, 1));
     }

--- a/tests/Cookie/CookieTest.php
+++ b/tests/Cookie/CookieTest.php
@@ -120,10 +120,10 @@ class CookieTest extends TestCase
         $cookieJar->expire('foobar', '/path', '/domain');
 
         $cookie = $cookieJar->queued('foobar');
-        $this->assertEquals('foobar', $cookie->getName());
+        $this->assertSame('foobar', $cookie->getName());
         $this->assertEquals(null, $cookie->getValue());
-        $this->assertEquals('/path', $cookie->getPath());
-        $this->assertEquals('/domain', $cookie->getDomain());
+        $this->assertSame('/path', $cookie->getPath());
+        $this->assertSame('/domain', $cookie->getDomain());
         $this->assertTrue($cookie->getExpiresTime() < time());
         $this->assertCount(1, $cookieJar->getQueuedCookies());
     }

--- a/tests/Database/DatabaseEloquentBelongsToManySyncReturnValueTypeTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManySyncReturnValueTypeTest.php
@@ -90,7 +90,7 @@ class DatabaseEloquentBelongsToManySyncReturnValueTypeTest extends TestCase
         });
 
         $user->articles->each(function (BelongsToManySyncTestTestArticle $article) {
-            $this->assertEquals('0', $article->pivot->visible);
+            $this->assertSame('0', $article->pivot->visible);
         });
     }
 
@@ -108,7 +108,7 @@ class DatabaseEloquentBelongsToManySyncReturnValueTypeTest extends TestCase
         });
 
         $user->articles->each(function (BelongsToManySyncTestTestArticle $article) {
-            $this->assertEquals('1', $article->pivot->visible);
+            $this->assertSame('1', $article->pivot->visible);
         });
     }
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -3699,7 +3699,7 @@ SQL;
         $results = collect([['test' => 'foo'], ['test' => 'bar']]);
 
         $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results) {
-            $this->assertEquals(
+            $this->assertSame(
                 'select * from "foobar" where ("test" > ?) order by "test" asc limit 17',
                 $builder->toSql());
             $this->assertEquals(['bar'], $builder->bindings['where']);
@@ -3737,7 +3737,7 @@ SQL;
         $results = collect([['test' => 'foo', 'another' => 1], ['test' => 'bar', 'another' => 2]]);
 
         $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results) {
-            $this->assertEquals(
+            $this->assertSame(
                 'select * from "foobar" where ("test" > ? or ("test" = ? and ("another" > ?))) order by "test" asc, "another" asc limit 17',
                 $builder->toSql()
             );
@@ -3775,7 +3775,7 @@ SQL;
         $results = collect([['test' => 'foo'], ['test' => 'bar']]);
 
         $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results) {
-            $this->assertEquals(
+            $this->assertSame(
                 'select * from "foobar" where ("test" > ?) order by "test" asc limit 16',
                 $builder->toSql());
             $this->assertEquals(['bar'], $builder->bindings['where']);
@@ -3845,7 +3845,7 @@ SQL;
         $results = collect([['id' => 3, 'name' => 'Taylor'], ['id' => 5, 'name' => 'Mohamed']]);
 
         $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results) {
-            $this->assertEquals(
+            $this->assertSame(
                 'select * from "foobar" where ("id" > ?) order by "id" asc limit 17',
                 $builder->toSql());
             $this->assertEquals([2], $builder->bindings['where']);
@@ -3883,7 +3883,7 @@ SQL;
         $results = collect([['foo' => 1, 'bar' => 2, 'baz' => 4], ['foo' => 1, 'bar' => 1, 'baz' => 1]]);
 
         $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results) {
-            $this->assertEquals(
+            $this->assertSame(
                 'select * from "foobar" where ("foo" > ? or ("foo" = ? and ("bar" < ? or ("bar" = ? and ("baz" > ?))))) order by "foo" asc, "bar" desc, "baz" asc limit 17',
                 $builder->toSql()
             );

--- a/tests/Foundation/Testing/Concerns/InteractsWithViewsTest.php
+++ b/tests/Foundation/Testing/Concerns/InteractsWithViewsTest.php
@@ -14,7 +14,7 @@ class InteractsWithViewsTest extends TestCase
     {
         $string = (string) $this->blade('@if(true)test @endif');
 
-        $this->assertEquals('test ', $string);
+        $this->assertSame('test ', $string);
     }
 
     public function testComponentCanAccessPublicProperties()
@@ -36,8 +36,8 @@ class InteractsWithViewsTest extends TestCase
 
         $component = $this->component(get_class($exampleComponent));
 
-        $this->assertEquals('bar', $component->foo);
-        $this->assertEquals('hello', $component->speak());
+        $this->assertSame('bar', $component->foo);
+        $this->assertSame('hello', $component->speak());
         $component->assertSee('content');
     }
 }

--- a/tests/Http/Middleware/TrustProxiesTest.php
+++ b/tests/Http/Middleware/TrustProxiesTest.php
@@ -26,9 +26,9 @@ class TrustProxiesTest extends TestCase
     {
         $req = $this->createProxiedRequest();
 
-        $this->assertEquals('192.168.10.10', $req->getClientIp(), 'Assert untrusted proxy x-forwarded-for header not used');
-        $this->assertEquals('http', $req->getScheme(), 'Assert untrusted proxy x-forwarded-proto header not used');
-        $this->assertEquals('localhost', $req->getHost(), 'Assert untrusted proxy x-forwarded-host header not used');
+        $this->assertSame('192.168.10.10', $req->getClientIp(), 'Assert untrusted proxy x-forwarded-for header not used');
+        $this->assertSame('http', $req->getScheme(), 'Assert untrusted proxy x-forwarded-proto header not used');
+        $this->assertSame('localhost', $req->getHost(), 'Assert untrusted proxy x-forwarded-host header not used');
         $this->assertEquals(8888, $req->getPort(), 'Assert untrusted proxy x-forwarded-port header not used');
     }
 
@@ -43,9 +43,9 @@ class TrustProxiesTest extends TestCase
         $req = $this->createProxiedRequest();
         $req->setTrustedProxies(['192.168.10.10'], $this->headerAll);
 
-        $this->assertEquals('173.174.200.38', $req->getClientIp(), 'Assert trusted proxy x-forwarded-for header used');
-        $this->assertEquals('https', $req->getScheme(), 'Assert trusted proxy x-forwarded-proto header used');
-        $this->assertEquals('serversforhackers.com', $req->getHost(), 'Assert trusted proxy x-forwarded-host header used');
+        $this->assertSame('173.174.200.38', $req->getClientIp(), 'Assert trusted proxy x-forwarded-for header used');
+        $this->assertSame('https', $req->getScheme(), 'Assert trusted proxy x-forwarded-proto header used');
+        $this->assertSame('serversforhackers.com', $req->getHost(), 'Assert trusted proxy x-forwarded-host header used');
         $this->assertEquals(443, $req->getPort(), 'Assert trusted proxy x-forwarded-port header used');
     }
 
@@ -59,7 +59,7 @@ class TrustProxiesTest extends TestCase
         $request = $this->createProxiedRequest();
 
         $trustedProxy->handle($request, function ($request) {
-            $this->assertEquals('173.174.200.38', $request->getClientIp(), 'Assert trusted proxy x-forwarded-for header used with wildcard proxy setting');
+            $this->assertSame('173.174.200.38', $request->getClientIp(), 'Assert trusted proxy x-forwarded-for header used with wildcard proxy setting');
         });
     }
 
@@ -73,7 +73,7 @@ class TrustProxiesTest extends TestCase
         $request = $this->createProxiedRequest();
 
         $trustedProxy->handle($request, function ($request) {
-            $this->assertEquals('173.174.200.38', $request->getClientIp(), 'Assert trusted proxy x-forwarded-for header used with wildcard proxy setting');
+            $this->assertSame('173.174.200.38', $request->getClientIp(), 'Assert trusted proxy x-forwarded-for header used with wildcard proxy setting');
         });
     }
 
@@ -87,7 +87,7 @@ class TrustProxiesTest extends TestCase
         $request = $this->createProxiedRequest();
 
         $trustedProxy->handle($request, function ($request) {
-            $this->assertEquals('173.174.200.38', $request->getClientIp(), 'Assert trusted proxy x-forwarded-for header used');
+            $this->assertSame('173.174.200.38', $request->getClientIp(), 'Assert trusted proxy x-forwarded-for header used');
         });
     }
 
@@ -110,7 +110,7 @@ class TrustProxiesTest extends TestCase
 
             $trustedProxy->handle($request, function ($request) use ($forwardedForHeader) {
                 $ips = $request->getClientIps();
-                $this->assertEquals('192.0.2.2', end($ips), 'Assert sets the '.$forwardedForHeader);
+                $this->assertSame('192.0.2.2', end($ips), 'Assert sets the '.$forwardedForHeader);
             });
         }
     }
@@ -133,7 +133,7 @@ class TrustProxiesTest extends TestCase
             $request = $this->createProxiedRequest(['HTTP_X_FORWARDED_FOR' => $forwardedForHeader]);
 
             $trustedProxy->handle($request, function ($request) use ($forwardedForHeader) {
-                $this->assertEquals('192.0.2.2', $request->getClientIp(), 'Assert sets the '.$forwardedForHeader);
+                $this->assertSame('192.0.2.2', $request->getClientIp(), 'Assert sets the '.$forwardedForHeader);
             });
         }
     }
@@ -156,7 +156,7 @@ class TrustProxiesTest extends TestCase
             $request = $this->createProxiedRequest(['HTTP_X_FORWARDED_FOR' => $forwardedForHeader]);
 
             $trustedProxy->handle($request, function ($request) use ($forwardedForHeader) {
-                $this->assertEquals('192.0.2.2', $request->getClientIp(), 'Assert sets the '.$forwardedForHeader);
+                $this->assertSame('192.0.2.2', $request->getClientIp(), 'Assert sets the '.$forwardedForHeader);
             });
         }
     }
@@ -177,11 +177,11 @@ class TrustProxiesTest extends TestCase
         ]);
 
         $trustedProxy->handle($request, function ($request) {
-            $this->assertEquals('173.174.200.40', $request->getClientIp(),
+            $this->assertSame('173.174.200.40', $request->getClientIp(),
                 'Assert trusted proxy used forwarded header for IP');
-            $this->assertEquals('https', $request->getScheme(),
+            $this->assertSame('https', $request->getScheme(),
                 'Assert trusted proxy used forwarded header for scheme');
-            $this->assertEquals('serversforhackers.com', $request->getHost(),
+            $this->assertSame('serversforhackers.com', $request->getHost(),
                 'Assert trusted proxy used forwarded header for host');
             $this->assertEquals(443, $request->getPort(), 'Assert trusted proxy used forwarded header for port');
         });
@@ -197,11 +197,11 @@ class TrustProxiesTest extends TestCase
         $request = $this->createProxiedRequest();
 
         $trustedProxy->handle($request, function ($request) {
-            $this->assertEquals('173.174.200.38', $request->getClientIp(),
+            $this->assertSame('173.174.200.38', $request->getClientIp(),
                 'Assert trusted proxy used forwarded header for IP');
-            $this->assertEquals('http', $request->getScheme(),
+            $this->assertSame('http', $request->getScheme(),
                 'Assert trusted proxy did not use forwarded header for scheme');
-            $this->assertEquals('localhost', $request->getHost(),
+            $this->assertSame('localhost', $request->getHost(),
                 'Assert trusted proxy did not use forwarded header for host');
             $this->assertEquals(8888, $request->getPort(), 'Assert trusted proxy did not use forwarded header for port');
         });
@@ -217,11 +217,11 @@ class TrustProxiesTest extends TestCase
         $request = $this->createProxiedRequest(['HTTP_X_FORWARDED_HOST' => 'serversforhackers.com:8888']);
 
         $trustedProxy->handle($request, function ($request) {
-            $this->assertEquals('192.168.10.10', $request->getClientIp(),
+            $this->assertSame('192.168.10.10', $request->getClientIp(),
                 'Assert trusted proxy did not use forwarded header for IP');
-            $this->assertEquals('http', $request->getScheme(),
+            $this->assertSame('http', $request->getScheme(),
                 'Assert trusted proxy did not use forwarded header for scheme');
-            $this->assertEquals('serversforhackers.com', $request->getHost(),
+            $this->assertSame('serversforhackers.com', $request->getHost(),
                 'Assert trusted proxy used forwarded header for host');
             $this->assertEquals(8888, $request->getPort(), 'Assert trusted proxy did not use forwarded header for port');
         });
@@ -237,11 +237,11 @@ class TrustProxiesTest extends TestCase
         $request = $this->createProxiedRequest();
 
         $trustedProxy->handle($request, function ($request) {
-            $this->assertEquals('192.168.10.10', $request->getClientIp(),
+            $this->assertSame('192.168.10.10', $request->getClientIp(),
                 'Assert trusted proxy did not use forwarded header for IP');
-            $this->assertEquals('http', $request->getScheme(),
+            $this->assertSame('http', $request->getScheme(),
                 'Assert trusted proxy did not use forwarded header for scheme');
-            $this->assertEquals('localhost', $request->getHost(),
+            $this->assertSame('localhost', $request->getHost(),
                 'Assert trusted proxy did not use forwarded header for host');
             $this->assertEquals(443, $request->getPort(), 'Assert trusted proxy used forwarded header for port');
         });
@@ -257,11 +257,11 @@ class TrustProxiesTest extends TestCase
         $request = $this->createProxiedRequest();
 
         $trustedProxy->handle($request, function ($request) {
-            $this->assertEquals('192.168.10.10', $request->getClientIp(),
+            $this->assertSame('192.168.10.10', $request->getClientIp(),
                 'Assert trusted proxy did not use forwarded header for IP');
-            $this->assertEquals('https', $request->getScheme(),
+            $this->assertSame('https', $request->getScheme(),
                 'Assert trusted proxy used forwarded header for scheme');
-            $this->assertEquals('localhost', $request->getHost(),
+            $this->assertSame('localhost', $request->getHost(),
                 'Assert trusted proxy did not use forwarded header for host');
             $this->assertEquals(8888, $request->getPort(), 'Assert trusted proxy did not use forwarded header for port');
         });
@@ -281,11 +281,11 @@ class TrustProxiesTest extends TestCase
         $request = $this->createProxiedRequest();
 
         $trustedProxy->handle($request, function ($request) {
-            $this->assertEquals('173.174.200.38', $request->getClientIp(),
+            $this->assertSame('173.174.200.38', $request->getClientIp(),
                 'Assert trusted proxy used forwarded header for IP');
-            $this->assertEquals('https', $request->getScheme(),
+            $this->assertSame('https', $request->getScheme(),
                 'Assert trusted proxy used forwarded header for scheme');
-            $this->assertEquals('serversforhackers.com', $request->getHost(),
+            $this->assertSame('serversforhackers.com', $request->getHost(),
                 'Assert trusted proxy used forwarded header for host');
             $this->assertEquals(443, $request->getPort(), 'Assert trusted proxy used forwarded header for port');
         });

--- a/tests/Integration/Database/DatabaseEloquentBroadcastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentBroadcastingTest.php
@@ -52,7 +52,7 @@ class DatabaseEloquentBroadcastingTest extends DatabaseTestCase
     {
         $model = new TestEloquentBroadcastUser;
 
-        $this->assertEquals('Illuminate.Tests.Integration.Database.TestEloquentBroadcastUser.{testEloquentBroadcastUser}', $model->broadcastChannelRoute());
+        $this->assertSame('Illuminate.Tests.Integration.Database.TestEloquentBroadcastUser.{testEloquentBroadcastUser}', $model->broadcastChannelRoute());
     }
 
     public function testBroadcastingOnModelTrashing()

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -135,7 +135,7 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $post->tagsWithCustomPivot()->attach($tag->id);
 
         $this->assertInstanceOf(PostTagPivot::class, $post->tagsWithCustomPivot[0]->pivot);
-        $this->assertEquals('1507630210', $post->tagsWithCustomPivot[0]->pivot->getAttributes()['created_at']);
+        $this->assertSame('1507630210', $post->tagsWithCustomPivot[0]->pivot->getAttributes()['created_at']);
 
         $this->assertInstanceOf(PostTagPivot::class, $post->tagsWithCustomPivotClass[0]->pivot);
         $this->assertSame('posts_tags', $post->tagsWithCustomPivotClass()->getTable());
@@ -229,8 +229,8 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         );
         foreach ($post->tagsWithCustomExtraPivot as $tag) {
             $this->assertSame('exclude', $tag->pivot->flag);
-            $this->assertEquals('1507630210', $tag->pivot->getAttributes()['created_at']);
-            $this->assertEquals('1507630220', $tag->pivot->getAttributes()['updated_at']); // +10 seconds
+            $this->assertSame('1507630210', $tag->pivot->getAttributes()['created_at']);
+            $this->assertSame('1507630220', $tag->pivot->getAttributes()['updated_at']); // +10 seconds
         }
     }
 

--- a/tests/Integration/Database/EloquentCollectionLoadCountTest.php
+++ b/tests/Integration/Database/EloquentCollectionLoadCountTest.php
@@ -52,9 +52,9 @@ class EloquentCollectionLoadCountTest extends DatabaseTestCase
         $posts->loadCount('comments');
 
         $this->assertCount(1, DB::getQueryLog());
-        $this->assertEquals('2', $posts[0]->comments_count);
-        $this->assertEquals('0', $posts[1]->comments_count);
-        $this->assertEquals('2', $posts[0]->getOriginal('comments_count'));
+        $this->assertSame('2', $posts[0]->comments_count);
+        $this->assertSame('0', $posts[1]->comments_count);
+        $this->assertSame('2', $posts[0]->getOriginal('comments_count'));
     }
 
     public function testLoadCountWithSameModels()
@@ -66,9 +66,9 @@ class EloquentCollectionLoadCountTest extends DatabaseTestCase
         $posts->loadCount('comments');
 
         $this->assertCount(1, DB::getQueryLog());
-        $this->assertEquals('2', $posts[0]->comments_count);
-        $this->assertEquals('0', $posts[1]->comments_count);
-        $this->assertEquals('2', $posts[2]->comments_count);
+        $this->assertSame('2', $posts[0]->comments_count);
+        $this->assertSame('0', $posts[1]->comments_count);
+        $this->assertSame('2', $posts[2]->comments_count);
     }
 
     public function testLoadCountOnDeletedModels()
@@ -80,8 +80,8 @@ class EloquentCollectionLoadCountTest extends DatabaseTestCase
         $posts->loadCount('comments');
 
         $this->assertCount(1, DB::getQueryLog());
-        $this->assertEquals('2', $posts[0]->comments_count);
-        $this->assertEquals('0', $posts[1]->comments_count);
+        $this->assertSame('2', $posts[0]->comments_count);
+        $this->assertSame('0', $posts[1]->comments_count);
     }
 
     public function testLoadCountWithArrayOfRelations()
@@ -93,10 +93,10 @@ class EloquentCollectionLoadCountTest extends DatabaseTestCase
         $posts->loadCount(['comments', 'likes']);
 
         $this->assertCount(1, DB::getQueryLog());
-        $this->assertEquals('2', $posts[0]->comments_count);
-        $this->assertEquals('1', $posts[0]->likes_count);
-        $this->assertEquals('0', $posts[1]->comments_count);
-        $this->assertEquals('0', $posts[1]->likes_count);
+        $this->assertSame('2', $posts[0]->comments_count);
+        $this->assertSame('1', $posts[0]->likes_count);
+        $this->assertSame('0', $posts[1]->comments_count);
+        $this->assertSame('0', $posts[1]->likes_count);
     }
 
     public function testLoadCountDoesNotOverrideAttributesWithDefaultValue()
@@ -107,7 +107,7 @@ class EloquentCollectionLoadCountTest extends DatabaseTestCase
         Collection::make([$post])->loadCount('comments');
 
         $this->assertSame(200, $post->some_default_value);
-        $this->assertEquals('2', $post->comments_count);
+        $this->assertSame('2', $post->comments_count);
     }
 }
 

--- a/tests/Integration/Database/EloquentStrictMorphsTest.php
+++ b/tests/Integration/Database/EloquentStrictMorphsTest.php
@@ -34,7 +34,7 @@ class EloquentStrictMorphsTest extends TestCase
         ]);
 
         $morphName = $model->getMorphClass();
-        $this->assertEquals('test', $morphName);
+        $this->assertSame('test', $morphName);
     }
 
     public function testMapsCanBeEnforcedInOneMethod()
@@ -48,7 +48,7 @@ class EloquentStrictMorphsTest extends TestCase
         ]);
 
         $morphName = $model->getMorphClass();
-        $this->assertEquals('test', $morphName);
+        $this->assertSame('test', $morphName);
     }
 
     protected function tearDown(): void

--- a/tests/Integration/Foundation/FoundationHelpersTest.php
+++ b/tests/Integration/Foundation/FoundationHelpersTest.php
@@ -15,14 +15,14 @@ class FoundationHelpersTest extends TestCase
 {
     public function testRescue()
     {
-        $this->assertEquals(
+        $this->assertSame(
             'rescued!',
             rescue(function () {
                 throw new Exception;
             }, 'rescued!')
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             'rescued!',
             rescue(function () {
                 throw new Exception;
@@ -31,7 +31,7 @@ class FoundationHelpersTest extends TestCase
             })
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             'no need to rescue',
             rescue(function () {
                 return 'no need to rescue';
@@ -46,7 +46,7 @@ class FoundationHelpersTest extends TestCase
             }
         };
 
-        $this->assertEquals(
+        $this->assertSame(
             'rescued!',
             rescue(function () use ($testClass) {
                 $testClass->test([]);

--- a/tests/Mail/MailFailoverTransportTest.php
+++ b/tests/Mail/MailFailoverTransportTest.php
@@ -36,7 +36,7 @@ class MailFailoverTransportTest extends TestCase
         $transports = $transport->getTransports();
         $this->assertCount(2, $transports);
         $this->assertInstanceOf(\Swift_SendmailTransport::class, $transports[0]);
-        $this->assertEquals('/usr/sbin/sendmail -bs', $transports[0]->getCommand());
+        $this->assertSame('/usr/sbin/sendmail -bs', $transports[0]->getCommand());
         $this->assertInstanceOf(ArrayTransport::class, $transports[1]);
     }
 
@@ -57,7 +57,7 @@ class MailFailoverTransportTest extends TestCase
         $transports = $transport->getTransports();
         $this->assertCount(2, $transports);
         $this->assertInstanceOf(\Swift_SendmailTransport::class, $transports[0]);
-        $this->assertEquals('/usr/sbin/sendmail -bs', $transports[0]->getCommand());
+        $this->assertSame('/usr/sbin/sendmail -bs', $transports[0]->getCommand());
         $this->assertInstanceOf(ArrayTransport::class, $transports[1]);
     }
 }

--- a/tests/Queue/QueueSyncQueueTest.php
+++ b/tests/Queue/QueueSyncQueueTest.php
@@ -74,7 +74,7 @@ class QueueSyncQueueTest extends TestCase
         try {
             $sync->push(new SyncQueueJob());
         } catch (LogicException $e) {
-            $this->assertEquals('extraValue', $e->getMessage());
+            $this->assertSame('extraValue', $e->getMessage());
         }
     }
 }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -815,7 +815,7 @@ class SupportArrTest extends TestCase
             'mt-4',
         ]);
 
-        $this->assertEquals('font-bold mt-4', $classes);
+        $this->assertSame('font-bold mt-4', $classes);
 
         $classes = Arr::toCssClasses([
             'font-bold',
@@ -824,7 +824,7 @@ class SupportArrTest extends TestCase
             'mr-2' => false,
         ]);
 
-        $this->assertEquals('font-bold mt-4 ml-2', $classes);
+        $this->assertSame('font-bold mt-4 ml-2', $classes);
     }
 
     public function testWhere()

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -671,8 +671,8 @@ class SupportStringableTest extends TestCase
 
     public function testMarkdown()
     {
-        $this->assertEquals("<p><em>hello world</em></p>\n", $this->stringable('*hello world*')->markdown());
-        $this->assertEquals("<h1>hello world</h1>\n", $this->stringable('# hello world')->markdown());
+        $this->assertSame("<p><em>hello world</em></p>\n", $this->stringable('*hello world*')->markdown());
+        $this->assertSame("<h1>hello world</h1>\n", $this->stringable('# hello world')->markdown());
     }
 
     public function testRepeat()

--- a/tests/Support/ValidatedInputTest.php
+++ b/tests/Support/ValidatedInputTest.php
@@ -11,8 +11,8 @@ class ValidatedInputTest extends TestCase
     {
         $input = new ValidatedInput(['name' => 'Taylor', 'votes' => 100]);
 
-        $this->assertEquals('Taylor', $input->name);
-        $this->assertEquals('Taylor', $input['name']);
+        $this->assertSame('Taylor', $input->name);
+        $this->assertSame('Taylor', $input['name']);
         $this->assertEquals(['name' => 'Taylor'], $input->only(['name']));
         $this->assertEquals(['name' => 'Taylor'], $input->except(['votes']));
         $this->assertEquals(['name' => 'Taylor', 'votes' => 100], $input->all());
@@ -24,8 +24,8 @@ class ValidatedInputTest extends TestCase
 
         $input = $input->merge(['votes' => 100]);
 
-        $this->assertEquals('Taylor', $input->name);
-        $this->assertEquals('Taylor', $input['name']);
+        $this->assertSame('Taylor', $input->name);
+        $this->assertSame('Taylor', $input['name']);
         $this->assertEquals(['name' => 'Taylor'], $input->only(['name']));
         $this->assertEquals(['name' => 'Taylor'], $input->except(['votes']));
         $this->assertEquals(['name' => 'Taylor', 'votes' => 100], $input->all());


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Stricter assertions for strings comparisons can safely be used.
