### PR TITLE
[8.x] Adds dynamic middleware set on route declaration

### DIFF
--- a/src/Illuminate/Routing/ForwardsCallToMiddleware.php
+++ b/src/Illuminate/Routing/ForwardsCallToMiddleware.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Illuminate\Routing;
+
+use Illuminate\Foundation\Http\Kernel;
+
+trait ForwardsCallToMiddleware
+{
+    /**
+     * Sets the middleware in the route if set in the HTTP Kernel.
+     *
+     * @param  string  $middleware
+     * @param  array  $parameters
+     * @return static|void
+     */
+    protected function forwardToMiddleware($middleware, $parameters)
+    {
+        return $this->middleware($this->parseMiddlewareFromMethod($middleware, $parameters));
+    }
+
+    /**
+     * Transforms method call to a middleware declaration.
+     *
+     * @param  string  $middleware
+     * @param  array  $parameters
+     * @return string
+     */
+    protected function parseMiddlewareFromMethod($middleware, $parameters)
+    {
+        return rtrim($middleware.':'.implode(',', $parameters), ':');
+    }
+
+    /**
+     * Check if the method name exists as a route middleware key.
+     *
+     * @param  string  $method
+     * @return bool
+     */
+    protected function existsInRouteMiddleware($method)
+    {
+        return isset(app(Kernel::class)->getRouteMiddleware()[$method]);
+    }
+}

