### PR TITLE
[8.x] Artisan Testing: Add assertExecuted

### DIFF
--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -193,6 +193,18 @@ class PendingCommand
     }
 
     /**
+     * Assert that the command has executed.
+     *
+     * @return $this
+     */
+    public function assertExecuted()
+    {
+        $this->expectedExitCode = 0;
+
+        return $this;
+    }
+
+    /**
      * Execute the command.
      *
      * @return int


### PR DESCRIPTION
Add `assertExecuted` to assert that the command has been executed successfully.

Old way:
```php
$this->artisan('list')->assertExitCode(0);
```

New way:
```php
$this->artisan('list')->assertExecuted();
```