### PR TITLE
[8.x] Generate docblocks for real-time facades

### DIFF
--- a/src/Illuminate/Foundation/stubs/facade.stub
+++ b/src/Illuminate/Foundation/stubs/facade.stub
@@ -5,6 +5,7 @@ namespace DummyNamespace;
 use Illuminate\Support\Facades\Facade;
 
 /**
+DummyDocs
  * @see \DummyTarget
  */
 class DummyClass extends Facade


### PR DESCRIPTION
Realtime facades are introduced way back in laravel 5.4 I think, but they are not used that often.
One of the main reasons that people get peace off is that they immediately lose IDE auto-completion when switching to a real-time facade.

This PR makes docblocks available for public non-static methods on the generated facade class in the cache folder.

- We can have an artisan command to remove the generated facades to refresh the docblocks when the underlying class evolves over time.

![image](https://user-images.githubusercontent.com/6961695/149632142-92034791-98f3-49fd-a124-3423575887fd.png)
