### PR TITLE
[8.x] Allow a Closure to be passed as a ttl in Cache remember() method

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -373,7 +373,7 @@ class Repository implements ArrayAccess, CacheContract
      * Get an item from the cache, or execute the given Closure and store the result.
      *
      * @param  string  $key
-     * @param  \DateTimeInterface|\DateInterval|int|null  $ttl
+     * @param  \Closure|\DateTimeInterface|\DateInterval|int|null  $ttl
      * @param  \Closure  $callback
      * @return mixed
      */
@@ -388,7 +388,7 @@ class Repository implements ArrayAccess, CacheContract
             return $value;
         }
 
-        $this->put($key, $value = $callback(), $ttl);
+        $this->put($key, $value = $callback(), value($ttl));
 
         return $value;
     }

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -113,6 +113,19 @@ class CacheRepositoryTest extends TestCase
             return 'qux';
         });
         $this->assertSame('qux', $result);
+        
+        /*
+         * Use a callable...
+         */
+        $repo = $this->getRepository();
+        $repo->getStore()->shouldReceive('get')->once()->andReturn(null);
+        $repo->getStore()->shouldReceive('put')->once()->with('foo', 'bar', 10);
+        $result = $repo->remember('foo', function () {
+            return 10;
+        }, function () {
+            return 'bar';
+        });
+        $this->assertSame('bar', $result);
     }
 
     public function testRememberForeverMethodCallsForeverAndReturnsDefault()


### PR DESCRIPTION
This PR simplifies the code needed in case the $ttl is calculated each time we have to store a value. I simply added the value() function for the $ttl parameter.

In the following code i want to know how many events the User has hosted so I'm calculating the ttl taking in account when is the next hosted event for that user ending, so the counter will be recalculated because the stored cached value will be expired by then.

```
function countEventsHostedCached($user) {
    if (Cache::has('count_events_hosted')) {
        return Cache::get('count_events_hosted', 0);
    }

    $closestEventEndsAt = $user->hostedEvents()
        ->select('ends_at')
        ->where('starts_at', '>', Date::now())
        ->orderBy('ends_at')
        ->limit(1)
        ->value('ends_at');

    $value = $user->hostedEvents()->ended()->count();

    Cache::put(
        'count_events_hosted',
        $value,
        // Expire when closest event ends
        $closestEventEndsAt ? Date::parse($closestEventEndsAt) : 60
    );

    return $value;
}
```

Turns into:

```
function countEventsHostedCached($user) {
    return Cache::remember(
        'count_events_hosted',
        function () use ($user) {
            // Expire when closest event ends
            $closestEventEndsAt = $user->hostedEvents()
                ->select('ends_at')
                ->where('starts_at', '>', Date::now())
                ->orderBy('ends_at')
                ->limit(1)
                ->value('ends_at');

            return $closestEventEndsAt ? Date::parse($closestEventEndsAt) : 60;
        },
        function () use ($user) {
            return $user->hostedEvents()->ended()->count();
        }
    );
} 
```