### PR TITLE
[8.x] Update the modelName() method to guess the model names inside the folder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -675,7 +675,7 @@ abstract class Factory
     public function modelName()
     {
         $resolver = static::$modelNameResolver ?: function (self $factory) {
-            $factoryBasename = Str::replaceLast('Factory', '', class_basename($factory));
+            $factoryBasename = Str::replaceLast('Factory', '', Str::replaceFirst('Database\Factories\\', '', get_class($factory)));
 
             $appNamespace = static::appNamespace();
 


### PR DESCRIPTION
Update the modelName() method to guess the model names inside the folder

If we create a model by make:model -f command that is inside a folder, Factory is also inside the same folder, but we have to fill in the $model field inside Factory, but it can be guessed
