### PR TITLE
[8.x] Fixed BelongsToMany UpdateOrCreate Create operation

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -634,7 +634,7 @@ class BelongsToMany extends Relation
     public function updateOrCreate(array $attributes, array $values = [], array $joining = [], $touch = true)
     {
         if (is_null($instance = $this->where($attributes)->first())) {
-            return $this->create($values, $joining, $touch);
+            return $this->create(array_merge($attributes, $values), $joining, $touch);
         }
 
         $instance->fill($values);

--- a/tests/Database/DatabaseEloquentBelongsToManyTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyTest.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Tests\Database\EloquentRelationshipsTest\FakeRelationship;
+use Illuminate\Tests\Database\EloquentRelationshipsTest\Post;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseEloquentBelongsToManyTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $db = new DB;
+
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+
+        $db->bootEloquent();
+        $db->setAsGlobal();
+
+        $this->createSchema();
+    }
+
+    /**
+     * Setup the database schema.
+     *
+     * @return void
+     */
+    public function createSchema()
+    {
+        $this->schema()->create('users', function ($table) {
+            $table->id('id');
+        });
+
+        $this->schema()->create('articles', function ($table) {
+            $table->id('id');
+
+            $table->string('title');
+            $table->string('description');
+        });
+
+        $this->schema()->create('article_user', function ($table) {
+            $table->foreignId('article_id')->references('id')->on('articles');
+            $table->foreignId('user_id')->references('id')->on('users');
+        });
+    }
+
+    /**
+     * Tear down the database schema.
+     *
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        $this->schema()->drop('users');
+        $this->schema()->drop('articles');
+        $this->schema()->drop('article_user');
+    }
+
+    public function testCreateWithDesiredAttributesUsingUpdateOrCreate()
+    {
+        /** @var BelongsToManySyncTestTestUser $user */
+        $user = BelongsToManySyncTestTestUser::create();
+
+        $user->articles()->updateOrCreate(
+            ['title' => 'Fixing UpdateOrCreate'],
+            ['description' => 'Fixed']
+        );
+
+        $article = $user->articles()->first();
+
+        $this->assertSame($article->description, 'Fixed');
+    }
+
+    public function testUpdateWithDesiredAttributesUsingUpdateOrCreate()
+    {
+        /** @var BelongsToManySyncTestTestUser $user */
+        $user = BelongsToManySyncTestTestUser::create();
+        $user->articles()->create([
+            'title' => $title = 'Fixing UpdateOrCreate',
+            'description' => 'Not fixed',
+        ]);
+
+        $user->articles()->updateOrCreate(
+            ['title' => $title],
+            ['description' => 'Fixed']
+        );
+
+        $article = $user->articles()->first();
+
+        $this->assertSame($article->description, 'Fixed');
+    }
+
+    /**
+     * Get a database connection instance.
+     *
+     * @return \Illuminate\Database\ConnectionInterface
+     */
+    protected function connection()
+    {
+        return Model::getConnectionResolver()->connection();
+    }
+
+    /**
+     * Get a schema builder instance.
+     *
+     * @return \Illuminate\Database\Schema\Builder
+     */
+    protected function schema()
+    {
+        return $this->connection()->getSchemaBuilder();
+    }
+}
+
+class BelongsToManySyncTestTestUser extends Model
+{
+    protected $table = 'users';
+
+    protected $fillable = ['email'];
+
+    public $timestamps = false;
+
+    public function articles()
+    {
+        return $this->belongsToMany(BelongsToManySyncTestTestArticle::class, 'article_user', 'user_id', 'article_id');
+    }
+}
+
+class BelongsToManySyncTestTestArticle extends Model
+{
+    protected $table = 'articles';
+
+    public $timestamps = false;
+
+    protected $fillable = ['title', 'description'];
+}

--- a/tests/Database/DatabaseEloquentBelongsToManyTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyTest.php
@@ -61,8 +61,8 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
 
     public function testCreateWithDesiredAttributesUsingUpdateOrCreate()
     {
-        /** @var BelongsToManySyncTestTestUser $user */
-        $user = BelongsToManySyncTestTestUser::create();
+        /** @var FakeUpdateOrCreateUser $user */
+        $user = FakeUpdateOrCreateUser::create();
 
         $user->articles()->updateOrCreate(
             ['title' => 'Fixing UpdateOrCreate'],
@@ -76,8 +76,8 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
 
     public function testUpdateWithDesiredAttributesUsingUpdateOrCreate()
     {
-        /** @var BelongsToManySyncTestTestUser $user */
-        $user = BelongsToManySyncTestTestUser::create();
+        /** @var FakeUpdateOrCreateUser $user */
+        $user = FakeUpdateOrCreateUser::create();
         $user->articles()->create([
             'title' => $title = 'Fixing UpdateOrCreate',
             'description' => 'Not fixed',
@@ -114,7 +114,7 @@ class DatabaseEloquentBelongsToManyTest extends TestCase
     }
 }
 
-class BelongsToManySyncTestTestUser extends Model
+class FakeUpdateOrCreateUser extends Model
 {
     protected $table = 'users';
 
@@ -124,11 +124,11 @@ class BelongsToManySyncTestTestUser extends Model
 
     public function articles()
     {
-        return $this->belongsToMany(BelongsToManySyncTestTestArticle::class, 'article_user', 'user_id', 'article_id');
+        return $this->belongsToMany(FakeUpdateOrCreateArticle::class, 'article_user', 'user_id', 'article_id');
     }
 }
 
-class BelongsToManySyncTestTestArticle extends Model
+class FakeUpdateOrCreateArticle extends Model
 {
     protected $table = 'articles';
 

--- a/tests/Database/DatabaseEloquentBelongsToManyTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyTest.php
@@ -4,8 +4,6 @@ namespace Illuminate\Tests\Database;
 
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Tests\Database\EloquentRelationshipsTest\FakeRelationship;
-use Illuminate\Tests\Database\EloquentRelationshipsTest\Post;
 use PHPUnit\Framework\TestCase;
 
 class DatabaseEloquentBelongsToManyTest extends TestCase


### PR DESCRIPTION
I was working on a project and I was trying to do `$model->relation()->updateOrCreate($attributesToLookFor, $attributesToUpdateOrCreateWith)` and the issue is that the `create` flow is not adding the first attributes.

Related issue https://github.com/laravel/framework/issues/35798 and https://github.com/laravel/framework/issues/34083 (this last one is not the same issue, but is related to the same part of the code).

---

I just saw there is a fix for this only for Laravel 9.x on https://github.com/laravel/framework/pull/35827, I am working on 8.x and I need this fix as soon as possible...