### PR TITLE
[8.x] Add the ability to select the count fields in paginate method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -799,13 +799,13 @@ class Builder
      *
      * @throws \InvalidArgumentException
      */
-    public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null)
+    public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null, $count = ['*'])
     {
         $page = $page ?: Paginator::resolveCurrentPage($pageName);
 
         $perPage = $perPage ?: $this->model->getPerPage();
 
-        $results = ($total = $this->toBase()->getCountForPagination())
+        $results = ($total = $this->toBase()->getCountForPagination($count))
                                     ? $this->forPage($page, $perPage)->get($columns)
                                     : $this->model->newCollection();
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -795,6 +795,7 @@ class Builder
      * @param  array  $columns
      * @param  string  $pageName
      * @param  int|null  $page
+     * @param  array  $count
      * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
      *
      * @throws \InvalidArgumentException

--- a/tests/Integration/Database/EloquentPaginateTest.php
+++ b/tests/Integration/Database/EloquentPaginateTest.php
@@ -96,6 +96,19 @@ class EloquentPaginateTest extends DatabaseTestCase
         $this->assertEquals(5, $query->count());
         $this->assertEquals(5, $query->paginate()->total());
     }
+
+    public function testPaginationWithSpecificCountFields()
+    {
+        for ($i = 1; $i <= 50; $i++) {
+            Post::create(['title' => 'Hello world ' . $i]);
+        }
+
+        $this->assertEquals(50, Post::query()->paginate(10, ['*'], 'page', null, ['id'])->total());
+        $this->assertEquals(
+            Post::query()->paginate(10, ['*'], 'page', null, ['id'])->total(),
+            Post::query()->paginate()->total()
+        );
+    }
 }
 
 class Post extends Model

--- a/tests/Integration/Database/EloquentPaginateTest.php
+++ b/tests/Integration/Database/EloquentPaginateTest.php
@@ -100,7 +100,7 @@ class EloquentPaginateTest extends DatabaseTestCase
     public function testPaginationWithSpecificCountFields()
     {
         for ($i = 1; $i <= 50; $i++) {
-            Post::create(['title' => 'Hello world ' . $i]);
+            Post::create(['title' => 'Hello world '.$i]);
         }
 
         $this->assertEquals(50, Post::query()->paginate(10, ['*'], 'page', null, ['id'])->total());


### PR DESCRIPTION
Currently in the `Model::paginate()` method you can configure the columns you want to return in the result but these columns are not used for the count operation.

![image](https://user-images.githubusercontent.com/198571/147133800-bf7a449d-1024-4c18-9ae0-24b115d2abf1.png)

In terms of improve the performance in the count process, my idea is add a new argument in the `paginate` method to configure separately the columns for the count and then you can use some indexed fields to improve the performance.

![image](https://user-images.githubusercontent.com/198571/147133868-4a1872ce-5fdc-498d-a0cd-8907072a3479.png)

another quick test:

![image](https://user-images.githubusercontent.com/198571/147135218-4c62fd5d-5a37-434e-a690-9ff36091bc52.png)

![image](https://user-images.githubusercontent.com/198571/147135173-9ac46759-662a-456d-b078-9ebc8959c4f1.png)

In my test `order_id` and `product_vendor_id` are indexed fields

