### PR TITLE
[8.x] Fix flushdb for predis cluster

### DIFF
--- a/src/Illuminate/Redis/Connections/PredisClusterConnection.php
+++ b/src/Illuminate/Redis/Connections/PredisClusterConnection.php
@@ -14,7 +14,7 @@ class PredisClusterConnection extends PredisConnection
     public function flushdb()
     {
         $this->client->executeCommandOnNodes(
-            tap(new ServerFlushDatabase)->setArguments(func_get_args());
+            tap(new ServerFlushDatabase)->setArguments(func_get_args())
         );
     }
 }

--- a/src/Illuminate/Redis/Connections/PredisClusterConnection.php
+++ b/src/Illuminate/Redis/Connections/PredisClusterConnection.php
@@ -13,7 +13,7 @@ class PredisClusterConnection extends PredisConnection
      */
     public function flushdb()
     {
-        foreach ($this->getConnection()->getIterator() as $node) {
+        foreach ($this->client->getIterator() as $node) {
             $node->executeCommand(new ServerFlushDatabase);
         }
     }

--- a/src/Illuminate/Redis/Connections/PredisClusterConnection.php
+++ b/src/Illuminate/Redis/Connections/PredisClusterConnection.php
@@ -13,8 +13,8 @@ class PredisClusterConnection extends PredisConnection
      */
     public function flushdb()
     {
-        foreach ($this->client->getIterator() as $node) {
-            $node->executeCommand(new ServerFlushDatabase);
-        }
+        $this->client->executeCommandOnNodes(
+            tap(new ServerFlushDatabase)->setArguments(func_get_args());
+        );
     }
 }

--- a/src/Illuminate/Redis/Connections/PredisClusterConnection.php
+++ b/src/Illuminate/Redis/Connections/PredisClusterConnection.php
@@ -7,7 +7,7 @@ use Predis\Command\ServerFlushDatabase;
 class PredisClusterConnection extends PredisConnection
 {
     /**
-     * Flush the selected Redis database on all custer nodes.
+     * Flush the selected Redis database on all cluster nodes.
      *
      * @return void
      */

--- a/src/Illuminate/Redis/Connections/PredisClusterConnection.php
+++ b/src/Illuminate/Redis/Connections/PredisClusterConnection.php
@@ -2,7 +2,19 @@
 
 namespace Illuminate\Redis\Connections;
 
+use Predis\Command\ServerFlushDatabase;
+
 class PredisClusterConnection extends PredisConnection
 {
-    //
+    /**
+     * Flush the selected Redis database.
+     *
+     * @return void
+     */
+    public function flushdb()
+    {
+        foreach ($this->getConnection()->getIterator() as $node) {
+            $node->executeCommand(new ServerFlushDatabase);
+        }
+    }
 }

--- a/src/Illuminate/Redis/Connections/PredisClusterConnection.php
+++ b/src/Illuminate/Redis/Connections/PredisClusterConnection.php
@@ -7,7 +7,7 @@ use Predis\Command\ServerFlushDatabase;
 class PredisClusterConnection extends PredisConnection
 {
     /**
-     * Flush the selected Redis database.
+     * Flush the selected Redis database on all custer nodes.
      *
      * @return void
      */

--- a/src/Illuminate/Redis/Connections/PredisConnection.php
+++ b/src/Illuminate/Redis/Connections/PredisConnection.php
@@ -50,14 +50,4 @@ class PredisConnection extends Connection implements ConnectionContract
 
         unset($loop);
     }
-
-    /**
-     * Flush the selected Redis database.
-     *
-     * @return void
-     */
-    public function flushdb()
-    {
-        $this->command('flushdb');
-    }
 }

--- a/src/Illuminate/Redis/Connections/PredisConnection.php
+++ b/src/Illuminate/Redis/Connections/PredisConnection.php
@@ -50,4 +50,14 @@ class PredisConnection extends Connection implements ConnectionContract
 
         unset($loop);
     }
+
+    /**
+     * Flush the selected Redis database.
+     *
+     * @return void
+     */
+    public function flushdb()
+    {
+        return $this->command('flushdb');
+    }
 }

--- a/src/Illuminate/Redis/Connections/PredisConnection.php
+++ b/src/Illuminate/Redis/Connections/PredisConnection.php
@@ -58,6 +58,6 @@ class PredisConnection extends Connection implements ConnectionContract
      */
     public function flushdb()
     {
-        return $this->command('flushdb');
+        $this->command('flushdb');
     }
 }

--- a/src/Illuminate/Redis/Connections/PredisConnection.php
+++ b/src/Illuminate/Redis/Connections/PredisConnection.php
@@ -4,8 +4,6 @@ namespace Illuminate\Redis\Connections;
 
 use Closure;
 use Illuminate\Contracts\Redis\Connection as ConnectionContract;
-use Predis\Command\ServerFlushDatabase;
-use Predis\Connection\Aggregate\ClusterInterface;
 
 /**
  * @mixin \Predis\Client
@@ -51,21 +49,5 @@ class PredisConnection extends Connection implements ConnectionContract
         }
 
         unset($loop);
-    }
-
-    /**
-     * Flush the selected Redis database.
-     *
-     * @return void
-     */
-    public function flushdb()
-    {
-        if (! $this->client->getConnection() instanceof ClusterInterface) {
-            return $this->command('flushdb');
-        }
-
-        foreach ($this->getConnection()->getIterator() as $node) {
-            $node->executeCommand(new ServerFlushDatabase);
-        }
     }
 }

--- a/src/Illuminate/Redis/Connections/PredisConnection.php
+++ b/src/Illuminate/Redis/Connections/PredisConnection.php
@@ -64,7 +64,7 @@ class PredisConnection extends Connection implements ConnectionContract
             return $this->command('flushdb');
         }
 
-        foreach ($this->getConnection() as $node) {
+        foreach ($this->getConnection()->getIterator() as $node) {
             $node->executeCommand(new ServerFlushDatabase);
         }
     }


### PR DESCRIPTION
This is to fix this issue: https://github.com/laravel/framework/issues/20406

`Redis::flushdb()` or `Cache::flush` does not work currently with predis cluster, this PR fixes that.

@tillkruss asked me to mention him