### PR TITLE
[8.x] Remove an useless check in Console Application class

### DIFF
--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -210,7 +210,7 @@ class Application extends SymfonyApplication implements ApplicationContract
             $input = new ArrayInput($parameters);
         }
 
-        return [$command, $input ?? null];
+        return [$command, $input];
     }
 
     /**


### PR DESCRIPTION
# What I do?

I create this PR as a re-open PR of https://github.com/laravel/framework/pull/40133

# Why I do this?

@GrahamCampbell said I was incorrect but I was **NOT** incorrect.

1. If the condition `! isset($callingClass) && empty($parameters)` is true, this line below will be executed and the `$input` will be an instance of StringInput.

```php
$command = $this->getCommandName($input = new StringInput($command));
```

2. Otherwise, these two lines will be executed and the `$input` will be an instance of ArrayInput.

```php
array_unshift($parameters, $command);

$input = new ArrayInput($parameters);
```

# Conclusion

To conclude, there are no cases of this context in which the `$input` isn't set, it's always set. Therefore, the check `$input ?? null` is absolutely useless.

If the Laravel team rejects this PR, it will be your final decision and I understand. But rejecting this PR doesn't mean my PR is incorrect. It's reasonable.

Let's see the method more details:

```php
protected function parseCommand($command, $parameters)
{
    if (is_subclass_of($command, SymfonyCommand::class)) {
        $callingClass = true;

        $command = $this->laravel->make($command)->getName();
    }

    if (! isset($callingClass) && empty($parameters)) {
        $command = $this->getCommandName($input = new StringInput($command));
    } else {
        array_unshift($parameters, $command);

        $input = new ArrayInput($parameters);
    }

    return [$command, $input ?? null];
}
```