### PR TITLE
[9.x] Unify trait set up/tear down and other hooks under a `Hook` implementation

### DIFF
--- a/src/Illuminate/Console/Concerns/CreatesMatchingTest.php
+++ b/src/Illuminate/Console/Concerns/CreatesMatchingTest.php
@@ -61,11 +61,7 @@ trait CreatesMatchingTest
         }
 
         $this->call('make:test', [
-            'name'   => Str::of($path)
-                ->after($this->laravel['path'])
-                ->beforeLast('.php')
-                ->append('Test')
-                ->replace('\\', '/'),
+            'name' => Str::of($path)->after($this->laravel['path'])->beforeLast('.php')->append('Test')->replace('\\', '/'),
             '--pest' => $this->option('pest'),
         ]);
     }

--- a/src/Illuminate/Console/Concerns/CreatesMatchingTest.php
+++ b/src/Illuminate/Console/Concerns/CreatesMatchingTest.php
@@ -27,7 +27,7 @@ trait CreatesMatchingTest
     {
         return Hook::make('generate', function ($name, $path) {
             // We want to run test creation after generation, so we'll return a callback to execute at the end
-            return fn() => $this->handleTestCreation($path);
+            return fn () => $this->handleTestCreation($path);
         });
     }
 

--- a/src/Illuminate/Console/Concerns/CreatesMatchingTest.php
+++ b/src/Illuminate/Console/Concerns/CreatesMatchingTest.php
@@ -9,7 +9,7 @@ use Symfony\Component\Console\Input\InputOption;
 trait CreatesMatchingTest
 {
     /**
-     * Register "initialize" hook
+     * Register "initialize" hook.
      *
      * @return \Illuminate\Support\Hooks\Hook
      */
@@ -19,7 +19,7 @@ trait CreatesMatchingTest
     }
 
     /**
-     * Register "generate" hook
+     * Register "generate" hook.
      *
      * @return \Illuminate\Support\Hooks\Hook
      */

