### PR TITLE
[8.x] Append data in JsonResource::collection

### DIFF
--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -80,6 +80,9 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
             if (property_exists(static::class, 'preserveKeys')) {
                 $collection->preserveKeys = (new static([]))->preserveKeys === true;
             }
+            if(method_exists(static::class,'withCollection')){
+                $collection->with = (new static([]))->withCollection();
+            }
         });
     }
 

--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -80,7 +80,7 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
             if (property_exists(static::class, 'preserveKeys')) {
                 $collection->preserveKeys = (new static([]))->preserveKeys === true;
             }
-            if(method_exists(static::class,'withCollection')){
+            if (method_exists(static::class, 'withCollection')) {
                 $collection->with = (new static([]))->withCollection();
             }
         });


### PR DESCRIPTION
Hi, I have a project in laravel and I have organized all my modals with a controller, request, resource, migration, policy and other standard files, but I ran into a problem where I needed to add a dataset to the collection's json and to not go out of the pattern and create another Resource class I created a small code snippet in which I can add additional fields in JsonResource when I run collection with it.
I would like to share this problem and the solution and I believe it would be very useful to add to the main library.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
