### PR TITLE
[8.x] Update docblock of Factory for PendingRequest::attach

### DIFF
--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\Assert as PHPUnit;
  * @method \Illuminate\Http\Client\PendingRequest asJson()
  * @method \Illuminate\Http\Client\PendingRequest asMultipart()
  * @method \Illuminate\Http\Client\PendingRequest async()
- * @method \Illuminate\Http\Client\PendingRequest attach(string|array $name, string $contents = '', string|null $filename = null, array $headers = [])
+ * @method \Illuminate\Http\Client\PendingRequest attach(string|array $name, string|resource $contents = '', string|null $filename = null, array $headers = [])
  * @method \Illuminate\Http\Client\PendingRequest baseUrl(string $url)
  * @method \Illuminate\Http\Client\PendingRequest beforeSending(callable $callback)
  * @method \Illuminate\Http\Client\PendingRequest bodyFormat(string $format)


### PR DESCRIPTION
The docblock of `Illuminate\Http\Client\Factory` for the `attach` method is not up to date with `Illuminate\Http\Client\PendingRequest`. `PendingRequest` accepts `resource` for the `$contents` while the docblock of `Factory` does not.


![image](https://user-images.githubusercontent.com/9074391/149943999-fc21cbb3-9969-4d52-9220-170be0845da3.png)

The screenshot shows that the first call using the docblock shows an IDE error, while the second one on the actual `PendingRequest` instance does not show the IDE error.

Reference to the `PendingRequest` type: https://github.com/laravel/framework/blob/8.x/src/Illuminate/Http/Client/PendingRequest.php#L230