### PR TITLE
[9.x] Database Engine independent Query Expressions

### DIFF
--- a/src/Illuminate/Contracts/Database/Query/Builder.php
+++ b/src/Illuminate/Contracts/Database/Query/Builder.php
@@ -390,7 +390,7 @@ interface Builder
     /**
      * Add a where between statement to the query.
      *
-     * @param  string|\Illuminate\Database\Query\Expression  $column
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  iterable  $values
      * @param  string  $boolean
      * @param  bool  $not
@@ -819,7 +819,7 @@ interface Builder
     /**
      * Add an "order by" clause to the query.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Expression|\Illuminate\Contracts\Database\Query\Builder|string  $column
+     * @param  \Closure|\Illuminate\Contracts\Database\Query\Expression|\Illuminate\Contracts\Database\Query\Builder|string  $column
      * @param  string  $direction
      * @return static
      */
@@ -828,7 +828,7 @@ interface Builder
     /**
      * Add a descending "order by" clause to the query.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Expression|\Illuminate\Contracts\Database\Query\Builder|string  $column
+     * @param  \Closure|\Illuminate\Contracts\Database\Query\Expression|\Illuminate\Contracts\Database\Query\Builder|string  $column
      * @return static
      */
     public function orderByDesc($column);
@@ -836,7 +836,7 @@ interface Builder
     /**
      * Add an "order by" clause for a timestamp to the query.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Expression|\Illuminate\Contracts\Database\Query\Builder|string  $column
+     * @param  \Closure|\Illuminate\Contracts\Database\Query\Expression|\Illuminate\Contracts\Database\Query\Builder|string  $column
      * @return static
      */
     public function latest($column = 'created_at');
@@ -844,7 +844,7 @@ interface Builder
     /**
      * Add an "order by" clause for a timestamp to the query.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Expression|\Illuminate\Contracts\Database\Query\Builder|string  $column
+     * @param  \Closure|\Illuminate\Contracts\Database\Query\Expression|\Illuminate\Contracts\Database\Query\Builder|string  $column
      * @return static
      */
     public function oldest($column = 'created_at');
@@ -986,7 +986,7 @@ interface Builder
      * Create a raw database expression.
      *
      * @param  mixed  $value
-     * @return \Illuminate\Database\Query\Expression
+     * @return \Illuminate\Contracts\Database\Query\Expression
      */
     public function raw($value);
 

--- a/src/Illuminate/Contracts/Database/Query/Expression.php
+++ b/src/Illuminate/Contracts/Database/Query/Expression.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Illuminate\Contracts\Database\Query;
+
+use Illuminate\Database\Grammar;
+
+interface Expression
+{
+    /**
+     * Get the value of the expression.
+     *
+     * @param  \Illuminate\Database\Grammar  $grammar
+     * @return mixed
+     */
+    public function getValue(Grammar $grammar);
+}

--- a/src/Illuminate/Database/Concerns/ExposesDatabase.php
+++ b/src/Illuminate/Database/Concerns/ExposesDatabase.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Illuminate\Database\Concerns;
+
+trait ExposesDatabase
+{
+    /**
+     * Get the grammar's database driver name.
+     *
+     * @return string
+     */
+    public function getDatabaseDriver()
+    {
+        return $this->connection->getDriverName();
+    }
+
+    /**
+     * Get the grammar's database version.
+     *
+     * @return string
+     */
+    public function getDatabaseVersion()
+    {
+        return $this->connection->getDatabaseVersion();
+    }
+}

--- a/src/Illuminate/Database/Concerns/QuotesValue.php
+++ b/src/Illuminate/Database/Concerns/QuotesValue.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Illuminate\Database\Concerns;
+
+trait QuotesValue
+{
+    /**
+     * Quote the given string literal.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    protected function quoteValue($value)
+    {
+        return $this->connection->quoteString($value);
+    }
+}

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -15,7 +15,6 @@ use Illuminate\Database\Events\TransactionCommitted;
 use Illuminate\Database\Events\TransactionRolledBack;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Database\Query\Expression;
-use Illuminate\Database\Query\Grammars\Grammar as QueryGrammar;
 use Illuminate\Database\Query\Processors\Processor;
 use Illuminate\Database\Schema\Builder as SchemaBuilder;
 use Illuminate\Support\Arr;
@@ -24,7 +23,7 @@ use PDO;
 use PDOStatement;
 use RuntimeException;
 
-class Connection implements ConnectionInterface
+abstract class Connection implements ConnectionInterface
 {
     use DetectsConcurrencyErrors,
         DetectsLostConnections,
@@ -229,10 +228,7 @@ class Connection implements ConnectionInterface
      *
      * @return \Illuminate\Database\Query\Grammars\Grammar
      */
-    protected function getDefaultQueryGrammar()
-    {
-        return new QueryGrammar;
-    }
+    abstract protected function getDefaultQueryGrammar();
 
     /**
      * Set the schema grammar to the default implementation.
@@ -249,10 +245,7 @@ class Connection implements ConnectionInterface
      *
      * @return \Illuminate\Database\Schema\Grammars\Grammar
      */
-    protected function getDefaultSchemaGrammar()
-    {
-        //
-    }
+    abstract protected function getDefaultSchemaGrammar();
 
     /**
      * Set the query post processor to the default implementation.
@@ -1456,5 +1449,31 @@ class Connection implements ConnectionInterface
     public static function getResolver($driver)
     {
         return static::$resolvers[$driver] ?? null;
+    }
+
+    /**
+     * Quote the given string literal.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    public function quoteString($value)
+    {
+        $this->reconnectIfMissingConnection();
+
+        // Here we will run this query. If an exception occurs we'll determine if it was
+        // caused by a connection that has been lost. If that is the cause, we'll try
+        // to re-establish connection and re-run the query with a fresh connection.
+        try {
+            return $this->getPdo()->quote($value);
+        } catch (QueryException $e) {
+            if ($this->causedByLostConnection($e->getPrevious())) {
+                $this->reconnect();
+
+                return $this->getPdo()->quote($value);
+            }
+
+            throw $e;
+        }
     }
 }

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -1476,4 +1476,29 @@ abstract class Connection implements ConnectionInterface
             throw $e;
         }
     }
+
+    /**
+     * Get the version of the connected database.
+     *
+     * @return string
+     */
+    public function getDatabaseVersion()
+    {
+        $this->reconnectIfMissingConnection();
+
+        // Here we will run this query. If an exception occurs we'll determine if it was
+        // caused by a connection that has been lost. If that is the cause, we'll try
+        // to re-establish connection and re-run the query with a fresh connection.
+        try {
+            return $this->getPdo()->getAttribute(PDO::ATTR_SERVER_VERSION);
+        } catch (QueryException $e) {
+            if ($this->causedByLostConnection($e->getPrevious())) {
+                $this->reconnect();
+
+                return $this->getPdo()->getAttribute(PDO::ATTR_SERVER_VERSION);
+            }
+
+            throw $e;
+        }
+    }
 }

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -882,7 +882,7 @@ class Connection implements ConnectionInterface
      * Get a new raw query expression.
      *
      * @param  mixed  $value
