### PR TITLE
[8.x] add common 4xx error status code boolean methods to response class

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -151,6 +151,26 @@ class Response implements ArrayAccess
     }
 
     /**
+     * Determine if the response code was "Unauthorized".
+     *
+     * @return bool
+     */
+    public function unauthorized()
+    {
+        return $this->status() === 401;
+    }
+
+    /**
+     * Determine if the response code was "Forbidden".
+     *
+     * @return bool
+     */
+    public function forbidden()
+    {
+        return $this->status() === 403;
+    }
+
+    /**
      * Determine if the response was a redirect.
      *
      * @return bool

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -151,7 +151,17 @@ class Response implements ArrayAccess
     }
 
     /**
-     * Determine if the response code was "Unauthorized".
+     * Determine if the response was a redirect.
+     *
+     * @return bool
+     */
+    public function redirect()
+    {
+        return $this->status() >= 300 && $this->status() < 400;
+    }
+
+    /**
+     * Determine if the response was a 401 "Unauthorized" response.
      *
      * @return bool
      */
@@ -161,23 +171,13 @@ class Response implements ArrayAccess
     }
 
     /**
-     * Determine if the response code was "Forbidden".
+     * Determine if the response was a 403 "Forbidden" response.
      *
      * @return bool
      */
     public function forbidden()
     {
         return $this->status() === 403;
-    }
-
-    /**
-     * Determine if the response was a redirect.
-     *
-     * @return bool
-     */
-    public function redirect()
-    {
-        return $this->status() >= 300 && $this->status() < 400;
     }
 
     /**

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -50,6 +50,28 @@ class HttpClientTest extends TestCase
         $this->assertTrue($response->ok());
     }
 
+    public function testUnauthorizedRequest()
+    {
+        $this->factory->fake([
+            'laravel.com' => $this->factory::response('', 401),
+        ]);
+
+        $response = $this->factory->post('http://laravel.com');
+
+        $this->assertTrue($response->unauthorized());
+    }
+
+    public function testForbiddenRequest()
+    {
+        $this->factory->fake([
+            'laravel.com' => $this->factory::response('', 403),
+        ]);
+
+        $response = $this->factory->post('http://laravel.com');
+
+        $this->assertTrue($response->forbidden());
+    }
+
     public function testResponseBodyCasting()
     {
         $this->factory->fake([


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This adds methods to check 401 and 403 status codes, respectively. I think these are pretty common status codes to work with when consuming an api.

Before:
```php
if ($response->status() === 401) {
    // ...
}

if ($response->status() === 403) {
    // ...
}
```
After:
```php
if ($response->unauthorized()) {
    // ...
}

if ($response->forbidden()) {
    // ...
}
```