### PR TITLE
Import the Laravel's TestCase class inside unit tests generated by the make command

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/test.unit.stub
+++ b/src/Illuminate/Foundation/Console/stubs/test.unit.stub
@@ -2,7 +2,7 @@
 
 namespace {{ namespace }};
 
-use PHPUnit\Framework\TestCase;
+use Tests\TestCase;
 
 class {{ class }} extends TestCase
 {


### PR DESCRIPTION
By default, the Unit test generated by the make command (ex: sail artisan make:test NewAppointmentMailTest --unit) has the PHPUnit's TestCase class imported (PHPUnit\Framework\TestCase).

However, I believe the correct TestCase to be imported the Laravel's one (Tests\TestCase) as in the Feature test.

I had to import Laravel's own TestCase class to make it run properly.
