### PR TITLE
[8.x] Add ability to use `withoutMiddleware` on route groups

### DIFF
--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -23,6 +23,7 @@ use InvalidArgumentException;
  * @method \Illuminate\Routing\RouteRegistrar namespace(string|null $value)
  * @method \Illuminate\Routing\RouteRegistrar prefix(string  $prefix)
  * @method \Illuminate\Routing\RouteRegistrar where(array  $where)
+ * @method \Illuminate\Routing\RouteRegistrar withoutMiddleware(array|string  $middleware)
  */
 class RouteRegistrar
 {
@@ -63,6 +64,7 @@ class RouteRegistrar
         'prefix',
         'scopeBindings',
         'where',
+        'withoutMiddleware',
     ];
 
     /**
@@ -73,6 +75,7 @@ class RouteRegistrar
     protected $aliases = [
         'name' => 'as',
         'scopeBindings' => 'scope_bindings',
+        'withoutMiddleware' => 'excluded_middleware',
     ];
 
     /**
@@ -107,7 +110,15 @@ class RouteRegistrar
             }
         }
 
-        $this->attributes[Arr::get($this->aliases, $key, $key)] = $value;
+        $attributeKey = Arr::get($this->aliases, $key, $key);
+
+        if ($key === 'withoutMiddleware') {
+            $value = array_merge(
+                (array) ($this->attributes[$attributeKey] ?? []), Arr::wrap($value)
+            );
+        }
+
+        $this->attributes[$attributeKey] = $value;
 
         return $this;
     }

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -245,6 +245,18 @@ class RouteRegistrarTest extends TestCase
         $this->seeMiddleware('group-middleware');
     }
 
+    public function testCanRegisterGroupWithoutMiddleware()
+    {
+        $this->router->withoutMiddleware('one')->group(function ($router) {
+            $router->get('users', function () {
+                return 'all-users';
+            })->middleware(['one', 'two']);
+        });
+
+        $this->seeResponse('all-users', Request::create('users', 'GET'));
+        $this->assertEquals(['one'], $this->getRoute()->excludedMiddleware());
+    }
+
     public function testCanRegisterGroupWithStringableMiddleware()
     {
         $one = new class implements Stringable


### PR DESCRIPTION
It's now possible to use `withoutMiddleware` on a route group. Previously, you could only use it on individual routes.