### PR TITLE
[8.x] Adds an `afterRefreshingDatabase` test method

### DIFF
--- a/src/Illuminate/Foundation/Testing/RefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/RefreshDatabase.php
@@ -19,6 +19,8 @@ trait RefreshDatabase
         $this->usingInMemoryDatabase()
                         ? $this->refreshInMemoryDatabase()
                         : $this->refreshTestDatabase();
+
+        $this->afterRefreshingDatabase();
     }
 
     /**
@@ -115,5 +117,14 @@ trait RefreshDatabase
     {
         return property_exists($this, 'connectionsToTransact')
                             ? $this->connectionsToTransact : [null];
+    }
+
+    /**
+     * Perform any work that should take place once the database has finished migrating.
+     *
+     * @return void
+     */
+    protected function afterRefreshingDatabase()
+    {
     }
 }

--- a/src/Illuminate/Foundation/Testing/RefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/RefreshDatabase.php
@@ -120,11 +120,12 @@ trait RefreshDatabase
     }
 
     /**
-     * Perform any work that should take place once the database has finished migrating.
+     * Perform any work that should take place once the database has finished refreshing.
      *
      * @return void
      */
     protected function afterRefreshingDatabase()
     {
+        // ...
     }
 }


### PR DESCRIPTION
Howdy!

This PR adds a new method that can be used in a `TestCase` that uses `RefreshDatabase` or `LazilyRefreshDatabase` that allows a user to perform work after the database has been refreshed. This can be used for seeding, for example, without worry that such work will negate the usefulness of `LazilyRefreshDatabase`.

## Background

I've been working today with an app that uses `LazilyRefreshDatabase` and seeds a bunch of roles and permissions into the database before tests. In order to get around the fact that seeding would negate the benefits of `LazilyRefreshDatabase`, I wrapped the seeding logic in the `MigrationsEnded` event.

However, this has a couple of caveats:

1. Most developers aren't aware of how to accomplish this, so would probably just leave it as is and suffer the performance consequences 🤷‍♂️
2. If a package has it's own migrations (such as `themsaid/wink`), then this event will fire twice and you'll end up in a heap on the floor crying 😪

## Implementation

So, instead, why not provide devs with a method that allows them to perform these setup operations at just the right time? This very simply adds an `afterRefreshingDatabase` method to the `RefreshDatabase` trait that can be implemented if desired to put all seeding/after database steps in one place controlled by the framework.

```php
abstract class TestCase extends BaseTestCase
{
   
    use CreatesApplication;
    use LazilyRefreshDatabase;

    protected function afterRefreshingDatabase()
    {
        $this->artisan('db:seed', ['--class' => RoleAndPermissionSeeder::class]);
    }

}
```

The nice thing about this is the fact that it works regardless of which refresh database trait you use, which makes it easier to switch and swap between the two traits depending on use-case.

As always, thanks for all your hard work.

Kind Regards,
Luke