### PR TITLE
[6.x] Fix inconsistent escaping of artisan argument

### DIFF
--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -116,7 +116,7 @@ class Application extends SymfonyApplication implements ApplicationContract
      */
     public static function artisanBinary()
     {
-        return defined('ARTISAN_BINARY') ? ProcessUtils::escapeArgument(ARTISAN_BINARY) : 'artisan';
+        return ProcessUtils::escapeArgument(defined('ARTISAN_BINARY') ? ARTISAN_BINARY : 'artisan');
     }
 
     /**

--- a/tests/Console/ConsoleEventSchedulerTest.php
+++ b/tests/Console/ConsoleEventSchedulerTest.php
@@ -101,9 +101,10 @@ class ConsoleEventSchedulerTest extends TestCase
 
         $events = $schedule->events();
         $binary = $escape.PHP_BINARY.$escape;
-        $this->assertEquals($binary.' artisan queue:listen', $events[0]->command);
-        $this->assertEquals($binary.' artisan queue:listen --tries=3', $events[1]->command);
-        $this->assertEquals($binary.' artisan queue:listen --tries=3', $events[2]->command);
+        $artisan = $escape.'artisan'.$escape;
+        $this->assertEquals($binary.' '.$artisan.' queue:listen', $events[0]->command);
+        $this->assertEquals($binary.' '.$artisan.' queue:listen --tries=3', $events[1]->command);
+        $this->assertEquals($binary.' '.$artisan.' queue:listen --tries=3', $events[2]->command);
     }
 
     public function testCreateNewArtisanCommandUsingCommandClass()
@@ -115,7 +116,8 @@ class ConsoleEventSchedulerTest extends TestCase
 
         $events = $schedule->events();
         $binary = $escape.PHP_BINARY.$escape;
-        $this->assertEquals($binary.' artisan foo:bar --force', $events[0]->command);
+        $artisan = $escape.'artisan'.$escape;
+        $this->assertEquals($binary.' '.$artisan.' foo:bar --force', $events[0]->command);
     }
 
     public function testCallCreatesNewJobWithTimezone()

--- a/tests/Console/Scheduling/EventTest.php
+++ b/tests/Console/Scheduling/EventTest.php
@@ -47,7 +47,7 @@ class EventTest extends TestCase
 
         $scheduleId = '"framework'.DIRECTORY_SEPARATOR.'schedule-eeb46c93d45e928d62aaf684d727e213b7094822"';
 
-        $this->assertSame("(php -i > '/dev/null' 2>&1 ; '".PHP_BINARY."' artisan schedule:finish {$scheduleId} \"$?\") > '/dev/null' 2>&1 &", $event->buildCommand());
+        $this->assertSame("(php -i > '/dev/null' 2>&1 ; '".PHP_BINARY."' 'artisan' schedule:finish {$scheduleId} \"$?\") > '/dev/null' 2>&1 &", $event->buildCommand());
     }
 
     public function testBuildCommandInBackgroundUsingWindows()
@@ -61,7 +61,7 @@ class EventTest extends TestCase
 
         $scheduleId = '"framework'.DIRECTORY_SEPARATOR.'schedule-eeb46c93d45e928d62aaf684d727e213b7094822"';
 
-        $this->assertSame('start /b cmd /c "(php -i & "'.PHP_BINARY.'" artisan schedule:finish '.$scheduleId.' "%errorlevel%") > "NUL" 2>&1"', $event->buildCommand());
+        $this->assertSame('start /b cmd /c "(php -i & "'.PHP_BINARY.'" 'artisan' schedule:finish '.$scheduleId.' "%errorlevel%") > "NUL" 2>&1"', $event->buildCommand());
     }
 
     public function testBuildCommandSendOutputTo()

--- a/tests/Console/Scheduling/EventTest.php
+++ b/tests/Console/Scheduling/EventTest.php
@@ -61,7 +61,7 @@ class EventTest extends TestCase
 
         $scheduleId = '"framework'.DIRECTORY_SEPARATOR.'schedule-eeb46c93d45e928d62aaf684d727e213b7094822"';
 
-        $this->assertSame('start /b cmd /c "(php -i & "'.PHP_BINARY.'" 'artisan' schedule:finish '.$scheduleId.' "%errorlevel%") > "NUL" 2>&1"', $event->buildCommand());
+        $this->assertSame('start /b cmd /c "(php -i & "'.PHP_BINARY.'" "artisan" schedule:finish '.$scheduleId.' "%errorlevel%") > "NUL" 2>&1"', $event->buildCommand());
     }
 
     public function testBuildCommandSendOutputTo()


### PR DESCRIPTION
The artisan binary is escaped if it is called from console/cron but not from within a web app via an `artisan()` call.

Call via console gives
```
'artisan'
```

Call via laravel gives
```
artisan
```

This has the unintended(?) side-effect of assigning different mutex for a command depending if it is triggered via cron or via a web app.

This bug appears to affect **all versions of Laravel/Framework** so I have targeted that latest **LTS release**.
