### PR TITLE
[8.x] Adds first-level test traits setUp/tearDown (opt-in)

### DIFF
--- a/src/Illuminate/Contracts/Testing/InitializeTraits.php
+++ b/src/Illuminate/Contracts/Testing/InitializeTraits.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Contracts\Testing;
+
+interface InitializeTraits
+{
+    //
+}

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -157,7 +157,7 @@ abstract class TestCase extends BaseTestCase
      */
     protected function initializeFirstLevelTraits()
     {
-        foreach (class_uses($this) as $trait) {
+        foreach (class_uses(static::class) as $trait) {
             if (method_exists($this, $setUpMethod = 'setUp'.class_basename($trait))) {
                 $this->{$setUpMethod}();
             }


### PR DESCRIPTION
## What?

Allows the developer to include and reuse traits that automatically set-up and tear-down in each test, when declared at first-level.

Given a reusable test `WithExamplePost`:

```php
namespace Tests\Feature\Concerns;

use App\Models\Post;

trait WithExamplePost
{    
    protected $post;

    protected function setUpWithExamplePost()
    {
        Post::factory()->createOne();
    }
    
    protected function tearDownWithExamplePost()
    {
        $this->post = null;
    }
}
```

The test class implementing `InitializeTraits`, will automatically call `setUpWithExamplePost` after the application is created, and `tearDownWithExamplePost` before is destroyed.

```php
<?php

namespace Tests\Feature;

use App\Models\User;
use Illuminate\Contracts\Testing\InitializeTraits;
use Illuminate\Foundation\Testing\RefreshDatabase;
use Tests\TestCase;

class PostTest extends TestCase implements InitializeTraits
{
    use RefreshDatabase;
    use Concerns\WithSubscribedUser;

    public function test_post_is_visible()
    {
        $this->get('post/' . $this->post->id)->assertOk();
    }
}
```

Since this is an additive opt-in feature, no test will break unless the interface is added on tests classes.

## Why?

There are three keys for this implementation:

- Reusable traits out of the box, no need to implement the feature by the developer.
- Opt-in
- Runs after the application is created, and before it's destroyed.
- Only works for **first-level traits**. Nested traits are not affected (like in PHPUnit), so initialization is _controllable_.

## BC?

Nope, opt-in additive.

## Notes

I decided to use an interface-check in the `TestCase` rather than adding a trait because:

- Avoids getting the trait into the initializers array (or even alone by itself, making no sense)
- Avoids polluting a test properties or methods if it were to check them.

## Didn't I see this before?

[Kinda](https://github.com/laravel/framework/pull/39395)