### PR TITLE
[8.x] Moves child model binding resolution to actual model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1877,7 +1877,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function resolveRouteBinding($value, $field = null)
     {
-        return $this->where($field ?? $this->getRouteKeyName(), $value)->first();
+        return $this->resolveRouteBindingQuery($this, $value, $field)->first();
     }
 
     /**
@@ -1889,7 +1889,20 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function resolveSoftDeletableRouteBinding($value, $field = null)
     {
-        return $this->where($field ?? $this->getRouteKeyName(), $value)->withTrashed()->first();
+        return $this->resolveRouteBindingQuery($this, $value, $field)->withTrashed()->first();
+    }
+
+    /**
+     * Retrieve the model for a bound value.
+     *
+     * @param Model|Relation $query
+     * @param  mixed  $value
+     * @param  string|null  $field
+     * @return Model|Illuminate\Database\Eloquent\Relations\Relation
+     */
+    public function resolveRouteBindingQuery($query, $value, $field = null)
+    {
+        return $query->where($field ?? $this->getRouteKeyName(), $value);
     }
 
     /**
@@ -1934,10 +1947,11 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
 
         if ($relationship instanceof HasManyThrough ||
             $relationship instanceof BelongsToMany) {
-            return $relationship->where($relationship->getRelated()->getTable().'.'.$field, $value);
+            return $relationship->getRelated()->resolveRouteBindingQuery(
+                $relationship, $value, $relationship->getRelated()->getTable().'.'.$field);
         }
 
-        return $relationship->where($field, $value);
+        return $relationship->getRelated()->resolveRouteBindingQuery($relationship, $value, $field);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1895,7 +1895,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Retrieve the model for a bound value.
      *
-     * @param Model|Relation $query
+     * @param  Model|Relation $query
      * @param  mixed  $value
      * @param  string|null  $field
      * @return Model|Illuminate\Database\Eloquent\Relations\Relation
@@ -1947,11 +1947,14 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
 
         if ($relationship instanceof HasManyThrough ||
             $relationship instanceof BelongsToMany) {
-            return $relationship->getRelated()->resolveRouteBindingQuery(
-                $relationship, $value, $relationship->getRelated()->getTable().'.'.$field);
+            $field = $relationship->getRelated()->getTable().'.'.$field;
         }
 
-        return $relationship->getRelated()->resolveRouteBindingQuery($relationship, $value, $field);
+        if ($relationship instanceof Model) {
+            return $relationship->getRelated()->resolveRouteBindingQuery($relationship, $value, $field);
+        }
+
+        return $relationship->where($field, $value);
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This is an approach to allow the user to define a custom model binding query by overwriting the added function `resolveRouteBindingQuery`.  It is needed if lookup of the model cannot be achieved by comparing the value with the field.   
The actual problem is briefly explained in https://github.com/laravel/framework/discussions/39779

I am open for other ideas to solve the problem 