### PR TITLE
[8.x] Add Str::initials() helper to get initials of a given value

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -253,7 +253,7 @@ class Str
     public static function initials($value, $separator = ' ', $glue = ' ')
     {
         return trim(collect(explode($separator, $value))->map(function ($segment) {
-            return $segment[0] ?? '';
+            return static::substr($segment, 0, 1) ?? '';
         })->join($glue));
     }
 

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -245,9 +245,9 @@ class Str
     /**
      * Extract the initials of a given value.
      *
-     * @param  string $value
-     * @param  string $separator
-     * @param  string $glue
+     * @param  string  $value
+     * @param  string  $separator
+     * @param  string  $glue
      * @return string
      */
     public static function initials($value, $separator = ' ', $glue = ' ')

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -243,6 +243,21 @@ class Str
     }
 
     /**
+     * Extract the initials of a given value.
+     *
+     * @param  string $value
+     * @param  string $separator
+     * @param  string $glue
+     * @return string
+     */
+    public static function initials($value, $separator = ' ', $glue = ' ')
+    {
+        return trim(collect(explode($separator, $value))->map(function ($segment) {
+            return $segment[0] ?? '';
+        })->join($glue));
+    }
+
+    /**
      * Determine if a given string matches a given pattern.
      *
      * @param  string|array  $pattern

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -263,6 +263,9 @@ class SupportStrTest extends TestCase
         $this->assertSame('T M O', Str::initials('Taylor Master Otwell'));
         $this->assertSame('T+O', Str::initials('Taylor Otwell', ' ', '+'));
         $this->assertSame('T O', Str::initials('Taylor_Otwell', '_'));
+        $this->assertSame('你 世', Str::initials('你好 世界'));
+        $this->assertSame('Т М О', Str::initials('Тейлор Мастер Отвелл'));
+        $this->assertSame('З м', Str::initials('Здравствуй мир'));
     }
 
     public function testIs()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -256,6 +256,15 @@ class SupportStrTest extends TestCase
         $this->assertSame('abcbbc', Str::finish('abcbbcbc', 'bc'));
     }
 
+    public function testInitials()
+    {
+        $this->assertSame('t o', Str::initials('taylor otwell'));
+        $this->assertSame('T O', Str::initials('Taylor Otwell'));
+        $this->assertSame('T M O', Str::initials('Taylor Master Otwell'));
+        $this->assertSame('T+O', Str::initials('Taylor Otwell', ' ', '+'));
+        $this->assertSame('T O', Str::initials('Taylor_Otwell', '_'));
+    }
+
     public function testIs()
     {
         $this->assertTrue(Str::is('/', '/'));


### PR DESCRIPTION
In Jetstream https://github.com/laravel/jetstream/pull/940, @geisi has introduced anonymized default profile photo url calls by only extracting the initials of a user's name. It would have been nice if he could have used an existing Laravel String helper function.

I am introducing `Str::initials()` for this purpose and hope it helps you in other use cases.

For those who already want to use this before it's accepted/merged, just extend `Illuminate\Support\Str` with this macro in your `AppServiceProvider`'s `boot()` method:

```php
        Str::macro('initials', fn($value, $sep = ' ', $glue = ' ') => trim(collect(explode($sep, $value))->map(function ($segment) {
            return $segment[0] ?? '';
        })->join($glue)));
```

and then just use `Str::initials('Firstname Lastname')` or as an Eloquent accessor in your `User` model:

```php
    public function getInitialsAttribute(): string
    {
        return \Illuminate\Support\Str::initials($this->name);
    }
```

so you can simply use something like `{{ Auth::user()->initials }}`.