### PR TITLE
[8.x] Fixed SQL injection for where()

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -695,6 +695,7 @@ class Builder
             if (! is_null($operator)) {
                 throw new \RuntimeException("When the operator is not null, the column shouldn't be array");
             }
+            
             return $this->addArrayOfWheres($column, $boolean);
         }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -872,6 +872,10 @@ class Builder
         // and can add them each as a where clause. We will maintain the boolean we
         // received when the method was called and pass it into the nested where.
         if (is_array($first)) {
+            if (! is_null($operator)) {
+                throw new \RuntimeException("When the operator is not null, the column shouldn't be array");
+            }
+
             return $this->addArrayOfWheres($first, $boolean, 'whereColumn');
         }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -695,7 +695,7 @@ class Builder
             if (! is_null($operator)) {
                 throw new \RuntimeException("When the operator is not null, the column shouldn't be array");
             }
-            
+
             return $this->addArrayOfWheres($column, $boolean);
         }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -692,6 +692,9 @@ class Builder
         // and can add them each as a where clause. We will maintain the boolean we
         // received when the method was called and pass it into the nested where.
         if (is_array($column)) {
+            if (! is_null($operator)) {
+                throw new \RuntimeException("When the operator is not null, the column shouldn't be array");
+            }
             return $this->addArrayOfWheres($column, $boolean);
         }
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -822,6 +822,23 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals($builder, $result);
     }
 
+    public function testQueryWhereSQLInjection()
+    {
+        $query = new BaseBuilder(m::mock(ConnectionInterface::class), new Grammar, m::mock(Processor::class));
+        $builder = new Builder($query);
+        $name = [[
+            'id',
+            '=',
+            1,
+            'and 1=2) UNION SELECT user()#'
+        ]];
+
+        $this->expectExceptionMessage("When the operator is not null, the column shouldn't be array");
+
+        // select "id" from "category" where (1=2) UNION SELECT user()# "id" = ?)
+        $builder->from('category')->select('id')->where($name, '=', 'bar');
+    }
+
     public function testNestedWhere()
     {
         $nestedQuery = m::mock(Builder::class);

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -830,7 +830,7 @@ class DatabaseEloquentBuilderTest extends TestCase
             'id',
             '=',
             1,
-            'and 1=2) UNION SELECT user()#'
+            'and 1=2) UNION SELECT user()#',
         ]];
 
         $this->expectExceptionMessage("When the operator is not null, the column shouldn't be array");


### PR DESCRIPTION
When I use an external variable as the key of the query, it will cause SQL injection.

```php
        $query = new BaseBuilder(m::mock(ConnectionInterface::class), new Grammar, m::mock(Processor::class));
        $builder = new Builder($query);
        $name = [[
            'id',
            '=',
            1,
            'and 1=2) UNION SELECT user()#'
        ]];

        // select "id" from "category" where (1=2) UNION SELECT user()# "id" = ?)
        $builder->from('category')->select('id')->where($name, '=', 'bar');
```