### PR TITLE
[8.x] Add getSourceTable method to Builder classes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -21,6 +21,7 @@ use ReflectionMethod;
 
 /**
  * @property-read HigherOrderBuilderProxy $orWhere
+ * @property-read string from
  *
  * @mixin \Illuminate\Database\Query\Builder
  */
@@ -1598,6 +1599,10 @@ class Builder
     {
         if ($key === 'orWhere') {
             return new HigherOrderBuilderProxy($this, $key);
+        }
+
+        if ($key === 'from') {
+            return $this->query->from;
         }
 
         throw new Exception("Property [{$key}] does not exist on the Eloquent builder instance.");

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -21,7 +21,7 @@ use ReflectionMethod;
 
 /**
  * @property-read HigherOrderBuilderProxy $orWhere
- * @property-read string from
+ * @property-read string $from
  *
  * @mixin \Illuminate\Database\Query\Builder
  */

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1588,6 +1588,16 @@ class Builder
     }
 
     /**
+     * Get the table which the query is targeting.
+     *
+     * @return string
+     */
+    public function getSourceTable()
+    {
+        return $this->query->getSourceTable();
+    }
+
+    /**
      * Dynamically access builder proxies.
      *
      * @param  string  $key

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -21,7 +21,6 @@ use ReflectionMethod;
 
 /**
  * @property-read HigherOrderBuilderProxy $orWhere
- * @property-read string $from
  *
  * @mixin \Illuminate\Database\Query\Builder
  */
@@ -1609,10 +1608,6 @@ class Builder
     {
         if ($key === 'orWhere') {
             return new HigherOrderBuilderProxy($this, $key);
-        }
-
-        if ($key === 'from') {
-            return $this->query->from;
         }
 
         throw new Exception("Property [{$key}] does not exist on the Eloquent builder instance.");

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -372,9 +372,10 @@ class Builder
         if ($query->getConnection()->getDatabaseName() !==
             $this->getConnection()->getDatabaseName()) {
             $databaseName = $query->getConnection()->getDatabaseName();
+            $tableName = $query->getSourceTable();
 
-            if (strpos($query->from, $databaseName) !== 0 && strpos($query->from, '.') === false) {
-                $query->from($databaseName.'.'.$query->from);
+            if (strpos($tableName, $databaseName) !== 0 && strpos($tableName, '.') === false) {
+                $query->from($databaseName.'.'.$tableName);
             }
         }
 
@@ -3364,6 +3365,16 @@ class Builder
     public function getGrammar()
     {
         return $this->grammar;
+    }
+
+    /**
+     * Get the table which the query is targeting.
+     *
+     * @return string
+     */
+    public function getSourceTable()
+    {
+        return $this->from;
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -882,10 +882,10 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertSame('select * from "table" where "one" = ? or ("two" = ?)', $query->toSql());
     }
 
-    public function testFromGetterReturnsBaseQueryValue()
+    public function testGetSourceTable()
     {
         $builder = $this->getBuilder();
-        $this->assertEquals($builder->from, $builder->getQuery()->from);
+        $this->assertEquals($builder->getSourceTable(), $builder->getQuery()->getSourceTable());
     }
 
     public function testRealQueryChainedHigherOrderOrWhereScopes()

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -882,6 +882,12 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertSame('select * from "table" where "one" = ? or ("two" = ?)', $query->toSql());
     }
 
+    public function testFromGetterReturnsBaseQueryValue()
+    {
+        $builder = $this->getBuilder();
+        $this->assertEquals($builder->from, $builder->getQuery()->from);
+    }
+
     public function testRealQueryChainedHigherOrderOrWhereScopes()
     {
         $model = new EloquentBuilderTestHigherOrderWhereScopeStub;

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1803,6 +1803,7 @@ class DatabaseEloquentBuilderTest extends TestCase
     {
         $query = m::mock(BaseBuilder::class);
         $query->shouldReceive('from')->with('foo_table');
+        $query->shouldReceive('getSourceTable')->withNoArgs();
 
         return $query;
     }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1537,6 +1537,12 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 'foo', 1 => 'bar'], $builder->getBindings());
     }
 
+    public function testGetSourceTable()
+    {
+        $builder = $this->getBuilder();
+        $this->assertEquals($builder->from, $builder->getSourceTable());
+    }
+
     public function testWhereExists()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
This PR makes the `Illuminate\Database\Query\Builder->from` property available to read from the `Illuminate\Database\Eloquent\Builder` instance.

This is done by adding a pass-through in the `__get` method of `Eloquent\Builder` that just returns the value on the base query builder.

### The Current Issue

Currently, the join/subquery methods on the Eloquent builder are documented as accepting _either_ a base query builder, or an Eloquent query builder.

However, if you attempt to do a cross-database join/subquery, the framework eventually calls `prependDatabaseNameIfCrossDatabaseQuery` on the `Query\Builder` instance. This method checks if the query is cross-database. If so, it attempts to access the `->from` property of the query.

When an Eloquent builder instance is passed along, it will error out at that point, as there is no `from` property accessible on the `Eloquent\Builder` instance.

### Rationale

The Eloquent builder currently throws an error when trying to access the `from` property, so this doesn't modify an existing accessor.

Because the PHP doc comments say you should be able to pass an Eloquent builder into the subquery/join methods, the fact that they can fail in some cases specifically with an Eloquent builder is a bug.

Adding this `from` property fixes the bug by making the call to `prependDatabaseNameIfCrossDatabaseQuery` succeed for either type of `Builder`.

This change is also fairly minor, and I've included an update to the class doc for `Eloquent\Builder` and a test for said property access.

### Related Issues

This fixes the issue described in #35631 and is an improved solution on #38629.
