### PR TITLE
[8.x] Replace strpos by Str::startsWith in Application class

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -650,7 +650,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
     {
         $providers = Collection::make($this->make('config')->get('app.providers'))
                         ->partition(function ($provider) {
-                            return strpos($provider, 'Illuminate\\') === 0;
+                            return Str::startsWith($provider, 'Illuminate\\');
                         });
 
         $providers->splice(1, 0, [$this->make(PackageManifest::class)->providers()]);


### PR DESCRIPTION
In in Application class, `Illuminate\Support\Str` has already been imported and used. Therefore, we can use `Str::startsWith` instead of `strpos($haystack, $needle) === 0`
