### PR TITLE
[8.x] Only select related columns by default in CanBeOneOfMany::ofMany

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/CanBeOneOfMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/CanBeOneOfMany.php
@@ -125,6 +125,7 @@ trait CanBeOneOfMany
         $this->addConstraints();
 
         $columns = $this->query->getQuery()->columns;
+
         if (is_null($columns) || $columns === ['*']) {
             $this->select([$this->qualifyColumn('*')]);
         }

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/CanBeOneOfMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/CanBeOneOfMany.php
@@ -124,6 +124,11 @@ trait CanBeOneOfMany
 
         $this->addConstraints();
 
+        $columns = $this->query->getQuery()->columns;
+        if (is_null($columns) || $columns === ['*']) {
+            $this->select([$this->qualifyColumn('*')]);
+        }
+
         return $this;
     }
 


### PR DESCRIPTION
#39187 introduced an issue with selected columns of related :

```php
dump($user->latestLogin->getAttributes());

/*
array:4 [
  "id" => "2"
  "user_id" => "1"
  "deleted_at" => null
  "id_aggregate" => "2"
]
*/
```
The `id_aggregate` column should not be selected and can cause issues. 

The problem comes from the sql query : 
```sql
select * 
from "logins" 
inner join (
    select MAX("id") as "id_aggregate", "logins"."user_id" 
    from "logins" 
    --- more sql
) as "latestOfMany"
on "latestOfMany"."id_aggregate" = "logins"."id" 
--- more sql
```

As the query selects `*`, `id_aggregate` is also selected.

Forcing the query to select `"logins".*` solves the problem.

```sql
select "logins".* 
from "logins" 
inner join (
    select MAX("id") as "id_aggregate", "logins"."user_id" 
    from "logins" 
    --- more sql
) as "latestOfMany"
on "latestOfMany"."id_aggregate" = "logins"."id" 
--- more sql
```

```php
dump($user->latestLogin->getAttributes());

/*
array:3 [
  "id" => "2"
  "user_id" => "1"
  "deleted_at" => null
]
*/
```

