### PR TITLE
[8.x] Fix timezone option in `schedule:list` command

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Console\Scheduling;
 
-use DateTimeZone;
 use Cron\CronExpression;
+use DateTimeZone;
 use Illuminate\Console\Command;
 use Illuminate\Support\Carbon;
 

--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Console\Scheduling;
 
+use DateTimeZone;
 use Cron\CronExpression;
 use Illuminate\Console\Command;
 use Illuminate\Support\Carbon;
@@ -39,7 +40,7 @@ class ScheduleListCommand extends Command
                 $event->description,
                 (new CronExpression($event->expression))
                             ->getNextRunDate(Carbon::now()->setTimezone($event->timezone))
-                            ->setTimezone($this->option('timezone', config('app.timezone')))
+                            ->setTimezone(new DateTimeZone($this->option('timezone') ?? config('app.timezone')))
                             ->format('Y-m-d H:i:s P'),
             ];
         }


### PR DESCRIPTION
Currently `php artisan schedule:list` fails with the following error:

```sh
 DateTime::setTimezone(): Argument #1 ($timezone) must be of type DateTimeZone, string given
```

This PR converts the timezone value from a string to an instance of `DateTimeZone`. It also sets default value with null coalescing check, because the `options` method does not have a 2nd parameter.
