### PR TITLE
[9.x] Fix session retrieval from HTTP request

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -421,7 +421,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
 
         $request->setJson($from->json());
 
-        if ($from->hasSession() && $session = $from->getSession()) {
+        if ($from->hasSession() && $session = $from->session()) {
             $request->setLaravelSession($session);
         }
 


### PR DESCRIPTION
This change is needed to circumvent the changes Symfony did in v6 for type-hinting their `getSession` method. I already had to remove the method in the Symfony v6 PR I made earlier: 

https://github.com/laravel/framework/pull/38376/files#diff-4a2dd251f1519763d08bb47f9ae2e9029687a3208542d09e317166b89f57a7a7L491-L500

The reason why is that our own session store doesn't implements Symfony's `SessionInterface` so we can't return like that anymore. We can safely call `->session` instead because we're checking if the object is a Laravel HTTP Request class with the `self` type-hint. 

This also solves the failing issues with Laravel 9 support in Fortify.