### PR TITLE
add countable interface to eloquent factory sequence

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Sequence.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Sequence.php
@@ -2,7 +2,9 @@
 
 namespace Illuminate\Database\Eloquent\Factories;
 
-class Sequence
+use Countable;
+
+class Sequence implements Countable
 {
     /**
      * The sequence of return values.
@@ -47,5 +49,15 @@ class Sequence
         return tap(value($this->sequence[$this->index % $this->count], $this), function () {
             $this->index = $this->index + 1;
         });
+    }
+
+    /**
+     * The count of the sequence items.
+     *
+     * @return int
+     */
+    public function count()
+    {
+        return $this->count;
     }
 }

--- a/src/Illuminate/Database/Eloquent/Factories/Sequence.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Sequence.php
@@ -40,6 +40,16 @@ class Sequence implements Countable
     }
 
     /**
+     * Get the current count of the sequence items.
+     *
+     * @return int
+     */
+    public function count()
+    {
+        return $this->count;
+    }
+
+    /**
      * Get the next value in the sequence.
      *
      * @return mixed
@@ -49,15 +59,5 @@ class Sequence implements Countable
         return tap(value($this->sequence[$this->index % $this->count], $this), function () {
             $this->index = $this->index + 1;
         });
-    }
-
-    /**
-     * The count of the sequence items.
-     *
-     * @return int
-     */
-    public function count()
-    {
-        return $this->count;
     }
 }


### PR DESCRIPTION
I recently submitted [a discussion](https://github.com/laravel/framework/discussions/39655) regarding this, but following [Dries Vints' request on twitter today](https://twitter.com/driesvints/status/1467838887921958913), I thought I would just go ahead and submit a PR.

Essentially, I tried to call `count($sequence)` on an instance of `Illuminate\Database\Eloquent\Factories\Sequence` and was surprised to find that it wasn't, well, `\Countable`.

Given the existence of the `$count` class variable, I thought it might be a sensible addition.