### PR TITLE
[8.x] Consistently negate conditions in @includeUnless() Blade directive

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesIncludes.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesIncludes.php
@@ -64,7 +64,7 @@ trait CompilesIncludes
     {
         $expression = $this->stripParentheses($expression);
 
-        return "<?php echo \$__env->renderWhen(! $expression, \Illuminate\Support\Arr::except(get_defined_vars(), ['__data', '__path'])); ?>";
+        return "<?php echo \$__env->renderUnless($expression, \Illuminate\Support\Arr::except(get_defined_vars(), ['__data', '__path'])); ?>";
     }
 
     /**

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -200,11 +200,7 @@ class Factory implements FactoryContract
      */
     public function renderUnless($condition, $view, $data = [], $mergeData = [])
     {
-        if ($condition) {
-            return '';
-        }
-
-        return $this->make($view, $this->parseData($data), $mergeData)->render();
+        return $this->renderWhen(! $condition, $view, $data, $mergeData);
     }
 
     /**

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -190,6 +190,24 @@ class Factory implements FactoryContract
     }
 
     /**
+     * Get the rendered content of the view based on the negation of a given condition.
+     *
+     * @param  bool  $condition
+     * @param  string  $view
+     * @param  \Illuminate\Contracts\Support\Arrayable|array  $data
+     * @param  array  $mergeData
+     * @return string
+     */
+    public function renderUnless($condition, $view, $data = [], $mergeData = [])
+    {
+        if ($condition) {
+            return '';
+        }
+
+        return $this->make($view, $this->parseData($data), $mergeData)->render();
+    }
+
+    /**
      * Get the rendered contents of a partial from a loop.
      *
      * @param  string  $view

--- a/tests/View/Blade/BladeIncludesTest.php
+++ b/tests/View/Blade/BladeIncludesTest.php
@@ -28,6 +28,12 @@ class BladeIncludesTest extends AbstractBladeTestCase
         $this->assertSame('<?php echo $__env->renderWhen(true, \'foo\', \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\'])); ?>', $this->compiler->compileString('@includeWhen(true, \'foo\')'));
     }
 
+    public function testIncludeUnlessesAreCompiled()
+    {
+        $this->assertSame('<?php echo $__env->renderUnless(true, \'foo\', ["foo" => "bar"], \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\'])); ?>', $this->compiler->compileString('@includeUnless(true, \'foo\', ["foo" => "bar"])'));
+        $this->assertSame('<?php echo $__env->renderUnless($undefined ?? true, \'foo\', \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\'])); ?>', $this->compiler->compileString('@includeUnless($undefined ?? true, \'foo\')'));
+    }
+
     public function testIncludeFirstsAreCompiled()
     {
         $this->assertSame('<?php echo $__env->first(["one", "two"], \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>', $this->compiler->compileString('@includeFirst(["one", "two"])'));


### PR DESCRIPTION
https://twitter.com/gonedark/status/1471514212363079681
<img width="593" alt="CleanShot 2021-12-16 at 14 05 28@2x" src="https://user-images.githubusercontent.com/353790/146432998-a140cd4b-689b-4f34-8ac8-9ee24ce0a437.png">

Before this change, `@includeUnless($undefined ?? true, 'template')` would result in a PHP Warning and an unexpected condition result, because `$undefined ?? true` would be compiled as `! $undefined ?? true`, which due to `!` having precedence over `??` is different than `! ($undefined ?? true)` (which is how `@unless` would compile it).

```
>>> ! $undefined ?? true
<warning>PHP Warning:  Undefined variable $undefined in eval()'d code on line 1</warning>
=> true
>>> ! ($undefined ?? true)
=> false
```

This change necessitated the creation of `renderUnless()`, because `@includeUnless()` accepts multiple arguments, and parsing out the first argument to a Blade directive is fraught. So `renderUnless()` takes the parameters as-is, and negates the condition inside the method.

`@includeUnless()` also lacked unit tests, which I added.

This change makes `@includeUnless()` work more like `@unless()`, which already correctly wraps the condition in parentheses (or rather, does not remove the parentheses that are already there).