### PR TITLE
Make accept header comparison case-insensitive

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php
@@ -143,6 +143,11 @@ trait InteractsWithContentTypes
      */
     public static function matchesType($actual, $type)
     {
+        // Type should be case-insensitive
+        // Ref: https://www.rfc-editor.org/rfc/rfc2045
+        $actual = strtolower($actual);
+        $type = strtolower($type);
+
         if ($actual === $type) {
             return true;
         }

--- a/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php
@@ -144,7 +144,7 @@ trait InteractsWithContentTypes
     public static function matchesType($actual, $type)
     {
         // Type should be case-insensitive
-        // Ref: https://www.rfc-editor.org/rfc/rfc2045
+        // RFC: https://datatracker.ietf.org/doc/html/rfc7231#section-5.3
         $actual = strtolower($actual);
         $type = strtolower($type);
 

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -1006,6 +1006,15 @@ class HttpRequestTest extends TestCase
         $this->assertFalse($request->accepts('text/html'));
     }
 
+    public function testCaseInsensitiveAcceptHeader()
+    {
+        $request1 = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'APPLICATION/JSON']);
+        $this->assertTrue($request1->accepts(['text/html', 'application/json']));
+
+        $request2 = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'AppLiCaTion/JsOn']);
+        $this->assertTrue($request2->accepts(['text/html', 'application/json']));
+    }
+
     public function testSessionMethod()
     {
         $this->expectException(RuntimeException::class);


### PR DESCRIPTION
This issue https://github.com/laravel/framework/issues/39411 mentioned that the accepts method is currently not case-insensitive.

This pull request will cast both variables to lowercase before making the comparison. By doing so, the `APPLICATION/JSON` header can match `application/json` in the code.

The new test method is added to the `\Illuminate\Tests\Http\HttpRequestTest` class for case-insensitive test.