### PR TITLE
[9.x] Adds `soundex` search to Mysql 

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1218,6 +1218,27 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Adds a "where soundex" clause to the query.
+     *
+     * @param  string  $columns
+     * @param  string  $value
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereSoundex($columns, $value, $boolean = 'and')
+    {
+        $type = 'Soundex';
+
+        $columns = Arr::wrap($columns);
+
+        $this->wheres[] = compact('type', 'value', 'columns', 'boolean');
+
+        $this->addBinding($value);
+
+        return $this;
+    }
+
+    /**
      * Add a full sub-select to the query.
      *
      * @param  string  $column
@@ -1281,6 +1302,18 @@ class Builder implements BuilderContract
     public function orWhereNotExists(Closure $callback)
     {
         return $this->orWhereExists($callback, true);
+    }
+
+    /**
+     * Adds a "or where soundex" clause to the query.
+     *
+     * @param $columns
+     * @param $value
+     * @return $this
+     */
+    public function orWhereSoundex($columns, $value)
+    {
+        return $this->whereSoundex($columns, $value, 'or');
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -488,6 +488,18 @@ class Grammar extends BaseGrammar
     }
 
     /**
+     * Compile a "where soundex" query.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereSoundex(Builder $query, $where)
+    {
+        throw new RuntimeException('This database engine does not support soundex search operations.');
+    }
+
+    /**
      * Compile a where condition with a sub-select.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -51,6 +51,20 @@ class MySqlGrammar extends Grammar
     }
 
     /**
+     * @param Builder $query
+     * @param $where
+     * @return string
+     */
+    public function whereSoundex(Builder $query, $where)
+    {
+        $columns = $this->columnize($where['columns']);
+
+        $value = $this->parameter($where['value']);
+
+        return "SOUNDEX({$columns}) = SOUNDEX({$value})";
+    }
+
+    /**
      * Compile an insert ignore statement into SQL.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -51,7 +51,7 @@ class MySqlGrammar extends Grammar
     }
 
     /**
-     * @param Builder $query
+     * @param  Builder  $query
      * @param $where
      * @return string
      */

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -437,6 +437,21 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 5, 1 => 6], $builder->getBindings());
     }
 
+    public function testWhereSoundex()
+    {
+        $builder = $this->getMySqlBuilderWithProcessor();
+        $builder->select('*')->from('users')->whereSoundex('name', 'Taylor Otwel');
+        $this->assertSame('select * from `users` where SOUNDEX(`name`) = SOUNDEX(?)', $builder->toSql());
+        $this->assertEquals(['Taylor Otwel'], $builder->getBindings());
+
+        $builder = $this->getMySqlBuilderWithProcessor();
+        $builder->select('*')->from('users')
+            ->where('email', 'taylor@laravel.com')
+            ->orWhereSoundex('name', 'Taylor Otwel');
+        $this->assertSame('select * from `users` where `email` = ? or SOUNDEX(`name`) = SOUNDEX(?)', $builder->toSql());
+        $this->assertEquals(['taylor@laravel.com', 'Taylor Otwel'], $builder->getBindings());
+    }
+
     public function testWhereYearMySql()
     {
         $builder = $this->getMySqlBuilder();

--- a/tests/Integration/Database/MySql/SoundexTest.php
+++ b/tests/Integration/Database/MySql/SoundexTest.php
@@ -30,7 +30,7 @@ class SoundexTest extends MySqlTestCase
         DB::table('users')->insert([
             ['email' => 'taylor@laravel.com', 'first_name' => 'Taylor', 'last_name' => 'Otwell'],
             ['email' => 'tailor@laravel.com', 'first_name' => 'Tailor', 'last_name' => 'Otwel'],
-            ['email' => 'jason@sloff.com', 'first_name' => 'Json', 'last_name' => 'Slooff']
+            ['email' => 'jason@sloff.com', 'first_name' => 'Json', 'last_name' => 'Slooff'],
         ]);
     }
 

--- a/tests/Integration/Database/MySql/SoundexTest.php
+++ b/tests/Integration/Database/MySql/SoundexTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\MySql;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class SoundexTest extends MySqlTestCase
+{
+    protected function defineDatabaseMigrationsAfterDatabaseRefreshed()
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->id();
+            $table->string('email', 200);
+            $table->string('first_name');
+            $table->string('last_name');
+        });
+    }
+
+    protected function destroyDatabaseMigrations()
+    {
+        Schema::drop('users');
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        DB::table('users')->insert([
+            ['email' => 'taylor@laravel.com', 'first_name' => 'Taylor', 'last_name' => 'Otwell'],
+            ['email' => 'tailor@laravel.com', 'first_name' => 'Tailor', 'last_name' => 'Otwel'],
+            ['email' => 'jason@sloff.com', 'first_name' => 'Json', 'last_name' => 'Slooff']
+        ]);
+    }
+
+    public function testWhereSoundex()
+    {
+        $users = DB::table('users')->whereSoundex('first_name', 'tailor')->get();
+
+        $this->assertCount(2, $users);
+        $this->assertEquals('Taylor', $users[0]->first_name);
+        $this->assertEquals('Tailor', $users[1]->first_name);
+
+        $users = DB::table('users')->whereSoundex('last_name', 'Otuel')->get();
+
+        $this->assertCount(2, $users);
+        $this->assertEquals('Otwell', $users[0]->last_name);
+        $this->assertEquals('Otwel', $users[1]->last_name);
+
+        $users = DB::table('users')->whereSoundex('last_name', 'sluf')->get();
+
+        $this->assertCount(1, $users);
+        $this->assertEquals('Slooff', $users[0]->last_name);
+    }
+}


### PR DESCRIPTION
This PR adds  implements [soundex search for mysql](https://dev.mysql.com/doc/refman/8.0/en/string-functions.html#function_soundex), adding `whereSoundex` and `orWhereSoundex` methods to the `Illuminate\Database\Query\Builder` class.

In mysql, the `SOUNDEX()` function in MySQL is used to return a phonetic representation of a string, which represents the way the string will sound.

```php
Schema::create('users', function (Blueprint $table) {
    $table->id();
    $table->string('email', 200);
    $table->string('first_name');
    $table->string('last_name');
});
```

```php
// Search users where their first name sounds like 'tailor'
$users = DB::table('users')->whereSoundex('first_name', 'tailor')->get();

// Search users where their last name sounds like 'otuel':
$users = DB::table('users')->whereSoundex('last_name', 'Otuel')->get();
```

If this PR gets merged, we can also add `soundex` support for other database engines:

- https://docs.microsoft.com/pt-br/sql/t-sql/functions/soundex-transact-sql?view=sql-server-ver15
- https://wiki.postgresql.org/wiki/Soundex