### PR TITLE
 [9.x] Added View Create Command

### DIFF
--- a/src/Illuminate/Foundation/Console/ViewCreateCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewCreateCommand.php
@@ -57,7 +57,7 @@ class ViewCreateCommand extends Command
         if (file_exists($viewPath) && ! $force) {
 
             $this->error('View already exists!');
-            
+
             return Command::FAILURE;
         } elseif (file_exists($viewPath) && $force) {
             unlink($viewPath);

--- a/src/Illuminate/Foundation/Console/ViewCreateCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewCreateCommand.php
@@ -12,8 +12,7 @@ class ViewCreateCommand extends GeneratorCommand
      *
      * @var string
      */
-    protected $signature = 'make:view {name} 
-                {--p|path : If the specified directory does not exist, it creates a directory.}
+    protected $signature = 'make:view {name}
                 {--f|force : Overwrite existing view if any}';
 
     /**
@@ -37,12 +36,11 @@ class ViewCreateCommand extends GeneratorCommand
     public function handle()
     {
 
-        // Here, we look at whether there is a view file to be created, then the relevant  
-        // answers are returned to those who use the command, and at the end, the view file is  
+        // Here, we look at whether there is a view file to be created, then the relevant
+        // answers are returned to those who use the command, and at the end, the view file is
         // created.
 
         $force = $this->option('force');
-        $path = $this->option('path');
 
         // If it specifies directory and file as dots, it converts dots to slash(/)
         $viewName = $this->getView();
@@ -52,19 +50,15 @@ class ViewCreateCommand extends GeneratorCommand
         // If the file exists, and the user wants to overwrite it, it will be overwritten.
         if (file_exists($viewPath) && ! $force) {
             $this->error('View already exists!');
+
             return GeneratorCommand::FAILURE;
         } elseif (file_exists($viewPath) && $force) {
             unlink($viewPath);
         }
 
         // If the directory exists, and the user wants to overwrite it, it will be overwritten.
-        if (! is_dir(dirname($viewPath)) && $path) {
+        if (! is_dir(dirname($viewPath))) {
             mkdir(dirname($viewPath), 0755, true);
-        } elseif (! is_dir(dirname($viewPath)) && ! $path) {
-            $this->error("Directory does not exist!");
-            $this->info('If you want to create the directory as well add the -p flag');
-
-            return GeneratorCommand::FAILURE;
         }
 
         $this->info('Creating view:'.$viewName.'.blade.php');

--- a/src/Illuminate/Foundation/Console/ViewCreateCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewCreateCommand.php
@@ -57,6 +57,7 @@ class ViewCreateCommand extends Command
         if (file_exists($viewPath) && ! $force) {
 
             $this->error('View already exists!');
+            
             return Command::FAILURE;
         } elseif (file_exists($viewPath) && $force) {
             unlink($viewPath);

--- a/src/Illuminate/Foundation/Console/ViewCreateCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewCreateCommand.php
@@ -41,8 +41,8 @@ class ViewCreateCommand extends Command
     public function handle()
     {
 
-        // Here, we look at whether there is a view file to be created, then the relevant  
-        // answers are returned to those who use the command, and at the end, the view file is  
+        // Here, we look at whether there is a view file to be created, then the relevant
+        // answers are returned to those who use the command, and at the end, the view file is
         // created.
 
         $force = $this->option('force');
@@ -66,14 +66,15 @@ class ViewCreateCommand extends Command
         if (! is_dir(dirname($viewPath)) && $path) {
             mkdir(dirname($viewPath), 0755, true);
         } elseif (! is_dir(dirname($viewPath)) && ! $path) {
-            $this->error("Directory does not exist!");
+            $this->error('Directory does not exist!');
             $this->info('If you want to create the directory as well add the -p flag');
 
             return Command::FAILURE;
         }
 
         $this->info('Creating view:'.$viewName.'.blade.php');
-        file_put_contents($viewPath, '@extends(\'layouts.app\')' . "\n\n" . '@section(\'content\')' . "\n\n" . '@endsection');
+        file_put_contents($viewPath, '@extends(\'layouts.app\')'."\n\n".'@section(\'content\')'."\n\n".'@endsection');
+
         return Command::SUCCESS;
     }
 }

--- a/src/Illuminate/Foundation/Console/ViewCreateCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewCreateCommand.php
@@ -43,7 +43,7 @@ class ViewCreateCommand extends GeneratorCommand
         $force = $this->option('force');
 
         // If it specifies directory and file as dots, it converts dots to slash(/)
-        $viewName = $this->getView();
+        $viewName = Str::of($this->argument('name'))->replace('.', DIRECTORY_SEPARATOR)->replace('//', '/');
 
         $viewPath = resource_path('views/'.$viewName.'.blade.php');
 
@@ -56,12 +56,12 @@ class ViewCreateCommand extends GeneratorCommand
             unlink($viewPath);
         }
 
-        // If the directory exists, and the user wants to overwrite it, it will be overwritten.
+        // If the folder does not exist, it creates a new folder.
         if (! is_dir(dirname($viewPath))) {
             mkdir(dirname($viewPath), 0755, true);
         }
 
-        $this->info('Creating view:'.$viewName.'.blade.php');
+        $this->info('Creating view: '.$viewName.'.blade.php');
 
         copy($this->getStub(), $viewPath);
 
@@ -71,10 +71,5 @@ class ViewCreateCommand extends GeneratorCommand
     protected function getStub()
     {
         return __DIR__.'/stubs/view-make.stub';
-    }
-
-    protected function getView()
-    {
-        return Str::of($this->argument('name'))->replace('.', DIRECTORY_SEPARATOR)->replace('//', '/');
     }
 }

--- a/src/Illuminate/Foundation/Console/ViewCreateCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewCreateCommand.php
@@ -12,7 +12,7 @@ class ViewCreateCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'view:create {name} 
+    protected $signature = 'make:view {name} 
                 {--p|path : If the specified directory does not exist, it creates a directory.}
                 {--f|force : Overwrite existing view if any}';
 

--- a/src/Illuminate/Foundation/Console/ViewCreateCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewCreateCommand.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Str;
+
+class ViewCreateCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'view:create {name} 
+                {--p|path : If the specified directory does not exist, it creates a directory.}
+                {--f|force : Overwrite existing view if any}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a view file in the resources/views directory';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+
+        // Here, we look at whether there is a view file to be created, then the relevant  
+        // answers are returned to those who use the command, and at the end, the view file is  
+        // created.
+
+        $force = $this->option('force');
+        $path = $this->option('path');
+
+        // If it specifies directory and file as dots, it converts dots to slash(/)
+        $viewName = Str::of($this->argument('name'))->replace('.', DIRECTORY_SEPARATOR)->replace('//', '/');
+
+        $viewPath = resource_path('views/' . $viewName . '.blade.php');
+
+        // If the file exists, and the user wants to overwrite it, it will be overwritten.
+        if (file_exists($viewPath) && !$force) {
+            $this->error('View already exists!');
+            return Command::FAILURE;
+        } elseif (file_exists($viewPath) && $force) {
+            unlink($viewPath);
+        }
+
+        // If the directory exists, and the user wants to overwrite it, it will be overwritten.
+        if (!is_dir(dirname($viewPath)) && $path) {
+            mkdir(dirname($viewPath), 0755, true);
+        } elseif (!is_dir(dirname($viewPath)) && !$path) {
+            $this->error("Directory does not exist!");
+            $this->info('If you want to create the directory as well add the -p flag');
+
+            return Command::FAILURE;
+        }
+        
+        $this->info('Creating view: ' . $viewName . '.blade.php');
+        file_put_contents($viewPath, '@extends(\'layouts.app\')' . "\n\n" . '@section(\'content\')' . "\n\n" . '@endsection');
+        return Command::SUCCESS;
+    }
+}

--- a/src/Illuminate/Foundation/Console/ViewCreateCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewCreateCommand.php
@@ -64,13 +64,13 @@ class ViewCreateCommand extends GeneratorCommand
         $this->info('Creating view:'.$viewName.'.blade.php');
 
         copy($this->getStub(), $viewPath);
-    
+
         return GeneratorCommand::SUCCESS;
     }
 
     protected function getStub()
     {
-        return __DIR__ .'/stubs/view-make.stub';
+        return __DIR__.'/stubs/view-make.stub';
     }
 
     protected function getView()

--- a/src/Illuminate/Foundation/Console/ViewCreateCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewCreateCommand.php
@@ -55,7 +55,6 @@ class ViewCreateCommand extends Command
 
         // If the file exists, and the user wants to overwrite it, it will be overwritten.
         if (file_exists($viewPath) && ! $force) {
-
             $this->error('View already exists!');
 
             return Command::FAILURE;

--- a/src/Illuminate/Foundation/Console/ViewCreateCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewCreateCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Foundation\Console;
+namespace App\Console\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Str;
@@ -51,10 +51,11 @@ class ViewCreateCommand extends Command
         // If it specifies directory and file as dots, it converts dots to slash(/)
         $viewName = Str::of($this->argument('name'))->replace('.', DIRECTORY_SEPARATOR)->replace('//', '/');
 
-        $viewPath = resource_path('views/' . $viewName . '.blade.php');
+        $viewPath = resource_path('views/'.$viewName.'.blade.php');
 
         // If the file exists, and the user wants to overwrite it, it will be overwritten.
-        if (file_exists($viewPath) && !$force) {
+        if (file_exists($viewPath) && ! $force) {
+
             $this->error('View already exists!');
             return Command::FAILURE;
         } elseif (file_exists($viewPath) && $force) {
@@ -62,16 +63,16 @@ class ViewCreateCommand extends Command
         }
 
         // If the directory exists, and the user wants to overwrite it, it will be overwritten.
-        if (!is_dir(dirname($viewPath)) && $path) {
+        if (! is_dir(dirname($viewPath)) && $path) {
             mkdir(dirname($viewPath), 0755, true);
-        } elseif (!is_dir(dirname($viewPath)) && !$path) {
+        } elseif (! is_dir(dirname($viewPath)) && ! $path) {
             $this->error("Directory does not exist!");
             $this->info('If you want to create the directory as well add the -p flag');
 
             return Command::FAILURE;
         }
-        
-        $this->info('Creating view: ' . $viewName . '.blade.php');
+
+        $this->info('Creating view:'.$viewName.'.blade.php');
         file_put_contents($viewPath, '@extends(\'layouts.app\')' . "\n\n" . '@section(\'content\')' . "\n\n" . '@endsection');
         return Command::SUCCESS;
     }

--- a/src/Illuminate/Foundation/Console/ViewCreateCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewCreateCommand.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace App\Console\Commands;
+namespace Illuminate\Foundation\Console;
 
-use Illuminate\Console\Command;
+use Illuminate\Console\GeneratorCommand;
 use Illuminate\Support\Str;
 
-class ViewCreateCommand extends Command
+class ViewCreateCommand extends GeneratorCommand
 {
     /**
      * The name and signature of the console command.
@@ -28,10 +28,6 @@ class ViewCreateCommand extends Command
      *
      * @return void
      */
-    public function __construct()
-    {
-        parent::__construct();
-    }
 
     /**
      * Execute the console command.
@@ -41,23 +37,22 @@ class ViewCreateCommand extends Command
     public function handle()
     {
 
-        // Here, we look at whether there is a view file to be created, then the relevant
-        // answers are returned to those who use the command, and at the end, the view file is
+        // Here, we look at whether there is a view file to be created, then the relevant  
+        // answers are returned to those who use the command, and at the end, the view file is  
         // created.
 
         $force = $this->option('force');
         $path = $this->option('path');
 
         // If it specifies directory and file as dots, it converts dots to slash(/)
-        $viewName = Str::of($this->argument('name'))->replace('.', DIRECTORY_SEPARATOR)->replace('//', '/');
+        $viewName = $this->getView();
 
         $viewPath = resource_path('views/'.$viewName.'.blade.php');
 
         // If the file exists, and the user wants to overwrite it, it will be overwritten.
         if (file_exists($viewPath) && ! $force) {
             $this->error('View already exists!');
-
-            return Command::FAILURE;
+            return GeneratorCommand::FAILURE;
         } elseif (file_exists($viewPath) && $force) {
             unlink($viewPath);
         }
@@ -66,15 +61,26 @@ class ViewCreateCommand extends Command
         if (! is_dir(dirname($viewPath)) && $path) {
             mkdir(dirname($viewPath), 0755, true);
         } elseif (! is_dir(dirname($viewPath)) && ! $path) {
-            $this->error('Directory does not exist!');
+            $this->error("Directory does not exist!");
             $this->info('If you want to create the directory as well add the -p flag');
 
-            return Command::FAILURE;
+            return GeneratorCommand::FAILURE;
         }
 
         $this->info('Creating view:'.$viewName.'.blade.php');
-        file_put_contents($viewPath, '@extends(\'layouts.app\')'."\n\n".'@section(\'content\')'."\n\n".'@endsection');
 
-        return Command::SUCCESS;
+        copy($this->getStub(), $viewPath);
+    
+        return GeneratorCommand::SUCCESS;
+    }
+
+    protected function getStub()
+    {
+        return __DIR__ .'/stubs/view-make.stub';
+    }
+
+    protected function getView()
+    {
+        return Str::of($this->argument('name'))->replace('.', DIRECTORY_SEPARATOR)->replace('//', '/');
     }
 }


### PR DESCRIPTION
This command allows to create a view file from terminal. In some cases, when projects grow, it can be annoying to navigate to the resources directory and navigate through the directories in it. With this command, it is sufficient to write only the directory name and the name of the view to be created.
> If the file exists, the command returns a warning.
## normal use
```
php artisan make:view viewName
```

If a view file exists in the specified directory, it will issue a warning and stop the command. If the user wants to force this, they add the -f flag and the corresponding file is overwritten.

```
php artisan make:view directory.viewName -f
```
