### PR TITLE
[8.x] Register middleware by annotation (Attribute)

### DIFF
--- a/src/Illuminate/Attributes/Routing/Middleware.php
+++ b/src/Illuminate/Attributes/Routing/Middleware.php
@@ -8,11 +8,11 @@ use Attribute;
 class Middleware
 {
     /**
-     * @param string $name
-     * @param string[] $arguments
-     * @param array $options
+     * @param  string  $name
+     * @param  string[]  $arguments
+     * @param  array  $options
      */
-    function __construct(public string $name, public array $arguments = [], public array $options = [])
+    public function __construct(public string $name, public array $arguments = [], public array $options = [])
     {
     }
 }

--- a/src/Illuminate/Attributes/Routing/Middleware.php
+++ b/src/Illuminate/Attributes/Routing/Middleware.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Attributes\Routing;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
+class Middleware
+{
+    /**
+     * @param string $name
+     * @param string[] $arguments
+     * @param array $options
+     */
+    function __construct(public string $name, public array $arguments = [], public array $options = [])
+    {
+    }
+}

--- a/src/Illuminate/Routing/Controller.php
+++ b/src/Illuminate/Routing/Controller.php
@@ -45,7 +45,7 @@ abstract class Controller
     }
 
     /**
-     * Get the controller middlewares by attributes
+     * Get the controller middlewares by attributes.
      *
      * @see \Illuminate\Attributes\Routing\Middleware
      *
@@ -56,7 +56,9 @@ abstract class Controller
         $middlewares = [];
 
         // PHP 8+
-        if (80000 > PHP_VERSION_ID) return $middlewares;
+        if (80000 > PHP_VERSION_ID) {
+            return $middlewares;
+        }
 
         /** @var \ReflectionAttribute[] $attributes */
         $push = function (array $attributes, ?string $method = null) use (&$middlewares) {
@@ -70,10 +72,12 @@ abstract class Controller
 
                 $middlewares[] = [
                     'middleware' => "$name$arguments",
-                    'options' => &$options
+                    'options' => &$options,
                 ];
 
-                if ($method) (new ControllerMiddlewareOptions($options))->only($method);
+                if ($method) {
+                    (new ControllerMiddlewareOptions($options))->only($method);
+                }
             }
         };
 

--- a/tests/Routing/RouteMiddlewareByAttributeTest.php
+++ b/tests/Routing/RouteMiddlewareByAttributeTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
 
 class RouteMiddlewareByAttributeTest extends TestCase
 {
-    /** @var \Illuminate\Tests\Routing\fixtures\MiddlewareByAttributeController | null $controller */
+    /** @var \Illuminate\Tests\Routing\fixtures\MiddlewareByAttributeController | null */
     protected $controller = null;
 
     protected function setUp(): void
@@ -16,7 +16,8 @@ class RouteMiddlewareByAttributeTest extends TestCase
 
         try {
             $this->controller = app()->make('\Illuminate\Tests\Routing\fixtures\MiddlewareByAttributeController');
-        } catch (Exception $e) {}
+        } catch (Exception $e) {
+        }
     }
 
     public function testControllerInstance()

--- a/tests/Routing/RouteMiddlewareByAttributeTest.php
+++ b/tests/Routing/RouteMiddlewareByAttributeTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Illuminate\Tests\Routing;
+
+use Exception;
+use PHPUnit\Framework\TestCase;
+
+class RouteMiddlewareByAttributeTest extends TestCase
+{
+    /** @var \Illuminate\Tests\Routing\fixtures\MiddlewareByAttributeController | null $controller */
+    protected $controller = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        try {
+            $this->controller = app()->make('\Illuminate\Tests\Routing\fixtures\MiddlewareByAttributeController');
+        } catch (Exception $e) {}
+    }
+
+    public function testControllerInstance()
+    {
+        $this->assertNotNull($this->controller);
+    }
+
+    public function testControllerMiddleware()
+    {
+        $middleware = collect($this->controller->getMiddleware())->pluck('middleware')->all();
+
+        $this->assertEquals(['one', 'two:arg1,arg2'], $middleware);
+    }
+}

--- a/tests/Routing/fixtures/MiddlewareByAttributeController.php
+++ b/tests/Routing/fixtures/MiddlewareByAttributeController.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Tests\Routing\fixtures;
+
+use Illuminate\Attributes\Routing\Middleware;
+use Illuminate\Routing\Controller;
+
+#[Middleware('one')]
+class MiddlewareByAttributeController extends Controller {
+    #[Middleware('two', ['arg1', 'arg2'])]
+    public function index()
+    {}
+}

--- a/tests/Routing/fixtures/MiddlewareByAttributeController.php
+++ b/tests/Routing/fixtures/MiddlewareByAttributeController.php
@@ -6,8 +6,10 @@ use Illuminate\Attributes\Routing\Middleware;
 use Illuminate\Routing\Controller;
 
 #[Middleware('one')]
-class MiddlewareByAttributeController extends Controller {
+class MiddlewareByAttributeController extends Controller
+{
     #[Middleware('two', ['arg1', 'arg2'])]
     public function index()
-    {}
+    {
+    }
 }


### PR DESCRIPTION
Hi !
I'm interested to new PHP 8 feature: annotation (Attribute)
So why we don't using it ? :)
Currently for assigning middleware to a method we do:
```php
class BlogController extend BaseController {
  function __constructor() {
    $this->middleware(UserHasRole::class.':blog_editor')->only('store');
  }
}
```
Now with this PR you can use annotation:
```php
use Illuminate\Attributes\Routing\Middleware;

class BlogController extend BaseController {
  #[Middleware(UserHasRole::class, ['blog_editor'])]
  function store(Request $request) {
    // Logic
  }
}
```
