### PR TITLE
[8.x] Implement Full-Text Search for MySQL & PostgreSQL

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1829,7 +1829,7 @@ class Builder
      * @param  string  $boolean
      * @return $this
      */
-    public function whereFulltext($columns, $value, array $options = [], $boolean = 'and')
+    public function whereFullText($columns, $value, array $options = [], $boolean = 'and')
     {
         $type = 'Fulltext';
 
@@ -1849,7 +1849,7 @@ class Builder
      * @param  string  $value
      * @return $this
      */
-    public function orWhereFulltext($columns, $value, array $options = [])
+    public function orWhereFullText($columns, $value, array $options = [])
     {
         return $this->whereFulltext($columns, $value, $options, 'or');
     }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1837,6 +1837,8 @@ class Builder
 
         $this->wheres[] = compact('type', 'columns', 'value', 'options', 'boolean');
 
+        $this->addBinding($value);
+
         return $this;
     }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1841,6 +1841,18 @@ class Builder
     }
 
     /**
+     * Add a "or where fulltext" clause to the query.
+     *
+     * @param  string|string[]  $columns
+     * @param  string  $value
+     * @return $this
+     */
+    public function orWhereFulltext($columns, $value, array $options = [])
+    {
+        return $this->whereFulltext($columns, $value, $options, 'or');
+    }
+
+    /**
      * Add a "group by" clause to the query.
      *
      * @param  array|string  ...$groups

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1822,18 +1822,16 @@ class Builder
     }
 
     /**
-     * Add a "match against" clause to the query.
+     * Add a "where fulltext" clause to the query.
      *
      * @param  string|string[]  $column
      * @param  string|string[]  $values
      * @param  string  $boolean
-     * @param  bool  $expanded
-     * @param  string  $mode
      * @return $this
      */
-    public function matchAgainst($columns, $values, $boolean = 'and', bool $expanded = false, string $mode = '')
+    public function whereFulltext($columns, $values, array $options = [], $boolean = 'and')
     {
-        $type = 'MatchAgainst';
+        $type = 'Fulltext';
 
         // Next, if the value is Arrayable we need to cast it to its raw array form so we
         // have the underlying array value instead of an Arrayable object which is not
@@ -1845,39 +1843,11 @@ class Builder
         $columns = (array) $columns;
         $value = collect($this->cleanBindings((array) $values))->implode(',');
 
-        $this->wheres[] = compact('type', 'columns', 'value', 'expanded', 'mode', 'boolean');
+        $this->wheres[] = compact('type', 'columns', 'value', 'options', 'boolean');
 
         $this->addBinding($value);
 
         return $this;
-    }
-
-    /**
-     * Add a "match against in boolean mode" clause to the query.
-     *
-     * @param  string|string[]  $column
-     * @param  string|string[]  $values
-     * @param  string  $boolean
-     * @param  bool  $expanded
-     * @return $this
-     */
-    public function matchAgainstBoolean($columns, $values, $boolean = 'and', bool $expanded = false)
-    {
-        return $this->matchAgainst($columns, $values, $boolean, $expanded, 'boolean');
-    }
-
-    /**
-     * Add a "match against with expanded query" clause to the query.
-     *
-     * @param  string|string[]  $column
-     * @param  string|string[]  $values
-     * @param  string  $boolean
-     * @param  string  $mode
-     * @return $this
-     */
-    public function matchAgainstExpanded($columns, $values, $boolean = 'and', string $mode = '')
-    {
-        return $this->matchAgainst($columns, $values, $boolean, true, $mode);
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1824,7 +1824,7 @@ class Builder
     /**
      * Add a "where fulltext" clause to the query.
      *
-     * @param  string|string[]  $column
+     * @param  string|string[]  $columns
      * @param  string  $value
      * @param  string  $boolean
      * @return $this

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1822,6 +1822,65 @@ class Builder
     }
 
     /**
+     * Add a "match against" clause to the query.
+     *
+     * @param  string|string[]  $column
+     * @param  string|string[]  $values
+     * @param  string  $boolean
+     * @param  bool  $expanded
+     * @param  string  $mode
+     * @return $this
+     */
+    public function matchAgainst($columns, $values, $boolean = 'and', bool $expanded = false, string $mode = '')
+    {
+        $type = 'MatchAgainst';
+
+        // Next, if the value is Arrayable we need to cast it to its raw array form so we
+        // have the underlying array value instead of an Arrayable object which is not
+        // able to be added as a binding, etc. We will then add to the wheres array.
+        if ($values instanceof Arrayable) {
+            $values = $values->toArray();
+        }
+
+        $columns = (array) $columns;
+        $value = collect($this->cleanBindings((array) $values))->implode(',');
+
+        $this->wheres[] = compact('type', 'columns', 'value', 'expanded', 'mode', 'boolean');
+
+        $this->addBinding($value);
+
+        return $this;
+    }
+
+    /**
+     * Add a "match against in boolean mode" clause to the query.
+     *
+     * @param  string|string[]  $column
+     * @param  string|string[]  $values
+     * @param  string  $boolean
+     * @param  bool  $expanded
+     * @return $this
+     */
+    public function matchAgainstBoolean($columns, $values, $boolean = 'and', bool $expanded = false)
+    {
+        return $this->matchAgainst($columns, $values, $boolean, $expanded, 'boolean');
+    }
+
+    /**
+     * Add a "match against with expanded query" clause to the query.
+     *
+     * @param  string|string[]  $column
+     * @param  string|string[]  $values
+     * @param  string  $boolean
+     * @param  string  $mode
+     * @return $this
+     */
+    public function matchAgainstExpanded($columns, $values, $boolean = 'and', string $mode = '')
+    {
+        return $this->matchAgainst($columns, $values, $boolean, true, $mode);
+    }
+
+    /**
      * Add a "group by" clause to the query.
      *
      * @param  array|string  ...$groups

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1837,8 +1837,6 @@ class Builder
 
         $this->wheres[] = compact('type', 'columns', 'value', 'options', 'boolean');
 
-        $this->addBinding($value);
-
         return $this;
     }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1825,23 +1825,15 @@ class Builder
      * Add a "where fulltext" clause to the query.
      *
      * @param  string|string[]  $column
-     * @param  string|string[]  $values
+     * @param  string  $value
      * @param  string  $boolean
      * @return $this
      */
-    public function whereFulltext($columns, $values, array $options = [], $boolean = 'and')
+    public function whereFulltext($columns, $value, array $options = [], $boolean = 'and')
     {
         $type = 'Fulltext';
 
-        // Next, if the value is Arrayable we need to cast it to its raw array form so we
-        // have the underlying array value instead of an Arrayable object which is not
-        // able to be added as a binding, etc. We will then add to the wheres array.
-        if ($values instanceof Arrayable) {
-            $values = $values->toArray();
-        }
-
         $columns = (array) $columns;
-        $value = collect($this->cleanBindings((array) $values))->implode(',');
 
         $this->wheres[] = compact('type', 'columns', 'value', 'options', 'boolean');
 

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -630,6 +630,18 @@ class Grammar extends BaseGrammar
     }
 
     /**
+     * Compile a "where match against" clause.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $match
+     * @return string
+     */
+    public function whereMatchAgainst(Builder $query, $match)
+    {
+        throw new RuntimeException('This database engine does not support MATCH AGAINST operations.');
+    }
+
+    /**
      * Compile the "group by" portions of the query.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -636,7 +636,7 @@ class Grammar extends BaseGrammar
      * @param  array  $where
      * @return string
      */
-    public function whereFulltext(Builder $query, $where)
+    public function whereFullText(Builder $query, $where)
     {
         throw new RuntimeException('This database engine does not support fulltext search operations.');
     }

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -630,15 +630,15 @@ class Grammar extends BaseGrammar
     }
 
     /**
-     * Compile a "where match against" clause.
+     * Compile a "where fulltext" clause.
      *
      * @param  \Illuminate\Database\Query\Builder  $query
-     * @param  array  $match
+     * @param  array  $where
      * @return string
      */
