### PR TITLE
[8.x] name convention changed for -R flag

### DIFF
--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -244,13 +244,13 @@ class ControllerMakeCommand extends GeneratorCommand
      */
     protected function generateFormRequests($modelClass, $storeRequestClass, $updateRequestClass)
     {
-        $storeRequestClass = 'Store'.class_basename($modelClass).'Request';
+        $storeRequestClass = class_basename($modelClass).'StoreRequest';
 
         $this->call('make:request', [
             'name' => $storeRequestClass,
         ]);
 
-        $updateRequestClass = 'Update'.class_basename($modelClass).'Request';
+        $updateRequestClass = class_basename($modelClass).'UpdateRequest';
 
         $this->call('make:request', [
             'name' => $updateRequestClass,


### PR DESCRIPTION
this pr will change nameing convention of -R flag #39120
R flag creates form requests starting with the **method** name followed by the **model** name like that :
`StoreUserRequest.php`
`UpdateUserRequest.php`
this will bundle and sort files by their methods . 
i have changed this naming to be **model** name followed by **method** name like that : 
`UserStoreRequest.php`
`UserUpdateRequest.php`
this way its easy to find relevant files to a model if you have a lot models and will bundle files by their models

thanks for reading and have a good day