### PR TITLE
[8.x] Add phpredis serialization and compression config support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,9 +49,12 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, gd, redis, memcached
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, gd, redis-phpredis/phpredis@5.3.5, igbinary, msgpack, lzf, zstd, lz4, memcached
           tools: composer:v2
           coverage: none
+        env:
+          REDIS_CONFIGURE_OPTS: --enable-redis --enable-redis-igbinary --enable-redis-msgpack --enable-redis-lzf --with-liblzf --enable-redis-zstd --with-libzstd --enable-redis-lz4 --with-liblz4
+          REDIS_LIBS: liblz4-dev, liblzf-dev, libzstd-dev
 
       - name: Set Minimum PHP 8.0 Versions
         uses: nick-invision/retry@v1

--- a/src/Illuminate/Cache/PhpRedisLock.php
+++ b/src/Illuminate/Cache/PhpRedisLock.php
@@ -7,13 +7,6 @@ use Illuminate\Redis\Connections\PhpRedisConnection;
 class PhpRedisLock extends RedisLock
 {
     /**
-     * The phpredis factory implementation.
-     *
-     * @var \Illuminate\Redis\Connections\PhpredisConnection
-     */
-    protected $redis;
-
-    /**
      * Create a new phpredis lock instance.
      *
      * @param  \Illuminate\Redis\Connections\PhpRedisConnection  $redis
@@ -38,72 +31,5 @@ class PhpRedisLock extends RedisLock
             $this->name,
             ...$this->redis->pack([$this->owner])
         );
-    }
-
-    /**
-     * Get the owner key, serialized and compressed.
-     *
-     * @return string
-     *
-     * @throws \UnexpectedValueException
-     *
-     * @deprecated Will be removed in a later laravel version. Use PhpRedisConnection::pack.
-     * @see \Illuminate\Redis\Connections\PhpRedisConnection::pack
-     */
-    protected function serializedAndCompressedOwner(): string
-    {
-        return $this->redis->pack([$this->owner])[0];
-    }
-
-    /**
-     * Determine if compression is enabled.
-     *
-     * @return bool
-     *
-     * @deprecated Will be removed in a later laravel version. Use PhpRedisConnection::compressed.
-     * @see \Illuminate\Redis\Connections\PhpRedisConnection::compressed
-     */
-    protected function compressed(): bool
-    {
-        return $this->redis->compressed();
-    }
-
-    /**
-     * Determine if LZF compression is enabled.
-     *
-     * @return bool
-     *
-     * @deprecated Will be removed in a later laravel version. Use PhpRedisConnection::lzfCompressed.
-     * @see \Illuminate\Redis\Connections\PhpRedisConnection::lzfCompressed
-     */
-    protected function lzfCompressed(): bool
-    {
-        return $this->redis->lzfCompressed();
-    }
-
-    /**
-     * Determine if ZSTD compression is enabled.
-     *
-     * @return bool
-     *
-     * @deprecated Will be removed in a later laravel version. Use PhpRedisConnection::zstdCompressed.
-     * @see \Illuminate\Redis\Connections\PhpRedisConnection::zstdCompressed
-     */
-    protected function zstdCompressed(): bool
-    {
-        return $this->redis->zstdCompressed();
-    }
-
-    /**
-     * Determine if LZ4 compression is enabled.
-     *
-     * @return bool
-     *
-     * @deprecated Will be removed in a later laravel version. Use PhpRedisConnection::lz4Compressed.
-     * @see \Illuminate\Redis\Connections\PhpRedisConnection::lz4Compressed
-     */
-    protected function lz4Compressed(): bool
-    {
-        return $this->redis->lz4Compressed();
     }
 }

