### PR TITLE
[8.x] Extend PostgreSQL updateFrom to support nested joins

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -337,7 +337,7 @@ class PostgresGrammar extends Grammar
         if (trim($baseWheres) != '') {
             $baseWheres = $this->replaceLeadingWhere($baseWheres, $query->wheres[0]['boolean']);
         }
-        
+
         return $joinWheres.' '.$baseWheres;
     }
 
@@ -374,7 +374,7 @@ class PostgresGrammar extends Grammar
      */
     protected function replaceLeadingWhere($value, $boolean)
     {
-        return preg_replace('/where /i', $boolean . ' ', $value, 1);
+        return preg_replace('/where /i', $boolean.' ', $value, 1);
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -298,7 +298,7 @@ class PostgresGrammar extends Grammar
 			})->all();
 
 			if (count($joinFroms) > 0) {
-				$joinFrom = ' ' . implode(', ', $joinFroms);
+				$joinFrom = ' '.implode(', ', $joinFroms);
 			}
         }
 

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -292,14 +292,14 @@ class PostgresGrammar extends Grammar
             }
 
             $joinFroms = collect($query->joins)->filter(function ($join) {
-				return collect($join->joins)->count();
-			})->map(function ($join) {
-				return $this->compileJoins($join, $join->joins);
-			})->all();
+                return collect($join->joins)->count();
+            })->map(function ($join) {
+                return $this->compileJoins($join, $join->joins);
+            })->all();
 
-			if (count($joinFroms) > 0) {
-				$joinFrom = ' '.implode(', ', $joinFroms);
-			}
+            if (count($joinFroms) > 0) {
+                $joinFrom = ' '.implode(', ', $joinFroms);
+            }
         }
 
         $where = $this->compileUpdateWheres($query);

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2477,6 +2477,17 @@ class DatabaseQueryBuilderTest extends TestCase
             })->where('name', 'baz')
            ->updateFrom(['email' => 'foo', 'name' => 'bar']);
         $this->assertEquals(1, $result);
+
+        $builder = $this->getPostgresBuilder();
+        $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "email" = ?, "name" = ? from "orders" left join "order_items" on "order_items"."order_id" = "orders"."id" where "name" = ? and "users"."id" = "orders"."user_id" and "users"."id" = ?', ['foo', 'bar', 'baz', 1])->andReturn(1);
+        $result = $builder->from('users')
+            ->join('orders', function ($join) {
+                $join->on('users.id', '=', 'orders.user_id')
+                    ->where('users.id', '=', 1)
+                    ->leftJoin('order_items', 'order_items.order_id', '=', 'orders.id');
+            })->where('name', 'baz')
+            ->updateFrom(['email' => 'foo', 'name' => 'bar']);
+        $this->assertEquals(1, $result);
     }
 
     public function testUpdateMethodRespectsRaw()

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2430,26 +2430,26 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testUpdateMethodWithJoinsOnPostgres()
     {
         $builder = $this->getPostgresBuilder();
-        $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "email" = ?, "name" = ? where "ctid" in (select "users"."ctid" from "users" inner join "orders" on "users"."id" = "orders"."user_id" where "users"."id" = ?)', ['foo', 'bar', 1])->andReturn(1);
-        $result = $builder->from('users')->join('orders', 'users.id', '=', 'orders.user_id')->where('users.id', '=', 1)->update(['email' => 'foo', 'name' => 'bar']);
+        $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "email" = ?, "name" = ? from "orders" where "users"."id" = "orders"."user_id" and "users"."id" = ?', ['foo', 'bar', 1])->andReturn(1);
+        $result = $builder->from('users')->join('orders', 'users.id', '=', 'orders.user_id')->where('users.id', '=', 1)->updateFrom(['email' => 'foo', 'name' => 'bar']);
         $this->assertEquals(1, $result);
 
         $builder = $this->getPostgresBuilder();
-        $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "email" = ?, "name" = ? where "ctid" in (select "users"."ctid" from "users" inner join "orders" on "users"."id" = "orders"."user_id" and "users"."id" = ?)', ['foo', 'bar', 1])->andReturn(1);
+        $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "email" = ?, "name" = ? from "orders" where "users"."id" = "orders"."user_id" and "users"."id" = ?', ['foo', 'bar', 1])->andReturn(1);
         $result = $builder->from('users')->join('orders', function ($join) {
             $join->on('users.id', '=', 'orders.user_id')
                 ->where('users.id', '=', 1);
-        })->update(['email' => 'foo', 'name' => 'bar']);
+        })->updateFrom(['email' => 'foo', 'name' => 'bar']);
         $this->assertEquals(1, $result);
 
         $builder = $this->getPostgresBuilder();
-        $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "email" = ?, "name" = ? where "ctid" in (select "users"."ctid" from "users" inner join "orders" on "users"."id" = "orders"."user_id" and "users"."id" = ? where "name" = ?)', ['foo', 'bar', 1, 'baz'])->andReturn(1);
+        $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "email" = ?, "name" = ? from "orders" where "users"."id" = "orders"."user_id" and "users"."id" = ? and "name" = ?', ['foo', 'bar', 1, 'baz'])->andReturn(1);
         $result = $builder->from('users')
             ->join('orders', function ($join) {
                 $join->on('users.id', '=', 'orders.user_id')
                     ->where('users.id', '=', 1);
             })->where('name', 'baz')
-            ->update(['email' => 'foo', 'name' => 'bar']);
+            ->updateFrom(['email' => 'foo', 'name' => 'bar']);
         $this->assertEquals(1, $result);
     }
 
