### PR TITLE
[8.x] Apply `--except` option in combination with `--model` for `model:prune`

### DIFF
--- a/src/Illuminate/Database/Console/PruneCommand.php
+++ b/src/Illuminate/Database/Console/PruneCommand.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Prunable;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Events\ModelsPruned;
 use Illuminate\Support\Str;
+use InvalidArgumentException;
 use Symfony\Component\Finder\Finder;
 
 class PruneCommand extends Command
@@ -89,7 +90,7 @@ class PruneCommand extends Command
         $except = collect($this->option('except'));
 
         if ($models->isNotEmpty() && $except->isNotEmpty()) {
-            $this->warn('Using a combination of the --except and --model options can result into unexpected behavior.');
+            throw new InvalidArgumentException("Combining the --except and --model options is not supported.");
         }
 
         if ($models->isEmpty()) {

--- a/src/Illuminate/Database/Console/PruneCommand.php
+++ b/src/Illuminate/Database/Console/PruneCommand.php
@@ -106,12 +106,12 @@ class PruneCommand extends Command
         }
 
         return $models->when($except->isNotEmpty(), function ($models) use ($except) {
-                return $models->reject(function ($model) use ($except) {
-                    return $except->contains($model);
-                });
-            })->filter(function ($model) {
-                return $this->isPrunable($model);
-            })->values();
+            return $models->reject(function ($model) use ($except) {
+                return $except->contains($model);
+            });
+        })->filter(function ($model) {
+            return $this->isPrunable($model);
+        })->values();
     }
 
     /**

--- a/tests/Database/PruneCommandTest.php
+++ b/tests/Database/PruneCommandTest.php
@@ -189,7 +189,6 @@ Using a combination of the --except and --model options can result into unexpect
 2 [Illuminate\Tests\Database\PrunableTestSoftDeletedModelWithPrunableRecords] records have been pruned.
 
 EOF, str_replace("\r", '', $output->fetch()));
-
     }
 
     protected function artisan($arguments)

--- a/tests/Database/PruneCommandTest.php
+++ b/tests/Database/PruneCommandTest.php
@@ -185,7 +185,7 @@ EOF, str_replace("\r", '', $output->fetch()));
         ]);
 
         $this->assertEquals(<<<'EOF'
-Using a combination of the --except and --model parameters can result into unexpected behavior.
+Using a combination of the --except and --model options can result into unexpected behavior.
 2 [Illuminate\Tests\Database\PrunableTestSoftDeletedModelWithPrunableRecords] records have been pruned.
 
 EOF, str_replace("\r", '', $output->fetch()));

--- a/tests/Database/PruneCommandTest.php
+++ b/tests/Database/PruneCommandTest.php
@@ -161,6 +161,8 @@ EOF, str_replace("\r", '', $output->fetch()));
 
     public function testCombinationOfModelAndExceptParameter()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $db = new DB;
         $db->addConnection([
             'driver' => 'sqlite',
@@ -183,12 +185,6 @@ EOF, str_replace("\r", '', $output->fetch()));
             '--model' => [PrunableTestModelWithPrunableRecords::class, PrunableTestSoftDeletedModelWithPrunableRecords::class],
             '--except' => PrunableTestModelWithPrunableRecords::class,
         ]);
-
-        $this->assertEquals(<<<'EOF'
-Using a combination of the --except and --model options can result into unexpected behavior.
-2 [Illuminate\Tests\Database\PrunableTestSoftDeletedModelWithPrunableRecords] records have been pruned.
-
-EOF, str_replace("\r", '', $output->fetch()));
     }
 
     protected function artisan($arguments)


### PR DESCRIPTION
Fixed an edge case when using the new `--except` option added in https://github.com/laravel/framework/pull/39749.

When using the `--model` options. The `--except` option normally would get ignored when used in combination.

I couldn't come up with a practical use case for this. That's why I added a warning when using both parameters. I still feel that it makes more sense to support a combination of both parameters. Especially because it never states that all other parameters will be ignored when the model option is used.

Looking forward to any feedback and suggestions regarding this PR.

Thanks!
