### PR TITLE
New: Email Column Shorcut Creation

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -608,6 +608,27 @@ class Blueprint
     }
 
     /**
+     * Create a new email column on the table.
+     *
+     * @param  string  $column
+     * @param  bool  $unique
+     * @param  int|null  $length
+     * @return \Illuminate\Database\Schema\ColumnDefinition
+     */
+    public function email($column = 'email', bool $unique = true, $length = null)
+    {
+        $length = $length ?: Builder::$defaultStringLength;
+
+        $emailColumn = $this->addColumn('string', $column, compact('length'));
+
+        if ($unique) {
+            $emailColumn->unique();
+        }
+
+        return $emailColumn;
+    }
+
+    /**
      * Create a new auto-incrementing integer (4-byte) column on the table.
      *
      * @param  string  $column

--- a/tests/Database/migrations/one/2016_01_01_000000_create_users_table.php
+++ b/tests/Database/migrations/one/2016_01_01_000000_create_users_table.php
@@ -16,7 +16,7 @@ class CreateUsersTable extends Migration
         Schema::create('users', function (Blueprint $table) {
             $table->increments('id');
             $table->string('name');
-            $table->string('email')->unique();
+            $table->email();
             $table->string('password');
             $table->rememberToken();
             $table->timestamps();

--- a/tests/Database/migrations/one/2016_01_01_100000_create_password_resets_table.php
+++ b/tests/Database/migrations/one/2016_01_01_100000_create_password_resets_table.php
@@ -14,7 +14,7 @@ class CreatePasswordResetsTable extends Migration
     public function up()
     {
         Schema::create('password_resets', function (Blueprint $table) {
-            $table->string('email')->index();
+            $table->email(unique: false)->index();
             $table->string('token')->index();
             $table->timestamp('created_at');
         });


### PR DESCRIPTION
This PR introduces the ability to **create email columns via a direct shortcut**, optionally setting the column to `unique` and also controlling the size via the `length` parameter, this saving time in writing email columns using the `string` method (the method known and used until today)

### Use Cases

**Before:**
```
$table->string('email')->unique();
```

**With the PR proposal:**
```
$table->email();
```

---

### Alternatives _(based on PHP 8+)_:

1. Setting a different name for the column:
```
$table->email('destination_email');
```

2. Disabling the `unique`:
```
$table->email(unique: false);
```

3. Controling the length to the column:
```
$table->email(length: 50);
```