### PR TITLE
with php artisan test --filter it need @test to recognize tests and r…

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/test.stub
+++ b/src/Illuminate/Foundation/Console/stubs/test.stub
@@ -11,6 +11,7 @@ class {{ class }} extends TestCase
     /**
      * A basic feature test example.
      *
+     * @test
      * @return void
      */
     public function test_example()


### PR DESCRIPTION
a little attribute in php doc that needed to run --filter of php artisan test