### PR TITLE
[9.x] Add setTimeout for Queueable jobs

### DIFF
--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -52,7 +52,7 @@ trait Queueable
     public $delay;
 
     /**
-     * The number of seconds the job can run
+     * The number of seconds the job can run.
      *
      * @var int|null
      */

--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -52,6 +52,13 @@ trait Queueable
     public $delay;
 
     /**
+     * The number of seconds the job can run
+     *
+     * @var int|null
+     */
+    public $timeout;
+
+    /**
      * Indicates whether the job should be dispatched after all database transactions have committed.
      *
      * @var bool|null
@@ -135,6 +142,19 @@ trait Queueable
     public function delay($delay)
     {
         $this->delay = $delay;
+
+        return $this;
+    }
+
+    /**
+     * The number of seconds the job can run.
+     *
+     * @param  int  $timeout
+     * @return $this
+     */
+    public function setTimeout(int $timeout = null)
+    {
+        $this->timeout = $timeout;
 
         return $this;
     }


### PR DESCRIPTION
Add new method fluent setTimeout()

Sometimes we need to set individual timeouts for our jobs (which is currently supported via public $timeout property which gets serialized) but it gets tedious and not so pretty when dispatching jobs like this:

Before:
```php
$job = (new SomeJob)
    ->onQueue('super-queue')
    ->onConnection('redis')
    ->delay(now()->addDay());
$job->timeout = 1000;
dispatch($job);
```

After:
```php
dispatch(
    (new SomeJob)
        ->onQueue('super-queue')
        ->onConnection('redis')
        ->delay(now()->addDay())
        ->setTimeout(1000)
);
```