### PR TITLE
[6.x] Fix rate limiting unicode issue

### DIFF
--- a/src/Illuminate/Cache/RateLimiter.php
+++ b/src/Illuminate/Cache/RateLimiter.php
@@ -36,6 +36,8 @@ class RateLimiter
      */
     public function tooManyAttempts($key, $maxAttempts)
     {
+        $key = $this->cleanRateLimiterKey($key);
+
         if ($this->attempts($key) >= $maxAttempts) {
             if ($this->cache->has($key.':timer')) {
                 return true;
@@ -56,6 +58,8 @@ class RateLimiter
      */
     public function hit($key, $decaySeconds = 60)
     {
+        $key = $this->cleanRateLimiterKey($key);
+
         $this->cache->add(
             $key.':timer', $this->availableAt($decaySeconds), $decaySeconds
         );
@@ -79,6 +83,8 @@ class RateLimiter
      */
     public function attempts($key)
     {
+        $key = $this->cleanRateLimiterKey($key);
+
         return $this->cache->get($key, 0);
     }
 
@@ -90,6 +96,8 @@ class RateLimiter
      */
     public function resetAttempts($key)
     {
+        $key = $this->cleanRateLimiterKey($key);
+
         return $this->cache->forget($key);
     }
 
@@ -102,6 +110,8 @@ class RateLimiter
      */
     public function retriesLeft($key, $maxAttempts)
     {
+        $key = $this->cleanRateLimiterKey($key);
+
         $attempts = $this->attempts($key);
 
         return $maxAttempts - $attempts;
@@ -115,6 +125,8 @@ class RateLimiter
      */
     public function clear($key)
     {
+        $key = $this->cleanRateLimiterKey($key);
+
         $this->resetAttempts($key);
 
         $this->cache->forget($key.':timer');
@@ -128,6 +140,19 @@ class RateLimiter
      */
     public function availableIn($key)
     {
+        $key = $this->cleanRateLimiterKey($key);
+
         return $this->cache->get($key.':timer') - $this->currentTime();
+    }
+
+    /**
+     * Clean the rate limiter key from unicode characters.
+     *
+     * @param  string  $key
+     * @return string
+     */
+    public function cleanRateLimiterKey($key)
+    {
+        return preg_replace("/&([a-z])[a-z]+;/i", "$1", htmlentities($key));
     }
 }

--- a/src/Illuminate/Cache/RateLimiter.php
+++ b/src/Illuminate/Cache/RateLimiter.php
@@ -153,6 +153,6 @@ class RateLimiter
      */
     public function cleanRateLimiterKey($key)
     {
-        return preg_replace("/&([a-z])[a-z]+;/i", "$1", htmlentities($key));
+        return preg_replace('/&([a-z])[a-z]+;/i', '$1', htmlentities($key));
     }
 }

--- a/tests/Cache/CacheRateLimiterTest.php
+++ b/tests/Cache/CacheRateLimiterTest.php
@@ -66,4 +66,15 @@ class CacheRateLimiterTest extends TestCase
 
         $rateLimiter->clear('key');
     }
+
+    public function testKeysAreSanitizedFromUnicodeCharacters()
+    {
+        $cache = m::mock(Cache::class);
+        $cache->shouldReceive('get')->once()->with('john', 0)->andReturn(1);
+        $cache->shouldReceive('has')->once()->with('john:timer')->andReturn(true);
+        $cache->shouldReceive('add')->never();
+        $rateLimiter = new RateLimiter($cache);
+
+        $this->assertTrue($rateLimiter->tooManyAttempts('jôhn', 1));
+    }
 }


### PR DESCRIPTION
This PR fixes an issue where rate limiting would be reset for characters with unicode in them. By converting these characters to regular ones, the same key is re-used and rate limiting is properly applied, albeit a bit stricter.
