### PR TITLE
PhpDoc for Log. Message can be mixed type

### DIFF
--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -532,7 +532,7 @@ class LogManager implements LoggerInterface
     /**
      * System is unusable.
      *
-     * @param  string  $message
+     * @param  mixed  $message
      * @param  array  $context
      * @return void
      */
@@ -547,7 +547,7 @@ class LogManager implements LoggerInterface
      * Example: Entire website down, database unavailable, etc. This should
      * trigger the SMS alerts and wake you up.
      *
-     * @param  string  $message
+     * @param  mixed  $message
      * @param  array  $context
      * @return void
      */
@@ -561,7 +561,7 @@ class LogManager implements LoggerInterface
      *
      * Example: Application component unavailable, unexpected exception.
      *
-     * @param  string  $message
+     * @param  mixed  $message
      * @param  array  $context
      * @return void
      */
@@ -574,7 +574,7 @@ class LogManager implements LoggerInterface
      * Runtime errors that do not require immediate action but should typically
      * be logged and monitored.
      *
-     * @param  string  $message
+     * @param  mixed  $message
      * @param  array  $context
      * @return void
      */
@@ -589,7 +589,7 @@ class LogManager implements LoggerInterface
      * Example: Use of deprecated APIs, poor use of an API, undesirable things
      * that are not necessarily wrong.
      *
-     * @param  string  $message
+     * @param  mixed  $message
      * @param  array  $context
      * @return void
      */
@@ -601,7 +601,7 @@ class LogManager implements LoggerInterface
     /**
      * Normal but significant events.
      *
-     * @param  string  $message
+     * @param  mixed  $message
      * @param  array  $context
      * @return void
      */
@@ -615,7 +615,7 @@ class LogManager implements LoggerInterface
      *
      * Example: User logs in, SQL logs.
      *
-     * @param  string  $message
+     * @param  mixed  $message
      * @param  array  $context
      * @return void
      */
@@ -627,7 +627,7 @@ class LogManager implements LoggerInterface
     /**
      * Detailed debug information.
      *
-     * @param  string  $message
+     * @param  mixed  $message
      * @param  array  $context
      * @return void
      */
@@ -640,7 +640,7 @@ class LogManager implements LoggerInterface
      * Logs with an arbitrary level.
      *
      * @param  mixed  $level
-     * @param  string  $message
+     * @param  mixed  $message
      * @param  array  $context
      * @return void
      */

--- a/src/Illuminate/Log/Logger.php
+++ b/src/Illuminate/Log/Logger.php
@@ -49,7 +49,7 @@ class Logger implements LoggerInterface
     /**
      * Log an emergency message to the logs.
      *
-     * @param  string  $message
+     * @param  mixed  $message
      * @param  array  $context
      * @return void
      */
@@ -61,7 +61,7 @@ class Logger implements LoggerInterface
     /**
      * Log an alert message to the logs.
      *
-     * @param  string  $message
+     * @param  mixed  $message
      * @param  array  $context
      * @return void
      */
@@ -73,7 +73,7 @@ class Logger implements LoggerInterface
     /**
      * Log a critical message to the logs.
      *
-     * @param  string  $message
+     * @param  mixed  $message
      * @param  array  $context
      * @return void
      */
@@ -85,7 +85,7 @@ class Logger implements LoggerInterface
     /**
      * Log an error message to the logs.
      *
-     * @param  string  $message
+     * @param  mixed  $message
      * @param  array  $context
      * @return void
      */
@@ -97,7 +97,7 @@ class Logger implements LoggerInterface
     /**
      * Log a warning message to the logs.
      *
-     * @param  string  $message
+     * @param  mixed  $message
      * @param  array  $context
      * @return void
      */
@@ -109,7 +109,7 @@ class Logger implements LoggerInterface
     /**
      * Log a notice to the logs.
      *
-     * @param  string  $message
+     * @param  mixed  $message
      * @param  array  $context
      * @return void
      */
@@ -121,7 +121,7 @@ class Logger implements LoggerInterface
     /**
      * Log an informational message to the logs.
      *
-     * @param  string  $message
+     * @param  mixed  $message
      * @param  array  $context
      * @return void
      */
@@ -133,7 +133,7 @@ class Logger implements LoggerInterface
     /**
      * Log a debug message to the logs.
      *
-     * @param  string  $message
+     * @param  mixed  $message
      * @param  array  $context
      * @return void
      */
@@ -146,7 +146,7 @@ class Logger implements LoggerInterface
      * Log a message to the logs.
      *
      * @param  string  $level
-     * @param  string  $message
+     * @param  mixed  $message
      * @param  array  $context
      * @return void
      */
@@ -159,7 +159,7 @@ class Logger implements LoggerInterface
      * Dynamically pass log calls into the writer.
      *
      * @param  string  $level
-     * @param  string  $message
+     * @param  mixed  $message
      * @param  array  $context
      * @return void
      */
@@ -172,7 +172,7 @@ class Logger implements LoggerInterface
      * Write a message to the log.
      *
      * @param  string  $level
-     * @param  string  $message
+     * @param  mixed  $message
      * @param  array  $context
      * @return void
      */


### PR DESCRIPTION
Hello. 
I just added the types to the phpDoc for `Illuminate\Log`. The `message `parameter can be not only a string, but also an array. In addition, in many methods it is declared as `mixed `(for example, in `Illuminate\Log\Logger::FormatMessage`). 
The advantage for development is that the IDE does not highlight the code when a variable other than a string is passed.