### PR TITLE
[8.x] Clarifies parallel testing token type

### DIFF
--- a/src/Illuminate/Testing/ParallelTesting.php
+++ b/src/Illuminate/Testing/ParallelTesting.php
@@ -257,7 +257,7 @@ class ParallelTesting
     /**
      * Gets a unique test token.
      *
-     * @return int|false
+     * @return string|false
      */
     public function token()
     {

--- a/tests/Testing/ParallelTestingTest.php
+++ b/tests/Testing/ParallelTestingTest.php
@@ -36,7 +36,7 @@ class ParallelTestingTest extends TestCase
                 $this->assertNull($testCase);
             }
 
-            $this->assertEquals(1, $token);
+            $this->assertSame('1', $token);
             $state = true;
         });
 

--- a/tests/Testing/ParallelTestingTest.php
+++ b/tests/Testing/ParallelTestingTest.php
@@ -44,7 +44,7 @@ class ParallelTestingTest extends TestCase
         $this->assertFalse($state);
 
         $parallelTesting->resolveTokenUsing(function () {
-            return 1;
+            return '1';
         });
 
         $parallelTesting->{$caller}($this);
@@ -80,10 +80,10 @@ class ParallelTestingTest extends TestCase
         $this->assertFalse($parallelTesting->token());
 
         $parallelTesting->resolveTokenUsing(function () {
-            return 1;
+            return '1';
         });
 
-        $this->assertSame(1, $parallelTesting->token());
+        $this->assertSame('1', $parallelTesting->token());
     }
 
     public function callbacks()


### PR DESCRIPTION
This pull request clarifies that the Parallel Testing token is a string.

Closes https://github.com/laravel/framework/issues/39397.