### PR TITLE
[8.x] Allow the creation of char columns with length 0

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -682,7 +682,7 @@ class Blueprint
      */
     public function char($column, $length = null)
     {
-        $length = $length ?: Builder::$defaultStringLength;
+        $length = isset($length) ? $length : Builder::$defaultStringLength;
 
         return $this->addColumn('char', $column, compact('length'));
     }


### PR DESCRIPTION
The most effective way, storage-wise, to store boolean values in the database, in MySQL, is to use a `char(0)` column that will store NULL for false and "" (empty string) for true. So allow the creation of a char column with the length of zero.

Note: This is only useful, and true, for MySQL. For PostgreSQL, for example, it's not.

This can also be merged in the 8.x branch.