### PR TITLE
[8.x] Allow assertion of multiple JSON validation errors.

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -871,7 +871,7 @@ EOF;
      */
     public function assertJsonValidationErrorFor($key, $responseKey = 'errors')
     {
-        $jsonErrors = $this->jsonErrors($responseKey);
+        $jsonErrors = Arr::get($this->json(), $responseKey) ?? [];
 
         $errorMessage = $jsonErrors
             ? 'Response has the following JSON validation errors:'.
@@ -927,17 +927,6 @@ EOF;
         }
 
         return $this;
-    }
-
-    /**
-     * Return decoded JSON validation errors.
-     *
-     * @param  string  $responseKey
-     * @return array
-     */
-    protected function jsonErrors($responseKey = 'errors')
-    {
-        return Arr::get($this->json(), $responseKey) ?? [];
     }
 
     /**

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -832,30 +832,58 @@ EOF;
                 : 'Response does not have JSON validation errors.';
 
         foreach ($errors as $key => $value) {
-            PHPUnit::assertArrayHasKey(
-                (is_int($key)) ? $value : $key,
-                $jsonErrors,
-                "Failed to find a validation error in the response for key: '{$value}'".PHP_EOL.PHP_EOL.$errorMessage
-            );
+            if (is_int($key)) {
+                $this->assertJsonValidationErrorFor($value, $responseKey);
 
-            if (! is_int($key)) {
-                $hasError = false;
+                continue;
+            }
+
+            $this->assertJsonValidationErrorFor($key, $responseKey);
+
+            foreach (Arr::wrap($value) as $expectedMessage) {
+                $errorMissing = true;
 
                 foreach (Arr::wrap($jsonErrors[$key]) as $jsonErrorMessage) {
-                    if (Str::contains($jsonErrorMessage, $value)) {
-                        $hasError = true;
+                    if (Str::contains($jsonErrorMessage, $expectedMessage)) {
+                        $errorMissing = false;
 
                         break;
                     }
                 }
+            }
 
-                if (! $hasError) {
-                    PHPUnit::fail(
-                        "Failed to find a validation error in the response for key and message: '$key' => '$value'".PHP_EOL.PHP_EOL.$errorMessage
-                    );
-                }
+            if ($errorMissing) {
+                PHPUnit::fail(
+                    "Failed to find a validation error in the response for key and message: '$key' => '$expectedMessage'".PHP_EOL.PHP_EOL.$errorMessage
+                );
             }
         }
+
+        return $this;
+    }
+
+    /**
+     * Assert the response has any JSON validation errors for the given key.
+     *
+     * @param  string  $key
+     * @param  string  $responseKey
+     *
+     * @return $this
+     */
+    public function assertJsonValidationErrorFor($key, $responseKey = 'errors')
+    {
+        $jsonErrors = $this->jsonErrors($responseKey);
+
+        $errorMessage = $jsonErrors
+            ? 'Response has the following JSON validation errors:'.
+            PHP_EOL.PHP_EOL.json_encode($jsonErrors, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE).PHP_EOL
+            : 'Response does not have JSON validation errors.';
+
+        PHPUnit::assertArrayHasKey(
+            $key,
+            $jsonErrors,
+            "Failed to find a validation error in the response for key: '{$key}'".PHP_EOL.PHP_EOL.$errorMessage
+        );
 
         return $this;
     }
@@ -900,6 +928,17 @@ EOF;
         }
 
         return $this;
+    }
+
+    /**
+     * Return decoded JSON validation errors.
+     *
+     * @param  string  $responseKey
+     * @return array
+     */
+    protected function jsonErrors($responseKey = 'errors')
+    {
+        return Arr::get($this->json(), $responseKey) ?? [];
     }
 
     /**

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -867,7 +867,6 @@ EOF;
      *
      * @param  string  $key
      * @param  string  $responseKey
-     *
      * @return $this
      */
     public function assertJsonValidationErrorFor($key, $responseKey = 'errors')

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -50,7 +50,8 @@ class TestResponseTest extends TestCase
 
     public function testAssertViewHasModel()
     {
-        $model = new class extends Model {
+        $model = new class extends Model
+        {
             public function is($model)
             {
                 return $this == $model;

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -50,8 +50,7 @@ class TestResponseTest extends TestCase
 
     public function testAssertViewHasModel()
     {
-        $model = new class extends Model
-        {
+        $model = new class extends Model {
             public function is($model)
             {
                 return $this == $model;
@@ -1210,6 +1209,45 @@ class TestResponseTest extends TestCase
         );
 
         $testResponse->assertJsonValidationErrors(['one' => 'taylor', 'otwell']);
+    }
+
+    public function testAssertJsonValidationErrorMessagesMultipleErrors()
+    {
+        $data = [
+            'status' => 'ok',
+            'errors' => [
+                'one' => [
+                    'First error message.',
+                    'Second error message.',
+                ],
+            ],
+        ];
+
+        $testResponse = TestResponse::fromBaseResponse(
+            (new Response)->setContent(json_encode($data))
+        );
+
+        $testResponse->assertJsonValidationErrors(['one' => ['First error message.', 'Second error message.']]);
+    }
+
+    public function testAssertJsonValidationErrorMessagesMultipleErrorsCanFail()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $data = [
+            'status' => 'ok',
+            'errors' => [
+                'one' => [
+                    'First error message.',
+                ],
+            ],
+        ];
+
+        $testResponse = TestResponse::fromBaseResponse(
+            (new Response)->setContent(json_encode($data))
+        );
+
+        $testResponse->assertJsonValidationErrors(['one' => ['First error message.', 'Second error message.']]);
     }
 
     public function testAssertJsonMissingValidationErrors()


### PR DESCRIPTION
Allow multiple validation error messages to be expected when testing responses from JSON API.

The `TestResponse::assertJsonValidationErrors()` method already accepts a single message to be expected for any given request attribute. It seems intuitive that since the actual JSON response might contain an array of validation errors, if more than one rule is violated, that this method could expect multiple messages per attribute.

Currently this assumes that each attribute will expect a single message and if an array is provided it will throw an exception for an array to string conversion when creating the error message.

The change allows for multiple messages to be expected and for the assertion to fail if any of the provided messages is not in the response.

All previous tests continue to pass and previous usages of this method still work so this should not break any existing code based on this method.