### PR TITLE
[8.x] Added new assertNothingDispatched method to BusFake

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -136,6 +136,16 @@ class BusFake implements QueueingDispatcher
     }
 
     /**
+     * Assert that no jobs were dispatched.
+     *
+     * @return void
+     */
+    public function assertNothingDispatched()
+    {
+        PHPUnit::assertEmpty($this->commands, 'Jobs were dispatched unexpectedly.');
+    }
+
+    /**
      * Assert if a job was explicitly dispatched synchronously based on a truth-test callback.
      *
      * @param  string|\Closure  $command

--- a/tests/Support/SupportTestingBusFakeTest.php
+++ b/tests/Support/SupportTestingBusFakeTest.php
@@ -366,7 +366,7 @@ class SupportTestingBusFakeTest extends TestCase
     {
         $this->fake->assertNothingDispatched();
 
-        $this->fake->push(new BusJobStub);
+        $this->fake->dispatch(new BusJobStub);
 
         try {
             $this->fake->assertNothingDispatched();

--- a/tests/Support/SupportTestingBusFakeTest.php
+++ b/tests/Support/SupportTestingBusFakeTest.php
@@ -362,6 +362,20 @@ class SupportTestingBusFakeTest extends TestCase
         }
     }
 
+    public function testAssertNothingDispatched()
+    {
+        $this->fake->assertNothingDispatched();
+
+        $this->fake->push(new BusJobStub);
+
+        try {
+            $this->fake->assertNothingDispatched();
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('Jobs were dispatched unexpectedly.'));
+        }
+    }
+
     public function testAssertDispatchedWithIgnoreClass()
     {
         $dispatcher = m::mock(QueueingDispatcher::class);


### PR DESCRIPTION
This is a simple port of the `QueueFake::assertNothingPushed` method to the `BusFake` helper class.