### PR TITLE
[8.x] Update FilterEmailValidation.php to remove unused EmailLexer

### DIFF
--- a/src/Illuminate/Validation/Concerns/FilterEmailValidation.php
+++ b/src/Illuminate/Validation/Concerns/FilterEmailValidation.php
@@ -39,10 +39,9 @@ class FilterEmailValidation implements EmailValidation
      * Returns true if the given email is valid.
      *
      * @param  string  $email
-     * @param  \Egulias\EmailValidator\EmailLexer  $emailLexer
      * @return bool
      */
-    public function isValid($email, EmailLexer $emailLexer)
+    public function isValid($email)
     {
         return is_null($this->flags)
                     ? filter_var($email, FILTER_VALIDATE_EMAIL) !== false


### PR DESCRIPTION
Remove unused $emailLexer from isValid() as this only checks against native PHP filter_var.
It seems that there are other remnants of EmailLexer throughout the page, but I don't feel comfortable touching those.