### PR TITLE
[9.x] Use match expression where possible

### DIFF
--- a/src/Illuminate/Auth/CreatesUserProviders.php
+++ b/src/Illuminate/Auth/CreatesUserProviders.php
@@ -33,16 +33,13 @@ trait CreatesUserProviders
             );
         }
 
-        switch ($driver) {
-            case 'database':
-                return $this->createDatabaseProvider($config);
-            case 'eloquent':
-                return $this->createEloquentProvider($config);
-            default:
-                throw new InvalidArgumentException(
-                    "Authentication user provider [{$driver}] is not defined."
-                );
-        }
+        return match ($driver) {
+            'database' => $this->createDatabaseProvider($config),
+            'eloquent' => $this->createEloquentProvider($config),
+            default => (throw new InvalidArgumentException(
+                "Authentication user provider [{$driver}] is not defined."
+            )),
+        };
     }
 
     /**

--- a/src/Illuminate/Auth/CreatesUserProviders.php
+++ b/src/Illuminate/Auth/CreatesUserProviders.php
@@ -36,9 +36,9 @@ trait CreatesUserProviders
         return match ($driver) {
             'database' => $this->createDatabaseProvider($config),
             'eloquent' => $this->createEloquentProvider($config),
-            default => (throw new InvalidArgumentException(
+            default => throw new InvalidArgumentException(
                 "Authentication user provider [{$driver}] is not defined."
-            )),
+            ),
         };
     }
 

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -856,14 +856,11 @@ class Connection implements ConnectionInterface
             return;
         }
 
-        switch ($event) {
-            case 'beganTransaction':
-                return $this->events->dispatch(new TransactionBeginning($this));
-            case 'committed':
-                return $this->events->dispatch(new TransactionCommitted($this));
-            case 'rollingBack':
-                return $this->events->dispatch(new TransactionRolledBack($this));
-        }
+        return $this->events->dispatch(match ($event) {
+            'beganTransaction' => new TransactionBeginning($this),
+            'committed' => new TransactionCommitted($this),
+            'rollingBack' => new TransactionRolledBack($this),
+        });
     }
 
     /**

--- a/src/Illuminate/Database/Connectors/ConnectionFactory.php
+++ b/src/Illuminate/Database/Connectors/ConnectionFactory.php
@@ -241,18 +241,13 @@ class ConnectionFactory
             return $this->container->make($key);
         }
 
-        switch ($config['driver']) {
-            case 'mysql':
-                return new MySqlConnector;
-            case 'pgsql':
-                return new PostgresConnector;
-            case 'sqlite':
-                return new SQLiteConnector;
-            case 'sqlsrv':
-                return new SqlServerConnector;
-        }
-
-        throw new InvalidArgumentException("Unsupported driver [{$config['driver']}].");
+        return match ($config['driver']) {
+            'mysql' => new MySqlConnector,
+            'pgsql' => new PostgresConnector,
+            'sqlite' => new SQLiteConnector,
+            'sqlsrv' => new SqlServerConnector,
+            default => (throw new InvalidArgumentException("Unsupported driver [{$config['driver']}].")),
+        };
     }
 
     /**
@@ -273,17 +268,12 @@ class ConnectionFactory
             return $resolver($connection, $database, $prefix, $config);
         }
 
-        switch ($driver) {
-            case 'mysql':
-                return new MySqlConnection($connection, $database, $prefix, $config);
-            case 'pgsql':
-                return new PostgresConnection($connection, $database, $prefix, $config);
-            case 'sqlite':
-                return new SQLiteConnection($connection, $database, $prefix, $config);
-            case 'sqlsrv':
-                return new SqlServerConnection($connection, $database, $prefix, $config);
-        }
-
-        throw new InvalidArgumentException("Unsupported driver [{$driver}].");
+        return match($driver) {
+            'mysql' => new MySqlConnection($connection, $database, $prefix, $config),
+            'pgsql' => new PostgresConnection($connection, $database, $prefix, $config),
+            'sqlite' => new SQLiteConnection($connection, $database, $prefix, $config),
+            'sqlsrv' => new SqlServerConnection($connection, $database, $prefix, $config),
+            default => (throw new InvalidArgumentException("Unsupported driver [{$driver}].")),
+        };
     }
 }

--- a/src/Illuminate/Database/Connectors/ConnectionFactory.php
+++ b/src/Illuminate/Database/Connectors/ConnectionFactory.php
@@ -268,7 +268,7 @@ class ConnectionFactory
             return $resolver($connection, $database, $prefix, $config);
         }
 
-        return match($driver) {
+        return match ($driver) {
             'mysql' => new MySqlConnection($connection, $database, $prefix, $config),
             'pgsql' => new PostgresConnection($connection, $database, $prefix, $config),
             'sqlite' => new SQLiteConnection($connection, $database, $prefix, $config),

--- a/src/Illuminate/Database/Connectors/ConnectionFactory.php
+++ b/src/Illuminate/Database/Connectors/ConnectionFactory.php
@@ -246,7 +246,7 @@ class ConnectionFactory
             'pgsql' => new PostgresConnector,
             'sqlite' => new SQLiteConnector,
             'sqlsrv' => new SqlServerConnector,
-            default => (throw new InvalidArgumentException("Unsupported driver [{$config['driver']}].")),
+            default => throw new InvalidArgumentException("Unsupported driver [{$config['driver']}]."),
         };
     }
 
@@ -273,7 +273,7 @@ class ConnectionFactory
             'pgsql' => new PostgresConnection($connection, $database, $prefix, $config),
             'sqlite' => new SQLiteConnection($connection, $database, $prefix, $config),
             'sqlsrv' => new SqlServerConnection($connection, $database, $prefix, $config),
-            default => (throw new InvalidArgumentException("Unsupported driver [{$driver}].")),
+            default => throw new InvalidArgumentException("Unsupported driver [{$driver}]."),
         };
     }
 }

--- a/src/Illuminate/Database/DBAL/TimestampType.php
+++ b/src/Illuminate/Database/DBAL/TimestampType.php
@@ -16,7 +16,7 @@ class TimestampType extends Type implements PhpDateTimeMappingType
      */
     public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
     {
-        return match($name = $platform->getName()) {
+        return match ($name = $platform->getName()) {
             'mysql',
             'mysql2' => $this->getMySqlPlatformSQLDeclaration($fieldDeclaration),
             'postgresql',

--- a/src/Illuminate/Database/DBAL/TimestampType.php
+++ b/src/Illuminate/Database/DBAL/TimestampType.php
@@ -16,28 +16,17 @@ class TimestampType extends Type implements PhpDateTimeMappingType
      */
     public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
     {
-        $name = $platform->getName();
-
-        switch ($name) {
-            case 'mysql':
-            case 'mysql2':
-                return $this->getMySqlPlatformSQLDeclaration($fieldDeclaration);
-
-            case 'postgresql':
-            case 'pgsql':
-            case 'postgres':
-                return $this->getPostgresPlatformSQLDeclaration($fieldDeclaration);
-
-            case 'mssql':
-                return $this->getSqlServerPlatformSQLDeclaration($fieldDeclaration);
-
-            case 'sqlite':
-            case 'sqlite3':
-                return $this->getSQLitePlatformSQLDeclaration($fieldDeclaration);
-
-            default:
-                throw new DBALException('Invalid platform: '.$name);
-        }
+        return match($name = $platform->getName()) {
+            'mysql',
+            'mysql2' => $this->getMySqlPlatformSQLDeclaration($fieldDeclaration),
+            'postgresql',
+            'pgsql',
+            'postgres' => $this->getPostgresPlatformSQLDeclaration($fieldDeclaration),
+            'mssql' => $this->getSqlServerPlatformSQLDeclaration($fieldDeclaration),
+            'sqlite',
+            'sqlite3' => $this->getSQLitePlatformSQLDeclaration($fieldDeclaration),
+            default => (throw new DBALException('Invalid platform: '.$name)),
+        };
     }
 
     /**

--- a/src/Illuminate/Database/DBAL/TimestampType.php
+++ b/src/Illuminate/Database/DBAL/TimestampType.php
@@ -25,7 +25,7 @@ class TimestampType extends Type implements PhpDateTimeMappingType
             'mssql' => $this->getSqlServerPlatformSQLDeclaration($fieldDeclaration),
             'sqlite',
             'sqlite3' => $this->getSQLitePlatformSQLDeclaration($fieldDeclaration),
-            default => (throw new DBALException('Invalid platform: '.$name)),
+            default => throw new DBALException('Invalid platform: '.$name),
         };
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -669,18 +669,11 @@ trait InteractsWithPivotTable
      */
     protected function getTypeSwapValue($type, $value)
     {
-        switch (strtolower($type)) {
-            case 'int':
-            case 'integer':
-                return (int) $value;
-            case 'real':
-            case 'float':
-            case 'double':
-                return (float) $value;
-            case 'string':
-                return (string) $value;
-            default:
-                return $value;
-        }
+        return match(strtolower($type)) {
+            'int', 'integer' => (int) $value,
+            'real', 'float', 'double' => (float) $value,
+            'string' => (string) $value,
+            default => $value,
+        };
     }
 }

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -669,7 +669,7 @@ trait InteractsWithPivotTable
      */
     protected function getTypeSwapValue($type, $value)
     {
-        return match(strtolower($type)) {
+        return match (strtolower($type)) {
             'int', 'integer' => (int) $value,
             'real', 'float', 'double' => (float) $value,
             'string' => (string) $value,

--- a/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
+++ b/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
@@ -145,26 +145,14 @@ class ChangeColumn
     {
         $type = strtolower($type);
 
-        switch ($type) {
-            case 'biginteger':
-                $type = 'bigint';
-                break;
-            case 'smallinteger':
-                $type = 'smallint';
-                break;
-            case 'mediumtext':
-            case 'longtext':
-                $type = 'text';
-                break;
-            case 'binary':
-                $type = 'blob';
-                break;
-            case 'uuid':
-                $type = 'guid';
-                break;
-        }
-
-        return Type::getType($type);
+        return Type::getType(match ($type) {
+            'biginteger' => 'bigint',
+            'smallinteger' => 'smallint',
+            'mediumtext', 'longtext' => 'text',
+            'binary' => 'blob',
+            'uuid' => 'guid',
+            default => $type,
+        });
     }
 
     /**
@@ -216,19 +204,13 @@ class ChangeColumn
      */
     protected static function mapFluentOptionToDoctrine($attribute)
     {
-        switch ($attribute) {
-            case 'type':
-            case 'name':
-                return;
-            case 'nullable':
-                return 'notnull';
-            case 'total':
-                return 'precision';
-            case 'places':
-                return 'scale';
-            default:
-                return $attribute;
-        }
+        return match ($attribute) {
+            'type', 'name' => null,
+            'nullable' => 'notnull',
+            'total' => 'precision',
+            'places' => 'scale',
+            default => $attribute,
+        };
     }
 
     /**

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -761,7 +761,7 @@ class FilesystemAdapter implements CloudFilesystemContract
         return match ($visibility) {
             FilesystemContract::VISIBILITY_PUBLIC => Visibility::PUBLIC,
             FilesystemContract::VISIBILITY_PRIVATE => Visibility::PRIVATE,
-            default => (throw new InvalidArgumentException("Unknown visibility: {$visibility}.")),
+            default => throw new InvalidArgumentException("Unknown visibility: {$visibility}."),
         };
     }
 

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -758,14 +758,11 @@ class FilesystemAdapter implements CloudFilesystemContract
             return;
         }
 
-        switch ($visibility) {
-            case FilesystemContract::VISIBILITY_PUBLIC:
-                return Visibility::PUBLIC;
-            case FilesystemContract::VISIBILITY_PRIVATE:
-                return Visibility::PRIVATE;
-        }
-
-        throw new InvalidArgumentException("Unknown visibility: {$visibility}.");
+        return match ($visibility) {
+            FilesystemContract::VISIBILITY_PUBLIC => Visibility::PUBLIC,
+            FilesystemContract::VISIBILITY_PRIVATE => Visibility::PRIVATE,
+            default => (throw new InvalidArgumentException("Unknown visibility: {$visibility}.")),
+        };
     }
 
     /**

--- a/src/Illuminate/Notifications/RoutesNotifications.php
+++ b/src/Illuminate/Notifications/RoutesNotifications.php
@@ -43,11 +43,9 @@ trait RoutesNotifications
             return $this->{$method}($notification);
         }
 
-        switch ($driver) {
-            case 'database':
-                return $this->notifications();
-            case 'mail':
-                return $this->email;
-        }
+        return match ($driver) {
+            'database' => $this->notifications(),
+            'mail' => $this->email,
+        };
     }
 }

--- a/src/Illuminate/Redis/RedisManager.php
+++ b/src/Illuminate/Redis/RedisManager.php
@@ -168,12 +168,10 @@ class RedisManager implements Factory
             return $customCreator();
         }
 
-        switch ($this->driver) {
-            case 'predis':
-                return new PredisConnector;
-            case 'phpredis':
-                return new PhpRedisConnector;
-        }
+        return match ($this->driver) {
+            'predis' => new PredisConnector,
+            'phpredis' => new PhpRedisConnector,
+        };
     }
 
     /**


### PR DESCRIPTION
Laravel 9 will require PHP 8.0 as the minimum version, so we are free to use match expression. In this PR, I try to convert a few switch statements into match expressions that makes code easier to read.

Please review the code changes and see how nice the match expression is.