@@ -2482,7 +2482,7 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testUpdateFromMethodWithNestedJoinsOnPostgres()
     {
         $builder = $this->getPostgresBuilder();
-        $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "email" = ?, "name" = ? from "orders" left join "order_items" on "order_items"."order_id" = "orders"."id" where "name" = ? and "users"."id" = "orders"."user_id" and "users"."id" = ?', ['foo', 'bar', 'baz', 1])->andReturn(1);
+        $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "email" = ?, "name" = ? from "orders" left join "order_items" on "order_items"."order_id" = "orders"."id" where "users"."id" = "orders"."user_id" and "users"."id" = ? and "name" = ?', ['foo', 'bar', 1, 'baz'])->andReturn(1);
         $result = $builder->from('users')
             ->join('orders', function ($join) {
                 $join->on('users.id', '=', 'orders.user_id')
@@ -2493,7 +2493,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(1, $result);
 
         $builder = $this->getPostgresBuilder();
-        $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "email" = ?, "name" = ? from "orders" left join "order_items" on "order_items"."order_id" = "orders"."id" and "t2"."id" = ? where "name" = ? and "users"."id" = "orders"."user_id" and "users"."id" = ?', ['foo', 'bar', 2, 'baz', 1])->andReturn(1);
+        $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "email" = ?, "name" = ? from "orders" left join "order_items" on "order_items"."order_id" = "orders"."id" and "order_items"."id" = ? where "users"."id" = "orders"."user_id" and "users"."id" = ? and "name" = ?', ['foo', 'bar', 2, 1, 'baz'])->andReturn(1);
         $result = $builder->from('users')
             ->join('orders', function ($join) {
                 $join->on('users.id', '=', 'orders.user_id')

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2477,7 +2477,10 @@ class DatabaseQueryBuilderTest extends TestCase
             })->where('name', 'baz')
            ->updateFrom(['email' => 'foo', 'name' => 'bar']);
         $this->assertEquals(1, $result);
+    }
 
+    public function testUpdateFromMethodWithNestedJoinsOnPostgres()
+    {
         $builder = $this->getPostgresBuilder();
         $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "email" = ?, "name" = ? from "orders" left join "order_items" on "order_items"."order_id" = "orders"."id" where "name" = ? and "users"."id" = "orders"."user_id" and "users"."id" = ?', ['foo', 'bar', 'baz', 1])->andReturn(1);
         $result = $builder->from('users')
@@ -2485,6 +2488,20 @@ class DatabaseQueryBuilderTest extends TestCase
                 $join->on('users.id', '=', 'orders.user_id')
                     ->where('users.id', '=', 1)
                     ->leftJoin('order_items', 'order_items.order_id', '=', 'orders.id');
+            })->where('name', 'baz')
+            ->updateFrom(['email' => 'foo', 'name' => 'bar']);
+        $this->assertEquals(1, $result);
+
+        $builder = $this->getPostgresBuilder();
+        $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "email" = ?, "name" = ? from "orders" left join "order_items" on "order_items"."order_id" = "orders"."id" and "t2"."id" = ? where "name" = ? and "users"."id" = "orders"."user_id" and "users"."id" = ?', ['foo', 'bar', 2, 'baz', 1])->andReturn(1);
+        $result = $builder->from('users')
+            ->join('orders', function ($join) {
+                $join->on('users.id', '=', 'orders.user_id')
+                    ->where('users.id', '=', 1)
+                    ->leftJoin('order_items', function ($join) {
+                        $join->on('order_items.order_id', '=', 'orders.id')
+                            ->where('order_items.id', 2);
+                    });
             })->where('name', 'baz')
             ->updateFrom(['email' => 'foo', 'name' => 'bar']);
         $this->assertEquals(1, $result);


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

### Description:
This PR builds upon the recent addition of the `updateFrom` method added in commit [#re-add update](https://github.com/laravel/framework/commit/64421305c9e31dc5d909cc96a053e2bf949f7f2b) to include nested joins.

Update statements in PostgreSQL require the use of a `from` clause when joining tables, but regular `join` clauses are allowed as long as at least one `from` clause is set. This is especially useful for including `left join` statements, as `from` always acts as an `inner join`.

There is also the matter of code consistency. Using `->update()` will include all nested joins in the compiled query, but using `->updateFrom()` ignores any nested joins.

### Example of Issue:
Given the query...
```
DB::table('table1')
	->join('table2', function ($join) {
		$join->on('table1.id', '=', 'table2.fk')
			->leftJoin('table3', 'table2.id', '=', 'table3.fk');
	})
	->updateFrom(['name' => 'newName']);
```
The following statement is output (missing `table3`)
```
update "table1"
set "name" = 'newName'
from "table2"
where "table1"."id" = "table2"."fk"
```
But using `->update()` outputs the following (includes `table3`)
```
update "table1"
set "name" = 'newName'
where "ctid" in (select "table1"."ctid"
                 from "table1"
                          inner join ("table2" left join "table3" on "table2"."id" = "table3"."fk")
                                     on "table1"."id" = "table2"."fk");
```

### Proposed Solution:
After the changes made to the `compileUpdateFrom` method in `PostgresGrammar.php`, the above query outputs as follows. 
```
update "table1"
set "name" = 'newName'
from "table2"
         left join "table3" on "table2"."id" = "table3"."fk"
where "table1"."id" = "table2"."fk"
```
