### PR TITLE
[8.x] Add invisible modifier for MySQL columns

### DIFF
--- a/src/Illuminate/Database/Schema/ColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ColumnDefinition.php
@@ -17,6 +17,7 @@ use Illuminate\Support\Fluent;
  * @method $this from(int $startingValue) Set the starting value of an auto-incrementing field (MySQL / PostgreSQL)
  * @method $this generatedAs(string|Expression $expression = null) Create a SQL compliant identity column (PostgreSQL)
  * @method $this index(string $indexName = null) Add an index
+ * @method $this invisible() Set column invisible
  * @method $this nullable(bool $value = true) Allow NULL values to be inserted into the column
  * @method $this persisted() Mark the computed generated column as persistent (SQL Server)
  * @method $this primary() Add a primary index

--- a/src/Illuminate/Database/Schema/ColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ColumnDefinition.php
@@ -17,7 +17,7 @@ use Illuminate\Support\Fluent;
  * @method $this from(int $startingValue) Set the starting value of an auto-incrementing field (MySQL / PostgreSQL)
  * @method $this generatedAs(string|Expression $expression = null) Create a SQL compliant identity column (PostgreSQL)
  * @method $this index(string $indexName = null) Add an index
- * @method $this invisible() Set column invisible
+ * @method $this invisible() Specify that the column should be invisible to "SELECT *" (MySQL)
  * @method $this nullable(bool $value = true) Allow NULL values to be inserted into the column
  * @method $this persisted() Mark the computed generated column as persistent (SQL Server)
  * @method $this primary() Add a primary index

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -15,7 +15,7 @@ class MySqlGrammar extends Grammar
      * @var string[]
      */
     protected $modifiers = [
-        'Unsigned', 'Charset', 'Collate', 'VirtualAs', 'StoredAs', 'Nullable',
+        'Unsigned', 'Charset', 'Collate', 'VirtualAs', 'StoredAs', 'Nullable', 'Invisible',
         'Srid', 'Default', 'Increment', 'Comment', 'After', 'First',
     ];
 
@@ -1035,6 +1035,20 @@ class MySqlGrammar extends Grammar
 
         if ($column->nullable === false) {
             return ' not null';
+        }
+    }
+
+    /**
+     * Get the SQL for an invisible column modifier.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string|null
+     */
+    protected function modifyInvisible(Blueprint $blueprint, Fluent $column)
+    {
+        if (! is_null($column->invisible)) {
+            return ' invisible';
         }
     }
 

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -560,6 +560,16 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertSame('alter table `links` add `url` varchar(2083) character set ascii not null, add `url_hash_virtual` varchar(64) character set ascii as (sha2(url, 256)), add `url_hash_stored` varchar(64) character set ascii as (sha2(url, 256)) stored', $statements[0]);
     }
 
+    public function testAddingInvisibleColumn()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->string('secret', 64)->nullable(false)->invisible();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `secret` varchar(64) not null invisible', $statements[0]);
+    }
+
     public function testAddingString()
     {
         $blueprint = new Blueprint('users');


### PR DESCRIPTION
This PR adds support for the new `invisible` modifier for columns introduced in MySQL 8.0.23: https://dev.mysql.com/doc/refman/8.0/en/invisible-columns.html

Columns marked as `invisible` are not implicitly selected by `SELECT *` and therefore, the columns will also not be automatically hydrated in a Laravel model. Those columns can still be selected explicitly, however, making it useful for columns that contain data that should only be fetched if really needed.

A concrete use case might be a model that contains several big JSON structures (e.g. with translation strings in multiple languages), but you only want to select specific keys out of those structures (only translations for the current language and a fallback language, for example). If you always fetched the whole translation structure, a lot of bandwidth and memory are wasted, and you will quickly run into sort buffer limits (which is the main reason why I would love to see this supported).

With this, you can use a new `->invisible()` method on the table Blueprint:

```php
Schema::table('users', function (Blueprint $table) {
    $table->string('secret')->nullable()->invisible();
});
```

This feature is not available in PostgreSQL and I am not aware of any other DBMS supporting this. 
I am not sure if you want any modifiers in that are not widely supported, so this is only a suggestion.

However, I do not see an easy way to turn this into a package?