### PR TITLE
[8.X] PATCH eloquent builder method find() performance improvement.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -384,6 +384,10 @@ class Builder
      */
     public function find($id, $columns = ['*'])
     {
+        if (is_null($id)) {
+            return null;
+        }
+
         if (is_array($id) || $id instanceof Arrayable) {
             return $this->findMany($id, $columns);
         }
@@ -483,6 +487,24 @@ class Builder
         }
 
         return tap($this->newModelInstance(array_merge($attributes, $values)), function ($instance) {
+            $instance->save();
+        });
+    }
+
+    /**
+     * Find a model by its primary key. If not found, creates a new record.
+     *
+     * @param  mixed  $id
+     * @param  array  $values
+     * @return \Illuminate\Database\Eloquent\Model|static
+     */
+    public function findOrCreate($id, array $values = [])
+    {
+        if (! is_null($instance = $this->find($id))) {
+            return $instance;
+        }
+
+        return tap($this->newModelInstance($values), function ($instance) {
             $instance->save();
         });
     }


### PR DESCRIPTION
### Included in this PR

**1.** Changes to the Eloquent Builder method `find()` . 
 Previously method would have run a database query if  `$id` parameter was `null`. 
 Now it returns early. Saves you a query 😊
 
 _**Example:**_

 Previously
 
`$user = User::find(null);`

> $user will be **null**.

Database query

> SELECT * FROM users WHERE users.id IS NULL and users.deleted_at IS NULL limit  1

After the patch 

`$user = User::find(null);`

> $user will be **null**.

Database query

> (no query at all)


**2.** Added a new `findOrCreate()` method to Eloquent Builder class.
Method is used to find a model by its primary key. If it is not found then creates a new record.

_**Example:1**_

 Lets us assume id 27 is in database and 28 is not

`$user = User::findOrcreate(27, ['name'=>'navaneeth', 'age'=>27]);`

> $user will have the record from database

Database query

> SELECT * FROM users WHERE users.id = 27 and users.deleted_at IS NULL limit  1

`$user = User::findOrcreate(28, ['name'=>'navaneeth', 'age'=>27]);`

> $user will have newly created data

Database query

> SELECT * FROM users WHERE users.id = 28 and users.deleted_at IS NULL limit  1
>  INSERT INTO users (id, name, age) VALUES (28, 'navaneeth', 27)
