### PR TITLE
[8.x] Fix `AssertableJson->whereContains()` to handle Closures correctly

### DIFF
--- a/src/Illuminate/Testing/Fluent/Concerns/Matching.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Matching.php
@@ -130,7 +130,7 @@ trait Matching
             if (! is_string($condition) && is_callable($condition)) {
                 $unsatisfiedClosures[] = $idx;
             } else {
-                $missingValues[] = (string)$condition;
+                $missingValues[] = (string) $condition;
             }
         }
 

--- a/src/Illuminate/Testing/Fluent/Concerns/Matching.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Matching.php
@@ -107,7 +107,7 @@ trait Matching
      * Asserts that the property contains the expected values.
      *
      * @param  string  $key
-     * @param  array|string|Closure  $expected
+     * @param  array|Closure|mixed  $expected
      * @return $this
      */
     public function whereContains(string $key, $expected)

--- a/tests/Testing/Fluent/AssertTest.php
+++ b/tests/Testing/Fluent/AssertTest.php
@@ -459,7 +459,9 @@ class AssertTest extends TestCase
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Property [foo] does not contain a value that satisfies closures at [0].');
 
-        $assert->whereContains('foo', [function ($actual) { return $actual === 5; }]);
+        $assert->whereContains('foo', [function ($actual) {
+            return $actual === 5;
+        }]);
     }
 
     public function testAssertWhereContainsFailsWhenHavingExpectedValueButDoesNotSatisfyClosure()
@@ -471,7 +473,9 @@ class AssertTest extends TestCase
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Property [foo] does not contain a value that satisfies closures at [1].');
 
-        $assert->whereContains('foo', [1, function ($actual) { return $actual === 5; }]);
+        $assert->whereContains('foo', [1, function ($actual) {
+            return $actual === 5;
+        }]);
     }
 
     public function testAssertWhereContainsFailsWhenSatisfiesClosureButDoesNotHaveExpectedValue()
@@ -483,7 +487,9 @@ class AssertTest extends TestCase
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Property [foo] does not contain [5].');
 
-        $assert->whereContains('foo', [5, function ($actual) { return $actual === 1; }]);
+        $assert->whereContains('foo', [5, function ($actual) {
+            return $actual === 1;
+        }]);
     }
 
     public function testAssertWhereContainsWithNestedValue()
@@ -546,7 +552,9 @@ class AssertTest extends TestCase
             'foo' => [1, 2, 3, 4],
         ]);
 
-        $assert->whereContains('foo', function ($actual) { return $actual % 3 === 0; });
+        $assert->whereContains('foo', function ($actual) {
+            return $actual % 3 === 0;
+        });
     }
 
     public function testAssertWhereContainsWithNestedClosure()
@@ -557,7 +565,9 @@ class AssertTest extends TestCase
             'baz' => 3,
         ]);
 
-        $assert->whereContains('baz', function ($actual) { return $actual % 3 === 0; });
+        $assert->whereContains('baz', function ($actual) {
+            return $actual % 3 === 0;
+        });
     }
 
     public function testAssertWhereContainsWithMultipleClosure()
@@ -567,8 +577,12 @@ class AssertTest extends TestCase
         ]);
 
         $assert->whereContains('foo', [
-            function ($actual) { return $actual % 3 === 0; },
-            function ($actual) { return $actual % 2 === 0; },
+            function ($actual) {
+                return $actual % 3 === 0;
+            },
+            function ($actual) {
+                return $actual % 2 === 0;
+            },
         ]);
     }
 

--- a/tests/Testing/Fluent/AssertTest.php
+++ b/tests/Testing/Fluent/AssertTest.php
@@ -450,6 +450,42 @@ class AssertTest extends TestCase
         $assert->whereContains('foo', ['1']);
     }
 
