### PR TITLE
[8.x] Test Improvements

### DIFF
--- a/tests/Integration/Database/MySql/MySqlTestCase.php
+++ b/tests/Integration/Database/MySql/MySqlTestCase.php
@@ -6,10 +6,8 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
 abstract class MySqlTestCase extends DatabaseTestCase
 {
-    protected function setUp(): void
+    protected function defineDatabaseMigrations()
     {
-        parent::setUp();
-
         if ($this->driver !== 'mysql') {
             $this->markTestSkipped('Test requires a MySQL connection.');
         }

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Integration\Database\SchemaTest;
+namespace Illuminate\Tests\Integration\Database;
 
 use Doctrine\DBAL\Types\Type;
 use Illuminate\Database\Schema\Blueprint;

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -7,7 +7,6 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\Grammars\SQLiteGrammar;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 use Illuminate\Tests\Integration\Database\Fixtures\TinyInteger;
 
 class SchemaBuilderTest extends DatabaseTestCase


### PR DESCRIPTION
Avoid running `DatabaseMigrations` when driver !== mysql.

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>