### PR TITLE
Database view

### DIFF
--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -269,6 +269,46 @@ class Builder
     }
 
     /**
+     * Create a view in the schema.
+     *
+     * @param $name
+     * @param  \Closure  $callback
+     * @return bool
+     *
+     * @throws \LogicException
+     */
+    public function createView($name, Closure $callback)
+    {
+        throw new LogicException('This database driver does not support creating views.');
+    }
+
+    /**
+     * Drop the given view from the schema.
+     *
+     * @param $name
+     * @return bool
+     *
+     * @throws \LogicException
+     */
+    public function dropView($name)
+    {
+        throw new LogicException('This database driver does not support dropping views.');
+    }
+
+    /**
+     * Drop the given view from schema if it exists.
+     *
+     * @param $name
+     * @return bool
+     *
+     * @throws \LogicException
+     */
+    public function dropViewIfExists($name)
+    {
+        throw new LogicException('This database driver does not support dropping views.');
+    }
+
+    /**
      * Drop all tables from the database.
      *
      * @return void

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Schema\AbstractSchemaManager as SchemaManager;
 use Doctrine\DBAL\Schema\TableDiff;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Grammar as BaseGrammar;
+use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Fluent;
@@ -53,6 +54,40 @@ abstract class Grammar extends BaseGrammar
     public function compileDropDatabaseIfExists($name)
     {
         throw new LogicException('This database driver does not support dropping databases.');
+    }
+
+    /**
+     * Compile a create view command.
+     *
+     * @param  string  $name
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @return string
+     */
+    public function compileCreateView($name, QueryBuilder $query)
+    {
+        throw new LogicException('This database driver does not support creating views.');
+    }
+
+    /**
+     * Compile a drop view command.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    public function compileDropView($name)
+    {
+        throw new LogicException('This database driver does not support dropping views.');
+    }
+
+    /**
+     * Compile a drop view if exists command.
+     *
+     * @param $name
+     * @return string
+     */
+    public function compileDropViewIfExists($name)
+    {
+        throw new LogicException('This database driver does not support dropping views.');
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Schema\Grammars;
 
 use Illuminate\Database\Connection;
+use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Fluent;
 use RuntimeException;
@@ -53,6 +54,50 @@ class MySqlGrammar extends Grammar
     {
         return sprintf(
             'drop database if exists %s',
+            $this->wrapValue($name)
+        );
+    }
+
+    /**
+     * Compile a create view command.
+     *
+     * @param  string  $name
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @return string
+     */
+    public function compileCreateView($name, QueryBuilder $query)
+    {
+        return sprintf(
+            'create view %s as %s',
+            $this->wrapValue($name),
+            $query->toSql()
+        );
+    }
+
+    /**
+     * Compile a drop view command.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    public function compileDropView($name)
+    {
+        return sprintf(
+            'drop view %s',
+            $this->wrapValue($name)
+        );
+    }
+
+    /**
+     * Compile a drop view if exists command.
+     *
+     * @param $name
+     * @return string
+     */
+    public function compileDropViewIfExists($name)
+    {
+        return sprintf(
+            'drop view if exists %s',
             $this->wrapValue($name)
         );
     }

--- a/src/Illuminate/Database/Schema/MySqlBuilder.php
+++ b/src/Illuminate/Database/Schema/MySqlBuilder.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Database\Schema;
 
+use Closure;
+
 class MySqlBuilder extends Builder
 {
     /**
@@ -27,6 +29,48 @@ class MySqlBuilder extends Builder
     {
         return $this->connection->statement(
             $this->grammar->compileDropDatabaseIfExists($name)
+        );
+    }
+
+    /**
+     * Create a view in the schema.
+     *
+     * @param $name
+     * @param  \Closure  $callback
+     * @return bool
+     */
+    public function createView($name, Closure $callback)
+    {
+        $query = tap($this->connection->query(), $callback);
+
+        return $this->connection->statement(
+            $this->grammar->compileCreateView($name, $query), $query->getBindings()
+        );
+    }
+
+    /**
+     * Drop the given view from the schema.
+     *
+     * @param $name
+     * @return bool
+     */
+    public function dropView($name)
+    {
+        return $this->connection->statement(
+            $this->grammar->compileDropView($name)
+        );
+    }
+
+    /**
+     * Drop the given view from schema if it exists.
+     *
+     * @param $name
+     * @return bool
+     */
+    public function dropViewIfExists($name)
+    {
+        return $this->connection->statement(
+            $this->grammar->compileDropViewIfExists($name)
         );
     }
 

--- a/src/Illuminate/Support/Facades/Schema.php
+++ b/src/Illuminate/Support/Facades/Schema.php
@@ -5,10 +5,13 @@ namespace Illuminate\Support\Facades;
 /**
  * @method static \Illuminate\Database\Schema\Builder create(string $table, \Closure $callback)
  * @method static \Illuminate\Database\Schema\Builder createDatabase(string $name)
+ * @method static \Illuminate\Database\Schema\Builder createView(string $name, \Closure $callback)
  * @method static \Illuminate\Database\Schema\Builder disableForeignKeyConstraints()
  * @method static \Illuminate\Database\Schema\Builder drop(string $table)
  * @method static \Illuminate\Database\Schema\Builder dropDatabaseIfExists(string $name)
  * @method static \Illuminate\Database\Schema\Builder dropIfExists(string $table)
+ * @method static \Illuminate\Database\Schema\Builder dropView(string $name)
+ * @method static \Illuminate\Database\Schema\Builder dropViewIfExists(string $name)
  * @method static \Illuminate\Database\Schema\Builder enableForeignKeyConstraints()
  * @method static \Illuminate\Database\Schema\Builder rename(string $from, string $to)
  * @method static \Illuminate\Database\Schema\Builder table(string $table, \Closure $callback)


### PR DESCRIPTION
I found it useful to create/drop database views through migration files using query builder. Currently we must run raw SQL to create views.  

```php
<?php

use Illuminate\Database\Migrations\Migration;
use Illuminate\Database\Query\Builder as QueryBuilder;
use Illuminate\Support\Facades\Schema;

class CreateRecentUsersView extends Migration
{
    /**
     * Run the migrations.
     *
     * @return void
     */
    public function up()
    {
        Schema::createView('recent_users', function (QueryBuilder $query) {
            $query->select('id', 'name')
                ->from('users')
                ->orderBy('id', 'DESC')
                ->take(100);
        });
    }

    /**
     * Reverse the migrations.
     *
     * @return void
     */
    public function down()
    {
        Schema::dropView('recent_users');
        // OR
        Schema::dropViewIfExists('recent_users');
    }
}
```
I have currently developed this feature for mysql driver, but if you are interested in it, I can provide other drivers too.
 Thanks