### PR TITLE
fix(rollback) required_if and exclude_if validation

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1509,10 +1509,6 @@ trait ValidatesAttributes
     {
         $this->requireParameterCount(2, $parameters, 'required_if');
 
-        if (! Arr::has($this->data, $parameters[0])) {
-            return true;
-        }
-
         [$values, $other] = $this->parseDependentRuleParameters($parameters);
 
         if (in_array($other, $values, is_bool($other) || is_null($other))) {
@@ -1611,10 +1607,6 @@ trait ValidatesAttributes
     public function validateExcludeIf($attribute, $value, $parameters)
     {
         $this->requireParameterCount(2, $parameters, 'exclude_if');
-
-        if (! Arr::has($this->data, $parameters[0])) {
-            return true;
-        }
 
         [$values, $other] = $this->parseDependentRuleParameters($parameters);
 


### PR DESCRIPTION
i think you do not want to return early in these cases as @driesvints changed in this PR: https://github.com/laravel/framework/pull/37128
that PR broke using this validation for `null` values (e.g. checkboxes that are not checked) so you cannot use it like `exclude_if,otherfield,null`