### PR TITLE
[8.x] Add user agent method in Http module

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -46,6 +46,16 @@ trait InteractsWithInput
     }
 
     /**
+     * Returns the client User-Agent.
+     *
+     * @return string|null
+     */
+    public function getUserAgent()
+    {
+        return $this->header('User-Agent');
+    }
+
+    /**
      * Get the bearer token from the request headers.
      *
      * @return string|null


### PR DESCRIPTION
It is strange that Http doesn't provide a method for getting the `User-Agent` from requests.