### PR TITLE
[9.x] View named arguments

### DIFF
--- a/src/Illuminate/Contracts/View/Factory.php
+++ b/src/Illuminate/Contracts/View/Factory.php
@@ -26,11 +26,10 @@ interface Factory
      * Get the evaluated view contents for the given view.
      *
      * @param  string  $view
-     * @param  \Illuminate\Contracts\Support\Arrayable|array  $data
-     * @param  array  $mergeData
+     * @param  mixed  ...$data
      * @return \Illuminate\Contracts\View\View
      */
-    public function make($view, $data = [], $mergeData = []);
+    public function make($view, ...$data);
 
     /**
      * Add a piece of shared data to the environment.

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -917,11 +917,10 @@ if (! function_exists('view')) {
      * Get the evaluated view contents for the given view.
      *
      * @param  string|null  $view
-     * @param  \Illuminate\Contracts\Support\Arrayable|array  $data
-     * @param  array  $mergeData
+     * @param  mixed  ...$data
      * @return \Illuminate\Contracts\View\View|\Illuminate\Contracts\View\Factory
      */
-    function view($view = null, $data = [], $mergeData = [])
+    function view($view = null, ...$data)
     {
         $factory = app(ViewFactory::class);
 
@@ -929,6 +928,6 @@ if (! function_exists('view')) {
             return $factory;
         }
 
-        return $factory->make($view, $data, $mergeData);
+        return $factory->make($view, ...$data);
     }
 }

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -128,11 +128,10 @@ class Factory implements FactoryContract
      * Get the evaluated view contents for the given view.
      *
      * @param  string  $view
-     * @param  \Illuminate\Contracts\Support\Arrayable|array  $data
-     * @param  array  $mergeData
+     * @param  mixed  ...$data
      * @return \Illuminate\Contracts\View\View
      */
-    public function make($view, $data = [], $mergeData = [])
+    public function make($view, ...$data)
     {
         $path = $this->finder->find(
             $view = $this->normalizeName($view)
@@ -141,9 +140,8 @@ class Factory implements FactoryContract
         // Next, we will create the view instance and call the view creator for the view
         // which can set any data, etc. Then we will return the view instance back to
         // the caller for rendering or performing other view manipulations on this.
-        $data = array_merge($mergeData, $this->parseData($data));
 
-        return tap($this->viewInstance($view, $path, $data), function ($view) {
+        return tap($this->viewInstance($view, $path, ...$data), function ($view) {
             $this->callCreator($view);
         });
     }
@@ -266,12 +264,12 @@ class Factory implements FactoryContract
      *
      * @param  string  $view
      * @param  string  $path
-     * @param  \Illuminate\Contracts\Support\Arrayable|array  $data
+     * @param  mixed  ...$data
      * @return \Illuminate\Contracts\View\View
      */
-    protected function viewInstance($view, $path, $data)
+    protected function viewInstance($view, $path, ...$data)
     {
-        return new View($this, $this->getEngineFromPath($path), $view, $path, $data);
+        return new View($this, $this->getEngineFromPath($path), $view, $path, ...$data);
     }
 
     /**

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -233,14 +233,27 @@ class ViewTest extends TestCase
         $this->assertSame('baz', $foo[0]);
     }
 
-    protected function getView($data = [])
+    public function testArgumentPassing()
+    {
+        $normal = $this->getView(['foo' => 'bar']);
+        $this->assertSame(['foo' => 'bar'], $normal->getData());
+        $named = $this->getView(foo: 'bar');
+        $this->assertSame(['foo' => 'bar'], $named->getData());
+
+        $normal = $this->getView(['foo' => 'bar'], ['bar' =>'baz']);
+        $this->assertSame(['bar' => 'baz', 'foo' => 'bar'], $normal->getData());
+        $named = $this->getView(foo: 'bar', mergeData: ['bar' => 'baz']);
+        $this->assertSame(['bar' => 'baz', 'foo' => 'bar'], $normal->getData());
+    }
+
+    protected function getView(...$data)
     {
         return new View(
             m::mock(Factory::class),
             m::mock(Engine::class),
             'view',
             'path',
-            $data
+            ...$data
         );
     }
 }


### PR DESCRIPTION
# View named arguments

Ever since i started with PHP I was wondering if there is better way of doing `view('view', ['foo' => 'bar'])`. And since Laravel 9 switches to PHP 8 I wanted to add ability to use named arguments in views. So now its possible not just 
```php
return view('view', ['foo' => 'bar'])
```

but also 

```php
return view('view', foo: 'bar')
```

For merge data there is
```php
return view('view', foo: 'bar', mergeData: $someData)
```

Since its my first pull request I know its not the best commit here, but I hope it will somehow help.