### PR TITLE
[8.x] Fix request dump and dd methods

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -496,9 +496,7 @@ trait InteractsWithInput
      */
     public function dd(...$keys)
     {
-        $keys = is_array($keys) ? $keys : func_get_args();
-
-        call_user_func_array([$this, 'dump'], $keys);
+        $this->dump(...$keys);
 
         exit(1);
     }
@@ -506,7 +504,7 @@ trait InteractsWithInput
     /**
      * Dump the items.
      *
-     * @param  array  $keys
+     * @param  array|mixed  $keys
      * @return $this
      */
     public function dump($keys = [])

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -491,7 +491,7 @@ trait InteractsWithInput
     /**
      * Dump the request items and end the script.
      *
-     * @param  array|mixed  $keys
+     * @param  mixed  $keys
      * @return void
      */
     public function dd(...$keys)
@@ -504,7 +504,7 @@ trait InteractsWithInput
     /**
      * Dump the items.
      *
-     * @param  array|mixed  $keys
+     * @param  mixed  $keys
      * @return $this
      */
     public function dump($keys = [])


### PR DESCRIPTION
## What do I do?
1. I fix the `dump` docblock because it doesn't only accept array as parameters but also an argument list. These two calls produce the same result.

```php
// it takes an array.
$request->dump(['name', 'age']);

// it takes an argument list.
$request->dump('name', 'age');
```

2. Because `dd` method uses ... oparator, `$keys` in this context will be always an array and the check is unnecessary. `dd` just need to forward the call to `dump` and then to end the script.

```php
class Request
{
    public function dd(...$keys)
    {
        $this->dump(...$keys);

        exit(1);
    }
}
```
