### PR TITLE
[9.x] Use Relative View Path Name When Hashing Compiled Views

### DIFF
--- a/src/Illuminate/View/Compilers/Compiler.php
+++ b/src/Illuminate/View/Compilers/Compiler.php
@@ -38,7 +38,7 @@ abstract class Compiler
      *
      * @throws \InvalidArgumentException
      */
-    public function __construct(Filesystem $files, $cachePath, $basePath)
+    public function __construct(Filesystem $files, $cachePath, $basePath = '')
     {
         if (! $cachePath) {
             throw new InvalidArgumentException('Please provide a valid cache path.');

--- a/src/Illuminate/View/Compilers/Compiler.php
+++ b/src/Illuminate/View/Compilers/Compiler.php
@@ -3,6 +3,7 @@
 namespace Illuminate\View\Compilers;
 
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Str;
 use InvalidArgumentException;
 
 abstract class Compiler
@@ -22,6 +23,13 @@ abstract class Compiler
     protected $cachePath;
 
     /**
+     * Get the base path of your application.
+     *
+     * @var string
+     */
+    protected $basePath;
+
+    /**
      * Create a new compiler instance.
      *
      * @param  \Illuminate\Filesystem\Filesystem  $files
@@ -30,7 +38,7 @@ abstract class Compiler
      *
      * @throws \InvalidArgumentException
      */
-    public function __construct(Filesystem $files, $cachePath)
+    public function __construct(Filesystem $files, $cachePath, $basePath)
     {
         if (! $cachePath) {
             throw new InvalidArgumentException('Please provide a valid cache path.');
@@ -38,6 +46,7 @@ abstract class Compiler
 
         $this->files = $files;
         $this->cachePath = $cachePath;
+        $this->basePath = $basePath;
     }
 
     /**
@@ -48,7 +57,20 @@ abstract class Compiler
      */
     public function getCompiledPath($path)
     {
-        return $this->cachePath.'/'.sha1($path).'.php';
+        $relativePath = $this->getRelativeViewPath($path);
+
+        return $this->cachePath.'/'.sha1($relativePath).'.php';
+    }
+
+    /**
+     * Get the relative path of a view.
+     *
+     * @param  string  $path
+     * @return string
+     */
+    public function getRelativeViewPath($path)
+    {
+        return Str::after($path, $this->basePath);
     }
 
     /**

--- a/src/Illuminate/View/Compilers/Compiler.php
+++ b/src/Illuminate/View/Compilers/Compiler.php
@@ -9,21 +9,21 @@ use InvalidArgumentException;
 abstract class Compiler
 {
     /**
-     * The Filesystem instance.
+     * The filesystem instance.
      *
      * @var \Illuminate\Filesystem\Filesystem
      */
     protected $files;
 
     /**
-     * Get the cache path for the compiled views.
+     * The cache path for the compiled views.
      *
      * @var string
      */
     protected $cachePath;
 
     /**
-     * Get the base path of your application.
+     * The base path that should be removed from paths before hashing.
      *
      * @var string
      */
@@ -34,6 +34,7 @@ abstract class Compiler
      *
      * @param  \Illuminate\Filesystem\Filesystem  $files
      * @param  string  $cachePath
+     * @param  string  $basePath
      * @return void
      *
      * @throws \InvalidArgumentException
@@ -57,20 +58,7 @@ abstract class Compiler
      */
     public function getCompiledPath($path)
     {
-        $relativePath = $this->getRelativeViewPath($path);
-
-        return $this->cachePath.'/'.sha1($relativePath).'.php';
-    }
-
-    /**
-     * Get the relative path of a view.
-     *
-     * @param  string  $path
-     * @return string
-     */
-    public function getRelativeViewPath($path)
-    {
-        return Str::after($path, $this->basePath);
+        return $this->cachePath.'/'.sha1(Str::after($path, $this->basePath)).'.php';
     }
 
     /**

--- a/src/Illuminate/View/ViewServiceProvider.php
+++ b/src/Illuminate/View/ViewServiceProvider.php
@@ -85,7 +85,7 @@ class ViewServiceProvider extends ServiceProvider
     public function registerBladeCompiler()
     {
         $this->app->singleton('blade.compiler', function ($app) {
-            return tap(new BladeCompiler($app['files'], $app['config']['view.compiled']), function ($blade) {
+            return tap(new BladeCompiler($app['files'], $app['config']['view.compiled'], $app['path.base']), function ($blade) {
                 $blade->component('dynamic-component', DynamicComponent::class);
             });
         });

--- a/src/Illuminate/View/ViewServiceProvider.php
+++ b/src/Illuminate/View/ViewServiceProvider.php
@@ -85,7 +85,11 @@ class ViewServiceProvider extends ServiceProvider
     public function registerBladeCompiler()
     {
         $this->app->singleton('blade.compiler', function ($app) {
-            return tap(new BladeCompiler($app['files'], $app['config']['view.compiled'], $app['path.base']), function ($blade) {
+            return tap(new BladeCompiler(
+                $app['files'],
+                $app['config']['view.compiled'],
+                $app['config']->get('view.relative_hash', false) ? $app->basePath() : '',
+            ), function ($blade) {
                 $blade->component('dynamic-component', DynamicComponent::class);
             });
         });


### PR DESCRIPTION
### Issue

We are not able to "pre-compile" views on say a local machine/build box, and push it into prod "pre-compiled". This is because the filename of the cached view is a sha1 of the absolute path of the file. Meaning, if the directory is different on which the view was initially compiled, then the view is then recompiled. 

This PR introduces a new `basePath` param into the the Compiler - which then allows us to take the absolute path of the view, and remove the base path from it - which is then used as the "name" before being hashed

Targeted into 9.x as this is a possible breaking change.

Driver behind this was during a vapor deploy, we can pre-compile the views (locally) into bootstrap/cache/views and serve them already compiled. Which is great for a read-only filesystem.
