### PR TITLE
[8.x] Fix assertDownload if testing against a filename with spaces in it

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -422,7 +422,7 @@ EOF;
                 PHPUnit::assertSame(
                     $filename,
                     isset(explode('=', $contentDisposition[1])[1])
-                        ? trim(explode('=', $contentDisposition[1])[1])
+                        ? trim(explode('=', $contentDisposition[1])[1], " \"'")
                         : '',
                     $message
                 );

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -1429,6 +1429,21 @@ class TestResponseTest extends TestCase
         $files->deleteDirectory($tempDir);
     }
 
+    public function testAssertDownloadOfferedWithAFileNameWithSpacesInIt()
+    {
+        $files = new Filesystem;
+        $tempDir = __DIR__.'/tmp';
+        $files->makeDirectory($tempDir, 0755, false, true);
+        $files->put($tempDir.'/file.txt', 'Hello World');
+        $testResponse = TestResponse::fromBaseResponse(new Response(
+            $files->get($tempDir.'/file.txt'), 200, [
+                'Content-Disposition' => 'attachment; filename = "test file.txt"',
+            ]
+        ));
+        $testResponse->assertDownload('test file.txt');
+        $files->deleteDirectory($tempDir);
+    }
+
     public function testMacroable()
     {
         TestResponse::macro('foo', function () {


### PR DESCRIPTION
This PR will fix an unexpected assertion failures when trying to check a `TestResponse` download filename:

let's suppose we are testing a method that returns a storage download:

```php
Storage::download('file.txt', 'test file.txt');
```

the generated `StreamedResponse` will have this header:

> content-disposition: attachment; filename="test file.txt"

as TestResponse checks `->assertDownload('test file.txt')` against that header, it will trow a failure because

```
test file.txt != "test file.txt"
```

the only way I found to make this to pass is to check `->assertDownload('"test file.txt"')`


My PR aims to fix this by adding a quotes trimming to the assertion
