### PR TITLE
[9.x] Posibility to calculate backoff value from total of exceptions, or from total of attempts

### DIFF
--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -285,7 +285,6 @@ abstract class Job
         return $this->payload()['backoff'] ?? $this->payload()['delay'] ?? null;
     }
 
-
     /**
      * @const Backoff Calculation Mode: From total of "attempts" (default) o "exceptions"
      */
@@ -293,7 +292,7 @@ abstract class Job
     const BACKOFF_FROM_EXCEPTIONS = 'exceptions';
 
     /**
-     * Decide how to calculate the backoff (default: "attempts" - same behavior as before)
+     * Decide how to calculate the backoff (default: "attempts" - same behavior as before).
      *
      * @return string
      */

--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -12,6 +12,12 @@ abstract class Job
     use InteractsWithTime;
 
     /**
+     * @const Backoff Calculation Mode: From total of "attempts" (default) o "exceptions"
+     */
+    const BACKOFF_FROM_ATTEMPTS = 'attempts';
+    const BACKOFF_FROM_EXCEPTIONS = 'exceptions';
+
+    /**
      * The job handler instance.
      *
      * @var mixed
@@ -286,19 +292,13 @@ abstract class Job
     }
 
     /**
-     * @const Backoff Calculation Mode: From total of "attempts" (default) o "exceptions"
-     */
-    const BACKOFF_FROM_ATTEMPTS = 'attempts';
-    const BACKOFF_FROM_EXCEPTIONS = 'exceptions';
-
-    /**
      * Decide how to calculate the backoff (default: "attempts" - same behavior as before).
      *
      * @return string
      */
     public function backoffMode()
     {
-        return $this->payload()['backoffMode'] ?? self::BACKOFF_FROM_ATTEMPTS;
+        return $this->payload()['backoffMode'] ?? static::BACKOFF_FROM_ATTEMPTS;
     }
 
     /**

--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -285,6 +285,23 @@ abstract class Job
         return $this->payload()['backoff'] ?? $this->payload()['delay'] ?? null;
     }
 
+
+    /**
+     * @const Backoff Calculation Mode: From total of "attempts" (default) o "exceptions"
+     */
+    const BACKOFF_FROM_ATTEMPTS = 'attempts';
+    const BACKOFF_FROM_EXCEPTIONS = 'exceptions';
+
+    /**
+     * Decide how to calculate the backoff (default: "attempts" - same behavior as before)
+     *
+     * @return string
+     */
+    public function backoffMode()
+    {
+        return $this->payload()['backoffMode'] ?? self::BACKOFF_FROM_ATTEMPTS;
+    }
+
     /**
      * Get the number of seconds the job can run.
      *

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -205,7 +205,7 @@ abstract class Queue
      * Get the backoff mode for an object-based queue handler.
      *
      * @param  mixed  $job
-     * @return string|null
+     * @return string
      */
     public function getJobBackoffMode($job)
     {

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -145,6 +145,7 @@ abstract class Queue
             'maxExceptions' => $job->maxExceptions ?? null,
             'failOnTimeout' => $job->failOnTimeout ?? false,
             'backoff' => $this->getJobBackoff($job),
+            'backoffMode' => $this->getJobBackoffMode($job),
             'timeout' => $job->timeout ?? null,
             'retryUntil' => $this->getJobExpiration($job),
             'data' => [
@@ -198,6 +199,25 @@ abstract class Queue
                 return $backoff instanceof DateTimeInterface
                                 ? $this->secondsUntil($backoff) : $backoff;
             })->implode(',');
