### PR TITLE
[9.x] Use `@before` and `@after` annotations in TestCase

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -77,6 +77,7 @@ abstract class TestCase extends BaseTestCase
      * Setup the test environment.
      *
      * @before
+     *
      * @return void
      */
     protected function setUpLaravelApplication(): void
@@ -150,6 +151,7 @@ abstract class TestCase extends BaseTestCase
      * Clean up the testing environment before the next test.
      *
      * @after
+     *
      * @return void
      *
      * @throws \Mockery\Exception\InvalidCountException

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -76,9 +76,10 @@ abstract class TestCase extends BaseTestCase
     /**
      * Setup the test environment.
      *
+     * @before
      * @return void
      */
-    protected function setUp(): void
+    protected function setUpLaravelApplication(): void
     {
         Facade::clearResolvedInstances();
 
@@ -148,11 +149,12 @@ abstract class TestCase extends BaseTestCase
     /**
      * Clean up the testing environment before the next test.
      *
+     * @after
      * @return void
      *
      * @throws \Mockery\Exception\InvalidCountException
      */
-    protected function tearDown(): void
+    protected function tearDownLaravelApplication(): void
     {
         if ($this->app) {
             $this->callBeforeApplicationDestroyedCallbacks();


### PR DESCRIPTION
Right now, the Laravel docs need to display this warning because the framework's base `TestCase` relies on logic in the `setUp` and `tearDown` methods:

![image](https://user-images.githubusercontent.com/21592/144912754-1f03068a-7cc5-48b1-885c-932dd4d45f66.png)

This PR moves the `setUp` and `tearDown` functionality into new `setUpLaravelApplication` and `tearDownLaravelApplication` methods with the `@before` and `@after` annotations applied to them respectively.

PHPUnit sets up and tears down tests in the following order (ignoring the undocumented preCondition/postCondition phases):

1. Methods with the `@before` annotation (in order: traits, base class, extending class(es))
2. The `setUp()` method
3. The actual test method
4. The `tearDown()` method
5. Methods with the `@after` annotation (in order: extending class(es), base class, traits)

This means that the new `setUpLaravelApplication()` method is called before the test's `setUp` method, and the `tearDownLaravelApplication` is called after the test's `tearDown` method.

<details>
<summary><b>More details about inheritance order</b></summary>

Basically, PHPUnit determines what methods to call by using the [`ReflectionClass::getMethods()`](https://www.php.net/manual/en/reflectionclass.getmethods.php) function. This function returns methods in the following order:

1. Methods defined in the actual class
2. Methods defined in parent classes
3. Methods defined in traits (in the order of the `use` statements)

PHPUnit then adds these hooks to an array using `array_unshift` for `@before` and `array_push` for `@after`. These arrays are called in order during the test run. That means `@before` hooks in the parent class are prepended last and run first, and `@after` hooks in the parent class are appended last and run last.

</details>

The end result is that framework users can go on using `setUp` and `tearDown` exactly as they do right now, but don't have to worry about remembering to call `parent::setUp()` or `parent::tearDown()` (just like normal PHPUnit tests).

I'm submitting this against `9.x` because it could theoretically affect someone using a method called `setUpLaravelApplication` or intentionally trying to override the default Laravel `setUp` method (in which case the solution is just to rename their custom method `setUpLaravelApplication`).