### PR TITLE
[9.x] Adds `WithoutModelEvents` trait for running seeds without Model Events

### DIFF
--- a/src/Illuminate/Database/Console/Seeds/WithoutEvents.php
+++ b/src/Illuminate/Database/Console/Seeds/WithoutEvents.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\Database\Console\Seeds;
+
+use Illuminate\Database\Eloquent\Model;
+
+trait WithoutEvents
+{
+    /**
+     * Prevent all event handles from being executed by the given callback.
+     *
+     * @param  callable  $callback
+     * @return callable
+     */
+    public function withoutEvents(callable $callback)
+    {
+        return fn () => Model::withoutEvents($callback);
+    }
+}

--- a/src/Illuminate/Database/Console/Seeds/WithoutModelEvents.php
+++ b/src/Illuminate/Database/Console/Seeds/WithoutModelEvents.php
@@ -7,7 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 trait WithoutModelEvents
 {
     /**
-     * Prevent model event handles from being executed by the given callback.
+     * Prevent model events from being dispatched by the given callback.
      *
      * @param  callable  $callback
      * @return callable

--- a/src/Illuminate/Database/Console/Seeds/WithoutModelEvents.php
+++ b/src/Illuminate/Database/Console/Seeds/WithoutModelEvents.php
@@ -4,15 +4,15 @@ namespace Illuminate\Database\Console\Seeds;
 
 use Illuminate\Database\Eloquent\Model;
 
-trait WithoutEvents
+trait WithoutModelEvents
 {
     /**
-     * Prevent all event handles from being executed by the given callback.
+     * Prevent model event handles from being executed by the given callback.
      *
      * @param  callable  $callback
      * @return callable
      */
-    public function withoutEvents(callable $callback)
+    public function withoutModelEvents(callable $callback)
     {
         return fn () => Model::withoutEvents($callback);
     }

--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database;
 
 use Illuminate\Console\Command;
 use Illuminate\Container\Container;
+use Illuminate\Database\Console\Seeds\WithoutEvents;
 use Illuminate\Support\Arr;
 use InvalidArgumentException;
 
@@ -170,8 +171,16 @@ abstract class Seeder
             throw new InvalidArgumentException('Method [run] missing from '.get_class($this));
         }
 
-        return isset($this->container)
-                    ? $this->container->call([$this, 'run'], $parameters)
-                    : $this->run(...$parameters);
+        $callback = fn () => isset($this->container)
+            ? $this->container->call([$this, 'run'], $parameters)
+            : $this->run(...$parameters);
+
+        $uses = array_flip(class_uses_recursive(static::class));
+
+        if (isset($uses[WithoutEvents::class])) {
+            $callback = $this->withoutEvents($callback);
+        }
+
+        return $callback();
     }
 }

--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -4,7 +4,7 @@ namespace Illuminate\Database;
 
 use Illuminate\Console\Command;
 use Illuminate\Container\Container;
-use Illuminate\Database\Console\Seeds\WithoutEvents;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Support\Arr;
 use InvalidArgumentException;
 
@@ -177,8 +177,8 @@ abstract class Seeder
 
         $uses = array_flip(class_uses_recursive(static::class));
 
-        if (isset($uses[WithoutEvents::class])) {
-            $callback = $this->withoutEvents($callback);
+        if (isset($uses[WithoutModelEvents::class])) {
+            $callback = $this->withoutModelEvents($callback);
         }
 
         return $callback();

--- a/tests/Database/SeedCommandTest.php
+++ b/tests/Database/SeedCommandTest.php
@@ -7,7 +7,7 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Database\Console\Seeds\SeedCommand;
-use Illuminate\Database\Console\Seeds\WithoutEvents;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Seeder;
 use Illuminate\Events\NullDispatcher;
@@ -51,16 +51,16 @@ class SeedCommandTest extends TestCase
         $container->shouldHaveReceived('call')->with([$command, 'handle']);
     }
 
-    public function testWithoutEvents()
+    public function testWithoutModelEvents()
     {
         $input = new ArrayInput([
             '--force' => true,
             '--database' => 'sqlite',
-            '--class' => UserWithoutEventsSeeder::class,
+            '--class' => UserWithoutModelEventsSeeder::class,
         ]);
         $output = new NullOutput;
 
-        $instance = new UserWithoutEventsSeeder();
+        $instance = new UserWithoutModelEventsSeeder();
 
         $seeder = m::mock($instance);
         $seeder->shouldReceive('setContainer')->once()->andReturnSelf();
@@ -73,7 +73,7 @@ class SeedCommandTest extends TestCase
         $container = m::mock(Container::class);
         $container->shouldReceive('call');
         $container->shouldReceive('environment')->once()->andReturn('testing');
-        $container->shouldReceive('make')->with(UserWithoutEventsSeeder::class)->andReturn($seeder);
+        $container->shouldReceive('make')->with(UserWithoutModelEventsSeeder::class)->andReturn($seeder);
         $container->shouldReceive('make')->with(OutputStyle::class, m::any())->andReturn(
             new OutputStyle($input, $output)
         );
@@ -100,9 +100,9 @@ class SeedCommandTest extends TestCase
     }
 }
 
