### PR TITLE
[8.x] support action_level configuration

### DIFF
--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Monolog\Formatter\LineFormatter;
 use Monolog\Handler\ErrorLogHandler;
+use Monolog\Handler\FingersCrossedHandler;
 use Monolog\Handler\FormattableHandlerInterface;
 use Monolog\Handler\HandlerInterface;
 use Monolog\Handler\RotatingFileHandler;
@@ -416,6 +417,10 @@ class LogManager implements LoggerInterface
      */
     protected function prepareHandler(HandlerInterface $handler, array $config = [])
     {
+        if (isset($config['action_level'])) {
+            $handler = new FingersCrossedHandler($handler, $this->actionLevel($config));
+        }
+
         if (Monolog::API !== 1 && (Monolog::API !== 2 || ! $handler instanceof FormattableHandlerInterface)) {
             return $handler;
         }

--- a/src/Illuminate/Log/ParsesLogConfiguration.php
+++ b/src/Illuminate/Log/ParsesLogConfiguration.php
@@ -49,6 +49,12 @@ trait ParsesLogConfiguration
         throw new InvalidArgumentException('Invalid log level.');
     }
 
+    /**
+     * Parse the action level from the given configuration.
+     *
+     * @param  array  $config
+     * @return int
+     */
     protected function actionLevel(array $config)
     {
         $level = $config['action_level'] ?? 'debug';

--- a/src/Illuminate/Log/ParsesLogConfiguration.php
+++ b/src/Illuminate/Log/ParsesLogConfiguration.php
@@ -49,6 +49,17 @@ trait ParsesLogConfiguration
         throw new InvalidArgumentException('Invalid log level.');
     }
 
+    protected function actionLevel(array $config)
+    {
+        $level = $config['action_level'] ?? 'debug';
+
+        if (isset($this->levels[$level])) {
+            return $this->levels[$level];
+        }
+
+        throw new InvalidArgumentException('Invalid log action level.');
+    }
+
     /**
      * Extract the log channel from the given configuration.
      *

--- a/tests/Log/LogManagerTest.php
+++ b/tests/Log/LogManagerTest.php
@@ -471,7 +471,13 @@ class LogManagerTest extends TestCase
 
         $this->assertEquals(Monolog::CRITICAL, $actionLevelValue);
 
-        $expectedStreamHandler = $expectedFingersCrossedHandler->getHandler();
+        if (method_exists($expectedFingersCrossedHandler, 'getHandler')) {
+            $expectedStreamHandler = $expectedFingersCrossedHandler->getHandler();
+        } else {
+            $handlerProp = new ReflectionProperty(get_class($expectedFingersCrossedHandler), 'handler');
+            $handlerProp->setAccessible(true);
+            $expectedStreamHandler = $handlerProp->getValue($expectedFingersCrossedHandler);
+        }
         $this->assertInstanceOf(StreamHandler::class, $expectedStreamHandler);
         $this->assertEquals(Monolog::DEBUG, $expectedStreamHandler->getLevel());
     }

--- a/tests/Log/LogManagerTest.php
+++ b/tests/Log/LogManagerTest.php
@@ -7,6 +7,7 @@ use Illuminate\Log\LogManager;
 use Monolog\Formatter\HtmlFormatter;
 use Monolog\Formatter\LineFormatter;
 use Monolog\Formatter\NormalizerFormatter;
+use Monolog\Handler\FingersCrossedHandler;
 use Monolog\Handler\LogEntriesHandler;
 use Monolog\Handler\NewRelicHandler;
 use Monolog\Handler\NullHandler;
@@ -431,5 +432,47 @@ class LogManagerTest extends TestCase
         $url->setAccessible(true);
 
         $this->assertSame(storage_path('logs/custom.log'), $url->getValue($handler));
+    }
+
+    public function testWrappingHandlerInFingersCrossedWhenActionLevelIsUsed()
+    {
+        $config = $this->app['config'];
+
+        $config->set('logging.channels.fingerscrossed', [
+            'driver' => 'monolog',
+            'handler' => StreamHandler::class,
+            'level' => 'debug',
+            'action_level' => 'critical',
+            'with' => [
+                'stream' => 'php://stderr',
+                'bubble' => false,
+            ],
+        ]);
+
+        $manager = new LogManager($this->app);
+
+        // create logger with handler specified from configuration
+        $logger = $manager->channel('fingerscrossed');
+        $handlers = $logger->getLogger()->getHandlers();
+
+        $this->assertInstanceOf(Logger::class, $logger);
+        $this->assertCount(1, $handlers);
+
+        $expectedFingersCrossedHandler = $handlers[0];
+        $this->assertInstanceOf(FingersCrossedHandler::class, $expectedFingersCrossedHandler, );
+
+        $activationStrategyProp = new ReflectionProperty(get_class($expectedFingersCrossedHandler), 'activationStrategy');
+        $activationStrategyProp->setAccessible(true);
+        $activationStrategyValue = $activationStrategyProp->getValue($expectedFingersCrossedHandler);
+
+        $actionLevelProp = new ReflectionProperty(get_class($activationStrategyValue), 'actionLevel');
+        $actionLevelProp->setAccessible(true);
+        $actionLevelValue = $actionLevelProp->getValue($activationStrategyValue);
+
+        $this->assertEquals(Monolog::CRITICAL, $actionLevelValue);
+
+        $expectedStreamHandler = $expectedFingersCrossedHandler->getHandler();
+        $this->assertInstanceOf(StreamHandler::class, $expectedStreamHandler);
+        $this->assertEquals(Monolog::DEBUG, $expectedStreamHandler->getLevel());
     }
 }


### PR DESCRIPTION
Adding an action_level configuration option for log channels. When the action_level configuration is used the chosen handler by the developer will be wrapped in a [Fingerscrossed handler](https://github.com/Seldaek/monolog/blob/main/src/Monolog/Handler/FingersCrossedHandler.php).

The Fingerscrossed handler will buffer all log records that are at or above the provided level configuration. Only when a log record is provided at or above the action_level all the buffered records will be flushed to the log itself.

This methodology can be usefull for a developer to gather debug information about a process while only logging that debug information if the code actually hits a critical error.

An example of the usage of the action_level configuration can be found in the [Symfony documentation](https://symfony.com/doc/current/logging.html#handlers-that-modify-log-entries) about logging using Monolog.