### PR TITLE
[8.x] Added ignorable functionality to migration files

### DIFF
--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -107,7 +107,7 @@ class Migrator
         ));
 
         // This section filters ignorable migrations out from pending migration files.
-        $runnableMigrations = Collection::make($migrations)->reject(function($file) {
+        $runnableMigrations = Collection::make($migrations)->reject(function ($file) {
             $migration = $this->resolve(
                 $this->getMigrationName($file)
             );

--- a/src/Illuminate/Database/Migrations/stubs/migration.create.stub
+++ b/src/Illuminate/Database/Migrations/stubs/migration.create.stub
@@ -7,6 +7,11 @@ use Illuminate\Support\Facades\Schema;
 class {{ class }} extends Migration
 {
     /**
+     * Allows Migrator to ignore file during migration (optional)
+     */
+    public bool $ignore = false;
+
+    /**
      * Run the migrations.
      *
      * @return void
@@ -27,5 +32,15 @@ class {{ class }} extends Migration
     public function down()
     {
         Schema::dropIfExists('{{ table }}');
+    }
+
+    /**
+     * Condition to evaluate for ignoring migration file
+     *
+     * @return bool
+     */
+    public function ignore()
+    {
+        return false;
     }
 }

--- a/src/Illuminate/Database/Migrations/stubs/migration.stub
+++ b/src/Illuminate/Database/Migrations/stubs/migration.stub
@@ -7,6 +7,11 @@ use Illuminate\Support\Facades\Schema;
 class {{ class }} extends Migration
 {
     /**
+     * Allows Migrator to ignore file during migration (optional)
+     */
+    public bool $ignore = false;
+
+    /**
      * Run the migrations.
      *
      * @return void
@@ -24,5 +29,15 @@ class {{ class }} extends Migration
     public function down()
     {
         //
+    }
+
+    /**
+     * Condition to evaluate for ignoring migration file
+     *
+     * @return bool
+     */
+    public function ignore()
+    {
+        return false;
     }
 }

--- a/src/Illuminate/Database/Migrations/stubs/migration.update.stub
+++ b/src/Illuminate/Database/Migrations/stubs/migration.update.stub
@@ -7,6 +7,11 @@ use Illuminate\Support\Facades\Schema;
 class {{ class }} extends Migration
 {
     /**
+     * Allows Migrator to ignore file during migration (optional)
+     */
+    public bool $ignore = false;
+
+    /**
      * Run the migrations.
      *
      * @return void
@@ -28,5 +33,15 @@ class {{ class }} extends Migration
         Schema::table('{{ table }}', function (Blueprint $table) {
             //
         });
+    }
+
+    /**
+     * Condition to evaluate for ignoring migration file
+     *
+     * @return bool
+     */
+    public function ignore()
+    {
+        return false;
     }
 }


### PR DESCRIPTION
### Description
This PR adds the ability to ignore migration files either by setting the `ignore` property to true or returning a truthy evaluation in the `ignore()` method of the migration file.

### Purpose
This will enable developers to ignore migration files that are not ready/needed to be migrated yet at the time of running the migrate command. There are some occasions that we needed to ignore some files from been migrated but had to move the files out of the migrations directory.