### PR TITLE
Resolve an issue with ->load or ->fresh on models with different connections defaulting to parent connection when $connection is not specified

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1626,7 +1626,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function getConnectionName()
     {
-        return $this->connection;
+        return $this->connection ?? config('database.default');
     }
 
     /**


### PR DESCRIPTION
This is a followup to this post. Since i'm dumb, i wanted to avoid creating PR because there's most likely better way of fixing this. In the end though i decided to create one anyway.

Here's description of an issue with examples:
https://github.com/laravel/framework/discussions/39262
