### PR TITLE
[9.x] Make use of vendor:publish for stubs, so packages can hook into it

### DIFF
--- a/src/Illuminate/Foundation/Console/StubPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/StubPublishCommand.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
-use Illuminate\Filesystem\Filesystem;
 
 class StubPublishCommand extends Command
 {

--- a/src/Illuminate/Foundation/Console/StubPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/StubPublishCommand.php
@@ -37,56 +37,7 @@ class StubPublishCommand extends Command
      */
     public function handle()
     {
-        if (! is_dir($stubsPath = $this->laravel->basePath('stubs'))) {
-            (new Filesystem)->makeDirectory($stubsPath);
-        }
-
-        $files = [
-            __DIR__.'/stubs/cast.stub' => $stubsPath.'/cast.stub',
-            __DIR__.'/stubs/console.stub' => $stubsPath.'/console.stub',
-            __DIR__.'/stubs/event.stub' => $stubsPath.'/event.stub',
-            __DIR__.'/stubs/job.queued.stub' => $stubsPath.'/job.queued.stub',
-            __DIR__.'/stubs/job.stub' => $stubsPath.'/job.stub',
-            __DIR__.'/stubs/mail.stub' => $stubsPath.'/mail.stub',
-            __DIR__.'/stubs/markdown-mail.stub' => $stubsPath.'/markdown-mail.stub',
-            __DIR__.'/stubs/markdown-notification.stub' => $stubsPath.'/markdown-notification.stub',
-            __DIR__.'/stubs/model.pivot.stub' => $stubsPath.'/model.pivot.stub',
-            __DIR__.'/stubs/model.stub' => $stubsPath.'/model.stub',
-            __DIR__.'/stubs/notification.stub' => $stubsPath.'/notification.stub',
-            __DIR__.'/stubs/observer.plain.stub' => $stubsPath.'/observer.plain.stub',
-            __DIR__.'/stubs/observer.stub' => $stubsPath.'/observer.stub',
-            __DIR__.'/stubs/policy.plain.stub' => $stubsPath.'/policy.plain.stub',
-            __DIR__.'/stubs/policy.stub' => $stubsPath.'/policy.stub',
-            __DIR__.'/stubs/provider.stub' => $stubsPath.'/provider.stub',
-            __DIR__.'/stubs/request.stub' => $stubsPath.'/request.stub',
-            __DIR__.'/stubs/resource-collection.stub' => $stubsPath.'/resource-collection.stub',
-            __DIR__.'/stubs/resource.stub' => $stubsPath.'/resource.stub',
-            __DIR__.'/stubs/rule.stub' => $stubsPath.'/rule.stub',
-            __DIR__.'/stubs/scope.stub' => $stubsPath.'/scope.stub',
-            __DIR__.'/stubs/test.stub' => $stubsPath.'/test.stub',
-            __DIR__.'/stubs/test.unit.stub' => $stubsPath.'/test.unit.stub',
-            __DIR__.'/stubs/view-component.stub' => $stubsPath.'/view-component.stub',
-            realpath(__DIR__.'/../../Database/Console/Factories/stubs/factory.stub') => $stubsPath.'/factory.stub',
-            realpath(__DIR__.'/../../Database/Console/Seeds/stubs/seeder.stub') => $stubsPath.'/seeder.stub',
-            realpath(__DIR__.'/../../Database/Migrations/stubs/migration.create.stub') => $stubsPath.'/migration.create.stub',
-            realpath(__DIR__.'/../../Database/Migrations/stubs/migration.stub') => $stubsPath.'/migration.stub',
-            realpath(__DIR__.'/../../Database/Migrations/stubs/migration.update.stub') => $stubsPath.'/migration.update.stub',
-            realpath(__DIR__.'/../../Routing/Console/stubs/controller.api.stub') => $stubsPath.'/controller.api.stub',
-            realpath(__DIR__.'/../../Routing/Console/stubs/controller.invokable.stub') => $stubsPath.'/controller.invokable.stub',
-            realpath(__DIR__.'/../../Routing/Console/stubs/controller.model.api.stub') => $stubsPath.'/controller.model.api.stub',
-            realpath(__DIR__.'/../../Routing/Console/stubs/controller.model.stub') => $stubsPath.'/controller.model.stub',
-            realpath(__DIR__.'/../../Routing/Console/stubs/controller.nested.api.stub') => $stubsPath.'/controller.nested.api.stub',
-            realpath(__DIR__.'/../../Routing/Console/stubs/controller.nested.stub') => $stubsPath.'/controller.nested.stub',
-            realpath(__DIR__.'/../../Routing/Console/stubs/controller.plain.stub') => $stubsPath.'/controller.plain.stub',
-            realpath(__DIR__.'/../../Routing/Console/stubs/controller.stub') => $stubsPath.'/controller.stub',
-            realpath(__DIR__.'/../../Routing/Console/stubs/middleware.stub') => $stubsPath.'/middleware.stub',
-        ];
-
-        foreach ($files as $from => $to) {
-            if (! file_exists($to) || $this->option('force')) {
-                file_put_contents($to, file_get_contents($from));
-            }
-        }
+        $this->call('vendor:publish', ['--tag' => 'laravel-stubs']);
 
         $this->info('Stubs published successfully.');
     }

--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -43,7 +43,6 @@ class FoundationServiceProvider extends AggregateServiceProvider
                 'laravel-stubs'
             );
         }
