### PR TITLE
[8.x] Add `undot()` method to Arr helpers and Collections

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -122,6 +122,23 @@ class Arr
     }
 
     /**
+     * Elevate an associative array with dots to a multi-dimensional array.
+     *
+     * @param iterable $array
+     * @return array
+     */
+    public static function elevate($array)
+    {
+        $results = [];
+
+        foreach ($array as $key => $value) {
+            static::set($results, $key, $value);
+        }
+
+        return $results;
+    }
+
+    /**
      * Get all of the given array except for a specified array of keys.
      *
      * @param  array  $array

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -124,7 +124,7 @@ class Arr
     /**
      * Elevate an associative array with dots to a multi-dimensional array.
      *
-     * @param iterable $array
+     * @param  iterable $array
      * @return array
      */
     public static function elevate($array)

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -124,7 +124,7 @@ class Arr
     /**
      * Elevate an associative array with dots to a multi-dimensional array.
      *
-     * @param  iterable $array
+     * @param  iterable  $array
      * @return array
      */
     public static function elevate($array)

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -122,12 +122,12 @@ class Arr
     }
 
     /**
-     * Elevate an associative array with dots to a multi-dimensional array.
+     * Convert a flatten "dot" notation array into an expanded array.
      *
      * @param  iterable  $array
      * @return array
      */
