### PR TITLE
[8.x] Add `Http::configure()` method

### DIFF
--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -140,7 +140,7 @@ class Factory
      *
      * @param  \Closure  $callback
      * @return $this
-    */
+     */
     public function configure(Closure $callback)
     {
         $this->configureCallback = $callback;

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -149,6 +149,16 @@ class Factory
     }
 
     /**
+     * Get the callback used to configure all requests.
+     *
+     * @return \Closure|null
+     */
+    public function getConfigureCallback()
+    {
+        return $this->configureCallback;
+    }
+
+    /**
      * Get an invokable object that returns a sequence of responses in order for use during stubbing.
      *
      * @param  array  $responses
@@ -381,11 +391,7 @@ class Factory
      */
     protected function newPendingRequest()
     {
-        return tap(new PendingRequest($this), function (PendingRequest $request) {
-            if ($this->configureCallback) {
-                call_user_func($this->configureCallback, $request);
-            }
-        });
+        return new PendingRequest($this);
     }
 
     /**

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -650,6 +650,10 @@ class PendingRequest
      */
     public function send(string $method, string $url, array $options = [])
     {
+        if ($configureCallback = $this->factory->getConfigureCallback()) {
+            call_user_func($configureCallback, $this);
+        }
+
         $url = ltrim(rtrim($this->baseUrl, '/').'/'.ltrim($url, '/'), '/');
 
         if (isset($options[$this->bodyFormat])) {

--- a/src/Illuminate/Support/Facades/Http.php
+++ b/src/Illuminate/Support/Facades/Http.php
@@ -37,6 +37,7 @@ use Illuminate\Http\Client\Factory;
  * @method static \Illuminate\Http\Client\PendingRequest withoutVerifying()
  * @method static array pool(callable $callback)
  * @method static \Illuminate\Http\Client\Factory configure(\Closure $callback)
+ * @method static \Closure|null getConfigureCallback()
  * @method static \Illuminate\Http\Client\Response delete(string $url, array $data = [])
  * @method static \Illuminate\Http\Client\Response get(string $url, array|string|null $query = null)
  * @method static \Illuminate\Http\Client\Response head(string $url, array|string|null $query = null)

--- a/src/Illuminate/Support/Facades/Http.php
+++ b/src/Illuminate/Support/Facades/Http.php
@@ -36,6 +36,7 @@ use Illuminate\Http\Client\Factory;
  * @method static \Illuminate\Http\Client\PendingRequest withoutRedirecting()
  * @method static \Illuminate\Http\Client\PendingRequest withoutVerifying()
  * @method static array pool(callable $callback)
+ * @method static \Illuminate\Http\Client\Factory configure(\Closure $callback)
  * @method static \Illuminate\Http\Client\Response delete(string $url, array $data = [])
  * @method static \Illuminate\Http\Client\Response get(string $url, array|string|null $query = null)
  * @method static \Illuminate\Http\Client\Response head(string $url, array|string|null $query = null)

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -1067,4 +1067,21 @@ class HttpClientTest extends TestCase
 
         $this->factory->get('https://example.com');
     }
+
+    public function testConfigureCallbackIsCalled()
+    {
+        $this->factory->configure(function (PendingRequest $request) {
+            $request->withHeaders([
+                'custom' => 'yes!',
+            ]);
+        });
+
+        $this->factory->fake(function (Request $request) {
+            $this->assertTrue($request->hasHeader('custom', 'yes!'));
+
+            return $this->factory->response();
+        });
+
+        $this->factory->get('https://example.com');
+    }
 }


### PR DESCRIPTION
This pull request introduces a new `Http::configure()` method that can be used to modify all `PendingRequest` objects globally.

```php
class AppServiceProvider extends ServiceProvider
{
    public function boot() {
        Http::configure(function (PendingRequest $request) {
            $request->withHeaders(['custom' => 'yes!']);
        });
    }
}
```

In this scenario, all requests made from the app will have this custom header applied.