### PR TITLE
[8.x] Dispatch command instantly for `dispatchAfterResponse` when running in console

### DIFF
--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -262,6 +262,12 @@ class Dispatcher implements QueueingDispatcher
      */
     public function dispatchAfterResponse($command, $handler = null)
     {
+        if ($this->container->runningInConsole()) {
+            $this->dispatchNow($command, $handler);
+
+            return;
+        }
+
         $this->container->terminating(function () use ($command, $handler) {
             $this->dispatchNow($command, $handler);
         });


### PR DESCRIPTION
Hey,

Some members of our team started using the new `dispatchAfterResponse` for jobs and others, which weren't aware of it, couldn't understand why a job isn't dispatched when testing in tinker. At first I thought that exiting tinker (with `exit`) will dispatch the job but that didn't happen either. Changing `dispatchAfterResponse` to `dispatch` in code every time you need to test it from console seems wrong too. 
Should we dispatch jobs instantly when running in console?