### PR TITLE
[8.x] Add set method to Collection class that works like Arr::set()

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -920,6 +920,20 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Set a value recursively in the collection by key.
+     *
+     * @param  mixed  $key
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function set($key, $value)
+    {
+        Arr::set($this->items, $key, $value);
+
+        return $this;
+    }
+
+    /**
      * Get one or a specified number of items randomly from the collection.
      *
      * @param  int|null  $number

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2141,6 +2141,13 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['taylor', 'shawn', 'dayle'], $data->all());
     }
 
+    public function testSet()
+    {
+        $data = new Collection(['user' => ['name' => 'taylor', 'email' => 'foo']]);
+        $data = $data->set('user.name', 'dayle');
+        $this->assertEquals(['user' => ['name' => 'dayle', 'email' => 'foo']], $data->all());
+    }
+
     /**
      * @dataProvider collectionClassProvider
      */


### PR DESCRIPTION
When working with collections I missed an easy way to set dot notated data to my collections.

Example:
```php
$data = collect([
    'user' => [
        'name' => 'taylor', 
        'email' => 'foo'
    ]
]);

$data->set('user.name', 'dayle');
```