### PR TITLE
[8.x] Add method for on-demand log creation

### DIFF
--- a/tests/Log/LogManagerTest.php
+++ b/tests/Log/LogManagerTest.php
@@ -13,6 +13,7 @@ use Monolog\Handler\NullHandler;
 use Monolog\Handler\StreamHandler;
 use Monolog\Handler\SyslogHandler;
 use Monolog\Logger as Monolog;
+use Monolog\Processor\UidProcessor;
 use Orchestra\Testbench\TestCase;
 use ReflectionProperty;
 use RuntimeException;
@@ -376,5 +377,59 @@ class LogManagerTest extends TestCase
         $manager->forgetChannel('single');
 
         $this->assertEmpty($manager->getChannels());
+    }
+
+    public function testLogManagerCanBuildOnDemandChannel()
+    {
+        $manager = new LogManager($this->app);
+
+        $logger = $manager->build([
+            'driver' => 'single',
+            'path' => storage_path('logs/on-demand.log'),
+        ]);
+        $handler = $logger->getLogger()->getHandlers()[0];
+
+        $this->assertInstanceOf(StreamHandler::class, $handler);
+
+        $url = new ReflectionProperty(get_class($handler), 'url');
+        $url->setAccessible(true);
+
+        $this->assertSame(storage_path('logs/on-demand.log'), $url->getValue($handler));
+    }
+
+    public function testLogManagerCanUseOnDemandChannelInOnDemandStack()
+    {
+        $manager = new LogManager($this->app);
+        $this->app['config']->set('logging.channels.test', [
+            'driver' => 'single',
+        ]);
+
+        $factory = new class()
+            {
+                public function __invoke()
+                {
+                    return new Monolog(
+                        'uuid',
+                        [new StreamHandler(storage_path('logs/custom.log'))],
+                        [new UidProcessor()]
+                    );
+                }
+            };
+        $channel = $manager->build([
+            'driver' => 'custom',
+            'via' => get_class($factory),
+        ]);
+        $logger = $manager->stack(['test', $channel]);
+
+        $handler = $logger->getLogger()->getHandlers()[1];
+        $processor = $logger->getLogger()->getProcessors()[0];
+
+        $this->assertInstanceOf(StreamHandler::class, $handler);
+        $this->assertInstanceOf(UidProcessor::class, $processor);
+
+        $url = new ReflectionProperty(get_class($handler), 'url');
+        $url->setAccessible(true);
+
+        $this->assertSame(storage_path('logs/custom.log'), $url->getValue($handler));
     }
 }


### PR DESCRIPTION
This patch proposes a new method `LogManager::build` to create on-demand logger instances.

The implementation and method name are based on the recently added `FilesystemManager::build` method.

```php
use Illuminate\Support\Facades\Log;

$logger = Log::build([
    'driver' => 'single',
    'path' => storage_path('logs/custom.log'),
]);

$logger->info('Ahoy custom log!');

// Use in on-demand stack.
$stack = Log::stack(['syslog', $logger]);
$stack->warning('Watch out, stack!');
```

**Why is this useful?**
Occasionally it would useful to configure a logger at runtime. For example setting the log path based on a command option or
writing entries to their own location for a niche use-case or debugging.

This could also be useful to divert to a one-off log from `tinker`.

I needed this functionality recently for a command to ingest several hundred models from an external XML data export. The XML was provided by a 3rd party and expected to contain a small number of errors which needed recording and communicating back for correction. To this end the tool allows dry runs which do not modify the database but log results to a user-defined local path.

In order to write to a dedicated log file based on an optional parameter I ended up duplicating and adapting initialization code from within the core `LogManager` inside the command which felt a bit of a kludge. As use will be very infrequent adding an entry to the main `config/logging.php` seemed overkill.

**Is it backwards compatible?**
The new functionality extends the existing public API so should not be a breaking change.
