### PR TITLE
[8.x] Prevents `TypeError` when validating int backed enum with string value

### DIFF
--- a/src/Illuminate/Validation/Rules/Enum.php
+++ b/src/Illuminate/Validation/Rules/Enum.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Validation\Rules;
 
+use BackedEnum;
 use Illuminate\Contracts\Validation\Rule;
 
 class Enum implements Rule
@@ -37,7 +38,7 @@ class Enum implements Rule
             return false;
         }
 
-        return ! is_null($this->type::tryFrom($value));
+        return in_array($value, array_map(fn (BackedEnum $enum) => $enum->value, $this->type::cases()));
     }
 
     /**

--- a/tests/Validation/ValidationEnumRuleTest.php
+++ b/tests/Validation/ValidationEnumRuleTest.php
@@ -70,6 +70,22 @@ class ValidationEnumRuleTest extends TestCase
         $this->assertEquals(['The selected status is invalid.'], $v->messages()->get('status'));
     }
 
+    public function testValidationFailsWhenProvidingStringToIntegerType()
+    {
+        $v = new Validator(
+            resolve('translator'),
+            [
+                'status' => 'abc',
+            ],
+            [
+                'status' => new Enum(IntegerStatus::class),
+            ]
+        );
+
+        $this->assertTrue($v->fails());
+        $this->assertEquals(['The selected status is invalid.'], $v->messages()->get('status'));
+    }
+
     public function testValidationPassesWhenProvidingDifferentTypeThatIsCastableToTheEnumType()
     {
         $v = new Validator(


### PR DESCRIPTION
Let's say we have the following enum:
```php
enum Status: int
{
    case pending = 1;
    case done = 2;
}
```

We want to validate the incoming request against the values in this enum with the following ruleset:
```php
['status' => ['required', new \Illuminate\Validation\Rules\Enum(Status::class)]]
```

Currently if from application receives `status` as anything other than an integer, like a string of "abc", the application throws `TypeError` exception, because of the enum's `tryFrom()` usage. For string enums, this method expects a string, for integer enums it expects integer only.

It is possible to prevent `TypeError` by adding the `integer` and `bail` rules to the ruleset
```php
['status' => ['bail', 'required', 'integer', new \Illuminate\Validation\Rules\Enum(Status::class)]]
```
This way validation will not go into enum value check if anything other than an integer is passed.

This PR offers a solution to prevent the `TypeError` error completely by using the `in_array` check against enum values, instead of using the `tryFrom()` method. Even when a string is passed to integer-backed enum, validation will fail without throwing an exception, no need to use `bail`.