### PR TITLE
[8.x] Adds support for using custom mapping when authorizing requests via controller

### DIFF
--- a/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
+++ b/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
@@ -98,6 +98,45 @@ trait AuthorizesRequests
     }
 
     /**
+     * Authorize a resource action based on the incoming request with custom mapping.
+     *
+     * @param string $model
+     * @param string|null $parameter
+     * @param array $options
+     * @param array $methodsWithModels
+     * @param array $methodsWithoutModels
+     * @param bool $useResourceMap
+     * @return void
+     */
+    public function authorizeMap($model, $parameter = null, array $options = [], array $methodsWithModels = [],
+                                 array $methodsWithoutModels = [], bool $useResourceMap = false)
+    {
+        $parameter = $parameter ?: Str::snake(class_basename($model));
+
+        $middleware = [];
+
+        foreach ($methodsWithModels as $method => $ability) {
+            $middleware["can:{$ability},{$parameter}"][] = $method;
+        }
+
+        foreach ($methodsWithoutModels as $method => $ability) {
+            $middleware["can:{$ability},{$model}"][] = $method;
+        }
+
+        if ($useResourceMap) {
+            foreach ($this->resourceAbilityMap() as $method => $ability) {
+                $modelName = in_array($method,$this->resourceMethodsWithoutModels()) ? $model : $parameter;
+
+                $middleware["can:{$ability},{$modelName}"][] = $method;
+            }
+        }
+
+        foreach ($middleware as $middlewareName => $methods) {
+            $this->middleware($middlewareName, $options)->only($methods);
+        }
+    }
+
+    /**
      * Get the map of resource methods to ability names.
      *
      * @return array

--- a/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
+++ b/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
@@ -100,12 +100,12 @@ trait AuthorizesRequests
     /**
      * Authorize a resource action based on the incoming request with custom mapping.
      *
-     * @param string $model
-     * @param string|null $parameter
-     * @param array $options
-     * @param array $methodsWithModels
-     * @param array $methodsWithoutModels
-     * @param bool $useResourceMap
+     * @param  string  $model
+     * @param  string|null  $parameter
+     * @param  array  $options
+     * @param  array  $methodsWithModels
+     * @param  array  $methodsWithoutModels
+     * @param  bool  $useResourceMap
      * @return void
      */
     public function authorizeMap($model, $parameter = null, array $methodsWithModels = [], array $methodsWithoutModels = [],
@@ -125,7 +125,7 @@ trait AuthorizesRequests
 
         if ($useResourceMap) {
             foreach ($this->resourceAbilityMap() as $method => $ability) {
-                $modelName = in_array($method,$this->resourceMethodsWithoutModels()) ? $model : $parameter;
+                $modelName = in_array($method, $this->resourceMethodsWithoutModels()) ? $model : $parameter;
 
                 $middleware["can:{$ability},{$modelName}"][] = $method;
             }

--- a/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
+++ b/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
@@ -108,8 +108,8 @@ trait AuthorizesRequests
      * @param bool $useResourceMap
      * @return void
      */
-    public function authorizeMap($model, $parameter = null, array $options = [], array $methodsWithModels = [],
-                                 array $methodsWithoutModels = [], bool $useResourceMap = false)
+    public function authorizeMap($model, $parameter = null, array $methodsWithModels = [], array $methodsWithoutModels = [],
+                                 bool $useResourceMap = false, array $options = [])
     {
         $parameter = $parameter ?: Str::snake(class_basename($model));
 


### PR DESCRIPTION
Hola!

# Problem
We usually tend to add many custom methods to controllers for a lot of reasons. And when we need to authorize those custom methods via Controller, we need to use ```authorize('action', 'model or parameter')``` syntax in all methods which I felt was a bit not so developer friendly. This may not be a problem for those who does only a lot of basic CRUD applications, but in applications which depend more on custom methods, its not fully following DRY principle.

# Current way of authorizing custom methods
```php
class ExampleController extends Controller
{
    public function method1()
    {
        $this->authorize('action1', Example::class);

        //Some code
    }

    public function method2(Example $example)
    {
        $this->authorize('action2', $example);

        //Some code
    }

    public function method3(Example $example)
    {
        $this->authorize('action3', $example);

        //Some code
    }
```

# Solution
I have added a ```authorizeMap``` method to AuthorizesRequests trait. It basically extends the usage of the famous ```authorizeResource``` method, which uses it's predefined mapping, whereas ```authorizeMap``` allows developers to provide their own method => ability mapping, which can be used to authorize custom methods in the Controller's Constructor without using ```authorize``` in all custom methods.

# Syntax
```php
authorizeMap($model, $parameter = null, array $methodsWithModels = [], array $methodsWithoutModels = [],
                                 bool $useResourceMap = false, array $options = [])
```

# Parameters
- ```model```   -->   Model's class name
- ```parameter```   -->   Name of the route / request parameter that will contain the model's ID
- ```methodsWithModels```   -->   Array of method => ability mapping for actions that require a model instance
- ```methodsWithoutModels```   -->   Array of method => ability mapping for actions that require a model instance
- ```useResourceMap```   -->   Whether to use existing default resource action mapping along with custom mapping
- ```options```   -->   Relevant options that are passed to the middleware

# Usage

```php
class ExampleController extends Controller
{
    public function __construct()
    {
        $this->authorizeMap(Example::class, 'example',  [
            'method2' => 'action2',
            'method3' => 'action3',
        ], [
            'method1' => 'action1'
        ]);
    }

    public function method1()
    {
        //Some code
    }

    public function method2(Example $example)
    {
        //Some code
    }

    public function method3(Example $example)
    {
        //Some code
    }
```

# What I actually wanted to do
I actually wanted to do something like
```php
authorizeMagic($model, $parameter = null, array $options = [])
```
which actually just gets the basic parameters and map each method to their action which has the same name as the controller method. The major problem here is guessing which actions require a model instance and which don't. That's why I ended up doing it this way. If it's possible and if I can get some help, I can do it :)
