### PR TITLE
[8.x] Allow drop / rename multiple Columns in one Statement using SQLite

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1667,6 +1667,7 @@ class Blueprint
                 unset($this->commands[$index]);
             }
         }
+
         return $this;
     }
 

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1662,8 +1662,8 @@ class Blueprint
      */
     public function removeCommand($name)
     {
-        foreach($this->commands as $index => $command) {
-            if($command->name === $name) {
+        foreach ($this->commands as $index => $command) {
+            if ($command->name === $name) {
                 unset($this->commands[$index]);
             }
         }

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -153,12 +153,6 @@ class Blueprint
     protected function ensureCommandsAreValid(Connection $connection)
     {
         if ($connection instanceof SQLiteConnection) {
-            if ($this->commandsNamed(['dropColumn', 'renameColumn'])->count() > 1) {
-                throw new BadMethodCallException(
-                    "SQLite doesn't support multiple calls to dropColumn / renameColumn in a single modification."
-                );
-            }
-
             if ($this->commandsNamed(['dropForeign'])->count() > 0) {
                 throw new BadMethodCallException(
                     "SQLite doesn't support dropping foreign keys (you would need to re-create the table)."

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1660,7 +1660,8 @@ class Blueprint
      * @param $name
      * @return Blueprint
      */
-    public function removeCommand($name) {
+    public function removeCommand($name)
+    {
         foreach($this->commands as $index => $command) {
             if($command->name === $name) {
                 unset($this->commands[$index]);
@@ -1710,9 +1711,10 @@ class Blueprint
      *
      * @return bool
      */
-    public function hasRenamedOrDroppedColumn() {
-        return ! is_null(collect($this->commands)->filter(function($command) {
-            if(Str::contains($command->name, ['renameColumn', 'dropColumn'])) {
+    public function hasRenamedOrDroppedColumn()
+    {
+        return ! is_null(collect($this->commands)->filter(function ($command) {
+            if (Str::contains($command->name, ['renameColumn', 'dropColumn'])) {
                 return $command;
             }
         })->first());

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Grammars\Grammar;
 use Illuminate\Database\SQLiteConnection;
 use Illuminate\Support\Fluent;
+use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 
 class Blueprint
@@ -1656,6 +1657,19 @@ class Blueprint
     }
 
     /**
+     * @param $name
+     * @return Blueprint
+     */
+    public function removeCommand($name) {
+        foreach($this->commands as $index => $command) {
+            if($command->name === $name) {
+                unset($this->commands[$index]);
+            }
+        }
+        return $this;
+    }
+
+    /**
      * Get the columns on the blueprint that should be added.
      *
      * @return \Illuminate\Database\Schema\ColumnDefinition[]
@@ -1689,6 +1703,19 @@ class Blueprint
         return ! is_null(collect($this->getAddedColumns())->first(function ($column) {
             return $column->autoIncrement === true;
         }));
+    }
+
+    /**
+     * Determine if the blueprint has renamed or dropped columns.
+     *
+     * @return bool
+     */
+    public function hasRenamedOrDroppedColumn() {
+        return ! is_null(collect($this->commands)->filter(function($command) {
+            if(Str::contains($command->name, ['renameColumn', 'dropColumn'])) {
+                return $command;
+            }
+        })->first());
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -219,6 +219,7 @@ class Builder
                     $params = collect($method->getParameters())->mapWithKeys(
                         function ($parameter) use ($command) {
                             $paramName = $parameter->name;
+
                             return [$paramName => $command->$paramName];
                         }
                     )->toArray();

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -215,7 +215,7 @@ class Builder
     public function table($table, Closure $callback)
     {
         $blueprint = $this->createBlueprint($table, $callback);
-        if($blueprint->hasRenamedOrDroppedColumn()) {
+        if($this->connection->getDriverName() === 'sqlite' && $blueprint->hasRenamedOrDroppedColumn()) {
             foreach($blueprint->getCommands() as $command) {
                 $seperateBlueprint = new Blueprint($table);
                 if(method_exists($seperateBlueprint, $command->name)) {
@@ -234,7 +234,7 @@ class Builder
             }
             $this->build($blueprint);
         }else {
-            $this->build($this->createBlueprint($table, $callback));
+            $this->build($blueprint);
         }
     }
 

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -210,10 +210,10 @@ class Builder
     public function table($table, Closure $callback)
     {
         $blueprint = $this->createBlueprint($table, $callback);
-        if($this->connection->getDriverName() === 'sqlite' && $blueprint->hasRenamedOrDroppedColumn()) {
-            foreach($blueprint->getCommands() as $command) {
+        if ($this->connection->getDriverName() === 'sqlite' && $blueprint->hasRenamedOrDroppedColumn()) {
+            foreach ($blueprint->getCommands() as $command) {
                 $seperateBlueprint = new Blueprint($table);
-                if(method_exists($seperateBlueprint, $command->name)) {
+                if (method_exists($seperateBlueprint, $command->name)) {
                     $method = (new ReflectionClass($seperateBlueprint))->getMethod($command->name);
                     $methodName = $method->name;
                     $params = collect($method->getParameters())->mapWithKeys(
@@ -228,7 +228,7 @@ class Builder
                 }
             }
             $this->build($blueprint);
-        }else {
+        } else {
             $this->build($blueprint);
         }
     }

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -5,7 +5,6 @@ namespace Illuminate\Database\Schema;
 use Closure;
 use Illuminate\Container\Container;
 use Illuminate\Database\Connection;
-use Illuminate\Database\Schema\Grammars\SqlServerGrammar;
 use InvalidArgumentException;
 use LogicException;
 use ReflectionClass;
@@ -50,7 +49,7 @@ class Builder
     /**
      * Create a new database Schema manager.
      *
-     * @param  \Illuminate\Database\Connection $connection
+     * @param  \Illuminate\Database\Connection  $connection
      * @return void
      */
     public function __construct(Connection $connection)
@@ -62,7 +61,7 @@ class Builder
     /**
      * Set the default string length for migrations.
      *
-     * @param  int $length
+     * @param  int  $length
      * @return void
      */
     public static function defaultStringLength($length)
@@ -73,7 +72,7 @@ class Builder
     /**
      * Set the default morph key type for migrations.
      *
-     * @param  string $type
+     * @param  string  $type
      * @return void
      *
      * @throws \InvalidArgumentException
@@ -100,7 +99,7 @@ class Builder
     /**
      * Create a database in the schema.
      *
-     * @param  string $name
+     * @param  string  $name
      * @return bool
      *
      * @throws \LogicException
@@ -113,7 +112,7 @@ class Builder
     /**
      * Drop a database from the schema if the database exists.
      *
-     * @param  string $name
+     * @param  string  $name
      * @return bool
      *
      * @throws \LogicException
@@ -126,25 +125,23 @@ class Builder
     /**
      * Determine if the given table exists.
      *
-     * @param  string $table
+     * @param  string  $table
      * @return bool
      */
     public function hasTable($table)
     {
         $table = $this->connection->getTablePrefix().$table;
 
-        return count(
-            $this->connection->selectFromWriteConnection(
-                $this->grammar->compileTableExists(), [$table]
-            )
-        ) > 0;
+        return count($this->connection->selectFromWriteConnection(
+            $this->grammar->compileTableExists(), [$table]
+        )) > 0;
     }
 
     /**
      * Determine if the given table has a given column.
      *
-     * @param  string $table
-     * @param  string $column
+     * @param  string  $table
+     * @param  string  $column
      * @return bool
      */
     public function hasColumn($table, $column)
@@ -157,7 +154,7 @@ class Builder
     /**
      * Determine if the given table has given columns.
      *
-     * @param  string $table
+     * @param  string  $table
      * @param  array  $columns
      * @return bool
      */
@@ -177,8 +174,8 @@ class Builder
     /**
      * Get the data type for the given column name.
      *
-     * @param  string $table
-     * @param  string $column
+     * @param  string  $table
+     * @param  string  $column
      * @return string
      */
     public function getColumnType($table, $column)
@@ -191,16 +188,14 @@ class Builder
     /**
      * Get the column listing for a given table.
      *
-     * @param  string $table
+     * @param  string  $table
      * @return array
      */
     public function getColumnListing($table)
     {
-        $results = $this->connection->selectFromWriteConnection(
-            $this->grammar->compileColumnListing(
-                $this->connection->getTablePrefix().$table
-            )
-        );
+        $results = $this->connection->selectFromWriteConnection($this->grammar->compileColumnListing(
+            $this->connection->getTablePrefix().$table
+        ));
 
         return $this->connection->getPostProcessor()->processColumnListing($results);
     }
@@ -208,8 +203,8 @@ class Builder
     /**
      * Modify a table on the schema.
      *
-     * @param  string   $table
-     * @param  \Closure $callback
+     * @param  string  $table
+     * @param  \Closure  $callback
      * @return void
      */
     public function table($table, Closure $callback)
@@ -241,71 +236,57 @@ class Builder
     /**
      * Create a new table on the schema.
      *
-     * @param  string   $table
-     * @param  \Closure $callback
+     * @param  string  $table
+     * @param  \Closure  $callback
      * @return void
      */
     public function create($table, Closure $callback)
     {
-        $this->build(
-            tap(
-                $this->createBlueprint($table), function ($blueprint) use ($callback) {
-                    $blueprint->create();
+        $this->build(tap($this->createBlueprint($table), function ($blueprint) use ($callback) {
+            $blueprint->create();
 
-                    $callback($blueprint);
-                }
-            )
-        );
+            $callback($blueprint);
+        }));
     }
 
     /**
      * Drop a table from the schema.
      *
-     * @param  string $table
+     * @param  string  $table
      * @return void
      */
     public function drop($table)
     {
-        $this->build(
-            tap(
-                $this->createBlueprint($table), function ($blueprint) {
-                    $blueprint->drop();
-                }
-            )
-        );
+        $this->build(tap($this->createBlueprint($table), function ($blueprint) {
+            $blueprint->drop();
+        }));
     }
 
     /**
      * Drop a table from the schema if it exists.
      *
-     * @param  string $table
+     * @param  string  $table
      * @return void
      */
     public function dropIfExists($table)
     {
-        $this->build(
-            tap(
-                $this->createBlueprint($table), function ($blueprint) {
-                    $blueprint->dropIfExists();
-                }
-            )
-        );
+        $this->build(tap($this->createBlueprint($table), function ($blueprint) {
+            $blueprint->dropIfExists();
+        }));
     }
 
     /**
      * Drop columns from a table schema.
      *
-     * @param  string       $table
-     * @param  string|array $columns
+     * @param  string  $table
+     * @param  string|array  $columns
      * @return void
      */
     public function dropColumns($table, $columns)
     {
-        $this->table(
-            $table, function (Blueprint $blueprint) use ($columns) {
-                $blueprint->dropColumn($columns);
-            }
-        );
+        $this->table($table, function (Blueprint $blueprint) use ($columns) {
+            $blueprint->dropColumn($columns);
+        });
     }
 
     /**
@@ -359,19 +340,15 @@ class Builder
     /**
      * Rename a table on the schema.
      *
-     * @param  string $from
-     * @param  string $to
+     * @param  string  $from
+     * @param  string  $to
      * @return void
      */
     public function rename($from, $to)
     {
-        $this->build(
-            tap(
-                $this->createBlueprint($from), function ($blueprint) use ($to) {
-                    $blueprint->rename($to);
-                }
-            )
-        );
+        $this->build(tap($this->createBlueprint($from), function ($blueprint) use ($to) {
+            $blueprint->rename($to);
+        }));
     }
 
     /**
@@ -401,7 +378,7 @@ class Builder
     /**
      * Execute the blueprint to build / modify the table.
      *
-     * @param  \Illuminate\Database\Schema\Blueprint $blueprint
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
      * @return void
      */
     protected function build(Blueprint $blueprint)
@@ -412,8 +389,8 @@ class Builder
     /**
      * Create a new command set with a Closure.
      *
-     * @param  string        $table
-     * @param  \Closure|null $callback
+     * @param  string  $table
+     * @param  \Closure|null  $callback
      * @return \Illuminate\Database\Schema\Blueprint
      */
     protected function createBlueprint($table, Closure $callback = null)
@@ -432,9 +409,9 @@ class Builder
     /**
      * Register a custom Doctrine mapping type.
      *
-     * @param  string $class
-     * @param  string $name
-     * @param  string $type
+     * @param  string  $class
+     * @param  string  $name
+     * @param  string  $type
      * @return void
      */
     public function registerCustomDoctrineType($class, $name, $type)
@@ -455,7 +432,7 @@ class Builder
     /**
      * Set the database connection instance.
      *
-     * @param  \Illuminate\Database\Connection $connection
+     * @param  \Illuminate\Database\Connection  $connection
      * @return $this
      */
     public function setConnection(Connection $connection)
@@ -468,7 +445,7 @@ class Builder
     /**
      * Set the Schema Blueprint resolver callback.
      *
-     * @param  \Closure $resolver
+     * @param  \Closure  $resolver
      * @return void
      */
     public function blueprintResolver(Closure $resolver)

--- a/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
@@ -373,7 +373,6 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
         });
     }
 
-
     public function testItEnsuresDroppingForeignKeyIsAvailable()
     {
         $this->expectException(BadMethodCallException::class);

--- a/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
@@ -325,39 +325,6 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
         $this->assertEquals($expected, $queries);
     }
 
-    public function testItEnsuresDroppingMultipleColumnsIsAvailable()
-    {
-        $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage("SQLite doesn't support multiple calls to dropColumn / renameColumn in a single modification.");
-
-        $this->db->connection()->getSchemaBuilder()->table('users', function (Blueprint $table) {
-            $table->dropColumn('name');
-            $table->dropColumn('email');
-        });
-    }
-
-    public function testItEnsuresRenamingMultipleColumnsIsAvailable()
-    {
-        $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage("SQLite doesn't support multiple calls to dropColumn / renameColumn in a single modification.");
-
-        $this->db->connection()->getSchemaBuilder()->table('users', function (Blueprint $table) {
-            $table->renameColumn('name', 'first_name');
-            $table->renameColumn('name2', 'last_name');
-        });
-    }
-
-    public function testItEnsuresRenamingAndDroppingMultipleColumnsIsAvailable()
-    {
-        $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage("SQLite doesn't support multiple calls to dropColumn / renameColumn in a single modification.");
-
-        $this->db->connection()->getSchemaBuilder()->table('users', function (Blueprint $table) {
-            $table->dropColumn('name');
-            $table->renameColumn('name2', 'last_name');
-        });
-    }
-
     public function testItEnsuresDroppingForeignKeyIsAvailable()
     {
         $this->expectException(BadMethodCallException::class);

--- a/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
@@ -325,6 +325,55 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
         $this->assertEquals($expected, $queries);
     }
 
+    public function testItEnsuresDroppingMultipleColumnsIsAvailable()
+    {
+        $this->db->connection()->getSchemaBuilder()->create('users', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email');
+        });
+
+        $this->db->connection()->commit();
+
+        $this->db->connection()->getSchemaBuilder()->table('users', function (Blueprint $table) {
+            $table->dropColumn('name');
+            $table->dropColumn('email');
+        });
+    }
+
+    public function testItEnsuresRenamingMultipleColumnsIsAvailable()
+    {
+        $this->db->connection()->getSchemaBuilder()->create('users', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email');
+        });
+
+        $this->db->connection()->commit();
+
+        $this->db->connection()->getSchemaBuilder()->table('users', function (Blueprint $table) {
+            $table->renameColumn('name', 'first_name');
+            $table->renameColumn('email', 'last_name');
+        });
+    }
+
+    public function testItEnsuresRenamingAndDroppingMultipleColumnsIsAvailable()
+    {
+        $this->db->connection()->getSchemaBuilder()->create('users', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email');
+        });
+
+        $this->db->connection()->commit();
+
+        $this->db->connection()->getSchemaBuilder()->table('users', function (Blueprint $table) {
+            $table->dropColumn('name');
+            $table->renameColumn('email', 'first_name');
+        });
+    }
+
+
     public function testItEnsuresDroppingForeignKeyIsAvailable()
     {
         $this->expectException(BadMethodCallException::class);

--- a/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
@@ -130,6 +130,76 @@ class DatabaseSchemaBuilderIntegrationTest extends TestCase
         $this->assertFalse($this->schemaBuilder()->hasColumn('pandemic_table', 'covid19'));
     }
 
+    public function testAddAndRenameColumns() {
+        $this->schemaBuilder()
+            ->create('users', function (Blueprint $table) {
+                $table->id();
+                $table->string('name');
+                $table->timestamps();
+            });
+        $this->schemaBuilder()->table('users', function (Blueprint $table) {
+            $table->renameColumn('name', 'first_name');
+            $table->string('last_name')->after('first_name');
+        });
+        $this->assertFalse($this->schemaBuilder()->hasColumn('users', 'name'));
+        $this->assertTrue($this->schemaBuilder()->hasColumn('users', 'first_name'));
+        $this->assertTrue($this->schemaBuilder()->hasColumn('users', 'last_name'));
+    }
+
+    public function testAddAndDropColumns() {
+        $this->schemaBuilder()
+            ->create('users', function (Blueprint $table) {
+                $table->id();
+                $table->string('name');
+                $table->string('first_name');
+                $table->string('last_name');
+                $table->timestamps();
+            });
+        $this->schemaBuilder()->table('users', function (Blueprint $table) {
+            $table->dropColumn('name');
+            $table->string('email');
+        });
+        $this->assertFalse($this->schemaBuilder()->hasColumn('users', 'name'));
+        $this->assertTrue($this->schemaBuilder()->hasColumn('users', 'email'));
+    }
+
+    public function testMultipleDropColumns() {
+        $this->schemaBuilder()
+            ->create('users', function (Blueprint $table) {
+                $table->id();
+                $table->string('first_name');
+                $table->string('last_name');
+                $table->timestamps();
+            });
+        $this->schemaBuilder()->table('users', function (Blueprint $table) {
+            $table->dropColumn('first_name');
+            $table->dropColumn('last_name');
+        });
+
+        $this->assertFalse($this->schemaBuilder()->hasColumn('users', 'first_name'));
+        $this->assertFalse($this->schemaBuilder()->hasColumn('users', 'last_name'));
+    }
+
+    public function testMultipleRenameColumns() {
+        $this->schemaBuilder()
+            ->create('users', function (Blueprint $table) {
+                $table->id();
+                $table->string('first_name');
+                $table->string('last_name');
+                $table->timestamps();
+            });
+        $this->schemaBuilder()
+            ->table('users', function (Blueprint $table) {
+                $table->renameColumn('first_name', 'firstName');
+                $table->renameColumn('last_name', 'lastName');
+            });
+
+        $this->assertFalse($this->schemaBuilder()->hasColumn('users', 'first_name'));
+        $this->assertFalse($this->schemaBuilder()->hasColumn('users', 'last_name'));
+        $this->assertTrue($this->schemaBuilder()->hasColumn('users', 'firstName'));
+        $this->assertTrue($this->schemaBuilder()->hasColumn('users', 'lastName'));
+    }
+
     private function schemaBuilder()
     {
         return $this->db->connection()->getSchemaBuilder();

--- a/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
@@ -130,7 +130,8 @@ class DatabaseSchemaBuilderIntegrationTest extends TestCase
         $this->assertFalse($this->schemaBuilder()->hasColumn('pandemic_table', 'covid19'));
     }
 
-    public function testAddAndRenameColumns() {
+    public function testAddAndRenameColumns()
+    {
         $this->schemaBuilder()
             ->create('users', function (Blueprint $table) {
                 $table->id();
@@ -146,7 +147,8 @@ class DatabaseSchemaBuilderIntegrationTest extends TestCase
         $this->assertTrue($this->schemaBuilder()->hasColumn('users', 'last_name'));
     }
 
-    public function testAddAndDropColumns() {
+    public function testAddAndDropColumns()
+    {
         $this->schemaBuilder()
             ->create('users', function (Blueprint $table) {
                 $table->id();
@@ -163,7 +165,8 @@ class DatabaseSchemaBuilderIntegrationTest extends TestCase
         $this->assertTrue($this->schemaBuilder()->hasColumn('users', 'email'));
     }
 
-    public function testMultipleDropColumns() {
+    public function testMultipleDropColumns()
+    {
         $this->schemaBuilder()
             ->create('users', function (Blueprint $table) {
                 $table->id();
@@ -180,7 +183,8 @@ class DatabaseSchemaBuilderIntegrationTest extends TestCase
         $this->assertFalse($this->schemaBuilder()->hasColumn('users', 'last_name'));
     }
 
-    public function testMultipleRenameColumns() {
+    public function testMultipleRenameColumns()
+    {
         $this->schemaBuilder()
             ->create('users', function (Blueprint $table) {
                 $table->id();


### PR DESCRIPTION
Currently it is not possible using SQLite, to rename and create / drop and create multiple columns in one Schema::table() statement.

This PR splits the Migration if SQLite is in use to first execute the commands (rename and drop), then creating new columns.

So there is no need to split the Schema::table() Statement in one Migration File for each dropColumn / renameColumn and adding new Columns.

Before (need in Migration File):

```
Schema::table('users', function(Blueprint $table) {
$table->renameColumn('name', 'first_name');
});

Schema::table('users', function(Blueprint $table) {
$table->string('last_name')->after('first_name');
});
```

After (splitter during Migration):

```
Schema::table('users', function(Blueprint $table) {
$table->renameColumn('name', 'first_name');
$table->string('last_name')->after('first_name');
});
```