### PR TITLE
Fix for the GT, GTE, LT, LTE comparison operators not comparing strings, arrays, or files to a numeric parameter

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1000,7 +1000,7 @@ trait ValidatesAttributes
 
         $this->shouldBeNumeric($attribute, 'Gt');
 
-        if (is_null($comparedToValue) && (is_numeric($value) && is_numeric($parameters[0]))) {
+        if (is_null($comparedToValue) && is_numeric($parameters[0])) {
             return $this->getSize($attribute, $value) > $parameters[0];
         }
 
@@ -1035,7 +1035,7 @@ trait ValidatesAttributes
 
         $this->shouldBeNumeric($attribute, 'Lt');
 
-        if (is_null($comparedToValue) && (is_numeric($value) && is_numeric($parameters[0]))) {
+        if (is_null($comparedToValue) && is_numeric($parameters[0])) {
             return $this->getSize($attribute, $value) < $parameters[0];
         }
 
@@ -1070,7 +1070,7 @@ trait ValidatesAttributes
 
         $this->shouldBeNumeric($attribute, 'Gte');
 
-        if (is_null($comparedToValue) && (is_numeric($value) && is_numeric($parameters[0]))) {
+        if (is_null($comparedToValue) && is_numeric($parameters[0])) {
             return $this->getSize($attribute, $value) >= $parameters[0];
         }
 
@@ -1105,7 +1105,7 @@ trait ValidatesAttributes
 
         $this->shouldBeNumeric($attribute, 'Lte');
 
-        if (is_null($comparedToValue) && (is_numeric($value) && is_numeric($parameters[0]))) {
+        if (is_null($comparedToValue) && is_numeric($parameters[0])) {
             return $this->getSize($attribute, $value) <= $parameters[0];
         }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1677,12 +1677,31 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => [1, 'string']], ['lhs' => 'gt:rhs']);
         $this->assertTrue($v->fails());
 
+        $v = new Validator($trans, ['lhs' => 'string'], ['lhs' => 'gt:5']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['lhs' => 'string'], ['lhs' => 'gt:6']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['lhs' => 'string'], ['lhs' => 'gt:7']);
+        $this->assertTrue($v->fails());
+
         $fileOne = $this->getMockBuilder(File::class)->onlyMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $fileOne->expects($this->any())->method('getSize')->willReturn(5472);
         $fileTwo = $this->getMockBuilder(File::class)->onlyMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $fileTwo->expects($this->any())->method('getSize')->willReturn(3151);
         $v = new Validator($trans, ['lhs' => $fileOne, 'rhs' => $fileTwo], ['lhs' => 'gt:rhs']);
         $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['lhs' => $fileOne], ['lhs' => 'gt:5']);
+        $this->assertTrue($v->passes());
+        $v = new Validator($trans, ['lhs' => $fileOne], ['lhs'=>'gt:8']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['lhs' => ['a' => 'one', 'b'=>'two']], ['lhs'=>'gt:1']);
+        $this->assertTrue($v->passes());
+        $v = new Validator($trans, ['lhs' => ['a' => 'one', 'b'=>'two']], ['lhs'=>'gt:2']);
+        $this->assertTrue($v->fails());
 
         $v = new Validator($trans, ['lhs' => 15], ['lhs' => 'numeric|gt:10']);
         $this->assertTrue($v->passes());
@@ -1718,11 +1737,30 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => [1, 'string']], ['lhs' => 'lt:rhs']);
         $this->assertTrue($v->passes());
 
+        $v = new Validator($trans, ['lhs' => 'string'], ['lhs' => 'lt:5']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['lhs' => 'string'], ['lhs' => 'lt:6']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['lhs' => 'string'], ['lhs' => 'lt:7']);
+        $this->assertTrue($v->passes());
+
         $fileOne = $this->getMockBuilder(File::class)->onlyMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $fileOne->expects($this->any())->method('getSize')->willReturn(5472);
         $fileTwo = $this->getMockBuilder(File::class)->onlyMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $fileTwo->expects($this->any())->method('getSize')->willReturn(3151);
         $v = new Validator($trans, ['lhs' => $fileOne, 'rhs' => $fileTwo], ['lhs' => 'lt:rhs']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['lhs' => $fileOne], ['lhs' => 'lt:6']);
