### PR TITLE
[9.x] Skip unnecessary check before calling `openssl_encrypt`

### DIFF
--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -99,17 +99,10 @@ class Encrypter implements EncrypterContract, StringEncrypter
     {
         $iv = random_bytes(openssl_cipher_iv_length(strtolower($this->cipher)));
 
-        $tag = '';
-
-        $value = self::$supportedCiphers[strtolower($this->cipher)]['aead']
-            ? \openssl_encrypt(
-                $serialize ? serialize($value) : $value,
-                strtolower($this->cipher), $this->key, 0, $iv, $tag
-            )
-            : \openssl_encrypt(
-                $serialize ? serialize($value) : $value,
-                strtolower($this->cipher), $this->key, 0, $iv
-            );
+        $value = \openssl_encrypt(
+            $serialize ? serialize($value) : $value,
+            strtolower($this->cipher), $this->key, 0, $iv, $tag
+        );
 
         if ($value === false) {
             throw new EncryptException('Could not encrypt the data.');


### PR DESCRIPTION
In PHP `7.4` (before `7.4.13`) `openssl_encrypt` emitted a warning when the `$tag` parameter was passed and the chosen cipher was not an AEAD cipher (AEAD ciphers set `$tag` by reference, other ciphers do not use this at all).

Since `7.4.13` and `8.0.0` this has been resolved and `$tag` is simply ignored, even if passed. This PR simplifies the code by removing the now unnecessary (but previously necessary) check.

Here's the PHP fix
https://github.com/php/php-src/commit/6c6a58e930c5863ab1bd11f6a19cbf22aa2f20d4

And the PHP documentation for `openssl_encrypt`
https://www.php.net/manual/en/function.openssl-encrypt.php
