### PR TITLE
[8.x] Avoid constructor call when fetching resource JSON options

### DIFF
--- a/src/Illuminate/Http/Resources/CollectsResources.php
+++ b/src/Illuminate/Http/Resources/CollectsResources.php
@@ -6,6 +6,8 @@ use Illuminate\Pagination\AbstractCursorPaginator;
 use Illuminate\Pagination\AbstractPaginator;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use ReflectionClass;
+use ReflectionException;
 
 trait CollectsResources
 {
@@ -58,12 +60,20 @@ trait CollectsResources
      * Get the JSON serialization options that should be applied to the resource response.
      *
      * @return int
+     *
+     * @throws ReflectionException
      */
     public function jsonOptions()
     {
         $collects = $this->collects();
 
-        return $collects ? (new $collects([]))->jsonOptions() : 0;
+        if (! $collects) {
+            return 0;
+        }
+
+        $class = new ReflectionClass($collects);
+
+        return $class->newInstanceWithoutConstructor()->jsonOptions();
     }
 
     /**

--- a/src/Illuminate/Http/Resources/CollectsResources.php
+++ b/src/Illuminate/Http/Resources/CollectsResources.php
@@ -7,7 +7,6 @@ use Illuminate\Pagination\AbstractPaginator;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use ReflectionClass;
-use ReflectionException;
 
 trait CollectsResources
 {
@@ -60,8 +59,6 @@ trait CollectsResources
      * Get the JSON serialization options that should be applied to the resource response.
      *
      * @return int
-     *
-     * @throws ReflectionException
      */
     public function jsonOptions()
     {

--- a/src/Illuminate/Http/Resources/CollectsResources.php
+++ b/src/Illuminate/Http/Resources/CollectsResources.php
@@ -71,9 +71,9 @@ trait CollectsResources
             return 0;
         }
 
-        $class = new ReflectionClass($collects);
-
-        return $class->newInstanceWithoutConstructor()->jsonOptions();
+        return (new ReflectionClass($collects))
+                  ->newInstanceWithoutConstructor()
+                  ->jsonOptions();
     }
 
     /**

--- a/tests/Integration/Http/Fixtures/PostResourceWithJsonOptionsAndTypeHints.php
+++ b/tests/Integration/Http/Fixtures/PostResourceWithJsonOptionsAndTypeHints.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http\Fixtures;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class PostResourceWithJsonOptionsAndTypeHints extends JsonResource
+{
+    public function __construct(Post $resource)
+    {
+        parent::__construct($resource);
+    }
+
+    public function toArray($request)
+    {
+        return [
+            'id' => $this->id,
+            'title' => $this->title,
+            'reading_time' => $this->reading_time,
+        ];
+    }
+
+    public function jsonOptions()
+    {
+        return JSON_PRESERVE_ZERO_FRACTION;
+    }
+}

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -25,6 +25,7 @@ use Illuminate\Tests\Integration\Http\Fixtures\PostResource;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithAnonymousResourceCollectionWithPaginationInformation;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithExtraData;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithJsonOptions;
+use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithJsonOptionsAndTypeHints;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalAppendedAttributes;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalData;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalMerging;
@@ -551,6 +552,26 @@ class ResourceTest extends TestCase
 
         $this->assertEquals(
             '{"data":[{"id":5,"title":"Test Title","reading_time":3.0}],"links":{"first":"\/?page=1","last":"\/?page=1","prev":null,"next":null},"meta":{"current_page":1,"from":1,"last_page":1,"links":[{"url":null,"label":"&laquo; Previous","active":false},{"url":"\/?page=1","label":"1","active":true},{"url":null,"label":"Next &raquo;","active":false}],"path":"\/","per_page":15,"to":1,"total":10}}',
+            $response->baseResponse->content()
+        );
+    }
+
+    public function testResourcesMayCustomizeJsonOptionsWithTypeHintedConstructor()
+    {
+        Route::get('/', function () {
+            return new PostResourceWithJsonOptionsAndTypeHints(new Post([
+                'id' => 5,
+                'title' => 'Test Title',
+                'reading_time' => 3.0,
+            ]));
+        });
+
+        $response = $this->withoutExceptionHandling()->get(
+            '/', ['Accept' => 'application/json']
+        );
+
+        $this->assertEquals(
+            '{"data":{"id":5,"title":"Test Title","reading_time":3.0}}',
             $response->baseResponse->content()
         );
     }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

As described in https://github.com/laravel/framework/issues/40258 when we use a type hinted constructor, or a constructor that accepts more than 1 required parameter on a singular resource and it's constructed through a collection resource, the `collectsResources::jsonOptions()` method fails because it passes in an empty array just to be able to call the non-static `jsonOptions` method on the singular resource.

I'm not sure if this is too much "magic", but it's the the only thing I can think of to maintain backwards compatibility with whats recently been added without reverting the original PR, so if you don't agree, please feel free to reject the PR.

This will work to fix the issue however, as the constructor is no longer called when creating a new instance of the singular resource, therefore bypassing any type hints or multiple required parameters. This should be safer than passing in an empty array, as by passing in an empty array it's assumed that the constructor does nothing other than set the `$resource` property as the passed in parameter.

Automated test has been added, and I've checked this solution locally in https://github.com/philcross/laravel-jsonOptions-bug which is a project to reproduce the bug.