### PR TITLE
[8.x] Add Str::onlyNumbers()

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -886,6 +886,24 @@ class Str
         return str_word_count($string);
     }
 
+
+    /**
+     * Get only the numbers from a string
+     *
+     * @param  string $string
+     * @return int|null
+     */
+    public static function onlyNumbers($string)
+    {
+        preg_match('/[0-9]/', $string, $matches);
+
+        if ( ! count($matches)) {
+            return null;
+        }
+
+        return (int) preg_replace('/[^0-9]/', '', $string);
+    }
+
     /**
      * Generate a UUID (version 4).
      *

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -743,6 +743,16 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Get only the numbers from a string
+     *
+     * @return static
+     */
+    public function onlyNumbers()
+    {
+        return new static(Str::onlyNumbers($this->value));
+    }
+
+    /**
      * Execute the given callback if the string is empty.
      *
      * @param  callable  $callback

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -536,6 +536,15 @@ class SupportStrTest extends TestCase
         $this->assertSame('Мама мыла раму', Str::ucfirst('мама мыла раму'));
     }
 
+    public function testOnlyNumbers()
+    {
+        $this->assertSame(123, Str::onlyNumbers("f1o2o3"));
+        $this->assertSame(45612, Str::onlyNumbers("U$ 456.12"));
+        $this->assertSame(9870, Str::onlyNumbers("foo987bar ,.0-."));
+        $this->assertSame(0, Str::onlyNumbers("0foo"));
+        $this->assertNull(Str::onlyNumbers("bar"));
+    }
+
     public function testUuid()
     {
         $this->assertInstanceOf(UuidInterface::class, Str::uuid());


### PR DESCRIPTION
### Description
This PR adds a new `Stringable` method to get only the numbers from a string.

### Purpose
There's not a Laravel way to get only the numbers from a string, just using `regex` or `filter_var`

### Use Case

```
// Displays: "123456"
echo Str::onlyNumbers("foobar123456");
```

```
// Displays: "1256"
echo Str::onlyNumbers("U$ 12,56");
```

When no number is find in string will return `null`