### PR TITLE
[8.x] Corrected parameters for migration fulltext and spatial index on columns

### DIFF
--- a/src/Illuminate/Database/Schema/ColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ColumnDefinition.php
@@ -21,8 +21,8 @@ use Illuminate\Support\Fluent;
  * @method $this nullable(bool $value = true) Allow NULL values to be inserted into the column
  * @method $this persisted() Mark the computed generated column as persistent (SQL Server)
  * @method $this primary() Add a primary index
- * @method $this fulltext() Add a fulltext index
- * @method $this spatialIndex() Add a spatial index
+ * @method $this fulltext(string $indexName = null) Add a fulltext index
+ * @method $this spatialIndex(string $indexName = null) Add a spatial index
  * @method $this startingValue(int $startingValue) Set the starting value of an auto-incrementing field (MySQL/PostgreSQL)
  * @method $this storedAs(string $expression) Create a stored generated column (MySQL/PostgreSQL/SQLite)
  * @method $this type(string $type) Specify a type for the column


### PR DESCRIPTION
The `ColumnDefinition` docblock is currently missing the `indexName` parameter for `fulltext()` and `spatialIndex()` column modifiers.
