### PR TITLE
[7.x] Add varbinary type to Schema.

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1140,6 +1140,17 @@ class Blueprint
     }
 
     /**
+     * Create a new varbinary column on the table.
+     *
+     * @param  string  $column
+     * @return \Illuminate\Database\Schema\ColumnDefinition
+     */
+    public function varbinary($column)
+    {
+        return $this->addColumn('varbinary', $column);
+    }
+
+    /**
      * Create a new uuid column on the table.
      *
      * @param  string  $column

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -729,6 +729,17 @@ class MySqlGrammar extends Grammar
     }
 
     /**
+     * Create the column definition for a varbinary type.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+    protected function typeVarbinary(Fluent $column)
+    {
+        return 'blob';
+    }
+
+    /**
      * Create the column definition for a uuid type.
      *
      * @param  \Illuminate\Support\Fluent  $column

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -748,6 +748,17 @@ class PostgresGrammar extends Grammar
     }
 
     /**
+     * Create the column definition for a varbinary type.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+    protected function typeVarbinary(Fluent $column)
+    {
+        return 'bytea';
+    }
+
+    /**
      * Create the column definition for a uuid type.
      *
      * @param  \Illuminate\Support\Fluent  $column

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -703,6 +703,17 @@ class SQLiteGrammar extends Grammar
     }
 
     /**
+     * Create the column definition for a varbinary type.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+    protected function typeVarbinary(Fluent $column)
+    {
+        return 'blob';
+    }
+
+    /**
      * Create the column definition for a uuid type.
      *
      * @param  \Illuminate\Support\Fluent  $column

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -663,6 +663,17 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
+     * Create the column definition for a varbinary type.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+    protected function typeVarbinary(Fluent $column)
+    {
+        return 'varbinary(max)';
+    }
+
+    /**
      * Create the column definition for a uuid type.
      *
      * @param  \Illuminate\Support\Fluent  $column

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -920,6 +920,16 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertSame('alter table `users` add `foo` blob not null', $statements[0]);
     }
 
+    public function testAddingVarbinary()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->varbinary('foo');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `foo` blob not null', $statements[0]);
+    }
+
     public function testAddingUuid()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -754,6 +754,16 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertSame('alter table "users" add column "foo" bytea not null', $statements[0]);
     }
 
+    public function testAddingVarbinary()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->varbinary('foo');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add column "foo" bytea not null', $statements[0]);
+    }
+
     public function testAddingUuid()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -700,6 +700,16 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertSame('alter table "users" add column "foo" blob not null', $statements[0]);
     }
 
+    public function testAddingVarbinary()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->varbinary('foo');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add column "foo" blob not null', $statements[0]);
+    }
+
     public function testAddingUuid()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -719,6 +719,16 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertSame('alter table "users" add "foo" varbinary(max) not null', $statements[0]);
     }
 
+    public function testAddingVarbinary()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->varbinary('foo');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add "foo" varbinary(max) not null', $statements[0]);
+    }
+
     public function testAddingUuid()
     {
         $blueprint = new Blueprint('users');


### PR DESCRIPTION
## Motivation

According to [this]( https://laracasts.com/discuss/channels/eloquent/varbinary-equivalent-in-eloquent) and [this]( https://stackoverflow.com/questions/17795517/laravel-4-saving-ip-address-to-model) there is a convenient way to store IP addresses through inet_pton() and inet_ntop() and retain them in a database in a VARBINARY(16) column. It's efficient and suitable for both IP versions. Unfortunately, I haven’t found a way how it is possible to make a columns varbinary. So, I started to seek a solution. The first one was to use:
```code
DB::statement('ALTER TABLE `my_logs` ADD `ip_address` VARBINARY(16)');
```

But it’s not flexible, because it’s impossible to set the exact order of the column in the table. So, the next solution was almost the same, but without this problem. It is possible to create a column of any type and then modify its type.
```code
DB::statement('ALTER TABLE `my_logs` MODIFY COLUMN `ip_address` VARBINARY(16)');
```

Unfortunately, it turned out, that SQLite (which I use during testing) doesn’t support the modify command. I searched for PRs on this topic and found only #39461, which was closed.

## Proposition

This is my PR with a proposition to add the possibility to create a column of the varbinary type using Schema.

**P.S.** This solution doesn’t get any additional options (because binary() method does it neither). In case, if you need to provide any additional information to the database it is possible to do that through addColumn() method.
```code
$table->addColumn('varbinary', 'ip_address', ['length' => 16]);
```
