### PR TITLE
[8.x] Add `elseisset` directive

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -223,6 +223,17 @@ trait CompilesConditionals
     }
 
     /**
+     * Compile the else-isset statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileElseIsset($expression)
+    {
+        return "<?php elseif(isset{$expression}): ?>";
+    }
+
+    /**
      * Compile the end-isset statements into valid PHP.
      *
      * @return string

--- a/tests/View/Blade/BladeElseIssetStatementsTest.php
+++ b/tests/View/Blade/BladeElseIssetStatementsTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Illuminate\Tests\View\Blade;
+
+class BladeElseIssetStatementsTest extends AbstractBladeTestCase
+{
+    public function testElseIssetStatementsAreCompiled()
+    {
+        $string = '@isset ($test)
+breeze
+@elseisset($test1)
+boom
+@endisset';
+        $expected = '<?php if(isset($test)): ?>
+breeze
+<?php elseif(isset($test1)): ?>
+boom
+<?php endif; ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+}


### PR DESCRIPTION
Currently we have only ```@isset``` and ```@endisset``` directives and we need ```@elseisset``` directive (that's the goal of this PR)

```
@isset($foo)
  //
@elseisset($bar)
  //
@endisset
```