### PR TITLE
[8.x] Adds support for specifying a route group controller

### DIFF
--- a/src/Illuminate/Routing/RouteGroup.php
+++ b/src/Illuminate/Routing/RouteGroup.php
@@ -20,6 +20,10 @@ class RouteGroup
             unset($old['domain']);
         }
 
+        if (isset($new['controller'])) {
+            unset($old['controller']);
+        }
+
         $new = array_merge(static::formatAs($new, $old), [
             'namespace' => static::formatNamespace($new, $old),
             'prefix' => static::formatPrefix($new, $old, $prependExistingPrefix),

--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -17,6 +17,7 @@ use InvalidArgumentException;
  * @method \Illuminate\Routing\Route options(string $uri, \Closure|array|string|null $action = null)
  * @method \Illuminate\Routing\Route any(string $uri, \Closure|array|string|null $action = null)
  * @method \Illuminate\Routing\RouteRegistrar as(string $value)
+ * @method \Illuminate\Routing\RouteRegistrar controller(string $controller)
  * @method \Illuminate\Routing\RouteRegistrar domain(string $value)
  * @method \Illuminate\Routing\RouteRegistrar middleware(array|string|null $middleware)
  * @method \Illuminate\Routing\RouteRegistrar name(string $value)
@@ -58,6 +59,7 @@ class RouteRegistrar
      */
     protected $allowedAttributes = [
         'as',
+        'controller',
         'domain',
         'middleware',
         'name',

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -555,8 +555,19 @@ class Router implements BindingRegistrar, RegistrarContract
     {
         $group = end($this->groupStack);
 
-        return isset($group['controller']) && strpos($class, '@') === false
-                ? $group['controller'].'@'.$class : $class;
+        if (! isset($group['controller'])) {
+            return $class;
+        }
+
+        if (class_exists($class)) {
+            return $class;
+        }
+
+        if (strpos($class, '@') !== false) {
+            return $class;
+        }
+
+        return $group['controller'].'@'.$class;
     }
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -516,8 +516,8 @@ class Router implements BindingRegistrar, RegistrarContract
         }
 
         // Here we'll merge any group "controller" and "uses" statements if necessary so that
-        // the action has the proper clause for this property. Then we can simply set the
-        // name of the controller on the action and return the action array for usage.
+        // the action has the proper clause for this property. Then, we can simply set the
+        // name of this controller on the action plus return the action array for usage.
         if ($this->hasGroupStack()) {
             $action['uses'] = $this->prependGroupController($action['uses']);
             $action['uses'] = $this->prependGroupNamespace($action['uses']);

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -515,10 +515,11 @@ class Router implements BindingRegistrar, RegistrarContract
             $action = ['uses' => $action];
         }
 
-        // Here we'll merge any group "uses" statement if necessary so that the action
-        // has the proper clause for this property. Then we can simply set the name
-        // of the controller on the action and return the action array for usage.
+        // Here we'll merge any group "controller" and "uses" statements if necessary so that
+        // the action has the proper clause for this property. Then we can simply set the
+        // name of the controller on the action and return the action array for usage.
         if ($this->hasGroupStack()) {
+            $action['uses'] = $this->prependGroupController($action['uses']);
             $action['uses'] = $this->prependGroupNamespace($action['uses']);
         }
 
@@ -542,6 +543,20 @@ class Router implements BindingRegistrar, RegistrarContract
 
         return isset($group['namespace']) && strpos($class, '\\') !== 0
                 ? $group['namespace'].'\\'.$class : $class;
+    }
+
+    /**
+     * Prepend the last group controller onto the use clause.
+     *
+     * @param  string  $class
+     * @return string
+     */
+    protected function prependGroupController($class)
+    {
+        $group = end($this->groupStack);
+
+        return isset($group['controller']) && strpos($class, '@') === false
+                ? $group['controller'].'@'.$class : $class;
     }
 
     /**

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -372,6 +372,17 @@ class RouteRegistrarTest extends TestCase
         );
     }
 
+    public function testCanOverrideGroupControllerWithClosureSyntax()
+    {
+        $this->router->controller(RouteRegistrarControllerStub::class)->group(function ($router) {
+            $router->get('users', function () {
+                return 'hello world';
+            });
+        });
+
+        $this->seeResponse('hello world', Request::create('users', 'GET'));
+    }
+
     public function testWillUseTheLatestGroupController()
     {
         $this->router->controller(RouteRegistrarControllerStub::class)->group(function ($router) {
@@ -874,7 +885,7 @@ class RouteRegistrarTest extends TestCase
      * Assert that the last route has the given content.
      *
      * @param  string  $content
-     * @param Request $request
+     * @param  Request  $request
      * @return void
      */
     protected function seeResponse($content, Request $request)

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -383,6 +383,18 @@ class RouteRegistrarTest extends TestCase
         $this->seeResponse('hello world', Request::create('users', 'GET'));
     }
 
