### PR TITLE
Add rails style column definitions to make:migration commands

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -22,7 +22,7 @@ class MigrateMakeCommand extends BaseCommand
         {--path= : The location where the migration file should be created}
         {--realpath : Indicate any provided migration file paths are pre-resolved absolute paths}
         {--fullpath : Output the full path of the migration}
-        {--c|columns=* : Predefine columns in the migration, format is name:type}';
+        {--c|columns=* : Add column definitions in the migration, the format is name:type:chain; eg: col:integer:index}';
 
     /**
      * The console command description.

--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -148,7 +148,7 @@ class MigrateMakeCommand extends BaseCommand
         foreach ($this->input->getOption('columns') ?? [] as $column) {
             $values = explode(':', $column);
             if (count($values) < 2) {
-                $this->error("$column is invalid, the format is type:name");
+                $this->error("$column is invalid, the format is name:type");
                 abort(0);
             }
 

--- a/src/Illuminate/Database/Migrations/MigrationCreator.php
+++ b/src/Illuminate/Database/Migrations/MigrationCreator.php
@@ -169,6 +169,8 @@ class MigrationCreator
      * @param  string  $stub
      * @param  MigrationLine[]  $columns
      * @return string
+     * 
+     * @throws InvalidArgumentException thrown from MigrationLine class
      */
     protected function fillColumns($stub, $columns = [])
     {
@@ -268,8 +270,8 @@ class MigrationCreator
     /**
      * Get the number of spaces behind a word in a given string until we reach the previous word, if word is not found then 0 is returned
      * 
-     * @param  string $string
-     * @param  string $word
+     * @param  string  $string
+     * @param  string  $word
      * @return int
      */
     protected function spacesBehindWord($string, $word)

--- a/src/Illuminate/Database/Migrations/MigrationLine.php
+++ b/src/Illuminate/Database/Migrations/MigrationLine.php
@@ -77,14 +77,14 @@ class MigrationLine
             throw new InvalidArgumentException("The method {$this->getMethod()} for column {$this->getName()} is invalid");
         }
 
-        $line = sprintf('%s%s->%s(\'%s\')', $prependWhitespace, $this->caller, $this->method, $this->name);
+        $line = sprintf('%s%s->%s(\'%s\')', $prependWhitespace, $this->caller, $this->method, addslashes($this->name));
 
         collect($this->chainedMethods)->each(function ($method) use (&$line) {
             if (!self::$blueprintClassReflection->hasMethod($method)) {
                 throw new InvalidArgumentException("The chained method {$method} for column {$this->getName()} is invalid");
             }
 
-            $line .= sprintf('->%s()', $method);
+            $line .= sprintf('->%s()', addslashes($method));
         });
 
         $line .= ';';

