### PR TITLE
[8.x] Add Conditionable trait to ComponentAttributeBag

### DIFF
--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -8,12 +8,14 @@ use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
+use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
 use IteratorAggregate;
 
 class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
 {
     use Macroable;
+    use Conditionable;
 
     /**
      * The raw array of attributes.

--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -14,8 +14,7 @@ use IteratorAggregate;
 
 class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
 {
-    use Macroable;
-    use Conditionable;
+    use Conditionable, Macroable;
 
     /**
      * The raw array of attributes.


### PR DESCRIPTION
This is a simple PR to make the `ComponentAttributeBag` use `Conditionable` trait.

```php
$attributes
    ->except('href')
    ->when($error, fn ($attributes) => $attributes->merge(['class' => 'bg-warning']));
```

The above code is compact and provides better readability than using blade's @if or php if blocks.