-class UserWithoutEventsSeeder extends Seeder
+class UserWithoutModelEventsSeeder extends Seeder
 {
-    use WithoutEvents;
+    use WithoutModelEvents;
 
     public function run()
     {

--- a/tests/Database/SeedCommandTest.php
+++ b/tests/Database/SeedCommandTest.php
@@ -4,9 +4,14 @@ namespace Illuminate\Tests\Database;
 
 use Illuminate\Console\OutputStyle;
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Database\Console\Seeds\SeedCommand;
+use Illuminate\Database\Console\Seeds\WithoutEvents;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Seeder;
+use Illuminate\Events\NullDispatcher;
+use Illuminate\Testing\Assert;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -46,8 +51,61 @@ class SeedCommandTest extends TestCase
         $container->shouldHaveReceived('call')->with([$command, 'handle']);
     }
 
+    public function testWithoutEvents()
+    {
+        $input = new ArrayInput([
+            '--force' => true,
+            '--database' => 'sqlite',
+            '--class' => UserWithoutEventsSeeder::class,
+        ]);
+        $output = new NullOutput;
+
+        $instance = new UserWithoutEventsSeeder();
+
+        $seeder = m::mock($instance);
+        $seeder->shouldReceive('setContainer')->once()->andReturnSelf();
+        $seeder->shouldReceive('setCommand')->once()->andReturnSelf();
+
+        $resolver = m::mock(ConnectionResolverInterface::class);
+        $resolver->shouldReceive('getDefaultConnection')->once();
+        $resolver->shouldReceive('setDefaultConnection')->once()->with('sqlite');
+
+        $container = m::mock(Container::class);
+        $container->shouldReceive('call');
+        $container->shouldReceive('environment')->once()->andReturn('testing');
+        $container->shouldReceive('make')->with(UserWithoutEventsSeeder::class)->andReturn($seeder);
+        $container->shouldReceive('make')->with(OutputStyle::class, m::any())->andReturn(
+            new OutputStyle($input, $output)
+        );
+
+        $command = new SeedCommand($resolver);
+        $command->setLaravel($container);
+
+        Model::setEventDispatcher($dispatcher = m::mock(Dispatcher::class));
+
+        // call run to set up IO, then fire manually.
+        $command->run($input, $output);
+        $command->handle();
+
+        Assert::assertSame($dispatcher, Model::getEventDispatcher());
+
+        $container->shouldHaveReceived('call')->with([$command, 'handle']);
+    }
+
     protected function tearDown(): void
     {
+        Model::unsetEventDispatcher();
+
         m::close();
+    }
+}
+
+class UserWithoutEventsSeeder extends Seeder
+{
+    use WithoutEvents;
+
+    public function run()
+    {
+        Assert::assertInstanceOf(NullDispatcher::class, Model::getEventDispatcher());
     }
 }


### PR DESCRIPTION
This pull request proposes a creation of a public trait — `WithoutModelEvents` — that prevents **Model Events** from being executed while running seeds.

Laravel developers often use Model events for firing queueable or not queueable tasks, that will send emails, index their Laravel Scout data, logging, etc. And, while useful, I don't necessarily want these tasks to be executed by my seeders.

So, having this `WithoutModelEvents` trait, which is very similar to the testing trait `WithoutModelEvents`, it's super useful, especially when using Factories on my seeds:

```php
<?php

namespace Database\Seeders;

use Illuminate\Database\Seeder;
use Illuminate\Database\Console\Seeds\WithoutModelEvents;

class DatabaseSeeder extends Seeder
{
    use WithoutModelEvents;

    public function run()
    {
        // these models are created, but no Model Events are
        // fired thanks to the `WithoutModelEvents` trait...
        User::factory(10)->create(); 
    }
}
``` 

Regarding the implementation there are two things to keep in mind:
- First, we are **only disabling Model Events**, and not events in general.
- Second, when using the method `$this->call` to call multiple seeders, the `WithoutModelEvents` propagates down. Let's see two examples:


1. In this example, the DatabaseSeeder is called, and because it contains the `WithoutModelEvents` trait, no Models Events are ever fired when using this seeder:
```php
<?php

namespace Database\Seeders;

use Illuminate\Database\Seeder;
use Illuminate\Database\Console\Seeds\WithoutModelEvents;

class DatabaseSeeder extends Seeder
{
    use WithoutModelEvents;

    public function run()
    {
        User::factory(10)->create(); // no Model Events are fired... 🔇

        $this->call([
            UserSeeder::class, // no Model Events are fired... 🔇
            UserWithoutModelEventsSeeder::class, // no Model Events are fired... 🔇
        ]);
    }
}
``` 

2. In this example, the DatabaseSeeder is called, and it do not contain the `WithoutModelEvents` trait, so Model Events get fired by the `UserSeeder::class` but not by `UserWithoutModelEventsSeeder::class`:
```php
<?php

namespace Database\Seeders;

use Illuminate\Database\Seeder;

class DatabaseSeeder extends Seeder
{
    public function run()
    {
        User::factory(10)->create(); // Model Events are fired... 🔈✅

        $this->call([
            UserSeeder::class, // Model Events are fired... 🔈✅
            UserWithoutModelEventsSeeder::class,  // no Model Events are fired... 🔇
        ]);
    }
}
``` 
