### PR TITLE
[9.x] Add support for psr/simple-cache v2 and v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "nesbot/carbon": "^2.53.1",
         "psr/container": "^1.1.1|^2.0.1",
         "psr/log": "^1.0|^2.0|^3.0",
-        "psr/simple-cache": "^1.0",
+        "psr/simple-cache": "^1.0|^2.0|^3.0",
         "ramsey/uuid": "^4.2.2",
         "symfony/console": "^6.0",
         "symfony/error-handler": "^6.0",
@@ -96,7 +96,7 @@
     },
     "provide": {
         "psr/container-implementation": "1.0",
-        "psr/simple-cache-implementation": "1.0"
+        "psr/simple-cache-implementation": "1.0|2.0|3.0"
     },
     "conflict": {
         "tightenco/collect": "<5.5.33"

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -224,7 +224,7 @@ class Repository implements ArrayAccess, CacheContract
      *
      * @return bool
      */
-    public function set($key, $value, $ttl = null)
+    public function set($key, $value, $ttl = null): bool
     {
         return $this->put($key, $value, $ttl);
     }

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -88,7 +88,7 @@ class Repository implements ArrayAccess, CacheContract
      * @param  mixed  $default
      * @return mixed
      */
-    public function get($key, $default = null)
+    public function get($key, $default = null): mixed
     {
         if (is_array($key)) {
             return $this->many($key);

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -65,7 +65,7 @@ class Repository implements ArrayAccess, CacheContract
      * @param  string  $key
      * @return bool
      */
-    public function has($key)
+    public function has($key): bool
     {
         return ! is_null($this->get($key));
     }
@@ -134,7 +134,7 @@ class Repository implements ArrayAccess, CacheContract
      *
      * @return iterable
      */
-    public function getMultiple($keys, $default = null)
+    public function getMultiple($keys, $default = null): iterable
     {
         $defaults = [];
 
@@ -283,7 +283,7 @@ class Repository implements ArrayAccess, CacheContract
      *
      * @return bool
      */
-    public function setMultiple($values, $ttl = null)
+    public function setMultiple($values, $ttl = null): bool
     {
         return $this->putMany(is_array($values) ? $values : iterator_to_array($values), $ttl);
     }
@@ -448,7 +448,7 @@ class Repository implements ArrayAccess, CacheContract
      *
      * @return bool
      */
-    public function delete($key)
+    public function delete($key): bool
     {
         return $this->forget($key);
     }
@@ -458,7 +458,7 @@ class Repository implements ArrayAccess, CacheContract
      *
      * @return bool
      */
-    public function deleteMultiple($keys)
+    public function deleteMultiple($keys): bool
     {
         $result = true;
 
@@ -476,7 +476,7 @@ class Repository implements ArrayAccess, CacheContract
      *
      * @return bool
      */
-    public function clear()
+    public function clear(): bool
     {
         return $this->store->flush();
     }

--- a/src/Illuminate/Cache/composer.json
+++ b/src/Illuminate/Cache/composer.json
@@ -21,7 +21,7 @@
         "illuminate/support": "^9.0"
     },
     "provide": {
-        "psr/simple-cache-implementation": "1.0"
+        "psr/simple-cache-implementation": "1.0|2.0|3.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Illuminate/Contracts/composer.json
+++ b/src/Illuminate/Contracts/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "^8.0.2",
         "psr/container": "^1.1.1|^2.0.1",
-        "psr/simple-cache": "^1.0"
+        "psr/simple-cache": "^1.0|^2.0|^3.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Add support for `psr/simple-cache` v2 and v3 in Laravel v9.