### PR TITLE
[8.x] Replace escaped dot with place holder in dependent rules parameters

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -575,10 +575,12 @@ class Validator implements ValidatorContract
         // First we will get the correct keys for the given attribute in case the field is nested in
         // an array. Then we determine if the given rule accepts other field names as parameters.
         // If so, we will replace any asterisks found in the parameters with the correct keys.
-        if (($keys = $this->getExplicitKeys($attribute)) &&
-            $this->dependsOnOtherFields($rule)) {
+    if($this->dependsOnOtherFields($rule)){
+        $parameters = $this->replaceDotInParameters($parameters);
+        if ($keys = $this->getExplicitKeys($attribute)) {
             $parameters = $this->replaceAsterisksInParameters($parameters, $keys);
         }
+    }
 
         $value = $this->getValue($attribute);
 
@@ -671,6 +673,20 @@ class Validator implements ValidatorContract
     {
         return array_map(function ($field) use ($keys) {
             return vsprintf(str_replace('*', '%s', $field), $keys);
+        }, $parameters);
+    }
+
+    /**
+     * Replace each field parameter which has escaped dot with the dot placeholder.
+     *
+     * @param  array  $parameters
+     * @param  array  $keys
+     * @return array
+     */
+    protected function replaceDotInParameters(array $parameters)
+    {
+        return array_map(function ($field) {
+            return str_replace('\.', $this->dotPlaceholder, $field);
         }, $parameters);
     }
 

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -575,7 +575,7 @@ class Validator implements ValidatorContract
         // First we will get the correct keys for the given attribute in case the field is nested in
         // an array. Then we determine if the given rule accepts other field names as parameters.
         // If so, we will replace any asterisks found in the parameters with the correct keys.
-        if($this->dependsOnOtherFields($rule)){
+        if ($this->dependsOnOtherFields($rule)) {
             $parameters = $this->replaceDotInParameters($parameters);
             if ($keys = $this->getExplicitKeys($attribute)) {
                 $parameters = $this->replaceAsterisksInParameters($parameters, $keys);

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -575,12 +575,12 @@ class Validator implements ValidatorContract
         // First we will get the correct keys for the given attribute in case the field is nested in
         // an array. Then we determine if the given rule accepts other field names as parameters.
         // If so, we will replace any asterisks found in the parameters with the correct keys.
-    if($this->dependsOnOtherFields($rule)){
-        $parameters = $this->replaceDotInParameters($parameters);
-        if ($keys = $this->getExplicitKeys($attribute)) {
-            $parameters = $this->replaceAsterisksInParameters($parameters, $keys);
+        if($this->dependsOnOtherFields($rule)){
+            $parameters = $this->replaceDotInParameters($parameters);
+            if ($keys = $this->getExplicitKeys($attribute)) {
+                $parameters = $this->replaceAsterisksInParameters($parameters, $keys);
+            }
         }
-    }
 
         $value = $this->getValue($attribute);
 

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -577,6 +577,7 @@ class Validator implements ValidatorContract
         // If so, we will replace any asterisks found in the parameters with the correct keys.
         if ($this->dependsOnOtherFields($rule)) {
             $parameters = $this->replaceDotInParameters($parameters);
+
             if ($keys = $this->getExplicitKeys($attribute)) {
                 $parameters = $this->replaceAsterisksInParameters($parameters, $keys);
             }
@@ -663,6 +664,20 @@ class Validator implements ValidatorContract
     }
 
     /**
+     * Replace each field parameter which has an escaped dot with the dot placeholder.
+     *
+     * @param  array  $parameters
+     * @param  array  $keys
+     * @return array
+     */
+    protected function replaceDotInParameters(array $parameters)
+    {
+        return array_map(function ($field) {
+            return str_replace('\.', $this->dotPlaceholder, $field);
+        }, $parameters);
+    }
+
+    /**
      * Replace each field parameter which has asterisks with the given keys.
      *
      * @param  array  $parameters
@@ -673,20 +688,6 @@ class Validator implements ValidatorContract
     {
         return array_map(function ($field) use ($keys) {
             return vsprintf(str_replace('*', '%s', $field), $keys);
-        }, $parameters);
-    }
-
-    /**
-     * Replace each field parameter which has escaped dot with the dot placeholder.
-     *
-     * @param  array  $parameters
-     * @param  array  $keys
-     * @return array
-     */
-    protected function replaceDotInParameters(array $parameters)
-    {
-        return array_map(function ($field) {
-            return str_replace('\.', $this->dotPlaceholder, $field);
         }, $parameters);
     }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4874,7 +4874,7 @@ class ValidationValidatorTest extends TestCase
     }
 
     public function testParsingArrayKeysWithDotWhenTestingExistence()
-	{
+    {
         $trans = $this->getIlluminateArrayTranslator();
         // RequiredWith using escaped dot in a nested array
         $v = new Validator($trans, ['foo' => '', 'bar' => ['foo.bar' => 'valid']], ['foo' => 'required_with:bar.foo\.bar']);
@@ -4894,7 +4894,7 @@ class ValidationValidatorTest extends TestCase
         // RequiredUnless using escaped dot in a nested array
         $v = new Validator($trans, ['foo' => '', 'bar' => ['foo.bar' => 'valid']], ['foo' => 'required_unless:bar.foo\.bar,valid']);
         $this->assertTrue($v->passes());
-	}
+    }
 
     public function testPassingSlashVulnerability()
     {

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4856,44 +4856,44 @@ class ValidationValidatorTest extends TestCase
     public function testParsingArrayKeysWithDot()
     {
         $trans = $this->getIlluminateArrayTranslator();
-		// Interpreted dot fails on empty value
+        // Interpreted dot fails on empty value
         $v = new Validator($trans, ['foo' => ['bar' => ''], 'foo.bar' => 'valid'], ['foo.bar' => 'required']);
         $this->assertTrue($v->fails());
-		// Escaped dot fails on empty value
+        // Escaped dot fails on empty value
         $v = new Validator($trans, ['foo' => ['bar' => 'valid'], 'foo.bar' => ''], ['foo\.bar' => 'required']);
         $this->assertTrue($v->fails());
-		// Interpreted dot succeeds
+        // Interpreted dot succeeds
         $v = new Validator($trans, ['foo' => ['bar' => 'valid'], 'foo.bar' => 'zxc'], ['foo\.bar' => 'required']);
         $this->assertFalse($v->fails());
-		// Interpreted dot followed by escaped dot fails on empty value
+        // Interpreted dot followed by escaped dot fails on empty value
         $v = new Validator($trans, ['foo' => ['bar.baz' => '']], ['foo.bar\.baz' => 'required']);
         $this->assertTrue($v->fails());
-		// Interpreted dot followed by escaped dot fails on empty value
+        // Interpreted dot followed by escaped dot fails on empty value
         $v = new Validator($trans, ['foo' => [['bar.baz' => ''], ['bar.baz' => '']]], ['foo.*.bar\.baz' => 'required']);
         $this->assertTrue($v->fails());
     }
 
     public function testParsingArrayKeysWithDotWhenTestingExistence()
 	{
-		$trans = $this->getIlluminateArrayTranslator();
+        $trans = $this->getIlluminateArrayTranslator();
         // RequiredWith using escaped dot in a nested array
-		$v = new Validator($trans, ['foo' => '', 'bar' => ['foo.bar' => 'valid']], ['foo' => 'required_with:bar.foo\.bar']);
-		$this->assertFalse($v->passes());
+        $v = new Validator($trans, ['foo' => '', 'bar' => ['foo.bar' => 'valid']], ['foo' => 'required_with:bar.foo\.bar']);
+        $this->assertFalse($v->passes());
         // RequiredWithAll using escaped dot in a nested array
-		$v = new Validator($trans, ['foo' => '', 'bar' => ['foo.bar' => 'valid']], ['foo' => 'required_with_all:bar.foo\.bar']);
-		$this->assertFalse($v->passes());
+        $v = new Validator($trans, ['foo' => '', 'bar' => ['foo.bar' => 'valid']], ['foo' => 'required_with_all:bar.foo\.bar']);
+        $this->assertFalse($v->passes());
         // RequiredWithout using escaped dot in a nested array
-		$v = new Validator($trans, ['foo' => 'valid', 'bar' => ['foo.bar' => 'valid']], ['foo' => 'required_without:bar.foo\.bar']);
-		$this->assertTrue($v->passes());
+        $v = new Validator($trans, ['foo' => 'valid', 'bar' => ['foo.bar' => 'valid']], ['foo' => 'required_without:bar.foo\.bar']);
+        $this->assertTrue($v->passes());
         // RequiredWithoutAll using escaped dot in a nested array
-		$v = new Validator($trans, ['foo' => 'valid', 'bar' => ['foo.bar' => 'valid']], ['foo' => 'required_without_all:bar.foo\.bar']);
-		$this->assertTrue($v->passes());
+        $v = new Validator($trans, ['foo' => 'valid', 'bar' => ['foo.bar' => 'valid']], ['foo' => 'required_without_all:bar.foo\.bar']);
+        $this->assertTrue($v->passes());
         // Same using escaped dot in a nested array
-		$v = new Validator($trans, ['foo' => 'valid', 'bar' => ['foo.bar' => 'valid']], ['foo' => 'same:bar.foo\.bar']);
-		$this->assertTrue($v->passes());
+        $v = new Validator($trans, ['foo' => 'valid', 'bar' => ['foo.bar' => 'valid']], ['foo' => 'same:bar.foo\.bar']);
+        $this->assertTrue($v->passes());
         // RequiredUnless using escaped dot in a nested array
-		$v = new Validator($trans, ['foo' => '', 'bar' => ['foo.bar' => 'valid']], ['foo' => 'required_unless:bar.foo\.bar,valid']);
-		$this->assertTrue($v->passes());
+        $v = new Validator($trans, ['foo' => '', 'bar' => ['foo.bar' => 'valid']], ['foo' => 'required_unless:bar.foo\.bar,valid']);
+        $this->assertTrue($v->passes());
 	}
 
     public function testPassingSlashVulnerability()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4856,22 +4856,45 @@ class ValidationValidatorTest extends TestCase
     public function testParsingArrayKeysWithDot()
     {
         $trans = $this->getIlluminateArrayTranslator();
-
+		// Interpreted dot fails on empty value
         $v = new Validator($trans, ['foo' => ['bar' => ''], 'foo.bar' => 'valid'], ['foo.bar' => 'required']);
         $this->assertTrue($v->fails());
-
+		// Escaped dot fails on empty value
         $v = new Validator($trans, ['foo' => ['bar' => 'valid'], 'foo.bar' => ''], ['foo\.bar' => 'required']);
         $this->assertTrue($v->fails());
-
+		// Interpreted dot succeeds
         $v = new Validator($trans, ['foo' => ['bar' => 'valid'], 'foo.bar' => 'zxc'], ['foo\.bar' => 'required']);
         $this->assertFalse($v->fails());
-
+		// Interpreted dot followed by escaped dot fails on empty value
         $v = new Validator($trans, ['foo' => ['bar.baz' => '']], ['foo.bar\.baz' => 'required']);
         $this->assertTrue($v->fails());
-
+		// Interpreted dot followed by escaped dot fails on empty value
         $v = new Validator($trans, ['foo' => [['bar.baz' => ''], ['bar.baz' => '']]], ['foo.*.bar\.baz' => 'required']);
         $this->assertTrue($v->fails());
     }
+
+    public function testParsingArrayKeysWithDotWhenTestingExistence()
+	{
+		$trans = $this->getIlluminateArrayTranslator();
+        // RequiredWith using escaped dot in a nested array
+		$v = new Validator($trans, ['foo' => '', 'bar' => ['foo.bar' => 'valid']], ['foo' => 'required_with:bar.foo\.bar']);
+		$this->assertFalse($v->passes());
+        // RequiredWithAll using escaped dot in a nested array
+		$v = new Validator($trans, ['foo' => '', 'bar' => ['foo.bar' => 'valid']], ['foo' => 'required_with_all:bar.foo\.bar']);
+		$this->assertFalse($v->passes());
+        // RequiredWithout using escaped dot in a nested array
+		$v = new Validator($trans, ['foo' => 'valid', 'bar' => ['foo.bar' => 'valid']], ['foo' => 'required_without:bar.foo\.bar']);
+		$this->assertTrue($v->passes());
+        // RequiredWithoutAll using escaped dot in a nested array
+		$v = new Validator($trans, ['foo' => 'valid', 'bar' => ['foo.bar' => 'valid']], ['foo' => 'required_without_all:bar.foo\.bar']);
+		$this->assertTrue($v->passes());
+        // Same using escaped dot in a nested array
+		$v = new Validator($trans, ['foo' => 'valid', 'bar' => ['foo.bar' => 'valid']], ['foo' => 'same:bar.foo\.bar']);
+		$this->assertTrue($v->passes());
+        // RequiredUnless using escaped dot in a nested array
+		$v = new Validator($trans, ['foo' => '', 'bar' => ['foo.bar' => 'valid']], ['foo' => 'required_unless:bar.foo\.bar,valid']);
+		$this->assertTrue($v->passes());
+	}
 
     public function testPassingSlashVulnerability()
     {


### PR DESCRIPTION
Hi,
While using the validation tool i stumbled upon an issue with the "required_without" rule.
My use case was somewhat unusual but i needed to check that a field was required if a key was present in an array.
The catch is that the key had a dot in it and i couldn't escape it.

Example:
data: `["country" => ["country_code" => "FR"], "city" => ["iata.alternate_name" => "ORY"]]`
rules: `['country.country_code' => ['required_without:city.iata\.alternate_name', 'size:2'], 
'city.iata\.alternate_name' => ['required_without:country.country_code', 'size:3'],];`

Issue:
The rule wouldn't passe because the dot was interpreted as a nested array.

Solution:
I replaced the dot with the dot placeholder for dependent rules.