### PR TITLE
[8.x] Add `allowIf` and `denyIf` helpers to `HandlesAuthorization`

### DIFF
--- a/src/Illuminate/Auth/Access/HandlesAuthorization.php
+++ b/src/Illuminate/Auth/Access/HandlesAuthorization.php
@@ -32,7 +32,7 @@ trait HandlesAuthorization
      * Conditionally create an access response or throw
      * an unauthorized exception.
      *
-     * @param  mixed $condition
+     * @param  mixed  $condition
      * @param  string|null  $message
      * @param  mixed|null  $code
      * @return \Illuminate\Auth\Access\Response
@@ -46,7 +46,7 @@ trait HandlesAuthorization
      * Conditionally throw an unauthorized exception
      * or create an access response.
      *
-     * @param  mixed $condition
+     * @param  mixed  $condition
      * @param  string|null  $message
      * @param  mixed|null  $code
      * @return \Illuminate\Auth\Access\Response

--- a/src/Illuminate/Auth/Access/HandlesAuthorization.php
+++ b/src/Illuminate/Auth/Access/HandlesAuthorization.php
@@ -27,4 +27,32 @@ trait HandlesAuthorization
     {
         return Response::deny($message, $code);
     }
+
+    /**
+     * Conditionally create an access response or throw
+     * an unauthorized exception.
+     *
+     * @param  mixed $condition
+     * @param  string|null  $message
+     * @param  mixed|null  $code
+     * @return \Illuminate\Auth\Access\Response
+     */
+    protected function allowIf($condition, $message = null, $code = null)
+    {
+        return value($condition) ? $this->allow() : $this->deny($message, $code);
+    }
+
+    /**
+     * Conditionally throw an unauthorized exception
+     * or create an access response.
+     *
+     * @param  mixed $condition
+     * @param  string|null  $message
+     * @param  mixed|null  $code
+     * @return \Illuminate\Auth\Access\Response
+     */
+    protected function denyIf($condition, $message = null, $code = null)
+    {
+        return value($condition) ? $this->deny($message, $code) : $this->allow();
+    }
 }

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -1176,6 +1176,6 @@ class AccessGateTestPolicyWithConditionalResponse
 
     public function update($user)
     {
-        return $this->denyIf(!$user->isAdmin, 'You must be an admin.', 'some_code');
+        return $this->denyIf(! $user->isAdmin, 'You must be an admin.', 'some_code');
     }
 }

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -619,7 +619,7 @@ class AuthAccessGateTest extends TestCase
         $gate->authorize('view', new AccessGateTestDummy);
     }
 
-    public function testAuthorizeReturnsAccessResponseWhenUsinlAllowIfHelper()
+    public function testAuthorizeReturnsAccessResponseWhenUsingAllowIfHelper()
     {
         $gate = $this->getBasicGate(true);
 
@@ -641,7 +641,7 @@ class AuthAccessGateTest extends TestCase
         $gate->authorize('update', new AccessGateTestDummy);
     }
 
-    public function testAuthorizeReturnsAccessResponseWhenUsinlDenyIfHelper()
+    public function testAuthorizeReturnsAccessResponseWhenUsingDenyIfHelper()
     {
         $gate = $this->getBasicGate(true);
 

--- a/tests/Auth/AuthHandlesAuthorizationTest.php
+++ b/tests/Auth/AuthHandlesAuthorizationTest.php
@@ -28,4 +28,44 @@ class AuthHandlesAuthorizationTest extends TestCase
         $this->assertSame('some message', $response->message());
         $this->assertSame('some_code', $response->code());
     }
+
+    public function testAllowIfMethodWhenFalse()
+    {
+        $response = $this->allowIf(false, 'some message', 'some_code');
+
+        $this->assertTrue($response->denied());
+        $this->assertFalse($response->allowed());
+        $this->assertSame('some message', $response->message());
+        $this->assertSame('some_code', $response->code());
+    }
+
+    public function testAllowIfMethodWhenTrue()
+    {
+        $response = $this->allowIf(true);
+
+        $this->assertTrue($response->allowed());
+        $this->assertFalse($response->denied());
+        $this->assertSame(null, $response->message());
+        $this->assertSame(null, $response->code());
+    }
+
+    public function testDenyIfMethodWhenTrue()
+    {
+        $response = $this->denyIf(true, 'some message', 'some_code');
+
+        $this->assertTrue($response->denied());
+        $this->assertFalse($response->allowed());
+        $this->assertSame('some message', $response->message());
+        $this->assertSame('some_code', $response->code());
+    }
+
+    public function testDenyIfMethodWhenFalse()
+    {
+        $response = $this->denyIf(false);
+
+        $this->assertTrue($response->allowed());
+        $this->assertFalse($response->denied());
+        $this->assertSame(null, $response->message());
+        $this->assertSame(null, $response->code());
+    }
 }


### PR DESCRIPTION
This PR allows a way to quickly return a policy response conditionally using similar syntax that is used elsewhere in the framework such as `$this->when( ... )`, `abort_if( ... )` and `throw_if( ... )`.

The two methods would accept either a value or a callback.

I have only allowed the message and code to be specified for the `deny` response as I was unsure as to where/when an `allow` response would actually ever be returned and used as a response.

An example of its usage is;
```php

// Current implementation
public function delete(User $user, Patient $patient): Response
{
    if ($user->hasPatient($patient)) {
        return $this->allow();
    }

    return $this->deny('You must be assigned to this patient.');
}

// Using new methods
public function delete(User $user, Patient $patient): Response
{
    return $this->allowIf($user->hasPatient($patient), 'You must be assigned to this patient.');
}
```

And to deny;
```php
public function delete(User $user, Product $product)
{
    return $this->denyIf($user->isCustomer());
}
```