### PR TITLE
[9.x] Add giveConfig to ContextualBindingBuilder

### DIFF
--- a/src/Illuminate/Contracts/Container/ContextualBindingBuilder.php
+++ b/src/Illuminate/Contracts/Container/ContextualBindingBuilder.php
@@ -27,4 +27,13 @@ interface ContextualBindingBuilder
      * @return void
      */
     public function giveTagged($tag);
+
+    /**
+     * Specify the configuration item to bind as a primitive.
+     *
+     * @param  string  $key
+     * @param  ?string  $default
+     * @return void
+     */
+    public function giveConfig($key, $default = null);
 }


### PR DESCRIPTION
This is a follow-up to #36241. I had intended to work on the contract eventually and thought maybe it would just get added eventually by someone else.

> I believe this may require additional work on the contract (?) that I'll do if this gets approved. Would just need to know which branch to target that change on. I can also do the docs on this if it looks like this will be able to be merged. :)

This afternoon I decided to go ahead and add it. In the process, I discovered I'm not the first to send a PR for this addition! Unfortunately, both #36361 and #38925 were rejected.

I'm going to send my PR anyway to open the discussion again. In my initial PR, it was not stated that this was syntactical sugar that would never make it to the contract. Similar to `giveTagged` in #32514, I fully expected we'd be able to get this into the contract eventually.

Going to bring this discussion up in Discord, too. :)

Ultimately, nobody will ever be able to discover this method exists and probably shouldn't be relying on it being available:

![image](https://user-images.githubusercontent.com/191200/143966113-140a6b97-0f30-4ced-89f6-f7e993b0db5c.png)


