### PR TITLE
[8.x] Fix Eloquent builder type hints

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -587,7 +587,7 @@ class Builder
      * Execute the query as a "select" statement.
      *
      * @param  array|string  $columns
-     * @return \Illuminate\Database\Eloquent\Collection|static[]
+     * @return \Illuminate\Database\Eloquent\Collection
      */
     public function get($columns = ['*'])
     {


### PR DESCRIPTION
1. The `static[]` return type is just a lie. The method always returns a `Collection`. I understand that it was added there to get type hinting when iterating over the collection, but it's not the best way to achieve this. The proper way is to make the `Collection` a generic via PHPDocs.
2. The `static[]` return type ruins static analysis when you try to return the result of `$builder->get()` from a function with a `Collection` return type.
3. The `static[]` return type ruins static analysis when you try to pass the result of `$builder->get()` as a function parameter with the `Collection` type.
