### PR TITLE
[6.x] Add support for MariaDB to skip locked rows with the database queue driver

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -31,7 +31,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      *
      * @var string
      */
-    const VERSION = '6.20.35';
+    const VERSION = '6.20.36';
 
     /**
      * The base path for the Laravel installation.

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Connection;
 use Illuminate\Queue\Jobs\DatabaseJob;
 use Illuminate\Queue\Jobs\DatabaseJobRecord;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
 use PDO;
 
 class DatabaseQueue extends Queue implements QueueContract
@@ -234,7 +235,8 @@ class DatabaseQueue extends Queue implements QueueContract
         $databaseEngine = $this->database->getPdo()->getAttribute(PDO::ATTR_DRIVER_NAME);
         $databaseVersion = $this->database->getPdo()->getAttribute(PDO::ATTR_SERVER_VERSION);
 
-        if ($databaseEngine == 'mysql' && ! strpos($databaseVersion, 'MariaDB') && version_compare($databaseVersion, '8.0.1', '>=') ||
+        if ($databaseEngine == 'mysql' && version_compare($databaseVersion, '8.0.1', '>=') ||
+            strpos($databaseVersion, 'MariaDB') && version_compare(Str::after($databaseVersion, '-'), '10.6.0', '>=') ||
             $databaseEngine == 'pgsql' && version_compare($databaseVersion, '9.5', '>=')) {
             return 'FOR UPDATE SKIP LOCKED';
         }


### PR DESCRIPTION
As documented in https://mariadb.com/kb/en/select/#skip-locked since MariaDB 10.6 there is support for skipping locked rows when fetching from the database.

This change adds support to it.

Addresses comment within commit https://github.com/laravel/framework/commit/fff96e7df7de470e162a6b7f6dd528e6fe17aadc

Thank you

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
