### PR TITLE
[8.x] Adds toRawSql() method on both Query and Eloquent builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -98,6 +98,7 @@ class Builder
         'raw',
         'sum',
         'toSql',
+        'toRawSql',
     ];
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2304,6 +2304,21 @@ class Builder
     }
 
     /**
+     * Get the SQL representation of the query including the bindings
+     *
+     * @return string
+     */
+    public function toRawSql()
+    {
+        return array_reduce($this->getBindings(), function ($sql, $binding) {
+            $binding = str_replace(['\\', "'"], ['\\\\', "\'"], $binding);
+            return preg_replace('/\?/', is_numeric($binding)
+                ? $binding
+                : "'" . $binding . "'", $sql, 1);
+        }, $this->toSql());
+    }
+
+    /**
      * Execute a query for a single record by ID.
      *
      * @param  int|string  $id

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2304,7 +2304,7 @@ class Builder
     }
 
     /**
-     * Get the SQL representation of the query including the bindings
+     * Get the SQL representation of the query including the bindings.
      *
      * @return string
      */
@@ -2314,7 +2314,7 @@ class Builder
             $binding = str_replace(['\\', "'"], ['\\\\', "\'"], $binding);
             return preg_replace('/\?/', is_numeric($binding)
                 ? $binding
-                : "'" . $binding . "'", $sql, 1);
+                : "'".$binding."'", $sql, 1);
         }, $this->toSql());
     }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2312,6 +2312,7 @@ class Builder
     {
         return array_reduce($this->getBindings(), function ($sql, $binding) {
             $binding = str_replace(['\\', "'"], ['\\\\', "\'"], $binding);
+
             return preg_replace('/\?/', is_numeric($binding)
                 ? $binding
                 : "'".$binding."'", $sql, 1);

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -29,6 +29,18 @@ class DatabaseEloquentBuilderTest extends TestCase
         m::close();
     }
 
+    public function testToRawSql()
+    {
+        $query = new BaseBuilder(m::mock(ConnectionInterface::class), new Grammar, m::mock(Processor::class));
+        $builder = new Builder($query);
+        $model = new EloquentBuilderTestStub;
+        $this->mockConnectionForModel($model, '');
+        $builder->setModel($model);
+        $builder->select('*')->where('id', 1);
+
+        $this->assertSame('select * from "table" where "id" = 1', $builder->toRawSql());
+    }
+
     public function testFindMethod()
     {
         $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -33,6 +33,13 @@ class DatabaseQueryBuilderTest extends TestCase
         m::close();
     }
 
+    public function testToRawSql()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('id', 1);
+        $this->assertSame('select * from "users" where "id" = 1', $builder->toRawSql());
+    }
+
     public function testBasicSelect()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
### What does it do?
This PR adds `toRawSql()` both the Query and Eloquent builders which will output the raw SQL query with the bindings inline. 

### Does it break anything?
No, these a new methods that do not conflict with any existing methods.

### Benefits
The benefit is logging complete queries instead of an array of the query and the bindings separately. This helper method returns a string with the bindings inserted into the query. Seems this is popular request on Twitter.

### Tests
Tests are added for both Query and Eloquent builders