### PR TITLE
[8.x] Ensure event mutex is always removed

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -228,7 +228,7 @@ class Event
 
             $this->callAfterCallbacks($container);
         } finally {
-            $this->deleteMutex();
+            $this->removeMutex();
         }
     }
 
@@ -245,7 +245,7 @@ class Event
 
             Process::fromShellCommandline($this->buildCommand(), base_path(), null, null, null)->run();
         } catch (Throwable $exception) {
-            $this->deleteMutex();
+            $this->removeMutex();
 
             throw $exception;
         }
@@ -291,7 +291,7 @@ class Event
         try {
             $this->callAfterCallbacks($container);
         } finally {
-            $this->deleteMutex();
+            $this->removeMutex();
         }
     }
 
@@ -936,7 +936,7 @@ class Event
      *
      * @return void
      */
-    protected function deleteMutex()
+    protected function removeMutex()
     {
         if ($this->withoutOverlapping) {
             $this->mutex->forget($this);

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -228,7 +228,7 @@ class Event
 
             $this->callAfterCallbacks($container);
         } finally {
-            $this->removeMutex();
+            $this->deleteMutex();
         }
     }
 
@@ -245,7 +245,7 @@ class Event
 
             Process::fromShellCommandline($this->buildCommand(), base_path(), null, null, null)->run();
         } catch (Throwable $exception) {
-            $this->removeMutex();
+            $this->deleteMutex();
 
             throw $exception;
         }
@@ -291,7 +291,7 @@ class Event
         try {
             $this->callAfterCallbacks($container);
         } finally {
-            $this->removeMutex();
+            $this->deleteMutex();
         }
     }
 
@@ -653,18 +653,6 @@ class Event
     }
 
     /**
-     * Clear the mutex for the event.
-     *
-     * @return void
-     */
-    protected function removeMutex()
-    {
-        if ($this->withoutOverlapping) {
-            $this->mutex->forget($this);
-        }
-    }
-
-    /**
      * Do not allow the event to overlap each other.
      *
      * @param  int  $expiresAt
@@ -943,5 +931,17 @@ class Event
         $this->mutex = $mutex;
 
         return $this;
+    }
+
+    /**
+     * Delete the mutex for the event.
+     *
+     * @return void
+     */
+    protected function deleteMutex()
+    {
+        if ($this->withoutOverlapping) {
+            $this->mutex->forget($this);
+        }
     }
 }

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -676,9 +676,7 @@ class Event
 
         $this->expiresAt = $expiresAt;
 
-        return $this->then(function () {
-            $this->mutex->forget($this);
-        })->skip(function () {
+        return $this->skip(function () {
             return $this->mutex->exists($this);
         });
     }


### PR DESCRIPTION
This is a fix for #39452

- Added a new `removeMutex` method (which already exists on `CallbackEvent`) that only clears the mutex if necessary
- For commands running foreground, we wrap everything in a `try`/`finally` to call `removeMutex`
- For commands running the the background, we wrap the before callbacks in a `try`/`catch` that re-throws any exceptions after first calling `removeMutex`. Then, we call `removeMutex` in `callAfterCallbacksWithExitCode` after the background job completes.