### PR TITLE
[8.x] Make assertPath() check if $path exists

### DIFF
--- a/src/Illuminate/Testing/AssertableJsonString.php
+++ b/src/Illuminate/Testing/AssertableJsonString.php
@@ -219,6 +219,19 @@ class AssertableJsonString implements ArrayAccess, Countable
      */
     public function assertPath($path, $expect)
     {
+        if (! Arr::has($this->json(), $path)) {
+            $actual = json_encode(Arr::sortRecursive(
+                (array) $this->decoded
+            ));
+
+            PHPUnit::fail(
+                'Unable to find path: '.PHP_EOL.PHP_EOL.
+                '['.$path.']'.PHP_EOL.PHP_EOL.
+                'within'.PHP_EOL.PHP_EOL.
+                "[{$actual}]"
+            );
+        }
+
         PHPUnit::assertSame($expect, $this->json($path));
 
         return $this;

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -827,6 +827,17 @@ class TestResponseTest extends TestCase
         $response->assertJsonPath('0.id', '10');
     }
 
+    /** @test */
+    public function testAssertJsonPathCanFailWhenPathDoesNotExist()
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Unable to find path: [data.5.id] within');
+
+        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceWithIntegersStub));
+
+        $response->assertJsonPath('data.5.id', '10');
+    }
+
     public function testAssertJsonFragment()
     {
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceStub));

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -831,7 +831,12 @@ class TestResponseTest extends TestCase
     public function testAssertJsonPathCanFailWhenPathDoesNotExist()
     {
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Unable to find path: [data.5.id] within');
+        $this->expectExceptionMessage(
+            'Unable to find path: '.PHP_EOL.PHP_EOL.
+            '[data.5.id]'.PHP_EOL.PHP_EOL.
+            'within'.PHP_EOL.PHP_EOL.
+            '[[{"foo":"bar","id":10},{"foo":"bar","id":20},{"foo":"bar","id":30}]]'
+        );
 
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceWithIntegersStub));
 


### PR DESCRIPTION
This PR updates the behavior of the `assertJsonPath()` method to make it fail when `$expect` is `null` and `$path` is not a real path.

This change will prevent from creating assertions that will always pass:
```php
// Response
[
  data: [
    [id: int, first: null],
    ...
  ]
]

// Before
->get('/users')
  ->assertJsonPath('data.first', null) // This will always pass.

// After
->get('/notes')
  ->assertJsonPath('data.0.first', null) // This will pass.
  ->assertJsonPath('data.first', null) // This will fail: Unable to find path: user within JSON: {data: ...}
```

Notes:
* It will potentially make some tests fail in users' projects but only if their `$expected` is `null` and `$path` does not exist in the response.
* I'll add tests if this idea is approved.