### PR TITLE
[9.x] Add `recalled` parameter to Login event

### DIFF
--- a/src/Illuminate/Auth/Events/Login.php
+++ b/src/Illuminate/Auth/Events/Login.php
@@ -45,7 +45,7 @@ class Login
      * @param  bool  $recalled
      * @return void
      */
-    public function __construct($guard, $user, $remember, $recalled)
+    public function __construct($guard, $user, $remember, $recalled = false)
     {
         $this->user = $user;
         $this->guard = $guard;

--- a/src/Illuminate/Auth/Events/Login.php
+++ b/src/Illuminate/Auth/Events/Login.php
@@ -30,17 +30,26 @@ class Login
     public $remember;
 
     /**
+     * Indicates if the user has been retrieved using a "recaller" (remember) cookie.
+     *
+     * @var bool
+     */
+    public $recalled;
+
+    /**
      * Create a new event instance.
      *
      * @param  string  $guard
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @param  bool  $remember
+     * @param  bool  $recalled
      * @return void
      */
-    public function __construct($guard, $user, $remember)
+    public function __construct($guard, $user, $remember, $recalled)
     {
         $this->user = $user;
         $this->guard = $guard;
         $this->remember = $remember;
+        $this->recalled = $recalled;
     }
 }

--- a/src/Illuminate/Auth/Events/Login.php
+++ b/src/Illuminate/Auth/Events/Login.php
@@ -30,7 +30,7 @@ class Login
     public $remember;
 
     /**
-     * Indicates if the user has been retrieved using a "recaller" (remember) cookie.
+     * Indicates if the user was authenticated using a "remember me" cookie.
      *
      * @var bool
      */

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -149,7 +149,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
             if ($this->user) {
                 $this->updateSession($this->user->getAuthIdentifier());
 
-                $this->fireLoginEvent($this->user, true);
+                $this->fireLoginEvent($this->user, true, true);
             }
         }
 
@@ -432,7 +432,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
         // If we have an event dispatcher instance set we will fire an event so that
         // any listeners will hook into the authentication events and run actions
         // based on the login and logout events fired from the guard instances.
-        $this->fireLoginEvent($user, $remember);
+        $this->fireLoginEvent($user, $remember, false);
 
         $this->setUser($user);
     }
@@ -651,13 +651,14 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      *
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @param  bool  $remember
+     * @param  bool  $recalled
      * @return void
      */
-    protected function fireLoginEvent($user, $remember = false)
+    protected function fireLoginEvent($user, $remember = false, $recalled = false)
     {
         if (isset($this->events)) {
             $this->events->dispatch(new Login(
-                $this->name, $user, $remember
+                $this->name, $user, $remember, $recalled
             ));
         }
     }


### PR DESCRIPTION
I was writing some code that provides certain pages with an extra layer of protection, by requiring the user to re-enter their password if it has not been entered for 30 minutes or longer.

I noticed that there was an existing piece of code for the SessionGuard that retrieves a user from the remember-me-cookie, and it also seems to fire the `/Illuminate/Auth/Events/Login` event which I am using to set a `last_authenticated_at` (timestamp) property in the user's session. However, I could not distinguish the Login event from being either:

- Directly called as a result of a `POST /login` request
- Called indirectly from a `Auth::check()`/`Auth::user()` call which may trigger this event too when the user is retrieved using the remember-me cookie. In this case, the user is "silently authenticated".

This PR adds an extra `$recalled` property to this `Login` event, so you know what the original trigger was for this event.

I've added it to 9.x because this might cause issues with people manually calling the `Login` event who now need an extra parameter.
