### PR TITLE
[9.x] Makes `with` generic

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -368,9 +368,11 @@ if (! function_exists('with')) {
     /**
      * Return the given value, optionally passed through the given callback.
      *
-     * @param  mixed  $value
-     * @param  callable|null  $callback
-     * @return mixed
+     * @template TValue
+     *
+     * @param  TValue  $value
+     * @param  (callable(TValue): TValue)|null  $callback
+     * @return TValue
      */
     function with($value, callable $callback = null)
     {

--- a/types/Support/Helpers.php
+++ b/types/Support/Helpers.php
@@ -1,0 +1,15 @@
+<?php
+
+use function PHPStan\Testing\assertType;
+
+assertType('User', with(new User()));
+assertType('bool', with(new User())->save());
+assertType('User', with(new User(), function (User $user) {
+    return $user;
+}));
+
+assertType('int|User', with(new User(), function ($user) {
+    assertType('int|User', $user);
+
+    return 10;
+}));


### PR DESCRIPTION
This pull request makes the `with` helper generic. The current type definition is not perfect, assuming that the return value from `with` callback will be same as the given value. Yet, it's better then what we had before. At PHPStan level 5 works perfectly, and PHPStorm, of course, is able to infer the types correctly.

<img width="262" alt="Screenshot 2021-11-15 at 12 05 10" src="https://user-images.githubusercontent.com/5457236/141779596-9b63e858-e1db-4d79-8c53-b9ffaadee938.png">

<img width="388" alt="Screenshot 2021-11-15 at 12 06 17" src="https://user-images.githubusercontent.com/5457236/141779600-dd63fafe-07f6-4ff7-bf62-b348d1a60eed.png">

