### PR TITLE
[8.x] Ensure cache directory permissions

### DIFF
--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -137,7 +137,11 @@ class FileStore implements Store, LockProvider
 
         if (! $this->files->exists($directory)) {
             $this->files->makeDirectory($directory, 0777, true, true);
+
+            // We are creating two levels of prefix directories, e.g. 7e/24.
+            // So have to check them both.
             $this->ensurePermissionsAreCorrect($directory);
+            $this->ensurePermissionsAreCorrect(dirname($directory));
         }
     }
 

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -78,7 +78,7 @@ class FileStore implements Store, LockProvider
         );
 
         if ($result !== false && $result > 0) {
-            $this->ensureFileHasCorrectPermissions($path);
+            $this->ensurePermissionsAreCorrect($path);
 
             return true;
         }
@@ -115,7 +115,7 @@ class FileStore implements Store, LockProvider
                 ->write($this->expiration($seconds).serialize($value))
                 ->close();
 
-            $this->ensureFileHasCorrectPermissions($path);
+            $this->ensurePermissionsAreCorrect($path);
 
             return true;
         }
@@ -133,18 +133,21 @@ class FileStore implements Store, LockProvider
      */
     protected function ensureCacheDirectoryExists($path)
     {
-        if (! $this->files->exists(dirname($path))) {
-            $this->files->makeDirectory(dirname($path), 0777, true, true);
+        $directory = dirname($path);
+
+        if (! $this->files->exists($directory)) {
+            $this->files->makeDirectory($directory, 0777, true, true);
+            $this->ensurePermissionsAreCorrect($directory);
         }
     }
 
     /**
-     * Ensure the cache file has the correct permissions.
+     * Ensure the created node has the correct permissions.
      *
      * @param  string  $path
      * @return void
      */
-    protected function ensureFileHasCorrectPermissions($path)
+    protected function ensurePermissionsAreCorrect($path)
     {
         if (is_null($this->filePermission) ||
             intval($this->files->chmod($path), 8) == $this->filePermission) {

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -138,8 +138,7 @@ class FileStore implements Store, LockProvider
         if (! $this->files->exists($directory)) {
             $this->files->makeDirectory($directory, 0777, true, true);
 
-            // We are creating two levels of prefix directories, e.g. 7e/24.
-            // So have to check them both.
+            // We're creating two levels of directories (e.g. 7e/24), so we check them both...
             $this->ensurePermissionsAreCorrect($directory);
             $this->ensurePermissionsAreCorrect(dirname($directory));
         }

--- a/tests/Cache/CacheFileStoreTest.php
+++ b/tests/Cache/CacheFileStoreTest.php
@@ -107,7 +107,8 @@ class CacheFileStoreTest extends TestCase
         $files->shouldIgnoreMissing();
         $store = $this->getMockBuilder(FileStore::class)->onlyMethods(['expiration'])->setConstructorArgs([$files, __DIR__, 0606])->getMock();
         $hash = sha1('foo');
-        $cache_dir = substr($hash, 0, 2).'/'.substr($hash, 2, 2);
+        $cache_parent_dir = substr($hash, 0, 2);
+        $cache_dir = $cache_parent_dir.'/'.substr($hash, 2, 2);
 
         $files->shouldReceive('put')->withArgs([__DIR__.'/'.$cache_dir.'/'.$hash, m::any(), m::any()])->andReturnUsing(function ($name, $value) {
             return strlen($value);
@@ -115,6 +116,8 @@ class CacheFileStoreTest extends TestCase
 
         $files->shouldReceive('exists')->withArgs([__DIR__.'/'.$cache_dir])->andReturn(false)->once();
         $files->shouldReceive('makeDirectory')->withArgs([__DIR__.'/'.$cache_dir, 0777, true, true])->once();
+        $files->shouldReceive('chmod')->withArgs([__DIR__.'/'.$cache_parent_dir])->andReturn(['0600'])->once();
+        $files->shouldReceive('chmod')->withArgs([__DIR__.'/'.$cache_parent_dir, 0606])->andReturn([true])->once();
         $files->shouldReceive('chmod')->withArgs([__DIR__.'/'.$cache_dir])->andReturn(['0600'])->once();
         $files->shouldReceive('chmod')->withArgs([__DIR__.'/'.$cache_dir, 0606])->andReturn([true])->once();
 

--- a/tests/Cache/CacheFileStoreTest.php
+++ b/tests/Cache/CacheFileStoreTest.php
@@ -101,6 +101,28 @@ class CacheFileStoreTest extends TestCase
         m::close();
     }
 
+    public function testStoreItemDirectoryProperlySetsPermissions()
+    {
+        $files = m::mock(Filesystem::class);
+        $files->shouldIgnoreMissing();
+        $store = $this->getMockBuilder(FileStore::class)->onlyMethods(['expiration'])->setConstructorArgs([$files, __DIR__, 0606])->getMock();
+        $hash = sha1('foo');
+        $cache_dir = substr($hash, 0, 2).'/'.substr($hash, 2, 2);
+
+        $files->shouldReceive('put')->withArgs([__DIR__.'/'.$cache_dir.'/'.$hash, m::any(), m::any()])->andReturnUsing(function ($name, $value) {
+            return strlen($value);
+        });
+
+        $files->shouldReceive('exists')->withArgs([__DIR__.'/'.$cache_dir])->andReturn(false)->once();
+        $files->shouldReceive('makeDirectory')->withArgs([__DIR__.'/'.$cache_dir, 0777, true, true])->once();
+        $files->shouldReceive('chmod')->withArgs([__DIR__.'/'.$cache_dir])->andReturn(['0600'])->once();
+        $files->shouldReceive('chmod')->withArgs([__DIR__.'/'.$cache_dir, 0606])->andReturn([true])->once();
+
+        $result = $store->put('foo', 'foo', 10);
+        $this->assertTrue($result);
+        m::close();
+    }
+
     public function testForeversAreStoredWithHighTimestamp()
     {
         $files = $this->mockFilesystem();


### PR DESCRIPTION
There's an option to specify file permissions for the cache file store. But currently it only affects the files. All the prefix directories (e.g. `cache/data/0b/ee`) are created via Filesystem's `makeDirectory($path, 0777)` which ends up getting whatever umask implies, not what was specified in the config.

The function to ensure the correct permissions was already there. I use it to check the permissions of parent dirs (e.g. `cache/data/0b` and `cache/data/0b/ee`) as well. Ideally there would be a separate option for directory permissions and/or just use the Flysystem instead of Filesystem, but I wanted to keep the scope of this PR limited to the actual issue for now.

This should resolve issues like #33770.