### PR TITLE
[8.x] Avoid overwrite on `php artisan make:listener` command.

### DIFF
--- a/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
@@ -85,7 +85,7 @@ class ListenerMakeCommand extends GeneratorCommand
      */
     protected function alreadyExists($rawName)
     {
-        return class_exists($rawName);
+        return class_exists($rawName) || parent::alreadyExists($rawName);
     }
 
     /**


### PR DESCRIPTION
Hey, This PR fixes an issue that I running `php artisan make:listener`.

So if I run it as it is right now it overwrites the file, instead of returning `Listener already exists!`.

## Before:
![image](https://user-images.githubusercontent.com/823088/143082834-847c6b47-5009-4cdc-be53-d7c77d768ff6.png)

## After:
![image](https://user-images.githubusercontent.com/823088/143082996-1775481b-d343-48d1-94f8-5af9a526db39.png)


Thanks,
Francisco.