### PR TITLE
[8.x] Throws an error upon make:policy if no model class is configured

### DIFF
--- a/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
@@ -85,6 +85,10 @@ class PolicyMakeCommand extends GeneratorCommand
             throw new LogicException('The ['.$guard.'] guard is not defined in your "auth" configuration file.');
         }
 
+        if (!$config->get('auth.providers.'.$guardProvider.'.model')) {
+            throw new LogicException('The user provider in your "auth" configuration file misses the model key.');
+        }
+
         return $config->get(
             'auth.providers.'.$guardProvider.'.model'
         );

--- a/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
@@ -86,7 +86,7 @@ class PolicyMakeCommand extends GeneratorCommand
         }
 
         if (! $config->get('auth.providers.'.$guardProvider.'.model')) {
-            throw new LogicException('The ['.$guardProvider.'] user provider in your "auth" configuration file does not contain a [model] configuration key.');
+            throw new LogicException('The ['.$guardProvider.'] user provider in your "auth" configuration file does not contain a [model] configuration value.');
         }
 
         return $config->get(

--- a/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
@@ -85,7 +85,7 @@ class PolicyMakeCommand extends GeneratorCommand
             throw new LogicException('The ['.$guard.'] guard is not defined in your "auth" configuration file.');
         }
 
-        if (!$config->get('auth.providers.'.$guardProvider.'.model')) {
+        if (! $config->get('auth.providers.'.$guardProvider.'.model')) {
             throw new LogicException('The user provider in your "auth" configuration file misses the model key.');
         }
 

--- a/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
@@ -86,7 +86,7 @@ class PolicyMakeCommand extends GeneratorCommand
         }
 
         if (! $config->get('auth.providers.'.$guardProvider.'.model')) {
-            throw new LogicException('The ['.$guardProvider.'] user provider in your "auth" configuration file does not contain a [model] configuration value.');
+            return 'App\\Models\\User';
         }
 
         return $config->get(

--- a/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
@@ -86,7 +86,7 @@ class PolicyMakeCommand extends GeneratorCommand
         }
 
         if (! $config->get('auth.providers.'.$guardProvider.'.model')) {
-            throw new LogicException('The user provider in your "auth" configuration file misses the model key.');
+            throw new LogicException('The ['.$guardProvider.'] user provider in your "auth" configuration file does not contain a [model] configuration key.');
         }
 
         return $config->get(


### PR DESCRIPTION
If the model config key is not present in `auth.providers.users` the `make:policy` command will silently spit out some very poor stub.

Fixes: #40345