### PR TITLE
[8.x] Add onLastPage method to the Paginator

### DIFF
--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -385,7 +385,7 @@ abstract class AbstractPaginator implements Htmlable
      */
     public function onLastPage()
     {
-        return !$this->hasMorePages();
+        return ! $this->hasMorePages();
     }
 
     /**

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -379,6 +379,16 @@ abstract class AbstractPaginator implements Htmlable
     }
 
     /**
+     * Determine if the paginator is on the last page.
+     *
+     * @return bool
+     */
+    public function onLastPage()
+    {
+        return !$this->hasMorePages();
+    }
+
+    /**
      * Get the current page.
      *
      * @return int

--- a/tests/Pagination/LengthAwarePaginatorTest.php
+++ b/tests/Pagination/LengthAwarePaginatorTest.php
@@ -54,6 +54,19 @@ class LengthAwarePaginatorTest extends TestCase
         $this->assertFalse($paginator->hasPages());
         $this->assertFalse($paginator->hasMorePages());
         $this->assertEmpty($paginator->items());
+    }    
+
+    public function testLengthAwarePaginatorisOnFirstAndLastPage()
+    {
+        $paginator = new LengthAwarePaginator(['1', '2', '3', '4'], 4, 2, 2);
+
+        $this->assertTrue($paginator->onLastPage());
+        $this->assertFalse($paginator->onFirstPage());        
+
+        $paginator = new LengthAwarePaginator(['1', '2', '3', '4'], 4, 2, 1);
+
+        $this->assertFalse($paginator->onLastPage());
+        $this->assertTrue($paginator->onFirstPage());
     }
 
     public function testLengthAwarePaginatorCanGenerateUrls()

--- a/tests/Pagination/LengthAwarePaginatorTest.php
+++ b/tests/Pagination/LengthAwarePaginatorTest.php
@@ -54,7 +54,7 @@ class LengthAwarePaginatorTest extends TestCase
         $this->assertFalse($paginator->hasPages());
         $this->assertFalse($paginator->hasMorePages());
         $this->assertEmpty($paginator->items());
-    }    
+    }
 
     public function testLengthAwarePaginatorisOnFirstAndLastPage()
     {

--- a/tests/Pagination/LengthAwarePaginatorTest.php
+++ b/tests/Pagination/LengthAwarePaginatorTest.php
@@ -61,7 +61,7 @@ class LengthAwarePaginatorTest extends TestCase
         $paginator = new LengthAwarePaginator(['1', '2', '3', '4'], 4, 2, 2);
 
         $this->assertTrue($paginator->onLastPage());
-        $this->assertFalse($paginator->onFirstPage());        
+        $this->assertFalse($paginator->onFirstPage());
 
         $paginator = new LengthAwarePaginator(['1', '2', '3', '4'], 4, 2, 1);
 


### PR DESCRIPTION
**In short:**
This PR adds a convenience method to the paginator to determine if we are on the last page.

**Why:**
There is a useful `onFirstPage` method but it lacks the opposite `onLastPage` method.

I was just writing some blade code for a Tailwind pagination component and without reading a any documentation `onFirstPage` worked.

Meaning, you can have the following code:

```blade
@if ($paginator->onFirstPage())
```

But for the last page, you need to call an unexpected `hasMorePages` method and reverse the logic, so it becomes:
```blade
@if (!$paginator->hasMorePages())
```
So not only did I encounter a blade error, because `onLastPage` did not exist, but also I had to reverse the logic.

This PR keeps things consistent by adding a `onLastPage()` so you can simple do:

```blade
@if ($paginator->onLastPage())
```

Which, in my mind, is a very logical thing to try after using `onFirstPage` without reading any documentation.