### PR TITLE
[8.x] Added varbinary schema type

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1196,7 +1196,7 @@ class Blueprint
     public function varbinary($column, $length = null)
     {
         $length = $length ?: Builder::$defaultStringLength;
-        
+
         return $this->addColumn('varbinary', $column, compact('length'));
     }
 

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1187,6 +1187,20 @@ class Blueprint
     }
 
     /**
+     * Create a new varbinary column on the table.
+     *
+     * @param  string  $column
+     * @param  int|null  $length
+     * @return \Illuminate\Database\Schema\ColumnDefinition
+     */
+    public function varbinary($column, $length = null)
+    {
+        $length = $length ?: Builder::$defaultStringLength;
+        
+        return $this->addColumn('varbinary', $column, compact('length'));
+    }
+
+    /**
      * Create a new uuid column on the table.
      *
      * @param  string  $column

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -793,6 +793,17 @@ class MySqlGrammar extends Grammar
     }
 
     /**
+     * Create the column definition for a varbinary type.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+    protected function typeVarBinary(Fluent $column)
+    {
+        return "varbinary({$column->length})";
+    }
+
+    /**
      * Create the column definition for a uuid type.
      *
      * @param  \Illuminate\Support\Fluent  $column


### PR DESCRIPTION
Adds

```php
$table->varbinary('column_name', 255);
```

I was dealing with a legacy project and I was using https://github.com/bennett-treptow/laravel-migration-generator to generate migrations so laravel can be in sync with the legacy applications database migrations, which is when i noticed varbinary is not supported by laravel