### PR TITLE
[8.x] helpful message on 404

### DIFF
--- a/src/Illuminate/Routing/AbstractRouteCollection.php
+++ b/src/Illuminate/Routing/AbstractRouteCollection.php
@@ -40,7 +40,12 @@ abstract class AbstractRouteCollection implements Countable, IteratorAggregate, 
             return $this->getRouteForMethods($request, $others);
         }
 
-        throw new NotFoundHttpException;
+        throw new NotFoundHttpException(
+            sprintf(
+                'The requested URL %s was not found on this server.',
+                $request->getPathInfo()
+            )
+        );
     }
 
     /**


### PR DESCRIPTION
web routes already have default 404 page , however api does not have appropriate json message.
This pr will provide not found exception a helpful message message like this :

```json
{
    "message": "The requested URL /api/some/url was not found on this server."
}
```

thanks for reviewing and have a good day