### PR TITLE
[8.x] Add collection methond double() and triple()

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -432,7 +432,7 @@ class Arr
      */
     public static function multiples($array, $multiple)
     {
-        return array_map(function($item) use ($multiple) {
+        return array_map(function ($item) use ($multiple) {
             return (int) $item * $multiple;
         }, $array);
     }

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -424,7 +424,7 @@ class Arr
     }
 
     /**
-     * Map over an array multiples each value by passed value
+     * Map over an array multiples each value by passed value.
      *
      * @param  array  $array
      * @param  int|float  $multiple
@@ -432,9 +432,9 @@ class Arr
      */
     public static function multiples($array, $multiple)
     {
-        return array_map(function($item) use($multiple){
+        return array_map(function($item) use ($multiple) {
             return (int) $item * $multiple;
-        },$array);
+        }, $array);
     }
 
     /**

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -424,6 +424,20 @@ class Arr
     }
 
     /**
+     * Map over an array multiples each value by passed value
+     *
+     * @param  array  $array
+     * @param  int|float  $multiple
+     * @return array
+     */
+    public static function multiples($array, $multiple)
+    {
+        return array_map(function($item) use($multiple){
+            return (int) $item * $multiple;
+        },$array);
+    }
+
+    /**
      * Get a subset of the items from the given array.
      *
      * @param  array  $array

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -317,6 +317,16 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Double up each item.
+     *
+     * @return static
+     */
+    public function double()
+    {
+        return new static(Arr::multiples($this->items,2));
+    }
+
+    /**
      * Get all items except for those with the specified keys.
      *
      * @param  \Illuminate\Support\Collection|mixed  $keys
@@ -1433,6 +1443,16 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
         $this->items = $this->map($callback)->all();
 
         return $this;
+    }
+
+    /**
+     * Triple up each item.
+     *
+     * @return static
+     */
+    public function triple()
+    {
+        return new static(Arr::multiples($this->items,3));
     }
 
     /**

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -323,7 +323,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function double()
     {
-        return new static(Arr::multiples($this->items,2));
+        return new static(Arr::multiples($this->items, 2));
     }
 
     /**
@@ -1452,7 +1452,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function triple()
     {
-        return new static(Arr::multiples($this->items,3));
+        return new static(Arr::multiples($this->items, 3));
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -4891,6 +4891,20 @@ class SupportCollectionTest extends TestCase
         ], $data->all());
     }
 
+    public function testDoubleMethod()
+    {
+        $data = collect([2, 3, 4]);
+        $result = $data->double()->all();
+        $this->assertSame([4, 6, 8], $result);
+    }
+
+    public function testTripleMethod()
+    {
+        $data = collect([2, 3, 4]);
+        $result = $data->triple()->all();
+        $this->assertSame([6, 9, 12], $result);
+    }
+
     /**
      * Provides each collection class, respectively.
      *


### PR DESCRIPTION
Hi All,

I proposed adding the double() and triple() method to collection , which will double/triple up each value.
Without letting users manually call map or reduce methods.
I added a ```Arr::multiples($array,$multiples)``` which you can also multiply by any values.

### User Case

1, for example , an e-commerce website, I fetch api from a provider to get their product price. Now I want to double up our product price or I want to multiply 1.2.

2, when doing some kind of promotion , for example , if you spend at least 5000 with your credit card on a holiday, your total reward point will be doubled up at the end of today. so i can make a cron job get all qualified users, double up their points, update the db.

I think this one can be useful in many calculational scenarios that are business specific.

Thanks

  