### PR TITLE
[9.x] Reinvents `route:list` command

### DIFF
--- a/src/Illuminate/Contracts/Routing/UrlGenerator.php
+++ b/src/Illuminate/Contracts/Routing/UrlGenerator.php
@@ -70,17 +70,17 @@ interface UrlGenerator
     public function action($action, $parameters = [], $absolute = true);
 
     /**
+     * Get the root controller namespace.
+     *
+     * @return string
+     */
+    public function getRootControllerNamespace();
+
+    /**
      * Set the root controller namespace.
      *
      * @param  string  $rootNamespace
      * @return $this
      */
     public function setRootControllerNamespace($rootNamespace);
-
-    /**
-     * Get the root controller namespace.
-     *
-     * @return string
-     */
-    public function getRootControllerNamespace();
 }

--- a/src/Illuminate/Contracts/Routing/UrlGenerator.php
+++ b/src/Illuminate/Contracts/Routing/UrlGenerator.php
@@ -76,4 +76,11 @@ interface UrlGenerator
      * @return $this
      */
     public function setRootControllerNamespace($rootNamespace);
+
+    /**
+     * Get the root controller namespace.
+     *
+     * @return string
+     */
+    public function getRootControllerNamespace();
 }

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -300,7 +300,7 @@ class RouteListCommand extends Command
             fn ($route) => array_merge($route, [
                 'action' => $this->formatAction($route['action']),
                 'method' => $route['method'] == 'GET|HEAD|POST|PUT|PATCH|DELETE|OPTIONS' ? 'ANY' : $route['method'],
-                'name' => $this->output->isVerbose() ? $route['name'] : null,
+                'name' => $route['name'] && $this->output->isVerbose() ? (' '.$route['name']) : null,
                 'uri' => $route['domain'] ? ($route['domain'].'/'.$route['uri']) : $route['uri'],
             ]),
         );
@@ -346,7 +346,7 @@ class RouteListCommand extends Command
                 $method,
                 $spaces,
                 preg_replace('#({[^}]+})#', '<fg=yellow>$1</>', $uri),
-                $name ? " $name" : '',
+                $name,
                 $dots,
                 str_replace('   ', ' › ', $action),
             ), $this->output->isVerbose() && ! empty($middleware) ? "<fg=#6C7280>$middleware</>" : null];

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -4,11 +4,15 @@ namespace Illuminate\Foundation\Console;
 
 use Closure;
 use Illuminate\Console\Command;
+use Illuminate\Contracts\Routing\UrlGenerator;
 use Illuminate\Routing\Route;
 use Illuminate\Routing\Router;
