### PR TITLE
[8.x] Added whenEndsWith(), whenExactly(), whenStartsWith(), etc to Stringable

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -775,17 +775,7 @@ class Stringable implements JsonSerializable
      */
     public function whenContains($needles, $callback, $default = null)
     {
-        if ($this->contains($needles)) {
-            $result = $callback($this);
-
-            return $result ?? $this;
-        } elseif ($default) {
-            $result = $default($this);
-
-            return $result ?? $this;
-        }
-
-        return $this;
+        return $this->when($this->contains($needles), $callback, $default);
     }
 
     /**
@@ -798,17 +788,7 @@ class Stringable implements JsonSerializable
      */
     public function whenContainsAll(array $needles, $callback, $default = null)
     {
-        if ($this->containsAll($needles)) {
-            $result = $callback($this);
-
-            return $result ?? $this;
-        } elseif ($default) {
-            $result = $default($this);
-
-            return $result ?? $this;
-        }
-
-        return $this;
+        return $this->when($this->containsAll($needles), $callback, $default);
     }
 
     /**

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -766,6 +766,52 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Execute the given callback if the string contains a given substring.
+     *
+     * @param  string|array  $needles
+     * @param  callable  $callback
+     * @param  callable|null  $default
+     * @return static
+     */
+    public function whenContains($needles, $callback, $default = null)
+    {
+        if ($this->contains($needles)) {
+            $result = $callback($this);
+
+            return $result ?? $this;
+        } elseif ($default) {
+            $result = $default($this);
+
+            return $result ?? $this;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Execute the given callback if the string contains all array values.
+     *
+     * @param  array  $needles
+     * @param  callable  $callback
+     * @param  callable|null  $default
+     * @return static
+     */
+    public function whenContainsAll(array $needles, $callback, $default = null)
+    {
+        if ($this->containsAll($needles)) {
+            $result = $callback($this);
+
+            return $result ?? $this;
+        } elseif ($default) {
+            $result = $default($this);
+
+            return $result ?? $this;
+        }
+
+        return $this;
+    }
+
+    /**
      * Execute the given callback if the string is empty.
      *
      * @param  callable  $callback

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -812,6 +812,165 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Execute the given callback if the string ends with a given substring.
+     *
+     * @param  string|array  $needles
+     * @param  callable  $callback
+     * @param  callable|null  $default
+     * @return static
+     */
+    public function whenEndsWith($needles, $callback, $default = null)
+    {
+        if ($this->endsWith($needles)) {
+            $result = $callback($this);
+
+            return $result ?? $this;
+        } elseif ($default) {
+            $result = $default($this);
+
+            return $result ?? $this;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Execute the given callback if the string is an exact match with the given value.
+     *
+     * @param  string  $value
+     * @param  callable  $callback
+     * @param  callable|null  $default
+     * @return static
+     */
+    public function whenExactly($value, $callback, $default = null)
+    {
+        if ($this->exactly($value)) {
+            $result = $callback($this);
+
+            return $result ?? $this;
+        } elseif ($default) {
+            $result = $default($this);
+
+            return $result ?? $this;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Execute the given callback if the string matches a given pattern.
+     *
+     * @param  string|array  $pattern
+     * @param  callable  $callback
+     * @param  callable|null  $default
+     * @return static
+     */
+    public function whenIs($pattern, $callback, $default = null)
+    {
+        if ($this->is($pattern)) {
+            $result = $callback($this);
+
+            return $result ?? $this;
+        } elseif ($default) {
+            $result = $default($this);
+
+            return $result ?? $this;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Execute the given callback if the string is 7 bit ASCII.
+     *
+     * @param  callable  $callback
+     * @param  callable|null  $default
+     * @return static
+     */
+    public function whenIsAscii($callback, $default = null)
+    {
+        if ($this->isAscii()) {
+            $result = $callback($this);
+
+            return $result ?? $this;
+        } elseif ($default) {
+            $result = $default($this);
+
+            return $result ?? $this;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Execute the given callback if the string is a valid UUID.
+     *
+     * @param  callable  $callback
+     * @param  callable|null  $default
+     * @return static
+     */
+    public function whenIsUuid($callback, $default = null)
+    {
+        if ($this->isUuid()) {
+            $result = $callback($this);
+
+            return $result ?? $this;
+        } elseif ($default) {
+            $result = $default($this);
+
+            return $result ?? $this;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Execute the given callback if the string matches the given pattern.
+     *
+     * @param  string  $pattern
+     * @param  callable  $callback
+     * @param  callable|null  $default
+     * @return static
+     */
+    public function whenTest($pattern, $callback, $default = null)
+    {
+        if ($this->test($pattern)) {
+            $result = $callback($this);
+
+            return $result ?? $this;
+        } elseif ($default) {
+            $result = $default($this);
+
+            return $result ?? $this;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Execute the given callback if the string starts with a given substring.
+     *
+     * @param  string|array  $needles
+     * @param  callable  $callback
+     * @param  callable|null  $default
+     * @return static
+     */
+    public function whenStartsWith($needles, $callback, $default = null)
+    {
+        if ($this->startsWith($needles)) {
+            $result = $callback($this);
+
+            return $result ?? $this;
+        } elseif ($default) {
+            $result = $default($this);
+
+            return $result ?? $this;
+        }
+
+        return $this;
+    }
+
+    /**
      * Execute the given callback if the string is empty.
      *
      * @param  callable  $callback

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -821,17 +821,7 @@ class Stringable implements JsonSerializable
      */
     public function whenEndsWith($needles, $callback, $default = null)
     {
-        if ($this->endsWith($needles)) {
-            $result = $callback($this);
-
-            return $result ?? $this;
-        } elseif ($default) {
-            $result = $default($this);
-
-            return $result ?? $this;
-        }
-
-        return $this;
+        return $this->when($this->endsWith($needles), $callback, $default);
     }
 
     /**
@@ -844,17 +834,7 @@ class Stringable implements JsonSerializable
      */
     public function whenExactly($value, $callback, $default = null)
     {
-        if ($this->exactly($value)) {
-            $result = $callback($this);
-
-            return $result ?? $this;
-        } elseif ($default) {
-            $result = $default($this);
-
-            return $result ?? $this;
-        }
-
-        return $this;
+        return $this->when($this->exactly($value), $callback, $default);
     }
 
     /**
@@ -867,17 +847,7 @@ class Stringable implements JsonSerializable
      */
     public function whenIs($pattern, $callback, $default = null)
     {
-        if ($this->is($pattern)) {
-            $result = $callback($this);
-
-            return $result ?? $this;
-        } elseif ($default) {
-            $result = $default($this);
-
-            return $result ?? $this;
-        }
-
-        return $this;
+        return $this->when($this->is($pattern), $callback, $default);
     }
 
     /**
@@ -889,17 +859,7 @@ class Stringable implements JsonSerializable
      */
     public function whenIsAscii($callback, $default = null)
     {
-        if ($this->isAscii()) {
-            $result = $callback($this);
-
-            return $result ?? $this;
-        } elseif ($default) {
-            $result = $default($this);
-
-            return $result ?? $this;
-        }
-
-        return $this;
+        return $this->when($this->isAscii(), $callback, $default);
     }
 
     /**
@@ -911,17 +871,7 @@ class Stringable implements JsonSerializable
      */
     public function whenIsUuid($callback, $default = null)
     {
-        if ($this->isUuid()) {
-            $result = $callback($this);
-
-            return $result ?? $this;
-        } elseif ($default) {
-            $result = $default($this);
-
-            return $result ?? $this;
-        }
-
-        return $this;
+        return $this->when($this->isUuid(), $callback, $default);
     }
 
     /**
@@ -934,17 +884,7 @@ class Stringable implements JsonSerializable
      */
     public function whenTest($pattern, $callback, $default = null)
     {
-        if ($this->test($pattern)) {
-            $result = $callback($this);
-
-            return $result ?? $this;
-        } elseif ($default) {
-            $result = $default($this);
-
-            return $result ?? $this;
-        }
-
-        return $this;
+        return $this->when($this->test($pattern), $callback, $default);
     }
 
     /**
@@ -957,17 +897,7 @@ class Stringable implements JsonSerializable
      */
     public function whenStartsWith($needles, $callback, $default = null)
     {
-        if ($this->startsWith($needles)) {
-            $result = $callback($this);
-
-            return $result ?? $this;
-        } elseif ($default) {
-            $result = $default($this);
-
-            return $result ?? $this;
-        }
-
-        return $this;
+        return $this->when($this->startsWith($needles), $callback, $default);
     }
 
     /**

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -150,6 +150,155 @@ class SupportStringableTest extends TestCase
         }));
     }
 
+    public function testWhenEndsWith()
+    {
+        $this->assertSame('Tony Stark', (string) $this->stringable('tony stark')->whenEndsWith('ark', function ($stringable) {
+            return $stringable->title();
+        }, function ($stringable) {
+            return $stringable->studly();
+        }));
+
+        $this->assertSame('Tony Stark', (string) $this->stringable('tony stark')->whenEndsWith(['kra', 'ark'], function ($stringable) {
+            return $stringable->title();
+        }, function ($stringable) {
+            return $stringable->studly();
+        }));
+
+        $this->assertSame('tony stark', (string) $this->stringable('tony stark')->whenEndsWith(['xxx'], function ($stringable) {
+            return $stringable->title();
+        }));
+
+        $this->assertSame('TonyStark', (string) $this->stringable('tony stark')->whenEndsWith(['tony', 'xxx'], function ($stringable) {
+            return $stringable->title();
+        }, function ($stringable) {
+            return $stringable->studly();
+        }));
+    }
+
+    public function testWhenExactly()
+    {
+        $this->assertSame('Nailed it...!', (string) $this->stringable('Tony Stark')->whenExactly('Tony Stark', function ($stringable) {
+            return 'Nailed it...!';
+        }, function ($stringable) {
+            return 'Swing and a miss...!';
+        }));
+
+        $this->assertSame('Swing and a miss...!', (string) $this->stringable('Tony Stark')->whenExactly('Iron Man', function ($stringable) {
+            return 'Nailed it...!';
+        }, function ($stringable) {
+            return 'Swing and a miss...!';
+        }));
+
+        $this->assertSame('Tony Stark', (string) $this->stringable('Tony Stark')->whenExactly('Iron Man', function ($stringable) {
+            return 'Nailed it...!';
+        }));
+    }
+
+    public function testWhenIs()
+    {
+        $this->assertSame('Winner: /', (string) $this->stringable('/')->whenIs('/', function ($stringable) {
+            return $stringable->prepend('Winner: ');
+        }, function ($stringable) {
+            return 'Try again';
+        }));
+
+        $this->assertSame('/', (string) $this->stringable('/')->whenIs(' /', function ($stringable) {
+            return $stringable->prepend('Winner: ');
+        }));
+
+        $this->assertSame('Try again', (string) $this->stringable('/')->whenIs(' /', function ($stringable) {
+            return $stringable->prepend('Winner: ');
+        }, function ($stringable) {
+            return 'Try again';
+        }));
+
+        $this->assertSame('Winner: foo/bar/baz', (string) $this->stringable('foo/bar/baz')->whenIs('foo/*', function ($stringable) {
+            return $stringable->prepend('Winner: ');
+        }));
+    }
+
+    public function testWhenIsAscii()
+    {
+        $this->assertSame('Ascii: A', (string) $this->stringable('A')->whenIsAscii(function ($stringable) {
+            return $stringable->prepend('Ascii: ');
+        }, function ($stringable) {
+            return $stringable->prepend('Not Ascii: ');
+        }));
+
+        $this->assertSame('ù', (string) $this->stringable('ù')->whenIsAscii(function ($stringable) {
+            return $stringable->prepend('Ascii: ');
+        }));
+
+        $this->assertSame('Not Ascii: ù', (string) $this->stringable('ù')->whenIsAscii(function ($stringable) {
+            return $stringable->prepend('Ascii: ');
+        }, function ($stringable) {
+            return $stringable->prepend('Not Ascii: ');
+        }));
+    }
+
+    public function testWhenIsUuid()
+    {
+        $this->assertSame('Uuid: 2cdc7039-65a6-4ac7-8e5d-d554a98e7b15', (string) $this->stringable('2cdc7039-65a6-4ac7-8e5d-d554a98e7b15')->whenIsUuid(function ($stringable) {
+            return $stringable->prepend('Uuid: ');
+        }, function ($stringable) {
+            return $stringable->prepend('Not Uuid: ');
+        }));
+
+        $this->assertSame('2cdc7039-65a6-4ac7-8e5d-d554a98', (string) $this->stringable('2cdc7039-65a6-4ac7-8e5d-d554a98')->whenIsUuid(function ($stringable) {
+            return $stringable->prepend('Uuid: ');
+        }));
+
+        $this->assertSame('Not Uuid: 2cdc7039-65a6-4ac7-8e5d-d554a98', (string) $this->stringable('2cdc7039-65a6-4ac7-8e5d-d554a98')->whenIsUuid(function ($stringable) {
+            return $stringable->prepend('Uuid: ');
+        }, function ($stringable) {
+            return $stringable->prepend('Not Uuid: ');
+        }));
+    }
+
+    public function testWhenTest()
+    {
+        $this->assertSame('Winner: foo bar', (string) $this->stringable('foo bar')->whenTest('/bar/', function ($stringable) {
+            return $stringable->prepend('Winner: ');
+        }, function ($stringable) {
+            return 'Try again';
+        }));
+
+        $this->assertSame('Try again', (string) $this->stringable('foo bar')->whenTest('/link/', function ($stringable) {
+            return $stringable->prepend('Winner: ');
+        }, function ($stringable) {
+            return 'Try again';
+        }));
+
+        $this->assertSame('foo bar', (string) $this->stringable('foo bar')->whenTest('/link/', function ($stringable) {
+            return $stringable->prepend('Winner: ');
+        }));
+    }
+
+    public function testWhenStartsWith()
+    {
+        $this->assertSame('Tony Stark', (string) $this->stringable('tony stark')->whenStartsWith('ton', function ($stringable) {
+            return $stringable->title();
+        }, function ($stringable) {
+            return $stringable->studly();
+        }));
+
+        $this->assertSame('Tony Stark', (string) $this->stringable('tony stark')->whenStartsWith(['ton', 'not'], function ($stringable) {
+            return $stringable->title();
+        }, function ($stringable) {
+            return $stringable->studly();
+        }));
+
+        $this->assertSame('tony stark', (string) $this->stringable('tony stark')->whenStartsWith(['xxx'], function ($stringable) {
+            return $stringable->title();
+        }));
+
+        $this->assertSame('Tony Stark', (string) $this->stringable('tony stark')->whenStartsWith(['tony', 'xxx'], function ($stringable) {
+            return $stringable->title();
+        }, function ($stringable) {
+            return $stringable->studly();
+        }));
+    }
+
     public function testWhenEmpty()
     {
         tap($this->stringable(), function ($stringable) {

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -112,6 +112,44 @@ class SupportStringableTest extends TestCase
         }));
     }
 
+    public function testWhenContains()
+    {
+        $this->assertSame('Tony Stark', (string) $this->stringable('stark')->whenContains('tar', function ($stringable) {
+            return $stringable->prepend('Tony ')->title();
+        }, function ($stringable) {
+            return $stringable->prepend('Arno ')->title();
+        }));
+
+        $this->assertSame('stark', (string) $this->stringable('stark')->whenContains('xxx', function ($stringable) {
+            return $stringable->prepend('Tony ')->title();
+        }));
+
+        $this->assertSame('Arno Stark', (string) $this->stringable('stark')->whenContains('xxx', function ($stringable) {
+            return $stringable->prepend('Tony ')->title();
+        }, function ($stringable) {
+            return $stringable->prepend('Arno ')->title();
+        }));
+    }
+
+    public function testWhenContainsAll()
+    {
+        $this->assertSame('Tony Stark', (string) $this->stringable('tony stark')->whenContainsAll(['tony', 'stark'], function ($stringable) {
+            return $stringable->title();
+        }, function ($stringable) {
+            return $stringable->studly();
+        }));
+
+        $this->assertSame('tony stark', (string) $this->stringable('tony stark')->whenContainsAll(['xxx'], function ($stringable) {
+            return $stringable->title();
+        }));
+
+        $this->assertSame('TonyStark', (string) $this->stringable('tony stark')->whenContainsAll(['tony', 'xxx'], function ($stringable) {
+            return $stringable->title();
+        }, function ($stringable) {
+            return $stringable->studly();
+        }));
+    }
+
     public function testWhenEmpty()
     {
         tap($this->stringable(), function ($stringable) {


### PR DESCRIPTION
Completing the changes noted in #40285, I implemented the following (remaining) "check-like" methods on the `Stringable` class:
- `endsWith()`
- `exactly()`
- `is()`
- `isAscii()`
- `isUuid()`
- `test()`
- `startsWith()`

Please let me know if there are any questions/concerns. 🤓