### PR TITLE
[8.x] Add helper msleep(); and rest();

### DIFF
--- a/src/Illuminate/Contracts/Support/Restable.php
+++ b/src/Illuminate/Contracts/Support/Restable.php
@@ -7,34 +7,39 @@ use Carbon\Carbon;
 interface Restable
 {
     /**
-     * @var  int  $seconds
-     * @var  int  $milliseconds
-     * @var  int  $microseconds
+     * @var  int
+     * @var  int
+     * @var  int
+     *
      * @return  void
      */
     public function for(int $seconds = 0, int $milliseconds = 0, int $microseconds = 0): void;
 
     /**
-     * @var  int  $seconds
+     * @var  int
+     *
      * @return  void
      */
     public function forSeconds(int $seconds = 0): void;
 
     /**
-     * @var  int  $milliseconds
+     * @var  int
+     *
      * @return  void
      */
     public function forMilliseconds(int $milliseconds = 0): void;
 
     /**
-     * @var  int  $microseconds
+     * @var  int
+     *
      * @return  void
      */
     public function forMicroseconds(int $microseconds = 0): void;
 
     /**
      * Rest until the time specified. Timestamp or Carbon Object.
-     * @var  float|int|Carbon  $until
+     * @var  float|int|Carbon
+     *
      * @return  void
      */
     public function until($until): void;

--- a/src/Illuminate/Contracts/Support/Restable.php
+++ b/src/Illuminate/Contracts/Support/Restable.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Illuminate\Contracts\Support;
+
+use Carbon\Carbon;
+
+interface Restable
+{
+    /**
+     * @var  int  $seconds
+     * @var  int  $milliseconds
+     * @var  int  $microseconds
+     * @return  void
+     */
+    public function for(int $seconds = 0, int $milliseconds = 0, int $microseconds = 0): void;
+
+    /**
+     * @var  int  $seconds
+     * @return  void
+     */
+    public function forSeconds(int $seconds = 0): void;
+
+    /**
+     * @var  int  $milliseconds
+     * @return  void
+     */
+    public function forMilliseconds(int $milliseconds = 0): void;
+
+    /**
+     * @var  int  $microseconds
+     * @return  void
+     */
+    public function forMicroseconds(int $microseconds = 0): void;
+
+    /**
+     * Rest until the time specified. Timestamp or Carbon Object.
+     * @var  float|int|Carbon  $until
+     * @return  void
+     */
+    public function until($until): void;
+}

--- a/src/Illuminate/Contracts/Support/Restable.php
+++ b/src/Illuminate/Contracts/Support/Restable.php
@@ -38,6 +38,7 @@ interface Restable
 
     /**
      * Rest until the time specified. Timestamp or Carbon Object.
+     *
      * @var float|int|Carbon
      *
      * @return void

--- a/src/Illuminate/Contracts/Support/Restable.php
+++ b/src/Illuminate/Contracts/Support/Restable.php
@@ -7,40 +7,40 @@ use Carbon\Carbon;
 interface Restable
 {
     /**
-     * @var  int
-     * @var  int
-     * @var  int
+     * @var int
+     * @var int
+     * @var int
      *
-     * @return  void
+     * @return void
      */
     public function for(int $seconds = 0, int $milliseconds = 0, int $microseconds = 0): void;
 
     /**
-     * @var  int
+     * @var int
      *
-     * @return  void
+     * @return void
      */
     public function forSeconds(int $seconds = 0): void;
 
     /**
-     * @var  int
+     * @var int
      *
-     * @return  void
+     * @return void
      */
     public function forMilliseconds(int $milliseconds = 0): void;
 
     /**
-     * @var  int
+     * @var int
      *
-     * @return  void
+     * @return void
      */
     public function forMicroseconds(int $microseconds = 0): void;
 
     /**
      * Rest until the time specified. Timestamp or Carbon Object.
-     * @var  float|int|Carbon
+     * @var float|int|Carbon
      *
-     * @return  void
+     * @return void
      */
     public function until($until): void;
 }

