### PR TITLE
[8.x] Add support for countables to the pluralizer

### DIFF
--- a/src/Illuminate/Support/Pluralizer.php
+++ b/src/Illuminate/Support/Pluralizer.php
@@ -64,7 +64,7 @@ class Pluralizer
      * Get the plural form of an English word.
      *
      * @param  string  $value
-     * @param  int|Countable  $count
+     * @param  int|array|Countable  $count
      * @return string
      */
     public static function plural($value, $count = 2)

--- a/src/Illuminate/Support/Pluralizer.php
+++ b/src/Illuminate/Support/Pluralizer.php
@@ -64,7 +64,7 @@ class Pluralizer
      * Get the plural form of an English word.
      *
      * @param  string  $value
-     * @param  int|array|Countable  $count
+     * @param  int|array|\Countable  $count
      * @return string
      */
     public static function plural($value, $count = 2)

--- a/src/Illuminate/Support/Pluralizer.php
+++ b/src/Illuminate/Support/Pluralizer.php
@@ -64,11 +64,15 @@ class Pluralizer
      * Get the plural form of an English word.
      *
      * @param  string  $value
-     * @param  int  $count
+     * @param  int|Countable  $count
      * @return string
      */
     public static function plural($value, $count = 2)
     {
+        if (is_countable($count)) {
+            $count = count($count);
+        }
+
         if ((int) abs($count) === 1 || static::uncountable($value) || preg_match('/^(.*)[A-Za-z0-9\x{0080}-\x{FFFF}]$/u', $value) == 0) {
             return $value;
         }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -521,7 +521,7 @@ class Str
      * Get the plural form of an English word.
      *
      * @param  string  $value
-     * @param  int|array|Countable  $count
+     * @param  int|array|\Countable  $count
      * @return string
      */
     public static function plural($value, $count = 2)

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -521,7 +521,7 @@ class Str
      * Get the plural form of an English word.
      *
      * @param  string  $value
-     * @param  int  $count
+     * @param  int|array|Countable  $count
      * @return string
      */
     public static function plural($value, $count = 2)

--- a/tests/Support/SupportPluralizerTest.php
+++ b/tests/Support/SupportPluralizerTest.php
@@ -85,6 +85,20 @@ class SupportPluralizerTest extends TestCase
         $this->assertSame('User3s', Str::plural('User3'));
     }
 
+    public function testPluralSupportsArrays()
+    {
+        $this->assertSame('users', Str::plural('user', []));
+        $this->assertSame('user', Str::plural('user', ['one']));
+        $this->assertSame('users', Str::plural('user', ['one', 'two']));
+    }
+
+    public function testPluralSupportsCollections()
+    {
+        $this->assertSame('users', Str::plural('user', collect()));
+        $this->assertSame('user', Str::plural('user', collect(['one'])));
+        $this->assertSame('users', Str::plural('user', collect(['one', 'two'])));
+    }
+
     private function assertPluralStudly($expected, $value, $count = 2)
     {
         $this->assertSame($expected, Str::pluralStudly($value, $count));


### PR DESCRIPTION
This PR adds support for countable values to the `Str::plural` method.

In doing so, you will be able to pass anything that passes PHP's `is_countable` check i.e. arrays, objects that implement `Countable` as the second parameter of the `plural` method.

This is useful when you want to pluralize a string based on a collection returned directly from an Eloquent query or otherwise filtered collection.
