### PR TITLE
[8.x] Fixed behavior when unsaved *soft delete* models are `restore()` before `save()`

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -119,9 +119,11 @@ trait SoftDeletes
         // Once we have saved the model, we will fire the "restored" event so this
         // developer will do anything they need to after a restore operation is
         // totally finished. Then we will return the result of the save call.
-        $this->exists = true;
+        $result = null;
+        if ($this->exists) {
+            $result = $this->save();
+        }
 
-        $result = $this->save();
 
         $this->fireModelEvent('restored', false);
 

--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -124,7 +124,6 @@ trait SoftDeletes
             $result = $this->save();
         }
 
-
         $this->fireModelEvent('restored', false);
 
         return $result;

--- a/tests/Database/DatabaseSoftDeletingTraitTest.php
+++ b/tests/Database/DatabaseSoftDeletingTraitTest.php
@@ -47,6 +47,20 @@ class DatabaseSoftDeletingTraitTest extends TestCase
         $this->assertNull($model->deleted_at);
     }
 
+    public function testRestoreBeforeSaveInNewInstance()
+    {
+        $model = m::mock(DatabaseSoftDeletingTraitStub::class);
+        $model->makePartial();
+        $model->exists = false;
+        $model->shouldReceive('fireModelEvent')->with('restoring')->andReturn(true);
+        $model->shouldNotReceive('save');
+        $model->shouldReceive('fireModelEvent')->with('restored', false)->andReturn(true);
+
+        $model->restore();
+
+        $this->assertFalse($model->exists);
+    }
+
     public function testRestoreCancel()
     {
         $model = m::mock(DatabaseSoftDeletingTraitStub::class);
@@ -64,6 +78,7 @@ class DatabaseSoftDeletingTraitStub
     public $deleted_at;
     public $updated_at;
     public $timestamps = true;
+    public $exists = true;
 
     public function newQuery()
     {


### PR DESCRIPTION
If we perform `restore()` on a newly created instance of "soft delete" models, subsequent `save()` will not save the model to the database.

## Example of Issue

```php
$model = new Foo(); // Foo is a "soft delete" model.
$model->restore();
$model->save();

$model->refresh();
// Illuminate\Database\Eloquent\ModelNotFoundException with message 'No query results for model [Foo].'

DB::select("select * from foos");
// []
```

## Expected behavior

The model should be saved.

`restore()` for a non-soft-deleted model simply does nothing if it exists in the database, and subsequent `save()` works fine. So, `save()` should work the same even if it doesn't exist in the database.

## Solution

At the time of `restore()`, `$model->exists`  is [always set to true](https://github.com/laravel/framework/blob/v8.77.1/src/Illuminate/Database/Eloquent/SoftDeletes.php#L122) . Therefore, the cause is that the subsequent `save()` queries the database for update instead of insert. 

Fixed to not change `$model->exists` when `restore()`, and do not do `save()` because the record does not exist from the beginning, that is, do nothing.
