### PR TITLE
[8.x] Add Event::fakeExcept() to fake all but certain events

### DIFF
--- a/src/Illuminate/Support/Facades/Event.php
+++ b/src/Illuminate/Support/Facades/Event.php
@@ -46,6 +46,21 @@ class Event extends Facade
     }
 
     /**
+     * Replace the bound instance with a fake, but allow the given events.
+     *
+     * @param  string|string[]  $eventsToAllow
+     * @return \Illuminate\Support\Testing\Fakes\EventFake
+     */
+    public static function fakeExcept($eventsToAllow)
+    {
+        return static::fake([
+            function (string $eventName) use ($eventsToAllow) {
+                return ! in_array($eventName, (array) $eventsToAllow);
+            },
+        ]);
+    }
+
+    /**
      * Replace the bound instance with a fake during the given callable's execution.
      *
      * @param  callable  $callable

--- a/src/Illuminate/Support/Facades/Event.php
+++ b/src/Illuminate/Support/Facades/Event.php
@@ -46,15 +46,15 @@ class Event extends Facade
     }
 
     /**
-     * Replace the bound instance with a fake, but allow the given events.
+     * Replace the bound instance with a fake that fakes all events except the given events.
      *
-     * @param  string|string[]  $eventsToAllow
+     * @param  string[]|string  $eventsToAllow
      * @return \Illuminate\Support\Testing\Fakes\EventFake
      */
     public static function fakeExcept($eventsToAllow)
     {
         return static::fake([
-            function (string $eventName) use ($eventsToAllow) {
+            function ($eventName) use ($eventsToAllow) {
                 return ! in_array($eventName, (array) $eventsToAllow);
             },
         ]);
@@ -72,6 +72,27 @@ class Event extends Facade
         $originalDispatcher = static::getFacadeRoot();
 
         static::fake($eventsToFake);
+
+        return tap($callable(), function () use ($originalDispatcher) {
+            static::swap($originalDispatcher);
+
+            Model::setEventDispatcher($originalDispatcher);
+            Cache::refreshEventDispatcher();
+        });
+    }
+
+    /**
+     * Replace the bound instance with a fake during the given callable's execution.
+     *
+     * @param  callable  $callable
+     * @param  array  $eventsToAllow
+     * @return mixed
+     */
+    public static function fakeExceptFor(callable $callable, array $eventsToAllow = [])
+    {
+        $originalDispatcher = static::getFacadeRoot();
+
+        static::fakeExcept($eventsToAllow);
 
         return tap($callable(), function () use ($originalDispatcher) {
             static::swap($originalDispatcher);

--- a/tests/Integration/Events/EventFakeTest.php
+++ b/tests/Integration/Events/EventFakeTest.php
@@ -98,6 +98,29 @@ class EventFakeTest extends TestCase
         Event::assertNotDispatched(NonImportantEvent::class);
     }
 
+    public function testFakeExceptAllowsGivenEventToBeDispatched()
+    {
+        Event::fakeExcept(NonImportantEvent::class);
+
+        Event::dispatch(NonImportantEvent::class);
+
+        Event::assertNotDispatched(NonImportantEvent::class);
+    }
+
+    public function testFakeExceptAllowsGivenEventsToBeDispatched()
+    {
+        Event::fakeExcept([
+            NonImportantEvent::class,
+            'non-fake-event',
+        ]);
+
+        Event::dispatch(NonImportantEvent::class);
+        Event::dispatch('non-fake-event');
+
+        Event::assertNotDispatched(NonImportantEvent::class);
+        Event::assertNotDispatched('non-fake-event');
+    }
+
     public function testAssertListening()
     {
         Event::fake();


### PR DESCRIPTION
I sometimes find myself working on feature tests that trigger multiple events. I try to fake all events to avoid unexpected side effects, but sometimes certain events may be required to simulate expected behaviour. I would use this to fake all but certain events:

```php
Event::fake([
    fn (string $eventClass) => $eventClass !== ServiceSaving::class,
]);
```

This PR adds a new `fakeExcept()` method to the `Event` facade to allow this:

```php
Event::fakeExcept(ServiceSaving::class);
Event::fakeExcept([ServiceSaving::class, 'some-other-event']);
```