### PR TITLE
Add the ability for `implode` method to accept callback

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -537,6 +537,9 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
         $first = $this->first();
 
         if (is_array($first) || (is_object($first) && ! $first instanceof Stringable)) {
+            if(is_callable($value)) {
+                return $this->map($value)->implode($glue ?? '');
+            }
             return implode($glue ?? '', $this->pluck($value)->all());
         }
 

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -537,9 +537,10 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
         $first = $this->first();
 
         if (is_array($first) || (is_object($first) && ! $first instanceof Stringable)) {
-            if(is_callable($value)) {
+            if (is_callable($value)) {
                 return $this->map($value)->implode($glue ?? '');
             }
+
             return implode($glue ?? '', $this->pluck($value)->all());
         }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2100,6 +2100,12 @@ class SupportCollectionTest extends TestCase
         $data = new $collection([['name' => 'taylor', 'email' => 'foo'], ['name' => 'dayle', 'email' => 'bar']]);
         $this->assertSame('foobar', $data->implode('email'));
         $this->assertSame('foo,bar', $data->implode('email', ','));
+        $this->assertSame('taylor:foodayle:bar', $data->implode(function($item) {
+            return "{$item['name']}:{$item['email']}";
+        }));
+        $this->assertSame('taylor:foo,dayle:bar', $data->implode(function($item) {
+            return "{$item['name']}:{$item['email']}";
+        }, ','));
 
         $data = new $collection(['taylor', 'dayle']);
         $this->assertSame('taylordayle', $data->implode(''));
@@ -2111,6 +2117,12 @@ class SupportCollectionTest extends TestCase
         ]);
         $this->assertSame('foobar', $data->implode('email'));
         $this->assertSame('foo,bar', $data->implode('email', ','));
+        $this->assertSame('taylor:foodayle:bar', $data->implode(function($item) {
+            return "{$item['name']}:{$item['email']}";
+        }));
+        $this->assertSame('taylor:foo,dayle:bar', $data->implode(function($item) {
+            return "{$item['name']}:{$item['email']}";
+        }, ','));
 
         $data = new $collection([Str::of('taylor'), Str::of('dayle')]);
         $this->assertSame('taylordayle', $data->implode(''));

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2100,10 +2100,10 @@ class SupportCollectionTest extends TestCase
         $data = new $collection([['name' => 'taylor', 'email' => 'foo'], ['name' => 'dayle', 'email' => 'bar']]);
         $this->assertSame('foobar', $data->implode('email'));
         $this->assertSame('foo,bar', $data->implode('email', ','));
-        $this->assertSame('taylor:foodayle:bar', $data->implode(function($item) {
+        $this->assertSame('taylor:foodayle:bar', $data->implode(function ($item) {
             return "{$item['name']}:{$item['email']}";
         }));
-        $this->assertSame('taylor:foo,dayle:bar', $data->implode(function($item) {
+        $this->assertSame('taylor:foo,dayle:bar', $data->implode(function ($item) {
             return "{$item['name']}:{$item['email']}";
         }, ','));
 
@@ -2117,10 +2117,10 @@ class SupportCollectionTest extends TestCase
         ]);
         $this->assertSame('foobar', $data->implode('email'));
         $this->assertSame('foo,bar', $data->implode('email', ','));
-        $this->assertSame('taylor:foodayle:bar', $data->implode(function($item) {
+        $this->assertSame('taylor:foodayle:bar', $data->implode(function ($item) {
             return "{$item['name']}:{$item['email']}";
         }));
-        $this->assertSame('taylor:foo,dayle:bar', $data->implode(function($item) {
+        $this->assertSame('taylor:foo,dayle:bar', $data->implode(function ($item) {
             return "{$item['name']}:{$item['email']}";
         }, ','));
 


### PR DESCRIPTION
Take this example:

I have this collection
```php
$sortings = collect(
  [ 'col' => 'firstname', 'dir' => 'ASC' ],
  [ 'col' => 'lastname', 'dir' => 'DESC' ],
  [ 'col' => 'age', 'dir' => 'DESC' ]
);
```

and I would like to print something like

```
ORDER BY firstname ASC, lastname DESC, age DESC
```

With this PR I could do:

```php
$clause = 'ORDER BY ' . $sortings->implode(fn($s) => "{$s['col']} {$s['dir']}", ', ');
```



