### PR TITLE
[8.x] Accept enums for insert update and where

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3274,7 +3274,7 @@ class Builder
     /**
      * Cast the given binding value.
      *
-     * @param  mixed $value
+     * @param  mixed  $value
      * @return mixed
      */
     public function castBinding($value)

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Query;
 
+use BackedEnum;
 use Closure;
 use DateTimeInterface;
 use Illuminate\Contracts\Support\Arrayable;
@@ -3258,12 +3259,31 @@ class Builder
         }
 
         if (is_array($value)) {
-            $this->bindings[$type] = array_values(array_merge($this->bindings[$type], $value));
+            $this->bindings[$type] = collect($this->bindings[$type])
+                            ->merge($value)
+                            ->map([$this, 'castBinding'])
+                            ->values()
+                            ->toArray();
         } else {
-            $this->bindings[$type][] = $value;
+            $this->bindings[$type][] = $this->castBinding($value);
         }
 
         return $this;
+    }
+
+    /**
+     * Cast the given binding value.
+     *
+     * @param  mixed $value
+     * @return mixed
+     */
+    public function castBinding($value)
+    {
+        if (function_exists('enum_exists') && $value instanceof BackedEnum) {
+            return $value->value;
+        }
+
+        return $value;
     }
 
     /**
@@ -3287,9 +3307,13 @@ class Builder
      */
     public function cleanBindings(array $bindings)
     {
-        return array_values(array_filter($bindings, function ($binding) {
-            return ! $binding instanceof Expression;
-        }));
+        return collect($bindings)
+                    ->reject(function ($binding) {
+                        return $binding instanceof Expression;
+                    })
+                    ->map([$this, 'castBinding'])
+                    ->values()
+                    ->toArray();
     }
 
     /**

--- a/tests/Integration/Database/EloquentModelEnumCastingTest.php
+++ b/tests/Integration/Database/EloquentModelEnumCastingTest.php
@@ -111,6 +111,48 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
             'integer_status' => null,
         ], DB::table('enum_casts')->where('id', $model->id)->first());
     }
+
+    public function testFirstOrNew()
+    {
+        DB::table('enum_casts')->insert([
+            'string_status' => 'pending',
+            'integer_status' => 1,
+        ]);
+
+        $model = EloquentModelEnumCastingTestModel::firstOrNew([
+            'string_status' => StringStatus::pending,
+        ]);
+
+        $model2 = EloquentModelEnumCastingTestModel::firstOrNew([
+            'string_status' => StringStatus::done,
+        ]);
+
+        $this->assertTrue($model->exists);
+        $this->assertFalse($model2->exists);
+
+        $model2->save();
+
+        $this->assertEquals(StringStatus::done, $model2->string_status);
+    }
+
+    public function testFirstOrCreate()
+    {
+        DB::table('enum_casts')->insert([
+            'string_status' => 'pending',
+            'integer_status' => 1,
+        ]);
+
+        $model = EloquentModelEnumCastingTestModel::firstOrCreate([
+            'string_status' => StringStatus::pending,
+        ]);
+
+        $model2 = EloquentModelEnumCastingTestModel::firstOrCreate([
+            'string_status' => StringStatus::done,
+        ]);
+
+        $this->assertEquals(StringStatus::pending, $model->string_status);
+        $this->assertEquals(StringStatus::done, $model2->string_status);
+    }
 }
 
 class EloquentModelEnumCastingTestModel extends Model

--- a/tests/Integration/Database/QueryingWithEnumsTest.php
+++ b/tests/Integration/Database/QueryingWithEnumsTest.php
@@ -12,7 +12,6 @@ if (PHP_VERSION_ID >= 80100) {
 
 /**
  * @requires PHP >= 8.1
- * @group integration
  */
 class QueryingWithEnumsTest extends DatabaseTestCase
 {

--- a/tests/Integration/Database/QueryingWithEnumsTest.php
+++ b/tests/Integration/Database/QueryingWithEnumsTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+if (PHP_VERSION_ID >= 80100) {
+    include_once 'Enums.php';
+}
+
+/**
+ * @requires PHP 8.1
+ * @group integration
+ */
+class QueryingWithEnumsTest extends DatabaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('enum_casts', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('string_status', 100)->nullable();
+            $table->integer('integer_status')->nullable();
+        });
+    }
+
+    public function testCanQueryWithEnums()
+    {
+        DB::table('enum_casts')->insert([
+            'string_status' => 'pending',
+            'integer_status' => 1,
+        ]);
+
+        $record = DB::table('enum_casts')->where('string_status', StringStatus::pending)->first();
+        $record2 = DB::table('enum_casts')->where('integer_status', IntegerStatus::pending)->first();
+        $record3 = DB::table('enum_casts')->whereIn('integer_status', [IntegerStatus::pending])->first();
+
+        $this->assertNotNull($record);
+        $this->assertNotNull($record2);
+        $this->assertNotNull($record3);
+        $this->assertEquals('pending', $record->string_status);
+        $this->assertEquals(1, $record2->integer_status);
+    }
+
+    public function testCanInsertWithEnums()
+    {
+        DB::table('enum_casts')->insert([
+            'string_status' => StringStatus::pending,
+            'integer_status' => IntegerStatus::pending,
+        ]);
+
+        $record = DB::table('enum_casts')->where('string_status', StringStatus::pending)->first();
+
+        $this->assertNotNull($record);
+        $this->assertEquals('pending', $record->string_status);
+        $this->assertEquals(1, $record->integer_status);
+    }
+}

--- a/tests/Integration/Database/QueryingWithEnumsTest.php
+++ b/tests/Integration/Database/QueryingWithEnumsTest.php
@@ -11,7 +11,7 @@ if (PHP_VERSION_ID >= 80100) {
 }
 
 /**
- * @requires PHP 8.1
+ * @requires PHP >= 8.1
  * @group integration
  */
 class QueryingWithEnumsTest extends DatabaseTestCase

--- a/tests/Integration/Database/QueryingWithEnumsTest.php
+++ b/tests/Integration/Database/QueryingWithEnumsTest.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Tests\Integration\Database;
 
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;


### PR DESCRIPTION
This PR allows using Enums for `insert()`, `update()`, and `select()`.