### PR TITLE
[8.x] Allow can method to be chained onto route for quick authorization

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1041,6 +1041,20 @@ class Route
     }
 
     /**
+     * Specify that the "Authorize" / "can" middleware should be applied to the route with the given options.
+     *
+     * @param  string  $ability
+     * @param  array|string  $models
+     * @return $this
+     */
+    public function can($ability, $models = [])
+    {
+        return empty($models)
+                    ? $this->middleware(['can:'.$ability])
+                    : $this->middleware(['can:'.$ability.','.implode(',', Arr::wrap($models))]);
+    }
+
+    /**
      * Get the middleware for the route's controller.
      *
      * @return array

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1926,6 +1926,24 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals(301, $response->getStatusCode());
     }
 
+    public function testRouteCanMiddlewareCanBeAssigned()
+    {
+        $route = new Route(['GET'], '/', []);
+        $route->middleware(['foo'])->can('create', Route::class);
+
+        $this->assertEquals([
+            'foo',
+            'can:create,Illuminate\Routing\Route',
+        ], $route->middleware());
+
+        $route = new Route(['GET'], '/', []);
+        $route->can('create');
+
+        $this->assertEquals([
+            'can:create',
+        ], $route->middleware());
+    }
+
     protected function getRouter()
     {
         $container = new Container;


### PR DESCRIPTION
Passing entire class names in the `can` middleware can be a bit cumbersome and annoying since you can't click through to the class definition. 

This adds a very simple helper for adding the `can` middleware to a given route.