### PR TITLE
[8.x] New `decorate` method for DI container

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1182,12 +1182,11 @@ class Container implements ArrayAccess, ContainerContract
             throw new InvalidArgumentException(sprintf('%s type has not been registered', $abstract));
         }
         $binding = $this->bindings[$abstract];
-        $shared = $binding['shared'];
         $concrete = function ($container, $parameters = []) use ($abstract, $decorator, $binding) {
             $container->addContextualBinding($decorator, $abstract, $binding['concrete']);
-            return $container->make($decorator);
+            return $container->resolve($decorator, $parameters);
         };
-        $this->bindings[$abstract] = compact('concrete', 'shared');
+        $this->bind($abstract, $concrete, $binding['shared']);
     }
 
     /**

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1178,12 +1178,13 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function decorate($abstract, $decorator)
     {
-        if (!isset($this->bindings[$abstract])) {
+        if (! isset($this->bindings[$abstract])) {
             throw new InvalidArgumentException(sprintf('%s type has not been registered', $abstract));
         }
         $binding = $this->bindings[$abstract];
         $concrete = function ($container, $parameters = []) use ($abstract, $decorator, $binding) {
             $container->addContextualBinding($decorator, $abstract, $binding['concrete']);
+
             return $container->resolve($decorator, $parameters);
         };
         $this->bind($abstract, $concrete, $binding['shared']);

--- a/src/Illuminate/Contracts/Container/Container.php
+++ b/src/Illuminate/Contracts/Container/Container.php
@@ -180,4 +180,13 @@ interface Container extends ContainerInterface
      * @return void
      */
     public function afterResolving($abstract, Closure $callback = null);
+
+    /**
+     * Decorate already registered service.
+     *
+     * @param  string  $abstract
+     * @param  string  $decorator
+     * @return void
+     */
+    public function decorate($abstract, $decorator);
 }

