### PR TITLE
[7.x] Update PHPDoc of Collection::forget()

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -391,7 +391,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Remove an item from the collection by key.
      *
-     * @param  string|array  $keys
+     * @param  string|int|array  $keys
      * @return $this
      */
     public function forget($keys)
@@ -1381,7 +1381,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Unset the item at a given offset.
      *
-     * @param  string  $key
+     * @param  string|int  $key
      * @return void
      */
     public function offsetUnset($key)


### PR DESCRIPTION
The PHPDoc of Collection::forget() is
```
/**
 * Remove an item from the collection by key.
 *
 * @param  string|array  $keys
 * @return $this
 */
public function forget($keys)
```
Available types of `$keys` is `string|array`, missing `int`, this PR add it.