### PR TITLE
[8.x] Adds `maskBetween()`, mask a string between two strings.

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -431,6 +431,29 @@ class Str
     }
 
     /**
+     * Masks a portion of a string between two given strings.
+     *
+     * @param  string  $string
+     * @param  string  $character
+     * @param  string  $start
+     * @param  string  $end
+     * @param  string  $encoding
+     * @return string
+     */
+    public function maskBetween($string, $character, $start, $end, $encoding = 'UTF-8')
+    {
+        $startIndex = mb_strpos($string, $start, 0, $encoding);
+
+        if ($startIndex === false) {
+            return $string;
+        }
+
+        $endIndex = mb_strpos($string, $end, $startIndex, $encoding) ?: mb_strlen($string, $encoding);
+
+        return static::mask($string, $character, $startIndex, $endIndex, $encoding);
+    }
+
+    /**
      * Get the string matching the given pattern.
      *
      * @param  string  $pattern

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -440,7 +440,7 @@ class Str
      * @param  string  $encoding
      * @return string
      */
-    public function maskBetween($string, $character, $start, $end, $encoding = 'UTF-8')
+    public static function maskBetween($string, $character, $start, $end, $encoding = 'UTF-8')
     {
         $startIndex = mb_strpos($string, $start, 0, $encoding);
 

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -357,6 +357,20 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Masks a portion of a string between two given strings.
+     *
+     * @param  string  $character
+     * @param  string  $start
+     * @param  string  $end
+     * @param  string  $encoding
+     * @return static
+     */
+    public function maskBetween($character, $start, $end, $encoding = 'UTF-8')
+    {
+        return new static(Str::maskBetween($this->value, $start, $end, $character, $encoding));
+    }
+
+    /**
      * Get the string matching the given pattern.
      *
      * @param  string  $pattern

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -367,7 +367,7 @@ class Stringable implements JsonSerializable
      */
     public function maskBetween($character, $start, $end, $encoding = 'UTF-8')
     {
-        return new static(Str::maskBetween($this->value, $start, $end, $character, $encoding));
+        return new static(Str::maskBetween($this->value, $character, $start, $end, $encoding));
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -480,6 +480,22 @@ class SupportStrTest extends TestCase
         $this->assertSame('**一段中文', Str::mask('这是一段中文', '*', 0, 2));
     }
 
+    public function testMaskBetween()
+    {
+        $this->assertSame('tay*************', Str::maskBetween('taylor@email.com', '*', 'tay', 'not_found'));
+        $this->assertSame('taylor@email.com', Str::maskBetween('taylor@email.com', '*', 'not_found', '@email.com'));
+        $this->assertSame('tay***@email.com', Str::maskBetween('taylor@email.com', '*', 'tay', '@email.com'));
+
+        $this->assertSame('taylor@email.com', Str::maskBetween('taylor@email.com', '*', 'not_found', 'not_found'));
+
+        $this->assertSame('taysssssssssssss', Str::maskBetween('taylor@email.com', 's', 'tay', 'not_found'));
+        $this->assertSame('taysssssssssssss', Str::maskBetween('taylor@email.com', Str::of('something'), 'tay', 'not_found'));
+
+        $this->assertSame('这是一***', Str::maskBetween('这是一段中文', '*', '这是一', 'not_found'));
+        $this->assertSame('这是一段中文', Str::maskBetween('这是一段中文', '*', 'not_found', '段中文'));
+        $this->assertSame('这***中文', Str::maskBetween('这是一段中文', '*', '这', '中文'));
+    }
+
     public function testMatch()
     {
         $this->assertSame('bar', Str::match('/bar/', 'foo bar'));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -710,6 +710,22 @@ class SupportStringableTest extends TestCase
         $this->assertEquals('**一段中文', $this->stringable('这是一段中文')->mask('*', 0, 2));
     }
 
+    public function testMaskBetween()
+    {
+        $this->assertEquals('tay*************', $this->stringable('taylor@email.com')->maskBetween('*', 'tay', 'not_found'));
+        $this->assertEquals('taylor@email.com', $this->stringable('taylor@email.com')->maskBetween('*', 'not_found', '@email.com'));
+        $this->assertEquals('tay***@email.com', $this->stringable('taylor@email.com')->maskBetween('*', 'tay', '@email.com'));
+
+        $this->assertEquals('taylor@email.com', $this->stringable('taylor@email.com')->maskBetween('*', 'not_found', 'not_found'));
+
+        $this->assertEquals('taysssssssssssss', $this->stringable('taylor@email.com')->maskBetween('s', 'tay', 'not_found'));
+        $this->assertEquals('taysssssssssssss', $this->stringable('taylor@email.com')->maskBetween(Str::of('something'), 'tay', 'not_found'));
+
+        $this->assertEquals('这是一***', $this->stringable('这是一段中文')->maskBetween('*', '这是一', 'not_found'));
+        $this->assertEquals('这是一段中文', $this->stringable('这是一段中文')->maskBetween('*', 'not_found', '段中文'));
+        $this->assertEquals('这***中文', $this->stringable('这是一段中文')->maskBetween('*', '这', '中文'));
+    }
+
     public function testRepeat()
     {
         $this->assertSame('aaaaa', (string) $this->stringable('a')->repeat(5));


### PR DESCRIPTION
## What?

Adds a way to mask a portion of a string between two given strings, without knowing its length.

```php
$text = 'The private address is Almond 259, Texas.';

Str::maskBetween($text, '*', 'address is ', '.'); 

// 'The private address is ******************.'
```

## Why?

Because without this you will need to find the start and end index manually, which is cumbersome when you don't know the mask-able text length, but you know or how is contained.

```php
$text = 'The private address is Almond 259, Texas.';

$start = strpos($text, 'address is ');

Str::maskBetween($text, '*', $start  + strlen('address is'), strlen($text) - 1;
```

## BC?

Additive. PR does not expects users adding `maskBetween` as a Macro to `Str` and `Stringable`.