### PR TITLE
[8.x] Add shortcut for searching in Postgres Array (`[]`) type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -155,7 +155,10 @@
         "wildbit/swiftmailer-postmark": "Required to use Postmark mail driver (^3.0)."
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "composer/package-versions-deprecated": true
+        }
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/composer.json
+++ b/composer.json
@@ -155,10 +155,7 @@
         "wildbit/swiftmailer-postmark": "Required to use Postmark mail driver (^3.0)."
     },
     "config": {
-        "sort-packages": true,
-        "allow-plugins": {
-            "composer/package-versions-deprecated": true
-        }
+        "sort-packages": true
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1760,6 +1760,65 @@ class Builder
     }
 
     /**
+     * Add a "where Array contains" clause to the query.
+     *
+     * @param  string  $column
+     * @param  mixed  $value
+     * @param  string  $boolean
+     * @param  bool  $not
+     * @return $this
+     */
+    public function whereArrayContains($column, $value, $boolean = 'and', $not = false)
+    {
+        $type = 'ArrayContains';
+
+        $this->wheres[] = compact('type', 'column', 'value', 'boolean', 'not');
+
+        if (! $value instanceof Expression) {
+            $this->addBinding($value);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Add an "or where Array contains" clause to the query.
+     *
+     * @param  string  $column
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function orWhereArrayContains($column, $value)
+    {
+        return $this->whereArrayContains($column, $value, 'or');
+    }
+
+    /**
+     * Add a "where Array not contains" clause to the query.
+     *
+     * @param  string  $column
+     * @param  mixed  $value
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereArrayDoesntContain($column, $value, $boolean = 'and')
+    {
+        return $this->whereArrayContains($column, $value, $boolean, true);
+    }
+
+    /**
+     * Add an "or where Array not contains" clause to the query.
+     *
+     * @param  string  $column
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function orWhereArrayDoesntContain($column, $value)
+    {
+        return $this->whereArrayDoesntContain($column, $value, 'or');
+    }
+
+    /**
      * Handles dynamic "where" clauses to the query.
      *
      * @param  string  $method

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -630,6 +630,36 @@ class Grammar extends BaseGrammar
     }
 
     /**
+     * Compile a "where JSON contains" clause.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereArrayContains(Builder $query, $where)
+    {
+        $not = $where['not'] ? 'not ' : '';
+
+        return $not.$this->compileArrayContains(
+            $where['column'], $this->parameter($where['value'])
+        );
+    }
+
+    /**
+     * Compile a "JSON contains" statement into SQL.
+     *
+     * @param  string  $column
+     * @param  string  $value
+     * @return string
+     *
+     * @throws \RuntimeException
+     */
+    protected function compileArrayContains($column, $value)
+    {
+        throw new RuntimeException('This database engine does not support Array contains operations.');
+    }
+
+    /**
      * Compile the "group by" portions of the query.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -127,6 +127,18 @@ class PostgresGrammar extends Grammar
     }
 
     /**
+     * Compile a "Array contains" statement into SQL.
+     *
+     * @param  string  $column
+     * @param  string  $value
+     * @return string
+     */
+    protected function compileArrayContains($column, $value)
+    {
+        return $value.' = ANY ('.$column.')';
+    }
+
+    /**
      * Compile a "JSON length" statement into SQL.
      *
      * @param  string  $column

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -4147,6 +4147,70 @@ SQL;
         $this->assertEquals([1], $builder->getBindings());
     }
 
+    public function testWhereArrayContainsMySql()
+    {
+        $this->expectException(RuntimeException::class);
+
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereArrayContains('languages', 'en')->toSql();
+    }
+
+    public function testWhereArrayContainsPostgres()
+    {
+        $builder = $this->getPostgresBuilder();
+        $builder->select('*')->from('users')->whereArrayContains('languages', 'en');
+        $this->assertSame('select * from "users" where ? = ANY (languages)', $builder->toSql());
+        $this->assertEquals(['en'], $builder->getBindings());
+    }
+
+    public function testWhereArrayContainsSqlite()
+    {
+        $this->expectException(RuntimeException::class);
+
+        $builder = $this->getSQLiteBuilder();
+        $builder->select('*')->from('users')->whereArrayContains('languages', 'en')->toSql();
+    }
+
+    public function testWhereArrayContainsSqlServer()
+    {
+        $this->expectException(RuntimeException::class);
+
+        $builder = $this->getSqlServerBuilder();
+        $builder->select('*')->from('users')->whereArrayContains('languages', 'en')->toSql();
+    }
+
+    public function testWhereArrayDoesntContainMySql()
+    {
+        $this->expectException(RuntimeException::class);
+
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereArrayDoesntContain('languages', 'en')->toSql();
+    }
+
+    public function testWhereArrayDoesntContainPostgres()
+    {
+        $builder = $this->getPostgresBuilder();
+        $builder->select('*')->from('users')->whereArrayDoesntContain('languages', ['en']);
+        $this->assertSame('select * from "users" where not ? = ANY (languages)', $builder->toSql());
+        $this->assertEquals(['en'], $builder->getBindings());
+    }
+
+    public function testWhereArrayDoesntContainSqlite()
+    {
+        $this->expectException(RuntimeException::class);
+
+        $builder = $this->getSQLiteBuilder();
+        $builder->select('*')->from('users')->whereArrayDoesntContain('languages', 'en')->toSql();
+    }
+
+    public function testWhereArrayDoesntContainSqlServer()
+    {
+        $this->expectException(RuntimeException::class);
+
+        $builder = $this->getSqlServerBuilder();
+        $builder->select('*')->from('users')->whereArrayDoesntContain('languages', 'en')->toSql();
+    }
+
     public function testFromSub()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
Similar to `whereJsonContains()`, this makes it easier to search in columns with `[]` types. I am not sure which databases support this besides Postgres.