--- a/src/Illuminate/Database/Migrations/MigrationLine.php
+++ b/src/Illuminate/Database/Migrations/MigrationLine.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Illuminate\Database\Migrations;
+
+use Illuminate\Database\Schema\Blueprint;
+use InvalidArgumentException;
+use ReflectionClass;
+
+class MigrationLine
+{
+    protected $name;
+    protected $method;
+    protected $caller;
+    protected $chainedMethods;
+    protected static $blueprintClassReflection;
+
+    public function __construct($name, $method, $chainedMethods = [], $caller = '$table')
+    {
+        $this->name = $name;
+        $this->method = $method;
+        $this->caller = $caller;
+        $this->chainedMethods = $chainedMethods;
+
+        if (is_null(self::$blueprintClassReflection)) {
+            self::$blueprintClassReflection = new ReflectionClass(Blueprint::class);
+        }
+    }
+
+    /**
+     * Get the caller property
+     *
+     * @return string
+     */
+    public function getCaller() 
+    {
+        return $this->caller;
+    }
+
+    /**
+     * Get the name property
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * Get the method property
+     *
+     * @return string
+     */
+    public function getMethod()
+    {
+        return $this->method;
+    }
+
+    /**
+     * Convert the object to string
+     *
+     * @param  string $prependWhitespace
+     * @param  boolean $appendLineFeed
+     * @throws InvalidArgumentException
+     * @return string
+     */
+    public function resolve($prependWhitespace = '', $appendLineFeed = true)
+    {
+        if (!self::$blueprintClassReflection->hasMethod($this->method)) {
+            throw new InvalidArgumentException("The method {$this->getMethod()} for column {$this->getName()} is invalid");
+        }
+
+        $line = sprintf('%s%s->%s(\'%s\')', $prependWhitespace, $this->caller, $this->method, $this->name);
+
+        collect($this->chainedMethods)->each(function ($method) use (&$line) {
+            if (!self::$blueprintClassReflection->hasMethod($method)) {
+                throw new InvalidArgumentException("The chained method {$method} for column {$this->getName()} is invalid");
+            }
+
+            $line .= sprintf('->%s()', $method);
+        });
+
+        $line .= ';';
+        if ($appendLineFeed) {
+            $line .= PHP_EOL;
+        }
+
+        return $line;
+    }
+
+    /**
+     * convert line to a dropColumn statement using the objects name and caller
+     *
+     * @param  string $prependWhitespace
+     * @param  boolean $appendLineFeed
+     * @return string
+     */
+    public function dropColumn($prependWhitespace = '', $appendLineFeed = true)
+    {
+        $line = sprintf('%s%s->dropColumn(\'%s\');', $prependWhitespace, $this->caller, $this->name);
+        if ($appendLineFeed) {
+            $line .= PHP_EOL;
+        }
+
+        return $line;
+    }
+
+    /**
+     * Format the parameters of a function call correctly
+     *
+     * @param  array $parameters
+     * @return string
+     */
+    protected function resolveParameters($parameters)
+    {
+        return collect($parameters)->map(fn ($parameter) => "'$parameter'")->implode(',');
+    }
+
+    public function __toString()
+    {
+        return $this->resolve();
+    }
+}

--- a/src/Illuminate/Database/Migrations/MigrationLine.php
+++ b/src/Illuminate/Database/Migrations/MigrationLine.php
@@ -14,6 +14,12 @@ class MigrationLine
     protected $chainedMethods;
     protected static $blueprintClassReflection;
 
+    /**
+     * @param string  $name
+     * @param string  $method
+     * @param array  $chainedMethods
+     * @param string  $caller
+     */
     public function __construct($name, $method, $chainedMethods = [], $caller = '$table')
     {
         $this->name = $name;
@@ -59,10 +65,11 @@ class MigrationLine
     /**
      * Convert the object to string
      *
-     * @param  string $prependWhitespace
-     * @param  boolean $appendLineFeed
-     * @throws InvalidArgumentException
+     * @param  string  $prependWhitespace
+     * @param  boolean  $appendLineFeed
      * @return string
+     * 
+     * @throws InvalidArgumentException
      */
     public function resolve($prependWhitespace = '', $appendLineFeed = true)
     {
@@ -91,8 +98,8 @@ class MigrationLine
     /**
      * convert line to a dropColumn statement using the objects name and caller
      *
-     * @param  string $prependWhitespace
-     * @param  boolean $appendLineFeed
+     * @param  string  $prependWhitespace
+     * @param  boolean  $appendLineFeed
      * @return string
      */
     public function dropColumn($prependWhitespace = '', $appendLineFeed = true)
@@ -103,17 +110,6 @@ class MigrationLine
         }
 
         return $line;
-    }
-
-    /**
-     * Format the parameters of a function call correctly
-     *
-     * @param  array $parameters
-     * @return string
-     */
-    protected function resolveParameters($parameters)
-    {
-        return collect($parameters)->map(fn ($parameter) => "'$parameter'")->implode(',');
     }
 
     public function __toString()

--- a/src/Illuminate/Database/Migrations/stubs/migration.create.stub
+++ b/src/Illuminate/Database/Migrations/stubs/migration.create.stub
@@ -15,6 +15,7 @@ class {{ class }} extends Migration
     {
         Schema::create('{{ table }}', function (Blueprint $table) {
             $table->id();
+            {{ columns }}
             $table->timestamps();
         });
     }

