### PR TITLE
[8.x] Arr::get contains a logic error

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -315,7 +315,7 @@ class Arr
         }
 
         if (strpos($key, '.') === false) {
-            return $array[$key] ?? value($default);
+            return value($default);
         }
 
         foreach (explode('.', $key) as $segment) {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6877485/149343393-5ce81b15-f608-4061-94e3-0be254843183.png)
The $array[$key] there isn't logic because $key simply doesn't exists in $array on this line. If it did exist, it is returned in the previous if statement.