### PR TITLE
[9.x] Added View Create Command

### DIFF
--- a/src/Illuminate/Foundation/Console/ViewCreateCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewCreateCommand.php
@@ -57,7 +57,7 @@ class ViewCreateCommand extends Command
         if (file_exists($viewPath) && ! $force) {
 
             $this->error('View already exists!');
-            
+
             return Command::FAILURE;
         } elseif (file_exists($viewPath) && $force) {
             unlink($viewPath);

--- a/src/Illuminate/Foundation/Console/ViewCreateCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewCreateCommand.php
@@ -57,6 +57,7 @@ class ViewCreateCommand extends Command
         if (file_exists($viewPath) && ! $force) {
 
             $this->error('View already exists!');
+            
             return Command::FAILURE;
         } elseif (file_exists($viewPath) && $force) {
             unlink($viewPath);

--- a/src/Illuminate/Foundation/Console/ViewCreateCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewCreateCommand.php
@@ -41,8 +41,8 @@ class ViewCreateCommand extends Command
     public function handle()
     {
 
-        // Here, we look at whether there is a view file to be created, then the relevant  
-        // answers are returned to those who use the command, and at the end, the view file is  
+        // Here, we look at whether there is a view file to be created, then the relevant
+        // answers are returned to those who use the command, and at the end, the view file is
         // created.
 
         $force = $this->option('force');
@@ -66,14 +66,15 @@ class ViewCreateCommand extends Command
         if (! is_dir(dirname($viewPath)) && $path) {
             mkdir(dirname($viewPath), 0755, true);
         } elseif (! is_dir(dirname($viewPath)) && ! $path) {
-            $this->error("Directory does not exist!");
+            $this->error('Directory does not exist!');
             $this->info('If you want to create the directory as well add the -p flag');
 
             return Command::FAILURE;
         }
 
         $this->info('Creating view:'.$viewName.'.blade.php');
-        file_put_contents($viewPath, '@extends(\'layouts.app\')' . "\n\n" . '@section(\'content\')' . "\n\n" . '@endsection');
+        file_put_contents($viewPath, '@extends(\'layouts.app\')'."\n\n".'@section(\'content\')'."\n\n".'@endsection');
+
         return Command::SUCCESS;
     }
 }

--- a/src/Illuminate/Foundation/Console/ViewCreateCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewCreateCommand.php
@@ -12,7 +12,7 @@ class ViewCreateCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'view:create {name} 
+    protected $signature = 'make:view {name} 
                 {--p|path : If the specified directory does not exist, it creates a directory.}
                 {--f|force : Overwrite existing view if any}';
 

--- a/src/Illuminate/Foundation/Console/ViewCreateCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewCreateCommand.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Str;
+
+class ViewCreateCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'view:create {name} 
+                {--p|path : If the specified directory does not exist, it creates a directory.}
+                {--f|force : Overwrite existing view if any}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a view file in the resources/views directory';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+
+        // Here, we look at whether there is a view file to be created, then the relevant  
+        // answers are returned to those who use the command, and at the end, the view file is  
+        // created.
+
+        $force = $this->option('force');
+        $path = $this->option('path');
+
+        // If it specifies directory and file as dots, it converts dots to slash(/)
+        $viewName = Str::of($this->argument('name'))->replace('.', DIRECTORY_SEPARATOR)->replace('//', '/');
+
+        $viewPath = resource_path('views/' . $viewName . '.blade.php');
+
+        // If the file exists, and the user wants to overwrite it, it will be overwritten.
+        if (file_exists($viewPath) && !$force) {
+            $this->error('View already exists!');
+            return Command::FAILURE;
+        } elseif (file_exists($viewPath) && $force) {
+            unlink($viewPath);
+        }
+
+        // If the directory exists, and the user wants to overwrite it, it will be overwritten.
+        if (!is_dir(dirname($viewPath)) && $path) {
+            mkdir(dirname($viewPath), 0755, true);
+        } elseif (!is_dir(dirname($viewPath)) && !$path) {
+            $this->error("Directory does not exist!");
+            $this->info('If you want to create the directory as well add the -p flag');
+
+            return Command::FAILURE;
+        }
+        
+        $this->info('Creating view: ' . $viewName . '.blade.php');
+        file_put_contents($viewPath, '@extends(\'layouts.app\')' . "\n\n" . '@section(\'content\')' . "\n\n" . '@endsection');
+        return Command::SUCCESS;
+    }
+}

--- a/src/Illuminate/Foundation/Console/ViewCreateCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewCreateCommand.php
@@ -55,7 +55,6 @@ class ViewCreateCommand extends Command
 
         // If the file exists, and the user wants to overwrite it, it will be overwritten.
         if (file_exists($viewPath) && ! $force) {
-
             $this->error('View already exists!');
 
             return Command::FAILURE;

--- a/src/Illuminate/Foundation/Console/ViewCreateCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewCreateCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Foundation\Console;
+namespace App\Console\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Str;
@@ -51,10 +51,11 @@ class ViewCreateCommand extends Command
         // If it specifies directory and file as dots, it converts dots to slash(/)
         $viewName = Str::of($this->argument('name'))->replace('.', DIRECTORY_SEPARATOR)->replace('//', '/');
 
-        $viewPath = resource_path('views/' . $viewName . '.blade.php');
+        $viewPath = resource_path('views/'.$viewName.'.blade.php');
 
         // If the file exists, and the user wants to overwrite it, it will be overwritten.
-        if (file_exists($viewPath) && !$force) {
+        if (file_exists($viewPath) && ! $force) {
+
             $this->error('View already exists!');
             return Command::FAILURE;
         } elseif (file_exists($viewPath) && $force) {
@@ -62,16 +63,16 @@ class ViewCreateCommand extends Command
         }
 
         // If the directory exists, and the user wants to overwrite it, it will be overwritten.
-        if (!is_dir(dirname($viewPath)) && $path) {
+        if (! is_dir(dirname($viewPath)) && $path) {
             mkdir(dirname($viewPath), 0755, true);
-        } elseif (!is_dir(dirname($viewPath)) && !$path) {
+        } elseif (! is_dir(dirname($viewPath)) && ! $path) {
             $this->error("Directory does not exist!");
             $this->info('If you want to create the directory as well add the -p flag');
 
             return Command::FAILURE;
         }
-        
-        $this->info('Creating view: ' . $viewName . '.blade.php');
+
+        $this->info('Creating view:'.$viewName.'.blade.php');
         file_put_contents($viewPath, '@extends(\'layouts.app\')' . "\n\n" . '@section(\'content\')' . "\n\n" . '@endsection');
         return Command::SUCCESS;
     }


### PR DESCRIPTION
This command allows to create a view file from terminal. In some cases, when projects grow, it can be annoying to navigate to the resources directory and navigate through the directories in it. With this command, it is sufficient to write only the directory name and the name of the view to be created.
> If the file exists, the command returns a warning.
## normal use
```
php artisan make:view viewName
```

If the specified directory does not exist, it creates a directory by adding the `-p` flag.

```
php artisan make:view directory.viewName -p
```

If a view file exists in the specified directory, it will issue a warning and stop the command. If the user wants to force this, they add the -f flag and the corresponding file is overwritten.

```
php artisan make:view directory.viewName -f
```
