### PR TITLE
Optimize the execution time of the unique method

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1454,7 +1454,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function unique($key = null, $strict = false)
     {
-        if ($key === null && $strict === false) {
+        if (is_null($key) && $strict === false) {
             return new static(array_unique($this->items, SORT_REGULAR));
         }
 

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1457,7 +1457,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
         if ($key === null && $strict === false) {
             return new static(array_unique($this->items, SORT_REGULAR));
         }
-        
+
         $callback = $this->valueRetriever($key);
 
         $exists = [];

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1454,6 +1454,10 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function unique($key = null, $strict = false)
     {
+        if ($key === null && $strict === false) {
+            return new static(array_unique($this->items, SORT_REGULAR));
+        }
+        
         $callback = $this->valueRetriever($key);
 
         $exists = [];


### PR DESCRIPTION
When passing a large array, the unique method is very slow. 
This modification can increase the speed by hundreds of times, 
and it is also suitable for most scenarios.
