### PR TITLE
[9.x] Allows to remove the `server.php` file

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -49,8 +49,6 @@ class ServeCommand extends Command
      */
     public function handle()
     {
-        chdir(public_path());
-
         $this->line("<info>Starting Laravel development server:</info> http://{$this->host()}:{$this->port()}");
 
         $environmentFile = $this->option('env')
@@ -104,7 +102,7 @@ class ServeCommand extends Command
      */
     protected function startProcess($hasEnvironment)
     {
-        $process = new Process($this->serverCommand(), null, collect($_ENV)->mapWithKeys(function ($value, $key) use ($hasEnvironment) {
+        $process = new Process($this->serverCommand(), public_path(), collect($_ENV)->mapWithKeys(function ($value, $key) use ($hasEnvironment) {
             if ($this->option('no-reload') || ! $hasEnvironment) {
                 return [$key => $value];
             }
@@ -132,11 +130,15 @@ class ServeCommand extends Command
      */
     protected function serverCommand()
     {
+        $server = file_exists(base_path('server.php'))
+            ? base_path('server.php')
+            : __DIR__ . '/../resources/server.php';
+
         return [
             (new PhpExecutableFinder)->find(false),
             '-S',
             $this->host().':'.$this->port(),
-            base_path('server.php'),
+            $server,
         ];
     }
 

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -132,7 +132,7 @@ class ServeCommand extends Command
     {
         $server = file_exists(base_path('server.php'))
             ? base_path('server.php')
-            : __DIR__ . '/../resources/server.php';
+            : __DIR__.'/../resources/server.php';
 
         return [
             (new PhpExecutableFinder)->find(false),

--- a/src/Illuminate/Foundation/resources/server.php
+++ b/src/Illuminate/Foundation/resources/server.php
@@ -1,6 +1,6 @@
 <?php
 
-$publicPath  = getcwd();
+$publicPath = getcwd();
 
 $uri = urldecode(
     parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH)
@@ -13,4 +13,4 @@ if ($uri !== '/' && file_exists($publicPath.$uri)) {
     return false;
 }
 
-require_once $publicPath. '/index.php';
+require_once $publicPath.'/index.php';

--- a/src/Illuminate/Foundation/resources/server.php
+++ b/src/Illuminate/Foundation/resources/server.php
@@ -1,0 +1,16 @@
+<?php
+
+$publicPath  = getcwd();
+
+$uri = urldecode(
+    parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH)
+);
+
+// This file allows us to emulate Apache's "mod_rewrite" functionality from the
+// built-in PHP web server. This provides a convenient way to test a Laravel
+// application without having installed a "real" web server software here.
+if ($uri !== '/' && file_exists($publicPath.$uri)) {
+    return false;
+}
+
+require_once $publicPath. '/index.php';


### PR DESCRIPTION
The `serve` artisan command makes use of the `server.php` file that exists on the root of each Laravel project. This file, it's basically the same since 11 Jan 2013, and never needs to be modified at user-land.

So this pull request proposes that we remove the file from the Laravel 9 skeleton (user-land), and move it to the framework itself. 

https://github.com/laravel/laravel/pull/5747