### PR TITLE
[8.x] Add PHP8.1 ReturnTypeWillChange attribute to support test classes

### DIFF
--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -4970,21 +4970,25 @@ class TestArrayAccessImplementation implements ArrayAccess
         $this->arr = $arr;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->arr[$offset]);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->arr[$offset];
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->arr[$offset] = $value;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->arr[$offset]);


### PR DESCRIPTION
Co-Authored-By: Jake Bathman <jake.bathman@gmail.com>
Co-Authored-By: Jamison Valenta <2752727+jamisonvalenta@users.noreply.github.com>

This PR adds the PHP 8.1 `ReturnTypeWillChange` attribute to classes used in support tests to suppress errors when running the tests in PHP 8.1.