### PR TITLE
[9.x] Add session decorator

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -5,12 +5,15 @@ namespace Illuminate\Http;
 use ArrayAccess;
 use Closure;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Session\SymfonySessionDecorator;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use RuntimeException;
+use Symfony\Component\HttpFoundation\Exception\SessionNotFoundException;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 /**
  * @method array validate(array $rules, ...$params)
@@ -490,6 +493,26 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
         }
 
         return $files;
+    }
+
+    /**
+     * Whether the request contains a Session object.
+     *
+     * {@inheritdoc}
+     */
+    public function hasSession(bool $skipIfUninitialized = false): bool
+    {
+        return ! is_null($this->session);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSession(): SessionInterface
+    {
+        return $this->hasSession()
+                    ? new SymfonySessionDecorator($this->session())
+                    : throw new SessionNotFoundException;
     }
 
     /**

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -496,8 +496,6 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     }
 
     /**
-     * Whether the request contains a Session object.
-     *
      * {@inheritdoc}
      */
     public function hasSession(bool $skipIfUninitialized = false): bool

--- a/src/Illuminate/Session/SymfonySessionDecorator.php
+++ b/src/Illuminate/Session/SymfonySessionDecorator.php
@@ -75,10 +75,10 @@ class SymfonySessionDecorator implements SessionInterface
      * Clears all session attributes and flashes and regenerates the
      * session and deletes the old session from persistence.
      *
-     * @param int $lifetime Sets the cookie lifetime for the session cookie. A null value
-     *                      will leave the system settings unchanged, 0 sets the cookie
-     *                      to expire with browser session. Time is in seconds, and is
-     *                      not a Unix timestamp.
+     * @param  int  $lifetime  Sets the cookie lifetime for the session cookie. A null value
+     *                         will leave the system settings unchanged, 0 sets the cookie
+     *                         to expire with browser session. Time is in seconds, and is
+     *                         not a Unix timestamp.
      */
     public function invalidate(int $lifetime = null): bool
     {
@@ -91,11 +91,11 @@ class SymfonySessionDecorator implements SessionInterface
      * Migrates the current session to a new session id while maintaining all
      * session attributes.
      *
-     * @param bool $destroy  Whether to delete the old session or leave it to garbage collection
-     * @param int  $lifetime Sets the cookie lifetime for the session cookie. A null value
-     *                       will leave the system settings unchanged, 0 sets the cookie
-     *                       to expire with browser session. Time is in seconds, and is
-     *                       not a Unix timestamp.
+     * @param  bool  $destroy  Whether to delete the old session or leave it to garbage collection
+     * @param  int  $lifetime  Sets the cookie lifetime for the session cookie. A null value
+     *                         will leave the system settings unchanged, 0 sets the cookie
+     *                         to expire with browser session. Time is in seconds, and is
+     *                         not a Unix timestamp.
      */
     public function migrate(bool $destroy = false, int $lifetime = null): bool
     {
@@ -187,7 +187,7 @@ class SymfonySessionDecorator implements SessionInterface
      */
     public function registerBag(SessionBagInterface $bag)
     {
-        throw new BadMethodCallException("Method not implemented by Laravel.");
+        throw new BadMethodCallException('Method not implemented by Laravel.');
     }
 
     /**
@@ -195,7 +195,7 @@ class SymfonySessionDecorator implements SessionInterface
      */
     public function getBag(string $name): SessionBagInterface
     {
-        throw new BadMethodCallException("Method not implemented by Laravel.");
+        throw new BadMethodCallException('Method not implemented by Laravel.');
     }
 
     /**
@@ -203,6 +203,6 @@ class SymfonySessionDecorator implements SessionInterface
      */
     public function getMetadataBag(): MetadataBag
     {
-        throw new BadMethodCallException("Method not implemented by Laravel.");
+        throw new BadMethodCallException('Method not implemented by Laravel.');
     }
 }

--- a/src/Illuminate/Session/SymfonySessionDecorator.php
+++ b/src/Illuminate/Session/SymfonySessionDecorator.php
@@ -28,9 +28,7 @@ class SymfonySessionDecorator implements SessionInterface
     }
 
     /**
-     * Starts the session storage.
-     *
-     * @throws \RuntimeException if session fails to start
+     * {@inheritdoc}
      */
     public function start(): bool
     {
@@ -38,7 +36,7 @@ class SymfonySessionDecorator implements SessionInterface
     }
 
     /**
-     * Returns the session ID.
+     * {@inheritdoc}
      */
     public function getId(): string
     {
@@ -46,7 +44,7 @@ class SymfonySessionDecorator implements SessionInterface
     }
 
     /**
-     * Sets the session ID.
+     * {@inheritdoc}
      */
     public function setId(string $id)
     {
@@ -54,7 +52,7 @@ class SymfonySessionDecorator implements SessionInterface
     }
 
     /**
-     * Returns the session name.
+     * {@inheritdoc}
      */
     public function getName(): string
     {
@@ -62,7 +60,7 @@ class SymfonySessionDecorator implements SessionInterface
     }
 
     /**
-     * Sets the session name.
+     * {@inheritdoc}
      */
     public function setName(string $name)
     {
@@ -70,15 +68,7 @@ class SymfonySessionDecorator implements SessionInterface
     }
 
     /**
-     * Invalidates the current session.
-     *
-     * Clears all session attributes and flashes and regenerates the
-     * session and deletes the old session from persistence.
-     *
-     * @param int $lifetime Sets the cookie lifetime for the session cookie. A null value
-     *                      will leave the system settings unchanged, 0 sets the cookie
-     *                      to expire with browser session. Time is in seconds, and is
-     *                      not a Unix timestamp.
+     * {@inheritdoc}
      */
     public function invalidate(int $lifetime = null): bool
     {
@@ -88,14 +78,7 @@ class SymfonySessionDecorator implements SessionInterface
     }
 
     /**
-     * Migrates the current session to a new session id while maintaining all
-     * session attributes.
-     *
-     * @param bool $destroy  Whether to delete the old session or leave it to garbage collection
-     * @param int  $lifetime Sets the cookie lifetime for the session cookie. A null value
-     *                       will leave the system settings unchanged, 0 sets the cookie
-     *                       to expire with browser session. Time is in seconds, and is
-     *                       not a Unix timestamp.
+     * {@inheritdoc}
      */
     public function migrate(bool $destroy = false, int $lifetime = null): bool
     {
@@ -105,11 +88,7 @@ class SymfonySessionDecorator implements SessionInterface
     }
 
     /**
-     * Force the session to be saved and closed.
-     *
-     * This method is generally not required for real sessions as
-     * the session will be automatically saved at the end of
-     * code execution.
+     * {@inheritdoc}
      */
     public function save()
     {
@@ -117,7 +96,7 @@ class SymfonySessionDecorator implements SessionInterface
     }
 
     /**
-     * Checks if an attribute is defined.
+     * {@inheritdoc}
      */
     public function has(string $name): bool
     {
@@ -125,7 +104,7 @@ class SymfonySessionDecorator implements SessionInterface
     }
 
     /**
-     * Returns an attribute.
+     * {@inheritdoc}
      */
     public function get(string $name, mixed $default = null): mixed
     {
@@ -133,7 +112,7 @@ class SymfonySessionDecorator implements SessionInterface
     }
 
     /**
-     * Sets an attribute.
+     * {@inheritdoc}
      */
     public function set(string $name, mixed $value)
     {
@@ -141,7 +120,7 @@ class SymfonySessionDecorator implements SessionInterface
     }
 
     /**
-     * Returns attributes.
+     * {@inheritdoc}
      */
     public function all(): array
     {
@@ -149,7 +128,7 @@ class SymfonySessionDecorator implements SessionInterface
     }
 
     /**
-     * Sets attributes.
+     * {@inheritdoc}
      */
     public function replace(array $attributes)
     {
@@ -157,9 +136,7 @@ class SymfonySessionDecorator implements SessionInterface
     }
 
     /**
-     * Removes an attribute.
-     *
-     * @return mixed The removed value or null when it does not exist
+     * {@inheritdoc}
      */
     public function remove(string $name): mixed
     {
@@ -167,7 +144,7 @@ class SymfonySessionDecorator implements SessionInterface
     }
 
     /**
-     * Clears all attributes.
+     * {@inheritdoc}
      */
     public function clear()
     {
@@ -175,7 +152,7 @@ class SymfonySessionDecorator implements SessionInterface
     }
 
     /**
-     * Checks if the session was started.
+     * {@inheritdoc}
      */
     public function isStarted(): bool
     {
@@ -183,7 +160,7 @@ class SymfonySessionDecorator implements SessionInterface
     }
 
     /**
-     * Registers a SessionBagInterface with the session.
+     * {@inheritdoc}
      */
     public function registerBag(SessionBagInterface $bag)
     {
@@ -191,7 +168,7 @@ class SymfonySessionDecorator implements SessionInterface
     }
 
     /**
-     * Gets a bag instance by name.
+     * {@inheritdoc}
      */
     public function getBag(string $name): SessionBagInterface
     {
@@ -199,7 +176,7 @@ class SymfonySessionDecorator implements SessionInterface
     }
 
     /**
-     * Gets session meta.
+     * {@inheritdoc}
      */
     public function getMetadataBag(): MetadataBag
     {

--- a/src/Illuminate/Session/SymfonySessionDecorator.php
+++ b/src/Illuminate/Session/SymfonySessionDecorator.php
@@ -1,0 +1,208 @@
+<?php
+
+namespace Illuminate\Session;
+
+use BadMethodCallException;
+use Symfony\Component\HttpFoundation\Session\SessionBagInterface;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpFoundation\Session\Storage\MetadataBag;
+
+class SymfonySessionDecorator implements SessionInterface
+{
+    /**
+     * The underlying Laravel session store.
+     *
+     * @var \Illuminate\Session\Store
+     */
+    protected $store;
+
+    /**
+     * Create a new session decorator.
+     *
+     * @param  \Illuminate\Session\Store  $store
+     * @return void
+     */
+    public function __construct(Store $store)
+    {
+        $this->store = $store;
+    }
+
+    /**
+     * Starts the session storage.
+     *
+     * @throws \RuntimeException if session fails to start
+     */
+    public function start(): bool
+    {
+        return $this->store->start();
+    }
+
+    /**
+     * Returns the session ID.
+     */
+    public function getId(): string
+    {
+        return $this->store->getId();
+    }
+
+    /**
+     * Sets the session ID.
+     */
+    public function setId(string $id)
+    {
+        $this->store->setId($id);
+    }
+
+    /**
+     * Returns the session name.
+     */
+    public function getName(): string
+    {
+        return $this->store->getName();
+    }
+
+    /**
+     * Sets the session name.
+     */
+    public function setName(string $name)
+    {
+        $this->store->setName($name);
+    }
+
+    /**
+     * Invalidates the current session.
+     *
+     * Clears all session attributes and flashes and regenerates the
+     * session and deletes the old session from persistence.
+     *
+     * @param int $lifetime Sets the cookie lifetime for the session cookie. A null value
+     *                      will leave the system settings unchanged, 0 sets the cookie
+     *                      to expire with browser session. Time is in seconds, and is
+     *                      not a Unix timestamp.
+     */
+    public function invalidate(int $lifetime = null): bool
+    {
+        $this->store->invalidate();
+
+        return true;
+    }
+
+    /**
+     * Migrates the current session to a new session id while maintaining all
+     * session attributes.
+     *
+     * @param bool $destroy  Whether to delete the old session or leave it to garbage collection
+     * @param int  $lifetime Sets the cookie lifetime for the session cookie. A null value
+     *                       will leave the system settings unchanged, 0 sets the cookie
+     *                       to expire with browser session. Time is in seconds, and is
+     *                       not a Unix timestamp.
+     */
+    public function migrate(bool $destroy = false, int $lifetime = null): bool
+    {
+        $this->store->migrate($destroy);
+
+        return true;
+    }
+
+    /**
+     * Force the session to be saved and closed.
+     *
+     * This method is generally not required for real sessions as
+     * the session will be automatically saved at the end of
+     * code execution.
+     */
+    public function save()
+    {
+        $this->store->save();
+    }
+
+    /**
+     * Checks if an attribute is defined.
+     */
+    public function has(string $name): bool
+    {
+        return $this->store->has($name);
+    }
+
+    /**
+     * Returns an attribute.
+     */
+    public function get(string $name, mixed $default = null): mixed
+    {
+        return $this->store->get($name, $default);
+    }
+
+    /**
+     * Sets an attribute.
+     */
+    public function set(string $name, mixed $value)
+    {
+        $this->store->put($name, $value);
+    }
+
+    /**
+     * Returns attributes.
+     */
+    public function all(): array
+    {
+        return $this->store->all();
+    }
+
+    /**
+     * Sets attributes.
+     */
+    public function replace(array $attributes)
+    {
+        $this->store->replace($attributes);
+    }
+
+    /**
+     * Removes an attribute.
+     *
+     * @return mixed The removed value or null when it does not exist
+     */
+    public function remove(string $name): mixed
+    {
+        return $this->store->remove($name);
+    }
+
+    /**
+     * Clears all attributes.
+     */
+    public function clear()
+    {
+        $this->store->flush();
+    }
+
+    /**
+     * Checks if the session was started.
+     */
+    public function isStarted(): bool
+    {
+        return $this->store->isStarted();
+    }
+
+    /**
+     * Registers a SessionBagInterface with the session.
+     */
+    public function registerBag(SessionBagInterface $bag)
+    {
+        throw new BadMethodCallException("Method not implemented by Laravel.");
+    }
+
+    /**
+     * Gets a bag instance by name.
+     */
+    public function getBag(string $name): SessionBagInterface
+    {
+        throw new BadMethodCallException("Method not implemented by Laravel.");
+    }
+
+    /**
+     * Gets session meta.
+     */
+    public function getMetadataBag(): MetadataBag
+    {
+        throw new BadMethodCallException("Method not implemented by Laravel.");
+    }
+}


### PR DESCRIPTION
Decorate Symfony session store when needed.

This is required because Symfony 6 adds a `SessionInterface` return type on Symfony 6 - so any packages or code interacting directly with `$request->getSession()` are currently broken on Laravel 9 because the `getSession` method is entirely broken. This fixes that by decorating our session behind a compatible implementation when `getSession` is called.