### PR TITLE
Fixes slight oversight

### DIFF
--- a/src/Illuminate/Pagination/resources/views/simple-tailwind.blade.php
+++ b/src/Illuminate/Pagination/resources/views/simple-tailwind.blade.php
@@ -1,5 +1,5 @@
 @if ($paginator->hasPages())
-    <nav role="navigation" aria-label="{{ __('pagination.label') }}" class="flex justify-between">
+    <nav aria-label="{{ __('pagination.label') }}" class="flex justify-between">
         {{-- Previous Page Link --}}
         @if ($paginator->onFirstPage())
             <span class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-500 bg-white border border-gray-300 cursor-default leading-5 rounded-md">

--- a/src/Illuminate/Pagination/resources/views/simple-tailwind.blade.php
+++ b/src/Illuminate/Pagination/resources/views/simple-tailwind.blade.php
@@ -1,5 +1,5 @@
 @if ($paginator->hasPages())
-    <nav role="navigation" aria-label="{{ __('Pagination') }}" class="flex justify-between">
+    <nav role="navigation" aria-label="{{ __('pagination.label') }}" class="flex justify-between">
         {{-- Previous Page Link --}}
         @if ($paginator->onFirstPage())
             <span class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-500 bg-white border border-gray-300 cursor-default leading-5 rounded-md">

--- a/src/Illuminate/Pagination/resources/views/tailwind.blade.php
+++ b/src/Illuminate/Pagination/resources/views/tailwind.blade.php
@@ -1,5 +1,5 @@
 @if ($paginator->hasPages())
-    <nav role="navigation" aria-label="{{ __('pagination.label') }}" class="flex items-center justify-between">
+    <nav aria-label="{{ __('pagination.label') }}" class="flex items-center justify-between">
         <div class="flex justify-between flex-1 sm:hidden">
             @if ($paginator->onFirstPage())
                 <span class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-500 bg-white border border-gray-300 cursor-default leading-5 rounded-md">

--- a/src/Illuminate/Pagination/resources/views/tailwind.blade.php
+++ b/src/Illuminate/Pagination/resources/views/tailwind.blade.php
@@ -1,5 +1,5 @@
 @if ($paginator->hasPages())
-    <nav role="navigation" aria-label="{{ __('Pagination') }}" class="flex items-center justify-between">
+    <nav role="navigation" aria-label="{{ __('pagination.label') }}" class="flex items-center justify-between">
         <div class="flex justify-between flex-1 sm:hidden">
             @if ($paginator->onFirstPage())
                 <span class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-500 bg-white border border-gray-300 cursor-default leading-5 rounded-md">


### PR DESCRIPTION
In my previous PR, I made a small error where I used the same key for a translation string as a filename (i.e. `__("Pagination")` and `en/pagination.php`) which caused issues for someone (see: https://github.com/laravel/framework/pull/39928#issuecomment-994112464) and does not line up with best practices explained in the documentation (see "Key / File Conflicts" https://laravel.com/docs/8.x/localization#using-translation-strings-as-keys)

This PR goes hand in hand with https://github.com/laravel/laravel/pull/5748 -- and should resolve the aforementioned issue and oversight. 