### PR TITLE
[9.x] Adds timestamp awareness to `SoftDeletes`

### DIFF
--- a/src/Illuminate/Database/Eloquent/BroadcastsEvents.php
+++ b/src/Illuminate/Database/Eloquent/BroadcastsEvents.php
@@ -26,6 +26,10 @@ trait BroadcastsEvents
                 $model->broadcastTrashed();
             });
 
+            static::willTrash(function ($model) {
+                $model->broadcastWillTrash();
+            });
+
             static::restored(function ($model) {
                 $model->broadcastRestored();
             });
@@ -72,6 +76,19 @@ trait BroadcastsEvents
     {
         return $this->broadcastIfBroadcastChannelsExistForEvent(
             $this->newBroadcastableModelEvent('trashed'), 'trashed', $channels
+        );
+    }
+
+    /**
+     * Broadcast that the model will be trashed.
+     *
+     * @param  \Illuminate\Broadcasting\Channel|\Illuminate\Contracts\Broadcasting\HasBroadcastChannel|array|null  $channels
+     * @return \Illuminate\Broadcasting\PendingBroadcast
+     */
+    public function broadcastWillTrash($channels = null)
+    {
+        return $this->broadcastIfBroadcastChannelsExistForEvent(
+            $this->newBroadcastableModelEvent('willTrash'), 'willTrash', $channels
         );
     }
 

--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -111,7 +111,7 @@ trait SoftDeletes
      * @param  \DateTimeInterface|string  $datetime
      * @return void
      */
