### PR TITLE
[8.x] Fix forwarded call with named arguments

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -824,6 +824,6 @@ class FilesystemAdapter implements CloudFilesystemContract
             return $this->macroCall($method, $parameters);
         }
 
-        return $this->driver->{$method}(...array_values($parameters));
+        return $this->driver->{$method}(...$parameters);
     }
 }


### PR DESCRIPTION
This PR fixes one instance where passing named arguments is currently broken.

```php
// Doesn't work before this PR, ends up calling the base `listContents` method
// with arguments `true, false` instead of `'', true`

app('filesystem')->listContents(recursive: true);
```

[Laravel's support policy](https://laravel.com/docs/8.x/releases#named-arguments) is very clear that named arguments are not guaranteed to be backwards-compatible:

> PHP's named arguments functionality are not covered by Laravel's backwards compatibility guidelines [...] using named arguments when calling Laravel methods should be done cautiously.

However, the `array_values` call that this PR removes explicitly prevents named arguments from being used at all, even if the developer is using them intentionally and understands the implications of doing so.

I understand that there are a lot of strong opinions about whether named arguments are a good idea, and personally I agree with the decision to exclude them from any backwards-compatibility guarantees, but they are part of the language so it makes sense for it to at least be **possible** to use them.

See also #38066.