### PR TITLE
[9.x] Use request isMethod instead of method comparison

### DIFF
--- a/src/Illuminate/Routing/AbstractRouteCollection.php
+++ b/src/Illuminate/Routing/AbstractRouteCollection.php
@@ -94,7 +94,7 @@ abstract class AbstractRouteCollection implements Countable, IteratorAggregate, 
      */
     protected function getRouteForMethods($request, array $methods)
     {
-        if ($request->method() === 'OPTIONS') {
+        if ($request->isMethod('OPTIONS')) {
             return (new Route('OPTIONS', $request->path(), function () use ($methods) {
                 return new Response('', 200, ['Allow' => implode(',', $methods)]);
             }))->bind($request);

--- a/src/Illuminate/Routing/Redirector.php
+++ b/src/Illuminate/Routing/Redirector.php
@@ -84,7 +84,7 @@ class Redirector
     {
         $request = $this->generator->getRequest();
 
-        $intended = $request->method() === 'GET' && $request->route() && ! $request->expectsJson()
+        $intended = $request->isMethod('GET') && $request->route() && ! $request->expectsJson()
                         ? $this->generator->full()
                         : $this->generator->previous();
 

--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -199,7 +199,7 @@ class StartSession
      */
     protected function storeCurrentUrl(Request $request, $session)
     {
-        if ($request->method() === 'GET' &&
+        if ($request->isMethod('GET') &&
             $request->route() instanceof Route &&
             ! $request->ajax() &&
             ! $request->prefetch()) {

--- a/tests/Routing/RoutingRedirectorTest.php
+++ b/tests/Routing/RoutingRedirectorTest.php
@@ -83,7 +83,7 @@ class RoutingRedirectorTest extends TestCase
 
     public function testGuestPutPreviousUrlInSession()
     {
-        $this->request->shouldReceive('method')->once()->andReturn('POST');
+        $this->request->shouldReceive('isMethod')->once()->with('GET')->andReturn(false);
         $this->session->shouldReceive('put')->once()->with('url.intended', 'http://foo.com/bar');
         $this->url->shouldReceive('previous')->once()->andReturn('http://foo.com/bar');
 


### PR DESCRIPTION
Symfony Request class has a built-in method called `isMethod` to determine which HTTP method a request is. Using the method `isMethod` is a little bit nicer than method comparison.

```php
use Symfony\Component\HttpFoundation\Request;

$request = Request::create('/', 'POST');

// Using isMethod looks a bit nicer.
if ($request->isMethod('POST') {
    // do something...  
}

// than method comparison
if ($request->method() === 'POST') {
    // 
}
``` 