### PR TITLE
Add Str::conact helper to concatenate strings

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -170,6 +170,24 @@ class Str
 
         return static::$camelCache[$value] = lcfirst(static::studly($value));
     }
+    
+    /**
+     * Concatenate an array of strings together with an optional seperator.
+     *
+     * @param  array  $strings
+     * @param  string|null  $separator
+     * @return string
+     */
+    public static function concat(array $strings, $separator = ' ')
+    {
+        $output = '';
+        
+        foreach ($strings as $string) {
+            $output .= $string . $separator;
+        }
+
+        return trim($output, $separator);
+    }
 
     /**
      * Determine if a given string contains a given substring.

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -203,6 +203,15 @@ class SupportStrTest extends TestCase
         $this->assertSame('foo', Str::afterLast('----foo', '---'));
     }
 
+    public function testStrConcat()
+    {
+        $this->assertSame(Str::concat(['Hello', 'world.']), 'Hello world.');
+        $this->assertSame(Str::concat(['foo', 'bar', 'baz'], '_'), 'foo_bar_baz');
+      
+        $title = 'Example Title';
+        $this->assertSame(Str::concat(['Your post titled:', $title, 'has been successfully saved.']), 'Your post titled: Example Title has been successfully saved.');
+    }
+    
     public function testStrContains()
     {
         $this->assertTrue(Str::contains('taylor', 'ylo'));


### PR DESCRIPTION
`Str::concat` is a new string helper I am proposing to make concatenating strings easier.

**The Problem:**
I find myself regularly concatenating strings together, often with variables interleaved in a string, and I end up with some mess like:

`return 'Thank you, ' . $user->name . ' for your entry titled ' . $entry->title . '. It is now live.';`

You see the problem, its not very readable, Each `.` you must closely look at to determine if its a period to end a sentence or if it is a concatenation operator. Now, may be thinking what about string interpolation. It is true, you can do something like:

`return "Thank you, {$user->name} for your entry titled {$entry->title}. It is now live.";`

And while that certainly solves the readability problems, its less ideal when you are already concatenating to build a string in parts.

`Str::concat` is a proposal to add a string helper to the mix. Simply provide an array for each part of the string. And as an optional second parameter include a separator (its space by default, but you can change to anything, such as "-", "_", or "" [empty string]) or anything else you can think of.