### PR TITLE
[8.x] Added helpers to produce sentence case from other non-space containing strings

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -172,6 +172,17 @@ class Str
     }
 
     /**
+     * Convert a camel case to lower case sentence.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    public static function camelToSentence($value)
+    {
+        return trim(static::lower(preg_replace('/([A-Z])/', ' $1', $value)));
+    }
+
+    /**
      * Determine if a given string contains a given substring.
      *
      * @param  string  $haystack
@@ -319,6 +330,17 @@ class Str
     public static function kebab($value)
     {
         return static::snake($value, '-');
+    }
+
+    /**
+     * Convert a kebab case to lower case string.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    public static function kebabToSentence($value)
+    {
+        return static::snakeToSentence($value, '-');
     }
 
     /**
@@ -808,6 +830,20 @@ class Str
     }
 
     /**
+     * Convert a snake case string to lower case sentence
+     *
+     * @param  string  $value
+     * @param  string  $delimiter
+     * @return string
+     */
+    public static function snakeToSentence($value, $delimiter = '_')
+    {
+        $pattern = '/\\' . $delimiter . '+/';
+
+        return static::lower(preg_replace($pattern, ' ', $value));
+    }
+
+    /**
      * Determine if a given string starts with a given substring.
      *
      * @param  string  $haystack
@@ -842,6 +878,17 @@ class Str
         $value = ucwords(str_replace(['-', '_'], ' ', $value));
 
         return static::$studlyCache[$key] = str_replace(' ', '', $value);
+    }
+
+    /**
+     * Convert a studly caps case to sentence case.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    public static function studlyToSentence($value)
+    {
+        return trim(static::lower(preg_replace('/([A-Z])/', ' $1', $value)));
     }
 
     /**

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -141,6 +141,16 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Convert a camel case to lower case sentence.
+     *
+     * @return static
+     */
+    public function camelToSentence()
+    {
+        return new static(Str::camelToSentence($this->value));
+    }
+
+    /**
      * Determine if a given string contains a given substring.
      *
      * @param  string|array  $needles
@@ -296,6 +306,15 @@ class Stringable implements JsonSerializable
     public function kebab()
     {
         return new static(Str::kebab($this->value));
+    }
+
+    /* Convert a kebab case to lower case.
+     *
+     * @return static
+     */
+    public function kebabToSentence()
+    {
+        return new static(Str::kebabToSentence($this->value));
     }
 
     /**
@@ -664,6 +683,17 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Convert a snake case string to lower case sentence
+     *
+     * @param  string  $delimiter
+     * @return static
+     */
+    public function snakeToSentence($delimiter = '_')
+    {
+        return new static(Str::snakeToSentence($this->value, $delimiter));
+    }
+
+    /**
      * Determine if a given string starts with a given substring.
      *
      * @param  string|array  $needles
@@ -682,6 +712,16 @@ class Stringable implements JsonSerializable
     public function studly()
     {
         return new static(Str::studly($this->value));
+    }
+
+    /**
+     * Convert a studly caps case to sentence case.
+     *
+     * @return static
+     */
+    public function studlyToSentence()
+    {
+        return new static(Str::studlyToSentence($this->value));
     }
 
     /**

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -446,6 +446,12 @@ class SupportStringableTest extends TestCase
         $this->assertSame('laravel-php-framework', (string) $this->stringable('LaravelPhpFramework')->kebab());
     }
 
+    public function testKebabToSentence()
+    {
+        $this->assertSame('foo bar', (string) $this->stringable('foo-bar')->kebabToSentence());
+        $this->assertSame('foo bar', (string) $this->stringable('Foo-Bar')->kebabToSentence());
+    }
+
     public function testLower()
     {
         $this->assertSame('foo bar baz', (string) $this->stringable('FOO BAR BAZ')->lower());
@@ -564,6 +570,20 @@ class SupportStringableTest extends TestCase
         $this->assertSame('żółtałódka', (string) $this->stringable('ŻółtaŁódka')->snake());
     }
 
+    public function testSnakeToSentence()
+    {
+        $this->assertSame('laravel php framework', (string) $this->stringable('laravel_php_framework')->snakeToSentence());
+        $this->assertSame('laravel php framework', (string) $this->stringable('laravel/php/framework')->snakeToSentence('/'));
+       
+        $this->assertSame('laravel php framework', (string) $this->stringable('laravel__php__framework')->snakeToSentence('__'));
+        $this->assertSame('laravel php framework ', (string) $this->stringable('laravel_php_framework_')->snakeToSentence('_'));
+        $this->assertSame('laravel php frame work', (string) $this->stringable('laravel_php_frame_work')->snakeToSentence());
+        // prevent breaking changes
+        $this->assertSame('foo-bar', (string) $this->stringable('foo-bar')->snakeToSentence());
+        $this->assertSame('foo- bar', (string) $this->stringable('foo-_bar')->snakeToSentence());
+        $this->assertSame('foo bar', (string) $this->stringable('foo__bar')->snakeToSentence());
+    }
+
     public function testStudly()
     {
         $this->assertSame('LaravelPHPFramework', (string) $this->stringable('laravel_p_h_p_framework')->studly());
@@ -578,6 +598,12 @@ class SupportStringableTest extends TestCase
         $this->assertSame('FooBarBaz', (string) $this->stringable('foo-bar_baz')->studly());
     }
 
+    public function testStudlyToSentence()
+    {
+        $this->assertSame('laravel php framework', (string) $this->stringable('LaravelPhpFramework')->studlyToSentence());
+        $this->assertSame('foo bar', (string) $this->stringable('FooBar')->studlyToSentence());
+    }
+
     public function testCamel()
     {
         $this->assertSame('laravelPHPFramework', (string) $this->stringable('Laravel_p_h_p_framework')->camel());
@@ -590,6 +616,14 @@ class SupportStringableTest extends TestCase
         $this->assertSame('fooBar', (string) $this->stringable('foo_bar')->camel()); // test cache
         $this->assertSame('fooBarBaz', (string) $this->stringable('Foo-barBaz')->camel());
         $this->assertSame('fooBarBaz', (string) $this->stringable('foo-bar_baz')->camel());
+    }
+
+    public function testCamelToSentence()
+    {
+        $this->assertSame('laravel php framework', (string) $this->stringable('laravelPhpFramework')->camelToSentence());
+        $this->assertSame('foo bar', (string) $this->stringable('fooBar')->camelToSentence());
+        $this->assertSame('foo bar', (string) $this->stringable('FooBar')->camelToSentence());
+        $this->assertSame('foo bar baz', (string) $this->stringable('fooBarBaz')->camelToSentence());
     }
 
     public function testSubstr()


### PR DESCRIPTION
Sometimes you want to convert "non-space containing" strings (like database column names or class names) back to sentences. This PR adds a few string helpers (with tests) to convert various case types to lowercase sentence case as follows:

```php
use Illuminate\Support\Str;

$convertedFromCamel = Str::of('fooBar')->camelToSentence(); // convert camel case to sentence case

// foo bar


$convertedFromKebab = Str::of('foo-bar')->kebabToSentence(); // convert kebab case to sentence case

// foo bar


$convertedFromSnake = Str::of('foo_bar')->snakeToSentence(); // convert snake case to sentence case

// foo bar


$convertedFromStudly = Str::of('FooBar')->studlyToSentence(); // convert studly case to sentence case

// foo bar


```
