### PR TITLE
[8.x] Publish view-component.stub in stub:publish command

### DIFF
--- a/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
@@ -121,7 +121,20 @@ class ComponentMakeCommand extends GeneratorCommand
      */
     protected function getStub()
     {
-        return __DIR__.'/stubs/view-component.stub';
+        return $this->resolveStubPath('/stubs/view-component.stub');
+    }
+
+    /**
+     * Resolve the fully-qualified path to the stub.
+     *
+     * @param  string  $stub
+     * @return string
+     */
+    protected function resolveStubPath($stub)
+    {
+        return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
+                        ? $customPath
+                        : __DIR__.$stub;
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/StubPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/StubPublishCommand.php
@@ -55,6 +55,7 @@ class StubPublishCommand extends Command
             __DIR__.'/stubs/rule.stub' => $stubsPath.'/rule.stub',
             __DIR__.'/stubs/test.stub' => $stubsPath.'/test.stub',
             __DIR__.'/stubs/test.unit.stub' => $stubsPath.'/test.unit.stub',
+            __DIR__.'/stubs/view-component.stub' => $stubsPath.'/view-component.stub',
             realpath(__DIR__.'/../../Database/Console/Factories/stubs/factory.stub') => $stubsPath.'/factory.stub',
             realpath(__DIR__.'/../../Database/Console/Seeds/stubs/seeder.stub') => $stubsPath.'/seeder.stub',
             realpath(__DIR__.'/../../Database/Migrations/stubs/migration.create.stub') => $stubsPath.'/migration.create.stub',


### PR DESCRIPTION
Component stubs were updated in e60b8da21f753b5dd486307539469b4a528b0f12 which resolved the concern in [38999](https://github.com/laravel/framework/pull/38999#issuecomment-929194839)

The component stubs are something users may want to customize and it's been requested in a few places, (e.g. https://github.com/laravel/framework/issues/37389 and [Laracasts forum](https://laracasts.com/discuss/channels/laravel/how-to-edit-componentstub))