### PR TITLE
[8.x] Use real `count` return type

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Sequence.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Sequence.php
@@ -44,8 +44,7 @@ class Sequence implements Countable
      *
      * @return int
      */
-    #[\ReturnTypeWillChange]
-    public function count()
+    public function count(): int
     {
         return $this->count;
     }


### PR DESCRIPTION
No BC break. Not in tagged release yet.