### PR TITLE
[9.x] Update psr/container-implementation constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -95,7 +95,7 @@
         "symfony/cache": "^6.0"
     },
     "provide": {
-        "psr/container-implementation": "1.0",
+        "psr/container-implementation": "1.1|2.0",
         "psr/simple-cache-implementation": "1.0|2.0|3.0"
     },
     "conflict": {

--- a/src/Illuminate/Container/composer.json
+++ b/src/Illuminate/Container/composer.json
@@ -19,7 +19,7 @@
         "psr/container": "^1.1.1|^2.0.1"
     },
     "provide": {
-        "psr/container-implementation": "1.0"
+        "psr/container-implementation": "1.1|2.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Since we implement v2 we should reflect that in the `psr/container-implementation` constraints. Also bumps to 1.0 to 1.1 because that's the minimum version.