### PR TITLE
[9.x] add `Http::connectTimeout` to set `connect_timeout` option

### DIFF
--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -22,6 +22,7 @@ use PHPUnit\Framework\Assert as PHPUnit;
  * @method \Illuminate\Http\Client\PendingRequest baseUrl(string $url)
  * @method \Illuminate\Http\Client\PendingRequest beforeSending(callable $callback)
  * @method \Illuminate\Http\Client\PendingRequest bodyFormat(string $format)
+ * @method \Illuminate\Http\Client\PendingRequest connectTimeout(int $seconds)
  * @method \Illuminate\Http\Client\PendingRequest contentType(string $contentType)
  * @method \Illuminate\Http\Client\PendingRequest dd()
  * @method \Illuminate\Http\Client\PendingRequest dump()

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -455,6 +455,19 @@ class PendingRequest
     }
 
     /**
+     * Specify the connect timeout (in seconds) for the request.
+     *
+     * @param  int  $seconds
+     * @return $this
+     */
+    public function connectTimeout(int $seconds)
+    {
+        return tap($this, function () use ($seconds) {
+            $this->options['connect_timeout'] = $seconds;
+        });
+    }
+
+    /**
      * Specify the number of times the request should be attempted.
      *
      * @param  int  $times


### PR DESCRIPTION
Closes #40465

This PR #40187 introduces breaking change to `Http` call:
```php
Http::withOptions([
  'timeout' => 1,
  'connect_timeout' => 1,
])->get('http://laravel.com')
```

There's standalone `timeout` method to set timeout, but currently there's no way to set `connect_timeout` outside of `withOptions`. This is due to `withOptions` is doing `array_merge_recursive` causing existing options to be arrayed and when the options get to guzzle, it cannot handle `array * int`.