### PR TITLE
[8.x] Fix date validation

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -265,9 +265,11 @@ trait ValidatesAttributes
         $firstDate = $this->getDateTimeWithOptionalFormat($format, $first);
 
         if (! $secondDate = $this->getDateTimeWithOptionalFormat($format, $second)) {
-            $second = $this->getValue($second);
+            if (is_null($second = $this->getValue($second))) {
+                return true;
+            }
 
-            $secondDate = is_null($second) ? null : $this->getDateTimeWithOptionalFormat($format, $second);
+            $secondDate = $this->getDateTimeWithOptionalFormat($format, $second);
         }
 
         return ($firstDate && $secondDate) && ($this->compare($firstDate, $secondDate, $operator));

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4173,6 +4173,9 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['start' => '31/12/2012', 'ends' => null], ['start' => 'date_format:d/m/Y|before:ends', 'ends' => 'date_format:d/m/Y|after:start']);
         $this->assertTrue($v->fails());
 
+        $v = new Validator($trans, ['start' => '31/12/2012', 'ends' => null], ['start' => 'date_format:d/m/Y|before:ends', 'ends' => 'nullable|date_format:d/m/Y|after:start']);
+        $this->assertTrue($v->passes());
+
         $v = new Validator($trans, ['x' => date('d/m/Y')], ['x' => 'date_format:d/m/Y|after:yesterday|before:tomorrow']);
         $this->assertTrue($v->passes());
 


### PR DESCRIPTION
This PR fixes a regression introduced with https://github.com/laravel/framework/pull/39937. If a date under validation by a `before` (or similar) rule is validating a field that's `null` and allowed to be `nullable` through its own validation rules, then the rule should be ignored and the validation should pass. This was the behaviour before the change introduced in #39937.

The changes in this PR still contain the fix from #39937 for PHP 8.1.

Fixes https://github.com/laravel/framework/issues/40086