### PR TITLE
[8.x] Pusher 6.x+ does not support TLS options anymore

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -148,7 +148,7 @@
         "phpunit/phpunit": "Required to use assertions and run tests (^8.5.19|^9.5.8).",
         "predis/predis": "Required to use the predis connector (^1.1.9).",
         "psr/http-message": "Required to allow Storage::put to accept a StreamInterface (^1.0).",
-        "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (^4.0|^5.0|^6.0|^7.0).",
+        "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (^6.0|^7.0).",
         "symfony/cache": "Required to PSR-6 cache bridge (^5.4).",
         "symfony/filesystem": "Required to enable support for relative symbolic links (^5.4).",
         "symfony/psr-http-message-bridge": "Required to use PSR-7 bridging features (^2.0).",

--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -4,6 +4,7 @@ namespace Illuminate\Broadcasting;
 
 use Ably\AblyRest;
 use Closure;
+use GuzzleHttp\Client as GuzzleClient;
 use Illuminate\Broadcasting\Broadcasters\AblyBroadcaster;
 use Illuminate\Broadcasting\Broadcasters\LogBroadcaster;
 use Illuminate\Broadcasting\Broadcasters\NullBroadcaster;
@@ -215,7 +216,8 @@ class BroadcastManager implements FactoryContract
     {
         $pusher = new Pusher(
             $config['key'], $config['secret'],
-            $config['app_id'], $config['options'] ?? []
+            $config['app_id'], $config['options'] ?? [],
+            new GuzzleClient($config['client_options'] ?? [])
         );
 
         if ($config['log'] ?? false) {

--- a/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
@@ -116,46 +116,19 @@ class PusherBroadcaster extends Broadcaster
     public function broadcast(array $channels, $event, array $payload = [])
     {
         $socket = Arr::pull($payload, 'socket');
+        $parameters = $socket !== null ? ['socket_id' => $socket] : [];
 
-        if ($this->pusherServerIsVersionFiveOrGreater()) {
-            $parameters = $socket !== null ? ['socket_id' => $socket] : [];
-
-            try {
-                $this->pusher->trigger(
-                    $this->formatChannels($channels), $event, $payload, $parameters
-                );
-            } catch (ApiErrorException $e) {
-                throw new BroadcastException(
-                    sprintf('Pusher error: %s.', $e->getMessage())
-                );
-            }
-        } else {
-            $response = $this->pusher->trigger(
-                $this->formatChannels($channels), $event, $payload, $socket, true
+        try {
+            $this->pusher->trigger(
+                $this->formatChannels($channels), $event, $payload, $parameters
             );
-
-            if ((is_array($response) && $response['status'] >= 200 && $response['status'] <= 299)
-                || $response === true) {
-                return;
-            }
-
+        } catch (ApiErrorException $e) {
             throw new BroadcastException(
-                ! empty($response['body'])
-                    ? sprintf('Pusher error: %s.', $response['body'])
-                    : 'Failed to connect to Pusher.'
+                sprintf('Pusher error: %s.', $e->getMessage())
             );
         }
     }
 
-    /**
-     * Determine if the Pusher PHP server is version 5.0 or greater.
-     *
-     * @return bool
-     */
-    protected function pusherServerIsVersionFiveOrGreater()
-    {
-        return class_exists(ApiErrorException::class);
-    }
 
     /**
      * Get the Pusher SDK instance.

--- a/src/Illuminate/Broadcasting/composer.json
+++ b/src/Illuminate/Broadcasting/composer.json
@@ -34,7 +34,7 @@
         }
     },
     "suggest": {
-        "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (^4.0|^5.0|^6.0|^7.0)."
+        "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (^6.0|^7.0)."
     },
     "config": {
         "sort-packages": true


### PR DESCRIPTION
### The problem
Pusher 6.x+ swapped their support from CURLOPT to Guzzle, and removed the TLS options, and this brought a [series of issues](https://github.com/pusher/pusher-http-php/issues/313) for TLS users that use self-signed certs in servers like [Laravel WebSockets](https://github.com/beyondcode/laravel-websockets/issues/879) and [soketi](https://github.com/soketi/soketi/issues/191), locally or in private networks.

### Potential fixes 

There may be [an approach to fix this](https://github.com/beyondcode/laravel-websockets/issues/879#issuecomment-987780296) by overwriting the `BroadcastManager` class at bootstrapping, but I had to find a way to overcome this by solving it at the root so that it isn't required.

Along the way, pre-6.x Pusher support has to be deprecated, and this might lead to issues in 8.x and should be in 9.x, but at the same time, it should be seen as a fix to support the new Pusher version's client argument.

This PR initializes Pusher with a Guzzle client whose options are defined in `config/broadcasting.php`. `curl_options` are no longer used, so in case it's defined, it should be removed:

```php
'pusher' => [
    'driver' => 'pusher',
    'key' => env('PUSHER_APP_KEY', 'app-key'),
    'secret' => env('PUSHER_APP_SECRET', 'app-secret'),
    'app_id' => env('PUSHER_APP_ID', 'app-id'),
    'options' => [
        // ...
    ],
    'client_options' => [
        // You can pass request options: https://docs.guzzlephp.org/en/stable/request-options.html
        'verify' => false, // to disable TLS checks
    ],
],
```