### PR TITLE
[8.x] Add scheduler integration tests

### DIFF
--- a/tests/Integration/Console/CallbackSchedulingTest.php
+++ b/tests/Integration/Console/CallbackSchedulingTest.php
@@ -10,6 +10,7 @@ use Illuminate\Console\Scheduling\CacheSchedulingMutex;
 use Illuminate\Console\Scheduling\EventMutex;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Console\Scheduling\SchedulingMutex;
+use Illuminate\Container\Container;
 use Illuminate\Contracts\Cache\Factory;
 use Illuminate\Contracts\Events\Dispatcher;
 use Orchestra\Testbench\TestCase;
@@ -28,7 +29,7 @@ class CallbackSchedulingTest extends TestCase
 
             public function __construct()
             {
-                $this->store = new Repository(new ArrayStore());
+                $this->store = new Repository(new ArrayStore(true));
             }
 
             public function store($name = null)
@@ -37,8 +38,10 @@ class CallbackSchedulingTest extends TestCase
             }
         };
 
-        $this->app->instance(EventMutex::class, new CacheEventMutex($cache));
-        $this->app->instance(SchedulingMutex::class, new CacheSchedulingMutex($cache));
+        $container = Container::getInstance();
+
+        $container->instance(EventMutex::class, new CacheEventMutex($cache));
+        $container->instance(SchedulingMutex::class, new CacheSchedulingMutex($cache));
     }
 
     /**

--- a/tests/Integration/Console/CallbackSchedulingTest.php
+++ b/tests/Integration/Console/CallbackSchedulingTest.php
@@ -48,7 +48,7 @@ class CallbackSchedulingTest extends TestCase
     protected function tearDown(): void
     {
         Container::setInstance(null);
-        
+
         parent::tearDown();
     }
 

--- a/tests/Integration/Console/CallbackSchedulingTest.php
+++ b/tests/Integration/Console/CallbackSchedulingTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Console;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Support\Facades\Queue;
+use Orchestra\Testbench\TestCase;
+
+class CallbackSchedulingTest extends TestCase
+{
+    protected $log = [];
+
+    /**
+     * @dataProvider executionProvider
+     */
+    public function testExecutionOrder($background)
+    {
+        $event = $this->app->make(Schedule::class)
+            ->call($this->logger('call'))
+            ->after($this->logger('after 1'))
+            ->before($this->logger('before 1'))
+            ->after($this->logger('after 2'))
+            ->before($this->logger('before 2'));
+
+        if ($background) {
+            $event->runInBackground();
+        }
+
+        $this->artisan('schedule:run');
+
+        $this->assertLogged('before 1', 'before 2', 'call', 'after 1', 'after 2');
+    }
+
+    public function executionProvider()
+    {
+        return [
+            'Foreground' => [false],
+            'Background' => [true],
+        ];
+    }
+
+    protected function logger($message)
+    {
+        return function () use ($message) {
+            $this->log[] = $message;
+        };
+    }
+
+    protected function assertLogged(...$message)
+    {
+        $this->assertEquals($message, $this->log);
+    }
+}

