### PR TITLE
[8.x] Add `sscanf` to Stringable

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -581,7 +581,7 @@ class Stringable implements JsonSerializable
     /**
      * Parse input from a string to a collection, according to a format.
      *
-     * @param  string $format
+     * @param  string  $format
      * @return \Illuminate\Support\Collection
      */
     public function scan($format)

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -579,6 +579,17 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Parse input from a string to a collection, according to a format.
+     *
+     * @param  string $format
+     * @return \Illuminate\Support\Collection
+     */
+    public function scan($format)
+    {
+        return collect(sscanf($this->value, $format));
+    }
+
+    /**
      * Begin a string with a single instance of a given value.
      *
      * @param  string  $prefix

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -929,7 +929,7 @@ class SupportStringableTest extends TestCase
     public function testScan()
     {
         $this->assertSame([123456], $this->stringable('SN/123456')->scan('SN/%d')->toArray());
-        $this->assertSame(['Otwell', 'Taylor'], $this->stringable('Otwell, Taylor')->scan("%[^,],%s")->toArray());
-        $this->assertSame(['filename', 'jpg'], $this->stringable('filename.jpg')->scan("%[^.].%s")->toArray());
+        $this->assertSame(['Otwell', 'Taylor'], $this->stringable('Otwell, Taylor')->scan('%[^,],%s')->toArray());
+        $this->assertSame(['filename', 'jpg'], $this->stringable('filename.jpg')->scan('%[^.].%s')->toArray());
     }
 }

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -925,4 +925,11 @@ class SupportStringableTest extends TestCase
         $this->assertSame('before<br>after', (string) $this->stringable('<strong>before</strong><br>after')->stripTags('<br>'));
         $this->assertSame('<strong>before</strong><br>after', (string) $this->stringable('<strong>before</strong><br>after')->stripTags('<br><strong>'));
     }
+
+    public function testScan()
+    {
+        $this->assertSame([123456], $this->stringable('SN/123456')->scan('SN/%d')->toArray());
+        $this->assertSame(['Otwell', 'Taylor'], $this->stringable('Otwell, Taylor')->scan("%[^,],%s")->toArray());
+        $this->assertSame(['filename', 'jpg'], $this->stringable('filename.jpg')->scan("%[^.].%s")->toArray());
+    }
 }


### PR DESCRIPTION
This small PR adds `sscanf` to Support Stringable. It returns a Collection.

Example:

```php
[$filename, $ext] = Str::of('filename.jpg')->scan('%[^.].%s')->toArray();
``` 
