### PR TITLE
[8.x] Use parents to resolve middleware priority

### DIFF
--- a/src/Illuminate/Routing/SortedMiddleware.php
+++ b/src/Illuminate/Routing/SortedMiddleware.php
@@ -101,6 +101,14 @@ class SortedMiddleware extends Collection
                 yield $interface;
             }
         }
+
+        $parents = @class_parents($stripped);
+
+        if ($parents !== false) {
+            foreach ($parents as $parent) {
+                yield $parent;
+            }
+        }
     }
 
     /**

--- a/tests/Routing/RoutingSortedMiddlewareTest.php
+++ b/tests/Routing/RoutingSortedMiddlewareTest.php
@@ -64,4 +64,59 @@ class RoutingSortedMiddlewareTest extends TestCase
         $this->assertEquals(['a', $closure, 'b', $closure2, 'foo'], (new SortedMiddleware(['a', 'b'], ['a', $closure, 'b', $closure2, 'foo']))->all());
         $this->assertEquals([$closure, $closure2, 'foo', 'a'], (new SortedMiddleware(['a', 'b'], [$closure, $closure2, 'foo', 'a']))->all());
     }
+
+    public function testItSortsUsingParentsAndContracts()
+    {
+        $priority = [
+            FirstContractStub::class,
+            SecondStub::class,
+            'Third',
+        ];
+
+        $middleware = [
+            'Something',
+            'Something',
+            'Something',
+            'Something',
+            SecondChildStub::class,
+            'Otherthing',
+            FirstStub::class.':api',
+            'Third:foo',
+            FirstStub::class.':foo,bar',
+            'Third',
+            SecondChildStub::class,
+        ];
+
+        $expected = [
+            'Something',
+            FirstStub::class.':api',
+            FirstStub::class.':foo,bar',
+            SecondChildStub::class,
+            'Otherthing',
+            'Third:foo',
+            'Third',
+        ];
+
+        $this->assertEquals($expected, (new SortedMiddleware($priority, $middleware))->all());
+    }
+}
+
+interface FirstContractStub
+{
+    //
+}
+
+class FirstStub implements FirstContractStub
+{
+    //
+}
+
+class SecondStub
+{
+    //
+}
+
+class SecondChildStub extends SecondStub
+{
+    //
 }


### PR DESCRIPTION
Currently when middlewares are ordered it uses the class name and its interfaces for sorting but not it's parents.

This is a problem for example in Jetstream because:
- Jetstream extends the `AuthenticateSession` middleware with it's own.
- Since it doesn't have a contract it will run before any `Authenticate` middleware
- Resulting in it's always being initialized via the default guard instead of the authenticated one
- This prevents using two guards simultaniously (for example a user and an admin guard)

This PR fixes this behaviour by using parent classes for ordering so the Jetstream `AuthenticateSession` middleware will be in the correct place because it extends the Laravel `AuthenticateSession` middleware.

I also added test for the parent sorting and the already present interface sorting.