### PR TITLE
[9.x] Exclude PHPStan related files from distributions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,6 +9,7 @@
 /.github export-ignore
 /bin export-ignore
 /tests export-ignore
+/types export-ignore
 .editorconfig export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
@@ -17,4 +18,5 @@ CHANGELOG-* export-ignore
 CODE_OF_CONDUCT.md export-ignore
 CONTRIBUTING.md export-ignore
 docker-compose.yml export-ignore
+phpstan.neon.dist export-ignore
 phpunit.xml.dist export-ignore


### PR DESCRIPTION
Noticed PHPStan files were included in the `vendor` directory.

![image](https://user-images.githubusercontent.com/3661474/141842809-d0456c59-8df5-40a4-a1b2-ebffb0751ddd.png)
