### PR TITLE
Include makeWith method into docblock

### DIFF
--- a/src/Illuminate/Support/Facades/App.php
+++ b/src/Illuminate/Support/Facades/App.php
@@ -8,6 +8,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Support\ServiceProvider resolveProvider(string $provider)
  * @method static array getProviders(\Illuminate\Support\ServiceProvider|string $provider)
  * @method static mixed make($abstract, array $parameters = [])
+ * @method static mixed makeWith($abstract, array $parameters = [])
  * @method static bool configurationIsCached()
  * @method static bool hasBeenBootstrapped()
  * @method static bool isDownForMaintenance()


### PR DESCRIPTION
makeWith() is an alias of make() according to the Container source code. However, makeWith wasn't documented on the facade so far and thus couldn't be autocompleted in an IDE.