### PR TITLE
[8.x] Fulltext index for PostgreSQL

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -547,12 +547,11 @@ class Blueprint
      * @param  string|array  $columns
      * @param  string|null  $name
      * @param  string|null  $algorithm
-     * @param  string|null  $language
      * @return \Illuminate\Support\Fluent
      */
-    public function fulltext($columns, $name = null, $algorithm = null, $language = null)
+    public function fulltext($columns, $name = null, $algorithm = null)
     {
-        return $this->indexCommand('fulltext', $columns, $name, $algorithm, $language);
+        return $this->indexCommand('fulltext', $columns, $name, $algorithm);
     }
 
     /**
@@ -1483,10 +1482,9 @@ class Blueprint
      * @param  string|array  $columns
      * @param  string  $index
      * @param  string|null  $algorithm
-     * @param  string|null  $language
      * @return \Illuminate\Support\Fluent
      */
-    protected function indexCommand($type, $columns, $index, $algorithm = null, $language = null)
+    protected function indexCommand($type, $columns, $index, $algorithm = null)
     {
         $columns = (array) $columns;
 
@@ -1496,7 +1494,7 @@ class Blueprint
         $index = $index ?: $this->createIndexName($type, $columns);
 
         return $this->addCommand(
-            $type, compact('index', 'columns', 'algorithm', 'language')
+            $type, compact('index', 'columns', 'algorithm')
         );
     }
 

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -547,11 +547,12 @@ class Blueprint
      * @param  string|array  $columns
      * @param  string|null  $name
      * @param  string|null  $algorithm
+     * @param  string|null  $language
      * @return \Illuminate\Support\Fluent
      */
-    public function fulltext($columns, $name = null, $algorithm = null)
+    public function fulltext($columns, $name = null, $algorithm = null, $language = null)
     {
-        return $this->indexCommand('fulltext', $columns, $name, $algorithm);
+        return $this->indexCommand('fulltext', $columns, $name, $algorithm, $language);
     }
 
     /**
@@ -1482,9 +1483,10 @@ class Blueprint
      * @param  string|array  $columns
      * @param  string  $index
      * @param  string|null  $algorithm
+     * @param  string|null  $language
      * @return \Illuminate\Support\Fluent
      */
-    protected function indexCommand($type, $columns, $index, $algorithm = null)
+    protected function indexCommand($type, $columns, $index, $algorithm = null, $language = null)
     {
         $columns = (array) $columns;
 
@@ -1494,7 +1496,7 @@ class Blueprint
         $index = $index ?: $this->createIndexName($type, $columns);
 
         return $this->addCommand(
-            $type, compact('index', 'columns', 'algorithm')
+            $type, compact('index', 'columns', 'algorithm', 'language')
         );
     }
 

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -188,17 +188,16 @@ class PostgresGrammar extends Grammar
      */
     public function compileFulltext(Blueprint $blueprint, Fluent $command)
     {
-        if (is_null($command->language)) {
-            throw new RuntimeException('The PostgreSQL driver requires a language for fulltext index creation.');
-        }
+        $language = $command->language ?: 'english';
+
         if (count($command->columns) > 1) {
-            throw new RuntimeException('The PostgreSQL driver does not support fulltext index creation with multiple columns. Please create the index by yourself.');
+            throw new RuntimeException('The PostgreSQL driver does not support fulltext index creation using multiple columns.');
         }
 
         return sprintf('create index %s on %s using gin (to_tsvector(%s, %s))',
             $this->wrap($command->index),
             $this->wrapTable($blueprint),
-            $this->quoteString($command->language),
+            $this->quoteString($language),
             $this->wrap($command->columns[0])
         );
     }

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database\Schema\Grammars;
 
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Fluent;
+use RuntimeException;
 
 class PostgresGrammar extends Grammar
 {
@@ -173,6 +174,32 @@ class PostgresGrammar extends Grammar
             $this->wrapTable($blueprint),
             $command->algorithm ? ' using '.$command->algorithm : '',
             $this->columnize($command->columns)
+        );
+    }
+
+    /**
+     * Compile a fulltext index key command.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
+     * @return string
+     *
+     * @throws \RuntimeException
+     */
+    public function compileFulltext(Blueprint $blueprint, Fluent $command)
+    {
+        if (is_null($command->language)) {
+            throw new RuntimeException('The PostgreSQL driver requires a language for fulltext index creation.');
+        }
+        if (count($command->columns) > 1) {
+            throw new RuntimeException('The PostgreSQL driver does not support fulltext index creation with multiple columns. Please create the index by yourself.');
+        }
+
+        return sprintf('create index %s on %s using gin (to_tsvector(%s, %s))',
+            $this->wrap($command->index),
+            $this->wrapTable($blueprint),
+            $this->quoteString($command->language),
+            $this->wrap($command->columns[0])
         );
     }
 
@@ -357,6 +384,18 @@ class PostgresGrammar extends Grammar
     public function compileDropIndex(Blueprint $blueprint, Fluent $command)
     {
         return "drop index {$this->wrap($command->index)}";
+    }
+
+    /**
+     * Compile a drop fulltext index command.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
+     * @return string
+     */
+    public function compileDropFulltext(Blueprint $blueprint, Fluent $command)
+    {
+        return $this->compileDropIndex($blueprint, $command);
     }
 
     /**

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -265,11 +265,31 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
     public function testAddingFulltextIndex()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->fulltext('body', null, null, 'english');
+        $blueprint->fulltext('body');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
         $this->assertSame('create index "users_body_fulltext" on "users" using gin (to_tsvector(\'english\', "body"))', $statements[0]);
+    }
+
+    public function testAddingFulltextIndexWithLanguage()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->fulltext('body')->language('spanish');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('create index "users_body_fulltext" on "users" using gin (to_tsvector(\'spanish\', "body"))', $statements[0]);
+    }
+
+    public function testAddingFulltextIndexWithFluency()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->string('body')->fulltext();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(2, $statements);
+        $this->assertSame('create index "users_body_fulltext" on "users" using gin (to_tsvector(\'english\', "body"))', $statements[1]);
     }
 
     public function testAddingSpatialIndex()

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -262,6 +262,16 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertSame('create index "baz" on "users" using hash ("foo", "bar")', $statements[0]);
     }
 
+    public function testAddingFulltextIndex()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->fulltext('body', null, null, 'english');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('create index "users_body_fulltext" on "users" using gin (to_tsvector(\'english\', "body"))', $statements[0]);
+    }
+
     public function testAddingSpatialIndex()
     {
         $blueprint = new Blueprint('geo');


### PR DESCRIPTION
As promised on Twitter, I want to help with the PostgreSQL support for fulltext search.

But as fulltext searching is no SQL standard, every database has an entirely different implementation. The most significant difference is that PostgreSQL fulltext searching is language-dependent because the stemming algorithms are always only designed for a specific language. Also, adding a fulltext index for multiple columns is different. The vectors for multiple columns need to be combined for the index creation. But when querying the database the exact same syntax for combining the vectors needs to be used for the query or the index will not be used. As there is no query builder method to build these conditions, I restricted the usage to a single column for the moment. With an official way to query the index the restriction could be lifted.

So the following changes had to be made:

- An optional language parameter was added to `Blueprint::fulltext()`
- The PostgreSQL driver will fail if no language was provided
- The PostgreSQL driver will fail when trying to add a fulltext index with multiple columns