### PR TITLE
[9.x] Add cache-based maintenance mode support

### DIFF
--- a/src/Illuminate/Foundation/CacheBasedMaintenanceMode.php
+++ b/src/Illuminate/Foundation/CacheBasedMaintenanceMode.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Illuminate\Foundation;
+
+use Illuminate\Contracts\Cache\Factory;
+use Illuminate\Contracts\Cache\Repository;
+use Illuminate\Contracts\Foundation\MaintenanceMode;
+
+class CacheBasedMaintenanceMode implements MaintenanceMode
+{
+    /**
+     * The cache factory.
+     *
+     * @var \Illuminate\Contracts\Cache\Factory
+     */
+    protected $cache;
+
+    /**
+     * The cache store to use.
+     *
+     * @var string
+     */
+    protected $store;
+
+    /**
+     * The cache key to use.
+     *
+     * @var string
+     */
+    protected $key;
+
+    /**
+     * Create a new cache-based maintenance mode manager.
+     *
+     * @param  \Illuminate\Contracts\Cache\Factory $cache
+     * @param  string $store
+     * @param  string $key
+     * @return void
+     */
+    public function __construct(Factory $cache, string $store, string $key)
+    {
+        $this->cache = $cache;
+        $this->store = $store;
+        $this->key = $key;
+    }
+
+    /**
+     * Take the application down for maintenance.
+     *
+     * @param  array $payload
+     * @return void
+     */
+    public function activate(array $payload): void
+    {
+        $this->getStore()->put($this->key, $payload);
+    }
+
+    /**
+     * Take the application out of maintenance.
+     *
+     * @return void
+     */
+    public function deactivate(): void
+    {
+        $this->getStore()->forget($this->key);
+    }
+
+    /**
+     * Determine if the application is currently down for maintenance.
+     *
+     * @return bool
+     */
+    public function active(): bool
+    {
+        return $this->getStore()->has($this->key);
+    }
+
+    /**
+     * Get the data array which was provided when the application was placed into maintenance.
+     *
+     * @return array
+     */
+    public function data(): array
+    {
+        return $this->getStore()->get($this->key);
+    }
+
+    /**
+     * Get the cache store to use.
+     *
+     * @return \Illuminate\Contracts\Cache\Repository
+     */
+    protected function getStore(): Repository
+    {
+        return $this->cache->store($this->store);
+    }
+}

--- a/src/Illuminate/Foundation/CacheBasedMaintenanceMode.php
+++ b/src/Illuminate/Foundation/CacheBasedMaintenanceMode.php
@@ -16,21 +16,21 @@ class CacheBasedMaintenanceMode implements MaintenanceMode
     protected $cache;
 
     /**
-     * The cache store to use.
+     * The cache store that should be utilized.
      *
      * @var string
      */
     protected $store;
 
     /**
-     * The cache key to use.
+     * The cache key to use when storing maintenance mode information.
      *
      * @var string
      */
     protected $key;
 
     /**
-     * Create a new cache-based maintenance mode manager.
+     * Create a new cache based maintenance mode implementation.
      *
      * @param  \Illuminate\Contracts\Cache\Factory  $cache
      * @param  string  $store

--- a/src/Illuminate/Foundation/CacheBasedMaintenanceMode.php
+++ b/src/Illuminate/Foundation/CacheBasedMaintenanceMode.php
@@ -32,9 +32,9 @@ class CacheBasedMaintenanceMode implements MaintenanceMode
     /**
      * Create a new cache-based maintenance mode manager.
      *
-     * @param  \Illuminate\Contracts\Cache\Factory $cache
-     * @param  string $store
-     * @param  string $key
+     * @param  \Illuminate\Contracts\Cache\Factory  $cache
+     * @param  string  $store
+     * @param  string  $key
      * @return void
      */
     public function __construct(Factory $cache, string $store, string $key)
@@ -47,7 +47,7 @@ class CacheBasedMaintenanceMode implements MaintenanceMode
     /**
      * Take the application down for maintenance.
      *
-     * @param  array $payload
+     * @param  array  $payload
      * @return void
      */
     public function activate(array $payload): void

--- a/src/Illuminate/Foundation/MaintenanceModeManager.php
+++ b/src/Illuminate/Foundation/MaintenanceModeManager.php
@@ -20,6 +20,7 @@ class MaintenanceModeManager extends Manager
      * Create an instance of the cache maintenance driver.
      *
      * @return \Illuminate\Foundation\CacheBasedMaintenanceMode
+     *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
     protected function createCacheDriver(): CacheBasedMaintenanceMode

