### PR TITLE
[8.x] Add event map getter to HasEvents trait

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -360,6 +360,16 @@ trait HasEvents
     }
 
     /**
+     * Get the event map array.
+     *
+     * @return array
+     */
+    public function getEventMap()
+    {
+        return $this->dispatchesEvents;
+    }
+
+    /**
      * Get the event dispatcher instance.
      *
      * @return \Illuminate\Contracts\Events\Dispatcher


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Without access to the protected `$dispatchesEvents` attribute, it's very hard to write a unit test that simply asserts a custom event class is defined in the model.

The only way around is to test that the event was dispatched but this requires multiple queries and I personally feel this is basically testing the framework does its job.

```php
class Article extends Model
{
    protected $dispatchesEvents = ['saved' => ArticleSaved::class];
}
```

```php
/** @test */ ❌
public function it_has_a_custom_saved_model_event_class()  
{
    Event::fake(ArticleSaved::class);

    $article = Article::factory()->create();

    $article->save();

    Event::assertDispatched(ArticleSaved::class);
}
```

Adding this getter allows for more simple tests, with no queries to db:

```php
/** @test */ ✅
public function it_has_a_custom_saved_model_event_class()
{
    $this->assertContains(ArticleSaved::class, (new Article)->getEventMap());
}
```

This is already the case for the `$observables` attribute by making use of the existing `getObservableEvents`
https://github.com/laravel/framework/blob/07c14c52de0783a583e2bb7233d31d8e10fad036/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php#L95-L105

