### PR TITLE
[9.x] Prevent further lookups of user if not found

### DIFF
--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -147,7 +147,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
             return $this->user;
         }
 
-        // Indicate the we already attempted to retrieve the user 
+        // Indicate the we already attempted to retrieve the user
         $this->retrievalAttempted = true;
 
         $id = $this->session->get($this->getName());

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -172,12 +172,6 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
             }
         }
 
-        // If the user is still null though there is a stored user id we clear the
-        // user data from storage to prevent any further attempts to retrieve the user.
-        if (! is_null($id) && is_null($this->user)) {
-            $this->clearUserDataFromStorage();
-        }
-
         return $this->user;
     }
 

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -103,6 +103,13 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     protected $recallAttempted = false;
 
     /**
+     * Indicates if a user retrieval has been attempted.
+     *
+     * @var bool
+     */
+    protected $retrievalAttempted = false;
+
+    /**
      * Create a new authentication guard.
      *
      * @param  string  $name
@@ -133,12 +140,15 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
             return;
         }
 
-        // If we've already retrieved the user for the current request we can just
-        // return it back immediately. We do not want to fetch the user data on
-        // every call to this method because that would be tremendously slow.
-        if (! is_null($this->user)) {
+        // If we've already attempted to retrieve the user for the current request we
+        // can just return it back immediately. We do not want to fetch the user data
+        // on every call to this method because that would be tremendously slow.
+        if ($this->retrievalAttempted) {
             return $this->user;
         }
+
+        // Indicate the we already attempted to retrieve the user 
+        $this->retrievalAttempted = true;
 
         $id = $this->session->get($this->getName());
 
@@ -160,6 +170,12 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
 
                 $this->fireLoginEvent($this->user, true);
             }
+        }
+
+        // If the user is still null though there is a stored user id we clear the
+        // user data from storage to prevent any further attempts to retrieve the user.
+        if (! is_null($id) && is_null($this->user)) {
+            $this->clearUserDataFromStorage();
         }
 
         return $this->user;

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -74,6 +74,43 @@ class Builder implements BuilderContract
     protected $onDelete;
 
     /**
+     * The properties that should be returned from query builder.
+     *
+     * @var string[]
+     */
+    protected $propertyPassthru = [
+        'from',
+    ];
+
+    /**
+     * The methods that should be returned from query builder.
+     *
+     * @var string[]
+     */
+    protected $passthru = [
+        'aggregate',
+        'average',
+        'avg',
+        'count',
+        'dd',
+        'doesntExist',
+        'dump',
+        'exists',
+        'getBindings',
+        'getConnection',
+        'getGrammar',
+        'insert',
+        'insertGetId',
+        'insertOrIgnore',
+        'insertUsing',
+        'max',
+        'min',
+        'raw',
+        'sum',
+        'toSql',
+    ];
+
+    /**
      * Applied global scopes.
      *
      * @var array
@@ -1570,6 +1607,10 @@ class Builder implements BuilderContract
     {
         if ($key === 'orWhere') {
             return new HigherOrderBuilderProxy($this, $key);
+        }
+
+        if (in_array($key, $this->propertyPassthru)) {
+            return $this->toBase()->{$key};
         }
 
         throw new Exception("Property [{$key}] does not exist on the Eloquent builder instance.");

--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -64,9 +64,9 @@ trait SoftDeletes
     protected function performDeleteOnModel()
     {
         if ($this->forceDeleting) {
-            $this->exists = false;
-
-            return $this->setKeysForSaveQuery($this->newModelQuery())->forceDelete();
+            return tap($this->setKeysForSaveQuery($this->newModelQuery())->forceDelete(), function () {
+                $this->exists = false;
+            });
         }
 
         return $this->runSoftDelete();

--- a/src/Illuminate/Database/Schema/ColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ColumnDefinition.php
@@ -17,6 +17,7 @@ use Illuminate\Support\Fluent;
  * @method $this from(int $startingValue) Set the starting value of an auto-incrementing field (MySQL / PostgreSQL)
  * @method $this generatedAs(string|Expression $expression = null) Create a SQL compliant identity column (PostgreSQL)
  * @method $this index(string $indexName = null) Add an index
+ * @method $this invisible() Specify that the column should be invisible to "SELECT *" (MySQL)
  * @method $this nullable(bool $value = true) Allow NULL values to be inserted into the column
  * @method $this persisted() Mark the computed generated column as persistent (SQL Server)
  * @method $this primary() Add a primary index

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -15,7 +15,7 @@ class MySqlGrammar extends Grammar
      * @var string[]
      */
     protected $modifiers = [
-        'Unsigned', 'Charset', 'Collate', 'VirtualAs', 'StoredAs', 'Nullable',
+        'Unsigned', 'Charset', 'Collate', 'VirtualAs', 'StoredAs', 'Nullable', 'Invisible',
         'Srid', 'Default', 'Increment', 'Comment', 'After', 'First',
     ];
 
