### PR TITLE
[8.x] Adds `mask()` for masking part of a string

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -427,7 +427,7 @@ class Str
         $start = mb_substr($string, 0, mb_strpos($string, $swap, 0, $encoding), $encoding);
         $end = mb_substr($string, mb_strpos($string, $swap, 0, $encoding) + mb_strlen($swap, $encoding));
 
-        return $start . str_repeat(mb_substr($character, 0, 1, $encoding), mb_strlen($swap, $encoding)) . $end;
+        return $start.str_repeat(mb_substr($character, 0, 1, $encoding), mb_strlen($swap, $encoding)).$end;
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -399,6 +399,24 @@ class Str
     }
 
     /**
+     * Masks a portion of a string with a repeated character.
+     *
+     * @param  string  $string
+     * @param  string  $character
+     * @param  int  $index
+     * @param  int|null  $length
+     * @return string
+     */
+    public static function mask($string, $character, $index, $length = null)
+    {
+        if ($character === '' || ! $replace = mb_strlen(mb_substr($string, $index, $length, 'UTF-8'), 'UTF-8')) {
+            return $string;
+        }
+
+        return substr_replace($string, str_repeat(mb_substr($character, 0, 1, 'UTF-8'), $replace), $index, $length);
+    }
+
+    /**
      * Get the string matching the given pattern.
      *
      * @param  string  $pattern

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -405,23 +405,29 @@ class Str
      * @param  string  $character
      * @param  int  $index
      * @param  int|null  $length
+     * @param  string  $encoding
      * @return string
      */
