### PR TITLE
[6.x] append cookie

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -438,8 +438,10 @@ trait MakesHttpRequests
             'Accept' => 'application/json',
         ], $headers);
 
+        $cookies = $this->prepareCookiesForRequest();
+
         return $this->call(
-            $method, $uri, [], [], $files, $this->transformHeadersToServerVars($headers), $content
+            $method, $uri, [], $cookies, $files, $this->transformHeadersToServerVars($headers), $content
         );
     }
 


### PR DESCRIPTION
i hava a auth token in cookies.
but json function cannot attach cookies like other functions.
and In 7.x 8.x versions this function attach cookies

My English is not very good, I hope you can understand what I say
