### PR TITLE
[8.x] Fix setTestNow return type

### DIFF
--- a/src/Illuminate/Support/DateFactory.php
+++ b/src/Illuminate/Support/DateFactory.php
@@ -64,7 +64,7 @@ use InvalidArgumentException;
  * @method static Carbon setHumanDiffOptions($humanDiffOptions)
  * @method static bool setLocale($locale)
  * @method static void setMidDayAt($hour)
- * @method static Carbon setTestNow($testNow = null)
+ * @method static void setTestNow($testNow = null)
  * @method static void setToStringFormat($format)
  * @method static void setTranslator(\Symfony\Component\Translation\TranslatorInterface $translator)
  * @method static Carbon setUtf8($utf8)

--- a/src/Illuminate/Support/Facades/Date.php
+++ b/src/Illuminate/Support/Facades/Date.php
@@ -28,7 +28,7 @@ use Illuminate\Support\DateFactory;
  * @method static \Illuminate\Support\Carbon now($tz = null)
  * @method static \Illuminate\Support\Carbon parse($time = null, $tz = null)
  * @method static \Illuminate\Support\Carbon setHumanDiffOptions($humanDiffOptions)
- * @method static \Illuminate\Support\Carbon setTestNow($testNow = null)
+ * @method static void setTestNow($testNow = null)
  * @method static \Illuminate\Support\Carbon setUtf8($utf8)
  * @method static \Illuminate\Support\Carbon today($tz = null)
  * @method static \Illuminate\Support\Carbon tomorrow($tz = null)


### PR DESCRIPTION
`Illuminate\Support\Facades\Date::setTestNow()` is documented as returning a `Carbon` instance, but it doesn't actually return anything.

You can test this by running the following command on a Laravel project:

```bash
php artisan tinker <<< dd(Illuminate\\Support\\Facades\\Date::setTestNow(\'now\'))
```

Carbon's implementation: https://github.com/briannesbitt/Carbon/blob/master/src/Carbon/Traits/Test.php#L57
Laravel's implementation: https://github.com/laravel/framework/blob/8.x/src/Illuminate/Support/Carbon.php#L13