### PR TITLE
[8.x] Update PHPDoc of Collection::forget()

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1628,7 +1628,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Unset the item at a given offset.
      *
-     * @param  string|int  $key
+     * @param  mixed  $key
      * @return void
      */
     #[\ReturnTypeWillChange]

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -397,7 +397,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Remove an item from the collection by key.
      *
-     * @param  string|array  $keys
+     * @param  string|int|array  $keys
      * @return $this
      */
     public function forget($keys)
@@ -1628,7 +1628,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Unset the item at a given offset.
      *
-     * @param  string  $key
+     * @param  string|int  $key
      * @return void
      */
     #[\ReturnTypeWillChange]


### PR DESCRIPTION
The PHPDoc of Collection::forget() is

```
/**
 * Remove an item from the collection by key.
 *
 * @param  string|array  $keys
 * @return $this
 */
public function forget($keys)
```

Available types of $keys is string|array, missing int, this PR add it.