### PR TITLE
[8.x] Fixes logging deprecations when `null` driver do not exist

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -7,6 +7,7 @@ use Exception;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Log\LogManager;
+use Monolog\Handler\NullHandler;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\ErrorHandler\Error\FatalError;
 use Throwable;
@@ -112,9 +113,30 @@ class HandleExceptions
                 return;
             }
 
+            $this->ensureNullLogDriverIsConfigured();
+
             $driver = $config->get('logging.deprecations') ?? 'null';
 
             $config->set('logging.channels.deprecations', $config->get("logging.channels.{$driver}"));
+        });
+    }
+
+    /**
+     * Ensure the "null" log driver is configured.
+     *
+     * @return void
+     */
+    protected function ensureNullLogDriverIsConfigured()
+    {
+        with($this->app['config'], function ($config) {
+            if ($config->get('logging.channels.null')) {
+                return;
+            }
+
+            $config->set('logging.channels.null', [
+                'driver' => 'monolog',
+                'handler' => NullHandler::class,
+            ]);
         });
     }
 


### PR DESCRIPTION
By default, Laravel logs deprecations to the `null` log driver. While this driver exists in probably most of the applications, there is this edge case where applications upgrading from old versions of Laravel don't have their `config/logging.php` configuration file up-to-date.

This pull request ensures there is always a `null` log driver available, avoiding an runtime exception `Unable to create configured "null" logger. Using emergency logger...`.