### PR TITLE
[9.x] Prevent further lookups of user if not found

### DIFF
--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -103,6 +103,13 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     protected $recallAttempted = false;
 
     /**
+     * Indicates if a user retrieval has been attempted.
+     *
+     * @var bool
+     */
+    protected $retrievalAttempted = false;
+
+    /**
      * Create a new authentication guard.
      *
      * @param  string  $name
@@ -133,12 +140,15 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
             return;
         }
 
-        // If we've already retrieved the user for the current request we can just
-        // return it back immediately. We do not want to fetch the user data on
-        // every call to this method because that would be tremendously slow.
-        if (! is_null($this->user)) {
+        // If we've already attempted to retrieve the user for the current request we
+        // can just return it back immediately. We do not want to fetch the user data
+        // on every call to this method because that would be tremendously slow.
+        if ($this->retrievalAttempted) {
             return $this->user;
         }
+
+        // Indicate the we already attempted to retrieve the user
+        $this->retrievalAttempted = true;
 
         $id = $this->session->get($this->getName());
 

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -143,7 +143,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
         // If we've already attempted to retrieve the user for the current request we
         // can just return it back immediately. We do not want to fetch the user data
         // on every call to this method because that would be tremendously slow.
-        if ($this->retrievalAttempted) {
+        if ($this->user || $this->retrievalAttempted) {
             return $this->user;
         }
 

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -306,6 +306,17 @@ class AuthGuardTest extends TestCase
         $this->assertSame($user, $mock->getUser());
     }
 
+    public function testUserIsRetrievedOnlyOnce()
+    {
+        $mock = $this->getGuard();
+        $mock->getSession()->shouldReceive('get')->once()->andReturn(1);
+        $user = null;
+        $mock->getProvider()->shouldReceive('retrieveById')->once()->with(1)->andReturn($user);
+        $this->assertSame($user, $mock->user());
+        $mock->getProvider()->shouldReceive('retrieveById')->never();
+        $this->assertSame($user, $mock->user());
+    }
+
     public function testLogoutRemovesSessionTokenAndRememberMeCookie()
     {
         [$session, $provider, $request, $cookie] = $this->getMocks();


### PR DESCRIPTION
In case there is still a user id in the session and the user was deleted, the framework tries to retrieve the user every time the user() method is called. Right now it has the possibility to significantly decrease the performance of the app because the user() function can easily be triggered a few dozens times and each call causes a new database request. This PR simply sets a flag to prevent further lookups.

This is a follow-up of https://github.com/laravel/framework/pull/39973 which suggested the change to `8.x` but it was rejected by Taylor since he did not want it to be part of a patch release.