### PR TITLE
[9.x] Fixes `Command::setHidden()`

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -172,6 +172,16 @@ class Command extends SymfonyCommand
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function setHidden(bool $hidden = true): static
+    {
+        parent::setHidden($this->hidden = $hidden);
+
+        return $this;
+    }
+
+    /**
      * Get the Laravel application instance.
      *
      * @return \Illuminate\Contracts\Foundation\Application

--- a/tests/Console/CommandTest.php
+++ b/tests/Console/CommandTest.php
@@ -120,6 +120,46 @@ class CommandTest extends TestCase
         $command->info('foo');
     }
 
+    public function testSetHidden()
+    {
+        $command = new class extends Command
+        {
+            public function parentIsHidden()
+            {
+                return parent::isHidden();
+            }
+        };
+
+        $this->assertFalse($command->isHidden());
+        $this->assertFalse($command->parentIsHidden());
+
+        $command->setHidden(true);
+
+        $this->assertTrue($command->isHidden());
+        $this->assertTrue($command->parentIsHidden());
+    }
+
+    public function testHiddenProperty()
+    {
+        $command = new class extends Command
+        {
+            protected $hidden = true;
+
+            public function parentIsHidden()
+            {
+                return parent::isHidden();
+            }
+        };
+
+        $this->assertTrue($command->isHidden());
+        $this->assertTrue($command->parentIsHidden());
+
+        $command->setHidden(false);
+
+        $this->assertFalse($command->isHidden());
+        $this->assertFalse($command->parentIsHidden());
+    }
+
     public function testChoiceIsSingleSelectByDefault()
     {
         $output = m::mock(OutputStyle::class);


### PR DESCRIPTION
This pull request fixes the `Command::setHidden()` method that was not actually hidden the command from the `list` command.

This regression was introduced on the https://github.com/laravel/framework/pull/37941 pull request, and I've added a few tests to ensure this don't happen in the future.