### PR TITLE
[8.x] Modify DatabaseRule to accept Arrayable instance inside where methods

### DIFF
--- a/src/Illuminate/Validation/Rules/DatabaseRule.php
+++ b/src/Illuminate/Validation/Rules/DatabaseRule.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Validation\Rules;
 
 use Closure;
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
 
@@ -86,7 +87,7 @@ trait DatabaseRule
      */
     public function where($column, $value = null)
     {
-        if (is_array($value)) {
+        if ($value instanceof Arrayable || is_array($value)) {
             return $this->whereIn($column, $value);
         }
 
@@ -112,7 +113,7 @@ trait DatabaseRule
      */
     public function whereNot($column, $value)
     {
-        if (is_array($value)) {
+        if ($value instanceof Arrayable || is_array($value)) {
             return $this->whereNotIn($column, $value);
         }
 
@@ -145,10 +146,10 @@ trait DatabaseRule
      * Set a "where in" constraint on the query.
      *
      * @param  string  $column
-     * @param  array  $values
+     * @param  \Illuminate\Contracts\Support\Arrayable|array  $values
      * @return $this
      */
-    public function whereIn($column, array $values)
+    public function whereIn($column, $values)
     {
         return $this->where(function ($query) use ($column, $values) {
             $query->whereIn($column, $values);
@@ -159,10 +160,10 @@ trait DatabaseRule
      * Set a "where not in" constraint on the query.
      *
      * @param  string  $column
-     * @param  array  $values
+     * @param  \Illuminate\Contracts\Support\Arrayable|array  $values
      * @return $this
      */
-    public function whereNotIn($column, array $values)
+    public function whereNotIn($column, $values)
     {
         return $this->where(function ($query) use ($column, $values) {
             $query->whereNotIn($column, $values);

--- a/src/Illuminate/Validation/Rules/DatabaseRule.php
+++ b/src/Illuminate/Validation/Rules/DatabaseRule.php
@@ -82,7 +82,7 @@ trait DatabaseRule
      * Set a "where" constraint on the query.
      *
      * @param  \Closure|string  $column
-     * @param  array|string|int|null  $value
+     * @param  \Illuminate\Contracts\Support\Arrayable|array|string|int|null  $value
      * @return $this
      */
     public function where($column, $value = null)
@@ -108,7 +108,7 @@ trait DatabaseRule
      * Set a "where not" constraint on the query.
      *
      * @param  string  $column
-     * @param  array|string  $value
+     * @param  \Illuminate\Contracts\Support\Arrayable|array|string  $value
      * @return $this
      */
     public function whereNot($column, $value)


### PR DESCRIPTION
i found that when using the **Rule::where** or any where methods they only accept arrays ... while the [underlying query builder ](https://github.com/laravel/framework/blob/8.x/src/Illuminate/Database/Query/Builder.php#L963) can accept collections too ... so I have modified the implementation and here is an example of before vs after

**before**

```php

$names = collect(['foo', 'bar']);
$companiesIds = collect([1, 2]);

$request->validate([
    'first_name' => Rule::in($names),
    
     //here we have to chain ->toArray()
    'company' => Rule::exists('companies','id')->wereIn('id', $companiesIds->toArray()); 
]);

```

**after**

```php

$names = collect(['foo', 'bar']);
$companiesIds = collect([1, 2]);

$request->validate([
    'first_name' => Rule::in($names),
    'company' => Rule::exists('companies', 'id')->wereIn('id', $companiesIds); //no need to chain ->toArray()
]);

```

i didn't write tests for that behavior cause i felt i will have to repeat some methods inside or use data providers [ValidationExistsRuleTest](https://github.com/laravel/framework/blob/8.x/tests/Validation/ValidationExistsRuleTest.php#L75) ... and also the query builder behavior is already been tested ... so if it's ok to duplicate am ok to write them