--- a/tests/Integration/Console/CallbackSchedulingTest.php
+++ b/tests/Integration/Console/CallbackSchedulingTest.php
@@ -24,7 +24,8 @@ class CallbackSchedulingTest extends TestCase
     {
         parent::setUp();
 
-        $cache = new class implements Factory {
+        $cache = new class implements Factory
+        {
             public $store;
 
             public function __construct()

--- a/tests/Integration/Console/CallbackSchedulingTest.php
+++ b/tests/Integration/Console/CallbackSchedulingTest.php
@@ -45,6 +45,13 @@ class CallbackSchedulingTest extends TestCase
         $container->instance(SchedulingMutex::class, new CacheSchedulingMutex($cache));
     }
 
+    protected function tearDown(): void
+    {
+        Container::setInstance(null);
+        
+        parent::tearDown();
+    }
+
     /**
      * @dataProvider executionProvider
      */

--- a/tests/Integration/Console/CommandSchedulingTest.php
+++ b/tests/Integration/Console/CommandSchedulingTest.php
@@ -1,0 +1,225 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Console;
+
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Str;
+use Orchestra\Testbench\TestCase;
+
+class CommandSchedulingTest extends TestCase
+{
+    /**
+     * Each run of this test is assigned a random ID to ensure that separate runs
+     * do not interfere with each other.
+     *
+     * @var string
+     */
+    protected $id;
+
+    /**
+     * The path to the file that execution logs will be written to.
+     *
+     * @var string
+     */
+    protected $logFile;
+
+    /**
+     * The path to the custom command that will be written for this test.
+     *
+     * @var string
+     */
+    protected $commandFile;
+
+    /**
+     * The Filesystem instance for writing stubs and logs.
+     *
+     * @var \Illuminate\Filesystem\Filesystem
+     */
+    protected $fs;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->fs = new Filesystem;
+
+        $this->id = Str::random();
+        $this->logFile = storage_path("logs/command_scheduling_test_{$this->id}.log");
+        $this->commandFile = app_path("Console/Commands/CommandSchedulingTestCommand_{$this->id}.php");
+
+        // We always need to clean this up in case of an Exception in a previous run,
+        // since Test Bench will automatically include it when we execute a command.
+        $this->fs->delete($this->app->basePath('routes/console.php'));
+
+        $this->writeTestStubs();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->fs->delete($this->logFile);
+        $this->fs->delete(base_path('artisan'));
+        $this->fs->delete(base_path('routes/console.php'));
+        $this->fs->delete($this->commandFile);
+
+        parent::tearDown();
+    }
+
+    /**
+     * @dataProvider executionProvider
+     */
+    public function testExecutionOrder($background)
+    {
+        $event = $this->app->make(Schedule::class)
+            ->command("test:{$this->id}")
+            ->onOneServer()
+            ->after(function () {
+                $this->fs->append($this->logFile, "after\n");
+            })
+            ->before(function () {
+                $this->fs->append($this->logFile, "before\n");
+            });
+
+        if ($background) {
+            $event->runInBackground();
+        }
+
+        // We'll trigger the scheduler three times to simulate multiple servers
+        $this->artisan('schedule:run');
+        $this->artisan('schedule:run');
+        $this->artisan('schedule:run');
+
+        if ($background) {
+            // Since our command is running in a separate process, we need to wait
+            // until it has finished executing before running our assertions.
+            $this->waitForLogMessages('before', 'handled', 'after');
+        }
+
+        $this->assertLogged('before', 'handled', 'after');
+    }
+
+    public function executionProvider()
+    {
+        return [
+            'Foreground' => [false],
+            'Background' => [true],
+        ];
+    }
+
+    protected function waitForLogMessages(...$messages)
+    {
+        $tries = 0;
+        $sleep = 100000; // 100K microseconds = 0.1 second
+        $limit = 50; // 0.1s * 50 = 5 second wait limit
+
+        do {
+            $log = $this->fs->get($this->logFile);
+
+            if (Str::containsAll($log, $messages)) {
+                return;
+            }
+
+            $tries++;
+            usleep($sleep);
+        } while ($tries < $limit);
+    }
+
+    protected function assertLogged(...$messages)
+    {
+        $log = trim($this->fs->get($this->logFile));
+
+        $this->assertEquals(implode("\n", $messages), $log);
+    }
+
+    protected function writeTestStubs()
+    {
+        // Make sure our target directories exist
+        $this->fs->ensureDirectoryExists(app_path('Console/Commands'));
+        $this->fs->ensureDirectoryExists(base_path('routes'));
+
+        // Get PHP-ready representation of our paths
+        $logFile = var_export($this->logFile, true);
+        $commandFile = var_export($this->commandFile, true);
+
+        // Testbench doesn't ship with an artisan script, so we need to add one to the project
+        // so that we can execute commands in a separate process
+        $artisan = <<<PHP
+#!/usr/bin/env php
+<?php
+
+define('LARAVEL_START', microtime(true));
+
+require __DIR__.'/../../../autoload.php';
+
+\$app = require_once __DIR__.'/bootstrap/app.php';
+\$kernel = \$app->make(Illuminate\Contracts\Console\Kernel::class);
+
+\$status = \$kernel->handle(
+    \$input = new Symfony\Component\Console\Input\ArgvInput,
+    new Symfony\Component\Console\Output\ConsoleOutput
+);
+
+\$kernel->terminate(\$input, \$status);
+
+exit(\$status);
+
+PHP;
+
+        // Each time we run the test we need to write to a unique log file to ensure that separate
+        // test runs don't pollute the results of each other
+        $command = <<<PHP
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+
+class CommandSchedulingTestCommand_{$this->id} extends Command
+{
+    protected \$signature = 'test:{$this->id}';
+
+    public function handle()
+    {
+        \$logfile = {$logFile};
+        (new Filesystem)->append(\$logfile, "handled\\n");
+    }
+}
+PHP;
+
+        // Testbench automatically loads `routes/console.php` on initialization of the console
+        // Kernel, so this is a convenient place to register out command and set up the scheduler
+        $route = <<<PHP
+<?php
+
+require_once {$commandFile};
+
+// Register command with Kernel
+Illuminate\Console\Application::starting(function (\$artisan) {
+    \$artisan->add(new App\Console\Commands\CommandSchedulingTestCommand_{$this->id});
+});
+
+// Add command to scheduler so that the after() callback is trigger in our spawned process
+Illuminate\Foundation\Application::getInstance()
+    ->booted(function (\$app) {
+        \$app->resolving(Illuminate\Console\Scheduling\Schedule::class, function(\$schedule) {
+            \$fs = new Illuminate\Filesystem\Filesystem;
+            \$schedule->command("test:{$this->id}")
+                ->after(function() use (\$fs) {
+                    \$logfile = {$logFile};
+                    \$fs->append(\$logfile, "after\\n");
+                })
+                ->before(function() use (\$fs) {
+                    \$logfile = {$logFile};
+                    \$fs->append(\$logfile, "before\\n");
+                });
+        });
+    });
+
+PHP;
+
+        $this->fs->put($this->commandFile, $command);
+        $this->fs->put(base_path('routes/console.php'), $route);
+        $this->fs->put(base_path('artisan'), $artisan);
+    }
+}


### PR DESCRIPTION
This adds two tests for the scheduler. The first tests scheduled callbacks, and the second tests scheduled commands.

Scheduled callbacks are relatively easy to test because they always run in the same process as the scheduler. These tests verify execution order, exception handling, and mutex processing (for `onOneServer`).

Scheduled commands are trickier to test because they rely on spawning an external `php artisan ...` process, which is currently not supported in Orchestra Testbench. To work around this issue, we write a custom `artisan` script that is used for our test. It includes:

1. A custom console command (which must exist outside of the scope of the test so that it's available to execute in a secondary process)
2. Command and scheduler registration (again, necessary because half the test does not execute inside the context of PHPUnit)
3. A custom version of the typical `artisan` script that is modified to account for the location of the `testbench-core/laravel` directory

(This file is removed during the tear down phase.)

The command tests work by writing to a log file and then checking that the expected output exists in that file. This means that we can use the full Laravel scheduler (including the call to `php artisan schedule:finish` when running in background) without having to mock or fake anything.