### PR TITLE
[9.x] Allow event listeners to be invokables when auto-discovered

### DIFF
--- a/src/Illuminate/Foundation/Events/DiscoverEvents.php
+++ b/src/Illuminate/Foundation/Events/DiscoverEvents.php
@@ -65,7 +65,7 @@ class DiscoverEvents
             }
 
             foreach ($listener->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
-                if (! Str::is('handle*', $method->name) ||
+                if ((! Str::is('handle*', $method->name) && ! Str::is('__invoke', $method->name)) ||
                     ! isset($method->getParameters()[0])) {
                     continue;
                 }


### PR DESCRIPTION
Listen for `handle*()` or `__invoke()` methods on discovery of event listeners. It's a common practice to implement invokable classes for single responsible actions. The use of the `handle()` method is a pseudo-interface construct which is opinionated naming convention compared to built in `__invoke()` method.

Needs a unit test still. Could be back-ported to the earliest version supporting discovery which would be 5.8. 