### PR TITLE
[8.x] Add integer() method to InteractsWithInput trait

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -303,7 +303,7 @@ trait InteractsWithInput
      *
      * @param  null  $key
      * @param  false  $default
-     * @return  mixed
+     * @return mixed
      */
     public function integer($key = null, $default = false)
     {

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -297,6 +297,20 @@ trait InteractsWithInput
     }
 
     /**
+     * Retrieve input as an integer value.
+     *
+     * Returns an integer when value is a boolean or a number in string form i.e. "123". Otherwise, returns false.
+     *
+     * @param  null  $key
+     * @param  false  $default
+     * @return  mixed
+     */
+    public function integer($key = null, $default = false)
+    {
+        return filter_var($this->input($key, $default), FILTER_VALIDATE_INT);
+    }
+
+    /**
      * Retrieve input from the request as a collection.
      *
      * @param  array|string|null  $key

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -503,6 +503,17 @@ class HttpRequestTest extends TestCase
         $this->assertFalse($request->boolean('some_undefined_key'));
     }
 
+    public function testIntegerMethod()
+    {
+        $request = Request::create('/', 'GET', ['with_trashed' => 'false', 'price' => '1.23', 'download' => true, 'checked' => 1, 'unchecked' => '0', 'id' => '123']);
+        $this->assertFalse($request->integer('with_trashed'));
+        $this->assertFalse($request->integer('price'));
+        $this->assertIsInt($request->integer('download'));
+        $this->assertIsInt($request->integer('checked'));
+        $this->assertIsInt($request->integer('unchecked'));
+        $this->assertIsInt($request->integer('id'));
+    }
+
     public function testCollectMethod()
     {
         $request = Request::create('/', 'GET', ['users' => [1, 2, 3]]);


### PR DESCRIPTION
This PR is inspired by the `boolean()` method on the `InteractsWithInput` trait. I often find that I have to write something like this when reading numbers out of a request:

```
$myVal = (int)$request->query('myval');
```

This PR eliminates the typecasting by adding an `integer()` method similar to the `boolean()` method.

```
$myVal = $request->integer('myval');
```

If there's already an existing way to do something like this and I've overlooked it, please let me know. I didn't see anything like this in the documentation.