### PR TITLE
[9.x] Allow http client to call send-related method without parameter.

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -663,15 +663,15 @@ class PendingRequest
      */
     public function delete(string $url = null, $data = [])
     {
-        return $this->send('DELETE', $url ?? $this->url, $this->sendOptions($data));
+        return $this->send('DELETE', $url ?? $this->url, $this->sendOptions(empty($data) ? null : $data));
     }
 
     /**
      * Construct sending options containing query and bodyFormat when available.
      *
-     * @param  array  $data
+     * @param  array|null  $data
      */
-    protected function sendOptions($data = [])
+    protected function sendOptions($data)
     {
         $options = [];
 
@@ -681,6 +681,10 @@ class PendingRequest
 
         if (! empty($data)) {
             $options[$this->bodyFormat] = $data;
+        } elseif (isset($this->pendingBody)) {
+            $options[$this->bodyFormat] = $this->pendingBody;
+        } elseif (count($this->pendingFiles) !== 0 || ! is_null($data)) {
+            $options[$this->bodyFormat] = [];
         }
 
         return $options;

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -1070,7 +1070,6 @@ class HttpClientTest extends TestCase
                 && $request->data()['test'] === 'phpunit';
         });
 
-
         $this->factory->fake();
         $this->factory->url($url)->query(['foo' => 'bar'])->withData(['test' => 'phpunit'])->post();
         $this->factory->assertSent(function (Request $request) {

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -1050,4 +1050,34 @@ class HttpClientTest extends TestCase
 
         $this->factory->get('https://example.com');
     }
+
+    public function testSendWithoutParameters()
+    {
+        $url = 'http://foo.com/api';
+
+        $this->factory->fake();
+        $this->factory->url($url)->query(['foo' => 'bar'])->get();
+        $this->factory->assertSent(function (Request $request) {
+            return $request->method() === 'GET'
+                && $request->url() === 'http://foo.com/api?foo=bar';
+        });
+
+        $this->factory->fake();
+        $this->factory->url($url)->withData(['test' => 'phpunit'])->delete();
+        $this->factory->assertSent(function (Request $request) {
+            return $request->method() === 'DELETE'
+                && isset($request->data()['test'])
+                && $request->data()['test'] === 'phpunit';
+        });
+
+
+        $this->factory->fake();
+        $this->factory->url($url)->query(['foo' => 'bar'])->withData(['test' => 'phpunit'])->post();
+        $this->factory->assertSent(function (Request $request) {
+            return $request->method() === 'POST'
+                && $request->url() === 'http://foo.com/api?foo=bar'
+                && isset($request->data()['test'])
+                && $request->data()['test'] === 'phpunit';
+        });
+    }
 }


### PR DESCRIPTION
Based on #39934.

Similar to query builder that can be passed around before actually `->get()`-ing the result,
I want to be able to pass around `PendingRequest` so it can be send later. Ex:

```php
[$method, $http] = ['post', \Http::withOptions([...])->url($url)->withData((array) $body)];
// later
$response = $http->$method(); // options, url, body, etc already defined
```

Additional benefit is that you can now do bodied-request with query string.