### PR TITLE
[8.x] Add explicit tests for countables on Str::pluralStudly

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -533,7 +533,7 @@ class Str
      * Pluralize the last word of an English, studly caps case string.
      *
      * @param  string  $value
-     * @param  int  $count
+     * @param  int|array|\Countable  $count
      * @return string
      */
     public static function pluralStudly($value, $count = 2)

--- a/tests/Support/SupportPluralizerTest.php
+++ b/tests/Support/SupportPluralizerTest.php
@@ -99,6 +99,20 @@ class SupportPluralizerTest extends TestCase
         $this->assertSame('users', Str::plural('user', collect(['one', 'two'])));
     }
 
+    public function testPluralStudlySupportsArrays()
+    {
+        $this->assertPluralStudly('SomeUsers', 'SomeUser', []);
+        $this->assertPluralStudly('SomeUser', 'SomeUser', ['one']);
+        $this->assertPluralStudly('SomeUsers', 'SomeUser', ['one', 'two']);
+    }
+
+    public function testPluralStudlySupportsCollections()
+    {
+        $this->assertPluralStudly('SomeUsers', 'SomeUser', collect());
+        $this->assertPluralStudly('SomeUser', 'SomeUser', collect(['one']));
+        $this->assertPluralStudly('SomeUsers', 'SomeUser', collect(['one', 'two']));
+    }
+
     private function assertPluralStudly($expected, $value, $count = 2)
     {
         $this->assertSame($expected, Str::pluralStudly($value, $count));


### PR DESCRIPTION
Support for countables was added in #39641 and it was later pointed out that this had been previously attempted in #34758.

This PR just adds explicit tests for `Str::pluralStudly`, and updates the relevant docblock on the `Str` class, seeing as the underlying functionality is provided by `Str::plural` already.
