### PR TITLE
[9.x] Proper fix when provided path is '0'

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -460,7 +460,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
     public function storagePath($path = '')
     {
         return ($this->storagePath ?: $this->basePath.DIRECTORY_SEPARATOR.'storage')
-                            .($path ? DIRECTORY_SEPARATOR.$path : $path);
+                            .($path != '' ? DIRECTORY_SEPARATOR.$path : '');
     }
 
     /**


### PR DESCRIPTION
#40013 was incorrect, because when provided argument was '0',
we were appending `$path` (i.e. '0') instead of `DIRECTORY_SEPARATOR.$path` (i.e. '/0').

To summarize the behavior after this PR:

| argument       | appended string |
|----------------|-----------------|
| `'foo'`        | `'/foo'`        |
| `'0'`          | `'/0'`          |
| `''` (default) | `''`            |

In addition, as I'm using a loose comparison, it supports the following cases (they are not supported nor expected, though it doesn't harm to work better with them):

| argument | appended string |
|----------|-----------------|
| `null`   | `''`            |
| `false`  | `''`            |
