### PR TITLE
[8.x] Remove an useless check in Console Application class

### DIFF
--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -210,7 +210,7 @@ class Application extends SymfonyApplication implements ApplicationContract
             $input = new ArrayInput($parameters);
         }
 
-        return [$command, $input ?? null];
+        return [$command, $input];
     }
 
     /**


### PR DESCRIPTION
The local variable `$input` inside the `parseCommand` method of Console Application class is always an instance of either `StringInput` or `ArrayInput`. It's never null (false), so "$input ?? null" is useless. I just remove that check.