### PR TITLE
[8.x] TestResponse::statusMessageWithException - Caters for situations where exception may be an array

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -19,6 +19,7 @@ use Illuminate\Testing\Assert as PHPUnit;
 use Illuminate\Testing\Constraints\SeeInOrder;
 use Illuminate\Testing\Fluent\AssertableJson;
 use LogicException;
+use ErrorException;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 /**
@@ -223,7 +224,11 @@ class TestResponse implements ArrayAccess
      */
     protected function statusMessageWithException($expected, $actual, $exception)
     {
-        $exception = (string) $exception;
+        try {
+            $exception = (string) $exception;
+        } catch (ErrorException $e) {
+            $exception = var_export($exception, true);
+        }
 
         return <<<EOF
 Expected response status code [$expected] but received $actual.

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -4,6 +4,7 @@ namespace Illuminate\Testing;
 
 use ArrayAccess;
 use Closure;
+use ErrorException;
 use Illuminate\Contracts\View\View;
 use Illuminate\Cookie\CookieValuePrefix;
 use Illuminate\Database\Eloquent\Model;
@@ -19,7 +20,6 @@ use Illuminate\Testing\Assert as PHPUnit;
 use Illuminate\Testing\Constraints\SeeInOrder;
 use Illuminate\Testing\Fluent\AssertableJson;
 use LogicException;
-use ErrorException;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 /**


### PR DESCRIPTION
Sometime fairly recently, some additional functionality was added to output exceptions when using (in our case) the assertJsonValidationErrors() function. For us at least, sometimes the exception is not an instance of throwable, but an array - ie.

```php
array(4) {
["code"]=>
int(0)
["message"]=>
string(26) "Could not create resource."
["line"]=>
int(71)
["file"]=>
string(34) "/var/www/app/Helpers/Utilities.php"
}
```

These tests then will result in an ErrorException being thrown with the message `Array to string conversion`, as php won't cast-convert an array into a string, and the tests fail with this error. Potentially there can be other situations with a variable that cannot be stringified in this way.

What I propose is to keep the current functionality as it is, but try and catch an ErrorException on this cast conversion, and if there is a problem, use the more universal var_export instead.
