### PR TITLE
[8.x] Return false on trashed() if the value in deleted_at is a future time…

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -138,7 +138,7 @@ trait SoftDeletes
         if (is_null($this->{$this->getDeletedAtColumn()})) {
             return false;
         }
-        return $this->{$this->getDeletedAtColumn()} < now();
+        return $this->{$this->getDeletedAtColumn()} <= now();
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -138,6 +138,7 @@ trait SoftDeletes
         if (is_null($this->{$this->getDeletedAtColumn()})) {
             return false;
         }
+
         return $this->{$this->getDeletedAtColumn()} <= now();
     }
 

--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -135,7 +135,10 @@ trait SoftDeletes
      */
     public function trashed()
     {
-        return ! is_null($this->{$this->getDeletedAtColumn()});
+        if (is_null($this->{$this->getDeletedAtColumn()})) {
+            return false;
+        }
+        return $this->{$this->getDeletedAtColumn()} < now();
     }
 
     /**


### PR DESCRIPTION
The current behavior of the trashed() method in the SoftDeletes trait is to return true (item is trashed) if the value in the deleted_at column is anything other than null. But that column is a timestamp, so we could let users take advantage of that fact by only returning true if the value is a timestamp right now or in the past. This would allow the user to schedule an item to be soft deleted in the future. 

A sample use case would be a contact management system that pulls contact information from external directories. When a contact disappears from a directory, it's likely that they've left the organization and that change should be reflected in my own database. But maybe they've actually just changed their name so they're still there but my scraper isn't finding them. If I can set any newly "not found" contacts to be deleted at some time in the future, I can give my ops team the time to investigate these newly missing contacts and reconcile any non-departure changes before we drop them from our database.

This PR is limited to just adding the check for a past timestamp rather than any non-null value to the trashed() method. My original vision was to build out a "scheduled soft deletion" feature, but I think for now that might be a better fit in userland. I'll probably build a package implementing my vision of it.

The reason I'm sending in this PR rather than just handling it in my package is that if this one method is changed, then my and any other userland code that might try to implement scheduled soft deletions is simple. I don't have to totally reproduce the trait or override the trashed() method via insteadof.

The original behavior of the method and the trait overall is preserved for anyone who uses the SoftDeletes trait as documented. 