### PR TITLE
Validation Rules: remove duplicate table name resolving

### DIFF
--- a/src/Illuminate/Validation/Rules/DatabaseRule.php
+++ b/src/Illuminate/Validation/Rules/DatabaseRule.php
@@ -4,7 +4,6 @@ namespace Illuminate\Validation\Rules;
 
 use Closure;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Str;
 
 trait DatabaseRule
 {
@@ -47,34 +46,7 @@ trait DatabaseRule
     {
         $this->column = $column;
 
-        $this->table = $this->resolveTableName($table);
-    }
-
-    /**
-     * Resolves the name of the table from the given string.
-     *
-     * @param  string  $table
-     * @return string
-     */
-    public function resolveTableName($table)
-    {
-        if (! Str::contains($table, '\\') || ! class_exists($table)) {
-            return $table;
-        }
-
-        if (is_subclass_of($table, Model::class)) {
-            $model = new $table;
-
-            if (Str::contains($model->getTable(), '.')) {
-                return $table;
-            }
-
-            return implode('.', array_map(function (string $part) {
-                return trim($part, '.');
-            }, array_filter([$model->getConnectionName(), $model->getTable()])));
-        }
-
-        return $table;
+        $this->table = $table;
     }
 
     /**


### PR DESCRIPTION
I don't understand why need table name resolving on DatabaseRule.

Rules in _Illuminate\Validation\Rules_ converted to a validation string.
Database validation rules (e.g. _exists_, _unique_) accepted DB table name or model class, this is implemented in _ValidatesAttributes::parseTable_ method.
https://github.com/laravel/framework/blob/8.x/src/Illuminate/Validation/Concerns/ValidatesAttributes.php#L887

May need to remove table name resolving duplication?