### PR TITLE
[8.x] Replace property_exists by null coalescing operator

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastEvent.php
+++ b/src/Illuminate/Broadcasting/BroadcastEvent.php
@@ -44,9 +44,9 @@ class BroadcastEvent implements ShouldQueue
     public function __construct($event)
     {
         $this->event = $event;
-        $this->tries = property_exists($event, 'tries') ? $event->tries : null;
-        $this->timeout = property_exists($event, 'timeout') ? $event->timeout : null;
-        $this->afterCommit = property_exists($event, 'afterCommit') ? $event->afterCommit : null;
+        $this->tries = $event->tries ?? null;
+        $this->timeout = $event->timeout ?? null;
+        $this->afterCommit = $event->afterCommit ?? null;
     }
 
     /**

--- a/src/Illuminate/Database/Console/PruneCommand.php
+++ b/src/Illuminate/Database/Console/PruneCommand.php
@@ -63,9 +63,7 @@ class PruneCommand extends Command
         $models->each(function ($model) {
             $instance = new $model;
 
-            $chunkSize = property_exists($instance, 'prunableChunkSize')
-                            ? $instance->prunableChunkSize
-                            : $this->option('chunk');
+            $chunkSize = $instance->prunableChunkSize ?? $this->option('chunk');
 
             $total = $this->isPrunable($model)
                         ? $instance->pruneAll($chunkSize)

--- a/src/Illuminate/Database/Eloquent/BroadcastsEvents.php
+++ b/src/Illuminate/Database/Eloquent/BroadcastsEvents.php
@@ -129,17 +129,11 @@ trait BroadcastsEvents
     public function newBroadcastableModelEvent($event)
     {
         return tap($this->newBroadcastableEvent($event), function ($event) {
-            $event->connection = property_exists($this, 'broadcastConnection')
-                            ? $this->broadcastConnection
-                            : $this->broadcastConnection();
+            $event->connection = $this->broadcastConnection ?? $this->broadcastConnection();
 
-            $event->queue = property_exists($this, 'broadcastQueue')
-                            ? $this->broadcastQueue
-                            : $this->broadcastQueue();
+            $event->queue = $this->broadcastQueue ?? $this->broadcastQueue();
 
-            $event->afterCommit = property_exists($this, 'broadcastAfterCommit')
-                            ? $this->broadcastAfterCommit
-                            : $this->broadcastAfterCommit();
+            $event->afterCommit = $this->broadcastAfterCommit ?? $this->broadcastAfterCommit();
         });
     }
 

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -601,7 +601,7 @@ class Dispatcher implements DispatcherContract
     protected function propagateListenerOptions($listener, $job)
     {
         return tap($job, function ($job) use ($listener) {
-            $job->afterCommit = property_exists($listener, 'afterCommit') ? $listener->afterCommit : null;
+            $job->afterCommit = $listener->afterCommit ?? null;
             $job->backoff = method_exists($listener, 'backoff') ? $listener->backoff() : ($listener->backoff ?? null);
             $job->maxExceptions = $listener->maxExceptions ?? null;
             $job->retryUntil = method_exists($listener, 'retryUntil') ? $listener->retryUntil() : null;

--- a/src/Illuminate/Foundation/Testing/DatabaseTransactions.php
+++ b/src/Illuminate/Foundation/Testing/DatabaseTransactions.php
@@ -42,7 +42,6 @@ trait DatabaseTransactions
      */
     protected function connectionsToTransact()
     {
-        return property_exists($this, 'connectionsToTransact')
-                            ? $this->connectionsToTransact : [null];
+        return $this->connectionsToTransact ?? [null];
     }
 }

