### PR TITLE
[8.x] Fix possible out of memory error when deleting values by reference key from cache in Redis driver

### DIFF
--- a/src/Illuminate/Cache/RedisTaggedCache.php
+++ b/src/Illuminate/Cache/RedisTaggedCache.php
@@ -185,10 +185,10 @@ class RedisTaggedCache extends TaggedCache
                 $referenceKey, $cursor, ['match' => '*', 'count' => 1000]
             );
 
-            // PhpRedis client returns false if set does not exist or empty. Destruction on false stores null
-            // in each variable. If valuesChunk is null, it means that there is no results from sscan command.
-            // Iteration over set could be finished.
-            if ($valuesChunk === null) {
+            // PhpRedis client returns false if set does not exist or empty. Array destruction
+            // on false stores null in each variable. If valuesChunk is null, it means that
+            // there were not results from the previously executed "sscan" Redis command.
+            if (is_null($valuesChunk)) {
                 break;
             }
 

--- a/tests/Cache/CacheTaggedCacheTest.php
+++ b/tests/Cache/CacheTaggedCacheTest.php
@@ -267,16 +267,16 @@ class CacheTaggedCacheTest extends TestCase
         $store->shouldReceive('connection')->andReturn($conn = m::mock(stdClass::class));
 
         // Forever tag keys
-        $conn->shouldReceive('smembers')->once()->with('prefix:foo:forever_ref')->andReturn(['key1', 'key2']);
-        $conn->shouldReceive('smembers')->once()->with('prefix:bar:forever_ref')->andReturn(['key3']);
+        $conn->shouldReceive('sscan')->once()->with('prefix:foo:forever_ref', '0', ['match' => '*', 'count' => 1000])->andReturn(['0', ['key1', 'key2']]);
+        $conn->shouldReceive('sscan')->once()->with('prefix:bar:forever_ref', '0', ['match' => '*', 'count' => 1000])->andReturn(['0', ['key3']]);
         $conn->shouldReceive('del')->once()->with('key1', 'key2');
         $conn->shouldReceive('del')->once()->with('key3');
         $conn->shouldReceive('del')->once()->with('prefix:foo:forever_ref');
         $conn->shouldReceive('del')->once()->with('prefix:bar:forever_ref');
 
         // Standard tag keys
-        $conn->shouldReceive('smembers')->once()->with('prefix:foo:standard_ref')->andReturn(['key4', 'key5']);
-        $conn->shouldReceive('smembers')->once()->with('prefix:bar:standard_ref')->andReturn(['key6']);
+        $conn->shouldReceive('sscan')->once()->with('prefix:foo:standard_ref', '0', ['match' => '*', 'count' => 1000])->andReturn(['0', ['key4', 'key5']]);
+        $conn->shouldReceive('sscan')->once()->with('prefix:bar:standard_ref', '0', ['match' => '*', 'count' => 1000])->andReturn(['0', ['key6']]);
         $conn->shouldReceive('del')->once()->with('key4', 'key5');
         $conn->shouldReceive('del')->once()->with('key6');
         $conn->shouldReceive('del')->once()->with('prefix:foo:standard_ref');


### PR DESCRIPTION
This PR solves possible out of memory issue when deleting values by reference key from cache in Redis driver. PR contains changes from #39939, but also takes into consideration that Laravel supports 2 Redis clients: phpredis and predis (issue #40037).

Changes from the PR #39939:

1. In case of empty results of `sscan` command _predis_ client returns default cursor value and empty array. At the same time _phpredis_ just returns `false`.
To process this I suggest break the loop if `$valuesChunk` is `null`. Because array destruction on `false` writes `null` to all array items.

2. _phpredis_ returns integer values as cursor. So we should cast `$cursor` to string to make a correct comparison with a default value.

3. Options for `sscan` command are in lowercase to work correct with both Redis clients. Otherwise _phpredis_ processes set by 10 items per iteration