### PR TITLE
[8.x] Configurable lost connection and concurrency error checks

### DIFF
--- a/src/Illuminate/Database/DetectsConcurrencyErrors.php
+++ b/src/Illuminate/Database/DetectsConcurrencyErrors.php
@@ -38,7 +38,7 @@ trait DetectsConcurrencyErrors
     {
         if (
             is_callable($this->concurrencyErrorCheck)
-            && call_user_func($this->concurrencyErrorCheck, $e)
+            && ($this->concurrencyErrorCheck)($e)
         ) {
             return true;
         }

--- a/src/Illuminate/Database/DetectsConcurrencyErrors.php
+++ b/src/Illuminate/Database/DetectsConcurrencyErrors.php
@@ -18,7 +18,7 @@ trait DetectsConcurrencyErrors
     /**
      * Set a custom check to be used in the concurrency error check.
      *
-     * @param callable $check
+     * @param  callable  $check
      * @return $this
      */
     public function setConcurrencyErrorCheck(callable $check)

--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -8,6 +8,26 @@ use Throwable;
 trait DetectsLostConnections
 {
     /**
+     * A configurable check for a lost connection exception.
+     *
+     * @var callable|null
+     */
+    protected $lostConnectionCheck;
+
+    /**
+     * Set a custom check to be used in the lost connection check.
+     *
+     * @param callable $check
+     * @return $this
+     */
+    public function setLostConnectionCheck(callable $check)
+    {
+        $this->lostConnectionCheck = $check;
+
+        return $this;
+    }
+
+    /**
      * Determine if the given exception was caused by a lost connection.
      *
      * @param  \Throwable  $e
@@ -15,6 +35,13 @@ trait DetectsLostConnections
      */
     protected function causedByLostConnection(Throwable $e)
     {
+        if (
+            is_callable($this->lostConnectionCheck)
+            && call_user_func($this->lostConnectionCheck, $e)
+        ) {
+            return true;
+        }
+
         $message = $e->getMessage();
 
         return Str::contains($message, [

--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -37,7 +37,7 @@ trait DetectsLostConnections
     {
         if (
             is_callable($this->lostConnectionCheck)
-            && call_user_func($this->lostConnectionCheck, $e)
+            && ($this->lostConnectionCheck)($e)
         ) {
             return true;
         }

--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -17,7 +17,7 @@ trait DetectsLostConnections
     /**
      * Set a custom check to be used in the lost connection check.
      *
-     * @param callable $check
+     * @param  callable  $check
      * @return $this
      */
     public function setLostConnectionCheck(callable $check)

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -3,10 +3,8 @@
 namespace Illuminate\Tests\Database;
 
 use DateTime;
-use Throwable;
 use ErrorException;
 use Exception;
-use Illuminate\Support\Str;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Events\QueryExecuted;
@@ -18,6 +16,7 @@ use Illuminate\Database\Query\Grammars\Grammar;
 use Illuminate\Database\Query\Processors\Processor;
 use Illuminate\Database\QueryException;
 use Illuminate\Database\Schema\Builder;
+use Illuminate\Support\Str;
 use Mockery as m;
 use PDO;
 use PDOException;
@@ -25,6 +24,7 @@ use PDOStatement;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use stdClass;
+use Throwable;
 
 class DatabaseConnectionTest extends TestCase
 {
@@ -396,7 +396,7 @@ class DatabaseConnectionTest extends TestCase
         $connection = $this->getMockConnection();
         $connection->setLostConnectionCheck(function (Throwable $e) {
             return Str::contains($e->getMessage(), [
-                'not a previously defined exception message'
+                'not a previously defined exception message',
             ]);
         });
 
@@ -427,7 +427,7 @@ class DatabaseConnectionTest extends TestCase
         $connection = $this->getMockConnection();
         $connection->setConcurrencyErrorCheck(function (Throwable $e) {
             return Str::contains($e->getMessage(), [
-                'not a previously defined exception message'
+                'not a previously defined exception message',
             ]);
         });
 


### PR DESCRIPTION
Currently, the checks for a lost connection or a concurrency error is not configurable in any way (not any way I could figure out at least).

This adds a way to set a callback to be used as part of the checks, so I can just configure this callback, and expect Laravel to behave as it normally would when encountering these two cases.

I don't know how your process for backporting things is, but if possible, I would love for this to be backported to previous versions.

Open to suggestion, if you have a better idea on how to solve this issue :)