### PR TITLE
[8.x] Fixes `AsEncrypted` traits not respecting nullable columns

### DIFF
--- a/src/Illuminate/Database/Eloquent/Casts/AsEncryptedArrayObject.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEncryptedArrayObject.php
@@ -20,17 +20,25 @@ class AsEncryptedArrayObject implements Castable
         {
             public function get($model, $key, $value, $attributes)
             {
-                return new ArrayObject(json_decode(Crypt::decryptString($attributes[$key]), true));
+                if (isset($attributes[$key])) {
+                    return new ArrayObject(json_decode(Crypt::decryptString($attributes[$key]), true));
+                }
+
+                return null;
             }
 
             public function set($model, $key, $value, $attributes)
             {
-                return [$key => Crypt::encryptString(json_encode($value))];
+                if ($value !== null) {
+                    return [$key => Crypt::encryptString(json_encode($value))];
+                }
+
+                return null;
             }
 
             public function serialize($model, string $key, $value, array $attributes)
             {
-                return $value->getArrayCopy();
+                return $value !== null ? $value->getArrayCopy() : null;
             }
         };
     }

--- a/src/Illuminate/Database/Eloquent/Casts/AsEncryptedCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEncryptedCollection.php
@@ -21,12 +21,20 @@ class AsEncryptedCollection implements Castable
         {
             public function get($model, $key, $value, $attributes)
             {
-                return new Collection(json_decode(Crypt::decryptString($attributes[$key]), true));
+                if (isset($attributes[$key])) {
+                    return new Collection(json_decode(Crypt::decryptString($attributes[$key]), true));
+                }
+
+                return null;
             }
 
             public function set($model, $key, $value, $attributes)
             {
-                return [$key => Crypt::encryptString(json_encode($value))];
+                if ($value !== null) {
+                    return [$key => Crypt::encryptString(json_encode($value))];
+                }
+
+                return null;
             }
         };
     }

--- a/tests/Integration/Database/EloquentModelEncryptedCastingTest.php
+++ b/tests/Integration/Database/EloquentModelEncryptedCastingTest.php
@@ -3,6 +3,9 @@
 namespace Illuminate\Tests\Integration\Database;
 
 use Illuminate\Contracts\Encryption\Encrypter;
+use Illuminate\Database\Eloquent\Casts\ArrayObject;
+use Illuminate\Database\Eloquent\Casts\AsEncryptedArrayObject;
+use Illuminate\Database\Eloquent\Casts\AsEncryptedCollection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Collection;
@@ -176,6 +179,110 @@ class EloquentModelEncryptedCastingTest extends DatabaseTestCase
             'id' => $subject->id,
             'secret_collection' => 'encrypted-secret-collection-string',
         ]);
