### PR TITLE
[8.x] Add new allows blade directive

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesAuthorizations.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesAuthorizations.php
@@ -132,6 +132,8 @@ trait CompilesAuthorizations
      */
     protected function compileEndallows()
     {
-        return '<?php endif; ?>';
+        return '<?php unset($message);
+if (isset($__messageOriginal)) { $message = $__messageOriginal; }
+endif; ?>';
     }
 }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesAuthorizations.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesAuthorizations.php
@@ -45,7 +45,8 @@ trait CompilesAuthorizations
      */
     protected function compileAllows($expression)
     {
-        return '<?php $access = app(\Illuminate\\Contracts\\Auth\\Access\\Gate::class)->inspect'.$expression.'; ?>
+        return '<?php if (isset($access)) { $__accessOriginal = $access; }
+$access = app(\Illuminate\\Contracts\\Auth\\Access\\Gate::class)->inspect'.$expression.'; ?>
 <?php if ($access->allowed()): ?>
 <?php if (isset($message)) { $__messageOriginal = $message; } $message = $access->message(); ?>';
     }
@@ -134,6 +135,8 @@ trait CompilesAuthorizations
     {
         return '<?php unset($message);
 if (isset($__messageOriginal)) { $message = $__messageOriginal; }
+unset($access);
+if (isset($__accessOriginal)) { $access = $__accessOriginal; }
 endif; ?>';
     }
 }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesAuthorizations.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesAuthorizations.php
@@ -45,7 +45,7 @@ trait CompilesAuthorizations
      */
     protected function compileAllows($expression)
     {
-        return '<?php $access = app(\Illuminate\\Contracts\\Auth\\Access\\Gate::class)->inspect' . $expression . '; ?>
+        return '<?php $access = app(\Illuminate\\Contracts\\Auth\\Access\\Gate::class)->inspect'.$expression.'; ?>
 <?php if ($access->allowed()): ?>
 <?php if (isset($message)) { $__messageOriginal = $message; } $message = $access->message(); ?>';
     }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesAuthorizations.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesAuthorizations.php
@@ -38,6 +38,19 @@ trait CompilesAuthorizations
     }
 
     /**
+     * Compile the allows statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileAllows($expression)
+    {
+        return '<?php $access = app(\Illuminate\\Contracts\\Auth\\Access\\Gate::class)->inspect' . $expression . '; ?>
+<?php if ($access->allowed()): ?>
+<?php if (isset($message)) { $__messageOriginal = $message; } $message = $access->message(); ?>';
+    }
+
+    /**
      * Compile the else-can statements into valid PHP.
      *
      * @param  string  $expression
@@ -71,6 +84,18 @@ trait CompilesAuthorizations
     }
 
     /**
+     * Compile the else-allows statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileElseallows($expression)
+    {
+        return '<?php else: ?>
+<?php if (isset($message)) { $__messageOriginal = $message; } $message = $access->message(); ?>';
+    }
+
+    /**
      * Compile the end-can statements into valid PHP.
      *
      * @return string
@@ -96,6 +121,16 @@ trait CompilesAuthorizations
      * @return string
      */
     protected function compileEndcanany()
+    {
+        return '<?php endif; ?>';
+    }
+
+    /**
+     * Compile the end-allows statements into valid PHP.
+     *
+     * @return string
+     */
+    protected function compileEndallows()
     {
         return '<?php endif; ?>';
     }

--- a/tests/View/Blade/BladeAllowsStatementsTest.php
+++ b/tests/View/Blade/BladeAllowsStatementsTest.php
@@ -12,7 +12,8 @@ allowed
 forbidden
 @endallows';
 
-        $expected = '<?php $access = app(\Illuminate\\Contracts\\Auth\\Access\\Gate::class)->inspect("create", $post); ?>
+        $expected = '<?php if (isset($access)) { $__accessOriginal = $access; }
+$access = app(\Illuminate\\Contracts\\Auth\\Access\\Gate::class)->inspect("create", $post); ?>
 <?php if ($access->allowed()): ?>
 <?php if (isset($message)) { $__messageOriginal = $message; } $message = $access->message(); ?>
 allowed
