### PR TITLE
Add `is_environment` helper

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -146,6 +146,20 @@ if (! function_exists('filled')) {
     }
 }
 
+if (! function_exists('is_environment')) {
+    /**
+     * Determine if the current environment is
+     * one of the passed environments.
+     *
+     * @param  mixed  $environments
+     * @return bool
+     */
+    function is_environment(...$environments)
+    {
+        return app()->environment(...func_get_args());
+    }
+}
+
 if (! function_exists('object_get')) {
     /**
      * Get an item from an object using "dot" notation.

--- a/tests/Integration/Support/HelpersTest.php
+++ b/tests/Integration/Support/HelpersTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Support;
+
+use Orchestra\Testbench\TestCase;
+
+class HelpersTest extends TestCase
+{
+    public function testIsEnvironment()
+    {
+        $this->assertTrue(is_environment('testing'));
+        $this->assertTrue(is_environment('foo', 'testing'));
+        $this->assertTrue(is_environment(['foo', 'testing']));
+
+        $this->assertFalse(is_environment('foo'));
+        $this->assertFalse(is_environment('foo', 'bar'));
+        $this->assertFalse(is_environment(['foo', 'bar']));
+    }
+}


### PR DESCRIPTION
While a similar method may be called through the `App` facade, I find I initially reach for an `environment` helper method. In addition, the overloading nature of the `App::environment()` method makes me forget how exactly to call it.

I thought this might be a welcome addition to the core helpers to clarify a common use case during development/testing.

**Before**
```php
if (App::environment('staging')) {
    // ...
}
```

**After**
```php
if (is_environment('staging')) {
    // ...
}
```