### PR TITLE
[8.x] Fix: Str::substrReplace() doesn't support multibyte

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -891,6 +891,7 @@ class Str
         }
 
         $start = static::substr($string, 0, $offset);
+
         $end = static::substr($string, $offset + $length, static::length($string, 'UTF-8'));
 
         return $start.$replace.$end;

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -893,7 +893,7 @@ class Str
         $start = static::substr($string, 0, $offset);
         $end = static::substr($string, $offset + $length, static::length($string, 'UTF-8'));
 
-        return $start . $replace . $end;
+        return $start.$replace.$end;
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -887,10 +887,13 @@ class Str
     public static function substrReplace($string, $replace, $offset = 0, $length = null)
     {
         if ($length === null) {
-            $length = strlen($string);
+            $length = static::length($string, 'UTF-8');
         }
 
-        return substr_replace($string, $replace, $offset, $length);
+        $start = static::substr($string, 0, $offset);
+        $end = static::substr($string, $offset + $length, static::length($string, 'UTF-8'));
+
+        return $start . $replace . $end;
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -540,6 +540,7 @@ class SupportStrTest extends TestCase
         $this->assertSame('12:00', Str::substrReplace('1200', ':', 2, 0));
         $this->assertSame('The Laravel Framework', Str::substrReplace('The Framework', 'Laravel ', 4, 0));
         $this->assertSame('Laravel – The PHP Framework for Web Artisans', Str::substrReplace('Laravel Framework', '– The PHP Framework for Web Artisans', 8));
+        $this->assertSame('Ларавел – PHP-фреймворк', Str::substrReplace('Ларавел фреймворк', '– PHP-фреймворк', 8));
     }
 
     public function testUcfirst()

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -665,6 +665,7 @@ class SupportStringableTest extends TestCase
         $this->assertSame('12:00', (string) $this->stringable('1200')->substrReplace(':', 2, 0));
         $this->assertSame('The Laravel Framework', (string) $this->stringable('The Framework')->substrReplace('Laravel ', 4, 0));
         $this->assertSame('Laravel – The PHP Framework for Web Artisans', (string) $this->stringable('Laravel Framework')->substrReplace('– The PHP Framework for Web Artisans', 8));
+        $this->assertSame('Ларавел – PHP-фреймворк', (string) $this->stringable('Ларавел фреймворк')->substrReplace('– PHP-фреймворк', 8));
     }
 
     public function testPadBoth()


### PR DESCRIPTION
Because of https://github.com/laravel/framework/pull/39988, Str::substrReplace() method doesn't support multibyte encoding.

```php
$expected = 'Ларавел – PHP-фреймворк';
$actual = \Illuminate\Support\Str::substrReplace('Ларавел фреймворк', '– PHP-фреймворк', 8);
dump($expected, $actual);

// Expected result:
// 'Ларавел – PHP-фреймворк'
// Actual result:
// 'Лара– PHP-фреймворк'
```

For now this was fixed. Thanks to https://github.com/sallaizalan/mb-substr-replace/blob/master/mbsubstrreplace.php