### PR TITLE
[8.x] Add ThrottleRequestsWithRedis to $middlewarePriority

### DIFF
--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -76,6 +76,7 @@ class Kernel implements KernelContract
         \Illuminate\View\Middleware\ShareErrorsFromSession::class,
         \Illuminate\Contracts\Auth\Middleware\AuthenticatesRequests::class,
         \Illuminate\Routing\Middleware\ThrottleRequests::class,
+        \Illuminate\Routing\Middleware\ThrottleRequestsWithRedis::class,
         \Illuminate\Session\Middleware\AuthenticateSession::class,
         \Illuminate\Routing\Middleware\SubstituteBindings::class,
         \Illuminate\Auth\Middleware\Authorize::class,

--- a/tests/Foundation/Http/KernelTest.php
+++ b/tests/Foundation/Http/KernelTest.php
@@ -34,6 +34,7 @@ class KernelTest extends TestCase
             \Illuminate\View\Middleware\ShareErrorsFromSession::class,
             \Illuminate\Contracts\Auth\Middleware\AuthenticatesRequests::class,
             \Illuminate\Routing\Middleware\ThrottleRequests::class,
+            \Illuminate\Routing\Middleware\ThrottleRequestsWithRedis::class,
             \Illuminate\Session\Middleware\AuthenticateSession::class,
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
             \Illuminate\Auth\Middleware\Authorize::class,


### PR DESCRIPTION
[Laravel has a property](https://laravel.com/docs/8.x/urls#url-defaults-middleware-priority) where we can configure middleware ordering. By default, it sets up a priority for the [ThrottleRequests](https://github.com/laravel/framework/blob/65d12ca73ef0b184d89de74566af5a8f1daf75d4/src/Illuminate/Foundation/Http/Kernel.php#L78) middleware but that variable doesn't set up any default priority for the sibling [ThrottleRequestsWithRedis](https://laravel.com/docs/8.x/routing#throttling-with-redis) middleware.

What means when somebody is switching to [use Redis for throttling](https://laravel.com/docs/8.x/routing#throttling-with-redis), it kind of deletes the ordering of the `throttle` middleware as there's no default priority set up for the [ThrottleRequestsWithRedis](https://laravel.com/docs/8.x/routing#throttling-with-redis) middleware.

This PR adds that middleware to the default middleware priority property to make sure the "throttle" middleware does not go away after switching throttling to Redis.

As an alternative solution, we can create an interface for these two middleware as [Laravel can order by interface](https://github.com/laravel/framework/blob/8.x/src/Illuminate/Routing/SortedMiddleware.php#L97) as well.

---

Also, pretty sure there's some projects that have [defaulted $middlewarePriority](https://laravel.com/docs/8.x/urls#url-defaults-middleware-priority) and switched to **ThrottleRequestsWithRedis** but have not noticed/reflected this switch in their default $middlewarePriority.

And if this PR gets merged, should we also update this documentation block? https://laravel.com/docs/8.x/middleware#sorting-middleware