### PR TITLE
[8.x] Make it possible to use prefixes on Predis per Connection

### DIFF
--- a/src/Illuminate/Redis/Connectors/PredisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PredisConnector.php
@@ -22,6 +22,10 @@ class PredisConnector implements Connector
         $formattedOptions = array_merge(
             ['timeout' => 10.0], $options, Arr::pull($config, 'options', [])
         );
+        
+        if (! empty($config['prefix'])) {
+            $formattedOptions['prefix'] = $config['prefix'];
+        }
 
         return new PredisConnection(new Client($config, $formattedOptions));
     }

--- a/src/Illuminate/Redis/Connectors/PredisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PredisConnector.php
@@ -23,7 +23,7 @@ class PredisConnector implements Connector
             ['timeout' => 10.0], $options, Arr::pull($config, 'options', [])
         );
 
-        if (! empty($config['prefix'])) {
+        if (isset($config['prefix'])) {
             $formattedOptions['prefix'] = $config['prefix'];
         }
 
@@ -42,7 +42,7 @@ class PredisConnector implements Connector
     {
         $clusterSpecificOptions = Arr::pull($config, 'options', []);
 
-        if (! empty($config['prefix'])) {
+        if (isset($config['prefix'])) {
             $clusterSpecificOptions['prefix'] = $config['prefix'];
         }
 

--- a/src/Illuminate/Redis/Connectors/PredisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PredisConnector.php
@@ -42,6 +42,10 @@ class PredisConnector implements Connector
     {
         $clusterSpecificOptions = Arr::pull($config, 'options', []);
 
+        if (! empty($config['prefix'])) {
+            $clusterSpecificOptions['prefix'] = $config['prefix'];
+        }
+
         return new PredisClusterConnection(new Client(array_values($config), array_merge(
             $options, $clusterOptions, $clusterSpecificOptions
         )));

--- a/src/Illuminate/Redis/Connectors/PredisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PredisConnector.php
@@ -22,7 +22,7 @@ class PredisConnector implements Connector
         $formattedOptions = array_merge(
             ['timeout' => 10.0], $options, Arr::pull($config, 'options', [])
         );
-        
+
         if (! empty($config['prefix'])) {
             $formattedOptions['prefix'] = $config['prefix'];
         }


### PR DESCRIPTION
This PR allows the ability to use prefixes on a per connection basis for Predis.

Basically the only way to setup a prefix is by doing the following `['redis' => ['options' => ['prefix' => 'prefix:']]]` in the  `/config/database.php` file.

So copying a similar setup in PHPRedis. Each connection can be given a unique prefix by defining them within the individual  connection config like so  `['redis' => ['connection1' => ['prefix' => 'prefix:'], 'connection2' => ['prefix' => 'prefix2:']]]`.