### PR TITLE
[8.x] Convert "/" in -e parameter to "\"

### DIFF
--- a/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
@@ -47,7 +47,7 @@ class ListenerMakeCommand extends GeneratorCommand
             'Illuminate',
             '\\',
         ])) {
-            $event = $this->laravel->getNamespace().'Events\\'.$event;
+            $event = $this->laravel->getNamespace().'Events\\'.str_replace('/', '\\', $event);
         }
 
         $stub = str_replace(


### PR DESCRIPTION
Convert "/" in `-e` parameter to "\\" when using `php artisan make:listener` command.

Example:
Run command `php artisan make:listener SendEmailListener -e UserModule/BirthdayEvent`.

Before:
![image](https://user-images.githubusercontent.com/31812811/149300669-feff8c76-1d76-47b0-a175-f6fdba087320.png)

After:
![image](https://user-images.githubusercontent.com/31812811/149300777-1391ddb6-338b-4ac6-9063-d6b3c7cf5868.png)

