### PR TITLE
[8.x] Add Support for custom Increment / Decrement in Collection range

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -34,13 +34,14 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Create a collection with the given range.
      *
-     * @param  int  $from
-     * @param  int  $to
+     * @param  int|float  $from
+     * @param  int|float  $to
+     * @param  int|float  $step
      * @return static
      */
-    public static function range($from, $to)
+    public static function range($from, $to, $step = 1)
     {
-        return new static(range($from, $to));
+        return new static(range($from, $to, $step));
     }
 
     /**

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -51,11 +51,11 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     {
         return new static(function () use ($from, $to, $step) {
             if ($from <= $to) {
-                for (; $from <= $to; $from++) {
+                for (; $from <= $to; $from+= $step) {
                     yield $from;
                 }
             } else {
-                for (; $from >= $to; $from--) {
+                for (; $from >= $to; $from-= $step) {
                     yield $from;
                 }
             }

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -44,11 +44,12 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      *
      * @param  int  $from
      * @param  int  $to
+     * @param  int|float  $step
      * @return static
      */
-    public static function range($from, $to)
+    public static function range($from, $to, $step = 1)
     {
-        return new static(function () use ($from, $to) {
+        return new static(function () use ($from, $to, $step) {
             if ($from <= $to) {
                 for (; $from <= $to; $from++) {
                     yield $from;

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2563,6 +2563,36 @@ class SupportCollectionTest extends TestCase
             [-2, -3, -4],
             $collection::range(-2, -4)->all()
         );
+
+        $this->assertSame(
+            [1, 3, 5, 7, 9],
+            $collection::range(1, 10, 2)->all()
+        );
+
+        $this->assertSame(
+            [-6, -3, 0, 3, 6],
+            $collection::range(-6, 6, 3)->all()
+        );
+
+        $this->assertSame(
+            [-8, -6, -4, -2],
+            $collection::range(-8, -2, 2)->all()
+        );
+
+        $this->assertSame(
+            [10, 8, 6, 4, 2],
+            $collection::range(10, 1, 2)->all()
+        );
+
+        $this->assertSame(
+            [6, 4, 2, 0, -2, -4, -6],
+            $collection::range(6, -6, 2)->all()
+        );
+
+        $this->assertSame(
+            [-2, -4, -6, -8, -10],
+            $collection::range(-2, -10, 2)->all()
+        );
     }
 
     /**


### PR DESCRIPTION
By default [php range](https://www.php.net/manual/en/function.range.php) function will accept 3rd argument for `increment/decrement` between elements in the sequence. 

Since [`Collection::range`](https://github.com/laravel/framework/blob/8.x/src/Illuminate/Collections/Collection.php#L43) function uses native php function I have added support for 3rd argument.

Before:

`collect(range(2,10,2));`

After:

`collect()->range(2,10,2);`