### PR TITLE
[8.x] Allow configuration of the CSRF cookie name

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -190,7 +190,7 @@ class VerifyCsrfToken
 
         $response->headers->setCookie(
             new Cookie(
-                'XSRF-TOKEN', $request->session()->token(), $this->availableAt(60 * $config['lifetime']),
+                $config['csrf_cookie'] ?? 'XSRF-TOKEN', $request->session()->token(), $this->availableAt(60 * $config['lifetime']),
                 $config['path'], $config['domain'], $config['secure'], false, false, $config['same_site'] ?? null
             )
         );
@@ -205,6 +205,6 @@ class VerifyCsrfToken
      */
     public static function serialized()
     {
-        return EncryptCookies::serialized('XSRF-TOKEN');
+        return EncryptCookies::serialized(config('session.csrf_cookie', 'XSRF-TOKEN'));
     }
 }

--- a/tests/Integration/Http/Middleware/VerifyCsrfTokenTest.php
+++ b/tests/Integration/Http/Middleware/VerifyCsrfTokenTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http\Middleware;
+
+use Illuminate\Encryption\Encrypter;
+use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Session\Store;
+use Mockery as m;
+use Orchestra\Testbench\TestCase;
+
+class VerifyCsrfTokenTest extends TestCase
+{
+    public function testHasDefaultCookieName()
+    {
+        $encrypter = new Encrypter(str_repeat('a', 16));
+
+        $request = new Request;
+        $request->setLaravelSession($session = m::mock(Store::class));
+        $session->shouldReceive('token')->andReturn('token');
+
+        $middleware = new VerifyCsrfToken(app(), $encrypter);
+
+        $response = $middleware->handle($request, function () {
+            return new Response();
+        });
+
+        $cookies = $response->headers->getCookies();
+        $this->assertSame('XSRF-TOKEN', $cookies[0]->getName());
+    }
+
+    public function testCanSetCookieName()
+    {
+        $this->app['config']->set('session.csrf_cookie', 'MY-XSRF-TOKEN');
+
+        $encrypter = new Encrypter(str_repeat('a', 16));
+
+        $request = new Request;
+        $request->setLaravelSession($session = m::mock(Store::class));
+        $session->shouldReceive('token')->andReturn('token');
+
+        $middleware = new VerifyCsrfToken(app(), $encrypter);
+
+        $response = $middleware->handle($request, function () {
+            return new Response();
+        });
+
+        $cookies = $response->headers->getCookies();
+        $this->assertSame('MY-XSRF-TOKEN', $cookies[0]->getName());
+    }
+}


### PR DESCRIPTION
## Intro
Allow users to change the CSRF cookie name using a new `session.csrf_cookie` config. If no name is set, the previously hardcoded `XSRF-TOKEN` name is used.

I didn't include the token name in this proposal, but I could implement if you find it useful.

## Motivation
In our use case we need to change the CSRF cookie name during runtime. Currently we override the entire `addCookieToResponse()` method, because the cookie name is hardcoded:
https://github.com/laravel/framework/blob/45995483913655b7061cdec58421539096afb7b9/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php#L191-L196

For reference, Axios [exposes](https://github.com/axios/axios-docs/blob/21930fea939cdb7f8b6ab616b8eaf18a1a2ffa91/posts/en/req_config.md?plain=1#L108) a setting for the cookie name (and header as well), so it was really simple to change this on the client side.
```js
// `xsrfCookieName` is the name of the cookie to use as a value for xsrf token
xsrfCookieName: 'XSRF-TOKEN', // default
```

If this is accepted, please let me know if it should be added to the app or docs.