### PR TITLE
[8.x] Remove unused parameter and redundant comments in `StartSession` middleware

### DIFF
--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -109,9 +109,6 @@ class StartSession
      */
     protected function handleStatefulRequest(Request $request, $session, Closure $next)
     {
-        // If a session driver has been configured, we will need to start the session here
-        // so that the data is ready for an application. Note that the Laravel sessions
-        // do not make use of PHP "native" sessions in any way since they are crappy.
         $request->setLaravelSession(
             $this->startSession($request, $session)
         );
@@ -124,9 +121,6 @@ class StartSession
 
         $this->addCookieToResponse($response, $session);
 
-        // Again, if the session has been configured we will need to close out the session
-        // so that the attributes may be persisted to some storage medium. We will also
-        // add the session identifier cookie to the application response headers now.
         $this->saveSession();
 
         return $response;

--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -127,7 +127,7 @@ class StartSession
         // Again, if the session has been configured we will need to close out the session
         // so that the attributes may be persisted to some storage medium. We will also
         // add the session identifier cookie to the application response headers now.
-        $this->saveSession($request);
+        $this->saveSession();
 
         return $response;
     }
@@ -228,10 +228,9 @@ class StartSession
     /**
      * Save the session data to storage.
      *
-     * @param  \Illuminate\Http\Request  $request
      * @return void
      */
-    protected function saveSession($request)
+    protected function saveSession()
     {
         $this->manager->driver()->save();
     }


### PR DESCRIPTION
Just removed a dead parameter and some redundant comments. I find the comments are not very useful and add some noise. The code is self explanatory. 