### PR TITLE
[9.x] Fixes `Collection::keyBy` related types

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -492,7 +492,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * Key an associative array by a field or using a callback.
      *
      * @param  (callable(TValue, TKey): array-key)|array|string  $keyBy
-     * @return static<array-key, array<array-key, TValue>>
+     * @return static<array-key, TValue>
      */
     public function keyBy($keyBy)
     {

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -513,7 +513,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Key an associative array by a field or using a callback.
      *
      * @param  (callable(TValue, TKey): array-key)|array|string  $keyBy
-     * @return static<array-key, array<array-key, TValue>>
+     * @return static<array-key, TValue>
      */
     public function keyBy($keyBy);
 

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -518,7 +518,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * Key an associative array by a field or using a callback.
      *
      * @param  (callable(TValue, TKey): array-key)|array|string  $keyBy
-     * @return static<array-key, array<array-key, TValue>>
+     * @return static<array-key, TValue>
      */
     public function keyBy($keyBy)
     {

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -388,8 +388,8 @@ assertType('Illuminate\Support\Collection<(int|string), array<User>>', $collecti
     return 'foo';
 }));
 
-assertType('Illuminate\Support\Collection<(int|string), array<User>>', $collection->keyBy('name'));
-assertType('Illuminate\Support\Collection<(int|string), array<User>>', $collection->keyBy(function ($user, $int) {
+assertType('Illuminate\Support\Collection<(int|string), User>', $collection->keyBy('name'));
+assertType('Illuminate\Support\Collection<(int|string), User>', $collection->keyBy(function ($user, $int) {
     // assertType('User', $user);
     // assertType('int', $int);
 

--- a/types/Support/LazyCollection.php
+++ b/types/Support/LazyCollection.php
@@ -388,8 +388,8 @@ assertType('Illuminate\Support\LazyCollection<(int|string), array<User>>', $coll
     return 'foo';
 }));
 
-assertType('Illuminate\Support\LazyCollection<(int|string), array<User>>', $collection->keyBy('name'));
-assertType('Illuminate\Support\LazyCollection<(int|string), array<User>>', $collection->keyBy(function ($user, $int) {
+assertType('Illuminate\Support\LazyCollection<(int|string), User>', $collection->keyBy('name'));
+assertType('Illuminate\Support\LazyCollection<(int|string), User>', $collection->keyBy(function ($user, $int) {
     // assertType('User', $user);
     // assertType('int', $int);
 


### PR DESCRIPTION
This pull request fixes the `Collection::keyBy` related types.