### PR TITLE
[9.x] Add a default user agent to the HTTP client

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -397,7 +397,7 @@ class PendingRequest
      */
     public function withDefaultUserAgent()
     {
-        $agent = config('app.name') . '/' . app()->version() . ' - ' . config('app.url');
+        $agent = config('app.name').'/'.app()->version().' - '.config('app.url');
 
         return $this->withUserAgent($agent);
     }

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -173,6 +173,8 @@ class PendingRequest
             'timeout' => 30,
         ];
 
+        $this->withDefaultUserAgent();
+
         $this->beforeSendingCallbacks = collect([function (Request $request, array $options, PendingRequest $pendingRequest) {
             $pendingRequest->request = $request;
             $pendingRequest->cookies = $options['cookies'];
@@ -386,6 +388,18 @@ class PendingRequest
         return tap($this, function ($request) use ($userAgent) {
             return $this->options['headers']['User-Agent'] = trim($userAgent);
         });
+    }
+
+    /**
+     * Assign the default user agent for the request.
+     *
+     * @return $this
+     */
+    public function withDefaultUserAgent()
+    {
+        $agent = config('app.name') . '/' . app()->version() . ' - ' . config('app.url');
+
+        return $this->withUserAgent($agent);
     }
 
     /**

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -19,7 +19,7 @@ use Illuminate\Support\Str;
 use Mockery as m;
 use OutOfBoundsException;
 use PHPUnit\Framework\AssertionFailedError;
-use PHPUnit\Framework\TestCase;
+use Orchestra\Testbench\TestCase;
 use Symfony\Component\VarDumper\VarDumper;
 
 class HttpClientTest extends TestCase
@@ -302,6 +302,27 @@ class HttpClientTest extends TestCase
         $this->factory->assertSent(function (Request $request) {
             return $request->url() === 'http://foo.com/json' &&
                 $request->hasHeader('Authorization', 'Bearer token');
+        });
+    }
+
+    public function testItUsesTheDefaultUserAgent()
+    {
+        $config = $this->app['config'];
+
+        $config->set('app', [
+            'name' => 'Laravel',
+            'url' => 'https://laravel.com',
+        ]);
+
+        $this->factory->fake();
+
+        $this->factory->post('http://foo.com/json');
+
+        $agent = 'Laravel/' . app()->version() . ' - https://laravel.com';
+
+        $this->factory->assertSent(function (Request $request) use ($agent) {
+            return $request->url() === 'http://foo.com/json' &&
+                $request->hasHeader('User-Agent', $agent);
         });
     }
 

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -17,9 +17,9 @@ use Illuminate\Http\Client\ResponseSequence;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Mockery as m;
+use Orchestra\Testbench\TestCase;
 use OutOfBoundsException;
 use PHPUnit\Framework\AssertionFailedError;
-use Orchestra\Testbench\TestCase;
 use Symfony\Component\VarDumper\VarDumper;
 
 class HttpClientTest extends TestCase
@@ -318,7 +318,7 @@ class HttpClientTest extends TestCase
 
         $this->factory->post('http://foo.com/json');
 
-        $agent = 'Laravel/' . app()->version() . ' - https://laravel.com';
+        $agent = 'Laravel/'.app()->version().' - https://laravel.com';
 
         $this->factory->assertSent(function (Request $request) use ($agent) {
             return $request->url() === 'http://foo.com/json' &&


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR adds a default user agent to the HTTP client (`PendingRequest` class).

## Reasoning

It is generally a considered a good idea to add a custom user agent when sending HTTP requests to external sites. This allows the maintainers of these sites to identify requests coming from your application and provides them the means to get in touch with you should there be any issues e.g. a need to use rate limiting, caching etc.

## Status Quo

Out of the box, Laravel doesn't use a user agent. This means, that the HTTP client defers to Guzzle's default user agent, which is simply 'Guzzle' followed by a version number.

## Solution

The PR adds a `withDefaultUserAgent` method, which is called from the `PendingRequest` constructor. This method generates and sets a user agent derived from the application's name, url and version e.g.

```
Example/1.0 - https://example.com
```

The developer is of course free to override this by using the already present `withUserAgent` method.

## Breaking Changes

In all likelihood, the chance of this causing a breaking change is low. However, since the PR does alter the constructor of `PendingRequest`, I've decided to submit it to the master branch.




