### PR TITLE
[8.x] Add support for SKIP LOCKED to MariaDB

### DIFF
--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -254,12 +254,14 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
         $databaseEngine = $this->database->getPdo()->getAttribute(PDO::ATTR_DRIVER_NAME);
         $databaseVersion = $this->database->getConfig('version') ?? $this->database->getPdo()->getAttribute(PDO::ATTR_SERVER_VERSION);
 
-        if (($databaseEngine === 'mysql' && (
-                (! strpos($databaseVersion, 'MariaDB') && version_compare($databaseVersion, '8.0.1', '>=')) ||
-                (strpos($databaseVersion, 'MariaDB') && version_compare(Str::before(Str::after($databaseVersion, '5.5.5-'), '-'), '10.6.0', '>='))
-            )) ||
-            ($databaseEngine === 'pgsql' && version_compare($databaseVersion, '9.5', '>='))
-        ) {
+        if (Str::of($databaseVersion)->contains('MariaDB')) {
+            $databaseEngine = 'mariadb';
+            $databaseVersion = Str::before(Str::after($databaseVersion, '5.5.5-'), '-');
+        }
+
+        if (($databaseEngine === 'mysql' && version_compare($databaseVersion, '8.0.1', '>=')) ||
+            ($databaseEngine === 'mariadb' && version_compare($databaseVersion, '10.6.0', '>=')) ||
+            ($databaseEngine === 'pgsql' && version_compare($databaseVersion, '9.5', '>='))) {
             return 'FOR UPDATE SKIP LOCKED';
         }
 

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Connection;
 use Illuminate\Queue\Jobs\DatabaseJob;
 use Illuminate\Queue\Jobs\DatabaseJobRecord;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
 use PDO;
 
 class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
@@ -253,8 +254,12 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
         $databaseEngine = $this->database->getPdo()->getAttribute(PDO::ATTR_DRIVER_NAME);
         $databaseVersion = $this->database->getConfig('version') ?? $this->database->getPdo()->getAttribute(PDO::ATTR_SERVER_VERSION);
 
-        if (($databaseEngine === 'mysql' && ! strpos($databaseVersion, 'MariaDB') && version_compare($databaseVersion, '8.0.1', '>=')) ||
-            ($databaseEngine === 'pgsql' && version_compare($databaseVersion, '9.5', '>='))) {
+        if (($databaseEngine === 'mysql' && (
+                (! strpos($databaseVersion, 'MariaDB') && version_compare($databaseVersion, '8.0.1', '>=')) ||
+                (strpos($databaseVersion, 'MariaDB') && version_compare(Str::before(Str::after($databaseVersion, '5.5.5-'), '-'), '10.6.0', '>='))
+            )) ||
+            ($databaseEngine === 'pgsql' && version_compare($databaseVersion, '9.5', '>='))
+        ) {
             return 'FOR UPDATE SKIP LOCKED';
         }
 


### PR DESCRIPTION
These changes add support to add SKIP LOCKED functionality to the MariaDB (MySQL) engine.

Implementation proof: https://3v4l.org/jShU9
Versioning sanitization: https://3v4l.org/2IqgH

Replaces #39311
