### PR TITLE
micro-optimize Illuminate\Support\Str::endsWith()

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -219,7 +219,7 @@ class Str
         foreach ((array) $needles as $needle) {
             if (
                 $needle !== '' && $needle !== null
-                && substr($haystack, -strlen($needle)) === (string) $needle
+                && 0 === substr_compare($haystack, $needle, - strlen($needle))
             ) {
                 return true;
             }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -219,7 +219,7 @@ class Str
         foreach ((array) $needles as $needle) {
             if (
                 $needle !== '' && $needle !== null
-                && 0 === substr_compare($haystack, $needle, - strlen($needle))
+                && 0 === substr_compare($haystack, $needle, -strlen($needle))
             ) {
                 return true;
             }


### PR DESCRIPTION
substr() creates a new string, substr_compare() doesn't

notably, in PHP8+ str_ends_with might be an even better choice, but it looks like this code is trying to be PHP5-compatible, so for 5 and 7, substr_compare is the 2nd-best-option.

if PHP<8 compatibility isn't an issue, str_ends_with should be used instead though. substr_compare was introduced in 5.0.0, str_ends_with was introduced in PHP8.0.0

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
