### PR TITLE
[8.x] Makes it easy to add additional options to `PendingBatch`

### DIFF
--- a/src/Illuminate/Bus/PendingBatch.php
+++ b/src/Illuminate/Bus/PendingBatch.php
@@ -215,7 +215,7 @@ class PendingBatch
 
         return $this;
     }
-    
+
     /**
      * Specify additional option.
      *
@@ -226,7 +226,7 @@ class PendingBatch
     public function addOption(string $key, $value)
     {
         $this->options[$key] = $value;
-        
+
         return $this;
     }
 

--- a/src/Illuminate/Bus/PendingBatch.php
+++ b/src/Illuminate/Bus/PendingBatch.php
@@ -215,6 +215,20 @@ class PendingBatch
 
         return $this;
     }
+    
+    /**
+     * Specify additional option.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function addOption(string $key, $value)
+    {
+        $this->options[$key] = $value;
+        
+        return $this;
+    }
 
     /**
      * Get the queue used by the pending batch.

--- a/tests/Bus/BusPendingBatchTest.php
+++ b/tests/Bus/BusPendingBatchTest.php
@@ -41,12 +41,14 @@ class BusPendingBatchTest extends TestCase
             //
         })->catch(function () {
             //
-        })->allowFailures()->onConnection('test-connection')->onQueue('test-queue');
+        })->allowFailures()->onConnection('test-connection')->onQueue('test-queue')->addOption('extra-option', 123);
 
         $this->assertSame('test-connection', $pendingBatch->connection());
         $this->assertSame('test-queue', $pendingBatch->queue());
         $this->assertCount(1, $pendingBatch->thenCallbacks());
         $this->assertCount(1, $pendingBatch->catchCallbacks());
+        $this->assertArrayHasKey('extra-option', $pendingBatch->options);
+        $this->assertSame(123, $pendingBatch->options['extra-option']);
 
         $repository = m::mock(BatchRepository::class);
         $repository->shouldReceive('store')->once()->with($pendingBatch)->andReturn($batch = m::mock(stdClass::class));


### PR DESCRIPTION
Useful when extra identifier or parameter needed on Batch.

Use-case:
When a batch is dispatched by a user we can set `user_id` as an extra option. When authorizing the batch model we can use the value of this option.