### PR TITLE
add Redis::bulk to simplify bulk operation

### DIFF
--- a/src/Illuminate/Redis/Connections/Connection.php
+++ b/src/Illuminate/Redis/Connections/Connection.php
@@ -5,9 +5,9 @@ namespace Illuminate\Redis\Connections;
 use Closure;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Redis\Events\CommandExecuted;
+use Illuminate\Redis\Limiters\BulkBuilder;
 use Illuminate\Redis\Limiters\ConcurrencyLimiterBuilder;
 use Illuminate\Redis\Limiters\DurationLimiterBuilder;
-use Illuminate\Redis\Limiters\BulkBuilder;
 use Illuminate\Support\Traits\Macroable;
 
 abstract class Connection
@@ -70,9 +70,9 @@ abstract class Connection
     }
 
     /**
-     * Cache items until the max number of items will be received then execute a callback with cached data
+     * Cache items until the max number of items will be received then execute a callback with cached data.
      *
-     * @param string $name
+     * @param  string  $name
      * @return \Illuminate\Redis\Limiters\BulkBuilder
      */
     public function bulk($name)

--- a/src/Illuminate/Redis/Connections/Connection.php
+++ b/src/Illuminate/Redis/Connections/Connection.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Redis\Events\CommandExecuted;
 use Illuminate\Redis\Limiters\ConcurrencyLimiterBuilder;
 use Illuminate\Redis\Limiters\DurationLimiterBuilder;
+use Illuminate\Redis\Limiters\BulkBuilder;
 use Illuminate\Support\Traits\Macroable;
 
 abstract class Connection
@@ -66,6 +67,17 @@ abstract class Connection
     public function throttle($name)
     {
         return new DurationLimiterBuilder($this, $name);
+    }
+
+    /**
+     * Cache items until the max number of items will be received then execute a callback with cached data
+     *
+     * @param string $name
+     * @return \Illuminate\Redis\Limiters\BulkBuilder
+     */
+    public function bulk($name)
+    {
+        return new BulkBuilder($this, $name);
     }
 
     /**

--- a/src/Illuminate/Redis/Limiters/Bulk.php
+++ b/src/Illuminate/Redis/Limiters/Bulk.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Illuminate\Redis\Limiters;
+
+use Illuminate\Contracts\Redis\LimiterTimeoutException;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use Throwable;
+
+class Bulk
+{
+    /**
+     * The Redis factory implementation.
+     *
+     * @var \Illuminate\Redis\Connections\Connection
+     */
+    protected $redis;
+
+    /**
+     * The name of the cache Key.
+     *
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * The item.
+     *
+     * @var string
+     */
+    protected $item;
+
+    /**
+     * The maximum number of items that can be cache.
+     *
+     * @var int
+     */
+    protected $maxItemCount;
+
+    /**
+     * force to release the cache.
+     * @var false|mixed
+     */
+    protected $forceRelease;
+
+    /**
+     * Create a new bulk instance.
+     *
+     * @param \Illuminate\Redis\Connections\Connection $redis
+     * @param string $name
+     * @param string $item
+     * @param int $maxItemCount
+     * @param bool $forceRelease
+     */
+    public function __construct($redis, $name, $item, $maxItemCount, $forceRelease)
+    {
+        $this->redis = $redis;
+        $this->name = $name;
+        $this->item = $item;
+        $this->maxItemCount = $maxItemCount;
+        $this->forceRelease = $forceRelease;
+    }
+
+    /**
+     * Decide to store items in cache or release them according to cache size or ForceRelease.
+     *
+     * @param callable $callable
+     */
+    public function then($callable)
+    {
+        if ($this->isCacheFull() || $this->forceRelease) {
+            $this->bulkFromCache($callable, $this->item);
+        } else {
+            $this->addToCache($this->item);
+        }
+    }
+
+    /**
+     * Detect cache is full or not, cached items + current item >= maxItem.
+     *
+     * @return bool
+     */
+    private function isCacheFull(): bool
+    {
+        return $this->redis->command('lLen', [$this->name]) >= $this->maxItemCount - 1 ;
+    }
+
+    /**
+     * add item to cache
+     *
+     * @param string $item
+     */
+    private function addToCache($item)
+    {
+        $this->redis->command('lpush', [$this->name,$item]);
+    }
+
+    /**
+     * Get items from the cache and add the current item to them and return with an ordinary sort.
+     *
+     * @param callable $callable
+     * @param string|null $item
+     */
+    private function bulkFromCache($callable, $item = null)
+    {
+        $items = $this->redis->command('lrange', [$this->name,0,$this->maxItemCount]);
+
+        $items = array_reverse($items);
+
+        if ($item) {
+            $items[count($items)] = $item;
+        }
+
+        $this->redis->command('del', [$this->name]);
+
+        $callable($items);
+    }
+}

