### PR TITLE
[9.x] Adds implicit `Enum` route binding

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -17,6 +17,7 @@ use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Response;
+use Illuminate\Routing\Exceptions\BackedEnumCaseNotFoundException;
 use Illuminate\Routing\Router;
 use Illuminate\Session\TokenMismatchException;
 use Illuminate\Support\Arr;
@@ -85,6 +86,7 @@ class Handler implements ExceptionHandlerContract
     protected $internalDontReport = [
         AuthenticationException::class,
         AuthorizationException::class,
+        BackedEnumCaseNotFoundException::class,
         HttpException::class,
         HttpResponseException::class,
         ModelNotFoundException::class,
@@ -352,6 +354,7 @@ class Handler implements ExceptionHandlerContract
     protected function prepareException(Throwable $e)
     {
         return match (true) {
+            $e instanceof BackedEnumCaseNotFoundException => new NotFoundHttpException($e->getMessage(), $e),
             $e instanceof ModelNotFoundException => new NotFoundHttpException($e->getMessage(), $e),
             $e instanceof AuthorizationException => new AccessDeniedHttpException($e->getMessage(), $e),
             $e instanceof TokenMismatchException => new HttpException(419, $e->getMessage(), $e),

--- a/src/Illuminate/Routing/Exceptions/BackedEnumCaseNotFoundException.php
+++ b/src/Illuminate/Routing/Exceptions/BackedEnumCaseNotFoundException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Illuminate\Routing\Exceptions;
+
+use RuntimeException;
+
+class BackedEnumCaseNotFoundException extends RuntimeException
+{
+    /**
+     * Create a new exception instance.
+     *
+     * @param  string  $backedEnumClass
+     * @param  string  $case
+     * @return void
+     */
+    public function __construct($backedEnumClass, $case)
+    {
+        parent::__construct("Case [{$case}] not found on Backed Enum [{$backedEnumClass}].");
+    }
+}

--- a/src/Illuminate/Routing/ImplicitRouteBinding.php
+++ b/src/Illuminate/Routing/ImplicitRouteBinding.php
@@ -25,7 +25,7 @@ class ImplicitRouteBinding
     {
         $parameters = $route->parameters();
 
-        $route = static::resolveBackedEnumsForRoute($route);
+        $route = static::resolveBackedEnumsForRoute($route, $parameters);
 
         foreach ($route->signatureParameters(['subClass' => UrlRoutable::class]) as $parameter) {
             if (! $parameterName = static::getParameterName($parameter->getName(), $parameters)) {
@@ -68,11 +68,12 @@ class ImplicitRouteBinding
      * Resolve the Backed Enums route bindings for the route.
      *
      * @param  \Illuminate\Routing\Route  $route
+     * @param  array  $parameters
      * @return \Illuminate\Routing\Route
      *
      * @throws \Illuminate\Routing\Exceptions\BackedEnumCaseNotFoundException
      */
-    protected static function resolveBackedEnumsForRoute($route)
+    protected static function resolveBackedEnumsForRoute($route, $parameters)
     {
         foreach ($route->signatureParameters(['backedEnum' => true]) as $parameter) {
             if (! $parameterName = static::getParameterName($parameter->getName(), $parameters)) {

--- a/src/Illuminate/Routing/ImplicitRouteBinding.php
+++ b/src/Illuminate/Routing/ImplicitRouteBinding.php
@@ -25,23 +25,7 @@ class ImplicitRouteBinding
     {
         $parameters = $route->parameters();
 
-        foreach ($route->signatureParameters(['backedEnum' => true]) as $parameter) {
-            if (! $parameterName = static::getParameterName($parameter->getName(), $parameters)) {
-                continue;
-            }
-
-            $parameterValue = $parameters[$parameterName];
-
-            $backedEnumClass = (string) $parameter->getType();
-
-            $backedEnum = $backedEnumClass::tryFrom((string) $parameterValue);
-
-            if (is_null($backedEnum)) {
-                throw new BackedEnumCaseNotFoundException($backedEnumClass, $parameterValue);
-            }
-
-            $route->setParameter($parameterName, $backedEnum);
-        }
+        $route = static::resolveBackedEnumsForRoute($route);
 
         foreach ($route->signatureParameters(['subClass' => UrlRoutable::class]) as $parameter) {
             if (! $parameterName = static::getParameterName($parameter->getName(), $parameters)) {
@@ -78,6 +62,37 @@ class ImplicitRouteBinding
 
             $route->setParameter($parameterName, $model);
         }
+    }
+
+    /**
+     * Resolve the Backed Enums route bindings for the route.
+     *
+     * @param  \Illuminate\Routing\Route  $route
+     * @return \Illuminate\Routing\Route
+     *
+     * @throws \Illuminate\Routing\Exceptions\BackedEnumCaseNotFoundException
+     */
+    protected static function resolveBackedEnumsForRoute($route)
+    {
+        foreach ($route->signatureParameters(['backedEnum' => true]) as $parameter) {
+            if (! $parameterName = static::getParameterName($parameter->getName(), $parameters)) {
+                continue;
+            }
+
+            $parameterValue = $parameters[$parameterName];
+
+            $backedEnumClass = (string) $parameter->getType();
+
+            $backedEnum = $backedEnumClass::tryFrom((string) $parameterValue);
+
+            if (is_null($backedEnum)) {
+                throw new BackedEnumCaseNotFoundException($backedEnumClass, $parameterValue);
+            }
+
+            $route->setParameter($parameterName, $backedEnum);
+        }
+
+        return $route;
     }
 
     /**

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -505,12 +505,12 @@ class Route
     /**
      * Get the parameters that are listed in the route / controller signature.
      *
-     * @param  string|null  $subClass
+     * @param  array  $conditions
      * @return array
      */
-    public function signatureParameters($subClass = null)
+    public function signatureParameters($conditions)
     {
-        return RouteSignatureParameters::fromAction($this->action, $subClass);
+        return RouteSignatureParameters::fromAction($this->action, $conditions);
     }
 
     /**

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -508,8 +508,12 @@ class Route
      * @param  array  $conditions
      * @return array
      */
-    public function signatureParameters($conditions)
+    public function signatureParameters($conditions = [])
     {
+        if (is_string($conditions)) {
+            $conditions = ['subClass' => $conditions];
+        }
+
         return RouteSignatureParameters::fromAction($this->action, $conditions);
     }
 

--- a/src/Illuminate/Routing/RouteSignatureParameters.php
+++ b/src/Illuminate/Routing/RouteSignatureParameters.php
@@ -16,7 +16,7 @@ class RouteSignatureParameters
      * @param  array  $conditions
      * @return array
      */
-    public static function fromAction(array $action, $conditions = []])
+    public static function fromAction(array $action, $conditions = [])
     {
         $callback = RouteAction::containsSerializedClosure($action)
                         ? unserialize($action['uses'])->getClosure()

--- a/src/Illuminate/Routing/RouteSignatureParameters.php
+++ b/src/Illuminate/Routing/RouteSignatureParameters.php
@@ -28,7 +28,7 @@ class RouteSignatureParameters
 
         return match (true) {
             ! empty($conditions['subClass']) => array_filter($parameters, fn ($p) => Reflector::isParameterSubclassOf($p, $conditions['subClass'])),
-            ! empty($conditions['backedEnum']) => array_filter($parameters, fn ($p) => Reflector::isParameterBackedEnum($p)),
+            ! empty($conditions['backedEnum']) => array_filter($parameters, fn ($p) => Reflector::isParameterBackedEnumWithStringBackingType($p)),
             default => $parameters,
         };
     }

--- a/src/Illuminate/Routing/RouteSignatureParameters.php
+++ b/src/Illuminate/Routing/RouteSignatureParameters.php
@@ -13,10 +13,10 @@ class RouteSignatureParameters
      * Extract the route action's signature parameters.
      *
      * @param  array  $action
-     * @param  string|null  $subClass
+     * @param  array  $conditions
      * @return array
      */
-    public static function fromAction(array $action, $subClass = null)
+    public static function fromAction(array $action, $conditions = []])
     {
         $callback = RouteAction::containsSerializedClosure($action)
                         ? unserialize($action['uses'])->getClosure()
@@ -26,9 +26,11 @@ class RouteSignatureParameters
                         ? static::fromClassMethodString($callback)
                         : (new ReflectionFunction($callback))->getParameters();
 
-        return is_null($subClass) ? $parameters : array_filter($parameters, function ($p) use ($subClass) {
-            return Reflector::isParameterSubclassOf($p, $subClass);
-        });
+        return match (true) {
+            ! empty($conditions['subClass']) => array_filter($parameters, fn ($p) => Reflector::isParameterSubclassOf($p, $conditions['subClass'])),
+            ! empty($conditions['backedEnum']) => array_filter($parameters, fn ($p) => Reflector::isParameterBackedEnum($p)),
+            default => $parameters,
+        };
     }
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -818,6 +818,7 @@ class Router implements BindingRegistrar, RegistrarContract
      * @return \Illuminate\Routing\Route
      *
      * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
+     * @throws \Illuminate\Routing\Exceptions\BackedEnumCaseNotFoundException
      */
     public function substituteBindings($route)
     {
@@ -831,12 +832,13 @@ class Router implements BindingRegistrar, RegistrarContract
     }
 
     /**
-     * Substitute the implicit Eloquent model bindings for the route.
+     * Substitute the implicit route bindings for the given route.
      *
      * @param  \Illuminate\Routing\Route  $route
      * @return void
      *
      * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
+     * @throws \Illuminate\Routing\Exceptions\BackedEnumCaseNotFoundException
      */
     public function substituteImplicitBindings($route)
     {

--- a/src/Illuminate/Support/Reflector.php
+++ b/src/Illuminate/Support/Reflector.php
@@ -142,7 +142,7 @@ class Reflector
     }
 
     /**
-     * Determine if the parameter's type is a Backed Enum.
+     * Determine if the parameter's type is a Backed Enum with a string backing type.
      *
      * @param  \ReflectionParameter  $parameter
      * @return bool

--- a/src/Illuminate/Support/Reflector.php
+++ b/src/Illuminate/Support/Reflector.php
@@ -151,8 +151,13 @@ class Reflector
     {
         $backedEnumClass = (string) $parameter->getType();
 
-        return function_exists('enum_exists')
-            && enum_exists($backedEnumClass)
-            && (new ReflectionEnum($backedEnumClass))->isBacked();
+        if (function_exists('enum_exists') && enum_exists($backedEnumClass)) {
+            $reflectionBackedEnum = new ReflectionEnum($backedEnumClass);
+
+            return $reflectionBackedEnum->isBacked()
+                && $reflectionBackedEnum->getBackingType()->getName() == 'string';
+        }
+
+        return false;
     }
 }

--- a/src/Illuminate/Support/Reflector.php
+++ b/src/Illuminate/Support/Reflector.php
@@ -147,7 +147,7 @@ class Reflector
      * @param  \ReflectionParameter  $parameter
      * @return bool
      */
-    public static function isParameterBackedEnum($parameter)
+    public static function isParameterBackedEnumWithStringBackingType($parameter)
     {
         $backedEnumClass = (string) $parameter->getType();
 

--- a/src/Illuminate/Support/Reflector.php
+++ b/src/Illuminate/Support/Reflector.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Support;
 
 use ReflectionClass;
+use ReflectionEnum;
 use ReflectionMethod;
 use ReflectionNamedType;
 use ReflectionUnionType;
@@ -138,5 +139,20 @@ class Reflector
         return $paramClassName
             && class_exists($paramClassName)
             && (new ReflectionClass($paramClassName))->isSubclassOf($className);
+    }
+
+    /**
+     * Determine if the parameter's type is a Backed Enum.
+     *
+     * @param  \ReflectionParameter  $parameter
+     * @return bool
+     */
+    public static function isParameterBackedEnum($parameter)
+    {
+        $backedEnumClass = (string) $parameter->getType();
+
+        return function_exists('enum_exists')
+            && enum_exists($backedEnumClass)
+            && (new ReflectionEnum($backedEnumClass))->isBacked();
     }
 }

--- a/tests/Integration/Routing/Enums.php
+++ b/tests/Integration/Routing/Enums.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Routing;
+
+enum CategoryBackedEnum: string
+{
+    case People = 'people';
+    case Fruits = 'fruits';
+}

--- a/tests/Integration/Routing/ImplicitBackedEnumRouteBindingTest.php
+++ b/tests/Integration/Routing/ImplicitBackedEnumRouteBindingTest.php
@@ -5,10 +5,14 @@ namespace Illuminate\Tests\Integration\Routing;
 use Illuminate\Support\Facades\Route;
 use Orchestra\Testbench\TestCase;
 
+if (PHP_VERSION_ID >= 80100) {
+    include 'Enums.php';
+}
+
 /**
  * @requires PHP 8.1
  */
-class ImplicitEnumRouteBindingTest extends TestCase
+class ImplicitBackedEnumRouteBindingTest extends TestCase
 {
     public function testWithRouteCachingEnabled()
     {
@@ -49,10 +53,4 @@ PHP);
         $response = $this->post('/categories/cars');
         $response->assertNotFound(404);
     }
-}
-
-enum CategoryBackedEnum: string
-{
-    case People = 'people';
-    case Fruits = 'fruits';
 }

--- a/tests/Integration/Routing/ImplicitEnumRouteBindingTest.php
+++ b/tests/Integration/Routing/ImplicitEnumRouteBindingTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Routing;
+
+use Illuminate\Support\Facades\Route;
+use Orchestra\Testbench\TestCase;
+
+/**
+ * @requires PHP 8.1
+ */
+class ImplicitEnumRouteBindingTest extends TestCase
+{
+    public function testWithRouteCachingEnabled()
+    {
+        $this->defineCacheRoutes(<<<PHP
+<?php
+
+use Illuminate\Tests\Integration\Routing\CategoryBackedEnum;
+
+Route::get('/categories/{category}', function (CategoryBackedEnum \$category) {
+    return \$category->value;
+})->middleware('web');
+PHP);
+
+        $response = $this->get('/categories/fruits');
+        $response->assertSee('fruits');
+
+        $response = $this->get('/categories/people');
+        $response->assertSee('people');
+
+        $response = $this->get('/categories/cars');
+        $response->assertNotFound(404);
+    }
+
+    public function testWithoutRouteCachingEnabled()
+    {
+        config(['app.key' => str_repeat('a', 32)]);
+
+        Route::post('/categories/{category}', function (CategoryBackedEnum $category) {
+            return $category->value;
+        })->middleware(['web']);
+
+        $response = $this->post('/categories/fruits');
+        $response->assertSee('fruits');
+
+        $response = $this->post('/categories/people');
+        $response->assertSee('people');
+
+        $response = $this->post('/categories/cars');
+        $response->assertNotFound(404);
+    }
+}
+
+enum CategoryBackedEnum: string
+{
+    case People = 'people';
+    case Fruits = 'fruits';
+}

--- a/tests/Integration/Routing/ImplicitModelRouteBindingTest.php
+++ b/tests/Integration/Routing/ImplicitModelRouteBindingTest.php
@@ -10,7 +10,7 @@ use Illuminate\Support\Facades\Schema;
 use Orchestra\Testbench\Concerns\InteractsWithPublishedFiles;
 use Orchestra\Testbench\TestCase;
 
-class ImplicitRouteBindingTest extends TestCase
+class ImplicitModelRouteBindingTest extends TestCase
 {
     use InteractsWithPublishedFiles;
 

--- a/tests/Routing/Enums.php
+++ b/tests/Routing/Enums.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Illuminate\Tests\Routing;
+
+enum CategoryEnum
+{
+    case People;
+    case Fruits;
+}
+
+enum CategoryBackedEnum: string
+{
+    case People = 'people';
+    case Fruits = 'fruits';
+}

--- a/tests/Routing/ImplicitRouteBindingTest.php
+++ b/tests/Routing/ImplicitRouteBindingTest.php
@@ -4,13 +4,74 @@ namespace Illuminate\Tests\Routing;
 
 use Illuminate\Container\Container;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Routing\Exceptions\BackedEnumCaseNotFoundException;
 use Illuminate\Routing\ImplicitRouteBinding;
 use Illuminate\Routing\Route;
 use PHPUnit\Framework\TestCase;
 
 class ImplicitRouteBindingTest extends TestCase
 {
-    public function test_it_can_resolve_the_implicit_route_bindings_for_the_given_route()
+    public function test_it_can_resolve_the_implicit_backed_enum_route_bindings_for_the_given_route()
+    {
+        $action = ['uses' => function (CategoryBackedEnum $category) {
+            return $category->value;
+        }];
+
+        $route = new Route('GET', '/test', $action);
+        $route->parameters = ['category' => 'fruits'];
+
+        $route->prepareForSerialization();
+
+        $container = Container::getInstance();
+
+        ImplicitRouteBinding::resolveForRoute($container, $route);
+
+        $this->assertSame('fruits', $route->parameter('category')->value);
+    }
+
+    public function test_it_does_not_resolve_implicit_non_backed_enum_route_bindings_for_the_given_route()
+    {
+        $action = ['uses' => function (CategoryEnum $category) {
+            return $category->value;
+        }];
+
+        $route = new Route('GET', '/test', $action);
+        $route->parameters = ['category' => 'fruits'];
+
+        $route->prepareForSerialization();
+
+        $container = Container::getInstance();
+
+        ImplicitRouteBinding::resolveForRoute($container, $route);
+
+        $this->assertIsString($route->parameter('category'));
+        $this->assertSame('fruits', $route->parameter('category'));
+    }
+
+    public function test_implicit_backed_enum_internal_exception()
+    {
+        $action = ['uses' => function (CategoryBackedEnum $category) {
+            return $category->value;
+        }];
+
+        $route = new Route('GET', '/test', $action);
+        $route->parameters = ['category' => 'cars'];
+
+        $route->prepareForSerialization();
+
+        $container = Container::getInstance();
+
+        $this->expectException(BackedEnumCaseNotFoundException::class);
+        $this->expectExceptionMessage(sprintf(
+            'Case [%s] not found on Backed Enum [%s].',
+            'cars',
+            CategoryBackedEnum::class,
+        ));
+
+        ImplicitRouteBinding::resolveForRoute($container, $route);
+    }
+
+    public function test_it_can_resolve_the_implicit_model_route_bindings_for_the_given_route()
     {
         $this->expectNotToPerformAssertions();
 
@@ -32,4 +93,16 @@ class ImplicitRouteBindingTest extends TestCase
 class ImplicitRouteBindingUser extends Model
 {
     //
+}
+
+enum CategoryEnum
+{
+    case People;
+    case Fruits;
+}
+
+enum CategoryBackedEnum: string
+{
+    case People = 'people';
+    case Fruits = 'fruits';
 }

--- a/tests/Routing/ImplicitRouteBindingTest.php
+++ b/tests/Routing/ImplicitRouteBindingTest.php
@@ -9,8 +9,15 @@ use Illuminate\Routing\ImplicitRouteBinding;
 use Illuminate\Routing\Route;
 use PHPUnit\Framework\TestCase;
 
+if (PHP_VERSION_ID >= 80100) {
+    include 'Enums.php';
+}
+
 class ImplicitRouteBindingTest extends TestCase
 {
+    /**
+     * @requires PHP 8.1
+     */
     public function test_it_can_resolve_the_implicit_backed_enum_route_bindings_for_the_given_route()
     {
         $action = ['uses' => function (CategoryBackedEnum $category) {
@@ -29,6 +36,9 @@ class ImplicitRouteBindingTest extends TestCase
         $this->assertSame('fruits', $route->parameter('category')->value);
     }
 
+    /**
+     * @requires PHP 8.1
+     */
     public function test_it_does_not_resolve_implicit_non_backed_enum_route_bindings_for_the_given_route()
     {
         $action = ['uses' => function (CategoryEnum $category) {
@@ -48,6 +58,9 @@ class ImplicitRouteBindingTest extends TestCase
         $this->assertSame('fruits', $route->parameter('category'));
     }
 
+    /**
+     * @requires PHP 8.1
+     */
     public function test_implicit_backed_enum_internal_exception()
     {
         $action = ['uses' => function (CategoryBackedEnum $category) {
@@ -93,16 +106,4 @@ class ImplicitRouteBindingTest extends TestCase
 class ImplicitRouteBindingUser extends Model
 {
     //
-}
-
-enum CategoryEnum
-{
-    case People;
-    case Fruits;
-}
-
-enum CategoryBackedEnum: string
-{
-    case People = 'people';
-    case Fruits = 'fruits';
 }


### PR DESCRIPTION
This pull request introduces implicit `Enum` route binding for Laravel v9.x. So let's see an example:

```php
// Assuming the following `Enum`
enum Category: string
{
    case Fruits = 'fruits';
    case People = 'people';
}

// And assuming the following route;
Route::get('/categories/{category}', function (Category $category) {
    return $category->value;
});

// GET `/categories/fruits` returns `fruits`...
// GET `/categories/people` returns `people`...
// GET `/categories/cars` returns `404 Not Found`...
```

In other words, when the given argument matches one of the `Enum` cases, the code in this pull request will resolve the associated `Enum` for the route method / closure. Otherwise, will respond `404 Not Found`, similar to Model route binding.

```php
Route::get('/categories/{category}', function (Category $category) {
    dd($category);

    // ^ Illuminate\Tests\Integration\Routing\Category^ {#1220
    //  +name: "Fruits"
    //  +value: "fruits"
    // }
});
```

Now, it's important to keep in mind, that the given `Enum` needs to be a [Backed Enum](https://www.php.net/manual/en/language.enumerations.backed.php) with a `string` backing type. Meaning that, the `Enum` header needs to look like this:

```php
enum {{ EnumName }}: string
```