### PR TITLE
[8.x] Add `Str::substrReplace()` and `Str::of($string)->substrReplace()` methods for the PHP native `substr_replace()` function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /vendor
-/vendor.nosync
 composer.phar
 composer.lock
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /vendor
+/vendor.nosync
 composer.phar
 composer.lock
 .DS_Store

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -876,6 +876,20 @@ class Str
     }
 
     /**
+     * Replace text within a portion of a string
+     *
+     * @param  string|array  $string
+     * @param  string|array  $replace
+     * @param  array|int  $offset
+     * @param  array|int|null  $length
+     * @return string|array
+     */
+    public static function substrReplace($string, $replace, $offset = 0, $length = null)
+    {
+        return substr_replace($string, $replace, $offset, $length);
+    }
+
+    /**
      * Make a string's first character uppercase.
      *
      * @param  string  $string

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -886,6 +886,10 @@ class Str
      */
     public static function substrReplace($string, $replace, $offset = 0, $length = null)
     {
+        if ($length ===  null) {
+            $length = strlen($string);
+        }
+        
         return substr_replace($string, $replace, $offset, $length);
     }
 

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -886,10 +886,10 @@ class Str
      */
     public static function substrReplace($string, $replace, $offset = 0, $length = null)
     {
-        if ($length ===  null) {
+        if ($length === null) {
             $length = strlen($string);
         }
-        
+
         return substr_replace($string, $replace, $offset, $length);
     }
 

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -876,7 +876,7 @@ class Str
     }
 
     /**
-     * Replace text within a portion of a string
+     * Replace text within a portion of a string.
      *
      * @param  string|array  $string
      * @param  string|array  $replace

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -710,7 +710,7 @@ class Stringable implements JsonSerializable
     }
 
     /**
-     * Replace text within a portion of a string
+     * Replace text within a portion of a string.
      *
      * @param  string|array  $replace
      * @param  array|int  $offset

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -710,6 +710,19 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Replace text within a portion of a string
+     *
+     * @param  string|array  $replace
+     * @param  array|int  $offset
+     * @param  array|int|null  $length
+     * @return string|array
+     */
+    public function substrReplace($string, $replace, $offset = 0, $length = null)
+    {
+        return Str::substrReplace($this->value, $replace, $offset, $length);
+    }
+
+    /**
      * Trim the string of the given characters.
      *
      * @param  string  $characters

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -717,9 +717,9 @@ class Stringable implements JsonSerializable
      * @param  array|int|null  $length
      * @return string|array
      */
-    public function substrReplace($string, $replace, $offset = 0, $length = null)
+    public function substrReplace($replace, $offset = 0, $length = null)
     {
-        return Str::substrReplace($this->value, $replace, $offset, $length);
+        return new static(Str::substrReplace($this->value, $replace, $offset, $length));
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -535,6 +535,13 @@ class SupportStrTest extends TestCase
         $this->assertSame(1, Str::substrCount('laravelPHPFramework', 'a', -10, -3));
     }
 
+    public function testSubstrReplace()
+    {
+        $this->assertSame('12:00', Str::substrReplace('1200', ':', 2, 0));
+        $this->assertSame('The Laravel Framework', Str::substrReplace('The Framework', 'Laravel ', 4, 0));
+        $this->assertSame('Laravel – The PHP Framework for Web Artisans', Str::substrReplace('Laravel Framework', '– The PHP Framework for Web Artisans', 8));
+    }
+
     public function testUcfirst()
     {
         $this->assertSame('Laravel', Str::ucfirst('laravel'));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Tests\Support;
 
 use Illuminate\Support\Collection;
-use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Support;
 
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
 use PHPUnit\Framework\TestCase;
 
@@ -619,6 +620,13 @@ class SupportStringableTest extends TestCase
         $this->assertSame(1, $this->stringable('laravelPHPFramework')->substrCount('a', 1, 2));
         $this->assertSame(3, $this->stringable('laravelPHPFramework')->substrCount('a', 1, -2));
         $this->assertSame(1, $this->stringable('laravelPHPFramework')->substrCount('a', -10, -3));
+    }
+
+    public function testSubstrReplace()
+    {
+        $this->assertSame('12:00', (string) $this->stringable('1200')->substrReplace(':', 2, 0));
+        $this->assertSame('The Laravel Framework', (string) $this->stringable('The Framework')->substrReplace('Laravel ', 4, 0));
+        $this->assertSame('Laravel – The PHP Framework for Web Artisans', (string) $this->stringable('Laravel Framework')->substrReplace('– The PHP Framework for Web Artisans', 8));
     }
 
     public function testPadBoth()


### PR DESCRIPTION
This pull request adds the ability to use the `substr_replace()` on the `Str` and `Stringable` classes. 

## What & why

Developers can now use directly use `Str::substrReplace(...)` and `Str::of($string)->substrReplace(...)`.

Substring replace can be used to insert a string at a certain position in another string (set the last parameter, the length, to `0`).
```php
$string = '1300';

$result = Str::substrReplace($string, ':', 2, 0); 
// '13:00'

$result = (string) Str::of($string)->substrReplace(':', 2, 0);
// '13:00'
```

It can also be used to replace the remainder of a string after a certain position:

```php
$result = (string) Str::of('Laravel Framework')->substrReplace('– The PHP Framework for Web Artisans', 8);
// 'Laravel – The PHP Framework for Web Artisans'
```
The benefit for webdevelopers is that they now have access to the `substr_replace()` method through the Str facade. The biggest benefit is (in my opinion), is that it's also a perfect candidate to be part of the fluent Stringable methods.

I'm also willing to PR a docs update for this, but I don't know if maintainers usually take care of updating the docs or if that is a task for contributors.

This is my first PR to Laravel, so please let me know if I missed anything or if there's anything I can improve. Thanks!


