### PR TITLE
[9.x] Automatically resolve route parameters into view data

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -119,7 +119,8 @@
     },
     "autoload-dev": {
         "files": [
-            "tests/Database/stubs/MigrationCreatorFakeMigration.php"
+            "tests/Database/stubs/MigrationCreatorFakeMigration.php",
+            "tests/Integration/Routing/Fixtures/User.php"
         ],
         "psr-4": {
             "Illuminate\\Tests\\": "tests/"

--- a/src/Illuminate/Routing/ImplicitRouteBinding.php
+++ b/src/Illuminate/Routing/ImplicitRouteBinding.php
@@ -77,7 +77,7 @@ class ImplicitRouteBinding
     /**
      * Guess the class from the parameter name.
      *
-     * @param  string $name
+     * @param  string  $name
      * @return string|null
      */
     protected static function guessClass($name)
@@ -85,12 +85,12 @@ class ImplicitRouteBinding
         $namespace = app()->getNamespace();
         $classname = Str::studly($name);
 
-        if (class_exists($namespace . $classname)) {
+        if (class_exists($namespace.$classname)) {
             return $classname;
         }
 
-        if (class_exists($namespace . 'Models\\' . $classname)) {
-            return $namespace . 'Models\\' . $classname;
+        if (class_exists($namespace.'Models\\'.$classname)) {
+            return $namespace.'Models\\'.$classname;
         }
 
         return null;
@@ -99,7 +99,7 @@ class ImplicitRouteBinding
     /**
      * Determine the class for the route parameters.
      *
-     * @param  \Illuminate\Routing\Route $route
+     * @param  \Illuminate\Routing\Route  $route
      * @return array
      */
     protected static function parametersAsClassmap($route)
@@ -111,7 +111,7 @@ class ImplicitRouteBinding
      * Determine the class name for the route parameters
      * specified in the view's URI.
      *
-     * @param  \Illuminate\Routing\Route $route
+     * @param  \Illuminate\Routing\Route  $route
      * @return array
      */
     protected static function viewParameters($route)
@@ -129,7 +129,7 @@ class ImplicitRouteBinding
      * Determine the class name for the route parameters
      * based on the signature of the route action.
      *
-     * @param  \Illuminate\Routing\Route $route
+     * @param  \Illuminate\Routing\Route  $route
      * @return array
      */
     protected static function signatureParameters($route)
@@ -140,10 +140,10 @@ class ImplicitRouteBinding
                 if (is_null($name)) {
                     return [];
                 }
+
                 return [$name => Reflector::getParameterClassName($parameter)];
             })
             ->filter()
             ->all();
     }
-
 }

--- a/src/Illuminate/Routing/ViewController.php
+++ b/src/Illuminate/Routing/ViewController.php
@@ -36,4 +36,14 @@ class ViewController extends Controller
 
         return $this->response->view($view, $data, $status, $headers);
     }
+
+    public function callAction($method, $parameters)
+    {
+        $data = collect($parameters)
+            ->except('view', 'data', 'status', 'headers')
+            ->merge($parameters['data'])
+            ->all();
+
+        return parent::callAction($method, [$parameters['view'], $data, $parameters['status'], $parameters['headers']]);
+    }
 }

--- a/tests/Integration/Routing/Fixtures/User.php
+++ b/tests/Integration/Routing/Fixtures/User.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class User extends Model
+{
+    public $table = 'users';
+
+    protected $guarded = [];
+}

--- a/tests/Integration/Routing/Fixtures/implicit_bindings.blade.php
+++ b/tests/Integration/Routing/Fixtures/implicit_bindings.blade.php
@@ -1,0 +1,1 @@
+Hello {{ $user->name }}, {{ $foo }}!

--- a/tests/Integration/Routing/RouteViewTest.php
+++ b/tests/Integration/Routing/RouteViewTest.php
@@ -2,12 +2,24 @@
 
 namespace Illuminate\Tests\Integration\Routing;
 
