### PR TITLE
[8.x] Cleanup tests

### DIFF
--- a/.github/workflows/databases.yml
+++ b/.github/workflows/databases.yml
@@ -171,7 +171,7 @@ jobs:
           command: composer update --prefer-stable --prefer-dist --no-interaction --no-progress
 
       - name: Execute tests
-        run: vendor/bin/phpunit tests/Integration/Database --verbose --exclude-group MySQL
+        run: vendor/bin/phpunit tests/Integration/Database --verbose
         env:
           DB_CONNECTION: pgsql
           DB_PASSWORD: password
@@ -213,7 +213,7 @@ jobs:
           command: composer update --prefer-stable --prefer-dist --no-interaction --no-progress
 
       - name: Execute tests
-        run: vendor/bin/phpunit tests/Integration/Database --verbose --exclude-group MySQL,SkipMSSQL
+        run: vendor/bin/phpunit tests/Integration/Database --verbose --exclude-group SkipMSSQL
         env:
           DB_CONNECTION: sqlsrv
           DB_DATABASE: master

--- a/tests/Integration/Auth/ApiAuthenticationWithEloquentTest.php
+++ b/tests/Integration/Auth/ApiAuthenticationWithEloquentTest.php
@@ -15,8 +15,6 @@ class ApiAuthenticationWithEloquentTest extends TestCase
 {
     protected function getEnvironmentSetUp($app)
     {
-        $app['config']->set('app.debug', 'true');
-
         // Auth configuration
         $app['config']->set('auth.defaults.guard', 'api');
         $app['config']->set('auth.providers.users.model', User::class);

--- a/tests/Integration/Auth/AuthenticationTest.php
+++ b/tests/Integration/Auth/AuthenticationTest.php
@@ -26,7 +26,6 @@ class AuthenticationTest extends TestCase
 {
     protected function getEnvironmentSetUp($app)
     {
-        $app['config']->set('app.debug', 'true');
         $app['config']->set('auth.providers.users.model', AuthenticationTestUser::class);
 
         $app['config']->set('database.default', 'testbench');

--- a/tests/Integration/Database/DatabaseTestCase.php
+++ b/tests/Integration/Database/DatabaseTestCase.php
@@ -6,6 +6,13 @@ use Orchestra\Testbench\TestCase;
 
 abstract class DatabaseTestCase extends TestCase
 {
+    /**
+     * The current database driver.
+     *
+     * @return string
+     */
+    protected $driver;
+
     protected function getEnvironmentSetUp($app)
     {
         $app['config']->set('database.connections.testbench', [
@@ -17,6 +24,10 @@ abstract class DatabaseTestCase extends TestCase
         if (! env('DB_CONNECTION')) {
             $app['config']->set('database.default', 'testbench');
         }
+
+        $connection = $app['config']->get('database.default');
+
+        $this->driver = $app['config']->get("database.connections.$connection.driver");
     }
 
     protected function tearDown(): void

--- a/tests/Integration/Database/DatabaseTestCase.php
+++ b/tests/Integration/Database/DatabaseTestCase.php
@@ -8,8 +8,6 @@ abstract class DatabaseTestCase extends TestCase
 {
     protected function getEnvironmentSetUp($app)
     {
-        $app['config']->set('app.debug', 'true');
-
         $app['config']->set('database.connections.testbench', [
             'driver' => 'sqlite',
             'database' => ':memory:',

--- a/tests/Integration/Database/EloquentDeleteTest.php
+++ b/tests/Integration/Database/EloquentDeleteTest.php
@@ -13,8 +13,6 @@ class EloquentDeleteTest extends TestCase
 {
     protected function getEnvironmentSetUp($app)
     {
-        $app['config']->set('app.debug', 'true');
-
         $app['config']->set('database.default', 'testbench');
 
         $app['config']->set('database.connections.testbench', [

--- a/tests/Integration/Database/EloquentDeleteTest.php
+++ b/tests/Integration/Database/EloquentDeleteTest.php
@@ -34,6 +34,7 @@ class EloquentDeleteTest extends DatabaseTestCase
         });
     }
 
+    /** @group SkipMSSQL */
     public function testDeleteWithLimit()
     {
         for ($i = 1; $i <= 10; $i++) {

--- a/tests/Integration/Database/EloquentDeleteTest.php
+++ b/tests/Integration/Database/EloquentDeleteTest.php
@@ -7,21 +7,9 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Tests\Integration\Database\Fixtures\Post;
-use Orchestra\Testbench\TestCase;
 
-class EloquentDeleteTest extends TestCase
+class EloquentDeleteTest extends DatabaseTestCase
 {
-    protected function getEnvironmentSetUp($app)
-    {
-        $app['config']->set('database.default', 'testbench');
-
-        $app['config']->set('database.connections.testbench', [
-            'driver' => 'sqlite',
-            'database' => ':memory:',
-            'prefix' => '',
-        ]);
-    }
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -46,7 +34,7 @@ class EloquentDeleteTest extends TestCase
         });
     }
 
-    public function testOnlyDeleteWhatGiven()
+    public function testDeleteWithLimit()
     {
         for ($i = 1; $i <= 10; $i++) {
             Comment::create([
@@ -57,7 +45,11 @@ class EloquentDeleteTest extends TestCase
         Post::latest('id')->limit(1)->delete();
         $this->assertCount(9, Post::all());
 
-        Post::join('comments', 'comments.post_id', '=', 'posts.id')->where('posts.id', '>', 1)->orderBy('posts.id')->limit(1)->delete();
+        Post::join('comments', 'comments.post_id', '=', 'posts.id')
+            ->where('posts.id', '>', 8)
+            ->orderBy('posts.id')
+            ->limit(1)
+            ->delete();
         $this->assertCount(8, Post::all());
     }
 

--- a/tests/Integration/Database/EloquentHasOneOfManyTest.php
+++ b/tests/Integration/Database/EloquentHasOneOfManyTest.php
@@ -22,12 +22,6 @@ class EloquentHasOneOfManyTest extends DatabaseTestCase
         });
     }
 
-    protected function getEnvironmentSetUp($app)
-    {
-        parent::getEnvironmentSetUp($app);
-        $app['config']->set('app.debug', 'true');
-    }
-
     public function testItOnlyEagerLoadsRequiredModels()
     {
         $this->retrievedLogins = 0;

--- a/tests/Integration/Database/EloquentModelConnectionsTest.php
+++ b/tests/Integration/Database/EloquentModelConnectionsTest.php
@@ -12,8 +12,6 @@ class EloquentModelConnectionsTest extends TestCase
 {
     protected function getEnvironmentSetUp($app)
     {
-        $app['config']->set('app.debug', 'true');
-
         $app['config']->set('database.default', 'conn1');
 
         $app['config']->set('database.connections.conn1', [

--- a/tests/Integration/Database/EloquentUpdateTest.php
+++ b/tests/Integration/Database/EloquentUpdateTest.php
@@ -48,6 +48,7 @@ class EloquentUpdateTest extends DatabaseTestCase
         $this->assertCount(0, TestUpdateModel1::all());
     }
 
+    /** @group SkipMSSQL */
     public function testUpdateWithLimitsAndOrders()
     {
         for ($i = 1; $i <= 10; $i++) {
@@ -112,7 +113,7 @@ class EloquentUpdateTest extends DatabaseTestCase
 
         TestUpdateModel3::increment('counter');
 
-        $models = TestUpdateModel3::withoutGlobalScopes()->get();
+        $models = TestUpdateModel3::withoutGlobalScopes()->orderBy('id')->get();
         $this->assertEquals(1, $models[0]->counter);
         $this->assertEquals(0, $models[1]->counter);
     }

--- a/tests/Integration/Database/EloquentUpdateTest.php
+++ b/tests/Integration/Database/EloquentUpdateTest.php
@@ -7,21 +7,9 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
-use Orchestra\Testbench\TestCase;
 
-class EloquentUpdateTest extends TestCase
+class EloquentUpdateTest extends DatabaseTestCase
 {
-    protected function getEnvironmentSetUp($app)
-    {
-        $app['config']->set('database.default', 'testbench');
-
-        $app['config']->set('database.connections.testbench', [
-            'driver' => 'sqlite',
-            'database' => ':memory:',
-            'prefix' => '',
-        ]);
-    }
-
     protected function setUp(): void
     {
         parent::setUp();

--- a/tests/Integration/Database/EloquentUpdateTest.php
+++ b/tests/Integration/Database/EloquentUpdateTest.php
@@ -13,8 +13,6 @@ class EloquentUpdateTest extends TestCase
 {
     protected function getEnvironmentSetUp($app)
     {
-        $app['config']->set('app.debug', 'true');
-
         $app['config']->set('database.default', 'testbench');
 
         $app['config']->set('database.connections.testbench', [

--- a/tests/Integration/Database/MigrateWithRealpathTest.php
+++ b/tests/Integration/Database/MigrateWithRealpathTest.php
@@ -9,8 +9,6 @@ class MigrateWithRealpathTest extends TestCase
 {
     protected function getEnvironmentSetUp($app)
     {
-        $app['config']->set('app.debug', 'true');
-
         $app['config']->set('database.connections.testbench', [
             'driver' => 'sqlite',
             'database' => ':memory:',

--- a/tests/Integration/Database/MySql/DatabaseEmulatePreparesMySqlConnectionTest.php
+++ b/tests/Integration/Database/MySql/DatabaseEmulatePreparesMySqlConnectionTest.php
@@ -1,11 +1,10 @@
 <?php
 
-namespace Illuminate\Tests\Integration\Database;
+namespace Illuminate\Tests\Integration\Database\MySql;
 
 use PDO;
 
 /**
- * @group MySQL
  * @requires extension pdo_mysql
  * @requires OS Linux|Darwin
  */

--- a/tests/Integration/Database/MySql/DatabaseMySqlConnectionTest.php
+++ b/tests/Integration/Database/MySql/DatabaseMySqlConnectionTest.php
@@ -5,7 +5,6 @@ namespace Illuminate\Tests\Integration\Database\MySql;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Tests\Integration\Database\MySql\MySqlTestCase;
 
 /**
  * @requires extension pdo_mysql

--- a/tests/Integration/Database/MySql/DatabaseMySqlConnectionTest.php
+++ b/tests/Integration/Database/MySql/DatabaseMySqlConnectionTest.php
@@ -1,29 +1,22 @@
 <?php
 
-namespace Illuminate\Tests\Integration\Database;
+namespace Illuminate\Tests\Integration\Database\MySql;
 
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Tests\Integration\Database\MySQL\MySqlTestCase;
 
 /**
- * @group MySQL
  * @requires extension pdo_mysql
  * @requires OS Linux|Darwin
  */
-class DatabaseMySqlConnectionTest extends DatabaseTestCase
+class DatabaseMySqlConnectionTest extends MySqlTestCase
 {
     const TABLE = 'player';
     const FLOAT_COL = 'float_col';
     const JSON_COL = 'json_col';
     const FLOAT_VAL = 0.2;
-
-    protected function getEnvironmentSetUp($app)
-    {
-        parent::getEnvironmentSetUp($app);
-
-        $app['config']->set('database.default', 'mysql');
-    }
 
     protected function setUp(): void
     {

--- a/tests/Integration/Database/MySql/DatabaseMySqlConnectionTest.php
+++ b/tests/Integration/Database/MySql/DatabaseMySqlConnectionTest.php
@@ -5,7 +5,7 @@ namespace Illuminate\Tests\Integration\Database\MySql;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Tests\Integration\Database\MySQL\MySqlTestCase;
+use Illuminate\Tests\Integration\Database\MySql\MySqlTestCase;
 
 /**
  * @requires extension pdo_mysql

--- a/tests/Integration/Database/MySql/DatabaseMySqlSchemaBuilderAlterTableWithEnumTest.php
+++ b/tests/Integration/Database/MySql/DatabaseMySqlSchemaBuilderAlterTableWithEnumTest.php
@@ -1,25 +1,17 @@
 <?php
 
-namespace Illuminate\Tests\Integration\Database;
+namespace Illuminate\Tests\Integration\Database\MySql;
 
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use stdClass;
 
 /**
- * @group MySQL
  * @requires extension pdo_mysql
  * @requires OS Linux|Darwin
  */
-class DatabaseMySqlSchemaBuilderAlterTableWithEnumTest extends DatabaseTestCase
+class DatabaseMySqlSchemaBuilderAlterTableWithEnumTest extends MySqlTestCase
 {
-    protected function getEnvironmentSetUp($app)
-    {
-        parent::getEnvironmentSetUp($app);
-
-        $app['config']->set('database.default', 'mysql');
-    }
-
     protected function setUp(): void
     {
         parent::setUp();

--- a/tests/Integration/Database/MySql/MySqlTestCase.php
+++ b/tests/Integration/Database/MySql/MySqlTestCase.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\MySql;
+
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+abstract class MySqlTestCase extends DatabaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if ($this->driver !== 'mysql') {
+            $this->markTestSkipped('Test requires a MySQL connection.');
+        }
+    }
+}

--- a/tests/Integration/Database/RefreshCommandTest.php
+++ b/tests/Integration/Database/RefreshCommandTest.php
@@ -9,8 +9,6 @@ class RefreshCommandTest extends TestCase
 {
     protected function getEnvironmentSetUp($app)
     {
-        $app['config']->set('app.debug', 'true');
-
         $app['config']->set('database.connections.testbench', [
             'driver' => 'sqlite',
             'database' => ':memory:',

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -40,10 +40,7 @@ class SchemaBuilderTest extends DatabaseTestCase
 
     public function testRegisterCustomDoctrineType()
     {
-        $connection = $this->app['config']->get('database.default');
-        $driver = $this->app['config']->get("database.connections.$connection.driver");
-
-        if ($driver !== 'sqlite') {
+        if ($this->driver !== 'sqlite') {
             $this->markTestSkipped('Test requires a SQLite connection.');
         }
 

--- a/tests/Integration/Events/EventFakeTest.php
+++ b/tests/Integration/Events/EventFakeTest.php
@@ -19,8 +19,6 @@ class EventFakeTest extends TestCase
      */
     protected function getEnvironmentSetUp($app)
     {
-        $app['config']->set('app.debug', 'true');
-
         // Database configuration
         $app['config']->set('database.default', 'testbench');
 

--- a/tests/Integration/Foundation/FoundationHelpersTest.php
+++ b/tests/Integration/Foundation/FoundationHelpersTest.php
@@ -68,6 +68,7 @@ class FoundationHelpersTest extends TestCase
     public function testMixSilentlyFailsWhenAssetIsMissingFromManifestWhenNotInDebugMode()
     {
         $this->app['config']->set('app.debug', false);
+
         $manifest = $this->makeManifest();
 
         $path = mix('missing.js');
@@ -83,6 +84,7 @@ class FoundationHelpersTest extends TestCase
         $this->expectExceptionMessage('Unable to locate Mix file: /missing.js.');
 
         $this->app['config']->set('app.debug', true);
+
         $manifest = $this->makeManifest();
 
         try {
@@ -99,7 +101,9 @@ class FoundationHelpersTest extends TestCase
         $handler = new FakeHandler;
         $this->app->instance(ExceptionHandler::class, $handler);
         $this->app['config']->set('app.debug', true);
+
         $manifest = $this->makeManifest();
+
         Route::get('test-route', function () {
             mix('missing.js');
         });

--- a/tests/Integration/Mail/SendingMailWithLocaleTest.php
+++ b/tests/Integration/Mail/SendingMailWithLocaleTest.php
@@ -17,8 +17,6 @@ class SendingMailWithLocaleTest extends TestCase
 {
     protected function getEnvironmentSetUp($app)
     {
-        $app['config']->set('app.debug', 'true');
-
         $app['config']->set('mail.driver', 'array');
 
         $app['config']->set('app.locale', 'en');

--- a/tests/Integration/Migration/MigratorTest.php
+++ b/tests/Integration/Migration/MigratorTest.php
@@ -27,8 +27,6 @@ class MigratorTest extends TestCase
 
     protected function getEnvironmentSetUp($app)
     {
-        $app['config']->set('app.debug', 'true');
-
         $app['config']->set('database.default', 'testbench');
         $app['config']->set('database.connections.testbench', [
             'driver' => 'sqlite',

--- a/tests/Integration/Notifications/SendingMailNotificationsTest.php
+++ b/tests/Integration/Notifications/SendingMailNotificationsTest.php
@@ -33,8 +33,6 @@ class SendingMailNotificationsTest extends TestCase
 
     protected function getEnvironmentSetUp($app)
     {
-        $app['config']->set('app.debug', 'true');
-
         $app['config']->set('database.default', 'testbench');
 
         $app['config']->set('database.connections.testbench', [

--- a/tests/Integration/Notifications/SendingNotificationsViaAnonymousNotifiableTest.php
+++ b/tests/Integration/Notifications/SendingNotificationsViaAnonymousNotifiableTest.php
@@ -12,11 +12,6 @@ class SendingNotificationsViaAnonymousNotifiableTest extends TestCase
 {
     public $mailer;
 
-    protected function getEnvironmentSetUp($app)
-    {
-        $app['config']->set('app.debug', 'true');
-    }
-
     public function testMailIsSent()
     {
         $notifiable = (new AnonymousNotifiable)

--- a/tests/Integration/Notifications/SendingNotificationsWithLocaleTest.php
+++ b/tests/Integration/Notifications/SendingNotificationsWithLocaleTest.php
@@ -25,8 +25,6 @@ class SendingNotificationsWithLocaleTest extends TestCase
 
     protected function getEnvironmentSetUp($app)
     {
-        $app['config']->set('app.debug', 'true');
-
         $app['config']->set('mail.driver', 'array');
 
         $app['config']->set('app.locale', 'en');

--- a/tests/Integration/Queue/JobChainingTest.php
+++ b/tests/Integration/Queue/JobChainingTest.php
@@ -16,8 +16,6 @@ class JobChainingTest extends TestCase
 
     protected function getEnvironmentSetUp($app)
     {
-        $app['config']->set('app.debug', 'true');
-
         $app['config']->set('database.default', 'testbench');
 
         $app['config']->set('queue.connections.sync1', [

--- a/tests/Integration/Queue/JobDispatchingTest.php
+++ b/tests/Integration/Queue/JobDispatchingTest.php
@@ -9,11 +9,6 @@ use Orchestra\Testbench\TestCase;
 
 class JobDispatchingTest extends TestCase
 {
-    protected function getEnvironmentSetUp($app)
-    {
-        $app['config']->set('app.debug', 'true');
-    }
-
     protected function tearDown(): void
     {
         Job::$ran = false;

--- a/tests/Integration/Queue/JobEncryptionTest.php
+++ b/tests/Integration/Queue/JobEncryptionTest.php
@@ -22,7 +22,6 @@ class JobEncryptionTest extends DatabaseTestCase
         parent::getEnvironmentSetUp($app);
 
         $app['config']->set('app.key', Str::random(32));
-        $app['config']->set('app.debug', 'true');
         $app['config']->set('queue.default', 'database');
     }
 

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -15,8 +15,6 @@ class ModelSerializationTest extends TestCase
 {
     protected function getEnvironmentSetUp($app)
     {
-        $app['config']->set('app.debug', 'true');
-
         $app['config']->set('database.default', 'testbench');
 
         $app['config']->set('database.connections.testbench', [

--- a/tests/Integration/Queue/QueueConnectionTest.php
+++ b/tests/Integration/Queue/QueueConnectionTest.php
@@ -15,7 +15,6 @@ class QueueConnectionTest extends TestCase
 {
     protected function getEnvironmentSetUp($app)
     {
-        $app['config']->set('app.debug', 'true');
         $app['config']->set('queue.default', 'sqs');
         $app['config']->set('queue.connections.sqs.after_commit', true);
     }

--- a/tests/Integration/Queue/WorkCommandTest.php
+++ b/tests/Integration/Queue/WorkCommandTest.php
@@ -13,8 +13,6 @@ class WorkCommandTest extends TestCase
 {
     protected function getEnvironmentSetUp($app)
     {
-        $app['config']->set('app.debug', 'true');
-
         $app['config']->set('database.default', 'testbench');
         $app['config']->set('database.connections.testbench', [
             'driver' => 'sqlite',

--- a/tests/Integration/Routing/ImplicitRouteBindingTest.php
+++ b/tests/Integration/Routing/ImplicitRouteBindingTest.php
@@ -18,9 +18,6 @@ class ImplicitRouteBindingTest extends TestCase
         'routes/testbench.php',
     ];
 
-    /**
-     * Teardown the test environment.
-     */
     protected function tearDown(): void
     {
         $this->tearDownInteractsWithPublishedFiles();
@@ -30,8 +27,6 @@ class ImplicitRouteBindingTest extends TestCase
 
     protected function defineEnvironment($app)
     {
-        $app['config']->set('app.debug', 'true');
-
         $app['config']->set('database.default', 'testbench');
 
         $app['config']->set('database.connections.testbench', [


### PR DESCRIPTION
This PR contains the following changes:

- Do not explicitly set debug mode anymore. These calls were probably legacy code lingering.
- Move MySQL specific tests in a separate MySql directory so they're grouped per-engine and easier discoverable. This way we can remove the `@group` call as well.
- Modify `EloquentUpdateTest` & `EloquentDeleteTest` to run on all engines and skip a few tests on MSSQL.