-    public function deleteAt($datetime)
+    public function trashAt($datetime)
     {
         if ($this->freshTimestamp() >= $datetime) {
             throw new InvalidArgumentException('The datetime must be set in the future.');

--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -184,7 +184,7 @@ trait SoftDeletes
     /**
      * Register a "willTrash" model event callback with the dispatcher.
      *
-     * @param \Closure|string $callback
+     * @param  \Closure|string  $callback
      * @return void
      */
     public static function willTrash($callback)

--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -8,7 +8,7 @@ use InvalidArgumentException;
  * @method static static|\Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder withTrashed(bool $withTrashed = true)
  * @method static static|\Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder onlyTrashed()
  * @method static static|\Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder withoutTrashed()
- * @method static static|\Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder futureTrashed()
+ * @method static static|\Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder willBeTrashed()
  * @method static static|\Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder deleteAt(\DateTimeInterface $datetime)
  */
 trait SoftDeletes

--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -116,7 +116,7 @@ trait SoftDeletes
             throw new InvalidArgumentException("The $datetime must be set in the future.");
         }
 
-        $this->runSoftDelete($datetime, 'willTrash')
+        $this->runSoftDelete($datetime, 'willTrash');
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -9,6 +9,7 @@ use InvalidArgumentException;
  * @method static static|\Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder onlyTrashed()
  * @method static static|\Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder withoutTrashed()
  * @method static static|\Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder futureTrashed()
+ * @method static static|\Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder deleteAt(\DateTimeInterface $datetime)
  */
 trait SoftDeletes
 {

--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -113,7 +113,7 @@ trait SoftDeletes
     public function deleteAt($datetime)
     {
         if ($this->freshTimestamp() >= $datetime) {
-            throw new InvalidArgumentException("The $datetime must be set in the future.");
+            throw new InvalidArgumentException('The datetime must be set in the future.');
         }
 
         $this->runSoftDelete($datetime, 'willTrash');
@@ -164,7 +164,7 @@ trait SoftDeletes
      */
     public function willBeTrashed()
     {
-        return (bool) $this->{$this->getDeletedAtColumn}}?->isFuture();
+        return (bool) $this->{$this->getDeletedAtColumn()}?->isFuture();
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -86,18 +86,16 @@ trait SoftDeletes
     {
         $query = $this->setKeysForSaveQuery($this->newModelQuery());
 
-        $time = $this->fromDateTime($time);
-
-        $columns = [$this->getDeletedAtColumn() => $time];
+        $columns = [$this->getDeletedAtColumn() => $this->fromDateTime($time)];
 
         $this->{$this->getDeletedAtColumn()} = $time;
 
         if ($this->timestamps && ! is_null($this->getUpdatedAtColumn())) {
             $updatedAt = $this->freshTimestamp();
 
-            $columns[$this->getUpdatedAtColumn()] = $updatedAt;
-
             $this->{$this->getUpdatedAtColumn()} = $updatedAt;
+
+            $columns[$this->getUpdatedAtColumn()] = $this->fromDateTime($updatedAt);
         }
 
         $query->update($columns);

--- a/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
@@ -139,7 +139,7 @@ class SoftDeletingScope implements Scope
      */
     protected function addFutureTrashed(Builder $builder)
     {
-        $builder->macro('futureTrashed', function (Builder $builder)) {
+        $builder->macro('futureTrashed', function (Builder $builder) {
             $model = $builder->getModel();
 
             $builder->withoutGlobalScope($this)->where(
@@ -147,6 +147,6 @@ class SoftDeletingScope implements Scope
             );
 
             return $builder;
-        }
+        });
     }
 }

--- a/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
@@ -24,7 +24,9 @@ class SoftDeletingScope implements Scope
     {
         $column = $model->getQualifiedDeletedAtColumn();
 
-        $builder->whereNull($column)->orWhere($column, '>', now());
+        $builder->where(function ($query) use ($column) {
+            $query->whereNull($column)->orWhere($column, '>', now());
+        });
     }
 
     /**
@@ -104,13 +106,11 @@ class SoftDeletingScope implements Scope
     protected function addWithoutTrashed(Builder $builder)
     {
         $builder->macro('withoutTrashed', function (Builder $builder) {
-            $model = $builder->getModel();
+            $column = $builder->getModel()->getQualifiedDeletedAtColumn();
 
-            $builder->withoutGlobalScope($this)->whereNull(
-                $model->getQualifiedDeletedAtColumn()
-            )->orWhere(
-                $model->getQualifiedDeletedAtColumn(), '>', now()
-            );
+            $builder->withoutGlobalScope($this)->where(function ($query) use ($column) {
+                $query->whereNull($column)->orWhere($column, '>', now());
+            });
 
             return $builder;
         });

--- a/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
@@ -7,11 +7,11 @@ use InvalidArgumentException;
 class SoftDeletingScope implements Scope
 {
     /**
-     * All of the extensions to be added to the builder.
+     * All the extensions to be added to the builder.
      *
      * @var string[]
      */
-    protected $extensions = ['Restore', 'WithTrashed', 'WithoutTrashed', 'OnlyTrashed', 'PendingTrash', 'DeleteAt'];
+    protected $extensions = ['Restore', 'WithTrashed', 'WithoutTrashed', 'OnlyTrashed', 'PendingTrash', 'TrashAt'];
 
     /**
      * Apply the scope to a given Eloquent query builder.
@@ -155,14 +155,14 @@ class SoftDeletingScope implements Scope
     }
 
     /**
-     * Add the delete-at extension to the builder.
+     * Add the trash-at extension to the builder.
      *
      * @param  \Illuminate\Database\Eloquent\Builder  $builder
      * @return void
      */
-    protected function addDeleteAt(Builder $builder)
+    protected function addTrashAt(Builder $builder)
     {
-        $builder->macro('deleteAt', function (Builder $builder, $datetime) {
+        $builder->macro('trashAt', function (Builder $builder, $datetime) {
             $model = $builder->getModel();
 
             if ($model->freshTimestamp() >= $datetime = $model->fromDateTime($datetime)) {

--- a/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
@@ -9,7 +9,7 @@ class SoftDeletingScope implements Scope
      *
      * @var string[]
      */
-    protected $extensions = ['Restore', 'WithTrashed', 'WithoutTrashed', 'OnlyTrashed'];
+    protected $extensions = ['Restore', 'WithTrashed', 'WithoutTrashed', 'OnlyTrashed', 'FutureTrashed'];
 
     /**
      * Apply the scope to a given Eloquent query builder.
@@ -104,6 +104,8 @@ class SoftDeletingScope implements Scope
 
             $builder->withoutGlobalScope($this)->whereNull(
                 $model->getQualifiedDeletedAtColumn()
+            )->orWhere(
+                $model->getQualifiedDeletedAtColumn(), '>', now()
             );
 
             return $builder;
@@ -121,11 +123,30 @@ class SoftDeletingScope implements Scope
         $builder->macro('onlyTrashed', function (Builder $builder) {
             $model = $builder->getModel();
 
-            $builder->withoutGlobalScope($this)->whereNotNull(
-                $model->getQualifiedDeletedAtColumn()
+            $builder->withoutGlobalScope($this)->where(
+                $model->getQualifiedDeletedAtColumn(), '<=', now()
             );
 
             return $builder;
         });
+    }
+
+    /**
+     * Add the future-trashed extension to the builder.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $builder
+     * @return void
+     */
+    protected function addFutureTrashed(Builder $builder)
+    {
+        $builder->macro('futureTrashed', function (Builder $builder)) {
+            $model = $builder->getModel();
+
+            $builder->withoutGlobalScope($this)->where(
+                $model->getQualifiedDeletedAtColumn(), '>', now()
+            );
+
+            return $builder;
+        }
     }
 }

--- a/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
@@ -172,7 +172,7 @@ class SoftDeletingScope implements Scope
             $builder->withTrashed();
 
             return $builder->update([
-                $model->getDeletedAtColumn() => $datetime
+                $model->getDeletedAtColumn() => $datetime,
             ]);
         });
     }

--- a/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Database\Eloquent;
 
+use InvalidArgumentException;
+
 class SoftDeletingScope implements Scope
 {
     /**
@@ -160,7 +162,7 @@ class SoftDeletingScope implements Scope
     {
         $builder->macro('deleteAt', function (Builder $builder, $datetime) {
             if ($builder->getModel()->freshTimestamp() >= $datetime) {
-                throw new InvalidArgumentException("The $datetime must be set in the future.");
+                throw new InvalidArgumentException('The datetime must be set in the future.');
             }
 
             $builder->withTrashed();

--- a/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
@@ -9,7 +9,7 @@ class SoftDeletingScope implements Scope
      *
      * @var string[]
      */
-    protected $extensions = ['Restore', 'WithTrashed', 'WithoutTrashed', 'OnlyTrashed', 'FutureTrashed', 'DeleteAt'];
+    protected $extensions = ['Restore', 'WithTrashed', 'WithoutTrashed', 'OnlyTrashed', 'WillBeTrashed', 'DeleteAt'];
 
     /**
      * Apply the scope to a given Eloquent query builder.
@@ -137,9 +137,9 @@ class SoftDeletingScope implements Scope
      * @param  \Illuminate\Database\Eloquent\Builder  $builder
      * @return void
      */
-    protected function addFutureTrashed(Builder $builder)
+    protected function addWillBeTrashed(Builder $builder)
     {
-        $builder->macro('futureTrashed', function (Builder $builder) {
+        $builder->macro('willBeTrashed', function (Builder $builder) {
             $model = $builder->getModel();
 
             $builder->withoutGlobalScope($this)->where(

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -1089,7 +1089,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $abigail->deleteAt(now()->addDay());
         $comment = SoftDeletesTestCommentWithTrashed::with('owner')->first();
 
-        $this->assertNull($comment->owner);
+        $this->assertNotNull($comment->owner);
 
         $abigail->delete();
         $comment = SoftDeletesTestCommentWithTrashed::with('owner')->first();

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -179,7 +179,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $this->assertNull(SoftDeletesTestUser::find(2)->deleted_at);
     }
 
-    public function testDeleteAtSetsDeleteColumnInFuture()
+    public function testTrashAtSetsDeleteColumnInFuture()
     {
         $this->createUsers();
         $this->assertInstanceOf(Carbon::class, SoftDeletesTestUser::withTrashed()->find(3)->deleted_at);
@@ -333,7 +333,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
 
         /** @var \Illuminate\Tests\Database\SoftDeletesTestUser $userModel */
         $userModel = SoftDeletesTestUser::find(2);
-        $userModel->deleteAt($now->addDay());
+        $userModel->trashAt($now->addDay());
         $this->assertEquals($now->toDateTimeString(), $userModel->getOriginal('deleted_at'));
         $this->assertEquals($userModel, SoftDeletesTestUser::find(2));
     }
@@ -356,13 +356,13 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
     /**
      * @throws \Exception
      */
-    public function testRestoreAfterSoftDeleteAt()
+    public function testRestoreAfterSoftTrashAt()
     {
         $this->createUsers();
 
         /** @var \Illuminate\Tests\Database\SoftDeletesTestUser $userModel */
         $userModel = SoftDeletesTestUser::find(2);
-        $userModel->deleteAt(now()->addDay());
+        $userModel->trashAt(now()->addDay());
         $userModel->restore();
 
         $this->assertEquals($userModel->id, SoftDeletesTestUser::find(2)->id);
@@ -390,7 +390,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
     /**
      * @throws \Exception
      */
-    public function testSoftDeleteAtAfterRestoring()
+    public function testSoftTrashAtAfterRestoring()
     {
         $this->createUsers();
 
@@ -399,7 +399,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $userModel->restore();
         $this->assertEquals($userModel->deleted_at, SoftDeletesTestUser::find(1)->deleted_at);
         $this->assertEquals($userModel->getOriginal('deleted_at'), SoftDeletesTestUser::find(1)->deleted_at);
-        $userModel->deleteAt($deletedAt = now()->addDay()->startOfSecond());
+        $userModel->trashAt($deletedAt = now()->addDay()->startOfSecond());
         $this->assertNotNull(SoftDeletesTestUser::find(1));
         $this->assertEquals($deletedAt, SoftDeletesTestUser::find(1)->deleted_at);
         $this->assertEquals($userModel->deleted_at, SoftDeletesTestUser::withTrashed()->find(1)->deleted_at);
@@ -427,7 +427,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         /** @var \Illuminate\Tests\Database\SoftDeletesTestUser $userModel */
         $userModel = SoftDeletesTestUser::find(2);
         $userModel->email = 'foo@bar.com';
-        $userModel->deleteAt(now()->addDay());
+        $userModel->trashAt(now()->addDay());
         $userModel->restore();
 
         $this->assertEquals($userModel->id, SoftDeletesTestUser::find(2)->id);
@@ -494,7 +494,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $abigail->address()->create(['address' => 'Laravel avenue 43']);
 
         // delete on builder
-        $abigail->address()->deleteAt(now()->addDay());
+        $abigail->address()->trashAt(now()->addDay());
 
         $abigail = $abigail->fresh();
 
@@ -510,7 +510,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $this->assertSame('Laravel avenue 43', $abigail->address->address);
 
         // delete on model
-        $abigail->address->deleteAt(now()->addDay());
+        $abigail->address->trashAt(now()->addDay());
 
         $abigail = $abigail->fresh();
 
@@ -576,7 +576,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $abigail->save();
 
         // delete on builder
-        $abigail->group()->deleteAt(now()->addDay());
+        $abigail->group()->trashAt(now()->addDay());
 
         $abigail = $abigail->fresh();
 
@@ -592,7 +592,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $this->assertSame('admin', $abigail->group->name);
 
         // delete on model
-        $abigail->group->deleteAt(now()->addDay());
+        $abigail->group->trashAt(now()->addDay());
 
         $abigail = $abigail->fresh();
 
@@ -649,7 +649,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $abigail->posts()->create(['title' => 'Second Title']);
 
         // delete on builder
-        $abigail->posts()->where('title', 'Second Title')->deleteAt(now()->addDay());
+        $abigail->posts()->where('title', 'Second Title')->trashAt(now()->addDay());
 
         $abigail = $abigail->fresh();
 
@@ -698,7 +698,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $post = $abigail->posts()->create(['title' => 'First Title']);
         $post->comments()->create(['body' => 'Comment Body']);
 
-        $abigail->posts()->first()->comments()->deleteAt(now()->addDay());
+        $abigail->posts()->first()->comments()->trashAt(now()->addDay());
 
         $abigail = $abigail->fresh();
 
@@ -738,7 +738,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $this->assertCount(1, $users);
 
         // With Post Deleted at...
-        $post->deleteAt(now()->addDay());
+        $post->trashAt(now()->addDay());
         $users = SoftDeletesTestUser::has('posts')->get();
         $this->assertCount(1, $users);
 
@@ -782,7 +782,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
 
         $abigail = SoftDeletesTestUser::where('email', 'abigailotwell@gmail.com')->first();
         $post = $abigail->posts()->create(['title' => 'First Title']);
-        $post->deleteAt(now()->addDay());
+        $post->trashAt(now()->addDay());
 
         $users = SoftDeletesTestUser::has('posts')->get();
         $this->assertCount(1, $users);
@@ -826,7 +826,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $abigail = SoftDeletesTestUser::where('email', 'abigailotwell@gmail.com')->first();
         $post = $abigail->posts()->create(['title' => 'First Title']);
         $comment = $post->comments()->create(['body' => 'Comment Body']);
-        $comment->deleteAt(now()->addDay());
+        $comment->trashAt(now()->addDay());
 
         $users = SoftDeletesTestUser::has('posts.comments')->get();
         $this->assertCount(1, $users);
@@ -861,7 +861,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
 
         $abigail = SoftDeletesTestUserWithTrashedPosts::where('email', 'abigailotwell@gmail.com')->first();
         $post = $abigail->posts()->create(['title' => 'First Title']);
-        $post->deleteAt(now()->addDay());
+        $post->trashAt(now()->addDay());
 
         $users = SoftDeletesTestUserWithTrashedPosts::has('posts')->get();
         $this->assertCount(1, $users);
@@ -912,7 +912,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
 
         $abigail = SoftDeletesTestUser::where('email', 'abigailotwell@gmail.com')->first();
         $post1 = $abigail->posts()->create(['title' => 'First Title']);
-        $post1->deleteAt(now()->addDay());
+        $post1->trashAt(now()->addDay());
         $abigail->posts()->create(['title' => 'Second Title']);
         $abigail->posts()->create(['title' => 'Third Title']);
 
@@ -1004,7 +1004,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
             'owner_id' => $abigail->id,
         ]);
 
-        $abigail->deleteAt(now()->addDay());
+        $abigail->trashAt(now()->addDay());
 
         $comment = SoftDeletesTestCommentWithTrashed::with(['owner' => function ($q) {
             $q->withoutGlobalScope(SoftDeletingScope::class);
@@ -1086,7 +1086,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
 
         $this->assertEquals($abigail->email, $comment->owner->email);
 
-        $abigail->deleteAt(now()->addDay());
+        $abigail->trashAt(now()->addDay());
         $comment = SoftDeletesTestCommentWithTrashed::with('owner')->first();
 
         $this->assertNotNull($comment->owner);
@@ -1127,7 +1127,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $marc = SoftDeletesTestUser::create(['id' => 3, 'email' => 'marcotwell@gmail.com']);
 
         $taylor->delete();
-        $marc->deleteAt(now()->addDay());
+        $marc->trashAt(now()->addDay());
     }
 
     /**

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -366,7 +366,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $userModel->restore();
 
         $this->assertEquals($userModel->id, SoftDeletesTestUser::find(2)->id);
-        $this->assertNull( SoftDeletesTestUser::find(2)->deleted_at);
+        $this->assertNull(SoftDeletesTestUser::find(2)->deleted_at);
     }
 
     /**

--- a/tests/Database/DatabaseSoftDeletingScopeTest.php
+++ b/tests/Database/DatabaseSoftDeletingScopeTest.php
@@ -201,9 +201,9 @@ class DatabaseSoftDeletingScopeTest extends TestCase
 
         $scope = new SoftDeletingScope;
         $scope->extend($builder);
-        $callback = $builder->getMacro('deleteAt');
+        $callback = $builder->getMacro('trashAt');
         $givenBuilder = m::mock(EloquentBuilder::class);
-        $givenBuilder->shouldReceive('withTrashed')->once();
+        $givenBuilder->shouldReceive('withTrashed')->once()->andReturn($givenBuilder);
         $givenBuilder->shouldReceive('getModel')->once()->andReturn($model = m::mock(stdClass::class));
         $model->shouldReceive('fromDateTime')->once()->with($now)->andReturn($now->format('Y-m-d H:i:s'));
         $model->shouldReceive('getDeletedAtColumn')->once()->andReturn('deleted_at');
@@ -230,7 +230,7 @@ class DatabaseSoftDeletingScopeTest extends TestCase
 
         $scope = new SoftDeletingScope;
         $scope->extend($builder);
-        $callback = $builder->getMacro('deleteAt');
+        $callback = $builder->getMacro('trashAt');
         $givenBuilder = m::mock(EloquentBuilder::class);
         $givenBuilder->shouldReceive('getModel')->once()->andReturn($model = m::mock(stdClass::class));
         $model->shouldReceive('freshTimestamp')->once()->andReturn(now());
@@ -258,7 +258,7 @@ class DatabaseSoftDeletingScopeTest extends TestCase
 
         $scope = new SoftDeletingScope;
         $scope->extend($builder);
-        $callback = $builder->getMacro('deleteAt');
+        $callback = $builder->getMacro('trashAt');
         $givenBuilder = m::mock(EloquentBuilder::class);
         $givenBuilder->shouldReceive('getModel')->once()->andReturn($model = m::mock(stdClass::class));
         $model->shouldReceive('freshTimestamp')->once()->andReturn(now());

--- a/tests/Database/DatabaseSoftDeletingScopeTest.php
+++ b/tests/Database/DatabaseSoftDeletingScopeTest.php
@@ -12,10 +12,9 @@ use Illuminate\Database\Query\Processors\Processor;
 use Illuminate\Support\Carbon;
 use InvalidArgumentException;
 use Mockery as m;
+use function now;
 use PHPUnit\Framework\TestCase;
 use stdClass;
-
-use function now;
 
 class DatabaseSoftDeletingScopeTest extends TestCase
 {
@@ -37,10 +36,12 @@ class DatabaseSoftDeletingScopeTest extends TestCase
             $this->assertSame('table.deleted_at', $column);
             $this->assertSame('>', $operator);
             $this->assertEquals($now, $datetime);
+
             return true;
         });
         $builder->shouldReceive('where')->once()->withArgs(function ($callback) use ($builder) {
             $callback($builder);
+
             return true;
         });
 
@@ -147,6 +148,7 @@ class DatabaseSoftDeletingScopeTest extends TestCase
         });
         $givenBuilder->shouldReceive('where')->once()->withArgs(function ($callback) use ($givenBuilder) {
             $callback($givenBuilder);
+
             return true;
         })->andReturn($givenBuilder);
         $result = $callback($givenBuilder);

--- a/tests/Database/DatabaseSoftDeletingScopeTest.php
+++ b/tests/Database/DatabaseSoftDeletingScopeTest.php
@@ -15,8 +15,6 @@ use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
-use function now;
-
 class DatabaseSoftDeletingScopeTest extends TestCase
 {
     protected function tearDown(): void

--- a/tests/Database/DatabaseSoftDeletingScopeTest.php
+++ b/tests/Database/DatabaseSoftDeletingScopeTest.php
@@ -94,6 +94,7 @@ class DatabaseSoftDeletingScopeTest extends TestCase
             $this->assertSame('table.deleted_at', $column);
             $this->assertSame('<=', $operator);
             $this->assertEquals($now, $datetime);
+
             return true;
         });
         $result = $callback($givenBuilder);

--- a/tests/Database/DatabaseSoftDeletingTraitTest.php
+++ b/tests/Database/DatabaseSoftDeletingTraitTest.php
@@ -9,8 +9,6 @@ use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
-use function now;
-
 class DatabaseSoftDeletingTraitTest extends TestCase
 {
     protected function tearDown(): void

--- a/tests/Database/DatabaseSoftDeletingTraitTest.php
+++ b/tests/Database/DatabaseSoftDeletingTraitTest.php
@@ -58,7 +58,7 @@ class DatabaseSoftDeletingTraitTest extends TestCase
         $this->assertFalse($model->restore());
     }
 
-    public function testDeleteAt()
+    public function testTrashAt()
     {
         Carbon::setTestNow($now = now());
 
@@ -78,13 +78,13 @@ class DatabaseSoftDeletingTraitTest extends TestCase
             'updated_at',
         ]);
 
-        $model->deleteAt($now->addSecond());
+        $model->trashAt($now->addSecond());
 
         $this->assertInstanceOf(Carbon::class, $model->deleted_at);
         $this->assertEquals($now, $model->deleted_at);
     }
 
-    public function testDeleteAtThrowsExceptionIfDatetimePresent()
+    public function testTrashAtThrowsExceptionIfDatetimePresent()
     {
         $this->expectExceptionMessage(InvalidArgumentException::class);
         $this->expectExceptionMessage('The datetime must be set in the future.');
@@ -95,10 +95,10 @@ class DatabaseSoftDeletingTraitTest extends TestCase
         $model->makePartial();
         $model->shouldNotReceive('newModelQuery');
 
-        $model->deleteAt($now->addSecond());
+        $model->trashAt($now->addSecond());
     }
 
-    public function testDeleteAtThrowsExceptionIfDatetimePast()
+    public function testTrashAtThrowsExceptionIfDatetimePast()
     {
         $this->expectExceptionMessage(InvalidArgumentException::class);
         $this->expectExceptionMessage('The datetime must be set in the future.');
@@ -111,7 +111,7 @@ class DatabaseSoftDeletingTraitTest extends TestCase
         $model->makePartial();
         $model->shouldNotReceive('newModelQuery');
 
-        $model->deleteAt($now->addSecond());
+        $model->trashAt($now->addSecond());
     }
 }
 

--- a/tests/Integration/Database/DatabaseEloquentBroadcastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentBroadcastingTest.php
@@ -79,7 +79,7 @@ class DatabaseEloquentBroadcastingTest extends DatabaseTestCase
         $model->name = 'Bean';
         $model->saveQuietly();
 
-        $model->deleteAt(now()->addDay());
+        $model->trashAt(now()->addDay());
 
         Event::assertDispatched(function (BroadcastableModelEventOccurred $event) {
             return $event->model instanceof SoftDeletableTestEloquentBroadcastUser


### PR DESCRIPTION
## What?

Inspired by #39532. Adds timestamp awareness to `SoftDeletes`. Timestamps set in the future are no longer considered "deleted".

This changes how trashed models are retrieved and saved.

- ⛔ A past or present timestamp is considered as _deleted_.
- ✅ A future timestamp is considered as _not deleted_.
- ✅ A `null` timestamp is considered as _not deleted_.

One notable advantage is that **the developer no longer has to push a job to a queue or schedule deletes**. This can be worse in AWS since it limits the delay to 15 minutes, so you're bound to an schedule.

Timestamp awareness _just works_ ™.

## Behavior

In synthesis, this PR changes how a record is considered "deleted", and adds both a query helper to get pending trash records, and a way to set a model to be trash in the future.

On the query side of things:

- A normal query will return all models that have a `null` timestamps or are set in the future.
- A `withTrashed()` will include models with timestamps set present or past.
- A `onlyTrashed()` will return only models with timestamps set present or past.
- A `withoutTrashed()` will return all models that have a `null` timestamps or are set in the future.
- A `restore()` will set to null any timestamp, even if is set in the future.
- ✨ A `trashAt()` method accepts a future timestamp to update the rows in the database.
- ✨ A `pendingTrash()` will return all models with a timestamp set in the future.

On the model side of things:

- The `trashed()` method now returns `false` if the timestamp is `null` or set in the future, `true` otherwise.
- The `restore()` method will set to null any timestamp, even if is set in the future.
- ✨ The `trashAt()` method accepts a future timestamp to update the model.
- ✨ The `willBeTrashed()` method returns `true` if the timestamps is set in the future, `false` otherwise.

Additionally, the ✨ event `willTrash` event will be fired if the model is set to be soft-deleted in the future when using `deleteAt()`.

> I decided to use `willBeTrashed()` instead of `isPendingTrash()` to avoid confusion between the builder and the model methods.

## BC? YES.

While developers using the `SoftDeletes` trait directly won't need to rewrite anything, those using manual checks into the `deleted_at` column or extending the `SoftDeletes` trait will need a minor rewrite.

## Notes

- `trastAt()` throws an exception if the time is already present or past.  This allows solid expectancy on which `trashed` or `willTrash` event fires, forcing the developer to pick one.