### PR TITLE
[8.x] move maintenance mode logic

### DIFF
--- a/src/Illuminate/Contracts/Foundation/Application.php
+++ b/src/Illuminate/Contracts/Foundation/Application.php
@@ -83,6 +83,13 @@ interface Application extends Container
     public function runningUnitTests();
 
     /**
+     * Get the instance of the MaintenanceMode.
+     *
+     * @return \Illuminate\Foundation\MaintenanceMode
+     */
+    public function maintenanceMode();
+
+    /**
      * Determine if the application is currently down for maintenance.
      *
      * @return bool

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1103,13 +1103,23 @@ class Application extends Container implements ApplicationContract, CachesConfig
     }
 
     /**
+     * Get the instance of the MaintenanceMode.
+     *
+     * @return \Illuminate\Foundation\MaintenanceMode
+     */
+    public function maintenanceMode()
+    {
+        return $this->make(MaintenanceMode::class);
+    }
+
+    /**
      * Determine if the application is currently down for maintenance.
      *
      * @return bool
      */
     public function isDownForMaintenance()
     {
-        return file_exists($this->storagePath().'/framework/down');
+        return $this->maintenanceMode()->isDown();
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -38,16 +38,13 @@ class DownCommand extends Command
     public function handle()
     {
         try {
-            if (is_file(storage_path('framework/down'))) {
+            if ($this->laravel->maintenanceMode()->isDown()) {
                 $this->comment('Application is already down.');
 
                 return 0;
             }
 
-            file_put_contents(
-                storage_path('framework/down'),
-                json_encode($this->getDownFilePayload(), JSON_PRETTY_PRINT)
-            );
+            $this->laravel->maintenanceMode()->down($this->getDownFilePayload());
 
             file_put_contents(
                 storage_path('framework/maintenance.php'),

--- a/src/Illuminate/Foundation/Console/UpCommand.php
+++ b/src/Illuminate/Foundation/Console/UpCommand.php
@@ -30,13 +30,13 @@ class UpCommand extends Command
     public function handle()
     {
         try {
-            if (! is_file(storage_path('framework/down'))) {
+            if ($this->laravel->maintenanceMode()->isUp()) {
                 $this->comment('Application is already up.');
 
                 return 0;
             }
 
-            unlink(storage_path('framework/down'));
+            $this->laravel->maintenanceMode()->up();
 
             if (is_file(storage_path('framework/maintenance.php'))) {
                 unlink(storage_path('framework/maintenance.php'));

--- a/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
+++ b/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
@@ -45,8 +45,8 @@ class PreventRequestsDuringMaintenance
      */
     public function handle($request, Closure $next)
     {
-        if ($this->app->isDownForMaintenance()) {
-            $data = json_decode(file_get_contents($this->app->storagePath().'/framework/down'), true);
+        if ($this->app->maintenanceMode()->isDown()) {
+            $data = $this->app->maintenanceMode()->getPayload();
 
             if (isset($data['secret']) && $request->path() === $data['secret']) {
                 return $this->bypassResponse($data['secret']);

--- a/src/Illuminate/Foundation/MaintenanceMode.php
+++ b/src/Illuminate/Foundation/MaintenanceMode.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Illuminate\Foundation;
+
+use function storage_path;
+
+class MaintenanceMode
+{
+    /**
+     * Determine if the application is currently down for maintenance.
+     *
+     * @return bool
+     */
+    public function isDown(): bool
+    {
+        return file_exists($this->getDownFilePath());
+    }
+
+    /**
+     * Determine if the application is currently up.
+     *
+     * @return bool
+     */
+    public function isUp(): bool
+    {
+        return $this->isDown() === false;
+    }
+
+    /**
+     * Take the application down for maintenance.
+     *
+     * @param  array  $payload
+     * @return void
+     */
+    public function down(array $payload): void
+    {
+        file_put_contents(
+            $this->getDownFilePath(),
+            json_encode($payload, JSON_PRETTY_PRINT)
+        );
+    }
+
+    /**
+     * Take the application out of maintenance.
+     *
+     * @return void
+     */
+    public function up(): void
+    {
+        if ($this->isDown() !== false) {
+            unlink($this->getDownFilePath());
+        }
+    }
+
+    /**
+     * Get the payload which was provided while the application was placed into maintenance.
+     *
+     * @return array
+     */
+    public function getPayload(): array
+    {
+        return json_decode(file_get_contents($this->getDownFilePath()), true);
+    }
+
+    /**
+     * Get the path where the file is stored that signals that the application is down for maintenance.
+     *
+     * @return string
+     */
+    protected function getDownFilePath(): string
+    {
+        return storage_path('framework/down');
+    }
+}


### PR DESCRIPTION
Moving the maintenance mode logic to its own class. This enables users to extend/overwrite the class with their own logic.

Overwriting the logic may be needed if for example the application is run on multiple servers. In this case the developer would want to extend the storage logic for the maintenance mode to implement a solution that can change the maintenance state for all the servers at once and reverse the maintenance mode with one command.

By separating the maintenance mode logic the framework opens the door for packages that could handle the maintenance mode through different mechanisms like using the cache (as proposed in a blog https://www.raypold.com/posts/laravel-distributed-maintenance-mode/).

The need for this was shown within the discussions https://github.com/laravel/ideas/issues/1944 and https://github.com/laravel/framework/discussions/36474.

Fixes #36474

This PR is a follow-up to the PR #40070 with suggested changes and pointed to the master instead of the 8.x branch because it contains backward incompatible changes.