### PR TITLE
rethrow helper

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -210,6 +210,37 @@ if (! function_exists('preg_replace_array')) {
     }
 }
 
+if (! function_exists('rethrow')) {
+    /**
+     * Return callback result, but convert to specified exception when exception thrown.
+     *
+     * @param  callable  $callback
+     * @param  \Throwable|string|callable  $exception
+     * @param  mixed  ...$parameters
+     * @return mixed
+     *
+     * @throws \Throwable
+     */
+    function rethrow(callable $callback, $exception, ...$parameters)
+    {
+        try {
+            return $callback();
+        } catch (Exception $e) {
+            if (is_callable($exception)) {
+                throw $exception($e);
+            }
+
+            if (is_string($exception) && class_exists($exception)) {
+                $exception = $parameters
+                    ? new $exception(...$parameters)
+                    : new $exception($e->getMessage(), $e->getCode());
+            }
+
+            throw is_string($exception) ? $e : $exception;
+        }
+    }
+}
+
 if (! function_exists('retry')) {
     /**
      * Retry an operation a given number of times.


### PR DESCRIPTION
In the same spirit as the likes of ```throw_if```/```throw_unless```/```rescue```, a little DX improvement to return the result of the passed callback (first argument), but if an exception would be thrown, allows to convert to a specified other exception class to rethrow as. Prevents try...catch..throw block, which imho makes for cleaner code (improving readability).

For example, instead of:
```php
try {
    $coupon = $validateCoupon->execute('CODE');
} catch (\Exception $e) {
    throw new MyCustomApiException($e->getMessage());
}
```

you may now use:
```php
$coupon = rethrow(fn() => $validateCoupon->execute('CODE'), MyCustomApiException::class);
```
... or additionally use another custom exception message:
```php
$coupon = rethrow(fn() => $validateCoupon->execute('CODE'), MyCustomApiException::class, 'Code no good');
```

Alternatively, for more control on the exception to rethrow, itself may also be returned from a callable:
```php
$coupon = rethrow(
    fn() => $validateCoupon->execute('CODE'),
    fn($e) => ValidationException::withMessages(['couponInput' => __($e->getMessage())])
);
```

Hope you like it too. If you do, I'll be happy to add tests, discuss improvements, etc.

PS. To be honest, I'm not fully sure if the naming is great: "rethrow()" may sound as-if an exception is _expected_. Thoughts ("when_thrown()",...) ?