### PR TITLE
[8.x] Add bcmath as an extension suggestion

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -125,6 +125,7 @@
         }
     },
     "suggest": {
+        "ext-bcmath": "Required to use the multiple_of validation rule.",
         "ext-ftp": "Required to use the Flysystem FTP driver.",
         "ext-gd": "Required to use Illuminate\\Http\\Testing\\FileFactory::image().",
         "ext-memcached": "Required to use the memcache cache driver.",


### PR DESCRIPTION
The [`multiple_of` validation rule requires bcmath](https://laravel.com/docs/8.x/validation#multiple-of). Added as a suggestion in 8.x but it might be good to make a hard requirement in 9.x for a smoother transition?

I can add a note to the docs as well indicating that this ext is needed if you wanna merge this one.