### PR TITLE
[8.x] Use parents to resolve middleware priority

### DIFF
--- a/src/Illuminate/Routing/SortedMiddleware.php
+++ b/src/Illuminate/Routing/SortedMiddleware.php
@@ -101,6 +101,14 @@ class SortedMiddleware extends Collection
                 yield $interface;
             }
         }
+
+        $parents = @class_parents($stripped);
+
+        if ($parents !== false) {
+            foreach ($parents as $parent) {
+                yield $parent;
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
This PR allows using parents of the middleware as fallback to resolve the middleware priority. This allows overriding system middlewares while it keeps the correct ordering.

Also this fixes a bug where Jetstream overrides the AuthenticateSession middleware but since the priority was lost, a password update will log out the user if it was authenticated on a non-default guard.