### PR TITLE
[8.x] Allow method typed variadics dependencies

### DIFF
--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -173,7 +173,11 @@ class BoundMethod
                 unset($parameters[$className]);
             } else {
                 if ($parameter->isVariadic()) {
-                    $dependencies = array_merge($dependencies, $container->make($className));
+                    $variadicDependencies = $container->make($className);
+
+                    $dependencies = array_merge($dependencies, is_array($variadicDependencies)
+                                ? $variadicDependencies
+                                : [$variadicDependencies]);
                 } else {
                     $dependencies[] = $container->make($className);
                 }

--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -172,7 +172,11 @@ class BoundMethod
 
                 unset($parameters[$className]);
             } else {
-                $dependencies[] = $container->make($className);
+                if ($parameter->isVariadic()) {
+                    $dependencies = array_merge($dependencies, $container->make($className));
+                } else {
+                    $dependencies[] = $container->make($className);
+                }
             }
         } elseif ($parameter->isDefaultValueAvailable()) {
             $dependencies[] = $parameter->getDefaultValue();

--- a/tests/Container/ContainerCallTest.php
+++ b/tests/Container/ContainerCallTest.php
@@ -160,6 +160,29 @@ class ContainerCallTest extends TestCase
         $this->assertSame('taylor', $result[1]);
     }
 
+    public function testCallWithVariadicDependency()
+    {
+        $stub1 = new ContainerCallConcreteStub;
+        $stub2 = new ContainerCallConcreteStub;
+
+        $container = new Container;
+        $container->bind(ContainerCallConcreteStub::class, function () use ($stub1, $stub2) {
+            return [
+                $stub1,
+                $stub2,
+            ];
+        });
+
+        $result = $container->call(function (stdClass $foo, ContainerCallConcreteStub ...$bar) {
+            return func_get_args();
+        });
+
+        $this->assertInstanceOf(stdClass::class, $result[0]);
+        $this->assertInstanceOf(ContainerCallConcreteStub::class, $result[1]);
+        $this->assertSame($stub1, $result[1]);
+        $this->assertSame($stub2, $result[2]);
+    }
+
     public function testCallWithCallableObject()
     {
         $container = new Container;


### PR DESCRIPTION
This reasonably simple change would enable to use variadic for DI when calling a `Callable`, in addition to class resolution.

Here is an example reusing the objects from the [documentation](https://laravel.com/docs/8.x/container#binding-typed-variadics):

```php
$app->bind(Filter::class, function ($app) {
    return [
        $app->make(NullFilter::class),
        $app->make(ProfanityFilter::class),
        $app->make(TooLongFilter::class),
    ];
});

$app->call(function (Logger $logger, Filter ...$filters) {
    //                               ⏫ this is currently unsupported
});
```

I think this can be beneficial for the following reasons:
* you may have a callable or a class method that receives an array of typed objects, the same way [documentation](https://laravel.com/docs/8.x/container#binding-typed-variadics) explains for constructors;
* there are cases when resolution for constructors only is not sufficient unless over objectifying things.
  * see my example below.
* this addition partially mitigates the need of contextual binding for methods (#30542):
  * for variadic, the enforced specific context is no more required, they can be use with classical bindings.
  * improve consistency across DI
* backward compatible, as it only match variadic when a type is specified (maybe array of arrays type can conflit? not even sure it is natively supported)
* it is not very easy to implement the suggested behavior via a package

<details>
<summary>Example of a case where a constructor cannot handle it</summary>

* Not allowed:
  ```php
  public function __construct(public Logger $logger, Filter ...$filters, Whatever ...$objects)
  { //                                                                   ⏫ this is illegal
      $this->filters = $filters;
      $this->objects = $objects;
      $this->method();
  }  

  public function method()
  {
      // attributes consumer
  }
  ```

* Naive remedy:
  ```php
  public function __construct(public Logger $logger, Filter ...$filters)
  {
      $this->filters = $filters;
      App::call([$this, 'method']);
  }
  
  public function method(Whatever ...$objects)
  {
      //
  }
  ```

</details>
