### PR TITLE
 [8.x] Make worker avoid timeout mechanism when queue is empty

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -159,14 +159,14 @@ class Worker
                 $this->manager->connection($connectionName), $queue
             );
 
-            if ($supportsAsyncSignals) {
-                $this->registerTimeoutHandler($job, $options);
-            }
-
             // If the daemon should run (not in maintenance mode, etc.), then we can run
             // fire off this job for processing. Otherwise, we will need to sleep the
             // worker so no more jobs are processed until they should be processed.
             if ($job) {
+                if ($supportsAsyncSignals) {
+                    $this->registerTimeoutHandler($job, $options);
+                }
+
                 $jobsProcessed++;
 
                 $this->runJob($job, $connectionName, $options);
@@ -174,12 +174,12 @@ class Worker
                 if ($options->rest > 0) {
                     $this->sleep($options->rest);
                 }
+
+                if ($supportsAsyncSignals) {
+                    $this->resetTimeoutHandler();
+                }
             } else {
                 $this->sleep($options->sleep);
-            }
-
-            if ($supportsAsyncSignals) {
-                $this->resetTimeoutHandler();
             }
 
             // Finally, we will check to see if we have exceeded our memory limits or if

--- a/tests/Queue/QueueFakeWorkerTest.php
+++ b/tests/Queue/QueueFakeWorkerTest.php
@@ -133,6 +133,15 @@ class QueueWorkerTest extends TestCase
         $this->assertEquals(5, $worker->sleptFor);
     }
 
+    public function testWorkerAvoidTimoutWhenSleeping()
+    {
+        $worker = new killedproofWorker(
+            ...$this->workerDependencies('default', ['queue' => []], null)
+        );
+        $worker->daemon('default', 'queue', $this->workerOptions(['sleep' => 1.1, 'timeout' => 1]));
+        $this->assertFalse($worker->killed);
+    }
+
     public function testJobIsReleasedOnException()
     {
         $e = new RuntimeException;
@@ -419,6 +428,30 @@ class InsomniacWorker extends Worker
     public function memoryExceeded($memoryLimit)
     {
         return $this->stopOnMemoryExceeded;
+    }
+}
+
+/**
+ * Fakes.
+ */
+class killedproofWorker extends Worker
+{
+    public $killed = false;
+    public $shouldQuit = true;
+
+    public function stop($status = 0)
+    {
+        return $status;
+    }
+
+    public function daemonShouldRun(WorkerOptions $options, $connectionName, $queue)
+    {
+        return ! ($this->isDownForMaintenance)();
+    }
+
+    public function kill($status = 0)
+    {
+        $this->killed = true;
     }
 }
 


### PR DESCRIPTION
When the sleep option bigger than (or equal to) timeout option, worker process will be killed.
In my opinion, when queue is empty, worker should sleep well until next job is pushed.
And the timeout mechanism should only restrict the job processing time.
So I moved registerTimeoutHandler in the if statement, which its condition is having a job.

![image](https://user-images.githubusercontent.com/74278922/144556441-2315fd3d-5336-49f7-8961-a2eb82725757.png)
