### PR TITLE
[8.x] Add `setApplication` method to `FilesystemManager`

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -312,6 +312,7 @@ class FilesystemManager implements FactoryContract
 
         return $this;
     }
+
     /**
      * Get the filesystem connection configuration.
      *

--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -312,6 +312,19 @@ class FilesystemManager implements FactoryContract
 
         return $this;
     }
+    
+    /**
+     * Set the application instance used by the manager.
+     *
+     * @param  \Illuminate\Contracts\Foundation\Application  $app
+     * @return $this
+     */
+    public function setApplication($app)
+    {
+        $this->app = $app;
+
+        return $this;
+    }
 
     /**
      * Get the filesystem connection configuration.

--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -312,7 +312,6 @@ class FilesystemManager implements FactoryContract
 
         return $this;
     }
-    
     /**
      * Get the filesystem connection configuration.
      *

--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -314,19 +314,6 @@ class FilesystemManager implements FactoryContract
     }
     
     /**
-     * Set the application instance used by the manager.
-     *
-     * @param  \Illuminate\Contracts\Foundation\Application  $app
-     * @return $this
-     */
-    public function setApplication($app)
-    {
-        $this->app = $app;
-
-        return $this;
-    }
-
-    /**
      * Get the filesystem connection configuration.
      *
      * @param  string  $name
@@ -395,6 +382,19 @@ class FilesystemManager implements FactoryContract
     public function extend($driver, Closure $callback)
     {
         $this->customCreators[$driver] = $callback;
+
+        return $this;
+    }
+
+    /**
+     * Set the application instance used by the manager.
+     *
+     * @param  \Illuminate\Contracts\Foundation\Application  $app
+     * @return $this
+     */
+    public function setApplication($app)
+    {
+        $this->app = $app;
 
         return $this;
     }


### PR DESCRIPTION
The `setApplication` method will be used to pass in a new `Application` to the filesystem manager by Octane when relevant (cfr. https://github.com/laravel/octane/blob/1.x/src/Listeners/GiveNewApplicationInstanceToDatabaseManager.php). 