### PR TITLE
Remove redundant check

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/ConvertEmptyStringsToNull.php
+++ b/src/Illuminate/Foundation/Http/Middleware/ConvertEmptyStringsToNull.php
@@ -40,7 +40,7 @@ class ConvertEmptyStringsToNull extends TransformsRequest
      */
     protected function transform($key, $value)
     {
-        return is_string($value) && $value === '' ? null : $value;
+        return $value === '' ? null : $value;
     }
 
     /**


### PR DESCRIPTION
This check should be enough to determinate if the variable is a string and empty.

```php
$value === ''
```