### PR TITLE
[8.x] Fix 'strstr' function usage based on its signature

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -60,7 +60,7 @@ trait InteractsWithInput
         if ($position !== false) {
             $header = substr($header, $position + 7);
 
-            return strpos($header, ',') !== false ? strstr(',', $header, true) : $header;
+            return strpos($header, ',') !== false ? strstr($header, ',', true) : $header;
         }
     }
 


### PR DESCRIPTION
Fixed invalid usage of `strstr` function of php in `InteractsWithInput` trait.
Here is the reference for the `strstr` function usage: 
https://www.php.net/manual/en/function.strstr.php