### PR TITLE
[8.x] Calculate the backoff value from total of exceptions

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -556,7 +556,7 @@ class Worker
         $totalExceptions = $this->cache->get($jobExceptionsKey);
         if (is_null($totalExceptions)) {
             $this->cache->put($jobExceptionsKey, 0, Carbon::now()->addDay());
-            
+
             return 0;
         }
 

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -529,18 +529,18 @@ class Worker
     }
 
     /**
-     * Get the stored key for job's total number of exceptions
+     * Get the stored key for job's total number of exceptions.
      *
      * @param  \Illuminate\Contracts\Queue\Job  $job
      * @return string
      */
     private function getJobTotalExceptionsKey($job)
     {
-        return 'job-exceptions:' . $job->uuid();
+        return 'job-exceptions:'.$job->uuid();
     }
 
     /**
-     * Get the job's total number of exceptions
+     * Get the job's total number of exceptions.
      *
      * @param  \Illuminate\Contracts\Queue\Job  $job
      * @return int|null

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -556,6 +556,7 @@ class Worker
         $totalExceptions = $this->cache->get($jobExceptionsKey);
         if (is_null($totalExceptions)) {
             $this->cache->put($jobExceptionsKey, 0, Carbon::now()->addDay());
+            
             return 0;
         }
 
@@ -645,7 +646,6 @@ class Worker
         else {
             $calculatedBackoff = (int) ($backoff[$job->attempts() - 1] ?? last($backoff));
         }
-
 
         return $calculatedBackoff;
     }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

#39976 

This PR makes the Worker to prefer to calculate the backoff value from total of exceptions (when the backoff is configured as an array), and fallback to the total of attempts.

## Situation
- A Job is configured with backoff as an array `[1, 10]`

### Current behavior
- 1st attempt, the job calls `release()`.
- (After `0` seconds) 2nd attempt, the job throws an exception.
- (After `10` seconds) 3rd attempt, the job throws an exception.
- (After `10` seconds) 4th attempt, the job throws an exception.
...

### Proposed behavior
- 1st attempt, the job calls `release()`.
- (After `0` seconds) 2nd attempt, the job throws an exception.
- (After `1` seconds) 3rd attempt, the job throws an exception.
- (After `10` seconds) 4th attempt, the job throws an exception.
...

Notice that on the 2nd attempt, the backoff was `10` seconds