### PR TITLE
[8.x] Add assertBatchCount

### DIFF
--- a/src/Illuminate/Support/Facades/Bus.php
+++ b/src/Illuminate/Support/Facades/Bus.php
@@ -24,6 +24,7 @@ use Illuminate\Support\Testing\Fakes\BusFake;
  * @method static void assertDispatchedAfterResponseTimes(string $command, int $times = 1)
  * @method static void assertNotDispatchedAfterResponse(string|\Closure $command, callable $callback = null)
  * @method static void assertBatched(callable $callback)
+ * @method static void assertBatchCount(int $count)
  * @method static void assertChained(array $expectedChain)
  * @method static void assertDispatchedSync(string|\Closure $command, callable $callback = null)
  * @method static void assertDispatchedSyncTimes(string $command, int $times = 1)

--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -416,10 +416,10 @@ class BusFake implements QueueingDispatcher
     /**
      * Assert the number of batches that have been dispatched.
      *
-     * @param  callable  $callback
+     * @param  int  $count
      * @return void
      */
-    public function assertBatchCount(int $count)
+    public function assertBatchCount($count)
     {
         PHPUnit::assertCount(
             $count, $this->batches,

--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -414,6 +414,19 @@ class BusFake implements QueueingDispatcher
     }
 
     /**
+     * Assert if a batch was dispatched based on a truth-test callback.
+     *
+     * @param  callable  $callback
+     * @return void
+     */
+    public function assertBatchCount(int $count)
+    {
+        PHPUnit::assertCount(
+            $count, $this->batches,
+        );
+    }
+
+    /**
      * Get all of the jobs matching a truth-test callback.
      *
      * @param  string  $command

--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -414,7 +414,7 @@ class BusFake implements QueueingDispatcher
     }
 
     /**
-     * Assert if a batch was dispatched based on a truth-test callback.
+     * Assert the number of batches that have been dispatched.
      *
      * @param  callable  $callback
      * @return void


### PR DESCRIPTION
Currently there is no way to assert how many batches have been dispatched. This adds a `assertBatchCount` method on the BusFake class which can be used like so:

```
Bus::assertBatchCount(3);
```