### PR TITLE
[8.x] Add a table option to the make:model command

### DIFF
--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -73,7 +73,7 @@ class ModelMakeCommand extends GeneratorCommand
         }
     }
 
-        /**
+    /**
      * Build the class with the given name.
      *
      * @param  string  $name
@@ -171,14 +171,14 @@ class ModelMakeCommand extends GeneratorCommand
     /**
      * Set the table property for the model.
      *
-     * @param  string $stub
-     * @param  string $table
+     * @param  string  $stub
+     * @param  string  $table
      * @return string
      */
     protected function setTable($stub, $table)
     {
         return $table ?
-            str_replace('{{ table }}', 'protected $table = \'' . $table . '\';', $stub) :
+        str_replace('{{ table }}', 'protected $table = \''.$table.'\';', $stub) :
             str_replace('{{ table }}', '//', $stub);
     }
 

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -108,7 +108,9 @@ class ModelMakeCommand extends GeneratorCommand
      */
     protected function createMigration()
     {
-        $table = Str::snake(Str::pluralStudly(class_basename($this->argument('name'))));
+        $table = $this->option('table')
+            ? $this->option('table')
+            : Str::snake(Str::pluralStudly(class_basename($this->argument('name'))));
 
         if ($this->option('pivot')) {
             $table = Str::singular($table);

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -73,6 +73,19 @@ class ModelMakeCommand extends GeneratorCommand
         }
     }
 
+        /**
+     * Build the class with the given name.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function buildClass($name)
+    {
+        $stub = parent::buildClass($name);
+
+        return $this->setTable($stub, $this->option('table'));
+    }
+
     /**
      * Create a model factory for the model.
      *
@@ -156,6 +169,20 @@ class ModelMakeCommand extends GeneratorCommand
     }
 
     /**
+     * Set the table property for the model.
+     *
+     * @param  string $stub
+     * @param  string $table
+     * @return string
+     */
+    protected function setTable($stub, $table)
+    {
+        return $table ?
+            str_replace('{{ table }}', 'protected $table = \'' . $table . '\';', $stub) :
+            str_replace('{{ table }}', '//', $stub);
+    }
+
+    /**
      * Get the stub file for the generator.
      *
      * @return string
@@ -210,6 +237,7 @@ class ModelMakeCommand extends GeneratorCommand
             ['resource', 'r', InputOption::VALUE_NONE, 'Indicates if the generated controller should be a resource controller'],
             ['api', null, InputOption::VALUE_NONE, 'Indicates if the generated controller should be an API controller'],
             ['requests', 'R', InputOption::VALUE_NONE, 'Create new form request classes and use them in the resource controller'],
+            ['table', 't', InputOption::VALUE_REQUIRED, 'Sets the table name for the model.'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -177,9 +177,9 @@ class ModelMakeCommand extends GeneratorCommand
      */
     protected function setTable($stub, $table)
     {
-        return $table ?
-        str_replace('{{ table }}', 'protected $table = \''.$table.'\';', $stub) :
-            str_replace('{{ table }}', '//', $stub);
+        return $table
+            ? str_replace('{{ table }}', 'protected $table = \''.$table.'\';', $stub)
+            : str_replace('{{ table }}', '//', $stub);
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/stubs/model.pivot.stub
+++ b/src/Illuminate/Foundation/Console/stubs/model.pivot.stub
@@ -6,5 +6,5 @@ use Illuminate\Database\Eloquent\Relations\Pivot;
 
 class {{ class }} extends Pivot
 {
-    //
+    {{ table }}
 }

--- a/src/Illuminate/Foundation/Console/stubs/model.stub
+++ b/src/Illuminate/Foundation/Console/stubs/model.stub
@@ -8,4 +8,6 @@ use Illuminate\Database\Eloquent\Model;
 class {{ class }} extends Model
 {
     use HasFactory;
+    
+    {{ table }}
 }


### PR DESCRIPTION
This PR adds a `table` option to the `php artistan make:model` command to specify the associated table for the model/pivot being created.

Example usage: 
`php artisan make:model Store --table=ecommerce_stores`
`php artisan make:model Enrollment -p -t student_course`

It is analogous to the `table` option in the `make:migration` command and adds a more seamless, natural, and "Laravel" way of specifying the table name for the model.

