### PR TITLE
[9.x] Allow seeders to be called only once

### DIFF
--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -24,6 +24,13 @@ abstract class Seeder
     protected $command;
 
     /**
+     * Seeders that have been called at least one time.
+     *
+     * @var array
+     */
+    protected static $called = [];
+
+    /**
      * Run the given seeder class.
      *
      * @param  array|string  $class
@@ -53,6 +60,8 @@ abstract class Seeder
             if ($silent === false && isset($this->command)) {
                 $this->command->getOutput()->writeln("<info>Seeded:</info>  {$name} ({$runTime}ms)");
             }
+
+            static::$called[] = $class;
         }
 
         return $this;
@@ -80,6 +89,22 @@ abstract class Seeder
     public function callSilent($class, array $parameters = [])
     {
         $this->call($class, true, $parameters);
+    }
+
+    /**
+     * Run the given seeder class once.
+     *
+     * @param  array|string  $class
+     * @param  bool  $silent
+     * @return void
+     */
+    public function callOnce($class, $silent = false, array $parameters = [])
+    {
+        if (in_array($class, static::$called)) {
+            return;
+        }
+
+        $this->call($class, $silent, $parameters);
     }
 
     /**


### PR DESCRIPTION
This PR adds a `callOnce` method to the `Seeder` class to call seeders only once (similar to `require_once` in PHP).

This makes seeders more composable. Say you have an application with `Post` and `Page` models, and they each can belong to a `Category`.

`PostSeeder` and `PageSeeder` expect `CategorySeeder` to run first to ensure there are categories in the database. The `DatabaseSeeder` respects this order:

```php
class DatabaseSeeder extends Seeder
{
    public function run()
    {
        $this->call([
            CategorySeeder::class,
            PageSeeder::class,
            PostSeeder::class,
        ]);
    }
}
```

However, you can't run `PageSeeder` or `PostSeeder` on their own anymore. Moving `$this->call(CategorySeeder::class)` to `PageSeeder` and `PostSeeder` isn't a good solution either, because then `DatabaseSeeder` will call `CategorySeeder` twice.

With `callOnce`, you call dependent seeders where there necessary.

```php
class PageSeeder extends Seeder
{
    public function run()
    {
        $this->callOnce(CategorySeeder::class);

        // …
}

class PostSeeder extends Seeder
{
    public function run()
    {
        $this->callOnce(CategorySeeder::class);

        // …
}

class DatabaseSeeder extends Seeder
{
    public function run()
    {
        $this->call([
            PageSeeder::class,
            PostSeeder::class,
        ]);
    }
}
```

This enabled developers to cherry pick which seeders they want to run.

An alternative solution would be to add a `$before` property to seeders.

```php
class PageSeeder extends Seeder
{
    protected $before = [
        CategorySeeder::class,
    ];
}
```

I opted for `callOnce` because it's consistent with the existing `call` method, is more discoverable, and requires less changes.

---

This is a non-breaking change, but I targeted it towards 9.x since it's a new feature and Laravel 9 isn't too far away. I'll rework this for 8.x it preferred.

I haven't added any tests yet because I want to discuss the API first. If this is something worth merging, I'll update the PR accordingly.