### PR TITLE
[8.x] [POC] Allow passing in Enum class to migration

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -91,7 +91,7 @@ class Blueprint
         $this->table = $table;
         $this->prefix = $prefix;
 
-        if (!is_null($callback)) {
+        if (! is_null($callback)) {
             $callback($this);
         }
     }
@@ -129,10 +129,10 @@ class Blueprint
         $this->ensureCommandsAreValid($connection);
 
         foreach ($this->commands as $command) {
-            $method = 'compile' . ucfirst($command->name);
+            $method = 'compile'.ucfirst($command->name);
 
             if (method_exists($grammar, $method) || $grammar::hasMacro($method)) {
-                if (!is_null($sql = $grammar->$method($this, $command, $connection))) {
+                if (! is_null($sql = $grammar->$method($this, $command, $connection))) {
                     $statements = array_merge($statements, (array) $sql);
                 }
             }
@@ -187,11 +187,11 @@ class Blueprint
      */
     protected function addImpliedCommands(Grammar $grammar)
     {
-        if (count($this->getAddedColumns()) > 0 && !$this->creating()) {
+        if (count($this->getAddedColumns()) > 0 && ! $this->creating()) {
             array_unshift($this->commands, $this->createCommand('add'));
         }
 
-        if (count($this->getChangedColumns()) > 0 && !$this->creating()) {
+        if (count($this->getChangedColumns()) > 0 && ! $this->creating()) {
             array_unshift($this->commands, $this->createCommand('change'));
         }
 
@@ -244,15 +244,14 @@ class Blueprint
             foreach ($grammar->getFluentCommands() as $commandName) {
                 $attributeName = lcfirst($commandName);
 
-                if (!isset($column->{$attributeName})) {
+                if (! isset($column->{$attributeName})) {
                     continue;
                 }
 
                 $value = $column->{$attributeName};
 
                 $this->addCommand(
-                    $commandName,
-                    compact('value', 'column')
+                    $commandName, compact('value', 'column')
                 );
             }
         }
@@ -901,8 +900,8 @@ class Blueprint
         }
 
         return $model->getKeyType() === 'int' && $model->getIncrementing()
-            ? $this->foreignId($column ?: $model->getForeignKey())
-            : $this->foreignUuid($column ?: $model->getForeignKey());
+                    ? $this->foreignId($column ?: $model->getForeignKey())
+                    : $this->foreignUuid($column ?: $model->getForeignKey());
     }
 
     /**
@@ -1004,7 +1003,7 @@ class Blueprint
      * @param  string|array  $allowed
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function enum($column, $allowed)
+    public function enum($column, string|array $allowed)
     {
         if (is_string($allowed)) {
             $allowed = collect($allowed::cases())->map(function ($case) {
@@ -1501,8 +1500,7 @@ class Blueprint
         $index = $index ?: $this->createIndexName($type, $columns);
 
         return $this->addCommand(
-            $type,
-            compact('index', 'columns', 'algorithm')
+            $type, compact('index', 'columns', 'algorithm')
         );
     }
 
@@ -1537,7 +1535,7 @@ class Blueprint
      */
     protected function createIndexName($type, array $columns)
     {
-        $index = strtolower($this->prefix . $this->table . '_' . implode('_', $columns) . '_' . $type);
+        $index = strtolower($this->prefix.$this->table.'_'.implode('_', $columns).'_'.$type);
 
         return str_replace(['-', '.'], '_', $index);
     }
@@ -1671,7 +1669,7 @@ class Blueprint
     public function getAddedColumns()
     {
         return array_filter($this->columns, function ($column) {
-            return !$column->change;
+            return ! $column->change;
         });
     }
 
@@ -1694,7 +1692,7 @@ class Blueprint
      */
     public function hasAutoIncrementColumn()
     {
-        return !is_null(collect($this->getAddedColumns())->first(function ($column) {
+        return ! is_null(collect($this->getAddedColumns())->first(function ($column) {
             return $column->autoIncrement === true;
         }));
     }
@@ -1706,14 +1704,14 @@ class Blueprint
      */
     public function autoIncrementingStartingValues()
     {
-        if (!$this->hasAutoIncrementColumn()) {
+        if (! $this->hasAutoIncrementColumn()) {
             return [];
         }
 
         return collect($this->getAddedColumns())->mapWithKeys(function ($column) {
             return $column->autoIncrement === true
-                ? [$column->name => $column->get('startingValue', $column->get('from'))]
-                : [$column->name => null];
+                        ? [$column->name => $column->get('startingValue', $column->get('from'))]
+                        : [$column->name => null];
         })->filter()->all();
     }
 }

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -91,7 +91,7 @@ class Blueprint
         $this->table = $table;
         $this->prefix = $prefix;
 
-        if (! is_null($callback)) {
+        if (!is_null($callback)) {
             $callback($this);
         }
     }
@@ -129,10 +129,10 @@ class Blueprint
         $this->ensureCommandsAreValid($connection);
 
         foreach ($this->commands as $command) {
-            $method = 'compile'.ucfirst($command->name);
+            $method = 'compile' . ucfirst($command->name);
 
             if (method_exists($grammar, $method) || $grammar::hasMacro($method)) {
-                if (! is_null($sql = $grammar->$method($this, $command, $connection))) {
+                if (!is_null($sql = $grammar->$method($this, $command, $connection))) {
                     $statements = array_merge($statements, (array) $sql);
                 }
             }
@@ -187,11 +187,11 @@ class Blueprint
      */
     protected function addImpliedCommands(Grammar $grammar)
     {
-        if (count($this->getAddedColumns()) > 0 && ! $this->creating()) {
+        if (count($this->getAddedColumns()) > 0 && !$this->creating()) {
             array_unshift($this->commands, $this->createCommand('add'));
         }
 
-        if (count($this->getChangedColumns()) > 0 && ! $this->creating()) {
+        if (count($this->getChangedColumns()) > 0 && !$this->creating()) {
             array_unshift($this->commands, $this->createCommand('change'));
         }
 
@@ -244,14 +244,15 @@ class Blueprint
             foreach ($grammar->getFluentCommands() as $commandName) {
                 $attributeName = lcfirst($commandName);
 
-                if (! isset($column->{$attributeName})) {
+                if (!isset($column->{$attributeName})) {
                     continue;
                 }
 
                 $value = $column->{$attributeName};
 
                 $this->addCommand(
-                    $commandName, compact('value', 'column')
+                    $commandName,
+                    compact('value', 'column')
                 );
             }
         }
@@ -900,8 +901,8 @@ class Blueprint
         }
 
         return $model->getKeyType() === 'int' && $model->getIncrementing()
-                    ? $this->foreignId($column ?: $model->getForeignKey())
-                    : $this->foreignUuid($column ?: $model->getForeignKey());
+            ? $this->foreignId($column ?: $model->getForeignKey())
+            : $this->foreignUuid($column ?: $model->getForeignKey());
     }
 
     /**
@@ -1003,7 +1004,7 @@ class Blueprint
      * @param  string|array  $allowed
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function enum($column, string|array $allowed)
+    public function enum($column, $allowed)
     {
         if (is_string($allowed)) {
             $allowed = collect($allowed::cases())->map(function ($case) {
@@ -1500,7 +1501,8 @@ class Blueprint
         $index = $index ?: $this->createIndexName($type, $columns);
 
         return $this->addCommand(
-            $type, compact('index', 'columns', 'algorithm')
+            $type,
+            compact('index', 'columns', 'algorithm')
         );
     }
 
@@ -1535,7 +1537,7 @@ class Blueprint
      */
     protected function createIndexName($type, array $columns)
     {
-        $index = strtolower($this->prefix.$this->table.'_'.implode('_', $columns).'_'.$type);
+        $index = strtolower($this->prefix . $this->table . '_' . implode('_', $columns) . '_' . $type);
 
         return str_replace(['-', '.'], '_', $index);
     }
@@ -1669,7 +1671,7 @@ class Blueprint
     public function getAddedColumns()
     {
         return array_filter($this->columns, function ($column) {
-            return ! $column->change;
+            return !$column->change;
         });
     }
 
@@ -1692,7 +1694,7 @@ class Blueprint
      */
     public function hasAutoIncrementColumn()
     {
-        return ! is_null(collect($this->getAddedColumns())->first(function ($column) {
+        return !is_null(collect($this->getAddedColumns())->first(function ($column) {
             return $column->autoIncrement === true;
         }));
     }
@@ -1704,14 +1706,14 @@ class Blueprint
      */
     public function autoIncrementingStartingValues()
     {
-        if (! $this->hasAutoIncrementColumn()) {
+        if (!$this->hasAutoIncrementColumn()) {
             return [];
         }
 
         return collect($this->getAddedColumns())->mapWithKeys(function ($column) {
             return $column->autoIncrement === true
-                        ? [$column->name => $column->get('startingValue', $column->get('from'))]
-                        : [$column->name => null];
+                ? [$column->name => $column->get('startingValue', $column->get('from'))]
+                : [$column->name => null];
         })->filter()->all();
     }
 }

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1003,7 +1003,7 @@ class Blueprint
      * @param  string|array  $allowed
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function enum($column, string|array $allowed)
+    public function enum($column, $allowed)
     {
         if (is_string($allowed)) {
             $allowed = collect($allowed::cases())->map(function ($case) {

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1000,11 +1000,17 @@ class Blueprint
      * Create a new enum column on the table.
      *
      * @param  string  $column
-     * @param  array  $allowed
+     * @param  string|array  $allowed
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function enum($column, array $allowed)
+    public function enum($column, string|array $allowed)
     {
+        if (is_string($allowed)) {
+            $allowed = collect($allowed::cases())->map(function ($case) {
+                return $case->value;
+            })->toArray();
+        }
+
         return $this->addColumn('enum', $column, compact('allowed'));
     }
 


### PR DESCRIPTION
Now that we can cast values to `Enum's`, it seems as though it would make sense to allow specifying the `Enum` class in the migration so that the class is the source of truth for the values

If you had the following enum class:

```php
<?php

namespace App\Enums;

enum ServerStatus: string
{
    case Online = 'online';
    case Offline = 'offline';
}
```

You could pass the class to the migration:

```php
<?php

use App\Enums\ServerStatus;
use Illuminate\Database\Migrations\Migration;
use Illuminate\Database\Schema\Blueprint;
use Illuminate\Support\Facades\Schema;

class CreateServersTable extends Migration
{
    /**
     * Run the migrations.
     *
     * @return void
     */
    public function up()
    {
        Schema::create('servers', function (Blueprint $table) {
            $table->id();

            $table->enum('status', ServerStatus::class);

            $table->timestamps();
        });
    }

    /**
     * Reverse the migrations.
     *
     * @return void
     */
    public function down()
    {
        Schema::dropIfExists('servers');
    }
}
```

I have not added any tests as I am not sure if anyone would like this idea, but I would be happy to add if this concept would be of value.