### PR TITLE
[8.x] Added `--migration` argument to specify a migration to be used with the `migrate:rollback` command

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
@@ -57,7 +57,11 @@ class RollbackCommand extends BaseCommand
 
         $this->migrator->usingConnection($this->option('database'), function () {
             $this->migrator->setOutput($this->output)->rollback(
-                $this->getMigrationPaths(), $this->options()
+                $this->getMigrationPaths(), [
+                    'pretend' => $this->option('pretend'),
+                    'step' => (int) $this->option('step'),
+                    'path' => $this->option('path'),
+                ]
             );
         });
 

--- a/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
@@ -57,10 +57,7 @@ class RollbackCommand extends BaseCommand
 
         $this->migrator->usingConnection($this->option('database'), function () {
             $this->migrator->setOutput($this->output)->rollback(
-                $this->getMigrationPaths(), [
-                    'pretend' => $this->option('pretend'),
-                    'step' => (int) $this->option('step'),
-                ]
+                $this->getMigrationPaths(), $this->options()
             );
         });
 

--- a/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
@@ -60,7 +60,7 @@ class RollbackCommand extends BaseCommand
                 $this->getMigrationPaths(), [
                     'pretend' => $this->option('pretend'),
                     'step' => (int) $this->option('step'),
-                    'path' => $this->option('path'),
+                    'migration' => $this->option('migration'),
                 ]
             );
         });
@@ -83,6 +83,8 @@ class RollbackCommand extends BaseCommand
             ['path', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'The path(s) to the migrations files to be executed'],
 
             ['realpath', null, InputOption::VALUE_NONE, 'Indicate any provided migration file paths are pre-resolved absolute paths'],
+
+            ['migration', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'The path of a migration file to be executed'],
 
             ['pretend', null, InputOption::VALUE_NONE, 'Dump the SQL queries that would be run'],
 

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -250,7 +250,7 @@ class Migrator
 
         if ($path = $options['path'] ?? []) {
             return collect($path)->map(function ($m) {
-                return (object) ['migration' => (string) \Str::of($m)->basename('.php')];
+                return (object) ['migration' => (string) Str::of($m)->basename('.php')];
             })->all();
         }
 

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -248,8 +248,8 @@ class Migrator
             return $this->repository->getMigrations($steps);
         }
 
-        if ($path = $options['path'] ?? []) {
-            return collect($path)->map(function ($m) {
+        if ($migrations = $options['migration'] ?? []) {
+            return collect($migrations)->map(function ($m) {
                 return (object) ['migration' => (string) Str::of($m)->basename('.php')];
             })->all();
         }

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -248,6 +248,12 @@ class Migrator
             return $this->repository->getMigrations($steps);
         }
 
+        if ($path = $options['path'] ?? []) {
+            return collect($path)->map(function ($m) {
+                return (object) ['migration' => (string) \Str::of($m)->basename('.php')];
+            })->all();
+        }
+
         return $this->repository->getLast();
     }
 

--- a/tests/Database/DatabaseMigrationRollbackCommandTest.php
+++ b/tests/Database/DatabaseMigrationRollbackCommandTest.php
@@ -28,7 +28,7 @@ class DatabaseMigrationRollbackCommandTest extends TestCase
             return $callback();
         });
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
-        $migrator->shouldReceive('rollback')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => 0, 'path' => null]);
+        $migrator->shouldReceive('rollback')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => 0, 'migration' => null]);
 
         $this->runCommand($command);
     }
@@ -44,7 +44,7 @@ class DatabaseMigrationRollbackCommandTest extends TestCase
             return $callback();
         });
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
-        $migrator->shouldReceive('rollback')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => 2, 'path' => null]);
+        $migrator->shouldReceive('rollback')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => 2, 'migration' => null]);
 
         $this->runCommand($command, ['--step' => 2]);
     }
@@ -76,28 +76,29 @@ class DatabaseMigrationRollbackCommandTest extends TestCase
             return $callback();
         });
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
-        $migrator->shouldReceive('rollback')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => true, 'step' => 2, 'path' => null]);
+        $migrator->shouldReceive('rollback')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => true, 'step' => 2, 'migration' => null]);
 
         $this->runCommand($command, ['--pretend' => true, '--database' => 'foo', '--step' => 2]);
     }
 
-    public function testRollbackCommandCallsMigratorWithPathOption()
+    public function testRollbackCommandCallsMigratorWithMigrationOption()
     {
         $migration = 'database/migrations/2014_10_12_000000_create_users_table.php';
         $command = new RollbackCommand($migrator = m::mock(Migrator::class));
         $app = new ApplicationDatabaseRollbackStub(['path.database' => __DIR__]);
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
+        $migrator->shouldReceive('paths')->once()->andReturn([]);
         $migrator->shouldReceive('usingConnection')->once()->andReturnUsing(function ($name, $callback) {
             return $callback();
         });
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
-        $migrator->shouldReceive('rollback')->once()->with(["/$migration"], ['path' => $migration, 'pretend' => false, 'step' => 0]);
+        $migrator->shouldReceive('rollback')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['migration' => $migration, 'pretend' => false, 'step' => 0]);
 
-        $this->runCommand($command, ['--path' => $migration]);
+        $this->runCommand($command, ['--migration' => $migration]);
     }
 
-    public function testRollbackCommandCallsMigratorWithMultiplePathOption()
+    public function testRollbackCommandCallsMigratorWithMultipleMigrationOption()
     {
         $migrations = [
             'database/migrations/2014_10_12_000000_create_users_table.php',
@@ -107,15 +108,14 @@ class DatabaseMigrationRollbackCommandTest extends TestCase
         $app = new ApplicationDatabaseRollbackStub(['path.database' => __DIR__]);
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
+        $migrator->shouldReceive('paths')->once()->andReturn([]);
         $migrator->shouldReceive('usingConnection')->once()->andReturnUsing(function ($name, $callback) {
             return $callback();
         });
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
-        $migrator->shouldReceive('rollback')->once()->with(collect($migrations)->map(function ($migration) {
-            return '/'.$migration;
-        })->toArray(), ['path' => $migrations, 'pretend' => false, 'step' => 0]);
+        $migrator->shouldReceive('rollback')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['migration' => $migrations, 'pretend' => false, 'step' => 0]);
 
-        $this->runCommand($command, ['--path' => $migrations]);
+        $this->runCommand($command, ['--migration' => $migrations]);
     }
 
     protected function runCommand($command, $input = [])


### PR DESCRIPTION
~I'm not sure if this ever worked before, but by reading the code I believe it never did, at least it doesn't right now.
Although, I found some [stack overflow answers](https://stackoverflow.com/questions/30287896/rollback-one-specific-migration-in-laravel) where some suggest the usage of `--path` arg to specify a migration to be rolled back.~

~This PR allows to specify one or multiple `--path` with the migrations we want to rollback.~

---
This PR adds `--migration` argument to specify one or many migrations we want to rollback.

```cmd
php artisan migrate:rollback --migration="database/migrations/first.php" --migration "database/migrations/second.php"
```

```cmd
Rolling back: first
Rolled back:  first (49.60ms)
Rolling back: second
Rolled back:  second (450.67ms)
```

This is particularly useful to rollback a single migration, in the middle of any batch.