### PR TITLE
[8.x] DatabaseUuidFailedJobProvider: switch docblock returntype to string for uuid

### DIFF
--- a/src/Illuminate/Queue/Failed/DatabaseUuidFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseUuidFailedJobProvider.php
@@ -51,7 +51,7 @@ class DatabaseUuidFailedJobProvider implements FailedJobProviderInterface, Pruna
      * @param  string  $queue
      * @param  string  $payload
      * @param  \Throwable  $exception
-     * @return int|null
+     * @return string|null
      */
     public function log($connection, $queue, $payload, $exception)
     {


### PR DESCRIPTION
Currently the docblock for the log method on the DatabaseUuidFailedJobProvider states the return as `int|null` when in-fact it returns a string `$uuid`.
I've just updated that so it's more accurate 👍 

