### PR TITLE
[6.x] Fix Application afterLoadingEnvironment  method

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -230,7 +230,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function afterLoadingEnvironment(Closure $callback)
     {
-        return $this->afterBootstrapping(
+        $this->afterBootstrapping(
             LoadEnvironmentVariables::class, $callback
         );
     }


### PR DESCRIPTION
## What is the problem?

Because the `afterLoadingEnvironment` method of `Application` class returns void, the return statement should not be present.
