### PR TITLE
[9.x] Fixes remaining `static<Tkey, TModel>` usages in Eloquent collection

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -332,7 +332,7 @@ class Collection extends BaseCollection implements QueueableCollection
      * Merge the collection with the given items.
      *
      * @param  iterable<array-key, TModel>  $items
-     * @return static<TKey, TModel>
+     * @return static
      */
     public function merge($items)
     {
@@ -386,7 +386,7 @@ class Collection extends BaseCollection implements QueueableCollection
      * Reload a fresh model instance from the database for all the entities.
      *
      * @param  array<array-key, string>|string  $with
-     * @return static<TKey, TModel>
+     * @return static
      */
     public function fresh($with = [])
     {
@@ -414,7 +414,7 @@ class Collection extends BaseCollection implements QueueableCollection
      * Diff the collection with the given items.
      *
      * @param  iterable<array-key, TModel>  $items
-     * @return static<TKey, TModel>
+     * @return static
      */
     public function diff($items)
     {
@@ -435,7 +435,7 @@ class Collection extends BaseCollection implements QueueableCollection
      * Intersect the collection with the given items.
      *
      * @param  iterable<array-key, TModel>  $items
-     * @return static<TKey, TModel>
+     * @return static
      */
     public function intersect($items)
     {


### PR DESCRIPTION
https://github.com/laravel/framework/pull/40393 fixed usages of `static<TKey, TValue>` but there were some missing ones in Eloquent collection. This PR fixes the remaining ones. This does not have any breaking effect.