### PR TITLE
[8.x] Implement Full-Text Search for PostgreSQL

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1837,8 +1837,6 @@ class Builder
 
         $this->wheres[] = compact('type', 'columns', 'value', 'options', 'boolean');
 
-        $this->addBinding($value);
-
         return $this;
     }
 

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -61,6 +61,7 @@ class MySqlGrammar extends Grammar
     {
         $columns = $this->columnize($where['columns']);
 
+        $query->addBinding($where['value']);
         $value = $this->parameter($where['value']);
 
         $mode = ($where['options']['mode'] ?? []) === 'boolean'

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -4,7 +4,6 @@ namespace Illuminate\Database\Schema\Grammars;
 
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Fluent;
-use RuntimeException;
 
 class PostgresGrammar extends Grammar
 {
@@ -190,15 +189,14 @@ class PostgresGrammar extends Grammar
     {
         $language = $command->language ?: 'english';
 
-        if (count($command->columns) > 1) {
-            throw new RuntimeException('The PostgreSQL driver does not support fulltext index creation using multiple columns.');
-        }
+        $columns = array_map(function ($column) use ($language) {
+            return "to_tsvector({$this->quoteString($language)}, {$this->wrap($column)})";
+        }, $command->columns);
 
-        return sprintf('create index %s on %s using gin (to_tsvector(%s, %s))',
+        return sprintf('create index %s on %s using gin ((%s))',
             $this->wrap($command->index),
             $this->wrapTable($blueprint),
-            $this->quoteString($language),
-            $this->wrap($command->columns[0])
+            implode(' || ', $columns)
         );
     }
 

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -269,7 +269,17 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('create index "users_body_fulltext" on "users" using gin (to_tsvector(\'english\', "body"))', $statements[0]);
+        $this->assertSame('create index "users_body_fulltext" on "users" using gin ((to_tsvector(\'english\', "body")))', $statements[0]);
+    }
+
+    public function testAddingFulltextIndexMultipleColumns()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->fulltext(['body', 'title']);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('create index "users_body_title_fulltext" on "users" using gin ((to_tsvector(\'english\', "body") || to_tsvector(\'english\', "title")))', $statements[0]);
     }
 
     public function testAddingFulltextIndexWithLanguage()
@@ -279,7 +289,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('create index "users_body_fulltext" on "users" using gin (to_tsvector(\'spanish\', "body"))', $statements[0]);
+        $this->assertSame('create index "users_body_fulltext" on "users" using gin ((to_tsvector(\'spanish\', "body")))', $statements[0]);
     }
 
     public function testAddingFulltextIndexWithFluency()
@@ -289,7 +299,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(2, $statements);
-        $this->assertSame('create index "users_body_fulltext" on "users" using gin (to_tsvector(\'english\', "body"))', $statements[1]);
+        $this->assertSame('create index "users_body_fulltext" on "users" using gin ((to_tsvector(\'english\', "body")))', $statements[1]);
     }
 
     public function testAddingSpatialIndex()

--- a/tests/Integration/Database/Postgres/FulltextTest.php
+++ b/tests/Integration/Database/Postgres/FulltextTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\Postgres;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * @requires extension pdo_pgsql
+ * @requires OS Linux|Darwin
+ */
+class FulltextTest extends PostgresTestCase
+{
+    protected function defineDatabaseMigrationsAfterDatabaseRefreshed()
+    {
+        Schema::create('articles', function (Blueprint $table) {
+            $table->id('id');
+            $table->string('title', 200);
+            $table->text('body');
+            $table->fulltext(['title', 'body']);
+        });
+    }
+
+    protected function destroyDatabaseMigrations()
+    {
+        Schema::drop('articles');
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        DB::table('articles')->insert([
+            ['title' => 'PostgreSQL Tutorial', 'body' => 'DBMS stands for DataBase ...'],
+            ['title' => 'How To Use PostgreSQL Well', 'body' => 'After you went through a ...'],
+            ['title' => 'Optimizing PostgreSQL', 'body' => 'In this tutorial, we show ...'],
+            ['title' => '1001 PostgreSQL Tricks', 'body' => '1. Never run mysqld as root. 2. ...'],
+            ['title' => 'PostgreSQL vs. YourSQL', 'body' => 'In the following database comparison ...'],
+            ['title' => 'PostgreSQL Security', 'body' => 'When configured properly, PostgreSQL ...'],
+        ]);
+    }
+
+    public function testWhereFulltext()
+    {
+        $articles = DB::table('articles')->whereFulltext(['title', 'body'], 'database')->orderBy('id')->get();
+
+        $this->assertCount(2, $articles);
+        $this->assertSame('PostgreSQL Tutorial', $articles[0]->title);
+        $this->assertSame('PostgreSQL vs. YourSQL', $articles[1]->title);
+    }
+
+    public function testWhereFulltextWithWebsearch()
+    {
+        $articles = DB::table('articles')->whereFulltext(['title', 'body'], '+PostgreSQL -YourSQL', ['mode' => 'websearch'])->get();
+
+        $this->assertCount(5, $articles);
+    }
+
+    public function testWhereFulltextWithPlain()
+    {
+        $articles = DB::table('articles')->whereFulltext(['title', 'body'], 'PostgreSQL tutorial', ['mode' => 'plain'])->get();
+
+        $this->assertCount(2, $articles);
+    }
+
+    public function testWhereFulltextWithPhrase()
+    {
+        $articles = DB::table('articles')->whereFulltext(['title', 'body'], 'PostgreSQL tutorial', ['mode' => 'phrase'])->get();
+
+        $this->assertCount(1, $articles);
+    }
+}

