### PR TITLE
[8.x] Add @count() to BladeEngine

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -160,6 +160,17 @@ trait CompilesConditionals
     }
 
     /**
+     * Compile the if-count statements into valid PHP.
+     *
+     * @param  array  $expression
+     * @return string
+     */
+    protected function compileCount($expression)
+    {
+        return "<?php if(count{$expression}): ?>";
+    }
+
+    /**
      * Compile the unless statements into valid PHP.
      *
      * @param  string  $expression
@@ -197,6 +208,16 @@ trait CompilesConditionals
      * @return string
      */
     protected function compileEndif()
+    {
+        return '<?php endif; ?>';
+    }
+
+    /**
+     * Compile the end-count statements into valid PHP.
+     *
+     * @return string
+     */
+    protected function compileEndCount()
     {
         return '<?php endif; ?>';
     }

--- a/tests/View/Blade/BladeCountStatementsTest.php
+++ b/tests/View/Blade/BladeCountStatementsTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Illuminate\Tests\View\Blade;
+
+class BladeCountStatementsTest extends AbstractBladeTestCase
+{
+    public function testCountStatementsAreCompiled()
+    {
+        $string = '@count ($test)
+breeze
+@endcount';
+        $expected = '<?php if(count($test)): ?>
+breeze
+<?php endif; ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+}


### PR DESCRIPTION
I frequently use @if ( count($array) ) like below, and sure a lot of devs do too.

```
@if ( count($array) )
//
@endif
```
 so I thought to simplify it by using @count
```
@count ( $array )
//
@endcount
```