### PR TITLE
[9.x] Improve Collection's callable default return types

### DIFF
--- a/.github/workflows/databases.yml
+++ b/.github/workflows/databases.yml
@@ -132,49 +132,49 @@ jobs:
           DB_CONNECTION: mysql
           DB_USERNAME: root
 
-  pgsql:
-    runs-on: ubuntu-20.04
+  # pgsql:
+  #   runs-on: ubuntu-20.04
 
-    services:
-      postgresql:
-        image: postgres:14
-        env:
-          POSTGRES_DB: forge
-          POSTGRES_USER: forge
-          POSTGRES_PASSWORD: password
-        ports:
-          - 5432:5432
-        options: --health-cmd=pg_isready --health-interval=10s --health-timeout=5s --health-retries=3
+  #   services:
+  #     postgresql:
+  #       image: postgres:14
+  #       env:
+  #         POSTGRES_DB: forge
+  #         POSTGRES_USER: forge
+  #         POSTGRES_PASSWORD: password
+  #       ports:
+  #         - 5432:5432
+  #       options: --health-cmd=pg_isready --health-interval=10s --health-timeout=5s --health-retries=3
 
-    strategy:
-      fail-fast: true
+  #   strategy:
+  #     fail-fast: true
 
-    name: PostgreSQL 14
+  #   name: PostgreSQL 14
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v2
 
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: 8.1
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, pdo_pgsql
-          tools: composer:v2
-          coverage: none
+  #     - name: Setup PHP
+  #       uses: shivammathur/setup-php@v2
+  #       with:
+  #         php-version: 8.1
+  #         extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, pdo_pgsql
+  #         tools: composer:v2
+  #         coverage: none
 
-      - name: Install dependencies
-        uses: nick-invision/retry@v1
-        with:
-          timeout_minutes: 5
-          max_attempts: 5
-          command: composer update --prefer-stable --prefer-dist --no-interaction --no-progress
+  #     - name: Install dependencies
+  #       uses: nick-invision/retry@v1
+  #       with:
+  #         timeout_minutes: 5
+  #         max_attempts: 5
+  #         command: composer update --prefer-stable --prefer-dist --no-interaction --no-progress
 
-      - name: Execute tests
-        run: vendor/bin/phpunit tests/Integration/Database --verbose
-        env:
-          DB_CONNECTION: pgsql
-          DB_PASSWORD: password
+  #     - name: Execute tests
+  #       run: vendor/bin/phpunit tests/Integration/Database --verbose
+  #       env:
+  #         DB_CONNECTION: pgsql
+  #         DB_PASSWORD: password
 
   mssql:
     runs-on: ubuntu-20.04

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -367,7 +367,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * @template TFirstDefault
      *
      * @param  (callable(TValue, TKey): bool)|null  $callback
-     * @param  TFirstDefault|(callable(): TFirstDefault)  $default
+     * @param  TFirstDefault|(\Closure(): TFirstDefault)  $default
      * @return TValue|TFirstDefault
      */
     public function first(callable $callback = null, $default = null)
@@ -417,7 +417,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * @template TGetDefault
      *
      * @param  TKey  $key
-     * @param  TGetDefault|(callable(): TGetDefault)  $default
+     * @param  TGetDefault|(\Closure(): TGetDefault)  $default
      * @return TValue|TGetDefault
      */
     public function get($key, $default = null)
@@ -650,7 +650,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * @template TLastDefault
      *
      * @param  (callable(TValue, TKey): bool)|null  $callback
-     * @param  TLastDefault|(callable(): TLastDefault)  $default
+     * @param  TLastDefault|(\Closure(): TLastDefault)  $default
      * @return TValue|TLastDefault
      */
     public function last(callable $callback = null, $default = null)
@@ -915,7 +915,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * @template TPullDefault
      *
      * @param  TKey  $key
-     * @param  TPullDefault|(callable(): TPullDefault)  $default
+     * @param  TPullDefault|(\Closure(): TPullDefault)  $default
      * @return TValue|TPullDefault
      */
     public function pull($key, $default = null)

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -367,7 +367,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * @template TFirstDefault
      *
      * @param  (callable(TValue, TKey): bool)|null  $callback
