### PR TITLE
[8.x] Add @errorclass directive

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesErrors.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesErrors.php
@@ -45,9 +45,9 @@ unset($__errorArgs, $__bag); ?>';
     {
         $expression = $this->stripParentheses($expression);
         $expression = explode(', ', $expression);
-        return '<?php $__errorArgs = [' . $expression[0].','.$expression[2] ?? '\'default\''.'];
+        return '<?php $__errorArgs = ['.$expression[0].','.$expression[2] ?? '\'default\''.'];
 $__bag = $errors->getBag($__errorArgs[1]);
-if ($__bag->has($__errorArgs[0])){ echo ' . $expression[1] . ';}
+if ($__bag->has($__errorArgs[0])){ echo '.$expression[1].';}
 unset($__errorArgs, $__bag);?>';
     }
 }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesErrors.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesErrors.php
@@ -34,4 +34,20 @@ if (isset($__messageOriginal)) { $message = $__messageOriginal; }
 endif;
 unset($__errorArgs, $__bag); ?>';
     }
+
+    /**
+     * Complie error classes into valid PHP.
+     *
+     * @param mixed $expression
+     * @return void
+     */
+    protected function compileErrorclass($expression)
+    {
+        $expression = $this->stripParentheses($expression);
+        $expression = explode(', ', $expression);
+        return '<?php $__errorArgs = [' . $expression[0].','.$expression[2] ?? '\'default\''.'];
+$__bag = $errors->getBag($__errorArgs[1]);
+if ($__bag->has($__errorArgs[0])){ echo ' . $expression[1] . ';}
+unset($__errorArgs, $__bag);?>';
+    }
 }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesErrors.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesErrors.php
@@ -46,6 +46,7 @@ unset($__errorArgs, $__bag); ?>';
         $expression = $this->stripParentheses($expression);
         $expression = explode(', ', $expression);
         $bag = $expression[2] ?? '\'default\'';
+
         return '<?php $__errorArgs = ['.$expression[0].','.$bag.'];
 $__bag = $errors->getBag($__errorArgs[1]);
 if ($__bag->has($__errorArgs[0])){ echo '.$expression[1].';}

--- a/src/Illuminate/View/Compilers/Concerns/CompilesErrors.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesErrors.php
@@ -38,7 +38,7 @@ unset($__errorArgs, $__bag); ?>';
     /**
      * Complie error classes into valid PHP.
      *
-     * @param mixed $expression
+     * @param  mixed  $expression
      * @return void
      */
     protected function compileErrorclass($expression)

