### PR TITLE
[9.x] Add SeeInOrder Mailable assertions

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -909,7 +909,7 @@ class Mailable implements MailableContract, Renderable
      * @param  array  $strings
      * @return $this
      */
-    public function assertSeeInOrderHtml($strings)
+    public function assertSeeInOrderInHtml($strings)
     {
         [$html, $text] = $this->renderForAssertions();
 
@@ -960,7 +960,7 @@ class Mailable implements MailableContract, Renderable
      * @param  array  $strings
      * @return $this
      */
-    public function assertSeeInOrderText($strings)
+    public function assertSeeInOrderInText($strings)
     {
         [$html, $text] = $this->renderForAssertions();
 

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -15,6 +15,7 @@ use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\ForwardsCalls;
 use Illuminate\Support\Traits\Localizable;
+use Illuminate\Testing\Constraints\SeeInOrder;
 use PHPUnit\Framework\Assert as PHPUnit;
 use ReflectionClass;
 use ReflectionProperty;
@@ -903,6 +904,21 @@ class Mailable implements MailableContract, Renderable
     }
 
     /**
+     * Assert that the given text strings are present in order in the HTML email body.
+     *
+     * @param  array  $strings
+     * @return $this
+     */
+    public function assertSeeInOrderHtml($strings)
+    {
+        [$html, $text] = $this->renderForAssertions();
+
+        PHPUnit::assertThat($strings, new SeeInOrder($html));
+
+        return $this;
+    }
+
+    /**
      * Assert that the given text is present in the plain-text email body.
      *
      * @param  string  $string
@@ -934,6 +950,21 @@ class Mailable implements MailableContract, Renderable
             Str::contains($text, $string),
             "Saw unexpected text [{$string}] within text email body."
         );
+
+        return $this;
+    }
+
+    /**
+     * Assert that the given text strings are present in order in the plain-text email body.
+     *
+     * @param  array  $strings
+     * @return $this
+     */
+    public function assertSeeInOrderText($strings)
+    {
+        [$html, $text] = $this->renderForAssertions();
+
+        PHPUnit::assertThat($strings, new SeeInOrder($text));
 
         return $this;
     }

--- a/tests/Mail/MailMailableAssertionsTest.php
+++ b/tests/Mail/MailMailableAssertionsTest.php
@@ -76,7 +76,7 @@ class MailMailableAssertionsTest extends TestCase
     {
         $mailable = new MailableAssertionsStub;
 
-        $mailable->assertSeeInOrderText([
+        $mailable->assertSeeInOrderInText([
             'First Item',
             'Second Item',
             'Third Item',
@@ -89,7 +89,7 @@ class MailMailableAssertionsTest extends TestCase
 
         $this->expectException(AssertionFailedError::class);
 
-        $mailable->assertSeeInOrderText([
+        $mailable->assertSeeInOrderInText([
             'First Item',
             'Third Item',
             'Second Item',
@@ -100,7 +100,7 @@ class MailMailableAssertionsTest extends TestCase
     {
         $mailable = new MailableAssertionsStub;
 
-        $mailable->assertSeeInOrderHtml([
+        $mailable->assertSeeInOrderInHtml([
             '<li>First Item</li>',
             '<li>Second Item</li>',
             '<li>Third Item</li>',
@@ -113,7 +113,7 @@ class MailMailableAssertionsTest extends TestCase
 
         $this->expectException(AssertionFailedError::class);
 
-        $mailable->assertSeeInOrderHtml([
+        $mailable->assertSeeInOrderInHtml([
             '<li>Second Item</li>',
             '<li>First Item</li>',
             '<li>Third Item</li>',

--- a/tests/Mail/MailMailableAssertionsTest.php
+++ b/tests/Mail/MailMailableAssertionsTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Illuminate\Tests\Mail;
+
+use Illuminate\Mail\Mailable;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\AssertionFailedError;
+
+class MailMailableAssertionsTest extends TestCase
+{
+    public function testMailableAssertSeeInTextPassesWhenPresent()
+    {
+        $mailable = new MailableAssertionsStub;
+
+        $mailable->assertSeeInText('First Item');
+    }
+
+    public function testMailableAssertSeeInTextFailsWhenAbsent()
+    {
+        $mailable = new MailableAssertionsStub;
+
+        $this->expectException(AssertionFailedError::class);
+
+        $mailable->assertSeeInText('Fourth Item');
+    }
+
+    public function testMailableAssertDontSeeInTextPassesWhenAbsent()
+    {
+        $mailable = new MailableAssertionsStub;
+
+        $mailable->assertDontSeeInText('Fourth Item');
+    }
+
+    public function testMailableAssertDontSeeInTextFailsWhenPresent()
+    {
+        $mailable = new MailableAssertionsStub;
+
+        $this->expectException(AssertionFailedError::class);
+
+        $mailable->assertDontSeeInText('First Item');
+    }
+
+    public function testMailableAssertSeeInHtmlPassesWhenPresent()
+    {
+        $mailable = new MailableAssertionsStub;
+
+        $mailable->assertSeeInHtml('<li>First Item</li>');
+    }
+
+    public function testMailableAssertSeeInHtmlFailsWhenAbsent()
+    {
+        $mailable = new MailableAssertionsStub;
+
+        $this->expectException(AssertionFailedError::class);
+
+        $mailable->assertSeeInHtml('<li>Fourth Item</li>');
+    }
+
+    public function testMailableAssertDontSeeInHtmlPassesWhenAbsent()
+    {
+        $mailable = new MailableAssertionsStub;
+
+        $mailable->assertDontSeeInHtml('<li>Fourth Item</li>');
+    }
+
+    public function testMailableAssertDontSeeInHtmlFailsWhenPresent()
+    {
+        $mailable = new MailableAssertionsStub;
+
+        $this->expectException(AssertionFailedError::class);
+
+        $mailable->assertDontSeeInHtml('<li>First Item</li>');
+    }
+}
+
+class MailableAssertionsStub extends Mailable
+{
+    protected function renderForAssertions()
+    {
+        $text = <<<EOD
+        # List
+        - First Item
+        - Second Item
+        - Third Item
+        EOD;
+
+        $html = <<<EOD
+        <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+        <html xmlns="http://www.w3.org/1999/xhtml">
+        <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+        </style>
+        </head>
+        <body>
+        <h1>List</h1>
+        <ul>
+        <li>First Item</li>
+        <li>Second Item</li>
+        <li>Third Item</li>
+        </ul>
+        </body>
+        </html>
+        EOD;
+
+        return [$html, $text];
+    }
+}

--- a/tests/Mail/MailMailableAssertionsTest.php
+++ b/tests/Mail/MailMailableAssertionsTest.php
@@ -71,6 +71,54 @@ class MailMailableAssertionsTest extends TestCase
 
         $mailable->assertDontSeeInHtml('<li>First Item</li>');
     }
+
+    public function testMailableAssertSeeInOrderTextPassesWhenPresentInOrder()
+    {
+        $mailable = new MailableAssertionsStub;
+
+        $mailable->assertSeeInOrderText([
+            'First Item',
+            'Second Item',
+            'Third Item',
+        ]);
+    }
+
+    public function testMailableAssertSeeInOrderTextFailsWhenAbsentInOrder()
+    {
+        $mailable = new MailableAssertionsStub;
+
+        $this->expectException(AssertionFailedError::class);
+
+        $mailable->assertSeeInOrderText([
+            'First Item',
+            'Third Item',
+            'Second Item',
+        ]);
+    }
+
+    public function testMailableAssertInOrderHtmlPassesWhenPresentInOrder()
+    {
+        $mailable = new MailableAssertionsStub;
+
+        $mailable->assertSeeInOrderHtml([
+            '<li>First Item</li>',
+            '<li>Second Item</li>',
+            '<li>Third Item</li>',
+        ]);
+    }
+
+    public function testMailableAssertInOrderHtmlFailsWhenAbsentInOrder()
+    {
+        $mailable = new MailableAssertionsStub;
+
+        $this->expectException(AssertionFailedError::class);
+
+        $mailable->assertSeeInOrderHtml([
+            '<li>Second Item</li>',
+            '<li>First Item</li>',
+            '<li>Third Item</li>',
+        ]);
+    }
 }
 
 class MailableAssertionsStub extends Mailable


### PR DESCRIPTION
I'm adding `assertSeeInOrderText` and `assertSeeInOrderHtml` to the Mailable class to compliment the other test assertions already present. They work similarly to the `assertSeeInOrder` available on `\Illuminate\Testing\TestResponse` and use the same PHPUnit constraint.

This is useful for testing that your mail is displaying items in the order you would expect. 

For instance for view
```blade
@component('mail::message')

# List
- Item 1
- Item 2
- Item 3

@endcomponent
```

and Mailable
```php
class ListMail extends Mailable
{

public function build()
{
    return $this->markdown('mail.list');
}
```

You would be able to test if the list was in order with
```php
/** @test */
public function list_items_are_in_order()
{
    $mailable = new ListMail;

    $mailable->assertSeeInOrderText([
        'Item 1',
        'Item 2',
        'Item 3',
    ]);
}
```

While trying to add tests for this assertion, I realized that none of the existing Mailable assertions were tested. I created `MailMailableAssertionsTest` to test the existing assertions and my new ones. 

I found `renderForAssertions` pretty hard to mock out without a good example, so I just overrode it with the expected in the test. I thought this was at least better than no the current state of no tests. However, I could remove the tests from this PR if that is better, or spend some more time mocking it further from the tests if someone could point me in the right direction.