+use Illuminate\Routing\ViewController;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use ReflectionClass;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Terminal;
 
 class RouteListCommand extends Command
 {
@@ -50,11 +54,27 @@ class RouteListCommand extends Command
     protected $headers = ['Domain', 'Method', 'URI', 'Name', 'Action', 'Middleware'];
 
     /**
-     * The columns to display when using the "compact" flag.
+     * The terminal width resolver callback.
      *
-     * @var string[]
+     * @var \Closure|null
      */
-    protected $compactColumns = ['method', 'uri', 'action'];
+    protected static $terminalWidthResolver;
+
+    /**
+     * The verb colors for the command.
+     *
+     * @var array
+     */
+    protected $verbColors = [
+        'ANY' => 'red',
+        'GET' => 'blue',
+        'HEAD' => '#6C7280',
+        'OPTIONS' => '#6C7280',
+        'POST' => 'yellow',
+        'PUT' => 'yellow',
+        'PATCH' => 'yellow',
+        'DELETE' => 'red',
+    ];
 
     /**
      * Create a new route command instance.
@@ -164,13 +184,11 @@ class RouteListCommand extends Command
      */
     protected function displayRoutes(array $routes)
     {
-        if ($this->option('json')) {
-            $this->line($this->asJson($routes));
+        $routes = collect($routes);
 
-            return;
-        }
-
-        $this->table($this->getHeaders(), $routes);
+        $this->output->writeln(
+            $this->option('json') ? $this->asJson($routes) : $this->forCli($routes)
+        );
     }
 
     /**
@@ -195,8 +213,8 @@ class RouteListCommand extends Command
     protected function filterRoute(array $route)
     {
         if (($this->option('name') && ! Str::contains($route['name'], $this->option('name'))) ||
-             $this->option('path') && ! Str::contains($route['uri'], $this->option('path')) ||
-             $this->option('method') && ! Str::contains($route['method'], strtoupper($this->option('method')))) {
+            $this->option('path') && ! Str::contains($route['uri'], $this->option('path')) ||
+            $this->option('method') && ! Str::contains($route['method'], strtoupper($this->option('method')))) {
             return;
         }
 
@@ -228,17 +246,7 @@ class RouteListCommand extends Command
      */
     protected function getColumns()
     {
-        $availableColumns = array_map('strtolower', $this->headers);
-
-        if ($this->option('compact')) {
-            return array_intersect($availableColumns, $this->compactColumns);
-        }
-
-        if ($columns = $this->option('columns')) {
-            return array_intersect($availableColumns, $this->parseColumns($columns));
-        }
-
-        return $availableColumns;
+        return array_map('strtolower', $this->headers);
     }
 
     /**
@@ -265,12 +273,12 @@ class RouteListCommand extends Command
     /**
      * Convert the given routes to JSON.
      *
-     * @param  array  $routes
+     * @param  \Illuminate\Support\Collection  $routes
      * @return string
      */
-    protected function asJson(array $routes)
+    protected function asJson($routes)
     {
-        return collect($routes)
+        return $routes
             ->map(function ($route) {
                 $route['middleware'] = empty($route['middleware']) ? [] : explode("\n", $route['middleware']);
 
@@ -281,6 +289,95 @@ class RouteListCommand extends Command
     }
 
     /**
+     * Convert the given routes to regular CLI output.
+     *
+     * @param  \Illuminate\Support\Collection  $routes
+     * @return array
+     */
+    protected function forCli($routes)
+    {
+        $maxMethod = mb_strlen($routes->max('method'));
+
+        $terminalWidth = $this->getTerminalWidth();
+
+        return $routes->map(function ($route) use ($maxMethod, $terminalWidth) {
+            [
+                'action' => $action,
+                'domain' => $domain,
+                'method' => $method,
+                'middleware' => $middleware,
+                'uri' => $uri,
+            ] = $route;
+
+            $middleware = Str::of($middleware)->explode("\n")->filter()->whenNotEmpty(
+                fn ($collection) => $collection->map(
+                    fn ($middleware) => sprintf('         %s⇂ %s', str_repeat(' ', $maxMethod), $middleware)
+                )
+            )->implode("\n");
+
+            $action = $this->formatAction($action);
+            $method = $method == 'GET|HEAD|POST|PUT|PATCH|DELETE|OPTIONS' ? 'ANY' : $method;
+            $name = $this->output->isVerbose() ? $route['name'] : null;
+            $uri = $domain ? "$domain/$uri" : $uri;
+
+            $spaces = str_repeat(' ', max($maxMethod + 6 - mb_strlen($method), 0));
+
+            $dots = str_repeat('.', max(
+                $terminalWidth - mb_strlen($method.$uri.$action.$name) - mb_strlen($spaces) - 14 - ($action ? 1 : 0), 0
+            ));
+
+            $dots = empty($dots) ? $dots : " $dots";
+
+            if ($action && ! $this->output->isVerbose() && mb_strlen($method.$spaces.$uri.$name.$dots.$action) > ($terminalWidth - 14)) {
+                $action = substr($action, 0, $terminalWidth - 15 - mb_strlen($method.$spaces.$uri.$name.$dots)).'…';
+            }
+
+            $method = Str::of($method)->explode('|')->map(
+                fn ($method) => sprintf('<fg=%s>%s</>', $this->verbColors[$method] ?? 'default', $method),
+            )->implode('<fg=#6C7280>|</>');
+
+            return [sprintf(
+                '  <fg=white;options=bold>%s</> %s<fg=white>%s</><fg=#6C7280>%s%s %s</>',
+                $method,
+                $spaces,
+                preg_replace('#({[^}]+})#', '<fg=yellow>$1</>', $uri),
+                $name ? " $name" : '',
+                $dots,
+                str_replace('   ', ' › ', $action),
+            ), $this->output->isVerbose() && ! empty($middleware) ? "<fg=#6C7280>$middleware</>" : null];
+        })->flatten()->filter()->prepend('')->push('')->toArray();
+    }
+
+    /**
+     * Get the formatted action for CLI.
+     *
+     * @return string
+     */
+    protected function formatAction($action)
+    {
+        if ($action === 'Closure' || $action === ViewController::class) {
+            return '';
+        }
+
+        $rootControllerNamespace = $this->laravel[UrlGenerator::class]->getRootControllerNamespace()
+            ?? ($this->laravel->getNamespace().'Http\\Controllers');
+
+        if (str_starts_with($action, $rootControllerNamespace)) {
+            return substr($action, mb_strlen($rootControllerNamespace) + 1);
+        }
+
+        $actionClass = explode('@', $action)[0];
+
+        if (class_exists($actionClass) && str_starts_with((new ReflectionClass($actionClass))->getFilename(), base_path('vendor'))) {
+            $actionCollection = collect(explode('\\', $action));
+
+            return $actionCollection->take(2)->implode('\\').'   '.$actionCollection->last();
+        }
+
+        return $action;
+    }
+
+    /**
      * Get the console command options.
      *
      * @return array
@@ -288,8 +385,6 @@ class RouteListCommand extends Command
     protected function getOptions()
     {
         return [
-            ['columns', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'Columns to include in the route table'],
-            ['compact', 'c', InputOption::VALUE_NONE, 'Only show method, URI and action columns'],
             ['json', null, InputOption::VALUE_NONE, 'Output the route list as JSON'],
             ['method', null, InputOption::VALUE_OPTIONAL, 'Filter the routes by method'],
             ['name', null, InputOption::VALUE_OPTIONAL, 'Filter the routes by name'],
@@ -298,5 +393,28 @@ class RouteListCommand extends Command
             ['reverse', 'r', InputOption::VALUE_NONE, 'Reverse the ordering of the routes'],
             ['sort', null, InputOption::VALUE_OPTIONAL, 'The column (precedence, domain, method, uri, name, action, middleware) to sort by', 'uri'],
         ];
+    }
+
+    /**
+     * Get the terminal width.
+     *
+     * @return int
+     */
+    public static function getTerminalWidth()
+    {
+        return is_null(static::$terminalWidthResolver)
+            ? (new Terminal())->getWidth()
+            : call_user_func(static::$terminalWidthResolver);
+    }
+
+    /**
+     * Set a callback that should be used when resolving the terminal width.
+     *
+     * @param  \Closure|null  $callback
+     * @return void
+     */
+    public static function resolveTerminalWidthUsing($resolver)
+    {
+        static::$terminalWidthResolver = $resolver;
     }
 }

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -323,13 +323,13 @@ class RouteListCommand extends Command
             $spaces = str_repeat(' ', max($maxMethod + 6 - mb_strlen($method), 0));
 
             $dots = str_repeat('.', max(
-                $terminalWidth - mb_strlen($method.$uri.$action.$name) - mb_strlen($spaces) - 14 - ($action ? 1 : 0), 0
+                $terminalWidth - mb_strlen($method.$uri.$action.$name) - mb_strlen($spaces) - 6 - ($action ? 1 : 0), 0
             ));
 
             $dots = empty($dots) ? $dots : " $dots";
 
-            if ($action && ! $this->output->isVerbose() && mb_strlen($method.$spaces.$uri.$name.$dots.$action) > ($terminalWidth - 14)) {
-                $action = substr($action, 0, $terminalWidth - 15 - mb_strlen($method.$spaces.$uri.$name.$dots)).'…';
+            if ($action && ! $this->output->isVerbose() && mb_strlen($method.$spaces.$uri.$name.$dots.$action) > ($terminalWidth - 4)) {
+                $action = substr($action, 0, $terminalWidth - 7 - mb_strlen($method.$spaces.$uri.$name.$dots)).'…';
             }
 
             $method = Str::of($method)->explode('|')->map(

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -298,7 +298,7 @@ class RouteListCommand extends Command
     {
         $routes = $routes->map(
             fn ($route) => array_merge($route, [
-                'action' => $this->formatAction($route),
+                'action' => $this->formatActionForCli($route),
                 'method' => $route['method'] == 'GET|HEAD|POST|PUT|PATCH|DELETE|OPTIONS' ? 'ANY' : $route['method'],
                 'uri' => $route['domain'] ? ($route['domain'].'/'.$route['uri']) : $route['uri'],
             ]),
@@ -351,12 +351,12 @@ class RouteListCommand extends Command
     }
 
     /**
-     * Get the formatted action for CLI.
+     * Get the formatted action for display on the CLI.
      *
      * @param  array  $route
      * @return string
      */
-    protected function formatAction($route)
+    protected function formatActionForCli($route)
     {
         ['action' => $action, 'name' => $name] = $route;
 
@@ -385,6 +385,29 @@ class RouteListCommand extends Command
     }
 
     /**
+     * Get the terminal width.
+     *
+     * @return int
+     */
+    public static function getTerminalWidth()
+    {
+        return is_null(static::$terminalWidthResolver)
+            ? (new Terminal)->getWidth()
+            : call_user_func(static::$terminalWidthResolver);
+    }
+
+    /**
+     * Set a callback that should be used when resolving the terminal width.
+     *
+     * @param  \Closure|null  $callback
+     * @return void
+     */
+    public static function resolveTerminalWidthUsing($resolver)
+    {
+        static::$terminalWidthResolver = $resolver;
+    }
+
+    /**
      * Get the console command options.
      *
      * @return array
@@ -400,28 +423,5 @@ class RouteListCommand extends Command
             ['reverse', 'r', InputOption::VALUE_NONE, 'Reverse the ordering of the routes'],
             ['sort', null, InputOption::VALUE_OPTIONAL, 'The column (precedence, domain, method, uri, name, action, middleware) to sort by', 'uri'],
         ];
-    }
-
-    /**
-     * Get the terminal width.
-     *
-     * @return int
-     */
-    public static function getTerminalWidth()
-    {
-        return is_null(static::$terminalWidthResolver)
-            ? (new Terminal())->getWidth()
-            : call_user_func(static::$terminalWidthResolver);
-    }
-
-    /**
-     * Set a callback that should be used when resolving the terminal width.
-     *
-     * @param  \Closure|null  $callback
-     * @return void
-     */
-    public static function resolveTerminalWidthUsing($resolver)
-    {
-        static::$terminalWidthResolver = $resolver;
     }
 }

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -333,7 +333,7 @@ class RouteListCommand extends Command
 
             $dots = empty($dots) ? $dots : " $dots";
 
-            if ($action && ! $this->output->isVerbose() && mb_strlen($method.$spaces.$uri.$action.$name.$dots) > ($terminalWidth - 4)) {
+            if ($action && ! $this->output->isVerbose() && mb_strlen($method.$spaces.$uri.$action.$name.$dots) > ($terminalWidth - 6)) {
                 $action = substr($action, 0, $terminalWidth - 7 - mb_strlen($method.$spaces.$uri.$name.$dots)).'…';
             }
 

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -296,6 +296,15 @@ class RouteListCommand extends Command
      */
     protected function forCli($routes)
     {
+        $routes = $routes->map(
+            fn ($route) => array_merge($route, [
+                'action' => $this->formatAction($route['action']),
+                'method' => $route['method'] == 'GET|HEAD|POST|PUT|PATCH|DELETE|OPTIONS' ? 'ANY' : $route['method'],
+                'name' => $this->output->isVerbose() ? $route['name'] : null,
+                'uri' => $route['domain'] ? ($route['domain'].'/'.$route['uri']) : $route['uri'],
+            ]),
+        );
+
         $maxMethod = mb_strlen($routes->max('method'));
 
         $terminalWidth = $this->getTerminalWidth();
@@ -306,6 +315,7 @@ class RouteListCommand extends Command
                 'domain' => $domain,
                 'method' => $method,
                 'middleware' => $middleware,
+                'name' => $name,
                 'uri' => $uri,
             ] = $route;
 
@@ -315,20 +325,15 @@ class RouteListCommand extends Command
                 )
             )->implode("\n");
 
-            $action = $this->formatAction($action);
-            $method = $method == 'GET|HEAD|POST|PUT|PATCH|DELETE|OPTIONS' ? 'ANY' : $method;
-            $name = $this->output->isVerbose() ? $route['name'] : null;
-            $uri = $domain ? "$domain/$uri" : $uri;
-
             $spaces = str_repeat(' ', max($maxMethod + 6 - mb_strlen($method), 0));
 
             $dots = str_repeat('.', max(
-                $terminalWidth - mb_strlen($method.$uri.$action.$name) - mb_strlen($spaces) - 6 - ($action ? 1 : 0), 0
+                $terminalWidth - mb_strlen($method.$spaces.$uri.$action.$name) - 6 - ($action ? 1 : 0), 0
             ));
 
             $dots = empty($dots) ? $dots : " $dots";
 
-            if ($action && ! $this->output->isVerbose() && mb_strlen($method.$spaces.$uri.$name.$dots.$action) > ($terminalWidth - 4)) {
+            if ($action && ! $this->output->isVerbose() && mb_strlen($method.$spaces.$uri.$action.$name.$dots) > ($terminalWidth - 4)) {
                 $action = substr($action, 0, $terminalWidth - 7 - mb_strlen($method.$spaces.$uri.$name.$dots)).'…';
             }
 

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -794,6 +794,16 @@ class UrlGenerator implements UrlGeneratorContract
     }
 
     /**
+     * Get the root controller namespace.
+     *
+     * @return string
+     */
+    public function getRootControllerNamespace()
+    {
+        return $this->rootNamespace;
+    }
+
+    /**
      * Set the root controller namespace.
      *
      * @param  string  $rootNamespace
@@ -804,15 +814,5 @@ class UrlGenerator implements UrlGeneratorContract
         $this->rootNamespace = $rootNamespace;
 
         return $this;
-    }
-
-    /**
-     * Get the root controller namespace.
-     *
-     * @return string
-     */
-    public function getRootControllerNamespace()
-    {
-        return $this->rootNamespace;
     }
 }

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -805,4 +805,14 @@ class UrlGenerator implements UrlGeneratorContract
 
         return $this;
     }
+
+    /**
+     * Get the root controller namespace.
+     *
+     * @return string
+     */
+    public function getRootControllerNamespace()
+    {
+        return $this->rootNamespace;
+    }
 }

