### PR TITLE
[8.x] Add support for MariaDB to skip locked rows with the database queue driver

### DIFF
--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Connection;
 use Illuminate\Queue\Jobs\DatabaseJob;
 use Illuminate\Queue\Jobs\DatabaseJobRecord;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
 use PDO;
 
 class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
@@ -253,7 +254,8 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
         $databaseEngine = $this->database->getPdo()->getAttribute(PDO::ATTR_DRIVER_NAME);
         $databaseVersion = $this->database->getConfig('version') ?? $this->database->getPdo()->getAttribute(PDO::ATTR_SERVER_VERSION);
 
-        if ($databaseEngine === 'mysql' && ! strpos($databaseVersion, 'MariaDB') && version_compare($databaseVersion, '8.0.1', '>=') ||
+        if ($databaseEngine === 'mysql' && version_compare($databaseVersion, '8.0.1', '>=') ||
+            strpos($databaseVersion, 'MariaDB') && version_compare(Str::after($databaseVersion, '-'), '10.6.0', '>=') ||
             $databaseEngine === 'pgsql' && version_compare($databaseVersion, '9.5', '>=')) {
             return 'FOR UPDATE SKIP LOCKED';
         }

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -252,11 +252,13 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
     protected function getLockForPopping()
     {
         $databaseEngine = $this->database->getPdo()->getAttribute(PDO::ATTR_DRIVER_NAME);
-        $databaseVersion = $this->database->getConfig('version') ?? $this->database->getPdo()->getAttribute(PDO::ATTR_SERVER_VERSION);
 
-        if ($databaseEngine === 'mysql' && version_compare($databaseVersion, '8.0.1', '>=') ||
-            strpos($databaseVersion, 'MariaDB') && version_compare(Str::after($databaseVersion, '-'), '10.6.0', '>=') ||
-            $databaseEngine === 'pgsql' && version_compare($databaseVersion, '9.5', '>=')) {
+        $databaseVersion = $this->database->getConfig('version') ?? 
+                           $this->database->getPdo()->getAttribute(PDO::ATTR_SERVER_VERSION);
+
+        if (($databaseEngine === 'mysql' && version_compare($databaseVersion, '8.0.1', '>=')) ||
+            (strpos($databaseVersion, 'MariaDB') && version_compare(Str::after($databaseVersion, '-'), '10.6.0', '>=')) ||
+            ($databaseEngine === 'pgsql' && version_compare($databaseVersion, '9.5', '>='))) {
             return 'FOR UPDATE SKIP LOCKED';
         }
 


### PR DESCRIPTION
As documented in https://mariadb.com/kb/en/select/#skip-locked since MariaDB 10.6 there is support for skipping locked rows when fetching from the database.

This change adds support to it.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