+    }
+
+    public function testAsEncryptedCollection()
+    {
+        $this->encrypter->expects('encryptString')
+            ->twice()
+            ->with('{"key1":"value1"}')
+            ->andReturn('encrypted-secret-collection-string-1');
+        $this->encrypter->expects('encryptString')
+            ->times(12)
+            ->with('{"key1":"value1","key2":"value2"}')
+            ->andReturn('encrypted-secret-collection-string-2');
+        $this->encrypter->expects('decryptString')
+            ->once()
+            ->with('encrypted-secret-collection-string-2')
+            ->andReturn('{"key1":"value1","key2":"value2"}');
+
+        $subject = new EncryptedCast;
+
+        $subject->mergeCasts(['secret_collection' => AsEncryptedCollection::class]);
+
+        $subject->secret_collection = new Collection(['key1' => 'value1']);
+        $subject->secret_collection->put('key2', 'value2');
+
+        $subject->save();
+
+        $this->assertInstanceOf(Collection::class, $subject->secret_collection);
+        $this->assertSame('value1', $subject->secret_collection->get('key1'));
+        $this->assertSame('value2', $subject->secret_collection->get('key2'));
+        $this->assertDatabaseHas('encrypted_casts', [
+            'id' => $subject->id,
+            'secret_collection' => 'encrypted-secret-collection-string-2',
+        ]);
+
+        $subject = $subject->fresh();
+
+        $this->assertInstanceOf(Collection::class, $subject->secret_collection);
+        $this->assertSame('value1', $subject->secret_collection->get('key1'));
+        $this->assertSame('value2', $subject->secret_collection->get('key2'));
+
+        $subject->secret_collection = null;
+        $subject->save();
+
+        $this->assertNull($subject->secret_collection);
+        $this->assertDatabaseHas('encrypted_casts', [
+            'id' => $subject->id,
+            'secret_collection' => null,
+        ]);
+
+        $this->assertNull($subject->fresh()->secret_collection);
+    }
+
+    public function testAsEncryptedArrayObject()
+    {
+        $this->encrypter->expects('encryptString')
+            ->once()
+            ->with('{"key1":"value1"}')
+            ->andReturn('encrypted-secret-array-string-1');
+        $this->encrypter->expects('decryptString')
+            ->once()
+            ->with('encrypted-secret-array-string-1')
+            ->andReturn('{"key1":"value1"}');
+        $this->encrypter->expects('encryptString')
+            ->times(12)
+            ->with('{"key1":"value1","key2":"value2"}')
+            ->andReturn('encrypted-secret-array-string-2');
+        $this->encrypter->expects('decryptString')
+            ->once()
+            ->with('encrypted-secret-array-string-2')
+            ->andReturn('{"key1":"value1","key2":"value2"}');
+
+        $subject = new EncryptedCast;
+
+        $subject->mergeCasts(['secret_array' => AsEncryptedArrayObject::class]);
+
+        $subject->secret_array = ['key1' => 'value1'];
+        $subject->secret_array['key2'] = 'value2';
+
+        $subject->save();
+
+        $this->assertInstanceOf(ArrayObject::class, $subject->secret_array);
+        $this->assertSame('value1', $subject->secret_array['key1']);
+        $this->assertSame('value2', $subject->secret_array['key2']);
+        $this->assertDatabaseHas('encrypted_casts', [
+            'id' => $subject->id,
+            'secret_array' => 'encrypted-secret-array-string-2',
+        ]);
+
+        $subject = $subject->fresh();
+
+        $this->assertInstanceOf(ArrayObject::class, $subject->secret_array);
+        $this->assertSame('value1', $subject->secret_array['key1']);
+        $this->assertSame('value2', $subject->secret_array['key2']);
+
+        $subject->secret_array = null;
+        $subject->save();
+
+        $this->assertNull($subject->secret_array);
+        $this->assertDatabaseHas('encrypted_casts', [
+            'id' => $subject->id,
+            'secret_array' => null,
+        ]);
+
+        $this->assertNull($subject->fresh()->secret_array);
     }
 
     public function testCustomEncrypterCanBeSpecified()


### PR DESCRIPTION
## What?

When using `AsEncryptedCollection` or `AsEncryptedArrayObject`, _nulling_ the property of the model results in an error because the cast object returned isn't aware of `null` values being passed to or received from the database.

```php
use Illuminate\Database\Eloquent\Casts\AsEncryptedArrayObject;
use Illuminate\Database\Eloquent\Casts\AsEncryptedCollection;
use Illuminate\Database\Eloquent\Model;

class Foo extends Model
{
    protected $casts = [
        'secret_array' => AsEncryptedArrayObject::class,
        'secret_collection' => AsEncryptedCollection::class,
    ]
}

Foo::make()->fill([
    'secret_array' => null,
    'secret_collection' => null,
])

// ErrorException : Undefined array key "secret_array"
// ErrorException : Undefined array key "secret_collection"
```

This fixes this behaviour by checking if the key in the attributes being passed to the cast object is not `null`. If it's not, proceeds to encrypt/decrypt the value, otherwise it keeps it as `null`.

## Notes

There is an **EXCESSIVE** amount of redundant encryption being done when setting a value into a property. For example, saving the model calls the encrypted **4 times**, when it only should be called once.

```php
$foo = Foo::make();

$foo->secret_array = ['foo' => 'bar'];

$foo->save(); // <-- Here the value encryption is called 4 times.
```

You can check this behaviour on the tests themselves. The encryption must be set to be expected **12 times** even if only it's saved twice in the database during a single test.