### PR TITLE
Fix casting attribute to object

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -901,6 +901,11 @@ trait HasAttributes
      */
     protected function castAttributeAsJson($key, $value)
     {
+        $castType = $this->getCastType($key);
+        if ($castType === 'object') {
+            $value = (object) $value;
+        }
+
         $value = $this->asJson($value);
 
         if ($value === false) {


### PR DESCRIPTION
This pull request fixes the casting to an object.

When using `array` as cast type, `[]` would be casted to an array and back, no matter using associative arrays or not.
However, for `object` this was not the case. The `{}` was casted to an object, but the way back didn't work.