+        $this->assertTrue($v->passes());
+        $v = new Validator($trans, ['lhs' => $fileOne], ['lhs'=>'lt:2']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['lhs' => ['a' => 'one', 'b'=>'two']], ['lhs'=>'lt:3']);
+        $this->assertTrue($v->passes());
+        $v = new Validator($trans, ['lhs' => ['a' => 'one', 'b'=>'two']], ['lhs'=>'lt:2']);
         $this->assertTrue($v->fails());
 
         $v = new Validator($trans, ['lhs' => 15], ['lhs' => 'numeric|lt:10']);
@@ -1759,12 +1797,35 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => [1, 'string']], ['lhs' => 'gte:rhs']);
         $this->assertTrue($v->fails());
 
+        $v = new Validator($trans, ['lhs' => 'string'], ['lhs' => 'gte:5']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['lhs' => 'string'], ['lhs' => 'gte:6']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['lhs' => 'string'], ['lhs' => 'gte:7']);
+        $this->assertTrue($v->fails());
+
         $fileOne = $this->getMockBuilder(File::class)->onlyMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $fileOne->expects($this->any())->method('getSize')->willReturn(5472);
         $fileTwo = $this->getMockBuilder(File::class)->onlyMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $fileTwo->expects($this->any())->method('getSize')->willReturn(5472);
         $v = new Validator($trans, ['lhs' => $fileOne, 'rhs' => $fileTwo], ['lhs' => 'gte:rhs']);
         $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['lhs' => $fileOne], ['lhs' => 'gte:4']);
+        $this->assertTrue($v->passes());
+        $v = new Validator($trans, ['lhs' => $fileOne], ['lhs'=>'gte:5']);
+        $this->assertTrue($v->passes());
+        $v = new Validator($trans, ['lhs' => $fileOne], ['lhs'=>'gte:6']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['lhs' => ['a' => 'one', 'b'=>'two']], ['lhs'=>'gte:1']);
+        $this->assertTrue($v->passes());
+        $v = new Validator($trans, ['lhs' => ['a' => 'one', 'b'=>'two']], ['lhs'=>'gte:2']);
+        $this->assertTrue($v->passes());
+        $v = new Validator($trans, ['lhs' => ['a' => 'one', 'b'=>'two']], ['lhs'=>'gte:3']);
+        $this->assertTrue($v->fails());
 
         $v = new Validator($trans, ['lhs' => 15], ['lhs' => 'numeric|gte:15']);
         $this->assertTrue($v->passes());
@@ -1800,11 +1861,32 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['lhs' => ['string'], 'rhs' => [1, 'string']], ['lhs' => 'lte:rhs']);
         $this->assertTrue($v->passes());
 
+        $v = new Validator($trans, ['lhs' => 'string'], ['lhs' => 'lte:7']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['lhs' => 'string'], ['lhs' => 'lte:6']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['lhs' => 'string'], ['lhs' => 'lte:5']);
+        $this->assertTrue($v->fails());
+
         $fileOne = $this->getMockBuilder(File::class)->onlyMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $fileOne->expects($this->any())->method('getSize')->willReturn(5472);
         $fileTwo = $this->getMockBuilder(File::class)->onlyMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $fileTwo->expects($this->any())->method('getSize')->willReturn(5472);
         $v = new Validator($trans, ['lhs' => $fileOne, 'rhs' => $fileTwo], ['lhs' => 'lte:rhs']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['lhs' => $fileOne], ['lhs'=>'lte:5']);
+        $this->assertTrue($v->fails());
+        $v = new Validator($trans, ['lhs' => $fileOne], ['lhs'=>'lte:6']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['lhs' => ['a' => 'one', 'b'=>'two']], ['lhs'=>'lte:1']);
+        $this->assertTrue($v->fails());
+        $v = new Validator($trans, ['lhs' => ['a' => 'one', 'b'=>'two']], ['lhs'=>'lte:2']);
+        $this->assertTrue($v->passes());
+        $v = new Validator($trans, ['lhs' => ['a' => 'one', 'b'=>'two']], ['lhs'=>'lte:3']);
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['lhs' => 15], ['lhs' => 'numeric|lte:10']);


### PR DESCRIPTION
Fix for the GT, GTE, LT, LTE operators not comparing to a numeric value (i.e. characters in strings, file length or array length). Fixes my issue #40308 

For proof of bug, run the tests included in this PR without the changes to ValidatesAttributes.php file.

Removes the numeric check for value (which may not be numeric if comparing strings, files or arrays). This is the case if you do not pass another attribute to compare to (i.e. just passing in a number to compare to). getSize has the logic required to deal with what type it is.

This means that the operators work correctly, as per the Laravel documentation.

Tests fully pass on my machine.