### PR TITLE
[9.x] add search method to eloquent

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -248,6 +248,20 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add a basic like clause to the query.
+     *
+     * @param  \Closure|string|array|\Illuminate\Database\Query\Expression  $column
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function search($column, $value)
+    {
+        $this->where($column, 'LIKE', "%{$value}%");
+
+        return $this;
+    }
+
+    /**
      * Add a basic where clause to the query, and return the first result.
      *
      * @param  \Closure|string|array|\Illuminate\Database\Query\Expression  $column

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -343,7 +343,7 @@ class DatabaseEloquentBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->getQuery()->shouldReceive('where')->once()->with('foo', 'LIKE', '%bar%');
-        $result = $builder->search('foo','bar');
+        $result = $builder->search('foo', 'bar');
         $this->assertEquals($result, $builder);
     }
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -339,6 +339,14 @@ class DatabaseEloquentBuilderTest extends TestCase
         });
     }
 
+    public function testSearch()
+    {
+        $builder = $this->getBuilder();
+        $builder->getQuery()->shouldReceive('where')->once()->with('foo', 'LIKE', '%bar%');
+        $result = $builder->search('foo','bar');
+        $this->assertEquals($result, $builder);
+    }
+
     public function testChunkWithCountZero()
     {
         $builder = m::mock(Builder::class.'[forPage,get]', [$this->getMockQueryBuilder()]);


### PR DESCRIPTION
Add new `search()` method to eloquent.
Sometimes we need to search a column for a specific text . insted of using raw query with `LIKE` , i added `search` method so you can use it like this: 
```php
Post::search('title' , 'something')->get();
```

i have added a test for search and i will make changes to the document in case you accepted it.
thanks for your time and attention.