### PR TITLE
[9.x] Refactor getTrustedHeaderNames with match function

### DIFF
--- a/src/Illuminate/Http/Middleware/TrustProxies.php
+++ b/src/Illuminate/Http/Middleware/TrustProxies.php
@@ -92,40 +92,16 @@ class TrustProxies
      */
     protected function getTrustedHeaderNames()
     {
-        switch ($this->headers) {
-            case 'HEADER_X_FORWARDED_AWS_ELB':
-            case Request::HEADER_X_FORWARDED_AWS_ELB:
-                return Request::HEADER_X_FORWARDED_AWS_ELB;
-
-            case 'HEADER_FORWARDED':
-            case Request::HEADER_FORWARDED:
-                return Request::HEADER_FORWARDED;
-
-            case 'HEADER_X_FORWARDED_FOR':
-            case Request::HEADER_X_FORWARDED_FOR:
-                return Request::HEADER_X_FORWARDED_FOR;
-
-            case 'HEADER_X_FORWARDED_HOST':
-            case Request::HEADER_X_FORWARDED_HOST:
-                return Request::HEADER_X_FORWARDED_HOST;
-
-            case 'HEADER_X_FORWARDED_PORT':
-            case Request::HEADER_X_FORWARDED_PORT:
-                return Request::HEADER_X_FORWARDED_PORT;
-
-            case 'HEADER_X_FORWARDED_PROTO':
-            case Request::HEADER_X_FORWARDED_PROTO:
-                return Request::HEADER_X_FORWARDED_PROTO;
-
-            case 'HEADER_X_FORWARDED_PREFIX':
-            case Request::HEADER_X_FORWARDED_PREFIX:
-                return Request::HEADER_X_FORWARDED_PREFIX;
-
-            default:
-                return Request::HEADER_X_FORWARDED_FOR | Request::HEADER_X_FORWARDED_HOST | Request::HEADER_X_FORWARDED_PORT | Request::HEADER_X_FORWARDED_PROTO | Request::HEADER_X_FORWARDED_PREFIX | Request::HEADER_X_FORWARDED_AWS_ELB;
-        }
-
-        return $this->headers;
+        return match ($this->headers) {
+            'HEADER_X_FORWARDED_AWS_ELB', Request::HEADER_X_FORWARDED_AWS_ELB => Request::HEADER_X_FORWARDED_AWS_ELB,
+            'HEADER_FORWARDED', Request::HEADER_FORWARDED => Request::HEADER_FORWARDED,
+            'HEADER_X_FORWARDED_FOR', Request::HEADER_X_FORWARDED_FOR => Request::HEADER_X_FORWARDED_FOR,
+            'HEADER_X_FORWARDED_HOST', Request::HEADER_X_FORWARDED_HOST => Request::HEADER_X_FORWARDED_HOST,
+            'HEADER_X_FORWARDED_PORT', Request::HEADER_X_FORWARDED_PORT => Request::HEADER_X_FORWARDED_PORT,
+            'HEADER_X_FORWARDED_PROTO', Request::HEADER_X_FORWARDED_PROTO => Request::HEADER_X_FORWARDED_PROTO,
+            'HEADER_X_FORWARDED_PREFIX', Request::HEADER_X_FORWARDED_PREFIX => Request::HEADER_X_FORWARDED_PREFIX,
+            default => Request::HEADER_X_FORWARDED_FOR | Request::HEADER_X_FORWARDED_HOST | Request::HEADER_X_FORWARDED_PORT | Request::HEADER_X_FORWARDED_PROTO | Request::HEADER_X_FORWARDED_PREFIX | Request::HEADER_X_FORWARDED_AWS_ELB,
+        };
     }
 
     /**


### PR DESCRIPTION
Replace the whole switch statement with the `match` function, and delete `return` in the last line which is never be executed.