--- a/src/Illuminate/Console/Concerns/CreatesMatchingTest.php
+++ b/src/Illuminate/Console/Concerns/CreatesMatchingTest.php
@@ -15,7 +15,7 @@ trait CreatesMatchingTest
      */
     public function addTestOptionsHook(): Hook
     {
-        return Hook::make('initialize', function() {
+        return Hook::make('initialize', function () {
             foreach (['test' => 'PHPUnit', 'pest' => 'Pest'] as $option => $name) {
                 $this->getDefinition()->addOption(new InputOption(
                     $option,
@@ -35,13 +35,13 @@ trait CreatesMatchingTest
      */
     public function addTestCreationHook($path): Hook
     {
-        return Hook::make('generate', function() use ($path) {
+        return Hook::make('generate', function () use ($path) {
             if (! $this->option('test') && ! $this->option('pest')) {
                 return;
             }
 
             // Run make:test after the "generate" hook has finished
-            return function() use ($path) {
+            return function () use ($path) {
                 $this->call('make:test', [
                     'name'   => Str::of($path)
                         ->after($this->laravel['path'])

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Console;
 
-use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Hookable;
 use Illuminate\Support\Str;

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -109,6 +109,7 @@ abstract class GeneratorCommand extends Command
     {
         parent::__construct();
 
+        // TODO: Switch to Hookable
         if (in_array(CreatesMatchingTest::class, class_uses_recursive($this))) {
             $this->addTestOptions();
         }
@@ -165,6 +166,7 @@ abstract class GeneratorCommand extends Command
 
         $this->info($this->type.' created successfully.');
 
+        // TODO: Switch to Hookable
         if (in_array(CreatesMatchingTest::class, class_uses_recursive($this))) {
             $this->handleTestCreation($path);
         }

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -111,9 +111,9 @@ abstract class GeneratorCommand extends Command
     {
         parent::__construct();
 
-        $this->runHooks('initialize');
-
         $this->files = $files;
+
+        $this->runHooks('initialize');
     }
 
     /**

--- a/src/Illuminate/Contracts/Support/Hook.php
+++ b/src/Illuminate/Contracts/Support/Hook.php
@@ -40,4 +40,18 @@ interface Hook
      * @param  array  $arguments
      */
     public function cleanup($instance, array $arguments = []);
+
+    /**
+     * Get the name of the hook.
+     *
+     * @return string
+     */
+    public function getName();
+
+    /**
+     * Get the priority of the hook.
+     *
+     * @return int
+     */
+    public function getPriority();
 }

--- a/src/Illuminate/Contracts/Support/Hook.php
+++ b/src/Illuminate/Contracts/Support/Hook.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Illuminate\Contracts\Support;
+
+interface Hook
+{
+    /**
+     * Indicates this hook should be run with higher priority.
+     *
+     * @var int
+     */
+    public const PRIORITY_HIGH = 100;
+
+    /**
+     * Indicates this hook should be run with normal priority.
+     *
+     * @var int
+     */
+    public const PRIORITY_NORMAL = 200;
+
+    /**
+     * Indicates this hook should be run with lower priority.
+     *
+     * @var int
+     */
+    public const PRIORITY_LOW = 300;
+
+    /**
+     * Run the hook.
+     *
+     * @param  object|string  $instance
+     * @param  array  $arguments
+     */
+    public function run($instance, array $arguments = []);
+
+    /**
+     * Clean up after the hook.
+     *
+     * @param  object|string  $instance
+     * @param  array  $arguments
+     */
+    public function cleanup($instance, array $arguments = []);
+}

--- a/src/Illuminate/Database/Console/Seeds/WithoutModelEvents.php
+++ b/src/Illuminate/Database/Console/Seeds/WithoutModelEvents.php
@@ -15,14 +15,14 @@ trait WithoutModelEvents
      */
     public static function withoutModelEvents(): Hook
     {
-        return Hook::make('invoke', static function () {
+        return Hook::make('run', function () {
             if (! $dispatcher = Model::getEventDispatcher()) {
                 return null;
             }
 
             Model::setEventDispatcher(new NullDispatcher($dispatcher));
 
-            return static fn () => Model::setEventDispatcher($dispatcher);
+            return fn () => Model::setEventDispatcher($dispatcher);
         });
     }
 }

--- a/src/Illuminate/Database/Console/Seeds/WithoutModelEvents.php
+++ b/src/Illuminate/Database/Console/Seeds/WithoutModelEvents.php
@@ -22,7 +22,7 @@ trait WithoutModelEvents
 
             Model::setEventDispatcher(new NullDispatcher($dispatcher));
 
-            return static fn() => Model::setEventDispatcher($dispatcher);
+            return static fn () => Model::setEventDispatcher($dispatcher);
         });
     }
 }

--- a/src/Illuminate/Database/Console/Seeds/WithoutModelEvents.php
+++ b/src/Illuminate/Database/Console/Seeds/WithoutModelEvents.php
@@ -3,17 +3,26 @@
 namespace Illuminate\Database\Console\Seeds;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Events\NullDispatcher;
+use Illuminate\Support\Hooks\Hook;
 
 trait WithoutModelEvents
 {
     /**
-     * Prevent model events from being dispatched by the given callback.
+     * Prevent model events from being dispatched when the seeder is invoked.
      *
-     * @param  callable  $callback
-     * @return callable
+     * @return Hook
      */
-    public function withoutModelEvents(callable $callback)
+    public static function withoutModelEvents(): Hook
     {
-        return fn () => Model::withoutEvents($callback);
+        return Hook::make('invoke', static function () {
+            if (! $dispatcher = Model::getEventDispatcher()) {
+                return null;
+            }
+
+            Model::setEventDispatcher(new NullDispatcher($dispatcher));
+
+            return static fn() => Model::setEventDispatcher($dispatcher);
+        });
     }
 }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -19,7 +19,7 @@ use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Support\Hookable;
-use Illuminate\Support\Hooks\TraitHook;
+use Illuminate\Support\Hooks\ConventionalHook;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\ForwardsCalls;
 use JsonSerializable;
@@ -256,23 +256,23 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     }
 
     /**
-     * Register hook for `bootX` trait methods.
+     * Register a conventions-based hook for boot[trait name] methods.
      *
-     * @return \Illuminate\Support\Hooks\TraitHook
+     * @return \Illuminate\Support\Hooks\ConventionalHook
      */
-    public static function registerBootHook(): TraitHook
+    public static function registerBootHook(): ConventionalHook
     {
-        return new TraitHook('boot');
+        return new ConventionalHook('boot');
     }
 
     /**
-     * Register hook for `initializeX` trait methods.
+     * Register a conventions-based hook for initialize[trait name] methods.
      *
-     * @return \Illuminate\Support\Hooks\TraitHook
+     * @return \Illuminate\Support\Hooks\ConventionalHook
      */
-    public static function registerInitializeHook(): TraitHook
+    public static function registerInitializeHook(): ConventionalHook
     {
-        return new TraitHook('initialize');
+        return new ConventionalHook('initialize');
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -265,6 +265,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
 
         static::$traitInitializers[$class] = [];
 
+        // TODO: Switch to Hookable
         foreach (class_uses_recursive($class) as $trait) {
             $method = 'boot'.class_basename($trait);
 

--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -173,7 +173,7 @@ abstract class Seeder
             throw new InvalidArgumentException('Method [run] missing from '.get_class($this));
         }
 
-        return $this->runHooks('invoke', $this, function () use ($parameters) {
+        return $this->runHooks('run', $this, function () use ($parameters) {
             return isset($this->container)
                 ? $this->container->call([$this, 'run'], $parameters)
                 : $this->run(...$parameters);

--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -4,7 +4,6 @@ namespace Illuminate\Database;
 
 use Illuminate\Console\Command;
 use Illuminate\Container\Container;
-use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Hookable;
 use InvalidArgumentException;
@@ -174,7 +173,7 @@ abstract class Seeder
             throw new InvalidArgumentException('Method [run] missing from '.get_class($this));
         }
 
-        return $this->runHooks('invoke', $this, function() use ($parameters) {
+        return $this->runHooks('invoke', $this, function () use ($parameters) {
             return isset($this->container)
                 ? $this->container->call([$this, 'run'], $parameters)
                 : $this->run(...$parameters);

--- a/src/Illuminate/Foundation/Testing/DatabaseMigrations.php
+++ b/src/Illuminate/Foundation/Testing/DatabaseMigrations.php
@@ -4,10 +4,21 @@ namespace Illuminate\Foundation\Testing;
 
 use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Foundation\Testing\Traits\CanConfigureMigrationCommands;
+use Illuminate\Support\Hooks\Hook;
 
 trait DatabaseMigrations
 {
     use CanConfigureMigrationCommands;
+
+    /**
+     * Register test case hook.
+     *
+     * @return \Illuminate\Support\Hooks\Hook
+     */
+    public function registerDatabaseMigrationsHook(): Hook
+    {
+        return new Hook('setUp', fn () => $this->runDatabaseMigrations(), 55);
+    }
 
     /**
      * Define hooks to migrate the database before and after each test.

--- a/src/Illuminate/Foundation/Testing/DatabaseTransactions.php
+++ b/src/Illuminate/Foundation/Testing/DatabaseTransactions.php
@@ -2,8 +2,20 @@
 
 namespace Illuminate\Foundation\Testing;
 
+use Illuminate\Support\Hooks\Hook;
+
 trait DatabaseTransactions
 {
+    /**
+     * Register test case hook.
+     *
+     * @return \Illuminate\Support\Hooks\Hook
+     */
+    public function registerDatabaseTransactionsHook(): Hook
+    {
+        return new Hook('setUp', fn () => $this->beginDatabaseTransaction(), 60);
+    }
+
     /**
      * Handle database transactions on the specified connections.
      *

--- a/src/Illuminate/Foundation/Testing/RefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/RefreshDatabase.php
@@ -4,10 +4,21 @@ namespace Illuminate\Foundation\Testing;
 
 use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Foundation\Testing\Traits\CanConfigureMigrationCommands;
+use Illuminate\Support\Hooks\Hook;
 
 trait RefreshDatabase
 {
     use CanConfigureMigrationCommands;
+
+    /**
+     * Register test case hook.
+     *
+     * @return \Illuminate\Support\Hooks\Hook
+     */
+    public function registerRefreshDatabaseHook(): Hook
+    {
+        return new Hook('setUp', fn () => $this->refreshDatabase(), 50);
+    }
 
     /**
      * Define hooks to migrate the database before and after each test.

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -116,6 +116,7 @@ abstract class TestCase extends BaseTestCase
      */
     protected function setUpTraits()
     {
+        // TODO: Switch to Hookable
         $uses = array_flip(class_uses_recursive(static::class));
 
         if (isset($uses[RefreshDatabase::class])) {

--- a/src/Illuminate/Foundation/Testing/WithFaker.php
+++ b/src/Illuminate/Foundation/Testing/WithFaker.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Testing;
 
 use Faker\Factory;
 use Faker\Generator;
+use Illuminate\Support\Hooks\Hook;
 
 trait WithFaker
 {
@@ -13,6 +14,16 @@ trait WithFaker
      * @var \Faker\Generator
      */
     protected $faker;
+
+    /**
+     * Register test case hook.
+     *
+     * @return \Illuminate\Support\Hooks\Hook
+     */
+    public function registerWithFakerHook(): Hook
+    {
+        return new Hook('setUp', fn () => $this->setUpFaker(), 75);
+    }
 
     /**
      * Setup up the Faker instance.

--- a/src/Illuminate/Foundation/Testing/WithoutEvents.php
+++ b/src/Illuminate/Foundation/Testing/WithoutEvents.php
@@ -3,9 +3,20 @@
 namespace Illuminate\Foundation\Testing;
 
 use Exception;
+use Illuminate\Support\Hooks\Hook;
 
 trait WithoutEvents
 {
+    /**
+     * Register test case hook.
+     *
+     * @return \Illuminate\Support\Hooks\Hook
+     */
+    public function registerWithoutEventsHook(): Hook
+    {
+        return new Hook('setUp', fn () => $this->disableEventsForAllTests(), 70);
+    }
+
     /**
      * Prevent all event handles from being executed.
      *

--- a/src/Illuminate/Foundation/Testing/WithoutMiddleware.php
+++ b/src/Illuminate/Foundation/Testing/WithoutMiddleware.php
@@ -3,9 +3,20 @@
 namespace Illuminate\Foundation\Testing;
 
 use Exception;
+use Illuminate\Support\Hooks\Hook;
 
 trait WithoutMiddleware
 {
+    /**
+     * Register test case hook.
+     *
+     * @return \Illuminate\Support\Hooks\Hook
+     */
+    public function registerWithoutMiddlewareHook(): Hook
+    {
+        return new Hook('setUp', fn () => $this->disableMiddlewareForAllTests(), 65);
+    }
+
     /**
      * Prevent all middleware from being executed for this test class.
      *

--- a/src/Illuminate/Support/Hookable.php
+++ b/src/Illuminate/Support/Hookable.php
@@ -2,17 +2,59 @@
 
 namespace Illuminate\Support;
 
+use Closure;
 use Illuminate\Support\Hooks\HookCollection;
+use Illuminate\Support\Hooks\TraitHook;
 
 trait Hookable
 {
-    protected static function runStaticHooks($name, ...$arguments)
+    /**
+     * Run hooks statically.
+     *
+     * @param  string  $name
+     * @param  array  $arguments
+     * @param  \Closure|null  $callback
+     * @return mixed
+     */
+    protected static function runStaticHooks($name, $arguments = [], Closure $callback = null)
     {
-        HookCollection::for(static::class)->run($name, null, $arguments);
+        return HookCollection::for(static::class)->run($name, static::class, $arguments, $callback);
     }
 
-    protected function runHooks($name, ...$arguments)
+    /**
+     * Run trait hooks statically.
+     *
+     * @param  string  $prefix
+     * @param  array  $arguments
+     * @return void
+     */
+    protected static function runStaticTraitHooks($prefix, $arguments = [])
     {
-        HookCollection::for(static::class)->run($name, $this, $arguments);
+        (new TraitHook($prefix))->run(static::class, $arguments);
+    }
+
+    /**
+     * Run hooks non-statically.
+     *
+     * @param  string  $name
+     * @param  array  $arguments
+     * @param  \Closure|null  $callback
+     * @return mixed
+     */
+    protected function runHooks($name, $arguments = [], Closure $callback = null)
+    {
+        return HookCollection::for(static::class)->run($name, $this, $arguments, $callback);
+    }
+
+    /**
+     * Run trait hooks.
+     *
+     * @param  string  $prefix
+     * @param  array  $arguments
+     * @return void
+     */
+    protected function runTraitHooks($prefix, $arguments = [])
+    {
+        (new TraitHook($prefix))->run($this, $arguments);
     }
 }

--- a/src/Illuminate/Support/Hookable.php
+++ b/src/Illuminate/Support/Hookable.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Support;
+
+use Illuminate\Support\Hooks\HookCollection;
+
+trait Hookable
+{
+    protected static function runHooks($name, ...$arguments)
+    {
+        HookCollection::for(static::class)->run($name, $arguments);
+    }
+}

--- a/src/Illuminate/Support/Hookable.php
+++ b/src/Illuminate/Support/Hookable.php
@@ -4,7 +4,6 @@ namespace Illuminate\Support;
 
 use Closure;
 use Illuminate\Support\Hooks\HookCollection;
-use Illuminate\Support\Hooks\TraitHook;
 
 trait Hookable
 {
@@ -22,18 +21,6 @@ trait Hookable
     }
 
     /**
-     * Run trait hooks statically.
-     *
-     * @param  string  $prefix
-     * @param  array  $arguments
-     * @return void
-     */
-    protected static function runStaticTraitHooks($prefix, $arguments = [])
-    {
-        (new TraitHook($prefix))->run(static::class, $arguments);
-    }
-
-    /**
      * Run hooks non-statically.
      *
      * @param  string  $name
@@ -44,17 +31,5 @@ trait Hookable
     protected function runHooks($name, $arguments = [], Closure $callback = null)
     {
         return HookCollection::for(static::class)->run($name, $this, $arguments, $callback);
-    }
-
-    /**
-     * Run trait hooks.
-     *
-     * @param  string  $prefix
-     * @param  array  $arguments
-     * @return void
-     */
-    protected function runTraitHooks($prefix, $arguments = [])
-    {
-        (new TraitHook($prefix))->run($this, $arguments);
     }
 }

--- a/src/Illuminate/Support/Hookable.php
+++ b/src/Illuminate/Support/Hookable.php
@@ -6,8 +6,13 @@ use Illuminate\Support\Hooks\HookCollection;
 
 trait Hookable
 {
-    protected static function runHooks($name, ...$arguments)
+    protected static function runStaticHooks($name, ...$arguments)
     {
-        HookCollection::for(static::class)->run($name, $arguments);
+        HookCollection::for(static::class)->run($name, null, $arguments);
+    }
+
+    protected function runHooks($name, ...$arguments)
+    {
+        HookCollection::for(static::class)->run($name, $this, $arguments);
     }
 }

--- a/src/Illuminate/Support/Hooks/ConventionalHook.php
+++ b/src/Illuminate/Support/Hooks/ConventionalHook.php
@@ -4,7 +4,7 @@ namespace Illuminate\Support\Hooks;
 
 use Illuminate\Contracts\Support\Hook as HookContract;
 
-class TraitHook implements HookContract
+class ConventionalHook implements HookContract
 {
     /**
      * Constructor.
@@ -25,15 +25,19 @@ class TraitHook implements HookContract
      */
     public function run($instance = null, array $arguments = [])
     {
+        $executed = [];
+
         foreach (class_uses_recursive($instance) as $trait) {
             $method = $this->prefix.class_basename($trait);
 
-            if (method_exists($instance, $method)) {
+            if (! in_array($method, $executed) && method_exists($instance, $method)) {
                 if (is_object($instance)) {
                     $instance->$method(...$arguments);
                 } else {
                     forward_static_call_array([$instance, $method], $arguments);
                 }
+
+                $executed[] = $method;
             }
         }
     }

--- a/src/Illuminate/Support/Hooks/Hook.php
+++ b/src/Illuminate/Support/Hooks/Hook.php
@@ -6,15 +6,35 @@ use Closure;
 
 class Hook
 {
+    public const PRIORITY_HIGH = 100;
+    public const PRIORITY_NORMAL = 200;
+    public const PRIORITY_LOW = 300;
+
+    public static function highPriority(string $name, Closure $callback): Hook
+    {
+        return new static($name, $callback, self::PRIORITY_HIGH);
+    }
+
+    public static function make(string $name, Closure $callback): Hook
+    {
+        return new static($name, $callback, self::PRIORITY_NORMAL);
+    }
+
+    public static function lowPriority(string $name, Closure $callback): Hook
+    {
+        return new static($name, $callback, self::PRIORITY_LOW);
+    }
+
     public function __construct(
         public string $name,
         public Closure $callback,
-        public bool $isStatic = true,
-        public int $weight = 100
+        public int $priority = self::PRIORITY_NORMAL
     ) { }
 
-    public function run(array $arguments)
+    public function run($instance = null, array $arguments = [])
     {
-        return call_user_func_array($this->callback, $arguments);
+        return $instance
+            ? $this->callback->call($instance, ...$arguments)
+            : call_user_func_array($this->callback, $arguments);
     }
 }

--- a/src/Illuminate/Support/Hooks/Hook.php
+++ b/src/Illuminate/Support/Hooks/Hook.php
@@ -92,6 +92,22 @@ class Hook implements HookContract
     }
 
     /**
+     * @inheritdoc
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getPriority()
+    {
+        return $this->priority;
+    }
+
+    /**
      * Run a callback that may or may not be static.
      *
      * @param  Closure  $callback

--- a/src/Illuminate/Support/Hooks/Hook.php
+++ b/src/Illuminate/Support/Hooks/Hook.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Illuminate\Support\Hooks;
+
+use Closure;
+
+class Hook
+{
+    public function __construct(
+        public string $name,
+        public Closure $callback,
+        public bool $isStatic = true,
+        public int $weight = 100
+    ) { }
+
+    public function run(array $arguments)
+    {
+        return call_user_func_array($this->callback, $arguments);
+    }
+}

--- a/src/Illuminate/Support/Hooks/Hook.php
+++ b/src/Illuminate/Support/Hooks/Hook.php
@@ -51,7 +51,7 @@ class Hook implements HookContract
     }
 
     /**
-     * Constructor
+     * Constructor.
      *
      * @param  string  $name
      * @param  \Closure  $callback
@@ -62,7 +62,8 @@ class Hook implements HookContract
         public string $name,
         public Closure $callback,
         public int $priority = HookContract::PRIORITY_NORMAL
-    ) { }
+    ) {
+    }
 
     /**
      * @inheritdoc

--- a/src/Illuminate/Support/Hooks/HookCollection.php
+++ b/src/Illuminate/Support/Hooks/HookCollection.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Illuminate\Support\Hooks;
+
+use Closure;
+use Illuminate\Support\Collection;
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionNamedType;
+
+class HookCollection extends Collection
+{
+    protected static array $cache = [];
+
+    protected static array $registrars = [];
+
+    public static function for($class)
+    {
+        if (is_object($class)) {
+            $class = get_class($class);
+        }
+
+        return static::$cache[$class] ??= new static(static::loadHooks($class));
+    }
+
+    public static function clearCache()
+    {
+        static::$cache = [];
+    }
+
+    public static function register($className, Closure $callback)
+    {
+        static::$registrars[$className][] = $callback;
+    }
+
+    public static function registerTraitPrefix($className, $prefix)
+    {
+        static::register($className, function($hooks, $class) use ($prefix) {
+            foreach (class_uses_recursive($class) as $trait) {
+                $method = $prefix.class_basename($trait);
+
+                if (method_exists($class, $method)) {
+                    $hooks->push(new Hook($prefix, Closure::fromCallable([$class, $method])));
+                }
+            }
+        });
+    }
+
+    protected static function loadHooks($class)
+    {
+        $classNames = array_merge([$class => $class], class_parents($class), class_implements($class));
+
+        return collect((new ReflectionClass($class))->getMethods())
+            ->map(fn($method) => static::hookForMethod($method, $classNames))
+            ->filter();
+    }
+
+    protected static function hookForMethod(ReflectionMethod $method, array $classNames): ?Hook
+    {
+        if (static::methodReturnsHook($method)) {
+            return $method->invoke(null);
+        }
+
+        return null;
+    }
+
+    protected static function methodReturnsHook(ReflectionMethod $method): bool
+    {
+        return $method->isStatic()
+            && $method->getReturnType() instanceof ReflectionNamedType
+            && $method->getReturnType()->getName() === Hook::class;
+    }
+
+    public function run($name, ...$arguments)
+    {
+        $this->where('name', $name)
+            ->sortBy('weight')
+            ->each(fn($hook) => $hook->run($arguments));
+    }
+}

--- a/src/Illuminate/Support/Hooks/HookCollection.php
+++ b/src/Illuminate/Support/Hooks/HookCollection.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Support\Hooks;
 
 use Closure;
+use Illuminate\Contracts\Support\Hook;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use ReflectionClass;
@@ -102,8 +103,8 @@ class HookCollection extends Collection
 
         $hooks = $this->onlyStatic(! is_object($instance))
             ->resolve($instance)
-            ->where('name', $name)
-            ->sortBy('priority');
+            ->filter(fn(Hook $hook) => $hook->getName() === $name)
+            ->sortBy(fn(Hook $hook) => $hook->getPriority());
 
         $hooks->each(fn (Hook $hook) => $hook->run($instance, $arguments));
 

--- a/src/Illuminate/Support/Hooks/HookCollection.php
+++ b/src/Illuminate/Support/Hooks/HookCollection.php
@@ -103,8 +103,8 @@ class HookCollection extends Collection
 
         $hooks = $this->onlyStatic(! is_object($instance))
             ->resolve($instance)
-            ->filter(fn(Hook $hook) => $hook->getName() === $name)
-            ->sortBy(fn(Hook $hook) => $hook->getPriority());
+            ->filter(fn (Hook $hook) => $hook->getName() === $name)
+            ->sortBy(fn (Hook $hook) => $hook->getPriority());
 
         $hooks->each(fn (Hook $hook) => $hook->run($instance, $arguments));
 

--- a/src/Illuminate/Support/Hooks/HookCollection.php
+++ b/src/Illuminate/Support/Hooks/HookCollection.php
@@ -67,7 +67,7 @@ class HookCollection extends Collection
     protected static function hookForMethod(ReflectionMethod $method): ?PendingHook
     {
         if (static::methodReturnsHook($method)) {
-            return new PendingHook(static function ($instance = null) use ($method) {
+            return new PendingHook(function ($instance = null) use ($method) {
                 return $method->invoke($instance);
             }, $method->isStatic());
         }

--- a/src/Illuminate/Support/Hooks/HookCollection.php
+++ b/src/Illuminate/Support/Hooks/HookCollection.php
@@ -54,7 +54,7 @@ class HookCollection extends Collection
     protected static function loadHooks($class)
     {
         return collect((new ReflectionClass($class))->getMethods())
-            ->map(fn($method) => static::hookForMethod($method))
+            ->map(fn ($method) => static::hookForMethod($method))
             ->filter();
     }
 
@@ -67,7 +67,7 @@ class HookCollection extends Collection
     protected static function hookForMethod(ReflectionMethod $method): ?PendingHook
     {
         if (static::methodReturnsHook($method)) {
-            return new PendingHook(static function($instance = null) use ($method) {
+            return new PendingHook(static function ($instance = null) use ($method) {
                 return $method->invoke($instance);
             }, $method->isStatic());
         }
@@ -105,13 +105,12 @@ class HookCollection extends Collection
             ->where('name', $name)
             ->sortBy('priority');
 
-        $hooks->each(fn(Hook $hook) => $hook->run($instance, $arguments));
+        $hooks->each(fn (Hook $hook) => $hook->run($instance, $arguments));
 
         try {
             return $callback ? $callback() : null;
-        }
-        finally {
-            $hooks->reverse()->each(fn(Hook $hook) => $hook->cleanup($instance, $arguments));
+        } finally {
+            $hooks->reverse()->each(fn (Hook $hook) => $hook->cleanup($instance, $arguments));
         }
     }
 

--- a/src/Illuminate/Support/Hooks/PendingHook.php
+++ b/src/Illuminate/Support/Hooks/PendingHook.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Support\Hooks;
 
 use Closure;
+use Illuminate\Contracts\Support\Hook;
 use RuntimeException;
 
 class PendingHook

--- a/src/Illuminate/Support/Hooks/PendingHook.php
+++ b/src/Illuminate/Support/Hooks/PendingHook.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Illuminate\Support\Hooks;
+
+use Closure;
+use RuntimeException;
+
+class PendingHook
+{
+    protected ?Hook $hook = null;
+
+    public function __construct(
+        public Closure $callback,
+        public bool $isStatic
+    ) { }
+
+    public function resolve($instance = null)
+    {
+        if (! $this->isStatic && is_null($instance)) {
+            throw new RuntimeException('Trying to resolve a non-static hook statically.');
+        }
+
+        return $this->getHook($instance);
+    }
+
+    protected function getHook($instance = null): Hook
+    {
+        if (is_null($this->hook)) {
+            $this->hook = $this->isStatic
+                ? call_user_func($this->callback)
+                : $this->callback->call($instance);
+        }
+
+        return $this->hook;
+    }
+}

--- a/src/Illuminate/Support/Hooks/PendingHook.php
+++ b/src/Illuminate/Support/Hooks/PendingHook.php
@@ -59,7 +59,8 @@ class PendingHook
                     ? call_user_func($this->callback)
                     : $this->callback->call($instance);
             } catch (BadMethodCallException $exception) {
-                $this->hook = new class implements Hook {
+                $this->hook = new class implements Hook
+                {
                     public function run($instance, array $arguments = [])
                     {
                         throw new RuntimeException('Unexpected hook call from mock object');

--- a/src/Illuminate/Support/Hooks/PendingHook.php
+++ b/src/Illuminate/Support/Hooks/PendingHook.php
@@ -7,22 +7,46 @@ use RuntimeException;
 
 class PendingHook
 {
+    /**
+     * The resolved hook.
+     *
+     * @var Hook|null
+     */
     protected ?Hook $hook = null;
 
+    /**
+     * Constructor.
+     *
+     * @param  \Closure  $callback
+     * @param  bool  $isStatic
+     * @return void
+     */
     public function __construct(
         public Closure $callback,
         public bool $isStatic
     ) { }
 
+    /**
+     * Resolve the pending hook into a Hook instance.
+     *
+     * @param  object|string|null  $instance
+     * @return \Illuminate\Support\Hooks\Hook
+     */
     public function resolve($instance = null)
     {
-        if (! $this->isStatic && is_null($instance)) {
-            throw new RuntimeException('Trying to resolve a non-static hook statically.');
+        if (is_object($instance) || $this->isStatic) {
+            return $this->getHook($instance);
         }
 
-        return $this->getHook($instance);
+        throw new RuntimeException('Trying to resolve a non-static hook statically.');
     }
 
+    /**
+     * Resolve or return the already resolved Hook.
+     *
+     * @param  object|string|null  $instance
+     * @return \Illuminate\Support\Hooks\Hook
+     */
     protected function getHook($instance = null): Hook
     {
         if (is_null($this->hook)) {

--- a/src/Illuminate/Support/Hooks/PendingHook.php
+++ b/src/Illuminate/Support/Hooks/PendingHook.php
@@ -24,7 +24,8 @@ class PendingHook
     public function __construct(
         public Closure $callback,
         public bool $isStatic
-    ) { }
+    ) {
+    }
 
     /**
      * Resolve the pending hook into a Hook instance.

--- a/src/Illuminate/Support/Hooks/TraitHook.php
+++ b/src/Illuminate/Support/Hooks/TraitHook.php
@@ -45,4 +45,20 @@ class TraitHook implements HookContract
     {
         // No cleanup is necessary
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function getName()
+    {
+        return $this->prefix;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getPriority()
+    {
+        return $this->priority;
+    }
 }

--- a/src/Illuminate/Support/Hooks/TraitHook.php
+++ b/src/Illuminate/Support/Hooks/TraitHook.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Illuminate\Support\Hooks;
+
+use Closure;
+use Illuminate\Contracts\Support\Hook as HookContract;
+
+class TraitHook implements HookContract
+{
+    /**
+     * Constructor
+     *
+     * @param  string  $prefix
+     * @return void
+     */
+    public function __construct(public string $prefix)
+    {
+        //
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function run($instance = null, array $arguments = [])
+    {
+        foreach (class_uses_recursive($instance) as $trait) {
+            $method = $this->prefix.class_basename($trait);
+
+            if (method_exists($instance, $method)) {
+                if (is_object($instance)) {
+                    $instance->$method(...$arguments);
+                } else {
+                    forward_static_call_array([$instance, $method], $arguments);
+                }
+            }
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function cleanup($instance, array $arguments = [])
+    {
+        // No cleanup is necessary
+    }
+}

--- a/src/Illuminate/Support/Hooks/TraitHook.php
+++ b/src/Illuminate/Support/Hooks/TraitHook.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Support\Hooks;
 
-use Closure;
 use Illuminate\Contracts\Support\Hook as HookContract;
 
 class TraitHook implements HookContract
@@ -11,10 +10,13 @@ class TraitHook implements HookContract
      * Constructor
      *
      * @param  string  $prefix
+     * @param  int  $priority
      * @return void
      */
-    public function __construct(public string $prefix)
-    {
+    public function __construct(
+        public string $prefix,
+        public int $priority = HookContract::PRIORITY_NORMAL
+    ) {
         //
     }
 

--- a/src/Illuminate/Support/Hooks/TraitHook.php
+++ b/src/Illuminate/Support/Hooks/TraitHook.php
@@ -7,7 +7,7 @@ use Illuminate\Contracts\Support\Hook as HookContract;
 class TraitHook implements HookContract
 {
     /**
-     * Constructor
+     * Constructor.
      *
      * @param  string  $prefix
      * @param  int  $priority


### PR DESCRIPTION
There are a number of places where we use the pattern of `class_uses_recursive(static::class)` to conditionally initialize traits or otherwise hook into the core logic of a class.

You can see this in:

- `WithoutModelEvents` (just added in #39922)
- `Model::boot*` and `Model::initialize*`
- `TestCase::setUpTraits`
- …and a handful of other places within the framework

There have also been attempts to provide more configurable access to this logic (most recently #39883 and at least as far back as #21126). This is particularly notable with `TestCase::setUpTraits`, because it maintains a hard-coded list of traits instead of relying on a convention like Eloquent models.

This PR is an exploration into providing a unified `Hook` concept that covers all these scenarios and provides a standardized way to use this behavior both in application code and future framework code.

The primary API looks like:

#### Class that supports hooks
```php
class Demo
{
  use Hookable;
  
  public function __construct()
  {
    // Just call a hook at a specific execution point
    $this->runHooks('initialize', $this);
  }
  
  public function handle()
  {
    $this->runHooks('handle', $this, function() {
      // Call a hook and do some work (allows for pre/post hooks)
      DB::table('demo')->insert(['foo' => 'bar']);
    });
  }
}
```

#### Trait that interacts with hooks
```php
trait LogDatabaseQueries
{
  public Collection $queries;
  
  // Any hook methods must type-hint Hook as the return type
  public static function getInitializeHook(): Hook
  {
    return Hook::make('initialize', function() {
      $this->queries = new Collection();
    });
  }

  public static function getHandleHook(): Hook
  {
    // Hooks can be registered at different priority levels
    return Hook::highPriority('handle', function () {
      // This runs at the beginning of "handle"
      DB::enableQueryLog();
      DB::flushQueryLog();
      
      // Return a callback if you want to perform "cleanup" after the hook
      return function() {
        $this->queries->push(...DB::getQueryLog());
      };
    });
  }
}
```

#### Application code
```php
class AppDemo extends Demo
{
  // Nothing is necessary beyond adding the trait, thanks to hooks!
  use LogDatabaseQueries;
}
```

This implementation takes into consideration static and non-static hooks, and also provides a backwards-compatibility layer so that you can easily register hooks that also support a `prefix` + `TraitName` naming convention.

(I've decided to use the `Hook` return type for hook discovery, as this makes the change 100% opt-in (where using a naming convention could potentially interfere with existing methods). I know there's generally a hesitance to rely on type-hints in the framework, so I'm open to revisiting this decision.)

As a proof of concept I've implemented the `WithoutModelEvents` trait using hooks. I've also identified some other areas in the framework that would benefit from hooks. I've decided to submit this as a draft PR in its current state for feedback before I spend much more time on it. With support, I'll add more tests and migrate more code over to hooks.