### PR TITLE
[8.x] Enforce implicit Route Model scoping

### DIFF
--- a/src/Illuminate/Routing/ImplicitRouteBinding.php
+++ b/src/Illuminate/Routing/ImplicitRouteBinding.php
@@ -41,7 +41,7 @@ class ImplicitRouteBinding
                         ? 'resolveSoftDeletableRouteBinding'
                         : 'resolveRouteBinding';
 
-            if ($parent instanceof UrlRoutable && in_array($parameterName, array_keys($route->bindingFields()))) {
+            if ($parent instanceof UrlRoutable && ($route->enforcesScoping() || array_key_exists($parameterName, $route->bindingFields()))) {
                 $childRouteBindingMethod = $route->allowsTrashedBindings()
                             ? 'resolveSoftDeletableChildRouteBinding'
                             : 'resolveChildRouteBinding';

--- a/src/Illuminate/Routing/ImplicitRouteBinding.php
+++ b/src/Illuminate/Routing/ImplicitRouteBinding.php
@@ -41,7 +41,7 @@ class ImplicitRouteBinding
                         ? 'resolveSoftDeletableRouteBinding'
                         : 'resolveRouteBinding';
 
-            if ($parent instanceof UrlRoutable && ($route->enforcesScoping() || array_key_exists($parameterName, $route->bindingFields()))) {
+            if ($parent instanceof UrlRoutable && ($route->enforcesScopedBindings() || array_key_exists($parameterName, $route->bindingFields()))) {
                 $childRouteBindingMethod = $route->allowsTrashedBindings()
                             ? 'resolveSoftDeletableChildRouteBinding'
                             : 'resolveChildRouteBinding';

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1078,13 +1078,25 @@ class Route
     }
 
     /**
-     * Determine if the route should enforce scoping of multiple Eloquent bindings.
+     * Indicate that the route should enforce scoping of multiple implicit Eloquent bindings.
      *
      * @return bool
      */
-    public function enforcesScoping()
+    public function scopeBindings()
     {
-        return (bool) ($this->action['scoping'] ?? false);
+        $this->action['scope_bindings'] = true;
+
+        return $this;
+    }
+
+    /**
+     * Determine if the route should enforce scoping of multiple implicit Eloquent bindings.
+     *
+     * @return bool
+     */
+    public function enforcesScopedBindings()
+    {
+        return (bool) ($this->action['scope_bindings'] ?? false);
     }
 
     /**

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1078,6 +1078,16 @@ class Route
     }
 
     /**
+     * Determine if the route should enforce scoping of multiple Eloquent bindings.
+     *
+     * @return bool
+     */
+    public function enforcesScoping()
+    {
+        return (bool) ($this->action['scoping'] ?? false);
+    }
+
+    /**
      * Specify that the route should not allow concurrent requests from the same session.
      *
      * @param  int|null  $lockSeconds

--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -55,7 +55,14 @@ class RouteRegistrar
      * @var string[]
      */
     protected $allowedAttributes = [
-        'as', 'domain', 'middleware', 'name', 'namespace', 'prefix', 'where',
+        'as',
+        'domain',
+        'middleware',
+        'name',
+        'namespace',
+        'prefix',
+        'scopeBindings',
+        'where',
     ];
 
     /**
@@ -65,6 +72,7 @@ class RouteRegistrar
      */
     protected $aliases = [
         'name' => 'as',
+        'scopeBindings' => 'scope_bindings',
     ];
 
     /**
@@ -216,7 +224,7 @@ class RouteRegistrar
                 return $this->attribute($method, is_array($parameters[0]) ? $parameters[0] : $parameters);
             }
 
-            return $this->attribute($method, $parameters[0]);
+            return $this->attribute($method, $parameters[0] ?? true);
         }
 
         throw new BadMethodCallException(sprintf(

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1326,6 +1326,6 @@ class Router implements BindingRegistrar, RegistrarContract
             return (new RouteRegistrar($this))->attribute($method, is_array($parameters[0]) ? $parameters[0] : $parameters);
         }
 
-        return (new RouteRegistrar($this))->attribute($method, $parameters[0]);
+        return (new RouteRegistrar($this))->attribute($method, $parameters[0] ?? true);
     }
 }

--- a/tests/Integration/Routing/ImplicitRouteBindingTest.php
+++ b/tests/Integration/Routing/ImplicitRouteBindingTest.php
@@ -147,7 +147,7 @@ PHP);
 
         config(['app.key' => str_repeat('a', 32)]);
 
-        Route::group(['scoping' => true], function () {
+        Route::scopeBindings()->group(function () {
             Route::get('/user/{user}/post/{post}', function (ImplicitBindingUser $user, ImplicitBindingPost $post) {
                 return [$user, $post];
             })->middleware(['web']);

--- a/tests/Integration/Routing/ImplicitRouteBindingTest.php
+++ b/tests/Integration/Routing/ImplicitRouteBindingTest.php
@@ -50,8 +50,15 @@ class ImplicitRouteBindingTest extends TestCase
             $table->softDeletes();
         });
 
+        Schema::create('posts', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('user_id');
+            $table->timestamps();
+        });
+
         $this->beforeApplicationDestroyed(function () {
             Schema::dropIfExists('users');
+            Schema::dropIfExists('posts');
         });
     }
 
@@ -60,14 +67,14 @@ class ImplicitRouteBindingTest extends TestCase
         $this->defineCacheRoutes(<<<PHP
 <?php
 
-use Illuminate\Tests\Integration\Routing\ImplicitBindingModel;
+use Illuminate\Tests\Integration\Routing\ImplicitBindingUser;
 
-Route::post('/user/{user}', function (ImplicitBindingModel \$user) {
+Route::post('/user/{user}', function (ImplicitBindingUser \$user) {
     return \$user;
 })->middleware('web');
 PHP);
 
-        $user = ImplicitBindingModel::create(['name' => 'Dries']);
+        $user = ImplicitBindingUser::create(['name' => 'Dries']);
 
         $response = $this->postJson("/user/{$user->id}");
 
@@ -79,11 +86,11 @@ PHP);
 
     public function testWithoutRouteCachingEnabled()
     {
-        $user = ImplicitBindingModel::create(['name' => 'Dries']);
+        $user = ImplicitBindingUser::create(['name' => 'Dries']);
 
         config(['app.key' => str_repeat('a', 32)]);
 
-        Route::post('/user/{user}', function (ImplicitBindingModel $user) {
+        Route::post('/user/{user}', function (ImplicitBindingUser $user) {
             return $user;
         })->middleware(['web']);
 
@@ -97,13 +104,13 @@ PHP);
 
     public function testSoftDeletedModelsAreNotRetrieved()
     {
-        $user = ImplicitBindingModel::create(['name' => 'Dries']);
+        $user = ImplicitBindingUser::create(['name' => 'Dries']);
 
         $user->delete();
 
         config(['app.key' => str_repeat('a', 32)]);
 
-        Route::post('/user/{user}', function (ImplicitBindingModel $user) {
+        Route::post('/user/{user}', function (ImplicitBindingUser $user) {
             return $user;
         })->middleware(['web']);
 
@@ -114,13 +121,13 @@ PHP);
 
     public function testSoftDeletedModelsCanBeRetrievedUsingWithTrashedMethod()
     {
-        $user = ImplicitBindingModel::create(['name' => 'Dries']);
+        $user = ImplicitBindingUser::create(['name' => 'Dries']);
 
         $user->delete();
 
         config(['app.key' => str_repeat('a', 32)]);
 
-        Route::post('/user/{user}', function (ImplicitBindingModel $user) {
+        Route::post('/user/{user}', function (ImplicitBindingUser $user) {
             return $user;
         })->middleware(['web'])->withTrashed();
 
@@ -131,13 +138,96 @@ PHP);
             'name' => $user->name,
         ]);
     }
+
+    public function testEnforceScopingImplicitRouteBindings()
+    {
+        $user = ImplicitBindingUser::create(['name' => 'Dries']);
+        $post = ImplicitBindingPost::create(['user_id' => 2]);
+        $this->assertEmpty($user->posts);
+
+        config(['app.key' => str_repeat('a', 32)]);
+
+        Route::group(['scoping' => true], function () {
+            Route::get('/user/{user}/post/{post}', function (ImplicitBindingUser $user, ImplicitBindingPost $post) {
+                return [$user, $post];
+            })->middleware(['web']);
+        });
+
+        $response = $this->getJson("/user/{$user->id}/post/{$post->id}");
+
+        $response->assertNotFound();
+    }
+
+    public function testEnforceScopingImplicitRouteBindingsWithRouteCachingEnabled()
+    {
+        $user = ImplicitBindingUser::create(['name' => 'Dries']);
+        $post = ImplicitBindingPost::create(['user_id' => 2]);
+        $this->assertEmpty($user->posts);
+
+        $this->defineCacheRoutes(<<<PHP
+<?php
+
+use Illuminate\Tests\Integration\Routing\ImplicitBindingUser;
+use Illuminate\Tests\Integration\Routing\ImplicitBindingPost;
+
+Route::group(['scoping' => true], function () {
+    Route::get('/user/{user}/post/{post}', function (ImplicitBindingUser \$user, ImplicitBindingPost \$post) {
+        return [\$user, \$post];
+    })->middleware(['web']);
+});
+PHP);
+
+        $response = $this->getJson("/user/{$user->id}/post/{$post->id}");
+
+        $response->assertNotFound();
+    }
+
+    public function testWithoutEnforceScopingImplicitRouteBindings()
+    {
+        $user = ImplicitBindingUser::create(['name' => 'Dries']);
+        $post = ImplicitBindingPost::create(['user_id' => 2]);
+        $this->assertEmpty($user->posts);
+
+        config(['app.key' => str_repeat('a', 32)]);
+
+        Route::group(['scoping' => false], function () {
+            Route::get('/user/{user}/post/{post}', function (ImplicitBindingUser $user, ImplicitBindingPost $post) {
+                return [$user, $post];
+            })->middleware(['web']);
+        });
+
+        $response = $this->getJson("/user/{$user->id}/post/{$post->id}");
+        $response->assertOk();
+        $response->assertJson([
+            [
+                'id' => $user->id,
+                'name' => $user->name,
+            ],
+            [
+                'id' => 1,
+                'user_id' => 2,
+            ],
+        ]);
+    }
 }
 
-class ImplicitBindingModel extends Model
+class ImplicitBindingUser extends Model
 {
     use SoftDeletes;
 
     public $table = 'users';
 
     protected $fillable = ['name'];
+
+    public function posts()
+    {
+        return $this->hasMany(ImplicitBindingPost::class, 'user_id');
+    }
+}
+
+class ImplicitBindingPost extends Model
+{
+    public $table = 'posts';
+
+    protected $fillable = ['user_id'];
 }

--- a/tests/Routing/ImplicitRouteBindingTest.php
+++ b/tests/Routing/ImplicitRouteBindingTest.php
@@ -3,9 +3,7 @@
 namespace Illuminate\Tests\Routing;
 
 use Illuminate\Container\Container;
-use Illuminate\Database\Capsule\Manager as DB;
-use Illuminate\Database\Eloquent\Model as Eloquent;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Routing\ImplicitRouteBinding;
 use Illuminate\Routing\Route;
 use PHPUnit\Framework\TestCase;
@@ -29,89 +27,9 @@ class ImplicitRouteBindingTest extends TestCase
 
         ImplicitRouteBinding::resolveForRoute($container, $route);
     }
-
-    /** @test */
-    public function it_enforces_scoping_of_implicit_route_bindings(): void
-    {
-        $this->prepareEloquent();
-
-        $action = ['uses' => function (ImplicitRouteBindingUser $user, ImplicitRouteBindingPost $post) {
-            return $user;
-        }];
-
-        $route = new Route('GET', '/users/{user}/posts/{post}', $action);
-        $route->action['scoping'] = true;
-        $route->parameters = ['user' => 1, 'post' => 1];
-
-        $container = Container::getInstance();
-
-        $this->expectException(ModelNotFoundException::class);
-        ImplicitRouteBinding::resolveForRoute($container, $route);
-    }
-
-    /** @test */
-    public function it_does_not_enforce_scoping_of_implicit_route_bindings(): void
-    {
-        $this->prepareEloquent();
-
-        $action = ['uses' => function (ImplicitRouteBindingUser $user, ImplicitRouteBindingPost $post) {
-            return $user;
-        }];
-
-        $route = new Route('GET', '/users/{user}/posts/{post}', $action);
-        $route->parameters = ['user' => 1, 'post' => 1];
-
-        $container = Container::getInstance();
-
-        ImplicitRouteBinding::resolveForRoute($container, $route);
-
-        $this->assertTrue($route->parameter('user')->is(ImplicitRouteBindingUser::findOrFail(1)));
-        $this->assertTrue($route->parameter('post')->is(ImplicitRouteBindingPost::findOrFail(1)));
-    }
-
-    protected function prepareEloquent()
-    {
-        $db = new DB;
-        $db->addConnection([
-            'driver' => 'sqlite',
-            'database' => ':memory:',
-        ]);
-
-        $db->bootEloquent();
-        $db->setAsGlobal();
-
-        $schema = Eloquent::getConnectionResolver()->connection()->getSchemaBuilder();
-        $schema->create('users', function ($table) {
-            $table->increments('id');
-        });
-
-        $schema->create('posts', function ($table) {
-            $table->increments('id');
-            $table->integer('user_id');
-        });
-
-        ImplicitRouteBindingUser::create(['id' => 1]);
-        ImplicitRouteBindingPost::create(['id' => 1, 'user_id' => 2]);
-    }
-}
-
-class Model extends Eloquent
-{
-    public $timestamps = false;
-    protected $guarded = false;
 }
 
 class ImplicitRouteBindingUser extends Model
 {
-    protected $table = 'users';
-
-    public function posts()
-    {
-        return $this->hasMany(ImplicitRouteBindingPost::class, 'user_id');
-    }
-}
-
-class ImplicitRouteBindingPost extends Model
-{
-    protected $table = 'posts';
+    //
 }

--- a/tests/Routing/ImplicitRouteBindingTest.php
+++ b/tests/Routing/ImplicitRouteBindingTest.php
@@ -3,7 +3,9 @@
 namespace Illuminate\Tests\Routing;
 
 use Illuminate\Container\Container;
-use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Routing\ImplicitRouteBinding;
 use Illuminate\Routing\Route;
 use PHPUnit\Framework\TestCase;
@@ -27,9 +29,89 @@ class ImplicitRouteBindingTest extends TestCase
 
         ImplicitRouteBinding::resolveForRoute($container, $route);
     }
+
+    /** @test */
+    public function it_enforces_scoping_of_implicit_route_bindings(): void
+    {
+        $this->prepareEloquent();
+
+        $action = ['uses' => function (ImplicitRouteBindingUser $user, ImplicitRouteBindingPost $post) {
+            return $user;
+        }];
+
+        $route = new Route('GET', '/users/{user}/posts/{post}', $action);
+        $route->action['scoping'] = true;
+        $route->parameters = ['user' => 1, 'post' => 1];
+
+        $container = Container::getInstance();
+
+        $this->expectException(ModelNotFoundException::class);
+        ImplicitRouteBinding::resolveForRoute($container, $route);
+    }
+
+    /** @test */
+    public function it_does_not_enforce_scoping_of_implicit_route_bindings(): void
+    {
+        $this->prepareEloquent();
+
+        $action = ['uses' => function (ImplicitRouteBindingUser $user, ImplicitRouteBindingPost $post) {
+            return $user;
+        }];
+
+        $route = new Route('GET', '/users/{user}/posts/{post}', $action);
+        $route->parameters = ['user' => 1, 'post' => 1];
+
+        $container = Container::getInstance();
+
+        ImplicitRouteBinding::resolveForRoute($container, $route);
+
+        $this->assertTrue($route->parameter('user')->is(ImplicitRouteBindingUser::findOrFail(1)));
+        $this->assertTrue($route->parameter('post')->is(ImplicitRouteBindingPost::findOrFail(1)));
+    }
+
+    protected function prepareEloquent()
+    {
+        $db = new DB;
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+
+        $db->bootEloquent();
+        $db->setAsGlobal();
+
+        $schema = Eloquent::getConnectionResolver()->connection()->getSchemaBuilder();
+        $schema->create('users', function ($table) {
+            $table->increments('id');
+        });
+
+        $schema->create('posts', function ($table) {
+            $table->increments('id');
+            $table->integer('user_id');
+        });
+
+        ImplicitRouteBindingUser::create(['id' => 1]);
+        ImplicitRouteBindingPost::create(['id' => 1, 'user_id' => 2]);
+    }
+}
+
+class Model extends Eloquent
+{
+    public $timestamps = false;
+    protected $guarded = false;
 }
 
 class ImplicitRouteBindingUser extends Model
 {
-    //
+    protected $table = 'users';
+
+    public function posts()
+    {
+        return $this->hasMany(ImplicitRouteBindingPost::class, 'user_id');
+    }
+}
+
+class ImplicitRouteBindingPost extends Model
+{
+    protected $table = 'posts';
 }


