### PR TITLE
[6.x] Add new lost connection error message for sqlsrv

### DIFF
--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -56,6 +56,7 @@ trait DetectsLostConnections
             'SQLSTATE[HY000]: General error: 7 SSL SYSCALL error: No route to host',
             'The client was disconnected by the server because of inactivity. See wait_timeout and interactive_timeout for configuring this behavior.',
             'SQLSTATE[08006] [7] could not translate host name',
+            'TCP Provider: Error code 0x274C',
         ]);
     }
 }


### PR DESCRIPTION
Error message occurs after first query sent to a remote instance of SQL Server that has been restarted.

Error documented by Microsoft here

https://docs.microsoft.com/en-us/sql/relational-databases/errors-events/mssqlserver-10060-database-engine-error?view=sql-server-ver15&viewFallbackFrom=sql-server-ver17

Error occurs as connection is attempted to a socket that has now been closed (by the aforementioned restart)