### PR TITLE
[8.x] Add `extend` method to Hash facade doc block

### DIFF
--- a/src/Illuminate/Support/Facades/Hash.php
+++ b/src/Illuminate/Support/Facades/Hash.php
@@ -7,6 +7,7 @@ namespace Illuminate\Support\Facades;
  * @method static bool check(string $value, string $hashedValue, array $options = [])
  * @method static bool needsRehash(string $hashedValue, array $options = [])
  * @method static string make(string $value, array $options = [])
+ * @method static \Illuminate\Hashing\HashManager extend($driver, \Closure $callback)
  *
  * @see \Illuminate\Hashing\HashManager
  */


### PR DESCRIPTION
This PR adds the `extend` method to `Illuminate\Support\Facades\Hash` class, in order to provide IDE auto completion when registering custom drivers.
