### PR TITLE
[8.x] Extend PostgreSQL updateFrom to support nested joins

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -277,6 +277,7 @@ class PostgresGrammar extends Grammar
         $columns = $this->compileUpdateColumns($query, $values);
 
         $from = '';
+        $joinFrom = '';
 
         if (isset($query->joins)) {
             // When using Postgres, updates with joins list the joined tables in the from
@@ -289,11 +290,17 @@ class PostgresGrammar extends Grammar
             if (count($froms) > 0) {
                 $from = ' from '.implode(', ', $froms);
             }
+            
+            $joinFrom = collect($query->joins)->map(function ($join) {
+                return (count($join->joins) > 0)
+                    ? $this->compileJoins($join, $join->joins)
+                    : null;
+            })->implode(' ');
         }
 
         $where = $this->compileUpdateWheres($query);
 
-        return trim("update {$table} set {$columns}{$from} {$where}");
+        return trim("update {$table} set {$columns}{$from} {$joinFrom} {$where}");
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -290,7 +290,7 @@ class PostgresGrammar extends Grammar
             if (count($froms) > 0) {
                 $from = ' from '.implode(', ', $froms);
             }
-            
+
             $joinFrom = collect($query->joins)->map(function ($join) {
                 return (count($join->joins) > 0)
                     ? $this->compileJoins($join, $join->joins)


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

In reference to https://github.com/laravel/framework/issues/40138

A recent PR (https://github.com/laravel/framework/pull/39151) introduced the `updateFrom()` method, an alternative way of formatting PostgreSQL update queries that allows the `set` clause to reference the joined table. It is missing support for nested joins, which the original `update()` method does support.