### PR TITLE
[8.x] Adds datetime parsing to `Request` instance

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -9,6 +9,8 @@ use SplFileInfo;
 use stdClass;
 use Symfony\Component\VarDumper\VarDumper;
 
+use function is_null;
+
 trait InteractsWithInput
 {
     /**
@@ -314,11 +316,12 @@ trait InteractsWithInput
      * @param  string  $key
      * @param  string|null  $format
      * @param  string|null  $tz
+     * @param  \Closure|string|null  $default
      * @return \DateTimeInterface|\Illuminate\Support\Carbon|null
      */
-    public function datetime($key, $format = null, $tz = null)
+    public function datetime($key, $format = null, $tz = null, $default = null)
     {
-        $date = $this->input($key);
+        $date = $this->input($key) ?? value($default, $this);
 
         if (is_null($date)) {
             return null;

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -314,19 +314,22 @@ trait InteractsWithInput
      * @param  string  $key
      * @param  string|null  $format
      * @param  string|null  $tz
-     * @param  \Closure|string|null  $default
-     * @return \DateTimeInterface|\Illuminate\Support\Carbon|null
+     * @return \Illuminate\Support\Carbon|bool|null
      */
-    public function datetime($key, $format = null, $tz = null, $default = null)
+    public function datetime($key, $format = null, $tz = null)
     {
-        $date = $this->input($key) ?? value($default, $this);
+        $date = $this->input($key);
 
         if (is_null($date)) {
             return null;
         }
 
         if ($format) {
-            return Date::createFromFormat($format, $date, $tz);
+            try {
+                return Date::createFromFormat($format, $date, $tz);
+            } catch (InvalidArgumentException $e) {
+                return false;
+            }
         }
 
         return Date::parse($date, $tz);

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -310,7 +310,7 @@ trait InteractsWithInput
 
     /**
      * Retrieve input from the request as a Carbon instance.
-     * 
+     *
      * @param  string  $key
      * @param  string|null  $format
      * @param  string|null  $tz

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -298,17 +298,6 @@ trait InteractsWithInput
     }
 
     /**
-     * Retrieve input from the request as a collection.
-     *
-     * @param  array|string|null  $key
-     * @return \Illuminate\Support\Collection
-     */
-    public function collect($key = null)
-    {
-        return collect(is_array($key) ? $this->only($key) : $this->input($key));
-    }
-
-    /**
      * Retrieve input from the request as a Carbon instance.
      *
      * @param  string  $key
@@ -327,6 +316,17 @@ trait InteractsWithInput
         }
 
         return Date::createFromFormat($format, $this->input($key), $tz);
+    }
+
+    /**
+     * Retrieve input from the request as a collection.
+     *
+     * @param  array|string|null  $key
+     * @return \Illuminate\Support\Collection
+     */
+    public function collect($key = null)
+    {
+        return collect(is_array($key) ? $this->only($key) : $this->input($key));
     }
 
     /**

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -4,6 +4,7 @@ namespace Illuminate\Http\Concerns;
 
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Date;
 use SplFileInfo;
 use stdClass;
 use Symfony\Component\VarDumper\VarDumper;
@@ -305,6 +306,29 @@ trait InteractsWithInput
     public function collect($key = null)
     {
         return collect(is_array($key) ? $this->only($key) : $this->input($key));
+    }
+
+    /**
+     * Retrieve input from the request as a Carbon instance.
+     * 
+     * @param  string  $key
+     * @param  string|null  $format
+     * @param  string|null  $tz
+     * @return \DateTimeInterface|\Illuminate\Support\Carbon|null
+     */
+    public function datetime($key, $format = null, $tz = null)
+    {
+        $date = $this->input($key);
+
+        if (is_null($date)) {
+            return null;
+        }
+
+        if ($format) {
+            return Date::createFromFormat($format, $date, $tz);
+        }
+
+        return Date::parse($date, $tz);
     }
 
     /**

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -5,6 +5,7 @@ namespace Illuminate\Http\Concerns;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Date;
+use InvalidArgumentException;
 use SplFileInfo;
 use stdClass;
 use Symfony\Component\VarDumper\VarDumper;
@@ -314,25 +315,23 @@ trait InteractsWithInput
      * @param  string  $key
      * @param  string|null  $format
      * @param  string|null  $tz
-     * @return \Illuminate\Support\Carbon|bool|null
+     * @return \Illuminate\Support\Carbon|null
      */
     public function datetime($key, $format = null, $tz = null)
     {
-        $date = $this->input($key);
-
-        if (is_null($date)) {
+        if ($this->isNotFilled($key)) {
             return null;
         }
 
-        if ($format) {
-            try {
-                return Date::createFromFormat($format, $date, $tz);
-            } catch (InvalidArgumentException $e) {
-                return false;
+        try {
+            if (is_null($format)) {
+                return Date::parse($this->input($key), $tz);
+            } else {
+                return Date::createFromFormat($format, $this->input($key), $tz);
             }
+        } catch (InvalidArgumentException $e) {
+            return null;
         }
-
-        return Date::parse($date, $tz);
     }
 
     /**

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -317,7 +317,7 @@ trait InteractsWithInput
      * @param  string|null  $tz
      * @return \Illuminate\Support\Carbon|null
      */
-    public function datetime($key, $format = null, $tz = null)
+    public function date($key, $format = null, $tz = null)
     {
         if ($this->isNotFilled($key)) {
             return null;

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -9,8 +9,6 @@ use SplFileInfo;
 use stdClass;
 use Symfony\Component\VarDumper\VarDumper;
 
-use function is_null;
-
 trait InteractsWithInput
 {
     /**

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -323,15 +323,11 @@ trait InteractsWithInput
             return null;
         }
 
-        try {
-            if (is_null($format)) {
-                return Date::parse($this->input($key), $tz);
-            } else {
-                return Date::createFromFormat($format, $this->input($key), $tz);
-            }
-        } catch (InvalidArgumentException $e) {
-            return null;
+        if (is_null($format)) {
+            return Date::parse($this->input($key), $tz);
         }
+        
+        return Date::createFromFormat($format, $this->input($key), $tz);
     }
 
     /**

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -5,7 +5,6 @@ namespace Illuminate\Http\Concerns;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Date;
-use InvalidArgumentException;
 use SplFileInfo;
 use stdClass;
 use Symfony\Component\VarDumper\VarDumper;
@@ -326,7 +325,7 @@ trait InteractsWithInput
         if (is_null($format)) {
             return Date::parse($this->input($key), $tz);
         }
-        
+
         return Date::createFromFormat($format, $this->input($key), $tz);
     }
 

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -532,6 +532,29 @@ class HttpRequestTest extends TestCase
         $this->assertEquals(['users' => [1, 2, 3], 'roles' => [4, 5, 6], 'foo' => ['bar', 'baz'], 'email' => 'test@example.com'], $request->collect()->all());
     }
 
+    public function testDatetimeMethod()
+    {
+        $request = Request::create('/', 'GET', [
+            'as_date' => '2020-01-01',
+            'as_datetime' => '20-01-01 16:30:25',
+            'as_time' => '16:30:25',
+            'as_timestamp' => '1577907000',
+            'as_null' => null,
+            'as_format' => '20200101163025',
+            'as_timezone' => '20200101173025',
+        ]);
+
+        $this->assertNull($request->datetime('as_null'));
+        $this->assertTrue($request->datetime('as_date')->equalTo('2020-01-01'));
+        $this->assertTrue($request->datetime('as_datetime')->equalTo('2020-01-01'));
+        $this->assertTrue($request->datetime('as_time')->equalTo('16:30:25'));
+        $this->assertTrue($request->datetime('as_timestamp')->equalTo('2020-01-01 16:30:25'));
+        $this->assertTrue($request->datetime('as_format', 'YmdHis')->equalTo('2020-01-01 16:30:25'));
+        $this->assertTrue(
+            $request->datetime('as_format', 'YmdHis', 'Europe/Stockholm')->equalTo('2020-01-01 16:30:25')
+        );
+    }
+
     public function testArrayAccess()
     {
         $request = Request::create('/', 'GET', ['name' => null, 'foo' => ['bar' => null, 'baz' => '']]);

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -537,7 +537,7 @@ class HttpRequestTest extends TestCase
     {
         $request = Request::create('/', 'GET', [
             'as_null' => null,
-            'as_invalid' => 'invalid'
+            'as_invalid' => 'invalid',
             'as_date' => '2020-01-01',
             'as_datetime' => '20-01-01 16:30:25',
             'as_time' => '16:30:25',
@@ -545,11 +545,11 @@ class HttpRequestTest extends TestCase
             'as_timezone' => '20-01-01 13:30:25',
         ]);
 
-        $current = Carbon::create(2020, 1, 1, 16, 30, 25, 'UTC');
+        $current = Carbon::create(2020, 1, 1, 16, 30, 25);
 
         $this->assertNull($request->datetime('as_null'));
         $this->assertNull($request->datetime('doesnt_exists'));
-        $this->assertFalse($request->datetime('as_invalid'))
+        $this->assertNull($request->datetime('as_invalid'));
         $this->assertTrue($request->datetime('as_date')->isSameDay($current));
         $this->assertEquals($current, $request->datetime('as_datetime'));
         $this->assertTrue($request->datetime('as_time')->isSameSecond('16:30:25'));

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -14,6 +14,8 @@ use RuntimeException;
 use Symfony\Component\HttpFoundation\File\UploadedFile as SymfonyUploadedFile;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
+use function now;
+
 class HttpRequestTest extends TestCase
 {
     protected function tearDown(): void
@@ -553,6 +555,15 @@ class HttpRequestTest extends TestCase
         $this->assertTrue($request->datetime('as_time')->isSameSecond('16:30:25'));
         $this->assertEquals($current, $request->datetime('as_format', 'U'));
         $this->assertEquals($current,  $request->datetime('as_timezone', null, 'America/Santiago'));
+
+        Carbon::setTestNow($current);
+
+        $this->assertEquals($current, $request->datetime('as_null', null, null, 'now'));
+        $this->assertEquals($current, $request->datetime('as_null', null, null, function ($request) {
+            return $request->input('as_datetime');
+        }));
+
+        Carbon::setTestNow();
     }
 
     public function testArrayAccess()

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -14,8 +14,6 @@ use RuntimeException;
 use Symfony\Component\HttpFoundation\File\UploadedFile as SymfonyUploadedFile;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
-use function now;
-
 class HttpRequestTest extends TestCase
 {
     protected function tearDown(): void
@@ -546,7 +544,7 @@ class HttpRequestTest extends TestCase
             'as_timezone' => '20-01-01 13:30:25',
         ]);
 
-        $current = Carbon::create(2020, 1, 1,16,30,25,'UTC');
+        $current = Carbon::create(2020, 1, 1, 16, 30, 25, 'UTC');
 
         $this->assertNull($request->datetime('as_null'));
         $this->assertNull($request->datetime('doesnt_exists'));
@@ -554,7 +552,7 @@ class HttpRequestTest extends TestCase
         $this->assertEquals($current, $request->datetime('as_datetime'));
         $this->assertTrue($request->datetime('as_time')->isSameSecond('16:30:25'));
         $this->assertEquals($current, $request->datetime('as_format', 'U'));
-        $this->assertEquals($current,  $request->datetime('as_timezone', null, 'America/Santiago'));
+        $this->assertEquals($current, $request->datetime('as_timezone', null, 'America/Santiago'));
 
         Carbon::setTestNow($current);
 

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Routing\Route;
 use Illuminate\Session\Store;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -538,21 +539,20 @@ class HttpRequestTest extends TestCase
             'as_date' => '2020-01-01',
             'as_datetime' => '20-01-01 16:30:25',
             'as_time' => '16:30:25',
-            'as_timestamp' => '1577907000',
+            'as_format' => '1577896225',
             'as_null' => null,
-            'as_format' => '20200101163025',
-            'as_timezone' => '20200101173025',
+            'as_timezone' => '20-01-01 13:30:25',
         ]);
 
+        $current = Carbon::create(2020, 1, 1,16,30,25,'UTC');
+
         $this->assertNull($request->datetime('as_null'));
-        $this->assertTrue($request->datetime('as_date')->equalTo('2020-01-01'));
-        $this->assertTrue($request->datetime('as_datetime')->equalTo('2020-01-01'));
-        $this->assertTrue($request->datetime('as_time')->equalTo('16:30:25'));
-        $this->assertTrue($request->datetime('as_timestamp')->equalTo('2020-01-01 16:30:25'));
-        $this->assertTrue($request->datetime('as_format', 'YmdHis')->equalTo('2020-01-01 16:30:25'));
-        $this->assertTrue(
-            $request->datetime('as_format', 'YmdHis', 'Europe/Stockholm')->equalTo('2020-01-01 16:30:25')
-        );
+        $this->assertNull($request->datetime('doesnt_exists'));
+        $this->assertTrue($request->datetime('as_date')->isSameDay($current));
+        $this->assertEquals($current, $request->datetime('as_datetime'));
+        $this->assertTrue($request->datetime('as_time')->isSameSecond('16:30:25'));
+        $this->assertEquals($current, $request->datetime('as_format', 'U'));
+        $this->assertEquals($current,  $request->datetime('as_timezone', null, 'America/Santiago'));
     }
 
     public function testArrayAccess()

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -2,13 +2,13 @@
 
 namespace Illuminate\Tests\Http;
 
-use InvalidArgumentException;
 use Illuminate\Http\Request;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Routing\Route;
 use Illuminate\Session\Store;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
+use InvalidArgumentException;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
@@ -563,7 +563,7 @@ class HttpRequestTest extends TestCase
 
     public function testDateMethodExceptionWhenValueInvalid()
     {
-        $this->expectsException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         
         $request = Request::create('/', 'GET', [
             'date' => 'invalid',
@@ -574,7 +574,7 @@ class HttpRequestTest extends TestCase
 
     public function testDateMethodExceptionWhenFormatInvalid()
     {
-        $this->expectsException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $request = Request::create('/', 'GET', [
             'date' => '20-01-01 16:30:25',

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -533,7 +533,7 @@ class HttpRequestTest extends TestCase
         $this->assertEquals(['users' => [1, 2, 3], 'roles' => [4, 5, 6], 'foo' => ['bar', 'baz'], 'email' => 'test@example.com'], $request->collect()->all());
     }
 
-    public function testDatetimeMethod()
+    public function testDateMethod()
     {
         $request = Request::create('/', 'GET', [
             'as_null' => null,
@@ -549,16 +549,16 @@ class HttpRequestTest extends TestCase
 
         $current = Carbon::create(2020, 1, 1, 16, 30, 25);
 
-        $this->assertNull($request->datetime('as_null'));
-        $this->assertNull($request->datetime('doesnt_exists'));
-        $this->assertNull($request->datetime('as_invalid'));
+        $this->assertNull($request->date('as_null'));
+        $this->assertNull($request->date('doesnt_exists'));
+        $this->assertNull($request->date('as_invalid'));
 
-        $this->assertEquals($current, $request->datetime('as_datetime'));
-        $this->assertEquals($current, $request->datetime('as_format', 'U'));
-        $this->assertEquals($current, $request->datetime('as_timezone', null, 'America/Santiago'));
+        $this->assertEquals($current, $request->date('as_datetime'));
+        $this->assertEquals($current, $request->date('as_format', 'U'));
+        $this->assertEquals($current, $request->date('as_timezone', null, 'America/Santiago'));
 
-        $this->assertTrue($request->datetime('as_date')->isSameDay($current));
-        $this->assertTrue($request->datetime('as_time')->isSameSecond('16:30:25'));
+        $this->assertTrue($request->date('as_date')->isSameDay($current));
+        $this->assertTrue($request->date('as_time')->isSameSecond('16:30:25'));
     }
 
     public function testArrayAccess()

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -564,7 +564,7 @@ class HttpRequestTest extends TestCase
     public function testDateMethodExceptionWhenValueInvalid()
     {
         $this->expectException(InvalidArgumentException::class);
-        
+
         $request = Request::create('/', 'GET', [
             'date' => 'invalid',
         ]);

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -538,11 +538,13 @@ class HttpRequestTest extends TestCase
         $request = Request::create('/', 'GET', [
             'as_null' => null,
             'as_invalid' => 'invalid',
-            'as_date' => '2020-01-01',
+
             'as_datetime' => '20-01-01 16:30:25',
-            'as_time' => '16:30:25',
             'as_format' => '1577896225',
             'as_timezone' => '20-01-01 13:30:25',
+
+            'as_date' => '2020-01-01',
+            'as_time' => '16:30:25',
         ]);
 
         $current = Carbon::create(2020, 1, 1, 16, 30, 25);
@@ -550,11 +552,13 @@ class HttpRequestTest extends TestCase
         $this->assertNull($request->datetime('as_null'));
         $this->assertNull($request->datetime('doesnt_exists'));
         $this->assertNull($request->datetime('as_invalid'));
-        $this->assertTrue($request->datetime('as_date')->isSameDay($current));
+
         $this->assertEquals($current, $request->datetime('as_datetime'));
-        $this->assertTrue($request->datetime('as_time')->isSameSecond('16:30:25'));
         $this->assertEquals($current, $request->datetime('as_format', 'U'));
         $this->assertEquals($current, $request->datetime('as_timezone', null, 'America/Santiago'));
+
+        $this->assertTrue($request->datetime('as_date')->isSameDay($current));
+        $this->assertTrue($request->datetime('as_time')->isSameSecond('16:30:25'));
     }
 
     public function testArrayAccess()

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -536,11 +536,12 @@ class HttpRequestTest extends TestCase
     public function testDatetimeMethod()
     {
         $request = Request::create('/', 'GET', [
+            'as_null' => null,
+            'as_invalid' => 'invalid'
             'as_date' => '2020-01-01',
             'as_datetime' => '20-01-01 16:30:25',
             'as_time' => '16:30:25',
             'as_format' => '1577896225',
-            'as_null' => null,
             'as_timezone' => '20-01-01 13:30:25',
         ]);
 
@@ -548,20 +549,12 @@ class HttpRequestTest extends TestCase
 
         $this->assertNull($request->datetime('as_null'));
         $this->assertNull($request->datetime('doesnt_exists'));
+        $this->assertFalse($request->datetime('as_invalid'))
         $this->assertTrue($request->datetime('as_date')->isSameDay($current));
         $this->assertEquals($current, $request->datetime('as_datetime'));
         $this->assertTrue($request->datetime('as_time')->isSameSecond('16:30:25'));
         $this->assertEquals($current, $request->datetime('as_format', 'U'));
         $this->assertEquals($current, $request->datetime('as_timezone', null, 'America/Santiago'));
-
-        Carbon::setTestNow($current);
-
-        $this->assertEquals($current, $request->datetime('as_null', null, null, 'now'));
-        $this->assertEquals($current, $request->datetime('as_null', null, null, function ($request) {
-            return $request->input('as_datetime');
-        }));
-
-        Carbon::setTestNow();
     }
 
     public function testArrayAccess()

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Http;
 
+use InvalidArgumentException;
 use Illuminate\Http\Request;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Routing\Route;
@@ -551,7 +552,6 @@ class HttpRequestTest extends TestCase
 
         $this->assertNull($request->date('as_null'));
         $this->assertNull($request->date('doesnt_exists'));
-        $this->assertNull($request->date('as_invalid'));
 
         $this->assertEquals($current, $request->date('as_datetime'));
         $this->assertEquals($current, $request->date('as_format', 'U'));
@@ -559,6 +559,28 @@ class HttpRequestTest extends TestCase
 
         $this->assertTrue($request->date('as_date')->isSameDay($current));
         $this->assertTrue($request->date('as_time')->isSameSecond('16:30:25'));
+    }
+
+    public function testDateMethodExceptionWhenValueInvalid()
+    {
+        $this->expectsException(InvalidArgumentException::class);
+        
+        $request = Request::create('/', 'GET', [
+            'date' => 'invalid',
+        ]);
+
+        $request->date('date');
+    }
+
+    public function testDateMethodExceptionWhenFormatInvalid()
+    {
+        $this->expectsException(InvalidArgumentException::class);
+
+        $request = Request::create('/', 'GET', [
+            'date' => '20-01-01 16:30:25',
+        ]);
+
+        $request->date('date', 'invalid_format');
     }
 
     public function testArrayAccess()


### PR DESCRIPTION
## What?

Allows to conveniently retrieve an input from the Request as a `Carbon` object (or `DateTimeInterface`). It uses the `Date` facade behind the scenes.

```php
public function post(Requets $request)
{
    // ...

    $post->publish_at = $request->date('publish_at')->addHour()->startOfHour();

    $post->save();

    return back();
}
```

## Why?

Because you can quickly get a lot of Carbon or Date calls to parse the date from the request, specially from different keys.

```php
// Before
if ($date = $request->input('when')) {
    $date = Carbon::parse($datetime);
}

// After
$date = $request->date('when');
```

It supports for custom formats (otherwise it will try to parse it).

```php
$timestamp = $request->date('when', 'U');
```

And also supports timezoning.

```php
$timestamp = $request->date('when', 'U', 'America/Santiago');
```

Since the input can be null, it's easier to create defaults:

```php
$now = $request->date('when', 'U') ?? now();
```

# BC?

No, only additive.