### PR TITLE
[8.x] Fixed SoftDeletes force deletion sets "exists" property to false only when deletion succeeded

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -64,9 +64,9 @@ trait SoftDeletes
     protected function performDeleteOnModel()
     {
         if ($this->forceDeleting) {
-            $this->exists = false;
-
-            return $this->setKeysForSaveQuery($this->newModelQuery())->forceDelete();
+            return tap($this->setKeysForSaveQuery($this->newModelQuery())->forceDelete(), function () {
+                $this->exists = false;
+            });
         }
 
         return $this->runSoftDelete();

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -204,7 +204,8 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
 
     public function testForceDeleteDoesntUpdateExistsPropertyIfFailed()
     {
-        $user = new class() extends SoftDeletesTestUser {
+        $user = new class() extends SoftDeletesTestUser
+        {
             public $exists = true;
 
             public function newModelQuery()

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Query\Builder;
 use Illuminate\Pagination\CursorPaginator;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Carbon;
+use Mockery;
 use PHPUnit\Framework\TestCase;
 
 class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
@@ -187,6 +188,41 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
 
         $this->assertCount(1, $users);
         $this->assertEquals(1, $users->first()->id);
+    }
+
+    public function testForceDeleteUpdateExistsProperty()
+    {
+        $this->createUsers();
+        $user = SoftDeletesTestUser::find(2);
+
+        $this->assertTrue($user->exists);
+
+        $user->forceDelete();
+
+        $this->assertFalse($user->exists);
+    }
+
+    public function testForceDeleteDoesntUpdateExistsPropertyIfFailed()
+    {
+        $user = new class() extends SoftDeletesTestUser {
+            public $exists = true;
+
+            public function newModelQuery()
+            {
+                return Mockery::spy(parent::newModelQuery(), function (Mockery\MockInterface $mock) {
+                    $mock->shouldReceive('forceDelete')->andThrow(new \Exception());
+                });
+            }
+        };
+
+        $this->assertTrue($user->exists);
+
+        try {
+            $user->forceDelete();
+        } catch (\Exception $exception) {
+        }
+
+        $this->assertTrue($user->exists);
     }
 
     public function testRestoreRestoresRecords()


### PR DESCRIPTION
Hi everybody ✋ 

This PR fixes the behavior of `SoftDeletes::performDeleteOnModel()` method in case of forceDeleting.

# The Current Issue
Currently, when a model with the `SoftDeletes` trait is force deleted, the model property `$model->exists` is set to `false` before the database is called for deletion.

```php
/** @in Illuminate\Database\Eloquent::performDeleteOnModel() */

$this->exists = false;

return $this->setKeysForSaveQuery($this->newModelQuery())->forceDelete();
```

This behavior is particularly annoying if an error occurs during the deletion (e.g: foreign key constraint), if we catch the Exception, the `$model->exists` property will be equal to `false` whereas the model has not been deleted.

```php
/** @var App\Models\User $user */

try {
    $user->forceDelete(); // this throws an error
} catch (\Exception $e) {
    echo $user->exists; // false

    // fix user deletion
}

// retry will do nothing because $user->exists === false
$user->forceDelete();
```

# The Fix
With this fix, the database deletion call is made before the property setting. This ensure that `$model->exists` property is set to false only when the deletion succeeded

```php
/** @in Illuminate\Database\Eloquent::performDeleteOnModel() */

 return tap($this->setKeysForSaveQuery($this->newModelQuery())->forceDelete(), function () {
    $this->exists = false;
});
```