--- a/src/Illuminate/Redis/Connections/PacksPhpRedisValues.php
+++ b/src/Illuminate/Redis/Connections/PacksPhpRedisValues.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace Illuminate\Redis\Connections;
+
+use Redis;
+use RuntimeException;
+use UnexpectedValueException;
+
+trait PacksPhpRedisValues
+{
+    /**
+     * Indicates if Redis supports packing.
+     *
+     * @var bool|null
+     */
+    protected $supportsPacking;
+
+    /**
+     * Indicates if Redis supports LZF compression.
+     *
+     * @var bool|null
+     */
+    protected $supportsLzf;
+
+    /**
+     * Indicates if Redis supports Zstd compression.
+     *
+     * @var bool|null
+     */
+    protected $supportsZstd;
+
+    /**
+     * Prepares the given values to be used with the `eval` command, including serialization and compression.
+     *
+     * @param  array<int|string,string>  $values
+     * @return array<int|string,string>
+     */
+    public function pack(array $values): array
+    {
+        if (empty($values)) {
+            return $values;
+        }
+
+        if ($this->supportsPacking()) {
+            return array_map([$this->client, '_pack'], $values);
+        }
+
+        if ($this->compressed()) {
+            if ($this->supportsLzf() && $this->lzfCompressed()) {
+                if (! function_exists('lzf_compress')) {
+                    throw new RuntimeException("'lzf' extension required to call 'lzf_compress'.");
+                }
+
+                $processor = function ($value) {
+                    return \lzf_compress($this->client->_serialize($value));
+                };
+            } elseif ($this->supportsZstd() && $this->zstdCompressed()) {
+                if (! function_exists('zstd_compress')) {
+                    throw new RuntimeException("'zstd' extension required to call 'zstd_compress'.");
+                }
+
+                $compressionLevel = $this->client->getOption(Redis::OPT_COMPRESSION_LEVEL);
+
+                $processor = function ($value) use ($compressionLevel) {
+                    return \zstd_compress(
+                        $this->client->_serialize($value),
+                        $compressionLevel === 0 ? Redis::COMPRESSION_ZSTD_DEFAULT : $compressionLevel
+                    );
+                };
+            } else {
+                throw new UnexpectedValueException(sprintf(
+                    'Unsupported phpredis compression in use [%d].',
+                    $this->client->getOption(Redis::OPT_COMPRESSION)
+                ));
+            }
+        } else {
+            $processor = function ($value) {
+                return $this->client->_serialize($value);
+            };
+        }
+
+        return array_map($processor, $values);
+    }
+
+    /**
+     * Determine if compression is enabled.
+     *
+     * @return bool
+     */
+    public function compressed(): bool
+    {
+        return defined('Redis::OPT_COMPRESSION') &&
+               $this->client->getOption(Redis::OPT_COMPRESSION) !== Redis::COMPRESSION_NONE;
+    }
+
+    /**
+     * Determine if LZF compression is enabled.
+     *
+     * @return bool
+     */
+    public function lzfCompressed(): bool
+    {
+        return defined('Redis::COMPRESSION_LZF') &&
+               $this->client->getOption(Redis::OPT_COMPRESSION) === Redis::COMPRESSION_LZF;
+    }
+
+    /**
+     * Determine if ZSTD compression is enabled.
+     *
+     * @return bool
+     */
+    public function zstdCompressed(): bool
+    {
+        return defined('Redis::COMPRESSION_ZSTD') &&
+               $this->client->getOption(Redis::OPT_COMPRESSION) === Redis::COMPRESSION_ZSTD;
+    }
+
+    /**
+     * Determine if LZ4 compression is enabled.
+     *
+     * @return bool
+     */
+    public function lz4Compressed(): bool
+    {
+        return defined('Redis::COMPRESSION_LZ4') &&
+               $this->client->getOption(Redis::OPT_COMPRESSION) === Redis::COMPRESSION_LZ4;
+    }
+
+    /**
+     * Determine if the current PhpRedis extension version supports packing.
+     *
+     * @return bool
+     */
+    protected function supportsPacking(): bool
+    {
+        if ($this->supportsPacking === null) {
+            $this->supportsPacking = $this->phpRedisVersionAtLeast('5.3.5');
+        }
+
+        return $this->supportsPacking;
+    }
+
+    /**
+     * Determine if the current PhpRedis extension version supports LZF compression.
+     *
+     * @return bool
+     */
+    protected function supportsLzf(): bool
+    {
+        if ($this->supportsLzf === null) {
+            $this->supportsLzf = $this->phpRedisVersionAtLeast('4.3.0');
+        }
+
+        return $this->supportsLzf;
+    }
+
+    /**
+     * Determine if the current PhpRedis extension version supports Zstd compression.
+     *
+     * @return bool
+     */
+    protected function supportsZstd(): bool
+    {
+        if ($this->supportsZstd === null) {
+            $this->supportsZstd = $this->phpRedisVersionAtLeast('5.1.0');
+        }
+
+        return $this->supportsZstd;
+    }
+
+    /**
+     * Determine if the PhpRedis extension version is at least the given version.
+     *
+     * @param  string  $version
+     * @return bool
+     */
+    protected function phpRedisVersionAtLeast(string $version): bool
+    {
+        $phpredisVersion = phpversion('redis');
+
+        return $phpredisVersion !== false && version_compare($phpredisVersion, $version, '>=');
+    }
+}

