### PR TITLE
[8.x] Add ability to customize json options on JsonResource response

### DIFF
--- a/src/Illuminate/Http/Resources/CollectsResources.php
+++ b/src/Illuminate/Http/Resources/CollectsResources.php
@@ -55,18 +55,7 @@ trait CollectsResources
     }
 
     /**
-     * Get an iterator for the resource collection.
-     *
-     * @return \ArrayIterator
-     */
-    #[\ReturnTypeWillChange]
-    public function getIterator()
-    {
-        return $this->collection->getIterator();
-    }
-
-    /**
-     * Get the serialization options applied to the resource response.
+     * Get the JSON serialization options that should be applied to the resource response.
      *
      * @return int
      */
@@ -75,5 +64,16 @@ trait CollectsResources
         $collects = $this->collects();
 
         return $collects ? (new $collects([]))->jsonOptions() : 0;
+    }
+
+    /**
+     * Get an iterator for the resource collection.
+     *
+     * @return \ArrayIterator
+     */
+    #[\ReturnTypeWillChange]
+    public function getIterator()
+    {
+        return $this->collection->getIterator();
     }
 }

--- a/src/Illuminate/Http/Resources/CollectsResources.php
+++ b/src/Illuminate/Http/Resources/CollectsResources.php
@@ -64,4 +64,16 @@ trait CollectsResources
     {
         return $this->collection->getIterator();
     }
+
+    /**
+     * Get the serialization options applied to the resource response.
+     *
+     * @return int
+     */
+    public function jsonOptions()
+    {
+        $collects = $this->collects();
+
+        return $collects ? (new $collects([]))->jsonOptions() : 0;
+    }
 }

--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -165,6 +165,16 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     }
 
     /**
+     * Get the serialization options applied to the resource response.
+     *
+     * @return int
+     */
+    public function jsonOptions()
+    {
+        return 0;
+    }
+
+    /**
      * Customize the response for a request.
      *
      * @param  \Illuminate\Http\Request  $request

--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -165,7 +165,7 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     }
 
     /**
-     * Get the serialization options applied to the resource response.
+     * Get the JSON serialization options that should be applied to the resource response.
      *
      * @return int
      */

--- a/src/Illuminate/Http/Resources/Json/PaginatedResourceResponse.php
+++ b/src/Illuminate/Http/Resources/Json/PaginatedResourceResponse.php
@@ -23,7 +23,9 @@ class PaginatedResourceResponse extends ResourceResponse
                     $this->resource->additional
                 )
             ),
-            $this->calculateStatus()
+            $this->calculateStatus(),
+            [],
+            $this->resource->jsonOptions()
         ), function ($response) use ($request) {
             $response->original = $this->resource->resource->map(function ($item) {
                 return is_array($item) ? Arr::get($item, 'resource') : $item->resource;

--- a/src/Illuminate/Http/Resources/Json/ResourceResponse.php
+++ b/src/Illuminate/Http/Resources/Json/ResourceResponse.php
@@ -40,7 +40,9 @@ class ResourceResponse implements Responsable
                 $this->resource->with($request),
                 $this->resource->additional
             ),
-            $this->calculateStatus()
+            $this->calculateStatus(),
+            [],
+            $this->resource->jsonOptions()
         ), function ($response) use ($request) {
             $response->original = $this->resource->resource;
 

--- a/tests/Integration/Http/Fixtures/PostResourceWithJsonOptions.php
+++ b/tests/Integration/Http/Fixtures/PostResourceWithJsonOptions.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http\Fixtures;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class PostResourceWithJsonOptions extends JsonResource
+{
+    public function toArray($request)
+    {
+        return [
+            'id' => $this->id,
+            'title' => $this->title,
+            'reading_time' => $this->reading_time,
+        ];
+    }
+
+    public function jsonOptions()
+    {
+        return JSON_PRESERVE_ZERO_FRACTION;
+    }
+}

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -24,6 +24,7 @@ use Illuminate\Tests\Integration\Http\Fixtures\PostCollectionResourceWithPaginat
 use Illuminate\Tests\Integration\Http\Fixtures\PostResource;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithAnonymousResourceCollectionWithPaginationInformation;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithExtraData;
+use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithJsonOptions;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalAppendedAttributes;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalData;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalMerging;
@@ -493,6 +494,26 @@ class ResourceTest extends TestCase
             'foo' => 'bar',
             'baz' => 'qux',
         ]);
