### PR TITLE
[8.x] Fix code to address different connection strings for MariaDB in the database queue driver

### DIFF
--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -256,8 +256,8 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
         $databaseVersion = $this->database->getConfig('version') ??
                            $this->database->getPdo()->getAttribute(PDO::ATTR_SERVER_VERSION);
 
-        if (($databaseEngine === 'mysql' && version_compare($databaseVersion, '8.0.1', '>=')) ||
-            (strpos($databaseVersion, 'MariaDB') && version_compare(Str::after($databaseVersion, '-'), '10.6.0', '>=')) ||
+        if (($databaseEngine === 'mysql' && ! strpos($databaseVersion, 'MariaDB') && version_compare($databaseVersion, '8.0.1', '>=')) ||
+            (strpos($databaseVersion, 'MariaDB') && version_compare(Str::after($databaseVersion, '5.5.5-'), '10.6.0', '>=')) ||
             ($databaseEngine === 'pgsql' && version_compare($databaseVersion, '9.5', '>='))) {
             return 'FOR UPDATE SKIP LOCKED';
         }


### PR DESCRIPTION
Hello,

There are some MariaDB connection strings that evaluate to ```true``` for supporting "FOR UPDATE". This PR re-adds the conditional ```! strpos($databaseVersion, 'MariaDB')``` to avoid any mismatches with MySQL and also is more strict with the ```Str::after``` to avoid removing the version of MariaDB...

As per noted in https://github.com/laravel/framework/pull/39311 and tested with multiple MariaDB connection strings:

![image](https://user-images.githubusercontent.com/6171197/138927322-f0d392f1-82d9-4a69-b7cd-26ae14540101.png)
