### PR TITLE
[8.x] Generate Markdown view name when not provided

### DIFF
--- a/src/Illuminate/Foundation/Console/MailMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/MailMakeCommand.php
@@ -55,12 +55,14 @@ class MailMakeCommand extends GeneratorCommand
      */
     protected function writeMarkdownTemplate()
     {
-        if (! ($viewName = $this->option('markdown'))) {
-            $viewName = 'emails.'.Str::kebab(class_basename($this->argument('name')));
+        $view = $this->option('markdown');
+
+        if (! $view) {
+            $view = 'mail.'.Str::kebab(class_basename($this->argument('name')));
         }
 
         $path = $this->viewPath(
-            str_replace('.', '/', $viewName).'.blade.php'
+            str_replace('.', '/', $view).'.blade.php'
         );
 
         if (! $this->files->isDirectory(dirname($path))) {

--- a/src/Illuminate/Foundation/Console/MailMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/MailMakeCommand.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Console\GeneratorCommand;
+use Illuminate\Support\Str;
 use Symfony\Component\Console\Input\InputOption;
 
 class MailMakeCommand extends GeneratorCommand
@@ -42,7 +43,7 @@ class MailMakeCommand extends GeneratorCommand
             return;
         }
 
-        if ($this->option('markdown')) {
+        if ($this->hasOption('markdown')) {
             $this->writeMarkdownTemplate();
         }
     }
@@ -54,8 +55,12 @@ class MailMakeCommand extends GeneratorCommand
      */
     protected function writeMarkdownTemplate()
     {
+        if (! ($viewName = $this->option('markdown'))) {
+            $viewName = 'emails.'.Str::kebab(class_basename($this->argument('name')));
+        }
+
         $path = $this->viewPath(
-            str_replace('.', '/', $this->option('markdown')).'.blade.php'
+            str_replace('.', '/', $viewName).'.blade.php'
         );
 
         if (! $this->files->isDirectory(dirname($path))) {


### PR DESCRIPTION
The `make:mail` command can now be provided with `--markdown` without a Markdown view name. Laravel will now auto-generate the file name and place it within `./resources/views/emails`.

For example, `make:mail OrderShipped -m` will generate `./resources/views/emails/order-shipped.blade.php`.