### PR TITLE
[8.x] SimpleMessage: Add method to add multiple lines as once

### DIFF
--- a/src/Illuminate/Notifications/Messages/SimpleMessage.php
+++ b/src/Illuminate/Notifications/Messages/SimpleMessage.php
@@ -160,7 +160,7 @@ class SimpleMessage
     /**
      * Add lines of text to the notification.
      *
-     * @param  array  $lines
+     * @param  iterable  $lines
      * @return $this
      */
     public function lines($lines)

--- a/src/Illuminate/Notifications/Messages/SimpleMessage.php
+++ b/src/Illuminate/Notifications/Messages/SimpleMessage.php
@@ -158,7 +158,7 @@ class SimpleMessage
     }
 
     /**
-     * Add a line of text to the notification.
+     * Add lines of text to the notification.
      *
      * @param  array  $lines
      * @return $this

--- a/src/Illuminate/Notifications/Messages/SimpleMessage.php
+++ b/src/Illuminate/Notifications/Messages/SimpleMessage.php
@@ -160,7 +160,7 @@ class SimpleMessage
     /**
      * Add a line of text to the notification.
      *
-     * @param  mixed  $lines
+     * @param  array  $lines
      * @return $this
      */
     public function lines($lines)

--- a/src/Illuminate/Notifications/Messages/SimpleMessage.php
+++ b/src/Illuminate/Notifications/Messages/SimpleMessage.php
@@ -163,6 +163,20 @@ class SimpleMessage
      * @param  mixed  $line
      * @return $this
      */
+    public function lines($lines) {
+        foreach ($lines as $line) {
+            $this->line($line);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Add a line of text to the notification.
+     *
+     * @param  mixed  $line
+     * @return $this
+     */
     public function with($line)
     {
         if ($line instanceof Action) {

--- a/src/Illuminate/Notifications/Messages/SimpleMessage.php
+++ b/src/Illuminate/Notifications/Messages/SimpleMessage.php
@@ -160,7 +160,7 @@ class SimpleMessage
     /**
      * Add a line of text to the notification.
      *
-     * @param  mixed  $line
+     * @param  mixed  $lines
      * @return $this
      */
     public function lines($lines)

--- a/src/Illuminate/Notifications/Messages/SimpleMessage.php
+++ b/src/Illuminate/Notifications/Messages/SimpleMessage.php
@@ -163,7 +163,8 @@ class SimpleMessage
      * @param  mixed  $line
      * @return $this
      */
-    public function lines($lines) {
+    public function lines($lines)
+    {
         foreach ($lines as $line) {
             $this->line($line);
         }


### PR DESCRIPTION
Not sure if we can change the phpdoc to:

```php
@param  mixed[]  $lines
```