--- a/tests/Testing/Console/RouteListCommandTest.php
+++ b/tests/Testing/Console/RouteListCommandTest.php
@@ -53,7 +53,7 @@ class RouteListCommandTest extends TestCase
             ->expectsOutput('  GET|HEAD   closure ............................................... ')
             ->expectsOutput('  POST       controller-invokable Illuminate\Tests\Testing\FooContr…')
             ->expectsOutput('  GET|HEAD   controller-method/{user} Illuminate\Tests\Testing\FooC…')
-            ->expectsOutput('  GET|HEAD   {account}.example.com/user/{id} ....................... ')
+            ->expectsOutput('  GET|HEAD   {account}.example.com/user/{id} ............. user.show')
             ->expectsOutput('');
     }
 
@@ -77,7 +77,7 @@ class RouteListCommandTest extends TestCase
             ->expectsOutput('  GET|HEAD   closure ............................................... ')
             ->expectsOutput('  POST       controller-invokable Illuminate\\Tests\\Testing\\FooController')
             ->expectsOutput('  GET|HEAD   controller-method/{user} Illuminate\\Tests\\Testing\\FooController@show')
-            ->expectsOutput('  GET|HEAD   {account}.example.com/user/{id} user.show ............. ')
+            ->expectsOutput('  GET|HEAD   {account}.example.com/user/{id} ............. user.show')
             ->expectsOutput('             ⇂ web')
             ->expectsOutput('');
     }

