### PR TITLE
[8.x] Adds on-demand authorization check

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -391,7 +391,7 @@ class Gate implements GateContract
      */
     public function authorizeIf($condition, $arguments = [])
     {
-        $response = value($condition, ...array_merge([$this->resolveUser()], $arguments));
+        $response = value($condition, ...array_merge([$this->resolveUser()], Arr::wrap($arguments)));
 
         if (! $response instanceof Response) {
             $response = new Response($response);
@@ -409,7 +409,7 @@ class Gate implements GateContract
      */
     public function authorizeUnless($condition, $arguments = [])
     {
-        $response = value($condition, ...array_merge([$this->resolveUser()], $arguments));
+        $response = value($condition, ...array_merge([$this->resolveUser()], Arr::wrap($arguments)));
 
         if (! $response instanceof Response) {
             $response = new Response(! $response);

--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -386,7 +386,8 @@ class Gate implements GateContract
      * Throws an authorization exception if the condition is truthy.
      *
      * @param  bool|callable  $condition
-     * @param  array  $arguments
+     * @param  string|null  $message
+     * @param  mixed  $code
      * @return void
      */
     public function authorizeIf($condition, $message = null, $code = null)
@@ -404,7 +405,8 @@ class Gate implements GateContract
      * Throws an authorization exception if the condition is truthy.
      *
      * @param  bool|callable  $condition
-     * @param  array  $arguments
+     * @param  string|null  $message
+     * @param  mixed  $code
      * @return void
      */
     public function authorizeUnless($condition, $message = null, $code = null)

--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -389,12 +389,12 @@ class Gate implements GateContract
      * @param  array  $arguments
      * @return void
      */
-    public function authorizeIf($condition, $arguments = [])
+    public function authorizeIf($condition, $message = null, $code = null)
     {
-        $response = value($condition, ...array_merge([$this->resolveUser()], Arr::wrap($arguments)));
+        $response = value($condition, $this->resolveUser());
 
         if (! $response instanceof Response) {
-            $response = new Response($response);
+            $response = new Response($response, $message, $code);
         }
 
         $response->authorize();
@@ -407,12 +407,12 @@ class Gate implements GateContract
      * @param  array  $arguments
      * @return void
      */
-    public function authorizeUnless($condition, $arguments = [])
+    public function authorizeUnless($condition, $message = null, $code = null)
     {
-        $response = value($condition, ...array_merge([$this->resolveUser()], Arr::wrap($arguments)));
+        $response = value($condition, $this->resolveUser());
 
         if (! $response instanceof Response) {
-            $response = new Response(! $response);
+            $response = new Response(! $response, $message, $code);
         }
 
         $response->authorize();

--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -391,7 +391,7 @@ class Gate implements GateContract
      */
     public function authorizeIf($condition, $arguments = [])
     {
-        $response = value($condition, ...array_merge([$this->resolveUser()], $arguments);
+        $response = value($condition, ...array_merge([$this->resolveUser()], $arguments));
 
         if (! $response instanceof Response) {
             $response = new Response($response);
@@ -409,7 +409,7 @@ class Gate implements GateContract
      */
     public function authorizeUnless($condition, $arguments = [])
     {
-        $response = value($condition, ...array_merge([$this->resolveUser()], $arguments);
+        $response = value($condition, ...array_merge([$this->resolveUser()], $arguments));
 
         if (! $response instanceof Response) {
             $response = new Response(! $response);

--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -383,6 +383,42 @@ class Gate implements GateContract
     }
 
     /**
+     * Throws an authorization exception if the condition is truthy.
+     *
+     * @param  bool|callable  $condition
+     * @param  array  $arguments
+     * @return void
+     */
+    public function authorizeIf($condition, $arguments = [])
+    {
+        $response = value($condition, ...array_merge([$this->resolveUser()], $arguments);
+
+        if (! $response instanceof Response) {
+            $response = new Response($response);
+        }
+
+        $response->authorize();
+    }
+
+    /**
+     * Throws an authorization exception if the condition is truthy.
+     *
+     * @param  bool|callable  $condition
+     * @param  array  $arguments
+     * @return void
+     */
+    public function authorizeUnless($condition, $arguments = [])
+    {
+        $response = value($condition, ...array_merge([$this->resolveUser()], $arguments);
+
+        if (! $response instanceof Response) {
+            $response = new Response(! $response);
+        }
+
+        $response->authorize();
+    }
+
+    /**
      * Determine whether the callback/method can be called with the given user.
      *
      * @param  \Illuminate\Contracts\Auth\Authenticatable|null  $user

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -688,7 +688,7 @@ class AuthAccessGateTest extends TestCase
     {
         $response = $this->getBasicGate()->authorizeIf(function($user, $string) {
             $this->assertSame(1, $user->id);
-            $this->assertSame('foo', $string)
+            $this->assertSame('foo', $string);
 
             return true;
         }, 'foo')
@@ -743,7 +743,7 @@ class AuthAccessGateTest extends TestCase
     {
         $response = $this->getBasicGate()->authorizeUnless(function($user, $string) {
             $this->assertSame(1, $user->id);
-            $this->assertSame('foo', $string)
+            $this->assertSame('foo', $string);
 
             return false;
         }, 'foo')

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -716,7 +716,7 @@ class AuthAccessGateTest extends TestCase
     {
         $this->expectException(AuthorizationException::class);
 
-        $response = $this->getBasicGate()->authorizeIf(function($user, $string) {
+        $response = $this->getBasicGate()->authorizeIf(function() {
             return false;
         });
     }
@@ -771,7 +771,7 @@ class AuthAccessGateTest extends TestCase
     {
         $this->expectException(AuthorizationException::class);
 
-        $response = $this->getBasicGate()->authorizeUnless(function($user, $string) {
+        $response = $this->getBasicGate()->authorizeUnless(function() {
             return true;
         });
     }

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -700,7 +700,7 @@ class AuthAccessGateTest extends TestCase
     {
         $response = $this->getBasicGate()->authorizeIf(function() {
             return Response::allow();
-        })
+        });
 
         $this->assertNull($response);
     }
@@ -718,7 +718,7 @@ class AuthAccessGateTest extends TestCase
 
         $response = $this->getBasicGate()->authorizeIf(function($user, $string) {
             return false;
-        })
+        });
     }
 
     public function testAuthorizeIfThrowsExceptionWhenCallbackResponseDenied()
@@ -773,7 +773,7 @@ class AuthAccessGateTest extends TestCase
 
         $response = $this->getBasicGate()->authorizeUnless(function($user, $string) {
             return true;
-        })
+        });
     }
 
     public function testAuthorizeUnlessThrowsExceptionWhenCallbackResponseDenied()

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -755,7 +755,7 @@ class AuthAccessGateTest extends TestCase
     {
         $response = $this->getBasicGate()->authorizeUnless(function() {
             return Response::allow();
-        })
+        });
 
         $this->assertNull($response);
     }

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -779,7 +779,7 @@ class AuthAccessGateTest extends TestCase
 
         $response = $this->getBasicGate()->authorizeUnless(function() {
             return true;
-        }, 'Not allowed', 'some_code');
+        }, 'Not allowed.', 'some_code');
     }
 
     public function testAuthorizeUnlessThrowsExceptionWhenCallbackResponseDenied()

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -677,6 +677,116 @@ class AuthAccessGateTest extends TestCase
         $this->assertSame('unpublished', $response->code());
     }
 
+    public function testAuthorizeIfAuthorizesConditionTrue()
+    {
+        $response = $this->getBasicGate()->authorizeIf(true);
+
+        $this->assertNull($response);
+    }
+
+    public function testAuthorizeIfAuthorizesCallbackTrue()
+    {
+        $response = $this->getBasicGate()->authorizeIf(function($user, $string) {
+            $this->assertSame(1, $user->id);
+            $this->assertSame('foo', $string)
+
+            return true;
+        }, 'foo')
+
+        $this->assertNull($response);
+    }
+
+    public function testAuthorizeIfAuthorizesCallbackResponseAllowed()
+    {
+        $response = $this->getBasicGate()->authorizeIf(function() {
+            return Response::allow();
+        })
+
+        $this->assertNull($response);
+    }
+
+    public function testAuthorizeIfThrowsExceptionWhenFalse()
+    {
+        $this->expectException(AuthorizationException::class);
+
+        $this->getBasicGate()->authorizeIf(false);
+    }
+
+    public function testAuthorizeIfThrowsExceptionWhenCallbackFalse()
+    {
+        $this->expectException(AuthorizationException::class);
+
+        $response = $this->getBasicGate()->authorizeIf(function($user, $string) {
+            return false;
+        })
+    }
+
+    public function testAuthorizeIfThrowsExceptionWhenCallbackResponseDenied()
+    {
+        $this->expectException(AuthorizationException::class);
+        $this->expectExceptionMessage('Not allowed.');
+        $this->expectExceptionCode('some_code');
+        
+        $this->getBasicGate()->authorizeIf(function () {
+            return Response::deny('Not allowed.', 'some_code');
+        });
+    }
+
+    public function testAuthorizeUnlessAuthorizesConditionFalse()
+    {
+        $response = $this->getBasicGate()->authorizeUnless(false);
+
+        $this->assertNull($response);
+    }
+
+    public function testAuthorizeUnlessAuthorizesCallbackFalse()
+    {
+        $response = $this->getBasicGate()->authorizeUnless(function($user, $string) {
+            $this->assertSame(1, $user->id);
+            $this->assertSame('foo', $string)
+
+            return false;
+        }, 'foo')
+
+        $this->assertNull($response);
+    }
+
+    public function testAuthorizeUnlessAuthorizesCallbackResponseAllowed()
+    {
+        $response = $this->getBasicGate()->authorizeUnless(function() {
+            return Response::allow();
+        })
+
+        $this->assertNull($response);
+    }
+
+    public function testAuthorizeUnlessThrowsExceptionWhenTrue()
+    {
+        $this->expectException(AuthorizationException::class);
+
+        $this->getBasicGate()->authorizeUnless(true);
+    }
+
+    public function testAuthorizeUnlessThrowsExceptionWhenCallbackTrue()
+    {
+        $this->expectException(AuthorizationException::class);
+
+        $response = $this->getBasicGate()->authorizeUnless(function($user, $string) {
+            return true;
+        })
+    }
+
+    public function testAuthorizeUnlessThrowsExceptionWhenCallbackResponseDenied()
+    {
+        $this->expectException(AuthorizationException::class);
+        $this->expectExceptionMessage('Not allowed.');
+        $this->expectExceptionCode('some_code');
+        
+        $this->getBasicGate()->authorizeUnless(function () {
+            return Response::deny('Not allowed.', 'some_code');
+        });
+    }
+
     public function testAuthorizeReturnsAnAllowedResponseForATruthyReturn()
     {
         $gate = $this->getBasicGate();

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -686,9 +686,8 @@ class AuthAccessGateTest extends TestCase
 
     public function testAuthorizeIfAuthorizesCallbackTrue()
     {
-        $response = $this->getBasicGate()->authorizeIf(function($user, $string) {
+        $response = $this->getBasicGate()->authorizeIf(function($user) {
             $this->assertSame(1, $user->id);
-            $this->assertSame('foo', $string);
 
             return true;
         }, 'foo');
@@ -708,17 +707,21 @@ class AuthAccessGateTest extends TestCase
     public function testAuthorizeIfThrowsExceptionWhenFalse()
     {
         $this->expectException(AuthorizationException::class);
+        $this->expectExceptionMessage('Not allowed.');
+        $this->expectExceptionCode('some_code');
 
-        $this->getBasicGate()->authorizeIf(false);
+        $this->getBasicGate()->authorizeIf(false, 'Not allowed.', 'some_code');
     }
 
     public function testAuthorizeIfThrowsExceptionWhenCallbackFalse()
     {
         $this->expectException(AuthorizationException::class);
+        $this->expectExceptionMessage('Not allowed.');
+        $this->expectExceptionCode('some_code');
 
         $response = $this->getBasicGate()->authorizeIf(function() {
             return false;
-        });
+        }, 'Not allowed.', 'some_code');
     }
 
     public function testAuthorizeIfThrowsExceptionWhenCallbackResponseDenied()
@@ -741,12 +744,11 @@ class AuthAccessGateTest extends TestCase
 
     public function testAuthorizeUnlessAuthorizesCallbackFalse()
     {
-        $response = $this->getBasicGate()->authorizeUnless(function($user, $string) {
+        $response = $this->getBasicGate()->authorizeUnless(function($user) {
             $this->assertSame(1, $user->id);
-            $this->assertSame('foo', $string);
 
             return false;
-        }, 'foo');
+        });
 
         $this->assertNull($response);
     }
@@ -763,17 +765,21 @@ class AuthAccessGateTest extends TestCase
     public function testAuthorizeUnlessThrowsExceptionWhenTrue()
     {
         $this->expectException(AuthorizationException::class);
+        $this->expectExceptionMessage('Not allowed.');
+        $this->expectExceptionCode('some_code');
 
-        $this->getBasicGate()->authorizeUnless(true);
+        $this->getBasicGate()->authorizeUnless(true, 'Not allowed.', 'some_code');
     }
 
     public function testAuthorizeUnlessThrowsExceptionWhenCallbackTrue()
     {
         $this->expectException(AuthorizationException::class);
+        $this->expectExceptionMessage('Not allowed.');
+        $this->expectExceptionCode('some_code');
 
         $response = $this->getBasicGate()->authorizeUnless(function() {
             return true;
-        });
+        }, 'Not allowed', 'some_code');
     }
 
     public function testAuthorizeUnlessThrowsExceptionWhenCallbackResponseDenied()

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -686,7 +686,7 @@ class AuthAccessGateTest extends TestCase
 
     public function testAuthorizeIfAuthorizesCallbackTrue()
     {
-        $response = $this->getBasicGate()->authorizeIf(function($user) {
+        $response = $this->getBasicGate()->authorizeIf(function ($user) {
             $this->assertSame(1, $user->id);
 
             return true;
@@ -697,7 +697,7 @@ class AuthAccessGateTest extends TestCase
 
     public function testAuthorizeIfAuthorizesCallbackResponseAllowed()
     {
-        $response = $this->getBasicGate()->authorizeIf(function() {
+        $response = $this->getBasicGate()->authorizeIf(function () {
             return Response::allow();
         });
 
@@ -719,7 +719,7 @@ class AuthAccessGateTest extends TestCase
         $this->expectExceptionMessage('Not allowed.');
         $this->expectExceptionCode('some_code');
 
-        $response = $this->getBasicGate()->authorizeIf(function() {
+        $response = $this->getBasicGate()->authorizeIf(function () {
             return false;
         }, 'Not allowed.', 'some_code');
     }
@@ -729,7 +729,7 @@ class AuthAccessGateTest extends TestCase
         $this->expectException(AuthorizationException::class);
         $this->expectExceptionMessage('Not allowed.');
         $this->expectExceptionCode('some_code');
-        
+
         $this->getBasicGate()->authorizeIf(function () {
             return Response::deny('Not allowed.', 'some_code');
         });
@@ -744,7 +744,7 @@ class AuthAccessGateTest extends TestCase
 
     public function testAuthorizeUnlessAuthorizesCallbackFalse()
     {
-        $response = $this->getBasicGate()->authorizeUnless(function($user) {
+        $response = $this->getBasicGate()->authorizeUnless(function ($user) {
             $this->assertSame(1, $user->id);
 
             return false;
@@ -755,7 +755,7 @@ class AuthAccessGateTest extends TestCase
 
     public function testAuthorizeUnlessAuthorizesCallbackResponseAllowed()
     {
-        $response = $this->getBasicGate()->authorizeUnless(function() {
+        $response = $this->getBasicGate()->authorizeUnless(function () {
             return Response::allow();
         });
 
@@ -777,7 +777,7 @@ class AuthAccessGateTest extends TestCase
         $this->expectExceptionMessage('Not allowed.');
         $this->expectExceptionCode('some_code');
 
-        $response = $this->getBasicGate()->authorizeUnless(function() {
+        $response = $this->getBasicGate()->authorizeUnless(function () {
             return true;
         }, 'Not allowed.', 'some_code');
     }
@@ -787,7 +787,7 @@ class AuthAccessGateTest extends TestCase
         $this->expectException(AuthorizationException::class);
         $this->expectExceptionMessage('Not allowed.');
         $this->expectExceptionCode('some_code');
-        
+
         $this->getBasicGate()->authorizeUnless(function () {
             return Response::deny('Not allowed.', 'some_code');
         });

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -691,7 +691,7 @@ class AuthAccessGateTest extends TestCase
             $this->assertSame('foo', $string);
 
             return true;
-        }, 'foo')
+        }, 'foo');
 
         $this->assertNull($response);
     }
@@ -746,7 +746,7 @@ class AuthAccessGateTest extends TestCase
             $this->assertSame('foo', $string);
 
             return false;
-        }, 'foo')
+        }, 'foo');
 
         $this->assertNull($response);
     }


### PR DESCRIPTION
## What

Allows the developer to throw an `AuthotizationException` using a condition, bypassing before/after callbacks or registering a gate or policy that's only used once.

Before:
```php
if (auth()->user()->comments()->count() > 3) {
    throw new AuthorizationException();
}
```

After:
```php
Gate::authorizeUnless(auth()->user()->comments()->count() > 3);
```

It also supports callbacks, which allows to use the authenticated user as parameter, and a message with a code.

```php
Gate::authorizeIf(function ($user) {
    return $user->comments()->count() < 2;
}, "You have allocated all of your comments", 406);
```

And supports using the `Response` itself as a callback result. When doing so, it can override the false/truthy result, giving more control on the callback.

```php
Gate::authorizeUnless(function ($user) {
    if ($user->notPremium()) {
        return Response::deny('You have to activate your account before commenting');
    }

    return $user->comments()->count() > 3;
}, "You have allocated all of your comments", 406);
```

> Includes `authorizeIf()` and `authorizeUnless()`  to do the opposite.

# BC?

None, only additive.