### PR TITLE
[8.x] Corrected app instance type in TestCase

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -32,7 +32,7 @@ abstract class TestCase extends BaseTestCase
     /**
      * The Illuminate application instance.
      *
-     * @var \Illuminate\Contracts\Foundation\Application
+     * @var \Illuminate\Foundation\Application
      */
     protected $app;
 


### PR DESCRIPTION
This PR fixes the typehint of `$app` property in `TestCase` Typehinting the contract is wrong because in the code there are stuff being used that are not in the interface but in the `\Illuminate\Foundation\Application` instance.