--- a/tests/Testing/Console/RouteListCommandTest.php
+++ b/tests/Testing/Console/RouteListCommandTest.php
@@ -50,10 +50,10 @@ class RouteListCommandTest extends TestCase
         $this->artisan(RouteListCommand::class)
             ->assertSuccessful()
             ->expectsOutput('')
-            ->expectsOutput('  GET|HEAD   closure ....................................... ')
-            ->expectsOutput('  POST       controller-invokable Illuminate\\Tests\\Testing\\…')
-            ->expectsOutput('  GET|HEAD   controller-method/{user} Illuminate\\Tests\\Test…')
-            ->expectsOutput('  GET|HEAD   {account}.example.com/user/{id} ............... ')
+            ->expectsOutput('  GET|HEAD   closure ............................................... ')
+            ->expectsOutput('  POST       controller-invokable Illuminate\Tests\Testing\FooContr…')
+            ->expectsOutput('  GET|HEAD   controller-method/{user} Illuminate\Tests\Testing\FooC…')
+            ->expectsOutput('  GET|HEAD   {account}.example.com/user/{id} ....................... ')
             ->expectsOutput('');
     }
 
@@ -74,10 +74,10 @@ class RouteListCommandTest extends TestCase
         $this->artisan(RouteListCommand::class, ['-v' => true])
             ->assertSuccessful()
             ->expectsOutput('')