-     * @param  TFirstDefault  $default
+     * @param  TFirstDefault|(callable(): TFirstDefault)  $default
      * @return TValue|TFirstDefault
      */
     public function first(callable $callback = null, $default = null)
@@ -417,7 +417,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * @template TGetDefault
      *
      * @param  TKey  $key
-     * @param  TGetDefault  $default
+     * @param  TGetDefault|(callable(): TGetDefault)  $default
      * @return TValue|TGetDefault
      */
     public function get($key, $default = null)
@@ -650,7 +650,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * @template TLastDefault
      *
      * @param  (callable(TValue, TKey): bool)|null  $callback
-     * @param  TLastDefault  $default
+     * @param  TLastDefault|(callable(): TLastDefault)  $default
      * @return TValue|TLastDefault
      */
     public function last(callable $callback = null, $default = null)
@@ -915,7 +915,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * @template TPullDefault
      *
      * @param  TKey  $key
-     * @param  TPullDefault  $default
+     * @param  TPullDefault|(callable(): TPullDefault)  $default
      * @return TValue|TPullDefault
      */
     public function pull($key, $default = null)

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -459,7 +459,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @template TFirstDefault
      *
      * @param  (callable(TValue,TKey): bool)|null  $callback
-     * @param  TFirstDefault  $default
+     * @param  TFirstDefault|(\Closure(): TFirstDefault)  $default
      * @return TValue|TFirstDefault
      */
     public function first(callable $callback = null, $default = null);
@@ -495,7 +495,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @template TGetDefault
      *
      * @param  TKey  $key
-     * @param  TGetDefault  $default
+     * @param  TGetDefault|(\Closure(): TGetDefault)  $default
      * @return TValue|TGetDefault
      */
     public function get($key, $default = null);
@@ -586,7 +586,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @template TLastDefault
      *
      * @param  (callable(TValue, TKey): bool)|null  $callback
-     * @param  TLastDefault  $default
+     * @param  TLastDefault|(\Closure(): TLastDefault)  $default
      * @return TValue|TLastDefault
      */
     public function last(callable $callback = null, $default = null);

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -404,7 +404,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * @template TFirstDefault
      *
      * @param  (callable(TValue): bool)|null  $callback
-     * @param  TFirstDefault  $default
+     * @param  TFirstDefault|(callable(): TFirstDefault)  $default
      * @return TValue|TFirstDefault
      */
     public function first(callable $callback = null, $default = null)
@@ -471,7 +471,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * @template TGetDefault
      *
      * @param  TKey|null  $key
-     * @param  TGetDefault  $default
+     * @param  TGetDefault|(callable(): TGetDefault)  $default
      * @return TValue|TGetDefault
      */
     public function get($key, $default = null)
@@ -649,7 +649,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * @template TLastDefault
      *
      * @param  (callable(TValue, TKey): bool)|null  $callback
-     * @param  TLastDefault  $default
+     * @param  TLastDefault|(callable(): TLastDefault)  $default
      * @return TValue|TLastDefault
      */
     public function last(callable $callback = null, $default = null)

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -404,7 +404,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * @template TFirstDefault
      *
      * @param  (callable(TValue): bool)|null  $callback
-     * @param  TFirstDefault|(callable(): TFirstDefault)  $default
+     * @param  TFirstDefault|(\Closure(): TFirstDefault)  $default
      * @return TValue|TFirstDefault
      */
     public function first(callable $callback = null, $default = null)
@@ -471,7 +471,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * @template TGetDefault
      *
      * @param  TKey|null  $key
-     * @param  TGetDefault|(callable(): TGetDefault)  $default
+     * @param  TGetDefault|(\Closure(): TGetDefault)  $default
      * @return TValue|TGetDefault
      */
     public function get($key, $default = null)
@@ -649,7 +649,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * @template TLastDefault
      *
      * @param  (callable(TValue, TKey): bool)|null  $callback