+use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\View;
 use Orchestra\Testbench\TestCase;
 
 class RouteViewTest extends TestCase
 {
+    protected function defineDatabaseMigrations(): void
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
     public function testRouteView()
     {
         Route::view('route', 'view', ['foo' => 'bar']);
@@ -53,5 +65,41 @@ class RouteViewTest extends TestCase
         View::addLocation(__DIR__.'/Fixtures');
 
         $this->assertSame('Laravel', $this->get('/route')->headers->get('Framework'));
+    }
+
+    public function testRouteViewInjectsParametersAsData()
+    {
+        $user = \App\Models\User::create(['name' => 'Dries']);
+
+        config(['app.key' => str_repeat('a', 32)]);
+
+        Route::bind('foo', function ($value) {
+            return $value . 'baz';
+        });
+        Route::view('/bindings/{user}/{foo}', 'implicit_bindings')->middleware('web');
+
+        View::addLocation(__DIR__.'/Fixtures');
+
+        $response = $this->get("/bindings/{$user->id}/bar");
+
+        $this->assertEquals("Hello Dries, barbaz!", trim($response->content()));
+    }
+
+    public function testRouteViewDoesNotOverwriteDataWithParameters()
+    {
+        $user = \App\Models\User::create(['name' => 'Jane']);
+
+        config(['app.key' => str_repeat('a', 32)]);
+
+        Route::bind('foo', function ($value) {
+            return $value . 'baz';
+        });
+        Route::view('/bindings/{user}/{foo}', 'implicit_bindings', ['foo' => 'huzzah'])->middleware('web');
+
+        View::addLocation(__DIR__.'/Fixtures');
+
+        $response = $this->get("/bindings/{$user->id}/baz");
+
+        $this->assertEquals("Hello Jane, huzzah!", trim($response->content()));
     }
 }

--- a/tests/Integration/Routing/RouteViewTest.php
+++ b/tests/Integration/Routing/RouteViewTest.php
@@ -74,7 +74,7 @@ class RouteViewTest extends TestCase
         config(['app.key' => str_repeat('a', 32)]);
 
         Route::bind('foo', function ($value) {
-            return $value . 'baz';
+            return $value.'baz';
         });
         Route::view('/bindings/{user}/{foo}', 'implicit_bindings')->middleware('web');
 
@@ -82,7 +82,7 @@ class RouteViewTest extends TestCase
 
         $response = $this->get("/bindings/{$user->id}/bar");
 
-        $this->assertEquals("Hello Dries, barbaz!", trim($response->content()));
+        $this->assertEquals('Hello Dries, barbaz!', trim($response->content()));
     }
 
     public function testRouteViewDoesNotOverwriteDataWithParameters()
@@ -92,7 +92,7 @@ class RouteViewTest extends TestCase
         config(['app.key' => str_repeat('a', 32)]);
 
         Route::bind('foo', function ($value) {
-            return $value . 'baz';
+            return $value.'baz';
         });
         Route::view('/bindings/{user}/{foo}', 'implicit_bindings', ['foo' => 'huzzah'])->middleware('web');
 
@@ -100,6 +100,6 @@ class RouteViewTest extends TestCase
 
         $response = $this->get("/bindings/{$user->id}/baz");
 
-        $this->assertEquals("Hello Jane, huzzah!", trim($response->content()));
+        $this->assertEquals('Hello Jane, huzzah!', trim($response->content()));
     }
 }


### PR DESCRIPTION
Recently, I attempted to register the following route:

```php
Route::view('event/{event}/sign-in', 'event.sign-in');
```

While I didn't _expect_ this to work, the magic within Laravel has surprised me numerous times.

Ultimately, I had to write:

```php
Route::get('event/{event}/sign-in', function (\App\Models\Event $event) {
    return view('event.sign-in', ['event' => $event]);
});
```

However, I think it'd be pretty neat if Laravel had this magic. So that's what this PR adds - resolving route parameters and automatically injecting them into the view data.

**How it works**
Any explicit route parameter bindings are resolved like any other route. Implicit model bindings are _guessed_ using a fallback similar to how model factories are guessed.

If view data with these names is not already defined, the parameter will be automatically injected into the view data. Said another way, values passed in the `$data` argument take precedence over parameters.

---

**Note:** this is targeted for Laravel 9 due to the change in default behavior of `Route::view()`. To be compatible with Laravel 8 or to make the behavior opt-in, a chained method could be used. For example, `Route::view()->withParameterBinding();`