### PR TITLE
[8.x] Add success and failure command assertions

### DIFF
--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Arr;
 use Mockery;
 use Mockery\Exception\NoMatchingExpectationException;
 use PHPUnit\Framework\TestCase as PHPUnitTestCase;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
@@ -190,6 +191,26 @@ class PendingCommand
         $this->expectedExitCode = $exitCode;
 
         return $this;
+    }
+
+    /**
+     * Assert that the command has the success exit code.
+     *
+     * @return $this
+     */
+    public function assertSuccessExitCode()
+    {
+        return $this->assertExitCode(Command::SUCCESS);
+    }
+
+    /**
+     * Assert that the command has the failure exit code.
+     *
+     * @return $this
+     */
+    public function assertFailureExitCode()
+    {
+        return $this->assertExitCode(Command::FAILURE);
     }
 
     /**

--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -198,7 +198,7 @@ class PendingCommand
      *
      * @return $this
      */
-    public function assertSuccessExitCode()
+    public function assertSuccessful()
     {
         return $this->assertExitCode(Command::SUCCESS);
     }
@@ -208,7 +208,7 @@ class PendingCommand
      *
      * @return $this
      */
-    public function assertFailureExitCode()
+    public function assertFailed()
     {
         return $this->assertExitCode(Command::FAILURE);
     }

--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -53,11 +53,11 @@ class PendingCommand
     protected $expectedExitCode;
 
     /**
-     * The not expected exit code.
+     * The unexpected exit code.
      *
      * @var int
      */
-    protected $notExpectedExitCode;
+    protected $unexpectedExitCode;
 
     /**
      * Determine if the command has executed.
@@ -208,7 +208,7 @@ class PendingCommand
      */
     public function assertNotExitCode($exitCode)
     {
-        $this->notExpectedExitCode = $exitCode;
+        $this->unexpectedExitCode = $exitCode;
 
         return $this;
     }
@@ -271,10 +271,10 @@ class PendingCommand
                 $this->expectedExitCode, $exitCode,
                 "Expected status code {$this->expectedExitCode} but received {$exitCode}."
             );
-        } elseif ($this->notExpectedExitCode !== null) {
+        } elseif (! is_null($this->unexpectedExitCode)) {
             $this->test->assertNotEquals(
-                $this->notExpectedExitCode, $exitCode,
-                "Not expected status code {$this->notExpectedExitCode} was received."
+                $this->unexpectedExitCode, $exitCode,
+                "Unexpected status code {$this->unexpectedExitCode} was received."
             );
         }
 

--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -53,6 +53,13 @@ class PendingCommand
     protected $expectedExitCode;
 
     /**
+     * The not expected exit code.
+     *
+     * @var int
+     */
+    protected $notExpectedExitCode;
+
+    /**
      * Determine if the command has executed.
      *
      * @var bool
@@ -194,6 +201,19 @@ class PendingCommand
     }
 
     /**
+     * Assert that the command does not have the given exit code.
+     *
+     * @param  int  $exitCode
+     * @return $this
+     */
+    public function assertNotExitCode($exitCode)
+    {
+        $this->notExpectedExitCode = $exitCode;
+
+        return $this;
+    }
+
+    /**
      * Assert that the command has the success exit code.
      *
      * @return $this
@@ -204,13 +224,13 @@ class PendingCommand
     }
 
     /**
-     * Assert that the command has the failure exit code.
+     * Assert that the command does not have the success exit code.
      *
      * @return $this
      */
     public function assertFailed()
     {
-        return $this->assertExitCode(Command::FAILURE);
+        return $this->assertNotExitCode(Command::SUCCESS);
     }
 
     /**
@@ -250,6 +270,11 @@ class PendingCommand
             $this->test->assertEquals(
                 $this->expectedExitCode, $exitCode,
                 "Expected status code {$this->expectedExitCode} but received {$exitCode}."
+            );
+        } elseif ($this->notExpectedExitCode !== null) {
+            $this->test->assertNotEquals(
+                $this->notExpectedExitCode, $exitCode,
+                "Not expected status code {$this->notExpectedExitCode} was received."
             );
         }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

After browsing some of my tests for the console commands, I found that I have been doing either:

```php
$this->artisan(FooCommand::class)->assertExitCode(0);
$this->artisan(FooCommand::class)->assertExitCode(1);
```

or

```php
$this->artisan(FooCommand::class)->assertExitCode(Command::SUCCESS);
$this->artisan(FooCommand::class)->assertExitCode(Command::FAILURE);
```

With this new set of assertions, this can be unified and by having the IDE to provide auto-completion, writing tests feels smoother:

```php
$this->artisan(FooCommand::class)->assertSuccessful();
$this->artisan(FooCommand::class)->assertFailed();
```
