### PR TITLE
[8.x] Change whereStartsWith, DocBlock to reflect that array is supported

### DIFF
--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -124,7 +124,7 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
      */
     public function whereStartsWith($needles)
     {
-        return $this->filter(function ($value, $key) use ($string) {
+        return $this->filter(function ($value, $key) use ($needles) {
             return Str::startsWith($key, $needles);
         });
     }
@@ -137,7 +137,7 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
      */
     public function whereDoesntStartWith($needles)
     {
-        return $this->filter(function ($value, $key) use ($string) {
+        return $this->filter(function ($value, $key) use ($needles) {
             return ! Str::startsWith($key, $needles);
         });
     }

--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -119,38 +119,38 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
     /**
      * Return a bag of attributes that have keys starting with the given value / pattern.
      *
-     * @param  string  $string
+     * @param  array|string  $needles
      * @return static
      */
-    public function whereStartsWith($string)
+    public function whereStartsWith($needles)
     {
         return $this->filter(function ($value, $key) use ($string) {
-            return Str::startsWith($key, $string);
+            return Str::startsWith($key, $needles);
         });
     }
 
     /**
      * Return a bag of attributes with keys that do not start with the given value / pattern.
      *
-     * @param  string  $string
+     * @param  array|string  $needles
      * @return static
      */
-    public function whereDoesntStartWith($string)
+    public function whereDoesntStartWith($needles)
     {
         return $this->filter(function ($value, $key) use ($string) {
-            return ! Str::startsWith($key, $string);
+            return ! Str::startsWith($key, $needles);
         });
     }
 
     /**
      * Return a bag of attributes that have keys starting with the given value / pattern.
      *
-     * @param  string  $string
+     * @param  array|string  $needles
      * @return static
      */
-    public function thatStartWith($string)
+    public function thatStartWith($needles)
     {
-        return $this->whereStartsWith($string);
+        return $this->whereStartsWith($needles);
     }
 
     /**

--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -119,7 +119,7 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
     /**
      * Return a bag of attributes that have keys starting with the given value / pattern.
      *
-     * @param  array|string  $needles
+     * @param  string|string[]  $needles
      * @return static
      */
     public function whereStartsWith($needles)
@@ -132,7 +132,7 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
     /**
      * Return a bag of attributes with keys that do not start with the given value / pattern.
      *
-     * @param  array|string  $needles
+     * @param  string|string[]  $needles
      * @return static
      */
     public function whereDoesntStartWith($needles)
@@ -145,7 +145,7 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
     /**
      * Return a bag of attributes that have keys starting with the given value / pattern.
      *
-     * @param  array|string  $needles
+     * @param  string|string[]  $needles
      * @return static
      */
     public function thatStartWith($needles)


### PR DESCRIPTION
A non-breaking change to avoid IDE warnings

`whereStartsWith`, `whereDoesntStartWith` and `thatStartWith` DocBlocks says it only accepts a `string`, but an `array` also works, as it's being passed to `Str::startsWith($haystack, $needles)` which accepts an array too.

I also changed the variable name from `$string` to `$needles` for better code readability.
That could potentially be a breaking change if php8 users have started to use named properties...

Would suggest that official documentation is updated to help others save time.

### User benefits:

Due to my IDE and official docs, I thought I had to do this:
```blade
<input  {{ $attributes->whereDoesntStartWith('wire:model')->whereDoesntStartWith('x-model') }}  />
```

When I discovered that this is supported:
```blade
<input  {{ $attributes->whereDoesntStartWith(['wire:model', 'x-model']) }}  />
```

Creds to @ryangjchandler who told me :)