### PR TITLE
[8.x] Add when helper function

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -377,3 +377,18 @@ if (! function_exists('with')) {
         return is_null($callback) ? $value : $callback($value);
     }
 }
+
+if (! function_exists('when')) {
+    /**
+     * If condition is true call the given Closure with the condition value then return the result.
+     *
+     * @param  mixed  $condition
+     * @param  callable  $callback
+     * @param  mixed  $otherwise
+     * @return mixed
+     */
+    function when($condition, callable $callback, $otherwise = null)
+    {
+        return $condition ? $callback($condition) : $otherwise;
+    }
+}


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR adds a new helper function `when($condition, callable $callback, $otherwise = null)`. 
This was inspired by Builder Query method when and I've found this is useful alongside with `tap`, `transform` & `with` helpers.

Some usage examples:
```
when(request('status_ids'), fn($ids) => $query->whereIn('status_id', explode(',', $ids)));
```
```
$filter->equal('user_id', __('fields.author_name'))->select(function ($id) {
    return when(User::find($id), fn(User $user) => [$user->id => "{$user->id} - {$user->name} - {$user->email}"]);
})->ajax('api/author');
```


**Sure, no breaking changes here.**



