### PR TITLE
[9.x] Register `db.schema` as deferred service

### DIFF
--- a/src/Illuminate/Database/DatabaseServiceProvider.php
+++ b/src/Illuminate/Database/DatabaseServiceProvider.php
@@ -72,10 +72,6 @@ class DatabaseServiceProvider extends ServiceProvider
             return $app['db']->connection();
         });
 
-        $this->app->bind('db.schema', function ($app) {
-            return $app['db']->connection()->getSchemaBuilder();
-        });
-
         $this->app->singleton('db.transactions', function ($app) {
             return new DatabaseTransactionsManager;
         });

--- a/src/Illuminate/Database/MigrationServiceProvider.php
+++ b/src/Illuminate/Database/MigrationServiceProvider.php
@@ -44,6 +44,8 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
     {
         $this->registerRepository();
 
+        $this->registerSchemaBuilder();
+
         $this->registerMigrator();
 
         $this->registerCreator();
@@ -62,6 +64,19 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
             $table = $app['config']['database.migrations'];
 
             return new DatabaseMigrationRepository($app['db'], $table);
+        });
+    }
+
+
+    /**
+     * Register the schema builder service.
+     *
+     * @return void
+     */
+    protected function registerSchemaBuilder()
+    {
+        $this->app->bind('db.schema', function ($app) {
+            return $app['db']->connection()->getSchemaBuilder();
         });
     }
 
@@ -216,7 +231,7 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
     public function provides()
     {
         return array_merge([
-            'migrator', 'migration.repository', 'migration.creator',
+            'db.schema', 'migrator', 'migration.repository', 'migration.creator',
         ], array_values($this->commands));
     }
 }

--- a/src/Illuminate/Database/MigrationServiceProvider.php
+++ b/src/Illuminate/Database/MigrationServiceProvider.php
@@ -67,7 +67,6 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
         });
     }
 
-
     /**
      * Register the schema builder service.
      *


### PR DESCRIPTION
`Illuminate\Database` only has two service providers, `DatabaseServiceProvider` (eager-loaded) and `MigrationServiceProvider` (deferred). Don't think it worth it to add another service provider specifically for `Schema`.

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>