### PR TITLE
[8.x] Update the weeklyOn() parameter type to match days()

### DIFF
--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -374,7 +374,7 @@ trait ManagesFrequencies
     /**
      * Schedule the event to run weekly on a given day and time.
      *
-     * @param  int  $dayOfWeek
+     * @param  array|mixed  $dayOfWeek
      * @param  string  $time
      * @return $this
      */


### PR DESCRIPTION
Currently the typehint on the weeklyOn method is not in line with the underlying function typehint. This patch aims to fix the inconsistency. 

With this you are able to use the weeklyOn method to select more than one day without static analysis/IDE's complaining.

```php
$schedule->command('inspire')
         ->weeklyOn([CarbonImmutable::MONDAY, CarbonImmutable::WEDNESDAY], '8:01');
```