--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -9,6 +9,8 @@ use Illuminate\Support\Str;
 use Redis;
 use RedisCluster;
 use RedisException;
+use RuntimeException;
+use UnexpectedValueException;
 
 /**
  * @mixin \Redis
@@ -28,6 +30,27 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      * @var array
      */
     protected $config;
+
+    /**
+     * In memory cache of version check whether phpredis supports packing.
+     *
+     * @var bool|null
+     */
+    private $supportsPack = null;
+
+    /**
+     * In memory cache of version check whether phpredis supports lzf compression.
+     *
+     * @var bool|null
+     */
+    private $supportsLzf = null;
+
+    /**
+     * In memory cache of version check whether phpredis supports zstd compression.
+     *
+     * @var bool|null
+     */
+    private $supportsZstd = null;
 
     /**
      * Create a new PhpRedis connection.
@@ -572,5 +595,139 @@ class PhpRedisConnection extends Connection implements ConnectionContract
     public function __call($method, $parameters)
     {
         return parent::__call(strtolower($method), $parameters);
+    }
+
+    /**
+     * Prepares values to be used with e.g. the `eval` command, because the
+     * phpredis extension does not do it for us. This includes serialization and
+     * compression if any of those settings are configured.
+     *
+     * @param  array<int|string,string>  $values
+     * @return array<int|string,string>
+     */
+    public function pack(array $values): array
+    {
+        if (empty($values)) {
+            return $values;
+        }
+
+        if ($this->supportsPack()) {
+            return array_map([$this->client, '_pack'], $values);
+        }
+
+        if ($this->compressed()) {
+            if ($this->supportsLzf() && $this->lzfCompressed()) {
+                if (! function_exists('lzf_compress')) {
+                    throw new RuntimeException("Missing 'lzf' extension to call 'lzf_compress'.");
+                }
+
+                $processor = function ($value) {
+                    return \lzf_compress($this->client->_serialize($value));
+                };
+            } elseif ($this->supportsZstd() && $this->zstdCompressed()) {
+                if (! function_exists('zstd_compress')) {
+                    throw new RuntimeException("Missing 'zstd' extension to call 'zstd_compress'.");
+                }
+
+                $compressionLevel = $this->client->getOption(Redis::OPT_COMPRESSION_LEVEL);
+                $processor = function ($value) use ($compressionLevel) {
+                    return \zstd_compress(
+                        $this->client->_serialize($value),
+                        $compressionLevel === 0 ? Redis::COMPRESSION_ZSTD_DEFAULT : $compressionLevel
+                    );
+                };
+            } else {
+                throw new UnexpectedValueException(sprintf(
+                    'Not supported phpredis compression in use [%d].',
+                    $this->client->getOption(Redis::OPT_COMPRESSION)
+                ));
+            }
+        } else {
+            $processor = function ($value) {
+                return $this->client->_serialize($value);
+            };
+        }
+
+        return array_map($processor, $values);
+    }
+
+    /**
+     * Determine if compression is enabled.
+     *
+     * @return bool
+     */
+    public function compressed(): bool
+    {
+        return defined('Redis::OPT_COMPRESSION') &&
+               $this->client->getOption(Redis::OPT_COMPRESSION) !== Redis::COMPRESSION_NONE;
+    }
+
+    /**
+     * Determine if LZF compression is enabled.
+     *
+     * @return bool
+     */
+    public function lzfCompressed(): bool
+    {
+        return defined('Redis::COMPRESSION_LZF') &&
+               $this->client->getOption(Redis::OPT_COMPRESSION) === Redis::COMPRESSION_LZF;
+    }
+
+    /**
+     * Determine if ZSTD compression is enabled.
+     *
+     * @return bool
+     */
+    public function zstdCompressed(): bool
+    {
+        return defined('Redis::COMPRESSION_ZSTD') &&
+               $this->client->getOption(Redis::OPT_COMPRESSION) === Redis::COMPRESSION_ZSTD;
+    }
+
+    /**
+     * Determine if LZ4 compression is enabled.
+     *
+     * @return bool
+     */
+    public function lz4Compressed(): bool
+    {
+        return defined('Redis::COMPRESSION_LZ4') &&
+               $this->client->getOption(Redis::OPT_COMPRESSION) === Redis::COMPRESSION_LZ4;
+    }
+
+    private function supportsPack(): bool
+    {
+        if ($this->supportsPack === null) {
+            $phpredisVersion = phpversion('redis');
+
+            $this->supportsPack =
+                ($phpredisVersion !== false && version_compare($phpredisVersion, '5.3.5', '>='));
+        }
+
+        return $this->supportsPack;
+    }
+
+    private function supportsLzf(): bool
+    {
+        if ($this->supportsLzf === null) {
+            $phpredisVersion = phpversion('redis');
+
+            $this->supportsLzf =
+                ($phpredisVersion !== false && version_compare($phpredisVersion, '4.3.0', '>='));
+        }
+
+        return $this->supportsLzf;
+    }
+
+    private function supportsZstd(): bool
+    {
+        if ($this->supportsZstd === null) {
+            $phpredisVersion = phpversion('redis');
+
+            $this->supportsZstd =
+                ($phpredisVersion !== false && version_compare($phpredisVersion, '5.1.0', '>='));
+        }
+
+        return $this->supportsZstd;
     }
 }

