### PR TITLE
[9.x] Allow HTTP client requests with retries to optionally throw RequestExceptions

### DIFF
--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -25,7 +25,7 @@ use PHPUnit\Framework\Assert as PHPUnit;
  * @method \Illuminate\Http\Client\PendingRequest contentType(string $contentType)
  * @method \Illuminate\Http\Client\PendingRequest dd()
  * @method \Illuminate\Http\Client\PendingRequest dump()
- * @method \Illuminate\Http\Client\PendingRequest retry(int $times, int $sleep = 0, ?callable $when = null)
+ * @method \Illuminate\Http\Client\PendingRequest retry(int $times, int $sleep = 0, ?callable $when = null, bool $throw = true)
  * @method \Illuminate\Http\Client\PendingRequest sink(string|resource $to)
  * @method \Illuminate\Http\Client\PendingRequest stub(callable $callback)
  * @method \Illuminate\Http\Client\PendingRequest timeout(int $seconds)

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -1050,4 +1050,30 @@ class HttpClientTest extends TestCase
 
         $this->factory->get('https://example.com');
     }
+
+    public function testRequestExceptionIsThrownWhenRetriesExhausted()
+    {
+        $this->expectException(RequestException::class);
+
+        $this->factory->fake([
+            '*' => $this->factory->response(['error'], 403),
+        ]);
+
+        $this->factory
+            ->retry(2, 1000, null, true)
+            ->get('http://foo.com/get');
+    }
+
+    public function testRequestExceptionIsNotThrownWhenDisabledAndRetriesExhausted()
+    {
+        $this->factory->fake([
+            '*' => $this->factory->response(['error'], 403),
+        ]);
+
+        $response = $this->factory
+            ->retry(2, 1000, null, false)
+            ->get('http://foo.com/get');
+
+        $this->assertTrue($response->failed());
+    }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

**Edit**: Changed to master branch at suggestion of @driesvints.

This PR addresses #40055 by adding functionality to the HTTP client so that you can prevent it from throwing a `RequestException` when `retries` are configured.

## The problem

Presently, and as highlighted in the docs, the HTTP client does not throw exceptions when a request fails. As a result, you can make use of methods like `failed` on the response e.g.

```php
$response = Http::get('http://example.com');

if ($response->failed())
{
    // Handle the error
}
```

However, if you configure `retries` on the HTTP client, it will throw a `RequestException` if all attempts fail. 

```php
$response = Http::retries(3, 1000)->get('http://example.com');
```

This means:

1. You cannot configure `throw()` on the client.
2. You cannot chain methods e.g. `throw()->json()`.
3. You cannot use `throwIf`.
4. You cannot use the response's error handling methods e.g. `$response->failed()`.

In addition, you have to wrap the request within a try/catch block if you want to handle the error. 

## The solution

The PR adds a fourth parameter `throw` to the `retries` method, which allows you to control whether the HTTP client should throw an exception when the retry limit is reached. 

By default, this parameter is set to `true` to preserve backward compatibility.

```php
Http::retries(3, 1000); // throws a RequestException if all retries fail
Http::retries(3, 1000, null, true); // throws a RequestException if all retries fail
Http::retries(3, 1000, null, false); // does not throw a RequestException if all retries fail
```