### PR TITLE
[8.x] Fixed return type of `Grammar::getValue`

### DIFF
--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -179,7 +179,7 @@ abstract class Grammar
      * Get the value of a raw expression.
      *
      * @param  \Illuminate\Database\Query\Expression  $expression
-     * @return string
+     * @return mixed
      */
     public function getValue($expression)
     {


### PR DESCRIPTION
this return type should be consistent with Expression class getValue method return type