@@ -1054,6 +1054,20 @@ class MySqlGrammar extends Grammar
 
         if ($column->nullable === false) {
             return ' not null';
+        }
+    }
+
+    /**
+     * Get the SQL for an invisible column modifier.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string|null
+     */
+    protected function modifyInvisible(Blueprint $blueprint, Fluent $column)
+    {
+        if (! is_null($column->invisible)) {
+            return ' invisible';
         }
     }
 

--- a/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
@@ -130,7 +130,20 @@ class ComponentMakeCommand extends GeneratorCommand
      */
     protected function getStub()
     {
-        return __DIR__.'/stubs/view-component.stub';
+        return $this->resolveStubPath('/stubs/view-component.stub');
+    }
+
+    /**
+     * Resolve the fully-qualified path to the stub.
+     *
+     * @param  string  $stub
+     * @return string
+     */
+    protected function resolveStubPath($stub)
+    {
+        return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
+                        ? $customPath
+                        : __DIR__.$stub;
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/StubPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/StubPublishCommand.php
@@ -65,6 +65,7 @@ class StubPublishCommand extends Command
             __DIR__.'/stubs/scope.stub' => $stubsPath.'/scope.stub',
             __DIR__.'/stubs/test.stub' => $stubsPath.'/test.stub',
             __DIR__.'/stubs/test.unit.stub' => $stubsPath.'/test.unit.stub',
+            __DIR__.'/stubs/view-component.stub' => $stubsPath.'/view-component.stub',
             realpath(__DIR__.'/../../Database/Console/Factories/stubs/factory.stub') => $stubsPath.'/factory.stub',
             realpath(__DIR__.'/../../Database/Console/Seeds/stubs/seeder.stub') => $stubsPath.'/seeder.stub',
             realpath(__DIR__.'/../../Database/Migrations/stubs/migration.create.stub') => $stubsPath.'/migration.create.stub',

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -890,6 +890,24 @@ class Str
     }
 
     /**
+     * Replace text within a portion of a string.
+     *
+     * @param  string|array  $string
+     * @param  string|array  $replace
+     * @param  array|int  $offset
+     * @param  array|int|null  $length
+     * @return string|array
+     */
+    public static function substrReplace($string, $replace, $offset = 0, $length = null)
+    {
+        if ($length === null) {
+            $length = strlen($string);
+        }
+
+        return substr_replace($string, $replace, $offset, $length);
+    }
+
+    /**
      * Make a string's first character uppercase.
      *
      * @param  string  $string

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -710,6 +710,19 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Replace text within a portion of a string.
+     *
+     * @param  string|array  $replace
+     * @param  array|int  $offset
+     * @param  array|int|null  $length
+     * @return string|array
+     */
+    public function substrReplace($replace, $offset = 0, $length = null)
+    {
+        return new static(Str::substrReplace($this->value, $replace, $offset, $length));
+    }
+
+    /**
      * Trim the string of the given characters.
      *
      * @param  string  $characters

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -306,6 +306,17 @@ class AuthGuardTest extends TestCase
         $this->assertSame($user, $mock->getUser());
     }
 
+    public function testUserIsRetrievedOnlyOnce()
+    {
+        $mock = $this->getGuard();
+        $mock->getSession()->shouldReceive('get')->once()->andReturn(1);
+        $user = null;
+        $mock->getProvider()->shouldReceive('retrieveById')->once()->with(1)->andReturn($user);
+        $this->assertSame($user, $mock->user());
+        $mock->getProvider()->shouldReceive('retrieveById')->never();
+        $this->assertSame($user, $mock->user());
+    }
+
     public function testLogoutRemovesSessionTokenAndRememberMeCookie()
     {
         [$session, $provider, $request, $cookie] = $this->getMocks();

--- a/tests/Cache/CacheTaggedCacheTest.php
+++ b/tests/Cache/CacheTaggedCacheTest.php
@@ -267,16 +267,16 @@ class CacheTaggedCacheTest extends TestCase
         $store->shouldReceive('connection')->andReturn($conn = m::mock(stdClass::class));
 
         // Forever tag keys
-        $conn->shouldReceive('smembers')->once()->with('prefix:foo:forever_ref')->andReturn(['key1', 'key2']);
-        $conn->shouldReceive('smembers')->once()->with('prefix:bar:forever_ref')->andReturn(['key3']);
+        $conn->shouldReceive('sscan')->once()->with('prefix:foo:forever_ref', '0', ['MATCH' => '*', 'COUNT' => 1000])->andReturn(['0', ['key1', 'key2']]);
+        $conn->shouldReceive('sscan')->once()->with('prefix:bar:forever_ref', '0', ['MATCH' => '*', 'COUNT' => 1000])->andReturn(['0', ['key3']]);
         $conn->shouldReceive('del')->once()->with('key1', 'key2');
         $conn->shouldReceive('del')->once()->with('key3');
         $conn->shouldReceive('del')->once()->with('prefix:foo:forever_ref');
         $conn->shouldReceive('del')->once()->with('prefix:bar:forever_ref');
 
         // Standard tag keys
-        $conn->shouldReceive('smembers')->once()->with('prefix:foo:standard_ref')->andReturn(['key4', 'key5']);
-        $conn->shouldReceive('smembers')->once()->with('prefix:bar:standard_ref')->andReturn(['key6']);
+        $conn->shouldReceive('sscan')->once()->with('prefix:foo:standard_ref', '0', ['MATCH' => '*', 'COUNT' => 1000])->andReturn(['0', ['key4', 'key5']]);
+        $conn->shouldReceive('sscan')->once()->with('prefix:bar:standard_ref', '0', ['MATCH' => '*', 'COUNT' => 1000])->andReturn(['0', ['key6']]);
         $conn->shouldReceive('del')->once()->with('key4', 'key5');
         $conn->shouldReceive('del')->once()->with('key6');
         $conn->shouldReceive('del')->once()->with('prefix:foo:standard_ref');

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Query\Builder;
 use Illuminate\Pagination\CursorPaginator;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Carbon;
+use Mockery;
 use PHPUnit\Framework\TestCase;
 
 class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
@@ -187,6 +188,42 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
 
         $this->assertCount(1, $users);
         $this->assertEquals(1, $users->first()->id);
+    }
+
+    public function testForceDeleteUpdateExistsProperty()
+    {
+        $this->createUsers();
+        $user = SoftDeletesTestUser::find(2);
+
+        $this->assertTrue($user->exists);
+
+        $user->forceDelete();
+
+        $this->assertFalse($user->exists);
+    }
+
+    public function testForceDeleteDoesntUpdateExistsPropertyIfFailed()
+    {
+        $user = new class() extends SoftDeletesTestUser
+        {
+            public $exists = true;
+
+            public function newModelQuery()
+            {
+                return Mockery::spy(parent::newModelQuery(), function (Mockery\MockInterface $mock) {
+                    $mock->shouldReceive('forceDelete')->andThrow(new \Exception());
+                });
+            }
+        };
+
+        $this->assertTrue($user->exists);
+
+        try {
+            $user->forceDelete();
+        } catch (\Exception $exception) {
+        }
+
+        $this->assertTrue($user->exists);
     }
 
     public function testRestoreRestoresRecords()

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -560,6 +560,16 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertSame('alter table `links` add `url` varchar(2083) character set ascii not null, add `url_hash_virtual` varchar(64) character set ascii as (sha2(url, 256)), add `url_hash_stored` varchar(64) character set ascii as (sha2(url, 256)) stored', $statements[0]);
     }
 
+    public function testAddingInvisibleColumn()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->string('secret', 64)->nullable(false)->invisible();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `secret` varchar(64) not null invisible', $statements[0]);
+    }
+
     public function testAddingString()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -533,6 +533,13 @@ class SupportStrTest extends TestCase
         $this->assertSame(1, Str::substrCount('laravelPHPFramework', 'a', -10, -3));
     }
 
+    public function testSubstrReplace()
+    {
+        $this->assertSame('12:00', Str::substrReplace('1200', ':', 2, 0));
+        $this->assertSame('The Laravel Framework', Str::substrReplace('The Framework', 'Laravel ', 4, 0));
+        $this->assertSame('Laravel – The PHP Framework for Web Artisans', Str::substrReplace('Laravel Framework', '– The PHP Framework for Web Artisans', 8));
+    }
+
     public function testUcfirst()
     {
         $this->assertSame('Laravel', Str::ucfirst('laravel'));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -621,6 +621,13 @@ class SupportStringableTest extends TestCase
         $this->assertSame(1, $this->stringable('laravelPHPFramework')->substrCount('a', -10, -3));
     }
 
+    public function testSubstrReplace()
+    {
+        $this->assertSame('12:00', (string) $this->stringable('1200')->substrReplace(':', 2, 0));
+        $this->assertSame('The Laravel Framework', (string) $this->stringable('The Framework')->substrReplace('Laravel ', 4, 0));
+        $this->assertSame('Laravel – The PHP Framework for Web Artisans', (string) $this->stringable('Laravel Framework')->substrReplace('– The PHP Framework for Web Artisans', 8));
+    }
+
     public function testPadBoth()
     {
         $this->assertSame('__Alien___', (string) $this->stringable('Alien')->padBoth(10, '_'));


### PR DESCRIPTION
In case there is still a user id in the session and the user was deleted, the framework tries to retrieve the user every time the `user()` method is called. Right now it has the possibility to significantly decrease the performance of the app because the `user()` function can easily be triggered a few dozens times and each call causes a new database request. This PR simply sets a flag to prevent further lookups. 