### PR TITLE
[8.x] Add type to foreignId()

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -871,15 +871,19 @@ class Blueprint
     }
 
     /**
-     * Create a new unsigned big integer (8-byte) column on the table.
+     * Create a new unsigned integer type column on the table.
      *
      * @param  string  $column
+     * @param  string  $type
      * @return \Illuminate\Database\Schema\ForeignIdColumnDefinition
      */
-    public function foreignId($column)
+    public function foreignId($column, $type = 'bigInteger')
     {
+        $type = in_array($type, ['bigInteger', 'integer', 'mediumInteger', 'smallInteger', 'tinyInteger'])
+            ? $type : 'bigInteger';
+
         return $this->addColumnDefinition(new ForeignIdColumnDefinition($this, [
-            'type' => 'bigInteger',
+            'type' => $type,
             'name' => $column,
             'autoIncrement' => false,
             'unsigned' => true,

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -467,21 +467,31 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
     {
         $blueprint = new Blueprint('users');
         $foreignId = $blueprint->foreignId('foo');
-        $blueprint->foreignId('company_id')->constrained();
-        $blueprint->foreignId('laravel_idea_id')->constrained();
-        $blueprint->foreignId('team_id')->references('id')->on('teams');
-        $blueprint->foreignId('team_column_id')->constrained('teams');
+        $blueprint->foreignId('company_id', 'integer')->constrained();
+        $blueprint->foreignId('laravel_idea_id', 'mediumInteger')->constrained();
+        $blueprint->foreignId('team_id', 'smallInteger')->references('id')->on('teams');
+        $blueprint->foreignId('team_column_id', 'tinyInteger')->constrained('teams');
 
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertInstanceOf(ForeignIdColumnDefinition::class, $foreignId);
         $this->assertSame([
-            'alter table `users` add `foo` bigint unsigned not null, add `company_id` bigint unsigned not null, add `laravel_idea_id` bigint unsigned not null, add `team_id` bigint unsigned not null, add `team_column_id` bigint unsigned not null',
+            'alter table `users` add `foo` bigint unsigned not null, add `company_id` int unsigned not null, add `laravel_idea_id` mediumint unsigned not null, add `team_id` smallint unsigned not null, add `team_column_id` tinyint unsigned not null',
             'alter table `users` add constraint `users_company_id_foreign` foreign key (`company_id`) references `companies` (`id`)',
             'alter table `users` add constraint `users_laravel_idea_id_foreign` foreign key (`laravel_idea_id`) references `laravel_ideas` (`id`)',
             'alter table `users` add constraint `users_team_id_foreign` foreign key (`team_id`) references `teams` (`id`)',
             'alter table `users` add constraint `users_team_column_id_foreign` foreign key (`team_column_id`) references `teams` (`id`)',
         ], $statements);
+    }
+
+    public function testAddingInvalidForeignIDType()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->foreignId('foreign_id', 'invalid');
+
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertEquals('alter table `users` add `foreign_id` bigint unsigned not null', $statements[0]);
     }
 
     public function testAddingBigIncrementingID()

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -373,16 +373,16 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
     {
         $blueprint = new Blueprint('users');
         $foreignId = $blueprint->foreignId('foo');
-        $blueprint->foreignId('company_id')->constrained();
-        $blueprint->foreignId('laravel_idea_id')->constrained();
-        $blueprint->foreignId('team_id')->references('id')->on('teams');
-        $blueprint->foreignId('team_column_id')->constrained('teams');
+        $blueprint->foreignId('company_id', 'integer')->constrained();
+        $blueprint->foreignId('laravel_idea_id', 'mediumInteger')->constrained();
+        $blueprint->foreignId('team_id', 'smallInteger')->references('id')->on('teams');
+        $blueprint->foreignId('team_column_id', 'tinyInteger')->constrained('teams');
 
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertInstanceOf(ForeignIdColumnDefinition::class, $foreignId);
         $this->assertSame([
-            'alter table "users" add column "foo" bigint not null, add column "company_id" bigint not null, add column "laravel_idea_id" bigint not null, add column "team_id" bigint not null, add column "team_column_id" bigint not null',
+            'alter table "users" add column "foo" bigint not null, add column "company_id" integer not null, add column "laravel_idea_id" integer not null, add column "team_id" smallint not null, add column "team_column_id" smallint not null',
             'alter table "users" add constraint "users_company_id_foreign" foreign key ("company_id") references "companies" ("id")',
             'alter table "users" add constraint "users_laravel_idea_id_foreign" foreign key ("laravel_idea_id") references "laravel_ideas" ("id")',
             'alter table "users" add constraint "users_team_id_foreign" foreign key ("team_id") references "teams" ("id")',

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -304,10 +304,10 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
     {
         $blueprint = new Blueprint('users');
         $foreignId = $blueprint->foreignId('foo');
-        $blueprint->foreignId('company_id')->constrained();
-        $blueprint->foreignId('laravel_idea_id')->constrained();
-        $blueprint->foreignId('team_id')->references('id')->on('teams');
-        $blueprint->foreignId('team_column_id')->constrained('teams');
+        $blueprint->foreignId('company_id', 'integer')->constrained();
+        $blueprint->foreignId('laravel_idea_id', 'mediumInteger')->constrained();
+        $blueprint->foreignId('team_id', 'smallInteger')->references('id')->on('teams');
+        $blueprint->foreignId('team_column_id', 'tinyInteger')->constrained('teams');
 
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -349,16 +349,16 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
     {
         $blueprint = new Blueprint('users');
         $foreignId = $blueprint->foreignId('foo');
-        $blueprint->foreignId('company_id')->constrained();
-        $blueprint->foreignId('laravel_idea_id')->constrained();
-        $blueprint->foreignId('team_id')->references('id')->on('teams');
-        $blueprint->foreignId('team_column_id')->constrained('teams');
+        $blueprint->foreignId('company_id', 'integer')->constrained();
+        $blueprint->foreignId('laravel_idea_id', 'mediumInteger')->constrained();
+        $blueprint->foreignId('team_id', 'smallInteger')->references('id')->on('teams');
+        $blueprint->foreignId('team_column_id', 'tinyInteger')->constrained('teams');
 
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertInstanceOf(ForeignIdColumnDefinition::class, $foreignId);
         $this->assertSame([
-            'alter table "users" add "foo" bigint not null, "company_id" bigint not null, "laravel_idea_id" bigint not null, "team_id" bigint not null, "team_column_id" bigint not null',
+            'alter table "users" add "foo" bigint not null, "company_id" int not null, "laravel_idea_id" int not null, "team_id" smallint not null, "team_column_id" tinyint not null',
             'alter table "users" add constraint "users_company_id_foreign" foreign key ("company_id") references "companies" ("id")',
             'alter table "users" add constraint "users_laravel_idea_id_foreign" foreign key ("laravel_idea_id") references "laravel_ideas" ("id")',
             'alter table "users" add constraint "users_team_id_foreign" foreign key ("team_id") references "teams" ("id")',


### PR DESCRIPTION
I think most developers use ``foreignId()``  method to generate foreign key constraints. But using certain integer types could just be an overkill or under used thus better to have a way to customize it.