### PR TITLE
[8.x] move maintenance mode logic

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -14,6 +14,7 @@ use Illuminate\Foundation\Bootstrap\LoadEnvironmentVariables;
 use Illuminate\Foundation\Events\LocaleUpdated;
 use Illuminate\Http\Request;
 use Illuminate\Log\LogServiceProvider;
+use Illuminate\Maintenance\MaintenanceMode;
 use Illuminate\Routing\RoutingServiceProvider;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
@@ -1109,7 +1110,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function isDownForMaintenance()
     {
-        return file_exists($this->storagePath().'/framework/down');
+        return app(MaintenanceMode::class)->isDown();
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -7,6 +7,7 @@ use Exception;
 use Illuminate\Console\Command;
 use Illuminate\Foundation\Events\MaintenanceModeEnabled;
 use Illuminate\Foundation\Exceptions\RegisterErrorViewPaths;
+use Illuminate\Maintenance\MaintenanceMode;
 use Throwable;
 
 class DownCommand extends Command
@@ -35,19 +36,16 @@ class DownCommand extends Command
      *
      * @return int
      */
-    public function handle()
+    public function handle(MaintenanceMode $maintenanceMode)
     {
         try {
-            if (is_file(storage_path('framework/down'))) {
+            if ($maintenanceMode->isDown()) {
                 $this->comment('Application is already down.');
 
                 return 0;
             }
 
-            file_put_contents(
-                storage_path('framework/down'),
-                json_encode($this->getDownFilePayload(), JSON_PRETTY_PRINT)
-            );
+            $maintenanceMode->down($this->getDownFilePayload());
 
             file_put_contents(
                 storage_path('framework/maintenance.php'),

--- a/src/Illuminate/Foundation/Console/UpCommand.php
+++ b/src/Illuminate/Foundation/Console/UpCommand.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Console;
 use Exception;
 use Illuminate\Console\Command;
 use Illuminate\Foundation\Events\MaintenanceModeDisabled;
+use Illuminate\Maintenance\MaintenanceMode;
 
 class UpCommand extends Command
 {
@@ -27,16 +28,16 @@ class UpCommand extends Command
      *
      * @return int
      */
-    public function handle()
+    public function handle(MaintenanceMode $maintenanceMode)
     {
         try {
-            if (! is_file(storage_path('framework/down'))) {
+            if ($maintenanceMode->isDown() === false) {
                 $this->comment('Application is already up.');
 
                 return 0;
             }
 
-            unlink(storage_path('framework/down'));
+            $maintenanceMode->up();
 
             if (is_file(storage_path('framework/maintenance.php'))) {
                 unlink(storage_path('framework/maintenance.php'));

--- a/src/Illuminate/Maintenance/MaintenanceMode.php
+++ b/src/Illuminate/Maintenance/MaintenanceMode.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Illuminate\Maintenance;
+
+class MaintenanceMode
+{
+    public function isDown(): bool
+    {
+        return file_exists($this->getDownFilePath());
+    }
+
+    public function down(array $payload): void
+    {
+        file_put_contents(
+            $this->getDownFilePath(),
+            json_encode($payload, JSON_PRETTY_PRINT)
+        );
+    }
+
+    public function up(): void
+    {
+        if ($this->isDown() === false) {
+            return;
+        }
+
+        unlink($this->getDownFilePath());
+    }
+
+    public function getPayload(): array
+    {
+        return json_decode(file_get_contents($this->getDownFilePath()), true);
+    }
+
+    private function getDownFilePath(): string
+    {
+        return storage_path('framework/down');
+    }
+}


### PR DESCRIPTION
Moving the maintenance mode logic to its own class. This enables users to extend/overwrite the class with their own logic.

Overwriting the logic may be needed if for example the application is running on multiple servers.

Fixes #36474 