### PR TITLE
[8.x] Added reason phrase getter to Response class

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -121,6 +121,16 @@ class Response implements ArrayAccess
     }
 
     /**
+     * Get the reason phrase of the response
+     *
+     * @return string
+     */
+    public function reasonPhrase()
+    {
+        return $this->response->getReasonPhrase();
+    }
+    
+    /**
      * Get the effective URI of the response.
      *
      * @return \Psr\Http\Message\UriInterface|null

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -121,15 +121,15 @@ class Response implements ArrayAccess
     }
 
     /**
-     * Get the reason phrase of the response
+     * Get the reason phrase of the response.
      *
      * @return string
      */
-    public function reasonPhrase()
+    public function reason()
     {
         return $this->response->getReasonPhrase();
     }
-    
+
     /**
      * Get the effective URI of the response.
      *


### PR DESCRIPTION
I am interfacing with a very legacy XML API in my application, which sends back error hints in the reasonPhrase field of a response - not super kosher, but it works, i guess.

This simply adds a getter to Illuminate\Http\Client\Response to get the reason phrase from the underlying PSR response.