### PR TITLE
[8.x] add `schedule:clear-mutex` command

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleClearCacheCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleClearCacheCommand.php
@@ -4,21 +4,21 @@ namespace Illuminate\Console\Scheduling;
 
 use Illuminate\Console\Command;
 
-class ScheduleClearMutexCommand extends Command
+class ScheduleClearCacheCommand extends Command
 {
     /**
      * The console command name.
      *
      * @var string
      */
-    protected $name = 'schedule:clear-mutex';
+    protected $name = 'schedule:clear-cache';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = 'Clear all the mutex files created by withoutOverlap()';
+    protected $description = 'Delete the cached mutex files created by scheduler';
 
     /**
      * Execute the console command.
@@ -29,17 +29,19 @@ class ScheduleClearMutexCommand extends Command
     public function handle(Schedule $schedule)
     {
         $mutexCleared = false;
+
         foreach ($schedule->events($this->laravel) as $event) {
-            $command = explode(' ', $event->command)[2];
             if ($event->mutex->exists($event)) {
-                $this->line('<info>Clearing mutex for:</info> '.$command);
+                $this->line('<info>Deleting mutex for:</info> '.$event->command);
+
                 $event->mutex->forget($event);
+
                 $mutexCleared = true;
             }
         }
 
         if (! $mutexCleared) {
-            $this->info('No mutex to clear.');
+            $this->info('No mutex files were found.');
         }
     }
 }

--- a/src/Illuminate/Console/Scheduling/ScheduleClearMutexCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleClearMutexCommand.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Illuminate\Console\Scheduling;
+
+use Illuminate\Console\Command;
+
+class ScheduleClearMutexCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'schedule:clear-mutex';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Clear all the mutex files created by withoutOverlap()';
+
+    /**
+     * Execute the console command.
+     *
+     * @param  \Illuminate\Console\Scheduling\Schedule  $schedule
+     * @return void
+     */
+    public function handle(Schedule $schedule)
+    {
+        $mutexCleared = false;
+        foreach ($schedule->events($this->laravel) as $event) {
+            $command = explode(' ', $event->command)[2];
+            if ($event->mutex->exists($event)) {
+                $this->line('<info>Clearing mutex for:</info> '.$command);
+                $event->mutex->forget($event);
+                $mutexCleared = true;
+            }
+        }
+
+        if (! $mutexCleared) {
+            $this->info('No mutex to clear.');
+        }
+    }
+}

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -6,7 +6,7 @@ use Illuminate\Auth\Console\ClearResetsCommand;
 use Illuminate\Cache\Console\CacheTableCommand;
 use Illuminate\Cache\Console\ClearCommand as CacheClearCommand;
 use Illuminate\Cache\Console\ForgetCommand as CacheForgetCommand;
-use Illuminate\Console\Scheduling\ScheduleClearMutexCommand;
+use Illuminate\Console\Scheduling\ScheduleClearCacheCommand;
 use Illuminate\Console\Scheduling\ScheduleFinishCommand;
 use Illuminate\Console\Scheduling\ScheduleListCommand;
 use Illuminate\Console\Scheduling\ScheduleRunCommand;
@@ -128,7 +128,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'ScheduleFinish' => ScheduleFinishCommand::class,
         'ScheduleList' => ScheduleListCommand::class,
         'ScheduleRun' => ScheduleRunCommand::class,
-        'ScheduleClearMutex' => ScheduleClearMutexCommand::class,
+        'ScheduleClearCache' => ScheduleClearCacheCommand::class,
         'ScheduleTest' => ScheduleTestCommand::class,
         'ScheduleWork' => ScheduleWorkCommand::class,
         'StorageLink' => 'command.storage.link',
@@ -1005,9 +1005,9 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      *
      * @return void
      */
-    protected function registerScheduleClearMutexCommand()
+    protected function registerScheduleClearCacheCommand()
     {
-        $this->app->singleton(ScheduleClearMutexCommand::class);
+        $this->app->singleton(ScheduleClearCacheCommand::class);
     }
 
     /**

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -6,6 +6,7 @@ use Illuminate\Auth\Console\ClearResetsCommand;
 use Illuminate\Cache\Console\CacheTableCommand;
 use Illuminate\Cache\Console\ClearCommand as CacheClearCommand;
 use Illuminate\Cache\Console\ForgetCommand as CacheForgetCommand;
+use Illuminate\Console\Scheduling\ScheduleClearMutexCommand;
 use Illuminate\Console\Scheduling\ScheduleFinishCommand;
 use Illuminate\Console\Scheduling\ScheduleListCommand;
 use Illuminate\Console\Scheduling\ScheduleRunCommand;
@@ -127,6 +128,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'ScheduleFinish' => ScheduleFinishCommand::class,
         'ScheduleList' => ScheduleListCommand::class,
         'ScheduleRun' => ScheduleRunCommand::class,
+        'ScheduleClearMutex' => ScheduleClearMutexCommand::class,
         'ScheduleTest' => ScheduleTestCommand::class,
         'ScheduleWork' => ScheduleWorkCommand::class,
         'StorageLink' => 'command.storage.link',
@@ -996,6 +998,16 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
     protected function registerScheduleRunCommand()
     {
         $this->app->singleton(ScheduleRunCommand::class);
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerScheduleClearMutexCommand()
+    {
+        $this->app->singleton(ScheduleClearMutexCommand::class);
     }
 
     /**

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -975,6 +975,16 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      *
      * @return void
      */
+    protected function registerScheduleClearCacheCommand()
+    {
+        $this->app->singleton(ScheduleClearCacheCommand::class);
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
     protected function registerScheduleFinishCommand()
     {
         $this->app->singleton(ScheduleFinishCommand::class);
@@ -998,16 +1008,6 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
     protected function registerScheduleRunCommand()
     {
         $this->app->singleton(ScheduleRunCommand::class);
-    }
-
-    /**
-     * Register the command.
-     *
-     * @return void
-     */
-    protected function registerScheduleClearCacheCommand()
-    {
-        $this->app->singleton(ScheduleClearCacheCommand::class);
     }
 
     /**


### PR DESCRIPTION
Currently there is no way to clear the mutex files created when using withoutOverlap(). The only way to clear them is using `php artisan cache:clear` however this is dangerous since it clears all other cache as well.

If your server restarts while a task is running, the mutex file does not get deleted. Then when the server comes up, it could take up to 24 hours (default value) for your task to re-run because the mutex file still exists. The only way currently to solve this is just running `cache:clear` however this is not optimal. 

In order to delete only mutex files I added a `schedule:clear-mutex` command. 
