### PR TITLE
[8.x] Adding a replacement character

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -828,7 +828,7 @@ class Str
             return static::$studlyCache[$key];
         }
 
-        $value = ucwords(str_replace(['-', '_'], ' ', $value));
+        $value = ucwords(str_replace(['-', '_', '.'], ' ', $value));
 
         return static::$studlyCache[$key] = str_replace(' ', '', $value);
     }


### PR DESCRIPTION
There was a problem if you specify an attribute with a "dot" in the name in $appends, laravel tries to call a method with a "dot" in the name, which is an error.
Example:
```php
protected $appends = [
        "user.fio"
]
```
Error:
`Call to undefined method App\\Models\\OwnerCar::getUser.fioAttribute()`