### PR TITLE
[8.x] Removed shrink-to-fit in error view

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/views/illustrated-layout.blade.php
+++ b/src/Illuminate/Foundation/Exceptions/views/illustrated-layout.blade.php
@@ -2,7 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
 
         <title>@yield('title')</title>
 


### PR DESCRIPTION
This tag isn't necessary anymore. This was needed with iOS 9, until iOS 9.3 restored the normal behaviour.

This PR brings it in sync with the other error template files.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
