### PR TITLE
[8.x] Add whereStartsWith, whereEndsWith, whereContains on Collection

### DIFF
--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -427,27 +427,30 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      *
      * @param  string  $key
      * @param  mixed  $value
+     * @param  boolean $casesensitive
      * @return static
      */
-    public function whereStartsWith($key, $value);
+    public function whereStartsWith($key, $value, $casesensitive = true);
 
     /**
      * Filter items that end with the given string.
      *
      * @param  string  $key
      * @param  mixed  $value
+     * @param  boolean $casesensitive
      * @return static
      */
-    public function whereEndsWith($key, $value);
+    public function whereEndsWith($key, $value, $casesensitive = true);
 
     /**
      * Filter items that contain the given string.
      *
      * @param  string  $key
      * @param  mixed  $value
+     * @param  boolean $casesensitive
      * @return static
      */
-    public function whereContains($key, $value);
+    public function whereContains($key, $value, $casesensitive = true);
 
     /**
      * Get the first item from the enumerable passing the given truth test.

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -427,7 +427,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      *
      * @param  string  $key
      * @param  mixed  $value
-     * @param  boolean $casesensitive
+     * @param  bool  $casesensitive
      * @return static
      */
     public function whereStartsWith($key, $value, $casesensitive = true);
@@ -437,7 +437,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      *
      * @param  string  $key
      * @param  mixed  $value
-     * @param  boolean $casesensitive
+     * @param  bool  $casesensitive
      * @return static
      */
     public function whereEndsWith($key, $value, $casesensitive = true);
@@ -447,7 +447,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      *
      * @param  string  $key
      * @param  mixed  $value
-     * @param  boolean $casesensitive
+     * @param  bool  $casesensitive
      * @return static
      */
     public function whereContains($key, $value, $casesensitive = true);

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -423,6 +423,33 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function whereInstanceOf($type);
 
     /**
+     * Filter items that begin with the given string.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return static
+     */
+    public function whereStartsWith($key, $value);
+
+    /**
+     * Filter items that end with the given string.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return static
+     */
+    public function whereEndsWith($key, $value);
+
+    /**
+     * Filter items that contain the given string.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return static
+     */
+    public function whereContains($key, $value);
+
+    /**
      * Get the first item from the enumerable passing the given truth test.
      *
      * @param  callable|null  $callback

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -711,6 +711,7 @@ trait EnumeratesValues
     {
         return $this->filter(function ($item) use ($key, $value, $casesensitive) {
             $comparer = ($casesensitive) ? 'strncmp' : 'strncasecmp';
+
             return $comparer(data_get($item, $key), $value, strlen($value)) === 0;
         });
     }
@@ -727,6 +728,7 @@ trait EnumeratesValues
     {
         return $this->filter(function ($item) use ($key, $value, $casesensitive) {
             $comparer = ($casesensitive) ? 'strncmp' : 'strncasecmp';
+
             return $comparer(strrev(data_get($item, $key)), strrev($value), strlen($value)) === 0;
         });
     }
@@ -744,7 +746,7 @@ trait EnumeratesValues
         return $this->filter(function ($item) use ($key, $value, $casesensitive) {
             $haystack = data_get($item, $key);
             $haystack = ($casesensitive) ? $haystack : strtolower($haystack);
-            $needle = ($casesensitive) ? $value : strtolower($value) ;
+            $needle = ($casesensitive) ? $value : strtolower($value);
             return str_contains($haystack, $needle);
         });
     }

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -700,6 +700,48 @@ trait EnumeratesValues
     }
 
     /**
+     * Filter items that begin with the given string.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return static
+     */
+    public function whereStartsWith($key, $value)
+    {
+        return $this->filter(function ($item) use ($key, $value) {
+            return strncmp(data_get($item, $key), $value, strlen($value)) === 0;
+        });
+    }
+
+    /**
+     * Filter items that end with the given string.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return static
+     */
+    public function whereEndsWith($key, $value)
+    {
+        return $this->filter(function ($item) use ($key, $value) {
+            return strncmp(strrev(data_get($item, $key)), strrev($value), strlen($value)) === 0;
+        });
+    }
+
+    /**
+     * Filter items that contain the given string.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return static
+     */
+    public function whereContains($key, $value)
+    {
+        return $this->filter(function ($item) use ($key, $value) {
+            return str_contains(data_get($item, $key), $value);
+        });
+    }
+
+    /**
      * Pass the collection to the given callback and return the result.
      *
      * @param  callable  $callback

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -747,7 +747,7 @@ trait EnumeratesValues
             $haystack = data_get($item, $key);
             $haystack = ($casesensitive) ? $haystack : strtolower($haystack);
             $needle = ($casesensitive) ? $value : strtolower($value);
-            
+
             return str_contains($haystack, $needle);
         });
     }

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -704,7 +704,7 @@ trait EnumeratesValues
      *
      * @param  string  $key
      * @param  mixed  $value
-     * @param  boolean $casesensitive
+     * @param  bool  $casesensitive
      * @return static
      */
     public function whereStartsWith($key, $value, $casesensitive = true)
