### PR TITLE
[8.x] Add `AssertableJson::hasAny`

### DIFF
--- a/src/Illuminate/Testing/Fluent/Concerns/Has.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Has.php
@@ -123,8 +123,9 @@ trait Has
             sprintf('None of properties [%s] exist.', implode(', ', $keys))
         );
 
-        foreach ($keys as $key)
+        foreach ($keys as $key) {
             $this->interactsWith($key);
+        }
 
         return $this;
     }

--- a/src/Illuminate/Testing/Fluent/Concerns/Has.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Has.php
@@ -109,6 +109,27 @@ trait Has
     }
 
     /**
+     * Assert that at least one of the given props exists.
+     *
+     * @param  array|string  $key
+     * @return $this
+     */
+    public function hasAny($key): self
+    {
+        $keys = is_array($key) ? $key : func_get_args();
+
+        PHPUnit::assertTrue(
+            Arr::hasAny($this->prop(), $keys),
+            sprintf('None of properties [%s] exist.', implode(', ', $keys))
+        );
+
+        foreach ($keys as $key)
+            $this->interactsWith($key);
+
+        return $this;
+    }
+
+    /**
      * Assert that none of the given props exist.
      *
      * @param  array|string  $key

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -726,7 +726,7 @@ class TestResponseTest extends TestCase
         $this->expectExceptionMessage('None of properties [data, errors, meta] exist.');
 
         $response->assertJson(function (AssertableJson $json) {
-            $json->hasAny('data', 'errors', 'meta')
+            $json->hasAny('data', 'errors', 'meta');
         });
     }
 
@@ -737,7 +737,7 @@ class TestResponseTest extends TestCase
         ]));
 
         $response->assertJson(function (AssertableJson $json) {
-            $json->hasAny('data', 'errors', 'meta')
+            $json->hasAny('data', 'errors', 'meta');
         });
     }
 

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -725,9 +725,9 @@ class TestResponseTest extends TestCase
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('None of properties [data, errors, meta] exist.');
 
-        $response->assertJson(fn (AssertableJson $json) =>
+        $response->assertJson(function (AssertableJson $json) {
             $json->hasAny('data', 'errors', 'meta')
-        );
+        });
     }
 
     public function testAssertJsonWithFluentHasAnyPasses()
@@ -736,9 +736,9 @@ class TestResponseTest extends TestCase
             'data' => [],
         ]));
 
-        $response->assertJson(fn (AssertableJson $json) =>
+        $response->assertJson(function (AssertableJson $json) {
             $json->hasAny('data', 'errors', 'meta')
-        );
+        });
     }
 
     public function testAssertSimilarJsonWithMixed()

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -718,6 +718,29 @@ class TestResponseTest extends TestCase
         });
     }
 
+    public function testAssertJsonWithFluentHasAnyThrows()
+    {
+        $response = TestResponse::fromBaseResponse(new Response([]));
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('None of properties [data, errors, meta] exist.');
+
+        $response->assertJson(fn (AssertableJson $json) =>
+            $json->hasAny('data', 'errors', 'meta')
+        );
+    }
+
+    public function testAssertJsonWithFluentHasAnyPasses()
+    {
+        $response = TestResponse::fromBaseResponse(new Response([
+            'data' => [],
+        ]));
+
+        $response->assertJson(fn (AssertableJson $json) =>
+            $json->hasAny('data', 'errors', 'meta')
+        );
+    }
+
     public function testAssertSimilarJsonWithMixed()
     {
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));


### PR DESCRIPTION
The need for such method arises when testing if a response conforms to a certain format, e.g. a specification. In my case it was [jsonapi](https://jsonapi.org/format/#document-top-level) which requires that at least one of `data`, `errors` or `meta` is present on the top level.