--- a/src/Illuminate/Database/Migrations/stubs/migration.update.stub
+++ b/src/Illuminate/Database/Migrations/stubs/migration.update.stub
@@ -14,7 +14,7 @@ class {{ class }} extends Migration
     public function up()
     {
         Schema::table('{{ table }}', function (Blueprint $table) {
-            //
+            {{ columns }}
         });
     }
 
@@ -26,7 +26,7 @@ class {{ class }} extends Migration
     public function down()
     {
         Schema::table('{{ table }}', function (Blueprint $table) {
-            //
+            {{ revert_columns }}
         });
     }
 }

--- a/tests/Database/DatabaseMigrationCreatorTest.php
+++ b/tests/Database/DatabaseMigrationCreatorTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Database;
 
 use Illuminate\Database\Migrations\MigrationCreator;
+use Illuminate\Database\Migrations\MigrationLine;
 use Illuminate\Filesystem\Filesystem;
 use InvalidArgumentException;
 use Mockery as m;
@@ -94,6 +95,176 @@ class DatabaseMigrationCreatorTest extends TestCase
         $creator->getFilesystem()->shouldReceive('requireOnce')->once()->with('foo/foo_create_bar.php');
 
         $creator->create('migration_creator_fake_migration', 'foo');
+    }
+
+    public function testTableCeateMigrationWillAddColumnsIfDefined()
+    {
+        $columns = [new MigrationLine('fake_string', 'string')];
+        $fakeStub = 'DummyClass DummyTable {{ columns }}';
+        $populatedFakeStub = 'CreateBar baz $table->string(\'fake_string\');' . PHP_EOL;
+
+        $creator = $this->getCreator();
+        $creator->expects($this->any())->method('getDatePrefix')->willReturn('foo');
+        $creator->getFilesystem()->shouldReceive('exists')->once()->with('stubs/migration.create.stub')->andReturn(false);
+        $creator->getFilesystem()->shouldReceive('get')->once()->with($creator->stubPath() . '/migration.create.stub')->andReturn($fakeStub);
+        $creator->getFilesystem()->shouldReceive('ensureDirectoryExists')->once()->with('foo');
+        $creator->getFilesystem()->shouldReceive('put')->once()->with('foo/foo_create_bar.php', $populatedFakeStub);
+        $creator->getFilesystem()->shouldReceive('glob')->once()->with('foo/*.php')->andReturn(['foo/foo_create_bar.php']);
+        $creator->getFilesystem()->shouldReceive('requireOnce')->once()->with('foo/foo_create_bar.php');
+        $creator->create('create_bar', 'foo', 'baz', true, $columns);
+    }
+
+    public function testTableCeateMigrationWillAddColumnsWithChainedMethodsIfDefined()
+    {
+        $columns = [new MigrationLine('fake_int', 'integer', ['index', 'primary'])];
+        $fakeStub = 'DummyClass DummyTable {{ columns }}';
+        $populatedFakeStub = 'CreateBar baz $table->integer(\'fake_int\')->index()->primary();' . PHP_EOL;
+
+        $creator = $this->getCreator();
+        $creator->expects($this->any())->method('getDatePrefix')->willReturn('foo');
+        $creator->getFilesystem()->shouldReceive('exists')->once()->with('stubs/migration.create.stub')->andReturn(false);
+        $creator->getFilesystem()->shouldReceive('get')->once()->with($creator->stubPath() . '/migration.create.stub')->andReturn($fakeStub);
+        $creator->getFilesystem()->shouldReceive('ensureDirectoryExists')->once()->with('foo');
+        $creator->getFilesystem()->shouldReceive('put')->once()->with('foo/foo_create_bar.php', $populatedFakeStub);
+        $creator->getFilesystem()->shouldReceive('glob')->once()->with('foo/*.php')->andReturn(['foo/foo_create_bar.php']);
+        $creator->getFilesystem()->shouldReceive('requireOnce')->once()->with('foo/foo_create_bar.php');
+        $creator->create('create_bar', 'foo', 'baz', true, $columns);
+    }
+
+    public function testTableCeateMigrationWillAddMultipleColumnsIfDefined()
+    {
+        $columns = [new MigrationLine('fake_string', 'string'), new MigrationLine('fake_integer', 'integer')];
+        $fakeStub = <<<'stub'
+            DummyClass DummyTable 
+            {{ columns }}
+        stub;
+
+        $populatedFakeStub = <<<'stub'
+            CreateBar baz 
+            $table->string('fake_string');
+            $table->integer('fake_integer');
+
+        stub;
+
+        $creator = $this->getCreator();
+        $creator->expects($this->any())->method('getDatePrefix')->willReturn('foo');
+        $creator->getFilesystem()->shouldReceive('exists')->once()->with('stubs/migration.create.stub')->andReturn(false);
+        $creator->getFilesystem()->shouldReceive('get')->once()->with($creator->stubPath() . '/migration.create.stub')->andReturn($fakeStub);
+        $creator->getFilesystem()->shouldReceive('ensureDirectoryExists')->once()->with('foo');
+        $creator->getFilesystem()->shouldReceive('put')->once()->with('foo/foo_create_bar.php', $populatedFakeStub);
+        $creator->getFilesystem()->shouldReceive('glob')->once()->with('foo/*.php')->andReturn(['foo/foo_create_bar.php']);
+        $creator->getFilesystem()->shouldReceive('requireOnce')->once()->with('foo/foo_create_bar.php');
+        $creator->create('create_bar', 'foo', 'baz', true, $columns);
+    }
+
+    public function testTableCeateMigrationWillAddMultipleColumnsIfDefinedWithReverts()
+    {
+        $columns = [new MigrationLine('fake_string', 'string'), new MigrationLine('fake_integer', 'integer')];
+        $fakeStub = <<<'stub'
+            DummyClass DummyTable 
+            {{ columns }}
+            {{ revert_columns }}
+        stub;
+
+        $populatedFakeStub = <<<'stub'
+            CreateBar baz 
+            $table->string('fake_string');
+            $table->integer('fake_integer');
+            $table->dropColumn('fake_string');
+            $table->dropColumn('fake_integer');
+
+        stub;
+
+        $creator = $this->getCreator();
+        $creator->expects($this->any())->method('getDatePrefix')->willReturn('foo');
+        $creator->getFilesystem()->shouldReceive('exists')->once()->with('stubs/migration.create.stub')->andReturn(false);
+        $creator->getFilesystem()->shouldReceive('get')->once()->with($creator->stubPath() . '/migration.create.stub')->andReturn($fakeStub);
+        $creator->getFilesystem()->shouldReceive('ensureDirectoryExists')->once()->with('foo');
+        $creator->getFilesystem()->shouldReceive('put')->once()->with('foo/foo_create_bar.php', $populatedFakeStub);
+        $creator->getFilesystem()->shouldReceive('glob')->once()->with('foo/*.php')->andReturn(['foo/foo_create_bar.php']);
+        $creator->getFilesystem()->shouldReceive('requireOnce')->once()->with('foo/foo_create_bar.php');
+        $creator->create('create_bar', 'foo', 'baz', true, $columns);
+    }
+
+    public function testTableCeateMigrationWillRemovePlaceholdersIfNoColumnsAreDefined()
+    {
+        $columns = [];
+        $fakeStub = <<<'stub'
+            DummyClass DummyTable
+            {{ columns }}
+            {{ revert_columns }}
+        stub;
+
+        $populatedFakeStub = <<<'stub'
+            CreateBar baz
+
+        stub;
+
+        $creator = $this->getCreator();
+        $creator->expects($this->any())->method('getDatePrefix')->willReturn('foo');
+        $creator->getFilesystem()->shouldReceive('exists')->once()->with('stubs/migration.create.stub')->andReturn(false);
+        $creator->getFilesystem()->shouldReceive('get')->once()->with($creator->stubPath() . '/migration.create.stub')->andReturn($fakeStub);
+        $creator->getFilesystem()->shouldReceive('ensureDirectoryExists')->once()->with('foo');
+        $creator->getFilesystem()->shouldReceive('put')->once()->with('foo/foo_create_bar.php', $populatedFakeStub);
+        $creator->getFilesystem()->shouldReceive('glob')->once()->with('foo/*.php')->andReturn(['foo/foo_create_bar.php']);
+        $creator->getFilesystem()->shouldReceive('requireOnce')->once()->with('foo/foo_create_bar.php');
+        $creator->create('create_bar', 'foo', 'baz', true, $columns);
+    }
+
+    public function testTableCeateMigrationFailsIfColumnTypeIsNotValid()
+    {
+        $columns = [new MigrationLine('date', 'not_a_type')];
+        $fakeStub = <<<'stub'
+            DummyClass DummyTable
+            {{ columns }}
+            {{ revert_columns }}
+        stub;
+
+        $populatedFakeStub = <<<'stub'
+            CreateBar baz
+
+        stub;
+
+        $creator = $this->getCreator();
+        $creator->expects($this->any())->method('getDatePrefix')->willReturn('foo');
+        $creator->getFilesystem()->shouldReceive('exists')->once()->with('stubs/migration.create.stub')->andReturn(false);
+        $creator->getFilesystem()->shouldReceive('get')->once()->with($creator->stubPath() . '/migration.create.stub')->andReturn($fakeStub);
+        $creator->getFilesystem()->shouldReceive('ensureDirectoryExists')->once()->with('foo');
+        $creator->getFilesystem()->shouldReceive('put')->with('foo/foo_create_bar.php', $populatedFakeStub);
+        $creator->getFilesystem()->shouldReceive('glob')->once()->with('foo/*.php')->andReturn(['foo/foo_create_bar.php']);
+        $creator->getFilesystem()->shouldReceive('requireOnce')->once()->with('foo/foo_create_bar.php');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The method not_a_type for column date is invalid');
+        $creator->create('create_bar', 'foo', 'baz', true, $columns);
+    }
+
+    public function testTableCeateMigrationFailsIfOneOfTheColumnChainedMethodsNotValid()
+    {
+        $columns = [new MigrationLine('date', 'timestamp', ['not_a_type'])];
+        $fakeStub = <<<'stub'
+            DummyClass DummyTable
+            {{ columns }}
+            {{ revert_columns }}
+        stub;
+
+        $populatedFakeStub = <<<'stub'
+            CreateBar baz
+
+        stub;
+
+        $creator = $this->getCreator();
+        $creator->expects($this->any())->method('getDatePrefix')->willReturn('foo');
+        $creator->getFilesystem()->shouldReceive('exists')->once()->with('stubs/migration.create.stub')->andReturn(false);
+        $creator->getFilesystem()->shouldReceive('get')->once()->with($creator->stubPath() . '/migration.create.stub')->andReturn($fakeStub);
+        $creator->getFilesystem()->shouldReceive('ensureDirectoryExists')->once()->with('foo');
+        $creator->getFilesystem()->shouldReceive('put')->with('foo/foo_create_bar.php', $populatedFakeStub);
+        $creator->getFilesystem()->shouldReceive('glob')->once()->with('foo/*.php')->andReturn(['foo/foo_create_bar.php']);
+        $creator->getFilesystem()->shouldReceive('requireOnce')->once()->with('foo/foo_create_bar.php');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The chained method not_a_type for column date is invalid');
+        $creator->create('create_bar', 'foo', 'baz', true, $columns);
     }
 
     protected function getCreator()


### PR DESCRIPTION
Rails has a very nice [feature](https://guides.rubyonrails.org/active_record_migrations.html#creating-a-migration) which enables you to define columns in the cli when creating a migration, this cuts down time and makes development more snappy.

Especially when creating a quick update or a POC migration, this change will help make it that much quicker to be up and running.

My goal is to reach this:
```console
user@device:~$ php artisan make:migration create_news_table --c=title:string --c=body:text --c=hashed_id:string:index
```
and the result would be:
```php
// ...
$table->string('title');
$table->text('body');
$table->string('hashed_id')->index();
```

This change won't break previous version because it adds new functionality to `MigrationMakeCommand` and `MigrationCreator` classes and in case the column definitions were empty, then nothing will happen.