### PR TITLE
[8.x] Extend Response::object() method's return typehint with null in docblock

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -504,11 +504,11 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Concatenate values of a given key as a string.
      *
-     * @param  string  $value
+     * @param  string|null  $value
      * @param  string|null  $glue
      * @return string
      */
-    public function implode($value, $glue = null)
+    public function implode($value = null, $glue = null)
     {
         $first = $this->first();
 

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -515,11 +515,11 @@ class LazyCollection implements Enumerable
     /**
      * Concatenate values of a given key as a string.
      *
-     * @param  string  $value
+     * @param  string|null  $value
      * @param  string|null  $glue
      * @return string
      */
-    public function implode($value, $glue = null)
+    public function implode($value = null, $glue = null)
     {
         return $this->collect()->implode(...func_get_args());
     }

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -71,7 +71,7 @@ class Response implements ArrayAccess
     /**
      * Get the JSON decoded body of the response as an object.
      *
-     * @return object
+     * @return object|null
      */
     public function object()
     {

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2088,6 +2088,7 @@ class SupportCollectionTest extends TestCase
         $this->assertSame('foo,bar', $data->implode('email', ','));
 
         $data = new $collection(['taylor', 'dayle']);
+        $this->assertSame('taylordayle', $data->implode());
         $this->assertSame('taylordayle', $data->implode(''));
         $this->assertSame('taylor,dayle', $data->implode(','));
 
@@ -2095,10 +2096,12 @@ class SupportCollectionTest extends TestCase
             ['name' => Str::of('taylor'), 'email' => Str::of('foo')],
             ['name' => Str::of('dayle'), 'email' => Str::of('bar')],
         ]);
+
         $this->assertSame('foobar', $data->implode('email'));
         $this->assertSame('foo,bar', $data->implode('email', ','));
 
         $data = new $collection([Str::of('taylor'), Str::of('dayle')]);
+        $this->assertSame('taylordayle', $data->implode());
         $this->assertSame('taylordayle', $data->implode(''));
         $this->assertSame('taylor,dayle', $data->implode(','));
     }


### PR DESCRIPTION
As the `json_decode()` method can return null, I think the `\Illuminate\Http\Client\Response::object()` method's return type alse should be `object|null`.

```
public function getContent(?Response $response = null): object
    {
        if (!$response || !$response->object()) {
            //...;
        }

        return $response->object();
    }
```

Currently phpstan throws a warning with the following error: `Negated boolean expression is always false.` because the dockblock only typehints object.
