### PR TITLE
[8.x] Don't name unnamed routes inside a group with a prefix

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -855,7 +855,7 @@ class Route
      */
     public function name($name)
     {
-        $this->action['as'] = isset($this->action['as']) ? $this->action['as'].$name : $name;
+        $this->action['as'] = isset($this->action['as_prefix']) ? $this->action['as_prefix'].$name : $name;
 
         return $this;
     }

--- a/src/Illuminate/Routing/RouteGroup.php
+++ b/src/Illuminate/Routing/RouteGroup.php
@@ -92,8 +92,12 @@ class RouteGroup
      */
     protected static function formatAs($new, $old)
     {
-        if (isset($old['as'])) {
-            $new['as'] = $old['as'].($new['as'] ?? '');
+        if ($prefix = $old['as'] ?? $old['as_prefix'] ?? null) {
+            $new['as_prefix'] = $prefix;
+        }
+
+        if ($prefix && isset($new['as'])) {
+            $new['as'] = $prefix.$new['as'];
         }
 
         return $new;

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -306,6 +306,24 @@ class RouteRegistrarTest extends TestCase
         $this->assertSame('api.users', $this->getRoute()->getName());
     }
 
+    public function testUnnamedRoutesRemainUnnamedInsideGroupWithNamePrefix()
+    {
+        $this->router->name('api.')->group(function ($router) {
+            $router->get('users', 'UsersController@index');
+        });
+
+        $this->assertSame(null, $this->getRoute()->getName());
+    }
+
+    public function testSettingNameTwiceUsesInitialPrefix()
+    {
+        $this->router->name('api.')->group(function ($router) {
+            $router->get('users', 'UsersController@index')->name('users')->name('foo');
+        });
+
+        $this->assertSame('api.foo', $this->getRoute()->getName());
+    }
+
     public function testCanRegisterGroupWithDomain()
     {
         $this->router->domain('{account}.myapp.com')->group(function ($router) {

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1014,7 +1014,7 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals(['domain' => 'baz', 'prefix' => null, 'namespace' => null, 'where' => []], RouteGroup::merge(['domain' => 'baz'], $old));
 
         $old = ['as' => 'foo.'];
-        $this->assertEquals(['as' => 'foo.bar', 'prefix' => null, 'namespace' => null, 'where' => []], RouteGroup::merge(['as' => 'bar'], $old));
+        $this->assertEquals(['as' => 'foo.bar', 'as_prefix' => 'foo.', 'prefix' => null, 'namespace' => null, 'where' => []], RouteGroup::merge(['as' => 'bar'], $old));
 
         $old = ['where' => ['var1' => 'foo', 'var2' => 'bar']];
         $this->assertEquals(['prefix' => null, 'namespace' => null, 'where' => [


### PR DESCRIPTION
Currently if you register an unnamed route within a group with a name prefix, the route's name is set to the prefix.

```php
$router->name('api.')->group(function ($router) {
    $router->get('users', 'UsersController@index');
});

$routes = $router->getRoutes()->get();
echo last($routes)->getName(); // "api."
```

While the consequences of this are somewhat obscure ([but definitely exist](https://github.com/laravel/framework/pull/31917)), it is indeed odd behavior and I would expect `getName()` to return `null` in the above example since I never explicitly set a name on the route.

This PR attempts to fix that within the constraints of the current architecture. I'm not sure if this would be considered a breaking change vs a bug fix, but I can PR this instead to master if desired.

Basically, instead of passing the group's `$action['as']` value into each new route created within it, it passes it as `$action['as_prefix']`. Then when a name is set on a route, it prepends `$action['as_prefix']`.

This also changes the behavior of calling `name` more than once on a route. Previously each time you called it, the value passed would be continually appended:

```php
$router->name('api.')->group(function ($router) {
    $router->get('users', 'UsersController@index')->name('foo')->name('bar') // "api.foobar"
});
```

Now, the value will be appended onto the initial group prefix each time:

```php
$router->name('api.')->group(function ($router) {
    $router->get('users', 'UsersController@index')->name('foo')->name('bar') // "api.bar"
});
```