### PR TITLE
Improve content negotiation for exception handling

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -405,9 +405,20 @@ class Handler implements ExceptionHandlerContract
      */
     protected function unauthenticated($request, AuthenticationException $exception)
     {
-        return $request->expectsJson()
+        return $this->shouldReturnJson($request)
                     ? response()->json(['message' => $exception->getMessage()], 401)
                     : redirect()->guest($exception->redirectTo() ?? route('login'));
+    }
+
+    /**
+     * Determine if the response should be json.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return bool
+     */
+    protected function shouldReturnJson(request)
+    {
+        return return $request->expectsJson();
     }
 
     /**

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -418,7 +418,7 @@ class Handler implements ExceptionHandlerContract
      */
     protected function shouldReturnJson(request)
     {
-        return return $request->expectsJson();
+        return $request->expectsJson();
     }
 
     /**

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -416,7 +416,7 @@ class Handler implements ExceptionHandlerContract
      * @param  \Illuminate\Http\Request  $request
      * @return bool
      */
-    protected function shouldReturnJson(request)
+    protected function shouldReturnJson($request)
     {
         return $request->expectsJson();
     }

--- a/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php
@@ -23,7 +23,7 @@ trait InteractsWithContentTypes
      */
     public function expectsJson()
     {
-        return ($this->ajax() && ! $this->pjax() && $this->acceptsAnyContentType()) || ($this->prefers(['text/html', 'text/json']) === 'text/json');
+        return ($this->ajax() && ! $this->pjax() && $this->acceptsAnyContentType()) || Str::contains($this->prefers(['text/html', 'application/json', 'application/ld+json']) ?? '', 'json'));
     }
 
     /**

--- a/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php
@@ -23,7 +23,7 @@ trait InteractsWithContentTypes
      */
     public function expectsJson()
     {
-        return ($this->ajax() && ! $this->pjax() && $this->acceptsAnyContentType()) || $this->wantsJson();
+        return ($this->ajax() && ! $this->pjax() && $this->acceptsAnyContentType()) || ($this->prefers(['text/html', 'text/json']) === 'text/json');
     }
 
     /**

--- a/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php
@@ -23,7 +23,7 @@ trait InteractsWithContentTypes
      */
     public function expectsJson()
     {
-        return ($this->ajax() && ! $this->pjax() && $this->acceptsAnyContentType()) || Str::contains($this->prefers(['text/html', 'application/json', 'application/ld+json']) ?? '', 'json'));
+        return ($this->ajax() && ! $this->pjax() && $this->acceptsAnyContentType()) || $this->wantsJson();
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR adds a new protected function `shouldReturnJson($request)` in the exception handler

There are situations where it might be worth having more complex logic about the contente type used for rendering exceptions. Currently one would have to override the entire `render()` method but with this PR one can simply override the very simple and newly introduced `shouldReturnJson()` method.

**This part has no breaking changes at all.**

*And why?*
Well imagine an API request with header `Accept: text/csv; application/json`. For succesfull responses we return a csv response but in case of an exception then we return a json response. Currently this is not possible without overriding the `render()` method because `$request->wantsJson()` returns `false` (arguable not ideal but intentionally left out from this PR).
