### PR TITLE
[9.x] Fix ThrottleRequestsException

### DIFF
--- a/src/Illuminate/Http/Exceptions/ThrottleRequestsException.php
+++ b/src/Illuminate/Http/Exceptions/ThrottleRequestsException.php
@@ -10,13 +10,13 @@ class ThrottleRequestsException extends TooManyRequestsHttpException
     /**
      * Create a new throttle requests exception instance.
      *
-     * @param  string|null  $message
+     * @param  string  $message
      * @param  \Throwable|null  $previous
      * @param  array  $headers
      * @param  int  $code
      * @return void
      */
-    public function __construct($message = null, Throwable $previous = null, array $headers = [], $code = 0)
+    public function __construct($message = '', Throwable $previous = null, array $headers = [], $code = 0)
     {
         parent::__construct(null, $message, $previous, $code, $headers);
     }


### PR DESCRIPTION
## What is the problem?

Passing `$message` as null into `Symfony\Component\HttpKernel\Exception\HttpException::__construct` has been deprecated since symfony v5.3 and will be remove in v6.0. Instead, we have to pass a string (an empty string by default). Visit [here](https://github.com/symfony/http-kernel/blob/6.0/Exception/HttpException.php) for more details.

Therefore, the constructor of  `ThrottleRequestsException` (that also extends `HttpException` via `TooManyRequestsHttpException`) now only has to accept `$message` as string.