### PR TITLE
[8.x] Adds `withoutDeprecationHandling`

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDeprecationHandling.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDeprecationHandling.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Illuminate\Foundation\Testing\Concerns;
+
+use ErrorException;
+
+trait InteractsWithDeprecationHandling
+{
+    /**
+     * The original deprecation handler.
+     *
+     * @var callable|null
+     */
+    protected $originalDeprecationHandler;
+
+    /**
+     * Restore deprecation handling.
+     *
+     * @return $this
+     */
+    protected function withDeprecationHandling()
+    {
+        if ($this->originalDeprecationHandler) {
+            set_error_handler(tap($this->originalDeprecationHandler, function () {
+                $this->originalDeprecationHandler = null;
+            }));
+        }
+
+        return $this;
+    }
+
+    /**
+     * Disable deprecation handling for the test.
+     *
+     * @return $this
+     */
+    protected function withoutDeprecationHandling()
+    {
+        if ($this->originalDeprecationHandler == null) {
+            $this->originalDeprecationHandler = set_error_handler(function ($level, $message, $file = '', $line = 0) {
+                if (error_reporting() & $level) {
+                    throw new ErrorException($message, 0, $level, $file, $line);
+                }
+            });
+        }
+
+        return $this;
+    }
+}

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -22,6 +22,7 @@ abstract class TestCase extends BaseTestCase
         Concerns\InteractsWithAuthentication,
         Concerns\InteractsWithConsole,
         Concerns\InteractsWithDatabase,
+        Concerns\InteractsWithDeprecationHandling,
         Concerns\InteractsWithExceptionHandling,
         Concerns\InteractsWithSession,
         Concerns\InteractsWithTime,

--- a/tests/Testing/Concerns/InteractsWithDeprecationHandlingTest.php
+++ b/tests/Testing/Concerns/InteractsWithDeprecationHandlingTest.php
@@ -34,10 +34,10 @@ class InteractsWithDeprecationHandlingTest extends TestCase
 
     public function testWithoutDeprecationHandling()
     {
+        $this->withoutDeprecationHandling();
+
         $this->expectException(ErrorException::class);
         $this->expectExceptionMessage('Something is deprecated');
-
-        $this->withoutDeprecationHandling();
 
         trigger_error('Something is deprecated', E_USER_DEPRECATED);
     }

--- a/tests/Testing/Concerns/InteractsWithDeprecationHandlingTest.php
+++ b/tests/Testing/Concerns/InteractsWithDeprecationHandlingTest.php
@@ -12,30 +12,28 @@ class InteractsWithDeprecationHandlingTest extends TestCase
 
     protected $original;
 
+    protected $deprecationsFound = false;
+
     public function setUp(): void
     {
         parent::setUp();
 
         $this->original = set_error_handler(function () {
-            // ..
+            $this->deprecationsFound = true;
         });
     }
 
     public function testWithDeprecationHandling()
     {
-        $deprecated = false;
-
         $this->withDeprecationHandling();
 
         trigger_error('Something is deprecated', E_USER_DEPRECATED);
 
-        $this->assertFalse($deprecated);
+        $this->assertTrue($this->deprecationsFound);
     }
 
     public function testWithoutDeprecationHandling()
     {
-        $deprecated = false;
-
         $this->expectException(ErrorException::class);
         $this->expectExceptionMessage('Something is deprecated');
 
@@ -49,6 +47,7 @@ class InteractsWithDeprecationHandlingTest extends TestCase
         set_error_handler($this->original);
 
         $this->originalDeprecationHandler = null;
+        $this->deprecationsFound = false;
 
         parent::tearDown();
     }

--- a/tests/Testing/Concerns/InteractsWithDeprecationHandlingTest.php
+++ b/tests/Testing/Concerns/InteractsWithDeprecationHandlingTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Illuminate\Tests\Testing\Concerns;
+
+use ErrorException;
+use Illuminate\Foundation\Testing\Concerns\InteractsWithDeprecationHandling;
+use PHPUnit\Framework\TestCase;
+
+class InteractsWithDeprecationHandlingTest extends TestCase
+{
+    use InteractsWithDeprecationHandling;
+
+    protected $original;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->original = set_error_handler(function () {
+            // ..
+        });
+    }
+
+    public function testWithDeprecationHandling()
+    {
+        $deprecated = false;
+
+        $this->withDeprecationHandling();
+
+        trigger_error('Something is deprecated', E_USER_DEPRECATED);
+
+        $this->assertFalse($deprecated);
+    }
+
+    public function testWithoutDeprecationHandling()
+    {
+        $deprecated = false;
+
+        $this->expectException(ErrorException::class);
+        $this->expectExceptionMessage('Something is deprecated');
+
+        $this->withoutDeprecationHandling();
+
+        trigger_error('Something is deprecated', E_USER_DEPRECATED);
+    }
+
+    public function tearDown(): void
+    {
+        set_error_handler($this->original);
+
+        $this->originalDeprecationHandler = null;
+
+        parent::tearDown();
+    }
+}


### PR DESCRIPTION
This pull request adds  `withoutDeprecationHandling` to the base Laravel's Test Case class so people can opt-in to have deprecations as exceptions in their test suites. Here is an example:

```php
// routes/web.php
Route::get('/', function () {
    str_contains(null, null);

    return view('welcome');
});

// Test A
it('has a home page', function () {
    $response = $this->get('/');

    $response->assertStatus(200); // passes ✅
});

// Test B
it('has a home page', function () {
    $this->withoutDeprecationHandling();

    $response = $this->get('/');

    $response->assertStatus(200); // 🛑 Expected response status code [200] but received 500. The following exception occurred during the request: ErrorException: str_contains(): Passing null to parameter #1 ($haystack) of type string is deprecated in /Users/nunomaduro/code/laravel/laravel/routes/web.php:17
});
```

@taylorotwell If this pull request gets merged, let me know if this deserves a section on the docs.