### PR TITLE
[8.x] Added Prohibits validation rule to dependentRules property

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -247,6 +247,7 @@ class Validator implements ValidatorContract
         'Prohibited',
         'ProhibitedIf',
         'ProhibitedUnless',
+        'Prohibits',
         'Same',
         'Unique',
     ];

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1509,6 +1509,17 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['email' => 'foo', 'emails' => 'bar', 'email_address' => 'baz'], ['email' => 'prohibits:emails,email_address']);
         $this->assertFalse($v->passes());
         $this->assertSame('The email field prohibits emails / email address being present.', $v->messages()->first('email'));
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, [
+            'foo' => [
+                ['email' => 'foo', 'emails' => 'foo'],
+                ['emails' => 'foo'],
+            ]
+        ], ['foo.*.email' => 'prohibits:foo.*.emails']);
+        $this->assertFalse($v->passes());
+        $this->assertTrue($v->messages()->has('foo.0.email'));
+        $this->assertFalse($v->messages()->has('foo.1.email'));
     }
 
     public function testFailedFileUploads()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1515,7 +1515,7 @@ class ValidationValidatorTest extends TestCase
             'foo' => [
                 ['email' => 'foo', 'emails' => 'foo'],
                 ['emails' => 'foo'],
-            ]
+            ],
         ], ['foo.*.email' => 'prohibits:foo.*.emails']);
         $this->assertFalse($v->passes());
         $this->assertTrue($v->messages()->has('foo.0.email'));


### PR DESCRIPTION
The prohibits validation rule depends on other fields. However the rule was not added to the `$dependentRules` property.