### PR TITLE
[8.x] Add do_if and do_unless as helpers

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -938,10 +938,10 @@ if (! function_exists('do_if')) {
      * execute a callable if the given condition is true.
      *
      * @param  bool  $boolean
-     * @param  callable $callable
+     * @param  callable  $callable
      * @return mixed|ErrorException
      */
-    function do_if($boolean,$callable) {
+    function do_if($boolean, $callable) {
         if (! is_callable($callable)) {
             throw new ErrorException('do_if expect a callable', 0, 1);
         }
@@ -957,10 +957,10 @@ if (! function_exists('do_unless')) {
      * execute a callable unless the given condition is true.
      *
      * @param  bool  $boolean
-     * @param  callable $callable
+     * @param  callable  $callable
      * @return mixed|ErrorException
      */
-     function do_unless($boolean ,$callable) {
+     function do_unless($boolean, $callable) {
         if (! is_callable($callable)) {
             throw new ErrorException('do_unless expect a callable', 0, 1);
         }

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -941,7 +941,7 @@ if (! function_exists('do_if')) {
      * @param  callable  $callable
      * @return mixed|ErrorException
      */
-    function do_if($boolean, $callable) 
+    function do_if($boolean, $callable)
     {
         if (! is_callable($callable)) {
             throw new ErrorException('do_if expect a callable', 0, 1);
@@ -961,7 +961,7 @@ if (! function_exists('do_unless')) {
      * @param  callable  $callable
      * @return mixed|ErrorException
      */
-    function do_unless($boolean, $callable) 
+    function do_unless($boolean, $callable)
     {
         if (! is_callable($callable)) {
             throw new ErrorException('do_unless expect a callable', 0, 1);

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -952,7 +952,6 @@ if (! function_exists('do_if')) {
     }
 }
 
-
 if (! function_exists('do_unless')) {
     /**
      * execute a callable unless the given condition is true.

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -941,7 +941,8 @@ if (! function_exists('do_if')) {
      * @param  callable  $callable
      * @return mixed|ErrorException
      */
-    function do_if($boolean, $callable) {
+    function do_if($boolean, $callable) 
+    {
         if (! is_callable($callable)) {
             throw new ErrorException('do_if expect a callable', 0, 1);
         }
@@ -960,7 +961,8 @@ if (! function_exists('do_unless')) {
      * @param  callable  $callable
      * @return mixed|ErrorException
      */
-     function do_unless($boolean, $callable) {
+    function do_unless($boolean, $callable) 
+    {
         if (! is_callable($callable)) {
             throw new ErrorException('do_unless expect a callable', 0, 1);
         }

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -932,3 +932,40 @@ if (! function_exists('view')) {
         return $factory->make($view, $data, $mergeData);
     }
 }
+
+if (! function_exists('do_if')) {
+    /**
+     * execute a callable if the given condition is true.
+     *
+     * @param  bool  $boolean
+     * @param  callable $callable
+     * @return mixed|ErrorException
+     */
+    function do_if($boolean,$callable) {
+        if (! is_callable($callable)) {
+            throw new ErrorException('do_if expect a callable', 0, 1);
+        }
+        if ($boolean) {
+            return call_user_func($callable);
+        }
+    }
+}
+
+
+if (! function_exists('do_unless')) {
+    /**
+     * execute a callable unless the given condition is true.
+     *
+     * @param  bool  $boolean
+     * @param  callable $callable
+     * @return mixed|ErrorException
+     */
+     function do_unless($boolean ,$callable) {
+        if (! is_callable($callable)) {
+            throw new ErrorException('do_unless expect a callable', 0, 1);
+        }
+        if (! $boolean) {
+            return call_user_func($callable);
+        }
+    }
+}

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -939,15 +939,12 @@ if (! function_exists('do_if')) {
      *
      * @param  bool  $boolean
      * @param  callable  $callable
-     * @return mixed|ErrorException
+     * @return mixed
      */
-    function do_if($boolean, $callable)
+    function do_if(bool $boolean, callable $callable)
     {
-        if (! is_callable($callable)) {
-            throw new ErrorException('do_if expect a callable', 0, 1);
-        }
         if ($boolean) {
-            return call_user_func($callable);
+            return $callable();
         }
     }
 }
@@ -958,15 +955,12 @@ if (! function_exists('do_unless')) {
      *
      * @param  bool  $boolean
      * @param  callable  $callable
-     * @return mixed|ErrorException
+     * @return mixed
      */
-    function do_unless($boolean, $callable)
+    function do_unless(bool $boolean, callable $callable)
     {
-        if (! is_callable($callable)) {
-            throw new ErrorException('do_unless expect a callable', 0, 1);
-        }
         if (! $boolean) {
-            return call_user_func($callable);
+            return $callable();
         }
     }
 }


### PR DESCRIPTION
This PR adds two methods to the helpers, `do_if` ( calls the passed function if the given condition is true.)
and `do_unless`( calls the passed function unless the given condition is true.)

examples :
`do_if(Auth::check(),updateSomething());`
`do_unless(App::environment('local'),do_buckup());`

the two helpers will reduce the amount of if statements used on the business logic and add more clarity  ;