### PR TITLE
[8.x] Add `Arr::isList()` method

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -394,6 +394,19 @@ class Arr
     }
 
     /**
+     * Determines if an array is a list.
+     *
+     * An array is a "list" if all array keys are sequential integers starting from 0 with no gaps in between.
+     *
+     * @param  array  $array
+     * @return bool
+     */
+    public static function isList($array)
+    {
+        return ! self::isAssoc($array);
+    }
+
+    /**
      * Get a subset of the items from the given array.
      *
      * @param  array  $array

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -424,6 +424,22 @@ class SupportArrTest extends TestCase
         $this->assertFalse(Arr::isAssoc(['a', 'b']));
     }
 
+    public function testIsList()
+    {
+        $this->assertTrue(Arr::isList([]));
+        $this->assertTrue(Arr::isList([1, 2, 3]));
+        $this->assertTrue(Arr::isList(['foo', 2, 3]));
+        $this->assertTrue(Arr::isList(['foo', 'bar']));
+        $this->assertTrue(Arr::isList([0 => 'foo', 'bar']));
+        $this->assertTrue(Arr::isList([0 => 'foo', 1 => 'bar']));
+
+        $this->assertFalse(Arr::isList([1 => 'foo', 'bar']));
+        $this->assertFalse(Arr::isList([1 => 'foo', 0 => 'bar']));
+        $this->assertFalse(Arr::isList([0 => 'foo', 'bar' => 'baz']));
+        $this->assertFalse(Arr::isList([0 => 'foo', 2 => 'bar']));
+        $this->assertFalse(Arr::isList(['foo' => 'bar', 'baz' => 'qux']));
+    }
+
     public function testOnly()
     {
         $array = ['name' => 'Desk', 'price' => 100, 'orders' => 10];


### PR DESCRIPTION
Added the `Arr::isList()` method  for determining if an array is a "list". An array is a "list" if all array keys are sequential integers starting from 0 with no gaps in between.

This is a polyfilled version of the [`array_is_list()`](https://www.php.net/manual/en/function.array-is-list.php) function that is coming to PHP with v8.1 (currently unreleased). Additionally, Laravel 8 supports PHP versions back to 7.3 so this PR brings this functionality to applications still on these versions.

## Implementation

~This implementation uses the polyfill code as described in the [RFC proposal](https://wiki.php.net/rfc/is_list#proposal) which avoids potential issues when using other methods (e.g. `array_values($array) === $array`) for determining "listness".~

## Future Considerations

In the future this method can be refactored to use the native `array_is_list()` function when support for PHP versions < 8.1 are dropped. Alternatively the method may be removed all together.