-            ->expectsOutput('  GET|HEAD   closure ....................................... ')
+            ->expectsOutput('  GET|HEAD   closure ............................................... ')
             ->expectsOutput('  POST       controller-invokable Illuminate\\Tests\\Testing\\FooController')
             ->expectsOutput('  GET|HEAD   controller-method/{user} Illuminate\\Tests\\Testing\\FooController@show')
-            ->expectsOutput('  GET|HEAD   {account}.example.com/user/{id} user.show ...... ')
+            ->expectsOutput('  GET|HEAD   {account}.example.com/user/{id} user.show .............. ')
             ->expectsOutput('             ⇂ web')
             ->expectsOutput('');
     }

--- a/tests/Testing/Console/RouteListCommandTest.php
+++ b/tests/Testing/Console/RouteListCommandTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Illuminate\Tests\Testing;
+
+use Illuminate\Contracts\Routing\Registrar;
+use Illuminate\Foundation\Auth\User;
+use Illuminate\Foundation\Console\RouteListCommand;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Facade;
+use Orchestra\Testbench\TestCase;
+
+class RouteListCommandTest extends TestCase
+{
+    /**
+     * @var \Illuminate\Contracts\Routing\Registrar
+     */
+    private $router;
+
+    /**
+     * @var \Illuminate\Routing\UrlGenerator
+     */
+    private $urlGenerator;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->router = $this->app->make(Registrar::class);
+
+        RouteListCommand::resolveTerminalWidthUsing(function () {
+            return 70;
+        });
+    }
+
+    public function testDisplayRoutesForCli()
+    {
+        $this->router->get('closure', function () {
+            return new RedirectResponse($this->urlGenerator->signedRoute('signed-route'));
+        });
+
+        $this->router->get('controller-method/{user}', [FooController::class, 'show']);
+        $this->router->post('controller-invokable', FooController::class);
+        $this->router->domain('{account}.example.com')->group(function () {
+            $this->router->get('user/{id}', function ($account, $id) {
+                //
+            })->name('user.show')->middleware('web');
+        });
+
+        $this->artisan(RouteListCommand::class)
+            ->assertSuccessful()
+            ->expectsOutput('')
+            ->expectsOutput('  GET|HEAD   closure ....................................... ')
+            ->expectsOutput('  POST       controller-invokable Illuminate\\Tests\\Testing\\…')
+            ->expectsOutput('  GET|HEAD   controller-method/{user} Illuminate\\Tests\\Test…')
+            ->expectsOutput('  GET|HEAD   {account}.example.com/user/{id} ............... ')
+            ->expectsOutput('');
+    }
+
+    public function testDisplayRoutesForCliInVerboseMode()
+    {
+        $this->router->get('closure', function () {
+            return new RedirectResponse($this->urlGenerator->signedRoute('signed-route'));
+        });
+
+        $this->router->get('controller-method/{user}', [FooController::class, 'show']);
+        $this->router->post('controller-invokable', FooController::class);
+        $this->router->domain('{account}.example.com')->group(function () {
+            $this->router->get('user/{id}', function ($account, $id) {
+                //
+            })->name('user.show')->middleware('web');
+        });
+
+        $this->artisan(RouteListCommand::class, ['-v' => true])
+            ->assertSuccessful()
+            ->expectsOutput('')
+            ->expectsOutput('  GET|HEAD   closure ....................................... ')
+            ->expectsOutput('  POST       controller-invokable Illuminate\\Tests\\Testing\\FooController')
+            ->expectsOutput('  GET|HEAD   controller-method/{user} Illuminate\\Tests\\Testing\\FooController@show')
+            ->expectsOutput('  GET|HEAD   {account}.example.com/user/{id} user.show ...... ')
+            ->expectsOutput('             ⇂ web')
+            ->expectsOutput('');
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+
+        Facade::setFacadeApplication(null);
+
+        RouteListCommand::resolveTerminalWidthUsing(null);
+    }
+}
+
+class FooController extends Controller
+{
+    public function show(User $user)
+    {
+        // ..
+    }
+
+    public function __invoke()
+    {
+        // ..
+    }
+}

