### PR TITLE
select fields for count in the paginate method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -799,13 +799,13 @@ class Builder
      *
      * @throws \InvalidArgumentException
      */
-    public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null)
+    public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null, $count = ['*'])
     {
         $page = $page ?: Paginator::resolveCurrentPage($pageName);
 
         $perPage = $perPage ?: $this->model->getPerPage();
 
-        $results = ($total = $this->toBase()->getCountForPagination())
+        $results = ($total = $this->toBase()->getCountForPagination($count))
                                     ? $this->forPage($page, $perPage)->get($columns)
                                     : $this->model->newCollection();
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -795,6 +795,7 @@ class Builder
      * @param  array  $columns
      * @param  string  $pageName
      * @param  int|null  $page
+     * @param  array  $count
      * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
      *
      * @throws \InvalidArgumentException

--- a/tests/Integration/Database/EloquentPaginateTest.php
+++ b/tests/Integration/Database/EloquentPaginateTest.php
@@ -96,6 +96,19 @@ class EloquentPaginateTest extends DatabaseTestCase
         $this->assertEquals(5, $query->count());
         $this->assertEquals(5, $query->paginate()->total());
     }
+
+    public function testPaginationWithSpecificCountFields()
+    {
+        for ($i = 1; $i <= 50; $i++) {
+            Post::create(['title' => 'Hello world ' . $i]);
+        }
+
+        $this->assertEquals(50, Post::query()->paginate(10, ['*'], 'page', null, ['id'])->total());
+        $this->assertEquals(
+            Post::query()->paginate(10, ['*'], 'page', null, ['id'])->total(),
+            Post::query()->paginate()->total()
+        );
+    }
 }
 
 class Post extends Model

--- a/tests/Integration/Database/EloquentPaginateTest.php
+++ b/tests/Integration/Database/EloquentPaginateTest.php
@@ -100,7 +100,7 @@ class EloquentPaginateTest extends DatabaseTestCase
     public function testPaginationWithSpecificCountFields()
     {
         for ($i = 1; $i <= 50; $i++) {
-            Post::create(['title' => 'Hello world ' . $i]);
+            Post::create(['title' => 'Hello world '.$i]);
         }
 
         $this->assertEquals(50, Post::query()->paginate(10, ['*'], 'page', null, ['id'])->total());


### PR DESCRIPTION
Hi!

Currently in the `Model::paginate()` method you can configure the columns to you want to return in the result but those columns are not used for the count operation.

![image](https://user-images.githubusercontent.com/198571/147004416-3ad6005b-70eb-4c1d-97a8-c36c89332e72.png)

In terms of improve the performance in the `count` my idea is add a new argument in the `paginate` method to configure separately the columns for the count and you can use some indexed fields to improve the performance.

 