### PR TITLE
[8.x] Suggest the latest version of `doctrine/dbal`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -81,7 +81,7 @@
     },
     "require-dev": {
         "aws/aws-sdk-php": "^3.198.1",
-        "doctrine/dbal": "^2.13.3|^3.1.2",
+        "doctrine/dbal": "^2.13.3|^3.1.4",
         "filp/whoops": "^2.14.3",
         "guzzlehttp/guzzle": "^6.5.5|^7.0.1",
         "league/flysystem-cached-adapter": "^1.0",
@@ -134,7 +134,7 @@
         "ext-redis": "Required to use the Redis cache and queue drivers (^4.0|^5.0).",
         "aws/aws-sdk-php": "Required to use the SQS queue driver, DynamoDb failed job storage and SES mail driver (^3.198.1).",
         "brianium/paratest": "Required to run tests in parallel (^6.0).",
-        "doctrine/dbal": "Required to rename columns and drop SQLite columns (^2.13.3|^3.1.2).",
+        "doctrine/dbal": "Required to rename columns and drop SQLite columns (^2.13.3|^3.1.4).",
         "filp/whoops": "Required for friendly error pages in development (^2.14.3).",
         "fakerphp/faker": "Required to use the eloquent factory builder (^1.9.1).",
         "guzzlehttp/guzzle": "Required to use the HTTP Client, Mailgun mail driver and the ping methods on schedules (^6.5.5|^7.0.1).",


### PR DESCRIPTION
This pull request makes the `composer.json` to suggest the latest version of `doctrine/dbal`.

Reason: https://github.com/doctrine/dbal/security/advisories/GHSA-r7cj-8hjg-x622.