### PR TITLE
Dedicated mailer support for Mailables

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -299,9 +299,11 @@ class Mailer implements MailerContract, MailQueueContract
      */
     protected function sendMailable(MailableContract $mailable)
     {
+        $mailer = $mailable->mailer ?? $this->name;
+
         return $mailable instanceof ShouldQueue
-                        ? $mailable->mailer($this->name)->queue($this->queue)
-                        : $mailable->mailer($this->name)->send($this);
+                        ? $mailable->mailer($mailer)->queue($this->queue)
+                        : $mailable->mailer($mailer)->send($this);
     }
 
     /**


### PR DESCRIPTION
With this change we will be able to use dedicated mailer that was set in Mailable, instead of overriding it.
Solves this issue: https://github.com/laravel/framework/issues/32979 and doesnt break anything.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
