### PR TITLE
[8.x] Arrayable/collection support for Collection::splice() replacement param

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1382,7 +1382,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
             return new static(array_splice($this->items, $offset));
         }
 
-        return new static(array_splice($this->items, $offset, $length, $replacement));
+        return new static(array_splice($this->items, $offset, $length, $this->getArrayableItems($replacement)));
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2645,6 +2645,14 @@ class SupportCollectionTest extends TestCase
         $cut = $data->splice(1, 1, 'bar');
         $this->assertEquals(['foo', 'bar'], $data->all());
         $this->assertEquals(['baz'], $cut->all());
+
+        $data = new Collection(['foo', 'baz']);
+        $data->splice(1, 0, ['bar']);
+        $this->assertEquals(['foo', 'bar', 'baz'], $data->all());
+
+        $data = new Collection(['foo', 'baz']);
+        $data->splice(1, 0, new Collection(['bar']));
+        $this->assertEquals(['foo', 'bar', 'baz'], $data->all());
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Hi there,

# Behavior
The `Collection::splice()`'s `$replacement` parameter has different behavior depending on whether a collection or array is passed in. I expected this to be the same. Example:

```php
$data = collect(['foo', 'baz']);
$data->splice(1, 0, ['bar']); // array
dump($data->all());

// Output:
// array:3 [
//   0 => "foo"
//   1 => "bar"
//   2 => "baz"
// ]

$data = collect(['foo', 'baz']);
$data->splice(1, 0, collect(['bar'])); // collection
dump($data->all());

// Output:
// array:3 [
//  0 => "foo"
//  1 => array:1 [
//    0 => "bar"
//  ]
//  2 => "baz"
// ]
```
This is due to the way PHP's native `array_splice` method handles objects. Although, I think this is unexpected for the user.

# Backwards compatibility
Backwards compatibility is broken for all objects which implements `Enumerable`, `Arrayable`, `Jsonable`, `JsonSerializable` or `Traversable`. Other types are cast to an `array` by the `getArrayableItems()` method, which is similar to what `array_splice` does. The latter does not break backward compatibility.