### PR TITLE
[8.x] Update conditionals for Collection and LazyCollection contains methods

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -163,7 +163,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function contains($key, $operator = null, $value = null)
     {
-        if (func_num_args() === 1) {
+        if ($operator === null && $value === null) {
             if ($this->useAsCallable($key)) {
                 $placeholder = new stdClass;
 

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -184,13 +184,13 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      */
     public function contains($key, $operator = null, $value = null)
     {
-        if (func_num_args() === 1 && $this->useAsCallable($key)) {
+        if ($operator === null && $value === null && $this->useAsCallable($key)) {
             $placeholder = new stdClass;
 
             return $this->first($key, $placeholder) !== $placeholder;
         }
 
-        if (func_num_args() === 1) {
+        if ($operator === null && $value === null) {
             $needle = $key;
 
             foreach ($this as $value) {


### PR DESCRIPTION
A small fix from my previous [PR](https://github.com/laravel/framework/pull/40044).

When calling the following:
```
$collection = collect([1, 2, 3, 4, 5]);

$collection->doesntContain(function ($value, $key) {
    return $value < 5;
});
```

A TypeError is returned by the method because the `operator` and `value` values are carried over to the `contains` method, therefore `func_num_args()` is equal to 3 instead of 1.

I've updated the conditionals so that it checks that the `operator` and `value` values are null instead and now the method works as expected.

Sorry bout that!