### PR TITLE
[8.x] Removes PHP deprecations from tests

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,6 +2,7 @@
 <phpunit backupGlobals="false"
          backupStaticAttributes="false"
          beStrictAboutTestsThatDoNotTestAnything="false"
+         bootstrap="tests/bootstrap.php"
          colors="true"
          convertDeprecationsToExceptions="true"
          convertErrorsToExceptions="true"

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,5 @@
+<?php
+
+error_reporting(E_ALL & ~E_DEPRECATED);
+
+require __DIR__.'/../vendor/autoload.php';


### PR DESCRIPTION
This pull request enforces the `E_ALL & ~E_DEPRECATED` error level in our framework tests. In other words, this ensures PHP deprecations are not reported, fixing this way a few deprecations we were seeing while running PHPUnit:

<img width="1192" alt="Screenshot 2022-01-10 at 12 48 47" src="https://user-images.githubusercontent.com/5457236/148768460-921c1983-f6ed-40d6-87ce-5daf0b5d4fdb.png">

Note that the `E_USER_DEPRECATED` level are still enabled, as we need user level deprecations to test our deprecations log channel: 

- [tests/Testing/Concerns/InteractsWithDeprecationHandlingTest.php](https://github.com/laravel/framework/blob/8.x/tests/Testing/Concerns/InteractsWithDeprecationHandlingTest.php)

This should be merged to `master` - that have a lot more warnings.