### PR TITLE
[8.x] Fix attribute casting

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -571,8 +571,7 @@ trait HasAttributes
 
         return static::$attributeMutatorCache[get_class($this)][$key] = $returnType &&
                     $returnType instanceof ReflectionNamedType &&
-                    $returnType->getName() === Attribute::class &&
-                    is_callable($this->{$method}()->get);
+                    $returnType->getName() === Attribute::class;
     }
 
     /**
@@ -949,8 +948,7 @@ trait HasAttributes
 
         return static::$setAttributeMutatorCache[$class][$key] = $returnType &&
                     $returnType instanceof ReflectionNamedType &&
-                    $returnType->getName() === Attribute::class &&
-                    is_callable($this->{$method}()->set);
+                    $returnType->getName() === Attribute::class;
     }
 
     /**

--- a/tests/Integration/Database/DatabaseEloquentModelAttributeCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelAttributeCastingTest.php
@@ -142,6 +142,8 @@ class DatabaseEloquentModelAttributeCastingTest extends DatabaseTestCase
     {
         $model = new TestEloquentModelWithAttributeCast;
 
+        $this->assertEquals(null, $model->password);
+
         $model->password = 'secret';
 
         $this->assertEquals(hash('sha256', 'secret'), $model->password);

--- a/tests/Integration/Database/DatabaseEloquentModelAttributeCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelAttributeCastingTest.php
@@ -142,7 +142,7 @@ class DatabaseEloquentModelAttributeCastingTest extends DatabaseTestCase
     {
         $model = new TestEloquentModelWithAttributeCast;
 
-        $this->assertEquals(null, $model->password);
+        $this->assertNull($model->password);
 
         $model->password = 'secret';
 


### PR DESCRIPTION
Fixes an oversight in https://github.com/laravel/framework/pull/40022.

At the moment when you omit a get cast with the new attribute casting, the attribute call will propagate through the getAttribute method and end up to getRelationValue which will throw an exception that the attribute isn't a relationship instance. This is because the way attribute calls work is to fallback on relationships when they're not available. So the way the checks are done on get/set callables with the new attribute casting isn't entirely correct. We should omit the callable checks and just check if the method that corresponds with the requested attribute is returning an Attribute cast instance. If that's the case we can assume the user wanted to use attribute casting, regardless of a getter/setter being available or not. 

A cavaet of this is that this will prevent the call to continue to class casts and the old date casting. I do not know how to solve this and would appreciate any insights you have @taylorotwell.

Fixes #40230