--- a/src/Illuminate/Foundation/Testing/RefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/RefreshDatabase.php
@@ -115,8 +115,7 @@ trait RefreshDatabase
      */
     protected function connectionsToTransact()
     {
-        return property_exists($this, 'connectionsToTransact')
-                            ? $this->connectionsToTransact : [null];
+        return $this->connectionsToTransact ?? [null];
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/Traits/CanConfigureMigrationCommands.php
+++ b/src/Illuminate/Foundation/Testing/Traits/CanConfigureMigrationCommands.php
@@ -29,7 +29,7 @@ trait CanConfigureMigrationCommands
      */
     protected function shouldDropViews()
     {
-        return property_exists($this, 'dropViews') ? $this->dropViews : false;
+        return $this->dropViews ?? false;
     }
 
     /**
@@ -39,7 +39,7 @@ trait CanConfigureMigrationCommands
      */
     protected function shouldDropTypes()
     {
-        return property_exists($this, 'dropTypes') ? $this->dropTypes : false;
+        return $this->dropTypes ?? false;
     }
 
     /**
@@ -49,7 +49,7 @@ trait CanConfigureMigrationCommands
      */
     protected function shouldSeed()
     {
-        return property_exists($this, 'seed') ? $this->seed : false;
+        return $this->seed ?? false;
     }
 
     /**
@@ -59,6 +59,6 @@ trait CanConfigureMigrationCommands
      */
     protected function seeder()
     {
-        return property_exists($this, 'seeder') ? $this->seeder : false;
+        return $this->seeder ?? false;
     }
 }

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -205,7 +205,7 @@ class Mailable implements MailableContract, Renderable
         $queueName = $this->queue ?? null;
 
         return $queue->connection($connection)->pushOn(
-            $queueName ?: null, $this->newQueuedJob()
+            $queueName, $this->newQueuedJob()
         );
     }
 
@@ -223,7 +223,7 @@ class Mailable implements MailableContract, Renderable
         $queueName = $this->queue ?? null;
 
         return $queue->connection($connection)->laterOn(
-            $queueName ?: null, $delay, $this->newQueuedJob()
+            $queueName, $delay, $this->newQueuedJob()
         );
     }
 

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -200,9 +200,9 @@ class Mailable implements MailableContract, Renderable
             return $this->later($this->delay, $queue);
         }
 
-        $connection = property_exists($this, 'connection') ? $this->connection : null;
+        $connection = $this->connection ?? null;
 
-        $queueName = property_exists($this, 'queue') ? $this->queue : null;
+        $queueName = $this->queue ?? null;
 
         return $queue->connection($connection)->pushOn(
             $queueName ?: null, $this->newQueuedJob()
@@ -218,9 +218,9 @@ class Mailable implements MailableContract, Renderable
      */
     public function later($delay, Queue $queue)
     {
-        $connection = property_exists($this, 'connection') ? $this->connection : null;
+        $connection = $this->connection ?? null;
 
-        $queueName = property_exists($this, 'queue') ? $this->queue : null;
+        $queueName = $this->queue ?? null;
 
         return $queue->connection($connection)->laterOn(
             $queueName ?: null, $delay, $this->newQueuedJob()

--- a/src/Illuminate/Mail/SendQueuedMailable.php
+++ b/src/Illuminate/Mail/SendQueuedMailable.php
@@ -48,9 +48,9 @@ class SendQueuedMailable
     public function __construct(MailableContract $mailable)
     {
         $this->mailable = $mailable;
-        $this->tries = property_exists($mailable, 'tries') ? $mailable->tries : null;
-        $this->timeout = property_exists($mailable, 'timeout') ? $mailable->timeout : null;
-        $this->afterCommit = property_exists($mailable, 'afterCommit') ? $mailable->afterCommit : null;
+        $this->tries = $mailable->tries ?? null;
+        $this->timeout = $mailable->timeout ?? null;
+        $this->afterCommit = $mailable->afterCommit ?? null;
         $this->shouldBeEncrypted = $mailable instanceof ShouldBeEncrypted;
     }
 

--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -93,7 +93,7 @@ class MailChannel
             return $message->view;
         }
 
-        if (property_exists($message, 'theme') && ! is_null($message->theme)) {
+        if ($message->theme ?? null) {
             $this->markdown->theme($message->theme);
         }
 

--- a/src/Illuminate/Notifications/SendQueuedNotifications.php
+++ b/src/Illuminate/Notifications/SendQueuedNotifications.php
@@ -70,9 +70,9 @@ class SendQueuedNotifications implements ShouldQueue
         $this->channels = $channels;
         $this->notification = $notification;
         $this->notifiables = $this->wrapNotifiables($notifiables);
-        $this->tries = property_exists($notification, 'tries') ? $notification->tries : null;
-        $this->timeout = property_exists($notification, 'timeout') ? $notification->timeout : null;
-        $this->afterCommit = property_exists($notification, 'afterCommit') ? $notification->afterCommit : null;
+        $this->tries = $notification->tries ?? null;
+        $this->timeout = $notification->timeout ?? null;
+        $this->afterCommit = $notification->afterCommit ?? null;
         $this->shouldBeEncrypted = $notification instanceof ShouldBeEncrypted;
     }
 


### PR DESCRIPTION
There are a lot of `property_exists` calls that can be replaced by using null coalescing operator. In this PR, I just help to replace where possible. 