### PR TITLE
[9.x] Fix postgresql build

### DIFF
--- a/.github/workflows/databases.yml
+++ b/.github/workflows/databases.yml
@@ -132,49 +132,49 @@ jobs:
           DB_CONNECTION: mysql
           DB_USERNAME: root
 
-  # pgsql:
-  #   runs-on: ubuntu-20.04
+  pgsql:
+    runs-on: ubuntu-20.04
 
-  #   services:
-  #     postgresql:
-  #       image: postgres:14
-  #       env:
-  #         POSTGRES_DB: forge
-  #         POSTGRES_USER: forge
-  #         POSTGRES_PASSWORD: password
-  #       ports:
-  #         - 5432:5432
-  #       options: --health-cmd=pg_isready --health-interval=10s --health-timeout=5s --health-retries=3
+    services:
+      postgresql:
+        image: postgres:14
+        env:
+          POSTGRES_DB: forge
+          POSTGRES_USER: forge
+          POSTGRES_PASSWORD: password
+        ports:
+          - 5432:5432
+        options: --health-cmd=pg_isready --health-interval=10s --health-timeout=5s --health-retries=3
 
-  #   strategy:
-  #     fail-fast: true
+    strategy:
+      fail-fast: true
 
-  #   name: PostgreSQL 14
+    name: PostgreSQL 14
 
-  #   steps:
-  #     - name: Checkout code
-  #       uses: actions/checkout@v2
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
 
-  #     - name: Setup PHP
-  #       uses: shivammathur/setup-php@v2
-  #       with:
-  #         php-version: 8.1
-  #         extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, pdo_pgsql
-  #         tools: composer:v2
-  #         coverage: none
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.1
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, pdo_pgsql
+          tools: composer:v2
+          coverage: none
 
-  #     - name: Install dependencies
-  #       uses: nick-invision/retry@v1
-  #       with:
-  #         timeout_minutes: 5
-  #         max_attempts: 5
-  #         command: composer update --prefer-stable --prefer-dist --no-interaction --no-progress
+      - name: Install dependencies
+        uses: nick-invision/retry@v1
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          command: composer update --prefer-stable --prefer-dist --no-interaction --no-progress
 
-  #     - name: Execute tests
-  #       run: vendor/bin/phpunit tests/Integration/Database --verbose --exclude-group MySQL
-  #       env:
-  #         DB_CONNECTION: pgsql
-  #         DB_PASSWORD: password
+      - name: Execute tests
+        run: vendor/bin/phpunit tests/Integration/Database --verbose --exclude-group MySQL
+        env:
+          DB_CONNECTION: pgsql
+          DB_PASSWORD: password
 
   mssql:
     runs-on: ubuntu-20.04

--- a/src/Illuminate/Database/Connectors/PostgresConnector.php
+++ b/src/Illuminate/Database/Connectors/PostgresConnector.php
@@ -93,8 +93,10 @@ class PostgresConnector extends Connector implements ConnectorInterface
      */
     protected function configureSearchPath($connection, $config)
     {
-        if (isset($config['search_path'])) {
-            $searchPath = $this->quoteSearchPath($this->parseSearchPath($config['search_path']));
+        if (isset($config['search_path']) || isset($config['schema'])) {
+            $searchPath = $this->quoteSearchPath(
+                $this->parseSearchPath($config['search_path'] ?? $config['schema'])
+            );
 
             $connection->prepare("set search_path to {$searchPath}")->execute();
         }
@@ -113,6 +115,8 @@ class PostgresConnector extends Connector implements ConnectorInterface
 
             $searchPath = $matches[0];
         }
+
+        $searchPath = $searchPath ?? [];
 
         array_walk($searchPath, function (&$schema) {
             $schema = trim($schema, '\'"');

--- a/src/Illuminate/Database/Schema/PostgresBuilder.php
+++ b/src/Illuminate/Database/Schema/PostgresBuilder.php
@@ -134,7 +134,9 @@ class PostgresBuilder extends Builder
     {
         return $this->connection->select(
             $this->grammar->compileGetAllTables(
-                $this->parseSearchPath($this->connection->getConfig('search_path'))
+                $this->parseSearchPath(
+                    $this->connection->getConfig('search_path') ?: $this->connection->getConfig('schema')
+                )
             )
         );
     }
@@ -148,7 +150,9 @@ class PostgresBuilder extends Builder
     {
         return $this->connection->select(
             $this->grammar->compileGetAllViews(
-                $this->parseSearchPath($this->connection->getConfig('search_path'))
+                $this->parseSearchPath(
+                    $this->connection->getConfig('search_path') ?: $this->connection->getConfig('schema')
+                )
             )
         );
     }

--- a/src/Illuminate/Database/Schema/PostgresBuilder.php
+++ b/src/Illuminate/Database/Schema/PostgresBuilder.php
@@ -237,7 +237,9 @@ class PostgresBuilder extends Builder
             $searchPath = $matches[0];
         }
 
-        array_walk($searchPath ?? [], function (&$schema) {
+        $searchPath = $searchPath ?? [];
+
+        array_walk($searchPath, function (&$schema) {
             $schema = trim($schema, '\'"');
 
             $schema = $schema === '$user'
@@ -245,6 +247,6 @@ class PostgresBuilder extends Builder
                 : $schema;
         });
 
-        return $searchPath ?? [];
+        return $searchPath;
     }
 }

--- a/src/Illuminate/Database/Schema/PostgresBuilder.php
+++ b/src/Illuminate/Database/Schema/PostgresBuilder.php
@@ -237,7 +237,7 @@ class PostgresBuilder extends Builder
             $searchPath = $matches[0];
         }
 
-        array_walk($searchPath, function (&$schema) {
+        array_walk($searchPath ?? [], function (&$schema) {
             $schema = trim($schema, '\'"');
 
             $schema = $schema === '$user'
@@ -245,6 +245,6 @@ class PostgresBuilder extends Builder
                 : $schema;
         });
 
-        return $searchPath;
+        return $searchPath ?? [];
     }
 }


### PR DESCRIPTION
More graceful phase out of the `schema` key for Postgres. Introduced in https://github.com/laravel/framework/pull/35463 & https://github.com/laravel/framework/pull/35588.

This PR will fallback to the old `schema` key if no `search_path` key is present in the database.php file. This way there's a smooth upgrade path for Postgres users.