### PR TITLE
[8.x] Make Listener Artisan command overwrites existing listener

### DIFF
--- a/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
@@ -85,7 +85,8 @@ class ListenerMakeCommand extends GeneratorCommand
      */
     protected function alreadyExists($rawName)
     {
-        return class_exists($rawName);
+        return class_exists($rawName) ||
+               $this->files->exists($this->getPath($this->qualifyClass($rawName)));
     }
 
     /**


### PR DESCRIPTION
The `artisan make:listener` command overwrites an existing listener. Updating the `alreadyExists()` method with the method taken from the EventMakeCommand fixes this.

To reproduce:

run `artisan make:listener TestListener`

Make changes to TestListener.php and run `artisan make:listener TestListener` again.

File overwritten en changes gone.
