### PR TITLE
[8.x] Add restrictOnUpdate() method to the schema builder

### DIFF
--- a/src/Illuminate/Database/Schema/ForeignKeyDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignKeyDefinition.php
@@ -35,6 +35,16 @@ class ForeignKeyDefinition extends Fluent
     }
 
     /**
+     * Indicate that updates should be restricted.
+     *
+     * @return $this
+     */
+    public function restrictOnUpdate()
+    {
+        return $this->onUpdate('restrict');
+    }
+
+    /**
      * Indicate that deletes should be restricted.
      *
      * @return $this

--- a/src/Illuminate/Database/Schema/ForeignKeyDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignKeyDefinition.php
@@ -25,16 +25,6 @@ class ForeignKeyDefinition extends Fluent
     }
 
     /**
-     * Indicate that deletes should cascade.
-     *
-     * @return $this
-     */
-    public function cascadeOnDelete()
-    {
-        return $this->onDelete('cascade');
-    }
-
-    /**
      * Indicate that updates should be restricted.
      *
      * @return $this
@@ -42,6 +32,16 @@ class ForeignKeyDefinition extends Fluent
     public function restrictOnUpdate()
     {
         return $this->onUpdate('restrict');
+    }
+
+    /**
+     * Indicate that deletes should cascade.
+     *
+     * @return $this
+     */
+    public function cascadeOnDelete()
+    {
+        return $this->onDelete('cascade');
     }
 
     /**


### PR DESCRIPTION
Hi,

In a new migration i tried using `restrictOnUpdate()` but it does not exist.

Laravel has a `cascadeOnUpdate()` but does not have a `restrictOnUpdate()`.

I know that i can use `onUpdate('restrict')` but since laravel already has a helper for the cascade on update and also has a restrict helper for the delete, it only makes sense to add helper for the restrict on update as well.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
