### PR TITLE
[8.x] Added console command to create Scope, Traits and Service Class

### DIFF
--- a/src/Illuminate/Foundation/Console/ScopeMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ScopeMakeCommand.php
@@ -2,13 +2,10 @@
 
 namespace Illuminate\Foundation\Console;
 
-use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Console\GeneratorCommand;
 
 class ScopeMakeCommand extends GeneratorCommand
-{
-    use CreatesMatchingTest;
-    
+{   
     /**
      * The name and signature of the console command.
      *

--- a/src/Illuminate/Foundation/Console/ScopeMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ScopeMakeCommand.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\Concerns\CreatesMatchingTest;
+use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Input\InputOption;
+
+class ScopeMakeCommand extends GeneratorCommand
+{
+    use CreatesMatchingTest;
+    
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'make:scope';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = "Create a new Scope Class";
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Scope';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        if (parent::handle() === false && ! $this->option('force')) {
+            return;
+        }
+    }
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return $this->resolveStubPath('/stubs/scope.stub');
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return is_dir(app_path('Scopes')) ? $rootNamespace.'\\Scopes' : $rootNamespace;
+    }
+}

--- a/src/Illuminate/Foundation/Console/ScopeMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ScopeMakeCommand.php
@@ -5,7 +5,7 @@ namespace Illuminate\Foundation\Console;
 use Illuminate\Console\GeneratorCommand;
 
 class ScopeMakeCommand extends GeneratorCommand
-{   
+{
     /**
      * The name and signature of the console command.
      *

--- a/src/Illuminate/Foundation/Console/ScopeMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ScopeMakeCommand.php
@@ -4,7 +4,6 @@ namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Console\GeneratorCommand;
-use Symfony\Component\Console\Input\InputOption;
 
 class ScopeMakeCommand extends GeneratorCommand
 {

--- a/src/Illuminate/Foundation/Console/ScopeMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ScopeMakeCommand.php
@@ -22,7 +22,7 @@ class ScopeMakeCommand extends GeneratorCommand
      *
      * @var string
      */
-    protected $description = "Create a new Scope Class";
+    protected $description = 'Create a new Scope Class';
 
     /**
      * The type of class being generated.

--- a/src/Illuminate/Foundation/Console/ServiceMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServiceMakeCommand.php
@@ -4,7 +4,6 @@ namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Console\GeneratorCommand;
-use Symfony\Component\Console\Input\InputOption;
 
 class ServiceMakeCommand extends GeneratorCommand
 {

--- a/src/Illuminate/Foundation/Console/ServiceMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServiceMakeCommand.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\Concerns\CreatesMatchingTest;
+use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Input\InputOption;
+
+class ServiceMakeCommand extends GeneratorCommand
+{
+    use CreatesMatchingTest;
+    
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'make:service';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = "Create a new Service Class";
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Service';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        if (parent::handle() === false && ! $this->option('force')) {
+            return;
+        }
+    }
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return $this->resolveStubPath('/stubs/service.stub');
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return is_dir(app_path('Services')) ? $rootNamespace.'\\Services' : $rootNamespace;
+    }
+}

--- a/src/Illuminate/Foundation/Console/ServiceMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServiceMakeCommand.php
@@ -2,13 +2,10 @@
 
 namespace Illuminate\Foundation\Console;
 
-use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Console\GeneratorCommand;
 
 class ServiceMakeCommand extends GeneratorCommand
 {
-    use CreatesMatchingTest;
-    
     /**
      * The name and signature of the console command.
      *

--- a/src/Illuminate/Foundation/Console/ServiceMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServiceMakeCommand.php
@@ -22,7 +22,7 @@ class ServiceMakeCommand extends GeneratorCommand
      *
      * @var string
      */
-    protected $description = "Create a new Service Class";
+    protected $description = 'Create a new Service Class';
 
     /**
      * The type of class being generated.

--- a/src/Illuminate/Foundation/Console/TraitMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/TraitMakeCommand.php
@@ -22,7 +22,7 @@ class TraitMakeCommand extends GeneratorCommand
      *
      * @var string
      */
-    protected $description = "Create a new Trait Class";
+    protected $description = 'Create a new Trait Class';
 
     /**
      * The type of class being generated.

--- a/src/Illuminate/Foundation/Console/TraitMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/TraitMakeCommand.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\Concerns\CreatesMatchingTest;
+use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Input\InputOption;
+
+class TraitMakeCommand extends GeneratorCommand
+{
+    use CreatesMatchingTest;
+    
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'make:trait';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = "Create a new Trait Class";
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Trait';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        if (parent::handle() === false && ! $this->option('force')) {
+            return;
+        }
+    }
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return $this->resolveStubPath('/stubs/trait.stub');
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return is_dir(app_path('Traits')) ? $rootNamespace.'\\Traits' : $rootNamespace;
+    }
+}

--- a/src/Illuminate/Foundation/Console/TraitMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/TraitMakeCommand.php
@@ -2,13 +2,10 @@
 
 namespace Illuminate\Foundation\Console;
 
-use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Console\GeneratorCommand;
 
 class TraitMakeCommand extends GeneratorCommand
 {
-    use CreatesMatchingTest;
-    
     /**
      * The name and signature of the console command.
      *

--- a/src/Illuminate/Foundation/Console/TraitMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/TraitMakeCommand.php
@@ -4,7 +4,6 @@ namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Console\GeneratorCommand;
-use Symfony\Component\Console\Input\InputOption;
 
 class TraitMakeCommand extends GeneratorCommand
 {

--- a/src/Illuminate/Foundation/Console/stubs/scope.stub
+++ b/src/Illuminate/Foundation/Console/stubs/scope.stub
@@ -1,0 +1,22 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Scope;
+
+class {{ class }}
+{
+	/**
+     * Apply the scope to a given Eloquent query builder.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $builder
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return void
+     */
+    public function apply(Builder $builder, Model $model)
+    {
+        //
+    }
+}

--- a/src/Illuminate/Foundation/Console/stubs/service.stub
+++ b/src/Illuminate/Foundation/Console/stubs/service.stub
@@ -1,0 +1,19 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Database\QueryException;
+
+class {{ class }}
+{
+	/**
+	 * Create New Service Instance
+	 * 
+	 * @return void
+	 */
+	public function __construct()
+	{
+		//
+	}
+}

--- a/src/Illuminate/Foundation/Console/stubs/trait.stub
+++ b/src/Illuminate/Foundation/Console/stubs/trait.stub
@@ -1,0 +1,8 @@
+<?php
+
+namespace {{ namespace }};
+
+trait {{ class }} 
+{
+    //
+}


### PR DESCRIPTION
For years I've been struggling to create manually some classes like `Scope`, `Trait` and `Scope` Class.

Now by this pull request, when it's accepted, Laravel Developer can do:

1. `php artisan make:scope LatestUpdateScope`
Then we can see `LatestUpdateScope` in folder of `app/Scopes/`

2. `php artisan make:trait ModelHasRelationship`
Then we can see `ModelHasRelationship` in folder of `app/Traits/`

3. `php artisan make:service ProductService`
Then we can see `ProductService` in folder of `app/Services/`

By then, creating classes to serve DRY principle will be easier