### PR TITLE
Map Illuminate\Support\ItemNotFoundException to 404 Not Found HTTP error

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -21,6 +21,7 @@ use Illuminate\Routing\Router;
 use Illuminate\Session\TokenMismatchException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\ItemNotFoundException;
 use Illuminate\Support\Reflector;
 use Illuminate\Support\Traits\ReflectsClosures;
 use Illuminate\Support\ViewErrorBag;
@@ -390,6 +391,8 @@ class Handler implements ExceptionHandlerContract
         } elseif ($e instanceof SuspiciousOperationException) {
             $e = new NotFoundHttpException('Bad hostname provided.', $e);
         } elseif ($e instanceof RecordsNotFoundException) {
+            $e = new NotFoundHttpException('Not found.', $e);
+        } elseif ($e instanceof ItemNotFoundException) {
             $e = new NotFoundHttpException('Not found.', $e);
         }
 

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -90,6 +90,7 @@ class Handler implements ExceptionHandlerContract
         AuthorizationException::class,
         HttpException::class,
         HttpResponseException::class,
+        ItemNotFoundException::class,
         ModelNotFoundException::class,
         MultipleRecordsFoundException::class,
         RecordsNotFoundException::class,

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -14,6 +14,7 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Redirector;
 use Illuminate\Routing\ResponseFactory;
+use Illuminate\Support\ItemNotFoundException;
 use Illuminate\Support\MessageBag;
 use Illuminate\Validation\ValidationException;
 use Illuminate\Validation\Validator;
@@ -284,6 +285,23 @@ class FoundationExceptionsHandlerTest extends TestCase
         $logger->shouldNotReceive('error');
 
         $this->handler->report(new RecordsNotFoundException);
+    }
+
+    public function testItemNotFoundReturns404WithoutReporting()
+    {
+        $this->config->shouldReceive('get')->with('app.debug', null)->once()->andReturn(true);
+        $this->request->shouldReceive('expectsJson')->once()->andReturn(true);
+
+        $response = $this->handler->render($this->request, new ItemNotFoundException);
+
+        $this->assertEquals(404, $response->getStatusCode());
+        $this->assertStringContainsString('"message": "Not found."', $response->getContent());
+
+        $logger = m::mock(LoggerInterface::class);
+        $this->container->instance(LoggerInterface::class, $logger);
+        $logger->shouldNotReceive('error');
+
+        $this->handler->report(new ItemNotFoundException);
     }
 }
 


### PR DESCRIPTION
The pull request aims to map the `Illuminate\Support\ItemNotFoundException` exception, thrown by the `firstOrFail()` methods both in Collection and LazyCollection, to a 404 HTTP error in `Illuminate\Foundation\Exceptions\Handler`.

The main reason is I think the exception should throw the same error code as of the `firstOrFail()` method of the Eloquent query.
When I, for some reason, must fetch all results of an eloquent query and filter them using the `filter()` method of `Illuminate\Support\Collection`, I get a different error code when executing the `firstOrFail()` method.

Here is an example of what I'm talking about: in both cases, I'm working with models, but the exception thrown is different, which should not be correct.

```
// throws 404 not found exception
User::query()
  ->where('created_at', '>=', now())
  ->firstOrFail();
```

```
// throws 500 internal server error exception
User::query()
  ->where('created_at', '>=', now())
  ->get()
  ->filter(
      fn ($user) => $user->someMethod()
  )
  ->firstOrFail();
```

I think in both cases the exception is about an entry not found (whether it is a model, a string, or whatever), so the exception should always be a 404 Not Found error.