### PR TITLE
[8.x] Fixes reporting deprecations when logger is not ready yet

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -86,6 +86,10 @@ class HandleExceptions
      */
     public function handleDeprecation($message, $file, $line)
     {
+        if (! class_exists(LogManager::class)) {
+            return;
+        }
+
         try {
             $logger = $this->app->make(LogManager::class);
         } catch (Exception $e) {


### PR DESCRIPTION
This pull request addresses [#286](https://github.com/laravel/sail/issues/286), and [laracasts.com/discuss/channels/laravel/logmanager-not-found](https://laracasts.com/discuss/channels/laravel/logmanager-not-found), by not trying to log deprecations if the deprecation itself comes while composer is trying to load the `LogManager` class.

It's unclear, at this time, where the deprecation comes from, but we suspect that it's from one of the `LogManager` class dependencies at one **specific version** that is allowed by our **composer.json** file.