### PR TITLE
[8.x] Cast strings into Stringable

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -597,7 +597,7 @@ trait HasAttributes
             case 'decimal':
                 return $this->asDecimal($value, explode(':', $this->getCasts()[$key], 2)[1]);
             case 'string':
-                return (string) $value;
+                return Str::of($value);
             case 'bool':
             case 'boolean':
                 return (bool) $value;


### PR DESCRIPTION
In the same way that dates like `created_at` casted into `Carbon` instances are convenient for easy manipulation:
```php
$model->created_at->format('Y-m-d')
```
instead of 
```php
Date::createFromTimestamp($model->created_at)->format('Y-m-d')
```

I thought it would be cool to cast strings attribute into `Stringable` instances:
```php
$model->name->title()
```
instead of 
```php
Str::of($model->name)->title()
```

What do you think about it?