### PR TITLE
[9.x] Allow HTTP client requests with retries to optionally throw RequestExceptions

### DIFF
--- a/CHANGELOG-8.x.md
+++ b/CHANGELOG-8.x.md
@@ -3,7 +3,7 @@
 ## [Unreleased](https://github.com/laravel/framework/compare/v8.76.1...8.x)
 
 
-## [v8.76.0 (2021-12-14)](https://github.com/laravel/framework/compare/v8.76.0...v8.76.1)
+## [v8.76.1 (2021-12-14)](https://github.com/laravel/framework/compare/v8.76.0...v8.76.1)
 
 ### Reverted
 - Reverted ["Fixed possible out of memory error when deleting values by reference key from cache in Redis driver"](https://github.com/laravel/framework/pull/39939) ([#40040](https://github.com/laravel/framework/pull/40040))

--- a/CHANGELOG-8.x.md
+++ b/CHANGELOG-8.x.md
@@ -1,6 +1,12 @@
 # Release Notes for 8.x
 
-## [Unreleased](https://github.com/laravel/framework/compare/v8.76.0...8.x)
+## [Unreleased](https://github.com/laravel/framework/compare/v8.76.1...8.x)
+
+
+## [v8.76.0 (2021-12-14)](https://github.com/laravel/framework/compare/v8.76.0...v8.76.1)
+
+### Reverted
+- Reverted ["Fixed possible out of memory error when deleting values by reference key from cache in Redis driver"](https://github.com/laravel/framework/pull/39939) ([#40040](https://github.com/laravel/framework/pull/40040))
 
 
 ## [v8.76.0 (2021-12-14)](https://github.com/laravel/framework/compare/v8.75.0...v8.76.0)

--- a/CHANGELOG-8.x.md
+++ b/CHANGELOG-8.x.md
@@ -1,6 +1,9 @@
 # Release Notes for 8.x
 
-## [Unreleased](https://github.com/laravel/framework/compare/v8.75.0...8.x)
+## [Unreleased](https://github.com/laravel/framework/compare/v8.76.0...8.x)
+
+
+## [v8.76.0 (2021-12-14)](https://github.com/laravel/framework/compare/v8.75.0...v8.76.0)
 
 ### Added
 - Added possibility to customize child model route binding resolution ([#39929](https://github.com/laravel/framework/pull/39929))
@@ -19,6 +22,7 @@
 - Fixes model:prune --pretend command for models with SoftDeletes ([#39991](https://github.com/laravel/framework/pull/39991))
 - Fixed SoftDeletes force deletion sets "exists" property to false only when deletion succeeded ([#39987](https://github.com/laravel/framework/pull/39987))
 - Fixed possible out of memory error when deleting values by reference key from cache in Redis driver ([#39939](https://github.com/laravel/framework/pull/39939))
+- Fixed Password validation failure to allow errors after min rule ([#40030](https://github.com/laravel/framework/pull/40030))
 
 ### Changed
 - Fail enum validation with pure enums ([#39926](https://github.com/laravel/framework/pull/39926))

--- a/CHANGELOG-8.x.md
+++ b/CHANGELOG-8.x.md
@@ -1,6 +1,15 @@
 # Release Notes for 8.x
 
-## [Unreleased](https://github.com/laravel/framework/compare/v8.76.1...8.x)
+## [Unreleased](https://github.com/laravel/framework/compare/v8.76.2...8.x)
+
+
+## [v8.76.2 (2021-12-15)](https://github.com/laravel/framework/compare/v8.76.1...v8.76.2)
+
+### Added
+- Added doesntContain method to Collection and LazyCollection ([#40044](https://github.com/laravel/framework/pull/40044), [3e3cbcf](https://github.com/laravel/framework/commit/3e3cbcf4cb4b8116f504a1e8363c7c958067b49a))
+
+### Reverted
+- Reverted ["Revert "[8.x] Remove redundant description & localize template"](https://github.com/laravel/framework/pull/39928) ([#40054](https://github.com/laravel/framework/pull/40054))
 
 
 ## [v8.76.1 (2021-12-14)](https://github.com/laravel/framework/compare/v8.76.0...v8.76.1)

--- a/src/Illuminate/Cache/RedisTaggedCache.php
+++ b/src/Illuminate/Cache/RedisTaggedCache.php
@@ -178,13 +178,26 @@ class RedisTaggedCache extends TaggedCache
      */
     protected function deleteValues($referenceKey)
     {
-        $values = array_unique($this->store->connection()->smembers($referenceKey));
+        $cursor = $defaultCursorValue = '0';
 
-        if (count($values) > 0) {
-            foreach (array_chunk($values, 1000) as $valuesChunk) {
+        do {
+            [$cursor, $valuesChunk] = $this->store->connection()->sscan(
+                $referenceKey, $cursor, ['match' => '*', 'count' => 1000]
+            );
+
+            // PhpRedis client returns false if set does not exist or empty. Array destruction
+            // on false stores null in each variable. If valuesChunk is null, it means that
+            // there were not results from the previously executed "sscan" Redis command.
+            if (is_null($valuesChunk)) {
+                break;
+            }
+
+            $valuesChunk = array_unique($valuesChunk);
+
+            if (count($valuesChunk) > 0) {
                 $this->store->connection()->del(...$valuesChunk);
             }
-        }
+        } while (((string) $cursor) !== $defaultCursorValue);
     }
 
     /**

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -186,7 +186,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function doesntContain($key, $operator = null, $value = null)
     {
-        return ! $this->contains($key, $operator, $value);
+        return ! $this->contains(...func_get_args());
     }
 
     /**

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -177,6 +177,19 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Determine if an item is missing in the collection.
+     *
+     * @param  mixed  $key
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function missing($key, $operator = null, $value = null)
+    {
+        return !$this->contains($key, $operator, $value);
+    }
+
+    /**
      * Cross join with the given lists, returning all possible permutations.
      *
      * @param  mixed  ...$lists

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -186,7 +186,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function missing($key, $operator = null, $value = null)
     {
-        return !$this->contains($key, $operator, $value);
+        return ! $this->contains($key, $operator, $value);
     }
 
     /**

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -177,14 +177,14 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
-     * Determine if an item is missing in the collection.
+     * Determine if an item is not contained in the collection.
      *
      * @param  mixed  $key
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return bool
      */
-    public function missing($key, $operator = null, $value = null)
+    public function doesntContain($key, $operator = null, $value = null)
     {
         return ! $this->contains($key, $operator, $value);
     }

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -206,6 +206,19 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
+     * Determine if an item is missing in the enumerable.
+     *
+     * @param  mixed  $key
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function missing($key, $operator = null, $value = null)
+    {
+        return !$this->contains($key, $operator, $value);
+    }
+
+    /**
      * Cross join the given iterables, returning all possible permutations.
      *
      * @param  array  ...$arrays

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -215,7 +215,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      */
     public function missing($key, $operator = null, $value = null)
     {
-        return !$this->contains($key, $operator, $value);
+        return ! $this->contains($key, $operator, $value);
     }
 
     /**

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -215,7 +215,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      */
     public function doesntContain($key, $operator = null, $value = null)
     {
-        return ! $this->contains($key, $operator, $value);
+        return ! $this->contains(...func_get_args());
     }
 
     /**

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -206,14 +206,14 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
-     * Determine if an item is missing in the enumerable.
+     * Determine if an item is not contained in the enumerable.
      *
      * @param  mixed  $key
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return bool
      */
-    public function missing($key, $operator = null, $value = null)
+    public function doesntContain($key, $operator = null, $value = null)
     {
         return ! $this->contains($key, $operator, $value);
     }

--- a/src/Illuminate/Database/Eloquent/Casts/Attribute.php
+++ b/src/Illuminate/Database/Eloquent/Casts/Attribute.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Casts;
+
+class Attribute
+{
+    /**
+     * The attribute accessor.
+     *
+     * @var callable
+     */
+    public $get;
+
+    /**
+     * The attribute mutator.
+     *
+     * @var callable
+     */
+    public $set;
+
+    /**
+     * Create a new attribute accessor / mutator.
+     *
+     * @param  callable  $get
+     * @param  callable  $set
+     * @return void
+     */
+    public function __construct(callable $get = null, callable $set = null)
+    {
+        $this->get = $get;
+        $this->set = $set;
+    }
+
+    /**
+     * Create a new attribute accessor.
+     *
+     * @param  callable  $get
+     * @return static
+     */
+    public static function get(callable $get)
+    {
+        return new static($get);
+    }
+
+    /**
+     * Create a new attribute mutator.
+     *
+     * @param  callable  $set
+     * @return static
+     */
+    public static function set(callable $set)
+    {
+        return new static(null, $set);
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\Database\Eloquent\CastsInboundAttributes;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Casts\AsArrayObject;
 use Illuminate\Database\Eloquent\Casts\AsCollection;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\InvalidCastException;
 use Illuminate\Database\Eloquent\JsonEncodingException;
 use Illuminate\Database\Eloquent\Relations\Relation;
@@ -22,6 +23,9 @@ use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 use LogicException;
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionNamedType;
 
 trait HasAttributes
 {
@@ -59,6 +63,13 @@ trait HasAttributes
      * @var array
      */
     protected $classCastCache = [];
+
+    /**
+     * The attributes that have been cast using "Attribute" return type mutators.
+     *
+     * @var array
+     */
+    protected $attributeCastCache = [];
 
     /**
      * The built-in, primitive cast types supported by Eloquent.
@@ -129,6 +140,20 @@ trait HasAttributes
      * @var array
      */
     protected static $mutatorCache = [];
+
+    /**
+     * The cache of the "Attribute" return type marked mutated attributes for each class.
+     *
+     * @var array
+     */
+    protected static $attributeMutatorCache = [];
+
+    /**
+     * The cache of the "Attribute" return type marked mutated, settable attributes for each class.
+     *
+     * @var array
+     */
+    protected static $setAttributeMutatorCache = [];
 
     /**
      * The encrypter instance that is used to encrypt attributes.
@@ -393,6 +418,7 @@ trait HasAttributes
         if (array_key_exists($key, $this->attributes) ||
             array_key_exists($key, $this->casts) ||
             $this->hasGetMutator($key) ||
+            $this->hasAttributeGetMutator($key) ||
             $this->isClassCastable($key)) {
             return $this->getAttributeValue($key);
         }
@@ -526,6 +552,30 @@ trait HasAttributes
     }
 
     /**
+     * Determine if a "Attribute" return type marked get mutator exists for an attribute.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function hasAttributeGetMutator($key)
+    {
+        if (isset(static::$attributeMutatorCache[get_class($this)][$key])) {
+            return static::$attributeMutatorCache[get_class($this)][$key];
+        }
+
+        if (! method_exists($this, $method = Str::camel($key))) {
+            return static::$attributeMutatorCache[get_class($this)][$key] = false;
+        }
+
+        $returnType = (new ReflectionMethod($this, $method))->getReturnType();
+
+        return static::$attributeMutatorCache[get_class($this)][$key] = $returnType &&
+                    $returnType instanceof ReflectionNamedType &&
+                    $returnType->getName() === Attribute::class &&
+                    is_callable($this->{$method}()->get);
+    }
+
+    /**
      * Get the value of an attribute using its mutator.
      *
      * @param  string  $key
@@ -538,6 +588,32 @@ trait HasAttributes
     }
 
     /**
+     * Get the value of an "Attribute" return type marked attribute using its mutator.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return mixed
+     */
+    protected function mutateAttributeMarkedAttribute($key, $value)
+    {
+        if (isset($this->attributeCastCache[$key])) {
+            return $this->attributeCastCache[$key];
+        }
+
+        $value = call_user_func($this->{Str::camel($key)}()->get ?: function ($value) {
+            return $value;
+        }, $value, $this->attributes);
+
+        if (! is_object($value)) {
+            unset($this->attributeCastCache[$key]);
+        } else {
+            $this->attributeCastCache[$key] = $value;
+        }
+
+        return $value;
+    }
+
+    /**
      * Get the value of an attribute using its mutator for array conversion.
      *
      * @param  string  $key
@@ -546,9 +622,18 @@ trait HasAttributes
      */
     protected function mutateAttributeForArray($key, $value)
     {
-        $value = $this->isClassCastable($key)
-            ? $this->getClassCastableAttributeValue($key, $value)
-            : $this->mutateAttribute($key, $value);
+        if ($this->isClassCastable($key)) {
+            $value = $this->getClassCastableAttributeValue($key, $value);
+        } elseif (isset(static::$attributeMutatorCache[get_class($this)][$key]) &&
+                  static::$attributeMutatorCache[get_class($this)][$key] === true) {
+            $value = $this->mutateAttributeMarkedAttribute($key, $value);
+
+            $value = $value instanceof DateTimeInterface
+                        ? $this->serializeDate($value)
+                        : $value;
+        } else {
+            $value = $this->mutateAttribute($key, $value);
+        }
 
         return $value instanceof Arrayable ? $value->toArray() : $value;
     }
@@ -788,6 +873,8 @@ trait HasAttributes
         // this model, such as "json_encoding" a listing of data for storage.
         if ($this->hasSetMutator($key)) {
             return $this->setMutatedAttributeValue($key, $value);
+        } elseif ($this->hasAttributeSetMutator($key)) {
+            return $this->setAttributeMarkedMutatedAttributeValue($key, $value);
         }
 
         // If an attribute is listed as a "date", we'll convert it from a DateTime
@@ -841,6 +928,32 @@ trait HasAttributes
     }
 
     /**
+     * Determine if an "Attribute" return type marked set mutator exists for an attribute.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function hasAttributeSetMutator($key)
+    {
+        $class = get_class($this);
+
+        if (isset(static::$setAttributeMutatorCache[$class][$key])) {
+            return static::$setAttributeMutatorCache[$class][$key];
+        }
+
+        if (! method_exists($this, $method = Str::camel($key))) {
+            return static::$setAttributeMutatorCache[$class][$key] = false;
+        }
+
+        $returnType = (new ReflectionMethod($this, $method))->getReturnType();
+
+        return static::$setAttributeMutatorCache[$class][$key] = $returnType &&
+                    $returnType instanceof ReflectionNamedType &&
+                    $returnType->getName() === Attribute::class &&
+                    is_callable($this->{$method}()->set);
+    }
+
+    /**
      * Set the value of an attribute using its mutator.
      *
      * @param  string  $key
@@ -850,6 +963,33 @@ trait HasAttributes
     protected function setMutatedAttributeValue($key, $value)
     {
         return $this->{'set'.Str::studly($key).'Attribute'}($value);
+    }
+
+    /**
+     * Set the value of a "Attribute" return type marked attribute using its mutator.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return mixed
+     */
+    protected function setAttributeMarkedMutatedAttributeValue($key, $value)
+    {
+        $callback = $this->{Str::camel($key)}()->set ?: function ($value) use ($key) {
+            $this->attributes[$key] = $value;
+        };
+
+        $this->attributes = array_merge(
+            $this->attributes,
+            $this->normalizeCastClassResponse(
+                $key, call_user_func($callback, $value, $this->attributes)
+            )
+        );
+
+        if (! is_object($value)) {
+            unset($this->attributeCastCache[$key]);
+        } else {
+            $this->attributeCastCache[$key] = $value;
+        }
     }
 
     /**
@@ -1435,6 +1575,17 @@ trait HasAttributes
     }
 
     /**
+     * Merge the cast class and attribute cast attributes back into the model.
+     *
+     * @return void
+     */
+    protected function mergeAttributesFromCachedCasts()
+    {
+        $this->mergeAttributesFromClassCasts();
+        $this->mergeAttributesFromAttributeCasts();
+    }
+
+    /**
      * Merge the cast class attributes back into the model.
      *
      * @return void
@@ -1449,6 +1600,27 @@ trait HasAttributes
                 $caster instanceof CastsInboundAttributes
                     ? [$key => $value]
                     : $this->normalizeCastClassResponse($key, $caster->set($this, $key, $value, $this->attributes))
+            );
+        }
+    }
+
+    /**
+     * Merge the cast class attributes back into the model.
+     *
+     * @return void
+     */
+    protected function mergeAttributesFromAttributeCasts()
+    {
+        foreach ($this->attributeCastCache as $key => $value) {
+            $callback = $this->{Str::camel($key)}()->set ?: function ($value) use ($key) {
+                $this->attributes[$key] = $value;
+            };
+
+            $this->attributes = array_merge(
+                $this->attributes,
+                $this->normalizeCastClassResponse(
+                    $key, call_user_func($callback, $value, $this->attributes)
+                )
             );
         }
     }
@@ -1472,7 +1644,7 @@ trait HasAttributes
      */
     public function getAttributes()
     {
-        $this->mergeAttributesFromClassCasts();
+        $this->mergeAttributesFromCachedCasts();
 
         return $this->attributes;
     }
@@ -1503,6 +1675,7 @@ trait HasAttributes
         }
 
         $this->classCastCache = [];
+        $this->attributeCastCache = [];
 
         return $this;
     }
@@ -1773,6 +1946,8 @@ trait HasAttributes
         // retrieval from the model to a form that is more useful for usage.
         if ($this->hasGetMutator($key)) {
             return $this->mutateAttribute($key, $value);
+        } elseif ($this->hasAttributeGetMutator($key)) {
+            return $this->mutateAttributeMarkedAttribute($key, $value);
         }
 
         // If the attribute exists within the cast array, we will convert it to
@@ -1856,9 +2031,17 @@ trait HasAttributes
      */
     public static function cacheMutatedAttributes($class)
     {
-        static::$mutatorCache[$class] = collect(static::getMutatorMethods($class))->map(function ($match) {
-            return lcfirst(static::$snakeAttributes ? Str::snake($match) : $match);
-        })->all();
+        static::$attributeMutatorCache[$class] =
+            collect($attributeMutatorMethods = static::getAttributeMarkedMutatorMethods($class))
+                    ->mapWithKeys(function ($match) {
+                        return [lcfirst(static::$snakeAttributes ? Str::snake($match) : $match) => true];
+                    })->all();
+
+        static::$mutatorCache[$class] = collect(static::getMutatorMethods($class))
+                ->merge($attributeMutatorMethods)
+                ->map(function ($match) {
+                    return lcfirst(static::$snakeAttributes ? Str::snake($match) : $match);
+                })->all();
     }
 
     /**
@@ -1872,5 +2055,32 @@ trait HasAttributes
         preg_match_all('/(?<=^|;)get([^;]+?)Attribute(;|$)/', implode(';', get_class_methods($class)), $matches);
 
         return $matches[1];
+    }
+
+    /**
+     * Get all of the "Attribute" return typed attribute mutator methods.
+     *
+     * @param  mixed  $class
+     * @return array
+     */
+    protected static function getAttributeMarkedMutatorMethods($class)
+    {
+        $instance = is_object($class) ? $class : new $class;
+
+        return collect((new ReflectionClass($instance))->getMethods())->filter(function ($method) use ($instance) {
+            $returnType = $method->getReturnType();
+
+            if ($returnType &&
+                $returnType instanceof ReflectionNamedType &&
+                $returnType->getName() === Attribute::class) {
+                $method->setAccessible(true);
+
+                if (is_callable($method->invoke($instance)->get)) {
+                    return true;
+                }
+            }
+
+            return false;
+        })->map->name->values()->all();
     }
 }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -968,7 +968,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function save(array $options = [])
     {
-        $this->mergeAttributesFromClassCasts();
+        $this->mergeAttributesFromCachedCasts();
 
         $query = $this->newModelQuery();
 
@@ -1237,7 +1237,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function delete()
     {
-        $this->mergeAttributesFromClassCasts();
+        $this->mergeAttributesFromCachedCasts();
 
         if (is_null($this->getKeyName())) {
             throw new LogicException('No primary key defined on model.');
@@ -2176,9 +2176,10 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function __sleep()
     {
-        $this->mergeAttributesFromClassCasts();
+        $this->mergeAttributesFromCachedCasts();
 
         $this->classCastCache = [];
+        $this->attributeCastCache = [];
 
         return array_keys(get_object_vars($this));
     }

--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -387,6 +387,19 @@ class FilesystemManager implements FactoryContract
     }
 
     /**
+     * Set the application instance used by the manager.
+     *
+     * @param  \Illuminate\Contracts\Foundation\Application  $app
+     * @return $this
+     */
+    public function setApplication($app)
+    {
+        $this->app = $app;
+
+        return $this;
+    }
+
+    /**
      * Dynamically call the default driver instance.
      *
      * @param  string  $method

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -33,7 +33,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      *
      * @var string
      */
-    const VERSION = '8.76.1';
+    const VERSION = '8.76.2';
 
     /**
      * The base path for the Laravel installation.

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -25,7 +25,7 @@ use PHPUnit\Framework\Assert as PHPUnit;
  * @method \Illuminate\Http\Client\PendingRequest contentType(string $contentType)
  * @method \Illuminate\Http\Client\PendingRequest dd()
  * @method \Illuminate\Http\Client\PendingRequest dump()
- * @method \Illuminate\Http\Client\PendingRequest retry(int $times, int $sleep = 0, ?callable $when = null)
+ * @method \Illuminate\Http\Client\PendingRequest retry(int $times, int $sleep = 0, ?callable $when = null, bool $throw = true)
  * @method \Illuminate\Http\Client\PendingRequest sink(string|resource $to)
  * @method \Illuminate\Http\Client\PendingRequest stub(callable $callback)
  * @method \Illuminate\Http\Client\PendingRequest timeout(int $seconds)

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -99,6 +99,13 @@ class PendingRequest
     protected $retryDelay = 100;
 
     /**
+     * Whether to throw an exception when all retries fail.
+     *
+     * @var bool
+     */
+    protected $retryThrow = true;    
+    
+    /**
      * The callback that will determine if the request should be retried.
      *
      * @var callable|null
@@ -451,12 +458,14 @@ class PendingRequest
      * @param  int  $times
      * @param  int  $sleep
      * @param  callable|null  $when
+     * @param  bool  $throw
      * @return $this
      */
-    public function retry(int $times, int $sleep = 0, ?callable $when = null)
+    public function retry(int $times, int $sleep = 0, ?callable $when = null, bool $throw = true)
     {
         $this->tries = $times;
         $this->retryDelay = $sleep;
+        $this->retryThrow = $throw;
         $this->retryWhenCallback = $when;
 
         return $this;
@@ -679,7 +688,7 @@ class PendingRequest
                 return tap(new Response($this->sendRequest($method, $url, $options)), function ($response) {
                     $this->populateResponse($response);
 
-                    if ($this->tries > 1 && ! $response->successful()) {
+                    if ($this->tries > 1 && $this->retryThrow && ! $response->successful()) {
                         $response->throw();
                     }
 

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -103,8 +103,8 @@ class PendingRequest
      *
      * @var bool
      */
-    protected $retryThrow = true;    
-    
+    protected $retryThrow = true;
+
     /**
      * The callback that will determine if the request should be retried.
      *

--- a/src/Illuminate/Pagination/resources/views/simple-tailwind.blade.php
+++ b/src/Illuminate/Pagination/resources/views/simple-tailwind.blade.php
@@ -1,5 +1,5 @@
 @if ($paginator->hasPages())
-    <nav role="navigation" aria-label="{{ __('Pagination') }}" class="flex justify-between">
+    <nav role="navigation" aria-label="Pagination Navigation" class="flex justify-between">
         {{-- Previous Page Link --}}
         @if ($paginator->onFirstPage())
             <span class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-500 bg-white border border-gray-300 cursor-default leading-5 rounded-md">

--- a/src/Illuminate/Pagination/resources/views/tailwind.blade.php
+++ b/src/Illuminate/Pagination/resources/views/tailwind.blade.php
@@ -1,5 +1,5 @@
 @if ($paginator->hasPages())
-    <nav role="navigation" aria-label="{{ __('Pagination') }}" class="flex items-center justify-between">
+    <nav role="navigation" aria-label="{{ __('Pagination Navigation') }}" class="flex items-center justify-between">
         <div class="flex justify-between flex-1 sm:hidden">
             @if ($paginator->onFirstPage())
                 <span class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-500 bg-white border border-gray-300 cursor-default leading-5 rounded-md">

--- a/tests/Cache/CacheTaggedCacheTest.php
+++ b/tests/Cache/CacheTaggedCacheTest.php
@@ -267,16 +267,16 @@ class CacheTaggedCacheTest extends TestCase
         $store->shouldReceive('connection')->andReturn($conn = m::mock(stdClass::class));
 
         // Forever tag keys
-        $conn->shouldReceive('smembers')->once()->with('prefix:foo:forever_ref')->andReturn(['key1', 'key2']);
-        $conn->shouldReceive('smembers')->once()->with('prefix:bar:forever_ref')->andReturn(['key3']);
+        $conn->shouldReceive('sscan')->once()->with('prefix:foo:forever_ref', '0', ['match' => '*', 'count' => 1000])->andReturn(['0', ['key1', 'key2']]);
+        $conn->shouldReceive('sscan')->once()->with('prefix:bar:forever_ref', '0', ['match' => '*', 'count' => 1000])->andReturn(['0', ['key3']]);
         $conn->shouldReceive('del')->once()->with('key1', 'key2');
         $conn->shouldReceive('del')->once()->with('key3');
         $conn->shouldReceive('del')->once()->with('prefix:foo:forever_ref');
         $conn->shouldReceive('del')->once()->with('prefix:bar:forever_ref');
 
         // Standard tag keys
-        $conn->shouldReceive('smembers')->once()->with('prefix:foo:standard_ref')->andReturn(['key4', 'key5']);
-        $conn->shouldReceive('smembers')->once()->with('prefix:bar:standard_ref')->andReturn(['key6']);
+        $conn->shouldReceive('sscan')->once()->with('prefix:foo:standard_ref', '0', ['match' => '*', 'count' => 1000])->andReturn(['0', ['key4', 'key5']]);
+        $conn->shouldReceive('sscan')->once()->with('prefix:bar:standard_ref', '0', ['match' => '*', 'count' => 1000])->andReturn(['0', ['key6']]);
         $conn->shouldReceive('del')->once()->with('key4', 'key5');
         $conn->shouldReceive('del')->once()->with('key6');
         $conn->shouldReceive('del')->once()->with('prefix:foo:standard_ref');

--- a/tests/Database/DatabaseEloquentBelongsToManyWithCastedAttributesTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyWithCastedAttributesTest.php
@@ -23,6 +23,7 @@ class DatabaseEloquentBelongsToManyWithCastedAttributesTest extends TestCase
         $model1->shouldReceive('getAttribute')->with('parent_key')->andReturn(1);
         $model1->shouldReceive('getAttribute')->with('foo')->passthru();
         $model1->shouldReceive('hasGetMutator')->andReturn(false);
+        $model1->shouldReceive('hasAttributeGetMutator')->andReturn(false);
         $model1->shouldReceive('getCasts')->andReturn([]);
         $model1->shouldReceive('getRelationValue', 'relationLoaded', 'setRelation', 'isRelation')->passthru();
 
@@ -30,6 +31,7 @@ class DatabaseEloquentBelongsToManyWithCastedAttributesTest extends TestCase
         $model2->shouldReceive('getAttribute')->with('parent_key')->andReturn(2);
         $model2->shouldReceive('getAttribute')->with('foo')->passthru();
         $model2->shouldReceive('hasGetMutator')->andReturn(false);
+        $model2->shouldReceive('hasAttributeGetMutator')->andReturn(false);
         $model2->shouldReceive('getCasts')->andReturn([]);
         $model2->shouldReceive('getRelationValue', 'relationLoaded', 'setRelation', 'isRelation')->passthru();
 

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -1054,7 +1054,7 @@ class HttpClientTest extends TestCase
     public function testRequestExceptionIsThrownWhenRetriesExhausted()
     {
         $this->expectException(RequestException::class);
-        
+
         $this->factory->fake([
             '*' => $this->factory->response(['error'], 403),
         ]);
@@ -1075,5 +1075,5 @@ class HttpClientTest extends TestCase
             ->get('http://foo.com/get');
 
         $this->assertTrue($response->failed());
-    }    
+    }
 }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -1050,4 +1050,30 @@ class HttpClientTest extends TestCase
 
         $this->factory->get('https://example.com');
     }
+
+    public function testRequestExceptionIsThrownWhenRetriesExhausted()
+    {
+        $this->factory->fake([
+            '*' => $this->factory->response(['error'], 403),
+        ]);
+
+        $this->factory
+            ->retry(2, 1000, null, true)
+            ->get('http://foo.com/get');
+
+        $this->expectException(RequestException::class);
+    }
+
+    public function testRequestExceptionIsNotThrownWhenDisabledAndRetriesExhausted()
+    {
+        $this->factory->fake([
+            '*' => $this->factory->response(['error'], 403),
+        ]);
+
+        $response = $this->factory
+            ->retry(2, 1000, null, false)
+            ->get('http://foo.com/get');
+
+        $this->assertTrue($response->failed());
+    }    
 }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -1053,6 +1053,8 @@ class HttpClientTest extends TestCase
 
     public function testRequestExceptionIsThrownWhenRetriesExhausted()
     {
+        $this->expectException(RequestException::class);
+        
         $this->factory->fake([
             '*' => $this->factory->response(['error'], 403),
         ]);
@@ -1060,8 +1062,6 @@ class HttpClientTest extends TestCase
         $this->factory
             ->retry(2, 1000, null, true)
             ->get('http://foo.com/get');
-
-        $this->expectException(RequestException::class);
     }
 
     public function testRequestExceptionIsNotThrownWhenDisabledAndRetriesExhausted()

--- a/tests/Integration/Database/DatabaseEloquentModelAttributeCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelAttributeCastingTest.php
@@ -1,0 +1,266 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Schema;
+
+class DatabaseEloquentModelAttributeCastingTest extends DatabaseTestCase
+{
+    protected function defineDatabaseMigrationsAfterDatabaseRefreshed()
+    {
+        Schema::create('test_eloquent_model_with_custom_casts', function (Blueprint $table) {
+            $table->increments('id');
+            $table->timestamps();
+        });
+    }
+
+    public function testBasicCustomCasting()
+    {
+        $model = new TestEloquentModelWithAttributeCast;
+        $model->uppercase = 'taylor';
+
+        $this->assertSame('TAYLOR', $model->uppercase);
+        $this->assertSame('TAYLOR', $model->getAttributes()['uppercase']);
+        $this->assertSame('TAYLOR', $model->toArray()['uppercase']);
+
+        $unserializedModel = unserialize(serialize($model));
+
+        $this->assertSame('TAYLOR', $unserializedModel->uppercase);
+        $this->assertSame('TAYLOR', $unserializedModel->getAttributes()['uppercase']);
+        $this->assertSame('TAYLOR', $unserializedModel->toArray()['uppercase']);
+
+        $model->syncOriginal();
+        $model->uppercase = 'dries';
+        $this->assertSame('TAYLOR', $model->getOriginal('uppercase'));
+
+        $model = new TestEloquentModelWithAttributeCast;
+        $model->uppercase = 'taylor';
+        $model->syncOriginal();
+        $model->uppercase = 'dries';
+        $model->getOriginal();
+
+        $this->assertSame('DRIES', $model->uppercase);
+
+        $model = new TestEloquentModelWithAttributeCast;
+
+        $model->address = $address = new AttributeCastAddress('110 Kingsbrook St.', 'My Childhood House');
+        $address->lineOne = '117 Spencer St.';
+        $this->assertSame('117 Spencer St.', $model->getAttributes()['address_line_one']);
+
+        $model = new TestEloquentModelWithAttributeCast;
+
+        $model->setRawAttributes([
+            'address_line_one' => '110 Kingsbrook St.',
+            'address_line_two' => 'My Childhood House',
+        ]);
+
+        $this->assertSame('110 Kingsbrook St.', $model->address->lineOne);
+        $this->assertSame('My Childhood House', $model->address->lineTwo);
+
+        $this->assertSame('110 Kingsbrook St.', $model->toArray()['address_line_one']);
+        $this->assertSame('My Childhood House', $model->toArray()['address_line_two']);
+
+        $model->address->lineOne = '117 Spencer St.';
+
+        $this->assertFalse(isset($model->toArray()['address']));
+        $this->assertSame('117 Spencer St.', $model->toArray()['address_line_one']);
+        $this->assertSame('My Childhood House', $model->toArray()['address_line_two']);
+
+        $this->assertSame('117 Spencer St.', json_decode($model->toJson(), true)['address_line_one']);
+        $this->assertSame('My Childhood House', json_decode($model->toJson(), true)['address_line_two']);
+
+        $model->address = null;
+
+        $this->assertNull($model->toArray()['address_line_one']);
+        $this->assertNull($model->toArray()['address_line_two']);
+
+        $model->options = ['foo' => 'bar'];
+        $this->assertEquals(['foo' => 'bar'], $model->options);
+        $this->assertEquals(['foo' => 'bar'], $model->options);
+        $model->options = ['foo' => 'bar'];
+        $model->options = ['foo' => 'bar'];
+        $this->assertEquals(['foo' => 'bar'], $model->options);
+        $this->assertEquals(['foo' => 'bar'], $model->options);
+
+        $this->assertSame(json_encode(['foo' => 'bar']), $model->getAttributes()['options']);
+
+        $model = new TestEloquentModelWithAttributeCast(['options' => []]);
+        $model->syncOriginal();
+        $model->options = ['foo' => 'bar'];
+        $this->assertTrue($model->isDirty('options'));
+
+        $model = new TestEloquentModelWithAttributeCast;
+        $model->birthday_at = now();
+        $this->assertIsString($model->toArray()['birthday_at']);
+    }
+
+    public function testGetOriginalWithCastValueObjects()
+    {
+        $model = new TestEloquentModelWithAttributeCast([
+            'address' => new AttributeCastAddress('110 Kingsbrook St.', 'My Childhood House'),
+        ]);
+
+        $model->syncOriginal();
+
+        $model->address = new AttributeCastAddress('117 Spencer St.', 'Another house.');
+
+        $this->assertSame('117 Spencer St.', $model->address->lineOne);
+        $this->assertSame('110 Kingsbrook St.', $model->getOriginal('address')->lineOne);
+        $this->assertSame('117 Spencer St.', $model->address->lineOne);
+
+        $model = new TestEloquentModelWithAttributeCast([
+            'address' => new AttributeCastAddress('110 Kingsbrook St.', 'My Childhood House'),
+        ]);
+
+        $model->syncOriginal();
+
+        $model->address = new AttributeCastAddress('117 Spencer St.', 'Another house.');
+
+        $this->assertSame('117 Spencer St.', $model->address->lineOne);
+        $this->assertSame('110 Kingsbrook St.', $model->getOriginal()['address_line_one']);
+        $this->assertSame('117 Spencer St.', $model->address->lineOne);
+        $this->assertSame('110 Kingsbrook St.', $model->getOriginal()['address_line_one']);
+
+        $model = new TestEloquentModelWithAttributeCast([
+            'address' => new AttributeCastAddress('110 Kingsbrook St.', 'My Childhood House'),
+        ]);
+
+        $model->syncOriginal();
+
+        $model->address = null;
+
+        $this->assertNull($model->address);
+        $this->assertInstanceOf(AttributeCastAddress::class, $model->getOriginal('address'));
+        $this->assertNull($model->address);
+    }
+
+    public function testOneWayCasting()
+    {
+        $model = new TestEloquentModelWithAttributeCast;
+
+        $model->password = 'secret';
+
+        $this->assertEquals(hash('sha256', 'secret'), $model->password);
+        $this->assertEquals(hash('sha256', 'secret'), $model->getAttributes()['password']);
+        $this->assertEquals(hash('sha256', 'secret'), $model->getAttributes()['password']);
+        $this->assertEquals(hash('sha256', 'secret'), $model->password);
+
+        $model->password = 'secret2';
+
+        $this->assertEquals(hash('sha256', 'secret2'), $model->password);
+        $this->assertEquals(hash('sha256', 'secret2'), $model->getAttributes()['password']);
+        $this->assertEquals(hash('sha256', 'secret2'), $model->getAttributes()['password']);
+        $this->assertEquals(hash('sha256', 'secret2'), $model->password);
+    }
+
+    public function testSettingRawAttributesClearsTheCastCache()
+    {
+        $model = new TestEloquentModelWithAttributeCast;
+
+        $model->setRawAttributes([
+            'address_line_one' => '110 Kingsbrook St.',
+            'address_line_two' => 'My Childhood House',
+        ]);
+
+        $this->assertSame('110 Kingsbrook St.', $model->address->lineOne);
+
+        $model->setRawAttributes([
+            'address_line_one' => '117 Spencer St.',
+            'address_line_two' => 'My Childhood House',
+        ]);
+
+        $this->assertSame('117 Spencer St.', $model->address->lineOne);
+    }
+}
+
+class TestEloquentModelWithAttributeCast extends Model
+{
+    /**
+     * The attributes that aren't mass assignable.
+     *
+     * @var string[]
+     */
+    protected $guarded = [];
+
+    public function uppercase(): Attribute
+    {
+        return new Attribute(
+            function ($value) {
+                return strtoupper($value);
+            },
+            function ($value) {
+                return strtoupper($value);
+            }
+        );
+    }
+
+    public function address(): Attribute
+    {
+        return new Attribute(
+            function ($value, $attributes) {
+                if (is_null($attributes['address_line_one'])) {
+                    return;
+                }
+
+                return new AttributeCastAddress($attributes['address_line_one'], $attributes['address_line_two']);
+            },
+            function ($value) {
+                if (is_null($value)) {
+                    return [
+                        'address_line_one' => null,
+                        'address_line_two' => null,
+                    ];
+                }
+
+                return ['address_line_one' => $value->lineOne, 'address_line_two' => $value->lineTwo];
+            }
+        );
+    }
+
+    public function options(): Attribute
+    {
+        return new Attribute(
+            function ($value) {
+                return json_decode($value, true);
+            },
+            function ($value) {
+                return json_encode($value);
+            }
+        );
+    }
+
+    public function birthdayAt(): Attribute
+    {
+        return new Attribute(
+            function ($value) {
+                return Carbon::parse($value);
+            },
+            function ($value) {
+                return $value->format('Y-m-d');
+            }
+        );
+    }
+
+    public function password(): Attribute
+    {
+        return new Attribute(null, function ($value) {
+            return hash('sha256', $value);
+        });
+    }
+}
+
+class AttributeCastAddress
+{
+    public $lineOne;
+    public $lineTwo;
+
+    public function __construct($lineOne, $lineTwo)
+    {
+        $this->lineOne = $lineOne;
+        $this->lineTwo = $lineTwo;
+    }
+}


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR addresses #40055 by adding functionality to the HTTP client so that you can prevent it from throwing a `RequestException` when `retries` are configured.

## The problem

Presently, and as highlighted in the docs, the HTTP client does not throw exceptions when a request fails. As a result, you can make use of methods like `failed` on the response e.g.

```php
$response = Http::get('http://example.com');

if ($response->failed())
{
    // Handle the error
}
```

However, if you configure `retries` on the HTTP client, it will throw a `RequestException` if all attempts fail. 

```php
$response = Http::retries(3, 1000)->get('http://example.com');
```

This means:

1. You cannot configure `throw()` on the client.
2. You cannot chain methods e.g. `throw()->json()`.
3. You cannot use `throwIf`.
4. You cannot use the response's error handling methods e.g. `$response->failed()`.

In addition, you have to wrap the request within a try/catch block if you want to handle the error. 

## The solution

The PR adds a fourth parameter `throw` to the `retries` method, which allows you to control whether the HTTP client should throw an exception when the retry limit is reached. 

By default, this parameter is set to `true` to preserve backward compatibility.

```php
Http::retries(3, 1000); // throws a RequestException if all retries fail
Http::retries(3, 1000, null, true); // throws a RequestException if all retries fail
Http::retries(3, 1000, null, false); // does not throw a RequestException if all retries fail
```
