### PR TITLE
[9.x] Fix empty root prefix for S3

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -227,7 +227,7 @@ class FilesystemManager implements FactoryContract
     {
         $s3Config = $this->formatS3Config($config);
 
-        $root = $s3Config['root'] ?? null;
+        $root = (string) ($s3Config['root'] ?? '');
 
         $visibility = new AwsS3PortableVisibilityConverter(
             $config['visibility'] ?? Visibility::PUBLIC


### PR DESCRIPTION
When a root path prefix for the S3 adapter is `null` it'll need to be converted to a string before being passed to the adapter.