--- a/src/Illuminate/Routing/PendingResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingResourceRegistration.php
@@ -261,7 +261,7 @@ class PendingResourceRegistration
     public function __call($method, $parameters)
     {
         if (static::hasMacro($method)) {
-            $this->macroCall($method, $parameters);
+            return $this->macroCall($method, $parameters);
         }
 
         if ($this->existsInRouteMiddleware($middleware = Str::snake($method, '.'))) {

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1275,7 +1275,7 @@ class Route
     public function __call($method, $parameters)
     {
         if (static::hasMacro($method)) {
-            $this->macroCall($method, $parameters);
+            return $this->macroCall($method, $parameters);
         }
 
         if ($this->existsInRouteMiddleware($middleware = Str::snake($method, '.'))) {

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1336,7 +1336,7 @@ class Router implements BindingRegistrar, RegistrarContract
         }
 
         if ($this->existsInRouteMiddleware($middleware = Str::snake($method, '.'))) {
-            [$method, $parameters] = ['middleware', $this->parseMiddlewareFromMethod($middleware, $parameters)];
+            [$method, $parameters] = ['middleware', [$this->parseMiddlewareFromMethod($middleware, $parameters)]];
         }
 
         if ($method === 'middleware') {

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1312,17 +1312,6 @@ class Router implements BindingRegistrar, RegistrarContract
     }
 
     /**
-     * Check if the method name exists as a route middleware key.
-     *
-     * @param  string  $method
-     * @return bool
-     */
-    protected function existsInRouteMiddleware($method)
-    {
-        return isset($this->container->make(Kernel::class)->getRouteMiddleware()[$method]);
-    }
-
-    /**
      * Dynamically handle calls into the router instance.
      *
      * @param  string  $method

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1331,6 +1331,6 @@ class Router implements BindingRegistrar, RegistrarContract
             return (new RouteRegistrar($this))->attribute($method, is_array($parameters[0]) ? $parameters[0] : $parameters);
         }
 
-        return (new RouteRegistrar($this))->attribute($method, $parameters[0]);
+        return (new RouteRegistrar($this))->attribute($method, $parameters[0] ?? []);
     }
 }

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -12,7 +12,6 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Foundation\Http\Kernel;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -831,7 +831,7 @@ class RouteRegistrarTest extends TestCase
         $this->assertEquals(['one.two:bar'], $this->getRoute()->middleware());
     }
 
-    public function testCanSetMiddlewareDynamicallyPrependingMiddlewareBeforeRouteGroup()
+    public function testCanSetMiddlewareDynamicallyPrependingBeforeRouteGroup()
     {
         Container::getInstance()->instance(Kernel::class, $mock = m::mock(Kernel::class));
 

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -4,7 +4,8 @@ namespace Illuminate\Tests\Routing;
 
 use BadMethodCallException;
 use Illuminate\Container\Container;
-use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
+use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Http\Kernel;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
@@ -19,22 +20,15 @@ class RouteRegistrarTest extends TestCase
      */
     protected $router;
 
-    /**
-     * @var \Illuminate\Foundation\Http\Kernel
-     */
-    protected $kernel;
-
     protected function setUp(): void
     {
         parent::setUp();
 
         $container = Container::getInstance();
 
-        $this->kernel = m::mock(Kernel::class);
-        $this->kernel->shouldReceive('getRouteMiddleware')->andReturn([]);
-        $container->instance(Kernel::class, $this->kernel);
+        $this->router = new Router(m::mock(DispatcherContract::class), $container);
 
-        $this->router = new Router(m::mock(Dispatcher::class), $container);
+        $container->instance(Kernel::class, new Kernel(new Application(), $this->router));
     }
 
     protected function tearDown(): void
@@ -42,6 +36,8 @@ class RouteRegistrarTest extends TestCase
         m::close();
 
         Container::getInstance()->forgetInstance(Kernel::class);
+        Container::getInstance()->flush();
+        Container::setInstance();
     }
 
     public function testMiddlewareFluentRegistration()

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -8,11 +8,14 @@ use Exception;
 use Illuminate\Auth\Middleware\Authenticate;
 use Illuminate\Auth\Middleware\Authorize;
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Foundation\Application as ApplicationContract;
 use Illuminate\Contracts\Routing\Registrar;
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Events\Dispatcher;
+use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Http\Kernel;
 use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
@@ -37,6 +40,18 @@ use UnexpectedValueException;
 
 class RoutingRouteTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        Container::getInstance()->instance(ApplicationContract::class, new Application());
+        Container::getInstance()->instance(Kernel::class, new Kernel(new Application(), new Router(new Dispatcher())));
+    }
+
+    protected function tearDown(): void
+    {
+        Container::getInstance()->flush();
+        Container::setInstance();
+    }
+
     public function testBasicDispatchingOfRoutes()
     {
         $router = $this->getRouter();


### PR DESCRIPTION
## What?

Based on #39464. Allows dynamically setting middleware in route declarations, including parameters, fluently.

```php
// Before
Route::get('flights', [FlightController::class , 'show'])
    ->middleware(['can:viewAny:\App\Models\Flight', 'auth:pilot']);

// After
Route::get('flights', [FlightController::class , 'show'])
    ->can('viewAny', Flight::class)
    ->auth('pilot');
```

## How?

When passing a method that doesn't exist or is not defined as a macro when declaring a route, the router will check if the method name is set as [route middleware](https://github.com/laravel/laravel/blob/5d22b2464c9d64443ecf60d5788d753430eff7fa/app/Http/Kernel.php#L49-L66). If that's the case, it will set is as a middleware for the given route.

> If these conditions don't met, an `BadMethodCallException` will be thrown. This avoids the developer to push any typo accidentally, where `middleware()` would, pushing the error when the route is called. For this to work, an `app(Kernel::class)` was implemented to check the registered array.

It also works on dot notation middleware, like `password.confirm`, with parameters:

```php
// Before
Route::get('flights', [FlightController::class , 'show'])
    ->middleware('password.confirm:auth.confirm');

// After
Route::get('flights', [FlightController::class , 'show'])
    ->passwordConfirm('auth.confirm');
```

It will also work when:

- using the `Router` facade directly:

```php
Route::passwordConfirm()->get('flights', ...);
```

- using a route group

```php
Route::auth()->group(fn() => ... );
```

- using a resource

```php
Route::resource('flight')->authBasic();
```

## BC?

1. No, as is expected route declarations using the available methods.
2. No, there are no method collisions when cross-checking the [default route middleware](https://github.com/laravel/laravel/blob/5d22b2464c9d64443ecf60d5788d753430eff7fa/app/Http/Kernel.php#L49-L66).
3. No. If there is a macro with the same name, macro takes precedence.

## Notes

Because it uses `app(Kernel::class)->getRouteMiddleware()` behind the scenes to check if the middleware exists or a `BadMethodCallException` should be thrown, some tests must be rewritten to add a container instance.