### PR TITLE
[8.x] Add proper paging offset when possible to sql server

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -31,15 +31,21 @@ class SqlServerGrammar extends Grammar
             return parent::compileSelect($query);
         }
 
-        // If an offset is present on the query, we will need to wrap the query in
-        // a big "ANSI" offset syntax block. This is very nasty compared to the
-        // other database systems but is necessary for implementing features.
         if (is_null($query->columns)) {
             $query->columns = ['*'];
         }
 
+        // For order by queries we can paginate, to avoid sorting issues.
+        $components = $this->compileComponents($query);
+        if (!empty($components['orders'])) {
+            return parent::compileSelect($query) . " OFFSET {$query->offset} ROWS FETCH NEXT {$query->limit} ROWS ONLY";
+        }
+
+        // If an offset is present on the query, we will need to wrap the query in
+        // a big "ANSI" offset syntax block. This is very nasty compared to the
+        // other database systems but is necessary for implementing features.
         return $this->compileAnsiOffset(
-            $query, $this->compileComponents($query)
+            $query, $components
         );
     }
 

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -37,8 +37,8 @@ class SqlServerGrammar extends Grammar
 
         // For order by queries we can paginate, to avoid sorting issues.
         $components = $this->compileComponents($query);
-        if (!empty($components['orders'])) {
-            return parent::compileSelect($query) . " OFFSET {$query->offset} ROWS FETCH NEXT {$query->limit} ROWS ONLY";
+        if (! empty($components['orders'])) {
+            return parent::compileSelect($query)." OFFSET {$query->offset} ROWS FETCH NEXT {$query->limit} ROWS ONLY";
         }
 
         // If an offset is present on the query, we will need to wrap the query in

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -35,10 +35,10 @@ class SqlServerGrammar extends Grammar
             $query->columns = ['*'];
         }
 
-        // For order by queries we can paginate, to avoid sorting issues.
         $components = $this->compileComponents($query);
+
         if (! empty($components['orders'])) {
-            return parent::compileSelect($query)." OFFSET {$query->offset} ROWS FETCH NEXT {$query->limit} ROWS ONLY";
+            return parent::compileSelect($query)." offset {$query->offset} rows fetch next {$query->limit} rows only";
         }
 
         // If an offset is present on the query, we will need to wrap the query in

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1221,7 +1221,7 @@ class DatabaseQueryBuilderTest extends TestCase
 
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('users')->skip(25)->take(10)->orderByRaw('[email] desc');
-        $this->assertSame('select * from (select *, row_number() over (order by [email] desc) as row_num from [users]) as temp_table where row_num between 26 and 35 order by row_num', $builder->toSql());
+        $this->assertSame('select * from [users] order by [email] desc OFFSET 25 ROWS FETCH NEXT 10 ROWS ONLY', $builder->toSql());
     }
 
     public function testReorder()
@@ -3109,8 +3109,8 @@ SQL;
         $this->assertSame('select * from (select *, row_number() over (order by (select 0)) as row_num from [users]) as temp_table where row_num between 11 and 20 order by row_num', $builder->toSql());
 
         $builder = $this->getSqlServerBuilder();
-        $builder->select('*')->from('users')->skip(10)->take(10)->orderBy('email', 'desc');
-        $this->assertSame('select * from (select *, row_number() over (order by [email] desc) as row_num from [users]) as temp_table where row_num between 11 and 20 order by row_num', $builder->toSql());
+        $builder->select('*')->from('users')->skip(11)->take(10)->orderBy('email', 'desc');
+        $this->assertSame('select * from [users] order by [email] desc OFFSET 11 ROWS FETCH NEXT 10 ROWS ONLY', $builder->toSql());
 
         $builder = $this->getSqlServerBuilder();
         $subQueryBuilder = $this->getSqlServerBuilder();
@@ -3118,8 +3118,8 @@ SQL;
             return $query->select('created_at')->from('logins')->where('users.name', 'nameBinding')->whereColumn('user_id', 'users.id')->limit(1);
         };
         $builder->select('*')->from('users')->where('email', 'emailBinding')->orderBy($subQuery)->skip(10)->take(10);
