### PR TITLE
[8.x] Add app_storage_path helper function

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -133,6 +133,19 @@ if (! function_exists('app_path')) {
     }
 }
 
+if (! function_exists('app_storage_path')) {
+    /**
+     * Get the path to the app storage folder.
+     *
+     * @param  string  $path
+     * @return string
+     */
+    function app_storage_path($path = '')
+    {
+        return storage_path('app/' . $path);
+    }
+}
+
 if (! function_exists('asset')) {
     /**
      * Generate an asset path for the application.

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -142,7 +142,7 @@ if (! function_exists('app_storage_path')) {
      */
     function app_storage_path($path = '')
     {
-        return storage_path('app/' . $path);
+        return storage_path('app/'.$path);
     }
 }
 

--- a/tests/Foundation/FoundationHelpersTest.php
+++ b/tests/Foundation/FoundationHelpersTest.php
@@ -244,4 +244,13 @@ class FoundationHelpersTest extends TestCase
 
         $this->assertSame('expected', mix('asset.png'));
     }
+
+    public function testAppStoragePathWithStoragePath()
+    {
+        app()->singleton('path.storage', function () {
+            return __DIR__;
+        });
+
+        $this->assertSame(app_storage_path(), storage_path('app/'));
+    }
 }


### PR DESCRIPTION
# What and Why

Most of the files uploaded will go to `storage/app` folder. So I've added a helper function to get the path to this folder.

This also help reducing hardcoding `'app/'` whenever we call storage_path();

before
```php
$photo_path = storage_path('app/'. $model->id);
```

after
```php
$photo_path = app_storage_path($model->id);
```

Another reason this is handy, Laravel Livewire by default uploads every media into `storage/app` folder, this can help clean up some codes.

```php
$path = "photos/{$model->id}";

$uploaded_media_path = $this->media->store($path);

// using spatie media library
$model->addMedia(storage_path($uploaded_media_path))->toMediaCollection('photo-collection'); // will raise an exception

$model->addMedia(storage_path('app/' . $uploaded_media_path))->toMediaCollection('photo-collection'); // ugly

$model->addMedia(app_storage_path($uploaded_media_path))->toMediaCollection('photo-collection');
```

# BC?
None, only additive.