-     * @return \Illuminate\Database\Query\Expression
+     * @return \Illuminate\Contracts\Database\Query\Expression
      */
     public function raw($value)
     {

--- a/src/Illuminate/Database/ConnectionInterface.php
+++ b/src/Illuminate/Database/ConnectionInterface.php
@@ -19,7 +19,7 @@ interface ConnectionInterface
      * Get a new raw query expression.
      *
      * @param  mixed  $value
-     * @return \Illuminate\Database\Query\Expression
+     * @return \Illuminate\Contracts\Database\Query\Expression
      */
     public function raw($value);
 

--- a/src/Illuminate/Database/ConnectionInterface.php
+++ b/src/Illuminate/Database/ConnectionInterface.php
@@ -169,6 +169,13 @@ interface ConnectionInterface
     public function getDatabaseName();
 
     /**
+     * Get the version of the connected database.
+     *
+     * @return string
+     */
+    public function getDatabaseVersion();
+
+    /**
      * Quote the given string literal.
      *
      * @param  string  $value

--- a/src/Illuminate/Database/ConnectionInterface.php
+++ b/src/Illuminate/Database/ConnectionInterface.php
@@ -167,4 +167,12 @@ interface ConnectionInterface
      * @return string
      */
     public function getDatabaseName();
+
+    /**
+     * Quote the given string literal.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    public function quoteString($value);
 }

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -265,7 +265,7 @@ class Builder implements BuilderContract
     /**
      * Add a basic where clause to the query.
      *
-     * @param  \Closure|string|array|\Illuminate\Database\Query\Expression  $column
+     * @param  \Closure|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @param  string  $boolean
@@ -287,7 +287,7 @@ class Builder implements BuilderContract
     /**
      * Add a basic where clause to the query, and return the first result.
      *
-     * @param  \Closure|string|array|\Illuminate\Database\Query\Expression  $column
+     * @param  \Closure|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @param  string  $boolean
@@ -301,7 +301,7 @@ class Builder implements BuilderContract
     /**
      * Add an "or where" clause to the query.
      *
-     * @param  \Closure|array|string|\Illuminate\Database\Query\Expression  $column
+     * @param  \Closure|array|string|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return $this
@@ -318,7 +318,7 @@ class Builder implements BuilderContract
     /**
      * Add an "order by" clause for a timestamp to the query.
      *
-     * @param  string|\Illuminate\Database\Query\Expression  $column
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
      * @return $this
      */
     public function latest($column = null)
@@ -335,7 +335,7 @@ class Builder implements BuilderContract
     /**
      * Add an "order by" clause for a timestamp to the query.
      *
-     * @param  string|\Illuminate\Database\Query\Expression  $column
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
      * @return $this
      */
     public function oldest($column = null)
@@ -570,7 +570,7 @@ class Builder implements BuilderContract
     /**
      * Get a single column's value from the first result of a query.
      *
-     * @param  string|\Illuminate\Database\Query\Expression  $column
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
      * @return mixed
      */
     public function value($column)
@@ -583,7 +583,7 @@ class Builder implements BuilderContract
     /**
      * Get a single column's value from the first result of the query or throw an exception.
      *
-     * @param  string|\Illuminate\Database\Query\Expression  $column
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
      * @return mixed
      *
      * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
@@ -766,7 +766,7 @@ class Builder implements BuilderContract
     /**
      * Get an array with the values of a given column.
      *
-     * @param  string|\Illuminate\Database\Query\Expression  $column
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  string|null  $key
      * @return \Illuminate\Support\Collection
      */
@@ -951,7 +951,7 @@ class Builder implements BuilderContract
     /**
      * Increment a column's value by a given amount.
      *
-     * @param  string|\Illuminate\Database\Query\Expression  $column
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  float|int  $amount
      * @param  array  $extra
      * @return int
@@ -966,7 +966,7 @@ class Builder implements BuilderContract
     /**
      * Decrement a column's value by a given amount.
      *
-     * @param  string|\Illuminate\Database\Query\Expression  $column
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  float|int  $amount
      * @param  array  $extra
      * @return int
@@ -1532,7 +1532,7 @@ class Builder implements BuilderContract
     /**
      * Qualify the given column name by the model's table.
      *
-     * @param  string|\Illuminate\Database\Query\Expression  $column
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
      * @return string
      */
     public function qualifyColumn($column)
@@ -1543,7 +1543,7 @@ class Builder implements BuilderContract
     /**
      * Qualify the given columns with the model's table.
      *
-     * @param  array|\Illuminate\Database\Query\Expression  $columns
+     * @param  array|\Illuminate\Contracts\Database\Query\Expression  $columns
      * @return array
      */
     public function qualifyColumns($columns)

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -355,7 +355,7 @@ trait QueriesRelationships
      * Add a basic where clause to a relationship query.
      *
      * @param  string  $relation
-     * @param  \Closure|string|array|\Illuminate\Database\Query\Expression  $column
+     * @param  \Closure|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return \Illuminate\Database\Eloquent\Builder|static
@@ -371,7 +371,7 @@ trait QueriesRelationships
      * Add an "or where" clause to a relationship query.
      *
      * @param  string  $relation
-     * @param  \Closure|string|array|\Illuminate\Database\Query\Expression  $column
+     * @param  \Closure|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return \Illuminate\Database\Eloquent\Builder|static
@@ -388,7 +388,7 @@ trait QueriesRelationships
      *
      * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation
      * @param  string|array  $types
-     * @param  \Closure|string|array|\Illuminate\Database\Query\Expression  $column
+     * @param  \Closure|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return \Illuminate\Database\Eloquent\Builder|static
@@ -405,7 +405,7 @@ trait QueriesRelationships
      *
      * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation
      * @param  string|array  $types
-     * @param  \Closure|string|array|\Illuminate\Database\Query\Expression  $column
+     * @param  \Closure|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return \Illuminate\Database\Eloquent\Builder|static

--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Database;
 
-use Illuminate\Database\Query\Expression;
+use Illuminate\Contracts\Database\Query\Expression;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use RuntimeException;
@@ -32,13 +32,13 @@ abstract class Grammar
     /**
      * Wrap a table in keyword identifiers.
      *
-     * @param  \Illuminate\Database\Query\Expression|string  $table
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $table
      * @return string
      */
     public function wrapTable($table)
     {
         if (! $this->isExpression($table)) {
-            return $this->wrap($this->tablePrefix.$table, true);
+            return $this->wrap($this->tablePrefix.$this->getValue($table), true);
         }
 
         return $this->getValue($table);
@@ -47,7 +47,7 @@ abstract class Grammar
     /**
      * Wrap a value in keyword identifiers.
      *
-     * @param  \Illuminate\Database\Query\Expression|string  $value
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $value
      * @param  bool  $prefixAlias
      * @return string
      */
@@ -216,7 +216,12 @@ abstract class Grammar
      */
     public function getValue($expression)
     {
-        return $expression->getValue();
+        $value = $expression;
+        while ($this->isExpression($value)) {
+            $value = $value->getValue($this);
+        }
+
+        return $value;
     }
 
     /**

--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -194,7 +194,7 @@ abstract class Grammar
             return implode(', ', array_map([$this, __FUNCTION__], $value));
         }
 
-        return "'$value'";
+        return $this->quoteValue($value);
     }
 
     /**
@@ -256,4 +256,12 @@ abstract class Grammar
 
         return $this;
     }
+
+    /**
+     * Quote the given string literal.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    abstract protected function quoteValue($value);
 }

--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -264,4 +264,18 @@ abstract class Grammar
      * @return string
      */
     abstract protected function quoteValue($value);
+
+    /**
+     * Get the grammar's database driver name.
+     *
+     * @return string
+     */
+    abstract public function getDatabaseDriver();
+
+    /**
+     * Get the grammar's database version.
+     *
+     * @return string
+     */
+    abstract public function getDatabaseVersion();
 }

--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -209,14 +209,13 @@ abstract class Grammar
     }
 
     /**
-     * Get the value of a raw expression.
+     * Get the value for the parameter.
      *
-     * @param  \Illuminate\Database\Query\Expression  $expression
+     * @param  mixed  $value
      * @return mixed
      */
-    public function getValue($expression)
+    public function getValue($value)
     {
-        $value = $expression;
         while ($this->isExpression($value)) {
             $value = $value->getValue($this);
         }

--- a/src/Illuminate/Database/MySqlConnection.php
+++ b/src/Illuminate/Database/MySqlConnection.php
@@ -30,7 +30,7 @@ class MySqlConnection extends Connection
      */
     protected function getDefaultQueryGrammar()
     {
-        return $this->withTablePrefix(new QueryGrammar);
+        return $this->withTablePrefix(new QueryGrammar($this));
     }
 
     /**
@@ -54,7 +54,7 @@ class MySqlConnection extends Connection
      */
     protected function getDefaultSchemaGrammar()
     {
-        return $this->withTablePrefix(new SchemaGrammar);
+        return $this->withTablePrefix(new SchemaGrammar($this));
     }
 
     /**

--- a/src/Illuminate/Database/PostgresConnection.php
+++ b/src/Illuminate/Database/PostgresConnection.php
@@ -46,7 +46,7 @@ class PostgresConnection extends Connection
      */
     protected function getDefaultQueryGrammar()
     {
-        return $this->withTablePrefix(new QueryGrammar);
+        return $this->withTablePrefix(new QueryGrammar($this));
     }
 
     /**
@@ -70,7 +70,7 @@ class PostgresConnection extends Connection
      */
     protected function getDefaultSchemaGrammar()
     {
-        return $this->withTablePrefix(new SchemaGrammar);
+        return $this->withTablePrefix(new SchemaGrammar($this));
     }
 
     /**

--- a/src/Illuminate/Database/Query/Expression.php
+++ b/src/Illuminate/Database/Query/Expression.php
@@ -2,7 +2,10 @@
 
 namespace Illuminate\Database\Query;
 
-class Expression
+use Illuminate\Contracts\Database\Query\Expression as ExpressionContract;
+use Illuminate\Database\Grammar;
+
+class Expression implements ExpressionContract
 {
     /**
      * The value of the expression.
@@ -25,20 +28,11 @@ class Expression
     /**
      * Get the value of the expression.
      *
+     * @param  \Illuminate\Database\Grammar  $grammar
      * @return mixed
      */
-    public function getValue()
+    public function getValue(Grammar $grammar)
     {
         return $this->value;
-    }
-
-    /**
-     * Get the value of the expression.
-     *
-     * @return string
-     */
-    public function __toString()
-    {
-        return (string) $this->getValue();
     }
 }

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use RuntimeException;
 
