### PR TITLE
[8.x] Add the possibility to translate arrays and do replacements

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -238,7 +238,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         if (is_string($line)) {
             return strtr($line, $shouldReplace);
         }
-        foreach($line as $key => $newLine) {
+        foreach ($line as $key => $newLine) {
             $line[$key] = $this->replace($newLine, $shouldReplace);
         }
         return $line;

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -241,6 +241,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         foreach ($line as $key => $newLine) {
             $line[$key] = $this->replace($newLine, $shouldReplace);
         }
+
         return $line;
     }
 

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -205,7 +205,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
     /**
      * Make the place-holder replacements on a line.
      *
-     * @param  string  $line
+     * @param  string|array  $line
      * @param  array  $replace
      * @return string
      */
@@ -223,7 +223,25 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
             $shouldReplace[':'.$key] = $value;
         }
 
-        return strtr($line, $shouldReplace);
+        return $this->replace($line, $shouldReplace);
+    }
+
+    /**
+     * Replaces recursively the line.
+     *
+     * @param  string|array  $line
+     * @param  array  $shouldReplace
+     * @return string|array
+     */
+    protected function replace($line, array $shouldReplace)
+    {
+        if (is_string($line)) {
+            return strtr($line, $shouldReplace);
+        }
+        foreach($line as $key => $newLine) {
+            $line[$key] = $this->replace($newLine, $shouldReplace);
+        }
+        return $line;
     }
 
     /**

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -157,6 +157,13 @@ class TranslationTranslatorTest extends TestCase
         $this->assertSame('Hello baz:bar!', $t->get('Hello :foo!', ['foo' => 'baz:bar', 'bar' => 'abcdef']));
     }
 
+    public function testGetJsonHasAtomicReplacementsWithArrays()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn(['foo' => ['bar' => 'Hello :foo!']]);
+        $this->assertSame(['bar' => 'Hello baz:bar!'], $t->get('foo', ['foo' => 'baz:bar', 'bar' => 'abcdef']));
+    }
+
     public function testGetJsonReplacesForAssociativeInput()
     {
         $t = new Translator($this->getLoader(), 'en');


### PR DESCRIPTION
Currently it is possible to translate arrays, but only if there's nothing to replace in them.

This makes possible to translate an array of results and make replacements recursively.

```
[
  "foo" => [
    "bar" => ":baz",
  ],
]
```

I already can  call `__('foo')` and it would return `["bar" => ":baz"]`,

Why can't I call `__('foo', ['baz' => 'one'])` and get back `["bar" => "one"]`?
