### PR TITLE
[8.x] Allows to clear translated parsed keys

### DIFF
--- a/src/Illuminate/Support/NamespacedItemResolver.php
+++ b/src/Illuminate/Support/NamespacedItemResolver.php
@@ -89,16 +89,6 @@ class NamespacedItemResolver
     }
 
     /**
-     * Clear the parsed keys.
-     *
-     * @return void
-     */
-    public function flushParsedKeys()
-    {
-        $this->parsed = [];
-    }
-
-    /**
      * Set the parsed value of a key.
      *
      * @param  string  $key
@@ -108,5 +98,15 @@ class NamespacedItemResolver
     public function setParsedKey($key, $parsed)
     {
         $this->parsed[$key] = $parsed;
+    }
+
+    /**
+     * Flush the cache of parsed keys.
+     *
+     * @return void
+     */
+    public function flushParsedKeys()
+    {
+        $this->parsed = [];
     }
 }

--- a/src/Illuminate/Support/NamespacedItemResolver.php
+++ b/src/Illuminate/Support/NamespacedItemResolver.php
@@ -89,6 +89,16 @@ class NamespacedItemResolver
     }
 
     /**
+     * Clear the parsed keys.
+     *
+     * @return void
+     */
+    public function flushParsedKeys()
+    {
+        $this->parsed = [];
+    }
+
+    /**
      * Set the parsed value of a key.
      *
      * @param  string  $key

--- a/tests/Support/SupportNamespacedItemResolverTest.php
+++ b/tests/Support/SupportNamespacedItemResolverTest.php
@@ -26,4 +26,17 @@ class SupportNamespacedItemResolverTest extends TestCase
 
         $this->assertEquals(['foo'], $r->parseKey('foo.bar'));
     }
+
+    public function testParsedItemsMayBeFlushed()
+    {
+        $r = $this->getMockBuilder(NamespacedItemResolver::class)->onlyMethods(['parseBasicSegments', 'parseNamespacedSegments'])->getMock();
+        $r->expects($this->once())->method('parseBasicSegments')->will(
+            $this->returnValue(['bar'])
+        );
+
+        $r->setParsedKey('foo.bar', ['foo']);
+        $r->flushParsedKeys();
+
+        $this->assertEquals(['bar'], $r->parseKey('foo.bar'));
+    }
 }


### PR DESCRIPTION
This pull request introduces a new method `NamespacedItemResolver::flushParsedKeys` that allows clearing the parsed keys at any time.

This is needed so we can clear this "parsed" keys cache between requests avoiding a memory leak in Octane: https://github.com/laravel/octane/pull/416.