### PR TITLE
[8.x] Correct pagination message

### DIFF
--- a/src/Illuminate/Pagination/resources/views/tailwind.blade.php
+++ b/src/Illuminate/Pagination/resources/views/tailwind.blade.php
@@ -26,9 +26,13 @@
             <div>
                 <p class="text-sm text-gray-700 leading-5">
                     {!! __('Showing') !!}
-                    <span class="font-medium">{{ $paginator->firstItem() }}</span>
-                    {!! __('to') !!}
-                    <span class="font-medium">{{ $paginator->lastItem() }}</span>
+                    @if ($paginator->firstItem())
+                        <span class="font-medium">{{ $paginator->firstItem() }}</span>
+                        {!! __('to') !!}
+                        <span class="font-medium">{{ $paginator->lastItem() }}</span>
+                    @else
+                        {{ $paginator->count() }}
+                    @endif
                     {!! __('of') !!}
                     <span class="font-medium">{{ $paginator->total() }}</span>
                     {!! __('results') !!}


### PR DESCRIPTION
When accessing an out-of-bounds page number, i.e. ?page=999999, the methods `firstItem()` and `lastItem()` return null causing this template to render “Showing to of 28 results” which isn't user-friendly. 

This PR catches that edge case and renders “Showing 0 of 28 results” instead.

I don't believe this PR will break any functionality.
