### PR TITLE
New hasManyThroughPivot table relation

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+use Illuminate\Database\Eloquent\Relations\HasManyThroughPivot;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\HasOneThrough;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
@@ -418,6 +419,47 @@ trait HasRelationships
     protected function newHasManyThrough(Builder $query, Model $farParent, Model $throughParent, $firstKey, $secondKey, $localKey, $secondLocalKey)
     {
         return new HasManyThrough($query, $farParent, $throughParent, $firstKey, $secondKey, $localKey, $secondLocalKey);
+    }
+
+    /**
+     * Define a has-many-through-pivot relationship.
+     *
+     * @param  string  $related
+     * @param  string  $through
+     * @param  string  $localKey
+     * @param  string  $foreignRelatedKey
+     * @param  string|null  $farForeignRelatedKey
+     * @param  string|null  $relatedKey
+     * @return \Illuminate\Database\Eloquent\Relations\HasManyThroughPivot
+     */
+    public function hasManyThroughPivot(string $related, string $through, string $localKey, string $foreignRelatedKey, string $farForeignRelatedKey = null, string $relatedKey = null) : HasManyThroughPivot
+    {
+        return new HasManyThroughPivot(
+            $this->newRelatedInstance($related)->newQuery(),
+            $this,
+            new $through,
+            $localKey,
+            $foreignRelatedKey,
+            $farForeignRelatedKey,
+            $relatedKey,
+        );
+    }
+
+    /**
+     * Instantiate a new HasManyThrough relationship.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  \Illuminate\Database\Eloquent\Model  $farParent
+     * @param  \Illuminate\Database\Eloquent\Model  $throughParent
+     * @param  string  $localKey
+     * @param  string  $foreignRelatedKey
+     * @param  string  $farForeignRelatedKey
+     * @param  string  $relatedKey
+     * @return \Illuminate\Database\Eloquent\Relations\HasManyThrough
+     */
+    protected function newHasManyThroughPivot(Builder $query, Model $farParent, Model $throughParent, $localKey, $foreignRelatedKey, $farForeignRelatedKey, $relatedKey)
+    {
+        return new HasManyThroughPivot($query, $farParent, $throughParent, $localKey, $foreignRelatedKey, $farForeignRelatedKey, $relatedKey);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThroughPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThroughPivot.php
@@ -1,0 +1,208 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Relations;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Relation;
+
+class HasManyThroughPivot extends Relation
+{
+    /**
+     * The model of the relationship to go through.
+     *
+     * @var \Illuminate\Database\Eloquent\Model
+     */
+    protected $throughParent;
+
+    /**
+     * The local key of the parent model.
+     *
+     * @var string
+     */
+    protected $localKey;
+
+    /**
+     * The related foreign key of the foreign model.
+     *
+     * @var string
+     */
+    protected $foreignRelatedKey;
+
+    /**
+     * The related foreign key of the far foreign model.
+     *
+     * @var string
+     */
+    protected $farForeignRelatedKey;
+
+    /**
+     * The related key of the far foreign model.
+     *
+     * @var string
+     */
+    protected $relatedKey;
+
+    public function __construct(Builder $query, Model $parent, Model $throughParent, $localKey, $foreignRelatedKey, $farForeignRelatedKey, $relatedKey)
+    {
+        $this->throughParent = $throughParent;
+        $this->localKey = $localKey;
+        $this->foreignRelatedKey = $foreignRelatedKey;
+        $this->farForeignRelatedKey = $farForeignRelatedKey;
+        $this->relatedKey = $relatedKey;
+
+        parent::__construct($query, $parent);
+    }
+
+    /**
+     * Set the base constraints on the relation query.
+     *
+     * @return void
+     */
+    public function addConstraints()
+    {
+        $query = $this->getRelationQuery();
+
+        $query->join($this->throughParent->getTable(), function ($join) {
+            return $join->on(
+                $this->related->getTable().'.'.$this->getRelatedKey(),
+                '=',
+                $this->throughParent->getTable().'.'.$this->getForeignRelatedKey(),
+            );
+        });
+
+        $query->join($this->parent->getTable(), function ($join) {
+            return $join->on(
+                $this->throughParent->getTable().'.'.$this->getFarForeignRelatedKey(),
+                '=',
+                $this->parent->getTable().'.'.$this->getLocalKey(),
+            );
+        });
+    }
+
+    /**
+     * Set the constraints for an eager load of the relation.
+     *
+     * @param  array  $models  An array of parent models
+     * @return void
+     */
+    public function addEagerConstraints(array $models)
+    {
+        $this->getRelationQuery()->whereIn(
+            $this->parent->getTable().'.'.$this->getLocalKey(),
+            $this->getKeys($models, $this->getLocalKey())
+        );
+    }
+
+    /**
+     * Initialize the relation on a set of models.
+     *
+     * It Initialises the empty relationship on every
+     * parent model, so that it can be filled afterwards.
+     *
+     * @param  array  $models
+     * @param  string  $relation
+     * @return array
+     */
+    public function initRelation(array $models, $relation)
+    {
+        foreach ($models as $model) {
+            $model->setRelation(
+                $relation,
+                $this->related->newCollection()
+            );
+        }
+
+        return $models;
+    }
+
+    /**
+     * Get the results of the relationship.
+     *
+     * Used when we access the relationship via dynamic property
+     *
+     * @return mixed
+     */
+    public function getResults()
+    {
+        return $this->query->get($this->related->getTable().'.*');
+    }
+
+    /**
+     * Execute the query as a "select" statement.
+     *
+     * @param  array  $columns
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    public function get($columns = ['*'])
+    {
+        if ($columns == ['*']) {
+            $columns = [$this->related->getTable().'.*'];
+        }
+
+        return $this->query->get($columns);
+    }
+
+    /**
+     * Match the eagerly loaded results to their parents.
+     *
+     * @param  array  $models
+     * @param  \Illuminate\Database\Eloquent\Collection  $results
+     * @param  string  $relation
+     * @return array
+     */
+    public function match(array $models, Collection $results, $relation)
+    {
+        foreach ($models as $model) {
+            $model->setRelation(
+                $relation,
+                new Collection($results),
+            );
+        }
+
+        return $models;
+    }
+
+    /**
+     * Get the local key for the relationship.
+     *
+     * @return string
+     */
+    public function getLocalKey()
+    {
+        return $this->localKey;
+    }
+
+    /**
+     * Get the far foregin related key for the relationship.
+     *
+     * @return string
+     */
+    public function getForeignRelatedKey()
+    {
+        return $this->foreignRelatedKey;
+    }
+
+    /**
+     * Get the far foregin related key on the given relationship and
+     * default to the related model foreign key name.
+     *
+     * @return string
+     */
+    public function getFarForeignRelatedKey()
+    {
+        return $this->farForeignRelatedKey ?: $this->related->getForeignKey();
+    }
+
+    /**
+     * Get the related key for the relationship and default to the
+     * model's primary key.
+     *
+     * @return string
+     */
+    public function getRelatedKey()
+    {
+        return $this->relatedKey ?: $this->related->getKeyName();
+    }
+}


### PR DESCRIPTION
This PR adds a new eloquent relationship to the pivot model that allows for many relations through the given pivot table

## Problem
I have tried using `hasManyThrough()` in order to get many permissions through another pivot table. However, since my pivot table has no primary ID column this becomes difficult. Below is the following ERD database structure for the given scenario:

```
users
- id
- name
- password 
etc...

team_user
- team_id
- user_id
- created_at
- updated_at

team_user_permissions
- team_id
- user_id
- permission_id
- created_at
- updated_at

permissions
- id
- name
- created_at
- updated_at
```

## My Proposed Solution
Create a new eloquent relationship where you can specify the given column names to match against the related table through another pivot table.

```
<?php

namespace App\Models;

use App\Relations\CustomRelations;
use Illuminate\Database\Eloquent\Relations\Pivot;

class TeamUser extends Pivot
{
    use CustomRelations;

    /**
     * Has many Permission through the pivot TeamUserPermission table
     */
    public function permissions()
    {
        return $this->hasManyThroughPivot(
            Permission::class,
            TeamUserPermission::class,
            'user_id', // team_user.user_id - local key
            'user_id', // team_user_permissions.user_id - foreign related key
            // 'permission_id', // team_user_permissions.permission_id - far foreign related key
            // 'id', // permissions.id - related key
        );
    }
}
```


## Breaking changes
This shouldn't break anything, it's a completely new suggested relationship which you can load custom relationships through a pivot table.

## Note
Any other suggestions for are definitely welcome! 👍 