### PR TITLE
Dedicated mailer support for Mailables

### DIFF
--- a/CHANGELOG-8.x.md
+++ b/CHANGELOG-8.x.md
@@ -1,6 +1,28 @@
 # Release Notes for 8.x
 
-## [Unreleased](https://github.com/laravel/framework/compare/v8.76.2...8.x)
+## [Unreleased](https://github.com/laravel/framework/compare/v8.77.0...8.x)
+
+
+## [v8.77.0 (2021-12-21)](https://github.com/laravel/framework/compare/v8.76.2...v8.77.0)
+
+### Added
+- Attribute Cast / Accessor Improvements ([#40022](https://github.com/laravel/framework/pull/40022))
+- Added `Illuminate/View/Factory::renderUnless()` ([#40077](https://github.com/laravel/framework/pull/40077))
+- Added datetime parsing to Request instance ([#39945](https://github.com/laravel/framework/pull/39945))
+- Make it possible to use prefixes on Predis per Connection ([#40083](https://github.com/laravel/framework/pull/40083))
+- Added rule to validate MAC address ([#40098](https://github.com/laravel/framework/pull/40098))
+- Added ability to define temporary URL macro for storage ([#40100](https://github.com/laravel/framework/pull/40100))
+
+### Fixed
+- Fixed possible out of memory error when deleting values by reference key from cache in Redis driver ([#40039](https://github.com/laravel/framework/pull/40039))
+- Added `Illuminate/Filesystem/FilesystemManager::setApplication()` ([#40058](https://github.com/laravel/framework/pull/40058))
+- Fixed arg passing in doesntContain ([739d847](https://github.com/laravel/framework/commit/739d8472eb2c97c4a8d8f86eb699c526e42f57fa))
+- Translate Enum rule message ([#40089](https://github.com/laravel/framework/pull/40089))
+- Fixed date validation ([#40088](https://github.com/laravel/framework/pull/40088))
+- Dont allow models and except together in PruneCommand.php ([f62fe66](https://github.com/laravel/framework/commit/f62fe66216ee11bc864e0877d4fd4be4655db4aa))
+
+### Changed
+- Passthru Eloquent\Query::explain function to Query\Builder:explain for the ability to use database-specific explain commands ([#40075](https://github.com/laravel/framework/pull/40075))
 
 
 ## [v8.76.2 (2021-12-15)](https://github.com/laravel/framework/compare/v8.76.1...v8.76.2)

--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -210,7 +210,7 @@ class Application extends SymfonyApplication implements ApplicationContract
             $input = new ArrayInput($parameters);
         }
 
-        return [$command, $input ?? null];
+        return [$command, $input];
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/ScheduleClearCacheCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleClearCacheCommand.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Illuminate\Console\Scheduling;
+
+use Illuminate\Console\Command;
+
+class ScheduleClearCacheCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'schedule:clear-cache';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Delete the cached mutex files created by scheduler';
+
+    /**
+     * Execute the console command.
+     *
+     * @param  \Illuminate\Console\Scheduling\Schedule  $schedule
+     * @return void
+     */
+    public function handle(Schedule $schedule)
+    {
+        $mutexCleared = false;
+
+        foreach ($schedule->events($this->laravel) as $event) {
+            if ($event->mutex->exists($event)) {
+                $this->line('<info>Deleting mutex for:</info> '.$event->command);
+
+                $event->mutex->forget($event);
+
+                $mutexCleared = true;
+            }
+        }
+
+        if (! $mutexCleared) {
+            $this->info('No mutex files were found.');
+        }
+    }
+}

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -5,6 +5,7 @@ namespace Illuminate\Database;
 use Closure;
 use DateTimeInterface;
 use Doctrine\DBAL\Connection as DoctrineConnection;
+use Doctrine\DBAL\Types\Type;
 use Exception;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Events\QueryExecuted;
@@ -21,6 +22,7 @@ use Illuminate\Support\Arr;
 use LogicException;
 use PDO;
 use PDOStatement;
+use RuntimeException;
 
 class Connection implements ConnectionInterface
 {
@@ -1008,6 +1010,34 @@ class Connection implements ConnectionInterface
         }
 
         return $this->doctrineConnection;
+    }
+
+    /**
+     * Register a custom Doctrine mapping type.
+     *
+     * @param  string  $class
+     * @param  string  $name
+     * @param  string  $type
+     * @return void
+     *
+     * @throws \Doctrine\DBAL\DBALException
+     * @throws \RuntimeException
+     */
+    public function registerDoctrineType(string $class, string $name, string $type): void
+    {
+        if (! $this->isDoctrineAvailable()) {
+            throw new RuntimeException(
+                'Registering a custom Doctrine type requires Doctrine DBAL (doctrine/dbal).'
+            );
+        }
+
+        if (! Type::hasType($name)) {
+            Type::addType($name, $class);
+        }
+
+        $this->getDoctrineSchemaManager()
+            ->getDatabasePlatform()
+            ->registerDoctrineTypeMapping($type, $name);
     }
 
     /**

--- a/src/Illuminate/Database/Console/PruneCommand.php
+++ b/src/Illuminate/Database/Console/PruneCommand.php
@@ -91,7 +91,7 @@ class PruneCommand extends Command
         }
 
         if (! empty($models) && ! empty($except = $this->option('except'))) {
-            throw new InvalidArgumentException("The --models and --except options cannot be combined.");
+            throw new InvalidArgumentException('The --models and --except options cannot be combined.');
         }
 
         return collect((new Finder)->in(app_path('Models'))->files()->name('*.php'))

--- a/src/Illuminate/Database/Console/PruneCommand.php
+++ b/src/Illuminate/Database/Console/PruneCommand.php
@@ -90,7 +90,9 @@ class PruneCommand extends Command
             return collect($models);
         }
 
-        if (! empty($models) && ! empty($except = $this->option('except'))) {
+        $except = $this->option('except');
+
+        if (! empty($models) && ! empty($except)) {
             throw new InvalidArgumentException('The --models and --except options cannot be combined.');
         }
 

--- a/src/Illuminate/Database/Console/PruneCommand.php
+++ b/src/Illuminate/Database/Console/PruneCommand.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Prunable;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Events\ModelsPruned;
 use Illuminate\Support\Str;
+use InvalidArgumentException;
 use Symfony\Component\Finder\Finder;
 
 class PruneCommand extends Command
@@ -89,7 +90,9 @@ class PruneCommand extends Command
             return collect($models);
         }
 
-        $except = $this->option('except');
+        if (! empty($models) && ! empty($except = $this->option('except'))) {
+            throw new InvalidArgumentException("The --models and --except options cannot be combined.");
+        }
 
         return collect((new Finder)->in(app_path('Models'))->files()->name('*.php'))
             ->map(function ($model) {

--- a/src/Illuminate/Database/DBAL/TimestampType.php
+++ b/src/Illuminate/Database/DBAL/TimestampType.php
@@ -2,10 +2,10 @@
 
 namespace Illuminate\Database\DBAL;
 
-use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\PhpDateTimeMappingType;
 use Doctrine\DBAL\Types\Type;
+use RuntimeException;
 
 class TimestampType extends Type implements PhpDateTimeMappingType
 {
@@ -36,7 +36,7 @@ class TimestampType extends Type implements PhpDateTimeMappingType
                 return $this->getSQLitePlatformSQLDeclaration($fieldDeclaration);
 
             default:
-                throw new DBALException('Invalid platform: '.$name);
+                throw new RuntimeException('Invalid platform: '.$name);
         }
     }
 

--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -183,6 +183,8 @@ class DatabaseManager implements ConnectionResolverInterface
         // the connection, which will allow us to reconnect from the connections.
         $connection->setReconnector($this->reconnector);
 
+        $this->registerConfiguredDoctrineTypes($connection);
+
         return $connection;
     }
 
@@ -202,6 +204,19 @@ class DatabaseManager implements ConnectionResolverInterface
         }
 
         return $connection;
+    }
+
+    /**
+     * Register custom Doctrine types from the configuration with the connection.
+     *
+     * @param  \Illuminate\Database\Connection  $connection
+     * @return void
+     */
+    protected function registerConfiguredDoctrineTypes(Connection $connection): void
+    {
+        foreach ($this->app['config']->get('database.dbal.types', []) as $name => $class) {
+            $connection->registerDoctrineType($class, $name, $name);
+        }
     }
 
     /**

--- a/src/Illuminate/Database/DatabaseServiceProvider.php
+++ b/src/Illuminate/Database/DatabaseServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Database;
 
-use Doctrine\DBAL\Types\Type;
 use Faker\Factory as FakerFactory;
 use Faker\Generator as FakerGenerator;
 use Illuminate\Contracts\Queue\EntityResolver;
@@ -44,7 +43,6 @@ class DatabaseServiceProvider extends ServiceProvider
         $this->registerConnectionServices();
         $this->registerEloquentFactory();
         $this->registerQueueableEntityResolver();
-        $this->registerDoctrineTypes();
     }
 
     /**
@@ -107,25 +105,5 @@ class DatabaseServiceProvider extends ServiceProvider
         $this->app->singleton(EntityResolver::class, function () {
             return new QueueEntityResolver;
         });
-    }
-
-    /**
-     * Register custom types with the Doctrine DBAL library.
-     *
-     * @return void
-     */
-    protected function registerDoctrineTypes()
-    {
-        if (! class_exists(Type::class)) {
-            return;
-        }
-
-        $types = $this->app['config']->get('database.dbal.types', []);
-
-        foreach ($types as $name => $class) {
-            if (! Type::hasType($name)) {
-                Type::addType($name, $class);
-            }
-        }
     }
 }

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -7,7 +7,6 @@ use Closure;
 use Exception;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Concerns\BuildsQueries;
-use Illuminate\Database\Concerns\ExplainsQueries;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Builder as QueryBuilder;
@@ -26,7 +25,7 @@ use ReflectionMethod;
  */
 class Builder
 {
-    use Concerns\QueriesRelationships, ExplainsQueries, ForwardsCalls;
+    use Concerns\QueriesRelationships, ForwardsCalls;
     use BuildsQueries {
         sole as baseSole;
     }
@@ -96,6 +95,7 @@ class Builder
         'doesntExist',
         'dump',
         'exists',
+        'explain',
         'getBindings',
         'getConnection',
         'getGrammar',

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -3,11 +3,9 @@
 namespace Illuminate\Database\Schema;
 
 use Closure;
-use Doctrine\DBAL\Types\Type;
 use Illuminate\Database\Connection;
 use InvalidArgumentException;
 use LogicException;
-use RuntimeException;
 
 class Builder
 {
@@ -392,26 +390,10 @@ class Builder
      * @param  string  $name
      * @param  string  $type
      * @return void
-     *
-     * @throws \Doctrine\DBAL\DBALException
-     * @throws \RuntimeException
      */
     public function registerCustomDoctrineType($class, $name, $type)
     {
-        if (! $this->connection->isDoctrineAvailable()) {
-            throw new RuntimeException(
-                'Registering a custom Doctrine type requires Doctrine DBAL (doctrine/dbal).'
-            );
-        }
-
-        if (! Type::hasType($name)) {
-            Type::addType($name, $class);
-
-            $this->connection
-                ->getDoctrineSchemaManager()
-                ->getDatabasePlatform()
-                ->registerDoctrineTypeMapping($type, $name);
-        }
+        $this->connection->registerDoctrineType($class, $name, $type);
     }
 
     /**

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -33,7 +33,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      *
      * @var string
      */
-    const VERSION = '8.77.0';
+    const VERSION = '8.77.1';
 
     /**
      * The base path for the Laravel installation.

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -33,7 +33,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      *
      * @var string
      */
-    const VERSION = '8.76.2';
+    const VERSION = '8.77.0';
 
     /**
      * The base path for the Laravel installation.

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -6,6 +6,7 @@ use Illuminate\Auth\Console\ClearResetsCommand;
 use Illuminate\Cache\Console\CacheTableCommand;
 use Illuminate\Cache\Console\ClearCommand as CacheClearCommand;
 use Illuminate\Cache\Console\ForgetCommand as CacheForgetCommand;
+use Illuminate\Console\Scheduling\ScheduleClearCacheCommand;
 use Illuminate\Console\Scheduling\ScheduleFinishCommand;
 use Illuminate\Console\Scheduling\ScheduleListCommand;
 use Illuminate\Console\Scheduling\ScheduleRunCommand;
@@ -127,6 +128,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'ScheduleFinish' => ScheduleFinishCommand::class,
         'ScheduleList' => ScheduleListCommand::class,
         'ScheduleRun' => ScheduleRunCommand::class,
+        'ScheduleClearCache' => ScheduleClearCacheCommand::class,
         'ScheduleTest' => ScheduleTestCommand::class,
         'ScheduleWork' => ScheduleWorkCommand::class,
         'StorageLink' => 'command.storage.link',
@@ -966,6 +968,16 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         $this->app->singleton('command.seed', function ($app) {
             return new SeedCommand($app['db']);
         });
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerScheduleClearCacheCommand()
+    {
+        $this->app->singleton(ScheduleClearCacheCommand::class);
     }
 
     /**

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -4,6 +4,7 @@ namespace Illuminate\Http\Concerns;
 
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Date;
 use SplFileInfo;
 use stdClass;
 use Symfony\Component\VarDumper\VarDumper;
@@ -294,6 +295,27 @@ trait InteractsWithInput
     public function boolean($key = null, $default = false)
     {
         return filter_var($this->input($key, $default), FILTER_VALIDATE_BOOLEAN);
+    }
+
+    /**
+     * Retrieve input from the request as a Carbon instance.
+     *
+     * @param  string  $key
+     * @param  string|null  $format
+     * @param  string|null  $tz
+     * @return \Illuminate\Support\Carbon|null
+     */
+    public function date($key, $format = null, $tz = null)
+    {
+        if ($this->isNotFilled($key)) {
+            return null;
+        }
+
+        if (is_null($format)) {
+            return Date::parse($this->input($key), $tz);
+        }
+
+        return Date::createFromFormat($format, $this->input($key), $tz);
     }
 
     /**

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -332,6 +332,19 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     }
 
     /**
+     * Merge new input into the request's input, but only when that key is missing from the request.
+     *
+     * @param  array  $input
+     * @return $this
+     */
+    public function mergeIfMissing(array $input)
+    {
+        return $this->merge(collect($input)->filter(function ($value, $key) {
+            return $this->missing($key);
+        })->toArray());
+    }
+
+    /**
      * Replace the input for the current request.
      *
      * @param  array  $input

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -299,9 +299,11 @@ class Mailer implements MailerContract, MailQueueContract
      */
     protected function sendMailable(MailableContract $mailable)
     {
+        $mailer = $mailable->mailer ?? $this->name;
+
         return $mailable instanceof ShouldQueue
-                        ? $mailable->mailer($this->name)->queue($this->queue)
-                        : $mailable->mailer($this->name)->send($this);
+                        ? $mailable->mailer($mailer)->queue($this->queue)
+                        : $mailable->mailer($mailer)->send($this);
     }
 
     /**

--- a/src/Illuminate/Redis/Connectors/PredisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PredisConnector.php
@@ -23,6 +23,10 @@ class PredisConnector implements Connector
             ['timeout' => 10.0], $options, Arr::pull($config, 'options', [])
         );
 
+        if (isset($config['prefix'])) {
+            $formattedOptions['prefix'] = $config['prefix'];
+        }
+
         return new PredisConnection(new Client($config, $formattedOptions));
     }
 
@@ -37,6 +41,10 @@ class PredisConnector implements Connector
     public function connectToCluster(array $config, array $clusterOptions, array $options)
     {
         $clusterSpecificOptions = Arr::pull($config, 'options', []);
+
+        if (isset($config['prefix'])) {
+            $clusterSpecificOptions['prefix'] = $config['prefix'];
+        }
 
         return new PredisClusterConnection(new Client(array_values($config), array_merge(
             $options, $clusterOptions, $clusterSpecificOptions

--- a/src/Illuminate/Support/Facades/Storage.php
+++ b/src/Illuminate/Support/Facades/Storage.php
@@ -41,6 +41,7 @@ use Illuminate\Filesystem\Filesystem;
  * @method static string|false putFile(string $path, \Illuminate\Http\File|\Illuminate\Http\UploadedFile|string $file, mixed $options = [])
  * @method static string|false putFileAs(string $path, \Illuminate\Http\File|\Illuminate\Http\UploadedFile|string $file, string $name, mixed $options = [])
  * @method static void macro(string $name, object|callable $macro)
+ * @method static void buildTemporaryUrlsUsing(\Closure $callback)
  *
  * @see \Illuminate\Filesystem\FilesystemManager
  */

--- a/src/Illuminate/Support/Facades/Storage.php
+++ b/src/Illuminate/Support/Facades/Storage.php
@@ -40,6 +40,7 @@ use Illuminate\Filesystem\Filesystem;
  * @method static string|false mimeType(string $path)
  * @method static string|false putFile(string $path, \Illuminate\Http\File|\Illuminate\Http\UploadedFile|string $file, mixed $options = [])
  * @method static string|false putFileAs(string $path, \Illuminate\Http\File|\Illuminate\Http\UploadedFile|string $file, string $name, mixed $options = [])
+ * @method static void macro(string $name, object|callable $macro)
  *
  * @see \Illuminate\Filesystem\FilesystemManager
  */

--- a/src/Illuminate/Support/MultipleInstanceManager.php
+++ b/src/Illuminate/Support/MultipleInstanceManager.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace Illuminate\Cache;
+
+use Closure;
+use InvalidArgumentException;
+
+abstract class MultipleInstanceManager
+{
+    /**
+     * The application instance.
+     *
+     * @var \Illuminate\Contracts\Foundation\Application
+     */
+    protected $app;
+
+    /**
+     * The array of resolved instances.
+     *
+     * @var array
+     */
+    protected $instances = [];
+
+    /**
+     * The registered custom instance creators.
+     *
+     * @var array
+     */
+    protected $customCreators = [];
+
+    /**
+     * Create a new manager instance.
+     *
+     * @param  \Illuminate\Contracts\Foundation\Application  $app
+     * @return void
+     */
+    public function __construct($app)
+    {
+        $this->app = $app;
+    }
+
+    /**
+     * Get the default instance name.
+     *
+     * @return string
+     */
+    abstract public function getDefaultInstance();
+
+    /**
+     * Set the default instance name.
+     *
+     * @param  string  $name
+     * @return void
+     */
+    abstract public function setDefaultInstance($name);
+
+    /**
+     * Get the instance specific configuration.
+     *
+     * @param  string  $name
+     * @return array
+     */
+    abstract public function getInstanceConfig($name);
+
+    /**
+     * Get an instance instance by name.
+     *
+     * @param  string|null  $name
+     * @return mixed
+     */
+    public function instance($name = null)
+    {
+        $name = $name ?: $this->getDefaultInstance();
+
+        return $this->instances[$name] = $this->get($name);
+    }
+
+    /**
+     * Attempt to get an instance from the local cache.
+     *
+     * @param  string  $name
+     * @return mixed
+     */
+    protected function get($name)
+    {
+        return $this->instances[$name] ?? $this->resolve($name);
+    }
+
+    /**
+     * Resolve the given instance.
+     *
+     * @param  string  $name
+     * @return mixed
+     *
+     * @throws \InvalidArgumentException
+     */
+    protected function resolve($name)
+    {
+        $config = $this->getInstanceConfig($name);
+
+        if (is_null($config)) {
+            throw new InvalidArgumentException("Instance [{$name}] is not defined.");
+        }
+
+        if (isset($this->customCreators[$config['driver']])) {
+            return $this->callCustomCreator($config);
+        } else {
+            $driverMethod = 'create'.ucfirst($config['driver']).'Driver';
+
+            if (method_exists($this, $driverMethod)) {
+                return $this->{$driverMethod}($config);
+            } else {
+                throw new InvalidArgumentException("Instance driver [{$config['driver']}] is not supported.");
+            }
+        }
+    }
+
+    /**
+     * Call a custom instance creator.
+     *
+     * @param  array  $config
+     * @return mixed
+     */
+    protected function callCustomCreator(array $config)
+    {
+        return $this->customCreators[$config['driver']]($this->app, $config);
+    }
+
+    /**
+     * Unset the given instances.
+     *
+     * @param  array|string|null  $name
+     * @return $this
+     */
+    public function forgetInstance($name = null)
+    {
+        $name = $name ?? $this->getDefaultInstance();
+
+        foreach ((array) $name as $instanceName) {
+            if (isset($this->instances[$instanceName])) {
+                unset($this->instances[$instanceName]);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * Disconnect the given instance and remove from local cache.
+     *
+     * @param  string|null  $name
+     * @return void
+     */
+    public function purge($name = null)
+    {
+        $name = $name ?? $this->getDefaultInstance();
+
+        unset($this->instances[$name]);
+    }
+
+    /**
+     * Register a custom instance creator Closure.
+     *
+     * @param  string  $name
+     * @param  \Closure  $callback
+     * @return $this
+     */
+    public function extend($name, Closure $callback)
+    {
+        $this->customCreators[$name] = $callback->bindTo($this, $this);
+
+        return $this;
+    }
+
+    /**
+     * Dynamically call the default instance.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     */
+    public function __call($method, $parameters)
+    {
+        return $this->instance()->$method(...$parameters);
+    }
+}

--- a/src/Illuminate/Support/MultipleInstanceManager.php
+++ b/src/Illuminate/Support/MultipleInstanceManager.php
@@ -1,9 +1,10 @@
 <?php
 
-namespace Illuminate\Cache;
+namespace Illuminate\Support;
 
 use Closure;
 use InvalidArgumentException;
+use RuntimeException;
 
 abstract class MultipleInstanceManager
 {
@@ -100,6 +101,10 @@ abstract class MultipleInstanceManager
 
         if (is_null($config)) {
             throw new InvalidArgumentException("Instance [{$name}] is not defined.");
+        }
+
+        if (! array_key_exists('driver', $config)) {
+            throw new RuntimeException("Instance [{$name}] does not specify a driver.");
         }
 
         if (isset($this->customCreators[$config['driver']])) {

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1231,6 +1231,18 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate that an attribute is a valid MAC address.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function validateMacAddress($attribute, $value)
+    {
+        return filter_var($value, FILTER_VALIDATE_MAC) !== false;
+    }
+
+    /**
      * Validate the attribute is a valid JSON string.
      *
      * @param  string  $attribute

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -265,9 +265,11 @@ trait ValidatesAttributes
         $firstDate = $this->getDateTimeWithOptionalFormat($format, $first);
 
         if (! $secondDate = $this->getDateTimeWithOptionalFormat($format, $second)) {
-            $second = $this->getValue($second);
+            if (is_null($second = $this->getValue($second))) {
+                return true;
+            }
 
-            $secondDate = is_null($second) ? null : $this->getDateTimeWithOptionalFormat($format, $second);
+            $secondDate = $this->getDateTimeWithOptionalFormat($format, $second);
         }
 
         return ($firstDate && $secondDate) && ($this->compare($firstDate, $secondDate, $operator));

--- a/src/Illuminate/Validation/Rules/Enum.php
+++ b/src/Illuminate/Validation/Rules/Enum.php
@@ -47,8 +47,10 @@ class Enum implements Rule
      */
     public function message()
     {
-        return [
-            'The selected :attribute is invalid.',
-        ];
+        $message = trans('validation.enum');
+
+        return $message === 'validation.enum'
+            ? ['The selected :attribute is invalid.']
+            : $message;
     }
 }

--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -80,6 +80,13 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
     protected $compromisedThreshold = 0;
 
     /**
+     * Additional validation rules that should be merged into the default rules during validation.
+     *
+     * @var array
+     */
+    protected $customRules = [];
+
+    /**
      * The failure messages, if any.
      *
      * @var array
@@ -260,6 +267,19 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
     }
 
     /**
+     * Specify additional validation rules that should be merged with the default rules during validation.
+     *
+     * @param  string|array  $rules
+     * @return $this
+     */
+    public function rules($rules)
+    {
+        $this->customRules = Arr::wrap($rules);
+
+        return $this;
+    }
+
+    /**
      * Determine if the validation rule passes.
      *
      * @param  string  $attribute
@@ -272,7 +292,7 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
 
         $validator = Validator::make(
             $this->data,
-            [$attribute => 'string|min:'.$this->min],
+            [$attribute => array_merge(['string', 'min:'.$this->min], $this->customRules)],
             $this->validator->customMessages,
             $this->validator->customAttributes
         )->after(function ($validator) use ($attribute, $value) {

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Filesystem;
 
+use Carbon\Carbon;
 use GuzzleHttp\Psr7\Stream;
 use Illuminate\Contracts\Filesystem\FileExistsException;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
@@ -330,5 +331,23 @@ class FilesystemAdapterTest extends TestCase
         });
 
         $this->assertSame('Hello World', $filesystemAdapter->getFoo());
+    }
+
+    public function testTemporaryUrlWithCustomCallback()
+    {
+        $filesystemAdapter = new FilesystemAdapter($this->filesystem);
+
+        $filesystemAdapter->buildTemporaryUrlsUsing(function ($path, Carbon $expiration, $options) {
+            return $path.$expiration->toString().implode('', $options);
+        });
+
+        $path = 'foo';
+        $expiration = Carbon::create(2021, 18, 12, 13);
+        $options = ['bar' => 'baz'];
+
+        $this->assertSame(
+            $path.$expiration->toString().implode('', $options),
+            $filesystemAdapter->temporaryUrl($path, $expiration, $options)
+        );
     }
 }

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -752,6 +752,21 @@ class HttpRequestTest extends TestCase
         $this->assertSame('Dayle', $request->input('buddy'));
     }
 
+    public function testMergeIfMissingMethod()
+    {
+        $request = Request::create('/', 'GET', ['name' => 'Taylor']);
+        $merge = ['boolean_setting' => 0];
+        $request->mergeIfMissing($merge);
+        $this->assertSame('Taylor', $request->input('name'));
+        $this->assertSame(0, $request->input('boolean_setting'));
+
+        $request = Request::create('/', 'GET', ['name' => 'Taylor', 'boolean_setting' => 1]);
+        $merge = ['boolean_setting' => 0];
+        $request->mergeIfMissing($merge);
+        $this->assertSame('Taylor', $request->input('name'));
+        $this->assertSame(1, $request->input('boolean_setting'));
+    }
+
     public function testReplaceMethod()
     {
         $request = Request::create('/', 'GET', ['name' => 'Taylor']);

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -6,7 +6,9 @@ use Illuminate\Http\Request;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Routing\Route;
 use Illuminate\Session\Store;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
+use InvalidArgumentException;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
@@ -530,6 +532,55 @@ class HttpRequestTest extends TestCase
         $this->assertEquals(['users' => [1, 2, 3], 'email' => 'test@example.com'], $request->collect(['users', 'email'])->all());
         $this->assertEquals(collect(['roles' => [4, 5, 6], 'foo' => ['bar', 'baz']]), $request->collect(['roles', 'foo']));
         $this->assertEquals(['users' => [1, 2, 3], 'roles' => [4, 5, 6], 'foo' => ['bar', 'baz'], 'email' => 'test@example.com'], $request->collect()->all());
+    }
+
+    public function testDateMethod()
+    {
+        $request = Request::create('/', 'GET', [
+            'as_null' => null,
+            'as_invalid' => 'invalid',
+
+            'as_datetime' => '20-01-01 16:30:25',
+            'as_format' => '1577896225',
+            'as_timezone' => '20-01-01 13:30:25',
+
+            'as_date' => '2020-01-01',
+            'as_time' => '16:30:25',
+        ]);
+
+        $current = Carbon::create(2020, 1, 1, 16, 30, 25);
+
+        $this->assertNull($request->date('as_null'));
+        $this->assertNull($request->date('doesnt_exists'));
+
+        $this->assertEquals($current, $request->date('as_datetime'));
+        $this->assertEquals($current, $request->date('as_format', 'U'));
+        $this->assertEquals($current, $request->date('as_timezone', null, 'America/Santiago'));
+
+        $this->assertTrue($request->date('as_date')->isSameDay($current));
+        $this->assertTrue($request->date('as_time')->isSameSecond('16:30:25'));
+    }
+
+    public function testDateMethodExceptionWhenValueInvalid()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $request = Request::create('/', 'GET', [
+            'date' => 'invalid',
+        ]);
+
+        $request->date('date');
+    }
+
+    public function testDateMethodExceptionWhenFormatInvalid()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $request = Request::create('/', 'GET', [
+            'date' => '20-01-01 16:30:25',
+        ]);
+
+        $request->date('date', 'invalid_format');
     }
 
     public function testArrayAccess()

--- a/tests/Integration/Database/ConfigureCustomDoctrineTypeTest.php
+++ b/tests/Integration/Database/ConfigureCustomDoctrineTypeTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\SchemaTest;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\Type;
+use Illuminate\Database\Grammar;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+class ConfigureCustomDoctrineTypeTest extends DatabaseTestCase
+{
+    protected function defineEnvironment($app)
+    {
+        $app['config']['database.connections.sqlite.database'] = ':memory:';
+        $app['config']['database.dbal.types'] = [
+            'bit' => MySQLBitType::class,
+            'xml' => PostgresXmlType::class,
+        ];
+    }
+
+    public function testRegisterCustomDoctrineTypesWithNonDefaultDatabaseConnections()
+    {
+        $this->assertTrue(
+            DB::connection()
+                ->getDoctrineSchemaManager()
+                ->getDatabasePlatform()
+                ->hasDoctrineTypeMappingFor('xml')
+        );
+
+        // Custom type mappings are registered for a connection when it's created,
+        // this is not the default connection but it has the custom type mappings
+        $this->assertTrue(
+            DB::connection('sqlite')
+                ->getDoctrineSchemaManager()
+                ->getDatabasePlatform()
+                ->hasDoctrineTypeMappingFor('xml')
+        );
+    }
+
+    public function testRenameConfiguredCustomDoctrineColumnTypeWithPostgres()
+    {
+        if ($this->driver !== 'pgsql') {
+            $this->markTestSkipped('Test requires a Postgres connection.');
+        }
+
+        Grammar::macro('typeXml', function () {
+            return 'xml';
+        });
+
+        Schema::create('test', function (Blueprint $table) {
+            $table->addColumn('xml', 'test_column');
+        });
+
+        Schema::table('test', function (Blueprint $table) {
+            $table->renameColumn('test_column', 'renamed_column');
+        });
+
+        $this->assertFalse(Schema::hasColumn('test', 'test_column'));
+        $this->assertTrue(Schema::hasColumn('test', 'renamed_column'));
+    }
+
+    public function testRenameConfiguredCustomDoctrineColumnTypeWithMysql()
+    {
+        if ($this->driver !== 'mysql') {
+            $this->markTestSkipped('Test requires a MySQL connection.');
+        }
+
+        Grammar::macro('typeBit', function () {
+            return 'bit';
+        });
+
+        Schema::create('test', function (Blueprint $table) {
+            $table->addColumn('bit', 'test_column');
+        });
+
+        Schema::table('test', function (Blueprint $table) {
+            $table->renameColumn('test_column', 'renamed_column');
+        });
+
+        $this->assertFalse(Schema::hasColumn('test', 'test_column'));
+        $this->assertTrue(Schema::hasColumn('test', 'renamed_column'));
+    }
+}
+
+class PostgresXmlType extends Type
+{
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    {
+        return 'xml';
+    }
+
+    public function getName()
+    {
+        return 'xml';
+    }
+}
+
+class MySQLBitType extends Type
+{
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    {
+        return 'bit';
+    }
+
+    public function getName()
+    {
+        return 'bit';
+    }
+}

--- a/tests/Integration/Database/DBAL/TimestampTypeTest.php
+++ b/tests/Integration/Database/DBAL/TimestampTypeTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\DBAL;
+
+use Illuminate\Database\DBAL\TimestampType;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+class TimestampTypeTest extends DatabaseTestCase
+{
+    protected function defineEnvironment($app)
+    {
+        $app['config']['database.dbal.types'] = [
+            'timestamp' => TimestampType::class,
+        ];
+    }
+
+    public function testRegisterTimestampTypeOnConnection()
+    {
+        $this->assertTrue(
+            $this->app['db']->connection()
+                ->getDoctrineSchemaManager()
+                ->getDatabasePlatform()
+                ->hasDoctrineTypeMappingFor('timestamp')
+        );
+    }
+
+    public function testChangeDatetimeColumnToTimestampColumn()
+    {
+        Schema::create('test', function (Blueprint $table) {
+            $table->addColumn('datetime', 'datetime_to_timestamp');
+        });
+
+        Schema::table('test', function (Blueprint $table) {
+            $table->timestamp('datetime_to_timestamp')->nullable(true)->change();
+        });
+
+        $this->assertTrue(Schema::hasColumn('test', 'datetime_to_timestamp'));
+        // Only Postgres and MySQL actually have a timestamp type
+        in_array($this->driver, ['pgsql', 'mysql'])
+            ? $this->assertSame('timestamp', Schema::getColumnType('test', 'datetime_to_timestamp'))
+            : $this->assertSame('datetime', Schema::getColumnType('test', 'datetime_to_timestamp'));
+    }
+
+    public function testChangeTimestampColumnToDatetimeColumn()
+    {
+        Schema::create('test', function (Blueprint $table) {
+            $table->addColumn('timestamp', 'timestamp_to_datetime');
+        });
+
+        Schema::table('test', function (Blueprint $table) {
+            $table->dateTime('timestamp_to_datetime')->nullable(true)->change();
+        });
+
+        $this->assertTrue(Schema::hasColumn('test', 'timestamp_to_datetime'));
+        // Postgres only has a timestamp type
+        $this->driver === 'pgsql'
+            ? $this->assertSame('timestamp', Schema::getColumnType('test', 'timestamp_to_datetime'))
+            : $this->assertSame('datetime', Schema::getColumnType('test', 'timestamp_to_datetime'));
+    }
+}

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -65,4 +65,26 @@ class SchemaBuilderTest extends DatabaseTestCase
         $this->assertArrayHasKey(TinyInteger::NAME, Type::getTypesMap());
         $this->assertSame('tinyinteger', Schema::getColumnType('test', 'test_column'));
     }
+
+    public function testRegisterCustomDoctrineTypeASecondTime()
+    {
+        if ($this->driver !== 'sqlite') {
+            $this->markTestSkipped('Test requires a SQLite connection.');
+        }
+
+        Schema::registerCustomDoctrineType(TinyInteger::class, TinyInteger::NAME, 'TINYINT');
+
+        Schema::create('test', function (Blueprint $table) {
+            $table->string('test_column');
+        });
+
+        $blueprint = new Blueprint('test', function (Blueprint $table) {
+            $table->tinyInteger('test_column')->change();
+        });
+
+        $blueprint->build($this->getConnection(), new SQLiteGrammar);
+
+        $this->assertArrayHasKey(TinyInteger::NAME, Type::getTypesMap());
+        $this->assertSame('tinyinteger', Schema::getColumnType('test', 'test_column'));
+    }
 }

--- a/tests/Integration/Support/Fixtures/MultipleInstanceManager.php
+++ b/tests/Integration/Support/Fixtures/MultipleInstanceManager.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Support\Fixtures;
+
+use Illuminate\Support\MultipleInstanceManager as BaseMultipleInstanceManager;
+
+class MultipleInstanceManager extends BaseMultipleInstanceManager
+{
+    protected $defaultInstance = 'foo';
+
+    protected function createFooDriver(array $config)
+    {
+        return new class($config) {
+            public $config;
+
+            public function __construct($config)
+            {
+                $this->config = $config;
+            }
+        };
+    }
+
+    protected function createBarDriver(array $config)
+    {
+        return new class($config) {
+            public $config;
+
+            public function __construct($config)
+            {
+                $this->config = $config;
+            }
+        };
+    }
+
+    /**
+     * Get the default instance name.
+     *
+     * @return string
+     */
+    public function getDefaultInstance()
+    {
+        return $this->defaultInstance;
+    }
+
+    /**
+     * Set the default instance name.
+     *
+     * @param  string  $name
+     * @return void
+     */
+    public function setDefaultInstance($name)
+    {
+        $this->defaultInstance = $name;
+    }
+
+    /**
+     * Get the instance specific configuration.
+     *
+     * @param  string  $name
+     * @return array
+     */
+    public function getInstanceConfig($name)
+    {
+        switch ($name) {
+            case 'foo':
+                return [
+                    'driver' => 'foo',
+                    'foo-option' => 'option-value'
+                ];
+            case 'bar':
+                return [
+                    'driver' => 'bar',
+                    'bar-option' => 'option-value'
+                ];
+            default:
+                return [];
+        }
+    }
+}

--- a/tests/Integration/Support/Fixtures/MultipleInstanceManager.php
+++ b/tests/Integration/Support/Fixtures/MultipleInstanceManager.php
@@ -10,7 +10,8 @@ class MultipleInstanceManager extends BaseMultipleInstanceManager
 
     protected function createFooDriver(array $config)
     {
-        return new class($config) {
+        return new class($config)
+        {
             public $config;
 
             public function __construct($config)
@@ -22,7 +23,8 @@ class MultipleInstanceManager extends BaseMultipleInstanceManager
 
     protected function createBarDriver(array $config)
     {
-        return new class($config) {
+        return new class($config)
+        {
             public $config;
 
             public function __construct($config)
@@ -65,12 +67,12 @@ class MultipleInstanceManager extends BaseMultipleInstanceManager
             case 'foo':
                 return [
                     'driver' => 'foo',
-                    'foo-option' => 'option-value'
+                    'foo-option' => 'option-value',
                 ];
             case 'bar':
                 return [
                     'driver' => 'bar',
-                    'bar-option' => 'option-value'
+                    'bar-option' => 'option-value',
                 ];
             default:
                 return [];

--- a/tests/Integration/Support/MultipleInstanceManagerTest.php
+++ b/tests/Integration/Support/MultipleInstanceManagerTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Support;
+
+use Illuminate\Tests\Integration\Support\Fixtures\MultipleInstanceManager;
+use Orchestra\Testbench\TestCase;
+
+class MultipleInstanceManagerTest extends TestCase
+{
+    public function test_configurable_instances_can_be_resolved()
+    {
+        $manager = new MultipleInstanceManager($this->app);
+
+        $fooInstance = $manager->instance('foo');
+        $this->assertEquals('option-value', $fooInstance->config['foo-option']);
+
+        $barInstance = $manager->instance('bar');
+        $this->assertEquals('option-value', $barInstance->config['bar-option']);
+
+        $duplicateFooInstance = $manager->instance('foo');
+        $duplicateBarInstance = $manager->instance('bar');
+        $this->assertEquals(spl_object_hash($fooInstance), spl_object_hash($duplicateFooInstance));
+        $this->assertEquals(spl_object_hash($barInstance), spl_object_hash($duplicateBarInstance));
+    }
+
+    public function test_unresolvable_isntances_throw_errors()
+    {
+        $this->expectException(\RuntimeException::class);
+
+        $manager = new MultipleInstanceManager($this->app);
+
+        $instance = $manager->instance('missing');
+    }
+}

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3023,6 +3023,49 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->fails());
     }
 
+    public function testValidateMacAddress()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['mac' => 'foo'], ['mac' => 'mac_address']);
+        $this->assertFalse($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['mac' => '01-23-45-67-89-ab'], ['mac' => 'mac_address']);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['mac' => '01-23-45-67-89-AB'], ['mac' => 'mac_address']);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['mac' => '01-23-45-67-89-aB'], ['mac' => 'mac_address']);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['mac' => '01:23:45:67:89:ab'], ['mac' => 'mac_address']);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['mac' => '01:23:45:67:89:AB'], ['mac' => 'mac_address']);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['mac' => '01:23:45:67:89:aB'], ['mac' => 'mac_address']);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['mac' => '01:23:45-67:89:aB'], ['mac' => 'mac_address']);
+        $this->assertFalse($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['mac' => 'xx:23:45:67:89:aB'], ['mac' => 'mac_address']);
+        $this->assertFalse($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['mac' => '0123.4567.89ab'], ['mac' => 'mac_address']);
+        $this->assertTrue($v->passes());
+    }
+
     public function testValidateEmail()
     {
         $trans = $this->getIlluminateArrayTranslator();

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4173,6 +4173,9 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['start' => '31/12/2012', 'ends' => null], ['start' => 'date_format:d/m/Y|before:ends', 'ends' => 'date_format:d/m/Y|after:start']);
         $this->assertTrue($v->fails());
 
+        $v = new Validator($trans, ['start' => '31/12/2012', 'ends' => null], ['start' => 'date_format:d/m/Y|before:ends', 'ends' => 'nullable|date_format:d/m/Y|after:start']);
+        $this->assertTrue($v->passes());
+
         $v = new Validator($trans, ['x' => date('d/m/Y')], ['x' => 'date_format:d/m/Y|after:yesterday|before:tomorrow']);
         $this->assertTrue($v->passes());
 


### PR DESCRIPTION
With this change we will be able to use dedicated mailer that was set in Mailable, instead of overriding it.
Solves this issue: https://github.com/laravel/framework/issues/32979#issuecomment-927112009
Doesnt break anything.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
