### PR TITLE
[8.x] Avoid overwrite last ip or user_agent with empty ones on DatabaseSessionHandler

### DIFF
--- a/src/Illuminate/Session/DatabaseSessionHandler.php
+++ b/src/Illuminate/Session/DatabaseSessionHandler.php
@@ -174,6 +174,15 @@ class DatabaseSessionHandler implements ExistenceAwareInterface, SessionHandlerI
      */
     protected function performUpdate($sessionId, $payload)
     {
+        if ($this->container->bound('request')) {
+            if (! $payload['ip_address']) {
+                unset($payload['ip_address']);
+            }
+            if (! $payload['user_agent']) {
+                unset($payload['user_agent']);
+            }
+        }
+
         return $this->getQuery()->where('id', $sessionId)->update($payload);
     }
 


### PR DESCRIPTION
https://github.com/tlaverdure/laravel-echo-server/pull/546
In some cases request does'nt has `ipAddress` or `userAgent`, with this change it avoid overwrite the last reported data