--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -106,6 +106,18 @@ class PhpRedisConnector implements Connector
             if (! empty($config['name'])) {
                 $client->client('SETNAME', $config['name']);
             }
+
+            if (array_key_exists('serializer', $config)) {
+                $client->setOption(Redis::OPT_SERIALIZER, $config['serializer']);
+            }
+
+            if (array_key_exists('compression', $config)) {
+                $client->setOption(Redis::OPT_COMPRESSION, $config['compression']);
+            }
+
+            if (array_key_exists('compression_level', $config)) {
+                $client->setOption(Redis::OPT_COMPRESSION_LEVEL, $config['compression_level']);
+            }
         });
     }
 
@@ -183,6 +195,18 @@ class PhpRedisConnector implements Connector
 
             if (! empty($options['name'])) {
                 $client->client('SETNAME', $options['name']);
+            }
+
+            if (array_key_exists('serializer', $options)) {
+                $client->setOption(RedisCluster::OPT_SERIALIZER, $options['serializer']);
+            }
+
+            if (array_key_exists('compression', $options)) {
+                $client->setOption(RedisCluster::OPT_COMPRESSION, $options['compression']);
+            }
+
+            if (array_key_exists('compression_level', $options)) {
+                $client->setOption(RedisCluster::OPT_COMPRESSION_LEVEL, $options['compression_level']);
             }
         });
     }

--- a/tests/Integration/Cache/PhpRedisCacheLockTest.php
+++ b/tests/Integration/Cache/PhpRedisCacheLockTest.php
@@ -224,11 +224,6 @@ class PhpRedisCacheLockTest extends TestCase
             $this->markTestSkipped('Redis extension is not configured to support the lz4 compression.');
         }
 
-        $this->markTestIncomplete(
-            'phpredis extension does not compress consistently with the php '.
-            'extension lz4. See: https://github.com/phpredis/phpredis/issues/1939'
-        );
-
         $this->app['config']->set('database.redis.client', 'phpredis');
         $this->app['config']->set('cache.stores.redis.connection', 'default');
         $this->app['config']->set('cache.stores.redis.lock_connection', 'default');

--- a/tests/Redis/RedisConnectionTest.php
+++ b/tests/Redis/RedisConnectionTest.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
 use Illuminate\Redis\Connections\Connection;
