### PR TITLE
[8.x] `withTrashed` on routes check if `SoftDeletes` is used in `Model`

### DIFF
--- a/src/Illuminate/Routing/ImplicitRouteBinding.php
+++ b/src/Illuminate/Routing/ImplicitRouteBinding.php
@@ -4,6 +4,7 @@ namespace Illuminate\Routing;
 
 use Illuminate\Contracts\Routing\UrlRoutable;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Reflector;
 use Illuminate\Support\Str;
 
@@ -37,7 +38,7 @@ class ImplicitRouteBinding
 
             $parent = $route->parentOfParameter($parameterName);
 
-            $routeBindingMethod = $route->allowsTrashedBindings()
+            $routeBindingMethod = $route->allowsTrashedBindings()  && in_array(SoftDeletes::class, class_uses($instance))
                         ? 'resolveSoftDeletableRouteBinding'
                         : 'resolveRouteBinding';
 

--- a/src/Illuminate/Routing/ImplicitRouteBinding.php
+++ b/src/Illuminate/Routing/ImplicitRouteBinding.php
@@ -38,7 +38,7 @@ class ImplicitRouteBinding
 
             $parent = $route->parentOfParameter($parameterName);
 
-            $routeBindingMethod = $route->allowsTrashedBindings()  && in_array(SoftDeletes::class, class_uses($instance))
+            $routeBindingMethod = $route->allowsTrashedBindings() && in_array(SoftDeletes::class, class_uses($instance))
                         ? 'resolveSoftDeletableRouteBinding'
                         : 'resolveRouteBinding';
 

--- a/src/Illuminate/Routing/ImplicitRouteBinding.php
+++ b/src/Illuminate/Routing/ImplicitRouteBinding.php
@@ -38,7 +38,7 @@ class ImplicitRouteBinding
 
             $parent = $route->parentOfParameter($parameterName);
 
-            $routeBindingMethod = $route->allowsTrashedBindings() && in_array(SoftDeletes::class, class_uses($instance))
+            $routeBindingMethod = $route->allowsTrashedBindings() && in_array(SoftDeletes::class, class_uses_recursive($instance))
                         ? 'resolveSoftDeletableRouteBinding'
                         : 'resolveRouteBinding';
 


### PR DESCRIPTION
When using `withTrashed()` on a route with two bind models and one model doesn't have `SoftDeletes` its throws a `BadMethodCallException`

For example, you have a route like this:

`
Route::put('admin/articles/(article)/comments/{comment}/restore')->withTrashed()
`

The article model doesn't have `SoftDeletes` but the comment model has. When you want to restore the comment now its throws an exception because the model article doesn't have `SoftDeletes`

