### PR TITLE
[8.x] Fix failover mailer when used with Mailgun & SES mailers

### DIFF
--- a/src/Illuminate/Mail/Transport/MailgunTransport.php
+++ b/src/Illuminate/Mail/Transport/MailgunTransport.php
@@ -3,7 +3,9 @@
 namespace Illuminate\Mail\Transport;
 
 use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\GuzzleException;
 use Swift_Mime_SimpleMessage;
+use Swift_TransportException;
 
 class MailgunTransport extends Transport
 {
@@ -68,11 +70,15 @@ class MailgunTransport extends Transport
 
         $message->setBcc([]);
 
-        $response = $this->client->request(
-            'POST',
-            "https://{$this->endpoint}/v3/{$this->domain}/messages.mime",
-            $this->payload($message, $to)
-        );
+        try {
+            $response = $this->client->request(
+                'POST',
+                "https://{$this->endpoint}/v3/{$this->domain}/messages.mime",
+                $this->payload($message, $to)
+            );
+        } catch (GuzzleException $e) {
+            throw new Swift_TransportException('Failed to make request to Mailgun API', $e->getCode(), $e);
+        }
 
         $messageId = $this->getMessageId($response);
 

--- a/src/Illuminate/Mail/Transport/SesTransport.php
+++ b/src/Illuminate/Mail/Transport/SesTransport.php
@@ -2,8 +2,10 @@
 
 namespace Illuminate\Mail\Transport;
 
+use Aws\Exception\AwsException;
 use Aws\Ses\SesClient;
 use Swift_Mime_SimpleMessage;
+use Swift_TransportException;
 
 class SesTransport extends Transport
 {
@@ -43,16 +45,20 @@ class SesTransport extends Transport
     {
         $this->beforeSendPerformed($message);
 
-        $result = $this->ses->sendRawEmail(
-            array_merge(
-                $this->options, [
-                    'Source' => key($message->getSender() ?: $message->getFrom()),
-                    'RawMessage' => [
-                        'Data' => $message->toString(),
-                    ],
-                ]
-            )
-        );
+        try {
+            $result = $this->ses->sendRawEmail(
+                array_merge(
+                    $this->options, [
+                        'Source' => key($message->getSender() ?: $message->getFrom()),
+                        'RawMessage' => [
+                            'Data' => $message->toString(),
+                        ],
+                    ]
+                )
+            );
+        } catch (AwsException $e) {
+            throw new Swift_TransportException('Failed to make request to AWS SES API', $e->getCode(), $e);
+        }
 
         $messageId = $result->get('MessageId');
 


### PR DESCRIPTION
### Description

#38344 introduced the `failover` mailer into the framework, with the idea being that if a mail fails to send via one mailer, alternative mailer(s) will be tried.

It seems that the first-party HTTP based mailers / transport included with the framework (Mailgun & SES) **don't** trigger an attempt to send using an alternative mailer if the API request fails - the exception from the underlying library isn't caught (a `GuzzleException` for Mailgun and `AwsException` for SES).

The issue seems to be that the `send()` method in the underlying `\Swift_Transport_FailoverTransport` class only catches `Swift_TransportException` exceptions, which trigger the failover logic. Other exceptions aren't handed.

### Steps To Reproduce (with Mailgun):

1) Setup a failover mailer in `config/mail.php`:

```php
'failover' => [
    'transport' => 'failover',
    'mailers' => [
        'mailgun',
        'log',
    ],
],
```

2) Ensure your attempt to send via Mailgun will fail (e.g. use incorrect credentials / block requests to the API domain on your local network).

3) Attempt to send a mail - you'll get a`ClientException` exception, rather than the alternative failover `log` mailer being used.

### Solution

The upstream `swiftmailer/swiftamiler` package is no longer maintained, so we can't suggest a PR to catch other exceptions in the failover logic. Plus this feels more like an issue with the Laravel transport classes not throwing the correct exceptions.

This PR simply catches any `\GuzzleHttp\Exception\GuzzleException` (Mailgun)  / `\Aws\Exception\AwsException` (SES) exceptions and then throws a new `Swift_TransportException` instead (with the original passed in via `$previous`).

_I haven't added any tests as there don't appear to be any for the `MailgunTransport` class, and wasn't sure of the best way of mocking a failure for SES - however I'm happy to add tests if anyone can assist!_