### PR TITLE
[8.x] Fix $component not being reverted if component doesn't render

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
@@ -78,13 +78,7 @@ trait CompilesComponents
      */
     protected function compileEndComponent()
     {
-        $hash = array_pop(static::$componentHashStack);
-
         return implode("\n", [
-            '<?php if (isset($__componentOriginal'.$hash.')): ?>',
-            '<?php $component = $__componentOriginal'.$hash.'; ?>',
-            '<?php unset($__componentOriginal'.$hash.'); ?>',
-            '<?php endif; ?>',
             '<?php echo $__env->renderComponent(); ?>',
         ]);
     }
@@ -96,7 +90,13 @@ trait CompilesComponents
      */
     public function compileEndComponentClass()
     {
+        $hash = array_pop(static::$componentHashStack);
+
         return $this->compileEndComponent()."\n".implode("\n", [
+            '<?php endif; ?>',
+            '<?php if (isset($__componentOriginal'.$hash.')): ?>',
+            '<?php $component = $__componentOriginal'.$hash.'; ?>',
+            '<?php unset($__componentOriginal'.$hash.'); ?>',
             '<?php endif; ?>',
         ]);
     }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
@@ -78,9 +78,7 @@ trait CompilesComponents
      */
     protected function compileEndComponent()
     {
-        return implode("\n", [
-            '<?php echo $__env->renderComponent(); ?>',
-        ]);
+        return '<?php echo $__env->renderComponent(); ?>';
     }
 
     /**

--- a/tests/View/Blade/BladeComponentsTest.php
+++ b/tests/View/Blade/BladeComponentsTest.php
@@ -23,22 +23,18 @@ class BladeComponentsTest extends AbstractBladeTestCase
     {
         $this->compiler->newComponentHash('foo');
 
-        $this->assertSame('<?php if (isset($__componentOriginal0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33)): ?>
-<?php $component = $__componentOriginal0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33; ?>
-<?php unset($__componentOriginal0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33); ?>
-<?php endif; ?>
-<?php echo $__env->renderComponent(); ?>', $this->compiler->compileString('@endcomponent'));
+        $this->assertSame('<?php echo $__env->renderComponent(); ?>', $this->compiler->compileString('@endcomponent'));
     }
 
     public function testEndComponentClassesAreCompiled()
     {
         $this->compiler->newComponentHash('foo');
 
-        $this->assertSame('<?php if (isset($__componentOriginal0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33)): ?>
+        $this->assertSame('<?php echo $__env->renderComponent(); ?>
+<?php endif; ?>
+<?php if (isset($__componentOriginal0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33)): ?>
 <?php $component = $__componentOriginal0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33; ?>
 <?php unset($__componentOriginal0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33); ?>
-<?php endif; ?>
-<?php echo $__env->renderComponent(); ?>
 <?php endif; ?>', $this->compiler->compileString('@endcomponentClass'));
     }
 


### PR DESCRIPTION
If a component does not render due to its `shouldRender` method returning false, then the value of the `$component` variable will never be reverted back to its original value.

Example:

```php
use Illuminate\Support\Facades\Blade;
use Illuminate\View\Component;

class Outer extends Component
{
  public $test = 'yay!';

  public function render()
  {
    return '{{ $slot }}';
  }
}

class Inner extends Component
{
  public function shouldRender()
  {
    return false;
  }

  public function render()
  {
    return 'inner';
  }
}

Blade::component(Outer::class, 'outer');
Blade::component(Inner::class, 'inner');

Route::get('/', function (){
  return view('test');
});
```

```blade
{{-- test.blade.php --}}
<x-outer>
    <x-inner />
    {{ $component->test }}
</x-outer>
```

Expected output:

> yay!

Actual output:

> Undefined property: Inner::$test

Fixed by moving the statements that revert `$component` outside of the `shouldRender` conditional. Tests updated accordingly. As far as I can tell, these statements aren't needed inside of `compileEndComponent` anyway, because the `$component` variable is only overwritten when starting a class component.