### PR TITLE
[8.x] Add an Enum validation rule

### DIFF
--- a/src/Illuminate/Validation/Rules/Enum.php
+++ b/src/Illuminate/Validation/Rules/Enum.php
@@ -2,15 +2,7 @@
 
 namespace Illuminate\Validation\Rules;
 
-use Illuminate\Container\Container;
-use Illuminate\Contracts\Validation\DataAwareRule;
 use Illuminate\Contracts\Validation\Rule;
-use Illuminate\Contracts\Validation\UncompromisedVerifier;
-use Illuminate\Contracts\Validation\ValidatorAwareRule;
-use Illuminate\Support\Arr;
-use Illuminate\Support\Facades\Validator;
-use Illuminate\Support\Traits\Conditionable;
-use InvalidArgumentException;
 
 class Enum implements Rule
 {

--- a/src/Illuminate/Validation/Rules/Enum.php
+++ b/src/Illuminate/Validation/Rules/Enum.php
@@ -56,7 +56,7 @@ class Enum implements Rule
     public function message()
     {
         return [
-            'The selected :attribute is invalid.'
+            'The selected :attribute is invalid.',
         ];
     }
 }

--- a/src/Illuminate/Validation/Rules/Enum.php
+++ b/src/Illuminate/Validation/Rules/Enum.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Validation\DataAwareRule;
+use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Contracts\Validation\UncompromisedVerifier;
+use Illuminate\Contracts\Validation\ValidatorAwareRule;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Traits\Conditionable;
+use InvalidArgumentException;
+
+class Enum implements Rule
+{
+    /**
+     * The type of the enum.
+     *
+     * @var string
+     */
+    protected $type;
+
+    /**
+     * Create a new rule instance.
+     *
+     * @param  string  $type
+     * @return void
+     */
+    public function __construct($type)
+    {
+        $this->type = $type;
+    }
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        if (is_null($value) || ! function_exists('enum_exists') || ! enum_exists($this->type)) {
+            return false;
+        }
+
+        return ! is_null($this->type::tryFrom($value));
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return array
+     */
+    public function message()
+    {
+        return [
+            'The selected :attribute is invalid.'
+        ];
+    }
+}

--- a/tests/Validation/Enums.php
+++ b/tests/Validation/Enums.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+enum StringStatus: string
+{
+    case pending = 'pending';
+    case done = 'done';
+}
+
+enum IntegerStatus: int
+{
+    case pending = 1;
+    case done = 2;
+}

--- a/tests/Validation/ValidationEnumRuleTest.php
+++ b/tests/Validation/ValidationEnumRuleTest.php
@@ -17,7 +17,7 @@ if (PHP_VERSION_ID >= 80100) {
 }
 
 /**
- * @requires PHP 8.1
+ * @requires PHP >= 8.1
  */
 class ValidationEnumRuleTest extends TestCase
 {

--- a/tests/Validation/ValidationEnumRuleTest.php
+++ b/tests/Validation/ValidationEnumRuleTest.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Illuminate\Container\Container;
+use Illuminate\Support\Facades\Facade;
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
+use Illuminate\Validation\Rules\Enum;
+use Illuminate\Validation\Rules\Password;
+use Illuminate\Validation\ValidationServiceProvider;
+use Illuminate\Validation\Validator;
+use PHPUnit\Framework\TestCase;
+
+if (PHP_VERSION_ID >= 80100) {
+    include 'Enums.php';
+}
+
+/**
+ * @requires PHP 8.1
+ */
+class ValidationEnumRuleTest extends TestCase
+{
+    public function testvalidationPassesWhenPassingCorrectEnum()
+    {
+        $v = new Validator(
+            resolve('translator'),
+            [
+                'status' => 'pending',
+                'int_status' => 1
+            ],
+            [
+                'status' => new Enum(StringStatus::class),
+                'int_status' => new Enum(IntegerStatus::class),
+            ]
+        );
+
+        $this->assertFalse($v->fails());
+    }
+
+    public function testValidationFailsWhenProvidingNoExistingCases()
+    {
+        $v = new Validator(
+            resolve('translator'),
+            [
+                'status' => 'finished',
+            ],
+            [
+                'status' => new Enum(StringStatus::class),
+            ]
+        );
+
+        $this->assertTrue($v->fails());
+        $this->assertEquals(['The selected status is invalid.'], $v->messages()->get('status'));
+    }
+
+    public function testValidationFailsWhenProvidingDifferentType()
+    {
+        $v = new Validator(
+            resolve('translator'),
+            [
+                'status' => 10,
+            ],
+            [
+                'status' => new Enum(StringStatus::class),
+            ]
+        );
+
+        $this->assertTrue($v->fails());
+        $this->assertEquals(['The selected status is invalid.'], $v->messages()->get('status'));
+    }
+
+    public function testValidationPassesWhenProvidingDifferentTypeThatIsCastableToTheEnumType()
+    {
+        $v = new Validator(
+            resolve('translator'),
+            [
+                'status' => '1',
+            ],
+            [
+                'status' => new Enum(IntegerStatus::class),
+            ]
+        );
+
+        $this->assertFalse($v->fails());
+    }
+
+    public function testValidationFailsWhenProvidingNull()
+    {
+        $v = new Validator(
+            resolve('translator'),
+            [
+                'status' => null,
+            ],
+            [
+                'status' => new Enum(StringStatus::class),
+            ]
+        );
+
+        $this->assertTrue($v->fails());
+        $this->assertEquals(['The selected status is invalid.'], $v->messages()->get('status'));
+    }
+
+    public function testValidationPassesWhenProvidingNullButTheFieldIsNullable()
+    {
+        $v = new Validator(
+            resolve('translator'),
+            [
+                'status' => null,
+            ],
+            [
+                'status' => ['nullable', new Enum(StringStatus::class)],
+            ]
+        );
+
+        $this->assertFalse($v->fails());
+    }
+
+    protected function setUp(): void
+    {
+        $container = Container::getInstance();
+
+        $container->bind('translator', function () {
+            return new Translator(
+                new ArrayLoader, 'en'
+            );
+        });
+
+        Facade::setFacadeApplication($container);
+
+        (new ValidationServiceProvider($container))->register();
+    }
+
+    protected function tearDown(): void
+    {
+        Container::setInstance(null);
+
+        Facade::clearResolvedInstances();
+
+        Facade::setFacadeApplication(null);
+
+        Password::$defaultCallback = null;
+    }
+}

--- a/tests/Validation/ValidationEnumRuleTest.php
+++ b/tests/Validation/ValidationEnumRuleTest.php
@@ -27,7 +27,7 @@ class ValidationEnumRuleTest extends TestCase
             resolve('translator'),
             [
                 'status' => 'pending',
-                'int_status' => 1
+                'int_status' => 1,
             ],
             [
                 'status' => new Enum(StringStatus::class),


### PR DESCRIPTION
This PR adds a new Enum validation rule that will make sure the provided data has a corresponding case in the enum.

```php
validator(
    ['status' => 'pending'],
    ['status' => [new Enum(ServerStatus::class)]]
)->validate();
```