-
     }
 
     /**
@@ -145,7 +144,7 @@ class FoundationServiceProvider extends AggregateServiceProvider
     }
 
     /**
-     * Return array of publishable stubs
+     * Return array of publishable stubs.
      *
      * @return array
      */

--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -36,6 +36,14 @@ class FoundationServiceProvider extends AggregateServiceProvider
                 __DIR__.'/../Exceptions/views' => $this->app->resourcePath('views/errors/'),
             ], 'laravel-errors');
         }
+
+        if ($this->app->runningInConsole()) {
+            $this->publishes(
+                $this->stubsToPublish(),
+                'laravel-stubs'
+            );
+        }
+
     }
 
     /**
@@ -134,5 +142,54 @@ class FoundationServiceProvider extends AggregateServiceProvider
             MaintenanceModeContract::class,
             fn () => $this->app->make(MaintenanceModeManager::class)->driver()
         );
+    }
+
+    /**
+     * Return array of publishable stubs
+     *
+     * @return array
+     */
+    private function stubsToPublish()
+    {
+        return [
+            realpath(__DIR__.'/../Console/stubs/cast.stub') => $this->app->basePath('stubs/cast.stub'),
+            realpath(__DIR__.'/../Console/stubs/console.stub') => $this->app->basePath('stubs/console.stub'),
+            realpath(__DIR__.'/../Console/stubs/event.stub') => $this->app->basePath('stubs/event.stub'),
+            realpath(__DIR__.'/../Console/stubs/job.queued.stub') => $this->app->basePath('stubs/job.queued.stub'),
+            realpath(__DIR__.'/../Console/stubs/job.stub') => $this->app->basePath('stubs/job.stub'),
+            realpath(__DIR__.'/../Console/stubs/mail.stub') => $this->app->basePath('stubs/mail.stub'),
+            realpath(__DIR__.'/../Console/stubs/markdown-mail.stub') => $this->app->basePath('stubs/markdown-mail.stub'),
+            realpath(__DIR__.'/../Console/stubs/markdown-notification.stub') => $this->app->basePath('stubs/markdown-notification.stub'),
+            realpath(__DIR__.'/../Console/stubs/model.pivot.stub') => $this->app->basePath('stubs/model.pivot.stub'),
+            realpath(__DIR__.'/../Console/stubs/model.stub') => $this->app->basePath('stubs/model.stub'),
+            realpath(__DIR__.'/../Console/stubs/notification.stub') => $this->app->basePath('stubs/notification.stub'),
+            realpath(__DIR__.'/../Console/stubs/observer.plain.stub') => $this->app->basePath('stubs/observer.plain.stub'),
+            realpath(__DIR__.'/../Console/stubs/observer.stub') => $this->app->basePath('stubs/observer.stub'),
+            realpath(__DIR__.'/../Console/stubs/policy.plain.stub') => $this->app->basePath('stubs/policy.plain.stub'),
+            realpath(__DIR__.'/../Console/stubs/policy.stub') => $this->app->basePath('stubs/policy.stub'),
+            realpath(__DIR__.'/../Console/stubs/provider.stub') => $this->app->basePath('stubs/provider.stub'),
+            realpath(__DIR__.'/../Console/stubs/request.stub') => $this->app->basePath('stubs/request.stub'),
+            realpath(__DIR__.'/../Console/stubs/resource-collection.stub') => $this->app->basePath('stubs/resource-collection.stub'),
+            realpath(__DIR__.'/../Console/stubs/resource.stub') => $this->app->basePath('stubs/resource.stub'),
+            realpath(__DIR__.'/../Console/stubs/rule.stub') => $this->app->basePath('stubs/rule.stub'),
+            realpath(__DIR__.'/../Console/stubs/scope.stub') => $this->app->basePath('stubs/scope.stub'),
+            realpath(__DIR__.'/../Console/stubs/test.stub') => $this->app->basePath('stubs/test.stub'),
+            realpath(__DIR__.'/../Console/stubs/test.unit.stub') => $this->app->basePath('stubs/test.unit.stub'),
+            realpath(__DIR__.'/../Console/stubs/view-component.stub') => $this->app->basePath('stubs/view-component.stub'),
+            realpath(__DIR__.'/../../Database/Console/Factories/stubs/factory.stub') => $this->app->basePath('stubs/factory.stub'),
+            realpath(__DIR__.'/../../Database/Console/Seeds/stubs/seeder.stub') => $this->app->basePath('stubs/seeder.stub'),
+            realpath(__DIR__.'/../../Database/Migrations/stubs/migration.create.stub') => $this->app->basePath('stubs/migration.create.stub'),
+            realpath(__DIR__.'/../../Database/Migrations/stubs/migration.stub') => $this->app->basePath('stubs/migration.stub'),
+            realpath(__DIR__.'/../../Database/Migrations/stubs/migration.update.stub') => $this->app->basePath('stubs/migration.update.stub'),
+            realpath(__DIR__.'/../../Routing/Console/stubs/controller.api.stub') => $this->app->basePath('stubs/controller.api.stub'),
+            realpath(__DIR__.'/../../Routing/Console/stubs/controller.invokable.stub') => $this->app->basePath('stubs/controller.invokable.stub'),
+            realpath(__DIR__.'/../../Routing/Console/stubs/controller.model.api.stub') => $this->app->basePath('stubs/controller.model.api.stub'),
+            realpath(__DIR__.'/../../Routing/Console/stubs/controller.model.stub') => $this->app->basePath('stubs/controller.model.stub'),
+            realpath(__DIR__.'/../../Routing/Console/stubs/controller.nested.api.stub') => $this->app->basePath('stubs/controller.nested.api.stub'),
+            realpath(__DIR__.'/../../Routing/Console/stubs/controller.nested.stub') => $this->app->basePath('stubs/controller.nested.stub'),
+            realpath(__DIR__.'/../../Routing/Console/stubs/controller.plain.stub') => $this->app->basePath('stubs/controller.plain.stub'),
+            realpath(__DIR__.'/../../Routing/Console/stubs/controller.stub') => $this->app->basePath('stubs/controller.stub'),
+            realpath(__DIR__.'/../../Routing/Console/stubs/middleware.stub') => $this->app->basePath('stubs/middleware.stub'),
+        ];
     }
 }


### PR DESCRIPTION
@GrahamCampbell new pull request to master branch as requested in #40220 

For reference:

> Make use of the vendor publish code in the same way exceptions are published. This allows packages to hook into the publishing of stubs. T
> 
> The use case would be for packages with custom make commands. Packages can publish relevant stubs when the 'laravel-stubs' tag is used with vendor:publish
> 
> Changing the existing stub:publish command to call the vendor:publish command, allows the command to work in exactly the same way it did previously, with the benefit of being able to use the laravel-stubs tag.