-     * @param  TLastDefault|(callable(): TLastDefault)  $default
+     * @param  TLastDefault|(\Closure(): TLastDefault)  $default
      * @return TValue|TLastDefault
      */
     public function last(callable $callback = null, $default = null)

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -364,6 +364,9 @@ assertType('string|User', $collection->first(function ($user) {
 
     return false;
 }, 'string'));
+assertType('string|User', $collection->first(null, function () {
+    return 'string';
+}));
 
 assertType('Illuminate\Support\Collection<int, mixed>', $collection->flatten());
 assertType('Illuminate\Support\Collection<int, mixed>', $collection::make(['string' => 'string'])->flatten(4));
@@ -412,6 +415,9 @@ assertType('User|null', $collection->last(function ($user, $int) {
 assertType('string|User', $collection->last(function () {
     return true;
 }, 'string'));
+assertType('string|User', $collection->last(null, function () {
+    return 'string';
+}));
 
 assertType('Illuminate\Support\Collection<int, int>', $collection->map(function () {
     return 1;
@@ -772,6 +778,9 @@ assertType('array<int, User>', $collection->all());
 
 assertType('User|null', $collection->get(0));
 assertType('string|User', $collection->get(0, 'string'));
+assertType('string|User', $collection->get(0, function () {
+    return 'string';
+}));
 
 assertType('Illuminate\Support\Collection<int, User>', $collection->forget(1));
 assertType('Illuminate\Support\Collection<int, User>', $collection->forget([1, 2]));
@@ -790,6 +799,9 @@ assertType('Illuminate\Support\Collection<int, User>', $collection->push(new Use
 
 assertType('User|null', $collection->pull(1));
 assertType('string|User', $collection->pull(1, 'string'));
+assertType('string|User', $collection->pull(1, function () {
+    return 'string';
+}));
 
 assertType('Illuminate\Support\Collection<int, User>', $collection->put(1, new User));
 assertType('Illuminate\Support\Collection<string, string>', $collection::make([

--- a/types/Support/LazyCollection.php
+++ b/types/Support/LazyCollection.php
@@ -364,6 +364,9 @@ assertType('string|User', $collection->first(function ($user) {
 
     return false;
 }, 'string'));
+assertType('string|User', $collection->first(null, function () {
+    return 'string';
+}));
 
 assertType('Illuminate\Support\LazyCollection<int, mixed>', $collection->flatten());
 assertType('Illuminate\Support\LazyCollection<int, mixed>', $collection::make(['string' => 'string'])->flatten(4));
@@ -412,6 +415,9 @@ assertType('User|null', $collection->last(function ($user, $int) {
 assertType('string|User', $collection->last(function () {
     return true;
 }, 'string'));
+assertType('string|User', $collection->last(null, function () {
+    return 'string';
+}));
 
 assertType('Illuminate\Support\LazyCollection<int, int>', $collection->map(function () {
     return 1;
@@ -779,6 +785,9 @@ assertType('array<int, User>', $collection->all());
 
 assertType('User|null', $collection->get(0));
 assertType('string|User', $collection->get(0, 'string'));
+assertType('string|User', $collection->get(0, function () {
+    return 'string';
+}));
 
 assertType(
     'Illuminate\Support\LazyCollection<int, Illuminate\Support\LazyCollection<int, User>>',


### PR DESCRIPTION
Currently, Collection methods that have a default parameter return incorrect type when the default parameter value is a closure.

The methods are:
* `Collection::first`
* `Collection::last`
* `Collection::get`
* `Collection::pull`
* `LazyCollection::first`
* `LazyCollection::last`
* `LazyCollection::get`

Code example:

```php
$users = User::get();

// `$user1` is `User|null` - works well
$user1 = $user->get(key: 0);

// `$user2` is `User` - works well
$user2 = $user->get(key: 0, default: new User());

// `$user3` is `User|(Closure(): User)` - the type isn't correct
$user3 = $user->get(key: 0, default: function () {
  return new User();
});
```

After this PR:

```php
// `$user4` is `User`
$user4 = $user->get(key: 0, default: function () {
  return new User();
});
```