### PR TITLE
[8.x] Add support for Http request defaults

### DIFF
--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -1067,4 +1067,25 @@ class HttpClientTest extends TestCase
 
         $this->factory->get('https://example.com');
     }
+
+    public function testDefaults()
+    {
+        $this->factory->fake();
+
+        $this->factory->defaults(function (PendingRequest $request) {
+            $request->withHeaders([
+                'X-Test-Header' => 'foo',
+            ]);
+        })->defaults(function (PendingRequest $request) {
+            $request->withUserAgent('Laravel');
+        });
+
+        $this->factory->get('http://foo.com/get');
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/get' &&
+                $request->hasHeader('X-Test-Header', 'foo') &&
+                $request->hasHeader('User-Agent', 'Laravel');
+        });
+    }
 }


### PR DESCRIPTION
This PR adds support for Http request defaults.

## Context
I'd like to add middleware to all Http requests, but don't want to scatter this across my entire codebase. Example middleware I'd like to add is a [debugbar middleware](https://www.csrhymes.com/2020/07/01/track-http-client-in-laravel-debugbar.html) on local environments or a Bugsnag breadcrumb middleware on production environments.

## Solution
I've added a `defaults` method to the request factory. This allows you to define callbacks that can set defaults on pending requests. This way you can easily add middleware, or set other options such as retry, on all requests.

```php
// In a service provider
Http::defaults(function (PendingRequest $request) {
    $request->middleware(new Middleware());
    $request->withHeaders(['X-Test-Header' => 'foo']);
    $request->retry(3, 100, fn ($exception) => $exception instanceof ConnectionException);
    // etc.
});

// Somewhere else
Http::get('http://example.com');
```

Now everytime you perform an Http request, these defaults are set.

## Alternatives
You could use a [macro](https://laravel.com/docs/8.x/http-client#macros) for this, but if you have multiple macros, you still have to add these defaults to all macros as you can't chain macros. Unless you add all other macros to the pending request itself, but I don't think that's an ideal solution.

## Breaking changes
This is only additive, but - as with all macroable classes - if someone has defined a 'defaults' macro, it would be a breaking change for them.