### PR TITLE
[8.x] Fix regression with capitalizing translation params

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -218,9 +218,9 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         $shouldReplace = [];
 
         foreach ($replace as $key => $value) {
-            $shouldReplace[':'.$key] = $value;
-            $shouldReplace[':'.Str::upper($key)] = Str::upper($value);
             $shouldReplace[':'.Str::ucfirst($key)] = Str::ucfirst($value);
+            $shouldReplace[':'.Str::upper($key)] = Str::upper($value);
+            $shouldReplace[':'.$key] = $value;
         }
 
         return strtr($line, $shouldReplace);

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -78,8 +78,8 @@ class TranslationTranslatorTest extends TestCase
     {
         $t = $this->getMockBuilder(Translator::class)->onlyMethods([])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
-        $t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn(['foo' => 'foo', 'baz' => 'breeze :Foo :BAR']);
-        $this->assertSame('breeze Bar FOO', $t->get('foo::bar.baz', ['foo' => 'bar', 'bar' => 'foo'], 'en'));
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn(['foo' => 'foo', 'baz' => 'breeze :0 :Foo :BAR']);
+        $this->assertSame('breeze john Bar FOO', $t->get('foo::bar.baz', ['john', 'foo' => 'bar', 'bar' => 'foo'], 'en'));
         $this->assertSame('foo', $t->get('foo::bar.foo'));
     }
 


### PR DESCRIPTION
This fixes an issue with capitalization for translation parameters.

I'm not 100% sure if just moving the sequence of the `$shouldReplace` assignments is correct but it does fixes the regression and the rest of the test suite passes.