--- a/tests/Testing/Console/RouteListCommandTest.php
+++ b/tests/Testing/Console/RouteListCommandTest.php
@@ -77,7 +77,7 @@ class RouteListCommandTest extends TestCase
             ->expectsOutput('  GET|HEAD   closure ............................................... ')
             ->expectsOutput('  POST       controller-invokable Illuminate\\Tests\\Testing\\FooController')
             ->expectsOutput('  GET|HEAD   controller-method/{user} Illuminate\\Tests\\Testing\\FooController@show')
-            ->expectsOutput('  GET|HEAD   {account}.example.com/user/{id} user.show .............. ')
+            ->expectsOutput('  GET|HEAD   {account}.example.com/user/{id} user.show ............. ')
             ->expectsOutput('             ⇂ web')
             ->expectsOutput('');
     }


### PR DESCRIPTION
This pull request proposes a brand new `route:list` command - for Laravel 9 - regarding the way displays the application routes on the console.

## What problem does this pull request solves?

Well, it's known that on Laravel applications with a huge and complex list of routes, the existing `route:list` artisan command don't display the routes properly:

<img width="1174" alt="Screenshot 2022-01-05 at 13 55 51" src="https://user-images.githubusercontent.com/5457236/148273024-577fdc1e-ae9c-44a7-9e6e-5331d1b25ae6.png">

