### PR TITLE
[9.x] Possibility to escape keys that contain dots in dot notation

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -733,17 +733,22 @@ class Arr
     }
 
     /**
-     * Explode the given key into segments that are delimtied by "dot".
-     * This way, we can also catch the escaped strings that are surrounded
-     * by quote strings, which can contain dots, and treat them as keys instead
-     * of further parsing them down as nested array.
+     * Explode the given key into segments that are delimtied by "dot"
+     * and escape strings that are surrounded by quote strings,
+     * which can contain dots, and treat them as keys instead of nested keys.
      *
      * @param  string  $key
      * @return array
      */
     protected static function explode(string $key)
     {
-        preg_match_all('/(?:"(.+?)"|[^\.]+)/', $key, $matches);
+        if (! Str::contains($key, '"')) {
+            return explode('.', $key);
+        }
+
+        // Search for keys like a."b.c".d and separate them by dots
+        // that are not within quotes.
+        preg_match_all('/(?:"(.+?)"|[^\.\s]+)/', $key, $matches);
 
         [$keys, ] = $matches;
 

--- a/src/Illuminate/Collections/composer.json
+++ b/src/Illuminate/Collections/composer.json
@@ -17,7 +17,8 @@
         "php": "^8.0.2",
         "illuminate/conditionable": "^9.0",
         "illuminate/contracts": "^9.0",
-        "illuminate/macroable": "^9.0"
+        "illuminate/macroable": "^9.0",
+        "illuminate/support": "^9.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -991,4 +991,35 @@ class SupportArrTest extends TestCase
             ['name' => 'John', 'age' => 8,  'meta' => ['key' => 3]],
         ], $sortedWithCallable);
     }
+
+    public function testSetKeysThatContainsDot()
+    {
+        $array = [
+            'a' => [],
+            'b' => [],
+        ];
+
+        Arr::set($array, '"a.b/c"', '1');
+        Arr::set($array, 'a."b.c"', '2');
+        Arr::set($array, 'a.b."c"."d"', '3');
+
+        Arr::set($array, 'b.0', '1');
+        Arr::set($array, 'b."1"', '2');
+        Arr::set($array, 'c', '3');
+
+        $this->assertEquals([
+            'a.b/c' => '1',
+            'a' => [
+                'b.c' => '2',
+                'b' => [
+                    'c' => ['d' => '3'],
+                ],
+            ],
+            'b' => [
+                '1',
+                '2',
+            ],
+            'c' => '3',
+        ], $array);
+    }
 }


### PR DESCRIPTION
## Problem

`Arr::set()` treats the dots within the key as separators for nested values. This is expected. The segments will create a nested value `some -> annotation -> com/ttl` with a value of `1800`.

```php
$annotations = [
    'some.annotation.com/ttl' => 900,
];

Arr::set($annotations, 'some.annotation.com/ttl', 1800);

// Current result
$annotations = [
    'some' => [
        'annotation' => [
            'com/ttl' => 1800,
        ],
    ],
];

// Desired result
$annotations = [
    'some.annotation.com/ttl' => 1800,
];
```

There is already `Arr::add()`, but this does not fix the case where you want to set it directly with the dot notation.

## Approach

It would be nice if the strings that need to be interpreted literally would sit between quotes (`"`) so that the segmentation would be made based on dots that are not between quotes. This way, the segments will consist of keys that can contain dots.

For example, this would be a syntax idea to fix the issue. No matter what's between quotes, it will be treated as an actual key name.

```php
Arr::set($annotations, '"some.annotation.com/ttl"', 1800);
```

## Implementation

I have changed the way that the keys are exploded by `.`. For all keys, the `explode()` method is still used. But for strings that contain `"`, they will get through a regex that will segment them by dots that are not enclosed between quotes. It was applied to all functions that use PHP's `explode()` function.

## Breaking Change

Not sure if this should be 8.x (that'd be nice), but I assume that changing the way this works might break for some people because they may have keys that can start with quotes and this leads to undesired results.