--- a/src/Illuminate/Foundation/MaintenanceModeManager.php
+++ b/src/Illuminate/Foundation/MaintenanceModeManager.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Illuminate\Foundation;
+
+use Illuminate\Support\Manager;
+
+class MaintenanceModeManager extends Manager
+{
+    /**
+     * Get the default driver name.
+     *
+     * @return string
+     */
+    public function getDefaultDriver(): string
+    {
+        return $this->config->get('app.maintenance.driver', 'file');
+    }
+
+    /**
+     * Create an instance of the cache maintenance driver.
+     *
+     * @return \Illuminate\Foundation\CacheBasedMaintenanceMode
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     */
+    protected function createCacheDriver(): CacheBasedMaintenanceMode
+    {
+        $cache = $this->container->make('cache');
+        $store = $this->config->get('app.maintenance.store') ?: $this->config->get('cache.default');
+        $key = 'illuminate:foundation:down';
+
+        return new CacheBasedMaintenanceMode($cache, $store, $key);
+    }
+
+    /**
+     * Create an instance of the file maintenance driver.
+     *
+     * @return \Illuminate\Foundation\FileBasedMaintenanceMode
+     */
+    protected function createFileDriver(): FileBasedMaintenanceMode
+    {
+        return new FileBasedMaintenanceMode();
+    }
+}

--- a/src/Illuminate/Foundation/MaintenanceModeManager.php
+++ b/src/Illuminate/Foundation/MaintenanceModeManager.php
@@ -7,17 +7,17 @@ use Illuminate\Support\Manager;
 class MaintenanceModeManager extends Manager
 {
     /**
-     * Get the default driver name.
+     * Create an instance of the file based maintenance driver.
      *
-     * @return string
+     * @return \Illuminate\Foundation\FileBasedMaintenanceMode
      */
-    public function getDefaultDriver(): string
+    protected function createFileDriver(): FileBasedMaintenanceMode
     {
-        return $this->config->get('app.maintenance.driver', 'file');
+        return new FileBasedMaintenanceMode();
     }
 
     /**
-     * Create an instance of the cache maintenance driver.
+     * Create an instance of the cache based maintenance driver.
      *
      * @return \Illuminate\Foundation\CacheBasedMaintenanceMode
      *
@@ -25,20 +25,20 @@ class MaintenanceModeManager extends Manager
      */
     protected function createCacheDriver(): CacheBasedMaintenanceMode
     {
-        $cache = $this->container->make('cache');
-        $store = $this->config->get('app.maintenance.store') ?: $this->config->get('cache.default');
-        $key = 'illuminate:foundation:down';
-
-        return new CacheBasedMaintenanceMode($cache, $store, $key);
+        return new CacheBasedMaintenanceMode(
+            $this->container->make('cache'),
+            $this->config->get('app.maintenance.store') ?: $this->config->get('cache.default'),
+            'illuminate:foundation:down'
+        );
     }
 
     /**
-     * Create an instance of the file maintenance driver.
+     * Get the default driver name.
      *
-     * @return \Illuminate\Foundation\FileBasedMaintenanceMode
+     * @return string
      */
-    protected function createFileDriver(): FileBasedMaintenanceMode
+    public function getDefaultDriver(): string
     {
-        return new FileBasedMaintenanceMode();
+        return $this->config->get('app.maintenance.driver', 'file');
     }
 }

--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -3,8 +3,7 @@
 namespace Illuminate\Foundation\Providers;
 
 use Illuminate\Contracts\Foundation\MaintenanceMode as MaintenanceModeContract;
-use Illuminate\Foundation\CacheBasedMaintenanceMode;
-use Illuminate\Foundation\FileBasedMaintenanceMode;
+use Illuminate\Foundation\MaintenanceModeManager;
 use Illuminate\Http\Request;
 use Illuminate\Log\Events\MessageLogged;
 use Illuminate\Support\AggregateServiceProvider;
@@ -129,16 +128,7 @@ class FoundationServiceProvider extends AggregateServiceProvider
      */
     public function registerMaintenanceModeManager()
     {
-        $this->app->bind(MaintenanceModeContract::class, function () {
-            $driver = config('app.maintenance_mode', 'filesystem');
-
-            if ($driver === 'cache') {
-                return new CacheBasedMaintenanceMode(
-                    $this->app->make('cache'), config('cache.default'), 'illuminate:foundation:down',
-                );
-            }
-
-            return new FileBasedMaintenanceMode();
-        });
+        $this->app->singleton('maintenance', MaintenanceModeManager::class);
+        $this->app->bind(MaintenanceModeContract::class, fn () => $this->app->make('maintenance')->driver());
     }
 }

--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -128,7 +128,11 @@ class FoundationServiceProvider extends AggregateServiceProvider
      */
     public function registerMaintenanceModeManager()
     {
-        $this->app->singleton('maintenance', MaintenanceModeManager::class);
-        $this->app->bind(MaintenanceModeContract::class, fn () => $this->app->make('maintenance')->driver());
+        $this->app->singleton(MaintenanceModeManager::class);
+
+        $this->app->bind(
+            MaintenanceModeContract::class,
+            fn () => $this->app->make(MaintenanceModeManager::class)->driver()
+        );
     }
 }

