### PR TITLE
[8.x] Make view errors shareable globally

### DIFF
--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -207,10 +207,20 @@ class View implements ArrayAccess, Htmlable, ViewContract
      *
      * @param  \Illuminate\Contracts\Support\MessageProvider|array  $provider
      * @param  string  $bag
+     * @param  bool  $share
      * @return $this
      */
-    public function withErrors($provider, $bag = 'default')
+    public function withErrors($provider, $bag = 'default', $share = false)
     {
+        if ($share) { // Add the errors to the globally shared $errors
+            $this->factory->share('errors', (new ViewErrorBag)->put(
+                $bag, $this->formatErrors($provider)
+            ));
+
+            return $this;
+        }
+
+        // Add the errors to a local $errors only accessable but this view
         return $this->with('errors', (new ViewErrorBag)->put(
             $bag, $this->formatErrors($provider)
         ));

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -218,6 +218,7 @@ class ViewTest extends TestCase
         $errors = ['foo' => 'bar', 'qu' => 'ux'];
         $this->assertSame($view, $view->withErrors($errors));
         $this->assertInstanceOf(ViewErrorBag::class, $view->errors);
+        $this->assertEmpty($view->getFactory()->getShared('errors'));
         $foo = $view->errors->get('foo');
         $this->assertSame('bar', $foo[0]);
         $qu = $view->errors->get('qu');
@@ -231,6 +232,12 @@ class ViewTest extends TestCase
         $this->assertSame($view, $view->withErrors(new MessageBag($data), 'login'));
         $foo = $view->errors->getBag('login')->get('foo');
         $this->assertSame('baz', $foo[0]);
+        $this->assertSame($view, $view->withErrors($errors, 'default', true));
+        $this->assertInstanceOf(ViewErrorBag::class, $view->errors);
+        $foo = $view->getFactory()->getShared('errors')->get('foo');
+        $this->assertSame('bar', $foo[0]);
+        $qu = $view->getFactory()->getShared('errors')->get('qu');
+        $this->assertSame('ux', $qu[0]);
     }
 
     protected function getView($data = [])

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -218,7 +218,6 @@ class ViewTest extends TestCase
         $errors = ['foo' => 'bar', 'qu' => 'ux'];
         $this->assertSame($view, $view->withErrors($errors));
         $this->assertInstanceOf(ViewErrorBag::class, $view->errors);
-        $this->assertEmpty($view->getFactory()->getShared('errors'));
         $foo = $view->errors->get('foo');
         $this->assertSame('bar', $foo[0]);
         $qu = $view->errors->get('qu');
@@ -232,12 +231,8 @@ class ViewTest extends TestCase
         $this->assertSame($view, $view->withErrors(new MessageBag($data), 'login'));
         $foo = $view->errors->getBag('login')->get('foo');
         $this->assertSame('baz', $foo[0]);
+        $view->getFactory()->shouldReceive('share')->once();
         $this->assertSame($view, $view->withErrors($errors, 'default', true));
-        $this->assertInstanceOf(ViewErrorBag::class, $view->errors);
-        $foo = $view->getFactory()->getShared('errors')->get('foo');
-        $this->assertSame('bar', $foo[0]);
-        $qu = $view->getFactory()->getShared('errors')->get('qu');
-        $this->assertSame('ux', $qu[0]);
     }
 
     protected function getView($data = [])


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR makes it possible to add errors to a view

```php
view('post-index')
    ->withErrors(['field' => 'Some error'], 'default', true); // only the third parameter is new
```

where the errors are now globally available meaning that not just `post-index.blade.php` has access to the `$errors` but also parent/child views like for example the main layout `resources/views/layouts/app.blade.php`. Note that this global `$errors` have already been made available using the existing middleware `ShareErrorsFromSession`.

This is aligned with the way that the redirect method of same name (`withErrors`) makes errors globally available on the redirected request: https://github.com/laravel/framework/blob/master/src/Illuminate/Http/RedirectResponse.php#L131

## Why

This is great if you would like to render errors from the `default` error bag as part of you main layout file

## Considerations

Personally I think the **default** behaviour should be that any errors added via `viewErrors()` were made globally available no matter if called on a view or a redirect. Usually if someone would like to target some errors for a specific view it would make sense to use a **named bag** like:

```php
view('post-index')
    ->withErrors(['field' => 'Some error'], 'port-index-bag'); // here I am assuming that errors are globally accepted by default
```

and if this is strictly not wanted, then simply set the `$share = false` or use the `view(..)->with()` method instead.
 
**But** sharing these errors globally to all views could probably be considered a breaking change - maybe not if we simply **added** them to any existing errors in the global error bag.

Questions for the editors:

1. Should the default be globally accessable?
2. Should errors be **added** (pushed) to any existing error bag or simply override any bag that already exist (current behaviour)?