### PR TITLE
[8.x] Fix model serialization on anonymous components

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -4,12 +4,12 @@ namespace Illuminate\Support;
 
 use ArrayAccess;
 use ArrayIterator;
-use Illuminate\Contracts\Support\CanBeEscapedWhenConvertedToString;
+use Illuminate\Contracts\Support\CanBeEscapedWhenCastToString;
 use Illuminate\Support\Traits\EnumeratesValues;
 use Illuminate\Support\Traits\Macroable;
 use stdClass;
 
-class Collection implements ArrayAccess, CanBeEscapedWhenConvertedToString, Enumerable
+class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerable
 {
     use EnumeratesValues, Macroable;
 

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -4,11 +4,12 @@ namespace Illuminate\Support;
 
 use ArrayAccess;
 use ArrayIterator;
+use Illuminate\Contracts\Support\CanBeEscapedWhenConvertedToString;
 use Illuminate\Support\Traits\EnumeratesValues;
 use Illuminate\Support\Traits\Macroable;
 use stdClass;
 
-class Collection implements ArrayAccess, Enumerable
+class Collection implements ArrayAccess, CanBeEscapedWhenConvertedToString, Enumerable
 {
     use EnumeratesValues, Macroable;
 

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -5,12 +5,13 @@ namespace Illuminate\Support;
 use ArrayIterator;
 use Closure;
 use DateTimeInterface;
+use Illuminate\Contracts\Support\CanBeEscapedWhenConvertedToString;
 use Illuminate\Support\Traits\EnumeratesValues;
 use Illuminate\Support\Traits\Macroable;
 use IteratorAggregate;
 use stdClass;
 
-class LazyCollection implements Enumerable
+class LazyCollection implements CanBeEscapedWhenConvertedToString, Enumerable
 {
     use EnumeratesValues, Macroable;
 

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -5,13 +5,13 @@ namespace Illuminate\Support;
 use ArrayIterator;
 use Closure;
 use DateTimeInterface;
-use Illuminate\Contracts\Support\CanBeEscapedWhenConvertedToString;
+use Illuminate\Contracts\Support\CanBeEscapedWhenCastToString;
 use Illuminate\Support\Traits\EnumeratesValues;
 use Illuminate\Support\Traits\Macroable;
 use IteratorAggregate;
 use stdClass;
 
-class LazyCollection implements CanBeEscapedWhenConvertedToString, Enumerable
+class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
 {
     use EnumeratesValues, Macroable;
 

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -47,6 +47,13 @@ use UnexpectedValueException;
 trait EnumeratesValues
 {
     /**
+     * Indicates that the object's string representation should be escaped when __toString is invoked.
+     *
+     * @var bool
+     */
+    protected $escapeWhenConvertingToString = false;
+
+    /**
      * The methods that can be proxied.
      *
      * @var string[]
@@ -900,7 +907,22 @@ trait EnumeratesValues
      */
     public function __toString()
     {
-        return $this->toJson();
+        return $this->escapeWhenConvertingToString
+                    ? e($this->toJson())
+                    : $this->toJson();
+    }
+
+    /**
+     * Indicate that the model's string representation should be escaped when __toString is invoked.
+     *
+     * @param  bool  $escape
+     * @return $this
+     */
+    public function escapeWhenConvertingToString($escape = true)
+    {
+        $this->escapeWhenConvertingToString = $escape;
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -51,7 +51,7 @@ trait EnumeratesValues
      *
      * @var bool
      */
-    protected $escapeWhenConvertingToString = false;
+    protected $escapeWhenCastingToString = false;
 
     /**
      * The methods that can be proxied.
@@ -907,7 +907,7 @@ trait EnumeratesValues
      */
     public function __toString()
     {
-        return $this->escapeWhenConvertingToString
+        return $this->escapeWhenCastingToString
                     ? e($this->toJson())
                     : $this->toJson();
     }
@@ -918,9 +918,9 @@ trait EnumeratesValues
      * @param  bool  $escape
      * @return $this
      */
-    public function escapeWhenConvertingToString($escape = true)
+    public function escapeWhenCastingToString($escape = true)
     {
-        $this->escapeWhenConvertingToString = $escape;
+        $this->escapeWhenCastingToString = $escape;
 
         return $this;
     }

--- a/src/Illuminate/Contracts/Support/CanBeEscapedWhenCastToString.php
+++ b/src/Illuminate/Contracts/Support/CanBeEscapedWhenCastToString.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Contracts\Support;
 
-interface CanBeEscapedWhenConvertedToString
+interface CanBeEscapedWhenCastToString
 {
     /**
      * Indicate that the object's string representation should be escaped when __toString is invoked.
@@ -10,5 +10,5 @@ interface CanBeEscapedWhenConvertedToString
      * @param  bool  $escape
      * @return $this
      */
-    public function escapeWhenConvertingToString($escape = true);
+    public function escapeWhenCastingToString($escape = true);
 }

--- a/src/Illuminate/Contracts/Support/CanBeEscapedWhenConvertedToString.php
+++ b/src/Illuminate/Contracts/Support/CanBeEscapedWhenConvertedToString.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Illuminate\Contracts\Support;
+
+interface CanBeEscapedWhenConvertedToString
+{
+    /**
+     * Indicate that the object's string representation should be escaped when __toString is invoked.
+     *
+     * @param  bool  $escape
+     * @return $this
+     */
+    public function escapeWhenConvertingToString($escape = true);
+}

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Queue\QueueableCollection;
 use Illuminate\Contracts\Queue\QueueableEntity;
 use Illuminate\Contracts\Routing\UrlRoutable;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\CanBeEscapedWhenConvertedToString;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
@@ -22,7 +23,7 @@ use Illuminate\Support\Traits\ForwardsCalls;
 use JsonSerializable;
 use LogicException;
 
-abstract class Model implements Arrayable, ArrayAccess, HasBroadcastChannel, Jsonable, JsonSerializable, QueueableEntity, UrlRoutable
+abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenConvertedToString, HasBroadcastChannel, Jsonable, JsonSerializable, QueueableEntity, UrlRoutable
 {
     use Concerns\HasAttributes,
         Concerns\HasEvents,
@@ -109,6 +110,13 @@ abstract class Model implements Arrayable, ArrayAccess, HasBroadcastChannel, Jso
      * @var bool
      */
     public $wasRecentlyCreated = false;
+
+    /**
+     * Indicates that the object's string representation should be escaped when __toString is invoked.
+     *
+     * @var bool
+     */
+    protected $escapeWhenConvertingToString = false;
 
     /**
      * The connection resolver instance.
@@ -2128,7 +2136,22 @@ abstract class Model implements Arrayable, ArrayAccess, HasBroadcastChannel, Jso
      */
     public function __toString()
     {
-        return $this->toJson();
+        return $this->escapeWhenConvertingToString
+                    ? e($this->toJson())
+                    : $this->toJson();
+    }
+
+    /**
+     * Indicate that the object's string representation should be escaped when __toString is invoked.
+     *
+     * @param  bool  $escape
+     * @return $this
+     */
+    public function escapeWhenConvertingToString($escape = true)
+    {
+        $this->escapeWhenConvertingToString = $escape;
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -8,7 +8,7 @@ use Illuminate\Contracts\Queue\QueueableCollection;
 use Illuminate\Contracts\Queue\QueueableEntity;
 use Illuminate\Contracts\Routing\UrlRoutable;
 use Illuminate\Contracts\Support\Arrayable;
-use Illuminate\Contracts\Support\CanBeEscapedWhenConvertedToString;
+use Illuminate\Contracts\Support\CanBeEscapedWhenCastToString;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
@@ -23,7 +23,7 @@ use Illuminate\Support\Traits\ForwardsCalls;
 use JsonSerializable;
 use LogicException;
 
-abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenConvertedToString, HasBroadcastChannel, Jsonable, JsonSerializable, QueueableEntity, UrlRoutable
+abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToString, HasBroadcastChannel, Jsonable, JsonSerializable, QueueableEntity, UrlRoutable
 {
     use Concerns\HasAttributes,
         Concerns\HasEvents,
@@ -116,7 +116,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenConverte
      *
      * @var bool
      */
-    protected $escapeWhenConvertingToString = false;
+    protected $escapeWhenCastingToString = false;
 
     /**
      * The connection resolver instance.
@@ -2136,7 +2136,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenConverte
      */
     public function __toString()
     {
-        return $this->escapeWhenConvertingToString
+        return $this->escapeWhenCastingToString
                     ? e($this->toJson())
                     : $this->toJson();
     }
@@ -2147,9 +2147,9 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenConverte
      * @param  bool  $escape
      * @return $this
      */
-    public function escapeWhenConvertingToString($escape = true)
+    public function escapeWhenCastingToString($escape = true)
     {
-        $this->escapeWhenConvertingToString = $escape;
+        $this->escapeWhenCastingToString = $escape;
 
         return $this;
     }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\View\Compilers\Concerns;
 
+use Illuminate\Contracts\Support\CanBeEscapedWhenConvertedToString;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
 use Illuminate\View\ComponentAttributeBag;
 
@@ -183,6 +185,10 @@ trait CompilesComponents
      */
     public static function sanitizeComponentAttribute($value)
     {
+        if (is_object($value) && $value instanceof CanBeEscapedWhenConvertedToString) {
+            return $value->escapeWhenConvertingToString(true);
+        }
+
         return is_string($value) ||
                (is_object($value) && ! $value instanceof ComponentAttributeBag && method_exists($value, '__toString'))
                         ? e($value)

--- a/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\View\Compilers\Concerns;
 
-use Illuminate\Contracts\Support\CanBeEscapedWhenConvertedToString;
+use Illuminate\Contracts\Support\CanBeEscapedWhenCastToString;
 use Illuminate\Support\Str;
 use Illuminate\View\ComponentAttributeBag;
 
@@ -184,8 +184,8 @@ trait CompilesComponents
      */
     public static function sanitizeComponentAttribute($value)
     {
-        if (is_object($value) && $value instanceof CanBeEscapedWhenConvertedToString) {
-            return $value->escapeWhenConvertingToString();
+        if (is_object($value) && $value instanceof CanBeEscapedWhenCastToString) {
+            return $value->escapeWhenCastingToString();
         }
 
         return is_string($value) ||

--- a/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
@@ -185,7 +185,7 @@ trait CompilesComponents
     public static function sanitizeComponentAttribute($value)
     {
         if (is_object($value) && $value instanceof CanBeEscapedWhenConvertedToString) {
-            return $value->escapeWhenConvertingToString(true);
+            return $value->escapeWhenConvertingToString();
         }
 
         return is_string($value) ||

--- a/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
@@ -3,7 +3,6 @@
 namespace Illuminate\View\Compilers\Concerns;
 
 use Illuminate\Contracts\Support\CanBeEscapedWhenConvertedToString;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
 use Illuminate\View\ComponentAttributeBag;
 

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\View\Blade;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\View\Factory;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\View\Compilers\BladeCompiler;
 use Illuminate\View\Compilers\ComponentTagCompiler;
 use Illuminate\View\Component;
@@ -291,10 +292,13 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
             }
         };
 
+        $model = new class extends Model {};
+
         $this->assertEquals(e('<hi>'), BladeCompiler::sanitizeComponentAttribute('<hi>'));
         $this->assertEquals(e('1'), BladeCompiler::sanitizeComponentAttribute('1'));
         $this->assertEquals(1, BladeCompiler::sanitizeComponentAttribute(1));
         $this->assertEquals(e('<hi>'), BladeCompiler::sanitizeComponentAttribute($class));
+        $this->assertSame($model, BladeCompiler::sanitizeComponentAttribute($model));
     }
 
     public function testItThrowsAnExceptionForNonExistingAliases()


### PR DESCRIPTION
Fixes #39232

When rendering anonymous components, we do not know which attributes passed to the components are going to be used as "props" (not sanitized) vs. "attributes" (sanitized since they are likely going to be rendered into the DOM directly). With class based components we do not have this issue since we can determine which attributes are actually props by looking at the properties on the class.

Therefore, when using anonymous components, we pass every attribute as both a prop and an attribute and then the `@props` directive removes the specified props from the `$attributes` bag. However, in the process of passing everything as attributes, every object with a `__toString` method gets escaped - I guess because we assumed they would be rendered in the DOM?

Anyways, that is pretty undesirable in the case of Eloquent models and collections especially because the serialization process could be resource intensive if it loads additional relationships.

In order to try to solve this in a way that is as backwards-compatible as possible (in case people really are putting JSON serialized models into the DOM, I introduced a new `CanBeEscapedWhenConvertedToString` interface which models and collections can use. 

When the Blade attribute sanitization method encounters an object of this type, we will invoke the method defined by the contract which states that when this object is converted to a string it should be escaped. Therefore, if people really do try to render this object as a string it will still be escaped.

--------------

Would appreciate any feedback on this if anyone has a better idea or sees any downfalls with this approach.