--- a/tests/Container/ContainerDecorateTest.php
+++ b/tests/Container/ContainerDecorateTest.php
@@ -114,14 +114,14 @@ class Clock implements IClock
 {
     public function utcNow(): string
     {
-        return time();
+        return (string)time();
     }
 }
 
 class CachedClock implements IClock
 {
     public IClock $origin;
-    private ?string $timestamp;
+    private ?string $timestamp = null;
 
     public function __construct(IClock $origin)
     {
@@ -130,7 +130,7 @@ class CachedClock implements IClock
 
     public function utcNow(): string
     {
-        if (!isset($this->timestamp)) {
+        if (is_null($this->timestamp)) {
             $this->timestamp = $this->origin->utcNow();
         }
         return $this->timestamp;
@@ -164,6 +164,7 @@ class ClockFormatter implements IClockFormatter
     public function format(IClock $clock): string
     {
         $timestamp = $clock->utcNow();
+
         return sprintf('[%s]', $timestamp);
     }
 }
@@ -176,5 +177,4 @@ class ClockHolder
     {
         $this->clock = $clock;
     }
-
 }

--- a/tests/Container/ContainerDecorateTest.php
+++ b/tests/Container/ContainerDecorateTest.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace Illuminate\Tests\Container;
+
+use Illuminate\Container\Container;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+class ContainerDecorateTest extends TestCase
+{
+    public function testDecorateExistingBinding()
+    {
+        $container = new Container();
+        $container->singleton(IClock::class, Clock::class);
+        $container->decorate(IClock::class, CachedClock::class);
+
+        $clock = $container->get(IClock::class);
+        $timestamp = $clock->utcNow();
+
+        $this->assertInstanceOf(CachedClock::class, $clock);
+        $this->assertEquals($timestamp, $clock->utcNow());
+    }
+
+    public function testChainingDecorators()
+    {
+        $container = new Container();
+        $container->singleton(IClock::class, Clock::class);
+        $container->decorate(IClock::class, CachedClock::class);
+        $container->decorate(IClock::class, PrettyPrintClock::class);
+        $container->singleton(IClockFormatter::class, ClockFormatter::class);
+
+        $clock = $container->get(IClock::class);
+        $timestamp = $clock->utcNow();
+
+        $this->assertInstanceOf(PrettyPrintClock::class, $clock);
+        $this->assertStringStartsWith('[', $timestamp);
+        $this->assertStringEndsWith(']', $timestamp);
+        $this->assertEquals($timestamp, $clock->utcNow());
+    }
+
+    public function testThrowExceptionWhenBindingDoesNotExist()
+    {
+        $container = new Container();
+        $this->expectException(InvalidArgumentException::class);
+        $container->decorate(IClock::class, Clock::class);
+    }
+
+    public function testDecoratorHasTheSameLifetimeAsDecoratedOne()
+    {
+        $container = new Container();
+        $container->bind(IClock::class, Clock::class);
+        $container->decorate(IClock::class, CachedClock::class);
+
+        $clock1 = $container->get(IClock::class);
+        $clock2 = $container->get(IClock::class);
+
+        $this->assertNotSame($clock1, $clock2);
+        $this->assertInstanceOf(CachedClock::class, $clock1);
+        $this->assertInstanceOf(CachedClock::class, $clock2);
+    }
+
+    public function testReboundSingleton()
+    {
+        $container = new Container();
+        $container->singleton(IClock::class, Clock::class);
+
+        $clock1 = $container->get(IClock::class);
+        $container->decorate(IClock::class, CachedClock::class);
+        $clock2 = $container->get(IClock::class);
+
+        $this->assertNotSame($clock1, $clock2);
+        $this->assertInstanceOf(Clock::class, $clock1);
+        $this->assertInstanceOf(CachedClock::class, $clock2);
+    }
+
+    public function testReboundDependency()
+    {
+        $container = new Container();
+        $container->singleton(IClock::class, Clock::class);
+        $container->bind(ClockHolder::class);
+
+        $holder1 = $container->get(ClockHolder::class);
+        $container->decorate(IClock::class, CachedClock::class);
+        $holder2 = $container->get(ClockHolder::class);
+
+        $this->assertNotSame($holder1, $holder2);
+        $this->assertInstanceOf(Clock::class, $holder1->clock);
+        $this->assertInstanceOf(CachedClock::class, $holder2->clock);
+    }
+
+    public function testRecursive()
+    {
+        $container = new Container();
+        $container->singleton(IClockFormatter::class, ClockFormatter::class);
+        $container->singleton(IClock::class, Clock::class);
+        $container->decorate(IClock::class, CachedClock::class);
+        $container->decorate(IClock::class, PrettyPrintClock::class);
+
+        $clock = $container->make(CachedClock::class);
+
+        $this->assertInstanceOf(CachedClock::class, $clock);
+        $this->assertInstanceOf(PrettyPrintClock::class, $clock->origin);
+        $this->assertInstanceOf(CachedClock::class, $clock->origin->origin);
+        $this->assertInstanceOf(Clock::class, $clock->origin->origin->origin);
+    }
+}
+
+interface IClock
+{
+    public function utcNow(): string;
+}
+
+class Clock implements IClock
+{
+    public function utcNow(): string
+    {
+        return time();
+    }
+}
+
+class CachedClock implements IClock
+{
+    public IClock $origin;
+    private ?string $timestamp;
+
+    public function __construct(IClock $origin)
+    {
+        $this->origin = $origin;
+    }
+
+    public function utcNow(): string
+    {
+        if (!isset($this->timestamp)) {
+            $this->timestamp = $this->origin->utcNow();
+        }
+        return $this->timestamp;
+    }
+}
+
+class PrettyPrintClock implements IClock
+{
+    public IClock $origin;
+    private IClockFormatter $formatter;
+
+    public function __construct(IClock $origin, IClockFormatter $fomatter)
+    {
+        $this->origin = $origin;
+        $this->formatter = $fomatter;
+    }
+
+    public function utcNow(): string
+    {
+        return $this->formatter->format($this->origin);
+    }
+}
+
+interface IClockFormatter
+{
+    public function format(IClock $clock): string;
+}
+
+class ClockFormatter implements IClockFormatter
+{
+    public function format(IClock $clock): string
+    {
+        $timestamp = $clock->utcNow();
+        return sprintf('[%s]', $timestamp);
+    }
+}
+
+class ClockHolder
+{
+    public IClock $clock;
+
+    public function __construct(IClock $clock)
+    {
+        $this->clock = $clock;
+    }
+
+}


### PR DESCRIPTION
I propose adding the new `decorate` method for the DI container.
The purpose of the last one is to add support for the decorator pattern. Its behaviour similar the `extend` function with few exception. Let's looks at the following example
```
interface IClock
{
    public function utcNow(): string
}

class Clock implements IClock
{
    public function utcNow(): string
    {
        return time();
    }
}

class CachedClock implements IClock
{
    private IClock $origin;
    private ?string $time;

    public function __construct(IClock $origin)
    {
        $this->origin = $origin;
    }

    public function utcNow(): string
    {
        if (!isset($this->time)) {
            $this->time = $this->origin->utcNow();
        }
        return $this->time;
    }
}

class Service
{
    private IClock $clock;

    public function __construct(IClock $clock)
    {
        $this->clock = $clock;
    }

    public function echo()
    {
        echo $this->clock->utcNow() . PHP_EOL;;
    }
}
```

Currently, we can use the `extend` method to decorate already registed implementation of the `IClock` interface. Something like this.

```
$container = new Container();
$container->singleton(IClock::class, Clock::class);
$container->extend(IClock::class, fn($decorated, $c) => new CachedClock($decorated));
$service = $contaner->make(Service::class);
```

But what if the decorator has more than one constructor parameter
```
class PrettyPrintClock implements IClock
{
    public function __construct(IClock $clock, Dep1 $dep1, Dep2 $dep2, ....)
}
```

In this case, we have to manually retrieve each dependency from the container and inject it.

```
$container->extend(IClock::class, fn($decorated, $c) => new PrettyPrintClock($decorated,
    $c->get(Dep1::class), $c->get(Dep2::class)));
```

I have added implementation of the `decorate` method that avoids this routine. The same example will look like this

```
$container->decorate(IClock:class, PrettyPrintClock::class);
```

Also the new method supports chaining.
```
$container->singleton(IClock:class, Clock::class);
$container->decorate(IClock:class, CachedClock::class);
$container->decorate(IClock:class, PrettyPrintClock::class);
```

Please see tests for more details. 