### PR TITLE
[8.x] Added a method to the Macroable trait that removes all configured macros.

### DIFF
--- a/src/Illuminate/Macroable/Traits/Macroable.php
+++ b/src/Illuminate/Macroable/Traits/Macroable.php
@@ -63,6 +63,16 @@ trait Macroable
     }
 
     /**
+     * Flush the macros, removing them all.
+     *
+     * @return void
+     */
+    public static function flushMacros()
+    {
+        static::$macros = [];
+    }
+
+    /**
      * Dynamically handle calls to the class.
      *
      * @param  string  $method

--- a/src/Illuminate/Macroable/Traits/Macroable.php
+++ b/src/Illuminate/Macroable/Traits/Macroable.php
@@ -63,7 +63,7 @@ trait Macroable
     }
 
     /**
-     * Flush the macros, removing them all.
+     * Flush the existing macros.
      *
      * @return void
      */

--- a/tests/Support/SupportMacroableTest.php
+++ b/tests/Support/SupportMacroableTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Support;
 
+use BadMethodCallException;
 use Illuminate\Support\Traits\Macroable;
 use PHPUnit\Framework\TestCase;
 
@@ -72,6 +73,23 @@ class SupportMacroableTest extends TestCase
 
         TestMacroable::mixin(new TestMixin);
         $this->assertSame('foo', $instance->methodThree());
+    }
+
+    public function testFlushMacros()
+    {
+        TestMacroable::macro('flushMethod', function () {
+            return 'flushMethod';
+        });
+
+        $instance = new TestMacroable;
+
+        $this->assertSame('flushMethod', $instance->flushMethod());
+
+        TestMacroable::flushMacros();
+
+        $this->expectException(BadMethodCallException::class);
+
+        $instance->flushMethod();
     }
 }
 


### PR DESCRIPTION
This pull request adds a static `flushMacros` method to the `Macroable` trait that removes all the configured macros.

The primary use of this method is in a unit testing environment. When running multiple test cases that add static macros in the same process, there can be side-effects between test cases caused by the use of `static` members.

When combined with either the `--random-order` flag to PHPUnit or parallelized testing, these side effects can cause intermittent failures, as tests may or may not pass depending on the order / process they are ran in and the result of the side effects.
Ideally each unit test case is ran in a sanitized environment to ensure the developer is testing exactly what they intended to test, and aren't relying on any aspects setup outside of the current test case.

I was unsure as to whether the framework should enforce the running of `flushMacros` on contained Macroable classes, or whether the developer should handle this manually so i haven't done that.
Also enforcing that macros are always flushed is a not fully backwards-compatible change, whereas adding a method to allow developers to handle it themselves is.

Thanks for your time.
