### PR TITLE
Ability to modify relation query

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -466,6 +466,19 @@ abstract class Relation
     }
 
     /**
+     * Ability to modify relation query
+     *
+     * @param $callback
+     * @return $this
+     */
+    public function modifyQuery($callback)
+    {
+        $callback($this->query);
+
+        return $this;
+    }
+
+    /**
      * Handle dynamic method calls to the relationship.
      *
      * @param  string  $method


### PR DESCRIPTION
Adds the ability to modify the relationship query globally. Before that, it was not possible to create a relationship based on another relationship by modifying the query

Example:
```
public function images(): MorphMany
{
    return $this->files()->where('type', '=', 'images')
}
```

After add ability:
```
public function images(): MorphMany
{
    return $this->files()->modifyQuery(function (Builder $query) {
        $query->where('type', '=', 'images');
    });
}
```

Now, this relationship can be lazily loaded. This is my case, but I think it can be applied in a variety of ways.