### PR TITLE
[8.x] Throw deprecation errors in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,6 +50,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, gd, redis, memcached
+          ini-values: error_reporting=E_ALL
           tools: composer:v2
           coverage: none
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,7 +67,7 @@ jobs:
         with:
           timeout_minutes: 5
           max_attempts: 5
-          command: composer require league/commonmark:^2.0.2 phpunit/phpunit:^9.5.8 ramsey/collection:^1.2 --no-interaction --no-update
+          command: composer require league/commonmark:^2.0.2 phpunit/phpunit:^9.5.8 ramsey/collection:^1.2 brick/math:^0.9.3 --no-interaction --no-update
         if: matrix.php >= 8.1
 
       - name: Install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,7 +67,7 @@ jobs:
         with:
           timeout_minutes: 5
           max_attempts: 5
-          command: composer require league/commonmark:^2.0.2 phpunit/phpunit:^9.5.8 --no-interaction --no-update
+          command: composer require league/commonmark:^2.0.2 phpunit/phpunit:^9.5.8 ramsey/collection:^1.2 --no-interaction --no-update
         if: matrix.php >= 8.1
 
       - name: Install dependencies

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "symfony/routing": "^5.4",
         "symfony/var-dumper": "^5.4",
         "tijsverkoyen/css-to-inline-styles": "^2.2.2",
-        "vlucas/phpdotenv": "^5.2",
+        "vlucas/phpdotenv": "^5.4.1",
         "voku/portable-ascii": "^1.4.8"
     },
     "replace": {

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -46,7 +46,7 @@
         "ramsey/uuid": "Required to use Str::uuid() (^4.2.2).",
         "symfony/process": "Required to use the composer class (^5.4).",
         "symfony/var-dumper": "Required to use the dd function (^5.4).",
-        "vlucas/phpdotenv": "Required to use the Env class and env helper (^5.2)."
+        "vlucas/phpdotenv": "Required to use the Env class and env helper (^5.4.1)."
     },
     "config": {
         "sort-packages": true

--- a/tests/Support/SupportFacadeTest.php
+++ b/tests/Support/SupportFacadeTest.php
@@ -99,7 +99,8 @@ class ApplicationStub implements ArrayAccess
         return isset($this->attributes[$offset]);
     }
 
-    public function offsetGet($key): mixed
+    #[\ReturnTypeWillChange]
+    public function offsetGet($key)
     {
         return $this->attributes[$key];
     }

--- a/tests/Support/SupportFacadeTest.php
+++ b/tests/Support/SupportFacadeTest.php
@@ -94,22 +94,22 @@ class ApplicationStub implements ArrayAccess
         $this->attributes[$key] = $instance;
     }
 
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->attributes[$offset]);
     }
 
-    public function offsetGet($key)
+    public function offsetGet($key): mixed
     {
         return $this->attributes[$key];
     }
 
-    public function offsetSet($key, $value)
+    public function offsetSet($key, $value): void
     {
         $this->attributes[$key] = $value;
     }
 
-    public function offsetUnset($key)
+    public function offsetUnset($key): void
     {
         unset($this->attributes[$key]);
     }

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -795,22 +795,22 @@ class SupportTestArrayAccess implements ArrayAccess
         $this->attributes = $attributes;
     }
 
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return array_key_exists($offset, $this->attributes);
     }
 
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return $this->attributes[$offset];
     }
 
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->attributes[$offset] = $value;
     }
 
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->attributes[$offset]);
     }

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -800,7 +800,8 @@ class SupportTestArrayAccess implements ArrayAccess
         return array_key_exists($offset, $this->attributes);
     }
 
-    public function offsetGet($offset): mixed
+    #[\ReturnTypeWillChange]
+    public function offsetGet($offset)
     {
         return $this->attributes[$offset];
     }


### PR DESCRIPTION
This PR enables the CI environment to also throw errors for deprecations. By doing this we both ensure we're on top of changes as soon as possible and make sure that the test suite can also be run in different environments (for example, locally) when deprecation throwing is enabled in PHP.

As soon as this is merged and 8.x is merged into master I'll also fix the tests on master.