### PR TITLE
Add a fluent Stringable `Str::of($string)->if()` method to allow longer chaining of a Stringable, based on the Stringable itself

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -245,7 +245,7 @@ class Stringable implements JsonSerializable
      * @param callable|null $false
      * @return static
      */
-    public function if($condition, $true, $false)
+    public function if($condition, $true, $false = null)
     {
         if ($condition($this)) {
             return new static($true ? $true($this) : $this);

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -240,9 +240,9 @@ class Stringable implements JsonSerializable
     /**
      * Conditionally apply a callback to the stringable, based on the stringable value itself.
      *
-     * @param callable $condition
-     * @param callable|null $true
-     * @param callable|null $false
+     * @param  callable  $condition
+     * @param  callable|null  $true
+     * @param  callable|null  $false
      * @return static
      */
     public function if($condition, $true, $false = null)

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -238,6 +238,23 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Conditionally apply a callback to the stringable, based on the stringable value itself.
+     *
+     * @param callable $condition
+     * @param callable|null $true
+     * @param callable|null $false
+     * @return static
+     */
+    public function if($condition, $true, $false)
+    {
+        if ($condition($this)) {
+            return new static($true ? $true($this) : $this);
+        } else {
+            return new static($false ? $false($this) : $this);
+        }
+    }
+
+    /**
      * Determine if a given string matches a given pattern.
      *
      * @param  string|array  $pattern

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -429,7 +429,7 @@ class SupportStringableTest extends TestCase
         $this->assertSame(
             'It keeps a string the same if $true = null',
             (string) $this->stringable('It keeps a string the same if $true = null ')
-                ->if(function($stringable) {
+                ->if(function() {
                     return true;
                 }, null, function($stringable) {
                     return $stringable->replace('keeps', 'doesn\'t keep');
@@ -439,11 +439,21 @@ class SupportStringableTest extends TestCase
         $this->assertSame(
             'It keeps a string the same if $false = null',
             (string) $this->stringable('It keeps a string the same if $false = null ')
-                ->if(function($stringable) {
+                ->if(function() {
                     return false;
                 }, function($stringable) {
                     return $stringable->replace('keeps', 'doesn\'t keep');
                 }, null)->trim()
+        );
+
+        $this->assertSame(
+            'It keeps a string the same if $false = null and third parameter omitted',
+            (string) $this->stringable('It keeps a string the same if $false = null and third parameter omitted ')
+                ->if(function() {
+                    return false;
+                }, function($stringable) {
+                    return $stringable->replace('keeps', 'doesn\'t keep');
+                })->trim()
         );
     }
 

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -408,9 +408,9 @@ class SupportStringableTest extends TestCase
     {
         $this->assertSame('200 is numeric',
             (string) $this->stringable(' 200')
-                ->if(function($stringable) {
+                ->if(function ($stringable) {
                     return is_numeric((string) $stringable);
-                }, function($stringable) {
+                }, function ($stringable) {
                     return $stringable->append(' is numeric');
                 }, function ($stringable) {
                     return $stringable->append(' is not numeric');
@@ -418,9 +418,9 @@ class SupportStringableTest extends TestCase
 
         $this->assertSame('Laravel is not numeric',
             (string) $this->stringable(' Laravel')
-                ->if(function($stringable) {
+                ->if(function ($stringable) {
                     return is_numeric((string) $stringable);
-                }, function($stringable) {
+                }, function ($stringable) {
                     return $stringable->append(' is numeric');
                 }, function ($stringable) {
                     return $stringable->append(' is not numeric');
@@ -431,7 +431,7 @@ class SupportStringableTest extends TestCase
             (string) $this->stringable('It keeps a string the same if $true = null ')
                 ->if(function() {
                     return true;
-                }, null, function($stringable) {
+                }, null, function ($stringable) {
                     return $stringable->replace('keeps', 'doesn\'t keep');
                 })->trim()
         );
@@ -441,7 +441,7 @@ class SupportStringableTest extends TestCase
             (string) $this->stringable('It keeps a string the same if $false = null ')
                 ->if(function() {
                     return false;
-                }, function($stringable) {
+                }, function ($stringable) {
                     return $stringable->replace('keeps', 'doesn\'t keep');
                 }, null)->trim()
         );
@@ -451,7 +451,7 @@ class SupportStringableTest extends TestCase
             (string) $this->stringable('It keeps a string the same if $false = null and third parameter omitted ')
                 ->if(function() {
                     return false;
-                }, function($stringable) {
+                }, function ($stringable) {
                     return $stringable->replace('keeps', 'doesn\'t keep');
                 })->trim()
         );

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -404,6 +404,49 @@ class SupportStringableTest extends TestCase
         $this->assertSame('abcbbc', (string) $this->stringable('abcbbcbc')->finish('bc'));
     }
 
+    public function testIf()
+    {
+        $this->assertSame('200 is numeric',
+            (string) $this->stringable(' 200')
+                ->if(function($stringable) {
+                    return is_numeric((string) $stringable);
+                }, function($stringable) {
+                    return $stringable->append(' is numeric');
+                }, function ($stringable) {
+                    return $stringable->append(' is not numeric');
+                })->trim());
+
+        $this->assertSame('Laravel is not numeric',
+            (string) $this->stringable(' Laravel')
+                ->if(function($stringable) {
+                    return is_numeric((string) $stringable);
+                }, function($stringable) {
+                    return $stringable->append(' is numeric');
+                }, function ($stringable) {
+                    return $stringable->append(' is not numeric');
+                })->trim());
+
+        $this->assertSame(
+            'It keeps a string the same if $true = null',
+            (string) $this->stringable('It keeps a string the same if $true = null ')
+                ->if(function($stringable) {
+                    return true;
+                }, null, function($stringable) {
+                    return $stringable->replace('keeps', 'doesn\'t keep');
+                })->trim()
+        );
+
+        $this->assertSame(
+            'It keeps a string the same if $false = null',
+            (string) $this->stringable('It keeps a string the same if $false = null ')
+                ->if(function($stringable) {
+                    return false;
+                }, function($stringable) {
+                    return $stringable->replace('keeps', 'doesn\'t keep');
+                }, null)->trim()
+        );
+    }
+
     public function testIs()
     {
         $this->assertTrue($this->stringable('/')->is('/'));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -429,7 +429,7 @@ class SupportStringableTest extends TestCase
         $this->assertSame(
             'It keeps a string the same if $true = null',
             (string) $this->stringable('It keeps a string the same if $true = null ')
-                ->if(function() {
+                ->if(function () {
                     return true;
                 }, null, function ($stringable) {
                     return $stringable->replace('keeps', 'doesn\'t keep');
@@ -439,7 +439,7 @@ class SupportStringableTest extends TestCase
         $this->assertSame(
             'It keeps a string the same if $false = null',
             (string) $this->stringable('It keeps a string the same if $false = null ')
-                ->if(function() {
+                ->if(function () {
                     return false;
                 }, function ($stringable) {
                     return $stringable->replace('keeps', 'doesn\'t keep');
@@ -449,7 +449,7 @@ class SupportStringableTest extends TestCase
         $this->assertSame(
             'It keeps a string the same if $false = null and third parameter omitted',
             (string) $this->stringable('It keeps a string the same if $false = null and third parameter omitted ')
-                ->if(function() {
+                ->if(function () {
                     return false;
                 }, function ($stringable) {
                     return $stringable->replace('keeps', 'doesn\'t keep');


### PR DESCRIPTION
This Pull Request adds the ability to use an `if()` method on an instance of Stringable. This would allow developers to chain more Stringables and keep the code cleaner.

## What & why

In certain situations, developers need to modify a fluent Stringable based on the value of the Stringable itself. The `when()` methods do not allow this, because they accept a boolean, which is based on a condition _outside_ of the Stringable, and not a condition on the contents of the Stringable itself. I think that an example will make this more clear.

Consider the following scenario, where I want to append a value to a string if the string is numeric. In the current situation, we have to do something like this:

```php
$stringable = Str::of('200');

$isNumeric = is_numeric((string) $stringable);

$stringable->when($isNumeric, function ($stringable) {
    return $stringable->append('is numeric');
});
// '200 is numeric'
```
```php
// Not possible (the first condition will always evaluate to true):
Str::of('200')->when(function ($stringable) {
    return is_numeric((string) $stringable);
}, function ($stringable) {
    return $stringable->append(' is numeric');
});
```
As you see, we need to extract the Stringable to a separate before before we can make assertions on it. This causes our code code to become more unclear. In particular in cases where there is no need to a separate `$stringable`, this is needless.

With the new `if()` method, we could refactor the above example to:
```php
Str::of('200')->if(function ($stringable) {
    return is_numeric((string) $stringable);
}, function ($stringable) {
    return $stringable->append(' is numeric');
});

// '200 is numeric'

```
Or, even shorter with PHP 7.4 short function calls:
```php
Str::of('200')->if(
    fn ($stringable) => is_numeric((string) $stringable),
    fn ($stringable) => $stringable->append(' is numeric')
    fn ($stringable) => $stringable->append(' is not numeric')
);
// '200 is numeric'
```

If you only want to modify the string in one of the two cases, you can just pass `null` instead of a callback. The third parameter can be omitted entirely.

The whole `if()` method returns a new instance of `Stringable`, so everything is chainable. That means that you could chain multiple `if()`s and easily create complex strings.

## Example 2
Imagine the following long and boring procedural code:
```php
$stringable = Str::of('200')->append('00');

$isNumeric = is_numeric((string) $stringable);
// true

$stringable = $stringable->when(true, function ($stringable) {
    return $stringable->append(' is a numeric string');
});

$containsLetterA = $stringable->contains('a');
// true

$stringable = $stringable->when($containsLetterA, function ($stringable) {
    return $stringable->append(' and now contains the letter \'a\'');
});
```

With the `if()` helper, we can replace it with the following:
```php
Str::of('200')->append('00')
    ->if(fn($stringable) => is_numeric((string) $stringable), fn($stringable) => $stringable->append(' is a numeric string'))
    ->if(fn($stringable) => $stringable->contains('a'), fn($stringable) => $stringable->append(' and now contains the letter \'a\''));
```
Both will output:
```
"20000 is a numeric string and now contains the letter 'a'"
```

It would also allow to perform an action directly inside an array, whereas we otherwise would have to inline the variable and perform the conditions before constructing the array.
```php
$array = [
    'key' => Str::of('200')->append('00')
                ->if(fn($stringable) => is_numeric((string) $stringable), fn($stringable) => $stringable->append(' is a numeric string'))
                ->if(fn($stringable) => $stringable->contains('a'), fn($stringable) => $stringable->append(' and now contains the letter \'a\''));,
];
```