### PR TITLE
[8.x] Add generator support to LazyCollection

### DIFF
--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -32,6 +32,10 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     {
         if ($source instanceof Closure || $source instanceof self) {
             $this->source = $source;
+        } elseif ($source instanceof \Generator) {
+            $this->source = function () use ($source) {
+                yield from $source;
+            };
         } elseif (is_null($source)) {
             $this->source = static::empty();
         } else {

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -29,13 +29,13 @@ class SupportLazyCollectionIsLazyTest extends TestCase
         });
     }
 
-    public function testMakeWithGeneratorIsNotLazy()
+    public function testMakeWithGeneratorIsLazy()
     {
         [$closure, $recorder] = $this->makeGeneratorFunctionWithRecorder(5);
 
         LazyCollection::make($closure());
 
-        $this->assertEquals([1, 2, 3, 4, 5], $recorder->all());
+        $this->assertEquals([], $recorder->all());
     }
 
     public function testEagerEnumeratesOnce()

--- a/tests/Support/SupportLazyCollectionTest.php
+++ b/tests/Support/SupportLazyCollectionTest.php
@@ -69,6 +69,31 @@ class SupportLazyCollectionTest extends TestCase
         ], $data->all());
     }
 
+    public function testCanCreateCollectionFromGenerator()
+    {
+        $generatorClosure = function () {
+            yield 1;
+            yield 2;
+            yield 3;
+        };
+        $data = LazyCollection::make($generatorClosure());
+
+        $this->assertSame([1, 2, 3], $data->all());
+
+        $generatorClosure = function () {
+            yield 'a' => 1;
+            yield 'b' => 2;
+            yield 'c' => 3;
+        };
+        $data = LazyCollection::make($generatorClosure());
+
+        $this->assertSame([
+            'a' => 1,
+            'b' => 2,
+            'c' => 3,
+        ], $data->all());
+    }
+
     public function testEager()
     {
         $source = [1, 2, 3, 4, 5];


### PR DESCRIPTION
LazyCollection fix

LazyCollection supports generator closures but not generators themselves, if you pass in a generator it gets eager loaded (turned into an array). My PR wraps the generator in a closure so it maintains the generator behavior.

```php
$source = [1, 2, 3, 4, 5];

$generatorClosure = function () use (&$source) {
    yield from $source;
};

$collection = LazyCollection::make($generatorClosure());

$source[] = 6;

$collection->all(); // before: [1, 2, 3, 4, 5]
                    // after: [1, 2, 3, 4, 5, 6]
```

An example use case would be the `cursor` method in the `Illuminate\Database\Query` class:

```php
public function cursor()
{
    if (is_null($this->columns)) {
        $this->columns = ['*'];
    }

    return new LazyCollection(function () {
        yield from $this->connection->cursor(
            $this->toSql(), $this->getBindings(), ! $this->useWritePdo
        );
    });
}
```
Becomes:
```php
public function cursor()
{
    if (is_null($this->columns)) {
        $this->columns = ['*'];
    }

    return new LazyCollection($this->connection->cursor(
        $this->toSql(), $this->getBindings(), ! $this->useWritePdo
    ));
}
```

Note: I am aware of [this PR](https://github.com/laravel/framework/discussions/33297), but I don't think the reasoning is valid. If you pass in a closure that returns a Generator there is no difference to us wrapping a generator into a closure.

Please share your thoughts about this below, I'm trying to find a reason why it shouldn't be supported.