### PR TITLE
[8.x] Accept constructor arguments for `partialMock()`

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
@@ -56,13 +56,24 @@ trait InteractsWithContainer
     /**
      * Mock a partial instance of an object in the container.
      *
-     * @param  string  $abstract
+     * @param  string|array  $abstract
      * @param  \Closure|null  $mock
      * @return \Mockery\MockInterface
      */
     protected function partialMock($abstract, Closure $mock = null)
     {
-        return $this->instance($abstract, Mockery::mock(...array_filter(func_get_args()))->makePartial());
+        $abstractClass = $abstract;
+        $args = func_get_args();
+
+        if (is_array($abstract)) {
+            $abstractClass = $abstract[0];
+
+            if (! is_null($mock)) {
+                $args = array_merge($abstract, [$mock]);
+            }
+        }
+
+        return $this->instance($abstractClass, Mockery::mock(...$args)->makePartial());
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
@@ -63,7 +63,7 @@ trait InteractsWithContainer
     protected function partialMock($abstract, Closure $mock = null)
     {
         $abstractClass = $abstract;
-        $args = func_get_args();
+        $args = array_filter(func_get_args());
 
         if (is_array($abstract)) {
             $abstractClass = $abstract[0];

--- a/tests/Foundation/Testing/Concerns/InteractsWithContainerTest.php
+++ b/tests/Foundation/Testing/Concerns/InteractsWithContainerTest.php
@@ -85,7 +85,7 @@ class PartialMockStub
 
     public function greet()
     {
-        return $this->getGreeting() . ' ' . $this->name;
+        return $this->getGreeting().' '.$this->name;
     }
 
     public function getGreeting()

--- a/tests/Foundation/Testing/Concerns/InteractsWithContainerTest.php
+++ b/tests/Foundation/Testing/Concerns/InteractsWithContainerTest.php
@@ -40,6 +40,30 @@ class InteractsWithContainerTest extends TestCase
         $this->forgetMock(IntanceStub::class);
         $this->assertSame('foo', $this->app->make(IntanceStub::class)->execute());
     }
+
+    public function testPartialMockSimple()
+    {
+        $this->partialMock(IntanceStub::class)
+            ->shouldReceive('sayHi')
+            ->andReturn('Hi');
+
+        $this->assertSame('Hi', $this->app->make(IntanceStub::class)->sayHi());
+    }
+
+    public function testPartialMockConstructor()
+    {
+        $this->partialMock(IntanceStub::class)
+            ->shouldReceive('execute')
+            ->andReturn('bar');
+
+        $this->partialMock([PartialMockStub::class, [$this->app->make(IntanceStub::class)]], function ($mock) {
+            $mock
+                ->shouldReceive('getGreeting')
+                ->andReturn('Hi');
+        });
+
+        $this->assertSame('Hi bar', $this->app->make(PartialMockStub::class)->greet());
+    }
 }
 
 class IntanceStub
@@ -47,5 +71,25 @@ class IntanceStub
     public function execute()
     {
         return 'foo';
+    }
+}
+
+class PartialMockStub
+{
+    private $intanceStub;
+
+    public function __construct(IntanceStub $intanceStub)
+    {
+        $this->intanceStub = $intanceStub;
+    }
+
+    public function greet()
+    {
+        return $this->getGreeting() . ' ' . $this->intanceStub->execute();
+    }
+
+    public function getGreeting()
+    {
+        return 'Hello';
     }
 }

--- a/tests/Foundation/Testing/Concerns/InteractsWithContainerTest.php
+++ b/tests/Foundation/Testing/Concerns/InteractsWithContainerTest.php
@@ -44,10 +44,10 @@ class InteractsWithContainerTest extends TestCase
     public function testPartialMockSimple()
     {
         $this->partialMock(IntanceStub::class)
-            ->shouldReceive('sayHi')
-            ->andReturn('Hi');
+            ->shouldReceive('execute')
+            ->andReturn('bar');
 
-        $this->assertSame('Hi', $this->app->make(IntanceStub::class)->sayHi());
+        $this->assertSame('bar', $this->app->make(IntanceStub::class)->execute());
     }
 
     public function testPartialMockConstructor()
@@ -56,7 +56,7 @@ class InteractsWithContainerTest extends TestCase
             ->shouldReceive('execute')
             ->andReturn('bar');
 
-        $this->partialMock([PartialMockStub::class, [$this->app->make(IntanceStub::class)]], function ($mock) {
+        $this->partialMock([PartialMockStub::class, ['bar']], function ($mock) {
             $mock
                 ->shouldReceive('getGreeting')
                 ->andReturn('Hi');
@@ -76,16 +76,16 @@ class IntanceStub
 
 class PartialMockStub
 {
-    private $intanceStub;
+    private $name;
 
-    public function __construct(IntanceStub $intanceStub)
+    public function __construct($name)
     {
-        $this->intanceStub = $intanceStub;
+        $this->name = $name;
     }
 
     public function greet()
     {
-        return $this->getGreeting() . ' ' . $this->intanceStub->execute();
+        return $this->getGreeting() . ' ' . $this->name;
     }
 
     public function getGreeting()


### PR DESCRIPTION
Currently `partialMock()` only accepts the abstract and an optional Closure. This works fine, until you need to mock classes with a constructor: in that case you can't anymore use `partialMock()` but you have to manually create a mock and swap the instance.

This PR adds additional parameters to the function: it's meant to be used for constructor arguments, but it works also for any other Mockery params, such as interfaces.

----

**Example**

```php
class MyService
{
    public function __construct(protected string $name)
    {
        //
    }

    public function greet()
    {
        return $this->getGreeting() . ' ' . $this->name;
    }

    public function getGreeting()
    {
        return 'Hello';
    }
}
```

Given this class, currently you can't just use `partialMock()` because it would lead to `$name` to not being initialized:

```php
$this->partialMock(MyService::class)
    ->shouldReceive('getGreeting')
    ->andReturn('Hi');

// Error: Typed property MyService::$name must not be accessed before initialization
```

Instead of you have to manually create the mock and bind it to the container:

```php
/** @var \Mockery\MockInterface $mock */
$mock = \Mockery::mock(MyService::class, ['Foo']);
$mock->makePartial()
    ->shouldReceive('getGreeting')
    ->andReturn('Hi');

$this->app->instance(MyService::class, $mock);
```

With this PR you can, instead, pass any additional argument and solve it easily:

```php
$this->partialMock([PartialMockStub::class, ['bar']], function (MockInterface $mock) {
    $mock
        ->shouldReceive('getGreeting')
        ->andReturn('Hi');
});
```

----

**Alternative syntax**

While writing this I was thinking about how to implement it without introducing a breaking change. The current solution I adopted is to pass an array with the `abstract` and then an array of any additional arguments.  
Another syntax (style 2) could be just to pass any additional arg after the abstract (no need for a nested array) that could be easier to read and write:

```php
$this->partialMock([PartialMockStub::class, 'bar'], function (MockInterface $mock) {
    $mock
        ->shouldReceive('getGreeting')
        ->andReturn('Hi');
});
```

And, finally, a third option:

```php
$this->withMockArguments($arg1, $arg2)->partialMock(PartialMockStub::class, function (MockInterface $mock) {
    $mock
        ->shouldReceive('getGreeting')
        ->andReturn('Hi');
});
```

What syntax do you think is better?