-class Grammar extends BaseGrammar
+abstract class Grammar extends BaseGrammar
 {
     /**
      * The grammar specific operators.

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -2,12 +2,14 @@
 
 namespace Illuminate\Database\Query\Grammars;
 
+use Illuminate\Database\Concerns\ExposesDatabase;
 use Illuminate\Database\Concerns\QuotesValue;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Str;
 
 class MySqlGrammar extends Grammar
 {
+    use ExposesDatabase;
     use QuotesValue;
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -2,17 +2,38 @@
 
 namespace Illuminate\Database\Query\Grammars;
 
+use Illuminate\Database\Concerns\QuotesValue;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Str;
 
 class MySqlGrammar extends Grammar
 {
+    use QuotesValue;
+
     /**
      * The grammar specific operators.
      *
      * @var string[]
      */
     protected $operators = ['sounds like'];
+
+    /**
+     * The connection the grammar is operating for.
+     *
+     * @var \Illuminate\Database\Connection
+     */
+    protected $connection;
+
+    /**
+     * Create a new MySql grammar instance.
+     *
+     * @param  \Illuminate\Database\Connection  $connection
+     * @return void
+     */
+    public function __construct($connection)
+    {
+        $this->connection = $connection;
+    }
 
     /**
      * Add a "where null" clause to the query.

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Query\Grammars;
 
+use Illuminate\Database\Concerns\ExposesDatabase;
 use Illuminate\Database\Concerns\QuotesValue;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Arr;
@@ -9,6 +10,7 @@ use Illuminate\Support\Str;
 
 class PostgresGrammar extends Grammar
 {
+    use ExposesDatabase;
     use QuotesValue;
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -2,12 +2,15 @@
 
 namespace Illuminate\Database\Query\Grammars;
 
+use Illuminate\Database\Concerns\QuotesValue;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 
 class PostgresGrammar extends Grammar
 {
+    use QuotesValue;
+
     /**
      * All of the available clause operators.
      *
@@ -20,6 +23,24 @@ class PostgresGrammar extends Grammar
         '&&', '@>', '<@', '?', '?|', '?&', '||', '-', '@?', '@@', '#-',
         'is distinct from', 'is not distinct from',
     ];
+
+    /**
+     * The connection the grammar is operating for.
+     *
+     * @var \Illuminate\Database\Connection
+     */
+    protected $connection;
+
+    /**
+     * Create a new Postgres grammar instance.
+     *
+     * @param  \Illuminate\Database\Connection  $connection
+     * @return void
+     */
+    public function __construct($connection)
+    {
+        $this->connection = $connection;
+    }
 
     /**
      * {@inheritdoc}

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Query\Grammars;
 
+use Illuminate\Database\Concerns\ExposesDatabase;
 use Illuminate\Database\Concerns\QuotesValue;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Arr;
@@ -9,6 +10,7 @@ use Illuminate\Support\Str;
 
 class SQLiteGrammar extends Grammar
 {
+    use ExposesDatabase;
     use QuotesValue;
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -2,12 +2,15 @@
 
 namespace Illuminate\Database\Query\Grammars;
 
+use Illuminate\Database\Concerns\QuotesValue;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 
 class SQLiteGrammar extends Grammar
 {
+    use QuotesValue;
+
     /**
      * All of the available clause operators.
      *
@@ -18,6 +21,24 @@ class SQLiteGrammar extends Grammar
         'like', 'not like', 'ilike',
         '&', '|', '<<', '>>',
     ];
+
+    /**
+     * The connection the grammar is operating for.
+     *
+     * @var \Illuminate\Database\Connection
+     */
+    protected $connection;
+
+    /**
+     * Create a new SQLite grammar instance.
+     *
+     * @param  \Illuminate\Database\Connection  $connection
+     * @return void
+     */
+    public function __construct($connection)
+    {
+        $this->connection = $connection;
+    }
 
     /**
      * Compile the lock into SQL.

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -2,12 +2,15 @@
 
 namespace Illuminate\Database\Query\Grammars;
 
+use Illuminate\Database\Concerns\QuotesValue;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 
 class SqlServerGrammar extends Grammar
 {
+    use QuotesValue;
+
     /**
      * All of the available clause operators.
      *
@@ -18,6 +21,24 @@ class SqlServerGrammar extends Grammar
         'like', 'not like', 'ilike',
         '&', '&=', '|', '|=', '^', '^=',
     ];
+
+    /**
+     * The connection the grammar is operating for.
+     *
+     * @var \Illuminate\Database\Connection
+     */
+    protected $connection;
+
+    /**
+     * Create a new SqlServer grammar instance.
+     *
+     * @param  \Illuminate\Database\Connection  $connection
+     * @return void
+     */
+    public function __construct($connection)
+    {
+        $this->connection = $connection;
+    }
 
     /**
      * Compile a select query into SQL.

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -509,7 +509,7 @@ class SqlServerGrammar extends Grammar
     /**
      * Wrap a table in keyword identifiers.
      *
-     * @param  \Illuminate\Database\Query\Expression|string  $table
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $table
      * @return string
      */
     public function wrapTable($table)

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Query\Grammars;
 
+use Illuminate\Database\Concerns\ExposesDatabase;
 use Illuminate\Database\Concerns\QuotesValue;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Arr;
@@ -9,6 +10,7 @@ use Illuminate\Support\Str;
 
 class SqlServerGrammar extends Grammar
 {
+    use ExposesDatabase;
     use QuotesValue;
 
     /**

--- a/src/Illuminate/Database/Query/JoinClause.php
+++ b/src/Illuminate/Database/Query/JoinClause.php
@@ -84,7 +84,7 @@ class JoinClause extends Builder
      *
      * @param  \Closure|string  $first
      * @param  string|null  $operator
-     * @param  \Illuminate\Database\Query\Expression|string|null  $second
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string|null  $second
      * @param  string  $boolean
      * @return $this
      *
@@ -104,7 +104,7 @@ class JoinClause extends Builder
      *
      * @param  \Closure|string  $first
      * @param  string|null  $operator
-     * @param  \Illuminate\Database\Query\Expression|string|null  $second
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string|null  $second
      * @return \Illuminate\Database\Query\JoinClause
      */
     public function orOn($first, $operator = null, $second = null)

--- a/src/Illuminate/Database/SQLiteConnection.php
+++ b/src/Illuminate/Database/SQLiteConnection.php
@@ -43,7 +43,7 @@ class SQLiteConnection extends Connection
      */
     protected function getDefaultQueryGrammar()
     {
-        return $this->withTablePrefix(new QueryGrammar);
+        return $this->withTablePrefix(new QueryGrammar($this));
     }
 
     /**
@@ -67,7 +67,7 @@ class SQLiteConnection extends Connection
      */
     protected function getDefaultSchemaGrammar()
     {
-        return $this->withTablePrefix(new SchemaGrammar);
+        return $this->withTablePrefix(new SchemaGrammar($this));
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -4,9 +4,9 @@ namespace Illuminate\Database\Schema\Grammars;
 
 use Doctrine\DBAL\Schema\AbstractSchemaManager as SchemaManager;
 use Doctrine\DBAL\Schema\TableDiff;
+use Illuminate\Contracts\Database\Query\Expression;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Grammar as BaseGrammar;
-use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Fluent;
 use LogicException;
@@ -305,7 +305,7 @@ abstract class Grammar extends BaseGrammar
     /**
      * Wrap a value in keyword identifiers.
      *
-     * @param  \Illuminate\Database\Query\Expression|string  $value
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $value
      * @param  bool  $prefixAlias
      * @return string
      */
@@ -325,7 +325,7 @@ abstract class Grammar extends BaseGrammar
     protected function getDefaultValue($value)
     {
         if ($value instanceof Expression) {
-            return $value;
+            return $this->getValue($value);
         }
 
         return is_bool($value)

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Schema\Grammars;
 
+use Illuminate\Database\Concerns\QuotesValue;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Fluent;
@@ -9,6 +10,8 @@ use RuntimeException;
 
 class MySqlGrammar extends Grammar
 {
+    use QuotesValue;
+
     /**
      * The possible column modifiers.
      *
@@ -25,6 +28,24 @@ class MySqlGrammar extends Grammar
      * @var string[]
      */
     protected $serials = ['bigInteger', 'integer', 'mediumInteger', 'smallInteger', 'tinyInteger'];
+
+    /**
+     * The connection the grammar is operating for.
+     *
+     * @var \Illuminate\Database\Connection
+     */
+    protected $connection;
+
+    /**
+     * Create a new MySql grammar instance.
+     *
+     * @param  \Illuminate\Database\Connection  $connection
+     * @return void
+     */
+    public function __construct($connection)
+    {
+        $this->connection = $connection;
+    }
 
     /**
      * Compile a create database command.

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Schema\Grammars;
 
+use Illuminate\Database\Concerns\ExposesDatabase;
 use Illuminate\Database\Concerns\QuotesValue;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Schema\Blueprint;
@@ -10,6 +11,7 @@ use RuntimeException;
 
 class MySqlGrammar extends Grammar
 {
+    use ExposesDatabase;
     use QuotesValue;
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Schema\Grammars;
 
+use Illuminate\Database\Concerns\ExposesDatabase;
 use Illuminate\Database\Concerns\QuotesValue;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Fluent;
@@ -9,6 +10,7 @@ use RuntimeException;
 
 class PostgresGrammar extends Grammar
 {
+    use ExposesDatabase;
     use QuotesValue;
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -2,12 +2,15 @@
 
 namespace Illuminate\Database\Schema\Grammars;
 
+use Illuminate\Database\Concerns\QuotesValue;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Fluent;
 use RuntimeException;
 
 class PostgresGrammar extends Grammar
 {
+    use QuotesValue;
+
     /**
      * If this Grammar supports schema changes wrapped in a transaction.
      *
@@ -35,6 +38,24 @@ class PostgresGrammar extends Grammar
      * @var string[]
      */
     protected $fluentCommands = ['Comment'];
+
+    /**
+     * The connection the grammar is operating for.
+     *
+     * @var \Illuminate\Database\Connection
+     */
+    protected $connection;
+
+    /**
+     * Create a new Postgres grammar instance.
+     *
+     * @param  \Illuminate\Database\Connection  $connection
+     * @return void
+     */
+    public function __construct($connection)
+    {
+        $this->connection = $connection;
+    }
 
     /**
      * Compile a create database command.

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Schema\Grammars;
 
 use Doctrine\DBAL\Schema\Index;
+use Illuminate\Database\Concerns\ExposesDatabase;
 use Illuminate\Database\Concerns\QuotesValue;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Schema\Blueprint;
@@ -12,6 +13,7 @@ use RuntimeException;
 
 class SQLiteGrammar extends Grammar
 {
+    use ExposesDatabase;
     use QuotesValue;
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Schema\Grammars;
 
 use Doctrine\DBAL\Schema\Index;
+use Illuminate\Database\Concerns\QuotesValue;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Arr;
@@ -11,6 +12,8 @@ use RuntimeException;
 
 class SQLiteGrammar extends Grammar
 {
+    use QuotesValue;
+
     /**
      * The possible column modifiers.
      *
@@ -24,6 +27,24 @@ class SQLiteGrammar extends Grammar
      * @var string[]
      */
     protected $serials = ['bigInteger', 'integer', 'mediumInteger', 'smallInteger', 'tinyInteger'];
+
+    /**
+     * The connection the grammar is operating for.
+     *
+     * @var \Illuminate\Database\Connection
+     */
+    protected $connection;
+
+    /**
+     * Create a new SQLite grammar instance.
+     *
+     * @param  \Illuminate\Database\Connection  $connection
+     * @return void
+     */
+    public function __construct($connection)
+    {
+        $this->connection = $connection;
+    }
 
     /**
      * Compile the query to determine if a table exists.

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -2,11 +2,14 @@
 
 namespace Illuminate\Database\Schema\Grammars;
 
+use Illuminate\Database\Concerns\QuotesValue;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Fluent;
 
 class SqlServerGrammar extends Grammar
 {
+    use QuotesValue;
+
     /**
      * If this Grammar supports schema changes wrapped in a transaction.
      *
@@ -27,6 +30,24 @@ class SqlServerGrammar extends Grammar
      * @var string[]
      */
     protected $serials = ['tinyInteger', 'smallInteger', 'mediumInteger', 'integer', 'bigInteger'];
+
+    /**
+     * The connection the grammar is operating for.
+     *
+     * @var \Illuminate\Database\Connection
+     */
+    protected $connection;
+
+    /**
+     * Create a new SqlServer grammar instance.
+     *
+     * @param  \Illuminate\Database\Connection  $connection
+     * @return void
+     */
+    public function __construct($connection)
+    {
+        $this->connection = $connection;
+    }
 
     /**
      * Compile a create database command.

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -905,7 +905,7 @@ class SqlServerGrammar extends Grammar
     /**
      * Wrap a table in keyword identifiers.
      *
-     * @param  \Illuminate\Database\Query\Expression|string  $table
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $table
      * @return string
      */
     public function wrapTable($table)

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -2,12 +2,14 @@
 
 namespace Illuminate\Database\Schema\Grammars;
 
+use Illuminate\Database\Concerns\ExposesDatabase;
 use Illuminate\Database\Concerns\QuotesValue;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Fluent;
 
 class SqlServerGrammar extends Grammar
 {
+    use ExposesDatabase;
     use QuotesValue;
 
     /**

--- a/src/Illuminate/Database/SqlServerConnection.php
+++ b/src/Illuminate/Database/SqlServerConnection.php
@@ -61,7 +61,7 @@ class SqlServerConnection extends Connection
      */
     protected function getDefaultQueryGrammar()
     {
-        return $this->withTablePrefix(new QueryGrammar);
+        return $this->withTablePrefix(new QueryGrammar($this));
     }
 
     /**
@@ -85,7 +85,7 @@ class SqlServerConnection extends Connection
      */
     protected function getDefaultSchemaGrammar()
     {
-        return $this->withTablePrefix(new SchemaGrammar);
+        return $this->withTablePrefix(new SchemaGrammar($this));
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -168,7 +168,7 @@ trait InteractsWithDatabase
      * Cast a JSON string to a database compatible type.
      *
      * @param  array|string  $value
-     * @return \Illuminate\Database\Query\Expression
+     * @return \Illuminate\Contracts\Database\Query\Expression
      */
     public function castAsJson($value)
     {

--- a/src/Illuminate/Support/Facades/DB.php
+++ b/src/Illuminate/Support/Facades/DB.php
@@ -6,7 +6,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Doctrine\DBAL\Driver\PDOConnection getPdo()
  * @method static \Illuminate\Database\ConnectionInterface connection(string $name = null)
  * @method static \Illuminate\Database\Query\Builder table(string $table, string $as = null)
- * @method static \Illuminate\Database\Query\Expression raw($value)
+ * @method static \Illuminate\Contracts\Database\Query\Expression raw($value)
  * @method static array getQueryLog()
  * @method static array prepareBindings(array $bindings)
  * @method static array pretend(\Closure $callback)

--- a/src/Illuminate/Testing/Constraints/HasInDatabase.php
+++ b/src/Illuminate/Testing/Constraints/HasInDatabase.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Testing\Constraints;
 
+use Illuminate\Contracts\Database\Query\Expression;
 use Illuminate\Database\Connection;
-use Illuminate\Database\Query\Expression;
 use PHPUnit\Framework\Constraint\Constraint;
 
 class HasInDatabase extends Constraint

--- a/tests/Database/DatabaseAbstractSchemaGrammarTest.php
+++ b/tests/Database/DatabaseAbstractSchemaGrammarTest.php
@@ -23,6 +23,16 @@ class DatabaseAbstractSchemaGrammarTest extends TestCase
             {
                 return "'{$value}'";
             }
+
+            public function getDatabaseDriver()
+            {
+                return 'tests';
+            }
+
+            public function getDatabaseVersion()
+            {
+                return '0.0.0';
+            }
         };
 
         $this->expectException(LogicException::class);
@@ -38,6 +48,16 @@ class DatabaseAbstractSchemaGrammarTest extends TestCase
             protected function quoteValue($value)
             {
                 return "'{$value}'";
+            }
+
+            public function getDatabaseDriver()
+            {
+                return 'tests';
+            }
+
+            public function getDatabaseVersion()
+            {
+                return '0.0.0';
             }
         };
 

--- a/tests/Database/DatabaseAbstractSchemaGrammarTest.php
+++ b/tests/Database/DatabaseAbstractSchemaGrammarTest.php
@@ -17,7 +17,13 @@ class DatabaseAbstractSchemaGrammarTest extends TestCase
 
     public function testCreateDatabase()
     {
-        $grammar = new class extends Grammar {};
+        $grammar = new class extends Grammar
+        {
+            protected function quoteValue($value)
+            {
+                return "'{$value}'";
+            }
+        };
 
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('This database driver does not support creating databases.');
@@ -27,7 +33,13 @@ class DatabaseAbstractSchemaGrammarTest extends TestCase
 
     public function testDropDatabaseIfExists()
     {
-        $grammar = new class extends Grammar {};
+        $grammar = new class extends Grammar
+        {
+            protected function quoteValue($value)
+            {
+                return "'{$value}'";
+            }
+        };
 
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('This database driver does not support dropping databases.');

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -459,6 +459,16 @@ class DatabaseConnectionTest extends TestCase
                     {
                         return "'{$value}'";
                     }
+
+                    public function getDatabaseDriver()
+                    {
+                        return 'tests';
+                    }
+
+                    public function getDatabaseVersion()
+                    {
+                        return '0.0.0';
+                    }
                 };
             }
 
@@ -469,6 +479,16 @@ class DatabaseConnectionTest extends TestCase
                     protected function quoteValue($value)
                     {
                         return "'{$value}'";
+                    }
+
+                    public function getDatabaseDriver()
+                    {
+                        return 'tests';
+                    }
+
+                    public function getDatabaseVersion()
+                    {
+                        return '0.0.0';
                     }
                 };
             }

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1794,6 +1794,16 @@ class DatabaseEloquentBuilderTest extends TestCase
             {
                 return "'{$value}'";
             }
+
+            public function getDatabaseDriver()
+            {
+                return 'tests';
+            }
+
+            public function getDatabaseVersion()
+            {
+                return '0.0.0';
+            }
         };
     }
 

--- a/tests/Database/DatabaseEloquentHasOneTest.php
+++ b/tests/Database/DatabaseEloquentHasOneTest.php
@@ -2,12 +2,12 @@
 
 namespace Illuminate\Tests\Database;
 
+use Illuminate\Contracts\Database\Query\Expression;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Query\Builder as BaseBuilder;
-use Illuminate\Database\Query\Expression;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Database/DatabaseMySqlBuilderTest.php
+++ b/tests/Database/DatabaseMySqlBuilderTest.php
@@ -17,9 +17,9 @@ class DatabaseMySqlBuilderTest extends TestCase
 
     public function testCreateDatabase()
     {
-        $grammar = new MySqlGrammar;
-
         $connection = m::mock(Connection::class);
+        $grammar = new MySqlGrammar($connection);
+
         $connection->shouldReceive('getConfig')->once()->with('charset')->andReturn('utf8mb4');
         $connection->shouldReceive('getConfig')->once()->with('collation')->andReturn('utf8mb4_unicode_ci');
         $connection->shouldReceive('getSchemaGrammar')->once()->andReturn($grammar);
@@ -33,9 +33,9 @@ class DatabaseMySqlBuilderTest extends TestCase
 
     public function testDropDatabaseIfExists()
     {
-        $grammar = new MySqlGrammar;
-
         $connection = m::mock(Connection::class);
+        $grammar = new MySqlGrammar($connection);
+
         $connection->shouldReceive('getSchemaGrammar')->once()->andReturn($grammar);
         $connection->shouldReceive('statement')->once()->with(
             'drop database if exists `my_database_a`'

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -759,9 +759,14 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingEnum()
     {
+        $connection = $this->getConnection();
+        $grammar = new MySqlGrammar($connection);
+
+        $connection->shouldReceive('quoteString')->andReturnUsing(fn ($value) => "'{$value}'");
+
         $blueprint = new Blueprint('users');
         $blueprint->enum('role', ['member', 'admin']);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($connection, $grammar);
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `role` enum(\'member\', \'admin\') not null', $statements[0]);
@@ -769,9 +774,14 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function testAddingSet()
     {
+        $connection = $this->getConnection();
+        $grammar = new MySqlGrammar($connection);
+
+        $connection->shouldReceive('quoteString')->andReturnUsing(fn ($value) => "'{$value}'");
+
         $blueprint = new Blueprint('users');
         $blueprint->set('role', ['member', 'admin']);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($connection, $grammar);
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `role` set(\'member\', \'admin\') not null', $statements[0]);
@@ -1391,6 +1401,6 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
     public function getGrammar()
     {
-        return new MySqlGrammar;
+        return new MySqlGrammar($this->getConnection());
     }
 }

--- a/tests/Database/DatabasePostgresBuilderTest.php
+++ b/tests/Database/DatabasePostgresBuilderTest.php
@@ -18,7 +18,7 @@ class DatabasePostgresBuilderTest extends TestCase
 
     public function testCreateDatabase()
     {
-        $grammar = new PostgresGrammar;
+        $grammar = $this->getGrammar();
 
         $connection = m::mock(Connection::class);
         $connection->shouldReceive('getConfig')->once()->with('charset')->andReturn('utf8');
@@ -33,7 +33,7 @@ class DatabasePostgresBuilderTest extends TestCase
 
     public function testDropDatabaseIfExists()
     {
-        $grammar = new PostgresGrammar;
+        $grammar = $this->getGrammar();
 
         $connection = m::mock(Connection::class);
         $connection->shouldReceive('getSchemaGrammar')->once()->andReturn($grammar);
@@ -328,6 +328,6 @@ class DatabasePostgresBuilderTest extends TestCase
 
     protected function getGrammar()
     {
-        return new PostgresGrammar;
+        return new PostgresGrammar($this->getConnection());
     }
 }

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -224,9 +224,14 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingPrimaryKey()
     {
+        $connection = $this->getConnection();
+        $grammar = new PostgresGrammar($connection);
+
+        $connection->shouldReceive('quoteValue')->andReturnUsing(fn ($value) => "'{$value}'");
+
         $blueprint = new Blueprint('users');
         $blueprint->primary('foo');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($connection, $grammar);
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add primary key ("foo")', $statements[0]);
@@ -264,9 +269,13 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingFulltextIndex()
     {
+        $connection = $this->getConnection();
+        $grammar = new PostgresGrammar($connection);
+        $connection->shouldReceive('quoteString')->andReturnUsing(fn ($value) => "'{$value}'");
+
         $blueprint = new Blueprint('users');
         $blueprint->fulltext('body');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($connection, $grammar);
 
         $this->assertCount(1, $statements);
         $this->assertSame('create index "users_body_fulltext" on "users" using gin (to_tsvector(\'english\', "body"))', $statements[0]);
@@ -274,9 +283,13 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingFulltextIndexWithLanguage()
     {
+        $connection = $this->getConnection();
+        $grammar = new PostgresGrammar($connection);
+        $connection->shouldReceive('quoteString')->andReturnUsing(fn ($value) => "'{$value}'");
+
         $blueprint = new Blueprint('users');
         $blueprint->fulltext('body')->language('spanish');
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($connection, $grammar);
 
         $this->assertCount(1, $statements);
         $this->assertSame('create index "users_body_fulltext" on "users" using gin (to_tsvector(\'spanish\', "body"))', $statements[0]);
@@ -284,9 +297,13 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingFulltextIndexWithFluency()
     {
+        $connection = $this->getConnection();
+        $grammar = new PostgresGrammar($connection);
+        $connection->shouldReceive('quoteString')->andReturnUsing(fn ($value) => "'{$value}'");
+
         $blueprint = new Blueprint('users');
         $blueprint->string('body')->fulltext();
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($connection, $grammar);
 
         $this->assertCount(2, $statements);
         $this->assertSame('create index "users_body_fulltext" on "users" using gin (to_tsvector(\'english\', "body"))', $statements[1]);
@@ -561,9 +578,14 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testAddingEnum()
     {
+        $connection = $this->getConnection();
+        $grammar = new PostgresGrammar($connection);
+
+        $connection->shouldReceive('quoteString')->andReturnUsing(fn ($value) => "'{$value}'");
+
         $blueprint = new Blueprint('users');
         $blueprint->enum('role', ['member', 'admin']);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($connection, $grammar);
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "role" varchar(255) check ("role" in (\'member\', \'admin\')) not null', $statements[0]);
@@ -1117,7 +1139,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function getGrammar()
     {
-        return new PostgresGrammar;
+        return new PostgresGrammar($this->getConnection());
     }
 
     public function testGrammarsAreMacroable()

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2207,7 +2207,7 @@ class DatabaseQueryBuilderTest extends TestCase
         }, 'post');
         $count = $builder->count();
         $this->assertEquals(1, $count);
-        $this->assertSame('(select "foo", "bar" from "posts" where "title" = ?) as "post"', $builder->columns[0]->getValue());
+        $this->assertSame('(select "foo", "bar" from "posts" where "title" = ?) as "post"', $builder->getGrammar()->getValue($builder->columns[0]));
         $this->assertEquals(['foo'], $builder->getBindings());
     }
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2572,7 +2572,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = m::mock(Builder::class.'[where,exists,insert]', [
             m::mock(ConnectionInterface::class),
-            new Grammar,
+            $this->getGrammar(),
             m::mock(Processor::class),
         ]);
 
@@ -2584,7 +2584,7 @@ class DatabaseQueryBuilderTest extends TestCase
 
         $builder = m::mock(Builder::class.'[where,exists,update]', [
             m::mock(ConnectionInterface::class),
-            new Grammar,
+            $this->getGrammar(),
             m::mock(Processor::class),
         ]);
 
@@ -2600,7 +2600,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = m::spy(Builder::class.'[where,exists,update]', [
             m::mock(ConnectionInterface::class),
-            new Grammar,
+            $this->getGrammar(),
             m::mock(Processor::class),
         ]);
 
@@ -2728,7 +2728,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->getConnection()->shouldReceive('statement')->once()->with('truncate table "users"', []);
         $builder->from('users')->truncate();
 
-        $sqlite = new SQLiteGrammar;
+        $sqlite = new SQLiteGrammar($this->getConnection());
         $builder = $this->getBuilder();
         $builder->from('users');
         $this->assertEquals([
@@ -2864,10 +2864,10 @@ class DatabaseQueryBuilderTest extends TestCase
 
     public function testMySqlUpdateWrappingJson()
     {
-        $grammar = new MySqlGrammar;
+        $connection = $this->createMock(ConnectionInterface::class);
+        $grammar = new MySqlGrammar($connection);
         $processor = m::mock(Processor::class);
 
-        $connection = $this->createMock(ConnectionInterface::class);
         $connection->expects($this->once())
                     ->method('update')
                     ->with(
@@ -2882,7 +2882,8 @@ class DatabaseQueryBuilderTest extends TestCase
 
     public function testMySqlUpdateWrappingNestedJson()
     {
-        $grammar = new MySqlGrammar;
+        $connection = m::mock(Connection::class);
+        $grammar = new MySqlGrammar($connection);
         $processor = m::mock(Processor::class);
 
         $connection = $this->createMock(ConnectionInterface::class);
@@ -2900,10 +2901,10 @@ class DatabaseQueryBuilderTest extends TestCase
 
     public function testMySqlUpdateWrappingJsonArray()
     {
-        $grammar = new MySqlGrammar;
+        $connection = $this->createMock(ConnectionInterface::class);
+        $grammar = new MySqlGrammar($connection);
         $processor = m::mock(Processor::class);
 
-        $connection = $this->createMock(ConnectionInterface::class);
         $connection->expects($this->once())
                     ->method('update')
                     ->with(
@@ -2927,10 +2928,10 @@ class DatabaseQueryBuilderTest extends TestCase
 
     public function testMySqlUpdateWrappingJsonPathArrayIndex()
     {
-        $grammar = new MySqlGrammar;
+        $connection = $this->createMock(ConnectionInterface::class);
+        $grammar = new MySqlGrammar($connection);
         $processor = m::mock(Processor::class);
 
-        $connection = $this->createMock(ConnectionInterface::class);
         $connection->expects($this->once())
                     ->method('update')
                     ->with(
@@ -2950,10 +2951,10 @@ class DatabaseQueryBuilderTest extends TestCase
 
     public function testMySqlUpdateWithJsonPreparesBindingsCorrectly()
     {
-        $grammar = new MySqlGrammar;
+        $connection = m::mock(ConnectionInterface::class);
+        $grammar = new MySqlGrammar($connection);
         $processor = m::mock(Processor::class);
 
-        $connection = m::mock(ConnectionInterface::class);
         $connection->shouldReceive('update')
                     ->once()
                     ->with(
@@ -4368,9 +4369,20 @@ SQL;
         return $connection;
     }
 
+    protected function getGrammar()
+    {
+        return new class extends Grammar
+        {
+            protected function quoteValue($value)
+            {
+                return "'{$value}'";
+            }
+        };
+    }
+
     protected function getBuilder()
     {
-        $grammar = new Grammar;
+        $grammar = $this->getGrammar();
         $processor = m::mock(Processor::class);
 
         return new Builder($this->getConnection(), $grammar, $processor);
@@ -4378,7 +4390,8 @@ SQL;
 
     protected function getPostgresBuilder()
     {
-        $grammar = new PostgresGrammar;
+        $connection = m::mock(Connection::class);
+        $grammar = new PostgresGrammar($connection);
         $processor = m::mock(Processor::class);
 
         return new Builder($this->getConnection(), $grammar, $processor);
@@ -4386,7 +4399,8 @@ SQL;
 
     protected function getMySqlBuilder()
     {
-        $grammar = new MySqlGrammar;
+        $connection = m::mock(Connection::class);
+        $grammar = new MySqlGrammar($connection);
         $processor = m::mock(Processor::class);
 
         return new Builder(m::mock(ConnectionInterface::class), $grammar, $processor);
@@ -4394,7 +4408,8 @@ SQL;
 
     protected function getSQLiteBuilder()
     {
-        $grammar = new SQLiteGrammar;
+        $connection = m::mock(Connection::class);
+        $grammar = new SQLiteGrammar($connection);
         $processor = m::mock(Processor::class);
 
         return new Builder(m::mock(ConnectionInterface::class), $grammar, $processor);
@@ -4402,7 +4417,8 @@ SQL;
 
     protected function getSqlServerBuilder()
     {
-        $grammar = new SqlServerGrammar;
+        $connection = m::mock(Connection::class);
+        $grammar = new SqlServerGrammar($connection);
         $processor = m::mock(Processor::class);
 
         return new Builder($this->getConnection(), $grammar, $processor);
@@ -4410,7 +4426,8 @@ SQL;
 
     protected function getMySqlBuilderWithProcessor()
     {
-        $grammar = new MySqlGrammar;
+        $connection = m::mock(Connection::class);
+        $grammar = new MySqlGrammar($connection);
         $processor = new MySqlProcessor;
 
         return new Builder(m::mock(ConnectionInterface::class), $grammar, $processor);
@@ -4423,7 +4440,7 @@ SQL;
     {
         return m::mock(Builder::class, [
             m::mock(ConnectionInterface::class),
-            new Grammar,
+            $this->getGrammar(),
             m::mock(Processor::class),
         ])->makePartial();
     }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -4377,6 +4377,16 @@ SQL;
             {
                 return "'{$value}'";
             }
+
+            public function getDatabaseDriver()
+            {
+                return 'tests';
+            }
+
+            public function getDatabaseVersion()
+            {
+                return '0.0.0';
+            }
         };
     }
 

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -492,9 +492,14 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function testAddingEnum()
     {
+        $connection = $this->getConnection();
+        $grammar = new SQLiteGrammar($connection);
+
+        $connection->shouldReceive('quoteString')->andReturnUsing(fn ($value) => "'{$value}'");
+
         $blueprint = new Blueprint('users');
         $blueprint->enum('role', ['member', 'admin']);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($connection, $grammar);
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "role" varchar check ("role" in (\'member\', \'admin\')) not null', $statements[0]);
@@ -963,6 +968,6 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
     public function getGrammar()
     {
-        return new SQLiteGrammar;
+        return new SQLiteGrammar($this->getConnection());
     }
 }

--- a/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
@@ -56,7 +56,7 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
             $table->integer('age')->change();
         });
 
-        $queries = $blueprint->toSql($this->db->connection(), new SQLiteGrammar);
+        $queries = $blueprint->toSql($this->db->connection(), new SQLiteGrammar($this->db->connection()));
 
         // Expect one of the following two query sequences to be present...
         $expected = [
@@ -103,8 +103,8 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
             $table->integer('age')->collation('NOCASE')->change();
         });
 
-        $queries = $blueprint->toSql($this->db->connection(), new SQLiteGrammar);
-        $queries2 = $blueprint2->toSql($this->db->connection(), new SQLiteGrammar);
+        $queries = $blueprint->toSql($this->db->connection(), new SQLiteGrammar($this->db->connection()));
+        $queries2 = $blueprint2->toSql($this->db->connection(), new SQLiteGrammar($this->db->connection()));
 
         $expected = [
             'CREATE TEMPORARY TABLE __temp__users AS SELECT age FROM users',
@@ -141,7 +141,7 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
             $table->renameIndex('index1', 'index2');
         });
 
-        $queries = $blueprint->toSql($this->db->connection(), new SQLiteGrammar);
+        $queries = $blueprint->toSql($this->db->connection(), new SQLiteGrammar($this->db->connection()));
 
         $expected = [
             'DROP INDEX index1',
@@ -150,7 +150,7 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
 
         $this->assertEquals($expected, $queries);
 
-        $queries = $blueprint->toSql($this->db->connection(), new SqlServerGrammar);
+        $queries = $blueprint->toSql($this->db->connection(), new SqlServerGrammar($this->db->connection()));
 
         $expected = [
             'sp_rename N\'"users"."index1"\', "index2", N\'INDEX\'',
@@ -158,7 +158,7 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
 
         $this->assertEquals($expected, $queries);
 
-        $queries = $blueprint->toSql($this->db->connection(), new MySqlGrammar);
+        $queries = $blueprint->toSql($this->db->connection(), new MySqlGrammar($this->db->connection()));
 
         $expected = [
             'alter table `users` rename index `index1` to `index2`',
@@ -166,7 +166,7 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
 
         $this->assertEquals($expected, $queries);
 
-        $queries = $blueprint->toSql($this->db->connection(), new PostgresGrammar);
+        $queries = $blueprint->toSql($this->db->connection(), new PostgresGrammar($this->db->connection()));
 
         $expected = [
             'alter index "index1" rename to "index2"',
@@ -185,7 +185,7 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
             $table->string('name')->nullable()->unique()->change();
         });
 
-        $queries = $blueprintMySql->toSql($this->db->connection(), new MySqlGrammar);
+        $queries = $blueprintMySql->toSql($this->db->connection(), new MySqlGrammar($this->db->connection()));
 
         $expected = [
             'CREATE TEMPORARY TABLE __temp__users AS SELECT name FROM users',
@@ -202,7 +202,7 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
             $table->string('name')->nullable()->unique()->change();
         });
 
-        $queries = $blueprintPostgres->toSql($this->db->connection(), new PostgresGrammar);
+        $queries = $blueprintPostgres->toSql($this->db->connection(), new PostgresGrammar($this->db->connection()));
 
         $expected = [
             'CREATE TEMPORARY TABLE __temp__users AS SELECT name FROM users',
@@ -219,7 +219,7 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
             $table->string('name')->nullable()->unique()->change();
         });
 
-        $queries = $blueprintSQLite->toSql($this->db->connection(), new SQLiteGrammar);
+        $queries = $blueprintSQLite->toSql($this->db->connection(), new SQLiteGrammar($this->db->connection()));
 
         $expected = [
             'CREATE TEMPORARY TABLE __temp__users AS SELECT name FROM users',
@@ -236,7 +236,7 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
             $table->string('name')->nullable()->unique()->change();
         });
 
-        $queries = $blueprintSqlServer->toSql($this->db->connection(), new SqlServerGrammar);
+        $queries = $blueprintSqlServer->toSql($this->db->connection(), new SqlServerGrammar($this->db->connection()));
 
         $expected = [
             'CREATE TEMPORARY TABLE __temp__users AS SELECT name FROM users',
@@ -260,7 +260,7 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
             $table->string('name')->nullable()->unique('index1')->change();
         });
 
-        $queries = $blueprintMySql->toSql($this->db->connection(), new MySqlGrammar);
+        $queries = $blueprintMySql->toSql($this->db->connection(), new MySqlGrammar($this->db->connection()));
 
         $expected = [
             'CREATE TEMPORARY TABLE __temp__users AS SELECT name FROM users',
@@ -277,7 +277,7 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
             $table->unsignedInteger('name')->nullable()->unique('index1')->change();
         });
 
-        $queries = $blueprintPostgres->toSql($this->db->connection(), new PostgresGrammar);
+        $queries = $blueprintPostgres->toSql($this->db->connection(), new PostgresGrammar($this->db->connection()));
 
         $expected = [
             'CREATE TEMPORARY TABLE __temp__users AS SELECT name FROM users',
@@ -294,7 +294,7 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
             $table->unsignedInteger('name')->nullable()->unique('index1')->change();
         });
 
-        $queries = $blueprintSQLite->toSql($this->db->connection(), new SQLiteGrammar);
+        $queries = $blueprintSQLite->toSql($this->db->connection(), new SQLiteGrammar($this->db->connection()));
 
         $expected = [
             'CREATE TEMPORARY TABLE __temp__users AS SELECT name FROM users',
@@ -311,7 +311,7 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
             $table->unsignedInteger('name')->nullable()->unique('index1')->change();
         });
 
-        $queries = $blueprintSqlServer->toSql($this->db->connection(), new SqlServerGrammar);
+        $queries = $blueprintSqlServer->toSql($this->db->connection(), new SqlServerGrammar($this->db->connection()));
 
         $expected = [
             'CREATE TEMPORARY TABLE __temp__users AS SELECT name FROM users',

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -113,16 +113,16 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $connection = m::mock(Connection::class);
 
         $blueprint = clone $base;
-        $this->assertEquals(['alter table `users` add `created` datetime default CURRENT_TIMESTAMP not null'], $blueprint->toSql($connection, new MySqlGrammar));
+        $this->assertEquals(['alter table `users` add `created` datetime default CURRENT_TIMESTAMP not null'], $blueprint->toSql($connection, new MySqlGrammar($connection)));
 
         $blueprint = clone $base;
-        $this->assertEquals(['alter table "users" add column "created" timestamp(0) without time zone default CURRENT_TIMESTAMP not null'], $blueprint->toSql($connection, new PostgresGrammar));
+        $this->assertEquals(['alter table "users" add column "created" timestamp(0) without time zone default CURRENT_TIMESTAMP not null'], $blueprint->toSql($connection, new PostgresGrammar($connection)));
 
         $blueprint = clone $base;
-        $this->assertEquals(['alter table "users" add column "created" datetime default CURRENT_TIMESTAMP not null'], $blueprint->toSql($connection, new SQLiteGrammar));
+        $this->assertEquals(['alter table "users" add column "created" datetime default CURRENT_TIMESTAMP not null'], $blueprint->toSql($connection, new SQLiteGrammar($connection)));
 
         $blueprint = clone $base;
-        $this->assertEquals(['alter table "users" add "created" datetime default CURRENT_TIMESTAMP not null'], $blueprint->toSql($connection, new SqlServerGrammar));
+        $this->assertEquals(['alter table "users" add "created" datetime default CURRENT_TIMESTAMP not null'], $blueprint->toSql($connection, new SqlServerGrammar($connection)));
     }
 
     public function testDefaultCurrentTimestamp()
@@ -134,16 +134,16 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $connection = m::mock(Connection::class);
 
         $blueprint = clone $base;
-        $this->assertEquals(['alter table `users` add `created` timestamp default CURRENT_TIMESTAMP not null'], $blueprint->toSql($connection, new MySqlGrammar));
+        $this->assertEquals(['alter table `users` add `created` timestamp default CURRENT_TIMESTAMP not null'], $blueprint->toSql($connection, new MySqlGrammar($connection)));
 
         $blueprint = clone $base;
-        $this->assertEquals(['alter table "users" add column "created" timestamp(0) without time zone default CURRENT_TIMESTAMP not null'], $blueprint->toSql($connection, new PostgresGrammar));
+        $this->assertEquals(['alter table "users" add column "created" timestamp(0) without time zone default CURRENT_TIMESTAMP not null'], $blueprint->toSql($connection, new PostgresGrammar($connection)));
 
         $blueprint = clone $base;
-        $this->assertEquals(['alter table "users" add column "created" datetime default CURRENT_TIMESTAMP not null'], $blueprint->toSql($connection, new SQLiteGrammar));
+        $this->assertEquals(['alter table "users" add column "created" datetime default CURRENT_TIMESTAMP not null'], $blueprint->toSql($connection, new SQLiteGrammar($connection)));
 
         $blueprint = clone $base;
-        $this->assertEquals(['alter table "users" add "created" datetime default CURRENT_TIMESTAMP not null'], $blueprint->toSql($connection, new SqlServerGrammar));
+        $this->assertEquals(['alter table "users" add "created" datetime default CURRENT_TIMESTAMP not null'], $blueprint->toSql($connection, new SqlServerGrammar($connection)));
     }
 
     public function testUnsignedDecimalTable()
@@ -155,7 +155,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $connection = m::mock(Connection::class);
 
         $blueprint = clone $base;
-        $this->assertEquals(['alter table `users` add `money` decimal(10, 2) unsigned not null'], $blueprint->toSql($connection, new MySqlGrammar));
+        $this->assertEquals(['alter table `users` add `money` decimal(10, 2) unsigned not null'], $blueprint->toSql($connection, new MySqlGrammar($connection)));
     }
 
     public function testRemoveColumn()
@@ -170,7 +170,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
         $blueprint = clone $base;
 
-        $this->assertEquals(['alter table `users` add `foo` varchar(255) not null'], $blueprint->toSql($connection, new MySqlGrammar));
+        $this->assertEquals(['alter table `users` add `foo` varchar(255) not null'], $blueprint->toSql($connection, new MySqlGrammar($connection)));
     }
 
     public function testMacroable()
@@ -189,7 +189,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
         $connection = m::mock(Connection::class);
 
-        $this->assertEquals(['bar'], $blueprint->toSql($connection, new MySqlGrammar));
+        $this->assertEquals(['bar'], $blueprint->toSql($connection, new MySqlGrammar($connection)));
     }
 
     public function testDefaultUsingIdMorph()
@@ -205,7 +205,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $this->assertEquals([
             'alter table `comments` add `commentable_type` varchar(255) not null, add `commentable_id` bigint unsigned not null',
             'alter table `comments` add index `comments_commentable_type_commentable_id_index`(`commentable_type`, `commentable_id`)',
-        ], $blueprint->toSql($connection, new MySqlGrammar));
+        ], $blueprint->toSql($connection, new MySqlGrammar($connection)));
     }
 
     public function testDefaultUsingNullableIdMorph()
@@ -221,7 +221,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $this->assertEquals([
             'alter table `comments` add `commentable_type` varchar(255) null, add `commentable_id` bigint unsigned null',
             'alter table `comments` add index `comments_commentable_type_commentable_id_index`(`commentable_type`, `commentable_id`)',
-        ], $blueprint->toSql($connection, new MySqlGrammar));
+        ], $blueprint->toSql($connection, new MySqlGrammar($connection)));
     }
 
     public function testDefaultUsingUuidMorph()
@@ -239,7 +239,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $this->assertEquals([
             'alter table `comments` add `commentable_type` varchar(255) not null, add `commentable_id` char(36) not null',
             'alter table `comments` add index `comments_commentable_type_commentable_id_index`(`commentable_type`, `commentable_id`)',
-        ], $blueprint->toSql($connection, new MySqlGrammar));
+        ], $blueprint->toSql($connection, new MySqlGrammar($connection)));
     }
 
     public function testDefaultUsingNullableUuidMorph()
@@ -257,7 +257,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $this->assertEquals([
             'alter table `comments` add `commentable_type` varchar(255) null, add `commentable_id` char(36) null',
             'alter table `comments` add index `comments_commentable_type_commentable_id_index`(`commentable_type`, `commentable_id`)',
-        ], $blueprint->toSql($connection, new MySqlGrammar));
+        ], $blueprint->toSql($connection, new MySqlGrammar($connection)));
     }
 
     public function testGenerateRelationshipColumnWithIncrementalModel()
