### PR TITLE
[9.x] add confirmation to clear:cache command

### DIFF
--- a/src/Illuminate/Cache/Console/ClearCommand.php
+++ b/src/Illuminate/Cache/Console/ClearCommand.php
@@ -4,12 +4,15 @@ namespace Illuminate\Cache\Console;
 
 use Illuminate\Cache\CacheManager;
 use Illuminate\Console\Command;
+use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Filesystem\Filesystem;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 
 class ClearCommand extends Command
 {
+    use ConfirmableTrait;
+
     /**
      * The console command name.
      *
@@ -69,6 +72,10 @@ class ClearCommand extends Command
      */
     public function handle()
     {
+        if (! $this->confirmToProceed()) {
+            return Command::SUCCESS;
+        }
+
         $this->laravel['events']->dispatch(
             'cache:clearing', [$this->argument('store'), $this->tags()]
         );
@@ -86,6 +93,8 @@ class ClearCommand extends Command
         );
 
         $this->info('Application cache cleared!');
+
+        return Command::SUCCESS;
     }
 
     /**


### PR DESCRIPTION
Hi,

Cache is kind of database and when cleared accidentally may create problems in production.

Imagine you have cached the API response to Redis and it gets cleared, now application has to rebuild the cache, which will slow down the application until cache is rebuild.

This is a breaking change for many, since they need to add `--force` flag to the command now.