### PR TITLE
[8.x] Fix return type for Model::resolveChildRouteBindingQuery()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1924,7 +1924,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      * @param  string  $childType
      * @param  mixed  $value
      * @param  string|null  $field
-     * @return \Illuminate\Database\Eloquent\Builder
+     * @return \Illuminate\Database\Eloquent\Relations\Relation
      */
     protected function resolveChildRouteBindingQuery($childType, $value, $field)
     {


### PR DESCRIPTION
Method calls from the Relation objects to the underlying Builder object return the relation and not the query. So the correct return type is `Illuminate\Database\Eloquent\Relations\Relation`.

See: https://github.com/laravel/framework/blob/8.x/src/Illuminate/Support/Traits/ForwardsCalls.php#L55
Fixes #39724 