### PR TITLE
[8.x] Add complimentary `Str::doesntContain`

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -208,6 +208,30 @@ class Str
     }
 
     /**
+     * Determine if a given string does not contain a given substring.
+     *
+     * @param  string  $haystack
+     * @param  string|string[]  $needles
+     * @return bool
+     */
+    public static function doesntContain($haystack, $needles)
+    {
+        return ! static::contains(...func_get_args());
+    }
+
+    /**
+     * Determine if a given string does not contain any array values.
+     *
+     * @param  string  $haystack
+     * @param  string[]  $needles
+     * @return bool
+     */
+    public static function doesntContainAny($haystack, array $needles)
+    {
+        return ! static::containsAll(...func_get_args());
+    }
+
+    /**
      * Determine if a given string ends with a given substring.
      *
      * @param  string  $haystack

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -220,18 +220,6 @@ class Str
     }
 
     /**
-     * Determine if a given string does not contain any array values.
-     *
-     * @param  string  $haystack
-     * @param  string[]  $needles
-     * @return bool
-     */
-    public static function doesntContainAny($haystack, array $needles)
-    {
-        return ! static::containsAll(...func_get_args());
-    }
-
-    /**
      * Determine if a given string ends with a given substring.
      *
      * @param  string  $haystack

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -174,6 +174,18 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Determine if a given string does not contain a given substring.
+     *
+     * @param  string  $haystack
+     * @param  string|string[]  $needles
+     * @return bool
+     */
+    public function doesntContain($needles)
+    {
+        return Str::doesntContain($this->value, $needles);
+    }
+
+    /**
      * Determine if a given string ends with a given substring.
      *
      * @param  string|array  $needles

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -217,11 +217,11 @@ class SupportStrTest extends TestCase
 
     public function testStrDoesntContain()
     {
+        $this->assertTrue(Str::doesntContain('', ''));
         $this->assertTrue(Str::doesntContain('taylor', 'xxx'));
         $this->assertTrue(Str::doesntContain('taylor', ['xxx']));
         $this->assertTrue(Str::doesntContain('taylor', ['foo', 'bar']));
         $this->assertTrue(Str::doesntContain('taylor', ''));
-        $this->assertTrue(Str::doesntContain('', ''));
         $this->assertFalse(Str::doesntContain('taylor', 'ylo'));
         $this->assertFalse(Str::doesntContain('taylor', 'taylor'));
         $this->assertFalse(Str::doesntContain('taylor', ['ylo']));

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -219,6 +219,7 @@ class SupportStrTest extends TestCase
     {
         $this->assertTrue(Str::doesntContain('taylor', 'xxx'));
         $this->assertTrue(Str::doesntContain('taylor', ['xxx']));
+        $this->assertTrue(Str::doesntContain('taylor', ['foo', 'bar']));
         $this->assertTrue(Str::doesntContain('taylor', ''));
         $this->assertTrue(Str::doesntContain('', ''));
         $this->assertFalse(Str::doesntContain('taylor', 'ylo'));
@@ -232,13 +233,6 @@ class SupportStrTest extends TestCase
         $this->assertTrue(Str::containsAll('taylor otwell', ['taylor', 'otwell']));
         $this->assertTrue(Str::containsAll('taylor otwell', ['taylor']));
         $this->assertFalse(Str::containsAll('taylor otwell', ['taylor', 'xxx']));
-    }
-
-    public function testStrDoesntContainAny()
-    {
-        $this->assertFalse(Str::doesntContainAny('taylor otwell', ['taylor', 'otwell']));
-        $this->assertFalse(Str::doesntContainAny('taylor otwell', ['taylor']));
-        $this->assertTrue(Str::doesntContainAny('taylor otwell', ['taylor', 'xxx']));
     }
 
     public function testParseCallback()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -215,11 +215,30 @@ class SupportStrTest extends TestCase
         $this->assertFalse(Str::contains('', ''));
     }
 
+    public function testStrDoesntContain()
+    {
+        $this->assertTrue(Str::doesntContain('taylor', 'xxx'));
+        $this->assertTrue(Str::doesntContain('taylor', ['xxx']));
+        $this->assertTrue(Str::doesntContain('taylor', ''));
+        $this->assertTrue(Str::doesntContain('', ''));
+        $this->assertFalse(Str::doesntContain('taylor', 'ylo'));
+        $this->assertFalse(Str::doesntContain('taylor', 'taylor'));
+        $this->assertFalse(Str::doesntContain('taylor', ['ylo']));
+        $this->assertFalse(Str::doesntContain('taylor', ['xxx', 'ylo']));
+    }
+
     public function testStrContainsAll()
     {
         $this->assertTrue(Str::containsAll('taylor otwell', ['taylor', 'otwell']));
         $this->assertTrue(Str::containsAll('taylor otwell', ['taylor']));
         $this->assertFalse(Str::containsAll('taylor otwell', ['taylor', 'xxx']));
+    }
+
+    public function testStrDoesntContainAny()
+    {
+        $this->assertFalse(Str::doesntContainAny('taylor otwell', ['taylor', 'otwell']));
+        $this->assertFalse(Str::doesntContainAny('taylor otwell', ['taylor']));
+        $this->assertTrue(Str::doesntContainAny('taylor otwell', ['taylor', 'xxx']));
     }
 
     public function testParseCallback()

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -551,6 +551,19 @@ class SupportStringableTest extends TestCase
         $this->assertFalse($this->stringable('taylor')->contains(''));
     }
 
+    public function testStrDoesntContain()
+    {
+        $this->assertTrue($this->stringable('')->doesntContain(''));
+        $this->assertTrue($this->stringable('taylor')->doesntContain('xxx'));
+        $this->assertTrue($this->stringable('taylor')->doesntContain(['xxx']));
+        $this->assertTrue($this->stringable('taylor')->doesntContain(['foo', 'bar']));
+        $this->assertTrue($this->stringable('taylor')->doesntContain(''));
+        $this->assertFalse($this->stringable('taylor')->doesntContain('ylo'));
+        $this->assertFalse($this->stringable('taylor')->doesntContain('taylor'));
+        $this->assertFalse($this->stringable('taylor')->doesntContain(['ylo']));
+        $this->assertFalse($this->stringable('taylor')->doesntContain(['xxx', 'ylo']));
+    }
+
     public function testContainsAll()
     {
         $this->assertTrue($this->stringable('taylor otwell')->containsAll(['taylor', 'otwell']));


### PR DESCRIPTION
Similar to the recent additions to the `Collection` class, this PR adds a complimentary `doesntContain` method. This may be used to test a string does not contain a substring or set of substrings, which allow the developer to write more expressive code.

**Before**
```php
if (! Str::contains('foo', 'bar')) {
    // ...
}

if (! Str::containsAll('foo', ['bar', 'baz'])) {
    // ...
}
```

**After**
```php
if (Str::doesntContain('foo', 'bar')) {
    // ...
}

if (Str::doesntContain('foo', ['bar', 'baz'])) {
    // ...
}
```