### PR TITLE
[8.x] Throwable error code can only be an integer

### DIFF
--- a/src/Illuminate/Database/DetectsConcurrencyErrors.php
+++ b/src/Illuminate/Database/DetectsConcurrencyErrors.php
@@ -16,7 +16,7 @@ trait DetectsConcurrencyErrors
      */
     protected function causedByConcurrencyError(Throwable $e)
     {
-        if ($e instanceof PDOException && $e->getCode() === 40001) {
+        if ($e instanceof PDOException && ($e->getCode() === 40001 || $e->getCode() === '40001')) {
             return true;
         }
 

--- a/src/Illuminate/Database/DetectsConcurrencyErrors.php
+++ b/src/Illuminate/Database/DetectsConcurrencyErrors.php
@@ -16,7 +16,7 @@ trait DetectsConcurrencyErrors
      */
     protected function causedByConcurrencyError(Throwable $e)
     {
-        if ($e instanceof PDOException && $e->getCode() === '40001') {
+        if ($e instanceof PDOException && $e->getCode() === 40001) {
             return true;
         }
 


### PR DESCRIPTION
While testing the automatic retrying of a transaction for concurrency issues, I noticed that it only worked if the message contained any of the strings. The error code could never match the `'40001'` since the `$e->getCode()` always returns an INT.