### PR TITLE
[8.x] Added ability to define extra default password rules

### DIFF
--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -80,7 +80,7 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
     protected $compromisedThreshold = 0;
 
     /**
-     * Custom validation rules that should be used.
+     * Additional validation rules that should be merged into the default rules during validation.
      *
      * @var array
      */
@@ -267,10 +267,10 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
     }
 
     /**
-     * Define custom validation rules that should be used.
+     * Specify additional validation rules that should be merged with the default rules during validation.
      *
-     * @param $rules
-     * @return Password
+     * @param  string|array  $rules
+     * @return $this
      */
     public function rules($rules)
     {

--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -80,6 +80,13 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
     protected $compromisedThreshold = 0;
 
     /**
+     * Custom validation rules that should be used.
+     *
+     * @var array
+     */
+    protected $customRules = [];
+
+    /**
      * The failure messages, if any.
      *
      * @var array
@@ -260,6 +267,19 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
     }
 
     /**
+     * Define custom validation rules that should be used.
+     *
+     * @param $rules
+     * @return Password
+     */
+    public function rules($rules)
+    {
+        $this->customRules = Arr::wrap($rules);
+
+        return $this;
+    }
+
+    /**
      * Determine if the validation rule passes.
      *
      * @param  string  $attribute
@@ -272,7 +292,7 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
 
         $validator = Validator::make(
             $this->data,
-            [$attribute => 'string|min:'.$this->min],
+            [$attribute => array_merge(['string', 'min:'.$this->min], $this->customRules)],
             $this->validator->customMessages,
             $this->validator->customAttributes
         )->after(function ($validator) use ($attribute, $value) {

--- a/tests/Validation/ValidationPasswordRuleTest.php
+++ b/tests/Validation/ValidationPasswordRuleTest.php
@@ -6,7 +6,6 @@ use Illuminate\Container\Container;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Translation\ArrayLoader;
 use Illuminate\Translation\Translator;
-use Illuminate\Validation\Rule;
 use Illuminate\Validation\Rules\Password;
 use Illuminate\Validation\ValidationServiceProvider;
 use Illuminate\Validation\Validator;
@@ -297,11 +296,11 @@ class ValidationPasswordRuleTest extends TestCase
         $this->passes(Password::min(2)->rules([$closureRule, $ruleObject]), ['aa']);
 
         $this->fails(Password::min(2)->rules($closureRule), ['ab'], [
-            'Custom rule closure failed'
+            'Custom rule closure failed',
         ]);
 
         $this->fails(Password::min(2)->rules($ruleObject), ['ab'], [
-            'Custom rule object failed'
+            'Custom rule object failed',
         ]);
     }
 


### PR DESCRIPTION
Hi! This PR is only fairly simple but I think could be really useful. It adds the functionality for you to define your own custom validation rules that should be run when using the `Password::defaults()` validation rule.

As far as I could see, this functionality doesn't already exist; but if it does, apologies.

To give a bit of context, I have an app that has 5 different places where users can be created and updated. At the moment, I'm using the password defaults, but also want to add a rule to make sure that every password passes a [zxcvbn](https://github.com/bjeavons/zxcvbn-php) validation check. So my form request rules look similar to this:

```php
public function rules()
{
    return  [
        // ...
       'password' => ['required', Password::defaults(), new ZxcvbnRule()],
        // ...
    ];
}
```

By default, I always want my passwords to pass the `ZxcvbnRule` validation check, so I have this in every place where I'm using `Password::defaults()`. So, in a way, I'm also treating that rule as a default one too.

So, with my proposed change, I can do something like this to define some extra default password rules:

```php
Password::defaults(function () {
    return Password::min(8)
        ->symbols()
        ->mixedCase()
        ->uncompromised()
        ->rules(new ZxcvbnRule());
});
```

This means that I can then clean up my form request rules and be confident that the `ZxcvbnRule()` will always be run wherever the password defaults are used. It could look more like this:

```php

public function rules()
{
    return  [
        // ...
       'password' => ['required', Password::defaults()],
        // ...
    ];
}
```

The new `->rules()` method that I've added supports rule objects and closures and they can be passed in individually or as an array like so:

```php
Password::defaults(function () {
    return Password::min(8)
        ->rules(new ZxcvbnRule());
});
```

```php
Password::defaults(function () {
    return Password::min(8)
        ->rules([new ZxcvbnRule(), new AnotherRule()]);
});
```

```php
Password::defaults(function () {
    return Password::min(8)
        ->rules(function ($attribute, $value, $fail) {
            if ($value !== 'foo') {
                $fail('Password is not foo');
            }
        });
});
```

As far as I can see, this appears to be working. If it's something that you might consider merging, please let me know if you need any changes making 😄