### PR TITLE
[8.x] Add `unix_timestamp` validation rule.

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -827,6 +827,18 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate that an attribute matches a unix timestamp format.
+     * @param  string  $attribute
+     * @param  string  $value
+     * @param  array  $parameters
+     * @return bool
+     */
+    public function validateUnixTimestamp($attribute, $value, $parameters)
+    {
+        return ($date = DateTime::createFromFormat('!U', $value)) && $date->format('U') == $value;
+    }
+
+    /**
      * Get the excluded ID column and value for the unique rule.
      *
      * @param  string|null  $idColumn

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -828,6 +828,7 @@ trait ValidatesAttributes
 
     /**
      * Validate that an attribute matches a unix timestamp format.
+     *
      * @param  string  $attribute
      * @param  string  $value
      * @param  array  $parameters

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -215,6 +215,7 @@ class Validator implements ValidatorContract
         'RequiredWithAll',
         'RequiredWithout',
         'RequiredWithoutAll',
+        'UnixTimestamp'
     ];
 
     /**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -215,7 +215,7 @@ class Validator implements ValidatorContract
         'RequiredWithAll',
         'RequiredWithout',
         'RequiredWithoutAll',
-        'UnixTimestamp'
+        'UnixTimestamp',
     ];
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2907,6 +2907,23 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
+    public function testValidateUnixTimestamp()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+
+        $v = new Validator($trans, ['x' => '1638884440', 'y' => '1638873440'], ['*' => 'unix_timestamp']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => 1638884440, 'y' => ''], ['x' => 'unix_timestamp']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => '2021-12-07'], ['x' => 'unix_timestamp']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => '2021-12-07 10:37:20'], ['x' => 'unix_timestamp']);
+        $this->assertFalse($v->passes());
+    }
+
     public function testValidateUniqueAndExistsSendsCorrectFieldNameToDBWithArrays()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
This idea came from [a tweet from @freekmurze](https://twitter.com/freekmurze/status/1468208014587043848), and adds a new validation rule called `unix_timestamp`, to validate unix timestamps.