### PR TITLE
[8.x] Add redirect_if and redirect_unless as helpers

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -613,6 +613,44 @@ if (! function_exists('redirect')) {
     }
 }
 
+if (! function_exists('redirect_if')) {
+    /**
+     * Get an instance of the redirector with the given data if the given condition is true.
+     *
+     * @param  bool $boolean
+     * @param  string|null  $to
+     * @param  int  $status
+     * @param  array  $headers
+     * @param  bool|null  $secure
+     * @return \Illuminate\Routing\Redirector|\Illuminate\Http\RedirectResponse
+     */
+    function redirect_if($boolean, $to = null, $status = 302, $headers = [], $secure = null)
+    {
+        if ($boolean) {
+            return redirect($to, $status, $headers, $secure);
+        }
+    }
+}
+
+if (! function_exists('redirect_unless')) {
+    /**
+     * Get an instance of the redirector with the given data unless the given condition is true.
+     *
+     * @param  bool $boolean
+     * @param  string|null  $to
+     * @param  int  $status
+     * @param  array  $headers
+     * @param  bool|null  $secure
+     * @return \Illuminate\Routing\Redirector|\Illuminate\Http\RedirectResponse
+     */
+    function redirect_unless($boolean, $to = null, $status = 302, $headers = [], $secure = null)
+    {
+        if (! $boolean) {
+            return redirect($to, $status, $headers, $secure);
+        }
+    }
+}
+
 if (! function_exists('report')) {
     /**
      * Report an exception.

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -617,7 +617,7 @@ if (! function_exists('redirect_if')) {
     /**
      * Get an instance of the redirector with the given data if the given condition is true.
      *
-     * @param  bool $boolean
+     * @param  bool  $boolean
      * @param  string|null  $to
      * @param  int  $status
      * @param  array  $headers
@@ -636,7 +636,7 @@ if (! function_exists('redirect_unless')) {
     /**
      * Get an instance of the redirector with the given data unless the given condition is true.
      *
-     * @param  bool $boolean
+     * @param  bool  $boolean
      * @param  string|null  $to
      * @param  int  $status
      * @param  array  $headers


### PR DESCRIPTION
This PR adds two methods to the helpers, `redirect_if` ( create a redirector with the given data if the given condition is true.) 
and `redirect_unless` ( create a redirector with the given data unless the given condition is true.) 

examples :
`redirect_if($user->isAdmin(),'/home/dashboard');`
`redirect_unless(Auth::check(),'/login');`

the two helpers will reduce the amount of if statements used to redirect requests based on business logic ;
 