### PR DESCRIPTION
This PR implements the functionality requested in #32144.

With this PR, any Route (or route group) with the `scoping` action set to `true` will tell the framework to scope the second Eloquent model as such that it must be a child of the previous Eloquent model in the same route, **without the need to provide a slug**.

```php
use App\Models\Post;
use App\Models\User;

Route::group(['scoping' => true], function () {
    Route::get('/users/{user}/posts/{post}', function (User $user, Post $post) {
        return $post;
    });
});
```

This is useful when:
- You always want this behaviour everywhere, or in a subset of routes (extra / automatic safety net)
- You don't want to look silly by specifying the `id` slug everywhere just to enable this behaviour
  (`Route::get('/users/{user}/posts/{post:id}', function (User ...`)

---

While by itself this is only a somewhat useful feature, I think it would be quite useful when also providing the ability to enable it application-wide using a class-level property in the `RouteServiceProvider`, essentially making it very easy to either opt-in or opt-out, and to what extent:

```php
    /**
     * Define the routes for the application.
     *
     * @param  \Illuminate\Routing\Router $router
     * @return void
     */
    public function map(Router $router)
    {
        $router->group([
            'namespace' => $this->namespace,
            'middleware' => 'web',
            'scoping' => $this->scoping,            // <----------------
        ], function ($router) {
            require base_path('routes/web.php');
        });

        $router->group([
            'middleware' => ['api'],
            'namespace' => 'App\Http\ApiControllers',
            'scoping' => $this->scoping,
            'prefix' => 'api/v1',
        ], function ($router) {
            require base_path('routes/api.php');
        });
    }
}
```