-    public function whereMatchAgainst(Builder $query, $match)
+    public function whereFulltext(Builder $query, $where)
     {
-        throw new RuntimeException('This database engine does not support MATCH AGAINST operations.');
+        throw new RuntimeException('This database engine does not support fulltext search operations.');
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -51,6 +51,26 @@ class MySqlGrammar extends Grammar
     }
 
     /**
+     * Compile a "where match against" clause.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $match
+     * @return string
+     */
+    public function whereMatchAgainst(Builder $query, $match)
+    {
+        $columns = $this->columnize($match['columns']);
+
+        $value = $this->parameter($match['value']);
+
+        $mode = $match['mode'] === 'boolean' ? 'in boolean mode' : 'in natural language mode';
+
+        $expand = $match['expanded'] && $match['mode'] !== 'boolean' ? ' with query expansion' : '';
+
+        return "match ({$columns}) against (".$value." {$mode}{$expand})";
+    }
+
+    /**
      * Compile an insert ignore statement into SQL.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -61,6 +61,7 @@ class MySqlGrammar extends Grammar
     {
         $columns = $this->columnize($where['columns']);
 
+        $query->addBinding($where['value']);
         $value = $this->parameter($where['value']);
 
         $mode = ($where['options']['mode'] ?? []) === 'boolean'

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -57,7 +57,7 @@ class MySqlGrammar extends Grammar
      * @param  array  $where
      * @return string
      */
