### PR TITLE
[9.0] Making `throw()` callback function argument explicit.

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -260,28 +260,24 @@ class Response implements ArrayAccess
     /**
      * Throw an exception if a server or client error occurred.
      *
-     * @param  \Closure|null $callback
+     * @param \Closure|null $callback called when response is not successful. Throw inside this callback if you want to return your custom excpetion.
      * @return $this
      *
      * @throws \Illuminate\Http\Client\RequestException
+     * @throws \InvalidArgumentException when $callback is not callable.
      */
     public function throw($callback = null)
     {
-        if ($this->failed()) {
-            if($callback === null) {
-                throw $this->toException();
-            }
-            if(is_callable($callback)) {
-                $exception = $callback($this);
-                if(!($exception instanceof \Throwable)) {
-                    throw new \InvalidArgumentException('$callback method must return a Throwable.');
-                }
-                throw $exception;
-            }
+        if($callback !== null && !is_callable($callback)) {
             throw new \InvalidArgumentException('$callback method must be a callable.');
         }
-
-        return $this;
+        if(!$this->failed()){
+            return $this;
+        }
+        if($callback !== null) {
+            $callback($this);
+        }
+        throw $this->toException();
     }
 
     /**

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -260,7 +260,7 @@ class Response implements ArrayAccess
     /**
      * Throw an exception if a server or client error occurred.
      *
-     * @param \Closure|null $callback called when response is not successful. Throw inside this callback if you want to return your custom excpetion.
+     * @param \Closure|null $callback called when response is not successful. Throw inside this callback if you want to return your custom Exception.
      * @return $this
      *
      * @throws \Illuminate\Http\Client\RequestException
@@ -284,13 +284,15 @@ class Response implements ArrayAccess
      * Throw an exception if a server or client error occurred and the given condition evaluates to true.
      *
      * @param  bool  $condition
+     * @param \Closure|null $callback called when condigtion fails and response is not successful. Throw inside this callback if you want to return your custom Exception.
+     *
      * @return $this
      *
      * @throws \Illuminate\Http\Client\RequestException
      */
-    public function throwIf($condition)
+    public function throwIf($condition, $callback = null)
     {
-        return $condition ? $this->throw() : $this;
+        return $condition ? $this->throw($callback) : $this;
     }
 
     /**


### PR DESCRIPTION
Breaking changes in `Response` class.

* Cleanup implicit argument in method `toException()` and more helpfull exceptions if fails
* Make `toException` always return an exception, seems much more logical otherwise i would call method:`toExceptionIfFailed()` 


## Why

To me this feature was not clear because not all IDE's show you the option for this parameter. ie: PHPstorm:
![image](https://user-images.githubusercontent.com/2960938/145470644-554a5585-eb3d-4311-8cf1-83bd12f10334.png)
