### PR TITLE
[9.x] Uses `static` instead `static<TKey, TValue>`

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -219,7 +219,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * Get the items in the collection that are not present in the given items.
      *
      * @param  \Illuminate\Contracts\Support\Arrayable<array-key, TValue>|iterable<array-key, TValue>  $items
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function diff($items)
     {
@@ -231,7 +231,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      *
      * @param  \Illuminate\Contracts\Support\Arrayable<array-key, TValue>|iterable<array-key, TValue>  $items
      * @param  callable(TValue): int  $callback
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function diffUsing($items, callable $callback)
     {
@@ -242,7 +242,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * Get the items in the collection whose keys and values are not present in the given items.
      *
      * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function diffAssoc($items)
     {
@@ -254,7 +254,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      *
      * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
      * @param  callable(TKey): int  $callback
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function diffAssocUsing($items, callable $callback)
     {
@@ -265,7 +265,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * Get the items in the collection whose keys are not present in the given items.
      *
      * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function diffKeys($items)
     {
@@ -277,7 +277,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      *
      * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
      * @param  callable(TKey): int  $callback
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function diffKeysUsing($items, callable $callback)
     {
@@ -289,7 +289,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      *
      * @param  (callable(TValue): bool)|string|null  $callback
      * @param  bool  $strict
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function duplicates($callback = null, $strict = false)
     {
@@ -316,7 +316,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * Retrieve duplicate items from the collection using strict comparison.
      *
      * @param  (callable(TValue): bool)|string|null  $callback
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function duplicatesStrict($callback = null)
     {
@@ -346,7 +346,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * Get all items except for those with the specified keys.
      *
      * @param  \Illuminate\Support\Enumerable<array-key, TKey>|array<array-key, TKey>  $keys
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function except($keys)
     {
@@ -363,7 +363,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * Run a filter over each of the items.
      *
      * @param (callable(TValue): bool)|null  $callback
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function filter(callable $callback = null)
     {
@@ -577,7 +577,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * Intersect the collection with the given items.
      *
      * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function intersect($items)
     {
@@ -588,7 +588,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * Intersect the collection with the given items by key.
      *
      * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function intersectByKeys($items)
     {
@@ -762,7 +762,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * Merge the collection with the given items.
      *
      * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function merge($items)
     {
@@ -797,7 +797,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * Union the collection with the given items.
      *
      * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function union($items)
     {
@@ -809,7 +809,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      *
      * @param  int  $step
      * @param  int  $offset
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function nth($step, $offset = 0)
     {
@@ -832,7 +832,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * Get the items with the specified keys.
      *
      * @param  \Illuminate\Support\Enumerable<array-key, TKey>|array<array-key, TKey>  $keys
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function only($keys)
     {
@@ -909,7 +909,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * Push all of the given items onto the collection.
      *
      * @param  iterable<array-key, TValue>  $source
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function concat($source)
     {
@@ -971,7 +971,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * Replace the collection items with the given items.
      *
      * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function replace($items)
     {
@@ -982,7 +982,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * Recursively replace the collection items with the given items.
      *
      * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function replaceRecursive($items)
     {
@@ -992,7 +992,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Reverse items order.
      *
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function reverse()
     {
@@ -1052,7 +1052,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * Shuffle the items in the collection.
      *
      * @param  int|null  $seed
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function shuffle($seed = null)
     {
@@ -1064,7 +1064,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      *
      * @param  int  $size
      * @param  int  $step
-     * @return static<int, static<TKey, TValue>>
+     * @return static<int, static>
      */
     public function sliding($size = 2, $step = 1)
     {
@@ -1079,7 +1079,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * Skip the first {$count} items.
      *
      * @param  int  $count
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function skip($count)
     {
@@ -1090,7 +1090,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * Skip items in the collection until the given condition is met.
      *
      * @param  TValue|callable(TValue,TKey): bool  $value
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function skipUntil($value)
     {
@@ -1101,7 +1101,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * Skip items in the collection while the given condition is met.
      *
      * @param  TValue|callable(TValue,TKey): bool  $value
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function skipWhile($value)
     {
@@ -1113,7 +1113,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      *
      * @param  int  $offset
      * @param  int|null  $length
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function slice($offset, $length = null)
     {
@@ -1124,7 +1124,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * Split a collection into a certain number of groups.
      *
      * @param  int  $numberOfGroups
-     * @return static<int, static<TKey, TValue>>
+     * @return static<int, static>
      */
     public function split($numberOfGroups)
     {
@@ -1161,7 +1161,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * Split a collection into a certain number of groups, and fill the first groups completely.
      *
      * @param  int  $numberOfGroups
-     * @return static<int, static<TKey, TValue>>
+     * @return static<int, static>
      */
     public function splitIn($numberOfGroups)
     {
@@ -1229,7 +1229,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * Chunk the collection into chunks of the given size.
      *
      * @param  int  $size
-     * @return static<int, static<TKey, TValue>>
+     * @return static<int, static>
      */
     public function chunk($size)
     {
@@ -1263,7 +1263,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * Sort through each item with a callback.
      *
      * @param  (callable(TValue, TValue): bool)|null|int  $callback
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function sort($callback = null)
     {
@@ -1280,7 +1280,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * Sort items in descending order.
      *
      * @param  int  $options
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function sortDesc($options = SORT_REGULAR)
     {
@@ -1297,7 +1297,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * @param  (callable(TValue, TKey): mixed)|string  $callback
      * @param  int  $options
      * @param  bool  $descending
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function sortBy($callback, $options = SORT_REGULAR, $descending = false)
     {
@@ -1378,7 +1378,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      *
      * @param  (callable(TValue, TKey): mixed)|string  $callback
      * @param  int  $options
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function sortByDesc($callback, $options = SORT_REGULAR)
     {
@@ -1390,7 +1390,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      *
      * @param  int  $options
      * @param  bool  $descending
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function sortKeys($options = SORT_REGULAR, $descending = false)
     {
@@ -1405,7 +1405,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * Sort the collection keys in descending order.
      *
      * @param  int  $options
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function sortKeysDesc($options = SORT_REGULAR)
     {
@@ -1418,7 +1418,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * @param  int  $offset
      * @param  int|null  $length
      * @param  array<array-key, TValue>  $replacement
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function splice($offset, $length = null, $replacement = [])
     {
@@ -1433,7 +1433,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * Take the first or last {$limit} items.
      *
      * @param  int  $limit
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function take($limit)
     {
@@ -1448,7 +1448,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * Take items in the collection until the given condition is met.
      *
      * @param  TValue|callable(TValue,TKey): bool  $value
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function takeUntil($value)
     {
@@ -1459,7 +1459,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * Take items in the collection while the given condition is met.
      *
      * @param  TValue|callable(TValue,TKey): bool  $value
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function takeWhile($value)
     {
@@ -1494,7 +1494,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      *
      * @param  (callable(TValue, TKey): bool)|string|null  $key
      * @param  bool  $strict
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function unique($key = null, $strict = false)
     {

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -893,7 +893,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Push one or more items onto the end of the collection.
      *
-     * @param  TValue ...$values
+     * @param  TValue  ...$values
      * @return $this
      */
     public function push(...$values)

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -893,7 +893,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Push one or more items onto the end of the collection.
      *
-     * @param  ...TValue  $values
+     * @param  TValue ...$values
      * @return $this
      */
     public function push(...$values)

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -71,7 +71,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Create a new instance with no items.
      *
-     * @return static<TKey, TValue>
+     * @return static
      */
     public static function empty();
 
@@ -180,7 +180,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Get the items that are not present in the given items.
      *
      * @param  \Illuminate\Contracts\Support\Arrayable<array-key, TValue>|iterable<array-key, TValue>  $items
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function diff($items);
 
@@ -189,7 +189,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      *
      * @param  \Illuminate\Contracts\Support\Arrayable<array-key, TValue>|iterable<array-key, TValue>  $items
      * @param  callable(TValue): int  $callback
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function diffUsing($items, callable $callback);
 
@@ -197,7 +197,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Get the items whose keys and values are not present in the given items.
      *
      * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function diffAssoc($items);
 
@@ -206,7 +206,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      *
      * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
      * @param  callable(TKey): int  $callback
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function diffAssocUsing($items, callable $callback);
 
@@ -214,7 +214,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Get the items whose keys are not present in the given items.
      *
      * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function diffKeys($items);
 
@@ -223,7 +223,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      *
      * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
      * @param  callable(TKey): int  $callback
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function diffKeysUsing($items, callable $callback);
 
@@ -232,7 +232,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      *
      * @param  (callable(TValue): bool)|string|null  $callback
      * @param  bool  $strict
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function duplicates($callback = null, $strict = false);
 
@@ -240,7 +240,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Retrieve duplicate items using strict comparison.
      *
      * @param  (callable(TValue): bool)|string|null  $callback
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function duplicatesStrict($callback = null);
 
@@ -256,7 +256,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Execute a callback over each nested chunk of items.
      *
      * @param  callable  $callback
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function eachSpread(callable $callback);
 
@@ -274,7 +274,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Get all items except for those with the specified keys.
      *
      * @param  \Illuminate\Support\Enumerable<array-key, TKey>|array<array-key, TKey>  $keys
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function except($keys);
 
@@ -282,7 +282,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Run a filter over each of the items.
      *
      * @param  (callable(TValue): bool)|null  $callback
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function filter(callable $callback = null);
 
@@ -360,7 +360,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @param  string  $key
      * @param  mixed  $operator
      * @param  mixed  $value
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function where($key, $operator = null, $value = null);
 
@@ -368,7 +368,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Filter items where the value for the given key is null.
      *
      * @param  string|null  $key
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function whereNull($key = null);
 
@@ -376,7 +376,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Filter items where the value for the given key is not null.
      *
      * @param  string|null  $key
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function whereNotNull($key = null);
 
@@ -385,7 +385,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      *
      * @param  string  $key
      * @param  mixed  $value
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function whereStrict($key, $value);
 
@@ -395,7 +395,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @param  string  $key
      * @param  \Illuminate\Contracts\Support\Arrayable|iterable  $values
      * @param  bool  $strict
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function whereIn($key, $values, $strict = false);
 
@@ -404,7 +404,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      *
      * @param  string  $key
      * @param  \Illuminate\Contracts\Support\Arrayable|iterable  $values
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function whereInStrict($key, $values);
 
@@ -413,7 +413,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      *
      * @param  string  $key
      * @param  \Illuminate\Contracts\Support\Arrayable|iterable  $values
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function whereBetween($key, $values);
 
@@ -422,7 +422,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      *
      * @param  string  $key
      * @param  \Illuminate\Contracts\Support\Arrayable|iterable  $values
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function whereNotBetween($key, $values);
 
@@ -432,7 +432,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @param  string  $key
      * @param  \Illuminate\Contracts\Support\Arrayable|iterable  $values
      * @param  bool  $strict
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function whereNotIn($key, $values, $strict = false);
 
@@ -441,7 +441,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      *
      * @param  string  $key
      * @param  \Illuminate\Contracts\Support\Arrayable|iterable  $values
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function whereNotInStrict($key, $values);
 
@@ -449,7 +449,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Filter the items, removing any items that don't match the given type(s).
      *
      * @param  class-string|array<array-key, class-string>  $type
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function whereInstanceOf($type);
 
@@ -478,7 +478,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Get a flattened array of the items in the collection.
      *
      * @param  int  $depth
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function flatten($depth = INF);
 
@@ -538,7 +538,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Intersect the collection with the given items.
      *
      * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function intersect($items);
 
@@ -546,7 +546,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Intersect the collection with the given items by key.
      *
      * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function intersectByKeys($items);
 
@@ -605,7 +605,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Run a map over each nested chunk of items.
      *
      * @param  callable  $callback
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function mapSpread(callable $callback);
 
@@ -670,7 +670,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Merge the collection with the given items.
      *
      * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function merge($items);
 
@@ -696,7 +696,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Union the collection with the given items.
      *
      * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function union($items);
 
@@ -721,7 +721,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      *
      * @param  int  $step
      * @param  int  $offset
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function nth($step, $offset = 0);
 
@@ -729,7 +729,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Get the items with the specified keys.
      *
      * @param  \Illuminate\Support\Enumerable<array-key, TKey>|array<array-key, TKey>  $keys
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function only($keys);
 
@@ -738,7 +738,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      *
      * @param  int  $page
      * @param  int  $perPage
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function forPage($page, $perPage);
 
@@ -748,7 +748,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @param  (callable(TValue, TKey): bool)|TValue|string  $key
      * @param  mixed  $operator
      * @param  mixed  $value
-     * @return array<int, static<TKey, TValue>>
+     * @return array<int, static>
      */
     public function partition($key, $operator = null, $value = null);
 
@@ -756,7 +756,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Push all of the given items onto the collection.
      *
      * @param  iterable<array-key, TValue>  $source
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function concat($source);
 
@@ -786,7 +786,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Replace the collection items with the given items.
      *
      * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function replace($items);
 
@@ -794,14 +794,14 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Recursively replace the collection items with the given items.
      *
      * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function replaceRecursive($items);
 
     /**
      * Reverse items order.
      *
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function reverse();
 
@@ -818,7 +818,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Shuffle the items in the collection.
      *
      * @param  int|null  $seed
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function shuffle($seed = null);
 
@@ -826,7 +826,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Skip the first {$count} items.
      *
      * @param  int  $count
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function skip($count);
 
@@ -834,7 +834,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Skip items in the collection until the given condition is met.
      *
      * @param  TValue|callable(TValue,TKey): bool  $value
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function skipUntil($value);
 
@@ -842,7 +842,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Skip items in the collection while the given condition is met.
      *
      * @param  TValue|callable(TValue,TKey): bool  $value
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function skipWhile($value);
 
@@ -851,7 +851,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      *
      * @param  int  $offset
      * @param  int|null  $length
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function slice($offset, $length = null);
 
@@ -859,7 +859,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Split a collection into a certain number of groups.
      *
      * @param  int  $numberOfGroups
-     * @return static<int, static<TKey, TValue>>
+     * @return static<int, static>
      */
     public function split($numberOfGroups);
 
@@ -880,7 +880,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Chunk the collection into chunks of the given size.
      *
      * @param  int  $size
-     * @return static<int, static<TKey, TValue>>
+     * @return static<int, static>
      */
     public function chunk($size);
 
@@ -896,7 +896,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Sort through each item with a callback.
      *
      * @param  (callable(TValue, TValue): bool)|null|int  $callback
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function sort($callback = null);
 
@@ -904,7 +904,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Sort items in descending order.
      *
      * @param  int  $options
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function sortDesc($options = SORT_REGULAR);
 
@@ -914,7 +914,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @param  (callable(TValue, TKey): mixed)|string  $callback
      * @param  int  $options
      * @param  bool  $descending
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function sortBy($callback, $options = SORT_REGULAR, $descending = false);
 
@@ -923,7 +923,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      *
      * @param  (callable(TValue, TKey): mixed)|string  $callback
      * @param  int  $options
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function sortByDesc($callback, $options = SORT_REGULAR);
 
@@ -932,7 +932,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      *
      * @param  int  $options
      * @param  bool  $descending
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function sortKeys($options = SORT_REGULAR, $descending = false);
 
@@ -940,7 +940,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Sort the collection keys in descending order.
      *
      * @param  int  $options
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function sortKeysDesc($options = SORT_REGULAR);
 
@@ -956,7 +956,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Take the first or last {$limit} items.
      *
      * @param  int  $limit
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function take($limit);
 
@@ -964,7 +964,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Take items in the collection until the given condition is met.
      *
      * @param  TValue|callable(TValue,TKey): bool  $value
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function takeUntil($value);
 
@@ -972,7 +972,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Take items in the collection while the given condition is met.
      *
      * @param  TValue|callable(TValue,TKey): bool  $value
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function takeWhile($value);
 
@@ -1007,7 +1007,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Create a collection of all elements that do not pass a given truth test.
      *
      * @param  (callable(TValue): bool)|bool  $callback
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function reject($callback = true);
 
@@ -1016,7 +1016,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      *
      * @param  (callable(TValue, TKey): bool)|string|null  $key
      * @param  bool  $strict
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function unique($key = null, $strict = false);
 
@@ -1024,7 +1024,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Return only unique items from the collection array using strict comparison.
      *
      * @param  (callable(TValue, TKey): bool)|string|null  $key
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function uniqueStrict($key = null);
 

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -27,7 +27,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     /**
      * The source from which to generate items.
      *
-     * @var (Closure(): \Generator<TKey, TValue, mixed, void>)|static<TKey, TValue>|array<TKey, TValue>
+     * @var (Closure(): \Generator<TKey, TValue, mixed, void>)|static|array<TKey, TValue>
      */
     public $source;
 
@@ -101,7 +101,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     /**
      * Eager load all items into a new lazy collection backed by an array.
      *
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function eager()
     {
@@ -289,7 +289,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * Get the items that are not present in the given items.
      *
      * @param  \Illuminate\Contracts\Support\Arrayable<array-key, TValue>|iterable<array-key, TValue>  $items
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function diff($items)
     {
@@ -301,7 +301,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      *
      * @param  \Illuminate\Contracts\Support\Arrayable<array-key, TValue>|iterable<array-key, TValue>  $items
      * @param  callable(TValue): int  $callback
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function diffUsing($items, callable $callback)
     {
@@ -312,7 +312,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * Get the items whose keys and values are not present in the given items.
      *
      * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function diffAssoc($items)
     {
@@ -324,7 +324,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      *
      * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
      * @param  callable(TKey): int  $callback
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function diffAssocUsing($items, callable $callback)
     {
@@ -335,7 +335,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * Get the items whose keys are not present in the given items.
      *
      * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function diffKeys($items)
     {
@@ -347,7 +347,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      *
      * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
      * @param  callable(TKey): int  $callback
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function diffKeysUsing($items, callable $callback)
     {
@@ -359,7 +359,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      *
      * @param  (callable(TValue): bool)|string|null  $callback
      * @param  bool  $strict
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function duplicates($callback = null, $strict = false)
     {
@@ -370,7 +370,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * Retrieve duplicate items using strict comparison.
      *
      * @param  (callable(TValue): bool)|string|null  $callback
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function duplicatesStrict($callback = null)
     {
@@ -381,7 +381,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * Get all items except for those with the specified keys.
      *
      * @param  \Illuminate\Support\Enumerable<array-key, TKey>|array<array-key, TKey>  $keys
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function except($keys)
     {
@@ -392,7 +392,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * Run a filter over each of the items.
      *
      * @param  (callable(TValue): bool)|null  $callback
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function filter(callable $callback = null)
     {
@@ -592,7 +592,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * Intersect the collection with the given items.
      *
      * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function intersect($items)
     {
@@ -603,7 +603,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * Intersect the collection with the given items by key.
      *
      * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function intersectByKeys($items)
     {
@@ -765,7 +765,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * Merge the collection with the given items.
      *
      * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function merge($items)
     {
@@ -820,7 +820,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * Union the collection with the given items.
      *
      * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function union($items)
     {
@@ -832,7 +832,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      *
      * @param  int  $step
      * @param  int  $offset
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function nth($step, $offset = 0)
     {
@@ -853,7 +853,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * Get the items with the specified keys.
      *
      * @param  \Illuminate\Support\Enumerable<array-key, TKey>|array<array-key, TKey>  $keys
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function only($keys)
     {
@@ -888,7 +888,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * Push all of the given items onto the collection.
      *
      * @param  iterable<array-key, TValue>  $source
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function concat($source)
     {
@@ -917,7 +917,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * Replace the collection items with the given items.
      *
      * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function replace($items)
     {
@@ -944,7 +944,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * Recursively replace the collection items with the given items.
      *
      * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function replaceRecursive($items)
     {
@@ -954,7 +954,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     /**
      * Reverse items order.
      *
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function reverse()
     {
@@ -1002,7 +1002,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      *
      * @param  int  $size
      * @param  int  $step
-     * @return static<int, static<TKey, TValue>>
+     * @return static<int, static>
      */
     public function sliding($size = 2, $step = 1)
     {
@@ -1063,7 +1063,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * Skip items in the collection until the given condition is met.
      *
      * @param  TValue|callable(TValue,TKey): bool  $value
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function skipUntil($value)
     {
@@ -1076,7 +1076,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * Skip items in the collection while the given condition is met.
      *
      * @param  TValue|callable(TValue,TKey): bool  $value
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function skipWhile($value)
     {
@@ -1102,7 +1102,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      *
      * @param  int  $offset
      * @param  int|null  $length
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function slice($offset, $length = null)
     {
@@ -1119,7 +1119,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * Split a collection into a certain number of groups.
      *
      * @param  int  $numberOfGroups
-     * @return static<int, static<TKey, TValue>>
+     * @return static<int, static>
      */
     public function split($numberOfGroups)
     {
@@ -1179,7 +1179,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * Chunk the collection into chunks of the given size.
      *
      * @param  int  $size
-     * @return static<int, static<TKey, TValue>>
+     * @return static<int, static>
      */
     public function chunk($size)
     {
@@ -1218,7 +1218,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * Split a collection into a certain number of groups, and fill the first groups completely.
      *
      * @param  int  $numberOfGroups
-     * @return static<int, static<TKey, TValue>>
+     * @return static<int, static>
      */
     public function splitIn($numberOfGroups)
     {
@@ -1266,7 +1266,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * Sort through each item with a callback.
      *
      * @param  (callable(TValue, TValue): bool)|null|int  $callback
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function sort($callback = null)
     {
@@ -1277,7 +1277,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * Sort items in descending order.
      *
      * @param  int  $options
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function sortDesc($options = SORT_REGULAR)
     {
@@ -1290,7 +1290,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * @param  (callable(TValue, TKey): mixed)|string  $callback
      * @param  int  $options
      * @param  bool  $descending
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function sortBy($callback, $options = SORT_REGULAR, $descending = false)
     {
@@ -1302,7 +1302,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      *
      * @param  (callable(TValue, TKey): mixed)|string  $callback
      * @param  int  $options
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function sortByDesc($callback, $options = SORT_REGULAR)
     {
@@ -1314,7 +1314,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      *
      * @param  int  $options
      * @param  bool  $descending
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function sortKeys($options = SORT_REGULAR, $descending = false)
     {
@@ -1325,7 +1325,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * Sort the collection keys in descending order.
      *
      * @param  int  $options
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function sortKeysDesc($options = SORT_REGULAR)
     {
@@ -1336,7 +1336,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * Take the first or last {$limit} items.
      *
      * @param  int  $limit
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function take($limit)
     {
@@ -1365,7 +1365,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * Take items in the collection until the given condition is met.
      *
      * @param  TValue|callable(TValue,TKey): bool  $value
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function takeUntil($value)
     {
@@ -1387,7 +1387,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * Take items in the collection until a given point in time.
      *
      * @param  \DateTimeInterface  $timeout
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function takeUntilTimeout(DateTimeInterface $timeout)
     {
@@ -1402,7 +1402,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * Take items in the collection while the given condition is met.
      *
      * @param  TValue|callable(TValue,TKey): bool  $value
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function takeWhile($value)
     {
@@ -1418,7 +1418,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * Pass each item in the collection to the given callback, lazily.
      *
      * @param  callable(TValue, TKey): mixed  $callback
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function tapEach(callable $callback)
     {
@@ -1446,7 +1446,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      *
      * @param  (callable(TValue, TKey): bool)|string|null  $key
      * @param  bool  $strict
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function unique($key = null, $strict = false)
     {

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -141,7 +141,7 @@ trait EnumeratesValues
     /**
      * Create a new instance with no items.
      *
-     * @return static<TKey, TValue>
+     * @return static
      */
     public static function empty()
     {
@@ -270,7 +270,7 @@ trait EnumeratesValues
      * Execute a callback over each nested chunk of items.
      *
      * @param  callable(...mixed): mixed  $callback
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function eachSpread(callable $callback)
     {
@@ -448,7 +448,7 @@ trait EnumeratesValues
      * @param  (callable(TValue, TKey): bool)|TValue|string  $key
      * @param  TValue|string|null  $operator
      * @param  TValue|null  $value
-     * @return array<int, static<TKey, TValue>>
+     * @return array<int, static>
      */
     public function partition($key, $operator = null, $value = null)
     {
@@ -549,7 +549,7 @@ trait EnumeratesValues
      * @param  string  $key
      * @param  mixed  $operator
      * @param  mixed  $value
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function where($key, $operator = null, $value = null)
     {
@@ -560,7 +560,7 @@ trait EnumeratesValues
      * Filter items where the value for the given key is null.
      *
      * @param  string|null  $key
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function whereNull($key = null)
     {
@@ -571,7 +571,7 @@ trait EnumeratesValues
      * Filter items where the value for the given key is not null.
      *
      * @param  string|null  $key
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function whereNotNull($key = null)
     {
@@ -584,7 +584,7 @@ trait EnumeratesValues
      * @param  string  $key
      * @param  mixed  $value
      * @param  bool  $strict
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function whereStrict($key, $value)
     {
@@ -597,7 +597,7 @@ trait EnumeratesValues
      * @param  string  $key
      * @param  \Illuminate\Contracts\Support\Arrayable|iterable  $values
      * @param  bool  $strict
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function whereIn($key, $values, $strict = false)
     {
@@ -613,7 +613,7 @@ trait EnumeratesValues
      *
      * @param  string  $key
      * @param  \Illuminate\Contracts\Support\Arrayable|iterable  $values
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function whereInStrict($key, $values)
     {
@@ -625,7 +625,7 @@ trait EnumeratesValues
      *
      * @param  string  $key
      * @param  \Illuminate\Contracts\Support\Arrayable|iterable  $values
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function whereBetween($key, $values)
     {
@@ -637,7 +637,7 @@ trait EnumeratesValues
      *
      * @param  string  $key
      * @param  \Illuminate\Contracts\Support\Arrayable|iterable  $values
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function whereNotBetween($key, $values)
     {
@@ -652,7 +652,7 @@ trait EnumeratesValues
      * @param  string  $key
      * @param  \Illuminate\Contracts\Support\Arrayable|iterable  $values
      * @param  bool  $strict
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function whereNotIn($key, $values, $strict = false)
     {
@@ -668,7 +668,7 @@ trait EnumeratesValues
      *
      * @param  string  $key
      * @param  \Illuminate\Contracts\Support\Arrayable|iterable  $values
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function whereNotInStrict($key, $values)
     {
@@ -679,7 +679,7 @@ trait EnumeratesValues
      * Filter the items, removing any items that don't match the given type(s).
      *
      * @param  class-string|array<array-key, class-string>  $type
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function whereInstanceOf($type)
     {
@@ -821,7 +821,7 @@ trait EnumeratesValues
      * Create a collection of all elements that do not pass a given truth test.
      *
      * @param  (callable(TValue): bool)|bool  $callback
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function reject($callback = true)
     {
@@ -852,7 +852,7 @@ trait EnumeratesValues
      *
      * @param  (callable(TValue, TKey): bool)|string|null  $key
      * @param  bool  $strict
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function unique($key = null, $strict = false)
     {
@@ -873,7 +873,7 @@ trait EnumeratesValues
      * Return only unique items from the collection array using strict comparison.
      *
      * @param  (callable(TValue, TKey): bool)|string|null  $key
-     * @return static<TKey, TValue>
+     * @return static
      */
     public function uniqueStrict($key = null)
     {


### PR DESCRIPTION
This PR changes the `static<TKey, TValue>` syntax to `static`. Some tools do not support generic static PHPDocs. And since they both have the same meaning, there is no braking change. 

Static analysis tool results or IDE completion is also not effected.