+    public function testCanOverrideGroupControllerWithInvokableControllerSyntax()
+    {
+        $this->router->controller(RouteRegistrarControllerStub::class)->group(function ($router) {
+            $router->get('users', InvokableRouteRegistrarControllerStub::class);
+        });
+
+        $this->assertSame(
+            InvokableRouteRegistrarControllerStub::class.'@__invoke',
+            $this->getRoute()->getAction()['uses']
+        );
+    }
+
     public function testWillUseTheLatestGroupController()
     {
         $this->router->controller(RouteRegistrarControllerStub::class)->group(function ($router) {
@@ -908,6 +920,14 @@ class RouteRegistrarControllerStub
     public function destroy()
     {
         return 'deleted';
+    }
+}
+
+class InvokableRouteRegistrarControllerStub
+{
+    public function __invoke()
+    {
+        return 'controller';
     }
 }
 

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -885,7 +885,7 @@ class RouteRegistrarTest extends TestCase
      * Assert that the last route has the given content.
      *
      * @param  string  $content
-     * @param  \Illuminate\Http\Request $request $request
+     * @param  \Illuminate\Http\Request  $request
      * @return void
      */
     protected function seeResponse($content, Request $request)

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -885,7 +885,7 @@ class RouteRegistrarTest extends TestCase
      * Assert that the last route has the given content.
      *
      * @param  string  $content
-     * @param  \Illuminate\Http\Request $request  $request
+     * @param  \Illuminate\Http\Request $request $request
      * @return void
      */
     protected function seeResponse($content, Request $request)

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -16,7 +16,7 @@ use Stringable;
 class RouteRegistrarTest extends TestCase
 {
     /**
-     * @var Router
+     * @var \Illuminate\Routing\Router
      */
     protected $router;
 
@@ -796,7 +796,7 @@ class RouteRegistrarTest extends TestCase
         $this->router->resource('users', RouteRegistrarControllerStub::class)
                      ->where($wheres);
 
-        /** @var Route $route */
+        /** @var \Illuminate\Routing\Route $route */
         foreach ($this->router->getRoutes() as $route) {
             $this->assertEquals($wheres, $route->wheres);
         }
@@ -809,7 +809,7 @@ class RouteRegistrarTest extends TestCase
         $this->router->get('/{foo}/{bar}')->whereNumber(['foo', 'bar']);
         $this->router->get('/api/{bar}/{foo}')->whereNumber(['bar', 'foo']);
 
-        /** @var Route $route */
+        /** @var \Illuminate\Routing\Route $route */
         foreach ($this->router->getRoutes() as $route) {
             $this->assertEquals($wheres, $route->wheres);
         }
@@ -822,7 +822,7 @@ class RouteRegistrarTest extends TestCase
         $this->router->get('/{foo}/{bar}')->whereAlpha(['foo', 'bar']);
         $this->router->get('/api/{bar}/{foo}')->whereAlpha(['bar', 'foo']);
 
-        /** @var Route $route */
+        /** @var \Illuminate\Routing\Route $route */
         foreach ($this->router->getRoutes() as $route) {
             $this->assertEquals($wheres, $route->wheres);
         }
@@ -834,7 +834,7 @@ class RouteRegistrarTest extends TestCase
 
         $this->router->get('/{foo}')->whereAlphaNumeric(['1a2b3c']);
 
-        /** @var Route $route */
+        /** @var \Illuminate\Routing\Route $route */
         foreach ($this->router->getRoutes() as $route) {
             $this->assertEquals($wheres, $route->wheres);
         }
@@ -863,7 +863,7 @@ class RouteRegistrarTest extends TestCase
     /**
      * Get the last route registered with the router.
      *
-     * @return Route
+     * @return \Illuminate\Routing\Route
      */
     protected function getRoute()
     {
@@ -885,7 +885,7 @@ class RouteRegistrarTest extends TestCase
      * Assert that the last route has the given content.
      *
      * @param  string  $content
-     * @param  Request  $request
+     * @param  \Illuminate\Http\Request $request  $request
      * @return void
      */
     protected function seeResponse($content, Request $request)


### PR DESCRIPTION
Howdy!

## Motivation

Whilst recently working on an application with a lot of routes, I came across a situation I thought could be solved quite easily. The application has many routes that sit in groups. All routes in each group reference a different method on the same controller.

```php
Route::prefix('placements')->as('placements.')->group(function () {
    Route::get('', [PlacementController::class, 'index'])->name('index');
    Route::get('/bills', [PlacementController::class, 'bills'])->name('bills');
    Route::get('/bills/{bill}/invoice/pdf', [PlacementController::class, 'invoice'])->name('pdf.invoice');
});
```

You can see here that not all methods fit in directly with CRUD. It is common that there is also a `forceDelete` and `download` method in these groups, along with other items.

## Solution

I thought it would be much cleaner to be able to reference the controller just once for each group rather than repeating the same controller class over and over. With this PR, the following syntax is now possible.

```php
 Route::controller(PlacementController::class)->prefix('placements')->as('placements.')->group(function () {
    Route::get('', 'index')->name('index');
    Route::get('/bills', 'bills')->name('bills');
    Route::get('/bills/{bill}/invoice/pdf', 'invoice')->name('pdf.invoice');
});
```

I think this removes a lot of visual load from a DX perspective. It also provides a nice location to group all controller methods together in route files when not using `resource` or `apiResource`.

## Considerations

This can be thought of a fallback; if the user specifies `@`, `array` or `closure` or `invokable` syntax, the router will override the group controller attribute. None of the following examples will use the `PlacementController`.

```php
 Route::controller(PlacementController::class)->prefix('placements')->as('placements.')->group(function () {
    // Overridden by @ syntax
    Route::get('', 'FooController@index')->name('index');

    // Overridden by array syntax
    Route::get('/bills', [FooController::class, 'bills'])->name('bills');

    // Overridden by closure syntax
    Route::get('/bills/{bill}/invoice/pdf', fn () => 'response')->name('pdf.invoice');

    // Overridden by invokable controller syntax
    Route::get('/bills/{bill}/invoice/pdf', FooController::class)->name('pdf.invoice');
});
```

For more thoughts on this, check out the comments on this tweet I put out: https://twitter.com/LukeDowning19/status/1479032102872096771?s=20

Thanks for all the hard work as always. What an awesome community to be a part of 🥳

Kind Regards,
Luke