--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Providers;
 
 use Illuminate\Contracts\Foundation\MaintenanceMode as MaintenanceModeContract;
+use Illuminate\Foundation\CacheBasedMaintenanceMode;
 use Illuminate\Foundation\FileBasedMaintenanceMode;
 use Illuminate\Http\Request;
 use Illuminate\Log\Events\MessageLogged;
@@ -128,6 +129,16 @@ class FoundationServiceProvider extends AggregateServiceProvider
      */
     public function registerMaintenanceModeManager()
     {
-        $this->app->bind(MaintenanceModeContract::class, FileBasedMaintenanceMode::class);
+        $this->app->bind(MaintenanceModeContract::class, function () {
+            $driver = config('app.maintenance_mode', 'filesystem');
+
+            if ($driver === 'cache') {
+                return new CacheBasedMaintenanceMode(
+                    $this->app->make('cache'), config('cache.default'), 'illuminate:foundation:down',
+                );
+            }
+
+            return new FileBasedMaintenanceMode();
+        });
     }
 }

--- a/tests/Foundation/FoundationCacheBasedMaintenanceModeTest.php
+++ b/tests/Foundation/FoundationCacheBasedMaintenanceModeTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Illuminate\Tests\Foundation;
+
+use Illuminate\Contracts\Cache\Factory;
+use Illuminate\Contracts\Cache\Repository;
+use Illuminate\Foundation\CacheBasedMaintenanceMode;
+use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+
+class FoundationCacheBasedMaintenanceModeTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    public function test_it_determines_whether_maintenance_mode_is_active()
+    {
+        $cache = m::mock(Factory::class, Repository::class);
+        $cache->shouldReceive('store')->with('store-key')->andReturnSelf();
+
+        $manager = new CacheBasedMaintenanceMode($cache, 'store-key', 'key');
+
+        $cache->shouldReceive('has')->once()->with('key')->andReturnFalse();
+        $this->assertFalse($manager->active());
+
+        $cache->shouldReceive('has')->once()->with('key')->andReturnTrue();
+        $this->assertTrue($manager->active());
+    }
+
+    public function test_it_retrieves_payload_from_cache()
+    {
+        $cache = m::mock(Factory::class, Repository::class);
+        $cache->shouldReceive('store')->with('store-key')->andReturnSelf();
+
+        $manager = new CacheBasedMaintenanceMode($cache, 'store-key', 'key');
+
+        $cache->shouldReceive('get')->once()->with('key')->andReturn(['payload']);
+        $this->assertSame(['payload'], $manager->data());
+    }
+
+    public function test_it_stores_payload_in_cache()
+    {
+        $cache = m::spy(Factory::class, Repository::class);
+        $cache->shouldReceive('store')->with('store-key')->andReturnSelf();
+
+        $manager = new CacheBasedMaintenanceMode($cache, 'store-key', 'key');
+        $manager->activate(['payload']);
+
+        $cache->shouldHaveReceived('put')->once()->with('key', ['payload']);
+    }
+
+    public function test_it_removes_payload_from_cache()
+    {
+        $cache = m::spy(Factory::class, Repository::class);
+        $cache->shouldReceive('store')->with('store-key')->andReturnSelf();
+
+        $manager = new CacheBasedMaintenanceMode($cache, 'store-key', 'key');
+        $manager->deactivate();
+
+        $cache->shouldHaveReceived('forget')->once()->with('key');
+    }
+}

--- a/tests/Foundation/FoundationCacheBasedMaintenanceModeTest.php
+++ b/tests/Foundation/FoundationCacheBasedMaintenanceModeTest.php
@@ -5,8 +5,8 @@ namespace Illuminate\Tests\Foundation;
 use Illuminate\Contracts\Cache\Factory;
 use Illuminate\Contracts\Cache\Repository;
 use Illuminate\Foundation\CacheBasedMaintenanceMode;
-use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
 class FoundationCacheBasedMaintenanceModeTest extends TestCase


### PR DESCRIPTION
Thanks to PR #40070 by @wimulkeman Laravel's maintenance mode is now configurable, this PR builds on this idea further by adding cache-based maintenance mode. This is especially useful when a Laravel application is distributed over multiple servers behind a load balancer, or for serverless Laravel applications. This solution uses Laravel's cache system and is not limited to a single cache solution.

Config would look something like the following:

```php
// config/app.php

'maintenance' => [
    'driver' => 'cache',
    'store' => 'my-cache-store', // Optional, default store is used if none is passed here
],
```
