### PR TITLE
[8.x] Resolve Blueprint class out of the container

### DIFF
--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Schema;
 
 use Closure;
+use Illuminate\Container\Container;
 use Illuminate\Database\Connection;
 use InvalidArgumentException;
 use LogicException;
@@ -380,7 +381,7 @@ class Builder
             return call_user_func($this->resolver, $table, $callback, $prefix);
         }
 
-        return new Blueprint($table, $callback, $prefix);
+        return Container::getInstance()->make(Blueprint::class, compact('table', 'callback', 'prefix'));
     }
 
     /**


### PR DESCRIPTION
Currently, it is almost impossible to swap the `Blueprint $table` implementation for migrations with a fake one from within a "package space".
Because the `Schema` facade returns a new object each time from the `getFacadeAccessor` method (hence there is no way of mocking or hot swapping) and non of the other objects are resolved out of the container. (Connection objects or Builder objects)
There is also no change of using the `resolver` property on the `Builder` class from a package space because if you set it before the migration starts it will be thrown away after the `Schema` is called in the migration.

Currently "illuminate/database" depends on "illuminate/container" so we can use the Container class directly. (if not wrong)
This way it is possible to swap the Blueprint class upon the `registration phase`.
