### PR TITLE
[8.x] Add an `only` method to JsonResource

### DIFF
--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -231,4 +231,24 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     {
         return $this->resolve(Container::getInstance()->make('request'));
     }
+
+    /**
+     * Get a subset of the resource's attributes.
+     *
+     * @param array|mixed $attributes
+     * @return array
+     */
+    public function only($attributes)
+    {
+        $resourceAttributes = $this->resolve();
+        $attributes = is_array($attributes) ? $attributes : func_get_args();
+
+        return array_filter(
+            $resourceAttributes,
+            static function ($attribute) use ($attributes) {
+                return in_array($attribute, $attributes, true);
+            },
+            ARRAY_FILTER_USE_KEY
+        );
+    }
 }

--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -235,7 +235,7 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     /**
      * Get a subset of the resource's attributes.
      *
-     * @param array|mixed $attributes
+     * @param mixed $attributes
      * @return array
      */
     public function only($attributes)


### PR DESCRIPTION
I think it could make some devs' life easier if we could filter some JsonResource attributes externally from the controller , like so:
```php
return response()->json([
  'character' => CharacterResource::make($character)->only('mp', 'location', 'area')
]);
```
I faced this with a "basic" use case that I'll describe to understand why this could be useful.

Building a browser game, I have a relatively complex model "Character" full or attributes and relations, here is its Resource class:
```php
public function toArray($request)
{
    return [
        'id' => $this->id,
        'pseudo' => $this->pseudo,
        'slug' => $this->slug,
        'race' => $this->race,
        'genre' => $this->genre,
        'profilePhotoUrl' => $this->profile_photo_url,
        'teamId' => $this->team_id,
        'worldId' => $this->world_id,
        'history' => $this->history,
        'location' => $this->location,
        'life' => $this->life,
        'maxLife' => $this->max_life,
        'lastRestoration' => $this->last_restoration,
        'state' => $this->state,
        'stamina' => $this->stamina,
        'maxStamina' => $this->max_stamina,
        'lumberjack' => $this->lumberjack,
        'attack' => $this->attack,
        'defense' => $this->defense,
        'prayer' => $this->prayer,
        'farmer' => $this->farmer,
        'dowser' => $this->dowser,
        'exp' => $this->exp,
        'ap' => $this->ap,
        'maximumAp' => $this->maximum_ap,
        'mp' => $this->mp,
        'maximumMp' => $this->maximum_mp,
        'apprentices' => $this->apprentices,
        'maximumApprentices' => $this->maximum_apprentices,
        'team' => TeamResource::make($this->whenLoaded('team')),
        'pictos' => PictoResource::collection($this->whenLoaded('pictos')),
        'world' => WorldResource::make($this->whenLoaded('world')),
        'teamRole' => TeamRoleResource::make($this->whenLoaded('team_role')),
        'god' => GodResource::make($this->whenLoaded('god')),
        'stats' => StatResource::collection($this->whenLoaded('stats')),
        'affections' => AffectionResource::collection($this->whenLoaded('affections')),
        'map' => MapResource::make($this->whenLoaded('map')),
        'resources' => ResourceResource::collection($this->whenLoaded('resources')),
        'spells' => SpellResource::collection($this->whenLoaded('spells')),
        'assignedApprentices' => ApprenticeResource::collection($this->whenLoaded('assigned_apprentices')),
        'area' => AreaResource::make($this->whenAppended('area')),
        'personalHomeLocation' => $this->whenAppended('personal_home_location')
    ];
}
```
The main problem is:
At the first load of the map, I load almost all of the relationships to initialize the front-end data.
But then when some event occurs, like a character movement, or an attack, I don't need to load all of the relationship to execute the request.
When the character moves, only the location, map and area can change.
When he attacks, only the life and action point can change.
An so on...

Basically on my front-end actions, if I update all the character instance with some missing relationships, it will break some getters, so I'd like to be able to update just some attributes of it, without the need to check on the front-end side which field need to be updated.

Plus, it would save a lot of bandwidth if just the field I need would be transferred through the call, as an example, here is the before/after call for moving the character:
Before:
![image](https://user-images.githubusercontent.com/53976837/146266937-8f850e52-86eb-4af3-931e-0a4f4fd93f19.png)

_______
After:
![image](https://user-images.githubusercontent.com/53976837/146266986-937baa7d-f2bc-4fbd-975d-ab1678f607c0.png)
