### PR TITLE
[8.x] Add `modelKeys` method to Eloquent Builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -779,6 +779,17 @@ class Builder
     }
 
     /**
+     * Get an array of primary keys, or the values of a given column, indexed by the primary keys.
+     *
+     * @param $column
+     * @return \Illuminate\Support\Collection
+     */
+    public function modelKeys($column = null)
+    {
+        return $this->pluck(...array_filter([$column, $this->model->getKeyName()]));
+    }
+
+    /**
      * Paginate the given query.
      *
      * @param  int|null  $perPage

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -309,15 +309,19 @@ class Collection extends BaseCollection implements QueueableCollection
     }
 
     /**
-     * Get the array of primary keys.
+     * Get an array of primary keys, or the values of a given column, indexed by the primary keys.
      *
-     * @return array
+     * @return array|static
      */
-    public function modelKeys()
+    public function modelKeys($column = null)
     {
-        return array_map(function ($model) {
-            return $model->getKey();
-        }, $this->items);
+        if ($column === null) {
+            return $this->map->getKey()->toArray();
+        }
+
+        return $this->mapWithKeys(function ($model) use ($column) {
+            return [$model->getKey() => $model->getAttribute($column)];
+        });
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -311,7 +311,7 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Get an array of primary keys, or the values of a given column, indexed by the primary keys.
      *
-     * @return array|static
+     * @return array
      */
     public function modelKeys($column = null)
     {
@@ -321,7 +321,7 @@ class Collection extends BaseCollection implements QueueableCollection
 
         return $this->mapWithKeys(function ($model) use ($column) {
             return [$model->getKey() => $model->getAttribute($column)];
-        });
+        })->toArray();
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -579,6 +579,32 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals(['bar', 'baz'], $builder->pluck('name')->all());
     }
 
+    public function testEloquentBuilderReturnsModelKeys()
+    {
+        $builder = $this->getBuilder();
+        $builder->getQuery()->shouldReceive('pluck')->with('foo', '')->andReturn(new BaseCollection([1, 12, 15, 18, 20, 25]));
+        $builder->setModel($this->getMockModel());
+        $builder->getModel()->shouldReceive('hasGetMutator')->with('foo')->andReturn(false);
+        $builder->getModel()->shouldReceive('hasCast')->with('foo')->andReturn(false);
+        $builder->getModel()->shouldReceive('getDates')->andReturn(['created_at']);
+
+        $this->assertEquals([1, 12, 15, 18, 20, 25], $builder->modelKeys()->all());
+    }
+
+    public function testEloquentBuilderReturnsColumnsByModelKeys()
+    {
+        $builder = $this->getBuilder();
+        $builder->getQuery()->shouldReceive('pluck')->with('name', 'foo')->andReturn(new BaseCollection([5 => 'five', 7 => 'seven', 9 => 'nine']));
+        $builder->setModel($this->getMockModel());
+        $builder->getModel()->shouldReceive('hasGetMutator')->with('foo')->andReturn(false);
+        $builder->getModel()->shouldReceive('hasGetMutator')->with('name')->andReturn(false);
+        $builder->getModel()->shouldReceive('hasCast')->with('foo')->andReturn(false);
+        $builder->getModel()->shouldReceive('hasCast')->with('name')->andReturn(false);
+        $builder->getModel()->shouldReceive('getDates')->andReturn(['created_at']);
+
+        $this->assertEquals([5 => 'five', 7 => 'seven', 9 => 'nine'], $builder->modelKeys('name')->all());
+    }
+
     public function testLocalMacrosAreCalledOnBuilder()
     {
         unset($_SERVER['__test.builder']);

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -186,6 +186,25 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertEquals([1, 2, 3], $c->modelKeys());
     }
 
+    public function testCollectionDictionaryPlucksColumnByModelKeys()
+    {
+        $one = m::mock(Model::class);
+        $one->shouldReceive('getKey')->andReturn(1);
+        $one->shouldReceive('getAttribute')->with('name')->andReturn('one');
+
+        $two = m::mock(Model::class);
+        $two->shouldReceive('getKey')->andReturn(2);
+        $two->shouldReceive('getAttribute')->with('name')->andReturn('two');
+
+        $three = m::mock(Model::class);
+        $three->shouldReceive('getKey')->andReturn(3);
+        $three->shouldReceive('getAttribute')->with('name')->andReturn('three');
+
+        $c = new Collection([$one, $two, $three]);
+
+        $this->assertEquals([1 => 'one', 2 => 'two', 3 => 'three'], $c->modelKeys('name')->all());
+    }
+
     public function testCollectionMergesWithGivenCollection()
     {
         $one = m::mock(Model::class);

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -202,7 +202,7 @@ class DatabaseEloquentCollectionTest extends TestCase
 
         $c = new Collection([$one, $two, $three]);
 
-        $this->assertEquals([1 => 'one', 2 => 'two', 3 => 'three'], $c->modelKeys('name')->all());
+        $this->assertEquals([1 => 'one', 2 => 'two', 3 => 'three'], $c->modelKeys('name'));
     }
 
     public function testCollectionMergesWithGivenCollection()


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Why?
====
There is a `modelKeys()` method which returns an array of the primary keys of all the models in an Eloquent Collection by calling:

```php
MyModel::get()->modelKeys();
```

This is favorable over hard coding the primary key name in the code like

```php
MyModel::get()->pluck('id');
```

However, we never use the code like this, but instead prefer to pluck directly on the Eloquent Builder:

```php
MyModel::pluck('id');
```

The advantage of this approach is that the resulting query with limit the results to the id column instead of needing to fetch all columns for all rows, which improves performance, limits traffic and saves memory.

However, there is no `modelKeys()` method available on the Builder.

So, in order to achieve the same result like with `modelKeys()`, you would need to do:

```php
MyModel::pluck(MyModel::getModel()->getKeyName());
```

...which is neither nice to write nor to read.

Secondly, I rarely encountered a situation where I need just all available primary keys - instead, we are having dozens of uses for preparing a list, for example for the options in select elements, where you need a display name keyed by the id:

```php
MyModel::pluck('name', 'id');
```

It would be cool to be able to just do

```php
MyModel::modelKeys('name');
```

in those cases and get an array or collection of all name values indexed by the model's primary key.

Let's do it
====

This PR adds a `modelKeys()` method to the Eloquent Builder that behaves much alike the `modelKeys()` method in the Eloquent Collection class, with the following exceptions:

1. it returns `static` instead of `array`, because it is using the pluck method and I found it makes sense it stays in line with pluck.
2. it accepts an optional `$column` parameter that indexes the given column values by the model's primary keys.

This PR also extends the existing Eloquent Collection's `modelKeys()` method by also accepting an optional `$column` parameter to replicate the behavior of the Builder's `modelKeys()` method.

Issues up for discussion
====

We run into an ugly situation here, because the existing `modelKeys()` method, unlike most other methods in the class, returns an array instead of an Eloquent Collection. 

In order not to introduce a breaking change, I left the return type to be an array.

I would leave up for discussion whether both the Collection AND Builder implementations should both return arrays. Currently, the Builder implementation stays in line with the `pluck` method it uses and returns an `Illuminate\Support\Collection`.

Personally, I would expect a collection return in order to be able to chain further method calls, and returning an array would in most cases lead to having to `collect()` the result again...

Let me know what you think!