### PR TITLE
[8.x] DB command: Cope with missing driver parameters for mysql

### DIFF
--- a/src/Illuminate/Database/Console/DbCommand.php
+++ b/src/Illuminate/Database/Console/DbCommand.php
@@ -135,8 +135,8 @@ class DbCommand extends Command
             '--user='.$connection['username'],
         ], $this->getOptionalArguments([
             'password' => '--password='.$connection['password'],
-            'unix_socket' => '--socket='.$connection['unix_socket'],
-            'charset' => '--default-character-set='.$connection['charset'],
+            'unix_socket' => '--socket='.($connection['unix_socket'] ?? ''),
+            'charset' => '--default-character-set='.($connection['charset'] ?? ''),
         ], $connection), [$connection['database']]);
     }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

# The problem

We don't expose our mysql installation via unix sockets (we only use network connections). Therefore our mysql config in `config/database.php` does not have a `unix_socket` entry.

This was causing the DB command to fail:

```
vagrant@dev:/var/www/api$ artisan db mysql 

In DbCommand.php line 138:
                                     
  Undefined array key "unix_socket"  
                                     
```

# Discussion

As the unix socket is not necessarily required to connect to a mysql database, it seems sensible to ignore it if it's not present rather than throwing an error. The charset is also not required to connect.

# Implementation

I have used the null coalescence operator to supply a blank string as default, which means `getOptionalArguments()` will filter it out and the socket/charset arguments won't be passed in the command string.

A similar change might be applicable for the other database drivers, but I do not have as much experience with them and don't have any instances to test against, so I have not changed those methods.

# Testing

I've tested this locally against our mysql 8 installation and it works. I could not find any relevant unit tests to update but am happy to do so if somebody points me in the right direction.
