### PR TITLE
[8.x] Cleanup request test

### DIFF
--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -757,29 +757,41 @@ class HttpRequestTest extends TestCase
         $this->assertEquals($payload, $data);
     }
 
-    public function testPrefers()
+    public function getPrefersCases()
     {
-        $this->assertSame('json', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json'])->prefers(['json']));
-        $this->assertSame('json', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json'])->prefers(['html', 'json']));
-        $this->assertSame('application/foo+json', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/foo+json'])->prefers('application/foo+json'));
-        $this->assertSame('json', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/foo+json'])->prefers('json'));
-        $this->assertSame('html', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json;q=0.5, text/html;q=1.0'])->prefers(['json', 'html']));
-        $this->assertSame('txt', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json;q=0.5, text/plain;q=1.0, text/html;q=1.0'])->prefers(['json', 'txt', 'html']));
-        $this->assertSame('json', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/*'])->prefers('json'));
-        $this->assertSame('json', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json; charset=utf-8'])->prefers('json'));
-        $this->assertNull(Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/xml; charset=utf-8'])->prefers(['html', 'json']));
-        $this->assertSame('json', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json, text/html'])->prefers(['html', 'json']));
-        $this->assertSame('html', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json;q=0.4, text/html;q=0.6'])->prefers(['html', 'json']));
+        return [
+            ['application/json', ['json'], 'json'],
+            ['application/json', ['html', 'json'], 'json'],
+            ['application/foo+json', 'application/foo+json', 'application/foo+json'],
+            ['application/foo+json', 'json', 'json'],
+            ['application/json;q=0.5, text/html;q=1.0', ['json', 'html'], 'html'],
+            ['application/json;q=0.5, text/plain;q=1.0, text/html;q=1.0', ['json', 'txt', 'html'], 'txt'],
+            ['application/*', 'json', 'json'],
+            ['application/json; charset=utf-8', 'json', 'json'],
+            ['application/xml; charset=utf-8', ['html', 'json'], null],
+            ['application/json, text/html', ['html', 'json'], 'json'],
+            ['application/json;q=0.4, text/html;q=0.6', ['html', 'json'], 'html'],
 
-        $this->assertSame('application/json', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json; charset=utf-8'])->prefers('application/json'));
-        $this->assertSame('application/json', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json, text/html'])->prefers(['text/html', 'application/json']));
-        $this->assertSame('text/html', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json;q=0.4, text/html;q=0.6'])->prefers(['text/html', 'application/json']));
-        $this->assertSame('text/html', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json;q=0.4, text/html;q=0.6'])->prefers(['application/json', 'text/html']));
+            ['application/json; charset=utf-8', 'application/json', 'application/json'],
+            ['application/json, text/html', ['text/html', 'application/json'], 'application/json'],
+            ['application/json;q=0.4, text/html;q=0.6', ['text/html', 'application/json'], 'text/html'],
+            ['application/json;q=0.4, text/html;q=0.6', ['application/json', 'text/html'], 'text/html'],
 
-        $this->assertSame('json', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => '*/*; charset=utf-8'])->prefers('json'));
-        $this->assertSame('application/json', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/*'])->prefers('application/json'));
-        $this->assertSame('application/xml', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/*'])->prefers('application/xml'));
-        $this->assertNull(Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/*'])->prefers('text/html'));
+            ['*/*; charset=utf-8', 'json', 'json'],
+            ['application/*', 'application/json', 'application/json'],
+            ['application/*', 'application/xml', 'application/xml'],
+            ['application/*', 'text/html', null],
+        ];
+    }
+
+    /**
+     * @dataProvider getPrefersCases
+     */
+    public function testPrefersMethod($accept, $prefers, $expected)
+    {
+        $this->assertSame(
+            $expected, Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => $accept])->prefers($prefers)
+        );
     }
 
     public function testAllInputReturnsInputAndFiles()

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -22,7 +22,7 @@ class HttpRequestTest extends TestCase
 
     public function testInstanceMethod()
     {
-        $request = Request::create('', 'GET');
+        $request = Request::create('');
         $this->assertSame($request, $request->instance());
     }
 
@@ -58,10 +58,10 @@ class HttpRequestTest extends TestCase
 
     public function testPathMethod()
     {
-        $request = Request::create('', 'GET');
+        $request = Request::create('');
         $this->assertSame('/', $request->path());
 
-        $request = Request::create('/foo/bar', 'GET');
+        $request = Request::create('/foo/bar');
         $this->assertSame('foo/bar', $request->path());
     }
 
@@ -76,7 +76,7 @@ class HttpRequestTest extends TestCase
      */
     public function testSegmentMethod($path, $segment, $expected)
     {
-        $request = Request::create($path, 'GET');
+        $request = Request::create($path);
         $this->assertEquals($expected, $request->segment($segment, 'default'));
     }
 
@@ -95,10 +95,10 @@ class HttpRequestTest extends TestCase
      */
     public function testSegmentsMethod($path, $expected)
     {
-        $request = Request::create($path, 'GET');
+        $request = Request::create($path);
         $this->assertEquals($expected, $request->segments());
 
-        $request = Request::create('foo/bar', 'GET');
+        $request = Request::create('foo/bar');
         $this->assertEquals(['foo', 'bar'], $request->segments());
     }
 
@@ -114,60 +114,60 @@ class HttpRequestTest extends TestCase
 
     public function testUrlMethod()
     {
-        $request = Request::create('http://foo.com/foo/bar?name=taylor', 'GET');
+        $request = Request::create('http://foo.com/foo/bar?name=taylor');
         $this->assertSame('http://foo.com/foo/bar', $request->url());
 
-        $request = Request::create('http://foo.com/foo/bar/?', 'GET');
+        $request = Request::create('http://foo.com/foo/bar/?');
         $this->assertSame('http://foo.com/foo/bar', $request->url());
     }
 
     public function testFullUrlMethod()
     {
-        $request = Request::create('http://foo.com/foo/bar?name=taylor', 'GET');
+        $request = Request::create('http://foo.com/foo/bar?name=taylor');
         $this->assertSame('http://foo.com/foo/bar?name=taylor', $request->fullUrl());
 
-        $request = Request::create('https://foo.com', 'GET');
+        $request = Request::create('https://foo.com');
         $this->assertSame('https://foo.com', $request->fullUrl());
 
-        $request = Request::create('https://foo.com', 'GET');
+        $request = Request::create('https://foo.com');
         $this->assertSame('https://foo.com/?coupon=foo', $request->fullUrlWithQuery(['coupon' => 'foo']));
 
-        $request = Request::create('https://foo.com?a=b', 'GET');
+        $request = Request::create('https://foo.com?a=b');
         $this->assertSame('https://foo.com/?a=b', $request->fullUrl());
 
-        $request = Request::create('https://foo.com?a=b', 'GET');
+        $request = Request::create('https://foo.com?a=b');
         $this->assertSame('https://foo.com/?a=b&coupon=foo', $request->fullUrlWithQuery(['coupon' => 'foo']));
 
-        $request = Request::create('https://foo.com?a=b', 'GET');
+        $request = Request::create('https://foo.com?a=b');
         $this->assertSame('https://foo.com/?a=c', $request->fullUrlWithQuery(['a' => 'c']));
 
-        $request = Request::create('http://foo.com/foo/bar?name=taylor', 'GET');
+        $request = Request::create('http://foo.com/foo/bar?name=taylor');
         $this->assertSame('http://foo.com/foo/bar?name=taylor', $request->fullUrlWithQuery(['name' => 'taylor']));
 
-        $request = Request::create('http://foo.com/foo/bar/?name=taylor', 'GET');
+        $request = Request::create('http://foo.com/foo/bar/?name=taylor');
         $this->assertSame('http://foo.com/foo/bar?name=graham', $request->fullUrlWithQuery(['name' => 'graham']));
 
-        $request = Request::create('https://foo.com', 'GET');
+        $request = Request::create('https://foo.com');
         $this->assertSame('https://foo.com/?key=value%20with%20spaces', $request->fullUrlWithQuery(['key' => 'value with spaces']));
     }
 
     public function testIsMethod()
     {
-        $request = Request::create('/foo/bar', 'GET');
+        $request = Request::create('/foo/bar');
 
         $this->assertTrue($request->is('foo*'));
         $this->assertFalse($request->is('bar*'));
         $this->assertTrue($request->is('*bar*'));
         $this->assertTrue($request->is('bar*', 'foo*', 'baz'));
 
-        $request = Request::create('/', 'GET');
+        $request = Request::create('/');
 
         $this->assertTrue($request->is('/'));
     }
 
     public function testFullUrlIsMethod()
     {
-        $request = Request::create('http://example.com/foo/bar', 'GET');
+        $request = Request::create('http://example.com/foo/bar');
 
         $this->assertTrue($request->fullUrlIs('http://example.com/foo/bar'));
         $this->assertFalse($request->fullUrlIs('example.com*'));
@@ -179,7 +179,7 @@ class HttpRequestTest extends TestCase
 
     public function testRouteIsMethod()
     {
-        $request = Request::create('/foo/bar', 'GET');
+        $request = Request::create('/foo/bar');
 
         $this->assertFalse($request->routeIs('foo.bar'));
 
@@ -197,7 +197,7 @@ class HttpRequestTest extends TestCase
 
     public function testRouteMethod()
     {
-        $request = Request::create('/foo/bar', 'GET');
+        $request = Request::create('/foo/bar');
 
         $request->setRouteResolver(function () use ($request) {
             $route = new Route('GET', '/foo/{required}/{optional?}', []);
@@ -214,7 +214,7 @@ class HttpRequestTest extends TestCase
 
     public function testAjaxMethod()
     {
-        $request = Request::create('/', 'GET');
+        $request = Request::create('/');
         $this->assertFalse($request->ajax());
         $request = Request::create('/', 'GET', [], [], [], ['HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest'], '{}');
         $this->assertTrue($request->ajax());
@@ -227,7 +227,7 @@ class HttpRequestTest extends TestCase
 
     public function testPrefetchMethod()
     {
-        $request = Request::create('/', 'GET');
+        $request = Request::create('/');
         $this->assertFalse($request->prefetch());
 
         $request->server->set('HTTP_X_MOZ', '');
@@ -261,9 +261,9 @@ class HttpRequestTest extends TestCase
 
     public function testSecureMethod()
     {
-        $request = Request::create('http://example.com', 'GET');
+        $request = Request::create('http://example.com');
         $this->assertFalse($request->secure());
-        $request = Request::create('https://example.com', 'GET');
+        $request = Request::create('https://example.com');
         $this->assertTrue($request->secure());
     }
 
@@ -852,7 +852,7 @@ class HttpRequestTest extends TestCase
 
     public function testOldMethodCallsSession()
     {
-        $request = Request::create('/', 'GET');
+        $request = Request::create('/');
         $session = m::mock(Store::class);
         $session->shouldReceive('getOldInput')->once()->with('foo', 'bar')->andReturn('boom');
         $request->setLaravelSession($session);
@@ -861,7 +861,7 @@ class HttpRequestTest extends TestCase
 
     public function testFlushMethodCallsSession()
     {
-        $request = Request::create('/', 'GET');
+        $request = Request::create('/');
         $session = m::mock(Store::class);
         $session->shouldReceive('flashInput')->once();
         $request->setLaravelSession($session);
@@ -1026,7 +1026,7 @@ class HttpRequestTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Session store not set on request.');
 
-        $request = Request::create('/', 'GET');
+        $request = Request::create('/');
         $request->session();
     }
 
@@ -1131,7 +1131,7 @@ class HttpRequestTest extends TestCase
         $this->assertNotEmpty($request->foo);
 
         // Simulates empty QueryString and Routes.
-        $request = Request::create('/', 'GET');
+        $request = Request::create('/');
         $request->setRouteResolver(function () use ($request) {
             $route = new Route('GET', '/', []);
             $route->bind($request);
@@ -1146,7 +1146,7 @@ class HttpRequestTest extends TestCase
 
         // Special case: simulates empty QueryString and Routes, without the Route Resolver.
         // It'll happen when you try to get a parameter outside a route.
-        $request = Request::create('/', 'GET');
+        $request = Request::create('/');
 
         // Parameter 'undefined' is undefined/null, then it NOT ISSET and is EMPTY.
         $this->assertNull($request->undefined);


### PR DESCRIPTION
There are two things I try to clean up in this PR:

1. Request::create() sets the second parameter (method) as "GET" by default. If a test doesn't care about the method, we needn't to pass it explicitly.

2. prefers method test doesn't look good to read. Using data provider make it easier to read.

For example, Within the case ['application/json', ['json'], 'json'], we can describe it like this:

> If the request has the header **accept** to be 'application/json', the prefers method that takes ['json'] as it's parameter will return 'json';
