### PR TITLE
[8.x] Add default message to password rule

### DIFF
--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -87,6 +87,13 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
     protected $messages = [];
 
     /**
+     * The default message that should be used when validation fails.
+     *
+     * @var string
+     */
+    protected $defaultMessage;
+
+    /**
      * The callback that will generate the "default" version of the password rule.
      *
      * @var string|array|callable|null
@@ -259,6 +266,13 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
         return $this;
     }
 
+    public function withDefaultMessage($message)
+    {
+        $this->defaultMessage = $message;
+
+        return $this;
+    }
+
     /**
      * Determine if the validation rule passes.
      *
@@ -319,6 +333,10 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
      */
     public function message()
     {
+        if ($this->defaultMessage) {
+            return [$this->defaultMessage];
+        }
+
         return $this->messages;
     }
 

--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -269,7 +269,7 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
     /**
      * Sets default failure message, this will override all the failure message.
      *
-     * @param string $message
+     * @param  string  $message
      * @return $this
      */
     public function withDefaultMessage($message)

--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -266,6 +266,12 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
         return $this;
     }
 
+    /**
+     * Sets default failure message, this will override all the failure message.
+     *
+     * @param string $message
+     * @return $this
+     */
     public function withDefaultMessage($message)
     {
         $this->defaultMessage = $message;

--- a/tests/Validation/ValidationPasswordRuleTest.php
+++ b/tests/Validation/ValidationPasswordRuleTest.php
@@ -134,6 +134,13 @@ class ValidationPasswordRuleTest extends TestCase
         ]);
     }
 
+    public function testWithDefaultMessage()
+    {
+        $this->fails(Password::min(8)->withDefaultMessage('This is the default message.'), ['ab', '1v'], [
+            'This is the default message.',
+        ]);
+    }
+
     public function testMessagesOrder()
     {
         $makeRules = function () {


### PR DESCRIPTION
Currently it is not ease to override all the error messages of the password rule at once.

With this change it is possible to add a defaultMessage that will override other messages.
You can use it by using:
```
Password::min(8)->withDefaultMessage('This is the default message.')
```