@@ -720,7 +720,7 @@ trait EnumeratesValues
      *
      * @param  string  $key
      * @param  mixed  $value
-     * @param  boolean $casesensitive
+     * @param  bool  $casesensitive
      * @return static
      */
     public function whereEndsWith($key, $value, $casesensitive = true)
@@ -736,7 +736,7 @@ trait EnumeratesValues
      *
      * @param  string  $key
      * @param  mixed  $value
-     * @param  boolean $casesensitive
+     * @param  bool  $casesensitive
      * @return static
      */
     public function whereContains($key, $value, $casesensitive = true)

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -704,12 +704,14 @@ trait EnumeratesValues
      *
      * @param  string  $key
      * @param  mixed  $value
+     * @param  boolean $casesensitive
      * @return static
      */
-    public function whereStartsWith($key, $value)
+    public function whereStartsWith($key, $value, $casesensitive = true)
     {
-        return $this->filter(function ($item) use ($key, $value) {
-            return strncmp(data_get($item, $key), $value, strlen($value)) === 0;
+        return $this->filter(function ($item) use ($key, $value, $casesensitive) {
+            $comparer = ($casesensitive) ? 'strncmp' : 'strncasecmp';
+            return $comparer(data_get($item, $key), $value, strlen($value)) === 0;
         });
     }
 
@@ -718,12 +720,14 @@ trait EnumeratesValues
      *
      * @param  string  $key
      * @param  mixed  $value
+     * @param  boolean $casesensitive
      * @return static
      */
-    public function whereEndsWith($key, $value)
+    public function whereEndsWith($key, $value, $casesensitive = true)
     {
-        return $this->filter(function ($item) use ($key, $value) {
-            return strncmp(strrev(data_get($item, $key)), strrev($value), strlen($value)) === 0;
+        return $this->filter(function ($item) use ($key, $value, $casesensitive) {
+            $comparer = ($casesensitive) ? 'strncmp' : 'strncasecmp';
+            return $comparer(strrev(data_get($item, $key)), strrev($value), strlen($value)) === 0;
         });
     }
 
@@ -732,12 +736,16 @@ trait EnumeratesValues
      *
      * @param  string  $key
      * @param  mixed  $value
+     * @param  boolean $casesensitive
      * @return static
      */
-    public function whereContains($key, $value)
+    public function whereContains($key, $value, $casesensitive = true)
     {
-        return $this->filter(function ($item) use ($key, $value) {
-            return str_contains(data_get($item, $key), $value);
+        return $this->filter(function ($item) use ($key, $value, $casesensitive) {
+            $haystack = data_get($item, $key);
+            $haystack = ($casesensitive) ? $haystack : strtolower($haystack);
+            $needle = ($casesensitive) ? $value : strtolower($value) ;
+            return str_contains($haystack, $needle);
         });
     }
 

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -747,6 +747,7 @@ trait EnumeratesValues
             $haystack = data_get($item, $key);
             $haystack = ($casesensitive) ? $haystack : strtolower($haystack);
             $needle = ($casesensitive) ? $value : strtolower($value);
+            
             return str_contains($haystack, $needle);
         });
     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1058,18 +1058,18 @@ class SupportCollectionTest extends TestCase
 
         $this->assertCount(4, $c->whereInstanceOf([stdClass::class, Str::class]));
     }
-    
+
     /**
      * @dataProvider collectionClassProvider
      */
     public function testWhereStartsWith($collection)
     {
-        $c = new $collection([['id' => 1, 'name' => 'A'], ['id' => 2, 'name' => 'B'], ['id' => 3 , 'name' => 'AB'], ['id' => 4 , 'name' => 'ABC']]);
-        $this->assertCount(3,$c->whereStartsWith('name', 'A'));
-        $this->assertCount(1,$c->whereStartsWith('name', 'B'));
-        $this->assertCount(0,$c->whereStartsWith('name', 'C'));
-        $this->assertCount(2,$c->whereStartsWith('name', 'AB'));
-        $this->assertCount(1,$c->whereStartsWith('name', 'ABC'));
+        $c = new $collection([['id' => 1, 'name' => 'A'], ['id' => 2, 'name' => 'B'], ['id' => 3, 'name' => 'AB'], ['id' => 4, 'name' => 'ABC']]);
+        $this->assertCount(3, $c->whereStartsWith('name', 'A'));
+        $this->assertCount(1, $c->whereStartsWith('name', 'B'));
+        $this->assertCount(0, $c->whereStartsWith('name', 'C'));
+        $this->assertCount(2, $c->whereStartsWith('name', 'AB'));
+        $this->assertCount(1, $c->whereStartsWith('name', 'ABC'));
     }
 
     /**
@@ -1077,12 +1077,12 @@ class SupportCollectionTest extends TestCase
      */
     public function testWhereEndsWith($collection)
     {
-        $c = new $collection([['id' => 1, 'name' => 'A'], ['id' => 2, 'name' => 'B'], ['id' => 3 , 'name' => 'AB'], ['id' => 4 , 'name' => 'ABC']]);
-        $this->assertCount(1,$c->whereEndsWith('name', 'A'));
-        $this->assertCount(2,$c->whereEndsWith('name', 'B'));
-        $this->assertCount(1,$c->whereEndsWith('name', 'C'));
-        $this->assertCount(1,$c->whereEndsWith('name', 'BC'));
-        $this->assertCount(1,$c->whereEndsWith('name', 'ABC'));
+        $c = new $collection([['id' => 1, 'name' => 'A'], ['id' => 2, 'name' => 'B'], ['id' => 3, 'name' => 'AB'], ['id' => 4, 'name' => 'ABC']]);
+        $this->assertCount(1, $c->whereEndsWith('name', 'A'));
+        $this->assertCount(2, $c->whereEndsWith('name', 'B'));
+        $this->assertCount(1, $c->whereEndsWith('name', 'C'));
+        $this->assertCount(1, $c->whereEndsWith('name', 'BC'));
+        $this->assertCount(1, $c->whereEndsWith('name', 'ABC'));
     }
 
     /**
@@ -1090,11 +1090,11 @@ class SupportCollectionTest extends TestCase
      */
     public function testWhereContains($collection)
     {
-        $c = new $collection([['id' => 1, 'name' => 'A'], ['id' => 2, 'name' => 'B'], ['id' => 3 , 'name' => 'AB'], ['id' => 4 , 'name' => 'ABC']]);
-        $this->assertCount(3,$c->whereContains('name', 'A'));
-        $this->assertCount(3,$c->whereContains('name', 'B'));
-        $this->assertCount(1,$c->whereContains('name', 'C'));
-        $this->assertCount(1,$c->whereContains('name', 'BC'));
+        $c = new $collection([['id' => 1, 'name' => 'A'], ['id' => 2, 'name' => 'B'], ['id' => 3, 'name' => 'AB'], ['id' => 4, 'name' => 'ABC']]);
+        $this->assertCount(3, $c->whereContains('name', 'A'));
+        $this->assertCount(3, $c->whereContains('name', 'B'));
+        $this->assertCount(1, $c->whereContains('name', 'C'));
+        $this->assertCount(1, $c->whereContains('name', 'BC'));
         $this->assertCount(1,$c->whereContains('name', 'ABC'));
         $this->assertCount(0,$c->whereContains('name', 'D'));
     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1058,19 +1058,18 @@ class SupportCollectionTest extends TestCase
 
         $this->assertCount(4, $c->whereInstanceOf([stdClass::class, Str::class]));
     }
-
-
+    
     /**
      * @dataProvider collectionClassProvider
      */
     public function testWhereStartsWith($collection)
     {
-        $c = new $collection([['id' => 1, 'name' => 'A'], ['id' => 2, 'name' => 'B'] , ['id' => 3 , 'name' => 'AB'], ['id' => 4 , 'name' => 'ABC']]);
-        $this->assertCount(3,$c->whereStartsWith('name','A'));
-        $this->assertCount(1,$c->whereStartsWith('name','B'));
-        $this->assertCount(0,$c->whereStartsWith('name','C'));
-        $this->assertCount(2,$c->whereStartsWith('name','AB'));
-        $this->assertCount(1,$c->whereStartsWith('name','ABC'));
+        $c = new $collection([['id' => 1, 'name' => 'A'], ['id' => 2, 'name' => 'B'], ['id' => 3 , 'name' => 'AB'], ['id' => 4 , 'name' => 'ABC']]);
+        $this->assertCount(3,$c->whereStartsWith('name', 'A'));
+        $this->assertCount(1,$c->whereStartsWith('name', 'B'));
+        $this->assertCount(0,$c->whereStartsWith('name', 'C'));
+        $this->assertCount(2,$c->whereStartsWith('name', 'AB'));
+        $this->assertCount(1,$c->whereStartsWith('name', 'ABC'));
     }
 
     /**
@@ -1078,12 +1077,12 @@ class SupportCollectionTest extends TestCase
      */
     public function testWhereEndsWith($collection)
     {
-        $c = new $collection([['id' => 1, 'name' => 'A'], ['id' => 2, 'name' => 'B'] , ['id' => 3 , 'name' => 'AB'], ['id' => 4 , 'name' => 'ABC']]);
-        $this->assertCount(1,$c->whereEndsWith('name','A'));
-        $this->assertCount(2,$c->whereEndsWith('name','B'));
-        $this->assertCount(1,$c->whereEndsWith('name','C'));
-        $this->assertCount(1,$c->whereEndsWith('name','BC'));
-        $this->assertCount(1,$c->whereEndsWith('name','ABC'));
+        $c = new $collection([['id' => 1, 'name' => 'A'], ['id' => 2, 'name' => 'B'], ['id' => 3 , 'name' => 'AB'], ['id' => 4 , 'name' => 'ABC']]);
+        $this->assertCount(1,$c->whereEndsWith('name', 'A'));
+        $this->assertCount(2,$c->whereEndsWith('name', 'B'));
+        $this->assertCount(1,$c->whereEndsWith('name', 'C'));
+        $this->assertCount(1,$c->whereEndsWith('name', 'BC'));
+        $this->assertCount(1,$c->whereEndsWith('name', 'ABC'));
     }
 
     /**
@@ -1091,13 +1090,13 @@ class SupportCollectionTest extends TestCase
      */
     public function testWhereContains($collection)
     {
-        $c = new $collection([['id' => 1, 'name' => 'A'], ['id' => 2, 'name' => 'B'] , ['id' => 3 , 'name' => 'AB'], ['id' => 4 , 'name' => 'ABC']]);
-        $this->assertCount(3,$c->whereContains('name','A'));
-        $this->assertCount(3,$c->whereContains('name','B'));
-        $this->assertCount(1,$c->whereContains('name','C'));
-        $this->assertCount(1,$c->whereContains('name','BC'));
-        $this->assertCount(1,$c->whereContains('name','ABC'));
-        $this->assertCount(0,$c->whereContains('name','D'));
+        $c = new $collection([['id' => 1, 'name' => 'A'], ['id' => 2, 'name' => 'B'], ['id' => 3 , 'name' => 'AB'], ['id' => 4 , 'name' => 'ABC']]);
+        $this->assertCount(3,$c->whereContains('name', 'A'));
+        $this->assertCount(3,$c->whereContains('name', 'B'));
+        $this->assertCount(1,$c->whereContains('name', 'C'));
+        $this->assertCount(1,$c->whereContains('name', 'BC'));
+        $this->assertCount(1,$c->whereContains('name', 'ABC'));
+        $this->assertCount(0,$c->whereContains('name', 'D'));
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1095,8 +1095,8 @@ class SupportCollectionTest extends TestCase
         $this->assertCount(3, $c->whereContains('name', 'B'));
         $this->assertCount(1, $c->whereContains('name', 'C'));
         $this->assertCount(1, $c->whereContains('name', 'BC'));
-        $this->assertCount(1,$c->whereContains('name', 'ABC'));
-        $this->assertCount(0,$c->whereContains('name', 'D'));
+        $this->assertCount(1, $c->whereContains('name', 'ABC'));
+        $this->assertCount(0, $c->whereContains('name', 'D'));
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1059,6 +1059,47 @@ class SupportCollectionTest extends TestCase
         $this->assertCount(4, $c->whereInstanceOf([stdClass::class, Str::class]));
     }
 
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testWhereStartsWith($collection)
+    {
+        $c = new $collection([['id' => 1, 'name' => 'A'], ['id' => 2, 'name' => 'B'] , ['id' => 3 , 'name' => 'AB'], ['id' => 4 , 'name' => 'ABC']]);
+        $this->assertCount(3,$c->whereStartsWith('name','A'));
+        $this->assertCount(1,$c->whereStartsWith('name','B'));
+        $this->assertCount(0,$c->whereStartsWith('name','C'));
+        $this->assertCount(2,$c->whereStartsWith('name','AB'));
+        $this->assertCount(1,$c->whereStartsWith('name','ABC'));
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testWhereEndsWith($collection)
+    {
+        $c = new $collection([['id' => 1, 'name' => 'A'], ['id' => 2, 'name' => 'B'] , ['id' => 3 , 'name' => 'AB'], ['id' => 4 , 'name' => 'ABC']]);
+        $this->assertCount(1,$c->whereEndsWith('name','A'));
+        $this->assertCount(2,$c->whereEndsWith('name','B'));
+        $this->assertCount(1,$c->whereEndsWith('name','C'));
+        $this->assertCount(1,$c->whereEndsWith('name','BC'));
+        $this->assertCount(1,$c->whereEndsWith('name','ABC'));
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testWhereContains($collection)
+    {
+        $c = new $collection([['id' => 1, 'name' => 'A'], ['id' => 2, 'name' => 'B'] , ['id' => 3 , 'name' => 'AB'], ['id' => 4 , 'name' => 'ABC']]);
+        $this->assertCount(3,$c->whereContains('name','A'));
+        $this->assertCount(3,$c->whereContains('name','B'));
+        $this->assertCount(1,$c->whereContains('name','C'));
+        $this->assertCount(1,$c->whereContains('name','BC'));
+        $this->assertCount(1,$c->whereContains('name','ABC'));
+        $this->assertCount(0,$c->whereContains('name','D'));
+    }
+
     /**
      * @dataProvider collectionClassProvider
      */

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1070,6 +1070,12 @@ class SupportCollectionTest extends TestCase
         $this->assertCount(0, $c->whereStartsWith('name', 'C'));
         $this->assertCount(2, $c->whereStartsWith('name', 'AB'));
         $this->assertCount(1, $c->whereStartsWith('name', 'ABC'));
+
+        $this->assertCount(3, $c->whereStartsWith('name', 'a', false));
+        $this->assertCount(1, $c->whereStartsWith('name', 'b', false));
+        $this->assertCount(0, $c->whereStartsWith('name', 'c', false));
+        $this->assertCount(2, $c->whereStartsWith('name', 'aB', false));
+        $this->assertCount(1, $c->whereStartsWith('name', 'Abc', false));
     }
 
     /**
@@ -1083,6 +1089,12 @@ class SupportCollectionTest extends TestCase
         $this->assertCount(1, $c->whereEndsWith('name', 'C'));
         $this->assertCount(1, $c->whereEndsWith('name', 'BC'));
         $this->assertCount(1, $c->whereEndsWith('name', 'ABC'));
+
+        $this->assertCount(1, $c->whereEndsWith('name', 'a', false));
+        $this->assertCount(2, $c->whereEndsWith('name', 'b', false));
+        $this->assertCount(1, $c->whereEndsWith('name', 'c', false));
+        $this->assertCount(1, $c->whereEndsWith('name', 'aB', false));
+        $this->assertCount(1, $c->whereEndsWith('name', 'Abc', false));
     }
 
     /**
@@ -1097,6 +1109,13 @@ class SupportCollectionTest extends TestCase
         $this->assertCount(1, $c->whereContains('name', 'BC'));
         $this->assertCount(1, $c->whereContains('name', 'ABC'));
         $this->assertCount(0, $c->whereContains('name', 'D'));
+
+        $this->assertCount(3, $c->whereContains('name', 'a', false));
+        $this->assertCount(3, $c->whereContains('name', 'b', false));
+        $this->assertCount(1, $c->whereContains('name', 'c', false));
+        $this->assertCount(1, $c->whereContains('name', 'bC', false));
+        $this->assertCount(1, $c->whereContains('name', 'AbC', false));
+        $this->assertCount(0, $c->whereContains('name', 'd', false));
     }
 
     /**


### PR DESCRIPTION
This pull request adds the possibility to filter collections based on the fact a specified key starts with, ends with or contains a given string.

## Interface 

```
public function whereStartsWith($key, $value, $casesensitive = true);
public function whereEndsWith($key, $value, $casesensitive = true);
public function whereContains($key, $value, $casesensitive = true);
```

## Usage 

```php
$collection = collect([['id' => 1, 'name' => 'A'], ['id' => 2, 'name' => 'B'] , ['id' => 3 , 'name' => 'AB'], ['id' => 4 , 'name' => 'ABC']]);

// retrieve all items with a name starting with A
$filtered = $collection->whereStartsWith('name','A');

// retrieve all items with a name ending with B
$filtered = $collection->whereEndsWith('name','B');

// retrieve all items with a name containing C
$filtered = $collection->whereContains('name','C');

// retrieve all items with a name containing c , ignoring the case 
$filtered = $collection->whereContains('name','c', false);

```
