### PR TITLE
[8.x] Fix the wrong of response::make() function's  parameter type

### DIFF
--- a/src/Illuminate/Contracts/Routing/ResponseFactory.php
+++ b/src/Illuminate/Contracts/Routing/ResponseFactory.php
@@ -7,7 +7,7 @@ interface ResponseFactory
     /**
      * Create a new response instance.
      *
-     * @param  string  $content
+     * @param  mixed  $content
      * @param  int  $status
      * @param  array  $headers
      * @return \Illuminate\Http\Response

--- a/src/Illuminate/Contracts/Routing/ResponseFactory.php
+++ b/src/Illuminate/Contracts/Routing/ResponseFactory.php
@@ -7,7 +7,7 @@ interface ResponseFactory
     /**
      * Create a new response instance.
      *
-     * @param  mixed  $content
+     * @param  array|string  $content
      * @param  int  $status
      * @param  array  $headers
      * @return \Illuminate\Http\Response

--- a/src/Illuminate/Support/Facades/Response.php
+++ b/src/Illuminate/Support/Facades/Response.php
@@ -12,7 +12,7 @@ use Illuminate\Contracts\Routing\ResponseFactory as ResponseFactoryContract;
  * @method static \Illuminate\Http\RedirectResponse redirectToAction(string $action, mixed $parameters = [], int $status = 302, array $headers = [])
  * @method static \Illuminate\Http\RedirectResponse redirectToIntended(string $default = '/', int $status = 302, array $headers = [], bool|null $secure = null)
  * @method static \Illuminate\Http\RedirectResponse redirectToRoute(string $route, mixed $parameters = [], int $status = 302, array $headers = [])
- * @method static \Illuminate\Http\Response make(string $content = '', int $status = 200, array $headers = [])
+ * @method static \Illuminate\Http\Response make(mixed $content = '', int $status = 200, array $headers = [])
  * @method static \Illuminate\Http\Response noContent($status = 204, array $headers = [])
  * @method static \Illuminate\Http\Response view(string $view, array $data = [], int $status = 200, array $headers = [])
  * @method static \Symfony\Component\HttpFoundation\BinaryFileResponse download(\SplFileInfo|string $file, string|null $name = null, array $headers = [], string|null $disposition = 'attachment')

--- a/src/Illuminate/Support/Facades/Response.php
+++ b/src/Illuminate/Support/Facades/Response.php
@@ -12,7 +12,7 @@ use Illuminate\Contracts\Routing\ResponseFactory as ResponseFactoryContract;
  * @method static \Illuminate\Http\RedirectResponse redirectToAction(string $action, mixed $parameters = [], int $status = 302, array $headers = [])
  * @method static \Illuminate\Http\RedirectResponse redirectToIntended(string $default = '/', int $status = 302, array $headers = [], bool|null $secure = null)
  * @method static \Illuminate\Http\RedirectResponse redirectToRoute(string $route, mixed $parameters = [], int $status = 302, array $headers = [])
- * @method static \Illuminate\Http\Response make(mixed $content = '', int $status = 200, array $headers = [])
+ * @method static \Illuminate\Http\Response make(array|string $content = '', int $status = 200, array $headers = [])
  * @method static \Illuminate\Http\Response noContent($status = 204, array $headers = [])
  * @method static \Illuminate\Http\Response view(string $view, array $data = [], int $status = 200, array $headers = [])
  * @method static \Symfony\Component\HttpFoundation\BinaryFileResponse download(\SplFileInfo|string $file, string|null $name = null, array $headers = [], string|null $disposition = 'attachment')


### PR DESCRIPTION
‘’‘
$content = [
    'code' => 1
];
\Illuminate\Support\Facades\Response::make($content);
’‘’

> The above syntax prompt is incorrect
> Expected parameter of type 'string|void', 'array' provided 

However, $content can actually pass array, but the annotation is wrong.