### PR TITLE
[8.x] Make view component namespace configurable

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -566,7 +566,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
 
         if (is_null($alias)) {
             $namespace = config('view.component_namespace', 'View\\Components');
-            
+
             $alias = Str::contains($class, '\\'.$namespace.'\\')
                             ? collect(explode('\\', Str::after($class, '\\'.$namespace.'\\')))->map(function ($segment) {
                                 return Str::kebab($segment);

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -565,8 +565,10 @@ class BladeCompiler extends Compiler implements CompilerInterface
         }
 
         if (is_null($alias)) {
-            $alias = Str::contains($class, '\\View\\Components\\')
-                            ? collect(explode('\\', Str::after($class, '\\View\\Components\\')))->map(function ($segment) {
+            $namespace = config('view.component_namespace', 'View\\Components');
+            
+            $alias = Str::contains($class, '\\'.$namespace.'\\')
+                            ? collect(explode('\\', Str::after($class, '\\'.$namespace.'\\')))->map(function ($segment) {
                                 return Str::kebab($segment);
                             })->implode(':')
                             : Str::kebab(class_basename($class));

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -316,7 +316,7 @@ class ComponentTagCompiler
 
         $class = $this->formatClassName($component);
 
-        return $namespace.'View\\Components\\'.$class;
+        return $namespace.config('view.component_namespace', 'View\\Components').'\\'.$class;
     }
 
     /**


### PR DESCRIPTION
these change will allow us to configure the view component namespace via the `view` config file

e.g inside `config/view.php`: 

```
'component_namespace' => 'Http\\View\\Components',
```

it falls back on the current namespace so there should be 0 conflicts.