### PR TITLE
[9.x] Add getTableName() on models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1685,6 +1685,16 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     }
 
     /**
+     * Get the table name for the model.
+     *
+     * @return string
+     */
+    public static function getTableName()
+    {
+        return (new static)->getTable();
+    }
+
+    /**
      * Get the table associated with the model.
      *
      * @return string


### PR DESCRIPTION
Replaces https://github.com/laravel/framework/pull/39698

Targeting 9.x mainly because I think that some people may already have this helper in their models (or at least I have).

The nice thing about this is that now, you will be able to use this in your tests like so instead of referencing the table name directly. 

```
$this->assertDatabaseHas(Category::getTableName(), [
     'id'   => $id,
     'name' => 'Abc'
])
```