### PR TITLE
[8.x] Using a different composer file

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1386,7 +1386,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
             return $this->namespace;
         }
 
-        $composer = json_decode(file_get_contents($this->basePath('composer.json')), true);
+        $composer = json_decode(file_get_contents($this->basePath(composer())), true);
 
         foreach ((array) data_get($composer, 'autoload.psr-4') as $namespace => $path) {
             foreach ((array) $path as $pathChoice) {

--- a/src/Illuminate/Foundation/PackageManifest.php
+++ b/src/Illuminate/Foundation/PackageManifest.php
@@ -154,12 +154,14 @@ class PackageManifest
      */
     protected function packagesToIgnore()
     {
-        if (! is_file($this->basePath.'/composer.json')) {
+        $composer = composer();
+
+        if (! is_file($this->basePath.DIRECTORY_SEPARATOR.$composer)) {
             return [];
         }
 
         return json_decode(file_get_contents(
-            $this->basePath.'/composer.json'
+            $this->basePath.DIRECTORY_SEPARATOR.$composer
         ), true)['extra']['laravel']['dont-discover'] ?? [];
     }
 

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -932,15 +932,3 @@ if (! function_exists('view')) {
         return $factory->make($view, $data, $mergeData);
     }
 }
-
-if (! function_exists('composer')) {
-    /**
-     * Get the current composer file.
-     *
-     * @return string
-     */
-    function composer($fileName = 'composer.json')
-    {
-        return env('COMPOSER', $fileName);
-    }
-}

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -935,7 +935,7 @@ if (! function_exists('view')) {
 
 if (! function_exists('composer')) {
     /**
-     * Get the current composer file
+     * Get the current composer file.
      *
      * @return string
      */

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -932,3 +932,15 @@ if (! function_exists('view')) {
         return $factory->make($view, $data, $mergeData);
     }
 }
+
+if (! function_exists('composer')) {
+    /**
+     * Get the current composer file
+     *
+     * @return string
+     */
+    function composer($fileName = 'composer.json')
+    {
+        return env('COMPOSER', $fileName);
+    }
+}

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -377,3 +377,15 @@ if (! function_exists('with')) {
         return is_null($callback) ? $value : $callback($value);
     }
 }
+
+if (! function_exists('composer')) {
+    /**
+     * Get the current composer file.
+     *
+     * @return string
+     */
+    function composer($fileName = 'composer.json')
+    {
+        return env('COMPOSER', $fileName);
+    }
+}

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -369,6 +369,15 @@ class FoundationApplicationTest extends TestCase
         $this->assertSame('Laravel\\Two\\', $app2->getNamespace());
     }
 
+    public function testGetNamespaceWithAnotherComposer()
+    {
+        putenv('COMPOSER=composer-dev.json');
+        $app = new Application(realpath(__DIR__.'/fixtures/laravel3'));
+
+        $this->assertSame('Laravel\\Three\\', $app->getNamespace());
+        unset($_ENV['COMPOSER']);
+    }
+
     public function testCachePathsResolveToBootstrapCacheDirectory()
     {
         $app = new Application('/base/path');

--- a/tests/Foundation/fixtures/laravel3/composer-dev.json
+++ b/tests/Foundation/fixtures/laravel3/composer-dev.json
@@ -1,0 +1,7 @@
+{
+    "autoload": {
+        "psr-4": {
+            "Laravel\\Three\\": "app/"
+        }
+    }
+}


### PR DESCRIPTION
For now, users should only use `composer.json` file with no choice.
Even though the official Composer documentation - https://getcomposer.org/doc/03-cli.md#composer allows it.
Multiple composer files are required if a project has multiple configurations. For example, composer-dev.json specifies the dependencies for the latest (develop) versions, and composer.json specifies the dependencies for specific versions.