### PR TITLE
[9.x] Fixes `containsStrict` and `modelKeys` collection method typehints

### DIFF
--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -126,7 +126,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Determine if an item exists, using strict comparison.
      *
-     * @param  (callable(TValue): bool)|TValue|string  $key
+     * @param  (callable(TValue): bool)|TValue|array-key  $key
      * @param  TValue|null  $value
      * @return bool
      */

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -195,7 +195,7 @@ trait EnumeratesValues
     /**
      * Determine if an item exists, using strict comparison.
      *
-     * @param  (callable(TValue): bool)|TValue|string  $key
+     * @param  (callable(TValue): bool)|TValue|array-key  $key
      * @param  TValue|null  $value
      * @return bool
      */

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -319,7 +319,7 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Get the array of primary keys.
      *
-     * @return array<int, mixed>
+     * @return array<int, array-key>
      */
     public function modelKeys()
     {

--- a/types/Database/Eloquent/Collection.php
+++ b/types/Database/Eloquent/Collection.php
@@ -80,7 +80,7 @@ assertType('bool', $collection->contains(function ($user) {
 }));
 assertType('bool', $collection->contains('string', '=', 'string'));
 
-assertType('array<int, mixed>', $collection->modelKeys());
+assertType('array<int, (int|string)>', $collection->modelKeys());
 
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->merge($collection));
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->merge([new User]));

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -92,6 +92,7 @@ assertType('bool', $collection->containsStrict(function ($user) {
     return true;
 }));
 assertType('bool', $collection::make(['string'])->containsStrict('string', 'string'));
+assertType('bool', $collection::make([[1]])->containsStrict(0));
 
 assertType('Illuminate\Support\LazyCollection<int, User>', $collection->lazy());
 


### PR DESCRIPTION
- `modelKeys` will return integer or string (for example UUID keys) So it makes sense to change `mixed` to `array-key`
- `containsStrict` can also accept integer in it's key. `collect([[1]])->containsStrict(0, 1)` for example would check if `0` keyed item contains value `1`