### PR TITLE
[9.x] fix case when '0' passed to Application::storagePath()

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -460,7 +460,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
     public function storagePath($path = '')
     {
         return ($this->storagePath ?: $this->basePath.DIRECTORY_SEPARATOR.'storage')
-                            .($path ? DIRECTORY_SEPARATOR.$path : '');
+                            .($path ? DIRECTORY_SEPARATOR.$path : $path);
     }
 
     /**


### PR DESCRIPTION
A little fix for my own fix (https://github.com/laravel/framework/pull/39648)
that handles case when '0' passed for $path