### PR TITLE
[8.x] Auth: Allows to use a callback in credentials array

### DIFF
--- a/src/Illuminate/Auth/DatabaseUserProvider.php
+++ b/src/Illuminate/Auth/DatabaseUserProvider.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Auth;
 
+use Closure;
 use Illuminate\Contracts\Auth\Authenticatable as UserContract;
 use Illuminate\Contracts\Auth\UserProvider;
 use Illuminate\Contracts\Hashing\Hasher as HasherContract;
@@ -117,7 +118,7 @@ class DatabaseUserProvider implements UserProvider
 
             if (is_array($value) || $value instanceof Arrayable) {
                 $query->whereIn($key, $value);
-            } elseif (is_callable($value)) {
+            } elseif ($value instanceof Closure) {
                 $value($query);
             } else {
                 $query->where($key, $value);

--- a/src/Illuminate/Auth/DatabaseUserProvider.php
+++ b/src/Illuminate/Auth/DatabaseUserProvider.php
@@ -117,6 +117,8 @@ class DatabaseUserProvider implements UserProvider
 
             if (is_array($value) || $value instanceof Arrayable) {
                 $query->whereIn($key, $value);
+            } elseif (is_callable($value)) {
+                $value($query);
             } else {
                 $query->where($key, $value);
             }

--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Auth;
 
+use Closure;
 use Illuminate\Contracts\Auth\Authenticatable as UserContract;
 use Illuminate\Contracts\Auth\UserProvider;
 use Illuminate\Contracts\Hashing\Hasher as HasherContract;
@@ -123,7 +124,7 @@ class EloquentUserProvider implements UserProvider
 
             if (is_array($value) || $value instanceof Arrayable) {
                 $query->whereIn($key, $value);
-            } elseif (is_callable($value)) {
+            } elseif ($value instanceof Closure) {
                 $value($query);
             } else {
                 $query->where($key, $value);

--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -123,6 +123,8 @@ class EloquentUserProvider implements UserProvider
 
             if (is_array($value) || $value instanceof Arrayable) {
                 $query->whereIn($key, $value);
+            } elseif (is_callable($value)) {
+                $value($query);
             } else {
                 $query->where($key, $value);
             }

--- a/tests/Auth/AuthEloquentUserProviderTest.php
+++ b/tests/Auth/AuthEloquentUserProviderTest.php
@@ -100,6 +100,23 @@ class AuthEloquentUserProviderTest extends TestCase
         $this->assertSame('bar', $user);
     }
 
+    public function testRetrieveByCredentialsAcceptsCallback()
+    {
+        $provider = $this->getProviderMock();
+        $mock = m::mock(stdClass::class);
+        $mock->shouldReceive('newQuery')->once()->andReturn($mock);
+        $mock->shouldReceive('where')->once()->with('username', 'dayle');
+        $mock->shouldReceive('whereIn')->once()->with('group', ['one', 'two']);
+        $mock->shouldReceive('first')->once()->andReturn('bar');
+        $provider->expects($this->once())->method('createModel')->willReturn($mock);
+        $user = $provider->retrieveByCredentials([function ($builder) {
+            $builder->where('username', 'dayle');
+            $builder->whereIn('group', ['one', 'two']);
+        }]);
+
+        $this->assertSame('bar', $user);
+    }
+
     public function testCredentialValidation()
     {
         $hasher = m::mock(Hasher::class);


### PR DESCRIPTION
## What?

Allows to use a callback on the `Auth::attempt()` credentials array:

```php
Auth::attempt([
    'email' => 'john@doe.com',
    function ($builder) {
        $builder->where('subscription_expires_at', '<', now());
    }
]);
```

## Why?

Both `EloquentUserProvider` and `DatabaseUserProvider` only support `where()` and `whereIn()` clauses when these receive a credentials array value. This allows to make further adjustments if the value is a callback.

The difference between this and `attemptWith()` is that this affects the query directly, which is useful to short-circuit the authentication procedure on user retrieval instead of using the aforementioned helper. In some cases, this may help reduce memory consumption as the model/row may not be retrieved before further checks.

## BC

None, as is not expected a developer used callbacks in the `attempt()` array.

## Notes

This may be also good for other packages as these can include their own callbacks into the credentials array.