### PR TITLE
[8.x] Add a mergeIfMissing method to the Illuminate Http Request class

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -344,9 +344,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
             return $this->getInputSource()->has($key);
         })->toArray();
 
-        $this->getInputSource()->add($input);
-
-        return $this;
+        return $this->merge($input);
     }
 
     /**

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -332,6 +332,24 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     }
 
     /**
+     * Merge new input into the current request's input array,
+     * but only when that key is missing from the request.
+     *
+     * @param  array  $input
+     * @return $this
+     */
+    public function mergeIfMissing(array $input)
+    {
+        $input = collect($input)->reject(function ($value, $key) {
+            return $this->getInputSource()->has($key);
+        })->toArray();
+
+        $this->getInputSource()->add($input);
+
+        return $this;
+    }
+
+    /**
      * Replace the input for the current request.
      *
      * @param  array  $input

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -332,19 +332,16 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     }
 
     /**
-     * Merge new input into the current request's input array,
-     * but only when that key is missing from the request.
+     * Merge new input into the request's input, but only when that key is missing from the request.
      *
      * @param  array  $input
      * @return $this
      */
     public function mergeIfMissing(array $input)
     {
-        $input = collect($input)->filter(function ($value, $key) {
+        return $this->merge(collect($input)->filter(function ($value, $key) {
             return $this->missing($key);
-        })->toArray();
-
-        return $this->merge($input);
+        })->toArray());
     }
 
     /**

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -340,8 +340,8 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      */
     public function mergeIfMissing(array $input)
     {
-        $input = collect($input)->reject(function ($value, $key) {
-            return $this->getInputSource()->has($key);
+        $input = collect($input)->filter(function ($value, $key) {
+            return $this->missing($key);
         })->toArray();
 
         return $this->merge($input);

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -752,6 +752,21 @@ class HttpRequestTest extends TestCase
         $this->assertSame('Dayle', $request->input('buddy'));
     }
 
+    public function testMergeIfMissingMethod()
+    {
+        $request = Request::create('/', 'GET', ['name' => 'Taylor']);
+        $merge = ['boolean_setting' => 0];
+        $request->mergeIfMissing($merge);
+        $this->assertSame('Taylor', $request->input('name'));
+        $this->assertSame(0, $request->input('boolean_setting'));
+
+        $request = Request::create('/', 'GET', ['name' => 'Taylor', 'boolean_setting' => 1]);
+        $merge = ['boolean_setting' => 0];
+        $request->mergeIfMissing($merge);
+        $this->assertSame('Taylor', $request->input('name'));
+        $this->assertSame(1, $request->input('boolean_setting'));
+    }
+
     public function testReplaceMethod()
     {
         $request = Request::create('/', 'GET', ['name' => 'Taylor']);


### PR DESCRIPTION
When unticking a checkbox and submitting my form, no value for that field is sent to the server. I couldn't guarantee that the column actually wanted to be turned off.

So I added a little check to merge in the "off" state when that key was missing from the request.

Thought it might make a nice little addition.

Before:
```
if ($request->missing('boolean_setting')) {
    $request->merge(['boolean_setting' => 0]);
}
```
After:
```
$request->mergeIfMissing(['boolean_setting' => 0])
```