### PR TITLE
[8.x] Add method to MigrationsStarted/MigrationEnded events

### DIFF
--- a/src/Illuminate/Database/Events/MigrationsEnded.php
+++ b/src/Illuminate/Database/Events/MigrationsEnded.php
@@ -2,9 +2,7 @@
 
 namespace Illuminate\Database\Events;
 
-use Illuminate\Contracts\Database\Events\MigrationEvent as MigrationEventContract;
-
-class MigrationsEnded implements MigrationEventContract
+class MigrationsEnded extends MigrationsEvent
 {
     //
 }

--- a/src/Illuminate/Database/Events/MigrationsEvent.php
+++ b/src/Illuminate/Database/Events/MigrationsEvent.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Illuminate\Database\Events;
+
+use Illuminate\Contracts\Database\Events\MigrationEvent as MigrationEventContract;
+
+abstract class MigrationsEvent implements MigrationEventContract
+{
+    /**
+     * The migration method that was called.
+     *
+     * @var string
+     */
+    public $method;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  string  $method
+     * @return void
+     */
+    public function __construct($method)
+    {
+        $this->method = $method;
+    }
+}

--- a/src/Illuminate/Database/Events/MigrationsEvent.php
+++ b/src/Illuminate/Database/Events/MigrationsEvent.php
@@ -7,7 +7,7 @@ use Illuminate\Contracts\Database\Events\MigrationEvent as MigrationEventContrac
 abstract class MigrationsEvent implements MigrationEventContract
 {
     /**
-     * The migration method that was called.
+     * The migration method that was invoked.
      *
      * @var string
      */

--- a/src/Illuminate/Database/Events/MigrationsStarted.php
+++ b/src/Illuminate/Database/Events/MigrationsStarted.php
@@ -2,9 +2,7 @@
 
 namespace Illuminate\Database\Events;
 
-use Illuminate\Contracts\Database\Events\MigrationEvent as MigrationEventContract;
-
-class MigrationsStarted implements MigrationEventContract
+class MigrationsStarted extends MigrationsEvent
 {
     //
 }

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -158,7 +158,7 @@ class Migrator
 
         $step = $options['step'] ?? false;
 
-        $this->fireMigrationEvent(new MigrationsStarted);
+        $this->fireMigrationEvent(new MigrationsStarted('up'));
 
         // Once we have the array of migrations, we will spin through them and run the
         // migrations "up" so the changes are made to the databases. We'll then log
@@ -171,7 +171,7 @@ class Migrator
             }
         }
 
-        $this->fireMigrationEvent(new MigrationsEnded);
+        $this->fireMigrationEvent(new MigrationsEnded('up'));
     }
 
     /**
@@ -265,7 +265,7 @@ class Migrator
 
         $this->requireFiles($files = $this->getMigrationFiles($paths));
 
-        $this->fireMigrationEvent(new MigrationsStarted);
+        $this->fireMigrationEvent(new MigrationsStarted('down'));
 
         // Next we will run through all of the migrations and call the "down" method
         // which will reverse each migration in order. This getLast method on the
@@ -287,7 +287,7 @@ class Migrator
             );
         }
 
-        $this->fireMigrationEvent(new MigrationsEnded);
+        $this->fireMigrationEvent(new MigrationsEnded('down'));
 
         return $rolledBack;
     }

--- a/tests/Integration/Database/MigratorEventsTest.php
+++ b/tests/Integration/Database/MigratorEventsTest.php
@@ -47,6 +47,12 @@ class MigratorEventsTest extends TestCase
         Event::assertDispatched(MigrationsStarted::class, function ($event) {
             return $event->method === 'down';
         });
+        Event::assertDispatched(MigrationsEnded::class, function ($event) {
+            return $event->method === 'up';
+        });
+        Event::assertDispatched(MigrationsEnded::class, function ($event) {
+            return $event->method === 'down';
+        });
 
         Event::assertDispatched(MigrationStarted::class, function ($event) {
             return $event->method === 'up' && $event->migration instanceof Migration;

--- a/tests/Integration/Database/MigratorEventsTest.php
+++ b/tests/Integration/Database/MigratorEventsTest.php
@@ -41,6 +41,13 @@ class MigratorEventsTest extends TestCase
         $this->artisan('migrate', $this->migrateOptions());
         $this->artisan('migrate:rollback', $this->migrateOptions());
 
+        Event::assertDispatched(MigrationsStarted::class, function ($event) {
+            return $event->method === 'up';
+        });
+        Event::assertDispatched(MigrationsStarted::class, function ($event) {
+            return $event->method === 'down';
+        });
+
         Event::assertDispatched(MigrationStarted::class, function ($event) {
             return $event->method === 'up' && $event->migration instanceof Migration;
         });


### PR DESCRIPTION
The `MigrationStarted` and `MigrationEnded` events that are fired for individual migrations have a `method` property that can have the values `up` or `down` to indicate whether this is a migration or a rollback.

However, the `MigrationsStarted` and `MigrationsEnded` (plural) which run at the beginning and end of a set of migrations do not have this property.

This PR adds the `method` property to those events as well.

The intended use-case of this change is to allow pre- and post-migration code to run better. For example, consider this code:

```php
// Check if the proper PostgreSQL extensions are loaded.
// Throws an exception if an extension is missing or the PostgreSQL version is too old.
Event::listen(function (MigrationsStarted $event) {
    Artisan::call('project:ensure-extensions', ['--ansi' => true]);
    echo Artisan::output();
});

// Ensure initial required data is present in the database after migrations are complete.
// See https://twitter.com/taylorotwell/status/1387766514674192384 (thread)
// for the inspiration behind this code.
Event::listen(function (MigrationsEnded $event) {
    Artisan::call('project:ensure-db', ['--ansi' => true]);
    echo Artisan::output();
});
```

There are two problems with the above code when running `migrate:rollback`:

1. (minor) It is unnecessary to run `project:ensure-extensions` because the database tables already exist so the requirements were clearly met.
2. (major) `project:ensure-db` will crash because it is trying to write to database tables that no longer exist.

With this PR, the code above can be modified like this:

```php
// Check if the proper PostgreSQL extensions are loaded.
// Throws an exception if an extension is missing or the PostgreSQL version is too old.
Event::listen(function (MigrationsStarted $event) {
    if ($event->method === 'up') {
        Artisan::call('project:ensure-extensions', ['--ansi' => true]);
        echo Artisan::output();
    }
});

// Ensure initial required data is present in the database after migrations are complete.
// See https://twitter.com/taylorotwell/status/1387766514674192384 (thread)
// for the inspiration behind this code.
Event::listen(function (MigrationsEnded $event) {
    if ($event->method === 'up') {
        Artisan::call('project:ensure-db', ['--ansi' => true]);
        echo Artisan::output();
    }
});
```