+    }
+
+    /**
+     * Get the backoff mode for an object-based queue handler.
+     *
+     * @param  mixed  $job
+     * @return string|null
+     */
+    public function getJobBackoffMode($job)
+    {
+        if (! method_exists($job, 'backoffMode') && ! isset($job->backoffMode)) {
+            return;
+        }
+
+        if (is_null($backoffMode = $job->backoffMode ?? $job->backoffMode())) {
+            return;
+        }
+
+        return $backoffMode;
     }
 
     /**

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -557,6 +557,7 @@ class Worker
             $this->cache->put($jobExceptionsKey, 0, Carbon::now()->addDay());
         }
     }
+
     /**
      * Get the job's total number of exceptions.
      *

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -12,8 +12,8 @@ use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Queue\Events\JobProcessing;
 use Illuminate\Queue\Events\Looping;
 use Illuminate\Queue\Events\WorkerStopping;
-use Illuminate\Support\Carbon;
 use Illuminate\Queue\Jobs\Job;
+use Illuminate\Support\Carbon;
 use Throwable;
 
 class Worker
@@ -654,8 +654,7 @@ class Worker
             $calculatedBackoff = (int) ($backoff[$job->attempts() - 1] ?? last($backoff));
 
             return $calculatedBackoff;
-        }
-        else if ($backoffMode === Job::BACKOFF_FROM_EXCEPTIONS) {
+        } elseif ($backoffMode === Job::BACKOFF_FROM_EXCEPTIONS) {
             // Determine the the backoff value based on total of exceptions
             $totalExceptions = $this->getJobTotalExceptions($job);
 
@@ -668,7 +667,7 @@ class Worker
             throw new \RuntimeException('Cannot get total exceptions');
         }
 
-        throw new \InvalidArgumentException('Invalid Backoff Mode "' . $backoffMode . '"');
+        throw new \InvalidArgumentException('Invalid Backoff Mode "'.$backoffMode.'"');
     }
 
     /**

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -540,7 +540,7 @@ class Worker
     }
 
     /**
-     * Init the job's total number of exceptions if it's missing
+     * Init the job's total number of exceptions if it's missing.
      *
      * @param  \Illuminate\Contracts\Queue\Job  $job
      * @return null
@@ -550,7 +550,7 @@ class Worker
         if (! $this->cache || is_null($job->uuid())) {
             return;
         }
-        
+
         $jobExceptionsKey = $this->getJobTotalExceptionsKey($job);
 
         if (! is_null($this->cache->get($jobExceptionsKey))) {
@@ -568,11 +568,11 @@ class Worker
         if (! $this->cache || is_null($job->uuid())) {
             return;
         }
-        
+
         $this->setupJobTotalExceptionsIfMissing($job);
 
         $jobExceptionsKey = $this->getJobTotalExceptionsKey($job);
-        
+
         return $this->cache->get($jobExceptionsKey);
     }
 
@@ -594,7 +594,7 @@ class Worker
         $jobExceptionsKey = $this->getJobTotalExceptionsKey($job);
 
         $this->setupJobTotalExceptionsIfMissing($job);
-        
+
         if ($maxExceptions <= $this->cache->increment($jobExceptionsKey)) {
             $this->cache->forget($jobExceptionsKey);
 

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -528,6 +528,41 @@ class Worker
         }
     }
 
+     /**
+     * Get the stored key for job's total number of exceptions.
+     *
+     * @param  \Illuminate\Contracts\Queue\Job  $job
+     * @return string
+     */
+    private function getJobTotalExceptionsKey($job)
+    {
+        return 'job-exceptions:'.$job->uuid();
+    }
+
+    /**
+     * Get the job's total number of exceptions.
+     *
+     * @param  \Illuminate\Contracts\Queue\Job  $job
+     * @return int|null
+     */
+    private function getJobTotalExceptions($job)
+    {
+        if (! $this->cache || is_null($job->uuid())) {
+            return;
+        }
+
+        $jobExceptionsKey = $this->getJobTotalExceptionsKey($job);
+
+        $totalExceptions = $this->cache->get($jobExceptionsKey);
+        if (is_null($totalExceptions)) {
+            $this->cache->put($jobExceptionsKey, 0, Carbon::now()->addDay());
+
+            return 0;
+        }
+
+        return $totalExceptions;
+    }
+
     /**
      * Mark the given job as failed if it has exceeded the maximum allowed attempts.
      *
@@ -538,19 +573,23 @@ class Worker
      */
     protected function markJobAsFailedIfWillExceedMaxExceptions($connectionName, $job, Throwable $e)
     {
-        if (! $this->cache || is_null($uuid = $job->uuid()) ||
+        if (! $this->cache || is_null($job->uuid()) ||
             is_null($maxExceptions = $job->maxExceptions())) {
             return;
         }
 
-        if (! $this->cache->get('job-exceptions:'.$uuid)) {
-            $this->cache->put('job-exceptions:'.$uuid, 0, Carbon::now()->addDay());
-        }
+        $jobExceptionsKey = $this->getJobTotalExceptionsKey($job);
 
-        if ($maxExceptions <= $this->cache->increment('job-exceptions:'.$uuid)) {
-            $this->cache->forget('job-exceptions:'.$uuid);
+        $totalExceptions = $this->getJobTotalExceptions($job);
 
-            $this->failJob($job, $e);
+        if (! is_null($totalExceptions)) {
+            if ($maxExceptions <= $totalExceptions + 1) {
+                $this->cache->forget($jobExceptionsKey);
+
+                $this->failJob($job, $e);
+            } else {
+                $this->cache->increment($jobExceptionsKey);
+            }
         }
     }
 
@@ -597,7 +636,18 @@ class Worker
                         : $options->backoff
         );
 
-        return (int) ($backoff[$job->attempts() - 1] ?? last($backoff));
+        // Determine the the backoff value based on total of exceptions
+        $totalExceptions = $this->getJobTotalExceptions($job);
+        if (! is_null($totalExceptions)) {
+            $calculatedBackoff = (int) ($backoff[$totalExceptions - 1] ?? last($backoff));
+        }
+
+        // If the value is not available, we fallback to the total of attempts
+        else {
+            $calculatedBackoff = (int) ($backoff[$job->attempts() - 1] ?? last($backoff));
+        }
+
+        return $calculatedBackoff;
     }
 
     /**

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -528,7 +528,7 @@ class Worker
         }
     }
 
-     /**
+    /**
      * Get the stored key for job's total number of exceptions.
      *
      * @param  \Illuminate\Contracts\Queue\Job  $job

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -480,6 +480,7 @@ class WorkerFakeJob implements QueueJobContract
     public $shouldFailOnTimeout = false;
     public $uuid;
     public $backoff;
+    public $backoffMode = 'attempts';
     public $retryUntil;
     public $attempts = 0;
     public $failedWith;
@@ -534,6 +535,11 @@ class WorkerFakeJob implements QueueJobContract
     public function backoff()
     {
         return $this->backoff;
+    }
+
+    public function backoffMode()
+    {
+        return $this->backoffMode;
     }
 
     public function retryUntil()

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -2,12 +2,12 @@
 
 namespace Illuminate\Tests\Queue;
 
-use Exception;
 use Closure;
+use Exception;
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Cache\Repository as CacheContract;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Events\Dispatcher;
-use Illuminate\Contracts\Cache\Repository as CacheContract;
 use Illuminate\Contracts\Queue\Job as QueueJobContract;
 use Illuminate\Queue\Events\JobExceptionOccurred;
 use Illuminate\Queue\Events\JobProcessed;
@@ -299,6 +299,7 @@ class QueueWorkerTest extends TestCase
 
         $this->assertEquals(1, $job->releaseAfter);
     }
+
     public function testJobBasedBackoffDefaultAttemptsMode()
     {
         $job = new WorkerFakeJob(function ($job) {
@@ -673,95 +674,121 @@ class LoopBreakerException extends RuntimeException
 
 class MemoryCache implements CacheContract
 {
-    private $data = array();
+    private $data = [];
 
-    public function pull($key, $default = null){
+    public function pull($key, $default = null)
+    {
         unset($this->data[$key]);
     }
 
-    public function put($key, $value, $ttl = null){
+    public function put($key, $value, $ttl = null)
+    {
         $this->data[$key] = $value;
     }
 
-    public function add($key, $value, $ttl = null){
+    public function add($key, $value, $ttl = null)
+    {
         if (! isset($this->data[$key])) {
             $this->data[$key] = $value;
         }
     }
 
-    public function increment($key, $value = 1){
+    public function increment($key, $value = 1)
+    {
         if (! isset($this->data[$key])) {
             return false;
         }
         return ++$this->data[$key];
     }
 
-    public function decrement($key, $value = 1){
+    public function decrement($key, $value = 1)
+    {
         if (! isset($this->data[$key])) {
             return false;
         }
         return --$this->data[$key];
     }
 
-    public function forever($key, $value){
+    public function forever($key, $value)
+    {
         $this->data[$key] = $value;
         return true;
     }
 
-    public function remember($key, $ttl, Closure $callback){
+    public function remember($key, $ttl, Closure $callback)
+    {
         if (! isset($this->data[$key])) {
-            return ($this->data[$key] = $callback());
+            return $this->data[$key] = $callback();
         }
         return $this->data[$key];
     }
 
-    public function sear($key, Closure $callback){
+    public function sear($key, Closure $callback)
+    {
         if (! isset($this->data[$key])) {
-            return ($this->data[$key] = $callback());
+            return $this->data[$key] = $callback();
         }
         return $this->data[$key];
     }
 
-    public function rememberForever($key, Closure $callback){
+    public function rememberForever($key, Closure $callback)
+    {
         if (! isset($this->data[$key])) {
-            return ($this->data[$key] = $callback());
+            return $this->data[$key] = $callback();
         }
         return $this->data[$key];
     }
 
-    public function forget($key) {
+    public function forget($key)
+    {
         unset($this->data[$key]);
         return true;
     }
 
-    public function getStore() {
+    public function getStore()
+    {
     }
 
-    public function get($key, $default = null) {
+    public function get($key, $default = null)
+    {
         if (! isset($this->data[$key])) {
             return null;
         }
         return $this->data[$key];
     }
-    public function set($key, $value, $ttl = null) {
+
+    public function set($key, $value, $ttl = null)
+    {
         $this->data[$key] = $value;
     }
-    public function delete($key, $default = null) {
+
+    public function delete($key, $default = null)
+    {
         unset($this->data[$key]);
     }
-    public function clear() {
+
+    public function clear()
+    {
         $this->data = [];
     }
-    public function getMultiple($key, $default = null) {
+
+    public function getMultiple($key, $default = null)
+    {
         return $this->data[$key];
     }
-    public function setMultiple($key, $default = null) {
+
+    public function setMultiple($key, $default = null)
+    {
         $this->data[$key] = $value;
     }
-    public function deleteMultiple($key, $default = null) {
+
+    public function deleteMultiple($key, $default = null)
+    {
         unset($this->data[$key]);
     }
-    public function has($key, $default = null) {
+
+    public function has($key, $default = null)
+    {
         return isset($this->data[$key]);
     }
 }

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -12,10 +12,10 @@ use Illuminate\Contracts\Queue\Job as QueueJobContract;
 use Illuminate\Queue\Events\JobExceptionOccurred;
 use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Queue\Events\JobProcessing;
+use Illuminate\Queue\Jobs\Job;
 use Illuminate\Queue\MaxAttemptsExceededException;
 use Illuminate\Queue\QueueManager;
 use Illuminate\Queue\Worker;
-use Illuminate\Queue\Jobs\Job;
 use Illuminate\Queue\WorkerOptions;
 use Illuminate\Support\Carbon;
 use Mockery as m;
@@ -434,6 +434,7 @@ class QueueWorkerTest extends TestCase
     protected function workerCache()
     {
         $repository = new Repository(new ArrayStore);
+
         return $repository;
     }
 }

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -2,12 +2,10 @@
 
 namespace Illuminate\Tests\Queue;
 
-use Closure;
 use Exception;
 use Illuminate\Cache\ArrayStore;
 use Illuminate\Cache\Repository;
 use Illuminate\Container\Container;
-use Illuminate\Contracts\Cache\Repository as CacheContract;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Queue\Job as QueueJobContract;
@@ -17,6 +15,7 @@ use Illuminate\Queue\Events\JobProcessing;
 use Illuminate\Queue\MaxAttemptsExceededException;
 use Illuminate\Queue\QueueManager;
 use Illuminate\Queue\Worker;
+use Illuminate\Queue\Jobs\Job;
 use Illuminate\Queue\WorkerOptions;
 use Illuminate\Support\Carbon;
 use Mockery as m;
@@ -293,7 +292,7 @@ class QueueWorkerTest extends TestCase
         $job->uuid = 'test';
         $job->attempts = 1;
         $job->maxExceptions = 10;
-        $job->backoffMode = 'exceptions';
+        $job->backoffMode = Job::BACKOFF_FROM_EXCEPTIONS;
 
         $worker = $this->getWorker('default', ['queue' => [$job]]);
         $worker->setCache($this->workerCache());
@@ -526,7 +525,7 @@ class WorkerFakeJob implements QueueJobContract
     public $shouldFailOnTimeout = false;
     public $uuid;
     public $backoff;
-    public $backoffMode = 'attempts';
+    public $backoffMode = Job::BACKOFF_FROM_ATTEMPTS;
     public $retryUntil;
     public $attempts = 0;
     public $failedWith;

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -433,9 +433,7 @@ class QueueWorkerTest extends TestCase
 
     protected function workerCache()
     {
-        $repository = new Repository(new ArrayStore);
-
-        return $repository;
+        return new Repository(new ArrayStore);
     }
 }
 

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -698,6 +698,7 @@ class MemoryCache implements CacheContract
         if (! isset($this->data[$key])) {
             return false;
         }
+
         return ++$this->data[$key];
     }
 
@@ -706,6 +707,7 @@ class MemoryCache implements CacheContract
         if (! isset($this->data[$key])) {
             return false;
         }
+
         return --$this->data[$key];
     }
 
@@ -720,6 +722,7 @@ class MemoryCache implements CacheContract
         if (! isset($this->data[$key])) {
             return $this->data[$key] = $callback();
         }
+
         return $this->data[$key];
     }
 
@@ -728,6 +731,7 @@ class MemoryCache implements CacheContract
         if (! isset($this->data[$key])) {
             return $this->data[$key] = $callback();
         }
+
         return $this->data[$key];
     }
 
@@ -736,6 +740,7 @@ class MemoryCache implements CacheContract
         if (! isset($this->data[$key])) {
             return $this->data[$key] = $callback();
         }
+
         return $this->data[$key];
     }
 
@@ -754,6 +759,7 @@ class MemoryCache implements CacheContract
         if (! isset($this->data[$key])) {
             return null;
         }
+
         return $this->data[$key];
     }
 

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -714,6 +714,7 @@ class MemoryCache implements CacheContract
     public function forever($key, $value)
     {
         $this->data[$key] = $value;
+
         return true;
     }
 
@@ -747,6 +748,7 @@ class MemoryCache implements CacheContract
     public function forget($key)
     {
         unset($this->data[$key]);
+
         return true;
     }
 
@@ -754,7 +756,7 @@ class MemoryCache implements CacheContract
     {
     }
 
-    public function get($key, $default = null)
+    public function get(string $key, mixed $default = null): mixed
     {
         if (! isset($this->data[$key])) {
             return null;
@@ -763,37 +765,37 @@ class MemoryCache implements CacheContract
         return $this->data[$key];
     }
 
-    public function set($key, $value, $ttl = null)
+    public function set(string $key, mixed $value, null|int|\DateInterval $ttl = null): bool
     {
         $this->data[$key] = $value;
     }
 
-    public function delete($key, $default = null)
+    public function delete(string $key): bool
     {
         unset($this->data[$key]);
     }
 
-    public function clear()
+    public function clear(): bool
     {
         $this->data = [];
     }
 
-    public function getMultiple($key, $default = null)
+    public function getMultiple(iterable $keys, mixed $default = null): iterable
     {
         return $this->data[$key];
     }
 
-    public function setMultiple($key, $default = null)
+    public function setMultiple(iterable $values, null|int|\DateInterval $ttl = null): bool
     {
         $this->data[$key] = $value;
     }
 
-    public function deleteMultiple($key, $default = null)
+    public function deleteMultiple(iterable $keys): bool
     {
         unset($this->data[$key]);
     }
 
-    public function has($key, $default = null)
+    public function has(string $key): bool
     {
         return isset($this->data[$key]);
     }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

#39976 

This PR ~~makes the Worker to prefer to calculate the backoff value from total of exceptions (when the backoff is configured as an array), and fallback to the total of attempts.~~ allows us to configure how to calculate backoff value, based on total of attempts (default), or on total of exceptions.

## Situation
- A Job is configured with backoff as an array `[1, 10]`

### Current behavior
- 1st attempt, the job calls `release()`.
- (After `0` seconds) 2nd attempt, the job throws an exception.
- (After `10` seconds) 3rd attempt, the job throws an exception.
- (After `10` seconds) 4th attempt, the job throws an exception.
...
Notice that on the 2nd attempt, the backoff was `10` seconds instead of `1`

### Proposed solution
1) Introducing `$job->backoffMode`: 
- `Illuminate\Queue\Jobs\Job::BACKOFF_FROM_ATTEMPTS` : (Default) Calculate backoff based on total of attempts
- `Illuminate\Queue\Jobs\Job::BACKOFF_FROM_EXCEPTIONS `: Calculate backoff based on total of exceptions

**Example**
```php
<?php

namespace App\Jobs;

use Exception;
use Illuminate\Bus\Queueable;
use Illuminate\Contracts\Queue\ShouldBeUnique;
use Illuminate\Contracts\Queue\ShouldQueue;
use Illuminate\Foundation\Bus\Dispatchable;
use Illuminate\Queue\InteractsWithQueue;
use Illuminate\Queue\SerializesModels;
use Illuminate\Queue\Jobs\Job;

class ExampleJob implements ShouldQueue
{
    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;

    public $tries = 10;
    public $maxExceptions = 5;
    
    // Define as class variable
    // public $backoffMode = Job::BACKOFF_FROM_EXCEPTIONS;

    public function __construct()
    {
    }

    public function backoff()
    {
        return [1, 5];
    }

    // Define as class method
    public function backoffMode()
    {
        return Job::BACKOFF_FROM_EXCEPTIONS;
    }

    public function handle()
    {
        if ($this->attempts() === 1) {
            $this->release();
        } else {
            throw new Exception();
        }
    }
}

```

2) New behavior (BACKOFF_FROM_EXCEPTIONS)
- 1st attempt, the job calls `release()`.
- (After `0` seconds) 2nd attempt, the job throws an exception.
- (After `1` seconds) 3rd attempt, the job throws an exception.
- (After `10` seconds) 4th attempt, the job throws an exception.
...
Notice that on the 2nd attempt, the backoff was `1` seconds, follows the backoff array
