### PR TITLE
[8.x] Cleanup tests

### DIFF
--- a/tests/Database/DatabaseEloquentRelationshipsTest.php
+++ b/tests/Database/DatabaseEloquentRelationshipsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Integration\Database\EloquentRelationshipsTest;
+namespace Illuminate\Tests\Database\EloquentRelationshipsTest;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
@@ -14,9 +14,9 @@ use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
-use Orchestra\Testbench\TestCase;
+use PHPUnit\Framework\TestCase;
 
-class EloquentRelationshipsTest extends TestCase
+class DatabaseEloquentRelationshipsTest extends TestCase
 {
     public function testStandardRelationships()
     {

--- a/tests/Database/DatabaseEloquentStrictMorphsTest.php
+++ b/tests/Database/DatabaseEloquentStrictMorphsTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Illuminate\Tests\Integration\Database;
+namespace Illuminate\Tests\Database;
 
 use Illuminate\Database\ClassMorphViolationException;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
-use Orchestra\Testbench\TestCase;
+use PHPUnit\Framework\TestCase;
 
-class EloquentStrictMorphsTest extends TestCase
+class DatabaseEloquentStrictMorphsTest extends TestCase
 {
     protected function setUp(): void
     {

--- a/tests/Integration/Database/Sqlite/EloquentModelConnectionsTest.php
+++ b/tests/Integration/Database/Sqlite/EloquentModelConnectionsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Integration\Database;
+namespace Illuminate\Tests\Integration\Database\Sqlite;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
@@ -12,6 +12,10 @@ class EloquentModelConnectionsTest extends TestCase
 {
     protected function getEnvironmentSetUp($app)
     {
+        if (getenv('DB_CONNECTION') !== 'testing') {
+            $this->markTestSkipped('Test requires a Sqlite connection.');
+        }
+
         $app['config']->set('database.default', 'conn1');
 
         $app['config']->set('database.connections.conn1', [


### PR DESCRIPTION
This PR moves some tests which aren't really integration tests out of the Integration directory. That way, no unnecessary database connections are made for them.

A specific Sqlite test was moved to a Sqlite directory in the same fashion as the MySQL specific tests.