### PR TITLE
[8.x] Add forget method to config repository

### DIFF
--- a/src/Illuminate/Config/Repository.php
+++ b/src/Illuminate/Config/Repository.php
@@ -38,6 +38,17 @@ class Repository implements ArrayAccess, ConfigContract
     }
 
     /**
+     * Remove a given configuration value.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function forget($key)
+    {
+        return Arr::forget($this->items, $key);
+    }
+
+    /**
      * Get the specified configuration value.
      *
      * @param  array|string  $key

--- a/tests/Config/RepositoryTest.php
+++ b/tests/Config/RepositoryTest.php
@@ -131,6 +131,12 @@ class RepositoryTest extends TestCase
         $this->assertSame('value2', $this->repository->get('key2'));
     }
 
+    public function testCanForget()
+    {
+        $this->repository->forget('foo');
+        $this->assertFalse($this->repository->has('foo'));
+    }
+
     public function testPrepend()
     {
         $this->repository->prepend('array', 'xxx');


### PR DESCRIPTION
This adds a `forget($key)` method to the config repository, which can be called like so: `config()->forget($key)`. It removes the config key from the config (similarly to how we can `set` config values at runtime).