### PR TITLE
[9.x] Auto close pull requests on illuminate repositories

### DIFF
--- a/src/Illuminate/Auth/.github/workflows/close-pull-request.yml
+++ b/src/Illuminate/Auth/.github/workflows/close-pull-request.yml
@@ -1,0 +1,13 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: "Heya,<br><br>Thanks for your PR. You've submitted this on the Illuminate organization which is a read-only sub split of `laravel/framework`. Please submit your PR on the https://github.com/laravel/framework repository.<br><br>Thanks!"

--- a/src/Illuminate/Auth/.github/workflows/close-pull-request.yml
+++ b/src/Illuminate/Auth/.github/workflows/close-pull-request.yml
@@ -10,4 +10,4 @@ jobs:
     steps:
     - uses: superbrothers/close-pull-request@v3
       with:
-        comment: "Heya,<br><br>Thanks for your PR. You've submitted this on the Illuminate organization which is a read-only sub split of `laravel/framework`. Please submit your PR on the https://github.com/laravel/framework repository.<br><br>Thanks!"
+        comment: "Thank you for your pull request. However, you have submitted this PR on the Illuminate organization which is a read-only sub split of `laravel/framework`. Please submit your PR on the https://github.com/laravel/framework repository.<br><br>Thanks!"


### PR DESCRIPTION
This PR will allow GitHub Actions to automatically close PR's for illuminate repositories. This saves us from having to keep an eye on these repositories for additional PR's. 

The reason why I sent this in to master and not 8.x is because the base branch on all Illuminate repositories is master.

This first PR is a test to see if everything works properly. After I've manually tried it out on the auth component I'll roll this out for the other components as well.
