### PR TITLE
[9.x] Do not instantiate the controller just for fetching the middleware

### DIFF
--- a/src/Illuminate/Routing/Contracts/ControllerDispatcher.php
+++ b/src/Illuminate/Routing/Contracts/ControllerDispatcher.php
@@ -19,9 +19,9 @@ interface ControllerDispatcher
     /**
      * Get the middleware for the controller instance.
      *
-     * @param  \Illuminate\Routing\Controller  $controller
+     * @param  string  $controllerClass
      * @param  string  $method
      * @return array
      */
-    public function getMiddleware($controller, $method);
+    public function getMiddleware(string $controllerClass, string $method): array;
 }

--- a/src/Illuminate/Routing/Controller.php
+++ b/src/Illuminate/Routing/Controller.php
@@ -11,7 +11,17 @@ abstract class Controller
      *
      * @var array
      */
-    protected $middleware = [];
+    protected static $middleware = [];
+
+    /**
+     * Clears registered middleware on the controller.
+     *
+     * @return void
+     */
+    public static function clearMiddleware(): void
+    {
+        static::$middleware = [];
+    }
 
     /**
      * Register middleware on the controller.
@@ -20,10 +30,10 @@ abstract class Controller
      * @param  array  $options
      * @return \Illuminate\Routing\ControllerMiddlewareOptions
      */