@@ -272,7 +272,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
         $this->assertEquals([
             'alter table `posts` add `user_id` bigint unsigned not null',
-        ], $blueprint->toSql($connection, new MySqlGrammar));
+        ], $blueprint->toSql($connection, new MySqlGrammar($connection)));
     }
 
     public function testGenerateRelationshipColumnWithUuidModel()
@@ -289,7 +289,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
         $this->assertEquals([
             'alter table `posts` add `eloquent_model_uuid_stub_id` char(36) not null',
-        ], $blueprint->toSql($connection, new MySqlGrammar));
+        ], $blueprint->toSql($connection, new MySqlGrammar($connection)));
     }
 
     public function testTinyTextColumn()
@@ -303,22 +303,22 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $blueprint = clone $base;
         $this->assertEquals([
             'alter table `posts` add `note` tinytext not null',
-        ], $blueprint->toSql($connection, new MySqlGrammar));
+        ], $blueprint->toSql($connection, new MySqlGrammar($connection)));
 
         $blueprint = clone $base;
         $this->assertEquals([
             'alter table "posts" add column "note" text not null',
-        ], $blueprint->toSql($connection, new SQLiteGrammar));
+        ], $blueprint->toSql($connection, new SQLiteGrammar($connection)));
 
         $blueprint = clone $base;
         $this->assertEquals([
             'alter table "posts" add column "note" varchar(255) not null',
-        ], $blueprint->toSql($connection, new PostgresGrammar));
+        ], $blueprint->toSql($connection, new PostgresGrammar($connection)));
 
         $blueprint = clone $base;
         $this->assertEquals([
             'alter table "posts" add "note" nvarchar(255) not null',
-        ], $blueprint->toSql($connection, new SqlServerGrammar));
+        ], $blueprint->toSql($connection, new SqlServerGrammar($connection)));
     }
 
     public function testTinyTextNullableColumn()