--- a/src/Illuminate/View/Compilers/Concerns/CompilesErrors.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesErrors.php
@@ -45,7 +45,8 @@ unset($__errorArgs, $__bag); ?>';
     {
         $expression = $this->stripParentheses($expression);
         $expression = explode(', ', $expression);
-        return '<?php $__errorArgs = ['.$expression[0].','.$expression[2] ?? '\'default\''.'];
+        $bag = $expression[2] ?? '\'default\'';
+        return '<?php $__errorArgs = ['.$expression[0].','.$bag.'];
 $__bag = $errors->getBag($__errorArgs[1]);
 if ($__bag->has($__errorArgs[0])){ echo '.$expression[1].';}
 unset($__errorArgs, $__bag);?>';

--- a/tests/View/Blade/BladeErrorTest.php
+++ b/tests/View/Blade/BladeErrorTest.php
@@ -50,7 +50,7 @@ unset($__errorArgs, $__bag); ?>';
         $string = '@errorclass(\'email\', \'is-danger\')';
 
         $expected = '
-<?php $__errorArgs = [\'email\',\'is-danger\'];
+<?php $__errorArgs = [\'email\',\'default\'];
 $__bag = $errors->getBag($__errorArgs[1]);
 if ($__bag->has($__errorArgs[0])){ echo \'is-danger\';}
 unset($__errorArgs, $__bag);?>';

--- a/tests/View/Blade/BladeErrorTest.php
+++ b/tests/View/Blade/BladeErrorTest.php
@@ -61,8 +61,7 @@ unset($__errorArgs, $__bag);?>';
     {
         $string = '@errorclass(\'email\', \'is-danger\', \'custom-bag\')';
 
-        $expected = '
-<?php $__errorArgs = [\'email\',\'custom-bag\'];
+        $expected = '<?php $__errorArgs = [\'email\',\'custom-bag\'];
 $__bag = $errors->getBag($__errorArgs[1]);
 if ($__bag->has($__errorArgs[0])){ echo \'is-danger\';}
 unset($__errorArgs, $__bag);?>';

--- a/tests/View/Blade/BladeErrorTest.php
+++ b/tests/View/Blade/BladeErrorTest.php
@@ -56,4 +56,16 @@ if ($__bag->has($__errorArgs[0])){ echo \'is-danger\';}
 unset($__errorArgs, $__bag);?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
+
+    public function testErrorClasseswithBagsAreComplied()
+    {
+        $string = '@errorclass(\'email\', \'is-danger\', \'custom-bag\')';
+
+        $expected = '
+<?php $__errorArgs = [\'email\',\'custom-bag\'];
+$__bag = $errors->getBag($__errorArgs[1]);
+if ($__bag->has($__errorArgs[0])){ echo \'is-danger\';}
+unset($__errorArgs, $__bag);?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
 }

--- a/tests/View/Blade/BladeErrorTest.php
+++ b/tests/View/Blade/BladeErrorTest.php
@@ -44,4 +44,16 @@ endif;
 unset($__errorArgs, $__bag); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
+
+    public function testErrorClassesAreComplied()
+    {
+        $string = '@errorclass(\'email\', \'is-danger\')';
+
+        $expected = '
+<?php $__errorArgs = [\'email\',\'is-danger\'];
+$__bag = $errors->getBag($__errorArgs[1]);
+if ($__bag->has($__errorArgs[0])){ echo \'is-danger\';}
+unset($__errorArgs, $__bag);?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
 }

--- a/tests/View/Blade/BladeErrorTest.php
+++ b/tests/View/Blade/BladeErrorTest.php
@@ -49,8 +49,7 @@ unset($__errorArgs, $__bag); ?>';
     {
         $string = '@errorclass(\'email\', \'is-danger\')';
 
-        $expected = '
-<?php $__errorArgs = [\'email\',\'default\'];
+        $expected = '<?php $__errorArgs = [\'email\',\'default\'];
 $__bag = $errors->getBag($__errorArgs[1]);
 if ($__bag->has($__errorArgs[0])){ echo \'is-danger\';}
 unset($__errorArgs, $__bag);?>';


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
`@errorclass` directive will enable users to print error classes on input instead of using the `@error` directive. the first time I was introduced to `@error` directive I thought it's gonna do that in the same way the `@section` directive does.

**before**
```blade
<label class="label">First name</label>
<input type="text" class="input @error('fname') is-danger @enderror" name="fname" value="{{ old('fname') }}">
@error('fname')
  <p class="help is-danger">{{ $message }} </p>
@enderror
```
**after**
```blade
<label class="label">First name</label>
<input type="text" class="input @errorclass('fname', 'is-danger')" name="fname" value="{{ old('fname') }}">
@error('fname')
  <p class="help is-danger">{{ $message }} </p>
@enderror
```

the user could also provide custom bag as a thrid parameter
```blade
<label class="label">First name</label>
<input type="text" class="input @errorclass('fname', 'is-danger', 'custom')" name="fname" value="{{ old('fname') }}">
@error('fname')
  <p class="help is-danger">{{ $message }} </p>
@enderror
```

another suggestion I thought of was to extend `@error` directive capability and add it as a third or second parameter but it was annoying because if you need to specify the bag you will be forced to pass a class (as second parameter) or the other way around. that's why I decided to create a new simplified directive for it.

thanks.

