### PR TITLE
[9.x] Fix array to string conversion when using custom validation messages for size rules

### DIFF
--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -31,9 +31,10 @@ trait FormatsMessages
 
         $lowerRule = Str::snake($rule);
 
-        $customKey = in_array($rule, $this->sizeRules)
-            ? "validation.custom.{$attribute}.{$lowerRule}.{$this->getAttributeType($attribute)}"
-            : "validation.custom.{$attribute}.{$lowerRule}";
+//        $customKey = in_array($rule, $this->sizeRules)
+//            ? "validation.custom.{$attribute}.{$lowerRule}.{$this->getAttributeType($attribute)}"
+//            : "validation.custom.{$attribute}.{$lowerRule}";
+            $customKey = "validation.custom.{$attribute}.{$lowerRule}";
 
         $customMessage = $this->getCustomMessageFromTranslator($customKey);
 

--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -31,10 +31,9 @@ trait FormatsMessages
 
         $lowerRule = Str::snake($rule);
 
-//        $customKey = in_array($rule, $this->sizeRules)
-//            ? "validation.custom.{$attribute}.{$lowerRule}.{$this->getAttributeType($attribute)}"
-//            : "validation.custom.{$attribute}.{$lowerRule}";
-            $customKey = "validation.custom.{$attribute}.{$lowerRule}";
+        $customKey = in_array($rule, $this->sizeRules)
+            ? "validation.custom.{$attribute}.{$lowerRule}.{$this->getAttributeType($attribute)}"
+            : "validation.custom.{$attribute}.{$lowerRule}";
 
         $customMessage = $this->getCustomMessageFromTranslator($customKey);
 

--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -31,9 +31,11 @@ trait FormatsMessages
 
         $lowerRule = Str::snake($rule);
 
-        $customMessage = $this->getCustomMessageFromTranslator(
-            $customKey = "validation.custom.{$attribute}.{$lowerRule}"
-        );
+        $customKey = in_array($rule, $this->sizeRules)
+            ? "validation.custom.{$attribute}.{$lowerRule}.{$this->getAttributeType($attribute)}"
+            : "validation.custom.{$attribute}.{$lowerRule}";
+
+        $customMessage = $this->getCustomMessageFromTranslator($customKey);
 
         // First we check for a custom defined validation message for the attribute
         // and rule. This allows the developer to specify specific messages for

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -600,6 +600,31 @@ class ValidationValidatorTest extends TestCase
         $this->assertSame('really required!', $v->messages()->first('name'));
     }
 
+    public function testCustomValidationLinesForSizeRules()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->getLoader()->addMessages('en', 'validation', [
+            'required' => 'required!',
+            'custom' => [
+                'image' => [
+                    'gte' => [
+                        'file' => 'Custom message for image files.',
+                        'string' => 'Custom message for image filenames.',
+                    ],
+                ]
+            ],
+        ]);
+
+        $v = new Validator($trans, ['image' => 'image.png'], ['image' => 'gte:50']);
+        $this->assertFalse($v->passes());
+        $this->assertSame('Custom message for image filenames.', $v->messages()->first('image'));
+
+        $file = new UploadedFile(__FILE__, '', null, null, true);
+        $v = new Validator($trans, ['image' => $file], ['image' => 'gte:50']);
+        $this->assertFalse($v->passes());
+        $this->assertSame('Custom message for image files.', $v->messages()->first('image'));
+    }
+
     public function testCustomValidationLinesAreRespectedWithAsterisks()
     {
         $trans = $this->getIlluminateArrayTranslator();

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -611,7 +611,7 @@ class ValidationValidatorTest extends TestCase
                         'file' => 'Custom message for image files.',
                         'string' => 'Custom message for image filenames.',
                     ],
-                ]
+                ],
             ],
         ]);
 


### PR DESCRIPTION
## Description
This PR is a follow up on #36885. I've tried ealier this year, but i think i haven't described correctly the issues or used wrong examples and it was rejected, so i'll try it again. When using custom validation messages for size rules, if you define your custom validation messages in `resources/lang/en/validation.php, then laravel thrown an exception when accessing those messages:

![image](https://user-images.githubusercontent.com/19756164/146384961-f5b10526-19e9-41af-813d-e5469632c5ab.png)

This exception comes from the following line, while replacing the `:message`:
https://github.com/laravel/framework/blob/96d2b48e45b9d113b95ce0edf542b3ffc76c5176/src/Illuminate/Support/MessageBag.php#L268

I'm sending this to master because if some user currently uses the custom validation messages, then the response he gets when using `$validator->errors()` is the following:
```json
{
    "file":[
        {
           "file":"The file must be between 20 and 50 kilobytes.",
           "string":"Some custom message here"
        }
    ]
}
```
and this PR changes it to:
```json
{
    "file":[
        "Some custom message here"
    ]
}
```

So, this changes the way you access validation errors from `$validator->errors()->toArray()['file'][0]['string']` to `$validator->errors()->toArray()['file'][0]` or `$validator->errors()->first('file)`, which is a breaking change.

## Steps to reproduce
- Define custom validation messages in `resources/lang/en/validation.php`:
```php
'custom' => [
    'file' => [
        'between' => [
            'numeric' => 'The :attribute must be between :min and :max.',
            'file' => 'The :attribute must be between :min and :max kilobytes.',
            'string' => 'Some custom message here',
            'array' => 'The :attribute must have between :min and :max items.',
        ],
    ],
],
```

- Create a test route in `web.php` to test the validation message:
```php
Route::get('/test', function() {
   return Validator::make(['file' => 'filename.png'], ['file' => 'between:20,50'])->errors()->first('file');
});
```

- Go to `localhost:8000/test`