### PR TITLE
[9.x] Split scheduled event handling into discrete parts

### DIFF
--- a/src/Illuminate/Console/Scheduling/CallbackEvent.php
+++ b/src/Illuminate/Console/Scheduling/CallbackEvent.php
@@ -32,6 +32,13 @@ class CallbackEvent extends Event
     protected $result;
 
     /**
+     * The exception that was thrown when calling the callback.
+     *
+     * @var \Throwable
+     */
+    protected $exception;
+
+    /**
      * Create a new event instance.
      *
      * @param  \Illuminate\Console\Scheduling\EventMutex  $mutex
@@ -68,6 +75,10 @@ class CallbackEvent extends Event
     {
         parent::run($container);
 
+        if ($this->exception) {
+            throw $this->exception;
+        }
+
         return $this->result;
     }
 
@@ -80,9 +91,8 @@ class CallbackEvent extends Event
 
             return $this->result === false ? 1 : 0;
         } catch (Throwable $e) {
-            $this->exitCode = 1;
-
-            throw $e;
+            $this->exception = $e;
+            return 1;
         }
     }
 

--- a/src/Illuminate/Console/Scheduling/CallbackEvent.php
+++ b/src/Illuminate/Console/Scheduling/CallbackEvent.php
@@ -98,6 +98,7 @@ class CallbackEvent extends Event
             return $this->result === false ? 1 : 0;
         } catch (Throwable $e) {
             $this->exception = $e;
+
             return 1;
         }
     }

--- a/src/Illuminate/Console/Scheduling/CallbackEvent.php
+++ b/src/Illuminate/Console/Scheduling/CallbackEvent.php
@@ -34,7 +34,7 @@ class CallbackEvent extends Event
     /**
      * The exception that was thrown when calling the callback.
      *
-     * @var \Throwable
+     * @var \Throwable|null
      */
     protected $exception;
 
@@ -42,7 +42,7 @@ class CallbackEvent extends Event
      * Create a new event instance.
      *
      * @param  \Illuminate\Console\Scheduling\EventMutex  $mutex
-     * @param  string  $callback
+     * @param  string|callable  $callback
      * @param  array  $parameters
      * @param  \DateTimeZone|string|null  $timezone
      * @return void
@@ -82,7 +82,13 @@ class CallbackEvent extends Event
         return $this->result;
     }
 
