### PR TITLE
[8.x] Fix custom channels for model broadcasting being ignored

### DIFF
--- a/src/Illuminate/Database/Eloquent/BroadcastsEvents.php
+++ b/src/Illuminate/Database/Eloquent/BroadcastsEvents.php
@@ -116,7 +116,7 @@ trait BroadcastsEvents
         }
 
         if (! empty($this->broadcastOn($event)) || ! empty($channels)) {
-            return broadcast($instance->onChannels(Arr::wrap($channels)));
+            return broadcast($instance->onChannels(array_merge(Arr::wrap($channels), $this->broadcastOn($event))));
         }
     }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Fix for issue #40478

Model broadcasting seemed like a very convenient way for real-time updates on the frontend, so I gave it a try.
Ran into an issue when I wanted to change the channel the events are broadcasted on.
As per docs, I added `BroadcastsEvents` trait on the model along with
```
    public function broadcastOn($event)
    {
        return [new PrivateChannel('foo-bar-baz')];
    }
```

This did not yield expected results, as the events kept broadcasting only on the default model channel.

I dug around for a bit and the culprit seems to be in https://github.com/laravel/framework/blob/8940ff3c9c643f8abcca026a6341fdfcfc83e983/src/Illuminate/Database/Eloquent/BroadcastsEvents.php#L112

We check `if (! empty($this->broadcastOn($event)) || ! empty($channels)) {` to ensure that there are channels to broadcast on, however:
`return broadcast($instance->onChannels(Arr::wrap($channels)));`
we completely ignore the channels we defined in `broadcastOn`. It's only broadcasted on `$channels`.

Changing https://github.com/laravel/framework/blob/ac6fc32c2933d5868a2c0d2aea4af9405d710378/src/Illuminate/Database/Eloquent/BroadcastsEvents.php#L119
to `return broadcast($instance->onChannels(array_merge(Arr::wrap($channels), $this->broadcastOn($event))));` rectifies the issue.
