### PR TITLE
[8.x] Clean up test suite

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithRedis.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithRedis.php
@@ -30,10 +30,6 @@ trait InteractsWithRedis
      */
     public function setUpRedis()
     {
-        $app = $this->app ?? new Application;
-        $host = Env::get('REDIS_HOST', '127.0.0.1');
-        $port = Env::get('REDIS_PORT', 6379);
-
         if (! extension_loaded('redis')) {
             $this->markTestSkipped('The redis extension is not installed. Please install the extension to enable '.__CLASS__);
         }
@@ -41,6 +37,10 @@ trait InteractsWithRedis
         if (static::$connectionFailedOnceWithDefaultsSkip) {
             $this->markTestSkipped('Trying default host/port failed, please set environment variable REDIS_HOST & REDIS_PORT to enable '.__CLASS__);
         }
+
+        $app = $this->app ?? new Application;
+        $host = Env::get('REDIS_HOST', '127.0.0.1');
+        $port = Env::get('REDIS_PORT', 6379);
 
         foreach ($this->redisDriverProvider() as $driver) {
             $this->redis[$driver[0]] = new RedisManager($app, $driver[0], [
@@ -63,6 +63,7 @@ trait InteractsWithRedis
         } catch (Exception $e) {
             if ($host === '127.0.0.1' && $port === 6379 && Env::get('REDIS_HOST') === null) {
                 static::$connectionFailedOnceWithDefaultsSkip = true;
+
                 $this->markTestSkipped('Trying default host/port failed, please set environment variable REDIS_HOST & REDIS_PORT to enable '.__CLASS__);
             }
         }

--- a/tests/Cache/CacheMemcachedConnectorTest.php
+++ b/tests/Cache/CacheMemcachedConnectorTest.php
@@ -13,6 +13,8 @@ class CacheMemcachedConnectorTest extends TestCase
     protected function tearDown(): void
     {
         m::close();
+
+        parent::tearDown();
     }
 
     public function testServersAreAddedCorrectly()
@@ -46,12 +48,11 @@ class CacheMemcachedConnectorTest extends TestCase
         $this->assertSame($result, $memcached);
     }
 
+    /**
+     * @requires extension memcached
+     */
     public function testServersAreAddedCorrectlyWithValidOptions()
     {
-        if (! class_exists('Memcached')) {
-            $this->markTestSkipped('Memcached module not installed');
-        }
-
         $validOptions = [
             Memcached::OPT_NO_BLOCK => true,
             Memcached::OPT_CONNECT_TIMEOUT => 2000,
@@ -70,12 +71,11 @@ class CacheMemcachedConnectorTest extends TestCase
         $this->assertSame($result, $memcached);
     }
 
+    /**
+     * @requires extension memcached
+     */
     public function testServersAreAddedCorrectlyWithSaslCredentials()
     {
-        if (! class_exists('Memcached')) {
-            $this->markTestSkipped('Memcached module not installed');
-        }
-
         $saslCredentials = ['foo', 'bar'];
 
         $memcached = $this->memcachedMockWithAddServer();

--- a/tests/Cache/CacheMemcachedStoreTest.php
+++ b/tests/Cache/CacheMemcachedStoreTest.php
@@ -9,6 +9,9 @@ use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
+/**
+ * @requires extension memcached
+ */
 class CacheMemcachedStoreTest extends TestCase
 {
     protected function tearDown(): void
@@ -20,10 +23,6 @@ class CacheMemcachedStoreTest extends TestCase
 
     public function testGetReturnsNullWhenNotFound()
     {
-        if (! class_exists(Memcached::class)) {
-            $this->markTestSkipped('Memcached module not installed');
-        }
-
         $memcache = $this->getMockBuilder(stdClass::class)->addMethods(['get', 'getResultCode'])->getMock();
         $memcache->expects($this->once())->method('get')->with($this->equalTo('foo:bar'))->willReturn(null);
         $memcache->expects($this->once())->method('getResultCode')->willReturn(1);
@@ -33,10 +32,6 @@ class CacheMemcachedStoreTest extends TestCase
 
     public function testMemcacheValueIsReturned()
     {
-        if (! class_exists(Memcached::class)) {
-            $this->markTestSkipped('Memcached module not installed');
-        }
-
         $memcache = $this->getMockBuilder(stdClass::class)->addMethods(['get', 'getResultCode'])->getMock();
         $memcache->expects($this->once())->method('get')->willReturn('bar');
         $memcache->expects($this->once())->method('getResultCode')->willReturn(0);
@@ -46,10 +41,6 @@ class CacheMemcachedStoreTest extends TestCase
 
     public function testMemcacheGetMultiValuesAreReturnedWithCorrectKeys()
     {
-        if (! class_exists(Memcached::class)) {
-            $this->markTestSkipped('Memcached module not installed');
-        }
-
         $memcache = $this->getMockBuilder(stdClass::class)->addMethods(['getMulti', 'getResultCode'])->getMock();
         $memcache->expects($this->once())->method('getMulti')->with(
             ['foo:foo', 'foo:bar', 'foo:baz']
@@ -69,10 +60,6 @@ class CacheMemcachedStoreTest extends TestCase
 
     public function testSetMethodProperlyCallsMemcache()
     {
-        if (! class_exists(Memcached::class)) {
-            $this->markTestSkipped('Memcached module not installed');
-        }
-
         Carbon::setTestNow($now = Carbon::now());
         $memcache = $this->getMockBuilder(Memcached::class)->onlyMethods(['set'])->getMock();
         $memcache->expects($this->once())->method('set')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo($now->timestamp + 60))->willReturn(true);
@@ -84,10 +71,6 @@ class CacheMemcachedStoreTest extends TestCase
 
     public function testIncrementMethodProperlyCallsMemcache()
     {
-        if (! class_exists(Memcached::class)) {
-            $this->markTestSkipped('Memcached module not installed');
-        }
-
         /* @link https://github.com/php-memcached-dev/php-memcached/pull/468 */
         if (version_compare(phpversion(), '8.0.0', '>=')) {
             $this->markTestSkipped('Test broken due to parse error in PHP Memcached.');
@@ -102,10 +85,6 @@ class CacheMemcachedStoreTest extends TestCase
 
     public function testDecrementMethodProperlyCallsMemcache()
     {
-        if (! class_exists(Memcached::class)) {
-            $this->markTestSkipped('Memcached module not installed');
-        }
-
         /* @link https://github.com/php-memcached-dev/php-memcached/pull/468 */
         if (version_compare(phpversion(), '8.0.0', '>=')) {
             $this->markTestSkipped('Test broken due to parse error in PHP Memcached.');
@@ -120,10 +99,6 @@ class CacheMemcachedStoreTest extends TestCase
 
     public function testStoreItemForeverProperlyCallsMemcached()
     {
-        if (! class_exists(Memcached::class)) {
-            $this->markTestSkipped('Memcached module not installed');
-        }
-
         $memcache = $this->getMockBuilder(Memcached::class)->onlyMethods(['set'])->getMock();
         $memcache->expects($this->once())->method('set')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(0))->willReturn(true);
         $store = new MemcachedStore($memcache);
@@ -133,10 +108,6 @@ class CacheMemcachedStoreTest extends TestCase
 
     public function testForgetMethodProperlyCallsMemcache()
     {
-        if (! class_exists(Memcached::class)) {
-            $this->markTestSkipped('Memcached module not installed');
-        }
-
         $memcache = $this->getMockBuilder(Memcached::class)->onlyMethods(['delete'])->getMock();
         $memcache->expects($this->once())->method('delete')->with($this->equalTo('foo'));
         $store = new MemcachedStore($memcache);
@@ -145,10 +116,6 @@ class CacheMemcachedStoreTest extends TestCase
 
     public function testFlushesCached()
     {
-        if (! class_exists(Memcached::class)) {
-            $this->markTestSkipped('Memcached module not installed');
-        }
-
         $memcache = $this->getMockBuilder(Memcached::class)->onlyMethods(['flush'])->getMock();
         $memcache->expects($this->once())->method('flush')->willReturn(true);
         $store = new MemcachedStore($memcache);
@@ -158,10 +125,6 @@ class CacheMemcachedStoreTest extends TestCase
 
     public function testGetAndSetPrefix()
     {
-        if (! class_exists(Memcached::class)) {
-            $this->markTestSkipped('Memcached module not installed');
-        }
-
         $store = new MemcachedStore(new Memcached, 'bar');
         $this->assertSame('bar:', $store->getPrefix());
         $store->setPrefix('foo');

--- a/tests/Console/Scheduling/EventTest.php
+++ b/tests/Console/Scheduling/EventTest.php
@@ -12,36 +12,35 @@ class EventTest extends TestCase
     protected function tearDown(): void
     {
         m::close();
+
+        parent::tearDown();
     }
 
+    /**
+     * @requires OSFAMILY Linux|Darwin
+     */
     public function testBuildCommandUsingUnix()
     {
-        if (windows_os()) {
-            $this->markTestSkipped('Skipping since operating system is Windows');
-        }
-
         $event = new Event(m::mock(EventMutex::class), 'php -i');
 
         $this->assertSame("php -i > '/dev/null' 2>&1", $event->buildCommand());
     }
 
+    /**
+     * @requires OSFAMILY Windows
+     */
     public function testBuildCommandUsingWindows()
     {
-        if (! windows_os()) {
-            $this->markTestSkipped('Skipping since operating system is not Windows');
-        }
-
         $event = new Event(m::mock(EventMutex::class), 'php -i');
 
         $this->assertSame('php -i > "NUL" 2>&1', $event->buildCommand());
     }
 
+    /**
+     * @requires OSFAMILY Linux|Darwin
+     */
     public function testBuildCommandInBackgroundUsingUnix()
     {
-        if (windows_os()) {
-            $this->markTestSkipped('Skipping since operating system is Windows');
-        }
-
         $event = new Event(m::mock(EventMutex::class), 'php -i');
         $event->runInBackground();
 
@@ -50,12 +49,11 @@ class EventTest extends TestCase
         $this->assertSame("(php -i > '/dev/null' 2>&1 ; '".PHP_BINARY."' artisan schedule:finish {$scheduleId} \"$?\") > '/dev/null' 2>&1 &", $event->buildCommand());
     }
 
+    /**
+     * @requires OSFAMILY Windows
+     */
     public function testBuildCommandInBackgroundUsingWindows()
     {
-        if (! windows_os()) {
-            $this->markTestSkipped('Skipping since operating system is not Windows');
-        }
-
         $event = new Event(m::mock(EventMutex::class), 'php -i');
         $event->runInBackground();
 

--- a/tests/Console/Scheduling/EventTest.php
+++ b/tests/Console/Scheduling/EventTest.php
@@ -17,7 +17,7 @@ class EventTest extends TestCase
     }
 
     /**
-     * @requires OSFAMILY Linux|Darwin
+     * @requires OS Linux|Darwin
      */
     public function testBuildCommandUsingUnix()
     {
@@ -27,7 +27,7 @@ class EventTest extends TestCase
     }
 
     /**
-     * @requires OSFAMILY Windows
+     * @requires OS Windows
      */
     public function testBuildCommandUsingWindows()
     {
@@ -37,7 +37,7 @@ class EventTest extends TestCase
     }
 
     /**
-     * @requires OSFAMILY Linux|Darwin
+     * @requires OS Linux|Darwin
      */
     public function testBuildCommandInBackgroundUsingUnix()
     {
@@ -50,7 +50,7 @@ class EventTest extends TestCase
     }
 
     /**
-     * @requires OSFAMILY Windows
+     * @requires OS Windows
      */
     public function testBuildCommandInBackgroundUsingWindows()
     {

--- a/tests/Database/DatabaseConnectorTest.php
+++ b/tests/Database/DatabaseConnectorTest.php
@@ -192,12 +192,11 @@ class DatabaseConnectorTest extends TestCase
         $this->assertSame($result, $connection);
     }
 
+    /**
+     * @requires extension odbc
+     */
     public function testSqlServerConnectCallsCreateConnectionWithPreferredODBC()
     {
-        if (! in_array('odbc', PDO::getAvailableDrivers())) {
-            $this->markTestSkipped('PHP was compiled without PDO ODBC support.');
-        }
-
         $config = ['odbc' => true, 'odbc_datasource_name' => 'server=localhost;database=test;'];
         $dsn = $this->getDsn($config);
         $connector = $this->getMockBuilder(SqlServerConnector::class)->onlyMethods(['createConnection', 'getOptions'])->getMock();

--- a/tests/Database/DatabaseEloquentHasOneOfManyTest.php
+++ b/tests/Database/DatabaseEloquentHasOneOfManyTest.php
@@ -8,9 +8,6 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @group one-of-many
- */
 class DatabaseEloquentHasOneOfManyTest extends TestCase
 {
     protected function setUp(): void

--- a/tests/Database/DatabaseEloquentMorphOneOfManyTest.php
+++ b/tests/Database/DatabaseEloquentMorphOneOfManyTest.php
@@ -6,9 +6,6 @@ use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @group one-of-many
- */
 class DatabaseEloquentMorphOneOfManyTest extends TestCase
 {
     protected function setUp(): void

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Tests\Database;
 
-use Doctrine\DBAL\Schema\SqliteSchemaManager;
 use Illuminate\Database\Capsule\Manager;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Schema\Blueprint;
@@ -98,10 +97,6 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function testDropColumn()
     {
-        if (! class_exists(SqliteSchemaManager::class)) {
-            $this->markTestSkipped('Doctrine should be installed to run dropColumn tests');
-        }
-
         $db = new Manager;
 
         $db->addConnection([
@@ -149,10 +144,6 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function testRenameIndex()
     {
-        if (! class_exists(SqliteSchemaManager::class)) {
-            $this->markTestSkipped('Doctrine should be installed to run renameIndex tests');
-        }
-
         $db = new Manager;
 
         $db->addConnection([

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -494,7 +494,7 @@ class FilesystemTest extends TestCase
 
     /**
      * @requires extension pcntl
-     * @requires OS Linux
+     * @requires OS Linux|Darwin
      */
     public function testSharedGet()
     {

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -100,7 +100,7 @@ class FilesystemTest extends TestCase
     }
 
     /**
-     * @requires OSFAMILY Linux|Darwin
+     * @requires OS Linux|Darwin
      */
     public function testReplaceWhenUnixSymlinkExists()
     {
@@ -494,7 +494,7 @@ class FilesystemTest extends TestCase
 
     /**
      * @requires extension pcntl
-     * @requires OSFAMILY Linux
+     * @requires OS Linux
      */
     public function testSharedGet()
     {

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -99,12 +99,11 @@ class FilesystemTest extends TestCase
         $this->assertStringEqualsFile($tempFile, 'Hello Taylor');
     }
 
+    /**
+     * @requires OSFAMILY Linux|Darwin
+     */
     public function testReplaceWhenUnixSymlinkExists()
     {
-        if (windows_os()) {
-            $this->markTestSkipped('The operating system is Windows');
-        }
-
         $tempFile = self::$tempDir.'/file.txt';
         $symlinkDir = self::$tempDir.'/symlink_dir';
         $symlink = "{$symlinkDir}/symlink.txt";
@@ -495,14 +494,10 @@ class FilesystemTest extends TestCase
 
     /**
      * @requires extension pcntl
-     * @requires function pcntl_fork
+     * @requires OSFAMILY Linux
      */
     public function testSharedGet()
     {
-        if (PHP_OS === 'Darwin') {
-            $this->markTestSkipped('The operating system is MacOS.');
-        }
-
         $content = str_repeat('123456', 1000000);
         $result = 1;
 

--- a/tests/Hashing/HasherTest.php
+++ b/tests/Hashing/HasherTest.php
@@ -23,10 +23,6 @@ class HasherTest extends TestCase
 
     public function testBasicArgon2iHashing()
     {
-        if (! defined('PASSWORD_ARGON2I')) {
-            $this->markTestSkipped('PHP not compiled with Argon2i hashing support.');
-        }
-
         $hasher = new ArgonHasher;
         $value = $hasher->make('password');
         $this->assertNotSame('password', $value);
@@ -38,10 +34,6 @@ class HasherTest extends TestCase
 
     public function testBasicArgon2idHashing()
     {
-        if (! defined('PASSWORD_ARGON2ID')) {
-            $this->markTestSkipped('PHP not compiled with Argon2id hashing support.');
-        }
-
         $hasher = new Argon2IdHasher;
         $value = $hasher->make('password');
         $this->assertNotSame('password', $value);
@@ -57,10 +49,6 @@ class HasherTest extends TestCase
     public function testBasicBcryptVerification()
     {
         $this->expectException(RuntimeException::class);
-
-        if (! defined('PASSWORD_ARGON2I')) {
-            $this->markTestSkipped('PHP not compiled with Argon2i hashing support.');
-        }
 
         $argonHasher = new ArgonHasher(['verify' => true]);
         $argonHashed = $argonHasher->make('password');

--- a/tests/Http/HttpTestingFileFactoryTest.php
+++ b/tests/Http/HttpTestingFileFactoryTest.php
@@ -5,14 +5,13 @@ namespace Illuminate\Tests\Http;
 use Illuminate\Http\Testing\FileFactory;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @requires extension gd
+ */
 class HttpTestingFileFactoryTest extends TestCase
 {
     public function testImagePng()
     {
-        if (! function_exists('imagepng')) {
-            $this->markTestSkipped('The extension gd is missing from your system or was compiled without PNG support.');
-        }
-
         $image = (new FileFactory)->image('test.png', 15, 20);
 
         $info = getimagesize($image->getRealPath());
@@ -24,10 +23,6 @@ class HttpTestingFileFactoryTest extends TestCase
 
     public function testImageJpeg()
     {
-        if (! function_exists('imagejpeg')) {
-            $this->markTestSkipped('The extension gd is missing from your system or was compiled without JPEG support.');
-        }
-
         $jpeg = (new FileFactory)->image('test.jpeg', 15, 20);
         $jpg = (new FileFactory)->image('test.jpg');
 
@@ -44,10 +39,6 @@ class HttpTestingFileFactoryTest extends TestCase
 
     public function testImageGif()
     {
-        if (! function_exists('imagegif')) {
-            $this->markTestSkipped('The extension gd is missing from your system or was compiled without GIF support.');
-        }
-
         $image = (new FileFactory)->image('test.gif');
 
         $this->assertSame(
@@ -58,10 +49,6 @@ class HttpTestingFileFactoryTest extends TestCase
 
     public function testImageWebp()
     {
-        if (! function_exists('imagewebp')) {
-            $this->markTestSkipped('The extension gd is missing from your system or was compiled without WEBP support.');
-        }
-
         $image = (new FileFactory)->image('test.webp');
 
         $this->assertSame(
@@ -72,10 +59,6 @@ class HttpTestingFileFactoryTest extends TestCase
 
     public function testImageWbmp()
     {
-        if (! function_exists('imagewbmp')) {
-            $this->markTestSkipped('The extension gd is missing from your system or was compiled without WBMP support.');
-        }
-
         $image = (new FileFactory)->image('test.wbmp');
 
         $this->assertSame(
@@ -86,10 +69,6 @@ class HttpTestingFileFactoryTest extends TestCase
 
     public function testImageBmp()
     {
-        if (! function_exists('imagebmp')) {
-            $this->markTestSkipped('The extension gd is missing from your system or was compiled without BMP support.');
-        }
-
         $image = (new FileFactory)->image('test.bmp');
 
         $imagePath = $image->getRealPath();

--- a/tests/Integration/Auth/AuthenticationTest.php
+++ b/tests/Integration/Auth/AuthenticationTest.php
@@ -22,9 +22,6 @@ use Illuminate\Tests\Integration\Auth\Fixtures\AuthenticationTestUser;
 use InvalidArgumentException;
 use Orchestra\Testbench\TestCase;
 
-/**
- * @group integration
- */
 class AuthenticationTest extends TestCase
 {
     protected function getEnvironmentSetUp($app)

--- a/tests/Integration/Auth/GatePolicyResolutionTest.php
+++ b/tests/Integration/Auth/GatePolicyResolutionTest.php
@@ -9,9 +9,6 @@ use Illuminate\Tests\Integration\Auth\Fixtures\AuthenticationTestUser;
 use Illuminate\Tests\Integration\Auth\Fixtures\Policies\AuthenticationTestUserPolicy;
 use Orchestra\Testbench\TestCase;
 
-/**
- * @group integration
- */
 class GatePolicyResolutionTest extends TestCase
 {
     public function testGateEvaluationEventIsFired()

--- a/tests/Integration/Broadcasting/BroadcastManagerTest.php
+++ b/tests/Integration/Broadcasting/BroadcastManagerTest.php
@@ -10,9 +10,6 @@ use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Queue;
 use Orchestra\Testbench\TestCase;
 
-/**
- * @group integration
- */
 class BroadcastManagerTest extends TestCase
 {
     public function testEventCanBeBroadcastNow()

--- a/tests/Integration/Cache/DynamoDbStoreTest.php
+++ b/tests/Integration/Cache/DynamoDbStoreTest.php
@@ -9,9 +9,6 @@ use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Str;
 use Orchestra\Testbench\TestCase;
 
-/**
- * @group integration
- */
 class DynamoDbStoreTest extends TestCase
 {
     protected function setUp(): void

--- a/tests/Integration/Cache/FileCacheLockTest.php
+++ b/tests/Integration/Cache/FileCacheLockTest.php
@@ -7,9 +7,6 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
 use Orchestra\Testbench\TestCase;
 
-/**
- * @group integration
- */
 class FileCacheLockTest extends TestCase
 {
     /**

--- a/tests/Integration/Cache/MemcachedCacheLockTestCase.php
+++ b/tests/Integration/Cache/MemcachedCacheLockTestCase.php
@@ -6,6 +6,9 @@ use Illuminate\Contracts\Cache\LockTimeoutException;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
 
+/**
+ * @requires extension memcached
+ */
 class MemcachedCacheLockTestCase extends MemcachedIntegrationTestCase
 {
     public function testMemcachedLocksCanBeAcquiredAndReleased()

--- a/tests/Integration/Cache/MemcachedCacheLockTestCase.php
+++ b/tests/Integration/Cache/MemcachedCacheLockTestCase.php
@@ -6,9 +6,6 @@ use Illuminate\Contracts\Cache\LockTimeoutException;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
 
-/**
- * @group integration
- */
 class MemcachedCacheLockTestCase extends MemcachedIntegrationTestCase
 {
     public function testMemcachedLocksCanBeAcquiredAndReleased()

--- a/tests/Integration/Cache/MemcachedIntegrationTestCase.php
+++ b/tests/Integration/Cache/MemcachedIntegrationTestCase.php
@@ -11,10 +11,6 @@ abstract class MemcachedIntegrationTestCase extends TestCase
     {
         parent::setUp();
 
-        if (! extension_loaded('memcached')) {
-            $this->markTestSkipped('Memcached module not installed');
-        }
-
         // Determine whether there is a running Memcached instance
         $testConnection = new Memcached;
 
@@ -26,7 +22,7 @@ abstract class MemcachedIntegrationTestCase extends TestCase
         $testConnection->getVersion();
 
         if ($testConnection->getResultCode() > Memcached::RES_SUCCESS) {
-            $this->markTestSkipped('Memcached could not establish a connection');
+            $this->markTestSkipped('Memcached could not establish a connection.');
         }
 
         $testConnection->quit();

--- a/tests/Integration/Cache/MemcachedIntegrationTestCase.php
+++ b/tests/Integration/Cache/MemcachedIntegrationTestCase.php
@@ -5,9 +5,6 @@ namespace Illuminate\Tests\Integration\Cache;
 use Memcached;
 use Orchestra\Testbench\TestCase;
 
-/**
- * @group integration
- */
 abstract class MemcachedIntegrationTestCase extends TestCase
 {
     protected function setUp(): void

--- a/tests/Integration/Cache/MemcachedTaggedCacheTestCase.php
+++ b/tests/Integration/Cache/MemcachedTaggedCacheTestCase.php
@@ -4,6 +4,9 @@ namespace Illuminate\Tests\Integration\Cache;
 
 use Illuminate\Support\Facades\Cache;
 
+/**
+ * @requires extension memcached
+ */
 class MemcachedTaggedCacheTestCase extends MemcachedIntegrationTestCase
 {
     public function testMemcachedCanStoreAndRetrieveTaggedCacheItems()

--- a/tests/Integration/Cache/MemcachedTaggedCacheTestCase.php
+++ b/tests/Integration/Cache/MemcachedTaggedCacheTestCase.php
@@ -4,9 +4,6 @@ namespace Illuminate\Tests\Integration\Cache;
 
 use Illuminate\Support\Facades\Cache;
 
-/**
- * @group integration
- */
 class MemcachedTaggedCacheTestCase extends MemcachedIntegrationTestCase
 {
     public function testMemcachedCanStoreAndRetrieveTaggedCacheItems()

--- a/tests/Integration/Cache/NoLockTest.php
+++ b/tests/Integration/Cache/NoLockTest.php
@@ -6,9 +6,6 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
 use Orchestra\Testbench\TestCase;
 
-/**
- * @group integration
- */
 class NoLockTest extends TestCase
 {
     /**

--- a/tests/Integration/Cache/PhpRedisCacheLockTest.php
+++ b/tests/Integration/Cache/PhpRedisCacheLockTest.php
@@ -7,9 +7,6 @@ use Illuminate\Support\Facades\Cache;
 use Orchestra\Testbench\TestCase;
 use Redis;
 
-/**
- * @group integration
- */
 class PhpRedisCacheLockTest extends TestCase
 {
     use InteractsWithRedis;

--- a/tests/Integration/Cache/PhpRedisCacheLockTest.php
+++ b/tests/Integration/Cache/PhpRedisCacheLockTest.php
@@ -138,14 +138,13 @@ class PhpRedisCacheLockTest extends TestCase
         $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
     }
 
+    /**
+     * @requires extension lzf
+     */
     public function testRedisLockCanBeAcquiredAndReleasedWithLzfCompression()
     {
         if (! defined('Redis::COMPRESSION_LZF')) {
             $this->markTestSkipped('Redis extension is not configured to support the lzf compression.');
-        }
-
-        if (! extension_loaded('lzf')) {
-            $this->markTestSkipped('Lzf extension is not installed.');
         }
 
         $this->app['config']->set('database.redis.client', 'phpredis');
@@ -168,14 +167,13 @@ class PhpRedisCacheLockTest extends TestCase
         $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
     }
 
+    /**
+     * @requires extension zstd
+     */
     public function testRedisLockCanBeAcquiredAndReleasedWithZstdCompression()
     {
         if (! defined('Redis::COMPRESSION_ZSTD')) {
             $this->markTestSkipped('Redis extension is not configured to support the zstd compression.');
-        }
-
-        if (! extension_loaded('zstd')) {
-            $this->markTestSkipped('Zstd extension is not installed.');
         }
 
         $this->app['config']->set('database.redis.client', 'phpredis');
@@ -217,14 +215,13 @@ class PhpRedisCacheLockTest extends TestCase
         $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
     }
 
+    /**
+     * @requires extension lz4
+     */
     public function testRedisLockCanBeAcquiredAndReleasedWithLz4Compression()
     {
         if (! defined('Redis::COMPRESSION_LZ4')) {
             $this->markTestSkipped('Redis extension is not configured to support the lz4 compression.');
-        }
-
-        if (! extension_loaded('lz4')) {
-            $this->markTestSkipped('Lz4 extension is not installed.');
         }
 
         $this->markTestIncomplete(
@@ -271,14 +268,13 @@ class PhpRedisCacheLockTest extends TestCase
         $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
     }
 
+    /**
+     * @requires extension Lzf
+     */
     public function testRedisLockCanBeAcquiredAndReleasedWithSerializationAndCompression()
     {
         if (! defined('Redis::COMPRESSION_LZF')) {
             $this->markTestSkipped('Redis extension is not configured to support the lzf compression.');
-        }
-
-        if (! extension_loaded('lzf')) {
-            $this->markTestSkipped('Lzf extension is not installed.');
         }
 
         $this->app['config']->set('database.redis.client', 'phpredis');

--- a/tests/Integration/Cache/RedisCacheLockTest.php
+++ b/tests/Integration/Cache/RedisCacheLockTest.php
@@ -8,9 +8,6 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
 use Orchestra\Testbench\TestCase;
 
-/**
- * @group integration
- */
 class RedisCacheLockTest extends TestCase
 {
     use InteractsWithRedis;

--- a/tests/Integration/Cache/RedisStoreTest.php
+++ b/tests/Integration/Cache/RedisStoreTest.php
@@ -6,9 +6,6 @@ use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
 use Illuminate\Support\Facades\Cache;
 use Orchestra\Testbench\TestCase;
 
-/**
- * @group integration
- */
 class RedisStoreTest extends TestCase
 {
     use InteractsWithRedis;

--- a/tests/Integration/Console/Scheduling/CallbackEventTest.php
+++ b/tests/Integration/Console/Scheduling/CallbackEventTest.php
@@ -8,9 +8,6 @@ use Illuminate\Console\Scheduling\EventMutex;
 use Mockery as m;
 use Orchestra\Testbench\TestCase;
 
-/**
- * @group integration
- */
 class CallbackEventTest extends TestCase
 {
     protected function tearDown(): void

--- a/tests/Integration/Console/Scheduling/EventPingTest.php
+++ b/tests/Integration/Console/Scheduling/EventPingTest.php
@@ -14,9 +14,6 @@ use Illuminate\Contracts\Debug\ExceptionHandler;
 use Mockery as m;
 use Orchestra\Testbench\TestCase;
 
-/**
- * @group integration
- */
 class EventPingTest extends TestCase
 {
     protected function tearDown(): void

--- a/tests/Integration/Cookie/CookieTest.php
+++ b/tests/Integration/Cookie/CookieTest.php
@@ -12,9 +12,6 @@ use Illuminate\Support\Str;
 use Mockery;
 use Orchestra\Testbench\TestCase;
 
-/**
- * @group integration
- */
 class CookieTest extends TestCase
 {
     public function test_cookie_is_sent_back_with_proper_expire_time_when_should_expire_on_close()

--- a/tests/Integration/Database/DatabaseArrayObjectAndCollectionCustomCastTest.php
+++ b/tests/Integration/Database/DatabaseArrayObjectAndCollectionCustomCastTest.php
@@ -8,9 +8,6 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-/**
- * @group integration
- */
 class DatabaseArrayObjectAndCollectionCustomCastTest extends DatabaseTestCase
 {
     protected function setUp(): void

--- a/tests/Integration/Database/DatabaseEloquentBroadcastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentBroadcastingTest.php
@@ -15,9 +15,6 @@ use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Schema;
 use Mockery as m;
 
-/**
- * @group integration
- */
 class DatabaseEloquentBroadcastingTest extends DatabaseTestCase
 {
     protected function setUp(): void

--- a/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
@@ -13,9 +13,6 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Schema;
 
-/**
- * @group integration
- */
 class DatabaseEloquentModelCustomCastingTest extends DatabaseTestCase
 {
     protected function setUp(): void

--- a/tests/Integration/Database/DatabaseEmulatePreparesMySqlConnectionTest.php
+++ b/tests/Integration/Database/DatabaseEmulatePreparesMySqlConnectionTest.php
@@ -6,7 +6,7 @@ use PDO;
 
 /**
  * @requires extension pdo_mysql
- * @requires OSFAMILY Linux|Darwin
+ * @requires OS Linux|Darwin
  */
 class DatabaseEmulatePreparesMySqlConnectionTest extends DatabaseMySqlConnectionTest
 {

--- a/tests/Integration/Database/DatabaseEmulatePreparesMySqlConnectionTest.php
+++ b/tests/Integration/Database/DatabaseEmulatePreparesMySqlConnectionTest.php
@@ -6,6 +6,7 @@ use PDO;
 
 /**
  * @requires extension pdo_mysql
+ * @requires OSFAMILY Linux|Darwin
  */
 class DatabaseEmulatePreparesMySqlConnectionTest extends DatabaseMySqlConnectionTest
 {

--- a/tests/Integration/Database/DatabaseLockTest.php
+++ b/tests/Integration/Database/DatabaseLockTest.php
@@ -7,9 +7,6 @@ use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
-/**
- * @group integration
- */
 class DatabaseLockTest extends DatabaseTestCase
 {
     protected function setUp(): void

--- a/tests/Integration/Database/DatabaseMySqlConnectionTest.php
+++ b/tests/Integration/Database/DatabaseMySqlConnectionTest.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Facades\Schema;
 
 /**
  * @requires extension pdo_mysql
- * @requires OSFAMILY Linux|Darwin
+ * @requires OS Linux|Darwin
  */
 class DatabaseMySqlConnectionTest extends DatabaseMySqlTestCase
 {

--- a/tests/Integration/Database/DatabaseMySqlConnectionTest.php
+++ b/tests/Integration/Database/DatabaseMySqlConnectionTest.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Schema;
 
 /**
  * @requires extension pdo_mysql
+ * @requires OSFAMILY Linux|Darwin
  */
 class DatabaseMySqlConnectionTest extends DatabaseMySqlTestCase
 {
@@ -19,10 +20,6 @@ class DatabaseMySqlConnectionTest extends DatabaseMySqlTestCase
     protected function setUp(): void
     {
         parent::setUp();
-
-        if (! isset($_SERVER['CI']) || windows_os()) {
-            $this->markTestSkipped('This test is only executed on CI in Linux.');
-        }
 
         if (! Schema::hasTable(self::TABLE)) {
             Schema::create(self::TABLE, function (Blueprint $table) {

--- a/tests/Integration/Database/DatabaseMySqlTestCase.php
+++ b/tests/Integration/Database/DatabaseMySqlTestCase.php
@@ -16,7 +16,7 @@ abstract class DatabaseMySqlTestCase extends TestCase
     {
         parent::setUp();
 
-        if (! isset($_SERVER['CI']) || windows_os()) {
+        if (! isset($_SERVER['CI'])) {
             $this->markTestSkipped('This test is only executed on CI.');
         }
     }

--- a/tests/Integration/Database/DatabaseSchemaBuilderAlterTableWithEnumTest.php
+++ b/tests/Integration/Database/DatabaseSchemaBuilderAlterTableWithEnumTest.php
@@ -8,7 +8,7 @@ use stdClass;
 
 /**
  * @requires extension pdo_mysql
- * @requires OSFAMILY Linux|Darwin
+ * @requires OS Linux|Darwin
  */
 class DatabaseSchemaBuilderAlterTableWithEnumTest extends DatabaseMySqlTestCase
 {

--- a/tests/Integration/Database/DatabaseSchemaBuilderAlterTableWithEnumTest.php
+++ b/tests/Integration/Database/DatabaseSchemaBuilderAlterTableWithEnumTest.php
@@ -6,8 +6,31 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use stdClass;
 
+/**
+ * @requires extension pdo_mysql
+ * @requires OSFAMILY Linux|Darwin
+ */
 class DatabaseSchemaBuilderAlterTableWithEnumTest extends DatabaseMySqlTestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('users', function (Blueprint $table) {
+            $table->integer('id');
+            $table->string('name');
+            $table->string('age');
+            $table->enum('color', ['red', 'blue']);
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        Schema::drop('users');
+
+        parent::tearDown();
+    }
+
     public function testRenameColumnOnTableWithEnum()
     {
         Schema::table('users', function (Blueprint $table) {
@@ -44,24 +67,5 @@ class DatabaseSchemaBuilderAlterTableWithEnumTest extends DatabaseMySqlTestCase
         $tables = Schema::getAllTables();
         $this->assertCount(2, $tables);
         Schema::drop('posts');
-    }
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        Schema::create('users', function (Blueprint $table) {
-            $table->integer('id');
-            $table->string('name');
-            $table->string('age');
-            $table->enum('color', ['red', 'blue']);
-        });
-    }
-
-    protected function tearDown(): void
-    {
-        Schema::drop('users');
-
-        parent::tearDown();
     }
 }

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -13,9 +13,6 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
-/**
- * @group integration
- */
 class EloquentBelongsToManyTest extends DatabaseTestCase
 {
     protected function setUp(): void

--- a/tests/Integration/Database/EloquentBelongsToTest.php
+++ b/tests/Integration/Database/EloquentBelongsToTest.php
@@ -8,9 +8,6 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
-/**
- * @group integration
- */
 class EloquentBelongsToTest extends DatabaseTestCase
 {
     protected function setUp(): void

--- a/tests/Integration/Database/EloquentCollectionFreshTest.php
+++ b/tests/Integration/Database/EloquentCollectionFreshTest.php
@@ -7,9 +7,6 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Tests\Integration\Database\Fixtures\User;
 
-/**
- * @group integration
- */
 class EloquentCollectionFreshTest extends DatabaseTestCase
 {
     protected function setUp(): void

--- a/tests/Integration/Database/EloquentCollectionLoadCountTest.php
+++ b/tests/Integration/Database/EloquentCollectionLoadCountTest.php
@@ -10,9 +10,6 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
-/**
- * @group integration
- */
 class EloquentCollectionLoadCountTest extends DatabaseTestCase
 {
     protected function setUp(): void

--- a/tests/Integration/Database/EloquentCollectionLoadMissingTest.php
+++ b/tests/Integration/Database/EloquentCollectionLoadMissingTest.php
@@ -8,9 +8,6 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
-/**
- * @group integration
- */
 class EloquentCollectionLoadMissingTest extends DatabaseTestCase
 {
     protected function setUp(): void

--- a/tests/Integration/Database/EloquentCursorPaginateTest.php
+++ b/tests/Integration/Database/EloquentCursorPaginateTest.php
@@ -8,9 +8,6 @@ use Illuminate\Pagination\Cursor;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
-/**
- * @group integration
- */
 class EloquentCursorPaginateTest extends DatabaseTestCase
 {
     protected function setUp(): void

--- a/tests/Integration/Database/EloquentCustomPivotCastTest.php
+++ b/tests/Integration/Database/EloquentCustomPivotCastTest.php
@@ -7,9 +7,6 @@ use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-/**
- * @group integration
- */
 class EloquentCustomPivotCastTest extends DatabaseTestCase
 {
     protected function setUp(): void

--- a/tests/Integration/Database/EloquentDeleteTest.php
+++ b/tests/Integration/Database/EloquentDeleteTest.php
@@ -9,9 +9,6 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Tests\Integration\Database\Fixtures\Post;
 use Orchestra\Testbench\TestCase;
 
-/**
- * @group integration
- */
 class EloquentDeleteTest extends TestCase
 {
     protected function getEnvironmentSetUp($app)

--- a/tests/Integration/Database/EloquentHasManyThroughTest.php
+++ b/tests/Integration/Database/EloquentHasManyThroughTest.php
@@ -9,9 +9,6 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
-/**
- * @group integration
- */
 class EloquentHasManyThroughTest extends DatabaseTestCase
 {
     protected function setUp(): void

--- a/tests/Integration/Database/EloquentHasOneIsTest.php
+++ b/tests/Integration/Database/EloquentHasOneIsTest.php
@@ -7,9 +7,6 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
-/**
- * @group integration
- */
 class EloquentHasOneIsTest extends DatabaseTestCase
 {
     protected function setUp(): void

--- a/tests/Integration/Database/EloquentHasOneOfManyTest.php
+++ b/tests/Integration/Database/EloquentHasOneOfManyTest.php
@@ -6,10 +6,6 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
-/**
- * @group integration
- * @group one-of-many
- */
 class EloquentHasOneOfManyTest extends DatabaseTestCase
 {
     protected function setUp(): void

--- a/tests/Integration/Database/EloquentLazyEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentLazyEagerLoadingTest.php
@@ -8,9 +8,6 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
-/**
- * @group integration
- */
 class EloquentLazyEagerLoadingTest extends DatabaseTestCase
 {
     protected function setUp(): void

--- a/tests/Integration/Database/EloquentModelConnectionsTest.php
+++ b/tests/Integration/Database/EloquentModelConnectionsTest.php
@@ -8,9 +8,6 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 use Orchestra\Testbench\TestCase;
 
-/**
- * @group integration
- */
 class EloquentModelConnectionsTest extends TestCase
 {
     protected function getEnvironmentSetUp($app)

--- a/tests/Integration/Database/EloquentModelCustomEventsTest.php
+++ b/tests/Integration/Database/EloquentModelCustomEventsTest.php
@@ -8,9 +8,6 @@ use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
-/**
- * @group integration
- */
 class EloquentModelCustomEventsTest extends DatabaseTestCase
 {
     protected function setUp(): void

--- a/tests/Integration/Database/EloquentModelDateCastingTest.php
+++ b/tests/Integration/Database/EloquentModelDateCastingTest.php
@@ -9,9 +9,6 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
-/**
- * @group integration
- */
 class EloquentModelDateCastingTest extends DatabaseTestCase
 {
     protected function setUp(): void

--- a/tests/Integration/Database/EloquentModelDecimalCastingTest.php
+++ b/tests/Integration/Database/EloquentModelDecimalCastingTest.php
@@ -7,9 +7,6 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
-/**
- * @group integration
- */
 class EloquentModelDecimalCastingTest extends DatabaseTestCase
 {
     protected function setUp(): void

--- a/tests/Integration/Database/EloquentModelEncryptedCastingTest.php
+++ b/tests/Integration/Database/EloquentModelEncryptedCastingTest.php
@@ -10,9 +10,6 @@ use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\Schema;
 use stdClass;
 
-/**
- * @group integration
- */
 class EloquentModelEncryptedCastingTest extends DatabaseTestCase
 {
     protected $encrypter;

--- a/tests/Integration/Database/EloquentModelImmutableDateCastingTest.php
+++ b/tests/Integration/Database/EloquentModelImmutableDateCastingTest.php
@@ -8,9 +8,6 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
-/**
- * @group integration
- */
 class EloquentModelImmutableDateCastingTest extends DatabaseTestCase
 {
     protected function setUp(): void

--- a/tests/Integration/Database/EloquentModelJsonCastingTest.php
+++ b/tests/Integration/Database/EloquentModelJsonCastingTest.php
@@ -9,9 +9,6 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 use stdClass;
 
-/**
- * @group integration
- */
 class EloquentModelJsonCastingTest extends DatabaseTestCase
 {
     protected function setUp(): void

--- a/tests/Integration/Database/EloquentModelLoadCountTest.php
+++ b/tests/Integration/Database/EloquentModelLoadCountTest.php
@@ -9,9 +9,6 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
-/**
- * @group integration
- */
 class EloquentModelLoadCountTest extends DatabaseTestCase
 {
     protected function setUp(): void

--- a/tests/Integration/Database/EloquentModelLoadMissingTest.php
+++ b/tests/Integration/Database/EloquentModelLoadMissingTest.php
@@ -8,9 +8,6 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
-/**
- * @group integration
- */
 class EloquentModelLoadMissingTest extends DatabaseTestCase
 {
     protected function setUp(): void

--- a/tests/Integration/Database/EloquentModelRefreshTest.php
+++ b/tests/Integration/Database/EloquentModelRefreshTest.php
@@ -9,9 +9,6 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
-/**
- * @group integration
- */
 class EloquentModelRefreshTest extends DatabaseTestCase
 {
     protected function setUp(): void

--- a/tests/Integration/Database/EloquentModelScopeTest.php
+++ b/tests/Integration/Database/EloquentModelScopeTest.php
@@ -4,9 +4,6 @@ namespace Illuminate\Tests\Integration\Database;
 
 use Illuminate\Database\Eloquent\Model;
 
-/**
- * @group integration
- */
 class EloquentModelScopeTest extends DatabaseTestCase
 {
     public function testModelHasScope()

--- a/tests/Integration/Database/EloquentModelStringCastingTest.php
+++ b/tests/Integration/Database/EloquentModelStringCastingTest.php
@@ -8,9 +8,6 @@ use Illuminate\Database\Schema\Blueprint;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
-/**
- * @group integration
- */
 class EloquentModelStringCastingTest extends TestCase
 {
     protected function setUp(): void

--- a/tests/Integration/Database/EloquentModelTest.php
+++ b/tests/Integration/Database/EloquentModelTest.php
@@ -8,9 +8,6 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 
-/**
- * @group integration
- */
 class EloquentModelTest extends DatabaseTestCase
 {
     protected function setUp(): void

--- a/tests/Integration/Database/EloquentModelWithoutEventsTest.php
+++ b/tests/Integration/Database/EloquentModelWithoutEventsTest.php
@@ -6,9 +6,6 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-/**
- * @group integration
- */
 class EloquentModelWithoutEventsTest extends DatabaseTestCase
 {
     protected function setUp(): void

--- a/tests/Integration/Database/EloquentMorphConstrainTest.php
+++ b/tests/Integration/Database/EloquentMorphConstrainTest.php
@@ -8,9 +8,6 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
-/**
- * @group integration
- */
 class EloquentMorphConstrainTest extends DatabaseTestCase
 {
     protected function setUp(): void

--- a/tests/Integration/Database/EloquentMorphCountEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentMorphCountEagerLoadingTest.php
@@ -8,9 +8,6 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
-/**
- * @group integration
- */
 class EloquentMorphCountEagerLoadingTest extends DatabaseTestCase
 {
     protected function setUp(): void

--- a/tests/Integration/Database/EloquentMorphCountLazyEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentMorphCountLazyEagerLoadingTest.php
@@ -7,9 +7,6 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
-/**
- * @group integration
- */
 class EloquentMorphCountLazyEagerLoadingTest extends DatabaseTestCase
 {
     protected function setUp(): void

--- a/tests/Integration/Database/EloquentMorphEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentMorphEagerLoadingTest.php
@@ -8,9 +8,6 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
-/**
- * @group integration
- */
 class EloquentMorphEagerLoadingTest extends DatabaseTestCase
 {
     protected function setUp(): void

--- a/tests/Integration/Database/EloquentMorphLazyEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentMorphLazyEagerLoadingTest.php
@@ -7,9 +7,6 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
-/**
- * @group integration
- */
 class EloquentMorphLazyEagerLoadingTest extends DatabaseTestCase
 {
     protected function setUp(): void

--- a/tests/Integration/Database/EloquentMorphManyTest.php
+++ b/tests/Integration/Database/EloquentMorphManyTest.php
@@ -9,9 +9,6 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
-/**
- * @group integration
- */
 class EloquentMorphManyTest extends DatabaseTestCase
 {
     protected function setUp(): void

--- a/tests/Integration/Database/EloquentMorphOneIsTest.php
+++ b/tests/Integration/Database/EloquentMorphOneIsTest.php
@@ -7,9 +7,6 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
-/**
- * @group integration
- */
 class EloquentMorphOneIsTest extends DatabaseTestCase
 {
     protected function setUp(): void

--- a/tests/Integration/Database/EloquentMorphToGlobalScopesTest.php
+++ b/tests/Integration/Database/EloquentMorphToGlobalScopesTest.php
@@ -9,9 +9,6 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
-/**
- * @group integration
- */
 class EloquentMorphToGlobalScopesTest extends DatabaseTestCase
 {
     protected function setUp(): void

--- a/tests/Integration/Database/EloquentMorphToIsTest.php
+++ b/tests/Integration/Database/EloquentMorphToIsTest.php
@@ -7,9 +7,6 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
-/**
- * @group integration
- */
 class EloquentMorphToIsTest extends DatabaseTestCase
 {
     protected function setUp(): void

--- a/tests/Integration/Database/EloquentMorphToLazyEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentMorphToLazyEagerLoadingTest.php
@@ -8,9 +8,6 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
-/**
- * @group integration
- */
 class EloquentMorphToLazyEagerLoadingTest extends DatabaseTestCase
 {
     protected function setUp(): void

--- a/tests/Integration/Database/EloquentMorphToSelectTest.php
+++ b/tests/Integration/Database/EloquentMorphToSelectTest.php
@@ -7,9 +7,6 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
-/**
- * @group integration
- */
 class EloquentMorphToSelectTest extends DatabaseTestCase
 {
     protected function setUp(): void

--- a/tests/Integration/Database/EloquentMorphToTouchesTest.php
+++ b/tests/Integration/Database/EloquentMorphToTouchesTest.php
@@ -8,9 +8,6 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
-/**
- * @group integration
- */
 class EloquentMorphToTouchesTest extends DatabaseTestCase
 {
     protected function setUp(): void

--- a/tests/Integration/Database/EloquentPaginateTest.php
+++ b/tests/Integration/Database/EloquentPaginateTest.php
@@ -6,9 +6,6 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-/**
- * @group integration
- */
 class EloquentPaginateTest extends DatabaseTestCase
 {
     protected function setUp(): void

--- a/tests/Integration/Database/EloquentPivotEventsTest.php
+++ b/tests/Integration/Database/EloquentPivotEventsTest.php
@@ -7,9 +7,6 @@ use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-/**
- * @group integration
- */
 class EloquentPivotEventsTest extends DatabaseTestCase
 {
     protected function setUp(): void

--- a/tests/Integration/Database/EloquentPivotSerializationTest.php
+++ b/tests/Integration/Database/EloquentPivotSerializationTest.php
@@ -10,9 +10,6 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Schema;
 
-/**
- * @group integration
- */
 class EloquentPivotSerializationTest extends DatabaseTestCase
 {
     protected function setUp(): void

--- a/tests/Integration/Database/EloquentPushTest.php
+++ b/tests/Integration/Database/EloquentPushTest.php
@@ -6,9 +6,6 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-/**
- * @group integration
- */
 class EloquentPushTest extends DatabaseTestCase
 {
     protected function setUp(): void

--- a/tests/Integration/Database/EloquentRelationshipsTest.php
+++ b/tests/Integration/Database/EloquentRelationshipsTest.php
@@ -16,9 +16,6 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Orchestra\Testbench\TestCase;
 
-/**
- * @group integration
- */
 class EloquentRelationshipsTest extends TestCase
 {
     public function testStandardRelationships()

--- a/tests/Integration/Database/EloquentStrictLoadingTest.php
+++ b/tests/Integration/Database/EloquentStrictLoadingTest.php
@@ -8,9 +8,6 @@ use Illuminate\Database\LazyLoadingViolationException;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-/**
- * @group integration
- */
 class EloquentStrictLoadingTest extends DatabaseTestCase
 {
     protected function setUp(): void

--- a/tests/Integration/Database/EloquentTouchParentWithGlobalScopeTest.php
+++ b/tests/Integration/Database/EloquentTouchParentWithGlobalScopeTest.php
@@ -9,9 +9,6 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
-/**
- * @group integration
- */
 class EloquentTouchParentWithGlobalScopeTest extends DatabaseTestCase
 {
     protected function setUp(): void

--- a/tests/Integration/Database/EloquentUpdateTest.php
+++ b/tests/Integration/Database/EloquentUpdateTest.php
@@ -9,9 +9,6 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 use Orchestra\Testbench\TestCase;
 
-/**
- * @group integration
- */
 class EloquentUpdateTest extends TestCase
 {
     protected function getEnvironmentSetUp($app)

--- a/tests/Integration/Database/EloquentWhereHasMorphTest.php
+++ b/tests/Integration/Database/EloquentWhereHasMorphTest.php
@@ -10,9 +10,6 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
-/**
- * @group integration
- */
 class EloquentWhereHasMorphTest extends DatabaseTestCase
 {
     protected function setUp(): void

--- a/tests/Integration/Database/EloquentWhereHasTest.php
+++ b/tests/Integration/Database/EloquentWhereHasTest.php
@@ -7,9 +7,6 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
-/**
- * @group integration
- */
 class EloquentWhereHasTest extends DatabaseTestCase
 {
     protected function setUp(): void

--- a/tests/Integration/Database/EloquentWhereTest.php
+++ b/tests/Integration/Database/EloquentWhereTest.php
@@ -9,9 +9,6 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
-/**
- * @group integration
- */
 class EloquentWhereTest extends DatabaseTestCase
 {
     protected function setUp(): void

--- a/tests/Integration/Database/EloquentWithCountTest.php
+++ b/tests/Integration/Database/EloquentWithCountTest.php
@@ -7,9 +7,6 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
-/**
- * @group integration
- */
 class EloquentWithCountTest extends DatabaseTestCase
 {
     protected function setUp(): void

--- a/tests/Integration/Database/QueryBuilderTest.php
+++ b/tests/Integration/Database/QueryBuilderTest.php
@@ -10,9 +10,6 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
-/**
- * @group integration
- */
 class QueryBuilderTest extends DatabaseTestCase
 {
     protected function setUp(): void

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -10,9 +10,6 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 use Illuminate\Tests\Integration\Database\Fixtures\TinyInteger;
 
-/**
- * @group integration
- */
 class SchemaBuilderTest extends DatabaseTestCase
 {
     public function testDropAllTables()

--- a/tests/Integration/Foundation/DiscoverEventsTest.php
+++ b/tests/Integration/Foundation/DiscoverEventsTest.php
@@ -33,7 +33,7 @@ class DiscoverEventsTest extends TestCase
     }
 
     /**
-     * @requires PHP 8
+     * @requires PHP >= 8
      */
     public function testUnionEventsCanBeDiscovered()
     {

--- a/tests/Integration/Foundation/FoundationHelpersTest.php
+++ b/tests/Integration/Foundation/FoundationHelpersTest.php
@@ -8,9 +8,6 @@ use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
 use Orchestra\Testbench\TestCase;
 
-/**
- * @group integration
- */
 class FoundationHelpersTest extends TestCase
 {
     public function testRescue()

--- a/tests/Integration/Foundation/FoundationServiceProvidersTest.php
+++ b/tests/Integration/Foundation/FoundationServiceProvidersTest.php
@@ -5,9 +5,6 @@ namespace Illuminate\Tests\Integration\Foundation;
 use Illuminate\Support\ServiceProvider;
 use Orchestra\Testbench\TestCase;
 
-/**
- * @group integration
- */
 class FoundationServiceProvidersTest extends TestCase
 {
     protected function getPackageProviders($app)

--- a/tests/Integration/Foundation/MaintenanceModeTest.php
+++ b/tests/Integration/Foundation/MaintenanceModeTest.php
@@ -14,9 +14,6 @@ use Illuminate\Support\Facades\Route;
 use Orchestra\Testbench\TestCase;
 use Symfony\Component\HttpFoundation\Cookie;
 
-/**
- * @group integration
- */
 class MaintenanceModeTest extends TestCase
 {
     protected function tearDown(): void

--- a/tests/Integration/Http/JsonResponseTest.php
+++ b/tests/Integration/Http/JsonResponseTest.php
@@ -6,9 +6,6 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Route;
 use Orchestra\Testbench\TestCase;
 
-/**
- * @group integration
- */
 class JsonResponseTest extends TestCase
 {
     public function testResponseWithInvalidJsonThrowsException()

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -35,9 +35,6 @@ use Illuminate\Tests\Integration\Http\Fixtures\Subscription;
 use Mockery;
 use Orchestra\Testbench\TestCase;
 
-/**
- * @group integration
- */
 class ResourceTest extends TestCase
 {
     public function testResourcesMayBeConvertedToJson()

--- a/tests/Integration/Http/ResponseTest.php
+++ b/tests/Integration/Http/ResponseTest.php
@@ -6,9 +6,6 @@ use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Route;
 use Orchestra\Testbench\TestCase;
 
-/**
- * @group integration
- */
 class ResponseTest extends TestCase
 {
     public function testResponseWithInvalidJsonThrowsException()

--- a/tests/Integration/Http/ThrottleRequestsTest.php
+++ b/tests/Integration/Http/ThrottleRequestsTest.php
@@ -12,9 +12,6 @@ use Illuminate\Support\Facades\Route;
 use Orchestra\Testbench\TestCase;
 use Throwable;
 
-/**
- * @group integration
- */
 class ThrottleRequestsTest extends TestCase
 {
     protected function tearDown(): void

--- a/tests/Integration/Http/ThrottleRequestsWithRedisTest.php
+++ b/tests/Integration/Http/ThrottleRequestsWithRedisTest.php
@@ -9,9 +9,6 @@ use Illuminate\Support\Facades\Route;
 use Orchestra\Testbench\TestCase;
 use Throwable;
 
-/**
- * @group integration
- */
 class ThrottleRequestsWithRedisTest extends TestCase
 {
     use InteractsWithRedis;

--- a/tests/Integration/Mail/RenderingMailWithLocaleTest.php
+++ b/tests/Integration/Mail/RenderingMailWithLocaleTest.php
@@ -6,9 +6,6 @@ use Illuminate\Mail\Mailable;
 use Illuminate\Support\Facades\View;
 use Orchestra\Testbench\TestCase;
 
-/**
- * @group integration
- */
 class RenderingMailWithLocaleTest extends TestCase
 {
     protected function getEnvironmentSetUp($app)

--- a/tests/Integration/Mail/SendingMailWithLocaleTest.php
+++ b/tests/Integration/Mail/SendingMailWithLocaleTest.php
@@ -13,9 +13,6 @@ use Illuminate\Support\Facades\View;
 use Illuminate\Testing\Assert;
 use Orchestra\Testbench\TestCase;
 
-/**
- * @group integration
- */
 class SendingMailWithLocaleTest extends TestCase
 {
     protected function getEnvironmentSetUp($app)

--- a/tests/Integration/Mail/SendingQueuedMailTest.php
+++ b/tests/Integration/Mail/SendingQueuedMailTest.php
@@ -10,9 +10,6 @@ use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\View;
 use Orchestra\Testbench\TestCase;
 
-/**
- * @group integration
- */
 class SendingQueuedMailTest extends TestCase
 {
     protected function getEnvironmentSetUp($app)

--- a/tests/Integration/Notifications/SendingMailNotificationsTest.php
+++ b/tests/Integration/Notifications/SendingMailNotificationsTest.php
@@ -19,9 +19,6 @@ use Illuminate\Support\Str;
 use Mockery as m;
 use Orchestra\Testbench\TestCase;
 
-/**
- * @group integration
- */
 class SendingMailNotificationsTest extends TestCase
 {
     public $mailer;

--- a/tests/Integration/Notifications/SendingNotificationsViaAnonymousNotifiableTest.php
+++ b/tests/Integration/Notifications/SendingNotificationsViaAnonymousNotifiableTest.php
@@ -8,9 +8,6 @@ use Illuminate\Support\Facades\Notification as NotificationFacade;
 use Illuminate\Support\Testing\Fakes\NotificationFake;
 use Orchestra\Testbench\TestCase;
 
-/**
- * @group integration
- */
 class SendingNotificationsViaAnonymousNotifiableTest extends TestCase
 {
     public $mailer;

--- a/tests/Integration/Notifications/SendingNotificationsWithLocaleTest.php
+++ b/tests/Integration/Notifications/SendingNotificationsWithLocaleTest.php
@@ -19,9 +19,6 @@ use Illuminate\Support\Facades\View;
 use Illuminate\Testing\Assert;
 use Orchestra\Testbench\TestCase;
 
-/**
- * @group integration
- */
 class SendingNotificationsWithLocaleTest extends TestCase
 {
     public $mailer;

--- a/tests/Integration/Queue/CallQueuedHandlerTest.php
+++ b/tests/Integration/Queue/CallQueuedHandlerTest.php
@@ -13,9 +13,6 @@ use Illuminate\Support\Facades\Event;
 use Mockery as m;
 use Orchestra\Testbench\TestCase;
 
-/**
- * @group integration
- */
 class CallQueuedHandlerTest extends TestCase
 {
     protected function tearDown(): void

--- a/tests/Integration/Queue/JobChainingTest.php
+++ b/tests/Integration/Queue/JobChainingTest.php
@@ -10,9 +10,6 @@ use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Queue;
 use Orchestra\Testbench\TestCase;
 
-/**
- * @group integration
- */
 class JobChainingTest extends TestCase
 {
     public static $catchCallbackRan = false;

--- a/tests/Integration/Queue/JobDispatchingTest.php
+++ b/tests/Integration/Queue/JobDispatchingTest.php
@@ -7,9 +7,6 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Orchestra\Testbench\TestCase;
 
-/**
- * @group integration
- */
 class JobDispatchingTest extends TestCase
 {
     protected function getEnvironmentSetUp($app)

--- a/tests/Integration/Queue/JobEncryptionTest.php
+++ b/tests/Integration/Queue/JobEncryptionTest.php
@@ -15,9 +15,6 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
-/**
- * @group integration
- */
 class JobEncryptionTest extends DatabaseTestCase
 {
     protected function getEnvironmentSetUp($app)

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -285,7 +285,7 @@ class ModelSerializationTest extends TestCase
     }
 
     /**
-     * @requires php >= 7.4
+     * @requires PHP >= 7.4
      */
     public function testItSerializesTypedProperties()
     {

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -284,12 +284,11 @@ class ModelSerializationTest extends TestCase
         $this->assertInstanceOf(ModelSerializationTestCustomUserCollection::class, $unserialized->users);
     }
 
+    /**
+     * @requires php < 7.4
+     */
     public function testItSerializesTypedProperties()
     {
-        if (version_compare(phpversion(), '7.4.0-dev', '<')) {
-            $this->markTestSkipped('Typed properties are only available from PHP 7.4 and up.');
-        }
-
         require_once __DIR__.'/typed-properties.php';
 
         $user = ModelSerializationTestUser::create([

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -285,7 +285,7 @@ class ModelSerializationTest extends TestCase
     }
 
     /**
-     * @requires php < 7.4
+     * @requires php >= 7.4
      */
     public function testItSerializesTypedProperties()
     {

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -11,9 +11,6 @@ use LogicException;
 use Orchestra\Testbench\TestCase;
 use Schema;
 
-/**
- * @group integration
- */
 class ModelSerializationTest extends TestCase
 {
     protected function getEnvironmentSetUp($app)

--- a/tests/Integration/Queue/QueueConnectionTest.php
+++ b/tests/Integration/Queue/QueueConnectionTest.php
@@ -11,9 +11,6 @@ use Mockery as m;
 use Orchestra\Testbench\TestCase;
 use Throwable;
 
-/**
- * @group integration
- */
 class QueueConnectionTest extends TestCase
 {
     protected function getEnvironmentSetUp($app)

--- a/tests/Integration/Queue/QueuedListenersTest.php
+++ b/tests/Integration/Queue/QueuedListenersTest.php
@@ -8,9 +8,6 @@ use Illuminate\Events\CallQueuedListener;
 use Orchestra\Testbench\TestCase;
 use Queue;
 
-/**
- * @group integration
- */
 class QueuedListenersTest extends TestCase
 {
     public function testListenersCanBeQueuedOptionally()

--- a/tests/Integration/Queue/RateLimitedTest.php
+++ b/tests/Integration/Queue/RateLimitedTest.php
@@ -14,9 +14,6 @@ use Illuminate\Queue\Middleware\RateLimited;
 use Mockery as m;
 use Orchestra\Testbench\TestCase;
 
-/**
- * @group integration
- */
 class RateLimitedTest extends TestCase
 {
     protected function tearDown(): void

--- a/tests/Integration/Queue/RateLimitedWithRedisTest.php
+++ b/tests/Integration/Queue/RateLimitedWithRedisTest.php
@@ -16,9 +16,6 @@ use Illuminate\Support\Str;
 use Mockery as m;
 use Orchestra\Testbench\TestCase;
 
-/**
- * @group integration
- */
 class RateLimitedWithRedisTest extends TestCase
 {
     use InteractsWithRedis;

--- a/tests/Integration/Queue/ThrottlesExceptionsTest.php
+++ b/tests/Integration/Queue/ThrottlesExceptionsTest.php
@@ -12,9 +12,6 @@ use Illuminate\Queue\Middleware\ThrottlesExceptions;
 use Mockery as m;
 use Orchestra\Testbench\TestCase;
 
-/**
- * @group integration
- */
 class ThrottlesExceptionsTest extends TestCase
 {
     protected function tearDown(): void

--- a/tests/Integration/Queue/ThrottlesExceptionsWithRedisTest.php
+++ b/tests/Integration/Queue/ThrottlesExceptionsWithRedisTest.php
@@ -14,9 +14,6 @@ use Illuminate\Support\Str;
 use Mockery as m;
 use Orchestra\Testbench\TestCase;
 
-/**
- * @group integration
- */
 class ThrottlesExceptionsWithRedisTest extends TestCase
 {
     use InteractsWithRedis;

--- a/tests/Integration/Queue/UniqueJobTest.php
+++ b/tests/Integration/Queue/UniqueJobTest.php
@@ -14,9 +14,6 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Support\Facades\Bus;
 use Orchestra\Testbench\TestCase;
 
-/**
- * @group integration
- */
 class UniqueJobTest extends TestCase
 {
     protected function getEnvironmentSetUp($app)

--- a/tests/Integration/Queue/WithoutOverlappingJobsTest.php
+++ b/tests/Integration/Queue/WithoutOverlappingJobsTest.php
@@ -13,9 +13,6 @@ use Illuminate\Queue\Middleware\WithoutOverlapping;
 use Mockery as m;
 use Orchestra\Testbench\TestCase;
 
-/**
- * @group integration
- */
 class WithoutOverlappingJobsTest extends TestCase
 {
     protected function tearDown(): void

--- a/tests/Integration/Queue/WorkCommandTest.php
+++ b/tests/Integration/Queue/WorkCommandTest.php
@@ -9,9 +9,6 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Orchestra\Testbench\TestCase;
 use Queue;
 
-/**
- * @group integration
- */
 class WorkCommandTest extends TestCase
 {
     protected function getEnvironmentSetUp($app)

--- a/tests/Integration/Routing/CompiledRouteCollectionTest.php
+++ b/tests/Integration/Routing/CompiledRouteCollectionTest.php
@@ -11,9 +11,6 @@ use Orchestra\Testbench\TestCase;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
-/**
- * @group integration
- */
 class CompiledRouteCollectionTest extends TestCase
 {
     /**

--- a/tests/Integration/Routing/FallbackRouteTest.php
+++ b/tests/Integration/Routing/FallbackRouteTest.php
@@ -5,9 +5,6 @@ namespace Illuminate\Tests\Integration\Routing;
 use Illuminate\Support\Facades\Route;
 use Orchestra\Testbench\TestCase;
 
-/**
- * @group integration
- */
 class FallbackRouteTest extends TestCase
 {
     public function testBasicFallback()

--- a/tests/Integration/Routing/FluentRoutingTest.php
+++ b/tests/Integration/Routing/FluentRoutingTest.php
@@ -5,9 +5,6 @@ namespace Illuminate\Tests\Integration\Routing;
 use Illuminate\Support\Facades\Route;
 use Orchestra\Testbench\TestCase;
 
-/**
- * @group integration
- */
 class FluentRoutingTest extends TestCase
 {
     public static $value = '';

--- a/tests/Integration/Routing/ResponsableTest.php
+++ b/tests/Integration/Routing/ResponsableTest.php
@@ -6,9 +6,6 @@ use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Support\Facades\Route;
 use Orchestra\Testbench\TestCase;
 
-/**
- * @group integration
- */
 class ResponsableTest extends TestCase
 {
     public function testResponsableObjectsAreRendered()

--- a/tests/Integration/Routing/RouteApiResourceTest.php
+++ b/tests/Integration/Routing/RouteApiResourceTest.php
@@ -7,9 +7,6 @@ use Illuminate\Tests\Integration\Routing\Fixtures\ApiResourceTaskController;
 use Illuminate\Tests\Integration\Routing\Fixtures\ApiResourceTestController;
 use Orchestra\Testbench\TestCase;
 
-/**
- * @group integration
- */
 class RouteApiResourceTest extends TestCase
 {
     public function testApiResource()

--- a/tests/Integration/Routing/RouteRedirectTest.php
+++ b/tests/Integration/Routing/RouteRedirectTest.php
@@ -5,9 +5,6 @@ namespace Illuminate\Tests\Integration\Routing;
 use Illuminate\Support\Facades\Route;
 use Orchestra\Testbench\TestCase;
 
-/**
- * @group integration
- */
 class RouteRedirectTest extends TestCase
 {
     /**

--- a/tests/Integration/Routing/RouteViewTest.php
+++ b/tests/Integration/Routing/RouteViewTest.php
@@ -6,9 +6,6 @@ use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\View;
 use Orchestra\Testbench\TestCase;
 
-/**
- * @group integration
- */
 class RouteViewTest extends TestCase
 {
     public function testRouteView()

--- a/tests/Integration/Routing/SimpleRouteTest.php
+++ b/tests/Integration/Routing/SimpleRouteTest.php
@@ -5,9 +5,6 @@ namespace Illuminate\Tests\Integration\Routing;
 use Illuminate\Support\Facades\Route;
 use Orchestra\Testbench\TestCase;
 
-/**
- * @group integration
- */
 class SimpleRouteTest extends TestCase
 {
     public function testSimpleRouteThroughTheFramework()

--- a/tests/Integration/Routing/UrlSigningTest.php
+++ b/tests/Integration/Routing/UrlSigningTest.php
@@ -11,9 +11,6 @@ use Illuminate\Support\Facades\URL;
 use InvalidArgumentException;
 use Orchestra\Testbench\TestCase;
 
-/**
- * @group integration
- */
 class UrlSigningTest extends TestCase
 {
     public function testSigningUrl()

--- a/tests/Integration/Session/SessionPersistenceTest.php
+++ b/tests/Integration/Session/SessionPersistenceTest.php
@@ -12,9 +12,6 @@ use Illuminate\Support\Str;
 use Mockery;
 use Orchestra\Testbench\TestCase;
 
-/**
- * @group integration
- */
 class SessionPersistenceTest extends TestCase
 {
     public function testSessionIsPersistedEvenIfExceptionIsThrownFromRoute()

--- a/tests/Integration/Validation/RequestValidationTest.php
+++ b/tests/Integration/Validation/RequestValidationTest.php
@@ -6,9 +6,6 @@ use Illuminate\Http\Request;
 use Illuminate\Validation\ValidationException;
 use Orchestra\Testbench\TestCase;
 
-/**
- * @group integration
- */
 class RequestValidationTest extends TestCase
 {
     public function testValidateMacro()

--- a/tests/Integration/View/BladeTest.php
+++ b/tests/Integration/View/BladeTest.php
@@ -5,9 +5,6 @@ namespace Illuminate\Tests\Integration\View;
 use Illuminate\Support\Facades\View;
 use Orchestra\Testbench\TestCase;
 
-/**
- * @group integration
- */
 class BladeTest extends TestCase
 {
     public function test_basic_blade_rendering()

--- a/tests/Queue/RedisQueueIntegrationTest.php
+++ b/tests/Queue/RedisQueueIntegrationTest.php
@@ -85,10 +85,6 @@ class RedisQueueIntegrationTest extends TestCase
      */
     public function testBlockingPop($driver)
     {
-        if (! function_exists('pcntl_fork')) {
-            $this->markTestSkipped('Skipping since the pcntl extension is not available');
-        }
-
         $this->tearDownRedis();
 
         if ($pid = pcntl_fork() > 0) {

--- a/tests/Redis/ConcurrentLimiterTest.php
+++ b/tests/Redis/ConcurrentLimiterTest.php
@@ -9,9 +9,6 @@ use Illuminate\Redis\Limiters\ConcurrencyLimiter;
 use PHPUnit\Framework\TestCase;
 use Throwable;
 
-/**
- * @group redislimiters
- */
 class ConcurrentLimiterTest extends TestCase
 {
     use InteractsWithRedis;

--- a/tests/Redis/DurationLimiterTest.php
+++ b/tests/Redis/DurationLimiterTest.php
@@ -8,9 +8,6 @@ use Illuminate\Redis\Limiters\DurationLimiter;
 use PHPUnit\Framework\TestCase;
 use Throwable;
 
-/**
- * @group redislimiters
- */
 class DurationLimiterTest extends TestCase
 {
     use InteractsWithRedis;

--- a/tests/Support/SupportReflectorTest.php
+++ b/tests/Support/SupportReflectorTest.php
@@ -49,7 +49,7 @@ class SupportReflectorTest extends TestCase
     }
 
     /**
-     * @requires PHP 8
+     * @requires PHP >= 8
      */
     public function testUnionTypeName()
     {

--- a/tests/Support/SupportReflectsClosuresTest.php
+++ b/tests/Support/SupportReflectsClosuresTest.php
@@ -65,7 +65,7 @@ class SupportReflectsClosuresTest extends TestCase
     }
 
     /**
-     * @requires PHP 8
+     * @requires PHP >= 8
      */
     public function testItWorksWithUnionTypes()
     {


### PR DESCRIPTION
Small bit of cleanup of our test suite. This cleans up a lot of things, especially quite a few `markTestSkipped` calls which are now replaced with PHPUnit `@requires` annotations. Also all `@group` annotation are removed as they aren't really used anyway.