### PR TITLE
Allow wildcard notations in validation.php 'attributes' field like they are allowed in the 'custom' field.

### DIFF
--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -276,7 +276,37 @@ trait FormatsMessages
      */
     protected function getAttributeFromTranslations($name)
     {
-        return Arr::get($this->translator->get('validation.attributes'), $name);
+        if ($translatedName = Arr::get($this->translator->get('validation.attributes'), $name)) {
+            return $translatedName;
+        }
+
+        // If an exact match was not found for the key, we will collapse all of these
+        // attributes and loop through them and try to find a wildcard match for the
+        // given key. Otherwise, we will simply return the key's value back out.
+        $shortKey = preg_replace('/^validation\.attributes\./', '', $name);
+
+        return $this->getWildcardCustomAttributes(Arr::dot(
+            (array) $this->translator->get('validation.attributes')
+        ), $shortKey, $name);
+    }
+
+    /**
+     * Check the given attributes for a wildcard key.
+     *
+     * @param  array  $messages
+     * @param  string  $search
+     * @param  string  $default
+     * @return string
+     */
+    protected function getWildcardCustomAttributes($attributes, $search, $default)
+    {
+        foreach ($attributes as $key => $attribute) {
+            if ($search === $key || (Str::contains($key, ['*']) && Str::is($key, $search))) {
+                return $attribute;
+            }
+        }
+
+        return $default;
     }
 
     /**


### PR DESCRIPTION
Allow wildcard notations in validation.php 'attributes' field like they are allowed in the 'custom' field.
This has been an issue since 5.* and never got addressed: #28453  #30525
