### PR TITLE
[8.x] Change PHPDoc for BelongsTo::associate() to allow null

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -198,7 +198,7 @@ class BelongsTo extends Relation
     /**
      * Associate the model instance to the given parent.
      *
-     * @param  \Illuminate\Database\Eloquent\Model|int|string  $model
+     * @param  \Illuminate\Database\Eloquent\Model|int|string|null  $model
      * @return \Illuminate\Database\Eloquent\Model
      */
     public function associate($model)


### PR DESCRIPTION
It's already (functionally) possible to "associate" null on a belongs to relation. However, the documented type for `$model` does not reflect this, which causes static analysis tools to report invalid argument types. This PR adds `null` to the accepted types for `$model`.

Example use case:
```php
public function assignRole(?Role $role)
{
    $this->role()->associate($role);
}
```