### PR TITLE
[9.x] Use environment method to determine which environment is

### DIFF
--- a/src/Illuminate/Console/ConfirmableTrait.php
+++ b/src/Illuminate/Console/ConfirmableTrait.php
@@ -45,8 +45,6 @@ trait ConfirmableTrait
      */
     protected function getDefaultConfirmCallback()
     {
-        return function () {
-            return $this->getLaravel()->environment() === 'production';
-        };
+        return fn () => $this->getLaravel()->environment('production');
     }
 }

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -584,7 +584,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function isLocal()
     {
-        return $this['env'] === 'local';
+        return $this->environment('local');
     }
 
     /**
@@ -594,7 +594,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function isProduction()
     {
-        return $this['env'] === 'production';
+        return $this->environment('production');
     }
 
     /**
@@ -605,9 +605,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function detectEnvironment(Closure $callback)
     {
-        $args = $_SERVER['argv'] ?? null;
-
-        return $this['env'] = (new EnvironmentDetector)->detect($callback, $args);
+        return $this['env'] = (new EnvironmentDetector)->detect($callback, $_SERVER['argv'] ?? null);
     }
 
     /**
@@ -631,7 +629,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function runningUnitTests()
     {
-        return $this->bound('env') && $this['env'] === 'testing';
+        return $this->bound('env') && $this->environment('testing');
     }
 
     /**


### PR DESCRIPTION
`Illuminate\Contracts\Foundation\Application::environment` already has a purpose to check which environment the application is running in. We should keep it consistent by using this method instead of manually comparisons.