## Proposed changes

This pull request changes the way we display routes on the `route:list` artisan command, and essentially there are two modes: default and verbose.

### Default (non-verbose)

The default - non-verbose - is the mode we get when running: `php artisan route:list`, and it looks like this:

<img width="1174" alt="Screenshot 2022-01-05 at 13 57 23" src="https://user-images.githubusercontent.com/5457236/148273199-895b7319-ba33-4a07-b73e-afec9314379f.png">

Now, in this mode, the following information is displayed: `method`, `domain@uri`, and `action`. In addition, we ensure that the console output is always pretty, even in small terminals:

<img width="767" alt="truncate" src="https://user-images.githubusercontent.com/5457236/148276786-57ffdece-a14d-4e0a-95e7-610856caa3db.png">

As you can see, the new display ensures we truncate the `action` at the end of the line, ensuring this way things are always properly displayed.

### Verbose

The verbose is the mode we get when using the option `-v`: `php artisan route:list -v`, and it looks like this:

<img width="1174" alt="Screenshot 2022-01-05 at 14 00 18" src="https://user-images.githubusercontent.com/5457236/148273585-2002cd1d-69dd-48c7-aaf1-a5f9e168c44f.png">

Now, in this mode, the following information is displayed: `method`, `domain@uri`, `name`, `action`, and list of `middleware`. In addition, we don't truncate any kind of information.

<img width="767" alt="name" src="https://user-images.githubusercontent.com/5457236/148276974-e7dd9b3b-31c3-45d7-ad3a-6ba6fde3cff6.png">

As you can see, in this mode, we display the `name` just next to the `domain@uri`, and we display a list of `middleware` used by the route.

### Displayed actions are abbreviated

One more thing regarding this new `route:list` artisan command, is the way we display actions:

<img width="870" alt="actions" src="https://user-images.githubusercontent.com/5457236/148279006-fc440e70-91ee-4a44-8714-46d4b060f39e.png">

In this example, you can see that `App\Http\Controllers\SearchController` got abbreviated to `SearchController` and `Laravel\Sanctum\Http\ControllersCsrfCookieController@show` got abbreviated to `Laravel\Sanctum › CsrfCookieController@show`.

### Domains

Domains are displayed right before actions:

<img width="966" alt="Screenshot 2022-01-05 at 14 36 48" src="https://user-images.githubusercontent.com/5457236/148278075-aa6d3f29-1926-4d4f-b0da-714bf8b959a2.png">


---

Finally, it's important to mention that all the options - `json`, `sort`, etc - work just like in the past. Except for the options `compact` and `columns` that got removed.

Also, this pull request it's originally inspired by https://github.com/Wulfheart/pretty-routes, but of course, the display and features at this point are a little bit different.

---

Edit 1: There is a breaking change, regarding the `Illuminate/Contracts/Routing/UrlGenerator` contract that needs to be documented on the upgrade guide, this pull request gets merged.

---

Edit 2: After reading the community feedback, we decided to add the `name` just before the action.

<img width="1217" alt="Screenshot 2022-01-05 at 22 07 21" src="https://user-images.githubusercontent.com/5457236/148321982-38c8b869-f188-4f42-a3cc-a03451d5216c.png">