### PR TITLE
add package_view helper function

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -932,3 +932,18 @@ if (! function_exists('view')) {
         return $factory->make($view, $data, $mergeData);
     }
 }
+
+if (! function_exists('package_view')) {
+    /**
+     * Get the evaluated package view contents for the given view.
+     *
+     * @param  array  $view
+     * @param  \Illuminate\Contracts\Support\Arrayable|array  $data
+     * @param  array  $mergeData
+     * @return \Illuminate\Contracts\View\View|\Illuminate\Contracts\View\Factory
+     */
+    function package_view($packageNameSpace, $path, $data = [], $mergeData = [])
+    {
+        return view($packageNameSpace . '::' . $path, $data, $mergeData);
+    }
+}

--- a/tests/Foundation/FoundationHelpersTest.php
+++ b/tests/Foundation/FoundationHelpersTest.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Config\Repository;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Mix;
 use Illuminate\Support\Str;
+use Illuminate\Contracts\View\Factory as ViewFactory;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use stdClass;
@@ -243,5 +244,23 @@ class FoundationHelpersTest extends TestCase
         });
 
         $this->assertSame('expected', mix('asset.png'));
+    }
+
+    public function testPackageViewHelper()
+    {
+        $mockedViewFactory = m::mock(ViewFactory::class);
+
+        app()->instance(ViewFactory::class, $mockedViewFactory);
+
+        $mockedViewFactory->shouldReceive('make')
+            ->once()
+            ->with('test_package::test_path', [], []);
+        package_view('test_package', 'test_path');
+
+        $mockedViewFactory->shouldReceive('make')
+            ->once()
+            ->with('test_package::test_path', ['data'], ['merge_data']);
+
+        package_view('test_package', 'test_path', ['data'], ['merge_data']);
     }
 }


### PR DESCRIPTION
Since the `view` helper function only accepts the string format for the path, to specify the path to the package's view file, it will require concatenation with special sting `::` for package and `.` syntax for the path. 

since we want to declare package slug variable during the package development to avoid string typo, most likely will end up a lot of the following code

```
view(MyPackageServiceProvider::$slug . '::' . 'viewto.my.index');
```


this new helper function help developer writer better readability and a cleaner way to specify view file from the package

```
package_view(MyPackageServiceProvider::$slug, 'viewto.my.index');
```