### PR TITLE
[8.x] Add `getDeeply` collection method

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -893,6 +893,18 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Get an item from the collection using "dot" notation.
+     *
+     * @param  mixed  $key
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public function getDeeply($key, $default = null)
+    {
+        return Arr::get($this->items, $key, $default);
+    }
+
+    /**
      * Put an item in the collection by key.
      *
      * @param  mixed  $key

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3415,6 +3415,34 @@ class SupportCollectionTest extends TestCase
         $this->assertSame('foo', $value);
     }
 
+    public function testGetDeeplyRetrievesItemFromCollection()
+    {
+        $c = new Collection(['foo', 'bar']);
+
+        $this->assertSame('foo', $c->getDeeply(0));
+    }
+
+    public function testGetDeeplyRetrievesItemFromCollectionMultidimensionally()
+    {
+        $c = new Collection(['products' => ['desk' => ['price' => 100]]]);
+
+        $this->assertSame(100, $c->getDeeply('products.desk.price'));
+    }
+
+    public function testGetDeeplyDoesntRemoveItemFromCollection()
+    {
+        $c = new Collection(['foo', 'bar']);
+        $c->getDeeply(0);
+        $this->assertEquals([0 => 'foo', 1 => 'bar'], $c->all());
+    }
+
+    public function testGetDeeplyReturnsDefault()
+    {
+        $c = new Collection([]);
+        $value = $c->getDeeply(0, 'foo');
+        $this->assertSame('foo', $value);
+    }
+
     /**
      * @dataProvider collectionClassProvider
      */


### PR DESCRIPTION
### Why?

Always when we want to get the data from a collection with multidimensional arrays, it was a way to use `pull` or multidimensional collections with `->get()->get()` which is not very elegant. The pull works well, but it actually removes the item from the collection besides retrieving. Most times working in Laravel I wanted to use dot notation, but to leave the item in the collection as other parts of the application might want access that data as well. The new method `getDeeply` works in a similar way as `pull` (using dot notation), but without removing an item from the collection.

### B/C?
- No. It's a completely new method, and under the hood, it's just an alias to `Arr::get()`.