### PR TITLE
[8.x] Adds select columns for Pivot

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -587,6 +587,19 @@ trait InteractsWithPivotTable
     }
 
     /**
+     * Override the columns on the pivot table to retrieve.
+     *
+     * @param  array|mixed  $columns
+     * @return $this
+     */
+    public function selectPivot($columns)
+    {
+        $this->pivotColumns = is_array($columns) ? $columns : func_get_args();
+
+        return $this;
+    }
+
+    /**
      * Get all of the IDs from the given mixed value.
      *
      * @param  mixed  $value

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -587,6 +587,18 @@ trait InteractsWithPivotTable
     }
 
     /**
+     * Removes additional columns to retrieve on the pivot table.
+     *
+     * @return $this
+     */
+    public function withoutPivotColumns()
+    {
+        $this->pivotColumns = [];
+
+        return $this;
+    }
+
+    /**
      * Override the columns on the pivot table to retrieve.
      *
      * @param  array|mixed  $columns

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -593,9 +593,7 @@ trait InteractsWithPivotTable
      */
     public function withoutPivotColumns()
     {
-        $this->pivotColumns = [];
-
-        return $this;
+        return $this->selectPivot([]);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBelongsToManySyncReturnValueTypeTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManySyncReturnValueTypeTest.php
@@ -120,11 +120,11 @@ class DatabaseEloquentBelongsToManySyncReturnValueTypeTest extends TestCase
         $articleIDs = BelongsToManySyncTestTestArticle::all()->pluck('id')->toArray();
         $user->articles()->sync($articleIDs);
 
-        $article = $user->articles()->selectPivot('user_id', 'title')->first();
+        $article = $user->articles()->selectPivot('artcle_id', 'user_id')->first();
         
         $this->assertNull($article->visible);
+        $this->assertNotNull($article->artcle_id);
         $this->assertNotNull($article->user_id);
-        $this->assertNotNull($article->title);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBelongsToManySyncReturnValueTypeTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManySyncReturnValueTypeTest.php
@@ -112,6 +112,21 @@ class DatabaseEloquentBelongsToManySyncReturnValueTypeTest extends TestCase
         });
     }
 
+    public function testReplacesPivotColumnSelect()
+    {
+        $this->seedData();
+
+        $user = BelongsToManySyncTestTestUser::query()->first();
+        $articleIDs = BelongsToManySyncTestTestArticle::all()->pluck('id')->toArray();
+        $user->articles()->sync($articleIDs);
+
+        $article = $user->articles()->selectPivot('article_id', 'user_id')->first();
+
+        $this->assertNull($article->pivot->visible);
+        $this->assertNotNull($article->pivot->article_id);
+        $this->assertNotNull($article->pivot->user_id);
+    }
+
     /**
      * Get a database connection instance.
      *

--- a/tests/Database/DatabaseEloquentBelongsToManySyncReturnValueTypeTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManySyncReturnValueTypeTest.php
@@ -120,10 +120,10 @@ class DatabaseEloquentBelongsToManySyncReturnValueTypeTest extends TestCase
         $articleIDs = BelongsToManySyncTestTestArticle::all()->pluck('id')->toArray();
         $user->articles()->sync($articleIDs);
 
-        $article = $user->articles()->selectPivot('artcle_id', 'user_id')->first();
+        $article = $user->articles()->selectPivot('article_id', 'user_id')->first();
         
         $this->assertNull($article->visible);
-        $this->assertNotNull($article->artcle_id);
+        $this->assertNotNull($article->article_id);
         $this->assertNotNull($article->user_id);
     }
 

--- a/tests/Database/DatabaseEloquentBelongsToManySyncReturnValueTypeTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManySyncReturnValueTypeTest.php
@@ -112,6 +112,21 @@ class DatabaseEloquentBelongsToManySyncReturnValueTypeTest extends TestCase
         });
     }
 
+    public function testReplacesPivotColumnSelect()
+    {
+        $this->seedData();
+
+        $user = BelongsToManySyncTestTestUser::query()->first();
+        $articleIDs = BelongsToManySyncTestTestArticle::all()->pluck('id')->toArray();
+        $user->articles()->sync($articleIDs);
+
+        $article = $user->articles()->selectPivot('user_id', 'name')->first();
+        
+        $this->assertNull($article->visible);
+        $this->assertNotNull($article->user_id);
+        $this->assertNotNull($article->name);
+    }
+
     /**
      * Get a database connection instance.
      *

--- a/tests/Database/DatabaseEloquentBelongsToManySyncReturnValueTypeTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManySyncReturnValueTypeTest.php
@@ -120,7 +120,28 @@ class DatabaseEloquentBelongsToManySyncReturnValueTypeTest extends TestCase
         $articleIDs = BelongsToManySyncTestTestArticle::all()->pluck('id')->toArray();
         $user->articles()->sync($articleIDs);
 
-        $article = $user->articles()->selectPivot('article_id', 'user_id')->first();
+        $article = $user->articles()->selectPivot('article_id')->first();
+
+        $this->assertNull($article->pivot->visible);
+        $this->assertNotNull($article->pivot->article_id);
+        $this->assertNotNull($article->pivot->user_id);
+
+        $article = $user->articles()->selectPivot('visible')->first();
+
+        $this->assertNotNull($article->pivot->visible);
+        $this->assertNotNull($article->pivot->article_id);
+        $this->assertNotNull($article->pivot->user_id);
+    }
+
+    public function testRemovesAdditionalPivotColumns()
+    {
+        $this->seedData();
+
+        $user = BelongsToManySyncTestTestUser::query()->first();
+        $articleIDs = BelongsToManySyncTestTestArticle::all()->pluck('id')->toArray();
+        $user->articles()->sync($articleIDs);
+
+        $article = $user->articles()->withoutPivotColumns()->first();
 
         $this->assertNull($article->pivot->visible);
         $this->assertNotNull($article->pivot->article_id);

--- a/tests/Database/DatabaseEloquentBelongsToManySyncReturnValueTypeTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManySyncReturnValueTypeTest.php
@@ -120,11 +120,11 @@ class DatabaseEloquentBelongsToManySyncReturnValueTypeTest extends TestCase
         $articleIDs = BelongsToManySyncTestTestArticle::all()->pluck('id')->toArray();
         $user->articles()->sync($articleIDs);
 
-        $article = $user->articles()->selectPivot('user_id', 'name')->first();
+        $article = $user->articles()->selectPivot('user_id', 'title')->first();
         
         $this->assertNull($article->visible);
         $this->assertNotNull($article->user_id);
-        $this->assertNotNull($article->name);
+        $this->assertNotNull($article->title);
     }
 
     /**


### PR DESCRIPTION
## What?

Allows to override pivot table selection. Useful when a relationship defines `withPivot()`, and later these can be discarded.

```php
public function tags() {
    return $this->belongsToMany(Tag::class)->withPivot('name', 'visible');
}

// Don't get the visible property
$post->tags()->selectPivot('name');

// Or don't get anything at all.
$post->tags()->withoutPivotColumns();
```

## Why?

Because there is no way to override the columns to get. `withPivot()` is additive.

## BC?

Nope, only additive.