### PR TITLE
[8.x] Fix typo in Connection property name

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -54,7 +54,7 @@ class Connection implements ConnectionInterface
      *
      * @var string|null
      */
-    protected $type;
+    protected $readWriteType;
 
     /**
      * The table prefix for the connection.


### PR DESCRIPTION
The uses of this property have been renamed in
https://github.com/laravel/framework/commit/d1a32f9acb225b6b7b360736f3c717461220dac9,
however the property declaration itself has not been adjusted.