### PR TITLE
[8.x] Memoize date format

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1386,7 +1386,7 @@ trait HasAttributes
      */
     public function getDateFormat()
     {
-        return $this->dateFormat ?: $this->getConnection()->getQueryGrammar()->getDateFormat();
+        return $this->dateFormat = $this->dateFormat ?: $this->getConnection()->getQueryGrammar()->getDateFormat();
     }
 
     /**


### PR DESCRIPTION
Right now, timestamp attributes cause `$model->toArray()` to fail if the model's connection doesn't exist. I think serialization of attributes should always work, regardless of the environment. This small change appears to fix the issue completely.

The reason why `toArray()` fails is that it calls the `getDateFormat()` which always fetches the model's connection to grab the format from the grammar.

However, there are valid use cases for using models without their connections existing. One such example is multi-tenancy, where you may briefly introduce a DB connection for a few queries and clean it up afterward. It seems like simply avoiding calling `toArray()` or making sure to call it while the connection still exists prevents this issue in most cases. But there are a few scenarios when `toArray()` is called in the background.

For example, Telescope will call `toArray()` on any model passed to a view (see https://github.com/archtechx/tenancy/issues/774#issuecomment-1010038755).

## Used date formats

The change seems small and harmless, but to be sure, I went through the relevant code to see how this is used.

I originally assumed the `getQueryGrammar()->getDateFormat()` call uses PDO to get the user-defined date format from the connection, but apparently, this is purely in the PHP land.

- All connections use `Illuminate\Database\Grammar::getDateFormat()` which returns `'Y-m-d H:i:s'`
- SQL server uses `Illuminate\Database\Query\Grammars\SqlServerGrammar::getDateFormat()` which returns `'Y-m-d H:i:s.v'`
- The docs instruct developers to set the `$dateFormat` property on the model to customize the timestamp formats

This makes me think that the value is never dynamic, and therefore memoizing it is safe. And there shouldn't be any breaking changes either, so 8.x is the appropriate target.