### PR TITLE
[8.0] Making `throw()` callback function argument explicit.

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -267,10 +267,8 @@ class Response implements ArrayAccess
      *
      * @throws \Illuminate\Http\Client\RequestException
      */
-    public function throw()
+    public function throw($callback = null)
     {
-        $callback = func_get_args()[0] ?? null;
-
         if ($this->failed()) {
             throw tap($this->toException(), function ($exception) use ($callback) {
                 if ($callback && is_callable($callback)) {


### PR DESCRIPTION
Made the callback function more explicit, by adding the parameter to the method.

This is probably breaking change for anyone overriding the `Response::throw` method, so you would probably only want to merge this in master?

Other suggestions:
* throw function let it also accept a class name of an exception eg: `->throw(MyExceptionClassWithResponseAsSingleParamterInConstructor::class)`
* toException() can return `null` => which is very weird as in this function it excepts to always return an exception. If user override the Response class and make it return null, this `throw()` method would crash because it would `throw null;` => thus i would suggest it not allow to return null, ever.

I would like to hear feedback on these ideas
I can make these changes if wanted.