### PR TITLE
[8.x] Add method `filterNulls()` to Arr

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -181,7 +181,7 @@ class Arr
     public static function filterNulls($array)
     {
         return array_filter($array, function ($value) {
-            return !is_null($value);
+            return ! is_null($value);
         });
     }
 

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -173,19 +173,6 @@ class Arr
     }
 
     /**
-     * Filter the array for nulls.
-     *
-     * @param  array  $array
-     * @return array
-     */
-    public static function filterNulls($array)
-    {
-        return array_filter($array, function ($value) {
-            return ! is_null($value);
-        });
-    }
-
-    /**
      * Return the first element in an array passing a given truth test.
      *
      * @param  iterable  $array
@@ -728,6 +715,17 @@ class Arr
     public static function where($array, callable $callback)
     {
         return array_filter($array, $callback, ARRAY_FILTER_USE_BOTH);
+    }
+
+    /**
+     * Filter items where the value is not null.
+     *
+     * @param  array  $array
+     * @return array
+     */
+    public static function whereNotNull($array)
+    {
+        return static::where($array, fn ($x) => ! is_null($x));
     }
 
     /**

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -173,6 +173,19 @@ class Arr
     }
 
     /**
+     * Filter the array for nulls.
+     *
+     * @param  array  $array
+     * @return array
+     */
+    public static function filterNulls($array)
+    {
+        return array_filter($array, function ($value) {
+            return !is_null($value);
+        });
+    }
+
+    /**
      * Return the first element in an array passing a given truth test.
      *
      * @param  iterable  $array

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -163,9 +163,9 @@ class SupportArrTest extends TestCase
         $this->assertFalse(Arr::exists(new Collection(['a' => null]), 'b'));
     }
 
-    public function testFilterNulls()
+    public function testWhereNotNull()
     {
-        $array = array_values(Arr::filterNulls([null, 0, false, '', null, []]));
+        $array = array_values(Arr::whereNotNull([null, 0, false, '', null, []]));
         $this->assertEquals([0, false, '', []], $array);
     }
 

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -165,7 +165,7 @@ class SupportArrTest extends TestCase
 
     public function testFilterNulls()
     {
-        $array = Arr::filterNulls([null, 0, false, '', null, []]);
+        $array = array_values(Arr::filterNulls([null, 0, false, '', null, []]));
         $this->assertEquals([0, false, '', []], $array);
     }
 

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -163,6 +163,12 @@ class SupportArrTest extends TestCase
         $this->assertFalse(Arr::exists(new Collection(['a' => null]), 'b'));
     }
 
+    public function testFilterNulls()
+    {
+        $array = Arr::filterNulls([null, 0, false, '', null, []]);
+        $this->assertEquals([0, false, '', []], $array);
+    }
+
     public function testFirst()
     {
         $array = [100, 200, 300];


### PR DESCRIPTION
This PR adds array helper to filter array from nulls, compared to base `array_filter` which filters on falsy values.