### PR TITLE
[8.x] Fix typehints on cache repositories

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -578,7 +578,7 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Fire an event for this cache instance.
      *
-     * @param  string|object  $event
+     * @param  object|string  $event
      * @return void
      */
     protected function event($event)

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -578,7 +578,7 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Fire an event for this cache instance.
      *
-     * @param  string  $event
+     * @param  string|object  $event
      * @return void
      */
     protected function event($event)

--- a/src/Illuminate/Cache/TaggedCache.php
+++ b/src/Illuminate/Cache/TaggedCache.php
@@ -105,7 +105,7 @@ class TaggedCache extends Repository
     /**
      * Fire an event for this cache instance.
      *
-     * @param  string  $event
+     * @param  \Illuminate\Cache\Events\CacheEvent  $event
      * @return void
      */
     protected function event($event)


### PR DESCRIPTION
The `event` method on the main cache repository is mainly used right now to send new cache event instances to the event dispatcher. The `event` method on the `TaggedCache` repository only accepts `Illuminate\Cache\Events\CacheEvent` instances.