--- a/src/Illuminate/Redis/Limiters/Bulk.php
+++ b/src/Illuminate/Redis/Limiters/Bulk.php
@@ -88,7 +88,7 @@ class Bulk
      */
     private function addToCache($item)
     {
-        $this->redis->command('lpush', [$this->name, $item]);
+        $this->redis->command('rpush', [$this->name, $item]);
     }
 
     /**
@@ -100,8 +100,6 @@ class Bulk
     private function bulkFromCache($callable, $item = null)
     {
         $items = $this->redis->command('lrange', [$this->name, 0, $this->maxItemCount]);
-
-        $items = array_reverse($items);
 
         if ($item) {
             $items[count($items)] = $item;

--- a/src/Illuminate/Redis/Limiters/Bulk.php
+++ b/src/Illuminate/Redis/Limiters/Bulk.php
@@ -2,11 +2,6 @@
 
 namespace Illuminate\Redis\Limiters;
 
-use Illuminate\Contracts\Redis\LimiterTimeoutException;
-use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
-use Throwable;
-
 class Bulk
 {
     /**
@@ -39,6 +34,7 @@ class Bulk
 
     /**
      * force to release the cache.
+     *
      * @var false|mixed
      */
     protected $forceRelease;
@@ -46,11 +42,11 @@ class Bulk
     /**
      * Create a new bulk instance.
      *
-     * @param \Illuminate\Redis\Connections\Connection $redis
-     * @param string $name
-     * @param string $item
-     * @param int $maxItemCount
-     * @param bool $forceRelease
+     * @param  \Illuminate\Redis\Connections\Connection  $redis
+     * @param  string  $name
+     * @param  string  $item
+     * @param  int  $maxItemCount
+     * @param  bool  $forceRelease
      */
     public function __construct($redis, $name, $item, $maxItemCount, $forceRelease)
     {
@@ -64,7 +60,7 @@ class Bulk
     /**
      * Decide to store items in cache or release them according to cache size or ForceRelease.
      *
-     * @param callable $callable
+     * @param  callable  $callable
      */
     public function then($callable)
     {
@@ -82,28 +78,28 @@ class Bulk
      */
     private function isCacheFull(): bool
     {
-        return $this->redis->command('lLen', [$this->name]) >= $this->maxItemCount - 1 ;
+        return $this->redis->command('lLen', [$this->name]) >= $this->maxItemCount - 1;
     }
 
     /**
-     * add item to cache
+     * add item to cache.
      *
-     * @param string $item
+     * @param  string  $item
      */
     private function addToCache($item)
     {
-        $this->redis->command('lpush', [$this->name,$item]);
+        $this->redis->command('lpush', [$this->name, $item]);
     }
 
     /**
      * Get items from the cache and add the current item to them and return with an ordinary sort.
      *
-     * @param callable $callable
-     * @param string|null $item
+     * @param  callable  $callable
+     * @param  string|null  $item
      */
     private function bulkFromCache($callable, $item = null)
     {
-        $items = $this->redis->command('lrange', [$this->name,0,$this->maxItemCount]);
+        $items = $this->redis->command('lrange', [$this->name, 0, $this->maxItemCount]);
 
         $items = array_reverse($items);
 

--- a/src/Illuminate/Redis/Limiters/BulkBuilder.php
+++ b/src/Illuminate/Redis/Limiters/BulkBuilder.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Illuminate\Redis\Limiters;
+
+use Illuminate\Contracts\Redis\LimiterTimeoutException;
+use Illuminate\Support\InteractsWithTime;
+
+class BulkBuilder
+{
+    use InteractsWithTime;
+
+    /**
+     * The Redis connection.
+     *
+     * @var \Illuminate\Redis\Connections\Connection
+     */
+    public $connection;
+
+    /**
+     * The name of the cache key.
+     *
+     * @var string
+     */
+    public $name;
+
+    /**
+     * The maximum number of items that can be cache.
+     *
+     * @var int
+     */
+    public $maxItemCount = 10;
+
+    /**
+     * The item.
+     *
+     * @var string
+     */
+    public $item = null;
+
+    /**
+     * force to release the cache
+     *
+     * @var bool
+     */
+    public $forceRelease = false;
+
+    /**
+     * Create a new builder instance.
+     *
+     * @param  \Illuminate\Redis\Connections\Connection  $connection
+     * @param  string  $name
+     * @return void
+     */
+    public function __construct($connection, $name)
+    {
+        $this->name = $name;
+        $this->connection = $connection;
+    }
+
+    /**
+     * Set the maximum number of item that can be cache.
+     *
+     * @param  int  $maxItemCount
+     * @return $this
+     */
+    public function count($maxItemCount)
+    {
+        $this->maxItemCount = $maxItemCount;
+
+        return $this;
+    }
+
+    /**
+     * Call this item to force release the cache.
+     *
+     * @return $this
+     */
+    public function forceRelease()
+    {
+        $this->forceRelease = true;
+
+        return $this;
+    }
+
+    /**
+     * Add the item to cache.
+     *
+     * @param  string  $item
+     * @return $this
+     */
+    public function add($item)
+    {
+        $this->item = $item;
+
+        return $this;
+    }
+
+    /**
+     * Execute the given callback when cached items count is equal to max item count,
+     * if error raise call the failure callback.
+     *
+     * @param callable $callback
+     * @param callable|null $failure
+     * @return mixed
+     * @throws LimiterTimeoutException
+     */
+    public function then(callable $callback, callable $failure = null)
+    {
+        try {
+            (new Bulk($this->connection, $this->name, $this->item, $this->maxItemCount, $this->forceRelease))
+                ->then($callback);
+        } catch (LimiterTimeoutException $e) {
+            if ($failure) {
+                return $failure($e);
+            }
+
+            throw $e;
+        }
+    }
+}

--- a/src/Illuminate/Redis/Limiters/BulkBuilder.php
+++ b/src/Illuminate/Redis/Limiters/BulkBuilder.php
@@ -38,7 +38,7 @@ class BulkBuilder
     public $item = null;
 
     /**
-     * force to release the cache
+     * force to release the cache.
      *
      * @var bool
      */
@@ -99,9 +99,10 @@ class BulkBuilder
      * Execute the given callback when cached items count is equal to max item count,
      * if error raise call the failure callback.
      *
-     * @param callable $callback
-     * @param callable|null $failure
+     * @param  callable  $callback
+     * @param  callable|null  $failure
      * @return mixed
+     *
      * @throws LimiterTimeoutException
      */
     public function then(callable $callback, callable $failure = null)

--- a/tests/Redis/BulkTest.php
+++ b/tests/Redis/BulkTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Illuminate\Tests\Redis;
+
+use Illuminate\Contracts\Redis\LimiterTimeoutException;
+use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
+use Illuminate\Redis\Limiters\Bulk;
+use Illuminate\Redis\Limiters\DurationLimiter;
+use Illuminate\Support\Env;
+use PHPUnit\Framework\TestCase;
+use Throwable;
+
+class BulkTest extends TestCase
+{
+    use InteractsWithRedis;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpRedis();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        $this->tearDownRedis();
+    }
+
+
+    public function testItCacheItemWhenCacheIsNotFull()
+    {
+        $store = [];
+
+        (new Bulk($this->redis(), 'key', '1', 3, false))
+            ->then(function ($items) use (&$store) {
+                $store = $items;
+            });
+
+        (new Bulk($this->redis(), 'key', '2', 3, false))
+            ->then(function ($items) use (&$store) {
+                $store = $items;
+            });
+
+        $this->assertEquals(0, count($store));
+
+        (new Bulk($this->redis(), 'key', '3', 3, false))
+            ->then(function ($items) use (&$store) {
+                $store = $items;
+            });
+
+        $this->assertEquals(3, count($store));
+
+        $this->assertSame(['1', '2','3'], $store);
+
+        $store = [];
+
+        (new Bulk($this->redis(), 'key', 2, 2, false))
+            ->then(function ($items) use (&$store) {
+                $store = $items;
+            });
+
+        $this->assertEquals(0, count($store));
+    }
+
+    public function testItReleaseCacheItemWhenForceRelease()
+    {
+        $store = [];
+
+        (new Bulk($this->redis(), 'key', 2, 2, true))
+            ->then(function ($items) use (&$store) {
+                $store = $items;
+            });
+
+        $this->assertEquals(1, count($store));
+    }
+
+    public function testItGetItemWhenCacheIsEmpty()
+    {
+        $store = [];
+
+        (new Bulk($this->redis(), 'key', 1, 0, true))
+            ->then(function ($items) use (&$store) {
+                $store = $items;
+            });
+
+        $this->assertEquals(1, count($store));
+    }
+
+    public function testItGetEmptyDataWhenCacheIsEmptyAndPassNullForItem()
+    {
+        $store = [];
+
+        (new Bulk($this->redis(), 'key', null, 0, true))
+            ->then(function ($items) use (&$store) {
+                $store = $items;
+            });
+
+        $this->assertEquals(0, count($store));
+    }
+
+    private function redis()
+    {
+        return $this->redis['phpredis']->connection();
+    }
+}

--- a/tests/Redis/BulkTest.php
+++ b/tests/Redis/BulkTest.php
@@ -23,7 +23,6 @@ class BulkTest extends TestCase
         $this->tearDownRedis();
     }
 
-
     public function testItCacheItemWhenCacheIsNotFull()
     {
         $store = [];

--- a/tests/Redis/BulkTest.php
+++ b/tests/Redis/BulkTest.php
@@ -2,13 +2,9 @@
 
 namespace Illuminate\Tests\Redis;
 
-use Illuminate\Contracts\Redis\LimiterTimeoutException;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
 use Illuminate\Redis\Limiters\Bulk;
-use Illuminate\Redis\Limiters\DurationLimiter;
-use Illuminate\Support\Env;
 use PHPUnit\Framework\TestCase;
-use Throwable;
 
 class BulkTest extends TestCase
 {
@@ -51,7 +47,7 @@ class BulkTest extends TestCase
 
         $this->assertEquals(3, count($store));
 
-        $this->assertSame(['1', '2','3'], $store);
+        $this->assertSame(['1', '2', '3'], $store);
 
         $store = [];
 


### PR DESCRIPTION
**What's the Problem and How to solve it?**
when you need to save data to the DB, and this data is obtained over time such as page visit count or the number of like, it is not a good idea to insert data into the database for each request. 

We can use Redis to cache this data, and when the number of items reaches a significant amount, read the data from Redis and save it to DB via a bulk insert query. 

This PR helps us to do this simply in a few lines of code for saving visits:
```php 
	Redis::bulk('page-visit')
            ->add(request()->ip())
	    ->then(function($visits)use($page){
		$page->visits()->attach($visits);
	    });
```
or for saving likes:
```php 
	Redis::bulk('like-count')
            ->add(auth()->id())
            ->then(function ($likes) use ($post) {
                $post->likes()->sync($likes);
            });
```
 
**How does this work internally?** 
- This code uses the Redis RPUSH command to add data to the cache,
- Check cache size with Redis LLEN command,
- And when the cache is full, release them with the Redis LRANGE command and delete the cache items with the Redis DEL command. 
 
**What are the benefits?** 
If you have a direct insert in each request and replace it with the Redis::bulk function, your performance will be 10 times better in the default configuration. you can configure your cache size with: 
```php 
	Redis::bulk('key')->count(cache_size)...; 
```	
for saving likes:
```php 
	Redis::bulk('like-count')
            ->add(auth()->id())
            ->count(100)
            ->then(function ($likes) use ($post) {
                $post->likes()->sync($likes);
            });
```
**How to extract cache data?**
And improve the performance again, but keep in mind that when the cache is large, saving your data will be delayed until the cache is full and remains in memory. 

When the execution of your code is going to finish, you need to release data from the cache and save it to DB.

To do this, you can use the forceRelease function as follows: 
```php 
	Redis::bulk('like-count')
            ->forceRelease()
            ->then(function ($likes) use ($post) {
                $post->likes()->sync($likes);
            });
```
You can add this code in Application::shutdown() function or any other place that runs at the end.  
