### PR TITLE
[8.x] Add allowed plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -155,7 +155,10 @@
         "wildbit/swiftmailer-postmark": "Required to use Postmark mail driver (^3.0)."
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "composer/package-versions-deprecated": true
+        }
     },
     "minimum-stability": "dev",
     "prefer-stable": true


### PR DESCRIPTION
Composer v2.2 added a new requirement to explicitly allow plugins that can execute code during a Composer run. This addition is the result of answering "yes" to the list of given plugins during a composer install of `laravel/framework`.

See:
- https://github.com/composer/composer/pull/10314
- https://blog.packagist.com/composer-2-2/