### PR TITLE
[8.x] Change documented exceptions to RuntimeException in QueriesRelationships

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -466,7 +466,7 @@ trait QueriesRelationships
      * @param  string  $boolean
      * @return $this
      *
-     * @throws \Exception
+     * @throws \RuntimeException
      */
     public function whereBelongsTo($related, $relationshipName = null, $boolean = 'and')
     {
@@ -501,7 +501,7 @@ trait QueriesRelationships
      * @param  string  $relationship
      * @return $this
      *
-     * @throws \Exception
+     * @throws \RuntimeException
      */
     public function orWhereBelongsTo($related, $relationshipName = null)
     {


### PR DESCRIPTION
`whereBelongsTo()` and `orWhereBelongsTo()` potentially throw `RelationNotFoundException`, which is a runtime exception. However, these methods currently document throwing `\Exception`. While that's technically the case, I believe we should document exceptions as specific as possible. This has the added benefit of PhpStorm not complaining about uncaught exceptions when using either of the aforementioned methods, because it ignores uncaught RuntimeExceptions by default.

The only other method in this trait that throws an exception is `has()`, [which documents `\RuntimeException`](https://github.com/laravel/framework/blob/8.x/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php#L28).

We could also document `RelationNotFoundException` instead of `RuntimeException`, but I felt `RuntimeException` would be more consistent.