### PR TITLE
[8.x] Adds support for paginating relations at query-time

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -709,7 +709,7 @@ class Builder
             $result, $name
         );
 
-        foreach($models as $model) {
+        foreach ($models as $model) {
             $model->setRelation($name, $pagination->wrapIntoPaginator($relation, $result));
         }
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1462,7 +1462,7 @@ class Builder
         foreach ($relations as $key => $relation) {
             $key = Str::before($key, '.');
 
-            $paginated[$key] = new Pagination($type, Str::finish($key, '_page'));
+            $paginated[$key] = new Pagination($type, (string) Str::of($key)->snake()->finish('_page'));
         }
 
         return $paginated;

--- a/src/Illuminate/Database/Eloquent/Pagination.php
+++ b/src/Illuminate/Database/Eloquent/Pagination.php
@@ -1,0 +1,374 @@
+<?php
+
+namespace Illuminate\Database\Eloquent;
+
+use Illuminate\Container\Container;
+use Illuminate\Pagination\Cursor;
+use Illuminate\Pagination\CursorPaginator;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Pagination\Paginator;
+
+class Pagination
+{
+    /**
+     * The type of paginator to build.
+     *
+     * @var string
+     */
+    protected $type;
+
+    /**
+     * The number of items to retrieve per page.
+     *
+     * @var int
+     */
+    protected $perPage;
+
+    /**
+     * The page number or cursor value.
+     *
+     * @var string|int|\Illuminate\Pagination\Cursor
+     */
+    protected $location;
+
+    /**
+     * The name of the page or cursor to capture and set in the Request.
+     *
+     * @var string
+     */
+    protected $pageName;
+
+    /**
+     * The order to enforce in the query when paginating by a Cursor.
+     *
+     * @var \Illuminate\Support\Collection
+     */
+    protected $orders;
+
+    /**
+     * Create a new Pagination instance.
+     *
+     * @param  string  $type
+     * @param  string  $pageName
+     * @return void
+     */
+    public function __construct($type, $pageName)
+    {
+        $this->pageName = $pageName;
+        $this->type = $type;
+    }
+
+    /**
+     * Sets the number of items to retrieve per page.
+     *
+     * @param  int|null  $perPage
+     * @param  string|int|\Illuminate\Pagination\Cursor|null  $page
+     * @param  string|null  $pageName
+     * @return $this
+     */
+    public function perPage($perPage, $page = null, $pageName = null)
+    {
+        $this->perPage = $perPage;
+
+        if ($page) {
+            $this->page($page);
+        }
+
+        if ($pageName) {
+            $this->pageName($pageName);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Sets the page for the pagination.
+     *
+     * @param  int  $page
+     * @return $this
+     */
+    public function page($page)
+    {
+        $this->location = $page;
+
+        return $this;
+    }
+
+    /**
+     * Sets the cursor for the pagination.
+     *
+     * @param  string|int|\Illuminate\Pagination\Cursor  $cursor
+     * @return $this
+     */
+    public function cursor($cursor)
+    {
+        return $this->page($cursor);
+    }
+
+    /**
+     * Sets the name of the page to capture from the request.
+     *
+     * @param  string|null  $pageName
+     * @return $this
+     */
+    public function pageName($pageName)
+    {
+        $this->pageName = $pageName;
+
+        return $this;
+    }
+
+    /**
+     * Sets the name of the cursor to capture from the request.
+     *
+     * @param  string|null  $cursorName
+     * @return $this
+     */
+    public function cursorName($cursorName)
+    {
+        return $this->pageName($cursorName);
+    }
+
+    /**
+     * Builds and returns a query with the stored pagination constraints.
+     *
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation  $relation
+     * @return \Illuminate\Database\Eloquent\Relations\Relation
+     */
+    public function buildPaginatedQuery($relation)
+    {
+        $this->perPage = $this->perPage ?? $relation->getModel()->getPerPage();
+
+        switch ($this->type) {
+            case 'page': default: return $this->pagination($relation);
+            case 'simple': return $this->simplePagination($relation);
+            case 'cursor': return $this->cursorPagination($relation);
+        }
+    }
+
+    /**
+     * Returns a paginated query.
+     *
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation  $relation
+     * @return \Illuminate\Database\Eloquent\Relations\Relation
+     */
+    protected function pagination($relation)
+    {
+        $this->location = $this->location ?? Paginator::resolveCurrentPage($this->pageName);
+
+        return $relation->forPage($this->location, $this->perPage);
+    }
+
+    /**
+     * Returns a simple paginated query.
+     *
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation  $relation
+     * @return \Illuminate\Database\Eloquent\Relations\Relation
+     */
+    protected function simplePagination($relation)
+    {
+        $this->location = $this->location ?? Paginator::resolveCurrentPage($this->pageName);
+
+        return $relation->skip(($this->location - 1) * $this->perPage)->take($this->perPage + 1);
+    }
+
+    /**
+     * Returns a cursor paginated query.
+     *
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation  $relation
+     * @return \Illuminate\Database\Eloquent\Relations\Relation
+     */
+    protected function cursorPagination($relation)
+    {
+        if (! $this->location instanceof Cursor) {
+            $this->location = is_string($this->location)
+                ? Cursor::fromEncoded($this->location)
+                : CursorPaginator::resolveCurrentCursor($this->pageName, $this->location);
+        }
+
+        $this->orders = $this->ensureOrderForCursorPagination(
+            $relation, ! is_null($this->location) && $this->location->pointsToPreviousItems()
+        );
+
+        if (! is_null($this->location)) {
+            $addCursorConditions = function ($query, $previousColumn, $i) use (&$addCursorConditions) {
+
+                if (! is_null($previousColumn)) {
+                    $query->where(
+                        $this->getOriginalColumnNameForCursorPagination($query, $previousColumn),
+                        '=',
+                        $this->location->parameter($previousColumn)
+                    );
+                }
+
+                $query->where(function ($query) use ($addCursorConditions, $i) {
+                    ['column' => $column, 'direction' => $direction] = $this->orders[$i];
+
+                    $query->where(
+                        $this->getOriginalColumnNameForCursorPagination($query, $column),
+                        $direction === 'asc' ? '>' : '<',
+                        $this->location->parameter($column)
+                    );
+
+                    if ($i < $this->orders->count() - 1) {
+                        $query->orWhere(function ($query) use ($addCursorConditions, $column, $i) {
+                            $addCursorConditions($query, $column, $i + 1);
+                        });
+                    }
+                });
+            };
+
+            $addCursorConditions($relation, null, 0);
+        }
+
+        return $relation->limit($this->perPage + 1);
+    }
+
+    /**
+     * Get the original column name of the given column, without any aliasing.
+     *
+     * @param  \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder  $builder
+     * @param  string  $parameter
+     * @return string
+     */
+    protected function getOriginalColumnNameForCursorPagination($builder, string $parameter)
+    {
+        $columns = $builder instanceof Builder ? $builder->getQuery()->columns : $builder->columns;
+
+        if (! is_null($columns)) {
+            foreach ($columns as $column) {
+                if (($position = stripos($column, ' as ')) !== false) {
+                    $as = substr($column, $position, 4);
+
+                    [$original, $alias] = explode($as, $column);
+
+                    if ($parameter === $alias) {
+                        return $original;
+                    }
+                }
+            }
+        }
+
+        return $parameter;
+    }
+
+    /**
+     * Ensure the proper order by required for cursor pagination.
+     *
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation  $relation
+     * @param  bool  $shouldReverse
+     * @return \Illuminate\Support\Collection
+     */
+    protected function ensureOrderForCursorPagination($relation, $shouldReverse = false)
+    {
+        $orders = collect($relation->getBaseQuery()->orders);
+
+        if ($orders->count() === 0) {
+            $this->enforceOrderBy($relation);
+        }
+
+        if ($shouldReverse) {
+            $relation->getBaseQuery()->orders = collect($relation->getBaseQuery()->orders)->map(function ($order) {
+                $order['direction'] = $order['direction'] === 'asc' ? 'desc' : 'asc';
+
+                return $order;
+            })->toArray();
+        }
+
+        return collect($relation->getBaseQuery()->orders);
+    }
+
+    /**
+     * Add a generic "order by" clause if the query doesn't already have one.
+     *
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation  $relation
+     * @return void
+     */
+    protected function enforceOrderBy($relation)
+    {
+        if (empty($relation->getBaseQuery()->orders) && empty($relation->getBaseQuery()->unionOrders)) {
+            $relation->orderBy($relation->getModel()->getQualifiedKeyName(), 'asc');
+        }
+    }
+
+    /**
+     * Wraps the results into their respective Paginator.
+     *
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation  $relation
+     * @param  \Illuminate\Database\Eloquent\Collection  $result
+     * @return \Illuminate\Pagination\LengthAwarePaginator|\Illuminate\Pagination\Paginator|\Illuminate\Pagination\CursorPaginator
+     */
+    public function wrapIntoPaginator($relation, Collection $result)
+    {
+        switch ($this->type) {
+            case 'page':
+            default:
+                $total = $relation->toBase()->getCountForPagination();
+
+                return static::createPaginator($result, $total, $this->perPage, $this->location, [
+                    'path' => Paginator::resolveCurrentPath(),
+                    'pageName' => $this->pageName,
+                ]);
+            case 'simple':
+                return static::createSimplePaginator($result, $this->perPage, $this->location, [
+                    'path' => Paginator::resolveCurrentPath(),
+                    'pageName' => $this->pageName,
+                ]);
+            case 'cursor':
+                return static::createCursorPaginator($result, $this->perPage, $this->location, [
+                    'path' => Paginator::resolveCurrentPath(),
+                    'cursorName' => $this->pageName,
+                    'parameters' => $this->orders->pluck('column')->toArray(),
+                ]);
+        }
+    }
+
+    /**
+     * Wraps the results into a paginator.
+     *
+     * @param  \Illuminate\Database\Eloquent\Collection  $items
+     * @param  int  $total
+     * @param  int  $perPage
+     * @param  int  $currentPage
+     * @param  array  $options
+     * @return \Illuminate\Pagination\LengthAwarePaginator
+     */
+    public static function createPaginator($items, $total, $perPage, $currentPage, $options)
+    {
+        return Container::getInstance()->makeWith(LengthAwarePaginator::class, compact(
+            'items', 'total', 'perPage', 'currentPage', 'options'
+        ));
+    }
+
+    /**
+     * Wraps the results into a simple paginator.
+     *
+     * @param  \Illuminate\Support\Collection  $items
+     * @param  int  $perPage
+     * @param  int  $currentPage
+     * @param  array  $options
+     * @return \Illuminate\Pagination\Paginator
+     */
+    public static function createSimplePaginator($items, $perPage, $currentPage, $options)
+    {
+        return Container::getInstance()->makeWith(Paginator::class, compact(
+            'items', 'perPage', 'currentPage', 'options'
+        ));
+    }
+
+    /**
+     * Wraps the results into a paginator.
+     *
+     * @param  \Illuminate\Support\Collection  $items
+     * @param  int  $perPage
+     * @param  \Illuminate\Pagination\Cursor  $cursor
+     * @param  array  $options
+     * @return \Illuminate\Pagination\CursorPaginator
+     */
+    public static function createCursorPaginator($items, $perPage, $cursor, $options)
+    {
+        return Container::getInstance()->makeWith(CursorPaginator::class, compact(
+            'items', 'perPage', 'cursor', 'options'
+        ));
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Pagination.php
+++ b/src/Illuminate/Database/Eloquent/Pagination.php
@@ -199,7 +199,6 @@ class Pagination
 
         if (! is_null($this->location)) {
             $addCursorConditions = function ($query, $previousColumn, $i) use (&$addCursorConditions) {
-
                 if (! is_null($previousColumn)) {
                     $query->where(
                         $this->getOriginalColumnNameForCursorPagination($query, $previousColumn),

--- a/src/Illuminate/Database/Eloquent/Pagination.php
+++ b/src/Illuminate/Database/Eloquent/Pagination.php
@@ -71,7 +71,11 @@ class Pagination
         $this->perPage = $perPage;
 
         if ($page) {
-            $this->page($page);
+            if ($this->type === 'cursor') {
+                $this->cursor($page);
+            } else {
+                $this->page($page);
+            }
         }
 
         if ($pageName) {
@@ -97,12 +101,15 @@ class Pagination
     /**
      * Sets the cursor for the pagination.
      *
-     * @param  string|int|\Illuminate\Pagination\Cursor  $cursor
+     * @param  array|int|string|\Illuminate\Pagination\Cursor  $cursor
+     * @param  bool  $pointsToNextItems
      * @return $this
      */
-    public function cursor($cursor)
+    public function cursor($cursor, $pointsToNextItems = true)
     {
-        return $this->page($cursor);
+        return $this->page(
+            is_array($cursor) ? new Cursor($cursor, $pointsToNextItems) : $cursor
+        );
     }
 
     /**

--- a/tests/Integration/Database/EloquentWithPaginationTest.php
+++ b/tests/Integration/Database/EloquentWithPaginationTest.php
@@ -19,57 +19,70 @@ class EloquentWithPaginationTest extends DatabaseTestCase
     {
         Schema::create('one', function (Blueprint $table) {
             $table->increments('id');
+            $table->timestamps();
         });
 
         Schema::create('two', function (Blueprint $table) {
             $table->increments('id');
             $table->integer('one_id');
+            $table->timestamps();
         });
 
         Schema::create('three', function (Blueprint $table) {
             $table->increments('id');
             $table->integer('two_id');
+            $table->timestamps();
         });
 
         Schema::create('four', function (Blueprint $table) {
             $table->increments('id');
             $table->integer('one_id');
+            $table->timestamps();
         });
 
         Schema::create('five', function (Blueprint $table) {
             $table->increments('id');
             $table->integer('one_id');
+            $table->timestamps();
         });
 
         Schema::create('six', function (Blueprint $table) {
             $table->increments('id');
             $table->integer('five_id');
+            $table->timestamps();
         });
 
-        Model1::query()->insert([[], []]);
+        $now = now();
+
+        Model1::query()->insert([
+            ['id' => 1, 'created_at' => $now->addMinute()],
+            ['id' => 2, 'created_at' => $now->addMinute()],
+        ]);
 
         Model2::query()->insert([
-            ['one_id' => 1],
-            ['one_id' => 1],
-            ['one_id' => 1],
-            ['one_id' => 1],
+            ['one_id' => 1, 'created_at' => $now->addMinute()],
+            ['one_id' => 1, 'created_at' => $now->addMinute()],
+            ['one_id' => 1, 'created_at' => $now->addMinute()],
+            ['one_id' => 1, 'created_at' => $now->addMinute()],
         ]);
         Model3::query()->insert([
-            ['two_id' => 2],
-            ['two_id' => 2],
-            ['two_id' => 3],
-            ['two_id' => 3],
-            ['two_id' => 3],
+            ['two_id' => 2, 'created_at' => $now->addMinute()],
+            ['two_id' => 2, 'created_at' => $now->addMinute()],
+            ['two_id' => 3, 'created_at' => $now->addMinute()],
+            ['two_id' => 3, 'created_at' => $now->addMinute()],
+            ['two_id' => 3, 'created_at' => $now->addMinute()],
         ]);
         Model4::query()->insert([
-            ['one_id' => 1],
-            ['one_id' => 1],
-            ['one_id' => 1],
+            ['one_id' => 1, 'created_at' => $now->addMinute()],
+            ['one_id' => 1, 'created_at' => $now->addMinute()],
+            ['one_id' => 1, 'created_at' => $now->addMinute()],
         ]);
-        Model5::query()->insert(['one_id' => 2]);
+        Model5::query()->insert(
+            ['one_id' => 2, 'created_at' => $now->addMinute()]
+        );
         Model6::query()->insert([
-            ['five_id' => 1],
-            ['five_id' => 1],
+            ['five_id' => 1, 'created_at' => $now->addMinute()],
+            ['five_id' => 1, 'created_at' => $now->addMinute()],
         ]);
     }
 

--- a/tests/Integration/Database/EloquentWithPaginationTest.php
+++ b/tests/Integration/Database/EloquentWithPaginationTest.php
@@ -442,6 +442,18 @@ class EloquentWithPaginationTest extends DatabaseTestCase
 
     /** General behavior */
 
+    public function testQueryCallbackOnNestedRelation()
+    {
+        $result = Model1::withPaged('twos.threes', function ($query) {
+            $query->where('id', '>', 3);
+        })->first();
+
+        $this->assertCount(4, $result->twos);
+        $this->assertCount(2, $result->twos->get(2)->threes);
+        $this->assertSame(4, $result->twos->get(2)->threes->first()->getKey());
+        $this->assertSame(5, $result->twos->get(2)->threes->last()->getKey());
+    }
+
     public function testPaginationGoneIfEagerLoadIsUnset()
     {
         $result = Model1::withPaged('twos')->without('twos')->first();

--- a/tests/Integration/Database/EloquentWithPaginationTest.php
+++ b/tests/Integration/Database/EloquentWithPaginationTest.php
@@ -1,0 +1,557 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentWithPaginationTest;
+
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\RelationNotFoundException;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Pagination\Cursor;
+use Illuminate\Pagination\CursorPaginator;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Pagination\Paginator;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+class EloquentWithPaginationTest extends DatabaseTestCase
+{
+    protected function defineDatabaseMigrationsAfterDatabaseRefreshed()
+    {
+        Schema::create('one', function (Blueprint $table) {
+            $table->increments('id');
+        });
+
+        Schema::create('two', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('one_id');
+        });
+
+        Schema::create('three', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('two_id');
+        });
+
+        Schema::create('four', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('one_id');
+        });
+
+        Schema::create('five', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('one_id');
+        });
+
+        Schema::create('six', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('five_id');
+        });
+
+        Model1::create();
+        Model1::create();
+
+        Model2::query()->insert([
+            ['one_id' => 1],
+            ['one_id' => 1],
+            ['one_id' => 1],
+            ['one_id' => 1],
+        ]);
+        Model3::query()->insert([
+            ['two_id' => 2],
+            ['two_id' => 2],
+            ['two_id' => 3],
+            ['two_id' => 3],
+            ['two_id' => 3],
+        ]);
+        Model4::query()->insert([
+            ['one_id' => 1],
+            ['one_id' => 1],
+            ['one_id' => 1],
+        ]);
+        Model5::query()->insert(['one_id' => 2]);
+        Model6::query()->insert([
+            ['five_id' => 1],
+            ['five_id' => 1],
+        ]);
+    }
+
+    public function testPaginatedOnlyListFirstLevelRelation()
+    {
+        $result = Model1::withPaged('twos.threes');
+
+        $this->assertArrayHasKey('twos', $result->getPaginatedEagerLoads());
+        $this->assertArrayNotHasKey('twos.threes', $result->getPaginatedEagerLoads());
+        $this->assertArrayNotHasKey('threes', $result->getPaginatedEagerLoads());
+    }
+
+    public function testPaginatedRelation()
+    {
+        $result = Model1::withPaged('twos')->first();
+
+        $this->assertInstanceOf(LengthAwarePaginator::class, $result->twos);
+        $this->assertCount(4, $result->twos);
+        $this->assertInstanceOf(Model2::class, $result->twos->first());
+        $this->assertSame('twos_page', $result->twos->getPageName());
+        $this->assertSame(1, $result->twos->currentPage());
+    }
+
+    public function testPaginatesOnlyFirstLevelRelation()
+    {
+        $result = Model1::withPaged('twos.threes')->first();
+
+        $this->assertInstanceOf(LengthAwarePaginator::class, $result->twos);
+        $this->assertCount(4, $result->twos);
+        $this->assertInstanceOf(Model2::class, $result->twos->first());
+        $this->assertSame('twos_page', $result->twos->getPageName());
+        $this->assertSame(1, $result->twos->currentPage());
+
+        $this->assertInstanceOf(Collection::class, $result->twos->first()->getRelation('threes'));
+        $this->assertInstanceOf(Collection::class, $result->twos->get(1)->getRelation('threes'));
+        $this->assertCount(2, $result->twos->get(1)->getRelation('threes'));
+    }
+
+    public function testPaginatesWithShorthand()
+    {
+        $result = Model1::withPaged('twos', 2, 2, 'foo')->first();
+
+        $this->assertInstanceOf(LengthAwarePaginator::class, $result->twos);
+        $this->assertCount(2, $result->twos);
+        $this->assertSame(2, $result->twos->currentPage());
+        $this->assertSame('foo', $result->twos->getPageName());
+    }
+
+    public function testPaginatesWithCallback()
+    {
+        $result = Model1::withPaged('twos', function ($query, $pagination) {
+            $query->where('id', '>', 1);
+            /** @var \Illuminate\Database\Eloquent\Pagination $pagination */
+            $pagination->perPage(2, 2, 'foo');
+        })->first();
+
+        $this->assertInstanceOf(LengthAwarePaginator::class, $result->twos);
+        $this->assertCount(1, $result->twos);
+        $this->assertSame(2, $result->twos->currentPage());
+        $this->assertSame('foo', $result->twos->getPageName());
+    }
+
+    public function testPaginatesMultipleRelations()
+    {
+        $result = Model1::withPaged('twos', 'fours', 'allFours')->first();
+
+        $this->assertInstanceOf(LengthAwarePaginator::class, $result->twos);
+        $this->assertCount(4, $result->twos);
+        $this->assertInstanceOf(LengthAwarePaginator::class, $result->fours);
+        $this->assertCount(2, $result->fours);
+        $this->assertInstanceOf(LengthAwarePaginator::class, $result->allFours);
+        $this->assertCount(3, $result->allFours);
+    }
+
+    public function testPaginatesRelationsWithColumns()
+    {
+        $result = Model1::withPaged('twos:id', 'fours', 'allFours:id')->first();
+
+        $this->assertNull($result->twos->first()->one_id);
+        $this->assertSame(1, $result->fours->first()->one_id);
+        $this->assertNull($result->allFours->first()->one_id);
+    }
+
+    public function testExceptionPaginatingRelationWithColumnsAndCallback()
+    {
+        $this->expectException(RelationNotFoundException::class);
+        $this->expectExceptionMessage('Call to undefined relationship [twos:id] on model [Illuminate\Tests\Integration\Database\EloquentWithPaginationTest\Model1].');
+
+        Model1::withPaged('twos:id', function ($query, $pagination) {
+            $query->select('one_id');
+
+            $pagination->pageName('foo');
+        })->first();
+    }
+
+    public function testPaginatesSingleRelation()
+    {
+        $result = Model1::withPaged('five.sixes')->skip(1)->first();
+
+        $this->assertInstanceOf(LengthAwarePaginator::class, $result->five);
+        $this->assertInstanceOf(Collection::class, $result->five->first()->sixes);
+    }
+
+    /* Simple Pagination tests */
+
+    public function testSimplePaginatedOnlyListFirstLevelRelation()
+    {
+        $result = Model1::withSimplePaged('twos.threes');
+
+        $this->assertArrayHasKey('twos', $result->getPaginatedEagerLoads());
+        $this->assertArrayNotHasKey('twos.threes', $result->getPaginatedEagerLoads());
+        $this->assertArrayNotHasKey('threes', $result->getPaginatedEagerLoads());
+    }
+
+    public function testSimplePaginatedRelation()
+    {
+        $result = Model1::withSimplePaged('twos.threes')->first();
+
+        $this->assertInstanceOf(Paginator::class, $result->twos);
+        $this->assertCount(4, $result->twos);
+        $this->assertInstanceOf(Model2::class, $result->twos->first());
+        $this->assertSame('twos_page', $result->twos->getPageName());
+        $this->assertSame(1, $result->twos->currentPage());
+
+        $this->assertInstanceOf(Collection::class, $result->twos->first()->getRelation('threes'));
+        $this->assertInstanceOf(Collection::class, $result->twos->get(1)->getRelation('threes'));
+        $this->assertCount(2, $result->twos->get(1)->getRelation('threes'));
+    }
+
+    public function testSimplePaginatesWithShorthand()
+    {
+        $result = Model1::withSimplePaged('twos', 2, 2, 'foo')->first();
+
+        $this->assertInstanceOf(Paginator::class, $result->twos);
+        $this->assertCount(2, $result->twos);
+        $this->assertSame(2, $result->twos->currentPage());
+        $this->assertSame('foo', $result->twos->getPageName());
+    }
+
+    public function testSimplePaginatesWithCallback()
+    {
+        $result = Model1::withSimplePaged('twos', function ($query, $pagination) {
+            $query->where('id', '>', 1);
+            /** @var \Illuminate\Database\Eloquent\Pagination $pagination */
+            $pagination->perPage(2, 2, 'foo');
+        })->first();
+
+        $this->assertInstanceOf(Paginator::class, $result->twos);
+        $this->assertCount(1, $result->twos);
+        $this->assertSame(2, $result->twos->currentPage());
+        $this->assertSame('foo', $result->twos->getPageName());
+    }
+
+    public function testSimplePaginatesMultipleRelations()
+    {
+        $result = Model1::withSimplePaged('twos', 'fours', 'allFours')->first();
+
+        $this->assertInstanceOf(Paginator::class, $result->twos);
+        $this->assertCount(4, $result->twos);
+        $this->assertInstanceOf(Paginator::class, $result->fours);
+        $this->assertCount(2, $result->fours);
+        $this->assertInstanceOf(Paginator::class, $result->allFours);
+        $this->assertCount(3, $result->allFours);
+    }
+
+    public function testSimplePaginatesRelationsWithColumns()
+    {
+        $result = Model1::withSimplePaged('twos:id', 'fours', 'allFours:id')->first();
+
+        $this->assertNull($result->twos->first()->one_id);
+        $this->assertSame(1, $result->fours->first()->one_id);
+        $this->assertNull($result->allFours->first()->one_id);
+    }
+
+    public function testExceptionSimplePaginatingRelationWithColumnsAndCallback()
+    {
+        $this->expectException(RelationNotFoundException::class);
+        $this->expectExceptionMessage('Call to undefined relationship [twos:id] on model [Illuminate\Tests\Integration\Database\EloquentWithPaginationTest\Model1].');
+
+        Model1::withSimplePaged('twos:id', function ($query, $pagination) {
+            $query->select('one_id');
+
+            $pagination->pageName('foo');
+        })->first();
+    }
+
+    public function testSimplePaginatesSingleRelation()
+    {
+        $result = Model1::withSimplePaged('five.sixes')->skip(1)->first();
+
+        $this->assertInstanceOf(Paginator::class, $result->five);
+        $this->assertInstanceOf(Collection::class, $result->five->first()->sixes);
+    }
+
+    /* Cursor Pagination tests */
+
+    public function testCursorPaginatedOnlyListFirstLevelRelation()
+    {
+        $result = Model1::withCursorPaged('twos.threes');
+
+        $this->assertArrayHasKey('twos', $result->getPaginatedEagerLoads());
+        $this->assertArrayNotHasKey('twos.threes', $result->getPaginatedEagerLoads());
+        $this->assertArrayNotHasKey('threes', $result->getPaginatedEagerLoads());
+    }
+
+    public function testCursorPaginatedRelation()
+    {
+        $result = Model1::withCursorPaged('twos.threes')->first();
+
+        $this->assertInstanceOf(CursorPaginator::class, $result->twos);
+        $this->assertCount(4, $result->twos);
+        $this->assertInstanceOf(Model2::class, $result->twos->first());
+        $this->assertSame('twos_page', $result->twos->getCursorName());
+        $this->assertNull($result->twos->cursor());
+        $this->assertNull($result->twos->previousCursor());
+        $this->assertNull($result->twos->nextCursor());
+
+        $this->assertInstanceOf(Collection::class, $result->twos->first()->getRelation('threes'));
+        $this->assertInstanceOf(Collection::class, $result->twos->get(1)->getRelation('threes'));
+        $this->assertCount(2, $result->twos->get(1)->getRelation('threes'));
+    }
+
+    public function testCursorPaginatesWithShorthandIgnoresCursor()
+    {
+        $result = Model1::withCursorPaged('twos', 2, 2, 'foo')->first();
+
+        $this->assertInstanceOf(CursorPaginator::class, $result->twos);
+        $this->assertCount(2, $result->twos);
+        $this->assertNull($result->twos->cursor());
+        $this->assertSame('foo', $result->twos->getCursorName());
+        $this->assertTrue($result->twos->hasMorePages());
+
+        $this->assertSame(
+            'http://localhost?foo=eyJ0d28uaWQiOjIsIl9wb2ludHNUb05leHRJdGVtcyI6dHJ1ZX0',
+            $result->twos->nextPageUrl()
+        );
+
+        $this->assertNull($result->twos->previousPageUrl());
+    }
+
+    public function testCursorPaginatesWithShorthandWithStringCursor()
+    {
+        $cursor = 'eyJ0d28uaWQiOjIsIl9wb2ludHNUb05leHRJdGVtcyI6dHJ1ZX0';
+
+        $result = Model1::withCursorPaged('twos', 2, $cursor, 'foo')->first();
+
+        $this->assertCount(2, $result->twos);
+        $this->assertEquals(2, $result->twos->cursor()->parameter('two.id'));
+        $this->assertFalse($result->twos->cursor()->pointsToPreviousItems());
+        $this->assertTrue($result->twos->cursor()->pointsToNextItems());
+
+        $this->assertSame(3, $result->twos->first()->getKey());
+        $this->assertSame(4, $result->twos->last()->getKey());
+
+        $this->assertSame('foo', $result->twos->getCursorName());
+    }
+
+    public function testCursorPaginatesWithShorthandWithCursor()
+    {
+        $cursor = new Cursor(['two.id' => 2], true);
+
+        $result = Model1::withCursorPaged('twos', 2, $cursor, 'foo')->first();
+
+        $this->assertCount(2, $result->twos);
+        $this->assertEquals(2, $result->twos->cursor()->parameter('two.id'));
+        $this->assertFalse($result->twos->cursor()->pointsToPreviousItems());
+        $this->assertTrue($result->twos->cursor()->pointsToNextItems());
+
+        $this->assertSame(3, $result->twos->first()->getKey());
+        $this->assertSame(4, $result->twos->last()->getKey());
+
+        $this->assertSame('foo', $result->twos->getCursorName());
+    }
+
+    public function testCursorPaginatesWithCallback()
+    {
+        $result = Model1::withCursorPaged('twos', function ($query, $pagination) {
+            $query->where('id', '>', 1);
+
+            /** @var \Illuminate\Database\Eloquent\Pagination $pagination */
+            $pagination->perPage(2, 2, 'foo');
+        })->first();
+
+        $this->assertInstanceOf(CursorPaginator::class, $result->twos);
+        $this->assertCount(2, $result->twos);
+
+        $this->assertSame(2, $result->twos->first()->getKey());
+        $this->assertSame(3, $result->twos->last()->getKey());
+
+        $this->assertSame('foo', $result->twos->getCursorName());
+
+        $this->assertSame(
+            'http://localhost?foo=eyJ0d28uaWQiOjMsIl9wb2ludHNUb05leHRJdGVtcyI6dHJ1ZX0',
+            $result->twos->nextPageUrl()
+        );
+
+        $this->assertNull($result->twos->previousPageUrl());
+    }
+
+    public function testCursorPaginatesMultipleRelations()
+    {
+        $result = Model1::withCursorPaged('twos', 'fours', 'allFours')->first();
+
+        $this->assertInstanceOf(CursorPaginator::class, $result->twos);
+        $this->assertCount(4, $result->twos);
+        $this->assertInstanceOf(CursorPaginator::class, $result->fours);
+        $this->assertCount(2, $result->fours);
+        $this->assertInstanceOf(CursorPaginator::class, $result->allFours);
+        $this->assertCount(3, $result->allFours);
+    }
+
+    public function testCursorPaginatesRelationsWithColumns()
+    {
+        $result = Model1::withCursorPaged('twos:id', 'fours', 'allFours:id')->first();
+
+        $this->assertNull($result->twos->first()->one_id);
+        $this->assertSame(1, $result->fours->first()->one_id);
+        $this->assertNull($result->allFours->first()->one_id);
+    }
+
+    public function testExceptionCursorPaginatingRelationWithColumnsAndCallback()
+    {
+        $this->expectException(RelationNotFoundException::class);
+        $this->expectExceptionMessage('Call to undefined relationship [twos:id] on model [Illuminate\Tests\Integration\Database\EloquentWithPaginationTest\Model1].');
+
+        Model1::withCursorPaged('twos:id', function ($query, $pagination) {
+            $query->select('one_id');
+
+            $pagination->pageName('foo');
+        })->first();
+    }
+
+    public function testCursorPaginatesSingleRelation()
+    {
+        $result = Model1::withCursorPaged('five.sixes')->skip(1)->first();
+
+        $this->assertInstanceOf(CursorPaginator::class, $result->five);
+        $this->assertInstanceOf(Collection::class, $result->five->first()->sixes);
+    }
+
+    /** General behavior */
+
+    public function testPaginationGoneIfEagerLoadIsUnset()
+    {
+        $result = Model1::withPaged('twos')->without('twos')->first();
+
+        $this->assertFalse($result->relationLoaded('twos'));
+
+        $result = Model1::withPaged('twos')->withOnly('five.sixes')->first();
+
+        $this->assertFalse($result->relationLoaded('twos'));
+    }
+
+    public function testPaginationNestedGoneIfEagerLoadIsUnset()
+    {
+        $result = Model1::withPaged('twos.threes')->without('twos')->first();
+
+        $this->assertFalse($result->relationLoaded('twos'));
+
+        $result = Model1::withPaged('twos.threes')->withOnly('twos')->first();
+
+        $this->assertInstanceOf(Collection::class, $result->twos);
+        $this->assertFalse($result->twos->first()->relationLoaded('threes'));
+    }
+
+    public function testPaginationGoneIfEagerLoadedKeyRewritten()
+    {
+        $result = Model1::withPaged('twos.threes', 'five.sixes')->with('twos.threes')->first();
+
+        $this->assertInstanceOf(Collection::class, $result->twos);
+        $this->assertInstanceOf(LengthAwarePaginator::class, $result->five);
+    }
+}
+
+/**
+ * @property-read \Illuminate\Support\Collection $twos
+ * @property-read \Illuminate\Support\Collection $fours
+ * @property-read \Illuminate\Support\Collection $allFours
+ * @property-read \Illuminate\Tests\Integration\Database\EloquentWithPaginationTest\Model5|null $five
+ */
+class Model1 extends Model
+{
+    public $table = 'one';
+    public $timestamps = false;
+    protected $guarded = [];
+
+    public function twos()
+    {
+        return $this->hasMany(Model2::class, 'one_id');
+    }
+
+    public function fours()
+    {
+        return $this->hasMany(Model4::class, 'one_id');
+    }
+
+    public function allFours()
+    {
+        return $this->fours()->withoutGlobalScopes();
+    }
+
+    public function five()
+    {
+        return $this->hasOne(Model5::class, 'one_id');
+    }
+}
+
+class Model2 extends Model
+{
+    public $table = 'two';
+    public $timestamps = false;
+    protected $guarded = [];
+    protected $withCount = ['threes'];
+
+    protected static function boot()
+    {
+        parent::boot();
+
+        static::addGlobalScope('app', function ($builder) {
+            $builder->latest();
+        });
+    }
+
+    public function threes()
+    {
+        return $this->hasMany(Model3::class, 'two_id');
+    }
+}
+
+class Model3 extends Model
+{
+    public $table = 'three';
+    public $timestamps = false;
+    protected $guarded = [];
+
+    protected static function boot()
+    {
+        parent::boot();
+
+        static::addGlobalScope('app', function ($builder) {
+            $builder->where('id', '>', 0);
+        });
+    }
+}
+
+class Model4 extends Model
+{
+    public $table = 'four';
+    public $timestamps = false;
+    protected $guarded = [];
+
+    protected static function boot()
+    {
+        parent::boot();
+
+        static::addGlobalScope('app', function ($builder) {
+            $builder->where('id', '>', 1);
+        });
+    }
+}
+
+class Model5 extends Model
+{
+    public $table = 'five';
+    public $timestamps = false;
+    protected $guarded = [];
+
+    public function one()
+    {
+        return $this->belongsTo(Model1::class, 'one_id');
+    }
+
+    public function sixes()
+    {
+        return $this->hasMany(Model6::class, 'five_id');
+    }
+}
+
+class Model6 extends Model
+{
+    public $table = 'six';
+    public $timestamps = false;
+    protected $guarded = [];
+}

--- a/tests/Integration/Database/EloquentWithPaginationTest.php
+++ b/tests/Integration/Database/EloquentWithPaginationTest.php
@@ -353,6 +353,23 @@ class EloquentWithPaginationTest extends DatabaseTestCase
         $this->assertSame('foo', $result->twos->getCursorName());
     }
 
+    public function testCursorPaginatesWithShorthandWithCursorArray()
+    {
+        $cursor = ['two.id' => 2];
+
+        $result = Model1::withCursorPaged('twos', 2, $cursor, 'foo')->first();
+
+        $this->assertCount(2, $result->twos);
+        $this->assertEquals(2, $result->twos->cursor()->parameter('two.id'));
+        $this->assertFalse($result->twos->cursor()->pointsToPreviousItems());
+        $this->assertTrue($result->twos->cursor()->pointsToNextItems());
+
+        $this->assertSame(3, $result->twos->first()->getKey());
+        $this->assertSame(4, $result->twos->last()->getKey());
+
+        $this->assertSame('foo', $result->twos->getCursorName());
+    }
+
     public function testCursorPaginatesWithCallback()
     {
         $result = Model1::withCursorPaged('twos', function ($query, $pagination) {

--- a/tests/Integration/Database/EloquentWithPaginationTest.php
+++ b/tests/Integration/Database/EloquentWithPaginationTest.php
@@ -55,8 +55,8 @@ class EloquentWithPaginationTest extends DatabaseTestCase
         $now = now();
 
         Model1::query()->insert([
-            ['id' => 1, 'created_at' => $now->addMinute()],
-            ['id' => 2, 'created_at' => $now->addMinute()],
+            ['created_at' => $now->addMinute()],
+            ['created_at' => $now->addMinute()],
         ]);
 
         Model2::query()->insert([

--- a/tests/Integration/Database/EloquentWithPaginationTest.php
+++ b/tests/Integration/Database/EloquentWithPaginationTest.php
@@ -143,6 +143,10 @@ class EloquentWithPaginationTest extends DatabaseTestCase
         $this->assertCount(2, $result->fours);
         $this->assertInstanceOf(LengthAwarePaginator::class, $result->allFours);
         $this->assertCount(3, $result->allFours);
+
+        $this->assertSame('twos_page', $result->twos->getPageName());
+        $this->assertSame('fours_page', $result->fours->getPageName());
+        $this->assertSame('all_fours_page', $result->allFours->getPageName());
     }
 
     public function testPaginatesRelationsWithColumns()
@@ -234,6 +238,10 @@ class EloquentWithPaginationTest extends DatabaseTestCase
         $this->assertCount(2, $result->fours);
         $this->assertInstanceOf(Paginator::class, $result->allFours);
         $this->assertCount(3, $result->allFours);
+
+        $this->assertSame('twos_page', $result->twos->getPageName());
+        $this->assertSame('fours_page', $result->fours->getPageName());
+        $this->assertSame('all_fours_page', $result->allFours->getPageName());
     }
 
     public function testSimplePaginatesRelationsWithColumns()
@@ -380,6 +388,10 @@ class EloquentWithPaginationTest extends DatabaseTestCase
         $this->assertCount(2, $result->fours);
         $this->assertInstanceOf(CursorPaginator::class, $result->allFours);
         $this->assertCount(3, $result->allFours);
+
+        $this->assertSame('twos_page', $result->twos->getCursorName());
+        $this->assertSame('fours_page', $result->fours->getCursorName());
+        $this->assertSame('all_fours_page', $result->allFours->getCursorName());
     }
 
     public function testCursorPaginatesRelationsWithColumns()

--- a/tests/Integration/Database/EloquentWithPaginationTest.php
+++ b/tests/Integration/Database/EloquentWithPaginationTest.php
@@ -46,8 +46,7 @@ class EloquentWithPaginationTest extends DatabaseTestCase
             $table->integer('five_id');
         });
 
-        Model1::create();
-        Model1::create();
+        Model1::query()->insert([[], []]);
 
         Model2::query()->insert([
             ['one_id' => 1],

--- a/tests/Integration/Database/EloquentWithPaginationTest.php
+++ b/tests/Integration/Database/EloquentWithPaginationTest.php
@@ -441,7 +441,6 @@ class EloquentWithPaginationTest extends DatabaseTestCase
     }
 
     /** General behavior */
-
     public function testQueryCallbackOnNestedRelation()
     {
         $result = Model1::withPaged('twos.threes', function ($query) {

--- a/tests/Integration/Database/EloquentWithPaginationTest.php
+++ b/tests/Integration/Database/EloquentWithPaginationTest.php
@@ -166,7 +166,7 @@ class EloquentWithPaginationTest extends DatabaseTestCase
         $result = Model1::withPaged('twos:id', 'fours', 'allFours:id')->first();
 
         $this->assertNull($result->twos->first()->one_id);
-        $this->assertSame(1, $result->fours->first()->one_id);
+        $this->assertEquals(1, $result->fours->first()->one_id);
         $this->assertNull($result->allFours->first()->one_id);
     }
 
@@ -261,7 +261,7 @@ class EloquentWithPaginationTest extends DatabaseTestCase
         $result = Model1::withSimplePaged('twos:id', 'fours', 'allFours:id')->first();
 
         $this->assertNull($result->twos->first()->one_id);
-        $this->assertSame(1, $result->fours->first()->one_id);
+        $this->assertEquals(1, $result->fours->first()->one_id);
         $this->assertNull($result->allFours->first()->one_id);
     }
 
@@ -428,7 +428,7 @@ class EloquentWithPaginationTest extends DatabaseTestCase
         $result = Model1::withCursorPaged('twos:id', 'fours', 'allFours:id')->first();
 
         $this->assertNull($result->twos->first()->one_id);
-        $this->assertSame(1, $result->fours->first()->one_id);
+        $this->assertEquals(1, $result->fours->first()->one_id);
         $this->assertNull($result->allFours->first()->one_id);
     }
 


### PR DESCRIPTION
## What?

Allows query relationships as paginated results at query-time.

```php
use App\Models\Post;

$post = Post::withPaged('comments')->find(1);

$post->comments->currentPage(); // 1

// https://myapp.com/post/1/?comments_page=1
```` 

It also works for simple and cursor pagination.

```php
Post::withSimplePaged('comments')->find(2);
Post::withCursorPaged('comments')->find(3);
```` 

This avoids a setting the relation, which is counter-intuitive, or creating a new query in other places.

```php
use App\Models\Post;

$post = Post::find(1);

$post->setRelation('comments', $post->comments()->paginate());
```` 

## Flexibility

You can use a short declaration to set the items per page, the page/cursor, and page name.

```php
Post::withPaged('comments', 10, 2, 'post_comments')->find(4);
```

It supports using a function to modify the query and the pagination parameters separately.

```php
use Illuminate\Pagination\Cursor;

Post::withPaged('comments', function ($query, $pagination) {
    $pagination->page(2)->perPage(10)->pageName('approved_comments');
    
    $query->where('is_approved', true);
})->find(5);

Post::withCursorPaged('comments', function ($query, $pagination) {
    $pagination->cursor(['comment.id' => 10])->perPage(10)->cursorName('approved_comments');
    
    $query->where('is_approved', true);
})->find(6);
```

Additionally, it works like `with()` if you use multiple relations,

```php
Post::withPaged('comments', 'drafts')->find(7);

// https://myapp.com/post/1/?comments_page=1&drafts_page=1
```

... or an array with callbacks.

```php
Post::withPaged([
    'comments' => function ($query) {
        $query->where('is_approved', true);
    },
    'drafts' => function ($query, $pagination) {
        $pagination->perPage(5);
    }
])->find(8);
```

### First level relation only

This approach avoids the shenanigans of using nested relations. If this happened, then multiple children would have multiple pages with the same name, forcing the developer to identify each by an ID, which would be more crazy if someone decides to use UUID.

```php
Post::withPaged('galleries.images')->find(9);

// https://myapp.com/post/1/?galleries_page=1&galleries_images_page=1&galleries_images_page=1...
```

Instead, the pagination works only at the first level, while eager-loading the nested relations.

### No Load

Some users may prefer to use something like `loadPaged()`. Instead, they should use the pagination helpers directly.

## How?

First, I separated the pagination procedure into two: modifying the query to paginate, and wrapping the result into a paginator. This is (was) done opaquely by the Query Builder.

Second, I blatantly copied the code of both tasks to the `Pagination` class. It exposes the last task as a static function.

This instance also outputs some convenient methods to change how the pagination should proceed, like changing the items per page. Is passed down as a second argument to the query callback.

Lastly, I created a function to handle eager-loading the relation if it was marked as paginated. This data is inside the Eloquent Builder.

PS: Happy new year.