### PR TITLE
[8.x] Hide or exclude pagination fields [links/meta] in Resources or Collections

### DIFF
--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -80,6 +80,10 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
             if (property_exists(static::class, 'preserveKeys')) {
                 $collection->preserveKeys = (new static([]))->preserveKeys === true;
             }
+
+            if (property_exists(static::class, 'hidden')) {
+                $collection->hidden = (new static([]))->hidden;
+            }
         });
     }
 

--- a/src/Illuminate/Http/Resources/Json/PaginatedResourceResponse.php
+++ b/src/Illuminate/Http/Resources/Json/PaginatedResourceResponse.php
@@ -68,7 +68,7 @@ class PaginatedResourceResponse extends ResourceResponse
      */
     protected function isHidden($key)
     {   
-        return in_array($key, $this->resource->hidden) || 
+        return in_array($key, $this->resource->hidden) ||
                 ! is_array($this->resource->hidden[$key] ?? []);
     }
 

--- a/src/Illuminate/Http/Resources/Json/PaginatedResourceResponse.php
+++ b/src/Illuminate/Http/Resources/Json/PaginatedResourceResponse.php
@@ -67,7 +67,7 @@ class PaginatedResourceResponse extends ResourceResponse
      * @return bool
      */
     protected function isHidden($key)
-    {   
+    {
         return in_array($key, $this->resource->hidden) ||
                 ! is_array($this->resource->hidden[$key] ?? []);
     }

--- a/src/Illuminate/Http/Resources/Json/PaginatedResourceResponse.php
+++ b/src/Illuminate/Http/Resources/Json/PaginatedResourceResponse.php
@@ -48,7 +48,6 @@ class PaginatedResourceResponse extends ResourceResponse
         if (! $this->isHidden('links')) {
             $default['links'] = $this->paginationLinks($paginated);
         }
-            
 
         if (! $this->isHidden('meta')) {
             $default['meta'] = $this->meta($paginated);

--- a/src/Illuminate/Http/Resources/Json/PaginatedResourceResponse.php
+++ b/src/Illuminate/Http/Resources/Json/PaginatedResourceResponse.php
@@ -62,7 +62,7 @@ class PaginatedResourceResponse extends ResourceResponse
 
     /**
      * Indicates whether the given key is hidden.
-     * 
+     *
      * @param  string  $key
      * @return bool
      */

--- a/src/Illuminate/Http/Resources/Json/ResourceCollection.php
+++ b/src/Illuminate/Http/Resources/Json/ResourceCollection.php
@@ -41,6 +41,13 @@ class ResourceCollection extends JsonResource implements Countable, IteratorAggr
     protected $queryParameters;
 
     /**
+     * The hidden pagination fields.
+     * 
+     * @var array
+     */
+    public $hidden = [];
+
+    /**
      * Create a new resource instance.
      *
      * @param  mixed  $resource

--- a/src/Illuminate/Http/Resources/Json/ResourceCollection.php
+++ b/src/Illuminate/Http/Resources/Json/ResourceCollection.php
@@ -42,7 +42,7 @@ class ResourceCollection extends JsonResource implements Countable, IteratorAggr
 
     /**
      * The hidden pagination fields.
-     * 
+     *
      * @var array
      */
     public $hidden = [];


### PR DESCRIPTION
I had to create collections for my api resources to override the `paginationInformation` method to hide some of the pagination array fields while that was extra work.

With this PR they can be hidden without the need for Collections.
It doesn't matter if you're in a `Resource` or `Collection`, it works both ways.

**Example:**
```php
class TransactionCollection extends ResourceCollection
{
    public $hidden = []; // hides nothing

    public $hidden = ['links', 'meta']; // hides both

    public $hidden = [
        'links' => ['first'], // excludes first
    ];

    public $hidden = [
        'meta' => [], // excludes nothing
        'links' // hides links
    ];

    ...
}

class TransactionResource extends JsonResource {
    ...
}
```