-    public function whereFulltext(Builder $query, $where)
+    public function whereFullText(Builder $query, $where)
     {
         $columns = $this->columnize($where['columns']);
 

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -61,7 +61,6 @@ class MySqlGrammar extends Grammar
     {
         $columns = $this->columnize($where['columns']);
 
-        $query->addBinding($where['value']);
         $value = $this->parameter($where['value']);
 
         $mode = ($where['options']['mode'] ?? []) === 'boolean'

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -51,23 +51,27 @@ class MySqlGrammar extends Grammar
     }
 
     /**
-     * Compile a "where match against" clause.
+     * Compile a "where fulltext" clause.
      *
      * @param  \Illuminate\Database\Query\Builder  $query
-     * @param  array  $match
+     * @param  array  $where
      * @return string
      */
-    public function whereMatchAgainst(Builder $query, $match)
+    public function whereFulltext(Builder $query, $where)
     {
-        $columns = $this->columnize($match['columns']);
+        $columns = $this->columnize($where['columns']);
 
-        $value = $this->parameter($match['value']);
+        $value = $this->parameter($where['value']);
 
-        $mode = $match['mode'] === 'boolean' ? 'in boolean mode' : 'in natural language mode';
+        $mode = ($where['options']['mode'] ?? []) === 'boolean'
+            ? ' in boolean mode'
+            : ' in natural language mode';
 
-        $expand = $match['expanded'] && $match['mode'] !== 'boolean' ? ' with query expansion' : '';
+        $expanded = ($where['options']['expanded'] ?? []) && ($where['options']['mode'] ?? []) !== 'boolean'
+            ? ' with query expansion'
+            : '';
 
-        return "match ({$columns}) against (".$value." {$mode}{$expand})";
+        return "match ({$columns}) against (".$value."{$mode}{$expanded})";
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -71,15 +71,34 @@ class PostgresGrammar extends Grammar
     }
 
     /**
+     * Compile a date based where clause.
+     *
+     * @param  string  $type
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function dateBasedWhere($type, Builder $query, $where)
+    {
+        $value = $this->parameter($where['value']);
+
+        return 'extract('.$type.' from '.$this->wrap($where['column']).') '.$where['operator'].' '.$value;
+    }
+
+    /**
      * Compile a "where fulltext" clause.
      *
      * @param  \Illuminate\Database\Query\Builder  $query
      * @param  array  $where
      * @return string
      */
-    public function whereFulltext(Builder $query, $where)
+    public function whereFullText(Builder $query, $where)
     {
-        $language = $where['options']['language'] ?? 'english';
+        $language = Str::slug($where['options']['language'] ?? 'english');
+
+        if (! in_array($language, $this->validFullTextLanguages())) {
+            $language = 'english';
+        };
 
         $columns = collect($where['columns'])->map(function ($column) use ($language) {
             return "to_tsvector('{$language}', {$this->wrap($column)})";
@@ -99,18 +118,36 @@ class PostgresGrammar extends Grammar
     }
 
     /**
-     * Compile a date based where clause.
+     * Get an array of valid full text languages.
      *
-     * @param  string  $type
-     * @param  \Illuminate\Database\Query\Builder  $query
-     * @param  array  $where
-     * @return string
+     * @return array
      */
-    protected function dateBasedWhere($type, Builder $query, $where)
+    protected function validFullTextLanguages()
     {
-        $value = $this->parameter($where['value']);
-
-        return 'extract('.$type.' from '.$this->wrap($where['column']).') '.$where['operator'].' '.$value;
+        return [
+            'simple',
+            'arabic',
+            'danish',
+            'dutch',
+            'english',
+            'finnish',
+            'french',
+            'german',
+            'hungarian',
+            'indonesian',
+            'irish',
+            'italian',
+            'lithuanian',
+            'nepali',
+            'norwegian',
+            'portuguese',
+            'romanian',
+            'russian',
+            'spanish',
+            'swedish',
+            'tamil',
+            'turkish',
+        ];
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -82,7 +82,7 @@ class PostgresGrammar extends Grammar
         $language = $where['options']['language'] ?? 'english';
 
         $columns = collect($where['columns'])->map(function ($column) use ($language) {
-            return "to_tsvector({$language}, {$this->wrap($column)})";
+            return "to_tsvector('{$language}', {$this->wrap($column)})";
         })->implode(' || ');
 
         $mode = 'plainto_tsquery';
@@ -95,7 +95,7 @@ class PostgresGrammar extends Grammar
             $mode = 'websearch_to_tsquery';
         }
 
-        return "({$columns}) @@ {$mode}({$language}, {$this->parameter($where['value'])})";
+        return "({$columns}) @@ {$mode}('{$language}', {$this->parameter($where['value'])})";
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -94,7 +94,7 @@ class PostgresGrammar extends Grammar
      */
     public function whereFullText(Builder $query, $where)
     {
-        $language = Str::slug($where['options']['language'] ?? 'english');
+        $language = $where['options']['language'] ?? 'english';
 
         if (! in_array($language, $this->validFullTextLanguages())) {
             $language = 'english';

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -98,7 +98,7 @@ class PostgresGrammar extends Grammar
 
         if (! in_array($language, $this->validFullTextLanguages())) {
             $language = 'english';
-        };
+        }
 
         $columns = collect($where['columns'])->map(function ($column) use ($language) {
             return "to_tsvector('{$language}', {$this->wrap($column)})";

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -87,9 +87,11 @@ class PostgresGrammar extends Grammar
         $columns = implode(' || ', $columns);
 
         $mode = 'plainto_tsquery';
+
         if (($where['options']['mode'] ?? []) === 'phrase') {
             $mode = 'phraseto_tsquery';
         }
+
         if (($where['options']['mode'] ?? []) === 'websearch') {
             $mode = 'websearch_to_tsquery';
         }

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -208,7 +208,7 @@ class Blueprint
     protected function addFluentIndexes()
     {
         foreach ($this->columns as $column) {
-            foreach (['primary', 'unique', 'index', 'fulltext', 'spatialIndex'] as $index) {
+            foreach (['primary', 'unique', 'index', 'fulltext', 'fullText', 'spatialIndex'] as $index) {
                 // If the index has been specified on the given column, but is simply equal
                 // to "true" (boolean), no name has been specified for this index so the
                 // index method can be called without a name and it will generate one.
@@ -373,9 +373,9 @@ class Blueprint
      * @param  string|array  $index
      * @return \Illuminate\Support\Fluent
      */
-    public function dropFulltext($index)
+    public function dropFullText($index)
     {
-        return $this->dropIndexCommand('dropFulltext', 'fulltext', $index);
+        return $this->dropIndexCommand('dropFullText', 'fulltext', $index);
     }
 
     /**
@@ -549,7 +549,7 @@ class Blueprint
      * @param  string|null  $algorithm
      * @return \Illuminate\Support\Fluent
      */
-    public function fulltext($columns, $name = null, $algorithm = null)
+    public function fullText($columns, $name = null, $algorithm = null)
     {
         return $this->indexCommand('fulltext', $columns, $name, $algorithm);
     }

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -104,7 +104,7 @@ abstract class Grammar extends BaseGrammar
      * @param  \Illuminate\Support\Fluent  $command
      * @return string
      */
-    public function compileDropFulltext(Blueprint $blueprint, Fluent $command)
+    public function compileDropFullText(Blueprint $blueprint, Fluent $command)
     {
         throw new RuntimeException('This database driver does not support fulltext index creation.');
     }

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -248,7 +248,7 @@ class MySqlGrammar extends Grammar
      * @param  \Illuminate\Support\Fluent  $command
      * @return string
      */
-    public function compileFulltext(Blueprint $blueprint, Fluent $command)
+    public function compileFullText(Blueprint $blueprint, Fluent $command)
     {
         return $this->compileKey($blueprint, $command, 'fulltext');
     }
@@ -369,7 +369,7 @@ class MySqlGrammar extends Grammar
      * @param  \Illuminate\Support\Fluent  $command
      * @return string
      */
-    public function compileDropFulltext(Blueprint $blueprint, Fluent $command)
+    public function compileDropFullText(Blueprint $blueprint, Fluent $command)
     {
         return $this->compileDropIndex($blueprint, $command);
     }

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -390,7 +390,7 @@ class PostgresGrammar extends Grammar
      * @param  \Illuminate\Support\Fluent  $command
      * @return string
      */
-    public function compileDropFulltext(Blueprint $blueprint, Fluent $command)
+    public function compileDropFullText(Blueprint $blueprint, Fluent $command)
     {
         return $this->compileDropIndex($blueprint, $command);
     }

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -4,7 +4,6 @@ namespace Illuminate\Database\Schema\Grammars;
 
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Fluent;
-use RuntimeException;
 
 class PostgresGrammar extends Grammar
 {
@@ -190,15 +189,14 @@ class PostgresGrammar extends Grammar
     {
         $language = $command->language ?: 'english';
 
-        if (count($command->columns) > 1) {
-            throw new RuntimeException('The PostgreSQL driver does not support fulltext index creation using multiple columns.');
-        }
+        $columns = array_map(function ($column) use ($language) {
+            return "to_tsvector({$this->quoteString($language)}, {$this->wrap($column)})";
+        }, $command->columns);
 
-        return sprintf('create index %s on %s using gin (to_tsvector(%s, %s))',
+        return sprintf('create index %s on %s using gin ((%s))',
             $this->wrap($command->index),
             $this->wrapTable($blueprint),
-            $this->quoteString($language),
-            $this->wrap($command->columns[0])
+            implode(' || ', $columns)
         );
     }
 

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -269,7 +269,17 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('create index "users_body_fulltext" on "users" using gin (to_tsvector(\'english\', "body"))', $statements[0]);
+        $this->assertSame('create index "users_body_fulltext" on "users" using gin ((to_tsvector(\'english\', "body")))', $statements[0]);
+    }
+
+    public function testAddingFulltextIndexMultipleColumns()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->fulltext(['body', 'title']);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('create index "users_body_title_fulltext" on "users" using gin ((to_tsvector(\'english\', "body") || to_tsvector(\'english\', "title")))', $statements[0]);
     }
 
     public function testAddingFulltextIndexWithLanguage()
@@ -279,7 +289,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('create index "users_body_fulltext" on "users" using gin (to_tsvector(\'spanish\', "body"))', $statements[0]);
+        $this->assertSame('create index "users_body_fulltext" on "users" using gin ((to_tsvector(\'spanish\', "body")))', $statements[0]);
     }
 
     public function testAddingFulltextIndexWithFluency()
@@ -289,7 +299,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(2, $statements);
-        $this->assertSame('create index "users_body_fulltext" on "users" using gin (to_tsvector(\'english\', "body"))', $statements[1]);
+        $this->assertSame('create index "users_body_fulltext" on "users" using gin ((to_tsvector(\'english\', "body")))', $statements[1]);
     }
 
     public function testAddingSpatialIndex()

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -891,38 +891,38 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getPostgresBuilderWithProcessor();
         $builder->select('*')->from('users')->whereFulltext('body', 'Hello World');
-        $this->assertSame('select * from "users" where (to_tsvector(?, "body")) @@ plainto_tsquery(?, ?)', $builder->toSql());
-        $this->assertEquals(['english', 'english', 'Hello World'], $builder->getBindings());
+        $this->assertSame('select * from "users" where (to_tsvector(english, "body")) @@ plainto_tsquery(english, ?)', $builder->toSql());
+        $this->assertEquals(['Hello World'], $builder->getBindings());
 
         $builder = $this->getPostgresBuilderWithProcessor();
         $builder->select('*')->from('users')->whereFulltext('body', 'Hello World', ['language' => 'simple']);
-        $this->assertSame('select * from "users" where (to_tsvector(?, "body")) @@ plainto_tsquery(?, ?)', $builder->toSql());
-        $this->assertEquals(['simple', 'simple', 'Hello World'], $builder->getBindings());
+        $this->assertSame('select * from "users" where (to_tsvector(simple, "body")) @@ plainto_tsquery(simple, ?)', $builder->toSql());
+        $this->assertEquals(['Hello World'], $builder->getBindings());
 
         $builder = $this->getPostgresBuilderWithProcessor();
         $builder->select('*')->from('users')->whereFulltext('body', 'Hello World', ['mode' => 'plain']);
-        $this->assertSame('select * from "users" where (to_tsvector(?, "body")) @@ plainto_tsquery(?, ?)', $builder->toSql());
-        $this->assertEquals(['english', 'english', 'Hello World'], $builder->getBindings());
+        $this->assertSame('select * from "users" where (to_tsvector(english, "body")) @@ plainto_tsquery(english, ?)', $builder->toSql());
+        $this->assertEquals(['Hello World'], $builder->getBindings());
 
         $builder = $this->getPostgresBuilderWithProcessor();
         $builder->select('*')->from('users')->whereFulltext('body', 'Hello World', ['mode' => 'phrase']);
-        $this->assertSame('select * from "users" where (to_tsvector(?, "body")) @@ phraseto_tsquery(?, ?)', $builder->toSql());
-        $this->assertEquals(['english', 'english', 'Hello World'], $builder->getBindings());
+        $this->assertSame('select * from "users" where (to_tsvector(english, "body")) @@ phraseto_tsquery(english, ?)', $builder->toSql());
+        $this->assertEquals(['Hello World'], $builder->getBindings());
 
         $builder = $this->getPostgresBuilderWithProcessor();
         $builder->select('*')->from('users')->whereFulltext('body', '+Hello -World', ['mode' => 'websearch']);
-        $this->assertSame('select * from "users" where (to_tsvector(?, "body")) @@ websearch_to_tsquery(?, ?)', $builder->toSql());
-        $this->assertEquals(['english', 'english', '+Hello -World'], $builder->getBindings());
+        $this->assertSame('select * from "users" where (to_tsvector(english, "body")) @@ websearch_to_tsquery(english, ?)', $builder->toSql());
+        $this->assertEquals(['+Hello -World'], $builder->getBindings());
 
         $builder = $this->getPostgresBuilderWithProcessor();
         $builder->select('*')->from('users')->whereFulltext('body', 'Hello World', ['language' => 'simple', 'mode' => 'plain']);
-        $this->assertSame('select * from "users" where (to_tsvector(?, "body")) @@ plainto_tsquery(?, ?)', $builder->toSql());
-        $this->assertEquals(['simple', 'simple', 'Hello World'], $builder->getBindings());
+        $this->assertSame('select * from "users" where (to_tsvector(simple, "body")) @@ plainto_tsquery(simple, ?)', $builder->toSql());
+        $this->assertEquals(['Hello World'], $builder->getBindings());
 
         $builder = $this->getPostgresBuilderWithProcessor();
         $builder->select('*')->from('users')->whereFulltext(['body', 'title'], 'Car Plane');
-        $this->assertSame('select * from "users" where (to_tsvector(?, "body") || to_tsvector(?, "title")) @@ plainto_tsquery(?, ?)', $builder->toSql());
-        $this->assertEquals(['english', 'english', 'english', 'Car Plane'], $builder->getBindings());
+        $this->assertSame('select * from "users" where (to_tsvector(english, "body") || to_tsvector(english, "title")) @@ plainto_tsquery(english, ?)', $builder->toSql());
+        $this->assertEquals(['Car Plane'], $builder->getBindings());
     }
 
     public function testUnions()

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -858,40 +858,30 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([], $builder->getBindings());
     }
 
-    public function testMatchAgainst()
+    public function testWhereFulltext()
     {
         $builder = $this->getMySqlBuilderWithProcessor();
-        $builder->select('*')->from('users')->matchAgainst('body', 'Hello World');
+        $builder->select('*')->from('users')->whereFulltext('body', 'Hello World');
         $this->assertSame('select * from `users` where match (`body`) against (? in natural language mode)', $builder->toSql());
         $this->assertEquals(['Hello World'], $builder->getBindings());
 
         $builder = $this->getMySqlBuilderWithProcessor();
-        $builder->select('*')->from('users')->matchAgainst('body', 'Hello World', 'and', true);
+        $builder->select('*')->from('users')->whereFulltext('body', 'Hello World', ['expanded' => true]);
         $this->assertSame('select * from `users` where match (`body`) against (? in natural language mode with query expansion)', $builder->toSql());
         $this->assertEquals(['Hello World'], $builder->getBindings());
 
         $builder = $this->getMySqlBuilderWithProcessor();
-        $builder->select('*')->from('users')->matchAgainstExpanded('body', 'Hello World');
-        $this->assertSame('select * from `users` where match (`body`) against (? in natural language mode with query expansion)', $builder->toSql());
-        $this->assertEquals(['Hello World'], $builder->getBindings());
-
-        $builder = $this->getMySqlBuilderWithProcessor();
-        $builder->select('*')->from('users')->matchAgainst('body', '+Hello -World', 'and', false, 'boolean');
+        $builder->select('*')->from('users')->whereFulltext('body', '+Hello -World', ['mode' => 'boolean']);
         $this->assertSame('select * from `users` where match (`body`) against (? in boolean mode)', $builder->toSql());
         $this->assertEquals(['+Hello -World'], $builder->getBindings());
 
         $builder = $this->getMySqlBuilderWithProcessor();
-        $builder->select('*')->from('users')->matchAgainstBoolean('body', '+Hello -World');
+        $builder->select('*')->from('users')->whereFulltext('body', '+Hello -World', ['mode' => 'boolean', 'expanded' => true]);
         $this->assertSame('select * from `users` where match (`body`) against (? in boolean mode)', $builder->toSql());
         $this->assertEquals(['+Hello -World'], $builder->getBindings());
 
         $builder = $this->getMySqlBuilderWithProcessor();
-        $builder->select('*')->from('users')->matchAgainst('body', '+Hello -World', 'and', true, 'boolean');
-        $this->assertSame('select * from `users` where match (`body`) against (? in boolean mode)', $builder->toSql());
-        $this->assertEquals(['+Hello -World'], $builder->getBindings());
-
-        $builder = $this->getMySqlBuilderWithProcessor();
-        $builder->select('*')->from('users')->matchAgainst(['body', 'title'], ['Car', 'Plane']);
+        $builder->select('*')->from('users')->whereFulltext(['body', 'title'], ['Car', 'Plane']);
         $this->assertSame('select * from `users` where match (`body`, `title`) against (? in natural language mode)', $builder->toSql());
         $this->assertEquals(['Car,Plane'], $builder->getBindings());
     }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -858,6 +858,44 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([], $builder->getBindings());
     }
 
+    public function testMatchAgainst()
+    {
+        $builder = $this->getMySqlBuilderWithProcessor();
+        $builder->select('*')->from('users')->matchAgainst('body', 'Hello World');
+        $this->assertSame('select * from `users` where match (`body`) against (? in natural language mode)', $builder->toSql());
+        $this->assertEquals(['Hello World'], $builder->getBindings());
+
+        $builder = $this->getMySqlBuilderWithProcessor();
+        $builder->select('*')->from('users')->matchAgainst('body', 'Hello World', 'and', true);
+        $this->assertSame('select * from `users` where match (`body`) against (? in natural language mode with query expansion)', $builder->toSql());
+        $this->assertEquals(['Hello World'], $builder->getBindings());
+
+        $builder = $this->getMySqlBuilderWithProcessor();
+        $builder->select('*')->from('users')->matchAgainstExpanded('body', 'Hello World');
+        $this->assertSame('select * from `users` where match (`body`) against (? in natural language mode with query expansion)', $builder->toSql());
+        $this->assertEquals(['Hello World'], $builder->getBindings());
+
+        $builder = $this->getMySqlBuilderWithProcessor();
+        $builder->select('*')->from('users')->matchAgainst('body', '+Hello -World', 'and', false, 'boolean');
+        $this->assertSame('select * from `users` where match (`body`) against (? in boolean mode)', $builder->toSql());
+        $this->assertEquals(['+Hello -World'], $builder->getBindings());
+
+        $builder = $this->getMySqlBuilderWithProcessor();
+        $builder->select('*')->from('users')->matchAgainstBoolean('body', '+Hello -World');
+        $this->assertSame('select * from `users` where match (`body`) against (? in boolean mode)', $builder->toSql());
+        $this->assertEquals(['+Hello -World'], $builder->getBindings());
+
+        $builder = $this->getMySqlBuilderWithProcessor();
+        $builder->select('*')->from('users')->matchAgainst('body', '+Hello -World', 'and', true, 'boolean');
+        $this->assertSame('select * from `users` where match (`body`) against (? in boolean mode)', $builder->toSql());
+        $this->assertEquals(['+Hello -World'], $builder->getBindings());
+
+        $builder = $this->getMySqlBuilderWithProcessor();
+        $builder->select('*')->from('users')->matchAgainst(['body', 'title'], ['Car', 'Plane']);
+        $this->assertSame('select * from `users` where match (`body`, `title`) against (? in natural language mode)', $builder->toSql());
+        $this->assertEquals(['Car,Plane'], $builder->getBindings());
+    }
+
     public function testUnions()
     {
         $builder = $this->getBuilder();

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -881,7 +881,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['+Hello -World'], $builder->getBindings());
 
         $builder = $this->getMySqlBuilderWithProcessor();
-        $builder->select('*')->from('users')->whereFulltext(['body', 'title'], ['Car', 'Plane']);
+        $builder->select('*')->from('users')->whereFulltext(['body', 'title'], 'Car,Plane');
         $this->assertSame('select * from `users` where match (`body`, `title`) against (? in natural language mode)', $builder->toSql());
         $this->assertEquals(['Car,Plane'], $builder->getBindings());
     }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -891,37 +891,37 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getPostgresBuilderWithProcessor();
         $builder->select('*')->from('users')->whereFulltext('body', 'Hello World');
-        $this->assertSame('select * from "users" where (to_tsvector(english, "body")) @@ plainto_tsquery(english, ?)', $builder->toSql());
+        $this->assertSame('select * from "users" where (to_tsvector(\'english\', "body")) @@ plainto_tsquery(\'english\', ?)', $builder->toSql());
         $this->assertEquals(['Hello World'], $builder->getBindings());
 
         $builder = $this->getPostgresBuilderWithProcessor();
         $builder->select('*')->from('users')->whereFulltext('body', 'Hello World', ['language' => 'simple']);
-        $this->assertSame('select * from "users" where (to_tsvector(simple, "body")) @@ plainto_tsquery(simple, ?)', $builder->toSql());
+        $this->assertSame('select * from "users" where (to_tsvector(\'simple\', "body")) @@ plainto_tsquery(\'simple\', ?)', $builder->toSql());
         $this->assertEquals(['Hello World'], $builder->getBindings());
 
         $builder = $this->getPostgresBuilderWithProcessor();
         $builder->select('*')->from('users')->whereFulltext('body', 'Hello World', ['mode' => 'plain']);
-        $this->assertSame('select * from "users" where (to_tsvector(english, "body")) @@ plainto_tsquery(english, ?)', $builder->toSql());
+        $this->assertSame('select * from "users" where (to_tsvector(\'english\', "body")) @@ plainto_tsquery(\'english\', ?)', $builder->toSql());
         $this->assertEquals(['Hello World'], $builder->getBindings());
 
         $builder = $this->getPostgresBuilderWithProcessor();
         $builder->select('*')->from('users')->whereFulltext('body', 'Hello World', ['mode' => 'phrase']);
-        $this->assertSame('select * from "users" where (to_tsvector(english, "body")) @@ phraseto_tsquery(english, ?)', $builder->toSql());
+        $this->assertSame('select * from "users" where (to_tsvector(\'english\', "body")) @@ phraseto_tsquery(\'english\', ?)', $builder->toSql());
         $this->assertEquals(['Hello World'], $builder->getBindings());
 
         $builder = $this->getPostgresBuilderWithProcessor();
         $builder->select('*')->from('users')->whereFulltext('body', '+Hello -World', ['mode' => 'websearch']);
-        $this->assertSame('select * from "users" where (to_tsvector(english, "body")) @@ websearch_to_tsquery(english, ?)', $builder->toSql());
+        $this->assertSame('select * from "users" where (to_tsvector(\'english\', "body")) @@ websearch_to_tsquery(\'english\', ?)', $builder->toSql());
         $this->assertEquals(['+Hello -World'], $builder->getBindings());
 
         $builder = $this->getPostgresBuilderWithProcessor();
         $builder->select('*')->from('users')->whereFulltext('body', 'Hello World', ['language' => 'simple', 'mode' => 'plain']);
-        $this->assertSame('select * from "users" where (to_tsvector(simple, "body")) @@ plainto_tsquery(simple, ?)', $builder->toSql());
+        $this->assertSame('select * from "users" where (to_tsvector(\'simple\', "body")) @@ plainto_tsquery(\'simple\', ?)', $builder->toSql());
         $this->assertEquals(['Hello World'], $builder->getBindings());
 
         $builder = $this->getPostgresBuilderWithProcessor();
         $builder->select('*')->from('users')->whereFulltext(['body', 'title'], 'Car Plane');
-        $this->assertSame('select * from "users" where (to_tsvector(english, "body") || to_tsvector(english, "title")) @@ plainto_tsquery(english, ?)', $builder->toSql());
+        $this->assertSame('select * from "users" where (to_tsvector(\'english\', "body") || to_tsvector(\'english\', "title")) @@ plainto_tsquery(\'english\', ?)', $builder->toSql());
         $this->assertEquals(['Car Plane'], $builder->getBindings());
     }
 

--- a/tests/Integration/Database/MySql/FulltextTest.php
+++ b/tests/Integration/Database/MySql/FulltextTest.php
@@ -10,7 +10,7 @@ use Illuminate\Support\Facades\Schema;
  * @requires extension pdo_mysql
  * @requires OS Linux|Darwin
  */
-class MatchAgainstTest extends MySqlTestCase
+class FulltextTest extends MySqlTestCase
 {
     protected function defineDatabaseMigrationsAfterDatabaseRefreshed()
     {
@@ -42,9 +42,9 @@ class MatchAgainstTest extends MySqlTestCase
     }
 
     /** @link https://dev.mysql.com/doc/refman/8.0/en/fulltext-natural-language.html */
-    public function testMatchAgainst()
+    public function testWhereFulltext()
     {
-        $articles = DB::table('articles')->matchAgainst(['title', 'body'], 'database')->get();
+        $articles = DB::table('articles')->whereFulltext(['title', 'body'], 'database')->get();
 
         $this->assertCount(2, $articles);
         $this->assertSame('MySQL Tutorial', $articles[0]->title);
@@ -52,17 +52,17 @@ class MatchAgainstTest extends MySqlTestCase
     }
 
     /** @link https://dev.mysql.com/doc/refman/8.0/en/fulltext-boolean.html */
-    public function testMatchAgainstBoolean()
+    public function testWhereFulltextWithBooleanMode()
     {
-        $articles = DB::table('articles')->matchAgainstBoolean(['title', 'body'], '+MySQL -YourSQL')->get();
+        $articles = DB::table('articles')->whereFulltext(['title', 'body'], '+MySQL -YourSQL', ['mode' => 'boolean'])->get();
 
         $this->assertCount(5, $articles);
     }
 
     /** @link https://dev.mysql.com/doc/refman/8.0/en/fulltext-query-expansion.html */
-    public function testMatchAgainstExpanded()
+    public function testWhereFulltextWithExpandedQuery()
     {
-        $articles = DB::table('articles')->matchAgainstExpanded(['title', 'body'], 'database')->get();
+        $articles = DB::table('articles')->whereFulltext(['title', 'body'], 'database', ['expanded' => true])->get();
 
         $this->assertCount(6, $articles);
     }

--- a/tests/Integration/Database/MySql/MatchAgainstTest.php
+++ b/tests/Integration/Database/MySql/MatchAgainstTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\MySql;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * @requires extension pdo_mysql
+ * @requires OS Linux|Darwin
+ */
+class MatchAgainstTest extends MySqlTestCase
+{
+    protected function defineDatabaseMigrationsAfterDatabaseRefreshed()
+    {
+        Schema::create('articles', function (Blueprint $table) {
+            $table->id('id');
+            $table->string('title', 200);
+            $table->text('body');
+            $table->fulltext(['title', 'body']);
+        });
+    }
+
+    protected function destroyDatabaseMigrations()
+    {
+        Schema::drop('articles');
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        DB::table('articles')->insert([
+            ['title' => 'MySQL Tutorial', 'body' => 'DBMS stands for DataBase ...'],
+            ['title' => 'How To Use MySQL Well', 'body' => 'After you went through a ...'],
+            ['title' => 'Optimizing MySQL', 'body' => 'In this tutorial, we show ...'],
+            ['title' => '1001 MySQL Tricks', 'body' => '1. Never run mysqld as root. 2. ...'],
+            ['title' => 'MySQL vs. YourSQL', 'body' => 'In the following database comparison ...'],
+            ['title' => 'MySQL Security', 'body' => 'When configured properly, MySQL ...'],
+        ]);
+    }
+
+    /** @link https://dev.mysql.com/doc/refman/8.0/en/fulltext-natural-language.html */
+    public function testMatchAgainst()
+    {
+        $articles = DB::table('articles')->matchAgainst(['title', 'body'], 'database')->get();
+
+        $this->assertCount(2, $articles);
+        $this->assertSame('MySQL Tutorial', $articles[0]->title);
+        $this->assertSame('MySQL vs. YourSQL', $articles[1]->title);
+    }
+
+    /** @link https://dev.mysql.com/doc/refman/8.0/en/fulltext-boolean.html */
+    public function testMatchAgainstBoolean()
+    {
+        $articles = DB::table('articles')->matchAgainstBoolean(['title', 'body'], '+MySQL -YourSQL')->get();
+
+        $this->assertCount(5, $articles);
+    }
+
+    /** @link https://dev.mysql.com/doc/refman/8.0/en/fulltext-query-expansion.html */
+    public function testMatchAgainstExpanded()
+    {
+        $articles = DB::table('articles')->matchAgainstExpanded(['title', 'body'], 'database')->get();
+
+        $this->assertCount(6, $articles);
+    }
+}

--- a/tests/Integration/Database/Postgres/FulltextTest.php
+++ b/tests/Integration/Database/Postgres/FulltextTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\Postgres;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * @requires extension pdo_pgsql
+ * @requires OS Linux|Darwin
+ */
+class FulltextTest extends PostgresTestCase
+{
+    protected function defineDatabaseMigrationsAfterDatabaseRefreshed()
+    {
+        Schema::create('articles', function (Blueprint $table) {
+            $table->id('id');
+            $table->string('title', 200);
+            $table->text('body');
+            $table->fulltext(['title', 'body']);
+        });
+    }
+
+    protected function destroyDatabaseMigrations()
+    {
+        Schema::drop('articles');
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        DB::table('articles')->insert([
+            ['title' => 'PostgreSQL Tutorial', 'body' => 'DBMS stands for DataBase ...'],
+            ['title' => 'How To Use PostgreSQL Well', 'body' => 'After you went through a ...'],
+            ['title' => 'Optimizing PostgreSQL', 'body' => 'In this tutorial, we show ...'],
+            ['title' => '1001 PostgreSQL Tricks', 'body' => '1. Never run mysqld as root. 2. ...'],
+            ['title' => 'PostgreSQL vs. YourSQL', 'body' => 'In the following database comparison ...'],
+            ['title' => 'PostgreSQL Security', 'body' => 'When configured properly, PostgreSQL ...'],
+        ]);
+    }
+
+    public function testWhereFulltext()
+    {
+        $articles = DB::table('articles')->whereFulltext(['title', 'body'], 'database')->orderBy('id')->get();
+
+        $this->assertCount(2, $articles);
+        $this->assertSame('PostgreSQL Tutorial', $articles[0]->title);
+        $this->assertSame('PostgreSQL vs. YourSQL', $articles[1]->title);
+    }
+
+    public function testWhereFulltextWithWebsearch()
+    {
+        $articles = DB::table('articles')->whereFulltext(['title', 'body'], '+PostgreSQL -YourSQL', ['mode' => 'websearch'])->get();
+
+        $this->assertCount(5, $articles);
+    }
+
+    public function testWhereFulltextWithPlain()
+    {
+        $articles = DB::table('articles')->whereFulltext(['title', 'body'], 'PostgreSQL tutorial', ['mode' => 'plain'])->get();
+
+        $this->assertCount(2, $articles);
+    }
+
+    public function testWhereFulltextWithPhrase()
+    {
+        $articles = DB::table('articles')->whereFulltext(['title', 'body'], 'PostgreSQL tutorial', ['mode' => 'phrase'])->get();
+
+        $this->assertCount(1, $articles);
+    }
+}

--- a/tests/Integration/Database/Postgres/PostgresTestCase.php
+++ b/tests/Integration/Database/Postgres/PostgresTestCase.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\Postgres;
+
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+abstract class PostgresTestCase extends DatabaseTestCase
+{
+    protected function defineDatabaseMigrations()
+    {
+        if ($this->driver !== 'pgsql') {
+            $this->markTestSkipped('Test requires a PostgreSQL connection.');
+        }
+    }
+}


### PR DESCRIPTION
This PR implements [natural language Full-Text Searches for MySQL](https://dev.mysql.com/doc/refman/8.0/en/fulltext-natural-language.html) and [PostgreSQL](https://github.com/laravel/framework/pull/40229). The columns that are searched in the `MATCH` part always need to exist as a `fulltext` index.

```php
Schema::create('articles', function (Blueprint $table) {
    $table->id('id');
    $table->string('title', 200);
    $table->text('body');
    $table->fulltext(['title', 'body']);
});
```

```php
// Search for "databases" in the title and body fulltext index...
$articles = DB::table('articles')->whereFulltext(['title', 'body'], 'database')->get();

// Search for "databases" in the title and body fulltext index with boolean mode...
$articles = DB::table('articles')->whereFulltext(['title', 'body'], 'database', ['mode' => 'boolean'])->get();

// Search for "databases" in the title and body fulltext index with an expanded query...
$articles = DB::table('articles')->whereFulltext(['title', 'body'], 'database', ['expanded' => true])->get();
```

More info:
- https://dev.mysql.com/doc/refman/8.0/en/fulltext-natural-language.html
- https://dev.mysql.com/doc/refman/8.0/en/fulltext-boolean.html
- https://dev.mysql.com/doc/refman/8.0/en/fulltext-query-expansion.html

Thanks to @tpetry for also implementing PostgreSQL support! https://github.com/laravel/framework/pull/40229