-    public static function mask($string, $character, $index, $length = null)
+    public static function mask($string, $character, $index, $length = null, $encoding = 'UTF-8')
     {
-        if ($character === '') {
+        if ('' === $character) {
             return $string;
         }
 
-        if (null === $length) {
-            return substr_replace(
-                $string, str_repeat($character[0], strlen(substr($string, $index))), $index
-            );
+        // On older versions, if length is null an empty string is returned.
+        if (null === $length && PHP_MAJOR_VERSION < 8) {
+            $length = mb_strlen($string, $encoding);
         }
 
-        return substr_replace(
-            $string, str_repeat($character[0], strlen(substr($string, $index, $length))), $index, $length
-        );
+        // When the index is out of bounds, there is nothing to replace.
+        if ('' === $swap = mb_substr($string, $index, $length, $encoding)) {
+            return $string;
+        }
+
+        $start = mb_substr($string, 0, mb_strpos($string, $swap, 0, $encoding), $encoding);
+        $end = mb_substr($string, mb_strpos($string, $swap, 0, $encoding) + mb_strlen($swap, $encoding));
+
+        return $start . str_repeat(mb_substr($character, 0, 1, $encoding), mb_strlen($swap, $encoding)) . $end;
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -410,24 +410,24 @@ class Str
      */
     public static function mask($string, $character, $index, $length = null, $encoding = 'UTF-8')
     {
-        if ('' === $character) {
+        if ($character === '') {
             return $string;
         }
 
-        // On older versions, if length is null an empty string is returned.
-        if (null === $length && PHP_MAJOR_VERSION < 8) {
+        if (is_null($length) && PHP_MAJOR_VERSION < 8) {
             $length = mb_strlen($string, $encoding);
         }
 
-        // When the index is out of bounds, there is nothing to replace.
-        if ('' === $swap = mb_substr($string, $index, $length, $encoding)) {
+        $segment = mb_substr($string, $index, $length, $encoding);
+
+        if ($segment === '') {
             return $string;
         }
 
-        $start = mb_substr($string, 0, mb_strpos($string, $swap, 0, $encoding), $encoding);
-        $end = mb_substr($string, mb_strpos($string, $swap, 0, $encoding) + mb_strlen($swap, $encoding));
+        $start = mb_substr($string, 0, mb_strpos($string, $segment, 0, $encoding), $encoding);
+        $end = mb_substr($string, mb_strpos($string, $segment, 0, $encoding) + mb_strlen($segment, $encoding));
 
-        return $start.str_repeat(mb_substr($character, 0, 1, $encoding), mb_strlen($swap, $encoding)).$end;
+        return $start.str_repeat(mb_substr($character, 0, 1, $encoding), mb_strlen($segment, $encoding)).$end;
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -409,11 +409,11 @@ class Str
      */
     public static function mask($string, $character, $index, $length = null)
     {
-        if ($character === '' || ! $replace = mb_strlen(mb_substr($string, $index, $length, 'UTF-8'), 'UTF-8')) {
+        if ($character === '' || ! $replace = strlen(substr($string, $index, $length))) {
             return $string;
         }
 
-        return substr_replace($string, str_repeat(mb_substr($character, 0, 1, 'UTF-8'), $replace), $index, $length);
+        return substr_replace($string, str_repeat($character[0], $replace), $index, $length);
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -409,11 +409,19 @@ class Str
      */
     public static function mask($string, $character, $index, $length = null)
     {
-        if ($character === '' || ! $replace = strlen(substr($string, $index, $length))) {
+        if ($character === '') {
             return $string;
         }
 
-        return substr_replace($string, str_repeat($character[0], $replace), $index, $length);
+        if (null === $length) {
+            return substr_replace(
+                $string, str_repeat($character[0], strlen(substr($string, $index))), $index
+            );
+        }
+
+        return substr_replace(
+            $string, str_repeat($character[0], strlen(substr($string, $index, $length))), $index, $length
+        );
     }
 
     /**

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -348,11 +348,12 @@ class Stringable implements JsonSerializable
      * @param  string  $character
      * @param  int  $index
      * @param  int|null  $length
+     * @param  string  $encoding
      * @return static
      */
-    public function mask($character, $index, $length = null)
+    public function mask($character, $index, $length = null, $encoding = 'UTF-8')
     {
-        return new static(Str::mask($this->value, $character, $index, $length));
+        return new static(Str::mask($this->value, $character, $index, $length, $encoding));
     }
 
     /**

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -343,6 +343,19 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Masks a portion of a string with a repeated character.
+     *
+     * @param  string  $character
+     * @param  int  $index
+     * @param  int|null  $length
+     * @return static
+     */
+    public function mask($character, $index, $length = null)
+    {
+        return new static(Str::mask($this->value, $character, $index, $length));
+    }
+
+    /**
      * Get the string matching the given pattern.
      *
      * @param  string  $pattern

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -467,6 +467,10 @@ class SupportStrTest extends TestCase
         $this->assertSame('taylor@email.com', Str::mask('taylor@email.com', '', 3));
 
         $this->assertSame('taysssssssssssss', Str::mask('taylor@email.com', 'something', 3));
+        $this->assertSame('taysssssssssssss', Str::mask('taylor@email.com', Str::of('something'), 3));
+
+        $this->assertSame('这是一***', Str::mask('这是一段中文', '*', 3));
+        $this->assertSame('**一段中文', Str::mask('这是一段中文', '*', 0, 2));
     }
 
     public function testMatch()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -467,12 +467,6 @@ class SupportStrTest extends TestCase
         $this->assertSame('taylor@email.com', Str::mask('taylor@email.com', '', 3));
 
         $this->assertSame('taysssssssssssss', Str::mask('taylor@email.com', 'something', 3));
-        $this->assertSame('tay1111111111111', Str::mask('taylor@email.com', 12, 3));
-
-        $this->assertSame('这***', Str::mask('这是一段中文', '*', 3));
-        $this->assertSame('******一段中文', Str::mask('这是一段中文', '*', 0, 6));
-        $this->assertSame('这是******', Str::mask('这是一段中文', '*', -12));
-        $this->assertSame('这是***段中文', Str::mask('这是一段中文', '*', -12, 3));
     }
 
     public function testMatch()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -451,6 +451,30 @@ class SupportStrTest extends TestCase
         $this->assertSame('FooBarBaz', Str::studly('foo-bar_baz'));
     }
 
+    public function testMask()
+    {
+        $this->assertSame('tay*************', Str::mask('taylor@email.com', '*', 3));
+        $this->assertSame('******@email.com', Str::mask('taylor@email.com', '*', 0, 6));
+        $this->assertSame('tay*************', Str::mask('taylor@email.com', '*', -13));
+        $this->assertSame('tay***@email.com', Str::mask('taylor@email.com', '*', -13, 3));
+
+        $this->assertSame('****************', Str::mask('taylor@email.com', '*', -17));
+        $this->assertSame('*****r@email.com', Str::mask('taylor@email.com', '*', -99, 5));
+
+        $this->assertSame('taylor@email.com', Str::mask('taylor@email.com', '*', 16));
+        $this->assertSame('taylor@email.com', Str::mask('taylor@email.com', '*', 16, 99));
+
+        $this->assertSame('taylor@email.com', Str::mask('taylor@email.com', '', 3));
+
+        $this->assertSame('taysssssssssssss', Str::mask('taylor@email.com', 'something', 3));
+        $this->assertSame('tay1111111111111', Str::mask('taylor@email.com', 12, 3));
+
+        $this->assertSame('这***', Str::mask('这是一段中文', '*', 3));
+        $this->assertSame('******一段中文', Str::mask('这是一段中文', '*', 0, 6));
+        $this->assertSame('这是******', Str::mask('这是一段中文', '*', -12));
+        $this->assertSame('这是***段中文', Str::mask('这是一段中文', '*', -12, 3));
+    }
+
     public function testMatch()
     {
         $this->assertSame('bar', Str::match('/bar/', 'foo bar'));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -691,6 +691,9 @@ class SupportStringableTest extends TestCase
         $this->assertEquals('taylor@email.com', $this->stringable('taylor@email.com')->mask('', 3));
 
         $this->assertEquals('taysssssssssssss', $this->stringable('taylor@email.com')->mask('something', 3));
+
+        $this->assertEquals('这是一***', $this->stringable('这是一段中文')->mask('*', 3));
+        $this->assertEquals('**一段中文', $this->stringable('这是一段中文')->mask('*', 0, 2));
     }
 
     public function testRepeat()

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -675,6 +675,30 @@ class SupportStringableTest extends TestCase
         $this->assertEquals("<h1>hello world</h1>\n", $this->stringable('# hello world')->markdown());
     }
 
+    public function testMask()
+    {
+        $this->assertEquals('tay*************', $this->stringable('taylor@email.com')->mask('*', 3));
+        $this->assertEquals('******@email.com', $this->stringable('taylor@email.com')->mask('*', 0, 6));
+        $this->assertEquals('tay*************', $this->stringable('taylor@email.com')->mask('*', -13));
+        $this->assertEquals('tay***@email.com', $this->stringable('taylor@email.com')->mask('*', -13, 3));
+
+        $this->assertEquals('****************', $this->stringable('taylor@email.com')->mask('*', -17));
+        $this->assertEquals('*****r@email.com', $this->stringable('taylor@email.com')->mask('*', -99, 5));
+
+        $this->assertEquals('taylor@email.com', $this->stringable('taylor@email.com')->mask('*', 16));
+        $this->assertEquals('taylor@email.com', $this->stringable('taylor@email.com')->mask('*', 16, 99));
+
+        $this->assertEquals('taylor@email.com', $this->stringable('taylor@email.com')->mask('', 3));
+
+        $this->assertEquals('taysssssssssssss', $this->stringable('taylor@email.com')->mask('something', 3));
+        $this->assertEquals('tay1111111111111', $this->stringable('taylor@email.com')->mask(12, 3));
+
+        $this->assertEquals('这***', $this->stringable('这是一段中文')->mask('*', 3));
+        $this->assertEquals('******一段中文', $this->stringable('这是一段中文')->mask('*', 0, 6));
+        $this->assertEquals('这是******', $this->stringable('这是一段中文')->mask('*', -12));
+        $this->assertEquals('这是***段中文', $this->stringable('这是一段中文')->mask('*', -12, 3));
+    }
+
     public function testRepeat()
     {
         $this->assertSame('aaaaa', (string) $this->stringable('a')->repeat(5));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -691,12 +691,6 @@ class SupportStringableTest extends TestCase
         $this->assertEquals('taylor@email.com', $this->stringable('taylor@email.com')->mask('', 3));
 
         $this->assertEquals('taysssssssssssss', $this->stringable('taylor@email.com')->mask('something', 3));
-        $this->assertEquals('tay1111111111111', $this->stringable('taylor@email.com')->mask(12, 3));
-
-        $this->assertEquals('这***', $this->stringable('这是一段中文')->mask('*', 3));
-        $this->assertEquals('******一段中文', $this->stringable('这是一段中文')->mask('*', 0, 6));
-        $this->assertEquals('这是******', $this->stringable('这是一段中文')->mask('*', -12));
-        $this->assertEquals('这是***段中文', $this->stringable('这是一段中文')->mask('*', -12, 3));
     }
 
     public function testRepeat()


### PR DESCRIPTION
## What?

Masks a portion of a string with a repeated character. Works just like `substr_replace()`. Useful for obfuscating sensible parts of texts like emails, addresses and what not.

```php
Str::mask('my-private@email.com', '*', 3);

// my******************
```

Since it works like `substr_replace()`, you can use a negative index with a custom length.

```php
Str::mask('+56 9 87654321', '*', -8, 6);

// + 56 9 ******21
```

## How?

1. I don't know I just made it multi-byte, so it works on hiragana.

## Why?

There is no helper to mask a portion of a string. Without this helper, you must first extract the replaceable portion of the string, repeat a character, and then manually look for the portion and replace it.

## BC?

Nope, only additive