### PR TITLE
[8.x] Add prefrom function to helpers

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -948,14 +948,14 @@ if (! function_exists('perform')) {
             if (! is_callable($callable_true)) {
                 throw new ErrorException('perform expect a callable', 0, 1);
             }
-            
+
             return call_user_func($callable_true);
         } else {
             if (isset($callable_false)) {
                 if (! is_callable($callable_false)) {
                     throw new ErrorException('perform expect a callable', 0, 1);
                 }
-                
+
                 return call_user_func($callable_false);
             } else {
                 return false;

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -942,7 +942,7 @@ if (! function_exists('perform')) {
      * @param  callable  $callable_false
      * @return mixed
      */
-    function perform(bool $boolean, callable  $callable_true, callable $callable_false = null)
+    function perform(bool $boolean, callable $callable_true, callable $callable_false = null)
     {
         $boolean ? $callable_true() : $callable_false();
     }

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -932,3 +932,33 @@ if (! function_exists('view')) {
         return $factory->make($view, $data, $mergeData);
     }
 }
+
+if (! function_exists('perform')) {
+    /**
+     * execute the first callable if the given condition is true, if not it will execute the second callable if passed.
+     *
+     * @param  bool  $boolean
+     * @param  callable_true  $callable
+     * @param  callable_false  $callable
+     * @return mixed|ErrorException
+     */
+    function perform($boolean, $callable_true, $callable_false = null) {
+       
+        if ($boolean) {
+            if (! is_callable($callable_true)) {
+                throw new ErrorException('perform expect a callable', 0, 1);
+            }
+            return call_user_func($callable_true);
+        }else{
+            if(isset($callable_false)){
+                if (! is_callable($callable_false)) {
+                    throw new ErrorException('perform expect a callable', 0, 1);
+                }
+                return call_user_func($callable_false);
+            }else{
+                return false;
+            }
+            
+        }
+    }
+}

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -938,28 +938,12 @@ if (! function_exists('perform')) {
      * execute the first callable if the given condition is true, if not it will execute the second callable if passed.
      *
      * @param  bool  $boolean
-     * @param  callable_true  $callable
-     * @param  callable_false  $callable
-     * @return mixed|ErrorException
+     * @param  callable  $callable_true
+     * @param  callable  $callable_false
+     * @return mixed
      */
-    function perform($boolean, $callable_true, $callable_false = null)
+    function perform(bool $boolean, callable  $callable_true, callable $callable_false = null)
     {
-        if ($boolean) {
-            if (! is_callable($callable_true)) {
-                throw new ErrorException('perform expect a callable', 0, 1);
-            }
-
-            return call_user_func($callable_true);
-        } else {
-            if (isset($callable_false)) {
-                if (! is_callable($callable_false)) {
-                    throw new ErrorException('perform expect a callable', 0, 1);
-                }
-
-                return call_user_func($callable_false);
-            } else {
-                return false;
-            }
-        }
+        $boolean ? $callable_true() : $callable_false();
     }
 }

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -948,17 +948,18 @@ if (! function_exists('perform')) {
             if (! is_callable($callable_true)) {
                 throw new ErrorException('perform expect a callable', 0, 1);
             }
+            
             return call_user_func($callable_true);
         } else {
-            if(isset($callable_false)){
+            if (isset($callable_false)) {
                 if (! is_callable($callable_false)) {
                     throw new ErrorException('perform expect a callable', 0, 1);
                 }
+                
                 return call_user_func($callable_false);
             } else {
                 return false;
             }
-            
         }
     }
 }

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -942,20 +942,20 @@ if (! function_exists('perform')) {
      * @param  callable_false  $callable
      * @return mixed|ErrorException
      */
-    function perform($boolean, $callable_true, $callable_false = null) {
-       
+    function perform($boolean, $callable_true, $callable_false = null)
+    {
         if ($boolean) {
             if (! is_callable($callable_true)) {
                 throw new ErrorException('perform expect a callable', 0, 1);
             }
             return call_user_func($callable_true);
-        }else{
+        } else {
             if(isset($callable_false)){
                 if (! is_callable($callable_false)) {
                     throw new ErrorException('perform expect a callable', 0, 1);
                 }
                 return call_user_func($callable_false);
-            }else{
+            } else {
                 return false;
             }
             


### PR DESCRIPTION
This PR adds a method `perform` to the helpers, which takes a boolean and two callbacks, executes the first callback if boolean is true, or executes the second if boolean is false and the callback is passed.

examples :

```
perform(Auth::check(),updateSomething(),doSomethingElseInstead());

perform(App::environment('local'),do_buckup());
```

the perform helper will reduce the amount of if statements used on the business logic and add more clarity ;