+    public function testAssertWhereContainsFailsWhenDoesNotSatisfyClosure()
+    {
+        $assert = AssertableJson::fromArray([
+            'foo' => [1, 2, 3, 4],
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Property [foo] does not contain a value that satisfies closures at [0].');
+
+        $assert->whereContains('foo', [function ($actual) { return $actual === 5; }]);
+    }
+
+    public function testAssertWhereContainsFailsWhenHavingExpectedValueButDoesNotSatisfyClosure()
+    {
+        $assert = AssertableJson::fromArray([
+            'foo' => [1, 2, 3, 4],
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Property [foo] does not contain a value that satisfies closures at [1].');
+
+        $assert->whereContains('foo', [1, function ($actual) { return $actual === 5; }]);
+    }
+
+    public function testAssertWhereContainsFailsWhenSatisfiesClosureButDoesNotHaveExpectedValue()
+    {
+        $assert = AssertableJson::fromArray([
+            'foo' => [1, 2, 3, 4],
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Property [foo] does not contain [5].');
+
+        $assert->whereContains('foo', [5, function ($actual) { return $actual === 1; }]);
+    }
+
     public function testAssertWhereContainsWithNestedValue()
     {
         $assert = AssertableJson::fromArray([
@@ -502,6 +538,38 @@ class AssertTest extends TestCase
         ]);
 
         $assert->whereContains('baz', 4);
+    }
+
+    public function testAssertWhereContainsWithClosure()
+    {
+        $assert = AssertableJson::fromArray([
+            'foo' => [1, 2, 3, 4],
+        ]);
+
+        $assert->whereContains('foo', function ($actual) { return $actual % 3 === 0; });
+    }
+
+    public function testAssertWhereContainsWithNestedClosure()
+    {
+        $assert = AssertableJson::fromArray([
+            'foo' => 1,
+            'bar' => 2,
+            'baz' => 3,
+        ]);
+
+        $assert->whereContains('baz', function ($actual) { return $actual % 3 === 0; });
+    }
+
+    public function testAssertWhereContainsWithMultipleClosure()
+    {
+        $assert = AssertableJson::fromArray([
+            'foo' => [1, 2, 3, 4],
+        ]);
+
+        $assert->whereContains('foo', [
+            function ($actual) { return $actual % 3 === 0; },
+            function ($actual) { return $actual % 2 === 0; },
+        ]);
     }
 
     public function testAssertWhereContainsWithNullExpectation()


### PR DESCRIPTION
# TL;DR
Fixed type annotation & error formatting on `AssertableJson->whereContains()` to handle closures correctly

# Details
The `Collection->containsStrict()` called under the hood inside `AssertableJson->whereContains()` accepts closures, and currently if you write a code like this:
```
$assert = AssertableJson::fromArray([
    'bar' => [0, 1, 2]
]);

$assert->whereContains('bar', [function ($actual) { return $actual == 0; }]);
```
It works.

But when the closure fails, the `sprintf()` call fails when trying to convert Closure into string to display an assertion error.
```
$assert = AssertableJson::fromArray([
    'bar' => [0, 1, 2]
]);

// "Error: Object of class Closure could not be converted to string" <- Hard to comprehend
$assert->whereContains('bar', [function ($actual) { return $actual == -1; }]);
```
With this PR, you can fluently use closures to assert arrays containing something with nice error message.
```
$assert = AssertableJson::fromArray([
    'bar' => [0, 1, 2]
]);

// Property [%s] does not contain a value that satisfies closures at [0, 1].
$assert->whereContains('bar', [
  function ($actual) { return $actual == -1; },
  function ($actual) { return $actual < 0; },
]);
```

You can mix raw expectation values with Closures too
```
$assert = AssertableJson::fromArray([
    'bar' => [0, 1, 2]
]);

// Property [%s] does not contain a value that satisfies closures at [0].
$assert->whereContains('bar', [0, function ($actual) { return $actual == -1; }]);
```

I also fixed the type annotation for $expected in order to make passing a raw closure as the second argument valid as it is inside the function.