### PR TITLE
[9.x] Use the model defined connection when present before using the fallback connection when testing

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -26,7 +26,7 @@ trait InteractsWithDatabase
     protected function assertDatabaseHas($table, array $data, $connection = null)
     {
         $this->assertThat(
-            $this->getTable($table), new HasInDatabase($this->getConnection($table, $connection), $data)
+            $this->getTable($table), new HasInDatabase($this->getConnection($connection, $table), $data)
         );
 
         return $this;
@@ -43,7 +43,7 @@ trait InteractsWithDatabase
     protected function assertDatabaseMissing($table, array $data, $connection = null)
     {
         $constraint = new ReverseConstraint(
-            new HasInDatabase($this->getConnection($table, $connection), $data)
+            new HasInDatabase($this->getConnection($connection, $table), $data)
         );
 
         $this->assertThat($this->getTable($table), $constraint);
@@ -62,7 +62,7 @@ trait InteractsWithDatabase
     protected function assertDatabaseCount($table, int $count, $connection = null)
     {
         $this->assertThat(
-            $this->getTable($table), new CountInDatabase($this->getConnection($table, $connection), $count)
+            $this->getTable($table), new CountInDatabase($this->getConnection($connection, $table), $count)
         );
 
         return $this;
@@ -89,7 +89,7 @@ trait InteractsWithDatabase
         }
 
         $this->assertThat(
-            $this->getTable($table), new SoftDeletedInDatabase($this->getConnection($table, $connection), $data, $deletedAtColumn)
+            $this->getTable($table), new SoftDeletedInDatabase($this->getConnection($connection, $table), $data, $deletedAtColumn)
         );
 
         return $this;
@@ -116,7 +116,7 @@ trait InteractsWithDatabase
         }
 
         $this->assertThat(
-            $this->getTable($table), new NotSoftDeletedInDatabase($this->getConnection($table, $connection), $data, $deletedAtColumn)
+            $this->getTable($table), new NotSoftDeletedInDatabase($this->getConnection($connection, $table), $data, $deletedAtColumn)
         );
 
         return $this;
@@ -189,7 +189,7 @@ trait InteractsWithDatabase
      * @param  string|null  $connection
      * @return \Illuminate\Database\Connection
      */
-    protected function getConnection($table, $connection = null)
+    protected function getConnection($connection = null, $table = null)
     {
         $database = $this->app->make('db');
 

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -26,7 +26,7 @@ trait InteractsWithDatabase
     protected function assertDatabaseHas($table, array $data, $connection = null)
     {
         $this->assertThat(
-            $this->getTable($table), new HasInDatabase($this->getConnection($connection), $data)
+            $this->getTable($table), new HasInDatabase($this->getConnection($table, $connection), $data)
         );
 
         return $this;
@@ -43,7 +43,7 @@ trait InteractsWithDatabase
     protected function assertDatabaseMissing($table, array $data, $connection = null)
     {
         $constraint = new ReverseConstraint(
-            new HasInDatabase($this->getConnection($connection), $data)
+            new HasInDatabase($this->getConnection($table, $connection), $data)
         );
 
         $this->assertThat($this->getTable($table), $constraint);
@@ -89,7 +89,7 @@ trait InteractsWithDatabase
         }
 
         $this->assertThat(
-            $this->getTable($table), new SoftDeletedInDatabase($this->getConnection($connection), $data, $deletedAtColumn)
+            $this->getTable($table), new SoftDeletedInDatabase($this->getConnection($table, $connection), $data, $deletedAtColumn)
         );
 
         return $this;
@@ -116,7 +116,7 @@ trait InteractsWithDatabase
         }
 
         $this->assertThat(
-            $this->getTable($table), new NotSoftDeletedInDatabase($this->getConnection($connection), $data, $deletedAtColumn)
+            $this->getTable($table), new NotSoftDeletedInDatabase($this->getConnection($table, $connection), $data, $deletedAtColumn)
         );
 
         return $this;


### PR DESCRIPTION
When an application has multiple DB connections and the tests use the database assertions for a certain connection and in that connection, for example, a prefix is used, then you must always include that connection in your assertion otherwise the table name will not be found.

It would be easier that if a connection is defined in a model, the test will use that connection and not the fallback connection. 

Example:

```php
class User extends Model
{
    protected $connection = 'custom-connection';
}
```

Before
```php
$this->assertDatabaseCount(User::class, 1, 'custom-connection');
```

After
```php
$this->assertDatabaseCount(User::class, 1);
```