### PR TITLE
[8.x] Fix Str::headline/Str::studly with unicode and add Str::ucsplit method

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -730,17 +730,15 @@ class Str
      */
     public static function headline($value)
     {
-        $parts = explode('_', static::replace(' ', '_', $value));
+        $parts = explode(' ', $value);
 
-        if (count($parts) > 1) {
-            $parts = array_map([static::class, 'title'], $parts);
-        }
+        $parts = count($parts) > 1
+            ? $parts = array_map([static::class, 'title'], $parts)
+            : $parts = array_map([static::class, 'title'], static::ucsplit(implode('_', $parts)));
 
-        $studly = static::studly(implode($parts));
+        $collapsed = static::replace(['-', '_', ' '], '_', implode('_', $parts));
 
-        $words = preg_split('/(?=[A-Z])/', $studly, -1, PREG_SPLIT_NO_EMPTY);
-
-        return implode(' ', $words);
+        return implode(' ', array_filter(explode('_', $collapsed)));
     }
 
     /**
@@ -839,9 +837,13 @@ class Str
             return static::$studlyCache[$key];
         }
 
-        $value = ucwords(str_replace(['-', '_'], ' ', $value));
+        $words = explode(' ', static::replace(['-', '_'], ' ', $value));
 
-        return static::$studlyCache[$key] = str_replace(' ', '', $value);
+        $studlyWords = array_map(function ($word) {
+            return static::ucfirst($word);
+        }, $words);
+
+        return static::$studlyCache[$key] = implode($studlyWords);
     }
 
     /**
@@ -902,6 +904,18 @@ class Str
     public static function ucfirst($string)
     {
         return static::upper(static::substr($string, 0, 1)).static::substr($string, 1);
+    }
+
+    /**
+     * Split a string into pieces by uppercase characters.
+     *
+     * @param string $string
+     * 
+     * @return array
+     */
+    public static function ucsplit($string)
+    {
+        return preg_split('/(?=\p{Lu})/u', $string, -1, PREG_SPLIT_NO_EMPTY);
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -909,8 +909,7 @@ class Str
     /**
      * Split a string into pieces by uppercase characters.
      *
-     * @param string $string
-     * 
+     * @param  string  $string
      * @return array
      */
     public static function ucsplit($string)

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -777,6 +777,16 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Split a string by uppercase characters.
+     *
+     * @return static
+     */
+    public function ucsplit()
+    {
+        return new static(Str::ucsplit($this->value));
+    }
+
+    /**
      * Execute the given callback if the string contains a given substring.
      *
      * @param  string|array  $needles

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -462,7 +462,7 @@ class SupportStrTest extends TestCase
         $this->assertSame('FooBar', Str::studly('foo_bar')); // test cache
         $this->assertSame('FooBarBaz', Str::studly('foo-barBaz'));
         $this->assertSame('FooBarBaz', Str::studly('foo-bar_baz'));
-        
+
         $this->assertSame('ÖffentlicheÜberraschungen', Str::studly('öffentliche-überraschungen'));
     }
 
@@ -564,7 +564,7 @@ class SupportStrTest extends TestCase
         $this->assertSame(['Laravel_', 'P_h_p_framework'], Str::ucsplit('Laravel_P_h_p_framework'));
         $this->assertSame(['laravel', 'P', 'H', 'P', 'Framework'], Str::ucsplit('laravelPHPFramework'));
         $this->assertSame(['Laravel-ph', 'P-framework'], Str::ucsplit('Laravel-phP-framework'));
-        
+
         $this->assertSame(['Żółta', 'Łódka'], Str::ucsplit('ŻółtaŁódka'));
         $this->assertSame(['sind', 'Öde', 'Und', 'So'], Str::ucsplit('sindÖdeUndSo'));
         $this->assertSame(['Öffentliche', 'Überraschungen'], Str::ucsplit('ÖffentlicheÜberraschungen'));

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -58,6 +58,11 @@ class SupportStrTest extends TestCase
         $this->assertSame('Öffentliche Überraschungen', Str::headline('-öffentliche überraschungen'));
 
         $this->assertSame('Sind Öde Und So', Str::headline('sindÖdeUndSo'));
+
+        $this->assertSame('Orwell 1984', Str::headline('orwell 1984'));
+        $this->assertSame('Orwell 1984', Str::headline('orwell   1984'));
+        $this->assertSame('Orwell 1984', Str::headline('-orwell-1984 -'));
+        $this->assertSame('Orwell 1984', Str::headline(' orwell_- 1984 '));
     }
 
     public function testStringWithoutWordsDoesntProduceError()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -52,6 +52,12 @@ class SupportStrTest extends TestCase
         $this->assertSame('Foo Bar', Str::headline('foo_bar'));
         $this->assertSame('Foo Bar Baz', Str::headline('foo-barBaz'));
         $this->assertSame('Foo Bar Baz', Str::headline('foo-bar_baz'));
+
+        $this->assertSame('Öffentliche Überraschungen', Str::headline('öffentliche-überraschungen'));
+        $this->assertSame('Öffentliche Überraschungen', Str::headline('-_öffentliche_überraschungen_-'));
+        $this->assertSame('Öffentliche Überraschungen', Str::headline('-öffentliche überraschungen'));
+
+        $this->assertSame('Sind Öde Und So', Str::headline('sindÖdeUndSo'));
     }
 
     public function testStringWithoutWordsDoesntProduceError()
@@ -456,6 +462,8 @@ class SupportStrTest extends TestCase
         $this->assertSame('FooBar', Str::studly('foo_bar')); // test cache
         $this->assertSame('FooBarBaz', Str::studly('foo-barBaz'));
         $this->assertSame('FooBarBaz', Str::studly('foo-bar_baz'));
+        
+        $this->assertSame('ÖffentlicheÜberraschungen', Str::studly('öffentliche-überraschungen'));
     }
 
     public function testMask()
@@ -548,6 +556,18 @@ class SupportStrTest extends TestCase
         $this->assertSame('Laravel framework', Str::ucfirst('laravel framework'));
         $this->assertSame('Мама', Str::ucfirst('мама'));
         $this->assertSame('Мама мыла раму', Str::ucfirst('мама мыла раму'));
+    }
+
+    public function testUcsplit()
+    {
+        $this->assertSame(['Laravel_p_h_p_framework'], Str::ucsplit('Laravel_p_h_p_framework'));
+        $this->assertSame(['Laravel_', 'P_h_p_framework'], Str::ucsplit('Laravel_P_h_p_framework'));
+        $this->assertSame(['laravel', 'P', 'H', 'P', 'Framework'], Str::ucsplit('laravelPHPFramework'));
+        $this->assertSame(['Laravel-ph', 'P-framework'], Str::ucsplit('Laravel-phP-framework'));
+        
+        $this->assertSame(['Żółta', 'Łódka'], Str::ucsplit('ŻółtaŁódka'));
+        $this->assertSame(['sind', 'Öde', 'Und', 'So'], Str::ucsplit('sindÖdeUndSo'));
+        $this->assertSame(['Öffentliche', 'Überraschungen'], Str::ucsplit('ÖffentlicheÜberraschungen'));
     }
 
     public function testUuid()


### PR DESCRIPTION
## Description

This PR resolves issues with unicode characters mentioned in issue https://github.com/laravel/framework/issues/40468, fixing `Str::headline()` and `Str::studly()`.

I've also added another `Str` helper function `ucsplit()` to split a string based on casing, which is compatible with english and unicode characters. This new function is used by `Str::headline()`, to help with parsing strings that do not contain spaces.

All previous tests pass and there are no BC breaks 🎉 

Let me know if you have any concerns/questions, thanks for your time! ❤️ 
