### PR TITLE
add firstOrThrow(), firstOrAbort(), findOrThrow() and findOrAbort() methods

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -441,11 +441,7 @@ class Builder implements BuilderContract
      */
     public function findOrAbort($id, $code, $columns = ['*'])
     {
-        try {
-            return $this->findOrFail($id, $columns);
-        } catch(ModelNotFoundException $exception) {
-            throw new HttpException($code, '', $exception);
-        }
+        return $this->findOrThrow($id, new HttpException($code), $columns);
     }
 
     /**
@@ -558,11 +554,7 @@ class Builder implements BuilderContract
      */
     public function firstOrAbort($code, $columns = ['*'])
     {
-        try {
-            return $this->firstOrFail($columns);
-        } catch(ModelNotFoundException $exception) {
-            throw new HttpException($code, '', $exception);
-        }
+        return $this->firstOrThrow(new HttpException($code), $columns);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -414,7 +414,7 @@ class Builder implements BuilderContract
      * Find a related model by its primary key or throw the given exception.
      *
      * @param  mixed  $id
-     * @param \Throwable $exception
+     * @param  \Throwable  $exception
      * @param  array  $columns
      * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection|static|static[]
      *
@@ -424,7 +424,7 @@ class Builder implements BuilderContract
     {
         try {
             return $this->findOrFail($id, $columns);
-        } catch(ModelNotFoundException) {
+        } catch (ModelNotFoundException) {
             throw $exception;
         }
     }
@@ -433,8 +433,8 @@ class Builder implements BuilderContract
      * Find a related model by its primary key or throw an HttpException with the code.
      *
      * @param  mixed  $id
-     * @param int  $code
-     * @param array $columns
+     * @param  int  $code
+     * @param  array  $columns
      * @return \Illuminate\Database\Eloquent\Model|static
      *
      * @throws \Throwable
@@ -528,8 +528,8 @@ class Builder implements BuilderContract
     /**
      * Execute the query and get the first result or throw the given exception.
      *
-     * @param \Throwable $exception
-     * @param array $columns
+     * @param  \Throwable  $exception
+     * @param  array  $columns
      * @return \Illuminate\Database\Eloquent\Model|static
      *
      * @throws \Throwable
@@ -538,7 +538,7 @@ class Builder implements BuilderContract
     {
         try {
             return $this->firstOrFail($columns);
-        } catch(ModelNotFoundException) {
+        } catch (ModelNotFoundException) {
             throw $exception;
         }
     }
@@ -546,8 +546,8 @@ class Builder implements BuilderContract
     /**
      * Execute the query and get the first result or throw an HttpException with the code.
      *
-     * @param \Symfony\Component\HttpFoundation\Response|\Illuminate\Contracts\Support\Responsable|int  $code
-     * @param array $columns
+     * @param  \Symfony\Component\HttpFoundation\Response|\Illuminate\Contracts\Support\Responsable|int  $code
+     * @param  array  $columns
      * @return \Illuminate\Database\Eloquent\Model|static
      *
      * @throws \Throwable

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -21,6 +21,7 @@ use Illuminate\Support\Str;
 use Illuminate\Support\Traits\ForwardsCalls;
 use ReflectionClass;
 use ReflectionMethod;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
 /**
  * @property-read HigherOrderBuilderProxy $orWhere
@@ -410,6 +411,44 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Find a related model by its primary key or throw the given exception.
+     *
+     * @param  mixed  $id
+     * @param \Throwable $exception
+     * @param  array  $columns
+     * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection|static|static[]
+     *
+     * @throws \Throwable
+     */
+    public function findOrThrow($id, $exception, $columns = ['*'])
+    {
+        try {
+            return $this->findOrFail($id, $columns);
+        } catch(ModelNotFoundException) {
+            throw $exception;
+        }
+    }
+
+    /**
+     * Find a related model by its primary key or throw an HttpException with the code.
+     *
+     * @param  mixed  $id
+     * @param int  $code
+     * @param array $columns
+     * @return \Illuminate\Database\Eloquent\Model|static
+     *
+     * @throws \Throwable
+     */
+    public function findOrAbort($id, $code, $columns = ['*'])
+    {
+        try {
+            return $this->findOrFail($id, $columns);
+        } catch(ModelNotFoundException $exception) {
+            throw new HttpException($code, '', $exception);
+        }
+    }
+
+    /**
      * Find a model by its primary key or return fresh model instance.
      *
      * @param  mixed  $id
@@ -488,6 +527,42 @@ class Builder implements BuilderContract
         }
 
         throw (new ModelNotFoundException)->setModel(get_class($this->model));
+    }
+
+    /**
+     * Execute the query and get the first result or throw the given exception.
+     *
+     * @param \Throwable $exception
+     * @param array $columns
+     * @return \Illuminate\Database\Eloquent\Model|static
+     *
+     * @throws \Throwable
+     */
+    public function firstOrThrow($exception, $columns = ['*'])
+    {
+        try {
+            return $this->firstOrFail($columns);
+        } catch(ModelNotFoundException) {
+            throw $exception;
+        }
+    }
+
+    /**
+     * Execute the query and get the first result or throw an HttpException with the code.
+     *
+     * @param \Symfony\Component\HttpFoundation\Response|\Illuminate\Contracts\Support\Responsable|int  $code
+     * @param array $columns
+     * @return \Illuminate\Database\Eloquent\Model|static
+     *
+     * @throws \Throwable
+     */
+    public function firstOrAbort($code, $columns = ['*'])
+    {
+        try {
+            return $this->firstOrFail($columns);
+        } catch(ModelNotFoundException $exception) {
+            throw new HttpException($code, '', $exception);
+        }
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -716,7 +716,7 @@ class BelongsToMany extends Relation
      * Find a related model by its primary key or throw the given exception.
      *
      * @param  mixed  $id
-     * @param \Throwable $exception
+     * @param  \Throwable  $exception
      * @param  array  $columns
      * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection|static|static[]
      *
@@ -726,7 +726,7 @@ class BelongsToMany extends Relation
     {
         try {
             return $this->findOrFail($id, $columns);
-        } catch(ModelNotFoundException) {
+        } catch (ModelNotFoundException) {
             throw $exception;
         }
     }
@@ -735,8 +735,8 @@ class BelongsToMany extends Relation
      * Find a related model by its primary key or throw an HttpException with the code.
      *
      * @param  mixed  $id
-     * @param int  $code
-     * @param array $columns
+     * @param  int  $code
+     * @param  array  $columns
      * @return \Illuminate\Database\Eloquent\Model|static
      *
      * @throws \Throwable
@@ -793,8 +793,8 @@ class BelongsToMany extends Relation
     /**
      * Execute the query and get the first result or throw the given exception.
      *
-     * @param \Throwable|string $exception
-     * @param array $columns
+     * @param  \Throwable|string  $exception
+     * @param  array  $columns
      * @return \Illuminate\Database\Eloquent\Model|static
      *
      * @throws \Throwable
@@ -803,7 +803,7 @@ class BelongsToMany extends Relation
     {
         try {
             return $this->firstOrFail($columns);
-        } catch(ModelNotFoundException) {
+        } catch (ModelNotFoundException) {
             throw $exception;
         }
     }
@@ -811,8 +811,8 @@ class BelongsToMany extends Relation
     /**
      * Execute the query and get the first result or throw an HttpException with the code.
      *
-     * @param int  $code
-     * @param array $columns
+     * @param  int  $code
+     * @param  array  $columns
      * @return \Illuminate\Database\Eloquent\Model|static
      *
      * @throws \Throwable

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -743,11 +743,7 @@ class BelongsToMany extends Relation
      */
     public function findOrAbort($id, $code, $columns = ['*'])
     {
-        try {
-            return $this->findOrFail($id, $columns);
-        } catch(ModelNotFoundException $exception) {
-            throw new HttpException($code, '', $exception);
-        }
+        return $this->findOrThrow($id, new HttpException($code), $columns);
     }
 
     /**
@@ -823,11 +819,7 @@ class BelongsToMany extends Relation
      */
     public function firstOrAbort($code, $columns = ['*'])
     {
-        try {
-            return $this->firstOrFail($columns);
-        } catch(ModelNotFoundException $exception) {
-            throw new HttpException($code, '', $exception);
-        }
+        return $this->firstOrThrow(new HttpException($code), $columns);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithDictionary;
 use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithPivotTable;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class BelongsToMany extends Relation
 {
@@ -712,6 +713,44 @@ class BelongsToMany extends Relation
     }
 
     /**
+     * Find a related model by its primary key or throw the given exception.
+     *
+     * @param  mixed  $id
+     * @param \Throwable $exception
+     * @param  array  $columns
+     * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection|static|static[]
+     *
+     * @throws \Throwable
+     */
+    public function findOrThrow($id, $exception, $columns = ['*'])
+    {
+        try {
+            return $this->findOrFail($id, $columns);
+        } catch(ModelNotFoundException) {
+            throw $exception;
+        }
+    }
+
+    /**
+     * Find a related model by its primary key or throw an HttpException with the code.
+     *
+     * @param  mixed  $id
+     * @param int  $code
+     * @param array $columns
+     * @return \Illuminate\Database\Eloquent\Model|static
+     *
+     * @throws \Throwable
+     */
+    public function findOrAbort($id, $code, $columns = ['*'])
+    {
+        try {
+            return $this->findOrFail($id, $columns);
+        } catch(ModelNotFoundException $exception) {
+            throw new HttpException($code, '', $exception);
+        }
+    }
+
+    /**
      * Add a basic where clause to the query, and return the first result.
      *
      * @param  \Closure|string|array  $column
@@ -753,6 +792,42 @@ class BelongsToMany extends Relation
         }
 
         throw (new ModelNotFoundException)->setModel(get_class($this->related));
+    }
+
+    /**
+     * Execute the query and get the first result or throw the given exception.
+     *
+     * @param \Throwable|string $exception
+     * @param array $columns
+     * @return \Illuminate\Database\Eloquent\Model|static
+     *
+     * @throws \Throwable
+     */
+    public function firstOrThrow($exception, $columns = ['*'])
+    {
+        try {
+            return $this->firstOrFail($columns);
+        } catch(ModelNotFoundException) {
+            throw $exception;
+        }
+    }
+
+    /**
+     * Execute the query and get the first result or throw an HttpException with the code.
+     *
+     * @param int  $code
+     * @param array $columns
+     * @return \Illuminate\Database\Eloquent\Model|static
+     *
+     * @throws \Throwable
+     */
+    public function firstOrAbort($code, $columns = ['*'])
+    {
+        try {
+            return $this->firstOrFail($columns);
+        } catch(ModelNotFoundException $exception) {
+            throw new HttpException($code, '', $exception);
+        }
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -332,11 +332,7 @@ class HasManyThrough extends Relation
      */
     public function firstOrAbort($code, $columns = ['*'])
     {
-        try {
-            return $this->firstOrFail($columns);
-        } catch(ModelNotFoundException $exception) {
-            throw new HttpException($code, '', $exception);
-        }
+        return $this->firstOrThrow(new HttpException($code), $columns);
     }
 
     /**
@@ -456,11 +452,7 @@ class HasManyThrough extends Relation
      */
     public function findOrAbort($id, $code, $columns = ['*'])
     {
-        try {
-            return $this->findOrFail($id, $columns);
-        } catch(ModelNotFoundException $exception) {
-            throw new HttpException($code, '', $exception);
-        }
+        return $this->findOrThrow(new HttpException($code), $columns);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -306,8 +306,8 @@ class HasManyThrough extends Relation
     /**
      * Execute the query and get the first result or throw the given exception.
      *
-     * @param \Throwable $exception
-     * @param array $columns
+     * @param  \Throwable  $exception
+     * @param  array  $columns
      * @return \Illuminate\Database\Eloquent\Model|static
      *
      * @throws \Throwable
@@ -316,7 +316,7 @@ class HasManyThrough extends Relation
     {
         try {
             return $this->firstOrFail($columns);
-        } catch(ModelNotFoundException) {
+        } catch (ModelNotFoundException) {
             throw $exception;
         }
     }
@@ -324,8 +324,8 @@ class HasManyThrough extends Relation
     /**
      * Execute the query and get the first result or throw an HttpException with the code.
      *
-     * @param int  $code
-     * @param array $columns
+     * @param  int  $code
+     * @param  array  $columns
      * @return \Illuminate\Database\Eloquent\Model|static
      *
      * @throws \Throwable
@@ -425,7 +425,7 @@ class HasManyThrough extends Relation
      * Find a related model by its primary key or throw the given exception.
      *
      * @param  mixed  $id
-     * @param \Throwable $exception
+     * @param  \Throwable  $exception
      * @param  array  $columns
      * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection|static|static[]
      *
@@ -435,7 +435,7 @@ class HasManyThrough extends Relation
     {
         try {
             return $this->findOrFail($id, $columns);
-        } catch(ModelNotFoundException) {
+        } catch (ModelNotFoundException) {
             throw $exception;
         }
     }
@@ -444,8 +444,8 @@ class HasManyThrough extends Relation
      * Find a related model by its primary key or throw an HttpException with the code.
      *
      * @param  mixed  $id
-     * @param int  $code
-     * @param array $columns
+     * @param  int  $code
+     * @param  array  $columns
      * @return \Illuminate\Database\Eloquent\Model|static
      *
      * @throws \Throwable

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithDictionary;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class HasManyThrough extends Relation
 {
@@ -303,6 +304,42 @@ class HasManyThrough extends Relation
     }
 
     /**
+     * Execute the query and get the first result or throw the given exception.
+     *
+     * @param \Throwable $exception
+     * @param array $columns
+     * @return \Illuminate\Database\Eloquent\Model|static
+     *
+     * @throws \Throwable
+     */
+    public function firstOrThrow($exception, $columns = ['*'])
+    {
+        try {
+            return $this->firstOrFail($columns);
+        } catch(ModelNotFoundException) {
+            throw $exception;
+        }
+    }
+
+    /**
+     * Execute the query and get the first result or throw an HttpException with the code.
+     *
+     * @param int  $code
+     * @param array $columns
+     * @return \Illuminate\Database\Eloquent\Model|static
+     *
+     * @throws \Throwable
+     */
+    public function firstOrAbort($code, $columns = ['*'])
+    {
+        try {
+            return $this->firstOrFail($columns);
+        } catch(ModelNotFoundException $exception) {
+            throw new HttpException($code, '', $exception);
+        }
+    }
+
+    /**
      * Execute the query and get the first result or call a callback.
      *
      * @param  \Closure|array  $columns
@@ -386,6 +423,44 @@ class HasManyThrough extends Relation
         }
 
         throw (new ModelNotFoundException)->setModel(get_class($this->related), $id);
+    }
+
+    /**
+     * Find a related model by its primary key or throw the given exception.
+     *
+     * @param  mixed  $id
+     * @param \Throwable $exception
+     * @param  array  $columns
+     * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection|static|static[]
+     *
+     * @throws \Throwable
+     */
+    public function findOrThrow($id, $exception, $columns = ['*'])
+    {
+        try {
+            return $this->findOrFail($id, $columns);
+        } catch(ModelNotFoundException) {
+            throw $exception;
+        }
+    }
+
+    /**
+     * Find a related model by its primary key or throw an HttpException with the code.
+     *
+     * @param  mixed  $id
+     * @param int  $code
+     * @param array $columns
+     * @return \Illuminate\Database\Eloquent\Model|static
+     *
+     * @throws \Throwable
+     */
+    public function findOrAbort($id, $code, $columns = ['*'])
+    {
+        try {
+            return $this->findOrFail($id, $columns);
+        } catch(ModelNotFoundException $exception) {
+            throw new HttpException($code, '', $exception);
+        }
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -20,7 +20,9 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection as BaseCollection;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 use stdClass;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class DatabaseEloquentBuilderTest extends TestCase
 {
@@ -144,6 +146,76 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->findOrFail(new Collection([1, 2]), ['column']);
     }
 
+    public function testFindOrThrowMethodThrowsRuntimeException()
+    {
+        $this->expectException(RuntimeException::class);
+
+        $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
+        $model = $this->getMockModel();
+        $model->shouldReceive('getKeyType')->once()->andReturn('int');
+        $builder->setModel($model);
+        $builder->getQuery()->shouldReceive('where')->once()->with('foo_table.foo', '=', 'bar');
+        $builder->shouldReceive('first')->with(['column'])->andReturn(null);
+        $builder->findOrThrow('bar', new RuntimeException(), ['column']);
+    }
+
+    public function testFindOrThrowMethodWithManyThrowsRuntimeException()
+    {
+        $this->expectException(RuntimeException::class);
+
+        $builder = m::mock(Builder::class.'[get]', [$this->getMockQueryBuilder()]);
+        $builder->setModel($this->getMockModel());
+        $builder->getQuery()->shouldReceive('whereIn')->once()->with('foo_table.foo', [1, 2]);
+        $builder->shouldReceive('get')->with(['column'])->andReturn(new Collection([1]));
+        $builder->findOrThrow([1, 2], new RuntimeException(), ['column']);
+    }
+
+    public function testFindOrThrowMethodWithManyUsingCollectionThrowsRuntimeException()
+    {
+        $this->expectException(RuntimeException::class);
+
+        $builder = m::mock(Builder::class.'[get]', [$this->getMockQueryBuilder()]);
+        $builder->setModel($this->getMockModel());
+        $builder->getQuery()->shouldReceive('whereIn')->once()->with('foo_table.foo', [1, 2]);
+        $builder->shouldReceive('get')->with(['column'])->andReturn(new Collection([1]));
+        $builder->findOrThrow(new Collection([1, 2]), new RuntimeException(), ['column']);
+    }
+
+    public function testFindOrAbortMethodThrowsHttpException()
+    {
+        $this->expectException(HttpException::class);
+
+        $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
+        $model = $this->getMockModel();
+        $model->shouldReceive('getKeyType')->once()->andReturn('int');
+        $builder->setModel($model);
+        $builder->getQuery()->shouldReceive('where')->once()->with('foo_table.foo', '=', 'bar');
+        $builder->shouldReceive('first')->with(['column'])->andReturn(null);
+        $builder->findOrAbort('bar', 500, ['column']);
+    }
+
+    public function testFindOrAbortMethodWithManyThrowsHttpException()
+    {
+        $this->expectException(HttpException::class);
+
+        $builder = m::mock(Builder::class.'[get]', [$this->getMockQueryBuilder()]);
+        $builder->setModel($this->getMockModel());
+        $builder->getQuery()->shouldReceive('whereIn')->once()->with('foo_table.foo', [1, 2]);
+        $builder->shouldReceive('get')->with(['column'])->andReturn(new Collection([1]));
+        $builder->findOrAbort([1, 2], 500, ['column']);
+    }
+
+    public function testFindOrAbortMethodWithManyUsingCollectionThrowsHttpException()
+    {
+        $this->expectException(HttpException::class);
+
+        $builder = m::mock(Builder::class.'[get]', [$this->getMockQueryBuilder()]);
+        $builder->setModel($this->getMockModel());
+        $builder->getQuery()->shouldReceive('whereIn')->once()->with('foo_table.foo', [1, 2]);
+        $builder->shouldReceive('get')->with(['column'])->andReturn(new Collection([1]));
+        $builder->findOrAbort(new Collection([1, 2]), 500, ['column']);
+    }
+
     public function testFirstOrFailMethodThrowsModelNotFoundException()
     {
         $this->expectException(ModelNotFoundException::class);
@@ -152,6 +224,26 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->setModel($this->getMockModel());
         $builder->shouldReceive('first')->with(['column'])->andReturn(null);
         $builder->firstOrFail(['column']);
+    }
+
+    public function testFirstOrThrowMethodThrowsRuntimeException()
+    {
+        $this->expectException(RuntimeException::class);
+
+        $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
+        $builder->setModel($this->getMockModel());
+        $builder->shouldReceive('first')->with(['column'])->andReturn(null);
+        $builder->firstOrThrow(new RuntimeException(), ['column']);
+    }
+
+    public function testFirstOrAbortMethodThrowsHttpException()
+    {
+        $this->expectException(HttpException::class);
+
+        $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
+        $builder->setModel($this->getMockModel());
+        $builder->shouldReceive('first')->with(['column'])->andReturn(null);
+        $builder->firstOrAbort(500, ['column']);
     }
 
     public function testFindWithMany()

--- a/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
@@ -9,6 +9,8 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Collection;
 use Illuminate\Support\LazyCollection;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
 {
@@ -166,6 +168,27 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
         HasManyThroughTestCountry::first()->posts()->firstOrFail();
     }
 
+    public function testFirstOrThrowThrowsAnException()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('I am a custom exception');
+
+        HasManyThroughTestCountry::create(['id' => 1, 'name' => 'United States of America', 'shortname' => 'us'])
+            ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us']);
+
+        HasManyThroughTestCountry::first()->posts()->firstOrThrow(new RuntimeException('I am a custom exception'));
+    }
+
+    public function testFirstOrAbortThrowsAnException()
+    {
+        $this->expectException(HttpException::class);
+
+        HasManyThroughTestCountry::create(['id' => 1, 'name' => 'United States of America', 'shortname' => 'us'])
+            ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us']);
+
+        HasManyThroughTestCountry::first()->posts()->firstOrAbort(500);
+    }
+
     public function testFindOrFailThrowsAnException()
     {
         $this->expectException(ModelNotFoundException::class);
@@ -199,6 +222,73 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
                                  ->posts()->create(['id' => 1, 'title' => 'A title', 'body' => 'A body', 'email' => 'taylorotwell@gmail.com']);
 
         HasManyThroughTestCountry::first()->posts()->findOrFail(new Collection([1, 2]));
+    }
+
+    public function testFindOrThrowThrowsAnException()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('I am a custom exception');
+
+        HasManyThroughTestCountry::create(['id' => 1, 'name' => 'United States of America', 'shortname' => 'us'])
+            ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us']);
+
+        HasManyThroughTestCountry::first()->posts()->findOrThrow(1, new RuntimeException('I am a custom exception'));
+    }
+
+    public function testFindOrThrowWithManyThrowsAnException()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('I am a custom exception');
+
+        HasManyThroughTestCountry::create(['id' => 1, 'name' => 'United States of America', 'shortname' => 'us'])
+            ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us'])
+            ->posts()->create(['id' => 1, 'title' => 'A title', 'body' => 'A body', 'email' => 'taylorotwell@gmail.com']);
+
+        HasManyThroughTestCountry::first()->posts()->findOrThrow([1, 2], new RuntimeException('I am a custom exception'));
+    }
+
+    public function testFindOrThrowWithManyUsingCollectionThrowsAnException()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('I am a custom exception');
+
+        HasManyThroughTestCountry::create(['id' => 1, 'name' => 'United States of America', 'shortname' => 'us'])
+            ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us'])
+            ->posts()->create(['id' => 1, 'title' => 'A title', 'body' => 'A body', 'email' => 'taylorotwell@gmail.com']);
+
+        HasManyThroughTestCountry::first()->posts()->findOrThrow(new Collection([1, 2]), new RuntimeException('I am a custom exception'));
+    }
+
+    public function testFindOrAbortThrowsAnException()
+    {
+        $this->expectException(HttpException::class);
+
+        HasManyThroughTestCountry::create(['id' => 1, 'name' => 'United States of America', 'shortname' => 'us'])
+            ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us']);
+
+        HasManyThroughTestCountry::first()->posts()->findOrAbort(1, 500);
+    }
+
+    public function testFindOrAbortWithManyThrowsAnException()
+    {
+        $this->expectException(HttpException::class);
+
+        HasManyThroughTestCountry::create(['id' => 1, 'name' => 'United States of America', 'shortname' => 'us'])
+            ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us'])
+            ->posts()->create(['id' => 1, 'title' => 'A title', 'body' => 'A body', 'email' => 'taylorotwell@gmail.com']);
+
+        HasManyThroughTestCountry::first()->posts()->findOrAbort([1, 2], 500);
+    }
+
+    public function testFindOrAbortWithManyUsingCollectionThrowsAnException()
+    {
+        $this->expectException(HttpException::class);
+
+        HasManyThroughTestCountry::create(['id' => 1, 'name' => 'United States of America', 'shortname' => 'us'])
+            ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us'])
+            ->posts()->create(['id' => 1, 'title' => 'A title', 'body' => 'A body', 'email' => 'taylorotwell@gmail.com']);
+
+        HasManyThroughTestCountry::first()->posts()->findOrAbort(new Collection([1, 2]), 500);
     }
 
     public function testFirstRetrievesFirstRecord()

--- a/tests/Database/DatabaseEloquentHasOneThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasOneThroughIntegrationTest.php
@@ -7,6 +7,8 @@ use Illuminate\Database\Eloquent\Model as Eloquent;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class DatabaseEloquentHasOneThroughIntegrationTest extends TestCase
 {
@@ -127,6 +129,26 @@ class DatabaseEloquentHasOneThroughIntegrationTest extends TestCase
         HasOneThroughTestPosition::first()->contract()->firstOrFail();
     }
 
+    public function testFirstOrThrowThrowsAnException()
+    {
+        $this->expectException(RuntimeException::class);
+
+        HasOneThroughTestPosition::create(['id' => 1, 'name' => 'President', 'shortname' => 'ps'])
+            ->user()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'position_short' => 'ps']);
+
+        HasOneThroughTestPosition::first()->contract()->firstOrThrow(new RuntimeException());
+    }
+
+    public function testFirstOrAbortThrowsAnException()
+    {
+        $this->expectException(HttpException::class);
+
+        HasOneThroughTestPosition::create(['id' => 1, 'name' => 'President', 'shortname' => 'ps'])
+            ->user()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'position_short' => 'ps']);
+
+        HasOneThroughTestPosition::first()->contract()->firstOrAbort(500);
+    }
+
     public function testFindOrFailThrowsAnException()
     {
         $this->expectException(ModelNotFoundException::class);
@@ -135,6 +157,26 @@ class DatabaseEloquentHasOneThroughIntegrationTest extends TestCase
             ->user()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'position_short' => 'ps']);
 
         HasOneThroughTestPosition::first()->contract()->findOrFail(1);
