### PR TITLE
[8.x] Models with constructor parameters throw an error when attributes are casted

### DIFF
--- a/tests/Integration/Database/DatabaseEloquentModelAttributeCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelAttributeCastingTest.php
@@ -188,6 +188,16 @@ class DatabaseEloquentModelAttributeCastingTest extends DatabaseTestCase
 
         $this->assertTrue(empty($model->getDirty()));
     }
+
+    public function testCastingModelWithConstructorParameters()
+    {
+        $model = new TestEloquentModelWithConstructor('__test__');
+        $model->uppercase = 'taylor';
+
+        $this->assertSame('TAYLOR', $model->uppercase);
+        $this->assertSame('TAYLOR', $model->getAttributes()['uppercase']);
+        $this->assertSame('TAYLOR', $model->toArray()['uppercase']);
+    }
 }
 
 class TestEloquentModelWithAttributeCast extends Model
@@ -272,6 +282,14 @@ class TestEloquentModelWithAttributeCast extends Model
                 return collect();
             }
         );
+    }
+}
+
+class TestEloquentModelWithConstructor extends TestEloquentModelWithAttributeCast
+{
+    public function __construct($param)
+    {
+       return parent::__construct();
     }
 }
 


### PR DESCRIPTION
When your model has constructor parameters, the new attribute casting logic produces an error.
It tries to create a new class but it does not provide the constructor parameters.

```php
protected static function getAttributeMarkedMutatorMethods($class)
{
   $instance = is_object($class) ? $class : new $class;
```

The error
```
1) Illuminate\Tests\Integration\Database\DatabaseEloquentModelAttributeCastingTest::testCastingModelWithConstructorParameters
ArgumentCountError: Too few arguments to function Illuminate\Tests\Integration\Database\TestEloquentModelWithConstructor::__construct(), 0 passed in /code/framework/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php on line 2099 and exactly 1 expected
```

This pull request only contains a failing test.
