### PR TITLE
[8.x] Allow QueuedClosure as Eloquent events callback typing

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database\Eloquent\Concerns;
 
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Events\NullDispatcher;
+use Illuminate\Events\QueuedClosure;
 use Illuminate\Support\Arr;
 use InvalidArgumentException;
 
@@ -147,7 +148,7 @@ trait HasEvents
      * Register a model event with the dispatcher.
      *
      * @param  string  $event
-     * @param  \Closure|string  $callback
+     * @param  \Closure|string|QueuedClosure  $callback
      * @return void
      */
     protected static function registerModelEvent($event, $callback)
@@ -230,7 +231,7 @@ trait HasEvents
     /**
      * Register a retrieved model event with the dispatcher.
      *
-     * @param  \Closure|string  $callback
+     * @param  \Closure|string|QueuedClosure  $callback
      * @return void
      */
     public static function retrieved($callback)
@@ -241,7 +242,7 @@ trait HasEvents
     /**
      * Register a saving model event with the dispatcher.
      *
-     * @param  \Closure|string  $callback
+     * @param  \Closure|string|QueuedClosure  $callback
      * @return void
      */
     public static function saving($callback)
@@ -252,7 +253,7 @@ trait HasEvents
     /**
      * Register a saved model event with the dispatcher.
      *
-     * @param  \Closure|string  $callback
+     * @param  \Closure|string|QueuedClosure  $callback
      * @return void
      */
     public static function saved($callback)
@@ -263,7 +264,7 @@ trait HasEvents
     /**
      * Register an updating model event with the dispatcher.
      *
-     * @param  \Closure|string  $callback
+     * @param  \Closure|string|QueuedClosure  $callback
      * @return void
      */
     public static function updating($callback)
@@ -274,7 +275,7 @@ trait HasEvents
     /**
      * Register an updated model event with the dispatcher.
      *
-     * @param  \Closure|string  $callback
+     * @param  \Closure|string|QueuedClosure  $callback
      * @return void
      */
     public static function updated($callback)
@@ -285,7 +286,7 @@ trait HasEvents
     /**
      * Register a creating model event with the dispatcher.
      *
-     * @param  \Closure|string  $callback
+     * @param  \Closure|string|QueuedClosure  $callback
      * @return void
      */
     public static function creating($callback)
@@ -296,7 +297,7 @@ trait HasEvents
     /**
      * Register a created model event with the dispatcher.
      *
-     * @param  \Closure|string  $callback
+     * @param  \Closure|string|QueuedClosure  $callback
      * @return void
      */
     public static function created($callback)
@@ -307,7 +308,7 @@ trait HasEvents
     /**
      * Register a replicating model event with the dispatcher.
      *
-     * @param  \Closure|string  $callback
+     * @param  \Closure|string|QueuedClosure  $callback
      * @return void
      */
     public static function replicating($callback)
@@ -318,7 +319,7 @@ trait HasEvents
     /**
      * Register a deleting model event with the dispatcher.
      *
-     * @param  \Closure|string  $callback
+     * @param  \Closure|string|QueuedClosure  $callback
      * @return void
      */
     public static function deleting($callback)
@@ -329,7 +330,7 @@ trait HasEvents
     /**
      * Register a deleted model event with the dispatcher.
      *
-     * @param  \Closure|string  $callback
+     * @param  \Closure|string|QueuedClosure  $callback
      * @return void
      */
     public static function deleted($callback)


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This silence IDE warning when passing a queued closure to model events.  

E.g. (from Cashier doc):
```php
static::updated(queueable(function ($customer) {
    $customer->syncStripeCustomerDetails();
}));
```
