### PR TITLE
[8.x] Add aggregate method to Eloquent passthru

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -79,6 +79,7 @@ class Builder
      * @var string[]
      */
     protected $passthru = [
+        'aggregate',
         'average',
         'avg',
         'count',


### PR DESCRIPTION
This PR adds `Illuminate\Database\Eloquent\Builder::aggregate(...)` to the list of passthru. This allows aggregations that are not included in the eloquent builder by default (e.g. count, min and max) to be used on the eloquent builder without having to call `->toBase()` first. 

While this is technically breaking, the method is currently unusable so its more of a bugfix. It should not affect anyone as far as I can tell. If you feel it should go to 9.x I'm happy to rebase.

Before:

```text
>>> App\Models\User::query()->aggregate('count', ['*'])
=> Illuminate\Database\Eloquent\Builder {#5256}
```

After:

```text
>>> App\Models\User::query()->aggregate('count', ['*'])
=> 5927
```

Edit: I'm also happy to add tests if necessary