### PR TITLE
[9.x] Fixes `Collection::unique` types

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1468,9 +1468,9 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Return only unique items from the collection array.
      *
-     * @param  string|callable|null  $key
+     * @param  (callable(TValue, TKey): bool)|string|null  $key
      * @param  bool  $strict
-     * @return static
+     * @return static<TKey, TValue>
      */
     public function unique($key = null, $strict = false)
     {


### PR DESCRIPTION
This pull request fixes the "types" GitHub build, that was failing because of an untyped new method on the Collection class.