### PR TITLE
[9.x] Add observer mapping

### DIFF
--- a/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
@@ -23,6 +23,13 @@ class EventServiceProvider extends ServiceProvider
     protected $subscribe = [];
 
     /**
+     * The observers mapping for the application models.
+     *
+     * @var array
+     */
+    protected $observers = [];
+
+    /**
      * Register the application's event listeners.
      *
      * @return void
@@ -41,6 +48,8 @@ class EventServiceProvider extends ServiceProvider
             foreach ($this->subscribe as $subscriber) {
                 Event::subscribe($subscriber);
             }
+
+            $this->registerObservers();
         });
     }
 
@@ -144,5 +153,27 @@ class EventServiceProvider extends ServiceProvider
     protected function eventDiscoveryBasePath()
     {
         return base_path();
+    }
+
+    /**
+     * Get the observers defined on the provider.
+     *
+     * @return array
+     */
+    public function observers()
+    {
+        return $this->observers;
+    }
+
+    /**
+     * Register the application model's observers.
+     *
+     * @return void
+     */
+    public function registerObservers()
+    {
+        foreach ($this->observers() as $model => $observers) {
+            $model::observe($observers);
+        }
     }
 }


### PR DESCRIPTION
#40112. This feature allows you to have cleaner observers mapping in `EventServiceProvider` which basically copies syntax of policies, event listeners and other similar stuff. Observers are automatically registered during `booting` hook. In general, this allows to write this:

```php
/**
 * Register any events for your application.
 *
 * @return void
 */
public function boot()
{
    User::observe([UserObserver::class, UserOrderObserver::class]);
    Blog::observe(BlogObserver::class);
    Transaction::observe(TransactionObserver::class);
    Order::observe(OrderObserver::class);
    Payout::observe(PayoutObserver::class);
}
```

like this:
```php
/**
 * The observers mapping for the application models.
 *
 * @var array
 */
protected $observers = [
    User::class             => [ UserObserver::class, UserOrderObserver::class ],
    Blog::class             => BlogObserver::class,
    Transaction::class      => TransactionObserver::class,
    Order::class            => OrderObserver::class,
    Payout::class           => PayoutObserver::class,
];
```