### PR TITLE
[8.x] Allow QueuedClosure as Eloquent events callback typing

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -147,7 +147,7 @@ trait HasEvents
      * Register a model event with the dispatcher.
      *
      * @param  string  $event
-     * @param  \Closure|string  $callback
+     * @param  \Closure|string|\Illuminate\Events\QueuedClosure  $callback
      * @return void
      */
     protected static function registerModelEvent($event, $callback)
@@ -230,7 +230,7 @@ trait HasEvents
     /**
      * Register a retrieved model event with the dispatcher.
      *
-     * @param  \Closure|string  $callback
+     * @param  \Closure|string|\Illuminate\Events\QueuedClosure  $callback
      * @return void
      */
     public static function retrieved($callback)
@@ -241,7 +241,7 @@ trait HasEvents
     /**
      * Register a saving model event with the dispatcher.
      *
-     * @param  \Closure|string  $callback
+     * @param  \Closure|string|\Illuminate\Events\QueuedClosure  $callback
      * @return void
      */
     public static function saving($callback)
@@ -252,7 +252,7 @@ trait HasEvents
     /**
      * Register a saved model event with the dispatcher.
      *
-     * @param  \Closure|string  $callback
+     * @param  \Closure|string|\Illuminate\Events\QueuedClosure  $callback
      * @return void
      */
     public static function saved($callback)
@@ -263,7 +263,7 @@ trait HasEvents
     /**
      * Register an updating model event with the dispatcher.
      *
-     * @param  \Closure|string  $callback
+     * @param  \Closure|string|\Illuminate\Events\QueuedClosure  $callback
      * @return void
      */
     public static function updating($callback)
@@ -274,7 +274,7 @@ trait HasEvents
     /**
      * Register an updated model event with the dispatcher.
      *
-     * @param  \Closure|string  $callback
+     * @param  \Closure|string|\Illuminate\Events\QueuedClosure  $callback
      * @return void
      */
     public static function updated($callback)
@@ -285,7 +285,7 @@ trait HasEvents
     /**
      * Register a creating model event with the dispatcher.
      *
-     * @param  \Closure|string  $callback
+     * @param  \Closure|string|\Illuminate\Events\QueuedClosure  $callback
      * @return void
      */
     public static function creating($callback)
@@ -296,7 +296,7 @@ trait HasEvents
     /**
      * Register a created model event with the dispatcher.
      *
-     * @param  \Closure|string  $callback
+     * @param  \Closure|string|\Illuminate\Events\QueuedClosure  $callback
      * @return void
      */
     public static function created($callback)
@@ -307,7 +307,7 @@ trait HasEvents
     /**
      * Register a replicating model event with the dispatcher.
      *
-     * @param  \Closure|string  $callback
+     * @param  \Closure|string|\Illuminate\Events\QueuedClosure  $callback
      * @return void
      */
     public static function replicating($callback)
@@ -318,7 +318,7 @@ trait HasEvents
     /**
      * Register a deleting model event with the dispatcher.
      *
-     * @param  \Closure|string  $callback
+     * @param  \Closure|string|\Illuminate\Events\QueuedClosure  $callback
      * @return void
      */
     public static function deleting($callback)
@@ -329,7 +329,7 @@ trait HasEvents
     /**
      * Register a deleted model event with the dispatcher.
      *
-     * @param  \Closure|string  $callback
+     * @param  \Closure|string|\Illuminate\Events\QueuedClosure  $callback
      * @return void
      */
     public static function deleted($callback)

--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -147,7 +147,7 @@ trait HasEvents
      * Register a model event with the dispatcher.
      *
      * @param  string  $event
-     * @param  \Closure|string|\Illuminate\Events\QueuedClosure  $callback
+     * @param  \Illuminate\Events\QueuedClosure|\Closure|string  $callback
      * @return void
      */
     protected static function registerModelEvent($event, $callback)
@@ -230,7 +230,7 @@ trait HasEvents
     /**
      * Register a retrieved model event with the dispatcher.
      *
-     * @param  \Closure|string|\Illuminate\Events\QueuedClosure  $callback
+     * @param  \Illuminate\Events\QueuedClosure|\Closure|string  $callback
      * @return void
      */
     public static function retrieved($callback)
@@ -241,7 +241,7 @@ trait HasEvents
     /**
      * Register a saving model event with the dispatcher.
      *
-     * @param  \Closure|string|\Illuminate\Events\QueuedClosure  $callback
+     * @param  \Illuminate\Events\QueuedClosure|\Closure|string  $callback
      * @return void
      */
     public static function saving($callback)
@@ -252,7 +252,7 @@ trait HasEvents
     /**
      * Register a saved model event with the dispatcher.
      *
-     * @param  \Closure|string|\Illuminate\Events\QueuedClosure  $callback
+     * @param  \Illuminate\Events\QueuedClosure|\Closure|string  $callback
      * @return void
      */
     public static function saved($callback)
@@ -263,7 +263,7 @@ trait HasEvents
     /**
      * Register an updating model event with the dispatcher.
      *
-     * @param  \Closure|string|\Illuminate\Events\QueuedClosure  $callback
+     * @param  \Illuminate\Events\QueuedClosure|\Closure|string  $callback
      * @return void
      */
     public static function updating($callback)
@@ -274,7 +274,7 @@ trait HasEvents
     /**
      * Register an updated model event with the dispatcher.
      *
-     * @param  \Closure|string|\Illuminate\Events\QueuedClosure  $callback
+     * @param  \Illuminate\Events\QueuedClosure|\Closure|string  $callback
      * @return void
      */
     public static function updated($callback)
@@ -285,7 +285,7 @@ trait HasEvents
     /**
      * Register a creating model event with the dispatcher.
      *
-     * @param  \Closure|string|\Illuminate\Events\QueuedClosure  $callback
+     * @param  \Illuminate\Events\QueuedClosure|\Closure|string  $callback
      * @return void
      */
     public static function creating($callback)
@@ -296,7 +296,7 @@ trait HasEvents
     /**
      * Register a created model event with the dispatcher.
      *
-     * @param  \Closure|string|\Illuminate\Events\QueuedClosure  $callback
+     * @param  \Illuminate\Events\QueuedClosure|\Closure|string  $callback
      * @return void
      */
     public static function created($callback)
@@ -307,7 +307,7 @@ trait HasEvents
     /**
      * Register a replicating model event with the dispatcher.
      *
-     * @param  \Closure|string|\Illuminate\Events\QueuedClosure  $callback
+     * @param  \Illuminate\Events\QueuedClosure|\Closure|string  $callback
      * @return void
      */
     public static function replicating($callback)
@@ -318,7 +318,7 @@ trait HasEvents
     /**
      * Register a deleting model event with the dispatcher.
      *
-     * @param  \Closure|string|\Illuminate\Events\QueuedClosure  $callback
+     * @param  \Illuminate\Events\QueuedClosure|\Closure|string  $callback
      * @return void
      */
     public static function deleting($callback)
@@ -329,7 +329,7 @@ trait HasEvents
     /**
      * Register a deleted model event with the dispatcher.
      *
-     * @param  \Closure|string|\Illuminate\Events\QueuedClosure  $callback
+     * @param  \Illuminate\Events\QueuedClosure|\Closure|string  $callback
      * @return void
      */
     public static function deleted($callback)


### PR DESCRIPTION
This silence IDE warning when passing a queued closure to model events.

E.g. (from Cashier doc):

```php
static::updated(queueable(function ($customer) {
    $customer->syncStripeCustomerDetails();
}));
```

With suggested edits from #39759