### PR TITLE
[8.x] Fixes model:prune --pretend command for models with SoftDeletes

### DIFF
--- a/src/Illuminate/Database/Console/PruneCommand.php
+++ b/src/Illuminate/Database/Console/PruneCommand.php
@@ -6,6 +6,7 @@ use Illuminate\Console\Command;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Eloquent\MassPrunable;
 use Illuminate\Database\Eloquent\Prunable;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Events\ModelsPruned;
 use Illuminate\Support\Str;
 use Symfony\Component\Finder\Finder;


### PR DESCRIPTION
This PR should fix the model:prune --pretend command when used in combination with soft deleted models.
The withTrashed method is never called because the SoftDeletes class is not found in the array. Therefore the --pretend option always returns 0 when using a condition in the model like

```php
 public function prunable()
    {
        return static::where('deleted_at', '<=', now()->subDays(30));
    }
```

the query will currently be appended with "where deleted_at is null"