+use Illuminate\Redis\Connections\PhpRedisConnection;
 use Illuminate\Redis\RedisManager;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -469,7 +470,13 @@ class RedisConnectionTest extends TestCase
     public function testItRunsEval()
     {
         foreach ($this->connections() as $redis) {
-            $redis->eval('redis.call("set", KEYS[1], ARGV[1])', 1, 'name', 'mohamed');
+            if ($redis instanceof PhpRedisConnection) {
+                // User must decide what needs to be serialized and compressed.
+                $redis->eval('redis.call("set", KEYS[1], ARGV[1])', 1, 'name', ...$redis->pack(['mohamed']));
+            } else {
+                $redis->eval('redis.call("set", KEYS[1], ARGV[1])', 1, 'name', 'mohamed');
+            }
+
             $this->assertSame('mohamed', $redis->get('name'));
 
             $redis->flushall();
@@ -777,7 +784,7 @@ class RedisConnectionTest extends TestCase
         $host = env('REDIS_HOST', '127.0.0.1');
         $port = env('REDIS_PORT', 6379);
 
-        $prefixedPhpredis = new RedisManager(new Application, 'phpredis', [
+        $connections[] = (new RedisManager(new Application, 'phpredis', [
             'cluster' => false,
             'default' => [
                 'url' => "redis://user@$host:$port",
@@ -787,9 +794,9 @@ class RedisConnectionTest extends TestCase
                 'options' => ['prefix' => 'laravel:'],
                 'timeout' => 0.5,
             ],
-        ]);
+        ]))->connection();
 
-        $persistentPhpRedis = new RedisManager(new Application, 'phpredis', [
+        $connections['persistent'] = (new RedisManager(new Application, 'phpredis', [
             'cluster' => false,
             'default' => [
                 'host' => $host,
@@ -800,9 +807,9 @@ class RedisConnectionTest extends TestCase
                 'persistent' => true,
                 'persistent_id' => 'laravel',
             ],
-        ]);
+        ]))->connection();
 
-        $serializerPhpRedis = new RedisManager(new Application, 'phpredis', [
+        $connections[] = (new RedisManager(new Application, 'phpredis', [
             'cluster' => false,
             'default' => [
                 'host' => $host,
@@ -811,9 +818,9 @@ class RedisConnectionTest extends TestCase
                 'options' => ['serializer' => Redis::SERIALIZER_JSON],
                 'timeout' => 0.5,
             ],
-        ]);
+        ]))->connection();
 
-        $scanRetryPhpRedis = new RedisManager(new Application, 'phpredis', [
+        $connections[] = (new RedisManager(new Application, 'phpredis', [
             'cluster' => false,
             'default' => [
                 'host' => $host,
@@ -822,12 +829,145 @@ class RedisConnectionTest extends TestCase
                 'options' => ['scan' => Redis::SCAN_RETRY],
                 'timeout' => 0.5,
             ],
-        ]);
+        ]))->connection();
 
-        $connections[] = $prefixedPhpredis->connection();
-        $connections[] = $serializerPhpRedis->connection();
-        $connections[] = $scanRetryPhpRedis->connection();
-        $connections['persistent'] = $persistentPhpRedis->connection();
+        if (defined('Redis::COMPRESSION_LZF')) {
+            $connections['compression_lzf'] = (new RedisManager(new Application, 'phpredis', [
+                'cluster' => false,
+                'default' => [
+                    'host' => $host,
+                    'port' => $port,
+                    'database' => 9,
+                    'options' => [
+                        'compression' => Redis::COMPRESSION_LZF,
+                        'name' => 'compression_lzf',
+                    ],
+                    'timeout' => 0.5,
+                ],
+            ]))->connection();
+        }
+
+        if (defined('Redis::COMPRESSION_ZSTD')) {
+            $connections['compression_zstd'] = (new RedisManager(new Application, 'phpredis', [
+                'cluster' => false,
+                'default' => [
+                    'host' => $host,
+                    'port' => $port,
+                    'database' => 10,
+                    'options' => [
+                        'compression' => Redis::COMPRESSION_ZSTD,
+                        'name' => 'compression_zstd',
+                    ],
+                    'timeout' => 0.5,
+                ],
+            ]))->connection();
+
+            $connections['compression_zstd_default'] = (new RedisManager(new Application, 'phpredis', [
+                'cluster' => false,
+                'default' => [
+                    'host' => $host,
+                    'port' => $port,
+                    'database' => 11,
+                    'options' => [
+                        'compression' => Redis::COMPRESSION_ZSTD,
+                        'compression_level' => Redis::COMPRESSION_ZSTD_DEFAULT,
+                        'name' => 'compression_zstd_default',
+                    ],
+                    'timeout' => 0.5,
+                ],
+            ]))->connection();
+
+            $connections['compression_zstd_min'] = (new RedisManager(new Application, 'phpredis', [
+                'cluster' => false,
+                'default' => [
+                    'host' => $host,
+                    'port' => $port,
+                    'database' => 12,
+                    'options' => [
+                        'compression' => Redis::COMPRESSION_ZSTD,
+                        'compression_level' => Redis::COMPRESSION_ZSTD_MIN,
+                        'name' => 'compression_zstd_min',
+                    ],
+                    'timeout' => 0.5,
+                ],
+            ]))->connection();
+
+            $connections['compression_zstd_max'] = (new RedisManager(new Application, 'phpredis', [
+                'cluster' => false,
+                'default' => [
+                    'host' => $host,
+                    'port' => $port,
+                    'database' => 13,
+                    'options' => [
+                        'compression' => Redis::COMPRESSION_ZSTD,
+                        'compression_level' => Redis::COMPRESSION_ZSTD_MAX,
+                        'name' => 'compression_zstd_max',
+                    ],
+                    'timeout' => 0.5,
+                ],
+            ]))->connection();
+        }
+
+        if (defined('Redis::COMPRESSION_LZ4')) {
+            $connections['compression_lz4'] = (new RedisManager(new Application, 'phpredis', [
+                'cluster' => false,
+                'default' => [
+                    'host' => $host,
+                    'port' => $port,
+                    'database' => 14,
+                    'options' => [
+                        'compression' => Redis::COMPRESSION_LZ4,
+                        'name' => 'compression_lz4',
+                    ],
+                    'timeout' => 0.5,
+                ],
+            ]))->connection();
+
+            $connections['compression_lz4_default'] = (new RedisManager(new Application, 'phpredis', [
+                'cluster' => false,
+                'default' => [
+                    'host' => $host,
+                    'port' => $port,
+                    'database' => 15,
+                    'options' => [
+                        'compression' => Redis::COMPRESSION_LZ4,
+                        'compression_level' => 0,
+                        'name' => 'compression_lz4_default',
+                    ],
+                    'timeout' => 0.5,
+                ],
+            ]))->connection();
+
+            $connections['compression_lz4_min'] = (new RedisManager(new Application, 'phpredis', [
+                'cluster' => false,
+                'default' => [
+                    'host' => $host,
+                    'port' => $port,
+                    'database' => 16,
+                    'options' => [
+                        'compression' => Redis::COMPRESSION_LZ4,
+                        'compression_level' => 1,
+                        'name' => 'compression_lz4_min',
+                    ],
+                    'timeout' => 0.5,
+                ],
+            ]))->connection();
+
+            $connections['compression_lz4_max'] = (new RedisManager(new Application, 'phpredis', [
+                'cluster' => false,
+                'default' => [
+                    'host' => $host,
+                    'port' => $port,
+                    'database' => 17,
+                    'options' => [
+                        'compression' => Redis::COMPRESSION_LZ4,
+                        'compression_level' => 12,
+                        'name' => 'compression_lz4_max',
+                    ],
+                    'timeout' => 0.5,
+                ],
+            ]))->connection();
+        }
 
         return $connections;
     }


### PR DESCRIPTION
This is a follow up from https://github.com/laravel/framework/pull/36791

This pull request allows the framework user to configure phpredis (https://github.com/phpredis/phpredis) serialization and compression options right in the config instead of the need to overwrite the service provider or a custom driver.

Supported serializers:

- NONE
- PHP
- JSON
- IGBINARY
- MSGPACK

Supported compressors:

- NONE
- LZF
- ZSTD
- LZ4

Also added tests for different compression algorithms.

### Notes

My first attempt was to always serialize + compress the passed arguments to eval, but then later decided to let the user take care of this as we can not know what kind of lua script he wants to execute and whether all arguments are expected to be serialized/compressed. Instead I provided a helper method on the `PhpredisConnection` class that the user may use. In addition I refactored the previous phpredis lock support (https://github.com/laravel/framework/issues/36337) for these functionalities to use this new helper method.