### PR TITLE
[8.x] Fix getting specified relationship from array

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -772,7 +772,7 @@ trait HasRelationships
      */
     public function getRelation($relation)
     {
-        return $this->relations[$relation];
+        return $this->relations[$relation] ?? null;
     }
 
     /**


### PR DESCRIPTION
Hi! This PR just fix `PHP Notice` in \Illuminate\Database\Eloquent\Concerns\HasRelationships::getRelation method.

```
PHP Notice:  Undefined index: relation in /vendor/illuminate/database/Eloquent/Concerns/HasRelationships.php on line 775
```

I think I've added this in the right place, but please let me know if not.
