### PR TITLE
[9.x] Perform type checking only in stable versions of PHP

### DIFF
--- a/.github/workflows/types.yml
+++ b/.github/workflows/types.yml
@@ -14,9 +14,6 @@ jobs:
       fail-fast: true
       matrix:
         php: ['8.0']
-        include:
-          - php: '8.1'
-            flags: "--ignore-platform-req=php"
 
     name: PHP ${{ matrix.php }}
 
@@ -39,5 +36,4 @@ jobs:
           command: composer update --prefer-stable --prefer-dist --no-interaction --no-progress ${{ matrix.flags }}
 
       - name: Execute type checking
-        continue-on-error: ${{ matrix.php > 8 }}
         run: vendor/bin/phpstan


### PR DESCRIPTION
This pull request adjusts the type checking workflow, so type checking gets only done in stable versions of PHP. PHPStan does not seem to support quite well PHP 8.1 yet, and in theory, does not make sense to check types twice.