### PR TITLE
[8.x] Add ability to provide a model instance into `Rule::exists()->where()` method

### DIFF
--- a/src/Illuminate/Validation/Rules/DatabaseRule.php
+++ b/src/Illuminate/Validation/Rules/DatabaseRule.php
@@ -81,7 +81,7 @@ trait DatabaseRule
      * Set a "where" constraint on the query.
      *
      * @param  \Closure|string  $column
-     * @param  array|string|int|null  $value
+     * @param  \Illuminate\Database\Eloquent\Model|array|string|int|null  $value
      * @return $this
      */
     public function where($column, $value = null)
@@ -96,6 +96,10 @@ trait DatabaseRule
 
         if (is_null($value)) {
             return $this->whereNull($column);
+        }
+
+        if ($value instanceof Model) {
+            $value = $value->getKey();
         }
 
         $this->wheres[] = compact('column', 'value');

--- a/tests/Validation/ValidationExistsRuleTest.php
+++ b/tests/Validation/ValidationExistsRuleTest.php
@@ -51,6 +51,10 @@ class ValidationExistsRuleTest extends TestCase
         $rule->where('foo', 'bar');
         $this->assertSame('exists:table,column,foo,"bar"', (string) $rule);
 
+        $rule = new Exists('table', 'column');
+        $rule->where('foo', User::create(['id' => '1', 'type' => 'foo']));
+        $this->assertSame('exists:table,column,foo,"1"', (string) $rule);
+
         $rule = new Exists(User::class, 'column');
         $rule->where('foo', 'bar');
         $this->assertSame('exists:users,column,foo,"bar"', (string) $rule);


### PR DESCRIPTION
## Description

This PR provides the ability to supply a model instance into the `Rule::exists()->where()` method, i.e.:

```php
Rule::exists(Comment::class, 'id')->where('post_id', $this->route('post'));
```

## Purpose

When using `FormRequest`'s that *may or may not* have route parameters that resolve to model instances, it allows us to omit the use the `optional()` helper or any conditional checks to automatically resolve the model's key into the `where` method:

**Before**:
```php
class PostRequest extends FormRequest
{
    public function rules()
    {
        return [
            'comments.*.id' => Rule::exists(Comment::class, 'id')->where('post_id', optional($this->route('post'))->id)
            // ...
        ];
    }
}
```

**After**:
```php
class PostRequest extends FormRequest
{
    public function rules()
    {
        return [
            'comments.*.id' => Rule::exists(Comment::class, 'id')->where('post_id', $this->route('post'))
            // ...
        ];
    }
}
```

Thanks for your time! No hard feelings on closure ❤️ 