### PR TITLE
Fix prune command with default options

### DIFF
--- a/src/Illuminate/Database/Console/PruneCommand.php
+++ b/src/Illuminate/Database/Console/PruneCommand.php
@@ -91,6 +91,7 @@ class PruneCommand extends Command
         }
 
         $except = $this->option('except');
+
         if (! empty($models) && ! empty($except)) {
             throw new InvalidArgumentException('The --models and --except options cannot be combined.');
         }

--- a/src/Illuminate/Database/Console/PruneCommand.php
+++ b/src/Illuminate/Database/Console/PruneCommand.php
@@ -90,7 +90,8 @@ class PruneCommand extends Command
             return collect($models);
         }
 
-        if (! empty($models) && ! empty($except = $this->option('except'))) {
+        $except = $this->option('except');
+        if (! empty($models) && ! empty($except)) {
             throw new InvalidArgumentException('The --models and --except options cannot be combined.');
         }
 


### PR DESCRIPTION
This PR should fix a bug that has been introduced after the [f62fe66](https://github.com/laravel/framework/commit/f62fe66216ee11bc864e0877d4fd4be4655db4aa) commit when running `model:prune` command with default options.

Step to reproduce:

```bash
php artisan:prune
```

Exception:
```
Undefined variable: except

  at XXX\vendor\laravel\framework\src\Illuminate\Database\Console\PruneCommand.php:106
```