### PR TITLE
[8.x] Enum casts accept backed values

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -926,7 +926,15 @@ trait HasAttributes
      */
     protected function setEnumCastableAttribute($key, $value)
     {
-        $this->attributes[$key] = isset($value) ? $value->value : null;
+        $enumClass = $this->getCasts()[$key];
+
+        if (! isset($value)) {
+            $this->attributes[$key] = null;
+        } else if ($value instanceof $enumClass) {
+            $this->attributes[$key] = $value->value;
+        } else {
+            $this->attributes[$key] = $enumClass::from($value)->value;
+        }
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -930,7 +930,7 @@ trait HasAttributes
 
         if (! isset($value)) {
             $this->attributes[$key] = null;
-        } else if ($value instanceof $enumClass) {
+        } elseif ($value instanceof $enumClass) {
             $this->attributes[$key] = $value->value;
         } else {
             $this->attributes[$key] = $enumClass::from($value)->value;

--- a/tests/Integration/Database/EloquentModelEnumCastingTest.php
+++ b/tests/Integration/Database/EloquentModelEnumCastingTest.php
@@ -111,6 +111,21 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
         ], DB::table('enum_casts')->where('id', $model->id)->first());
     }
 
+    public function testEnumsAcceptBackedValueOnSave()
+    {
+        $model = new EloquentModelEnumCastingTestModel([
+            'string_status' => 'pending',
+            'integer_status' => 1,
+        ]);
+
+        $model->save();
+
+        $model = EloquentModelEnumCastingTestModel::first();
+
+        $this->assertEquals(StringStatus::pending, $model->string_status);
+        $this->assertEquals(IntegerStatus::pending, $model->integer_status);
+    }
+
     public function testFirstOrNew()
     {
         DB::table('enum_casts')->insert([


### PR DESCRIPTION
This PR builds upon https://github.com/laravel/framework/pull/39315 to accept an enum's backed value as well.

Currently enum castable attributes first have to be instantiated (or be null) before they are accepted for casting:

```php
enum MyEnum: string
{
    case Pending = 'pending';
}
```

```php
$model = new Model;
$model->enum = MyEnum::Pending;
```

This can get verbose when handling requests:

```php
// Request input = ['enum' => 'pending']

$request->merge([
   'enum' => MyEnum::from($request->input('enum')),
]);

$model->fill(
    $request->all()
);
```

By also accepting the backed values of an enum when casting, fluent model filling will be enabled (again).

```php
$model = new Model;
$model->enum = 'pending';
```


```php
// Request input = ['enum' => 'pending']

$model->fill(
    $request->all()
);
```