### PR TITLE
[8.x] Patch to the Eloquent Builder find() method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -384,12 +384,10 @@ class Builder
      */
     public function find($id, $columns = ['*'])
     {
-        if (is_null($id)) {
-            return null;
-        }
-
         if (is_array($id) || $id instanceof Arrayable) {
             return $this->findMany($id, $columns);
+        } elseif (empty($id)) {
+            return null;
         }
 
         return $this->whereKey($id)->first($columns);

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -384,6 +384,10 @@ class Builder
      */
     public function find($id, $columns = ['*'])
     {
+        if (is_null($id)) {
+            return null;
+        }
+
         if (is_array($id) || $id instanceof Arrayable) {
             return $this->findMany($id, $columns);
         }


### PR DESCRIPTION
### Included in this PR

## Changes to the Eloquent Builder method `find()` . 
 Previously `find()` method would have run a database query if  `$id` parameter was `null`, `0`, `''` or  `false`. 
 Now it returns early. Saves you a query 😊
 
 _**Example:**_

 Previously for the following cases
 
1. `$user = User::find(null);`
2. `$user = User::find(0);`
3. `$user = User::find('');`
4. `$user = User::find(false);`

> $user is **null**.

All 4 would run 
> SELECT * FROM users WHERE users.id IS NULL and users.deleted_at IS NULL limit  1

After the patch

> (no query at all)