-        $this->assertSame('select * from (select *, row_number() over (order by (select top 1 [created_at] from [logins] where [users].[name] = ? and [user_id] = [users].[id]) asc) as row_num from [users] where [email] = ?) as temp_table where row_num between 11 and 20 order by row_num', $builder->toSql());
-        $this->assertEquals(['nameBinding', 'emailBinding'], $builder->getBindings());
+        $this->assertSame('select * from [users] where [email] = ? order by (select top 1 [created_at] from [logins] where [users].[name] = ? and [user_id] = [users].[id]) asc OFFSET 10 ROWS FETCH NEXT 10 ROWS ONLY', $builder->toSql());
+        $this->assertEquals(['emailBinding', 'nameBinding'], $builder->getBindings());
 
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('users')->take('foo');

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1221,7 +1221,7 @@ class DatabaseQueryBuilderTest extends TestCase
 
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('users')->skip(25)->take(10)->orderByRaw('[email] desc');
-        $this->assertSame('select * from [users] order by [email] desc OFFSET 25 ROWS FETCH NEXT 10 ROWS ONLY', $builder->toSql());
+        $this->assertSame('select * from [users] order by [email] desc offset 25 rows fetch next 10 rows only', $builder->toSql());
     }
 
     public function testReorder()
@@ -3110,7 +3110,7 @@ SQL;
 
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('users')->skip(11)->take(10)->orderBy('email', 'desc');
-        $this->assertSame('select * from [users] order by [email] desc OFFSET 11 ROWS FETCH NEXT 10 ROWS ONLY', $builder->toSql());
+        $this->assertSame('select * from [users] order by [email] desc offset 11 rows fetch next 10 rows only', $builder->toSql());
 
         $builder = $this->getSqlServerBuilder();
         $subQueryBuilder = $this->getSqlServerBuilder();
@@ -3118,7 +3118,7 @@ SQL;
             return $query->select('created_at')->from('logins')->where('users.name', 'nameBinding')->whereColumn('user_id', 'users.id')->limit(1);
         };
         $builder->select('*')->from('users')->where('email', 'emailBinding')->orderBy($subQuery)->skip(10)->take(10);
-        $this->assertSame('select * from [users] where [email] = ? order by (select top 1 [created_at] from [logins] where [users].[name] = ? and [user_id] = [users].[id]) asc OFFSET 10 ROWS FETCH NEXT 10 ROWS ONLY', $builder->toSql());
+        $this->assertSame('select * from [users] where [email] = ? order by (select top 1 [created_at] from [logins] where [users].[name] = ? and [user_id] = [users].[id]) asc offset 10 rows fetch next 10 rows only', $builder->toSql());
         $this->assertEquals(['emailBinding', 'nameBinding'], $builder->getBindings());
 
         $builder = $this->getSqlServerBuilder();


### PR DESCRIPTION
Sql server does not support paging without a `order by` column.

But the current implementation leads to issues when using `GUID` (or any other primary key column that is not ordered) column as ID's and generating those id's in laravel. (sql orders id's differently than alphabetically, so the order of the models inserted is differently than the order of ID's).


### Current setup
Old setup when paging and sorting:

page1:
```sql
SELECT TOP 50 [users].* FROM [users] WHERE [users].[deleted_at] IS NULL ORDER BY [id] ASC
```

page2:
```sql
SELECT * FROM (SELECT [users].*, row_number() OVER (ORDER BY [id] ASC) AS row_num FROM [users] WHERE [users].[deleted_at] IS NULL) AS temp_table WHERE row_num between 51 and 100 ORDER BY row_num
```
### Proposed solution

page1:
```sql
SELECT TOP 50 [users].* FROM [users] WHERE [users].[deleted_at] IS NULL ORDER BY [id] ASC
```
page2:
```sql
SELECT [users].* FROM [users] WHERE [users].[deleted_at] IS NULL ORDER BY [id] ASC OFFSET 50 ROWS FETCH NEXT 50 ROWS ONLY
```


### Edge cases

- `OFFSET 50 ROWS FETCH NEXT 10` is a feature added to sql server in 2012. But you are already using features that are not supported by older versions.
- this only works when you provide an order column as this is mandatory in sql server.

## improvements

- instead of needing to query the whole table, now it will stop after Offset+Limit. (eg page 2 on 50 results = after 100 results instead of the whole table). 
- when ordering you will no longer get the issue of rows being ordered differently on the first and subsequent pages.


# comments

please don't close my pull request without proper feedback, but actually help me land this pull request (previous PR got closed on just 1 tiny comment).