### PR TITLE
[8.x] Fix sqlserver paging issue

### DIFF
--- a/CHANGELOG-7.x.md
+++ b/CHANGELOG-7.x.md
@@ -1,6 +1,22 @@
 # Release Notes for 7.x
 
-## [Unreleased](https://github.com/laravel/framework/compare/v7.30.4...7.x)
+## [Unreleased](https://github.com/laravel/framework/compare/v7.30.5...7.x)
+
+
+## [v7.30.5 (2021-11-17)](https://github.com/laravel/framework/compare/v7.30.4...v7.30.5)
+
+### Added
+- Added new line to `DetectsLostConnections` ([#36373](https://github.com/laravel/framework/pull/36373))
+
+### Fixed
+- Fixed `Illuminate\View\ViewException::report()` ([#36110](https://github.com/laravel/framework/pull/36110))
+- Fixed `Illuminate\Redis\Connections\PhpRedisConnection::spop()` ([#36106](https://github.com/laravel/framework/pull/36106))
+- Fixed `Illuminate/Database/Query/Builder::limit()` to only cast integer when given other than null ([#39653](https://github.com/laravel/framework/pull/39653))
+- Fixes database offset value with non numbers ([#39656](https://github.com/laravel/framework/pull/39656))
+
+### Changed
+- Pipe new through render and report exception methods ([#36037](https://github.com/laravel/framework/pull/36037))
+- Typecast page number as integer in `Illuminate\Pagination\AbstractPaginator::resolveCurrentPage()` ([#36055](https://github.com/laravel/framework/pull/36055))
 
 
 ## [v7.30.4 (2021-01-21)](https://github.com/laravel/framework/compare/v7.30.3...v7.30.4)

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -38,8 +38,14 @@ class SqlServerGrammar extends Grammar
             $query->columns = ['*'];
         }
 
+        // For order by queries we can paginate, to avoid sorting issues.
+        $components = $this->compileComponents($query);
+        if (!empty($components['orders'])) {
+            return parent::compileSelect($query) . " OFFSET {$query->offset} ROWS FETCH NEXT {$query->limit} ROWS ONLY";
+        }
+
         return $this->compileAnsiOffset(
-            $query, $this->compileComponents($query)
+            $query, $components
         );
     }
 

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1264,7 +1264,7 @@ trait ValidatesAttributes
         }
 
         $phpExtensions = [
-            'php', 'php3', 'php4', 'php5', 'phtml',
+            'php', 'php3', 'php4', 'php5', 'phtml', 'phar'
         ];
 
         return ($value instanceof UploadedFile)

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2867,8 +2867,8 @@ SQL;
         $this->assertSame('select * from (select *, row_number() over (order by (select 0)) as row_num from [users]) as temp_table where row_num between 11 and 20 order by row_num', $builder->toSql());
 
         $builder = $this->getSqlServerBuilder();
-        $builder->select('*')->from('users')->skip(10)->take(10)->orderBy('email', 'desc');
-        $this->assertSame('select * from (select *, row_number() over (order by [email] desc) as row_num from [users]) as temp_table where row_num between 11 and 20 order by row_num', $builder->toSql());
+        $builder->select('*')->from('users')->skip(11)->take(10)->orderBy('email', 'desc');
+        $this->assertSame('select * from [users] order by [email] desc OFFSET 11 ROWS FETCH NEXT 10 ROWS ONLY', $builder->toSql());
     }
 
     public function testMySqlSoundsLikeOperator()


### PR DESCRIPTION
Sql server does not support paging without a `order by` column.

But the current implementation leads to issues when using `GUID` column as ID's and generating those id's in laravel. (sql orders id's differently than alphabetically, so the order of the models inserted is differently than the order of ID's).


### Current setup
Old setup when paging and sorting:

page1:
```sql
SELECT TOP 50 [users].* FROM [users] WHERE [users].[deleted_at] IS NULL ORDER BY [id] ASC
```

page2:
```sql
SELECT * FROM (SELECT [users].*, row_number() OVER (ORDER BY [id] ASC) AS row_num FROM [users] WHERE [users].[deleted_at] IS NULL) AS temp_table WHERE row_num between 51 and 100 ORDER BY row_num
```
### Proposed solution

page1:
```sql
SELECT TOP 50 [users].* FROM [users] WHERE [users].[deleted_at] IS NULL ORDER BY [id] ASC
```
page2:
```sql
SELECT [users].* FROM [users] WHERE [users].[deleted_at] IS NULL ORDER BY [id] ASC OFFSET 50 ROWS FETCH NEXT 50 ROWS ONLY
```




### Edge cases

- `OFFSET 50 ROWS FETCH NEXT 10` is a feature added to sql server in 2012. But you are already using features that are not supported by older versions.
- this only works when you provide an order column as this is mandatory in sql server.

## improvements

- instead of needing to query the whole table, now it will stop after Offset+Limit. (eg page 2 on 50 results = after 100 results instead of the whole table). 
- when ordering you will no longer get the issue of rows being ordered differently on the first and subsequent pages.
