### PR TITLE
[8.x] New static method getDefaultTableName to get table default name without create new instance

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1687,7 +1687,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Get the default table name associated with the model.
      *
-     * @param self|null  $class
+     * @param string|null $class
      * @return string
      */
     public static function getDefaultTableName($class = null)

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1685,13 +1685,14 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     }
 
     /**
-     * Get the table name associated with the model.
+     * Get the default table name associated with the model.
      *
+     * @param self|null $class
      * @return string
      */
-    public static function getTableName()
+    public static function getDefaultTableName($class = null)
     {
-        return Str::snake(Str::pluralStudly(class_basename(get_called_class())));
+        return Str::snake(Str::pluralStudly(class_basename($class ?? get_called_class())));
     }
 
     /**
@@ -1701,7 +1702,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function getTable()
     {
-        return $this->table ?? self::getTableName();
+        return $this->table ?? self::getDefaultTableName($this);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1687,7 +1687,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Get the default table name associated with the model.
      *
-     * @param self|null $class
+     * @param self|null  $class
      * @return string
      */
     public static function getDefaultTableName($class = null)

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1687,7 +1687,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Get the default table name associated with the model.
      *
-     * @param string|null $class
+     * @param string|null  $class
      * @return string
      */
     public static function getDefaultTableName($class = null)

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1687,7 +1687,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Get the default table name associated with the model.
      *
-     * @param string|null  $class
+     * @param  string|null  $class
      * @return string
      */
     public static function getDefaultTableName($class = null)

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1685,13 +1685,23 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     }
 
     /**
+     * Get the table name associated with the model.
+     *
+     * @return string
+     */
+    public static function getTableName()
+    {
+        return Str::snake(Str::pluralStudly(class_basename(get_called_class())));
+    }
+
+    /**
      * Get the table associated with the model.
      *
      * @return string
      */
     public function getTable()
     {
-        return $this->table ?? Str::snake(Str::pluralStudly(class_basename($this)));
+        return $this->table ?? self::getTableName();
     }
 
     /**


### PR DESCRIPTION
This PR adds a new method to the model that get the default table name for the model statically without creating new instance.

## Problem
We should create instance of model to be able to use getTable method that may take unneeded memory when the model contains a lot of logic or appends.
```  (new \App\Models\User)->getTable(); ```

## My Proposed Solution
To encapsulate the logic of getting table name in new method that can be callable through class itself and then we can call it statically and reduce the memory needed for instance.

## Usage 

```  \App\Models\User::getDefaultTableName(); ```



## Breaking changes
It shouldn't break any existing functionality, it's just encapsulate existing logic making new reusable method.

## Note
I have Fixed issue mentioned in https://github.com/laravel/framework/pull/39698 that if we use setTable.

Any other suggestions for improvement are welcome.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
