### PR TITLE
[8.x] Guess database factory model by default

### DIFF
--- a/src/Illuminate/Database/Console/Factories/stubs/factory.stub
+++ b/src/Illuminate/Database/Console/Factories/stubs/factory.stub
@@ -3,17 +3,9 @@
 namespace {{ factoryNamespace }};
 
 use Illuminate\Database\Eloquent\Factories\Factory;
-use {{ namespacedModel }};
 
 class {{ factory }}Factory extends Factory
 {
-    /**
-     * The name of the factory's corresponding model.
-     *
-     * @var string
-     */
-    protected $model = {{ model }}::class;
-
     /**
      * Define the model's default state.
      *

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -24,7 +24,7 @@ abstract class Factory
     /**
      * The name of the factory's corresponding model.
      *
-     * @var string
+     * @var string|null
      */
     protected $model;
 


### PR DESCRIPTION
At this time, database factories have this hidden feature where database models can be "guessed". As example, the following code just works:

```php
class User extends Model
{
    use HasFactory;
}

class UserFactory extends Factory
{
    public function definition()
    {
        return [
            // ..
        ];
    }
}

User::factory()->create(); // Guesses UserFactory
UserFactory::new()->create(); // Guesses User
```

So, this pull request proposes that remove `protected $model` from the Factory `stub`, as probably the current "guess" logic works for `99.99%` of the people. In addition, I've also pull requested to the skeleton that we remove `protected $model = User::class` from the `UserFactory.php`: https://github.com/laravel/laravel/pull/5713.