### PR TITLE
[8.x] Improves internal `./bin/test` script

### DIFF
--- a/bin/test.sh
+++ b/bin/test.sh
@@ -1,23 +1,50 @@
 #!/usr/bin/env bash
 
-docker-compose down -t 0 &> /dev/null
+down=false
+php="8.0"
+
+while true; do
+  case "$1" in
+    --down ) down=true; shift ;;
+    --php ) php=$2; shift 2;;
+    -- ) shift; break ;;
+    * ) break ;;
+  esac
+done
+
+if $down; then
+    docker-compose down -t 0
+
+    exit 0
+fi
+
+echo "Ensuring docker is running"
+
+if ! docker info > /dev/null 2>&1; then
+  echo "Please start docker first."
+  exit 1
+fi
+
+echo "Ensuring services are running"
+
 docker-compose up -d
 
-echo "Waiting for services to boot   ..."
+if docker run -it --rm "registry.gitlab.com/grahamcampbell/php:$php-base" -r "\$tries = 0; while (true) { try { \$tries++; if (\$tries > 30) { throw new RuntimeException('MySQL never became available'); } sleep(1); new PDO('mysql:host=docker.for.mac.localhost;dbname=forge', 'root', '', [PDO::ATTR_TIMEOUT => 3]); break; } catch (PDOException \$e) {} }"; then
+    echo "Running tests"
 
-if docker run -it --rm registry.gitlab.com/grahamcampbell/php:7.4-base -r "\$tries = 0; while (true) { try { \$tries++; if (\$tries > 30) { throw new RuntimeException('MySQL never became available'); } sleep(1); new PDO('mysql:host=docker.for.mac.localhost;dbname=forge', 'root', '', [PDO::ATTR_TIMEOUT => 3]); break; } catch (PDOException \$e) {} }"; then
-    if docker run -it -w /data -v ${PWD}:/data:delegated --entrypoint vendor/bin/phpunit \
+    if docker run -it -w /data -v ${PWD}:/data:delegated \
+       --user "www-data" --entrypoint vendor/bin/phpunit \
        --env CI=1 --env DB_HOST=docker.for.mac.localhost --env DB_USERNAME=root \
+       --env DB_HOST=docker.for.mac.localhost --env DB_PORT=3306 \
+       --env DYNAMODB_ENDPOINT=docker.for.mac.localhost:8000 --env DYNAMODB_CACHE_TABLE=cache --env AWS_ACCESS_KEY_ID=dummy --env AWS_SECRET_ACCESS_KEY=dummy \
        --env REDIS_HOST=docker.for.mac.localhost --env REDIS_PORT=6379 \
        --env MEMCACHED_HOST=docker.for.mac.localhost --env MEMCACHED_PORT=11211 \
-       --rm registry.gitlab.com/grahamcampbell/php:7.4-base "$@"; then
-        docker-compose down -t 0
+       --rm "registry.gitlab.com/grahamcampbell/php:$php-base" "$@"; then
+        exit 0
     else
-        docker-compose down -t 0
         exit 1
     fi
 else
     docker-compose logs
-    docker-compose down -t 0 &> /dev/null
     exit 1
 fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,22 @@
 version: '3'
 services:
+  dynamodb:
+    image:  amazon/dynamodb-local
+    ports:
+      - "8000:8000"
+    command: ["-jar", "DynamoDBLocal.jar", "-sharedDb", "-inMemory"]
   memcached:
     image: memcached:1.6-alpine
     ports:
       - "11211:11211"
     restart: always
   mysql:
-    image: mysql:5.7
+    image: mysql/mysql-server:5.7
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: 1
       MYSQL_ROOT_PASSWORD: ""
       MYSQL_DATABASE: "forge"
+      MYSQL_ROOT_HOST: "%"
     ports:
       - "3306:3306"
     restart: always

--- a/tests/Cache/CacheMemcachedStoreTest.php
+++ b/tests/Cache/CacheMemcachedStoreTest.php
@@ -88,6 +88,11 @@ class CacheMemcachedStoreTest extends TestCase
             $this->markTestSkipped('Memcached module not installed');
         }
 
+        /* @link https://github.com/php-memcached-dev/php-memcached/pull/468 */
+        if (version_compare(phpversion(), '8.0.0', '>=')) {
+            $this->markTestSkipped('Test broken due to parse error in PHP Memcached.');
+        }
+
         $memcached = m::mock(Memcached::class);
         $memcached->shouldReceive('increment')->with('foo', 5)->once()->andReturn(5);
 
@@ -99,6 +104,11 @@ class CacheMemcachedStoreTest extends TestCase
     {
         if (! class_exists(Memcached::class)) {
             $this->markTestSkipped('Memcached module not installed');
+        }
+
+        /* @link https://github.com/php-memcached-dev/php-memcached/pull/468 */
+        if (version_compare(phpversion(), '8.0.0', '>=')) {
+            $this->markTestSkipped('Test broken due to parse error in PHP Memcached.');
         }
 
         $memcached = m::mock(Memcached::class);

--- a/tests/Cache/CacheMemcachedStoreTest.php
+++ b/tests/Cache/CacheMemcachedStoreTest.php
@@ -88,11 +88,6 @@ class CacheMemcachedStoreTest extends TestCase
             $this->markTestSkipped('Memcached module not installed');
         }
 
-        /* @link https://github.com/php-memcached-dev/php-memcached/pull/468 */
-        if (version_compare(phpversion(), '8.0.0', '>=')) {
-            $this->markTestSkipped('Test broken due to parse error in PHP Memcached.');
-        }
-
         $memcached = m::mock(Memcached::class);
         $memcached->shouldReceive('increment')->with('foo', 5)->once()->andReturn(5);
 
@@ -104,11 +99,6 @@ class CacheMemcachedStoreTest extends TestCase
     {
         if (! class_exists(Memcached::class)) {
             $this->markTestSkipped('Memcached module not installed');
-        }
-
-        /* @link https://github.com/php-memcached-dev/php-memcached/pull/468 */
-        if (version_compare(phpversion(), '8.0.0', '>=')) {
-            $this->markTestSkipped('Test broken due to parse error in PHP Memcached.');
         }
 
         $memcached = m::mock(Memcached::class);

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -21,7 +21,7 @@ class FilesystemTest extends TestCase
      */
     public static function setUpTempDir()
     {
-        self::$tempDir = sys_get_temp_dir() .  '/tmp';
+        self::$tempDir = sys_get_temp_dir().'/tmp';
         mkdir(self::$tempDir);
     }
 

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -21,7 +21,7 @@ class FilesystemTest extends TestCase
      */
     public static function setUpTempDir()
     {
-        self::$tempDir = __DIR__.'/tmp';
+        self::$tempDir = sys_get_temp_dir() .  '/tmp';
         mkdir(self::$tempDir);
     }
 


### PR DESCRIPTION
This pull request improves the script `./bin/test.sh` on the following topics:

- Fixes 3 failing tests.
- Lower the skipped tests from 17 to 12. As an example, Dynamo DB tests are now been run.
- You can now specify the PHP version by doing: `./bin/test.sh --php 8.0`.
- PHP 8 is now the default version.
- Docker services are no longer "shut down" after the script run, so re-run the tests become faster.
- Docker services may be shut down by using `./bin/test.sh --down`.
- Fixes the usage of the MySQL service on M1.

@GrahamCampbell I may need your help with the remaining 10 skipped tests that concern the "redis" extension. It's out of my "docker" league. But we can do it on a different pull request.

You may "pass" PHPUnit options like so: `./bin/test.sh - ./your-test-name`