### PR TITLE
[8.x] Fix registering and renaming custom Doctrine columns

### DIFF
--- a/src/Illuminate/Database/DatabaseServiceProvider.php
+++ b/src/Illuminate/Database/DatabaseServiceProvider.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Queue\EntityResolver;
 use Illuminate\Database\Connectors\ConnectionFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\QueueEntityResolver;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\ServiceProvider;
 
 class DatabaseServiceProvider extends ServiceProvider
@@ -123,9 +124,7 @@ class DatabaseServiceProvider extends ServiceProvider
         $types = $this->app['config']->get('database.dbal.types', []);
 
         foreach ($types as $name => $class) {
-            if (! Type::hasType($name)) {
-                Type::addType($name, $class);
-            }
+            Schema::registerCustomDoctrineType($class, $name, $name);
         }
     }
 }

--- a/tests/Integration/Database/ConfigureCustomDoctrineTypeTest.php
+++ b/tests/Integration/Database/ConfigureCustomDoctrineTypeTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\SchemaTest;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\Type;
+use Illuminate\Database\Grammar;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+class ConfigureCustomDoctrineTypeTest extends DatabaseTestCase
+{
+    protected function resolveApplicationConfiguration($app)
+    {
+        parent::resolveApplicationConfiguration($app);
+
+        $app['config']['database.dbal.types'] = ['xml' => XmlType::class];
+    }
+
+    public function test_rename_column_with_custom_doctrine_type_listed_in_config()
+    {
+        if ($this->driver !== 'pgsql') {
+            $this->markTestSkipped('Test requires a Postgres connection.');
+        }
+
+        Grammar::macro('typeXml', function () {
+            return 'xml';
+        });
+
+        Schema::create('test', function (Blueprint $table) {
+            $table->addColumn('xml', 'test_column');
+        });
+
+        Schema::table('test', function (Blueprint $table) {
+            $table->renameColumn('test_column', 'renamed_column');
+        });
+
+        $this->assertFalse(Schema::hasColumn('test', 'test_column'));
+        $this->assertTrue(Schema::hasColumn('test', 'renamed_column'));
+    }
+}
+
+class XmlType extends Type
+{
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    {
+        return 'xml';
+    }
+
+    public function getName()
+    {
+        return 'xml';
+    }
+}


### PR DESCRIPTION
### Summary

This PR ensures that custom Doctrine types and their mappings are registered properly, to make it possible to rename database columns using them with Laravel's `$blueprint->renameColumn()` method.

Instead of `Type::addType()`, it uses `Schema::registerCustomDoctrineType()` to register custom Doctrine types, which calls `Type::addType()` internally but additionally registers the type "mapping."

Fixes #39682.

### Background

The documentation on [Modifying Columns](https://laravel.com/docs/8.x/migrations#modifying-columns) demonstrates how to add custom Doctrine types in `config/database.php`:

```php
use Illuminate\Database\DBAL\TimestampType;

'dbal' => [
    'types' => [
        'timestamp' => TimestampType::class,
    ],
],
```

However the code that registers these types with Doctrine, in the `DatabaseServiceProvider`, registers just the "types" but not the "type mappings", so columns using custom types registered in this way still can't be renamed with Laravel's `->renameColumn()` method.

When the ability to use custom types like this was originally added to Laravel it actually used `Schema::registerCustomDoctrineType()` and wouldn't have had this issue, but then it was changed to just register the type directly (see https://github.com/laravel/framework/commit/382445f8487de45a05ebe121837f917b92560a97#diff-6122e442c6d761f6a9c1cfcc5f14af3306fccea75d8eb94fecbd399660e72c54).

The [existing test for this behaviour](https://github.com/laravel/framework/blob/8.x/tests/Integration/Database/SchemaBuilderTest.php#L48-L68) actually still just calls `Schema::registerCustomDoctrineType()` directly.

### Testing

- The test only runs on Postgres because Postgres's `xml` type was the simplest one I could find that wasn't already built into Laravel.
- I'm overriding `resolveApplicationConfiguration()` because that was the only way I could figure out how to set configuration values _before_ Laravel's core service providers are registered, if there's a better way to do this I'm all ears!
- Test run showing failing test: https://github.com/bakerkretzmar/framework/runs/4247267107?check_suite_focus=true#step:6:24
- Test run showing passing test after changes in this PR: https://github.com/bakerkretzmar/framework/actions/runs/1474946027