### PR TITLE
[8.x] Fail enum validation with pure enums

### DIFF
--- a/src/Illuminate/Validation/Rules/Enum.php
+++ b/src/Illuminate/Validation/Rules/Enum.php
@@ -33,7 +33,7 @@ class Enum implements Rule
      */
     public function passes($attribute, $value)
     {
-        if (is_null($value) || ! function_exists('enum_exists') || ! enum_exists($this->type)) {
+        if (is_null($value) || ! function_exists('enum_exists') || ! enum_exists($this->type) || ! method_exists($this->type, 'tryFrom')) {
             return false;
         }
 

--- a/tests/Validation/Enums.php
+++ b/tests/Validation/Enums.php
@@ -13,3 +13,9 @@ enum IntegerStatus: int
     case pending = 1;
     case done = 2;
 }
+
+enum PureEnum
+{
+    case one;
+    case two;
+}

--- a/tests/Validation/ValidationEnumRuleTest.php
+++ b/tests/Validation/ValidationEnumRuleTest.php
@@ -116,6 +116,21 @@ class ValidationEnumRuleTest extends TestCase
         $this->assertFalse($v->fails());
     }
 
+    public function testValidationFailsOnPureEnum()
+    {
+        $v = new Validator(
+            resolve('translator'),
+            [
+                'status' => 'one',
+            ],
+            [
+                'status' => ['required', new Enum(PureEnum::class)],
+            ]
+        );
+
+        $this->assertTrue($v->fails());
+    }
+
     protected function setUp(): void
     {
         $container = Container::getInstance();


### PR DESCRIPTION
The current enum validation (#39437) throws an error if a pure enum is used. Since a pure enum doesn't make sense in this context, the validation should simply fail. This is similar to the behavior for if the validation is used on PHP < 8.1.

Consider the following code:

```php
enum PureEnum
{
    case ONE;
    case TWO;
}

validator(
    ['status' => 'ONE'],
    ['status' => [new Enum(PureEnum::class)],
)->validate();
```

This code will throw an error, because the code expects a `tryFrom` static method on the enum. This method only exists on backed enums.