### PR TITLE
Fix Mailable markdown text view

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -344,8 +344,7 @@ class Mailable implements MailableContract, Renderable
      */
     protected function buildMarkdownText($markdown, $data)
     {
-        return $this->textView
-                ?? $markdown->renderText($this->markdown, $data);
+        return $markdown->renderText($this->textView ?? $markdown, $data);
     }
 
     /**


### PR DESCRIPTION
Markdown mailables are using html views when there is a text view specified.
That's wrong, any markup in `text-plain` MIME type is useless and it will result in countless issues not having proper text messages for emails (accessibility, parsers, email clients that only support text like CLI clients). Instead the specified text view should be used to render plain text.

See the detailed description on this discussion: https://github.com/laravel/framework/discussions/39520
