### PR TITLE
[8.x] Remove TrustHosts reliance on config helper

### DIFF
--- a/src/Illuminate/Http/Middleware/TrustHosts.php
+++ b/src/Illuminate/Http/Middleware/TrustHosts.php
@@ -55,7 +55,7 @@ abstract class TrustHosts
      */
     protected function shouldSpecifyTrustedHosts()
     {
-        return config('app.env') !== 'local' &&
+        return ! $this->app->environment('local') &&
                ! $this->app->runningUnitTests();
     }
 


### PR DESCRIPTION
This PR removes the `TrustHosts` middleware's reliance on the `config()` helper, this achieves two things:
- Developers can now unit test their application's implementation more easily, because they can simply mock the application instance this middleware receives through it's constructor
- If a developer were to extend `Illuminate\Contracts\Foundation\Application::environment()` for some reason, the middleware would now take that into account

This change should be BC, except when `\Illuminate\Contracts\Foundation\Application::environment` has been extended. In which case the current check already didn't work and likely was overwritten at an application level anyway.
