### PR TITLE
Return arguments instead of ability

### DIFF
--- a/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
+++ b/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
@@ -55,7 +55,7 @@ trait AuthorizesRequests
 
         $method = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 3)[2]['function'];
 
-        return [$this->normalizeGuessedAbilityName($method), $ability];
+        return [$this->normalizeGuessedAbilityName($method), $arguments];
     }
 
     /**


### PR DESCRIPTION
Since the first array value is already the ability, the second value must be the arguments when guessing the ability.