### PR TITLE
[8.x] Added dateTime to columns that don't need character options

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
+++ b/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
@@ -198,6 +198,7 @@ class ChangeColumn
             'binary',
             'boolean',
             'date',
+            'dateTime',
             'decimal',
             'double',
             'float',


### PR DESCRIPTION
I stumbled across an error with altering some dateTime columns that led me to #30539. I was changing a string column to a dateTime column. DateTime is missing from the list of columns that don't need character options so I added it in, tested it in my application and it worked just fine. So that PR adds dateTime to the list of columns that don't need character options
