### PR TITLE
[8.x] Add `pipeThrough` collection method

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -722,12 +722,12 @@ trait EnumeratesValues
     }
 
     /**
-     * Pass the collection through a series of pipes and return the result.
+     * Pass the collection through a series of callable pipes and return the result.
      *
      * @param  array<callable>  $pipes
      * @return mixed
      */
-    public function pipeThrough(array $pipes)
+    public function pipeThrough($pipes)
     {
         return static::make($pipes)->reduce(
             function ($carry, $pipe) {

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -722,6 +722,22 @@ trait EnumeratesValues
     }
 
     /**
+     * Pass the collection through a series of pipes and return the result.
+     *
+     * @param  array<callable>  $pipes
+     * @return mixed
+     */
+    public function pipeThrough(array $pipes)
+    {
+        return static::make($pipes)->reduce(
+            function ($carry, $pipe) {
+                return $pipe($carry);
+            },
+            $this,
+        );
+    }
+
+    /**
      * Pass the collection to the given callback and then return it.
      *
      * @param  callable  $callback

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -4022,7 +4022,7 @@ class SupportCollectionTest extends TestCase
                 return $data->sum();
             },
         ]);
-    
+
         $this->assertEquals(15, $result);
     }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -4010,6 +4010,25 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testPipeThrough($collection)
+    {
+        $data = new $collection([1, 2, 3]);
+
+        $result = $data->pipeThrough([
+            function ($data) {
+                return $data->merge([4, 5]);
+            },
+            function ($data) {
+                return $data->sum();
+            },
+        ]);
+    
+        $this->assertEquals(15, $result);
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testMedianValueWithArrayCollection($collection)
     {
         $data = new $collection([1, 2, 2, 4]);


### PR DESCRIPTION
## Description

This PR adds the `pipeThrough()` method for collections, allowing developers to insert an array of pipe callbacks that can manipulate the collection, carrying the return value from the previous pipe into following pipes.

## Usage

```php
$pipes = [
    fn ($podcasts) => $podcasts->each(
        fn ($podcast) => $podcast->process()
    ),

    fn ($podcasts) => $podcasts->sum(
        fn ($podcast) => $podcast->hasProcessed()
    ),
];

$processed = Podcast::all()->pipeThrough($pipes);
```

Let me know if you would like anything adjusted. Thanks for your time! No hard feelings on closure ❤️ 