### PR TITLE
[8.x] Add cache-busting for public assets

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -141,9 +141,9 @@ if (! function_exists('asset')) {
      * @param  bool|null  $secure
      * @return string
      */
-    function asset($path, $secure = null)
+    function asset($path, $secure = null, $version = false)
     {
-        return app('url')->asset($path, $secure);
+        return app('url')->asset($path, $secure, $version);
     }
 }
 

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -255,10 +255,11 @@ class UrlGenerator implements UrlGeneratorContract
     protected function assetWithVersion($path, $url)
     {
         $fullPath = public_path($path);
-        if (!file_exists($fullPath)) {
+        if (! file_exists($fullPath)) {
             return $url;
         }
-        return $url . '?id=' . filemtime($fullPath);
+
+        return $url.'?id='.filemtime($fullPath);
     }
 
     /**

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -230,7 +230,7 @@ class UrlGenerator implements UrlGeneratorContract
      * @param  bool|null  $secure
      * @return string
      */
-    public function asset($path, $secure = null)
+    public function asset($path, $secure = null, $version = false)
     {
         if ($this->isValidUrl($path)) {
             return $path;
@@ -241,7 +241,24 @@ class UrlGenerator implements UrlGeneratorContract
         // for asset paths, but only for routes to endpoints in the application.
         $root = $this->assetRoot ?: $this->formatRoot($this->formatScheme($secure));
 
-        return $this->removeIndex($root).'/'.trim($path, '/');
+        $url = $this->removeIndex($root).'/'.trim($path, '/');
+
+        return $version ? $this->assetWithVersion($path, $url) : $url;
+    }
+
+    /**
+     * Get asset url with last modification time as version.
+     *
+     * @param  string  $path
+     * @return string
+     */
+    protected function assetWithVersion($path, $url)
+    {
+        $fullPath = public_path($path);
+        if (!file_exists($fullPath)) {
+            return $url;
+        }
+        return $url . '?id=' . filemtime($fullPath);
     }
 
     /**


### PR DESCRIPTION
This PR allows the use of cache-busting on public assets,
Using:
```php
asset('filePath', version: true)
```
generates a URL for the asset and appends an id with this format:
`https://your-domain.com/filePath?id=1639002822`
the value of the id is a UNIX timestamp of the last time the file was modified.
So using this feature we can make sure the browser always requests the new file whenever the file is changed, even if the file was cached on the browser. also, it eliminates the annoying need for updating file names when they change to make sure clients get the newest file every time the file is changed.

This PR also doesn't break the normal usage of the `asset` helper.
So the function:
```php
asset('filePath')
```
generates `https://your-domain.com/filePath` as expected

These changes don't introduce any security vulnerability as the files are already public and the only exposed info is the last modified time of the file.