### PR TITLE
[8.x] Passthru Eloquent\Query::explain function to Query\Builder:explain for the ability to use database-specific explain commands

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -7,7 +7,6 @@ use Closure;
 use Exception;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Concerns\BuildsQueries;
-use Illuminate\Database\Concerns\ExplainsQueries;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Builder as QueryBuilder;
@@ -26,7 +25,7 @@ use ReflectionMethod;
  */
 class Builder
 {
-    use Concerns\QueriesRelationships, ExplainsQueries, ForwardsCalls;
+    use Concerns\QueriesRelationships, ForwardsCalls;
     use BuildsQueries {
         sole as baseSole;
     }
@@ -96,6 +95,7 @@ class Builder
         'doesntExist',
         'dump',
         'exists',
+        'explain',
         'getBindings',
         'getConnection',
         'getGrammar',


### PR DESCRIPTION
After a [twitter discussion](https://twitter.com/mattkingshott/status/1471117843722903553?s=20) about laravel's ability to explain database queries and the insight that many optional features are missing from the explain output for PostgreSQL, i wanted to add them to [tpetry/laravel-postgresql-enhanced](https://github.com/tpetry/laravel-postgresql-enhanced).

I then discovered that the eloquent builder _and_ the query builder are using the same trait for generating explain information. As the eloquent builder is already passing many database query specific functions to the query builder i extended it to the explain command.

By this change database connections can use database-specific explain commands when they are using a custom query builder. And there is no need to change the model to make use of it. The enhanced laravel postgresql driver will use it to include many more optional explain options.