### PR TITLE
[8.x] Make Password Rule validation errors messages translatable

### DIFF
--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -315,7 +315,7 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
                 $validator->errors()->add($attribute, $this->getMessage(
                     'password.mixed_case',
                     'The :attribute must contain at least one uppercase and one lowercase letter.'
-                )));
+                ));
             }
 
             if ($this->letters && ! preg_match('/\pL/u', $value)) {

--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -386,12 +386,12 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
 
 
     /**
-     * @param  string       $key
-     * @param  string|null  $default
+     * @param  string $key
+     * @param  string|null $default
      *
      * @return bool|string
      */
-    protected function getMessage(string $key, ?string $default = null) {
+    protected function getMessage($key, $default = null) {
 
         $key = "validation.custom.{$key}";
 


### PR DESCRIPTION
The current `Illuminate\Validation\Rules\Password` has hard-coded validation errors messages and therefore it is not possible for the developper to translate them into a given language (eg: French) unless he overrides it.

This pull request allows the developer to customize these error messages by setting a custom validation message in their translation files. The current behavior will be preserved if custom messages are not defined.

```php 
// en/validation.php

    'custom' => [
        'password' => [
            'mixed_case' => 'The :attribute must contain at least one uppercase and one lowercase letter.',
            'letters' => 'The :attribute must contain at least one letter.',
            'symbols' => 'The :attribute must contain at least one symbol.',
            'numbers' => 'The :attribute must contain at least one number.',
            'compromised' => 'The givens :attribute has appeared in a data leak. Please choose a different :attribute.',
        ],
    ],
```

```php
// fr/validation.php
    'custom' => [
        'password' => [
            'compromised' => 'Le :attribute donné est apparu dans une fuite de données. Veuillez choisir un autre mot de passe.',
        ],
    ],
```