### PR TITLE
[8.x] Adds `enclose()` helper

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -119,6 +119,22 @@ if (! function_exists('e')) {
     }
 }
 
+if (! function_exists('enclose')) {
+    /**
+     * Creates a Closure to be called with the given argument values.
+     *
+     * @param  callable  $callable
+     * @param  mixed ...$arguments
+     * @return \Closure
+     */
+    function enclose(callable $callable, ...$arguments)
+    {
+        return function (...$override) use ($callable, $arguments) {
+            return $callable(...array_replace($arguments, $override));
+        };
+    }
+}
+
 if (! function_exists('env')) {
     /**
      * Gets the value of an environment variable.

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -124,7 +124,7 @@ if (! function_exists('enclose')) {
      * Creates a Closure to be called with the given argument values.
      *
      * @param  callable  $callable
-     * @param  mixed ...$arguments
+     * @param  mixed  ...$arguments
      * @return \Closure
      */
     function enclose(callable $callable, ...$arguments)

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Support;
 
 use ArrayAccess;
+use Closure;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Env;
 use Illuminate\Support\Optional;
@@ -26,6 +27,17 @@ class SupportHelpersTest extends TestCase
         $html = m::mock(Htmlable::class);
         $html->shouldReceive('toHtml')->andReturn($str);
         $this->assertEquals($str, e($html));
+    }
+
+    public function testEnclose(): void
+    {
+        $enclosed = enclose(function (int $number) {
+            return $number * 3;
+        }, 10);
+
+        $this->assertInstanceOf(Closure::class, $enclosed);
+        $this->assertSame(30, $enclosed());
+        $this->assertSame(60, $enclosed(20));
     }
 
     public function testClassBasename()


### PR DESCRIPTION
## What?

Encloses a callable into a Closure with arguments. Useful for places where a callable/Closure is required but there is no way to inject arguments.

```php
$enclosed = enclose(function (int $number, int $sum = 0): void {
    return ($number + $sum) * 10;
}, 20);

echo $enclosed(); // 200
```

It also supports argument overriding.

```php
echo $enclosed(30, 5); // 350
```

## Why?

There are a lot of places in the framework where a callable must be issued, but there is no place to add arguments, forcing the developer to create a `Closure` and adding the arguments inside.

For example, let's say we want to use `pipe()` in a `Stringable` for a function that does complex stuff. 

```php
use Illuminate\Support\Stringable;

$puppies = Str::of('I have 20 puppies');

$number = 10;

$callable = function complexStuff($string, $id) {
    // Very complex stuff!
}
```

Since the callable needs the ID as an additional parameter, we need to create a new callable and execute the function inside, which adds to the cognitive load.

```php
Str::of('I have 20 puppies')->pipe(function ($string) use ($number, $function) {
    return $function($string, $number);
});
```

Now, using `enclose()`:

```php
Str::of('I have 20 puppies')->pipe(enclose($function, $number));
```

And the Closure is not static, so it can be used to bind it to objects (like Macros).

```php
enclose($function, $number)->bind($object);
```

## BC?

None, it's additive.