### PR TITLE
[8.x] Validate connection name before resolve queue connection

### DIFF
--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -148,10 +148,15 @@ class QueueManager implements FactoryContract, MonitorContract
      *
      * @param  string  $name
      * @return \Illuminate\Contracts\Queue\Queue
+     * 
+     * @throws \InvalidArgumentException
      */
     protected function resolve($name)
     {
         $config = $this->getConfig($name);
+        if ($config === null){
+            throw new InvalidArgumentException("No config for connection [$name].");
+        }
 
         return $this->getConnector($config['driver'])
                         ->connect($config)

--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -154,8 +154,9 @@ class QueueManager implements FactoryContract, MonitorContract
     protected function resolve($name)
     {
         $config = $this->getConfig($name);
-        if ($config === null){
-            throw new InvalidArgumentException("No config for connection [$name].");
+
+        if (is_null($config)) {
+            throw new InvalidArgumentException("The [{$name}] queue connection has not been configured.");
         }
 
         return $this->getConnector($config['driver'])


### PR DESCRIPTION
As described in issue #39750  unknown config name throws `Trying to access array offset on value of type null`.
This PR validating config name before continue in resolve connection, throw a invalid argument exception when config is null.