### PR TITLE
[8.x] Makes mapWithKeys available as a higher order message

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -29,6 +29,7 @@ use UnexpectedValueException;
  * @property-read HigherOrderCollectionProxy $groupBy
  * @property-read HigherOrderCollectionProxy $keyBy
  * @property-read HigherOrderCollectionProxy $map
+ * @property-read HigherOrderCollectionProxy $mapWithKeys
  * @property-read HigherOrderCollectionProxy $max
  * @property-read HigherOrderCollectionProxy $min
  * @property-read HigherOrderCollectionProxy $partition
@@ -63,6 +64,7 @@ trait EnumeratesValues
         'groupBy',
         'keyBy',
         'map',
+        'mapWithKeys',
         'max',
         'min',
         'partition',

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -4347,6 +4347,29 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testHigherOrderCollectionMapWithKeys($collection)
+    {
+        $data = new $collection([
+            new TestSupportCollectionHigherOrderItem,
+            new TestSupportCollectionHigherOrderItem('david', 'bowie')
+        ]);
+
+        // By method
+        $this->assertEquals([
+            'otwell' => 'taylor',
+            'bowie' => 'david',
+        ], $data->mapWithKeys->keyByLastName()->toArray());
+
+        // By array
+        $this->assertEquals([
+            'taylor' => 'otwell',
+            'david' => 'bowie',
+        ], $data->mapWithKeys->keyByFirstName->toArray());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testPartition($collection)
     {
         $data = new $collection(range(1, 10));
@@ -4864,10 +4887,18 @@ class SupportCollectionTest extends TestCase
 class TestSupportCollectionHigherOrderItem
 {
     public $name;
+    public $lastName;
 
-    public function __construct($name = 'taylor')
+    public $keyByFirstName;
+
+    public function __construct($name = 'taylor', $lastName = 'otwell')
     {
         $this->name = $name;
+        $this->lastName = $lastName;
+
+        $this->keyByFirstName = [
+            $this->name => $this->lastName,
+        ];
     }
 
     public function uppercase()
@@ -4878,6 +4909,13 @@ class TestSupportCollectionHigherOrderItem
     public function is($name)
     {
         return $this->name === $name;
+    }
+
+    public function keyByLastName()
+    {
+        return [
+            $this->lastName => $this->name,
+        ];
     }
 }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -4351,7 +4351,7 @@ class SupportCollectionTest extends TestCase
     {
         $data = new $collection([
             new TestSupportCollectionHigherOrderItem,
-            new TestSupportCollectionHigherOrderItem('david', 'bowie')
+            new TestSupportCollectionHigherOrderItem('david', 'bowie'),
         ]);
 
         // By method


### PR DESCRIPTION
👋 hello!

Was writing some code the other day with the assumption that `mapWithKeys` was already available as a higher order message but found that it wasn't.

So I thought it might be a useful thing to add in.