### PR TITLE
[8.x] Fix Rule::in() to work with Enum values

### DIFF
--- a/src/Illuminate/Validation/Rules/In.php
+++ b/src/Illuminate/Validation/Rules/In.php
@@ -37,7 +37,7 @@ class In
     public function __toString()
     {
         $values = array_map(function ($value) {
-            if ($value instanceof \UnitEnum){
+            if ($value instanceof \UnitEnum) {
                 $value = $value->value;
             }
             return '"'.str_replace('"', '""', $value).'"';

--- a/src/Illuminate/Validation/Rules/In.php
+++ b/src/Illuminate/Validation/Rules/In.php
@@ -37,6 +37,9 @@ class In
     public function __toString()
     {
         $values = array_map(function ($value) {
+            if ($value instanceof \UnitEnum){
+                $value = $value->value;
+            }
             return '"'.str_replace('"', '""', $value).'"';
         }, $this->values);
 

--- a/src/Illuminate/Validation/Rules/In.php
+++ b/src/Illuminate/Validation/Rules/In.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Validation\Rules;
 
-use \UnitEnum;
+use UnitEnum;
 
 class In
 {

--- a/src/Illuminate/Validation/Rules/In.php
+++ b/src/Illuminate/Validation/Rules/In.php
@@ -40,6 +40,7 @@ class In
             if ($value instanceof \UnitEnum) {
                 $value = $value->value;
             }
+            
             return '"'.str_replace('"', '""', $value).'"';
         }, $this->values);
 

--- a/src/Illuminate/Validation/Rules/In.php
+++ b/src/Illuminate/Validation/Rules/In.php
@@ -40,7 +40,7 @@ class In
             if ($value instanceof \UnitEnum) {
                 $value = $value->value;
             }
-            
+
             return '"'.str_replace('"', '""', $value).'"';
         }, $this->values);
 

--- a/src/Illuminate/Validation/Rules/In.php
+++ b/src/Illuminate/Validation/Rules/In.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Validation\Rules;
 
+use \UnitEnum;
+
 class In
 {
     /**
@@ -37,7 +39,7 @@ class In
     public function __toString()
     {
         $values = array_map(function ($value) {
-            if ($value instanceof \UnitEnum) {
+            if ($value instanceof UnitEnum) {
                 $value = $value->value;
             }
 


### PR DESCRIPTION
## Why

Validation rule `In` throws `TypeError` when we pass Enum cases from PHP 8.1:

`Rule::in(SomeEnumObject::cases())`

## Error

`TypeError: str_replace(): Argument #3 ($subject) must be of type array|string, \App\Enums\SomeEnumObject given in /vendor/laravel/framework/src/Illuminate/Validation/Rules/In.php:43`
