### PR TITLE
[8.x] Added whenContains and whenContainsAll to Stringable

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -766,6 +766,52 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Execute the given callback if the string contains a given substring.
+     *
+     * @param  string|array  $needles
+     * @param  callable  $callback
+     * @param  callable|null  $default
+     * @return static
+     */
+    public function whenContains($needles, $callback, $default = null)
+    {
+        if ($this->contains($needles)) {
+            $result = $callback($this);
+
+            return $result ?? $this;
+        } elseif ($default) {
+            $result = $default($this);
+
+            return $result ?? $this;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Execute the given callback if the string contains all array values.
+     *
+     * @param  array  $needles
+     * @param  callable  $callback
+     * @param  callable|null  $default
+     * @return static
+     */
+    public function whenContainsAll(array $needles, $callback, $default = null)
+    {
+        if ($this->containsAll($needles)) {
+            $result = $callback($this);
+
+            return $result ?? $this;
+        } elseif ($default) {
+            $result = $default($this);
+
+            return $result ?? $this;
+        }
+
+        return $this;
+    }
+
+    /**
      * Execute the given callback if the string is empty.
      *
      * @param  callable  $callback

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -112,6 +112,44 @@ class SupportStringableTest extends TestCase
         }));
     }
 
+    public function testWhenContains()
+    {
+        $this->assertSame('Tony Stark', (string) $this->stringable('stark')->whenContains('tar', function ($stringable) {
+            return $stringable->prepend('Tony ')->title();
+        }, function ($stringable) {
+            return $stringable->prepend('Arno ')->title();
+        }));
+
+        $this->assertSame('stark', (string) $this->stringable('stark')->whenContains('xxx', function ($stringable) {
+            return $stringable->prepend('Tony ')->title();
+        }));
+
+        $this->assertSame('Arno Stark', (string) $this->stringable('stark')->whenContains('xxx', function ($stringable) {
+            return $stringable->prepend('Tony ')->title();
+        }, function ($stringable) {
+            return $stringable->prepend('Arno ')->title();
+        }));
+    }
+
+    public function testWhenContainsAll()
+    {
+        $this->assertSame('Tony Stark', (string) $this->stringable('tony stark')->whenContainsAll(['tony', 'stark'], function ($stringable) {
+            return $stringable->title();
+        }, function ($stringable) {
+            return $stringable->studly();
+        }));
+
+        $this->assertSame('tony stark', (string) $this->stringable('tony stark')->whenContainsAll(['xxx'], function ($stringable) {
+            return $stringable->title();
+        }));
+
+        $this->assertSame('TonyStark', (string) $this->stringable('tony stark')->whenContainsAll(['tony', 'xxx'], function ($stringable) {
+            return $stringable->title();
+        }, function ($stringable) {
+            return $stringable->studly();
+        }));
+    }
+
     public function testWhenEmpty()
     {
         tap($this->stringable(), function ($stringable) {


### PR DESCRIPTION
I mainly did this because I wanted to combine `when()` and `contains()`: `whenContains()`.  I added `whenContainsAll()` since it was quite similar.

I would also have taken the time to implement `whenXyz()` for all of the "check-like" methods on the class:
* `endsWith()`
* `exactly()`
* `is()`
* `isAscii()`
* `isUuid()`
* `test()`
* `startsWith()`

Please let me know if it's worthwhile or not.  I can definitely see it being valuable, so I'm happy to add these as well. 🤓  