### PR TITLE
[8.x] Sort collections by key when first element of sort operation is string (even if callable)

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1319,7 +1319,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
 
                 $result = 0;
 
-                if (!is_string($prop) && is_callable($prop)) {
+                if (! is_string($prop) && is_callable($prop)) {
                     $result = $prop($a, $b);
                 } else {
                     $values = [data_get($a, $prop), data_get($b, $prop)];

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1319,7 +1319,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
 
                 $result = 0;
 
-                if (is_callable($prop)) {
+                if (!is_string($prop) && is_callable($prop)) {
                     $result = $prop($a, $b);
                 } else {
                     $values = [data_get($a, $prop), data_get($b, $prop)];

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1831,6 +1831,17 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testSortByCallableString($collection)
+    {
+        $data = new $collection([['sort' => 2], ['sort' => 1]]);
+        $data = $data->sortBy([['sort', 'asc']]);
+
+        $this->assertEquals([['sort' => 1], ['sort' => 2]], array_values($data->all()));
+    }
+    
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testSortByAlwaysReturnsAssoc($collection)
     {
         $data = new $collection(['a' => 'taylor', 'b' => 'dayle']);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1838,7 +1838,7 @@ class SupportCollectionTest extends TestCase
 
         $this->assertEquals([['sort' => 1], ['sort' => 2]], array_values($data->all()));
     }
-    
+
     /**
      * @dataProvider collectionClassProvider
      */


### PR DESCRIPTION
This PR addresses #40203.

[The documentation](https://laravel.com/docs/8.x/collections#method-sortby) for `sortBy()` describes: "Each sort operation should be an array consisting of the attribute that you wish to sort by and the direction of the desired sort. [...] When sorting a collection by multiple attributes, you may also provide closures that define each sort operation." 

The following example summarizes the issue:

```
$collection = collect([
    ['name' => 'Taylor Otwell', 'sort' => 34],
    ['name' => 'Abigail Otwell', 'sort' => 30],
    ['name' => 'Taylor Otwell', 'sort' => 36],
    ['name' => 'Abigail Otwell', 'sort' => 32],
]);

$sorted = $collection->sortBy([
    ['name', 'asc'],
    ['sort', 'desc'],
]);
```

The developer expects the array to be sorted by the `"name"` and `"sort"` keys. However, because "sort" is also the name of an existing function (in this case a built-in function), it is considered callable and the framework attempts to call `sort()` instead, which can throw an error (that `sort()` was called with invalid parameters)

The change in this PR makes it check if the first element in each sort operation is a string in addition to callable. If it's a string, it will continue to be treated as a key even if it is also the name of an existing function. This PR preserves the ability to pass in a string key or a closure (which would not be a string).

This PR may break functionality that relies on being able to pass in a function name as a string instead of a closure. I think that might be okay since using it that way is undocumented (as far as I could tell?)

I'm new to this so please kindly let me know if I should do anything differently here, or if I'm mistaken about anything. Thank you :) 