### PR TITLE
Initializable traits in controllers

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -291,7 +291,7 @@ class Route
     {
         foreach (class_uses_recursive($this->controller) as $trait) {
             $method = 'initialize'.class_basename($trait);
-            if (method_exists($this->controller, $method) && !in_array($method, $this->initializedTraits)) {
+            if (method_exists($this->controller, $method) && ! in_array($method, $this->initializedTraits)) {
                 $this->controller->{$method}();
                 $this->initializedTraits[] = $method;
             }

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -151,6 +151,13 @@ class Route
     protected $bindingFields = [];
 
     /**
+     * The traits that have been initialized for the current controller.
+     *
+     * @var array
+     */
+    protected $initializedTraits = [];
+
+    /**
      * The validators used by the routes.
      *
      * @var array
@@ -274,9 +281,21 @@ class Route
             $class = $this->parseControllerCallback()[0];
 
             $this->controller = $this->container->make(ltrim($class, '\\'));
+            $this->initializeTraits();
         }
 
         return $this->controller;
+    }
+
+    protected function initializeTraits()
+    {
+        foreach (class_uses_recursive($this->controller) as $trait) {
+            $method = 'initialize'.class_basename($trait);
+            if (method_exists($this->controller, $method) && !in_array($method, $this->initializedTraits)) {
+                $this->controller->{$method}();
+                $this->initializedTraits[] = $method;
+            }
+        }
     }
 
     /**

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -194,6 +194,13 @@ class RoutingRouteTest extends TestCase
         $this->assertSame('caught', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
     }
 
+    public function testTraitMiddleware()
+    {
+        $router = $this->getRouter();
+        $router->get('test-trait', [RouteTestControllerMiddlewareTraitStub::class, 'index']);
+        $this->assertSame('trait', $router->dispatch(Request::create('test-trait', 'GET'))->getContent());
+    }
+
     public function testMiddlewareCanBeSkipped()
     {
         $router = $this->getRouter();
@@ -2063,6 +2070,16 @@ class RouteTestClosureMiddlewareController extends Controller
     }
 }
 
+class RouteTestControllerMiddlewareTraitStub extends Controller
+{
+    use RouteTestControllerMiddlewareTrait;
+
+    public function index()
+    {
+        return 'no trait middleware';
+    }
+}
+
 class RouteTestControllerMiddleware
 {
     public function handle($request, $next)
@@ -2110,6 +2127,14 @@ class RouteTestControllerExceptMiddleware
         $_SERVER['route.test.controller.except.middleware'] = true;
 
         return $next($request);
+    }
+}
+
+class RouteTestControllerTraitMiddleware
+{
+    public function handle($request, $next)
+    {
+        return new Response('trait');
     }
 }
 
@@ -2314,5 +2339,13 @@ class ExampleMiddleware implements ExampleMiddlewareContract
     public function handle($request, Closure $next)
     {
         return $next($request);
+    }
+}
+
+trait RouteTestControllerMiddlewareTrait
+{
+    public function initializeRouteTestControllerMiddlewareTrait()
+    {
+        $this->middleware(RouteTestControllerTraitMiddleware::class);
     }
 }


### PR DESCRIPTION
Inspired by the ability to initialize traits for models by adding a static method called `boot[Trait Name]`, I've introduced a similar feature for controllers. See [`bootTraits()`](https://github.com/laravel/framework/blob/36dfae9d9ef7f88e8f9489c484a0a0609592bc21/src/Illuminate/Database/Eloquent/Model.php#L260)

This will allow us to add a simple trait to many controllers, adding logic that could be placed in a constructor of a controller.

This comes from a need in our company, where we are adding a middleware to many controllers, caching an entire response from the controller. But instead of adding a constructor to all controllers, the trait could be used. This will also allow for defaults to be placed in the trait instead of adding it to all controllers.

Given the trait:
```php
trait CacheResponseTrait
{
    public function initializeCacheResponseTrait()
    {
        $ttl = 10;
        if (property_exists($this, 'ttl')) {
            $ttl = $this->ttl;
        }
        $this->middleware(CacheRequestsMiddleware::class . ':' . $ttl);
    }
}
```
We will be able to add the trait to all controllers needing to cache an entire response. And for the given controllers, that need a longer `ttl`, than the default, we'll simply be able to define the controller as such:

```php
class ApiController extends Controller
{
    use CacheResponseTrait;
    
    protected int $ttl = 3600;
```

Thank you for considering my pull request.