### PR TITLE
[8.x] Add 'getRouter' method to RouteRegistrar

### DIFF
--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -91,6 +91,16 @@ class RouteRegistrar
     }
 
     /**
+     * Get the router instance.
+     *
+     * @return \Illuminate\Routing\Router
+     */
+    public function getRouter()
+    {
+        return $this->router;
+    }
+
+    /**
      * Set the value for a given attribute.
      *
      * @param  string  $key


### PR DESCRIPTION
This PR adds the `getRouter` method to the `RouteRegistrar` class.

In some cases, it is would be very useful to get access to the router from the registrar.

```php
$registrar = Route::prefix('foo')->as('foo.');

$router = $registrar->getRouter();

// Do some stuff

$registrar->group(...);
```