### PR TITLE
[9.x] Names for on-demand log channels

### DIFF
--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -65,11 +65,12 @@ class LogManager implements LoggerInterface
      * Build an on-demand log channel.
      *
      * @param  array  $config
+     * @param  string|null  $name
      * @return \Psr\Log\LoggerInterface
      */
-    public function build(array $config)
+    public function build(array $config, ?string $name = null)
     {
-        return $this->get('ondemand', $config);
+        return $this->get($name ?? 'ondemand', $config);
     }
 
     /**

--- a/tests/Log/LogManagerTest.php
+++ b/tests/Log/LogManagerTest.php
@@ -432,4 +432,32 @@ class LogManagerTest extends TestCase
 
         $this->assertSame(storage_path('logs/custom.log'), $url->getValue($handler));
     }
+
+    public function testLogManagerCanBuildMultipleOnDemandChannels()
+    {
+        $manager = new LogManager($this->app);
+
+        $fooConfig = [
+            'driver' => 'single',
+            'path' => storage_path('foo/on-demand.log'),
+        ];
+
+        $fooLogger = $manager->build($fooConfig, 'foo-channel');
+        $fooHandler = $fooLogger->getLogger()->getHandlers()[0];
+        $fooUrl = new ReflectionProperty(get_class($fooHandler), 'url');
+        $fooUrl->setAccessible(true);
+
+        $barConfig = [
+            'driver' => 'single',
+            'path' => storage_path('bar/on-demand.log'),
+        ];
+
+        $barLogger = $manager->build($barConfig, 'bar-channel');
+        $barHandler = $barLogger->getLogger()->getHandlers()[0];
+        $barUrl = new ReflectionProperty(get_class($barHandler), 'url');
+        $barUrl->setAccessible(true);
+
+        $this->assertSame($fooConfig['path'], $fooUrl->getValue($fooHandler));
+        $this->assertSame($barConfig['path'], $barUrl->getValue($barHandler));
+    }
 }


### PR DESCRIPTION
This PR is connected with "On-Demand Channels" (https://laravel.com/docs/8.x/logging#on-demand-channels).
"On-Demand Channels" have been introduced by https://github.com/laravel/framework/pull/39273

## Problem

Every call of a Log::build(...) uses the same log channel. Example (can be executed in tinker):

```
use Illuminate\Support\Facades\Log;

// ... some code

Log::build([
  'driver' => 'single',
  'path' => storage_path('foo/custom.log'),
])->info('foo');

// Now we have a "foo" record in a "foo" directory

// ... some code

Log::build([
  'driver' => 'single',
  'path' => storage_path('bar/custom.log'),
])->info('bar');

// New "bar" record, but still in a "foo" directory

```

## Case

We have a queue running. Some jobs need certain channels (based on the names from a database). We've tried to use "On-Demand Channels". And now all information goes to one channel (the one is used by a first job appeared in a queue).

## Possible solution

We can extend a "build" method by adding second optional parameter - the name of a channel.
For me it's hard to say is it good or bad from architectural perspective. But it certainly can be useful in some situations.
I've prepared a code change and a test method. 
I've run tests by calling:
```
./vendor/bin/phpunit --filter=LogManagerTest
```