### PR TITLE
[8.x] Add App::isDebug() method to detect debug mode

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -608,16 +608,6 @@ class Application extends Container implements ApplicationContract, CachesConfig
     }
 
     /**
-     * Determine if the application is running with debug mode enabled.
-     *
-     * @return bool
-     */
-    public function isDebug()
-    {
-        return (bool) $this['config']->get('app.debug');
-    }
-
-    /**
      * Determine if the application is running in the console.
      *
      * @return bool
@@ -639,6 +629,16 @@ class Application extends Container implements ApplicationContract, CachesConfig
     public function runningUnitTests()
     {
         return $this->bound('env') && $this['env'] === 'testing';
+    }
+
+    /**
+     * Determine if the application is running with debug mode enabled.
+     *
+     * @return bool
+     */
+    public function hasDebugModeEnabled()
+    {
+        return (bool) $this['config']->get('app.debug');
     }
 
     /**

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -608,6 +608,16 @@ class Application extends Container implements ApplicationContract, CachesConfig
     }
 
     /**
+     * Determine if the application is running with debug mode enabled.
+     *
+     * @return bool
+     */
+    public function isDebug()
+    {
+        return (bool) $this['config']->get('app.debug');
+    }
+
+    /**
      * Determine if the application is running in the console.
      *
      * @return bool

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -245,12 +245,12 @@ class FoundationApplicationTest extends TestCase
         $debugOff = new Application;
         $debugOff['config'] = new Repository(['app' => ['debug' => false]]);
 
-        $this->assertFalse($debugOff->isDebug());
+        $this->assertFalse($debugOff->hasDebugModeEnabled());
 
         $debugOn = new Application;
         $debugOn['config'] = new Repository(['app' => ['debug' => true]]);
 
-        $this->assertTrue($debugOn->isDebug());
+        $this->assertTrue($debugOn->hasDebugModeEnabled());
     }
 
     public function testMethodAfterLoadingEnvironmentAddsClosure()

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Foundation;
 
+use Illuminate\Config\Repository;
 use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Bootstrap\RegisterFacades;
@@ -237,6 +238,19 @@ class FoundationApplicationTest extends TestCase
         $this->assertTrue($testing->runningUnitTests());
         $this->assertFalse($testing->isLocal());
         $this->assertFalse($testing->isProduction());
+    }
+
+    public function testDebugHelper()
+    {
+        $debugOff = new Application;
+        $debugOff['config'] = new Repository(['app' => ['debug' => false]]);
+
+        $this->assertFalse($debugOff->isDebug());
+
+        $debugOn = new Application;
+        $debugOn['config'] = new Repository(['app' => ['debug' => true]]);
+
+        $this->assertTrue($debugOn->isDebug());
     }
 
     public function testMethodAfterLoadingEnvironmentAddsClosure()


### PR DESCRIPTION
Like App::isLocal(), isProduction(), runningInConsole(), isLocale(), etc. it makes sense to have a method on the Container to detect debug mode.

I struggled with the method name, but isDebug() sort of matches most of the methods with similar functionality. I also like:

* debugMode()
* debugEnabled()
* debugModeEnabled()
* inDebugMode()

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
