### PR TITLE
[8.x] Update location of requests created by -R inside Requests\ModelName #39120

### DIFF
--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -207,7 +207,7 @@ class ControllerMakeCommand extends GeneratorCommand
         ];
 
         if ($this->option('requests')) {
-            $namespace = 'App\\Http\\Requests';
+            $namespace = 'App\\Http\\Requests\\'.class_basename($modelClass);
 
             [$storeRequestClass, $updateRequestClass] = $this->generateFormRequests(
                 $modelClass, $storeRequestClass, $updateRequestClass
@@ -244,16 +244,16 @@ class ControllerMakeCommand extends GeneratorCommand
      */
     protected function generateFormRequests($modelClass, $storeRequestClass, $updateRequestClass)
     {
-        $storeRequestClass = 'Store'.class_basename($modelClass).'Request';
+        $storeRequestClass = 'StoreRequest';
 
         $this->call('make:request', [
-            'name' => $storeRequestClass,
+            'name' => class_basename($modelClass).'/'.$storeRequestClass,
         ]);
 
-        $updateRequestClass = 'Update'.class_basename($modelClass).'Request';
+        $updateRequestClass = 'UpdateRequest';
 
         $this->call('make:request', [
-            'name' => $updateRequestClass,
+            'name' => class_basename($modelClass).'/'.$updateRequestClass,
         ]);
 
         return [$storeRequestClass, $updateRequestClass];


### PR DESCRIPTION
# Problem
I could see that the `—requests` command creates the `StoreUserRequest` and `UpdateUserRequest` inside the Requests folder, but as the project grows, the folder will get messy.
```
app
│
└───Http
│   │   Controller
│   │   Middleware
│   │
│   └───Requests
│       │   StoreUserRequest.php
│       │   UpdateUserRequest.php
│       │   StorePostRequest.php
│       │   UpdatePostRequest.php   
│       │   ....
```

# My Proposed Solution
The proposed solution is that they are organized by folders according to the model name and that contains `StoreRequest` and  `UpdateRequest`, also updating the use `App\Http\Requests\ModelName\StoreRequest` , `App\Http\Requests\ModelName\UpdateRequest` in controllers.
```
app
│
└───Http
│   │   Controller
│   │   Middleware
│   │
│   └───Requests
│       └───  User
│       │       StoreRequest.php
│       │       UpdateRequest.php
│       └───  Post
│       │       StoreRequest.php
│       │       UpdateRequest.php
```
`UserController`
<pre><code>namespace App\Http\Controllers;

use App\Http\Requests\User\StoreRequest;
use App\Http\Requests\User\UpdateRequest;
use App\Models\User;

public function store(StoreRequest $request){}

public function update(UpdateRequest $request, User $user){}
</code></pre>

