### PR TITLE
[8.x] Add generator support to LazyCollection

### DIFF
--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -32,6 +32,10 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     {
         if ($source instanceof Closure || $source instanceof self) {
             $this->source = $source;
+        } elseif ($source instanceof \Generator) {
+            $this->source = function () use ($source) {
+                yield from $source;
+            };
         } elseif (is_null($source)) {
             $this->source = static::empty();
         } else {

--- a/tests/Support/SupportLazyCollectionTest.php
+++ b/tests/Support/SupportLazyCollectionTest.php
@@ -69,6 +69,31 @@ class SupportLazyCollectionTest extends TestCase
         ], $data->all());
     }
 
+    public function testCanCreateCollectionFromGenerator()
+    {
+        $generatorClosure = function () {
+            yield 1;
+            yield 2;
+            yield 3;
+        };
+        $data = LazyCollection::make($generatorClosure());
+
+        $this->assertSame([1, 2, 3], $data->all());
+
+        $generatorClosure = function () {
+            yield 'a' => 1;
+            yield 'b' => 2;
+            yield 'c' => 3;
+        };
+        $data = LazyCollection::make($generatorClosure());
+
+        $this->assertSame([
+            'a' => 1,
+            'b' => 2,
+            'c' => 3,
+        ], $data->all());
+    }
+
     public function testEager()
     {
         $source = [1, 2, 3, 4, 5];
@@ -211,5 +236,20 @@ class SupportLazyCollectionTest extends TestCase
         $data->all();
 
         $this->assertSame([1, 2], $data->all());
+    }
+
+    public function testGenerator()
+    {
+        $source = [1, 2, 3, 4, 5];
+
+        $generatorClosure = function () use (&$source) {
+            yield from $source;
+        };
+
+        $collection = LazyCollection::make($generatorClosure());
+
+        $source[] = 6;
+
+        $this->assertSame($source, $collection->all());
     }
 }


### PR DESCRIPTION
LazyCollection supports generator closures but not generators themselves, if you pass in a generator it gets eager loaded (turned into an array). My PR wraps the generator in a closure so it maintains the generator behavior.

```php
$source = [1, 2, 3, 4, 5];

$generatorClosure = function () use (&$source) {
    yield from $source;
};

$collection = LazyCollection::make($generatorClosure());

$source[] = 6;

$collection->all(); // before: [1, 2, 3, 4, 5]
                    // after: [1, 2, 3, 4, 5, 6]
```

An example use case would be the `cursor` method in the `Illuminate\Database\Query` class:

```php
public function cursor()
{
    if (is_null($this->columns)) {
        $this->columns = ['*'];
    }

    return new LazyCollection(function () {
        yield from $this->connection->cursor(
            $this->toSql(), $this->getBindings(), ! $this->useWritePdo
        );
    });
}
```
Becomes:
```php
public function cursor()
{
    if (is_null($this->columns)) {
        $this->columns = ['*'];
    }

    return new LazyCollection($this->connection->cursor(
        $this->toSql(), $this->getBindings(), ! $this->useWritePdo
    ));
}
```