### PR TITLE
[8.x] Fix filesystem put method phpdoc

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -222,7 +222,7 @@ class FilesystemAdapter implements CloudFilesystemContract
      * Write the contents of a file.
      *
      * @param  string  $path
-     * @param  string|resource  $contents
+     * @param  \Illuminate\Http\File|\Illuminate\Http\UploadedFile|Psr\Http\Message\StreamInterface|string|resource  $contents
      * @param  mixed  $options
      * @return bool
      */

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -222,7 +222,7 @@ class FilesystemAdapter implements CloudFilesystemContract
      * Write the contents of a file.
      *
      * @param  string  $path
-     * @param  \Illuminate\Http\File|\Illuminate\Http\UploadedFile|Psr\Http\Message\StreamInterface|string|resource  $contents
+     * @param  \Psr\Http\Message\StreamInterface|\Illuminate\Http\File|\Illuminate\Http\UploadedFile|string|resource  $contents
      * @param  mixed  $options
      * @return bool
      */

--- a/src/Illuminate/Support/Facades/Storage.php
+++ b/src/Illuminate/Support/Facades/Storage.php
@@ -26,7 +26,7 @@ use Illuminate\Filesystem\Filesystem;
  * @method static bool missing(string $path)
  * @method static bool move(string $from, string $to)
  * @method static bool prepend(string $path, string $data)
- * @method static bool put(string $path, \Illuminate\Http\File|\Illuminate\Http\UploadedFile|Psr\Http\Message\StreamInterface|string|resource $contents, mixed $options = [])
+ * @method static bool put(string $path, \Psr\Http\Message\StreamInterface|\Illuminate\Http\File|\Illuminate\Http\UploadedFile|string|resource $contents, mixed $options = [])
  * @method static bool setVisibility(string $path, string $visibility)
  * @method static bool writeStream(string $path, resource $resource, array $options = [])
  * @method static int lastModified(string $path)

--- a/src/Illuminate/Support/Facades/Storage.php
+++ b/src/Illuminate/Support/Facades/Storage.php
@@ -26,7 +26,7 @@ use Illuminate\Filesystem\Filesystem;
  * @method static bool missing(string $path)
  * @method static bool move(string $from, string $to)
  * @method static bool prepend(string $path, string $data)
- * @method static bool put(string $path, string|resource $contents, mixed $options = [])
+ * @method static bool put(string $path, \Illuminate\Http\File|\Illuminate\Http\UploadedFile|Psr\Http\Message\StreamInterface|string|resource $contents, mixed $options = [])
  * @method static bool setVisibility(string $path, string $visibility)
  * @method static bool writeStream(string $path, resource $resource, array $options = [])
  * @method static int lastModified(string $path)


### PR DESCRIPTION
According to the multiple `instanceof` inside the method definition, `$contents` accepts more than string and resource
