### PR TITLE
[8.x] Automatically add event description when scheduling a command

### DIFF
--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -120,7 +120,11 @@ class Schedule
     public function command($command, array $parameters = [])
     {
         if (class_exists($command)) {
-            $command = Container::getInstance()->make($command)->getName();
+            $command = Container::getInstance()->make($command);
+
+            return $this->exec(
+                Application::formatCommandString($command->getName()), $parameters,
+            )->description($command->getDescription());
         }
 
         return $this->exec(

--- a/tests/Console/ConsoleEventSchedulerTest.php
+++ b/tests/Console/ConsoleEventSchedulerTest.php
@@ -120,6 +120,21 @@ class ConsoleEventSchedulerTest extends TestCase
         $this->assertEquals($binary.' '.$artisan.' foo:bar --force', $events[0]->command);
     }
 
+    public function testItUsesCommandDescriptionAsEventDescription()
+    {
+        $schedule = $this->schedule;
+        $event = $schedule->command(ConsoleCommandStub::class);
+        $this->assertEquals('This is a description about the command', $event->description);
+    }
+
+    public function testItShouldBePossibleToOverwriteTheDescription()
+    {
+        $schedule = $this->schedule;
+        $event = $schedule->command(ConsoleCommandStub::class)
+            ->description('This is an alternative description');
+        $this->assertEquals('This is an alternative description', $event->description);
+    }
+
     public function testCallCreatesNewJobWithTimezone()
     {
         $schedule = new Schedule('UTC');
@@ -147,6 +162,8 @@ class FooClassStub
 class ConsoleCommandStub extends Command
 {
     protected $signature = 'foo:bar';
+
+    protected $description = 'This is a description about the command';
 
     protected $foo;
 


### PR DESCRIPTION
# Description

This code will use the command description as event description. This could be useful when listing all scheduled commands.

**Before**

```php
$schedule->command(Command::class)
    ->description((new Command())->getDescription())
    ->daily();
```

**After**
```php
$schedule->command(Command::class)
    ->daily();
```

The code above will output the same result when running `php artisan schedule:list`.


