### PR TITLE
[8.x] add possibility to pass relation name of morphToMany relations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -536,13 +536,14 @@ trait HasRelationships
      * @param  string|null  $parentKey
      * @param  string|null  $relatedKey
      * @param  bool  $inverse
+     * @param  string|null  $relationName
      * @return \Illuminate\Database\Eloquent\Relations\MorphToMany
      */
     public function morphToMany($related, $name, $table = null, $foreignPivotKey = null,
                                 $relatedPivotKey = null, $parentKey = null,
-                                $relatedKey = null, $inverse = false)
+                                $relatedKey = null, $inverse = false, $relationName = null)
     {
-        $caller = $this->guessBelongsToManyRelation();
+        $caller = $relationName ?: $this->guessBelongsToManyRelation();
 
         // First, we will need to determine the foreign key and "other key" for the
         // relationship. Once we have determined the keys we will make the query
@@ -604,10 +605,11 @@ trait HasRelationships
      * @param  string|null  $relatedPivotKey
      * @param  string|null  $parentKey
      * @param  string|null  $relatedKey
+     * @param  string|null  $relationName
      * @return \Illuminate\Database\Eloquent\Relations\MorphToMany
      */
     public function morphedByMany($related, $name, $table = null, $foreignPivotKey = null,
-                                  $relatedPivotKey = null, $parentKey = null, $relatedKey = null)
+                                  $relatedPivotKey = null, $parentKey = null, $relatedKey = null, $relationName = null)
     {
         $foreignPivotKey = $foreignPivotKey ?: $this->getForeignKey();
 
@@ -618,7 +620,7 @@ trait HasRelationships
 
         return $this->morphToMany(
             $related, $name, $table, $foreignPivotKey,
-            $relatedPivotKey, $parentKey, $relatedKey, true
+            $relatedPivotKey, $parentKey, $relatedKey, true, $relationName
         );
     }
 


### PR DESCRIPTION
This PR adds the possibility to specify a custom name for the morphedByMany relation.

The primary added benefit comes from using the Dynamic relations (resolveRelationUsing). 

**Old behavior:**

```
Tag::resolveRelationUsing('posts', function(Tag $model) {
    return $model->morphedByMany(
        Post::class,
        'taggable',
    );
});
```

If you subsequently call ```$tag->posts()->getRelationName();``` you will get ```...{closure}```.

**New behavior:**

```
Tag::resolveRelationUsing('posts', function(Tag $model) {
    return $model->morphedByMany(
        Post::class,
        'taggable',
        null,
        null,
        null,
        null,
        null,
        false,
        'posts' // pass my relation name
    );
});
```

If you subsequently call ```$tag->posts()->getRelationName();``` you now get the ```posts``` instead of ```...{closure}```.