--- a/src/Illuminate/Support/Rest.php
+++ b/src/Illuminate/Support/Rest.php
@@ -9,11 +9,11 @@ use InvalidArgumentException;
 class Rest implements Restable
 {
     /**
-     * @var  int
-     * @var  int
-     * @var  int
+     * @var int
+     * @var int
+     * @var int
      *
-     * @return  void
+     * @return void
      */
     public function for(int $seconds = 0, $milliseconds = 0, $microseconds = 0): void
     {
@@ -23,9 +23,9 @@ class Rest implements Restable
     }
 
     /**
-     * @var  int
+     * @var int
      *
-     * @return  void
+     * @return void
      */
     public function forSeconds(int $seconds = 0): void
     {
@@ -34,9 +34,9 @@ class Rest implements Restable
 
 
     /**
-     * @var  int
+     * @var int
      *
-     * @return  void
+     * @return void
      */
     public function forMilliseconds(int $milliseconds = 0): void
     {
@@ -44,9 +44,9 @@ class Rest implements Restable
     }
 
     /**
-     * @var  int
+     * @var int
      *
-     * @return  void
+     * @return void
      */
     public function forMicroseconds(int $microseconds = 0): void
     {
@@ -54,9 +54,9 @@ class Rest implements Restable
     }
 
     /**
+     * @var float|int|Carbon
      *
-     * @var  float|int|Carbon
-     * @return  void
+     * @return void
      */
     public function until($until): void
     {

--- a/src/Illuminate/Support/Rest.php
+++ b/src/Illuminate/Support/Rest.php
@@ -1,0 +1,66 @@
+<?php
+
+
+namespace Illuminate\Support;
+
+use Illuminate\Contracts\Support\Restable;
+use InvalidArgumentException;
+
+class Rest implements Restable
+{
+    /**
+     * @var  int  $seconds
+     * @var  int  $milliseconds
+     * @var  int  $microseconds
+     * @return  void
+     */
+    public function for(int $seconds = 0, $milliseconds = 0, $microseconds = 0): void
+    {
+        $this->forSeconds($seconds);
+        $this->forMilliseconds($milliseconds);
+        $this->forMicroseconds($microseconds);
+    }
+
+    /**
+     * @var  int  $seconds
+     * @return  void
+     */
+    public function forSeconds(int $seconds = 0): void
+    {
+        sleep($seconds);
+    }
+
+
+    /**
+     * @var  int  $milliseconds
+     * @return  void
+     */
+    public function forMilliseconds(int $milliseconds = 0): void
+    {
+        msleep($milliseconds);
+    }
+
+    /**
+     * @var  int  $microseconds
+     * @return  void
+     */
+    public function forMicroseconds(int $microseconds = 0): void
+    {
+        usleep($microseconds);
+    }
+
+    /**
+     *
+     * @var  float|int|Carbon  $until
+     */
+    public function until($until): void
+    {
+        if ($until instanceof Carbon) {
+            time_sleep_until($until->timestamp);
+        } elseif (is_int($until) || is_float($until)) {
+            time_sleep_until($until);
+        } else {
+            throw new InvalidArgumentException('Invalid $until paramter. Must be instance of Carbon or float');
+        }
+    }
+}

--- a/src/Illuminate/Support/Rest.php
+++ b/src/Illuminate/Support/Rest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Illuminate\Support;
 
 use Illuminate\Contracts\Support\Restable;
@@ -31,7 +30,6 @@ class Rest implements Restable
     {
         sleep($seconds);
     }
-
 
     /**
      * @var int

--- a/src/Illuminate/Support/Rest.php
+++ b/src/Illuminate/Support/Rest.php
@@ -9,9 +9,10 @@ use InvalidArgumentException;
 class Rest implements Restable
 {
     /**
-     * @var  int  $seconds
-     * @var  int  $milliseconds
-     * @var  int  $microseconds
+     * @var  int
+     * @var  int
+     * @var  int
+     *
      * @return  void
      */
     public function for(int $seconds = 0, $milliseconds = 0, $microseconds = 0): void
@@ -22,7 +23,8 @@ class Rest implements Restable
     }
 
     /**
-     * @var  int  $seconds
+     * @var  int
+     *
      * @return  void
      */
     public function forSeconds(int $seconds = 0): void
@@ -32,7 +34,8 @@ class Rest implements Restable
 
 
     /**
-     * @var  int  $milliseconds
+     * @var  int
+     *
      * @return  void
      */
     public function forMilliseconds(int $milliseconds = 0): void
@@ -41,7 +44,8 @@ class Rest implements Restable
     }
 
     /**
-     * @var  int  $microseconds
+     * @var  int
+     *
      * @return  void
      */
     public function forMicroseconds(int $microseconds = 0): void
@@ -51,7 +55,8 @@ class Rest implements Restable
 
     /**
      *
-     * @var  float|int|Carbon  $until
+     * @var  float|int|Carbon
+     * @return  void
      */
     public function until($until): void
     {

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -391,9 +391,10 @@ if (! function_exists('rest')) {
     function rest(): Restable
     {
         static $rest;
-        if (!$rest) {
+        if (! $rest) {
             $rest = new Rest;
         }
+
         return $rest;
     }
 }

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -2,10 +2,12 @@
 
 use Illuminate\Contracts\Support\DeferringDisplayableValue;
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Contracts\Support\Restable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Env;
 use Illuminate\Support\HigherOrderTapProxy;
 use Illuminate\Support\Optional;
+use Illuminate\Support\Rest;
 
 if (! function_exists('append_config')) {
     /**
@@ -385,3 +387,13 @@ if (! function_exists('msleep')) {
     }
 }
 
+if (! function_exists('rest')) {
+    function rest(): Restable
+    {
+        static $rest;
+        if (!$rest) {
+            $rest = new Rest;
+        }
+        return $rest;
+    }
+}

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -377,3 +377,11 @@ if (! function_exists('with')) {
         return is_null($callback) ? $value : $callback($value);
     }
 }
+
+if (! function_exists('msleep')) {
+    function msleep(int $msleep)
+    {
+        return usleep($msleep * 1000);
+    }
+}
+


### PR DESCRIPTION
Resting or sleeping in PHP is tedious.

```
usleep();
```
and
```
sleep();
```

These are two method in PHP, however `msleep();` for milliseconds does not exist, despite languages such as JavaScript operating on milliseconds.

In this PR I've added a helper function 

```
msleep();
```

And in addition to this, provided a tidy and more verbose interface.

```
rest()->for($seconds, $milliseconds, $microseconds);
rest()->forSeconds($seconds);
rest()->forMilliseconds($milliseconds);
rest()->forMicroseconds($seconds);
```

This would help developers by reducing mathematical calculations they need to do, and therefore reducing the chance of a typo, and sleeping for too long or too short of a time.
