### PR TITLE
Update stub for unit tests

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/test.unit.stub
+++ b/src/Illuminate/Foundation/Console/stubs/test.unit.stub
@@ -2,7 +2,7 @@
 
 namespace {{ namespace }};
 
-use PHPUnit\Framework\TestCase;
+use Tests\TestCase;
 
 class {{ class }} extends TestCase
 {


### PR DESCRIPTION
This change addresses this idea: https://github.com/laravel/framework/discussions/39602

**PROBLEM**
As a newbie to testing, when I run `php artisan make:test SomeTest --unit`
Then I write a test, and then when I run it, I get this error:

`Illuminate\Contracts\Container\BindingResolutionException: Target class [config] does not exist.`

The problem is that all out-of-the-box generated `--unit` tests contain this on line 5:

`use PHPUnit\Framework\TestCase;`

So one of the first things I do when I create a new test is change this line to:

`use Tests\TestCase;`

**SOLUTION:**
I can run `php artisan stub:publish`
And update my own copy of `stubs/test.unit.stub.php`

But it would be nice if this worked as expected out of the box.
