### PR TITLE
[8.x] Added method to docblock

### DIFF
--- a/src/Illuminate/Support/Facades/Storage.php
+++ b/src/Illuminate/Support/Facades/Storage.php
@@ -41,6 +41,7 @@ use Illuminate\Filesystem\Filesystem;
  * @method static string|false putFile(string $path, \Illuminate\Http\File|\Illuminate\Http\UploadedFile|string $file, mixed $options = [])
  * @method static string|false putFileAs(string $path, \Illuminate\Http\File|\Illuminate\Http\UploadedFile|string $file, string $name, mixed $options = [])
  * @method static void macro(string $name, object|callable $macro)
+ * @method static void buildTemporaryUrlsUsing(\Closure $callback)
  *
  * @see \Illuminate\Filesystem\FilesystemManager
  */


### PR DESCRIPTION
Hey! This PR just adds the `buildTemporaryUrlsUsing()` method (that was merged in #40100) to the docblock for the `Storage` facade :)