### PR TITLE
More clear way to check if LogManager class exists

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -86,13 +86,9 @@ class HandleExceptions
      */
     public function handleDeprecation($message, $file, $line)
     {
-        if (! class_exists(LogManager::class)) {
-            return;
-        }
-
         try {
             $logger = $this->app->make(LogManager::class);
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             return;
         }
 


### PR DESCRIPTION
In some cases LogManager class is not available here. Previous change uses if statements, that is not necessary. This error throws an exception that may be caught.