### PR TITLE
[9.x] Make Builder->qualifyColumns consistent with Model->qualifyColumns

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1509,9 +1509,9 @@ class Builder implements BuilderContract
      * @param  array|\Illuminate\Database\Query\Expression  $columns
      * @return array
      */
-    public function qualifyColumns($columns)
+    public function qualifyColumns(...$columns)
     {
-        return $this->model->qualifyColumns($columns);
+        return $this->model->qualifyColumns(...$columns);
     }
 
     /**


### PR DESCRIPTION
The Model version of `qualifyColumns` handles and returns qualified names for multiple parameters passed in. However, the pass-through version on Builder only passes along the first parameter, leading to inconsistent behavior.

### Rationale
This changes the behavior of `qualifyColumns` on the `Eloquent\Builder` instance to be consistent with the behavior of `Eloquent\Model`. This inconsistency was introduced with Laravel 8, and differs from Laravel 7 (see below). Philosophically, this is a worthwhile change because, in general, I think developers expect methods on the Builder instance to have the same behavior as their counterparts on the Model, and in prior versions of the framework.

#### Laravel 7 Behavior (consistent)
```
Psy Shell v0.10.8 (PHP 7.4.21 — cli) by Justin Hileman
>>> (new App\Models\User)->qualifyColumns('a', 'b')
=> [
     "users.a",
     "users.b",
   ]
>>> (new App\Models\User)->query()->qualifyColumns('a', 'b')
=> [
     "users.a",
     "users.b",
   ]
>>> app()->version()
=> "7.30.4"
>>>
```

#### Laravel 8 Behavior (inconsistent)
```
Psy Shell v0.10.12 (PHP 7.4.21 — cli) by Justin Hileman
>>> (new App\Models\User)->qualifyColumns('a', 'b')
=> [
     "users.a",
     "users.b",
   ]
>>> (new App\Models\User)->query()->qualifyColumns('a', 'b')
=> [
     "users.a",
   ]
>>> app()->version()
=> "8.74.0"
>>>
```


<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
