### PR TITLE
[8.x] Fixes `middleware()` not accepting Stringable

### DIFF
--- a/src/Illuminate/Routing/PendingResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingResourceRegistration.php
@@ -149,12 +149,10 @@ class PendingResourceRegistration
      */
     public function middleware($middleware)
     {
-        if (! is_string($middleware)) {
-            $middleware = Arr::wrap($middleware);
+        $middleware = Arr::wrap($middleware);
 
-            foreach ($middleware as $key => $value) {
-                $middleware[$key] = (string) $value;
-            }
+        foreach ($middleware as $key => $value) {
+            $middleware[$key] = (string) $value;
         }
 
         $this->options['middleware'] = $middleware;

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -18,6 +18,7 @@ use Laravel\SerializableClosure\SerializableClosure;
 use LogicException;
 use Opis\Closure\SerializableClosure as OpisSerializableClosure;
 use ReflectionFunction;
+use Stringable;
 use Symfony\Component\Routing\Route as SymfonyRoute;
 
 class Route
@@ -1025,8 +1026,12 @@ class Route
             return (array) ($this->action['middleware'] ?? []);
         }
 
-        if (is_string($middleware)) {
+        if (is_string($middleware) || $middleware instanceof Stringable) {
             $middleware = func_get_args();
+        }
+
+        foreach ($middleware as $index => $value) {
+            $middleware[$index] = (string) $value;
         }
 
         $this->action['middleware'] = array_merge(

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -18,7 +18,6 @@ use Laravel\SerializableClosure\SerializableClosure;
 use LogicException;
 use Opis\Closure\SerializableClosure as OpisSerializableClosure;
 use ReflectionFunction;
-use Stringable;
 use Symfony\Component\Routing\Route as SymfonyRoute;
 
 class Route
@@ -1026,7 +1025,7 @@ class Route
             return (array) ($this->action['middleware'] ?? []);
         }
 
-        if (is_string($middleware) || $middleware instanceof Stringable) {
+        if (! is_array($middleware)) {
             $middleware = func_get_args();
         }
 

--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -93,9 +93,7 @@ class RouteRegistrar
             throw new InvalidArgumentException("Attribute [{$key}] does not exist.");
         }
 
-        if ($key === 'middleware' && ! is_string($value)) {
-            $value = Arr::wrap($value);
-
+        if ($key === 'middleware') {
             foreach ($value as $index => $middleware) {
                 $value[$index] = (string) $middleware;
             }

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -79,6 +79,24 @@ class RouteRegistrarTest extends TestCase
         $this->assertSame(['one'], $this->getRoute()->middleware());
     }
 
+    public function testMiddlewareAsStringableObjectOnRouteInstance()
+    {
+        $one = new class implements Stringable
+        {
+            public function __toString()
+            {
+                return 'one';
+            }
+        };
+
+        $this->router->get('users', function () {
+            return 'all-users';
+        })->middleware($one);
+
+        $this->seeResponse('all-users', Request::create('users', 'GET'));
+        $this->assertSame(['one'], $this->getRoute()->middleware());
+    }
+
     public function testMiddlewareAsArrayWithStringables()
     {
         $one = new class implements Stringable


### PR DESCRIPTION
## What?

Fixes declaring routes as `Route::get()->middleware()` with Stringable objects. As seen on TV:

> I may need to revert this already @DarkGhostHunter 
> 
> This simple test doesn't even work locally:
> 
> <img width="554" alt="image" src="https://user-images.githubusercontent.com/463230/139875115-0fdb715e-bc6f-4990-9a41-220050d05484.png">
> 
> <img width="1289" alt="image" src="https://user-images.githubusercontent.com/463230/139875124-dfcf7efe-2ea2-4ff5-adff-7045f4f808d7.png">
> 
> _Originally posted by @taylorotwell in https://github.com/laravel/framework/issues/39439#issuecomment-957792825_

This also removes son unnecessary checks for middleware declaration, as is expected to be an array, or a string (which gets converted to a one-member array anyway).