### PR TITLE
[8.x] Add capability to ignore chars on `Str::random()`

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -549,9 +549,10 @@ class Str
      * Generate a more truly "random" alpha-numeric string.
      *
      * @param  int  $length
+     * @param  array<int, string>  $ignoreChars
      * @return string
      */
-    public static function random($length = 16)
+    public static function random($length = 16, $ignoreChars = [])
     {
         $string = '';
 
@@ -560,7 +561,7 @@ class Str
 
             $bytes = random_bytes($size);
 
-            $string .= substr(str_replace(['/', '+', '='], '', base64_encode($bytes)), 0, $size);
+            $string .= substr(str_replace(array_merge(['/', '+', '='], $ignoreChars), '', base64_encode($bytes)), 0, $size);
         }
 
         return $string;

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -359,6 +359,12 @@ class SupportStrTest extends TestCase
         $this->assertIsString(Str::random());
     }
 
+    public function testRandomWithIgnoreChars()
+    {
+        $ignoreChars = array_merge(range('B', 'z'), range('0', '9'));
+        $this->assertEquals('A', Str::random(1, $ignoreChars));
+    }
+
     public function testReplace()
     {
         $this->assertSame('foo bar laravel', Str::replace('baz', 'laravel', 'foo bar baz'));


### PR DESCRIPTION
This PR adds a capability to ignore certain chars on the `Str::random()`:

# Usage:

```php
/* It will ignore the chars "I, i, o, O, 0, l and 1" when generating a random string */
$code = Str::random(6, ['I', 'i', 'o', 'O', '0', 'l', '1']);
```

Let me know if its a good addition of if I need to make any change.