### PR TITLE
[8.x] Fix Doctrine type mappings creating too many connections

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -178,6 +178,13 @@ class Connection implements ConnectionInterface
     protected $doctrineConnection;
 
     /**
+     * Type mappings that should be registered with new Doctrine connections.
+     *
+     * @var array
+     */
+    protected $doctrineTypeMappings = [];
+
+    /**
      * The connection resolvers.
      *
      * @var array
@@ -1007,6 +1014,10 @@ class Connection implements ConnectionInterface
                 'driver' => method_exists($driver, 'getName') ? $driver->getName() : null,
                 'serverVersion' => $this->getConfig('server_version'),
             ]), $driver);
+
+            foreach ($this->doctrineTypeMappings as $name => $type) {
+                $this->doctrineConnection->getDatabasePlatform()->registerDoctrineTypeMapping($type, $name);
+            }
         }
 
         return $this->doctrineConnection;
@@ -1035,9 +1046,7 @@ class Connection implements ConnectionInterface
             Type::addType($name, $class);
         }
 
-        $this->getDoctrineSchemaManager()
-            ->getDatabasePlatform()
-            ->registerDoctrineTypeMapping($type, $name);
+        $this->doctrineTypeMappings[$name] = $type;
     }
 
     /**

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -1016,7 +1016,9 @@ class Connection implements ConnectionInterface
             ]), $driver);
 
             foreach ($this->doctrineTypeMappings as $name => $type) {
-                $this->doctrineConnection->getDatabasePlatform()->registerDoctrineTypeMapping($type, $name);
+                $this->doctrineConnection
+                    ->getDatabasePlatform()
+                    ->registerDoctrineTypeMapping($type, $name);
             }
         }
 

--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -227,8 +227,8 @@ class DatabaseManager implements ConnectionResolverInterface
             $this->registerDoctrineType($class, $name, $name);
         }
 
-        foreach ($this->doctrineTypes as $name => $class) {
-            $connection->registerDoctrineType($class, $name, $name);
+        foreach ($this->doctrineTypes as $name => [$type, $class]) {
+            $connection->registerDoctrineType($class, $name, $type);
         }
     }
 
@@ -255,7 +255,7 @@ class DatabaseManager implements ConnectionResolverInterface
             Type::addType($name, $class);
         }
 
-        $this->doctrineTypes[$name] = $class;
+        $this->doctrineTypes[$name] = [$type, $class];
     }
 
     /**

--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -2,12 +2,14 @@
 
 namespace Illuminate\Database;
 
+use Doctrine\DBAL\Types\Type;
 use Illuminate\Database\Connectors\ConnectionFactory;
 use Illuminate\Support\Arr;
 use Illuminate\Support\ConfigurationUrlParser;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 use PDO;
+use RuntimeException;
 
 /**
  * @mixin \Illuminate\Database\Connection
@@ -34,6 +36,13 @@ class DatabaseManager implements ConnectionResolverInterface
      * @var array
      */
     protected $connections = [];
+
+    /**
+     * Custom Doctrine column types.
+     *
+     * @var array
+     */
+    protected $doctrineTypes = [];
 
     /**
      * The custom connection resolvers.
@@ -207,7 +216,7 @@ class DatabaseManager implements ConnectionResolverInterface
     }
 
     /**
-     * Register custom Doctrine types from the configuration with the connection.
+     * Register custom Doctrine types with the connection.
      *
      * @param  \Illuminate\Database\Connection  $connection
      * @return void
@@ -215,8 +224,38 @@ class DatabaseManager implements ConnectionResolverInterface
     protected function registerConfiguredDoctrineTypes(Connection $connection): void
     {
         foreach ($this->app['config']->get('database.dbal.types', []) as $name => $class) {
+            $this->registerDoctrineType($class, $name, $name);
+        }
+
+        foreach ($this->doctrineTypes as $name => $class) {
             $connection->registerDoctrineType($class, $name, $name);
         }
+    }
+
+    /**
+     * Register a custom Doctrine type.
+     *
+     * @param  string  $class
+     * @param  string  $name
+     * @param  string  $type
+     * @return void
+     *
+     * @throws \Doctrine\DBAL\DBALException
+     * @throws \RuntimeException
+     */
+    public function registerDoctrineType(string $class, string $name, string $type): void
+    {
+        if (! class_exists('Doctrine\DBAL\Connection')) {
+            throw new RuntimeException(
+                'Registering a custom Doctrine type requires Doctrine DBAL (doctrine/dbal).'
+            );
+        }
+
+        if (! Type::hasType($name)) {
+            Type::addType($name, $class);
+        }
+
+        $this->doctrineTypes[$name] = $class;
     }
 
     /**

--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -38,13 +38,6 @@ class DatabaseManager implements ConnectionResolverInterface
     protected $connections = [];
 
     /**
-     * Custom Doctrine column types.
-     *
-     * @var array
-     */
-    protected $doctrineTypes = [];
-
-    /**
      * The custom connection resolvers.
      *
      * @var array
@@ -57,6 +50,13 @@ class DatabaseManager implements ConnectionResolverInterface
      * @var callable
      */
     protected $reconnector;
+
+    /**
+     * The custom Doctrine column types.
+     *
+     * @var array
+     */
+    protected $doctrineTypes = [];
 
     /**
      * Create a new database manager instance.

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -394,7 +394,7 @@ class Builder
      */
     public function registerCustomDoctrineType($class, $name, $type)
     {
-        Container::getInstance()->make('db')->registerDoctrineType($class, $name, $type);
+        $this->connection->registerDoctrineType($class, $name, $type);
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Schema;
 
 use Closure;
+use Illuminate\Container\Container;
 use Illuminate\Database\Connection;
 use InvalidArgumentException;
 use LogicException;
@@ -393,7 +394,7 @@ class Builder
      */
     public function registerCustomDoctrineType($class, $name, $type)
     {
-        $this->connection->registerDoctrineType($class, $name, $type);
+        Container::getInstance()->make('db')->registerDoctrineType($class, $name);
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -394,7 +394,7 @@ class Builder
      */
     public function registerCustomDoctrineType($class, $name, $type)
     {
-        Container::getInstance()->make('db')->registerDoctrineType($class, $name);
+        Container::getInstance()->make('db')->registerDoctrineType($class, $name, $type);
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Database\Schema;
 
 use Closure;
-use Illuminate\Container\Container;
 use Illuminate\Database\Connection;
 use InvalidArgumentException;
 use LogicException;


### PR DESCRIPTION
**TLDR:** this PR closes #40297 by only registering custom Doctrine type mappings on a Doctrine connection after that connection is created (as opposed to creating one to register them).

### Context

My and @TomHAnderson's original PR, #40119, created an issue with tests where way too many database connections would be created. We were manually creating a database connection to register the custom type mappings, which caused database connections to be created every time the app boots, and dozens of unnecessary connections to be created when tests are run in parallel.

I'm still not entirely sure why all those connections stick around, I tried manually closing/destroying them through Doctrine and that didn't seem to work.