### PR TITLE
[8.x] Add serial property to loop variable for pagination

### DIFF
--- a/src/Illuminate/View/Concerns/ManagesLoops.php
+++ b/src/Illuminate/View/Concerns/ManagesLoops.php
@@ -3,8 +3,8 @@
 namespace Illuminate\View\Concerns;
 
 use Countable;
-use Illuminate\Support\Arr;
 use Illuminate\Pagination\AbstractPaginator;
+use Illuminate\Support\Arr;
 
 trait ManagesLoops
 {

--- a/src/Illuminate/View/Concerns/ManagesLoops.php
+++ b/src/Illuminate/View/Concerns/ManagesLoops.php
@@ -18,7 +18,7 @@ trait ManagesLoops
     /**
      * Add new loop to the stack.
      *
-     * @param  \Countable|array  $data
+     * @param  \Countable|AbstractPaginator|array  $data
      * @return void
      */
     public function addLoop($data)

--- a/src/Illuminate/View/Concerns/ManagesLoops.php
+++ b/src/Illuminate/View/Concerns/ManagesLoops.php
@@ -4,6 +4,7 @@ namespace Illuminate\View\Concerns;
 
 use Countable;
 use Illuminate\Support\Arr;
+use Illuminate\Pagination\AbstractPaginator;
 
 trait ManagesLoops
 {
@@ -24,11 +25,14 @@ trait ManagesLoops
     {
         $length = is_array($data) || $data instanceof Countable ? count($data) : null;
 
+        $serial = ($data instanceof AbstractPaginator) ? $data->perPage() * ($data->currentPage() - 1) : 0;
+
         $parent = Arr::last($this->loopsStack);
 
         $this->loopsStack[] = [
             'iteration' => 0,
             'index' => 0,
+            'serial' => $serial,
             'remaining' => $length ?? null,
             'count' => $length,
             'first' => true,
@@ -52,6 +56,7 @@ trait ManagesLoops
         $this->loopsStack[$index] = array_merge($this->loopsStack[$index], [
             'iteration' => $loop['iteration'] + 1,
             'index' => $loop['iteration'],
+            'serial' => $loop['serial'] + 1,
             'first' => $loop['iteration'] == 0,
             'odd' => ! $loop['odd'],
             'even' => ! $loop['even'],

--- a/src/Illuminate/View/Concerns/ManagesLoops.php
+++ b/src/Illuminate/View/Concerns/ManagesLoops.php
@@ -25,7 +25,7 @@ trait ManagesLoops
     {
         $length = is_array($data) || $data instanceof Countable ? count($data) : null;
 
-        $serial = ($data instanceof AbstractPaginator) ? $data->perPage() * ($data->currentPage() - 1) : 0;
+        $serial = $data instanceof AbstractPaginator ? ($data->perPage() * ($data->currentPage() - 1)) : 0;
 
         $parent = Arr::last($this->loopsStack);
 

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -10,6 +10,8 @@ use Illuminate\Contracts\View\Engine;
 use Illuminate\Contracts\View\View as ViewContract;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Pagination\Paginator;
 use Illuminate\Support\HtmlString;
 use Illuminate\View\Compilers\CompilerInterface;
 use Illuminate\View\Engines\CompilerEngine;
@@ -759,6 +761,164 @@ class ViewFactoryTest extends TestCase
         $this->assertFalse($factory->getLoopStack()[0]['first']);
         $this->assertNull($factory->getLoopStack()[0]['remaining']);
         $this->assertNull($factory->getLoopStack()[0]['last']);
+    }
+
+    public function testAddingPaginatorLoop()
+    {
+        $factory = $this->getFactory();
+
+        $p = new Paginator($array = ['item1', 'item2', 'item3', 'item4', 'item5'], 3, 1);
+
+        $factory->addLoop($p);
+
+        $expectedLoop = [
+            'iteration' => 0,
+            'index' => 0,
+            'serial' => 0,
+            'remaining' => 3,
+            'count' => 3,
+            'first' => true,
+            'last' => false,
+            'odd' => false,
+            'even' => true,
+            'depth' => 1,
+            'parent' => null,
+        ];
+
+        $this->assertEquals([$expectedLoop], $factory->getLoopStack());
+    }
+
+    public function testIncrementingFirstPageLoopIndicesOfPaginatorLoop()
+    {
+        $factory = $this->getFactory();
+
+        $p = new Paginator($array = ['item1', 'item2', 'item3', 'item4', 'item5'], 3, 1);
+
+        $factory->addLoop($p);
+
+        $factory->incrementLoopIndices();
+
+        $this->assertEquals(1, $factory->getLoopStack()[0]['iteration']);
+        $this->assertEquals(0, $factory->getLoopStack()[0]['index']);
+        $this->assertEquals(1, $factory->getLoopStack()[0]['serial']);
+        $this->assertEquals(2, $factory->getLoopStack()[0]['remaining']);
+        $this->assertTrue($factory->getLoopStack()[0]['odd']);
+        $this->assertFalse($factory->getLoopStack()[0]['even']);
+
+        $factory->incrementLoopIndices();
+
+        $this->assertEquals(2, $factory->getLoopStack()[0]['iteration']);
+        $this->assertEquals(1, $factory->getLoopStack()[0]['index']);
+        $this->assertEquals(2, $factory->getLoopStack()[0]['serial']);
+        $this->assertEquals(1, $factory->getLoopStack()[0]['remaining']);
+        $this->assertFalse($factory->getLoopStack()[0]['odd']);
+        $this->assertTrue($factory->getLoopStack()[0]['even']);
+    }
+
+    public function testIncrementingSecondPageLoopIndicesOfPaginatorLoop()
+    {
+        $factory = $this->getFactory();
+
+        $p = new Paginator($array = ['item1', 'item2', 'item3', 'item4', 'item5'], 3, 2);
+
+        $factory->addLoop($p);
+
+        $factory->incrementLoopIndices();
+
+        $this->assertEquals(1, $factory->getLoopStack()[0]['iteration']);
+        $this->assertEquals(0, $factory->getLoopStack()[0]['index']);
+        $this->assertEquals(4, $factory->getLoopStack()[0]['serial']);
+        $this->assertEquals(2, $factory->getLoopStack()[0]['remaining']);
+        $this->assertTrue($factory->getLoopStack()[0]['odd']);
+        $this->assertFalse($factory->getLoopStack()[0]['even']);
+
+        $factory->incrementLoopIndices();
+
+        $this->assertEquals(2, $factory->getLoopStack()[0]['iteration']);
+        $this->assertEquals(1, $factory->getLoopStack()[0]['index']);
+        $this->assertEquals(5, $factory->getLoopStack()[0]['serial']);
+        $this->assertEquals(1, $factory->getLoopStack()[0]['remaining']);
+        $this->assertFalse($factory->getLoopStack()[0]['odd']);
+        $this->assertTrue($factory->getLoopStack()[0]['even']);
+    }
+
+    public function testAddingLengthAwarePaginatorPaginatorLoop()
+    {
+        $factory = $this->getFactory();
+
+        $p = new LengthAwarePaginator($array = ['item1', 'item2', 'item3', 'item4', 'item5'], 5, 3, 1);
+
+        $factory->addLoop($p);
+
+        $expectedLoop = [
+            'iteration' => 0,
+            'index' => 0,
+            'serial' => 0,
+            'remaining' => 5,
+            'count' => 5,
+            'first' => true,
+            'last' => false,
+            'odd' => false,
+            'even' => true,
+            'depth' => 1,
+            'parent' => null,
+        ];
+
+        $this->assertEquals([$expectedLoop], $factory->getLoopStack());
+    }
+
+    public function testIncrementingFirstPageLoopIndicesOfLengthAwarePaginatorLoop()
+    {
+        $factory = $this->getFactory();
+
+        $p = new LengthAwarePaginator($array = ['item1', 'item2', 'item3', 'item4', 'item5'], 5, 3, 1);
+
+        $factory->addLoop($p);
+
+        $factory->incrementLoopIndices();
+
+        $this->assertEquals(1, $factory->getLoopStack()[0]['iteration']);
+        $this->assertEquals(0, $factory->getLoopStack()[0]['index']);
+        $this->assertEquals(1, $factory->getLoopStack()[0]['serial']);
+        $this->assertEquals(4, $factory->getLoopStack()[0]['remaining']);
+        $this->assertTrue($factory->getLoopStack()[0]['odd']);
+        $this->assertFalse($factory->getLoopStack()[0]['even']);
+
+        $factory->incrementLoopIndices();
+
+        $this->assertEquals(2, $factory->getLoopStack()[0]['iteration']);
+        $this->assertEquals(1, $factory->getLoopStack()[0]['index']);
+        $this->assertEquals(2, $factory->getLoopStack()[0]['serial']);
+        $this->assertEquals(3, $factory->getLoopStack()[0]['remaining']);
+        $this->assertFalse($factory->getLoopStack()[0]['odd']);
+        $this->assertTrue($factory->getLoopStack()[0]['even']);
+    }
+
+    public function testIncrementingSecondPageLoopIndicesOfLengthAwarePaginatorLoop()
+    {
+        $factory = $this->getFactory();
+
+        $p = new LengthAwarePaginator($array = ['item1', 'item2', 'item3', 'item4', 'item5'], 5, 3, 2);
+
+        $factory->addLoop($p);
+
+        $factory->incrementLoopIndices();
+
+        $this->assertEquals(1, $factory->getLoopStack()[0]['iteration']);
+        $this->assertEquals(0, $factory->getLoopStack()[0]['index']);
+        $this->assertEquals(4, $factory->getLoopStack()[0]['serial']);
+        $this->assertEquals(4, $factory->getLoopStack()[0]['remaining']);
+        $this->assertTrue($factory->getLoopStack()[0]['odd']);
+        $this->assertFalse($factory->getLoopStack()[0]['even']);
+
+        $factory->incrementLoopIndices();
+
+        $this->assertEquals(2, $factory->getLoopStack()[0]['iteration']);
+        $this->assertEquals(1, $factory->getLoopStack()[0]['index']);
+        $this->assertEquals(5, $factory->getLoopStack()[0]['serial']);
+        $this->assertEquals(3, $factory->getLoopStack()[0]['remaining']);
+        $this->assertFalse($factory->getLoopStack()[0]['odd']);
+        $this->assertTrue($factory->getLoopStack()[0]['even']);
     }
 
     public function testMacro()

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -626,6 +626,7 @@ class ViewFactoryTest extends TestCase
         $expectedLoop = [
             'iteration' => 0,
             'index' => 0,
+            'serial' => 0,
             'remaining' => 3,
             'count' => 3,
             'first' => true,
@@ -643,6 +644,7 @@ class ViewFactoryTest extends TestCase
         $secondExpectedLoop = [
             'iteration' => 0,
             'index' => 0,
+            'serial' => 0,
             'remaining' => 4,
             'count' => 4,
             'first' => true,
@@ -689,6 +691,7 @@ class ViewFactoryTest extends TestCase
         $expectedLoop = [
             'iteration' => 0,
             'index' => 0,
+            'serial' => 0,
             'remaining' => null,
             'count' => null,
             'first' => true,
@@ -712,6 +715,7 @@ class ViewFactoryTest extends TestCase
 
         $this->assertEquals(1, $factory->getLoopStack()[0]['iteration']);
         $this->assertEquals(0, $factory->getLoopStack()[0]['index']);
+        $this->assertEquals(1, $factory->getLoopStack()[0]['serial']);
         $this->assertEquals(3, $factory->getLoopStack()[0]['remaining']);
         $this->assertTrue($factory->getLoopStack()[0]['odd']);
         $this->assertFalse($factory->getLoopStack()[0]['even']);
@@ -720,6 +724,7 @@ class ViewFactoryTest extends TestCase
 
         $this->assertEquals(2, $factory->getLoopStack()[0]['iteration']);
         $this->assertEquals(1, $factory->getLoopStack()[0]['index']);
+        $this->assertEquals(2, $factory->getLoopStack()[0]['serial']);
         $this->assertEquals(2, $factory->getLoopStack()[0]['remaining']);
         $this->assertFalse($factory->getLoopStack()[0]['odd']);
         $this->assertTrue($factory->getLoopStack()[0]['even']);
@@ -750,6 +755,7 @@ class ViewFactoryTest extends TestCase
 
         $this->assertEquals(2, $factory->getLoopStack()[0]['iteration']);
         $this->assertEquals(1, $factory->getLoopStack()[0]['index']);
+        $this->assertEquals(2, $factory->getLoopStack()[0]['serial']);
         $this->assertFalse($factory->getLoopStack()[0]['first']);
         $this->assertNull($factory->getLoopStack()[0]['remaining']);
         $this->assertNull($factory->getLoopStack()[0]['last']);


### PR DESCRIPTION
Currently, there is no default way to show serial numbers in `@foreach` or `@forelse` loop variable in pagination. As you can see in the below screenshot.

![Screenshot 2021-12-25 032358](https://user-images.githubusercontent.com/35910749/147372613-84c6b7e8-092c-4456-af84-3bd508a0e3cc.png)

So, I add a new property for the loop variable '**serial**'. This property shows the current serial number in pagination.
```
@foreach($users as $user)

    <tr>
        <th scope="row" class="text-center">{{ $loop->serial }}</th>
        <td>{{ $user->name }}</td>
        <td>{{ $user->email }}</td>
    </tr>

@endforeach
```
So that it can show the current item serial in pagination as you can see in the below screenshot.
![Screenshot 2021-12-25 032156](https://user-images.githubusercontent.com/35910749/147372719-44f22a71-53c5-4a7b-8f1d-168161caafdb.png)


Note:  Using `CursorPaginator` this `$loop->serial` works like the `$loop->iteration` property because in `CursorPaginator` currently no way to get the current page number.

