### PR TITLE
[8.x] Set the PHP version on StyleCI to 8.1

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,9 +1,6 @@
 php:
   preset: laravel
-  version: 8
-  finder:
-    not-name:
-      - Enums.php
+  version: 8.1
 js:
   finder:
     not-name:


### PR DESCRIPTION
Almost all of the issues with PHP 8.1 on StyleCI have now been ironed out. I think we can safely switch over now. The analysis seems stable - no change in output between 8.0 and 8.1.