### PR TITLE
Fixed function Str::slug

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -769,6 +769,9 @@ class Str
         // Convert all dashes/underscores into separator
         $flip = $separator === '-' ? '_' : '-';
 
+        // Convert a '+' to a 'plus'
+        $title = strtr($title, '+', 'plus');
+
         $title = preg_replace('!['.preg_quote($flip).']+!u', $separator, $title);
 
         // Replace @ with the word 'at'


### PR DESCRIPTION
Sometimes product models, for example, mobile phones, have a + symbol in their names.

The function now ignores the sign and leaves a space.

When there are two products that have a difference in the + symbol, two duplicates are formed.

For instance, Mi mix Alpha and Mi mix Alpha +