### PR TITLE
Bugfix in model:prune, order of argument check is backwards

### DIFF
--- a/src/Illuminate/Database/Console/PruneCommand.php
+++ b/src/Illuminate/Database/Console/PruneCommand.php
@@ -86,14 +86,14 @@ class PruneCommand extends Command
      */
     protected function models()
     {
-        if (! empty($models = $this->option('model'))) {
-            return collect($models);
+        $models = $this->option('model');
+
+        if (! empty($except = $this->option('except')) && ! empty($models)) {
+            throw new InvalidArgumentException('The --models and --except options cannot be combined.');
         }
 
-        $except = $this->option('except');
-
-        if (! empty($models) && ! empty($except)) {
-            throw new InvalidArgumentException('The --models and --except options cannot be combined.');
+        if (! empty($models)) {
+            return collect($models);
         }
 
         return collect((new Finder)->in(app_path('Models'))->files()->name('*.php'))


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
I am using Laravel 8.77.0 and when using ```php artisan model:prune``` it would throw "Undefined variable $except" at line 106.

I looked into it and saw that the file was updated in the master branch but I still think that the command is not working properly.

On line 90 the code would return if the ```$models``` argument was not empty and therefore would not reach the check in line 95 so the order of the conditionals should be flipped. That makes it necessary to define the ```$models``` variable first and then to perform the conditionals. 