### PR TITLE
[8.x] Make accept header comparison case-insensitive

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php
@@ -35,7 +35,7 @@ trait InteractsWithContentTypes
     {
         $acceptable = $this->getAcceptableContentTypes();
 
-        return isset($acceptable[0]) && Str::contains($acceptable[0], ['/json', '+json']);
+        return isset($acceptable[0]) && Str::contains(strtolower($acceptable[0]), ['/json', '+json']);
     }
 
     /**
@@ -60,6 +60,11 @@ trait InteractsWithContentTypes
             }
 
             foreach ($types as $type) {
+                // Type should be case-insensitive
+                // Ref: https://www.rfc-editor.org/rfc/rfc2045
+                $accept = strtolower($accept);
+                $type = strtolower($type);
+
                 if ($this->matchesType($accept, $type) || $accept === strtok($type, '/').'/*') {
                     return true;
                 }
@@ -92,6 +97,11 @@ trait InteractsWithContentTypes
                 if (! is_null($mimeType = $this->getMimeType($contentType))) {
                     $type = $mimeType;
                 }
+
+                // Type should be case-insensitive
+                // Ref: https://www.rfc-editor.org/rfc/rfc2045
+                $accept = strtolower($accept);
+                $type = strtolower($type);
 
                 if ($this->matchesType($type, $accept) || $accept === strtok($type, '/').'/*') {
                     return $contentType;

--- a/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php
@@ -35,6 +35,9 @@ trait InteractsWithContentTypes
     {
         $acceptable = $this->getAcceptableContentTypes();
 
+        // Type checking should be case-insensitive
+        // Ref: https://www.rfc-editor.org/rfc/rfc2045
+        // RFC: https://datatracker.ietf.org/doc/html/rfc7231#section-5.3
         return isset($acceptable[0]) && Str::contains(strtolower($acceptable[0]), ['/json', '+json']);
     }
 
@@ -60,8 +63,9 @@ trait InteractsWithContentTypes
             }
 
             foreach ($types as $type) {
-                // Type should be case-insensitive
+                // Type checking should be case-insensitive
                 // Ref: https://www.rfc-editor.org/rfc/rfc2045
+                // RFC: https://datatracker.ietf.org/doc/html/rfc7231#section-5.3
                 $accept = strtolower($accept);
                 $type = strtolower($type);
 
@@ -98,8 +102,9 @@ trait InteractsWithContentTypes
                     $type = $mimeType;
                 }
 
-                // Type should be case-insensitive
+                // Type checking should be case-insensitive
                 // Ref: https://www.rfc-editor.org/rfc/rfc2045
+                // RFC: https://datatracker.ietf.org/doc/html/rfc7231#section-5.3
                 $accept = strtolower($accept);
                 $type = strtolower($type);
 

--- a/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php
@@ -35,9 +35,6 @@ trait InteractsWithContentTypes
     {
         $acceptable = $this->getAcceptableContentTypes();
 
-        // Type checking should be case-insensitive
-        // Ref: https://www.rfc-editor.org/rfc/rfc2045
-        // RFC: https://datatracker.ietf.org/doc/html/rfc7231#section-5.3
         return isset($acceptable[0]) && Str::contains(strtolower($acceptable[0]), ['/json', '+json']);
     }
 
@@ -63,10 +60,8 @@ trait InteractsWithContentTypes
             }
 
             foreach ($types as $type) {
-                // Type checking should be case-insensitive
-                // Ref: https://www.rfc-editor.org/rfc/rfc2045
-                // RFC: https://datatracker.ietf.org/doc/html/rfc7231#section-5.3
                 $accept = strtolower($accept);
+
                 $type = strtolower($type);
 
                 if ($this->matchesType($accept, $type) || $accept === strtok($type, '/').'/*') {
@@ -102,10 +97,8 @@ trait InteractsWithContentTypes
                     $type = $mimeType;
                 }
 
-                // Type checking should be case-insensitive
-                // Ref: https://www.rfc-editor.org/rfc/rfc2045
-                // RFC: https://datatracker.ietf.org/doc/html/rfc7231#section-5.3
                 $accept = strtolower($accept);
+
                 $type = strtolower($type);
 
                 if ($this->matchesType($type, $accept) || $accept === strtok($type, '/').'/*') {

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -1006,6 +1006,21 @@ class HttpRequestTest extends TestCase
         $this->assertFalse($request->accepts('text/html'));
     }
 
+    public function testCaseInsensitiveAcceptHeader()
+    {
+        $request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'APPLICATION/JSON']);
+        $this->assertTrue($request->accepts(['text/html', 'application/json']));
+
+        $request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'AppLiCaTion/JsOn']);
+        $this->assertTrue($request->accepts(['text/html', 'application/json']));
+
+        $request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'APPLICATION/*']);
+        $this->assertTrue($request->accepts(['text/html', 'application/json']));
+
+        $request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'APPLICATION/JSON']);
+        $this->assertTrue($request->expectsJson());
+    }
+
     public function testSessionMethod()
     {
         $this->expectException(RuntimeException::class);


### PR DESCRIPTION
This pull request is for the issue mentioned in the https://github.com/laravel/framework/issues/39411, that the `$request->accepts` method is currently allowing only case sensitive checking.

This pull request will convert both variables to lowercase before making the comparison. By doing so, the `APPLICATION/JSON` or `APPLICATION/*` header can match with any letter case in the code.

The new test method is added to the `\Illuminate\Tests\Http\HttpRequestTest` class for case-insensitive test.
