### PR TITLE
[8.x] Allows to use a closure to group nullable columns

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -79,6 +79,13 @@ class Blueprint
     public $after;
 
     /**
+     * Whether to make the column is null.
+     *
+     * @var bool
+     */
+    public $nullable = false;
+
+    /**
      * Create a new schema blueprint.
      *
      * @param  string  $table
@@ -1565,6 +1572,10 @@ class Blueprint
             $this->after = $definition->name;
         }
 
+        if($this->nullable) {
+            $definition->nullable();
+        }
+
         return $definition;
     }
 
@@ -1582,6 +1593,21 @@ class Blueprint
         $callback($this);
 
         $this->after = null;
+    }
+
+    /**
+     * Add nullable columns from the callback.
+     *
+     * @param  \Closure  $callback
+     * @return void
+     */
+    public function nullable(Closure $callback) 
+    {
+        $this->nullable = true;
+        
+        $callback($this);
+
+        $this->nullable = false;
     }
 
     /**

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -24,7 +24,6 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $blueprint->string('email');
         $blueprint->string('name')->collation('nb_NO.utf8');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-
         $this->assertCount(1, $statements);
         $this->assertSame('create table "users" ("id" serial primary key not null, "email" varchar(255) not null, "name" varchar(255) collate "nb_NO.utf8" not null)', $statements[0]);
 

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -349,4 +349,38 @@ class DatabaseSchemaBlueprintTest extends TestCase
             'alter table "posts" add "note" nvarchar(255) null',
         ], $blueprint->toSql($connection, new SqlServerGrammar));
     }
+
+    public function testNullableClosure()
+    {
+        $base = new Blueprint('posts', function ($table) {
+            $table->nullable(function($table) {
+                $table->string('note');
+            });
+
+            $table->string('description');
+        });
+
+        $connection = m::mock(Connection::class);
+
+        $blueprint = clone $base;
+        $this->assertEquals([
+            'alter table `posts` add `note` varchar(255) null, add `description` varchar(255) not null',
+        ], $blueprint->toSql($connection, new MySqlGrammar));
+
+        $blueprint = clone $base;
+        $this->assertEquals([
+            'alter table "posts" add column "note" varchar',
+            'alter table "posts" add column "description" varchar not null'
+        ], $blueprint->toSql($connection, new SQLiteGrammar));
+
+        $blueprint = clone $base;
+        $this->assertEquals([
+            'alter table "posts" add column "note" varchar(255) null, add column "description" varchar(255) not null',
+        ], $blueprint->toSql($connection, new PostgresGrammar));
+
+        $blueprint = clone $base;
+        $this->assertEquals([
+            'alter table "posts" add "note" nvarchar(255) null, "description" nvarchar(255) not null',
+        ], $blueprint->toSql($connection, new SqlServerGrammar));
+    }
 }


### PR DESCRIPTION
This PR introduces the use of a closure to group a nullable columns,
Sometimes we need to create columns and every one needs to be defined as nullable, instead of appends the method nullable() for every column, we can group it by using the clousure nullable

I think this should make the developer's life easier by avoiding to define nullable every time

```php
  Schema::create('posts', function (Blueprint $table) {
      $table->nullable(function($table) {
          $table->integer('foo'); // nullable
          $table->string('bar'); // nullable
      });
      $table->string('note'); // not nullable
  });
```

