### PR TITLE
[9.x] Add target status code to HTTP client retry method

### DIFF
--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -25,7 +25,7 @@ use PHPUnit\Framework\Assert as PHPUnit;
  * @method \Illuminate\Http\Client\PendingRequest contentType(string $contentType)
  * @method \Illuminate\Http\Client\PendingRequest dd()
  * @method \Illuminate\Http\Client\PendingRequest dump()
- * @method \Illuminate\Http\Client\PendingRequest retry(int $times, int $sleep = 0, ?callable $when = null)
+ * @method \Illuminate\Http\Client\PendingRequest retry(int $times, int $sleep = 0, ?callable $when = null, ?int $targetStatusCode = null)
  * @method \Illuminate\Http\Client\PendingRequest sink(string|resource $to)
  * @method \Illuminate\Http\Client\PendingRequest stub(callable $callback)
  * @method \Illuminate\Http\Client\PendingRequest timeout(int $seconds)

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -690,11 +690,11 @@ class PendingRequest
                     $this->populateResponse($response);
 
                     if ($this->tries > 1) {
-                        if($this->retryTargetStatusCode !== null && $this->retryTargetStatusCode !== $response->status()) {
+                        if ($this->retryTargetStatusCode !== null && $this->retryTargetStatusCode !== $response->status()) {
                             throw new \Illuminate\Http\Client\RequestException($response);
                         }
 
-                        if(! $response->successful()) {
+                        if (! $response->successful()) {
                             $response->throw();
                         }
                     }
@@ -702,7 +702,7 @@ class PendingRequest
                     $this->dispatchResponseReceivedEvent($response);
                 });
             } catch (Throwable $e) {
-                if($e instanceof ConnectException) {
+                if ($e instanceof ConnectException) {
                     $this->dispatchConnectionFailedEvent();
 
                     throw new ConnectionException($e->getMessage(), 0, $e);

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -16,6 +16,7 @@ use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use Psr\Http\Message\MessageInterface;
 use Symfony\Component\VarDumper\VarDumper;
+use Throwable;
 
 class PendingRequest
 {
@@ -700,7 +701,7 @@ class PendingRequest
 
                     $this->dispatchResponseReceivedEvent($response);
                 });
-            } catch (ConnectException|RequestException $e) {
+            } catch (Throwable $e) {
                 if($e instanceof ConnectException) {
                     $this->dispatchConnectionFailedEvent();
 

--- a/src/Illuminate/Support/Facades/Http.php
+++ b/src/Illuminate/Support/Facades/Http.php
@@ -20,7 +20,7 @@ use Illuminate\Http\Client\Factory;
  * @method static \Illuminate\Http\Client\PendingRequest contentType(string $contentType)
  * @method static \Illuminate\Http\Client\PendingRequest dd()
  * @method static \Illuminate\Http\Client\PendingRequest dump()
- * @method static \Illuminate\Http\Client\PendingRequest retry(int $times, int $sleep = 0, ?callable $when = null)
+ * @method static \Illuminate\Http\Client\PendingRequest retry(int $times, int $sleep = 0, ?callable $when = null, ?int $targetStatusCode = null)
  * @method static \Illuminate\Http\Client\PendingRequest sink(string|resource $to)
  * @method static \Illuminate\Http\Client\PendingRequest stub(callable $callback)
  * @method static \Illuminate\Http\Client\PendingRequest timeout(int $seconds)


### PR DESCRIPTION
This PR adds the ability to pass an additional argument to the retry method called "$targetStatusCode", see below:

```php
Http::retry(5, 1000, targetStatusCode: 200)->get('http://example.com');
```

The reason for this addition is that the current logic uses *$response->successful()* which quite rightly returns *true* if the status code is between 200 and 299.

This doesn't work if you are polling an endpoint and you're expecting a specific status code within the successful region, ie. 200-299, such as a 200 OK but the endpoint returns a 202 Accepted for example until the endpoint is ready to return its response.