### PR TITLE
[9.x] Add confirmation to model:prune command

### DIFF
--- a/src/Illuminate/Database/Console/PruneCommand.php
+++ b/src/Illuminate/Database/Console/PruneCommand.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Eloquent\MassPrunable;
 use Illuminate\Database\Eloquent\Prunable;
@@ -13,6 +14,8 @@ use Symfony\Component\Finder\Finder;
 
 class PruneCommand extends Command
 {
+    use ConfirmableTrait;
+
     /**
      * The console command name.
      *
@@ -39,6 +42,10 @@ class PruneCommand extends Command
      */
     public function handle(Dispatcher $events)
     {
+        if (! $this->confirmToProceed()) {
+            return Command::SUCCESS;
+        }
+
         $models = $this->models();
 
         if ($models->isEmpty()) {


### PR DESCRIPTION
Hi,

Lets add confirmation to model:prune command since it is a destructive command.

Users need to add `--force` flag to command in production.

thanks