### PR TITLE
Add string version of true and false

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -395,7 +395,7 @@ trait ValidatesAttributes
      */
     public function validateBoolean($attribute, $value)
     {
-        $acceptable = [true, false, 0, 1, '0', '1'];
+        $acceptable = [true, false, 0, 1, '0', '1', 'true', 'false'];
 
         return in_array($value, $acceptable, true);
     }


### PR DESCRIPTION
I created this pull request because the validation of boolean fields did not accept the **true** and **false** strings as valid values, which ends up causing confusion in the rule operation.