### PR TITLE
[8.x] Fix \Illuminate\Support\Facades\App::storagePath() method ignores $path argument

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -458,8 +458,8 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function storagePath($path = '')
     {
-        return ($this->storagePath ?: $this->basePath . DIRECTORY_SEPARATOR . 'storage')
-            . ($path ? DIRECTORY_SEPARATOR . $path : '');
+        return ($this->storagePath ?: $this->basePath.DIRECTORY_SEPARATOR.'storage')
+            .($path ? DIRECTORY_SEPARATOR . $path : '');
     }
 
     /**

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -453,11 +453,12 @@ class Application extends Container implements ApplicationContract, CachesConfig
     /**
      * Get the path to the storage directory.
      *
+     * @param  string  $path
      * @return string
      */
-    public function storagePath()
+    public function storagePath($path = '')
     {
-        return $this->storagePath ?: $this->basePath.DIRECTORY_SEPARATOR.'storage';
+        return ($this->storagePath ?: $this->basePath . DIRECTORY_SEPARATOR . 'storage') . ($path ? DIRECTORY_SEPARATOR . $path : '');
     }
 
     /**

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -458,7 +458,8 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function storagePath($path = '')
     {
-        return ($this->storagePath ?: $this->basePath . DIRECTORY_SEPARATOR . 'storage') . ($path ? DIRECTORY_SEPARATOR . $path : '');
+        return ($this->storagePath ?: $this->basePath . DIRECTORY_SEPARATOR . 'storage')
+            . ($path ? DIRECTORY_SEPARATOR . $path : '');
     }
 
     /**

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -459,7 +459,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
     public function storagePath($path = '')
     {
         return ($this->storagePath ?: $this->basePath.DIRECTORY_SEPARATOR.'storage')
-            .($path ? DIRECTORY_SEPARATOR . $path : '');
+            .($path ? DIRECTORY_SEPARATOR.$path : '');
     }
 
     /**

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -800,7 +800,7 @@ if (! function_exists('storage_path')) {
      */
     function storage_path($path = '')
     {
-        return app('path.storage').($path ? DIRECTORY_SEPARATOR.$path : $path);
+        return app()->storagePath($path);
     }
 }
 


### PR DESCRIPTION
`\Illuminate\Support\Facades\App::storagePath()` method ignores `$path` argument

This fix makes `App::storagePath()` method and `storage_path` helper return same result when `$path` is passed