### PR TITLE
[8.x] Fix CURRENT_TIMESTAMP as default when changing column

### DIFF
--- a/src/Illuminate/Database/DBAL/TimestampType.php
+++ b/src/Illuminate/Database/DBAL/TimestampType.php
@@ -4,9 +4,10 @@ namespace Illuminate\Database\DBAL;
 
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\PhpDateTimeMappingType;
 use Doctrine\DBAL\Types\Type;
 
-class TimestampType extends Type
+class TimestampType extends Type implements PhpDateTimeMappingType
 {
     /**
      * {@inheritdoc}


### PR DESCRIPTION
This PR implements PhpDateTimeMappingType for TimestampType, which allows us to use `CURRENT_TIMESTAMP` as the default value when changing a column ([DBAL](https://github.com/doctrine/dbal/blob/25496429ef4bba2352b0ced7daffe1b3dec83d13/src/Platforms/AbstractPlatform.php#L2302))
Without this change `CURRENT_TIMSTAMP` is [treated as a string](https://github.com/doctrine/dbal/blob/25496429ef4bba2352b0ced7daffe1b3dec83d13/src/Platforms/AbstractPlatform.php#L2318)
