### PR TITLE
[8.x] Fifo support for queue name suffix

### DIFF
--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -188,8 +188,22 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
         $queue = $queue ?: $this->default;
 
         return filter_var($queue, FILTER_VALIDATE_URL) === false
-            ? rtrim($this->prefix, '/').'/'.Str::finish($queue, $this->suffix)
+            ? $this->suffixQueue($queue, $this->suffix)
             : $queue;
+    }
+
+    /**
+     * Suffixes a queue
+     *
+     * @param string $queue
+     * @param string $suffix
+     * @return string
+     */
+    private function suffixQueue($queue, $suffix = '')
+    {
+        $fifo = Str::endsWith($queue, '.fifo') ? '.fifo' : '';
+        $queue = rtrim($queue, '.fifo');
+        return rtrim($this->prefix, '/') . '/' . Str::finish($queue, $suffix) . $fifo;
     }
 
     /**

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -162,6 +162,16 @@ class QueueSqsQueueTest extends TestCase
         $this->assertEquals($queueUrl, $queue->getQueue($queueUrl));
     }
 
+    public function testGetQueueProperlyResolvesFifoUrlWithoutPrefix()
+    {
+        $this->queueName = 'emails.fifo';
+        $this->queueUrl = $this->prefix . $this->queueName;
+        $queue = new SqsQueue($this->sqs, $this->queueUrl);
+        $this->assertEquals($this->queueUrl, $queue->getQueue(null));
+        $fifoQueueUrl = $this->baseUrl . '/' . $this->account . '/test.fifo';
+        $this->assertEquals($fifoQueueUrl, $queue->getQueue($fifoQueueUrl));
+    }
+
     public function testGetQueueProperlyResolvesUrlWithSuffix()
     {
         $queue = new SqsQueue($this->sqs, $this->queueName, $this->prefix, $suffix = '-staging');

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -144,6 +144,16 @@ class QueueSqsQueueTest extends TestCase
         $this->assertEquals($queueUrl, $queue->getQueue('test'));
     }
 
+    public function testGetQueueProperlyResolvesFifoUrlWithPrefix()
+    {
+        $this->queueName = 'emails.fifo';
+        $this->queueUrl = $this->prefix . $this->queueName;
+        $queue = new SqsQueue($this->sqs, $this->queueName, $this->prefix);
+        $this->assertEquals($this->queueUrl, $queue->getQueue(null));
+        $queueUrl = $this->baseUrl . '/' . $this->account . '/test.fifo';
+        $this->assertEquals($queueUrl, $queue->getQueue('test.fifo'));
+    }
+
     public function testGetQueueProperlyResolvesUrlWithoutPrefix()
     {
         $queue = new SqsQueue($this->sqs, $this->queueUrl);
@@ -160,11 +170,28 @@ class QueueSqsQueueTest extends TestCase
         $this->assertEquals($queueUrl, $queue->getQueue('test'));
     }
 
+    public function testGetQueueProperlyResolvesFifoUrlWithSuffix()
+    {
+        $this->queueName = 'emails.fifo';
+        $queue = new SqsQueue($this->sqs, $this->queueName, $this->prefix, $suffix = '-staging');
+        $this->assertEquals("{$this->prefix}emails-staging.fifo", $queue->getQueue(null));
+        $queueUrl = $this->baseUrl . '/' . $this->account . '/test' . $suffix . '.fifo';
+        $this->assertEquals($queueUrl, $queue->getQueue('test.fifo'));
+    }
+
     public function testGetQueueEnsuresTheQueueIsOnlySuffixedOnce()
     {
         $queue = new SqsQueue($this->sqs, "{$this->queueName}-staging", $this->prefix, $suffix = '-staging');
         $this->assertEquals($this->queueUrl.$suffix, $queue->getQueue(null));
         $queueUrl = $this->baseUrl.'/'.$this->account.'/test'.$suffix;
         $this->assertEquals($queueUrl, $queue->getQueue('test-staging'));
+    }
+
+    public function testGetFifoQueueEnsuresTheQueueIsOnlySuffixedOnce()
+    {
+        $queue = new SqsQueue($this->sqs, "{$this->queueName}-staging.fifo", $this->prefix, $suffix = '-staging');
+        $this->assertEquals("{$this->prefix}{$this->queueName}{$suffix}.fifo", $queue->getQueue(null));
+        $queueUrl = $this->baseUrl . '/' . $this->account . '/test' . $suffix . '.fifo';
+        $this->assertEquals($queueUrl, $queue->getQueue('test-staging.fifo'));
     }
 }


### PR DESCRIPTION
PR to add support for fifo naming conventions.

A FIFO SQS queue must always end with `.fifo`. For example, you set a queue name of `emails.fifo` and a suffix of `-staging` you end up with a queue name of `emails.fifo-staging`. After this PR you get `emails-staging.fifo`.

I appriciate FIFO queues aren't supported by the Framework. But there are packages that add support. This PR just adds support for the naming convention.

Thanks