@@ -21,6 +22,8 @@ allowed
 forbidden
 <?php unset($message);
 if (isset($__messageOriginal)) { $message = $__messageOriginal; }
+unset($access);
+if (isset($__accessOriginal)) { $access = $__accessOriginal; }
 endif; ?>';
 
         $this->assertEquals($expected, $this->compiler->compileString($string));

--- a/tests/View/Blade/BladeAllowsStatementsTest.php
+++ b/tests/View/Blade/BladeAllowsStatementsTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Illuminate\Tests\View\Blade;
+
+class BladeAllowsStatementsTest extends AbstractBladeTestCase
+{
+    public function testAllowsStatementsAreCompiled()
+    {
+        $string = '@allows ("create", $post)
+allowed
+@elseallows
+forbidden
+@endallows';
+
+        $expected = '<?php $access = app(\Illuminate\\Contracts\\Auth\\Access\\Gate::class)->inspect("create", $post); ?>
+<?php if ($access->allowed()): ?>
+<?php if (isset($message)) { $__messageOriginal = $message; } $message = $access->message(); ?>
+allowed
+<?php else: ?>
+<?php if (isset($message)) { $__messageOriginal = $message; } $message = $access->message(); ?>
+forbidden
+<?php endif; ?>';
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+}

--- a/tests/View/Blade/BladeAllowsStatementsTest.php
+++ b/tests/View/Blade/BladeAllowsStatementsTest.php
@@ -19,7 +19,9 @@ allowed
 <?php else: ?>
 <?php if (isset($message)) { $__messageOriginal = $message; } $message = $access->message(); ?>
 forbidden
-<?php endif; ?>';
+<?php unset($message);
+if (isset($__messageOriginal)) { $message = $__messageOriginal; }
+endif; ?>';
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }


### PR DESCRIPTION
This pull request adds a new "allows" directive. It is an alternative to the "can" directive, and only provides the possibility to get the "reason" (message) that is the result of the Gate inspect message.

Users can check if an action is authorized.

```php
@can("create", App\Models\Post::class)
    You can create a post!
@elsecan
    You cannot create a post...
@endcan
```

To get the message/reason for the denial, we have to pass a variable holding the result of the Gate's message method call like this:

```php
@php
    use App\Models\Post;

    $creatingPost = Gate::inspect("create", Post::class);
@endphp

@if($creatingPost->allowed())
    You can create a post!
@else
    {{ $creatingPost->message() }}
@endif
```

(Note that you would have probably pass the `$creatingPost` from your controller)

This pull request offers a more straight forward way to do all of this using a shortened code.

```php
@allows("create", App\Models\Post::class)
    You can create a post!
@elseallows
    {{ $message }}
@endallows
```

It works exactly like the `@error` directive, exposing a local `$message` variable that holds the result of the Gate's message call. Note that like the `@error` directive, if there was already an existing `$message` variable, its value will be stored in a variable called `$__messageOriginal`.

Also note that you can pass the message of the allowing result as well:

```php
namespace App\Policies;

use App\Models\Post;
use Illuminate\Auth\Access\HandlesAuthorization;
use Illuminate\Auth\Access\Response;

final class PostPolicy
{
  use HandlesAuthorization;

  public function update(User $user, Post $post): Response
  {
    return $post->author->is($user) ?
      Response::allow("Update your post.") :
      Response::deny("Only author can update their post.");
  }
}
```

```php
@allows("update", $post)
    {{ $message }}
@elseallows
    {{ $message }}
@endallows
```

No breaking changes should occur after merging this PR.

I shamelessly copy/pasted the source code on my own L8 project to test if it works (and it did), since I cannot figure out how to test the whole integration.