-    public function middleware($middleware, array $options = [])
+    public static function middleware($middleware, array $options = [])
     {
         foreach ((array) $middleware as $m) {
-            $this->middleware[] = [
+            static::$middleware[] = [
                 'middleware' => $m,
                 'options' => &$options,
             ];
@@ -37,9 +47,9 @@ abstract class Controller
      *
      * @return array
      */
-    public function getMiddleware()
+    public static function getMiddleware()
     {
-        return $this->middleware;
+        return static::$middleware;
     }
 
     /**

--- a/src/Illuminate/Routing/ControllerDispatcher.php
+++ b/src/Illuminate/Routing/ControllerDispatcher.php
@@ -51,17 +51,17 @@ class ControllerDispatcher implements ControllerDispatcherContract
     /**
      * Get the middleware for the controller instance.
      *
-     * @param  \Illuminate\Routing\Controller  $controller
+     * @param  string  $controllerClass
      * @param  string  $method
      * @return array
      */
-    public function getMiddleware($controller, $method)
+    public function getMiddleware(string $controllerClass, string $method): array
     {
-        if (! method_exists($controller, 'getMiddleware')) {
+        if (! method_exists($controllerClass, 'getMiddleware')) {
             return [];
         }
 
-        return collect($controller->getMiddleware())->reject(function ($data) use ($method) {
+        return collect($controllerClass::getMiddleware())->reject(function ($data) use ($method) {
             return static::methodExcludedByOptions($method, $data['options']);
         })->pluck('middleware')->all();
     }

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -215,7 +215,7 @@ class Route
      *
      * @return bool
      */
-    protected function isControllerAction()
+    public function isControllerAction()
     {
         return is_string($this->action['uses']) && ! $this->isSerializedClosure();
     }
@@ -270,12 +270,22 @@ class Route
     public function getController()
     {
         if (! $this->controller) {
-            $class = $this->parseControllerCallback()[0];
-
-            $this->controller = $this->container->make(ltrim($class, '\\'));
+            $this->controller = $this->container->make($this->getControllerClass());
         }
 
         return $this->controller;
+    }
+
+    /**
+     * Get the controller class for the route.
+     *
+     * @return string
+     */
+    public function getControllerClass(): string
+    {
+        $class = $this->parseControllerCallback()[0];
+
+        return ltrim($class, '\\');
     }
 
     /**
@@ -1068,7 +1078,7 @@ class Route
         }
 
         return $this->controllerDispatcher()->getMiddleware(
-            $this->getController(), $this->getControllerMethod()
+            $this->getControllerClass(), $this->getControllerMethod()
         );
     }
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -633,7 +633,19 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     public function dispatchToRoute(Request $request)
     {
-        return $this->runRoute($request, $this->findRoute($request));
+        $route = $this->findRoute($request);
+
+        try {
+            return $this->runRoute($request, $route);
+        } finally {
+            if ($route->isControllerAction()) {
+                $controllerClass = $route->getControllerClass();
+
+                if (method_exists($controllerClass, 'clearMiddleware')) {
+                    $controllerClass::clearMiddleware();
+                }
+            }
+        }
     }
 
     /**

--- a/tests/Integration/Routing/Fixtures/ControllerWithStaticallyDefinedMiddleware.php
+++ b/tests/Integration/Routing/Fixtures/ControllerWithStaticallyDefinedMiddleware.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Routing\Fixtures;
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Routing\Controller;
+
+class ControllerWithStaticallyDefinedMiddleware extends Controller
+{
+    public function __construct()
+    {
+        $_SERVER['controller_with_statically_defined_middleware_was_constructed'] = true;
+    }
+
+    public static function getMiddleware(): array
+    {
+        static::middleware('auth');
+
+        static::middleware(function (Request $request): RedirectResponse {
+            return new RedirectResponse('https://www.foo.com');
+        });
+
+        return parent::getMiddleware();
+    }
+
+    public function __invoke(): Response
+    {
+        return new Response('foobar');
+    }
+}

--- a/tests/Integration/Routing/RoutingMiddlewareTest.php
+++ b/tests/Integration/Routing/RoutingMiddlewareTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Routing;
+
+use Illuminate\Auth\GenericUser;
+use Illuminate\Contracts\Routing\Registrar;
+use Illuminate\Tests\Integration\Routing\Fixtures\ControllerWithStaticallyDefinedMiddleware;
+use Orchestra\Testbench\TestCase;
+
+final class RoutingMiddlewareTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        unset($_SERVER['controller_with_statically_defined_middleware_was_constructed']);
+
+        parent::tearDown();
+    }
+
+    public function testControllerIsNotInstantiatedWhenStaticallyDefiningMiddlewareOnIt()
+    {
+        $this->withoutExceptionHandling();
+        $this->actingAs(new GenericUser([]));
+
+        $_SERVER['controller_with_statically_defined_middleware_was_constructed'] = false;
+
+        /** @var Registrar $router */
+        $router = $this->app->make(Registrar::class);
+
+        $router->get('test-route', ControllerWithStaticallyDefinedMiddleware::class);
+
+        $response = $this->get('test-route');
+
+        $response->assertRedirect('https://www.foo.com');
+
+        $this->assertFalse($_SERVER['controller_with_statically_defined_middleware_was_constructed']);
+    }
+}

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1960,12 +1960,14 @@ class RoutingRouteTest extends TestCase
 
 class RouteTestControllerStub extends Controller
 {
-    public function __construct()
+    public static function getMiddleware(): array
     {
-        $this->middleware(RouteTestControllerMiddleware::class);
-        $this->middleware(RouteTestControllerParameterizedMiddlewareOne::class.':0');
-        $this->middleware(RouteTestControllerParameterizedMiddlewareTwo::class.':foo,bar');
-        $this->middleware(RouteTestControllerExceptMiddleware::class, ['except' => 'index']);
+        static::middleware(RouteTestControllerMiddleware::class);
+        static::middleware(RouteTestControllerParameterizedMiddlewareOne::class.':0');
+        static::middleware(RouteTestControllerParameterizedMiddlewareTwo::class.':foo,bar');
+        static::middleware(RouteTestControllerExceptMiddleware::class, ['except' => 'index']);
+
+        return parent::getMiddleware();
     }
 
     public function index()
@@ -1984,9 +1986,11 @@ class RouteTestControllerCallableStub extends Controller
 
 class RouteTestControllerMiddlewareGroupStub extends Controller
 {
-    public function __construct()
+    public static function getMiddleware(): array
     {
-        $this->middleware('web');
+        static::middleware('web');
+
+        return parent::getMiddleware();
     }
 
     public function index()
@@ -2046,15 +2050,17 @@ class RouteTestResourceControllerWithModelParameter extends Controller
 
 class RouteTestClosureMiddlewareController extends Controller
 {
-    public function __construct()
+    public static function getMiddleware(): array
     {
-        $this->middleware(function ($request, $next) {
+        static::middleware(function ($request, $next) {
             $response = $next($request);
 
             return $response->setContent(
                 $response->content().'-'.$request['foo-middleware'].'-controller-closure'
             );
         });
+
+        return parent::getMiddleware();
     }
 
     public function index()


### PR DESCRIPTION
This PR is a result of my comment on @stancl PR -> https://github.com/laravel/framework/pull/40165#issuecomment-1001806578

This PR wants to solve the problem of having to instantiate the controller just to get the defined middleware on it which in turn has all the problems described in that comment (it's not possible to fully and reliably rely on controller constructor dependency injection etc.).

Instead of completely removing this feature (as I originally suggested in my comment) I've opted to preserve that feature in order to minimize the breaking change while still fixing the problems described in that comment.

This is how the middleware definition would look after this PR (the example contains a string and Closure based middleware):

 ```diff

use Illuminate\Http\RedirectResponse;
use Illuminate\Http\Request;
use Illuminate\Routing\Controller;

 class UserController extends Controller
 {
-     public function __construct()
-     {
-        $this->middleware('auth')->except('fooMethod');
- 
-        $this->middleware(function (Request $request): RedirectResponse {
-            return new RedirectResponse('https://www.foo.com');
-        });
-     }

+     public static function getMiddleware(): array
+     {
+        static::middleware('auth')->except('fooMethod');
+
+        static::middleware(function (Request $request): RedirectResponse {
+            return new RedirectResponse('https://www.foo.com');
+        });
+
+        return parent::getMiddleware();
+     }
 }
 ```

I believe such a small breaking change is definitively worth it in order to decouple the middleware and controller layer (all the pros are described in my linked comment).

The only other purely technical breaking changes (which I don't expect to realistically impact anyone) are:

1. the controller dispatcher `getMiddleware` method no longer receives the controller object instance, it now receives the controller class name (string), I've added the typehints there to ensure that which in itself is a tiny BC
2. `\Illuminate\Routing\Route::isControllerAction` method was changed from `protected` to `public` visibility 
3.  The middleware related properties and methods in `Illuminate/Routing/Controller` are now `static`.