### PR TITLE
[8.x] Fix possible out of memory error when deleting values by reference key from cache in Redis driver

### DIFF
--- a/src/Illuminate/Cache/RedisTaggedCache.php
+++ b/src/Illuminate/Cache/RedisTaggedCache.php
@@ -178,11 +178,12 @@ class RedisTaggedCache extends TaggedCache
      */
     protected function deleteValues($referenceKey)
     {
-        $defaultCursorValue = '0';
-        $cursor = $defaultCursorValue;
+        $cursor = $defaultCursorValue = '0';
 
         do {
-            [$cursor, $valuesChunk] = $this->store->connection()->sscan($referenceKey, $cursor, ['MATCH' => '*', 'COUNT' => 1000]);
+            [$cursor, $valuesChunk] = $this->store->connection()->sscan(
+                $referenceKey, $cursor, ['MATCH' => '*', 'COUNT' => 1000]
+            );
 
             $valuesChunk = array_unique($valuesChunk);
 

--- a/src/Illuminate/Cache/RedisTaggedCache.php
+++ b/src/Illuminate/Cache/RedisTaggedCache.php
@@ -178,13 +178,18 @@ class RedisTaggedCache extends TaggedCache
      */
     protected function deleteValues($referenceKey)
     {
-        $values = array_unique($this->store->connection()->smembers($referenceKey));
+        $defaultCursorValue = '0';
+        $cursor = $defaultCursorValue;
 
-        if (count($values) > 0) {
-            foreach (array_chunk($values, 1000) as $valuesChunk) {
+        do {
+            [$cursor, $valuesChunk] = $this->store->connection()->sscan($referenceKey, $cursor, ['MATCH' => '*', 'COUNT' => 1000]);
+
+            $valuesChunk = array_unique($valuesChunk);
+
+            if (count($valuesChunk) > 0) {
                 $this->store->connection()->del(...$valuesChunk);
             }
-        }
+        } while ($cursor !== $defaultCursorValue);
     }
 
     /**

--- a/tests/Cache/CacheTaggedCacheTest.php
+++ b/tests/Cache/CacheTaggedCacheTest.php
@@ -267,16 +267,16 @@ class CacheTaggedCacheTest extends TestCase
         $store->shouldReceive('connection')->andReturn($conn = m::mock(stdClass::class));
 
         // Forever tag keys
-        $conn->shouldReceive('smembers')->once()->with('prefix:foo:forever_ref')->andReturn(['key1', 'key2']);
-        $conn->shouldReceive('smembers')->once()->with('prefix:bar:forever_ref')->andReturn(['key3']);
+        $conn->shouldReceive('sscan')->once()->with('prefix:foo:forever_ref', '0', ['MATCH' => '*', 'COUNT' => 1000])->andReturn(['0', ['key1', 'key2']]);
+        $conn->shouldReceive('sscan')->once()->with('prefix:bar:forever_ref', '0', ['MATCH' => '*', 'COUNT' => 1000])->andReturn(['0', ['key3']]);
         $conn->shouldReceive('del')->once()->with('key1', 'key2');
         $conn->shouldReceive('del')->once()->with('key3');
         $conn->shouldReceive('del')->once()->with('prefix:foo:forever_ref');
         $conn->shouldReceive('del')->once()->with('prefix:bar:forever_ref');
 
         // Standard tag keys
-        $conn->shouldReceive('smembers')->once()->with('prefix:foo:standard_ref')->andReturn(['key4', 'key5']);
-        $conn->shouldReceive('smembers')->once()->with('prefix:bar:standard_ref')->andReturn(['key6']);
+        $conn->shouldReceive('sscan')->once()->with('prefix:foo:standard_ref', '0', ['MATCH' => '*', 'COUNT' => 1000])->andReturn(['0', ['key4', 'key5']]);
+        $conn->shouldReceive('sscan')->once()->with('prefix:bar:standard_ref', '0', ['MATCH' => '*', 'COUNT' => 1000])->andReturn(['0', ['key6']]);
         $conn->shouldReceive('del')->once()->with('key4', 'key5');
         $conn->shouldReceive('del')->once()->with('key6');
         $conn->shouldReceive('del')->once()->with('prefix:foo:standard_ref');


### PR DESCRIPTION
Hi there,
This PR solves possible out of memory issue when deleting values by reference key from cache in Redis driver.

Example:
`$values = array_unique($this->store->connection()->smembers($referenceKey));`

Issue:
If there are too many values referenced by key, we get out of memory error. In this case deleting values using chunks does not make sense because memory overflows earlier.

Solution:
I suggest to use `sscan` to retrieve values from Redis by chunks using cursor. Then remove all unique values in chunk and get new chunk. Repeat before all values have been processed.