### PR TITLE
[9.x] Add ability to supply HTTP client methods with `Arrayable` instances

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -662,7 +662,7 @@ class PendingRequest
     public function send(string $method, string $url, array $options = [])
     {
         $options = $this->parseHttpOptions($options);
-        
+
         $url = ltrim(rtrim($this->baseUrl, '/').'/'.ltrim($url, '/'), '/');
 
         [$this->pendingBody, $this->pendingFiles] = [null, []];

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -690,7 +690,7 @@ class PendingRequest
         }, $this->retryDelay ?? 100, $this->retryWhenCallback);
     }
 
-     /**
+    /**
      * Parse the HTTP options.
      *
      * @param  array  $options

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -15,6 +15,7 @@ use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\Client\Response;
 use Illuminate\Http\Client\ResponseSequence;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Fluent;
 use Illuminate\Support\Str;
 use Mockery as m;
 use OutOfBoundsException;
@@ -172,6 +173,22 @@ class HttpClientTest extends TestCase
             'name' => 'Taylor',
             'title' => 'Laravel Developer',
         ]);
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/form' &&
+                   $request->hasHeader('Content-Type', 'application/x-www-form-urlencoded') &&
+                   $request['name'] === 'Taylor';
+        });
+    }
+
+    public function testCanSendArrayableFormData()
+    {
+        $this->factory->fake();
+
+        $this->factory->asForm()->post('http://foo.com/form', new Fluent([
+            'name' => 'Taylor',
+            'title' => 'Laravel Developer',
+        ]));
 
         $this->factory->assertSent(function (Request $request) {
             return $request->url() === 'http://foo.com/form' &&
@@ -428,6 +445,18 @@ class HttpClientTest extends TestCase
         $this->factory->fake();
 
         $this->factory->get('http://foo.com/get', ['foo' => 'bar']);
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/get?foo=bar'
+                && $request['foo'] === 'bar';
+        });
+    }
+
+    public function testGetWithArrayableQueryParam()
+    {
+        $this->factory->fake();
+
+        $this->factory->get('http://foo.com/get', new Fluent(['foo' => 'bar']));
 
         $this->factory->assertSent(function (Request $request) {
             return $request->url() === 'http://foo.com/get?foo=bar'


### PR DESCRIPTION
## Problem

Currently we cannot supply `Arrayable` instances into any of the `HTTP` methods, as Guzzle will throw an exception, saying that HTTP options must be an array or string.

## Description

This PR introduces the ability to supply `Arrayable` instances into the Laravel HTTP Client for more convenient use.

This is done by simply leveraging `collect($options)->toArray()` to transform all HTTP options that are `Arrayable` to their raw array format, prior to sending them along to Guzzle.

## Important

This is a breaking change due to the adjustment of the `post()` method signature.

I also wasn't sure if I should change the `array` doc block types to `mixed`, or simply add `Arrayable` as an allowed type.

Let me know what you'd like, thanks!

## Usage

Using a collection for query parameters:

```php
use Illuminate\Support\Facades\Http;

$query = collect(['brand' => 'Samsung', 'color' => 'Black']);

Http::get('/products', $query);
```

Using a fluent instance for form data:

```php
use Illuminate\Support\Fluent;
use Illuminate\Support\Facades\Http;

$user = new Fluent();

$user->name = 'Steve Bauman';
$user->email = 'steve@email.com';

//...

Http::post('/users', $user);
```

The above use-cases would be more useful when their `Fluent` or `Collection` instances coming from other sources in your application, so you don't have to transform them every time you want to send a request.

---

Thanks for your time :heart:. No hard feelings on closure.