### PR TITLE
[8.x] Running where clause when data is not empty and skip if empty

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -767,6 +767,12 @@ class Builder
         return $this;
     }
 
+    public function whereIfFilled ($field, $column, $operator = null, $value = null, $boolean = 'and') {
+        if (!empty($field)) {
+            $this->where($column, $operator = null, $value = null, $boolean = 'and');
+        }
+    }
+
     /**
      * Add an array of where clauses to the query.
      *

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -769,7 +769,7 @@ class Builder
 
     public function whereIfFilled ($field, $column, $operator = null, $value = null, $boolean = 'and') {
         if (!empty($field)) {
-            $this->where($column, $operator = null, $value = null, $boolean = 'and');
+            $this->where($column, $operator, $value, $boolean);
         }
     }
 


### PR DESCRIPTION
whereIfFilled can reduce code sometimes when building filters 
The main idea is to run where clause when some data is not empty 
Example:
whereIfFilled($request->category, ...);