@@ -332,21 +332,21 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $blueprint = clone $base;
         $this->assertEquals([
             'alter table `posts` add `note` tinytext null',
-        ], $blueprint->toSql($connection, new MySqlGrammar));
+        ], $blueprint->toSql($connection, new MySqlGrammar($connection)));
 
         $blueprint = clone $base;
         $this->assertEquals([
             'alter table "posts" add column "note" text',
-        ], $blueprint->toSql($connection, new SQLiteGrammar));
+        ], $blueprint->toSql($connection, new SQLiteGrammar($connection)));
 
         $blueprint = clone $base;
         $this->assertEquals([
             'alter table "posts" add column "note" varchar(255) null',
-        ], $blueprint->toSql($connection, new PostgresGrammar));
+        ], $blueprint->toSql($connection, new PostgresGrammar($connection)));
 
         $blueprint = clone $base;
         $this->assertEquals([
             'alter table "posts" add "note" nvarchar(255) null',
-        ], $blueprint->toSql($connection, new SqlServerGrammar));
+        ], $blueprint->toSql($connection, new SqlServerGrammar($connection)));
     }
 }

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -537,9 +537,14 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function testAddingEnum()
     {
+        $connection = $this->getConnection();
+        $grammar = new SqlServerGrammar($connection);
+
+        $connection->shouldReceive('quoteString')->andReturnUsing(fn ($value) => "N'{$value}'");
+
         $blueprint = new Blueprint('users');
         $blueprint->enum('role', ['member', 'admin']);
-        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+        $statements = $blueprint->toSql($connection, $grammar);
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add "role" nvarchar(255) check ("role" in (N\'member\', N\'admin\')) not null', $statements[0]);
@@ -967,6 +972,6 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
     public function getGrammar()
     {
-        return new SqlServerGrammar;
+        return new SqlServerGrammar($this->getConnection());
     }
 }

--- a/tests/Database/SqlServerBuilderTest.php
+++ b/tests/Database/SqlServerBuilderTest.php
@@ -17,9 +17,9 @@ class SqlServerBuilderTest extends TestCase
 
     public function testCreateDatabase()
     {
-        $grammar = new SqlServerGrammar;
-
         $connection = m::mock(Connection::class);
+        $grammar = new SqlServerGrammar($connection);
+
         $connection->shouldReceive('getSchemaGrammar')->once()->andReturn($grammar);
         $connection->shouldReceive('statement')->once()->with(
             'create database "my_temporary_database_a"'
@@ -31,9 +31,9 @@ class SqlServerBuilderTest extends TestCase
 
     public function testDropDatabaseIfExists()
     {
-        $grammar = new SqlServerGrammar;
-
         $connection = m::mock(Connection::class);
+        $grammar = new SqlServerGrammar($connection);
+
         $connection->shouldReceive('getSchemaGrammar')->once()->andReturn($grammar);
         $connection->shouldReceive('statement')->once()->with(
             'drop database if exists "my_temporary_database_b"'

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -82,7 +82,7 @@ class SchemaBuilderTest extends DatabaseTestCase
             $table->tinyInteger('test_column')->change();
         });
 
-        $blueprint->build($this->getConnection(), new SQLiteGrammar);
+        $blueprint->build($this->getConnection(), new SQLiteGrammar($this->getConnection()));
 
         $this->assertArrayHasKey(TinyInteger::NAME, Type::getTypesMap());
         $this->assertSame('tinyinteger', Schema::getColumnType('test', 'test_column'));

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -60,7 +60,7 @@ class SchemaBuilderTest extends DatabaseTestCase
             $table->tinyInteger('test_column')->change();
         });
 
-        $blueprint->build($this->getConnection(), new SQLiteGrammar);
+        $blueprint->build($this->getConnection(), new SQLiteGrammar($this->getConnection()));
 
         $this->assertArrayHasKey(TinyInteger::NAME, Type::getTypesMap());
         $this->assertSame('tinyinteger', Schema::getColumnType('test', 'test_column'));


### PR DESCRIPTION
I was impressed by [@olliecodes](https://twitter.com/olliecodes) on twitter about his idea on [using expression classes to replace `DB::raw()` statements](https://twitter.com/olliecodes/status/1469282288944828421?s=20). Basically, the idea is to use custom expression classes instead of raw expressions:

```php
use Illuminate\Database\Query\Expression;
use Illuminate\Support\Facades\DB;

DB::table('table')
    ->select(DB::raw('COALESCE(column1, column2) AS column'))
    ->dump(); // select coalesce(column1, column2) as column from "table"

// will be replaced with

class Alias extends Expression
{
    public function __construct(mixed $column, string $alias)
    {
        parent::__construct("{$column} as {$alias}");
    }
}

class Coalesce extends Expression
{
    public function __construct(mixed... $columns)
    {
        $columns = implode(', ', $columns);

        parent::__construct("coalesce({$columns})");
    }
}

DB::table('table')
    ->select(new Alias(new Column(['column1', 'column2']), 'column')))
    ->dump() // select coalesce(column1, column2) as column from "table";
``` 

The idea is really great because this concept will allow:
* Replacing of database-specifc raw code with objects which will work for all databases
* Higher-level database operations like fulltext relevance sorting hiding their details

But that's only the idea, in reality it does not work because database expressions are grammar-independent:
* You can't make a single class like `Uuid` which will use different functions for every database engine
* Column name escaping rules are dependent on the database engine (backticks for MySQL, double quotes for everyone else)
* Using raw string literals is impossible because there is no way to escape them

So i've been going through the Laravel source code to fix all these problems by making expression classes more intelligent. In the end the best solution i found was giving expressions access to the grammar they will be rendered for and add some more information to the grammar the expressions will need.

The pull request is basically separated into 3 steps to make it more understandable. I will explain the changes to Laravel and how they affect query expressions:

# Commits

## 1. Expression classes have access to the grammar

The biggest obstacle of the actual implementation is the expression class. It's sole purpose is to return a raw string which is directly embed into query. But as explained before, a simple construct like a sql alias may need to properly quote column or alias names because of reserved words in databases. To solve that problem the expression's `__toString()` function has been removed and the only way to get the string representation is now the `getValue()` method which will be provided a grammar instance. With access to the grammar class the name wrapping functions can be used.

```php
use Illuminate\Database\Grammar;
use Illuminate\Contracts\Database\Query\Expression;
use Illuminate\Support\Facades\DB;

class Alias implements Expression
{
    public function __construct(
        private Expression|string $expression,
        private string $alias,
    ) {}

    public function getValue(Grammar $grammar)
    {
        return $grammar->wrap($this->expression).' as '.$grammar->wrap($this->alias);
    }
}

DB::table('table')
    ->select([new Alias('column', 'aliased_column')])
    ->dump(); // select "column" as "aliased_column" from "table"
```

## 2. String quoting support in the grammar instance
The former step solves a big problem on how to build up correctly formatted sql constructs by expressions. But there will be cases you need to use raw literals and in the worst case they may be user-input. And user-input must never be used without precautionary measures: they need to be escaped. Adding placeholder support and returning bindings to expressions was a very hard task i didn't finish as i ran in to many edge cases. The most simple solution, and needing the least changes, was to add string quoting support to the grammar (`quoteString()`). For this, all grammars have been extended by getting the connection object. By using the connection, the expression can work on the real encoding settings used in the pdo connection. In the future the grammars could be more intelligent because they have real access to the database.

```php
use Illuminate\Database\Grammar;
use Illuminate\Contracts\Database\Query\Expression;
use Illuminate\Support\Facades\DB;

class Coalesce implements Expression
{
    private array $expresssions;

    public function __construct(mixed... $expresssions)
    {
        $this->expresssions = $expresssions;
    }

    public function getValue(Grammar $grammar)
    {
        return 'coalesce('.implode(', ', $grammar->wrapArray($grammar->getValue($this->expresssions))).')';
    }
}

class Value implements Expression
{
    public function __construct(
        private bool|float|int|string $value,
    ) { }

    public function getValue(Grammar $grammar)
    {
        return match (true) {
            is_bool($this->value) => $this->value ? 'true' : 'false',
            is_numeric($this->value) => $this->value,
            default => $grammar->quoteString($this->value),
        };
    }
}

DB::table('table')
    ->select([new Coalesce('column', new Value("Robert '); DROP TABLE Students;--"))])
    ->dump(); // select coalesce("column", 'Robert ''); DROP TABLE Students;--') from "table"
```

By the way, I also fixed with this change the database migration support for enums. If you specify an enum value with a single quote you get an invalid sql statement because you made a sql injection. With access to proper quoting these enum values can be correctly escaped!

## 3. Database driver name and version support for grammars
The functionality until this point is very nice, you can achieve a lot with it! But my goal was to get rid of database-specific implementations. The speciality should be handled by the expressions, not the programmer using different expressions. So again I extended the grammar and added methods to get the database driver name (`getDatabaseDriver()`) and database version (`getDatabaseVersion ()`) to the grammar which are invocable by the expression. Now we really gain support for expressions to be used in multiple databases:

```php
use Illuminate\Database\Grammar;
use Illuminate\Contracts\Database\Query\Expression;
use Illuminate\Support\Facades\DB;

class Uuid implements Expression
{
    public function getValue(Grammar $grammar)
    {
        return match (true) {
            $grammar->getDatabaseDriver() === 'mysql' => 'uuid()',
            $grammar->getDatabaseDriver() === 'pgsql'
                && version_compare($grammar->getDatabaseVersion(), '13', '>=') => 'gen_random_uuid()',
            $grammar->getDatabaseDriver() === 'pgsql' => 'uuid_generate_v4()',
        };
    }
}

DB::table('table')->update(['uuid' => new Uuid()]);
// MySQL: update `table` set `uuid` = uuid()
// PostgreSQL <13: update "table" set "uuid" = uuid_generate_v4()
// PostgreSQL >= 13: update "table" set "uuid" = gen_random_uuid()
```

# Notes

## Chaining
The expressions are "chainable" and support column names, expressions and literal values, so you can build very complex ones. Possible candidates for highly specific ones needing chainability are window-functions or many other cases:

```php
 DB::table('table')
    ->select(new Coalesce(new Coalesce('column1', 'column2'), 'column3', new Value('final value')))
    ->dump(); // select coalesce(coalesce("column1", "column2"), "column3", 'final value') from "table"
```

## Provided Expressions
Providing final ready-to-use expressions is out of the scope of this pull request. Also i believe Laravel should only provide the foundation for custom expressions but not their implementation to keep the core maintainable. Expressions should be provided by the community. When this will be merged, I will work with the community to [provide a set of expressions](https://github.com/tpetry/laravel-query-expressions) ready for the Laravel 9 release date.

---

This was multiple days of work, and I tried to find ways for changing the least amount of code. If there is something I should change, optimize or explain why I changed it, don't hesitate to comment. Any other feedback? Do you believe this is useful?

Final Note: The changes to the Laravel core are too deep for a package. So, it's not possible to repackage it for a package.