### PR TITLE
[9.x] Remove parameter from DecoratesQueryBuilder::delete()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/DecoratesQueryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/DecoratesQueryBuilder.php
@@ -1062,7 +1062,7 @@ trait DecoratesQueryBuilder
     /**
      * @inheritdoc
      */
-    public function delete($id = null)
+    public function delete()
     {
         return $this->forwardDecoratedCallTo($this->query, __FUNCTION__, func_get_args());
     }


### PR DESCRIPTION
#37956 added the `DecoratesQueryBuilder` trait to improve type hinting. `delete()` is a special case as its method signature in `Eloquent\Builder` is different from `Query\Builder`. Only the base query builder has an `$id` parameter, the Eloquent one doesn't:

https://github.com/laravel/framework/blob/05bba7c9b099806a9e91d715d50411c69e1bbf23/src/Illuminate/Database/Eloquent/Builder.php#L1031

https://github.com/laravel/framework/blob/05bba7c9b099806a9e91d715d50411c69e1bbf23/src/Illuminate/Database/Query/Builder.php#L2700

The trait is used in relationship classes and so the IDE suggests that `$user->posts()->delete(1)` works, but the parameter is actually ignored because `Eloquent\Builder::delete()` doesn't pass it on to `Query\Builder::delete().`