### PR TITLE
[6.x] Only allow PHP 8.0.x versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.5|^8.0",
+        "php": "^7.2.5|~8.0.0",
         "ext-json": "*",
         "ext-mbstring": "*",
         "ext-openssl": "*",


### PR DESCRIPTION
Looks like the PHP 8.1 compatibility PR is not merged into 6.x So it doesn't make sense to allow installing 6.x on PHP 8.1