### PR TITLE
[8.x] Add support to convert Boolean-like strings to actual Boolean

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -845,6 +845,31 @@ class Str
     }
 
     /**
+     * Convert boolean-like strings to actual boolean.
+     *
+     * @param  string|bool  $exp
+     * @return bool
+     */
+    public static function toBool($exp)
+    {
+        if (is_bool($exp)) {
+            return $exp;
+        }
+
+        $exp = strtolower($exp);
+
+        if ($exp === 'true') {
+            return true;
+        }
+
+        if ($exp === 'false') {
+            return false;
+        }
+
+        return false;
+    }
+
+    /**
      * Returns the portion of the string specified by the start and length parameters.
      *
      * @param  string  $string

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -611,6 +611,17 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Convert boolean-like strings to actual boolean.
+     *
+     *
+     * @return bool
+     */
+    public function toBool()
+    {
+        return Str::toBool($this->value);
+    }
+
+    /**
      * Convert the given string to title case.
      *
      * @return static

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -425,6 +425,15 @@ class SupportStrTest extends TestCase
         $this->assertSame('❤MultiByte☆', Str::reverse('☆etyBitluM❤'));
     }
 
+    public function testToBool()
+    {
+        $this->assertSame(true, Str::toBool(true));
+        $this->assertSame(true, Str::toBool('True'));
+        $this->assertSame(false, Str::toBool('FaLsE'));
+        $this->assertSame(false, Str::toBool('false'));
+        $this->assertSame(false, Str::toBool('Taylor'));
+    }
+
     public function testSnake()
     {
         $this->assertSame('laravel_p_h_p_framework', Str::snake('LaravelPHPFramework'));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -489,6 +489,15 @@ class SupportStringableTest extends TestCase
         $this->assertSame('foo/bar/baz/bam', (string) $this->stringable('?1/?2/?3/?4')->replace(['?1', '?2', '?3', '?4'], ['foo', 'bar', 'baz', 'bam']));
     }
 
+    public function testToBool()
+    {
+        $this->assertSame(false, $this->stringable((string) true)->toBool());
+        $this->assertSame(true, $this->stringable('True')->toBool());
+        $this->assertSame(false, $this->stringable('FaLsE')->toBool());
+        $this->assertSame(false, $this->stringable('false')->toBool());
+        $this->assertSame(false, $this->stringable('Taylor')->toBool());
+    }
+
     public function testReplaceArray()
     {
         $this->assertSame('foo/bar/baz', (string) $this->stringable('?/?/?')->replaceArray('?', ['foo', 'bar', 'baz']));


### PR DESCRIPTION
This simple PR adds the convenient ability to convert bool-like string i.e. `True` to actual bool type `true`.

This can be useful when dealing with API that uses only strings to communicate where "bool" fields from http responses isn't guaranteed to be "bool". 


This simple situation when you thought that you are dealing with bool and instead you got "True"!

Before

```php
$overwrite = (bool) $request->input('overwrite', 'false');

// when "overwrite" is "false", $overwrite will be always true
if($overwrite) {
   Storage::delete($file);
}

```

After

```php
$overwrite = Str::toBool($request->input('overwrite', 'false'));

if($overwrite) {
   Storage::delete($file);
}
```
