### PR TITLE
[9.x] Merges `attemptWhen` functionality with `attempt`

### DIFF
--- a/src/Illuminate/Contracts/Auth/StatefulGuard.php
+++ b/src/Illuminate/Contracts/Auth/StatefulGuard.php
@@ -9,9 +9,10 @@ interface StatefulGuard extends Guard
      *
      * @param  array  $credentials
      * @param  bool  $remember
+     * @param  callable  ...$callbacks
      * @return bool
      */
-    public function attempt(array $credentials = [], $remember = false);
+    public function attempt(array $credentials = [], $remember = false, ...$callbacks);
 
     /**
      * Log a user into the application without sessions or cookies.

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -126,7 +126,7 @@ class AuthGuardTest extends TestCase
         $this->assertFalse($mock->attempt(['foo']));
     }
 
-    public function testAttemptAndWithCallbacks()
+    public function testAttemptWithCallbacks()
     {
         [$session, $provider, $request, $cookie] = $this->getMocks();
         $mock = $this->getMockBuilder(SessionGuard::class)->onlyMethods(['getName'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
@@ -145,14 +145,14 @@ class AuthGuardTest extends TestCase
         $mock->getProvider()->shouldReceive('validateCredentials')->twice()->andReturnTrue();
         $mock->getProvider()->shouldReceive('validateCredentials')->once()->andReturnFalse();
 
-        $this->assertTrue($mock->attemptWhen(['foo'], function ($user, $guard) {
+        $this->assertTrue($mock->attempt(['foo'], false, function ($user, $guard) {
             static::assertInstanceOf(Authenticatable::class, $user);
             static::assertInstanceOf(SessionGuard::class, $guard);
 
             return true;
         }));
 
-        $this->assertFalse($mock->attemptWhen(['foo'], function ($user, $guard) {
+        $this->assertFalse($mock->attempt(['foo'], false, function ($user, $guard) {
             static::assertInstanceOf(Authenticatable::class, $user);
             static::assertInstanceOf(SessionGuard::class, $guard);
 
@@ -161,7 +161,7 @@ class AuthGuardTest extends TestCase
 
         $executed = false;
 
-        $this->assertFalse($mock->attemptWhen(['foo'], false, function () use (&$executed) {
+        $this->assertFalse($mock->attempt(['foo'], false, function () use (&$executed) {
             return $executed = true;
         }));
 


### PR DESCRIPTION
## What?

Merges the functionality of `attemptWhen()` with the `attempt()` method of the `StatefulGuard` contract, allowing to use callbacks on the latter as the last members.

```php
Auth::attempt($credentials, $request->filled('remember'), fn($user) => $user->isSubscribed());
```

This removes `attemptWith()` as it becomes redundant.

It also supports unpacking.

```php
$callbacks = [$callbackFoo, $callbackBar];

Auth::attempt($credentials, $request->filled('remember'), ...$callbacks);
```

## Why?

Just a more cleaner implementation.

## BC?

Yes, modifies the `StatefulGuard` contract and the `SessionGuard`. Developers implementing the `StatefulGuard` or the `SessionGuard` contract will have to change the method signature.