### PR TITLE
[9.x] Throw invalid argument exception from cache helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -228,7 +228,7 @@ if (! function_exists('cache')) {
      * @param  dynamic  key|key,default|data,expiration|null
      * @return mixed|\Illuminate\Cache\CacheManager
      *
-     * @throws \Exception
+     * @throws \InvalidArgumentException
      */
     function cache()
     {
@@ -243,7 +243,7 @@ if (! function_exists('cache')) {
         }
 
         if (! is_array($arguments[0])) {
-            throw new Exception(
+            throw new InvalidArgumentException(
                 'When setting a value in the cache, you must pass an array of key / value pairs.'
             );
         }


### PR DESCRIPTION
This PR changes the exception thrown by `cache()` to be an `\InvalidArgumentException`. Not only does this make more sense than the base `\Exception` class, editors such as PHPStorm will not complain about uncaught logic exceptions while they will complain about uncaught base exceptions.

![image](https://user-images.githubusercontent.com/3661474/148516093-57658617-3191-49e6-9d53-f4b4fa34986d.png)

This change should be non breaking, as any matching catch expression would still match.