### PR TITLE
[8.x] Publish provider.stub in stub:publish command

### DIFF
--- a/src/Illuminate/Foundation/Console/ProviderMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ProviderMakeCommand.php
@@ -34,7 +34,20 @@ class ProviderMakeCommand extends GeneratorCommand
      */
     protected function getStub()
     {
-        return __DIR__.'/stubs/provider.stub';
+        return $this->resolveStubPath('/stubs/provider.stub');
+    }
+
+    /**
+     * Resolve the fully-qualified path to the stub.
+     *
+     * @param  string  $stub
+     * @return string
+     */
+    protected function resolveStubPath($stub)
+    {
+        return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
+            ? $customPath
+            : __DIR__.$stub;
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/StubPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/StubPublishCommand.php
@@ -45,6 +45,7 @@ class StubPublishCommand extends Command
             __DIR__.'/stubs/notification.stub' => $stubsPath.'/notification.stub',
             __DIR__.'/stubs/observer.plain.stub' => $stubsPath.'/observer.plain.stub',
             __DIR__.'/stubs/observer.stub' => $stubsPath.'/observer.stub',
+            __DIR__.'/stubs/provider.stub' => $stubsPath.'/provider.stub',
             __DIR__.'/stubs/request.stub' => $stubsPath.'/request.stub',
             __DIR__.'/stubs/resource-collection.stub' => $stubsPath.'/resource-collection.stub',
             __DIR__.'/stubs/resource.stub' => $stubsPath.'/resource.stub',

--- a/src/Illuminate/Foundation/Console/stubs/provider.stub
+++ b/src/Illuminate/Foundation/Console/stubs/provider.stub
@@ -1,10 +1,10 @@
 <?php
 
-namespace DummyNamespace;
+namespace {{ namespace }};
 
 use Illuminate\Support\ServiceProvider;
 
-class DummyClass extends ServiceProvider
+class {{ class }} extends ServiceProvider
 {
     /**
      * Register services.


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Adding the provider.stub to the files that will be published when running php artisan stub:publish