### PR TITLE
[9.x] Move array access to container contract

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Container;
 
-use ArrayAccess;
 use Closure;
 use Exception;
 use Illuminate\Contracts\Container\BindingResolutionException;
@@ -14,7 +13,7 @@ use ReflectionException;
 use ReflectionParameter;
 use TypeError;
 
-class Container implements ArrayAccess, ContainerContract
+class Container implements ContainerContract
 {
     /**
      * The current globally available container (if any).

--- a/src/Illuminate/Contracts/Container/Container.php
+++ b/src/Illuminate/Contracts/Container/Container.php
@@ -2,10 +2,11 @@
 
 namespace Illuminate\Contracts\Container;
 
+use ArrayAccess;
 use Closure;
 use Psr\Container\ContainerInterface;
 
-interface Container extends ContainerInterface
+interface Container extends ContainerInterface, ArrayAccess
 {
     /**
      * Determine if the given abstract type has been bound.


### PR DESCRIPTION
Laravel's container (and by extension application) allows for its services to be retrieved via array access, e.g.: 

```php
$app = app();
$cache = $app['cache'];
```

The problem however, is that most of the time code doesn't actually "know" if the container supports being accessed as an array, because neither the container nor the application contract enforces it.

The framework itself uses this feature, primarily in service providers. Which is a context where it cannot be sure array access is supported, because the application is type-hinted as the application contract, which does not implement the array access interface.

Example:
https://github.com/laravel/framework/blob/b86e57e062fea77cc388c66b93fd006717f28c0f/src/Illuminate/Queue/QueueServiceProvider.php#L143

## What does this PR do?
It moves `ArrayAccess` from the framework's container implementation, to the container contract. Meaning all code will now be sure that array access is supported when interacting with an application or a container.

## Breaking change
This is a breaking change for any custom applications or containers that do not extend from Laravel's container or application. But these custom containers and applications would likely already have implemented `ArrayAccess` to be compatible with framework code. Because of this I estimate the impact to be very minimal.