### PR TITLE
[8.x] Make:model --all flag would auto-fire make:controller with --requests

### DIFF
--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -136,7 +136,7 @@ class ModelMakeCommand extends GeneratorCommand
             'name' => "{$controller}Controller",
             '--model' => $this->option('resource') || $this->option('api') ? $modelName : null,
             '--api' => $this->option('api'),
-            '--requests' => $this->option('requests'),
+            '--requests' => $this->option('requests') || $this->option('all'),
         ]));
     }
 


### PR DESCRIPTION
Following up on my [recently-merged PR](https://github.com/laravel/framework/pull/39120) about `--requests` flag, I received at least a few comments on my Youtube/Twitter that it would be beneficial to include Form Requests generation when launching `php artisan make:model Post --all` (or `-a` for short).