### PR TITLE
[8.x] Add custom pagination information in resource

### DIFF
--- a/src/Illuminate/Http/Resources/Json/PaginatedResourceResponse.php
+++ b/src/Illuminate/Http/Resources/Json/PaginatedResourceResponse.php
@@ -41,16 +41,18 @@ class PaginatedResourceResponse extends ResourceResponse
      */
     protected function paginationInformation($request)
     {
-        if (method_exists($this->resource, 'paginationInformation')) {
-            return $this->resource->paginationInformation($request);
-        }
-
         $paginated = $this->resource->resource->toArray();
 
-        return [
+        $default = [
             'links' => $this->paginationLinks($paginated),
             'meta' => $this->meta($paginated),
         ];
+
+        if (method_exists($this->resource, 'paginationInformation')) {
+            return $this->resource->paginationInformation($request, $paginated, $default);
+        }
+
+        return $default;
     }
 
     /**

--- a/src/Illuminate/Http/Resources/Json/PaginatedResourceResponse.php
+++ b/src/Illuminate/Http/Resources/Json/PaginatedResourceResponse.php
@@ -41,6 +41,10 @@ class PaginatedResourceResponse extends ResourceResponse
      */
     protected function paginationInformation($request)
     {
+        if (method_exists($this->resource, 'paginationInformation')) {
+            return $this->resource->paginationInformation($request);
+        }
+
         $paginated = $this->resource->resource->toArray();
 
         return [

--- a/tests/Integration/Http/Fixtures/AnonymousResourceCollectionWithPaginationInformation.php
+++ b/tests/Integration/Http/Fixtures/AnonymousResourceCollectionWithPaginationInformation.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http\Fixtures;
+
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+
+class AnonymousResourceCollectionWithPaginationInformation extends AnonymousResourceCollection
+{
+    public function paginationInformation($request)
+    {
+        $paginated = $this->resource->toArray();
+
+        return [
+            'current_page' => $paginated['current_page'],
+            'per_page' => $paginated['per_page'],
+            'total' => $paginated['total'],
+            'total_page' => $paginated['last_page'],
+        ];
+    }
+}

--- a/tests/Integration/Http/Fixtures/PostCollectionResourceWithPaginationInformation.php
+++ b/tests/Integration/Http/Fixtures/PostCollectionResourceWithPaginationInformation.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http\Fixtures;
+
+use Illuminate\Http\Resources\Json\ResourceCollection;
+
+class PostCollectionResourceWithPaginationInformation extends ResourceCollection
+{
+    public $collects = PostResource::class;
+
+    public function toArray($request)
+    {
+        return ['data' => $this->collection];
+    }
+
+    public function paginationInformation($request)
+    {
+        $paginated = $this->resource->toArray();
+
+        return [
+            'current_page' => $paginated['current_page'],
+            'per_page' => $paginated['per_page'],
+            'total' => $paginated['total'],
+            'total_page' => $paginated['last_page'],
+        ];
+    }
+}

--- a/tests/Integration/Http/Fixtures/PostResourceWithAnonymousResourceCollectionWithPaginationInformation.php
+++ b/tests/Integration/Http/Fixtures/PostResourceWithAnonymousResourceCollectionWithPaginationInformation.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http\Fixtures;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class PostResourceWithAnonymousResourceCollectionWithPaginationInformation extends JsonResource
+{
+    public function toArray($request)
+    {
+        return ['id' => $this->id, 'title' => $this->title, 'custom' => true];
+    }
+
+    /**
+     * Create a new anonymous resource collection.
+     *
+     * @param  mixed  $resource
+     * @return AnonymousResourceCollectionWithPaginationInformation
+     */
+    public static function collection($resource)
+    {
+        return tap(new AnonymousResourceCollectionWithPaginationInformation($resource, static::class), function ($collection) {
+            if (property_exists(static::class, 'preserveKeys')) {
+                $collection->preserveKeys = (new static([]))->preserveKeys === true;
+            }
+        });
+    }
+}


### PR DESCRIPTION
In our projects, there are many return formats. To return different custom paging information, customize all of the classes for resource classes in the project each time. I've found that simply adding this method to the `src/Illuminate/Http/Resources/Json/PaginatedResourceResponse.php` saves a lot of rework. 

Look at the tests to understand the use cases.

Before, I always re-customize these classes:
```
    AnonymousResourceCollection.php
    JsonResource.php
    PaginatedResourceResponse.php
    ResourceCollection.php
    ResourceResponse.php
```

After this pull request, I can return different paging information just add `paginationInformation` method to the collection resource class or custom `collection` method of the resource class. 

---- 
I have not found and do not know if there is a better and more convenient way, if there is, please tell me, thanks.