### PR TITLE
[8.x] Clear recorded calls when calling Http::fake()

### DIFF
--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -149,6 +149,8 @@ class Factory
     {
         $this->record();
 
+        $this->recorded = [];
+
         if (is_null($callback)) {
             $callback = function () {
                 return static::response();

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -183,12 +183,12 @@ class HttpClientTest extends TestCase
     public function testRecordedCallsAreEmptiedWhenFakeIsCalled()
     {
         $this->factory->fake([
-            'http://foo.com/*' => ['page' => 'foo']
+            'http://foo.com/*' => ['page' => 'foo'],
         ]);
 
         $this->factory->get('http://foo.com/test');
 
-        $this->factory->assertSent(function (Request $request){
+        $this->factory->assertSent(function (Request $request) {
             return $request->url() === 'http://foo.com/test';
         });
 

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -180,6 +180,23 @@ class HttpClientTest extends TestCase
         });
     }
 
+    public function testRecordedCallsAreEmptiedWhenFakeIsCalled()
+    {
+        $this->factory->fake([
+            'http://foo.com/*' => ['page' => 'foo']
+        ]);
+
+        $this->factory->get('http://foo.com/test');
+
+        $this->factory->assertSent(function (Request $request){
+            return $request->url() === 'http://foo.com/test';
+        });
+
+        $this->factory->fake();
+
+        $this->factory->assertNothingSent();
+    }
+
     public function testSpecificRequestIsNotBeingSent()
     {
         $this->factory->fake();


### PR DESCRIPTION
This PR aims to clear the `$recorded` array on `Illuminate\Http\Client\Factory` class.

## Background
Currently, i'm creating a test to ensure that  i will never login to an api while i still have a valid bearer token. The token management is handled with cache, with the token being stored in cache for `now() + $access_token['expires_in']` seconds. It works fine, but in my tests, in order to ensure that i'll only call the login api the token is already expired, i mock the `login` response using `Http::fake()`, freeze the time (using spatie's test-time package), then call the login api, receive and store the token in cache. Then, i call `Http::fake()` one more time (to forget recorded calls) and call the api again, with time freezed and token in cache yet. Now, as i haven't called the login api (due to token being in cache), i want to assert that nothing was sent using `Http::assertNothingSent()`, but the problem is: The `$recorded` property are never cleared when i call `fake`, and the assertion fails.

Here's some code snippets to illustrate what i'm explaining:

```php
TestTime::freeze();

Http::fake([
    '*/auth/oauth/v2/token' => Http::response([
        'token_type' => 'Bearer',
        'access_token' => $accessToken = '2XzMDjRfl76ZC9Ub0wnz4XsNiRVBChTYbJ',
        'expires_in' => 420,
        'scope' => 'my-scopes-here'
    ])
]);

$token = MyServiceClass::login()

$this->assertIsString($token);

$this->assertEquals("Bearer $accessToken", $token);

$this->assertEquals("Bearer $accessToken", Cache::get('login-token');

TestTime::addSeconds(419);

Http::fake();

$token = MyServiceClass::login()

$this->assertEquals("Bearer $accessToken", $token); // It works, because my service returns the token from cache.

$this->assertEquals("Bearer $accessToken", Cache::get('login-token');

Http::assertNothingSent(); // It fails, because $recored wasn't cleared.
```

## Solution
As a proposed solution, i've added a call to clear the `$recorded` array within the `fake` method:

```php
public function fake($callback = null)
{
    $this->record();

    $this->recorded = [];
```
