### PR TITLE
[8.x] Improve Tappable::tap() return type

### DIFF
--- a/src/Illuminate/Support/Traits/Tappable.php
+++ b/src/Illuminate/Support/Traits/Tappable.php
@@ -8,7 +8,7 @@ trait Tappable
      * Call the given Closure with this instance then return the instance.
      *
      * @param  callable|null  $callback
-     * @return mixed
+     * @return $this|\Illuminate\Support\HigherOrderTapProxy
      */
     public function tap($callback = null)
     {


### PR DESCRIPTION
Similar to #38018. 

Currently `Tappable::tap()` is documented as `mixed`, which prevents IDEs from autocompleting as well as hindering static analysis. Unlike the global `tap()` helper, this method's return type is entirely predictable and can be narrowed down to `$this|\Illuminate\Support\HigherOrderTapProxy`