### PR TITLE
[8.x] `Rule::requiredIf` should accept callable string

### DIFF
--- a/src/Illuminate/Validation/Rules/RequiredIf.php
+++ b/src/Illuminate/Validation/Rules/RequiredIf.php
@@ -21,7 +21,7 @@ class RequiredIf
      */
     public function __construct($condition)
     {
-        if (! is_string($condition)) {
+        if (is_callable($condition) || is_bool($condition)) {
             $this->condition = $condition;
         } else {
             throw new InvalidArgumentException('The provided condition must be a callable or boolean.');

--- a/tests/Validation/ValidationRequiredIfTest.php
+++ b/tests/Validation/ValidationRequiredIfTest.php
@@ -21,6 +21,14 @@ class ValidationRequiredIfTest extends TestCase
 
         $this->assertSame('', (string) $rule);
 
+        $rule = new RequiredIf('Illuminate\Tests\Validation\example_required_if_true_test');
+
+        $this->assertSame('required', (string) $rule);
+
+        $rule = new RequiredIf('Illuminate\Tests\Validation\example_required_if_false_test');
+
+        $this->assertSame('', (string) $rule);
+
         $rule = new RequiredIf(true);
 
         $this->assertSame('required', (string) $rule);
@@ -49,4 +57,14 @@ class ValidationRequiredIfTest extends TestCase
             return true;
         }));
     }
+}
+
+function example_required_if_true_test()
+{
+    return true;
+}
+
+function example_required_if_false_test()
+{
+    return false;
 }

--- a/tests/Validation/ValidationRequiredIfTest.php
+++ b/tests/Validation/ValidationRequiredIfTest.php
@@ -46,7 +46,7 @@ class ValidationRequiredIfTest extends TestCase
 
         $this->expectException(\InvalidArgumentException::class);
 
-        $rule = new RequiredIf('phpinfo');
+        $rule = new RequiredIf('Taylor Otwell');
     }
 
     public function testItReturnedRuleIsNotSerializable()


### PR DESCRIPTION
Dear,

Currently, the `$condition` param accepts `callable` or `boolean` type but it only checks `is_string` and it ignore the callable string.
This PR make it works with callable string (function name).

Thanks.