-    public static function elevate($array)
+    public static function undot($array)
     {
         $results = [];
 

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1548,6 +1548,16 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Elevate the collection to one that holds a multi-dimensional array.
+     *
+     * @return static
+     */
+    public function elevate()
+    {
+        return new static(Arr::elevate($this->all()));
+    }
+
+    /**
      * Get a base Support collection instance from this collection.
      *
      * @return \Illuminate\Support\Collection

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1436,6 +1436,16 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Convert a flatten "dot" notation array into an expanded array.
+     *
+     * @return static
+     */
+    public function undot()
+    {
+        return new static(Arr::undot($this->all()));
+    }
+
+    /**
      * Return only unique items from the collection array.
      *
      * @param  string|callable|null  $key
@@ -1545,16 +1555,6 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
         $this->items[] = $item;
 
         return $this;
-    }
-
-    /**
-     * Elevate the collection to one that holds a multi-dimensional array.
-     *
-     * @return static
-     */
-    public function elevate()
-    {
-        return new static(Arr::elevate($this->all()));
     }
 
     /**

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1465,6 +1465,16 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
+     * Elevate the lazy collection to one that holds a multi-dimensional array.
+     *
+     * @return static
+     */
+    public function elevate()
+    {
+        return $this->passthru('elevate', []);
+    }
+
+    /**
      * Get the values iterator.
      *
      * @return \Traversable

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1373,6 +1373,16 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
+     * Convert a flatten "dot" notation array into an expanded array.
+     *
+     * @return static
+     */
+    public function undot()
+    {
+        return $this->passthru('undot', []);
+    }
+
+    /**
      * Return only unique items from the collection array.
      *
      * @param  string|callable|null  $key
@@ -1462,16 +1472,6 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
                 yield $value;
             }
         });
-    }
-
-    /**
-     * Elevate the lazy collection to one that holds a multi-dimensional array.
-     *
-     * @return static
-     */
-    public function elevate()
-    {
-        return $this->passthru('elevate', []);
     }
 
     /**

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -113,6 +113,30 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['name' => 'taylor', 'languages.php' => true], $array);
     }
 
+    public function testElevate()
+    {
+        $array = Arr::elevate([
+            'user.name' => 'Taylor',
+            'user.age' => 25,
+            'user.languages.0' => 'PHP',
+            'user.languages.1' => 'C#',
+        ]);
+        $this->assertEquals(['user' => ['name' => 'Taylor', 'age' => 25, 'languages' => ['PHP', 'C#']]], $array);
+
+        $array = Arr::elevate([
+            'pagination.previous' => '<<',
+            'pagination.next' => '>>',
+        ]);
+        $this->assertEquals(['pagination' => ['previous' => '<<', 'next' => '>>']], $array);
+
+        $array = Arr::elevate([
+            'foo',
+            'foo.bar' => 'baz',
+            'foo.baz' => ['a' => 'b'],
+        ]);
+        $this->assertEquals(['foo', 'foo' => ['bar' => 'baz', 'baz' => ['a' => 'b']]], $array);
+    }
+
     public function testExcept()
     {
         $array = ['name' => 'taylor', 'age' => 26];

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -113,9 +113,9 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['name' => 'taylor', 'languages.php' => true], $array);
     }
 
-    public function testElevate()
+    public function testUndot()
     {
-        $array = Arr::elevate([
+        $array = Arr::undot([
             'user.name' => 'Taylor',
             'user.age' => 25,
             'user.languages.0' => 'PHP',
@@ -123,13 +123,13 @@ class SupportArrTest extends TestCase
         ]);
         $this->assertEquals(['user' => ['name' => 'Taylor', 'age' => 25, 'languages' => ['PHP', 'C#']]], $array);
 
-        $array = Arr::elevate([
+        $array = Arr::undot([
             'pagination.previous' => '<<',
             'pagination.next' => '>>',
         ]);
         $this->assertEquals(['pagination' => ['previous' => '<<', 'next' => '>>']], $array);
 
-        $array = Arr::elevate([
+        $array = Arr::undot([
             'foo',
             'foo.bar' => 'baz',
             'foo.baz' => ['a' => 'b'],

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -4856,6 +4856,42 @@ class SupportCollectionTest extends TestCase
     }
 
     /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testElevate($collection)
+    {
+        $data = $collection::make([
+            'name' => 'Taylor',
+            'meta.foo' => 'bar',
+            'meta.baz' => 'boom',
+            'meta.bam.boom' => 'bip',
+        ])->elevate();
+        $this->assertSame([
+            'name' => 'Taylor',
+            'meta' => [
+                'foo' => 'bar',
+                'baz' => 'boom',
+                'bam' => [
+                    'boom' => 'bip',
+                ],
+            ],
+        ], $data->all());
+
+        $data = $collection::make([
+            'foo.0' => 'bar',
+            'foo.1' => 'baz',
+            'foo.baz' => 'boom',
+        ])->elevate();
+        $this->assertSame([
+            'foo' => [
+                'bar',
+                'baz',
+                'baz' => 'boom',
+            ],
+        ], $data->all());
+    }
+
+    /**
      * Provides each collection class, respectively.
      *
      * @return array

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -4858,14 +4858,14 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
-    public function testElevate($collection)
+    public function testUndot($collection)
     {
         $data = $collection::make([
             'name' => 'Taylor',
             'meta.foo' => 'bar',
             'meta.baz' => 'boom',
             'meta.bam.boom' => 'bip',
-        ])->elevate();
+        ])->undot();
         $this->assertSame([
             'name' => 'Taylor',
             'meta' => [
@@ -4881,7 +4881,7 @@ class SupportCollectionTest extends TestCase
             'foo.0' => 'bar',
             'foo.1' => 'baz',
             'foo.baz' => 'boom',
-        ])->elevate();
+        ])->undot();
         $this->assertSame([
             'foo' => [
                 'bar',


### PR DESCRIPTION
This PR adds support for `elevate` method in array helpers and collections.

This method basically does the opposite of `Arr::dot()`, it takes an associative array and converts it to a multi-dimensional one based on keys with dot notation.

For example if we take this array and pass it through `Arr::dot()`:

```php
$original = [
    'user' => [
        'name' => 'foo',
        'occupation' => 'bar',
    ]
];

$dotted = Arr::dot($original);
```

We would get a _flattened_ associative array:

```php
$dotted = [
    'user.name' => 'foo',
    'user.occupation' => 'bar',
];
```

Now if we _elevate_ the _dotted_ array we should get the original.

```php
$elevated = Arr::elevate($dotted);
```

`$elevated ≡ $original`

Same goes for collections and lazy collections. Not sure if "elevate" is the best name for it, so I'm open to suggestions.

Cheers.

P.S. Will take a look on how to test if a collection is actually lazy and add an additional test. Some help is welcome, of course.

