### PR TITLE
[8.x] Fix Password validation failure to allow errors after min rule

### DIFF
--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -275,7 +275,7 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
         ], $this->validator->customMessages, $this->validator->customAttributes);
 
         if ($validator->fails()) {
-            return $this->fail($validator->messages()->all());
+            $this->fail($validator->messages()->all());
         }
 
         $value = (string) $value;

--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -300,7 +300,7 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
         });
 
         if ($validator->fails()) {
-            $this->fail($validator->messages()->all());
+            return $this->fail($validator->messages()->all());
         }
 
         if ($this->uncompromised && ! Container::getInstance()->make(UncompromisedVerifier::class)->verify([

--- a/tests/Validation/ValidationPasswordRuleTest.php
+++ b/tests/Validation/ValidationPasswordRuleTest.php
@@ -144,8 +144,15 @@ class ValidationPasswordRuleTest extends TestCase
             'validation.required',
         ]);
 
-        $this->fails($makeRules(), ['foo', 'azdazd', '1231231'], [
+        $this->fails($makeRules(), ['foo', 'azdazd'], [
             'validation.min.string',
+            'The my password must contain at least one uppercase and one lowercase letter.',
+            'The my password must contain at least one number.',
+        ]);
+
+        $this->fails($makeRules(), ['1231231'], [
+            'validation.min.string',
+            'The my password must contain at least one uppercase and one lowercase letter.',
         ]);
 
         $this->fails($makeRules(), ['4564654564564'], [
@@ -165,8 +172,15 @@ class ValidationPasswordRuleTest extends TestCase
 
         $this->passes($makeRules(), [null]);
 
-        $this->fails($makeRules(), ['foo', 'azdazd', '1231231'], [
+        $this->fails($makeRules(), ['foo', 'azdazd'], [
             'validation.min.string',
+            'The my password must contain at least one symbol.',
+        ]);
+
+        $this->fails($makeRules(), ['1231231'], [
+            'validation.min.string',
+            'The my password must contain at least one letter.',
+            'The my password must contain at least one symbol.',
         ]);
 
         $this->fails($makeRules(), ['aaaaaaaaa', 'TJQSJQSIUQHS'], [


### PR DESCRIPTION
I've noticed this behavior after this comment on my Youtube channel:

<img width="1031" alt="Screenshot 2021-12-14 at 11 44 44" src="https://user-images.githubusercontent.com/1510147/145973807-34fa2f20-293b-4c3c-8a01-56403fef3ecb.png">

Indeed, if there's a `min:X` rule failure in the Password class, then it doesn't even check other errors, fails immediately with `return`. All other validation failures just call `$this->fail` but without the `return`, which makes sense, as they add more potential errors to the messages array.

With this change in PR, it would show all errors: 

<img width="537" alt="Screenshot 2021-12-14 at 11 46 01" src="https://user-images.githubusercontent.com/1510147/145973977-67ab1341-799e-47c3-8618-ec3596805f2a.png">
