### PR TITLE
[8.x] Added missing method to docblock

### DIFF
--- a/src/Illuminate/Support/Facades/Storage.php
+++ b/src/Illuminate/Support/Facades/Storage.php
@@ -40,6 +40,7 @@ use Illuminate\Filesystem\Filesystem;
  * @method static string|false mimeType(string $path)
  * @method static string|false putFile(string $path, \Illuminate\Http\File|\Illuminate\Http\UploadedFile|string $file, mixed $options = [])
  * @method static string|false putFileAs(string $path, \Illuminate\Http\File|\Illuminate\Http\UploadedFile|string $file, string $name, mixed $options = [])
+ * @method static void macro(string $name, object|callable $macro)
  *
  * @see \Illuminate\Filesystem\FilesystemManager
  */


### PR DESCRIPTION
Hi! This PR just adds the `macro()` method to the docblock for the `Storage` facade.

I think I've added this in the right place, but please let me know if not :)