### PR TITLE
add whereLike function to query Builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1745,10 +1745,10 @@ class Builder
     /**
      * Simple and clean way to write 'where' with like operator.
      *
-     * @param string $column
-     * @param string $value
-     * @param string $position
-     * @return $this
+     * @param  string  $column
+     * @param  string  $value
+     * @param  string  $position
+     * @return  $this
      */
     public function whereLike($column, $value, $position = 'both')
     {

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1748,7 +1748,7 @@ class Builder
      * @param  string  $column
      * @param  string  $value
      * @param  string  $position
-     * @return  $this
+     * @return $this
      */
     public function whereLike($column, $value, $position = 'both')
     {

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1743,6 +1743,30 @@ class Builder
     }
 
     /**
+     * Simple and clean way to write 'where' with like operator.
+     *
+     * @param string $column
+     * @param string $value
+     * @param string $position
+     * @return $this
+     */
+    public function whereLike($column, $value, $position = 'both')
+    {
+        switch ($position) {
+            case 'before':
+                $value = '%'.$value;
+                break;
+            case 'after':
+                $value .= '%';
+                break;
+            default:
+                $value = '%'.$value.'%';
+        }
+
+        return $this->where($column, 'like', $value);
+    }
+
+    /**
      * Add an "or where JSON length" clause to the query.
      *
      * @param  string  $column

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -875,7 +875,6 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('users')->whereLike('first_name', 'eoffre');
         $this->assertSame('select * from "users" where "first_name" like ?', $builder->toSql());
         $this->assertEquals(['%eoffre%'], $builder->getBindings());
-
     }
 
     public function testWhereFulltextMySql()

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -859,6 +859,25 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([], $builder->getBindings());
     }
 
+    public function testWhereLike()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereLike('first_name', 'eoffrey', 'before');
+        $this->assertSame('select * from "users" where "first_name" like ?', $builder->toSql());
+        $this->assertEquals(['%eoffrey'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereLike('first_name', 'geoffre', 'after');
+        $this->assertSame('select * from "users" where "first_name" like ?', $builder->toSql());
+        $this->assertEquals(['geoffre%'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereLike('first_name', 'eoffre');
+        $this->assertSame('select * from "users" where "first_name" like ?', $builder->toSql());
+        $this->assertEquals(['%eoffre%'], $builder->getBindings());
+
+    }
+
     public function testWhereFulltextMySql()
     {
         $builder = $this->getMySqlBuilderWithProcessor();


### PR DESCRIPTION
This is a helper function that greatly simplifies writing a 'where' condition with the 'like' operator. The function
accepts 3 parameters:

-  `column`
-  `value`
- `position`

By default the value passed as a `position` parameter wrap the `value` with `%`. 

This `position` parameter can be
modified to `before` or `after` to specify where the `%` should be placed in relation to the `value`.

````php
$email = '@laravel.com';

// Default position case
User::where('email', 'like', '%'.$mail.'%');
User::whereLike('email', $email);

// Before position case
User::where('email', 'like', '%'.$mail);
User::whereLike('email', $email, 'before');

// After position case
User::where('email', 'like', $mail.'%');
User::whereLike('email', $email, 'after');
````