### PR TITLE
[9.x] Do not instantiate the controller just for fetching the middleware

### DIFF
--- a/src/Illuminate/Routing/Contracts/ControllerDispatcher.php
+++ b/src/Illuminate/Routing/Contracts/ControllerDispatcher.php
@@ -26,10 +26,10 @@ interface ControllerDispatcher
     public function getMiddleware($controller, $method);
 
     /**
-     * Whether a controller should gather middlewares or not.
+     * Whether a controller should gather middleware.
      *
      * @param  string  $controller
      * @return bool
      */
-    public function shouldGatherMiddlewares($controller);
+    public function shouldGatherMiddleware($controller);
 }

--- a/src/Illuminate/Routing/Contracts/ControllerDispatcher.php
+++ b/src/Illuminate/Routing/Contracts/ControllerDispatcher.php
@@ -24,4 +24,12 @@ interface ControllerDispatcher
      * @return array
      */
     public function getMiddleware($controller, $method);
+
+    /**
+     * Whether a controller should gather middlewares or not.
+     *
+     * @param  string  $controller
+     * @return bool
+     */
+    public function shouldGatherMiddlewares($controller);
 }

--- a/src/Illuminate/Routing/ControllerDispatcher.php
+++ b/src/Illuminate/Routing/ControllerDispatcher.php
@@ -4,6 +4,7 @@ namespace Illuminate\Routing;
 
 use Illuminate\Container\Container;
 use Illuminate\Routing\Contracts\ControllerDispatcher as ControllerDispatcherContract;
