### PR TITLE
[8.x] Return Default User::class FQCN if no model key is defined in config

### DIFF
--- a/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
@@ -87,7 +87,7 @@ class PolicyMakeCommand extends GeneratorCommand
 
         return $config->get(
             'auth.providers.'.$guardProvider.'.model'
-        ) ?? "App\\Models\\User";
+        ) ?? 'App\\Models\\User';
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
@@ -87,7 +87,7 @@ class PolicyMakeCommand extends GeneratorCommand
 
         return $config->get(
             'auth.providers.'.$guardProvider.'.model'
-        );
+        ) ?? "App\\Models\\User";
     }
 
     /**


### PR DESCRIPTION
As issued in #40345 this is a first idea to solve this Problem by return the default value of model Key in auth.php['providers']['users']['model'] using database instead of eloquent.