### PR TITLE
[8.x] Add `params` function to Str support class

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -943,4 +943,19 @@ class Str
     {
         static::$uuidFactory = null;
     }
+
+    /**
+     * Get query parameters from a url string as an associative array.
+     *
+     * @param  string  $url
+     * @return array
+     */
+    public static function params($url)
+    {
+        $queryString = parse_url($url, PHP_URL_QUERY);
+
+        parse_str($queryString, $params);
+
+        return $params;
+    }
 }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -945,7 +945,7 @@ class Str
     }
 
     /**
-     * Get query parameters from a url string as an associative array.
+     * Get the query parameters from a url string as an associative array.
      *
      * @param  string  $url
      * @return array

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -616,6 +616,15 @@ class SupportStrTest extends TestCase
         $this->assertSame('aaaaa', Str::repeat('a', 5));
         $this->assertSame('', Str::repeat('', 5));
     }
+
+    public function testParams()
+    {
+        $this->assertSame([
+            'name' => 'Ben Sherred',
+            'foo' => 'bar',
+            'array' => ['ping', 'pong']
+        ], Str::params('https://laravel.com/?name=Ben%20Sherred&foo=bar&array[]=ping&array[]=pong'));
+    }
 }
 
 class StringableObjectStub

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -622,7 +622,7 @@ class SupportStrTest extends TestCase
         $this->assertSame([
             'name' => 'Ben Sherred',
             'foo' => 'bar',
-            'array' => ['ping', 'pong']
+            'array' => ['ping', 'pong'],
         ], Str::params('https://laravel.com/?name=Ben%20Sherred&foo=bar&array[]=ping&array[]=pong'));
     }
 }


### PR DESCRIPTION
This PR adds a method for extracting query parameters from a URL string and returns an associate array.

e.g.

`https://laravel.com/?browser=Safari&origin[]=mobile&origin[]=iPhone`

would return

```
[
    "browser" => "Safari",
    "origin" => [
        "mobile",
        "iPhone",
    ],
]
```

This is particularly useful when a user submits a URL in a form and you wish to grab the parameters from the string.
