### PR TITLE
[8.x] Add tests and type annotation for `AssertableJson->whereContains()`

### DIFF
--- a/src/Illuminate/Testing/Fluent/Concerns/Matching.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Matching.php
@@ -130,7 +130,7 @@ trait Matching
             if (! is_string($condition) && is_callable($condition)) {
                 $unsatisfiedClosures[] = $idx;
             } else {
-                $missingValues[] = (string)$condition;
+                $missingValues[] = (string) $condition;
             }
         }
 

--- a/src/Illuminate/Testing/Fluent/Concerns/Matching.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Matching.php
@@ -107,7 +107,7 @@ trait Matching
      * Asserts that the property contains the expected values.
      *
      * @param  string  $key
-     * @param  array|string|Closure  $expected
+     * @param  array|Closure|mixed  $expected
      * @return $this
      */
     public function whereContains(string $key, $expected)

--- a/src/Illuminate/Testing/Fluent/Concerns/Matching.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Matching.php
@@ -107,7 +107,7 @@ trait Matching
      * Asserts that the property contains the expected values.
      *
      * @param  string  $key
-     * @param  array|Closure|mixed  $expected
+     * @param  mixed  $expected
      * @return $this
      */
     public function whereContains(string $key, $expected)

--- a/tests/Testing/Fluent/AssertTest.php
+++ b/tests/Testing/Fluent/AssertTest.php
@@ -459,7 +459,9 @@ class AssertTest extends TestCase
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Property [foo] does not contain a value that satisfies closures at [0].');
 
-        $assert->whereContains('foo', [function ($actual) { return $actual === 5; }]);
+        $assert->whereContains('foo', [function ($actual) {
+            return $actual === 5;
+        }]);
     }
 
     public function testAssertWhereContainsFailsWhenHavingExpectedValueButDoesNotSatisfyClosure()
@@ -471,7 +473,9 @@ class AssertTest extends TestCase
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Property [foo] does not contain a value that satisfies closures at [1].');
 
-        $assert->whereContains('foo', [1, function ($actual) { return $actual === 5; }]);
+        $assert->whereContains('foo', [1, function ($actual) {
+            return $actual === 5;
+        }]);
     }
 
     public function testAssertWhereContainsFailsWhenSatisfiesClosureButDoesNotHaveExpectedValue()
@@ -483,7 +487,9 @@ class AssertTest extends TestCase
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Property [foo] does not contain [5].');
 
-        $assert->whereContains('foo', [5, function ($actual) { return $actual === 1; }]);
+        $assert->whereContains('foo', [5, function ($actual) {
+            return $actual === 1;
+        }]);
     }
 
     public function testAssertWhereContainsWithNestedValue()
@@ -546,7 +552,9 @@ class AssertTest extends TestCase
             'foo' => [1, 2, 3, 4],
         ]);
 
-        $assert->whereContains('foo', function ($actual) { return $actual % 3 === 0; });
+        $assert->whereContains('foo', function ($actual) {
+            return $actual % 3 === 0;
+        });
     }
 
     public function testAssertWhereContainsWithNestedClosure()
@@ -557,7 +565,9 @@ class AssertTest extends TestCase
             'baz' => 3,
         ]);
 
-        $assert->whereContains('baz', function ($actual) { return $actual % 3 === 0; });
+        $assert->whereContains('baz', function ($actual) {
+            return $actual % 3 === 0;
+        });
     }
 
     public function testAssertWhereContainsWithMultipleClosure()
@@ -567,8 +577,12 @@ class AssertTest extends TestCase
         ]);
 
         $assert->whereContains('foo', [
-            function ($actual) { return $actual % 3 === 0; },
-            function ($actual) { return $actual % 2 === 0; },
+            function ($actual) {
+                return $actual % 3 === 0;
+            },
+            function ($actual) {
+                return $actual % 2 === 0;
+            },
         ]);
     }
 

--- a/tests/Testing/Fluent/AssertTest.php
+++ b/tests/Testing/Fluent/AssertTest.php
@@ -457,7 +457,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [foo] does not contain a value that satisfies closures at [0].');
+        $this->expectExceptionMessage('Property [foo] does not contain a value that passes the truth test within the given closure.');
 
         $assert->whereContains('foo', [function ($actual) {
             return $actual === 5;
@@ -471,7 +471,7 @@ class AssertTest extends TestCase
         ]);
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Property [foo] does not contain a value that satisfies closures at [1].');
+        $this->expectExceptionMessage('Property [foo] does not contain a value that passes the truth test within the given closure.');
 
         $assert->whereContains('foo', [1, function ($actual) {
             return $actual === 5;

--- a/tests/Testing/Fluent/AssertTest.php
+++ b/tests/Testing/Fluent/AssertTest.php
@@ -450,6 +450,42 @@ class AssertTest extends TestCase
         $assert->whereContains('foo', ['1']);
     }
 
+    public function testAssertWhereContainsFailsWhenDoesNotSatisfyClosure()
+    {
+        $assert = AssertableJson::fromArray([
+            'foo' => [1, 2, 3, 4],
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Property [foo] does not contain a value that satisfies closures at [0].');
+
+        $assert->whereContains('foo', [function ($actual) { return $actual === 5; }]);
+    }
+
+    public function testAssertWhereContainsFailsWhenHavingExpectedValueButDoesNotSatisfyClosure()
+    {
+        $assert = AssertableJson::fromArray([
+            'foo' => [1, 2, 3, 4],
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Property [foo] does not contain a value that satisfies closures at [1].');
+
+        $assert->whereContains('foo', [1, function ($actual) { return $actual === 5; }]);
+    }
+
+    public function testAssertWhereContainsFailsWhenSatisfiesClosureButDoesNotHaveExpectedValue()
+    {
+        $assert = AssertableJson::fromArray([
+            'foo' => [1, 2, 3, 4],
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Property [foo] does not contain [5].');
+
+        $assert->whereContains('foo', [5, function ($actual) { return $actual === 1; }]);
+    }
+
     public function testAssertWhereContainsWithNestedValue()
     {
         $assert = AssertableJson::fromArray([
@@ -502,6 +538,38 @@ class AssertTest extends TestCase
         ]);
 
         $assert->whereContains('baz', 4);
+    }
+
+    public function testAssertWhereContainsWithClosure()
+    {
+        $assert = AssertableJson::fromArray([
+            'foo' => [1, 2, 3, 4],
+        ]);
+
+        $assert->whereContains('foo', function ($actual) { return $actual % 3 === 0; });
+    }
+
+    public function testAssertWhereContainsWithNestedClosure()
+    {
+        $assert = AssertableJson::fromArray([
+            'foo' => 1,
+            'bar' => 2,
+            'baz' => 3,
+        ]);
+
+        $assert->whereContains('baz', function ($actual) { return $actual % 3 === 0; });
+    }
+
+    public function testAssertWhereContainsWithMultipleClosure()
+    {
+        $assert = AssertableJson::fromArray([
+            'foo' => [1, 2, 3, 4],
+        ]);
+
+        $assert->whereContains('foo', [
+            function ($actual) { return $actual % 3 === 0; },
+            function ($actual) { return $actual % 2 === 0; },
+        ]);
     }
 
     public function testAssertWhereContainsWithNullExpectation()


### PR DESCRIPTION
This is a follow-up PR to #39329 and 37217d56ca38c407395bb98ef2532cafd86efa30
It uses the logic from @taylorotwell 's commit (thank you!), with tests and type annotation from #39329 

The fix deployed still only accepts array|string as `$expected` so I thought the type annotation part from my PR still stands. 