### PR TITLE
Add unauthorized method for Laravel Http Client

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -191,6 +191,16 @@ class Response implements ArrayAccess
     }
 
     /**
+     * Determine if the response indicates the request is unauthorized or forbidden.
+     *
+     * @return bool
+     */
+    public function unauthorized()
+    {
+        return $this->status() == 401 || $this->status() == 403;
+    }
+
+    /**
      * Execute the given callback if there was a server or client error.
      *
      * @param  callable  $callback

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -636,6 +636,23 @@ class HttpClientTest extends TestCase
         $this->assertSame(401, $response->status());
     }
 
+    public function testOnErrorCallsClosureOnUnauthorizedError()
+    {
+        $status = 0;
+        $client = $this->factory->fake([
+            'laravel.com' => $this->factory::response('', 403),
+        ]);
+
+        $response = $client->get('laravel.com')
+            ->onError(function ($response) use (&$status) {
+                $status = $response->status();
+            });
+
+        $this->assertSame(403, $status);
+        $this->assertSame(403, $response->status());
+    }
+
+
     public function testOnErrorCallsClosureOnServerError()
     {
         $status = 0;

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -652,7 +652,6 @@ class HttpClientTest extends TestCase
         $this->assertSame(403, $response->status());
     }
 
-
     public function testOnErrorCallsClosureOnServerError()
     {
         $status = 0;


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

While working with the Http Client and making requests to services that require some form of authentication,  I found that I have been doing:
```php
$response = Http::withToken('apikey')->post('http://example.com', [
      'data' => $data,
]);

if ($response->status() == 401 ||  $response->status() == 403) {
    # authentication error
}
```

and it became repetitive. With this pull request, everything written above can now be achieved with:

```php
$response = Http::withToken('apikey')->post('http://example.com', [
      'data' => $data,
]);

if ($response->unauthorized()) {
    # authentication error
}
```
Hopefully someone else finds it useful 😀



