### PR TITLE
[8.x] Fix auto-generated Markdown views

### DIFF
--- a/src/Illuminate/Foundation/Console/MailMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/MailMakeCommand.php
@@ -55,10 +55,8 @@ class MailMakeCommand extends GeneratorCommand
      */
     protected function writeMarkdownTemplate()
     {
-        $view = $this->getView();
-
         $path = $this->viewPath(
-            str_replace('.', '/', $view).'.blade.php'
+            str_replace('.', '/', $this->getView()).'.blade.php'
         );
 
         if (! $this->files->isDirectory(dirname($path))) {

--- a/src/Illuminate/Foundation/Console/MailMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/MailMakeCommand.php
@@ -43,7 +43,7 @@ class MailMakeCommand extends GeneratorCommand
             return;
         }
 
-        if ($this->hasOption('markdown')) {
+        if ($this->option('markdown') !== false) {
             $this->writeMarkdownTemplate();
         }
     }
@@ -55,11 +55,7 @@ class MailMakeCommand extends GeneratorCommand
      */
     protected function writeMarkdownTemplate()
     {
-        $view = $this->option('markdown');
-
-        if (! $view) {
-            $view = 'mail.'.Str::kebab(class_basename($this->argument('name')));
-        }
+        $view = $this->getView();
 
         $path = $this->viewPath(
             str_replace('.', '/', $view).'.blade.php'
@@ -82,11 +78,27 @@ class MailMakeCommand extends GeneratorCommand
     {
         $class = parent::buildClass($name);
 
-        if ($this->option('markdown')) {
-            $class = str_replace('DummyView', $this->option('markdown'), $class);
+        if ($this->option('markdown') !== false) {
+            $class = str_replace('DummyView', $this->getView(), $class);
         }
 
         return $class;
+    }
+
+    /**
+     * Get the view name.
+     *
+     * @return string
+     */
+    protected function getView()
+    {
+        $view = $this->option('markdown');
+
+        if (! $view) {
+            $view = 'mail.'.Str::kebab(class_basename($this->argument('name')));
+        }
+
+        return $view;
     }
 
     /**
@@ -97,7 +109,7 @@ class MailMakeCommand extends GeneratorCommand
     protected function getStub()
     {
         return $this->resolveStubPath(
-            $this->option('markdown')
+            $this->option('markdown') !== false
                 ? '/stubs/markdown-mail.stub'
                 : '/stubs/mail.stub');
     }
@@ -136,7 +148,7 @@ class MailMakeCommand extends GeneratorCommand
         return [
             ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the mailable already exists'],
 
-            ['markdown', 'm', InputOption::VALUE_OPTIONAL, 'Create a new Markdown template for the mailable'],
+            ['markdown', 'm', InputOption::VALUE_OPTIONAL, 'Create a new Markdown template for the mailable', false],
         ];
     }
 }


### PR DESCRIPTION
This fixes a bug with the `mail:make -m` command not correctly generating the Markdown view.