### PR TITLE
[9.x] Use standard path helper for `Application::langPath()`

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -313,13 +313,20 @@ class Application extends Container implements ApplicationContract, CachesConfig
     {
         $this->instance('path', $this->path());
         $this->instance('path.base', $this->basePath());
-        $this->instance('path.lang', $this->langPath());
         $this->instance('path.config', $this->configPath());
         $this->instance('path.public', $this->publicPath());
         $this->instance('path.storage', $this->storagePath());
         $this->instance('path.database', $this->databasePath());
         $this->instance('path.resources', $this->resourcePath());
         $this->instance('path.bootstrap', $this->bootstrapPath());
+
+        $this->useLangPath(value(function () {
+            if (is_dir($directory = $this->resourcePath('lang')) {
+                return $directory;
+            }
+
+            return $this->basePath('lang');
+        });
     }
 
     /**
@@ -417,15 +424,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function langPath($path = '')
     {
-        if ($this->langPath) {
-            return $this->langPath.($path ? DIRECTORY_SEPARATOR.$path : '');
-        }
-
-        if (is_dir($directory = $this->resourcePath().DIRECTORY_SEPARATOR.'lang')) {
-            return $directory.($path ? DIRECTORY_SEPARATOR.$path : '');
-        }
-
-        return $this->basePath().DIRECTORY_SEPARATOR.'lang'.($path ? DIRECTORY_SEPARATOR.$path : '');
+        return $this->langPath.($path ? DIRECTORY_SEPARATOR.$path : '');
     }
 
     /**

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -321,12 +321,12 @@ class Application extends Container implements ApplicationContract, CachesConfig
         $this->instance('path.bootstrap', $this->bootstrapPath());
 
         $this->useLangPath(value(function () {
-            if (is_dir($directory = $this->resourcePath('lang')) {
+            if (is_dir($directory = $this->resourcePath('lang'))) {
                 return $directory;
             }
 
             return $this->basePath('lang');
-        });
+        }));
     }
 
     /**

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -412,19 +412,20 @@ class Application extends Container implements ApplicationContract, CachesConfig
     /**
      * Get the path to the language files.
      *
+     * @param  string  $path
      * @return string
      */
-    public function langPath()
+    public function langPath($path = '')
     {
         if ($this->langPath) {
-            return $this->langPath;
+            return $this->langPath.($path ? DIRECTORY_SEPARATOR.$path : '');
         }
 
-        if (is_dir($path = $this->resourcePath().DIRECTORY_SEPARATOR.'lang')) {
-            return $path;
+        if (is_dir($directory = $this->resourcePath().DIRECTORY_SEPARATOR.'lang')) {
+            return $directory.($path ? DIRECTORY_SEPARATOR.$path : '');
         }
 
-        return $this->basePath().DIRECTORY_SEPARATOR.'lang';
+        return $this->basePath().DIRECTORY_SEPARATOR.'lang'.($path ? DIRECTORY_SEPARATOR.$path : '');
     }
 
     /**

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -492,7 +492,7 @@ if (! function_exists('lang_path')) {
      */
     function lang_path($path = '')
     {
-        return app('path.lang').($path ? DIRECTORY_SEPARATOR.$path : $path);
+        return app()->langPath($path);
     }
 }
 


### PR DESCRIPTION
Also reduce trying to verify default langPath each time we call `langPath` method.

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>