### PR TITLE
[8.x] Add `Str::replaceBetween()` and `Str::of($string)->replaceBetween()` methods to replace part of a string between two markers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /vendor
-/vendor.nosync
 composer.phar
 composer.lock
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /vendor
+/vendor.nosync
 composer.phar
 composer.lock
 .DS_Store

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -615,7 +615,7 @@ class Str
         }
 
         return self::replace(
-            (new Stringable($subject))->after($start)->before($end),
+            self::of($subject)->after($start)->before($end),
             $replace,
             $subject
         );

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -600,6 +600,28 @@ class Str
     }
 
     /**
+     * Replace part of a string between two given substrings.
+     *
+     * @param  string  $start
+     * @param  string  $end
+     * @param  string  $replace
+     * @param  string  $subject
+     * @return string
+     */
+    public static function replaceBetween($start, $end, $replace, $subject)
+    {
+        if (! Str::containsAll($subject, [$start, $end])) {
+           return $subject;
+        }
+
+        return Str::replace(
+            (new Stringable($subject))->after($start)->before($end),
+            $replace,
+            $subject
+        );
+    }
+
+    /**
      * Replace the given value in the given string.
      *
      * @param  string|string[]  $search

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -610,11 +610,11 @@ class Str
      */
     public static function replaceBetween($start, $end, $replace, $subject)
     {
-        if (! Str::containsAll($subject, [$start, $end])) {
+        if (! self::containsAll($subject, [$start, $end])) {
            return $subject;
         }
 
-        return Str::replace(
+        return self::replace(
             (new Stringable($subject))->after($start)->before($end),
             $replace,
             $subject

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -611,7 +611,7 @@ class Str
     public static function replaceBetween($start, $end, $replace, $subject)
     {
         if (! self::containsAll($subject, [$start, $end])) {
-           return $subject;
+            return $subject;
         }
 
         return self::replace(

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -538,6 +538,19 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Replace part of a string between two given substrings.
+     *
+     * @param  string  $start
+     * @param  string  $end
+     * @param  string  $replace
+     * @return static
+     */
+    public function replaceBetween($start, $end, $replace)
+    {
+        return new static(Str::replaceBetween($start, $end, $replace, $this->value));
+    }
+
+    /**
      * Replace the first occurrence of a given value in the string.
      *
      * @param  string  $search

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -385,6 +385,9 @@ class SupportStrTest extends TestCase
         $this->assertSame('namespace Support\Models\User;', Str::replaceBetween('namespace ', ';', 'Support\Models\User', 'namespace App\Models\User;'));
         $this->assertSame('foo\new\baz', Str::replaceBetween('foo', 'baz', '\new\\', 'foo\bar\baz'));
         $this->assertSame('it keeps the string the same if nothing found', Str::replaceBetween('foo', 'found', 'ooops', 'it keeps the string the same if nothing found'));
+
+        $this->assertSame('foo\new\baz\baz', Str::replaceBetween('foo', 'baz', '\new\\', 'foo\bar\baz\baz'));
+        $this->assertSame('foo\new\baz\baz', Str::replaceBetween('foo', 'baz', '\new\\', 'foo\foo\bar\baz\baz'));
     }
 
     public function testReplaceFirst()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -387,6 +387,7 @@ class SupportStrTest extends TestCase
         $this->assertSame('it keeps the string the same if nothing found', Str::replaceBetween('foo', 'found', 'ooops', 'it keeps the string the same if nothing found'));
 
         $this->assertSame('foo\new\baz\baz', Str::replaceBetween('foo', 'baz', '\new\\', 'foo\bar\baz\baz'));
+        $this->assertSame('foo\new\baz', Str::replaceBetween('foo', 'baz', '\new\\', 'foo\foo\bar\baz'));
         $this->assertSame('foo\new\baz\baz', Str::replaceBetween('foo', 'baz', '\new\\', 'foo\foo\bar\baz\baz'));
     }
 

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -380,6 +380,13 @@ class SupportStrTest extends TestCase
         $this->assertSame('foo/bar', Str::replaceArray('?', ['x' => 'foo', 'y' => 'bar'], '?/?'));
     }
 
+    public function testReplaceBetween()
+    {
+        $this->assertSame('namespace Support\Models\User;', Str::replaceBetween('namespace ', ';', 'Support\Models\User', 'namespace App\Models\User;'));
+        $this->assertSame('foo\new\baz', Str::replaceBetween('foo', 'baz', '\new\\', 'foo\bar\baz'));
+        $this->assertSame('it keeps the string the same if nothing found', Str::replaceBetween('foo', 'found', 'ooops', 'it keeps the string the same if nothing found'));
+    }
+
     public function testReplaceFirst()
     {
         $this->assertSame('fooqux foobar', Str::replaceFirst('bar', 'qux', 'foobar foobar'));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -507,6 +507,7 @@ class SupportStringableTest extends TestCase
         $this->assertSame('it keeps the string the same if nothing found', (string) $this->stringable('it keeps the string the same if nothing found')->replaceBetween('foo', 'found', 'ooops'));
 
         $this->assertSame('foo\new\baz\baz', (string) $this->stringable('foo\bar\baz\baz')->replaceBetween('foo', 'baz', '\new\\'));
+        $this->assertSame('foo\new\baz', (string) $this->stringable('foo\foo\bar\baz')->replaceBetween('foo', 'baz', '\new\\'));
         $this->assertSame('foo\new\baz\baz', (string) $this->stringable('foo\foo\bar\baz\baz')->replaceBetween('foo', 'baz', '\new\\'));
     }
 

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -500,6 +500,13 @@ class SupportStringableTest extends TestCase
         $this->assertSame('foo/bar', (string) $this->stringable('?/?')->replaceArray('?', ['x' => 'foo', 'y' => 'bar']));
     }
 
+    public function testReplaceBetween()
+    {
+        $this->assertSame('namespace Support\Models\User;', (string) $this->stringable('namespace App\Models\User;')->replaceBetween('namespace ', ';', 'Support\Models\User'));
+        $this->assertSame('foo\new\baz', (string) $this->stringable('foo\bar\baz')->replaceBetween('foo', 'baz', '\new\\'));
+        $this->assertSame('it keeps the string the same if nothing found', (string) $this->stringable('it keeps the string the same if nothing found')->replaceBetween('foo', 'found', 'ooops'));
+    }
+
     public function testReplaceFirst()
     {
         $this->assertSame('fooqux foobar', (string) $this->stringable('foobar foobar')->replaceFirst('bar', 'qux'));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -505,6 +505,9 @@ class SupportStringableTest extends TestCase
         $this->assertSame('namespace Support\Models\User;', (string) $this->stringable('namespace App\Models\User;')->replaceBetween('namespace ', ';', 'Support\Models\User'));
         $this->assertSame('foo\new\baz', (string) $this->stringable('foo\bar\baz')->replaceBetween('foo', 'baz', '\new\\'));
         $this->assertSame('it keeps the string the same if nothing found', (string) $this->stringable('it keeps the string the same if nothing found')->replaceBetween('foo', 'found', 'ooops'));
+
+        $this->assertSame('foo\new\baz\baz', (string) $this->stringable('foo\bar\baz\baz')->replaceBetween('foo', 'baz', '\new\\'));
+        $this->assertSame('foo\new\baz\baz', (string) $this->stringable('foo\foo\bar\baz\baz')->replaceBetween('foo', 'baz', '\new\\'));
     }
 
     public function testReplaceFirst()


### PR DESCRIPTION
This pull request adds the ability for developers to replace a part of string between two substrings.

## What & why

Consider the following example, where I want to replace a namespace in a string. To accomplish that, I'd need to make several calls to an `after()`, `before()` and `replace()` method. 

```php

$string = 'namespace App\Models\User;';

Str::replace(
    Str::of($string)->after('namespace ')->before(';'),
    'Support\Models\User',
    $string
);
// 'namespace Support\Models\User;'
```

This is rather verbose for a very simple action. Now you can simply do this:

```php
Str::replaceBetween('namespace ', ';', 'Support\Models\User', 'namespace App\Models\User;')
// 'Support\Models\User;'
```

The fluent method is even better:
```php
(string) Str::of('namespace App\Models\User;')->replaceBetween('namespace ', ';', 'Support\Models\User');
// 'Support\Models\User;'
```

In the case that there are multiple occurrences of the `$start` or `$end` variable, it will replace the part that matches `Str::of($string)->after($start)->before($end)`. In other words, it will replace everything directly after the first occurrence of `$start` until the first occurrence of `$end`, even if that includes a second occurrence of `$start`.

This PR would allow developers to clean up their code a lot more and it fits nicely together with the existing replace methods, like `replaceArray()`, `replaceFirst()`, `replaceLast()`, etc.

NB. There were errors with Docker when running the tests in GitHub Actions. The tests are fully working, so please trigger GitHub Actions again if you're reviewing this. Hopefully the Docker issue will then be resolved. Thanks!