### PR TITLE
[8.x] Change Model increment() and decrement() methods to public

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -815,7 +815,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      * @param  array  $extra
      * @return int
      */
-    protected function increment($column, $amount = 1, array $extra = [])
+    public function increment($column, $amount = 1, array $extra = [])
     {
         return $this->incrementOrDecrement($column, $amount, $extra, 'increment');
     }
@@ -828,7 +828,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      * @param  array  $extra
      * @return int
      */
-    protected function decrement($column, $amount = 1, array $extra = [])
+    public function decrement($column, $amount = 1, array $extra = [])
     {
         return $this->incrementOrDecrement($column, $amount, $extra, 'decrement');
     }
@@ -2106,10 +2106,6 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function __call($method, $parameters)
     {
-        if (in_array($method, ['increment', 'decrement'])) {
-            return $this->$method(...$parameters);
-        }
-
         if ($resolver = (static::$relationResolvers[get_class($this)][$method] ?? null)) {
             return $resolver($this);
         }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1763,10 +1763,10 @@ class DatabaseEloquentModelTest extends TestCase
         $query->shouldReceive('where')->andReturn($query);
         $query->shouldReceive('increment');
 
-        $model->publicIncrement('foo', 1);
+        $model->increment('foo', 1);
         $this->assertFalse($model->isDirty());
 
-        $model->publicIncrement('foo', 1, ['category' => 1]);
+        $model->increment('foo', 1, ['category' => 1]);
         $this->assertEquals(4, $model->foo);
         $this->assertEquals(1, $model->category);
         $this->assertTrue($model->isDirty('category'));
@@ -2314,11 +2314,6 @@ class EloquentModelStub extends Model
     public function setPasswordAttribute($value)
     {
         $this->attributes['password_hash'] = sha1($value);
-    }
-
-    public function publicIncrement($column, $amount = 1, $extra = [])
-    {
-        return $this->increment($column, $amount, $extra);
     }
 
     public function belongsToStub()


### PR DESCRIPTION
This PR aims to remove some unneeded code from the `__call()`

The Model class has two methods

increment()
decrement()

that are meant to be publicly accessible by the developers.
The visibility of these two methods before the PR is set to `protected`.
Developers are able to call them because the magic `__call()` is checking if the method being called is one of these two mentioned in this PR
All the `__call()` is doing is calling the method, passing all the arguments without doing any kind of validation on the arguments.

For this reason I changed the visibility to public and removed the check from the `__call()`