### PR TITLE
[8.x] Fix bug where columns would be guarded while filling Eloquent models during unit tests

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
@@ -222,7 +222,6 @@ trait GuardsAttributes
                         ->getColumnListing($this->getTable());
 
             if (empty($columns)) {
-                // Column list is unavailable, do not cache it
                 return true;
             }
             static::$guardableColumns[get_class($this)] = $columns;

--- a/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
@@ -217,9 +217,15 @@ trait GuardsAttributes
     protected function isGuardableColumn($key)
     {
         if (! isset(static::$guardableColumns[get_class($this)])) {
-            static::$guardableColumns[get_class($this)] = $this->getConnection()
+            $columns = $this->getConnection()
                         ->getSchemaBuilder()
                         ->getColumnListing($this->getTable());
+
+            if (empty($columns)) {
+                // Column list is unavailable, do not cache it
+                return true;
+            }
+            static::$guardableColumns[get_class($this)] = $columns;
         }
 
         return in_array($key, static::$guardableColumns[get_class($this)]);


### PR DESCRIPTION
## Versions

laravel/framework: v8.74.0 (affects versions in 6.x and up)
PHP: 7.4.21

## Description

https://github.com/laravel/framework/pull/33777 introduces a change that caches Eloquent model database table columns in memory to determine whether they should be guardable attributes or not.

This change does not consider whether or not a database connection is available. If it is unavailable, an empty list of columns will be cached for that model, resulting in subsequent tests that do have a database connection treating all columns as unfillable.

## Example to reproduce

Create a unit test, and an integration test:

```php
<?php

namespace Tests\Unit;

use MyProject\Product;
use Tests\TestCase;

/**
 * @group guardedbug
 */
class EloquentModelFillingTest extends TestCase
{
    public function testFillModel()
    {
        $foo = new Product(['name' => 'testing', 'price' => 10]);
        $this->assertSame('testing', $foo->name);
    }
}

```

```php
<?php

namespace Tests\Feature;

use MyProject\Product;
use Illuminate\Foundation\Testing\RefreshDatabase;
use Tests\TestCase;

/**
 * @group guardedbug
 */
class EloquentSavingTest extends TestCase
{
    use RefreshDatabase;

    public function testFillAndSaveModel()
    {
        $foo = new Product();
        $foo->fill(['name' => 'testing', 'price' => 10]);
        $foo->save();
        $this->assertSame('testing', $foo->name);
    }
}
```

When you run these tests individually, the unit test fails, and the integration test passes:

```
# --filter EloquentModelFillingTest
1) Tests\Unit\EloquentModelFillingTest::testFillModel
Failed asserting that null is identical to 'testing'.

# --filter EloquentSavingTest
.                                                                   1 / 1 (100%)
OK (1 test, 1 assertion)
```

When you run them in the same test suite, they both fail. This is because the unit test run caches the empty list of columns in memory:

```
# --group guardedbug
Tests: 2, Assertions: 1, Errors: 1, Failures: 1.
```

(The error is because my environment has `name` as a non-nullable column in my table).

## Proposal

This pull request proposes that we do not cache the column list when it is empty. This means that when running tests that don't have access to a database, it won't interfere with the rest of a suite where tests may in future have access to a database.

With this patch both of these tests pass:

```
# --group guardedbug
OK (2 tests, 2 assertions)
```

---

I realise this change was made to address some security issues (https://blog.laravel.com/security-release-laravel-61834-7232, https://blog.laravel.com/security-release-laravel-61835-7240).

My workaround for now is to put `Model::unguard()` in `TestCase::setUp()`, however I thought I'd propose a fix here as well.