### PR TITLE
[8.x] Add `htmlString` helper method

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -822,6 +822,16 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Convert the string into a `HtmlString`.
+     *
+     * @return HtmlString
+     */
+    public function htmlString()
+    {
+        return new HtmlString($this->value);
+    }
+
+    /**
      * Dump the string.
      *
      * @return $this

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -824,7 +824,7 @@ class Stringable implements JsonSerializable
     /**
      * Convert the string into a `HtmlString`.
      *
-     * @return HtmlString
+     * @return \Illuminate\Support\HtmlString
      */
     public function html()
     {

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -826,7 +826,7 @@ class Stringable implements JsonSerializable
      *
      * @return HtmlString
      */
-    public function htmlString()
+    public function html()
     {
         return new HtmlString($this->value);
     }

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -822,11 +822,11 @@ class Stringable implements JsonSerializable
     }
 
     /**
-     * Convert the string into a `HtmlString`.
+     * Convert the string into a `HtmlString` instance.
      *
      * @return \Illuminate\Support\HtmlString
      */
-    public function html()
+    public function toHtmlString()
     {
         return new HtmlString($this->value);
     }

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -723,11 +723,11 @@ class SupportStringableTest extends TestCase
         $this->assertEquals(10, $this->stringable('Hi, this is my first contribution to the Laravel framework.')->wordCount());
     }
 
-    public function testHtml()
+    public function testToHtmlString()
     {
         $this->assertEquals(
             new HtmlString('<h1>Test String</h1>'),
-            $this->stringable('<h1>Test String</h1>')->html()
+            $this->stringable('<h1>Test String</h1>')->toHtmlString()
         );
     }
 

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -3,8 +3,8 @@
 namespace Illuminate\Tests\Support;
 
 use Illuminate\Support\Collection;
-use Illuminate\Support\Stringable;
 use Illuminate\Support\HtmlString;
+use Illuminate\Support\Stringable;
 use PHPUnit\Framework\TestCase;
 
 class SupportStringableTest extends TestCase

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Support;
 
 use Illuminate\Support\Collection;
 use Illuminate\Support\Stringable;
+use Illuminate\Support\HtmlString;
 use PHPUnit\Framework\TestCase;
 
 class SupportStringableTest extends TestCase
@@ -720,6 +721,14 @@ class SupportStringableTest extends TestCase
     {
         $this->assertEquals(2, $this->stringable('Hello, world!')->wordCount());
         $this->assertEquals(10, $this->stringable('Hi, this is my first contribution to the Laravel framework.')->wordCount());
+    }
+
+    public function testHtml()
+    {
+        $this->assertEquals(
+            new HtmlString('<h1>Test String</h1>'),
+            $this->stringable('<h1>Test String</h1>')->html()
+        );
     }
 
     public function testStripTags()


### PR DESCRIPTION
**Motivation:**

I often use the `HtmlString` to render `Stringable` data without using `{!! $content !!}`.

**Before:**

```php
return new HtmlString(Str::of($content)->markdown());

return new HtmlString(Str::markdown($content));
```

**After:**

```php
return Str::of($content)
    ->markdown()
    ->html();
```