### PR TITLE
[8.x] Add explode method to Request

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -304,7 +304,7 @@ trait InteractsWithInput
      * @param  mixed  $default
      * @return mixed
      */
-    public function explode($key = null, $delimiter = ',', $default = null)
+    public function explode($key = null, $delimiter = ',', $default = [])
     {
         $input = $this->input($key);
 

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -297,6 +297,21 @@ trait InteractsWithInput
     }
 
     /**
+     * Retrieve an exploded input from the request.
+     *
+     * @param  string|null  $key
+     * @param  string  $delimiter
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public function explode($key = null, $delimiter = ',', $default = null)
+    {
+        $input = $this->input($key);
+
+        return empty($input) ? $default : explode($delimiter, $input);
+    }
+
+    /**
      * Retrieve input from the request as a collection.
      *
      * @param  array|string|null  $key

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -506,10 +506,10 @@ class HttpRequestTest extends TestCase
     public function testExplodeMethod()
     {
         $request = Request::create('/', 'GET', ['tags' => 'Taylor,Laravel,Framework']);
-        $this->assertSame(['Taylor','Laravel','Framework'], $request->explode('tags'));
+        $this->assertSame(['Taylor', 'Laravel', 'Framework'], $request->explode('tags'));
 
         $request = Request::create('/', 'POST', ['tags' => 'Taylor/Laravel/Framework']);
-        $this->assertSame(['Taylor','Laravel','Framework'], $request->explode('tags', '/'));
+        $this->assertSame(['Taylor', 'Laravel', 'Framework'], $request->explode('tags', '/'));
 
         $request = Request::create('/', 'GET', []);
         $this->assertEmpty($request->explode('tags'));

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -503,6 +503,18 @@ class HttpRequestTest extends TestCase
         $this->assertFalse($request->boolean('some_undefined_key'));
     }
 
+    public function testExplodeMethod()
+    {
+        $request = Request::create('/', 'GET', ['tags' => 'Taylor,Laravel,Framework']);
+        $this->assertSame(['Taylor','Laravel','Framework'], $request->explode('tags'));
+
+        $request = Request::create('/', 'POST', ['tags' => 'Taylor/Laravel/Framework']);
+        $this->assertSame(['Taylor','Laravel','Framework'], $request->explode('tags', '/'));
+
+        $request = Request::create('/', 'GET', []);
+        $this->assertEmpty($request->explode('tags'));
+    }
+
     public function testCollectMethod()
     {
         $request = Request::create('/', 'GET', ['users' => [1, 2, 3]]);


### PR DESCRIPTION
This PR introduces a new helper method to the `Illuminate\Http\Request: explode($key, $delimiter)` which takes input using the input() method and explode value using given delimiter.

```
// Given that
// https://xyz.com?tags=Taylor,Laravel,Framework

// Before
$tags = !empty($input = $request->input('tags')) ? explode(',', $input) : [];

// After
$tags = $request->explode('tags');

// Or you can specify the delimiter
$tags = $request->explode('tags', ':');
```

Unsure how everyone feels about this and the naming of it though.