### PR TITLE
[8.x] Test Improvements

### DIFF
--- a/tests/Database/EloquentModelStringCastingTest.php
+++ b/tests/Database/EloquentModelStringCastingTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Integration\Database;
+namespace Illuminate\Tests\Database;
 
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Model as Eloquent;

--- a/tests/Integration/Database/DatabaseTestCase.php
+++ b/tests/Integration/Database/DatabaseTestCase.php
@@ -16,6 +16,17 @@ abstract class DatabaseTestCase extends TestCase
      */
     protected $driver;
 
+    protected function setUp(): void
+    {
+        $this->beforeApplicationDestroyed(function () {
+            foreach (array_keys($this->app['db']->getConnections()) as $name) {
+                $this->app['db']->purge($name);
+            }
+        });
+
+        parent::setUp();
+    }
+
     protected function getEnvironmentSetUp($app)
     {
         $connection = $app['config']->get('database.default');

--- a/tests/Integration/Database/EloquentModelStringCastingTest.php
+++ b/tests/Integration/Database/EloquentModelStringCastingTest.php
@@ -1,54 +1,23 @@
 <?php
 
-namespace Illuminate\Tests\Database;
+namespace Illuminate\Tests\Integration\Database;
 
-use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use Illuminate\Database\Schema\Blueprint;
-use PHPUnit\Framework\TestCase;
+use Illuminate\Support\Facades\Schema;
 use stdClass;
 
-class EloquentModelStringCastingTest extends TestCase
+class EloquentModelStringCastingTest extends DatabaseTestCase
 {
-    protected function setUp(): void
+    protected function defineDatabaseMigrationsAfterDatabaseRefreshed()
     {
-        $db = new DB;
-
-        $db->addConnection([
-            'driver' => 'sqlite',
-            'database' => ':memory:',
-        ]);
-
-        $db->bootEloquent();
-        $db->setAsGlobal();
-
-        $this->createSchema();
-    }
-
-    /**
-     * Setup the database schema.
-     *
-     * @return void
-     */
-    public function createSchema()
-    {
-        $this->schema()->create('casting_table', function (Blueprint $table) {
+        Schema::create('casting_table', function (Blueprint $table) {
             $table->increments('id');
             $table->string('array_attributes');
             $table->string('json_attributes');
             $table->string('object_attributes');
             $table->timestamps();
         });
-    }
-
-    /**
-     * Tear down the database schema.
-     *
-     * @return void
-     */
-    protected function tearDown(): void
-    {
-        $this->schema()->drop('casting_table');
     }
 
     /**
@@ -90,26 +59,6 @@ class EloquentModelStringCastingTest extends TestCase
 
         $this->assertSame([], $model->getOriginal('object_attributes'));
         $this->assertSame([], $model->getAttribute('object_attributes'));
-    }
-
-    /**
-     * Get a database connection instance.
-     *
-     * @return \Illuminate\Database\Connection
-     */
-    protected function connection()
-    {
-        return Eloquent::getConnectionResolver()->connection();
-    }
-
-    /**
-     * Get a schema builder instance.
-     *
-     * @return \Illuminate\Database\Schema\Builder
-     */
-    protected function schema()
-    {
-        return $this->connection()->getSchemaBuilder();
     }
 }
 

--- a/tests/Integration/Database/EloquentPrunableTest.php
+++ b/tests/Integration/Database/EloquentPrunableTest.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Prunable;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Events\ModelsPruned;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Schema;
 use LogicException;
 use Mockery as m;
@@ -16,19 +17,6 @@ use Mockery as m;
 /** @group SkipMSSQL */
 class EloquentPrunableTest extends DatabaseTestCase
 {
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        Container::setInstance($container = new Container);
-
-        $container->singleton(Dispatcher::class, function () {
-            return m::mock(Dispatcher::class);
-        });
-
-        $container->alias(Dispatcher::class, 'events');
-    }
-
     protected function defineDatabaseMigrationsAfterDatabaseRefreshed()
     {
         collect([
@@ -58,10 +46,7 @@ class EloquentPrunableTest extends DatabaseTestCase
 
     public function testPrunesRecords()
     {
-        app('events')
-            ->shouldReceive('dispatch')
-            ->times(2)
-            ->with(m::type(ModelsPruned::class));
+        Event::fake();
 
         collect(range(1, 5000))->map(function ($id) {
             return ['id' => $id];
@@ -73,14 +58,13 @@ class EloquentPrunableTest extends DatabaseTestCase
 
         $this->assertEquals(1500, $count);
         $this->assertEquals(3500, PrunableTestModel::count());
+
+        Event::assertDispatched(ModelsPruned::class, 2);
     }
 
     public function testPrunesSoftDeletedRecords()
     {
-        app('events')
-            ->shouldReceive('dispatch')
-            ->times(3)
-            ->with(m::type(ModelsPruned::class));
+        Event::fake();
 
         collect(range(1, 5000))->map(function ($id) {
             return ['id' => $id, 'deleted_at' => now()];
@@ -93,14 +77,13 @@ class EloquentPrunableTest extends DatabaseTestCase
         $this->assertEquals(3000, $count);
         $this->assertEquals(0, PrunableSoftDeleteTestModel::count());
         $this->assertEquals(2000, PrunableSoftDeleteTestModel::withTrashed()->count());
+
+        Event::assertDispatched(ModelsPruned::class, 3);
     }
 
     public function testPruneWithCustomPruneMethod()
     {
-        app('events')
-            ->shouldReceive('dispatch')
-            ->times(1)
-            ->with(m::type(ModelsPruned::class));
+        Event::fake();
 
         collect(range(1, 5000))->map(function ($id) {
             return ['id' => $id];
@@ -114,6 +97,8 @@ class EloquentPrunableTest extends DatabaseTestCase
         $this->assertTrue((bool) PrunableWithCustomPruneMethodTestModel::first()->pruned);
         $this->assertFalse((bool) PrunableWithCustomPruneMethodTestModel::orderBy('id', 'desc')->first()->pruned);
         $this->assertEquals(5000, PrunableWithCustomPruneMethodTestModel::count());
+
+        Event::assertDispatched(ModelsPruned::class, 1);
     }
 }
 

--- a/tests/Integration/Database/EloquentPrunableTest.php
+++ b/tests/Integration/Database/EloquentPrunableTest.php
@@ -2,8 +2,6 @@
 
 namespace Illuminate\Tests\Integration\Database;
 
-use Illuminate\Container\Container;
-use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Prunable;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -12,7 +10,6 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Schema;
 use LogicException;
-use Mockery as m;
 
 /** @group SkipMSSQL */
 class EloquentPrunableTest extends DatabaseTestCase


### PR DESCRIPTION
* Replace Capsule (using in-memory sqlite) test to extends `DatabaseTestCase`.
* Replace mocking `Container` to asserts on `events` and use `Event::fake()` 
* Purge all database connections on `tearDown()`.

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>