--- a/tests/Integration/Database/Postgres/PostgresTestCase.php
+++ b/tests/Integration/Database/Postgres/PostgresTestCase.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\Postgres;
+
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+abstract class PostgresTestCase extends DatabaseTestCase
+{
+    protected function defineDatabaseMigrations()
+    {
+        if ($this->driver !== 'pgsql') {
+            $this->markTestSkipped('Test requires a PostgreSQL connection.');
+        }
+    }
+}


### PR DESCRIPTION
I worked with @driesvints on a basic api for the query builder to do fulltext searching (#40129). Based on the agreed api and his implementation for MySQL, I was able to easily add PostgreSQL support:

```php
Schema::create('articles', function (Blueprint $table) {
    $table->id('id');
    $table->string('title', 200);
    $table->text('body');
    $table->fulltext(['title', 'body']);
});

// Search for "databases" in the title and body fulltext index...
$articles = DB::table('articles')
    ->whereFulltext(['title', 'body'], 'database')
    ->get();

// Search for "databases" in the title and body fulltext index with german language...
$articles = DB::table('articles')
    ->whereFulltext(['title', 'body'], 'database', ['language' => 'german'])
    ->get();

// Search for "databases" in the title and body fulltext index with phrase-mode...
$articles = DB::table('articles')
    ->whereFulltext(['title', 'body'], 'database', ['mode' => 'phrase'])
    ->get();

// Search for "databases" in the title and body fulltext index with websearch-mode...
$articles = DB::table('articles')
    ->whereFulltext(['title', 'body'], 'database', ['mode' => 'websearch'])
    ->get();
```

PostgreSQL has the great functionality that you can [fine tune fulltext-search](https://rob.conery.io/2019/10/29/fine-tuning-full-text-search-with-postgresql-12/) very much. For the moment, I only implemented the different search-term parsers to keep the pull request small. You will have access to the following search-term modes:
* `mode = 'plain'`: The plainto_tsquery function will transform a search string by and-ing the search terms: plainto_tsquery('english', 'The Fat Rats door') --> must match 'fat' & 'rat' & 'door'
* `mode = 'phraseto'`: The phraseto_tsquery function will transform a search string by needing the phrases to appear in the exact order one after another: phraseto_tsquery('english', 'The Fat Rats door') --> must match 'fat' <-> 'rat' <-> 'door'
* `mode = 'websearch'`: The websearch_to_tsquery function is mostly like MySQL's boolean search mode, which allows positive/negative operators in the text. But contrary to MySQL the terms are combined with and instead of or: websearch_to_tsquery('english', 'fat +rat -door') --> must match 'fat' & 'rat' & !'door'

The websearch mode ``mode = 'websearch'`` is only available in PostgreSQL 11+ so the standard mode has been set to `mode = 'plain'`.

In my pull request #39875 I added fulltext index support for PostgreSQL which was released with v8.75.0. I did not implement multiple columns as the there are different ways to build them and querying needs to use the same method as the index. With querying support now added, I also implemented multiple columns support.

---

This is a stacked Pull Request on #39875, i will rebase it to the `8.x` branch as soon as the pull request of @driesvints is merged.