### PR TITLE
[9.x] Improves default aliases API

### DIFF
--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -250,11 +250,11 @@ abstract class Facade
     /**
      * Get the application default aliases.
      *
-     * @return array
+     * @return \Illuminate\Support\Collection
      */
-    public static function defaultAliases()
+    public static function aliases()
     {
-        return [
+        return collect([
             'App' => App::class,
             'Arr' => Arr::class,
             'Artisan' => Artisan::class,
@@ -293,7 +293,7 @@ abstract class Facade
             'URL' => URL::class,
             'Validator' => Validator::class,
             'View' => View::class,
-        ];
+        ]);
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -252,7 +252,7 @@ abstract class Facade
      *
      * @return \Illuminate\Support\Collection
      */
-    public static function aliases()
+    public static function defaultAliases()
     {
         return collect([
             'App' => App::class,

--- a/tests/Integration/Support/FacadesTest.php
+++ b/tests/Integration/Support/FacadesTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Support;
 
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Facade;
 use Orchestra\Testbench\TestCase;
@@ -42,11 +43,13 @@ class FacadesTest extends TestCase
         $this->assertTrue(isset($_SERVER['__laravel.authResolved']));
     }
 
-    public function testDefaultAliases()
+    public function testAliases()
     {
-        $defaultAliases = Facade::defaultAliases();
+        $aliases = Facade::aliases();
 
-        foreach ($defaultAliases as $alias => $abstract) {
+        $this->assertInstanceOf(Collection::class, $aliases);
+
+        foreach ($aliases as $alias => $abstract) {
             $this->assertTrue(class_exists($alias));
             $this->assertTrue(class_exists($abstract));
 

--- a/tests/Integration/Support/FacadesTest.php
+++ b/tests/Integration/Support/FacadesTest.php
@@ -43,13 +43,13 @@ class FacadesTest extends TestCase
         $this->assertTrue(isset($_SERVER['__laravel.authResolved']));
     }
 
-    public function testAliases()
+    public function testDefaultAliases()
     {
-        $aliases = Facade::aliases();
+        $defaultAliases = Facade::defaultAliases();
 
-        $this->assertInstanceOf(Collection::class, $aliases);
+        $this->assertInstanceOf(Collection::class, $defaultAliases);
 
-        foreach ($aliases as $alias => $abstract) {
+        foreach ($defaultAliases as $alias => $abstract) {
             $this->assertTrue(class_exists($alias));
             $this->assertTrue(class_exists($abstract));
 


### PR DESCRIPTION
This pull request allows to refacto the skeleton for L9 like so:

Before:
<img width="792" alt="Screenshot 2022-01-17 at 12 34 26" src="https://user-images.githubusercontent.com/5457236/149770319-835f9682-e854-465c-8715-abce816bba1a.png">

After:
<img width="706" alt="Screenshot 2022-01-17 at 12 33 53" src="https://user-images.githubusercontent.com/5457236/149770254-a1821749-4d28-458c-9c9a-9a1701713fe5.png">

If this pull request gets merged, we will need to update TestBench and our skeleton.