### PR TITLE
[8.x] Fix forgetMailers with MailFake

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -416,18 +416,6 @@ class MailFake implements Factory, Mailer, MailQueue
     }
 
     /**
-     * Forget all of the resolved mailer instances.
-     *
-     * @return $this
-     */
-    public function forgetMailers()
-    {
-        $this->currentMailer = null;
-
-        return $this;
-    }
-
-    /**
      * Infer mailable class using reflection if a typehinted closure is passed to assertion.
      *
      * @param  string|\Closure  $mailable
@@ -441,5 +429,17 @@ class MailFake implements Factory, Mailer, MailQueue
         }
 
         return [$mailable, $callback];
+    }
+
+    /**
+     * Forget all of the resolved mailer instances.
+     *
+     * @return $this
+     */
+    public function forgetMailers()
+    {
+        $this->currentMailer = null;
+
+        return $this;
     }
 }

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -416,6 +416,18 @@ class MailFake implements Factory, Mailer, MailQueue
     }
 
     /**
+     * Forget all of the resolved mailer instances.
+     *
+     * @return $this
+     */
+    public function forgetMailers()
+    {
+        $this->currentMailer = null;
+
+        return $this;
+    }
+
+    /**
      * Infer mailable class using reflection if a typehinted closure is passed to assertion.
      *
      * @param  string|\Closure  $mailable


### PR DESCRIPTION
I use `\Illuminate\Support\Facades\Mail::forgetMailers()` to force a new mailer to be used. But I can't use that because my test will fail. That's because that method doesn't exist in `\Illuminate\Support\Testing\Fakes\MailFake`. It makes sense that `\Illuminate\Support\Testing\Fakes\MailFake` also has that method.

Error:
```
Error : Call to undefined method \Illuminate\Support\Testing\Fakes\MailFake::forgetMailers()
 (...)/vendor/laravel/framework/src/Illuminate/Support/Facades/Facade.php:261
 ```

_____

Workaround:
```php
        $facadeRoot = Mail::getFacadeRoot();
        if (method_exists($facadeRoot, 'forgetMailers')) {
            Mail::forgetMailers();
        }
```

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
