### PR TITLE
[9.x] Skip image create tests if gd library is not supported

### DIFF
--- a/tests/Http/HttpTestingFileFactoryTest.php
+++ b/tests/Http/HttpTestingFileFactoryTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * @requires extension gd
+ *
  * @link https://www.php.net/manual/en/function.gd-info.php
  */
 class HttpTestingFileFactoryTest extends TestCase
@@ -20,7 +21,7 @@ class HttpTestingFileFactoryTest extends TestCase
 
     public function testImagePng()
     {
-        if (!$this->isGDSupported(self::GD_PNG_SUPPORT)) {
+        if (! $this->isGDSupported(self::GD_PNG_SUPPORT)) {
             $this->markTestSkipped('Requires PNG support.');
         }
 
@@ -35,7 +36,7 @@ class HttpTestingFileFactoryTest extends TestCase
 
     public function testImageJpeg()
     {
-        if (!$this->isGDSupported(self::GD_JPEG_SUPPORT)) {
+        if (! $this->isGDSupported(self::GD_JPEG_SUPPORT)) {
             $this->markTestSkipped('Requires JPEG support.');
         }
 
@@ -55,7 +56,7 @@ class HttpTestingFileFactoryTest extends TestCase
 
     public function testImageGif()
     {
-        if (!$this->isGDSupported(self::GD_GIF_CREATE_SUPPORT)) {
+        if (! $this->isGDSupported(self::GD_GIF_CREATE_SUPPORT)) {
             $this->markTestSkipped('Requires GIF Create support.');
         }
 
@@ -69,7 +70,7 @@ class HttpTestingFileFactoryTest extends TestCase
 
     public function testImageWebp()
     {
-        if (!$this->isGDSupported(self::GD_WEBP_SUPPORT)) {
+        if (! $this->isGDSupported(self::GD_WEBP_SUPPORT)) {
             $this->markTestSkipped('Requires Webp support.');
         }
 
@@ -83,7 +84,7 @@ class HttpTestingFileFactoryTest extends TestCase
 
     public function testImageWbmp()
     {
-        if (!$this->isGDSupported(self::GD_WBMP_SUPPORT)) {
+        if (! $this->isGDSupported(self::GD_WBMP_SUPPORT)) {
             $this->markTestSkipped('Requires WBMP support.');
         }
 
@@ -123,7 +124,7 @@ class HttpTestingFileFactoryTest extends TestCase
     }
 
     /**
-     * @param string $driver
+     * @param  string  $driver
      * @return bool
      */
     private function isGDSupported(string $driver = self::GD_VERSION): bool

--- a/tests/Http/HttpTestingFileFactoryTest.php
+++ b/tests/Http/HttpTestingFileFactoryTest.php
@@ -12,16 +12,9 @@ use PHPUnit\Framework\TestCase;
  */
 class HttpTestingFileFactoryTest extends TestCase
 {
-    private const GD_VERSION = 'GD Version';
-    private const GD_PNG_SUPPORT = 'PNG Support';
-    private const GD_JPEG_SUPPORT = 'JPEG Support';
-    private const GD_GIF_CREATE_SUPPORT = 'GIF Create Support';
-    private const GD_WEBP_SUPPORT = 'WebP Support';
-    private const GD_WBMP_SUPPORT = 'WBMP Support';
-
     public function testImagePng()
     {
-        if (! $this->isGDSupported(self::GD_PNG_SUPPORT)) {
+        if (! $this->isGDSupported('PNG Support')) {
             $this->markTestSkipped('Requires PNG support.');
         }
 
@@ -36,7 +29,7 @@ class HttpTestingFileFactoryTest extends TestCase
 
     public function testImageJpeg()
     {
-        if (! $this->isGDSupported(self::GD_JPEG_SUPPORT)) {
+        if (! $this->isGDSupported('JPEG Support')) {
             $this->markTestSkipped('Requires JPEG support.');
         }
 
@@ -56,7 +49,7 @@ class HttpTestingFileFactoryTest extends TestCase
 
     public function testImageGif()
     {
-        if (! $this->isGDSupported(self::GD_GIF_CREATE_SUPPORT)) {
+        if (! $this->isGDSupported('GIF Create Support')) {
             $this->markTestSkipped('Requires GIF Create support.');
         }
 
@@ -70,7 +63,7 @@ class HttpTestingFileFactoryTest extends TestCase
 
     public function testImageWebp()
     {
-        if (! $this->isGDSupported(self::GD_WEBP_SUPPORT)) {
+        if (! $this->isGDSupported('WebP Support')) {
             $this->markTestSkipped('Requires Webp support.');
         }
 
@@ -84,7 +77,7 @@ class HttpTestingFileFactoryTest extends TestCase
 
     public function testImageWbmp()
     {
-        if (! $this->isGDSupported(self::GD_WBMP_SUPPORT)) {
+        if (! $this->isGDSupported('WBMP Support')) {
             $this->markTestSkipped('Requires WBMP support.');
         }
 
@@ -127,7 +120,7 @@ class HttpTestingFileFactoryTest extends TestCase
      * @param  string  $driver
      * @return bool
      */
-    private function isGDSupported(string $driver = self::GD_VERSION): bool
+    private function isGDSupported(string $driver = 'GD Version'): bool
     {
         $gdInfo = gd_info();
 

--- a/tests/Http/HttpTestingFileFactoryTest.php
+++ b/tests/Http/HttpTestingFileFactoryTest.php
@@ -7,11 +7,23 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * @requires extension gd
+ * @link https://www.php.net/manual/en/function.gd-info.php
  */
 class HttpTestingFileFactoryTest extends TestCase
 {
+    private const GD_VERSION = 'GD Version';
+    private const GD_PNG_SUPPORT = 'PNG Support';
+    private const GD_JPEG_SUPPORT = 'JPEG Support';
+    private const GD_GIF_CREATE_SUPPORT = 'GIF Create Support';
+    private const GD_WEBP_SUPPORT = 'WebP Support';
+    private const GD_WBMP_SUPPORT = 'WBMP Support';
+
     public function testImagePng()
     {
+        if (!$this->isGDSupported(self::GD_PNG_SUPPORT)) {
+            $this->markTestSkipped('Requires PNG support.');
+        }
+
         $image = (new FileFactory)->image('test.png', 15, 20);
 
         $info = getimagesize($image->getRealPath());
@@ -23,6 +35,10 @@ class HttpTestingFileFactoryTest extends TestCase
 
     public function testImageJpeg()
     {
+        if (!$this->isGDSupported(self::GD_JPEG_SUPPORT)) {
+            $this->markTestSkipped('Requires JPEG support.');
+        }
+
         $jpeg = (new FileFactory)->image('test.jpeg', 15, 20);
         $jpg = (new FileFactory)->image('test.jpg');
 
@@ -39,6 +55,10 @@ class HttpTestingFileFactoryTest extends TestCase
 
     public function testImageGif()
     {
+        if (!$this->isGDSupported(self::GD_GIF_CREATE_SUPPORT)) {
+            $this->markTestSkipped('Requires GIF Create support.');
+        }
+
         $image = (new FileFactory)->image('test.gif');
 
         $this->assertSame(
@@ -49,6 +69,10 @@ class HttpTestingFileFactoryTest extends TestCase
 
     public function testImageWebp()
     {
+        if (!$this->isGDSupported(self::GD_WEBP_SUPPORT)) {
+            $this->markTestSkipped('Requires Webp support.');
+        }
+
         $image = (new FileFactory)->image('test.webp');
 
         $this->assertSame(
@@ -59,6 +83,10 @@ class HttpTestingFileFactoryTest extends TestCase
 
     public function testImageWbmp()
     {
+        if (!$this->isGDSupported(self::GD_WBMP_SUPPORT)) {
+            $this->markTestSkipped('Requires WBMP support.');
+        }
+
         $image = (new FileFactory)->image('test.wbmp');
 
         $this->assertSame(
@@ -92,5 +120,20 @@ class HttpTestingFileFactoryTest extends TestCase
             'video/webm',
             (new FileFactory)->create('someaudio.webm')->getMimeType()
         );
+    }
+
+    /**
+     * @param string $driver
+     * @return bool
+     */
+    private function isGDSupported(string $driver = self::GD_VERSION): bool
+    {
+        $gdInfo = gd_info();
+
+        if (isset($gdInfo[$driver])) {
+            return $gdInfo[$driver];
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
Skipping test cases by using `@requires` is okay, but it is not enough in the `gd extension` case. 

The following error appears on running the test suite. 

```
1) Illuminate\Tests\Http\HttpTestingFileFactoryTest::testImageWebp
TypeError: call_user_func(): Argument #1 ($callback) must be a valid callback, function "imagewebp" not found or invalid function name
```

This is because `WebP Support` is not supported. Below is the `gd_info()` result.

```
array:13 [
  "GD Version" => "bundled (2.1.0 compatible)"
  "FreeType Support" => false
  "GIF Read Support" => true
  "GIF Create Support" => true
  "JPEG Support" => true
  "PNG Support" => true
  "WBMP Support" => true
  "XPM Support" => false
  "XBM Support" => true
  "WebP Support" => false // <-- Is not supported
  "BMP Support" => true
  "TGA Read Support" => true
  "JIS-mapped Japanese Font Support" => false
]
```

Note: I'm using the `bin/test.sh` to run tests.

**Solution**
Skip test case if the required library is not supported.