### PR TITLE
[8.x] Add .phar to blocked PHP extensions

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1329,7 +1329,7 @@ trait ValidatesAttributes
         }
 
         $phpExtensions = [
-            'php', 'php3', 'php4', 'php5', 'phtml',
+            'php', 'php3', 'php4', 'php5', 'phtml', 'phar',
         ];
 
         return ($value instanceof UploadedFile)


### PR DESCRIPTION
By default Debian includes support for executing .phar files alongside .php and .phtml files, and should be included in the blocked list.

See: https://salsa.debian.org/php-team/php/-/blob/debian/main/7.4/debian/php-cgi.conf#L5-7

This should also be backported into all currently supported versions of Laravel.