### PR TITLE
[8.x] Adds `TestResponse::dd`

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1359,6 +1359,43 @@ EOF;
     }
 
     /**
+     * Dump the content from the response and end the script.
+     *
+     * @return never
+     */
+    public function dd()
+    {
+        $this->dump();
+
+        exit(1);
+    }
+
+    /**
+     * Dump the headers from the response and end the script.
+     *
+     * @return never
+     */
+    public function ddHeaders()
+    {
+        $this->dumpHeaders();
+
+        exit(1);
+    }
+
+    /**
+     * Dump the session from the response and end the script.
+     *
+     * @param  string|array  $keys
+     * @return never
+     */
+    public function ddSession($keys = [])
+    {
+        $this->dumpSession($keys);
+
+        exit(1);
+    }
+
+    /**
      * Dump the content from the response.
      *
      * @return $this


### PR DESCRIPTION
This pull request revives (https://github.com/laravel/framework/pull/36378) by proposing the addition of `TestResponse::dd`, `TestResponse::ddHeaders`, and `TestResponse::ddSession` to the base `TestResponse::class` in Laravel.

In short, it's like `TestResponse::dump`, `TestResponse::dumpHeaders`, and `TestResponse::dumpSession`, but on don't have to filter by the test name to actually see the stuff you need on the terminal. 

### Before:
<img width="1680" alt="Screenshot 2021-10-25 at 22 21 42" src="https://user-images.githubusercontent.com/5457236/138773428-f7edca3a-6933-49c3-a4a3-b6a996484ca0.png">

### After:
<img width="1378" alt="Screenshot 2021-10-25 at 22 21 59" src="https://user-images.githubusercontent.com/5457236/138773435-5e7b93c6-cbb6-403f-944f-6f8594af6648.png">

