### PR TITLE
[8.x] Update Logger for multi-driver/multi-channels at once

### DIFF
--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -112,6 +112,7 @@ class LogManager implements LoggerInterface
         if (is_array($driver)) {
             return new MultiChannelLogger($driver, $this);
         }
+
         return $this->get($this->parseDriver($driver));
     }
 

--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -93,7 +93,7 @@ class LogManager implements LoggerInterface
     /**
      * Get a log channel instance.
      *
-     * @param  string|null  $channel
+     * @param  array|string|null  $channel
      * @return \Psr\Log\LoggerInterface
      */
     public function channel($channel = null)
@@ -104,11 +104,14 @@ class LogManager implements LoggerInterface
     /**
      * Get a log driver instance.
      *
-     * @param  string|null  $driver
+     * @param  array|string|null  $driver
      * @return \Psr\Log\LoggerInterface
      */
     public function driver($driver = null)
     {
+        if (is_array($driver)) {
+            return new MultiChannelLogger($driver, $this);
+        }
         return $this->get($this->parseDriver($driver));
     }
 

--- a/src/Illuminate/Log/MultiChannelLogger.php
+++ b/src/Illuminate/Log/MultiChannelLogger.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Illuminate\Log;
+
+use Illuminate\Support\Collection;
+use Psr\Log\LoggerInterface;
+
+class MultiChannelLogger implements LoggerInterface
+{
+    protected Collection $drivers;
+    protected LogManager $logManager;
+
+    public function __construct(array $drivers, LogManager $logManager)
+    {
+        $this->drivers = collect($drivers);
+        $this->logManager = $logManager;
+    }
+
+    public function emergency($message, array $context = array())
+    {
+        $this->drivers->each(fn () => $this->logManager->emergency($message, $context));
+    }
+
+    public function alert($message, array $context = array())
+    {
+        $this->drivers->each(fn () => $this->logManager->alert($message, $context));
+    }
+
+    public function critical($message, array $context = array())
+    {
+        $this->drivers->each(fn () => $this->logManager->critical($message, $context));
+    }
+
+    public function error($message, array $context = array())
+    {
+        $this->drivers->each(fn () => $this->logManager->error($message, $context));
+    }
+
+    public function warning($message, array $context = array())
+    {
+        $this->drivers->each(fn () => $this->logManager->warning($message, $context));
+    }
+
+    public function notice($message, array $context = array())
+    {
+        $this->drivers->each(fn () => $this->logManager->notice($message, $context));
+    }
+
+    public function info($message, array $context = array())
+    {
+        $this->drivers->each(fn () => $this->logManager->info($message, $context));
+    }
+
+    public function debug($message, array $context = array())
+    {
+        $this->drivers->each(fn () => $this->logManager->debug($message, $context));
+    }
+
+    public function log($level, $message, array $context = array())
+    {
+        $this->drivers->each(fn () => $this->logManager->log($message, $context));
+    }
+};

--- a/src/Illuminate/Log/MultiChannelLogger.php
+++ b/src/Illuminate/Log/MultiChannelLogger.php
@@ -16,48 +16,48 @@ class MultiChannelLogger implements LoggerInterface
         $this->logManager = $logManager;
     }
 
-    public function emergency($message, array $context = array())
+    public function emergency($message, array $context = [])
     {
         $this->drivers->each(fn () => $this->logManager->emergency($message, $context));
     }
 
-    public function alert($message, array $context = array())
+    public function alert($message, array $context = [])
     {
         $this->drivers->each(fn () => $this->logManager->alert($message, $context));
     }
 
-    public function critical($message, array $context = array())
+    public function critical($message, array $context = [])
     {
         $this->drivers->each(fn () => $this->logManager->critical($message, $context));
     }
 
-    public function error($message, array $context = array())
+    public function error($message, array $context = [])
     {
         $this->drivers->each(fn () => $this->logManager->error($message, $context));
     }
 
-    public function warning($message, array $context = array())
+    public function warning($message, array $context = [])
     {
         $this->drivers->each(fn () => $this->logManager->warning($message, $context));
     }
 
-    public function notice($message, array $context = array())
+    public function notice($message, array $context = [])
     {
         $this->drivers->each(fn () => $this->logManager->notice($message, $context));
     }
 
-    public function info($message, array $context = array())
+    public function info($message, array $context = [])
     {
         $this->drivers->each(fn () => $this->logManager->info($message, $context));
     }
 
-    public function debug($message, array $context = array())
+    public function debug($message, array $context = [])
     {
         $this->drivers->each(fn () => $this->logManager->debug($message, $context));
     }
 
-    public function log($level, $message, array $context = array())
+    public function log($level, $message, array $context = [])
     {
         $this->drivers->each(fn () => $this->logManager->log($message, $context));
     }
-};
+}


### PR DESCRIPTION
When the logger is interacted with, it can be beneficial for these messages to go to multiple places.

An example is I work as a PHP contractor, and connect logging into my Company Slack, but my client may also wish to know when an error occurs.

Multi-channel/Multi-driver support enables multiple logs being called without a copy/paste