### PR TITLE
[8.x] Adds support for `pusher/pusher-php-server: ^7.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -148,7 +148,7 @@
         "phpunit/phpunit": "Required to use assertions and run tests (^8.5.19|^9.5.8).",
         "predis/predis": "Required to use the predis connector (^1.1.9).",
         "psr/http-message": "Required to allow Storage::put to accept a StreamInterface (^1.0).",
-        "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (^4.0|^5.0|^6.0).",
+        "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (^4.0|^5.0|^6.0|^7.0).",
         "symfony/cache": "Required to PSR-6 cache bridge (^5.1.4).",
         "symfony/filesystem": "Required to enable support for relative symbolic links (^5.1.4).",
         "symfony/psr-http-message-bridge": "Required to use PSR-7 bridging features (^2.0).",


### PR DESCRIPTION
This pull request adds support for `pusher/pusher-php-server: ^7.0`. Note that, at this point, we are using a few [deprecated methods](https://github.com/pusher/pusher-http-php/blob/master/CHANGELOG.md), such as `$this->pusher->socket_auth(...`, etc. They will still work for now, but i guess they will be removed on `^8.0`.