### PR TITLE
support x-forwarded-prefix to set url prefix

### DIFF
--- a/src/Illuminate/Http/Middleware/TrustProxies.php
+++ b/src/Illuminate/Http/Middleware/TrustProxies.php
@@ -19,7 +19,7 @@ class TrustProxies
      *
      * @var int
      */
-    protected $headers = Request::HEADER_X_FORWARDED_FOR | Request::HEADER_X_FORWARDED_HOST | Request::HEADER_X_FORWARDED_PORT | Request::HEADER_X_FORWARDED_PROTO | Request::HEADER_X_FORWARDED_AWS_ELB;
+    protected $headers = Request::HEADER_X_FORWARDED_FOR | Request::HEADER_X_FORWARDED_HOST | Request::HEADER_X_FORWARDED_PORT | Request::HEADER_X_FORWARDED_PROTO | Request::HEADER_X_FORWARDED_PREFIX | Request::HEADER_X_FORWARDED_AWS_ELB;
 
     /**
      * Handle an incoming request.
@@ -116,9 +116,13 @@ class TrustProxies
             case 'HEADER_X_FORWARDED_PROTO':
             case Request::HEADER_X_FORWARDED_PROTO:
                 return Request::HEADER_X_FORWARDED_PROTO;
+            
+            case 'HEADER_X_FORWARDED_PREFIX':
+            case Request::HEADER_X_FORWARDED_PREFIX:
+                return Request::HEADER_X_FORWARDED_PREFIX;
 
             default:
-                return Request::HEADER_X_FORWARDED_FOR | Request::HEADER_X_FORWARDED_HOST | Request::HEADER_X_FORWARDED_PORT | Request::HEADER_X_FORWARDED_PROTO | Request::HEADER_X_FORWARDED_AWS_ELB;
+                return Request::HEADER_X_FORWARDED_FOR | Request::HEADER_X_FORWARDED_HOST | Request::HEADER_X_FORWARDED_PORT | Request::HEADER_X_FORWARDED_PROTO | Request::HEADER_X_FORWARDED_PREFIX | Request::HEADER_X_FORWARDED_AWS_ELB;
         }
 
         return $this->headers;


### PR DESCRIPTION
If we want to deploy laravel project in a subfolder of the domain like the following Nginx setting. We need to use the x-forwarded-prefix header.

```
server {
  listen 80;
  listen [::]:80;

  server_name _;
  location /to/project/ {
    proxy_set_header X-Forwarded-Prefix /to/project;
    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
    proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
    proxy_set_header X-Forwarded-Host my.domain;
    proxy_set_header X-Forwarded-Port 443;
    # laravel backend at localhost:8080
    proxy_pass http://localhost:8080/;
}
```

Symfony has already supported the x-forwarded-prefix header. We can deploy laravel in the subfolder of domain with this feature.
