### PR TITLE
[8.x] Introduce `@js()` directive

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -20,6 +20,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
         Concerns\CompilesIncludes,
         Concerns\CompilesInjections,
         Concerns\CompilesJson,
+        Concerns\CompilesJs,
         Concerns\CompilesLayouts,
         Concerns\CompilesLoops,
         Concerns\CompilesRawPhp,

--- a/src/Illuminate/View/Compilers/Concerns/CompilesJs.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesJs.php
@@ -7,7 +7,7 @@ use Illuminate\Support\JsString;
 trait CompilesJs
 {
     /**
-     * Compile the @js() directive into valid PHP.
+     * Compile the "@js" directive into valid PHP.
      *
      * @param  string  $expression
      * @return string

--- a/src/Illuminate/View/Compilers/Concerns/CompilesJs.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesJs.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Illuminate\View\Compilers\Concerns;
+
+use Illuminate\Support\JsString;
+
+trait CompilesJs
+{
+    /**
+     * Compile the @js() directive into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileJs(string $expression)
+    {
+        return sprintf(
+            "<?php echo \%s::from(%s)->toHtml() ?>",
+            JsString::class, $this->stripParentheses($expression)
+        );
+    }
+}

--- a/src/Illuminate/View/Compilers/Concerns/CompilesJs.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesJs.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\View\Compilers\Concerns;
 
-use Illuminate\Support\JsString;
+use Illuminate\Support\Js;
 
 trait CompilesJs
 {
@@ -16,7 +16,7 @@ trait CompilesJs
     {
         return sprintf(
             "<?php echo \%s::from(%s)->toHtml() ?>",
-            JsString::class, $this->stripParentheses($expression)
+            Js::class, $this->stripParentheses($expression)
         );
     }
 }

--- a/tests/Support/SupportJsTest.php
+++ b/tests/Support/SupportJsTest.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Js;
 use JsonSerializable;
 use PHPUnit\Framework\TestCase;
 
-class SupportJsStringTest extends TestCase
+class SupportJsTest extends TestCase
 {
     public function testScalars()
     {

--- a/tests/View/Blade/BladeJsTest.php
+++ b/tests/View/Blade/BladeJsTest.php
@@ -7,7 +7,7 @@ class BladeJsTest extends AbstractBladeTestCase
     public function testStatementIsCompiledWithoutAnyOptions()
     {
         $string = '<div x-data="@js($data)"></div>';
-        $expected = '<div x-data="<?php echo \Illuminate\Support\JsString::from($data)->toHtml() ?>"></div>';
+        $expected = '<div x-data="<?php echo \Illuminate\Support\Js::from($data)->toHtml() ?>"></div>';
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
@@ -15,7 +15,7 @@ class BladeJsTest extends AbstractBladeTestCase
     public function testJsonFlagsCanBeSet()
     {
         $string = '<div x-data="@js($data, JSON_FORCE_OBJECT)"></div>';
-        $expected = '<div x-data="<?php echo \Illuminate\Support\JsString::from($data, JSON_FORCE_OBJECT)->toHtml() ?>"></div>';
+        $expected = '<div x-data="<?php echo \Illuminate\Support\Js::from($data, JSON_FORCE_OBJECT)->toHtml() ?>"></div>';
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
@@ -23,7 +23,7 @@ class BladeJsTest extends AbstractBladeTestCase
     public function testEncodingDepthCanBeSet()
     {
         $string = '<div x-data="@js($data, JSON_FORCE_OBJECT, 256)"></div>';
-        $expected = '<div x-data="<?php echo \Illuminate\Support\JsString::from($data, JSON_FORCE_OBJECT, 256)->toHtml() ?>"></div>';
+        $expected = '<div x-data="<?php echo \Illuminate\Support\Js::from($data, JSON_FORCE_OBJECT, 256)->toHtml() ?>"></div>';
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }

--- a/tests/View/Blade/BladeJsTest.php
+++ b/tests/View/Blade/BladeJsTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Illuminate\Tests\View\Blade;
+
+class BladeJsTest extends AbstractBladeTestCase
+{
+    public function testStatementIsCompiledWithoutAnyOptions()
+    {
+        $string = '<div x-data="@js($data)"></div>';
+        $expected = '<div x-data="<?php echo \Illuminate\Support\JsString::from($data)->toHtml() ?>"></div>';
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testJsonFlagsCanBeSet()
+    {
+        $string = '<div x-data="@js($data, JSON_FORCE_OBJECT)"></div>';
+        $expected = '<div x-data="<?php echo \Illuminate\Support\JsString::from($data, JSON_FORCE_OBJECT)->toHtml() ?>"></div>';
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testEncodingDepthCanBeSet()
+    {
+        $string = '<div x-data="@js($data, JSON_FORCE_OBJECT, 256)"></div>';
+        $expected = '<div x-data="<?php echo \Illuminate\Support\JsString::from($data, JSON_FORCE_OBJECT, 256)->toHtml() ?>"></div>';
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+}


### PR DESCRIPTION
This is a rebased version of #39478 that I'm resubmitting [after a conversation](https://twitter.com/inxilpro/status/1456826254817103873) with @calebporzio. If this gets merged, either he or I can add a `version_compare` check to Livewire that would only register the existing Livewire directive for Laravel `v8.69.0` and lower (or whatever release is one below the version this ended up in).