### PR TITLE
[8.x] Added missing method to Route facade docblock

### DIFF
--- a/src/Illuminate/Support/Facades/Route.php
+++ b/src/Illuminate/Support/Facades/Route.php
@@ -27,6 +27,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Routing\RouteRegistrar name(string $value)
  * @method static \Illuminate\Routing\RouteRegistrar namespace(string|null $value)
  * @method static \Illuminate\Routing\RouteRegistrar prefix(string $prefix)
+ * @method static \Illuminate\Routing\RouteRegistrar scopeBindings()
  * @method static \Illuminate\Routing\RouteRegistrar where(array $where)
  * @method static \Illuminate\Routing\Router|\Illuminate\Routing\RouteRegistrar group(\Closure|string|array $attributes, \Closure|string $routes)
  * @method static \Illuminate\Routing\ResourceRegistrar resourceVerbs(array $verbs = [])


### PR DESCRIPTION
Hey!

This PR's only a small one to update a docblock. When I was using the new `scopeBindings()` method today in my route files, I noticed that there wasn't any mention of that method in the `Route` facade.

Hopefully, I've put this in the right place? 😄