### PR TITLE
[8.x] Add missing "flags" to redis zadd options list...

### DIFF
--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -220,7 +220,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
         $options = [];
 
         foreach (array_slice($dictionary, 0, 3) as $i => $value) {
-            if (in_array($value, ['nx', 'xx', 'ch', 'incr', 'NX', 'XX', 'CH', 'INCR'], true)) {
+            if (in_array($value, ['nx', 'xx', 'ch', 'incr', 'gt', 'lt', 'NX', 'XX', 'CH', 'INCR', 'GT', 'LT'], true)) {
                 $options[] = $value;
 
                 unset($dictionary[$i]);


### PR DESCRIPTION
Took me a while to find it, but it looks like the list of flags/options for the redis zadd method is not up to date.

I've added the two that were missing.  Here's a reference: https://redis.io/commands/zadd

Please let me know if you have any questions.