### PR TITLE
[8.x] Rename docblock "command" to "job" in DispatchesJobs.php 

### DIFF
--- a/src/Illuminate/Foundation/Bus/DispatchesJobs.php
+++ b/src/Illuminate/Foundation/Bus/DispatchesJobs.php
@@ -31,7 +31,7 @@ trait DispatchesJobs
     }
 
     /**
-     * Dispatch a command to its appropriate handler in the current process.
+     * Dispatch a job to its appropriate handler in the current process.
      *
      * Queueable jobs will be dispatched to the "sync" queue.
      *


### PR DESCRIPTION
rename "dispatch a command" to "dispatch a job" to be in sync with other docs

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
