### PR TITLE
[8.x] Fix: prevent re-casting of enum values

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -679,7 +679,7 @@ trait HasAttributes
         }
 
         $castType = $this->getCasts()[$key];
-        
+
         if ($value instanceof $castType) {
             return $value;
         }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -679,6 +679,10 @@ trait HasAttributes
         }
 
         $castType = $this->getCasts()[$key];
+        
+        if ($value instanceof $castType) {
+            return $value;
+        }
 
         return $castType::from($value);
     }


### PR DESCRIPTION
I ran into an issue in testing 8.1 enums where when using observers/jobs to set an enum after a previous update it was trying to re-cast the enum value into the enum class using `EnumClass::from()` which only accepts an integer/string value. A simple check here stops that from happening.