### PR TITLE
Add validation for object

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1429,6 +1429,18 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate that an attribute is an object.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function validateObject($attribute, $value)
+    {
+        return is_object($value);
+    }
+
+    /**
      * Validate that an attribute exists even if not filled.
      *
      * @param  string  $attribute


### PR DESCRIPTION
This pull request adds a validation rule for an object. It is similar to the `array` rule.

```php
$array = []; //The rule 'array' will succeed and the rule `object` will fail.

$object = (object) []; //The rule 'object' will succeed and the rule `array` will fail.
```