### PR TITLE
[8.x] The Queue Failed_Job Table be compatible with Job Table

### DIFF
--- a/src/Illuminate/Queue/Console/stubs/failed_jobs.stub
+++ b/src/Illuminate/Queue/Console/stubs/failed_jobs.stub
@@ -17,7 +17,7 @@ class Create{{tableClassName}}Table extends Migration
             $table->id();
             $table->string('uuid')->unique();
             $table->text('connection');
-            $table->text('queue');
+            $table->string('queue');
             $table->longText('payload');
             $table->longText('exception');
             $table->timestamp('failed_at')->useCurrent();

--- a/src/Illuminate/Queue/Console/stubs/failed_jobs.stub
+++ b/src/Illuminate/Queue/Console/stubs/failed_jobs.stub
@@ -17,7 +17,7 @@ class Create{{tableClassName}}Table extends Migration
             $table->id();
             $table->string('uuid')->unique();
             $table->text('connection');
-            $table->string('queue');
+            $table->string('queue')->index();
             $table->longText('payload');
             $table->longText('exception');
             $table->timestamp('failed_at')->useCurrent();


### PR DESCRIPTION
## The Queue Failed_Job Table be compatible with Job Table

The commit consists of two small improvements.

1. It makes no sense to have a field type greater than what is actually used. For example, forwarding a failure task from jobs of database.

https://github.com/laravel/framework/blob/7ef38c8f25f0f243d4512661ac0ec649236d738c/src/Illuminate/Queue/Console/stubs/jobs.stub#L18

2. It makes sense to index this field. This may be useful in future tasks. And very often projects use the queue of failure tasks for analysis. Other packages also often work with an error queue by selecting a certain type of task.