### PR TITLE
[8.x] Allows Stringable objects as middleware.

### DIFF
--- a/src/Illuminate/Routing/PendingResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingResourceRegistration.php
@@ -149,6 +149,14 @@ class PendingResourceRegistration
      */
     public function middleware($middleware)
     {
+        if (!is_string($middleware)) {
+            $middleware = Arr::wrap($middleware);
+
+            foreach ($middleware as $key => $value) {
+                $middleware[$key] = (string) $value;
+            }
+        }
+
         $this->options['middleware'] = $middleware;
 
         return $this;

--- a/src/Illuminate/Routing/PendingResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingResourceRegistration.php
@@ -149,7 +149,7 @@ class PendingResourceRegistration
      */
     public function middleware($middleware)
     {
-        if (!is_string($middleware)) {
+        if (! is_string($middleware)) {
             $middleware = Arr::wrap($middleware);
 
             foreach ($middleware as $key => $value) {

--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -93,6 +93,14 @@ class RouteRegistrar
             throw new InvalidArgumentException("Attribute [{$key}] does not exist.");
         }
 
+        if ($key === 'middleware' && ! is_string($value)) {
+            $value = Arr::wrap($value);
+
+            foreach ($value as $index => $middleware) {
+                $value[$index] = (string) $middleware;
+            }
+        }
+
         $this->attributes[Arr::get($this->aliases, $key, $key)] = $value;
 
         return $this;

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -63,7 +63,8 @@ class RouteRegistrarTest extends TestCase
 
     public function testMiddlewareAsStringableObject()
     {
-        $one = new class implements Stringable {
+        $one = new class implements Stringable
+        {
             public function __toString()
             {
                 return 'one';
@@ -80,7 +81,8 @@ class RouteRegistrarTest extends TestCase
 
     public function testMiddlewareAsArrayWithStringables()
     {
-        $one = new class implements Stringable {
+        $one = new class implements Stringable
+        {
             public function __toString()
             {
                 return 'one';
@@ -643,7 +645,8 @@ class RouteRegistrarTest extends TestCase
 
     public function testResourceWithMiddlewareAsStringable()
     {
-        $one = new class implements Stringable {
+        $one = new class implements Stringable
+        {
             public function __toString()
             {
                 return 'one';

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Stringable;
 
 class RouteRegistrarTest extends TestCase
 {
@@ -58,6 +59,40 @@ class RouteRegistrarTest extends TestCase
 
         $this->seeResponse('all-users', Request::create('users', 'GET'));
         $this->assertEquals(['seven'], $this->getRoute()->middleware());
+    }
+
+    public function testMiddlewareAsStringableObject()
+    {
+        $one = new class implements Stringable {
+            public function __toString()
+            {
+                return 'one';
+            }
+        };
+
+        $this->router->middleware($one)->get('users', function () {
+            return 'all-users';
+        });
+
+        $this->seeResponse('all-users', Request::create('users', 'GET'));
+        $this->assertSame(['one'], $this->getRoute()->middleware());
+    }
+
+    public function testMiddlewareAsArrayWithStringables()
+    {
+        $one = new class implements Stringable {
+            public function __toString()
+            {
+                return 'one';
+            }
+        };
+
+        $this->router->middleware([$one, 'two'])->get('users', function () {
+            return 'all-users';
+        });
+
+        $this->seeResponse('all-users', Request::create('users', 'GET'));
+        $this->assertSame(['one', 'two'], $this->getRoute()->middleware());
     }
 
     public function testWithoutMiddlewareRegistration()
@@ -603,6 +638,26 @@ class RouteRegistrarTest extends TestCase
 
         $this->seeResponse('controller', Request::create('users', 'GET'));
 
+        $this->assertEquals(['one'], $this->getRoute()->excludedMiddleware());
+    }
+
+    public function testResourceWithMiddlewareAsStringable()
+    {
+        $one = new class implements Stringable {
+            public function __toString()
+            {
+                return 'one';
+            }
+        };
+
+        $this->router->resource('users', RouteRegistrarControllerStub::class)
+                     ->only('index')
+                     ->middleware([$one, 'two'])
+                     ->withoutMiddleware('one');
+
+        $this->seeResponse('controller', Request::create('users', 'GET'));
+
+        $this->assertEquals(['one', 'two'], $this->getRoute()->middleware());
         $this->assertEquals(['one'], $this->getRoute()->excludedMiddleware());
     }
 

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -227,6 +227,26 @@ class RouteRegistrarTest extends TestCase
         $this->seeMiddleware('group-middleware');
     }
 
+    public function testCanRegisterGroupWithStringableMiddleware()
+    {
+        $one = new class implements Stringable
+        {
+            public function __toString()
+            {
+                return 'one';
+            }
+        };
+
+        $this->router->middleware($one)->group(function ($router) {
+            $router->get('users', function () {
+                return 'all-users';
+            });
+        });
+
+        $this->seeResponse('all-users', Request::create('users', 'GET'));
+        $this->seeMiddleware('one');
+    }
+
     public function testCanRegisterGroupWithNamespace()
     {
         $this->router->namespace('App\Http\Controllers')->group(function ($router) {


### PR DESCRIPTION
## What?

You can use `Stringable` objects into middleware declaration. These will be transformed into a string automatically. Pretty much like a `Rule::exists()` works.

```php
use Illuminate\Support\Facades\Route;
use App\Http\Middleware\Helpers\Subscribe;

Route::get('library', 'LibraryController@index')
    ->middleware(Subscribed::to('premium')->can('listen')->except('admin'));
```

## Why?

This allows to use helpers for middleware that contain multiple parameters into one fluid sentence. Useful for packages that have middleware with a parameters that should be overridden per-route basis.

For example, the built-in `ThrottlesRequest` middleware which has 3 parameters. Using a Stringable-based helper, we can transform the declaration into something more understandable forwarding the call to the helper.

```php
// Before
Route::get('library', 'LibraryController@index')
     ->middleware('throttle:120,5,download-book');

// After
Route::get('library', 'LibraryController@index')
     ->middleware(ThrottleRequests::as('download-book')->for(5)->max(120));
```

Also works on Resource routes:

```php
 $this->router->resource('song', 'SongController::class')
                     ->only('index')
                     ->middleware(['auth', ThrottleRequests::as('download-book')->for(5)->max(120)]);
```

## BC?

- No, it's adds a checks if the middleware is not a string and casts it to a string.