### PR TITLE
[8.x] Translate Enum rule message

### DIFF
--- a/src/Illuminate/Validation/Rules/Enum.php
+++ b/src/Illuminate/Validation/Rules/Enum.php
@@ -47,8 +47,10 @@ class Enum implements Rule
      */
     public function message()
     {
-        return [
-            'The selected :attribute is invalid.',
-        ];
+        $message = trans('validation.enum');
+
+        return $message === 'validation.enum'
+            ? ['The selected :attribute is invalid.']
+            : $message;
     }
 }


### PR DESCRIPTION
This implements a translatable message for the Enum validation rule. Previously, it was not possible to translate this message.

This uses a new validation entry added to the skeleton here: https://github.com/laravel/laravel/pull/5753. I specifically fall back to the current behaviour if the entry cannot be found to preserve BC.

See https://github.com/laravel/framework/issues/40080