### PR TITLE
[9.x] Replace foreach by collection contains in Request class

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -208,13 +208,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     {
         $path = $this->decodedPath();
 
-        foreach ($patterns as $pattern) {
-            if (Str::is($pattern, $path)) {
-                return true;
-            }
-        }
-
-        return false;
+        return collect($patterns)->contains(fn ($pattern) => Str::is($pattern, $path));
     }
 
     /**
@@ -238,13 +232,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     {
         $url = $this->fullUrl();
 
-        foreach ($patterns as $pattern) {
-            if (Str::is($pattern, $url)) {
-                return true;
-            }
-        }
-
-        return false;
+        return collect($patterns)->contains(fn ($pattern) => Str::is($pattern, $url));
     }
 
     /**


### PR DESCRIPTION
Because http component requires `illuminate/collections` package, we can use collection inside Request class. One more thing is Laravel v9 requires PHP >= 8.0, we also can use arrow functions right here. In this pull request, I replace two `foreach` statements by two one-line collection contains method. 

Before
```php
foreach ($patterns as $pattern) {
    if (Str::is($pattern, $path)) {
        return true;
    }
}

return false;
```

After

```php
return collect($patterns)->contains(fn ($pattern) => Str::is($pattern, $path));
```