### PR TITLE
[8.x] TaggedCache flush should also remove tags from cache

### DIFF
--- a/src/Illuminate/Cache/RedisTaggedCache.php
+++ b/src/Illuminate/Cache/RedisTaggedCache.php
@@ -89,7 +89,9 @@ class RedisTaggedCache extends TaggedCache
         $this->deleteForeverKeys();
         $this->deleteStandardKeys();
 
-        return parent::flush();
+        $this->tags->flush();
+
+        return true;
     }
 
     /**

--- a/src/Illuminate/Cache/TagSet.php
+++ b/src/Illuminate/Cache/TagSet.php
@@ -57,6 +57,26 @@ class TagSet
     }
 
     /**
+     * Flush all tags in the set.
+     *
+     * @return void
+     */
+    public function flush()
+    {
+        array_walk($this->names, [$this, 'flushTag']);
+    }
+
+    /**
+     * Flush the tag from cache.
+     *
+     * @param  string  $name
+     */
+    public function resetTag($name)
+    {
+        $this->store->forget($this->tagKey($name));
+    }
+
+    /**
      * Get a unique namespace that changes when any of the tags are flushed.
      *
      * @return string

--- a/src/Illuminate/Cache/TagSet.php
+++ b/src/Illuminate/Cache/TagSet.php
@@ -71,7 +71,7 @@ class TagSet
      *
      * @param  string  $name
      */
-    public function resetTag($name)
+    public function flushTag($name)
     {
         $this->store->forget($this->tagKey($name));
     }

--- a/src/Illuminate/Cache/TaggedCache.php
+++ b/src/Illuminate/Cache/TaggedCache.php
@@ -78,7 +78,7 @@ class TaggedCache extends Repository
      */
     public function flush()
     {
-        $this->tags->reset();
+        $this->tags->flush();
 
         return true;
     }

--- a/src/Illuminate/Cache/TaggedCache.php
+++ b/src/Illuminate/Cache/TaggedCache.php
@@ -78,7 +78,7 @@ class TaggedCache extends Repository
      */
     public function flush()
     {
-        $this->tags->flush();
+        $this->tags->reset();
 
         return true;
     }

--- a/tests/Cache/CacheTaggedCacheTest.php
+++ b/tests/Cache/CacheTaggedCacheTest.php
@@ -282,9 +282,18 @@ class CacheTaggedCacheTest extends TestCase
         $conn->shouldReceive('del')->once()->with('prefix:foo:standard_ref');
         $conn->shouldReceive('del')->once()->with('prefix:bar:standard_ref');
 
-        $tagSet->shouldReceive('reset')->once();
+        $tagSet->shouldReceive('flush')->once();
 
         $redis->flush();
+    }
+
+    public function testTagFlushRemovesTag()
+    {
+        $store = new ArrayStore;
+        $tags = ['bop'];
+        $store->tags($tags)->put('foo', 'bar', 10);
+        $store->tags($tags)->flush();
+        $this->assertNull($store->get('tag:bop:key'));
     }
 
     private function getTestCacheStoreWithTagValues(): ArrayStore

--- a/tests/Cache/CacheTaggedCacheTest.php
+++ b/tests/Cache/CacheTaggedCacheTest.php
@@ -287,15 +287,6 @@ class CacheTaggedCacheTest extends TestCase
         $redis->flush();
     }
 
-    public function testTagFlushRemovesTag()
-    {
-        $store = new ArrayStore;
-        $tags = ['bop'];
-        $store->tags($tags)->put('foo', 'bar', 10);
-        $store->tags($tags)->flush();
-        $this->assertNull($store->get('tag:bop:key'));
-    }
-
     private function getTestCacheStoreWithTagValues(): ArrayStore
     {
         $store = new ArrayStore;


### PR DESCRIPTION
At the moment flushing a tagged cache removes standard keys, forever keys and the key/value pair that was actually cached, but it leaves the tag itself as it only resets it.

In our project we use [renoki-co/laravel-eloquent-query-cache](https://github.com/renoki-co/laravel-eloquent-query-cache) and with heavy cache tag usage it leads to junk keys accumulating in our redis instance to a point where we now have close to 5 million keys that will never expire:
<img width="258" alt="image" src="https://user-images.githubusercontent.com/17316322/138311740-c86839af-c0f6-4f65-be89-fd867266639a.png">

IMO, cache tags (as well as standard keys) should have an expiration time as well, but I'm able to solve that in userland by setting expiration time to them manually after caching the value. But it doesn't solve the issue when you flush a tag.

This PR solves flushing issue by deleting the tags from cache instead of resetting them. I've added a small test that you can run without TaggedCache changes and see that the tag key actually persists after flush.