### PR TITLE
[9.x] View component `x-for` loop

### DIFF
--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -502,6 +502,8 @@ class ComponentTagCompiler
                 $attribute = Str::after($attribute, 'bind:');
 
                 $this->boundAttributes[$attribute] = true;
+            } elseif (Str::startsWith($attribute, 'x-for')) {
+                $this->boundAttributes[$attribute] = true;
             } else {
                 $value = "'".$this->compileAttributeEchos($value)."'";
             }

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -498,11 +498,10 @@ class ComponentTagCompiler
 
             $value = $this->stripQuotes($value);
 
-            if (Str::startsWith($attribute, 'bind:')) {
+            // x-for should be considered as bound attribute
+            if (Str::startsWith($attribute, 'bind:') || $attribute === 'x-for') {
                 $attribute = Str::after($attribute, 'bind:');
 
-                $this->boundAttributes[$attribute] = true;
-            } elseif (Str::startsWith($attribute, 'x-for')) {
                 $this->boundAttributes[$attribute] = true;
             } else {
                 $value = "'".$this->compileAttributeEchos($value)."'";

--- a/src/Illuminate/View/Concerns/ManagesComponents.php
+++ b/src/Illuminate/View/Concerns/ManagesComponents.php
@@ -97,7 +97,7 @@ trait ManagesComponents
             $view = value($view, $data);
 
             if ($view instanceof View) {
-                if ($data['attributes']->has('x-for')) {
+                if (isset($data['attributes']) && $data['attributes']->has('x-for')) {
                     [$resources, $bindingAttributeKey] = $data['attributes']->offsetGet('x-for');
 
                     return $this->renderLoopComponent($view, $data, $bindingAttributeKey, $resources);

--- a/src/Illuminate/View/Concerns/ManagesComponents.php
+++ b/src/Illuminate/View/Concerns/ManagesComponents.php
@@ -97,6 +97,12 @@ trait ManagesComponents
             $view = value($view, $data);
 
             if ($view instanceof View) {
+                if ($data['attributes']->has('x-for')) {
+                    [$resources, $bindingAttributeKey] = $data['attributes']->offsetGet('x-for');
+
+                    return $this->renderLoopComponent($view, $data, $bindingAttributeKey, $resources);
+                }
+
                 return $view->with($data)->render();
             } elseif ($view instanceof Htmlable) {
                 return $view->toHtml();
@@ -218,5 +224,32 @@ trait ManagesComponents
         $this->componentStack = [];
         $this->componentData = [];
         $this->currentComponentData = [];
+    }
+
+    /**
+     * Render component that need to loop through an iterable
+     *
+     * @param View $view
+     * @param array $data
+     * @param string $bindingAttributeKey
+     * @param iterable $resources
+     *
+     * @return string
+     */
+    protected function renderLoopComponent(
+        View $view,
+        array $data,
+        string $bindingAttributeKey,
+        iterable $resources
+    ): string {
+        $components = '';
+
+        foreach ($resources as $resource) {
+            $data[$bindingAttributeKey] = $resource;
+
+            $components .= $view->with($data)->render();
+        }
+
+        return $components;
     }
 }


### PR DESCRIPTION
## What & Why?

Hey guys, just a small idea for rendering components.

Inspired by `v-for` of VueJS - with the `x-for`, we don't have to wrap our component inside `@foreach`

### Before

```php
@foreach ($users as $user)
    <x-user-card :user="$user" />
@endforeach
```

### After & Usage
Pass an array, first param is the **iterable**, second is the **attribute key name** for your component.

```php
<x-user-card x-for="[$users, 'user']" />
```

Thanks and have a great day!

P/s: not sure this one is better for 9.x or 8.x, let me know if I need to bring it to 8.x instead.