### PR TITLE
Collection::mapItemsWithKey for creating Dictionary with the key in item.

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -717,6 +717,24 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
 
         return new static($result);
     }
+    
+    /**
+     * Run an associative map over each of the items with setting the value of the given key as associative index.
+     *
+     *
+     * @param  string  $key
+     * @return static
+     */
+    public function mapItemsWithKey(string $key)
+    {
+        $result = [];
+
+        foreach ($this->items as $item) {
+            $result[data_get($item, $key)] = $item;
+        }
+
+        return new static($result);
+    }
 
     /**
      * Merge the collection with the given items.

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -717,7 +717,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
 
         return new static($result);
     }
-    
+
     /**
      * Run an associative map over each of the items with setting the value of the given key as associative index.
      *


### PR DESCRIPTION
Added mapItemsWithKey method. Useful to create a dictionary with collections. Ex: It will replace the dictionary construction while matching the models on resolving the eager loads.

Currently:
`$users = User::get()->mapWithKeys(fn($each) => [$each->id => $each])->all();`

After mapItemsWithKey:
`$users = User::get()->mapItemsWithKey('id')->all();`

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
