### PR TITLE
[8.x] Use first host if multiple

### DIFF
--- a/src/Illuminate/Database/Console/DbCommand.php
+++ b/src/Illuminate/Database/Console/DbCommand.php
@@ -67,8 +67,14 @@ class DbCommand extends Command
         }
 
         if ($this->option('read')) {
+            if (is_array($connection['read']['host'])) {
+                $connection['read']['host'] = $connection['read']['host'][0];
+            }
             $connection = array_merge($connection, $connection['read']);
         } elseif ($this->option('write')) {
+            if (is_array($connection['write']['host'])) {
+                $connection['write']['host'] = $connection['write']['host'][0];
+            }
             $connection = array_merge($connection, $connection['write']);
         }
 

--- a/src/Illuminate/Database/Console/DbCommand.php
+++ b/src/Illuminate/Database/Console/DbCommand.php
@@ -70,11 +70,13 @@ class DbCommand extends Command
             if (is_array($connection['read']['host'])) {
                 $connection['read']['host'] = $connection['read']['host'][0];
             }
+
             $connection = array_merge($connection, $connection['read']);
         } elseif ($this->option('write')) {
             if (is_array($connection['write']['host'])) {
                 $connection['write']['host'] = $connection['write']['host'][0];
             }
+
             $connection = array_merge($connection, $connection['write']);
         }
 


### PR DESCRIPTION
According to the [docs](https://laravel.com/docs/8.x/database#read-and-write-connections), the host option can be an array of hosts. 

If the `php artisan db` is called with either `--read` or `--write`, this adds a check to use the first host from the array. 

This is a limited use case so impact should be low. I don't know how to write tests for this but if it is necessary and someone can kindly show me how, I'd be happy to add tests.

---

Fixes #40186.