### PR TITLE
[9.x] Lazy collection constructor throws when passed a generator

### DIFF
--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -48,7 +48,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
             $this->source = static::empty();
         } elseif ($source instanceof Generator) {
             throw new InvalidArgumentException(
-                'Generators should not be passed directly to LazyCollection. Instead, Pass a generator function.'
+                'Generators should not be passed directly to LazyCollection. Instead, pass a generator function.'
             );
         } else {
             $this->source = $this->getArrayableItems($source);

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -5,9 +5,11 @@ namespace Illuminate\Support;
 use ArrayIterator;
 use Closure;
 use DateTimeInterface;
+use Generator;
 use Illuminate\Contracts\Support\CanBeEscapedWhenCastToString;
 use Illuminate\Support\Traits\EnumeratesValues;
 use Illuminate\Support\Traits\Macroable;
+use InvalidArgumentException;
 use IteratorAggregate;
 use stdClass;
 use Traversable;
@@ -44,6 +46,10 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
             $this->source = $source;
         } elseif (is_null($source)) {
             $this->source = static::empty();
+        } elseif ($source instanceof Generator) {
+            throw new InvalidArgumentException(
+                'Generators should not be passed directly. Passs a generator function instead.'
+            );
         } else {
             $this->source = $this->getArrayableItems($source);
         }

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -48,7 +48,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
             $this->source = static::empty();
         } elseif ($source instanceof Generator) {
             throw new InvalidArgumentException(
-                'Generators should not be passed directly. Passs a generator function instead.'
+                'Generators should not be passed directly to LazyCollection. Instead, Pass a generator function.'
             );
         } else {
             $this->source = $this->getArrayableItems($source);

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -29,15 +29,6 @@ class SupportLazyCollectionIsLazyTest extends TestCase
         });
     }
 
-    public function testMakeWithGeneratorIsNotLazy()
-    {
-        [$closure, $recorder] = $this->makeGeneratorFunctionWithRecorder(5);
-
-        LazyCollection::make($closure());
-
-        $this->assertEquals([1, 2, 3, 4, 5], $recorder->all());
-    }
-
     public function testEagerEnumeratesOnce()
     {
         $this->assertEnumeratesOnce(function ($collection) {

--- a/tests/Support/SupportLazyCollectionTest.php
+++ b/tests/Support/SupportLazyCollectionTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Support;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\LazyCollection;
+use InvalidArgumentException;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
@@ -67,6 +68,17 @@ class SupportLazyCollectionTest extends TestCase
             'b' => 2,
             'c' => 3,
         ], $data->all());
+    }
+
+    public function testDoesNotCreateCollectionFromGenerator()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $generateNumber = function () {
+            yield 1;
+        };
+
+        LazyCollection::make($generateNumber());
     }
 
     public function testEager()


### PR DESCRIPTION
Passing a `Generator` to the `LazyCollection` constructor does not work as people think it should. It's enumerated right away.

People keep on bumping into this [again](https://github.com/laravel/framework/discussions/33297#discussioncomment-29102) and [again](https://github.com/laravel/framework/issues/36837#issuecomment-811926022) and [again](https://github.com/laravel/ideas/issues/1880) and [again](https://github.com/laravel/framework/discussions/33297) and [again](https://github.com/laravel/framework/pull/40326) and [again](https://github.com/laravel/framework/pull/40328).

As a stopgap, [we've added a test in 8.x](https://github.com/laravel/framework/pull/36846) ensuring that passing a `Generator` directly is _not_ lazy. But for 9.x, it should throw an error.

---

@taylorotwell I'm not sure about the error message. The reasoning for this is quite complex, and doesn't fit into a short message like that.

Should we write this up somewhere in the docs, and link to the docs from the error message?