### PR TITLE
[9.x] Adds Route Discovery

### DIFF
--- a/src/Illuminate/Support/Facades/Route.php
+++ b/src/Illuminate/Support/Facades/Route.php
@@ -35,6 +35,7 @@ namespace Illuminate\Support\Facades;
  * @method static string|null currentRouteName()
  * @method static void apiResources(array $resources, array $options = [])
  * @method static void bind(string $key, string|callable $binder)
+ * @method static void discover(string $path)
  * @method static void model(string $key, string $class, \Closure|null $callback = null)
  * @method static void pattern(string $key, string $pattern)
  * @method static void resources(array $resources, array $options = [])


### PR DESCRIPTION
This pull request is a **proof of concept** for what could potentially be an interesting feature for Laravel 9: **Route Discovery**.

It's known that we use the pattern "Discover by convention" in multiple places on the framework these days, discovering console command classes, container bindings, model policies, register packages, and more. And, seems that developers embrace so well these "Discover" features, that they even forget that you can still register things manually. 

Now, this pull request proposes applying the pattern "Discover by convention" to our HTTP routes. In short, it's about generating routes based on the project's folder/file structure. It's open to debate, but it could be something like this:

```php
<?php // routes/web.php

Route::discover(app_path('Http/Controllers'));
```

``` php
// Assuming the following structure within Http/Controllers:
- Api/Cars.php { public function show($car): Response }
- Photos.php { public function index(): Response }
```

```bash
$ php artisan route:list
+----------+---------------------+---------------+--------------------------------------+
| Method   | URI                 | Name          | Action                                                     |       
+----------+---------------------+---------------+--------------------------------------+
| GET|HEAD | api/cars/{car}      | api.cars.show | App\Http\Controllers\Api\Cars@show   |
| GET|HEAD | photos              | photos.index  | App\Http\Controllers\Photos@index    |
+----------+---------------------+---------------+--------------------------------------+
```

Of course, there are multiple things to investigate such as applying Middlewares, adding extra route parameters, etc. But for now, let me know what do you think about the concept. 👍🏻