### PR TITLE
[9.x] Remove `assertDeleted`

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -69,25 +69,6 @@ trait InteractsWithDatabase
     }
 
     /**
-     * Assert the given record has been deleted.
-     *
-     * @param  \Illuminate\Database\Eloquent\Model|string  $table
-     * @param  array  $data
-     * @param  string|null  $connection
-     * @return $this
-     */
-    protected function assertDeleted($table, array $data = [], $connection = null)
-    {
-        if ($table instanceof Model) {
-            return $this->assertDatabaseMissing($table->getTable(), [$table->getKeyName() => $table->getKey()], $table->getConnectionName());
-        }
-
-        $this->assertDatabaseMissing($this->getTable($table), $data, $connection);
-
-        return $this;
-    }
-
-    /**
      * Assert the given record has been "soft deleted".
      *
      * @param  \Illuminate\Database\Eloquent\Model|string  $table

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -161,17 +161,6 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertDatabaseMissing($this->table, $this->data);
     }
 
-    public function testAssertDeletedPassesWhenDoesNotFindModelResults()
-    {
-        $this->data = ['id' => 1];
-
-        $builder = $this->mockCountBuilder(0);
-
-        $builder->shouldReceive('get')->andReturn(collect());
-
-        $this->assertDeleted(new ProductStub($this->data));
-    }
-
     public function testAssertModelMissingPassesWhenDoesNotFindModelResults()
     {
         $this->data = ['id' => 1];
@@ -181,19 +170,6 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $builder->shouldReceive('get')->andReturn(collect());
 
         $this->assertModelMissing(new ProductStub($this->data));
-    }
-
-    public function testAssertDeletedFailsWhenFindsModelResults()
-    {
-        $this->expectException(ExpectationFailedException::class);
-
-        $this->data = ['id' => 1];
-
-        $builder = $this->mockCountBuilder(1);
-
-        $builder->shouldReceive('get')->andReturn(collect([$this->data]));
-
-        $this->assertDeleted(new ProductStub($this->data));
     }
 
     public function testAssertSoftDeletedInDatabaseFindsResults()

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -143,14 +143,14 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertDatabaseCount($this->table, 3);
     }
 
-    public function testAssertDeletedPassesWhenDoesNotFindResults()
+    public function testAssertDatabaseMissingPassesWhenDoesNotFindResults()
     {
         $this->mockCountBuilder(0);
 
         $this->assertDatabaseMissing($this->table, $this->data);
     }
 
-    public function testAssertDeletedFailsWhenFindsResults()
+    public function testAssertDatabaseMissingFailsWhenFindsResults()
     {
         $this->expectException(ExpectationFailedException::class);
 


### PR DESCRIPTION
This removes the asymmetrical, proxy assertion `assertDeleted`. Unlike other assertions, its opposite assertion does not exist (`assertNotDeleted`). It is also superseded in #38766 by `assertModelExists` and `assertModelMissing`.

Tests using this assertion may either adopt one of these more communicative methods, or fallback to the original `assertDatabaseMissing`.

Targeting Laravel 9 as this is a breaking change. Alternatively, I am glad to open a PR to add `assertNotDeleted` to provide symmetry. I believe removal is cleaner though as all paths should be covered by the other 4 assertions.