-    protected function executeCommand($container)
+    /**
+     * Run the callback.
+     *
+     * @param  \Illuminate\Contracts\Container\Container  $container
+     * @return int
+     */
+    protected function execute($container)
     {
         try {
             $this->result = is_object($this->callback)

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -17,6 +17,7 @@ use Illuminate\Support\Traits\Macroable;
 use Illuminate\Support\Traits\ReflectsClosures;
 use Psr\Http\Client\ClientExceptionInterface;
 use Symfony\Component\Process\Process;
+use Throwable;
 
 class Event
 {
@@ -187,17 +188,20 @@ class Event
      *
      * @param  \Illuminate\Contracts\Container\Container  $container
      * @return void
+     *
+     * @throws \Throwable
      */
     public function run(Container $container)
     {
-        if ($this->withoutOverlapping &&
-            ! $this->mutex->create($this)) {
+        if ($this->shouldSkipDueToOverlapping()) {
             return;
         }
 
-        $this->runInBackground
-                    ? $this->runCommandInBackground($container)
-                    : $this->runCommandInForeground($container);
+        $exitCode = $this->startCommand($container);
+
+        if (! $this->runInBackground) {
+            $this->finishCommand($container, $exitCode);
+        }
     }
 
     /**
@@ -211,31 +215,55 @@ class Event
     }
 
     /**
-     * Run the command in the foreground.
+     * Run the command process.
      *
      * @param  \Illuminate\Contracts\Container\Container  $container
-     * @return void
+     * @return int
+     *
+     * @throws \Throwable
      */
-    protected function runCommandInForeground(Container $container)
+    protected function startCommand($container)
     {
-        $this->callBeforeCallbacks($container);
+        try {
+            $this->callBeforeCallbacks($container);
 
-        $this->exitCode = Process::fromShellCommandline($this->buildCommand(), base_path(), null, null, null)->run();
+            return $this->executeCommand($container);
+        } catch (Throwable $exception) {
+            $this->removeMutex();
 
-        $this->callAfterCallbacks($container);
+            throw $exception;
+        }
     }
 
     /**
-     * Run the command in the background.
+     * Run the command process.
      *
      * @param  \Illuminate\Contracts\Container\Container  $container
+     * @return int
+     */
+    protected function executeCommand($container)
+    {
+        return Process::fromShellCommandline(
+            $this->buildCommand(), base_path(), null, null, null
+        )->run();
+    }
+
+    /**
+     * Mark the command process as finished and run callbacks/cleanup.
+     *
+     * @param  \Illuminate\Contracts\Container\Container  $container
+     * @param  int  $exitCode
      * @return void
      */
-    protected function runCommandInBackground(Container $container)
+    public function finishCommand(Container $container, $exitCode)
     {
-        $this->callBeforeCallbacks($container);
+        $this->exitCode = (int) $exitCode;
 
-        Process::fromShellCommandline($this->buildCommand(), base_path(), null, null, null)->run();
+        try {
+            $this->callAfterCallbacks($container);
+        } finally {
+            $this->removeMutex();
+        }
     }
 
     /**
@@ -262,20 +290,6 @@ class Event
         foreach ($this->afterCallbacks as $callback) {
             $container->call($callback);
         }
-    }
-
-    /**
-     * Call all of the "after" callbacks for the event.
-     *
-     * @param  \Illuminate\Contracts\Container\Container  $container
-     * @param  int  $exitCode
-     * @return void
-     */
-    public function callAfterCallbacksWithExitCode(Container $container, $exitCode)
-    {
-        $this->exitCode = (int) $exitCode;
-
-        $this->callAfterCallbacks($container);
     }
 
     /**
@@ -362,6 +376,16 @@ class Event
         }
 
         return true;
+    }
+
+    /**
+     * Determine if the event should skip because another process is overlapping.
+     *
+     * @return bool
+     */
+    public function shouldSkipDueToOverlapping()
+    {
+        return $this->withoutOverlapping && ! $this->mutex->create($this);
     }
 
     /**
@@ -647,9 +671,7 @@ class Event
 
         $this->expiresAt = $expiresAt;
 
-        return $this->then(function () {
-            $this->mutex->forget($this);
-        })->skip(function () {
+        return $this->skip(function () {
             return $this->mutex->exists($this);
         });
     }
@@ -914,5 +936,17 @@ class Event
         $this->mutex = $mutex;
 
         return $this;
+    }
+
+    /**
+     * Delete the mutex for the event.
+     *
+     * @return void
+     */
+    protected function removeMutex()
+    {
+        if ($this->withoutOverlapping) {
+            $this->mutex->forget($this);
+        }
     }
 }

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -197,10 +197,10 @@ class Event
             return;
         }
 
-        $exitCode = $this->startCommand($container);
+        $exitCode = $this->start($container);
 
         if (! $this->runInBackground) {
-            $this->finishCommand($container, $exitCode);
+            $this->finish($container, $exitCode);
         }
     }
 
@@ -222,12 +222,12 @@ class Event
      *
      * @throws \Throwable
      */
-    protected function startCommand($container)
+    protected function start($container)
     {
         try {
             $this->callBeforeCallbacks($container);
 
-            return $this->executeCommand($container);
+            return $this->execute($container);
         } catch (Throwable $exception) {
             $this->removeMutex();
 
@@ -241,7 +241,7 @@ class Event
      * @param  \Illuminate\Contracts\Container\Container  $container
      * @return int
      */
-    protected function executeCommand($container)
+    protected function execute($container)
     {
         return Process::fromShellCommandline(
             $this->buildCommand(), base_path(), null, null, null
@@ -255,7 +255,7 @@ class Event
      * @param  int  $exitCode
      * @return void
      */
-    public function finishCommand(Container $container, $exitCode)
+    public function finish(Container $container, $exitCode)
     {
         $this->exitCode = (int) $exitCode;
 

--- a/src/Illuminate/Console/Scheduling/ScheduleFinishCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleFinishCommand.php
@@ -49,7 +49,7 @@ class ScheduleFinishCommand extends Command
         collect($schedule->events())->filter(function ($value) {
             return $value->mutexName() == $this->argument('id');
         })->each(function ($event) {
-            $event->finishCommand($this->laravel, $this->argument('code'));
+            $event->finish($this->laravel, $this->argument('code'));
 
             $this->laravel->make(Dispatcher::class)->dispatch(new ScheduledBackgroundTaskFinished($event));
         });

--- a/src/Illuminate/Console/Scheduling/ScheduleFinishCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleFinishCommand.php
@@ -49,7 +49,7 @@ class ScheduleFinishCommand extends Command
         collect($schedule->events())->filter(function ($value) {
             return $value->mutexName() == $this->argument('id');
         })->each(function ($event) {
-            $event->callafterCallbacksWithExitCode($this->laravel, $this->argument('code'));
+            $event->finishCommand($this->laravel, $this->argument('code'));
 
             $this->laravel->make(Dispatcher::class)->dispatch(new ScheduledBackgroundTaskFinished($event));
         });


### PR DESCRIPTION
This is a continuation of #39498. I'm submitting it against `9.x` because I've changed some method names. This would only affect applications that have custom versions of `Scheduling\Event` or `Scheduling\CallbackEvent`.

This PR splits scheduled event execution into three parts:

1. `start`: Run before callbacks (removing mutex on exception)
2. `execute`: Execute the command or run the callback
3. `finish`: Set the exit code, run after callbacks, remove mutex

By doing so, we can improve the handling of mutex's and minimize the difference between foreground/background execution and across regular and callback events:

- This removes the need for `runCommandInBackground` and `runCommandInForeground` because start/finish are considered separate actions in both cases.
- We can centralize the calls to `callBeforeCallbacks` and `callAfterCallbacks` and easily perform exception handling around them.
- We can eliminate the need for `callAfterCallbacks` vs `callAfterCallbacksWithExitCode` — the `finish` method is used in foreground and background execution in exactly the same way.
- Much of the logic in `CallbackEvent` can be removed now that `execute` is its own discrete step. All the mutex handling and callback logic stays the same and the only real difference is the execution of the event.

This **should not be merged** until [my comment on #39498 is addressed](https://github.com/laravel/framework/pull/39498#issuecomment-962181501), though.