+    }
+
+    public function testFindOrThrowThrowsAnException()
+    {
+        $this->expectException(RuntimeException::class);
+
+        HasOneThroughTestPosition::create(['id' => 1, 'name' => 'President', 'shortname' => 'ps'])
+            ->user()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'position_short' => 'ps']);
+
+        HasOneThroughTestPosition::first()->contract()->findOrThrow(1, new RuntimeException());
+    }
+
+    public function testFindOrAbortThrowsAnException()
+    {
+        $this->expectException(HttpException::class);
+
+        HasOneThroughTestPosition::create(['id' => 1, 'name' => 'President', 'shortname' => 'ps'])
+            ->user()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'position_short' => 'ps']);
+
+        HasOneThroughTestPosition::first()->contract()->findOrAbort(1, 500);
     }
 
     public function testFirstRetrievesFirstRecord()


### PR DESCRIPTION
This PR is based on [the Tweet](https://twitter.com/sebdedeyne/status/1450837896487866373) by @sebastiandedeyne and adds 4 new methods to the Eloquent Query Builder.
* `firstOrThrow(new Exception())` will throw the given exception instead of `ModelNotFoundException`
* `firstOrAbort(500)` will throw a `HttpException` with given status code instead of `ModelNotFoundException`
* `findOrThrow(1, new Exception())` will throw the given exception instead of `ModelNotFoundException`
* `findOrAbort(1, 500)` will throw a `HttpException` with given status code instead of `ModelNotFoundException`

This is useful for action classes which should throw an exception and stop running but a specific one instead of the default model not found one. Or controllers where you want to return a different status code instead of the default 404.