### PR TITLE
[8.x] Forget and clear a mocked/spied instance of an object in the container

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
@@ -78,6 +78,19 @@ trait InteractsWithContainer
     }
 
     /**
+     * Forget and clear a mocked/spied instance of an object in the container.
+     *
+     * @param  string $abstract
+     * @return $this
+     */
+    protected function forgetMock($abstract)
+    {
+        $this->app->forgetInstance($abstract);
+
+        return $this;
+    }
+
+    /**
      * Register an empty handler for Laravel Mix in the container.
      *
      * @return $this

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
@@ -78,7 +78,7 @@ trait InteractsWithContainer
     }
 
     /**
-     * Forget and clear a mocked/spied instance of an object in the container.
+     * Instruct the container to forget a previously mocked / spied instance of an object.
      *
      * @param  string  $abstract
      * @return $this

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
@@ -80,7 +80,7 @@ trait InteractsWithContainer
     /**
      * Forget and clear a mocked/spied instance of an object in the container.
      *
-     * @param  string $abstract
+     * @param  string  $abstract
      * @return $this
      */
     protected function forgetMock($abstract)

--- a/tests/Foundation/Testing/Concerns/InteractsWithContainerTest.php
+++ b/tests/Foundation/Testing/Concerns/InteractsWithContainerTest.php
@@ -27,4 +27,25 @@ class InteractsWithContainerTest extends TestCase
         $this->assertSame($handler, resolve(Mix::class));
         $this->assertSame($this, $instance);
     }
+
+    public function testForgetMock()
+    {
+        $this->mock(IntanceStub::class)
+            ->shouldReceive('execute')
+            ->once()
+            ->andReturn('bar');
+
+        $this->assertSame('bar', $this->app->make(IntanceStub::class)->execute());
+
+        $this->forgetMock(IntanceStub::class);
+        $this->assertSame('foo', $this->app->make(IntanceStub::class)->execute());
+    }
+}
+
+class IntanceStub
+{
+    public function execute()
+    {
+        return 'foo';
+    }
 }


### PR DESCRIPTION
This PR was inspired by `Jest`'s `mockRestore()` method.
It introduces new `forgetMock()` method which uses `forgetInstance()` method internally and has a better DX.

The use-case:
Consider we have multiple test methods using a `mocked/spied` instance of an object which is prepared in the `setUp()` method.
If in that class some tests want to run tests without mock, they can call the `forgetMock()` method. 