### PR TITLE
[8.x] Customize type column in database notifications using databaseType me…

### DIFF
--- a/src/Illuminate/Notifications/Channels/DatabaseChannel.php
+++ b/src/Illuminate/Notifications/Channels/DatabaseChannel.php
@@ -55,24 +55,22 @@ class DatabaseChannel
     {
         return [
             'id' => $notification->id,
-            'type' => $this->chooseType($notification),
+            'type' => $this->storageType($notification),
             'data' => $this->getData($notifiable, $notification),
             'read_at' => null,
         ];
     }
 
     /**
-     * Use databaseType method or the notification class name for the type column.
+     * Determine the identifier that should be used to represent the notification type in the database.
      *
      * @param  mixed  $notification
      * @return string
      */
-    private function chooseType($notification)
+    protected function storageType($notification)
     {
-        if (method_exists($notification, 'databaseType')) {
-            return $notification->databaseType();
-        }
-
-        return get_class($notification);
+        return method_exists($notification, 'databaseType') 
+            ? $notification->databaseType() 
+            : get_class($notification);
     }
 }

--- a/src/Illuminate/Notifications/Channels/DatabaseChannel.php
+++ b/src/Illuminate/Notifications/Channels/DatabaseChannel.php
@@ -55,9 +55,24 @@ class DatabaseChannel
     {
         return [
             'id' => $notification->id,
-            'type' => get_class($notification),
+            'type' => $this->chooseType($notification),
             'data' => $this->getData($notifiable, $notification),
             'read_at' => null,
         ];
+    }
+
+    /**
+     * Use databaseType method or the notification class name for the type column.
+     *
+     * @param  mixed  $notification
+     * @return string
+     */
+    private function chooseType($notification)
+    {
+        if (method_exists($notification, 'databaseType')) {
+            return $notification->databaseType();
+        }
+
+        return get_class($notification);
     }
 }

--- a/src/Illuminate/Notifications/Channels/DatabaseChannel.php
+++ b/src/Illuminate/Notifications/Channels/DatabaseChannel.php
@@ -22,6 +22,25 @@ class DatabaseChannel
     }
 
     /**
+     * Build an array payload for the DatabaseNotification Model.
+     *
+     * @param  mixed  $notifiable
+     * @param  \Illuminate\Notifications\Notification  $notification
+     * @return array
+     */
+    protected function buildPayload($notifiable, Notification $notification)
+    {
+        return [
+            'id' => $notification->id,
+            'type' => method_exists($notification, 'databaseType')
+                        ? $notification->databaseType($notifiable)
+                        : get_class($notification),
+            'data' => $this->getData($notifiable, $notification),
+            'read_at' => null,
+        ];
+    }
+
+    /**
      * Get the data for the notification.
      *
      * @param  mixed  $notifiable
@@ -42,35 +61,5 @@ class DatabaseChannel
         }
 
         throw new RuntimeException('Notification is missing toDatabase / toArray method.');
-    }
-
-    /**
-     * Build an array payload for the DatabaseNotification Model.
-     *
-     * @param  mixed  $notifiable
-     * @param  \Illuminate\Notifications\Notification  $notification
-     * @return array
-     */
-    protected function buildPayload($notifiable, Notification $notification)
-    {
-        return [
-            'id' => $notification->id,
-            'type' => $this->storageType($notification),
-            'data' => $this->getData($notifiable, $notification),
-            'read_at' => null,
-        ];
-    }
-
-    /**
-     * Determine the identifier that should be used to represent the notification type in the database.
-     *
-     * @param  mixed  $notification
-     * @return string
-     */
-    protected function storageType($notification)
-    {
-        return method_exists($notification, 'databaseType') 
-            ? $notification->databaseType() 
-            : get_class($notification);
     }
 }

--- a/tests/Notifications/NotificationDatabaseChannelTest.php
+++ b/tests/Notifications/NotificationDatabaseChannelTest.php
@@ -49,6 +49,24 @@ class NotificationDatabaseChannelTest extends TestCase
         $channel = new ExtendedDatabaseChannel;
         $channel->send($notifiable, $notification);
     }
+
+    public function testCustomizeTypeIsSentToDatabase()
+    {
+        $notification = new NotificationDatabaseChannelCustomizeTypeTestNotification;
+        $notification->id = 1;
+        $notifiable = m::mock();
+
+        $notifiable->shouldReceive('routeNotificationFor->create')->with([
+            'id'        => 1,
+            'type'      => 'MONTHLY',
+            'data'      => ['invoice_id' => 1],
+            'read_at'   => null,
+            'something' => 'else',
+        ]);
+
+        $channel = new ExtendedDatabaseChannel;
+        $channel->send($notifiable, $notification);
+    }
 }
 
 class NotificationDatabaseChannelTestNotification extends Notification
@@ -56,6 +74,19 @@ class NotificationDatabaseChannelTestNotification extends Notification
     public function toDatabase($notifiable)
     {
         return new DatabaseMessage(['invoice_id' => 1]);
+    }
+}
+
+class NotificationDatabaseChannelCustomizeTypeTestNotification extends Notification
+{
+    public function toDatabase($notifiable)
+    {
+        return new DatabaseMessage(['invoice_id' => 1]);
+    }
+
+    public function databaseType()
+    {
+        return 'MONTHLY';
     }
 }
 


### PR DESCRIPTION
By this pull request, we can customize the `type` column in the database notifications.

By default, Laravel use class_name($notification) for the type column, and this can be undesirable on the client-side.


```php
class InvoiceNotification extends Notification implements ShouldQueue {

    public function via($notifiable)
    {
        return ['database'];
    }

    public function databaseType() 
    {
        return 'DAILY';
    }
```
