### PR TITLE
[8.x] Add `shuffle()` method to `Str` and `Stringable`

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -687,6 +687,26 @@ class Str
     }
 
     /**
+     * Shuffle the given string and return the result.
+     *
+     * @param  string  $value
+     * @param  int|null  $seed
+     * @return string
+     */
+    public static function shuffle(string $value, $seed = null)
+    {
+        if (is_null($seed)) {
+            $value = str_shuffle($value);
+        } else {
+            mt_srand($seed);
+            $value = str_shuffle($value);
+            mt_srand();
+        }
+
+        return $value;
+    }
+
+    /**
      * Begin a string with a single instance of a given value.
      *
      * @param  string  $value

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -526,6 +526,17 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Shuffle the given string and return the result.
+     *
+     * @param  int|null  $seed
+     * @return static
+     */
+    public function shuffle($seed = null)
+    {
+        return new static(Str::shuffle($this->value, $seed));
+    }
+
+    /**
      * Replace a given value in the string sequentially with an array.
      *
      * @param  string  $search

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -630,6 +630,19 @@ class SupportStrTest extends TestCase
         $this->assertSame('aaaaa', Str::repeat('a', 5));
         $this->assertSame('', Str::repeat('', 5));
     }
+
+    public function testShuffleWithSeed()
+    {
+        $this->assertEquals(
+            Str::shuffle('Hello123', 1234),
+            Str::shuffle('Hello123', 1234),
+        );
+
+        $this->assertNotEquals(
+            Str::shuffle('Hello123', 1234),
+            Str::shuffle('Hello123', 12345),
+        );
+    }
 }
 
 class StringableObjectStub

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -729,4 +729,17 @@ class SupportStringableTest extends TestCase
         $this->assertSame('before<br>after', (string) $this->stringable('<strong>before</strong><br>after')->stripTags('<br>'));
         $this->assertSame('<strong>before</strong><br>after', (string) $this->stringable('<strong>before</strong><br>after')->stripTags('<br><strong>'));
     }
+
+    public function testShuffleWithSeed()
+    {
+        $this->assertEquals(
+            $this->stringable('Hello, world!')->shuffle(1234),
+            $this->stringable('Hello, world!')->shuffle(1234)
+        );
+
+        $this->assertNotEquals(
+            $this->stringable('Hello, world!')->shuffle(1234),
+            $this->stringable('Hello, world!')->shuffle(12345)
+        );
+    }
 }


### PR DESCRIPTION
Hi! This PR adds a new `shuffle()` method to the `Str` and `Stringable` classes that just shuffles a string and then returns it.

I've taken a similar approach to how the `Arr` class implements `shuffle()` and allowed a seed to be passed in if needed.

Here's a few ways you could use the methods:

```php
// Without seed...
$result = Str::shuffle('hello123'); // $result is: "h132eoll"
$result = (new Stringable('hello123'))->shuffle(); // $result is: "l1h32loe"

// With seed...
$result = Str::shuffle('hello123', 1234); // $result is always: "lle21ho3"
$result = (new Stringable('hello123'))->shuffle(1234); // $result is always: "lle21ho3"
```

If this is something you might consider pulling in, please let me know if there's anything that needs changing on it 😄