### PR TITLE
[8.x] Add new function called `except()` to HasAttributes trait

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1744,6 +1744,8 @@ trait HasAttributes
     }
 
     /**
+     * Exclude specific attributes from a model
+     *
      * @param $attributes
      *
      * @return array

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1744,6 +1744,16 @@ trait HasAttributes
     }
 
     /**
+     * @param $attributes
+     *
+     * @return array
+     */
+    public function except($attributes)
+    {
+        return Arr::except($this->getAttributes(), $attributes);
+    }
+
+    /**
      * Sync the original attributes with the current.
      *
      * @return $this

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1744,7 +1744,7 @@ trait HasAttributes
     }
 
     /**
-     * Exclude specific attributes from a model
+     * Exclude specific attributes from a model.
      *
      * @param $attributes
      *

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1729,7 +1729,7 @@ trait HasAttributes
     /**
      * Get a subset of the model's attributes.
      *
-     * @param  array|mixed  $attributes
+     * @param  mixed  $attributes
      * @return array
      */
     public function only($attributes)
@@ -1746,7 +1746,7 @@ trait HasAttributes
     /**
      * Exclude specific attributes from a model.
      *
-     * @param  array|mixed  $attributes
+     * @param  mixed  $attributes
      * @return array
      */
     public function except($attributes)

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1746,8 +1746,7 @@ trait HasAttributes
     /**
      * Exclude specific attributes from a model.
      *
-     * @param $attributes
-     *
+     * @param  array|mixed  $attributes
      * @return array
      */
     public function except($attributes)

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -287,6 +287,16 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals(['first_name' => 'taylor', 'last_name' => 'otwell'], $model->only(['first_name', 'last_name']));
     }
 
+    public function testExcept()
+    {
+        $model = new EloquentModelStub;
+        $model->first_name = 'taylor';
+        $model->last_name = 'otwell';
+        $model->email = 'taylor@laravel.com';
+
+        $this->assertEquals(['first_name' => 'taylor', 'last_name' => 'otwell'], $model->except(['email']));
+    }
+
     public function testNewInstanceReturnsNewInstanceWithAttributesSet()
     {
         $model = new EloquentModelStub;


### PR DESCRIPTION
This new `except()` function serves as an inverse to the `only()` method

### Background
In my past Laravel applications, I've extended the BaseModel and added an `except()` function to exclude specific attributes of a model. It differs from the `$hidden` attribute because `except()` method is for one-off use cases. 


```
public function showUserInformation($userID): Response {
    // Don't show sensitive information unless it belongs to the user
    return Auth::id() === $userID ? User::find($userID):   User::find($userID)->except('email', 'phone_number')
}