+    }
+
+    public function testResourcesMayCustomizeJsonOptions()
+    {
+        Route::get('/', function () {
+            return new PostResourceWithJsonOptions(new Post([
+                'id' => 5,
+                'title' => 'Test Title',
+                'reading_time' => 3.0,
+            ]));
+        });
+
+        $response = $this->withoutExceptionHandling()->get(
+            '/', ['Accept' => 'application/json']
+        );
+
+        $this->assertEquals(
+            '{"data":{"id":5,"title":"Test Title","reading_time":3.0}}',
+            $response->baseResponse->content()
+        );
     }
 
     public function testCustomHeadersMayBeSetOnResponses()

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -516,6 +516,45 @@ class ResourceTest extends TestCase
         );
     }
 
+    public function testCollectionResourcesMayCustomizeJsonOptions()
+    {
+        Route::get('/', function () {
+            return PostResourceWithJsonOptions::collection(collect([
+                new Post(['id' => 5, 'title' => 'Test Title', 'reading_time' => 3.0]),
+            ]));
+        });
+
+        $response = $this->withoutExceptionHandling()->get(
+            '/', ['Accept' => 'application/json']
+        );
+
+        $this->assertEquals(
+            '{"data":[{"id":5,"title":"Test Title","reading_time":3.0}]}',
+            $response->baseResponse->content()
+        );
+    }
+
+    public function testResourcesMayCustomizeJsonOptionsOnPaginatedResponse()
+    {
+        Route::get('/', function () {
+            $paginator = new LengthAwarePaginator(
+                collect([new Post(['id' => 5, 'title' => 'Test Title', 'reading_time' => 3.0])]),
+                10, 15, 1
+            );
+
+            return PostResourceWithJsonOptions::collection($paginator);
+        });
+
+        $response = $this->withoutExceptionHandling()->get(
+            '/', ['Accept' => 'application/json']
+        );
+
+        $this->assertEquals(
+            '{"data":[{"id":5,"title":"Test Title","reading_time":3.0}],"links":{"first":"\/?page=1","last":"\/?page=1","prev":null,"next":null},"meta":{"current_page":1,"from":1,"last_page":1,"links":[{"url":null,"label":"&laquo; Previous","active":false},{"url":"\/?page=1","label":"1","active":true},{"url":null,"label":"Next &raquo;","active":false}],"path":"\/","per_page":15,"to":1,"total":10}}',
+            $response->baseResponse->content()
+        );
+    }
+
     public function testCustomHeadersMayBeSetOnResponses()
     {
         Route::get('/', function () {


### PR DESCRIPTION
Currently, it is possible to customize the options with `JsonResource::withResponse($request, $response)` doing something like
```php
public function withResponse($request, $response)
{
    $response->setEncodingOptions(JSON_PRETTY_PRINT);
}
```

The behaviour is that the original json is decoded then re-encoded with the given options https://github.com/laravel/framework/blob/676ba54b7d62eb76f0d1b025173b8f7134ed8b78/src/Illuminate/Http/JsonResponse.php#L119-L124
https://github.com/laravel/framework/blob/676ba54b7d62eb76f0d1b025173b8f7134ed8b78/src/Illuminate/Http/JsonResponse.php#L63-L66
https://github.com/laravel/framework/blob/676ba54b7d62eb76f0d1b025173b8f7134ed8b78/src/Illuminate/Http/JsonResponse.php#L73-L92

Unfortunately, json_encode with no option is destructive : 
`json_decode(json_encode(['float' => 3.0]), true)` gives `['float' => 3]`.

With this, `$response->setEncodingOptions(JSON_PRESERVE_ZERO_FRACTION);` returns a json like 
```json
{"data":{"float":3}}
```

That is, there is currently no way to encode JsonResources with `JSON_PRESERVE_ZERO_FRACTION`.

This PR adds the ability to customize json serialization options for responses from JsonResource at the time that the JsonResponse is created, providing the ability to preserve the zero fraction of floats.


<details>
<summary>Why do you need JSON_PRESERVE_ZERO_FRACTION btw ?</summary>

Imagine a Order model with a `quantity` property as float and you want to test some simple api call like 

```php
public function it_returns_the_order() 
{
    $order = Order::factory()->createOne();
    
    $this->getJson("api/orders/{$order->id}")
        ->assertOk()
        ->assertJsonPath('data', [
            'id' => $order->id,
            'quantity' => $order->quantity,
        ]);
}
```

Pretty easy no ? 

Well, if your factory is defined with
```php
public function definition()
{
    return [
        'quantity' => $this->faker->randomFloat(1, 0, 10), // random float with 1 digit max between 0 and 10
    ];
}
```
and faker generates a float with 1 digit, your test will pass. But if faker generates `3.0` for example, the test will fail with 

```
Failed asserting that two arrays are identical.
--- Expected
+++ Actual
@@ @@
-  'quantity' => 0.0
+  'quantity' => 0
````

Quite annoying to have randomly failing tests...

</detail>