### PR TITLE
[9.x] Add backoff functionality to retry helper

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -214,7 +214,7 @@ if (! function_exists('retry')) {
     /**
      * Retry an operation a given number of times.
      *
-     * @param  int  $times
+     * @param  int|array  $times
      * @param  callable  $callback
      * @param  int|\Closure  $sleepMilliseconds
      * @param  callable|null  $when
@@ -225,6 +225,12 @@ if (! function_exists('retry')) {
     function retry($times, callable $callback, $sleepMilliseconds = 0, $when = null)
     {
         $attempts = 0;
+        $backoff = [];
+
+        if (is_array($times)) {
+            $backoff = $times;
+            $times = count($times) + 1;
+        }
 
         beginning:
         $attempts++;
@@ -236,6 +242,8 @@ if (! function_exists('retry')) {
             if ($times < 1 || ($when && ! $when($e))) {
                 throw $e;
             }
+
+            $sleepMilliseconds = $backoff[$attempts - 1] ?? $sleepMilliseconds;
 
             if ($sleepMilliseconds) {
                 usleep(value($sleepMilliseconds, $attempts) * 1000);

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -623,6 +623,23 @@ class SupportHelpersTest extends TestCase
         });
     }
 
+    public function testRetryWithBackoff()
+    {
+        $startTime = microtime(true);
+        $attempts = retry([50, 100, 200], function ($attempts) {
+            if ($attempts > 3) {
+                return $attempts;
+            }
+
+            throw new RuntimeException;
+        });
+
+        // Make sure we made four attempts
+        $this->assertEquals(4, $attempts);
+
+        $this->assertEqualsWithDelta(0.05 + 0.1 + 0.2, microtime(true) - $startTime, 0.02);
+    }
+
     public function testTransform()
     {
         $this->assertEquals(10, transform(5, function ($value) {


### PR DESCRIPTION
This PR enables the retry helper function to also use an array as first argument in order to implement a backoff strategy

After this PR you can use the helper like this
```php
return retry([50, 100, 200], function () {
    // ...
});
```

As it is now, you have to use the following implementation
```php
return retry(4, function () {
    // ...
}, fn($attempt) => [50, 100, 200][$attempt - 1]);
```
I like the backoff approach of Queues Jobs and I think this would also be a good addition to the framework without breaking anything.

