### PR TITLE
[8.x] Added ability to define temporary URL macro for storage

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -574,8 +574,8 @@ class FilesystemAdapter implements CloudFilesystemContract
 
         if (method_exists($adapter, 'getTemporaryUrl')) {
             return $adapter->getTemporaryUrl($path, $expiration, $options);
-        } elseif (static::hasMacro('getTemporaryUrl')) {
-            return $this->macroCall('getTemporaryUrl', [$path, $expiration, $options]);
+        } elseif (static::hasMacro($this->getTemporaryUrlMacroName())) {
+            return $this->macroCall($this->getTemporaryUrlMacroName(), [$path, $expiration, $options]);
         } elseif ($adapter instanceof AwsS3Adapter) {
             return $this->getAwsTemporaryUrl($adapter, $path, $expiration, $options);
         } else {
@@ -613,6 +613,17 @@ class FilesystemAdapter implements CloudFilesystemContract
         }
 
         return (string) $uri;
+    }
+
+    /**
+     * Define any custom logic that should be used for building temporary URLs
+     * for a given filesystem.
+     *
+     * @param Closure $closure
+     */
+    public function buildTemporaryUrlUsing($closure)
+    {
+        self::macro($this->getTemporaryUrlMacroName(), $closure);
     }
 
     /**
@@ -778,6 +789,17 @@ class FilesystemAdapter implements CloudFilesystemContract
         }
 
         throw new InvalidArgumentException("Unknown visibility: {$visibility}.");
+    }
+
+    /**
+     * Build and return a name that can be used to define and fetch macros
+     * for the 'temporaryUrl' method for a specific filesystem driver.
+     *
+     * @return string
+     */
+    protected function getTemporaryUrlMacroName()
+    {
+        return get_class($this->driver->getAdapter()).'_temporaryUrl';
     }
 
     /**

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -574,6 +574,8 @@ class FilesystemAdapter implements CloudFilesystemContract
 
         if (method_exists($adapter, 'getTemporaryUrl')) {
             return $adapter->getTemporaryUrl($path, $expiration, $options);
+        } elseif (static::hasMacro('getTemporaryUrl')) {
+            return $this->macroCall('getTemporaryUrl', [$path, $expiration, $options]);
         } elseif ($adapter instanceof AwsS3Adapter) {
             return $this->getAwsTemporaryUrl($adapter, $path, $expiration, $options);
         } else {

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -619,7 +619,7 @@ class FilesystemAdapter implements CloudFilesystemContract
      * Define any custom logic that should be used for building temporary URLs
      * for a given filesystem.
      *
-     * @param Closure $closure
+     * @param  Closure  $closure
      */
     public function buildTemporaryUrlUsing($closure)
     {

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -48,7 +48,7 @@ class FilesystemAdapter implements CloudFilesystemContract
     /**
      * The temporary URL builder callback.
      *
-     * @var \Closure
+     * @var \Closure|null
      */
     protected $temporaryUrlCallback;
 

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -333,11 +333,11 @@ class FilesystemAdapterTest extends TestCase
         $this->assertSame('Hello World', $filesystemAdapter->getFoo());
     }
 
-    public function testTemporaryUrlWithMacro()
+    public function testTemporaryUrlWithCustomCallback()
     {
         $filesystemAdapter = new FilesystemAdapter($this->filesystem);
 
-        $filesystemAdapter->buildTemporaryUrlUsing(function ($path, Carbon $expiration, $options) {
+        $filesystemAdapter->buildTemporaryUrlsUsing(function ($path, Carbon $expiration, $options) {
             return $path.$expiration->toString().implode('', $options);
         });
 

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Filesystem;
 
+use Carbon\Carbon;
 use GuzzleHttp\Psr7\Stream;
 use Illuminate\Contracts\Filesystem\FileExistsException;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
@@ -330,5 +331,23 @@ class FilesystemAdapterTest extends TestCase
         });
 
         $this->assertSame('Hello World', $filesystemAdapter->getFoo());
+    }
+
+    public function testTemporaryUrlWithMacro()
+    {
+        $filesystemAdapter = new FilesystemAdapter($this->filesystem);
+
+        $filesystemAdapter->macro('getTemporaryUrl', function ($path, Carbon $expiration, $options) {
+            return $path.$expiration->toString().implode('', $options);
+        });
+
+        $path = 'foo';
+        $expiration = Carbon::create(2021, 18, 12, 13);
+        $options = ['bar' => 'baz'];
+
+        $this->assertSame(
+            $path.$expiration->toString().implode('', $options),
+            $filesystemAdapter->temporaryUrl($path, $expiration, $options)
+        );
     }
 }

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -337,7 +337,7 @@ class FilesystemAdapterTest extends TestCase
     {
         $filesystemAdapter = new FilesystemAdapter($this->filesystem);
 
-        $filesystemAdapter->macro('getTemporaryUrl', function ($path, Carbon $expiration, $options) {
+        $filesystemAdapter->buildTemporaryUrlUsing(function ($path, Carbon $expiration, $options) {
             return $path.$expiration->toString().implode('', $options);
         });
 


### PR DESCRIPTION
Hi! This PR adds the ability for you to add your own `getTemporaryUrl()` logic for the `Storage` facade.

At the moment, you can define a `getTemporaryUrl()` method on a file system adapter and it'll get called. So, this addition mirrors that same approach so that you can add the functionality via a macro.

I think this would be really handy for if you don't have direct access to make changes to the adapter itself. For example, you could use the macro so that you can use temporary URLs when using the `local` storage disk. Of course, you'd still need to make sure you create a controller to handle the actual request, but I think it could tidy up the code a bit.

As a really basic example, you could have something like this:

```php
Storage::macro('getTemporaryUrl', function ($path, $expiration, $options) {
    $options['path'] = $path;

    return URL::temporarySignedRoute('file.signed', $expiration, $options);
});
```

So, you can call the method in a much more Laravel-y way:

```php
$url = Storage::temporaryUrl(
    'file.jpg', now()->addMinutes(5)
);
```

If this is something you might want to pull in, please let me know if there are any changes I need to make 😄