+use function method_exists;
 
 class ControllerDispatcher implements ControllerDispatcherContract
 {
@@ -57,13 +58,20 @@ class ControllerDispatcher implements ControllerDispatcherContract
      */
     public function getMiddleware($controller, $method)
     {
-        if (! method_exists($controller, 'getMiddleware')) {
-            return [];
-        }
-
         return collect($controller->getMiddleware())->reject(function ($data) use ($method) {
             return static::methodExcludedByOptions($method, $data['options']);
         })->pluck('middleware')->all();
+    }
+
+    /**
+     * Whether a controller should gather middlewares or not.
+     *
+     * @param  string  $controller
+     * @return bool
+     */
+    public function shouldGatherMiddlewares($controller)
+    {
+        return method_exists($controller, 'getMiddleware');
     }
 
     /**

--- a/src/Illuminate/Routing/ControllerDispatcher.php
+++ b/src/Illuminate/Routing/ControllerDispatcher.php
@@ -4,7 +4,6 @@ namespace Illuminate\Routing;
 
 use Illuminate\Container\Container;
 use Illuminate\Routing\Contracts\ControllerDispatcher as ControllerDispatcherContract;
-use function method_exists;
 
 class ControllerDispatcher implements ControllerDispatcherContract
 {

--- a/src/Illuminate/Routing/ControllerDispatcher.php
+++ b/src/Illuminate/Routing/ControllerDispatcher.php
@@ -64,12 +64,12 @@ class ControllerDispatcher implements ControllerDispatcherContract
     }
 
     /**
-     * Whether a controller should gather middlewares or not.
+     * Whether a controller should gather middleware.
      *
      * @param  string  $controller
      * @return bool
      */
-    public function shouldGatherMiddlewares($controller)
+    public function shouldGatherMiddleware($controller)
     {
         return method_exists($controller, 'getMiddleware');
     }

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -59,6 +59,13 @@ class Route
     public $controller;
 
     /**
+     * The controller reference.
+     *
+     * @var string
+     */
+    public $controllerReference;
+
+    /**
      * The default values for the route.
      *
      * @var array
@@ -270,12 +277,21 @@ class Route
     public function getController()
     {
         if (! $this->controller) {
-            $class = $this->parseControllerCallback()[0];
-
-            $this->controller = $this->container->make(ltrim($class, '\\'));
+            $this->controller = $this->container->make($this->getControllerReference());
         }
 
         return $this->controller;
+    }
+
+    public function getControllerReference()
+    {
+        if (! $this->controllerReference) {
+            $class = $this->parseControllerCallback()[0];
+
+            $this->controllerReference = ltrim($class, '\\');
+        }
+
+        return $this->controllerReference;
     }
 
     /**
@@ -1064,6 +1080,10 @@ class Route
     public function controllerMiddleware()
     {
         if (! $this->isControllerAction()) {
+            return [];
+        }
+        
+        if (! $this->controllerDispatcher()->shouldGatherMiddlewares($this->getControllerReference())) {
             return [];
         }
 

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1082,7 +1082,7 @@ class Route
         if (! $this->isControllerAction()) {
             return [];
         }
-        
+
         if (! $this->controllerDispatcher()->shouldGatherMiddleware($this->getControllerClass())) {
             return [];
         }

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -63,7 +63,7 @@ class Route
      *
      * @var string
      */
-    public $controllerReference;
+    public $controllerClass;
 
     /**
      * The default values for the route.
@@ -277,21 +277,21 @@ class Route
     public function getController()
     {
         if (! $this->controller) {
-            $this->controller = $this->container->make($this->getControllerReference());
+            $this->controller = $this->container->make($this->getControllerClass());
         }
 
         return $this->controller;
     }
 
-    public function getControllerReference()
+    public function getControllerClass()
     {
-        if (! $this->controllerReference) {
+        if (! $this->controllerClass) {
             $class = $this->parseControllerCallback()[0];
 
-            $this->controllerReference = ltrim($class, '\\');
+            $this->controllerClass = ltrim($class, '\\');
         }
 
-        return $this->controllerReference;
+        return $this->controllerClass;
     }
 
     /**
@@ -1083,7 +1083,7 @@ class Route
             return [];
         }
         
-        if (! $this->controllerDispatcher()->shouldGatherMiddlewares($this->getControllerReference())) {
+        if (! $this->controllerDispatcher()->shouldGatherMiddleware($this->getControllerClass())) {
             return [];
         }
 

--- a/tests/Integration/Routing/RoutingMiddlewareTest.php
+++ b/tests/Integration/Routing/RoutingMiddlewareTest.php
@@ -69,6 +69,7 @@ class RoutingMiddlewareTestTestingMiddleware
     public function handle($request, $next)
     {
         $_SERVER['routing.middleware.test.last.constructed'] = 'middleware';
+
         return $next($request);
     }
 }

--- a/tests/Integration/Routing/RoutingMiddlewareTest.php
+++ b/tests/Integration/Routing/RoutingMiddlewareTest.php
@@ -2,11 +2,10 @@
 
 namespace Illuminate\Tests\Integration\Routing;
 
-
 use Illuminate\Http\Response;
+use Illuminate\Routing\Controller;
 use Illuminate\Routing\Router;
 use Orchestra\Testbench\TestCase;
-use Illuminate\Routing\Controller;
 
 class RoutingMiddlewareTest extends TestCase
 {
@@ -67,8 +66,6 @@ class RoutingMiddlewareTestWithGetMiddlewareController extends Controller
 
 class RoutingMiddlewareTestTestingMiddleware
 {
-
-
     public function handle($request, $next)
     {
         $_SERVER['routing.middleware.test.last.constructed'] = 'middleware';

--- a/tests/Integration/Routing/RoutingMiddlewareTest.php
+++ b/tests/Integration/Routing/RoutingMiddlewareTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Routing;
+
+
+use Illuminate\Http\Response;
+use Illuminate\Routing\Router;
+use Orchestra\Testbench\TestCase;
+use Illuminate\Routing\Controller;
+
+class RoutingMiddlewareTest extends TestCase
+{
+    public function testControllerConstructedAfterMiddlewares()
+    {
+        /** @var Router $router */
+        $router = $this->app->make(Router::class);
+        $router->middleware(RoutingMiddlewareTestTestingMiddleware::class)
+            ->get('test', RoutingMiddlewareTestWithoutGetMiddlewareController::class);
+
+        $this->get('test');
+
+        $this->assertEquals('controller', $_SERVER['routing.middleware.test.last.constructed']);
+
+        unset($_SERVER['routing.middleware.test.last.constructed']);
+    }
+
+    public function testControllerConstructedBeforeMiddlewares()
+    {
+        /** @var Router $router */
+        $router = $this->app->make(Router::class);
+        $router->middleware(RoutingMiddlewareTestTestingMiddleware::class)
+            ->get('test', RoutingMiddlewareTestWithGetMiddlewareController::class);
+
+        $this->get('test');
+
+        $this->assertEquals('middleware', $_SERVER['routing.middleware.test.last.constructed']);
+
+        unset($_SERVER['routing.middleware.test.last.constructed']);
+    }
+}
+
+class RoutingMiddlewareTestWithoutGetMiddlewareController
+{
+    public function __construct()
+    {
+        $_SERVER['routing.middleware.test.last.constructed'] = 'controller';
+    }
+
+    public function __invoke()
+    {
+        return new Response('ok');
+    }
+}
+
+class RoutingMiddlewareTestWithGetMiddlewareController extends Controller
+{
+    public function __construct()
+    {
+        $_SERVER['routing.middleware.test.last.constructed'] = 'controller';
+    }
+
+    public function __invoke()
+    {
+        return new Response('ok');
+    }
+}
+
+class RoutingMiddlewareTestTestingMiddleware
+{
+
+
+    public function handle($request, $next)
+    {
+        $_SERVER['routing.middleware.test.last.constructed'] = 'middleware';
+        return $next($request);
+    }
+}


### PR DESCRIPTION
This PR is a less intrusive submission of #40306

## Summary of what this intends to fix:
Laravel offers the option to have middleware definitions in the controller constructor via the `->middleware()` method.
This feature constructs the controller before the middleware are ran and we are therefore unable to inject classes that are bound in a middleware or of which the driver is selected in the middleware (`Guard` implementation for example [See an example here](https://github.com/laravel/framework/pull/40306#issuecomment-1008126705)).

Previous PR was super intrusive as it changed the current behavior for everyone, this PR aims to keep current behavior as is, but fixes the issue that me and others are running into.

The only downside is a new interface method, but i would argue that this is an interface that is rarely overridden.

## How it works
Previously a controller was constructed and then passed to the `ControllerDispatcher@getMiddleware()` method to retrieve the middleware defined in the dispatched controller. In there a `method_exists` resides to make sure the given Controller has a `getMiddleware` method.
This PR moves the `method_exists` to a method on the `ControllerDispatcher` and verifies if middlewares should be collected. If so it does what it always did. If not then the instantiation is delayed until controller method is ran, because of this the middlewares are constructed first, and then the Controller. Instead of the other way around.

ping @X-Coder264 
