### PR TITLE
Fixed ErrorException - Division by zero in LengthAwarePaginator

### DIFF
--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -47,7 +47,7 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
 
         $this->total = $total;
         $this->perPage = $perPage;
-        $this->lastPage = max((int) ceil($total / $perPage), 1);
+        $this->lastPage = ((int) $perPage != 0) ? max((int) ceil($total / $perPage), 1) : 1;
         $this->path = $this->path !== '/' ? rtrim($this->path, '/') : $this->path;
         $this->currentPage = $this->setCurrentPage($currentPage, $this->pageName);
         $this->items = $items instanceof Collection ? $items : Collection::make($items);

--- a/tests/Pagination/LengthAwarePaginatorTest.php
+++ b/tests/Pagination/LengthAwarePaginatorTest.php
@@ -56,6 +56,17 @@ class LengthAwarePaginatorTest extends TestCase
         $this->assertEmpty($paginator->items());
     }
 
+    public function testLengthAwarePaginatorDivisionByZero()
+    {
+        $paginator = new LengthAwarePaginator([], 0, 0, 1);
+
+        $this->assertEquals(1, $paginator->lastPage());
+        $this->assertEquals(1, $paginator->currentPage());
+        $this->assertFalse($paginator->hasPages());
+        $this->assertFalse($paginator->hasMorePages());
+        $this->assertEmpty($paginator->items());
+    }
+
     public function testLengthAwarePaginatorCanGenerateUrls()
     {
         $this->p->setPath('http://website.com');


### PR DESCRIPTION
$this->lastPage = max((int) ceil($total / $perPage), 1);

This line was causing the error and the applications were breaking due to the zero value of $perPage.

It was giving Error Exception - Division by zero

We have replaced it with the following code

$this->lastPage = ((int) $perPage != 0) ? max((int) ceil($total / $perPage), 1) : 1;


<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
