### PR TITLE
[8.x] Allows authorizeResource method to receive arrays of models and parameters

### DIFF
--- a/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
+++ b/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
@@ -83,6 +83,7 @@ trait AuthorizesRequests
     public function authorizeResource($model, $parameter = null, array $options = [], $request = null)
     {
         $model = is_array($model) ? implode(',', $model) : $model;
+
         $parameter = is_array($parameter) ? implode(',', $parameter) : $parameter;
 
         $parameter = $parameter ?: Str::snake(class_basename($model));

--- a/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
+++ b/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
@@ -74,14 +74,17 @@ trait AuthorizesRequests
     /**
      * Authorize a resource action based on the incoming request.
      *
-     * @param  string  $model
-     * @param  string|null  $parameter
+     * @param  string|array  $model
+     * @param  string|array|null  $parameter
      * @param  array  $options
      * @param  \Illuminate\Http\Request|null  $request
      * @return void
      */
     public function authorizeResource($model, $parameter = null, array $options = [], $request = null)
     {
+		$model = is_array($model) ? implode(',', $model) : $model;
+		$parameter = is_array($parameter) ? implode(',', $parameter) : $parameter;
+
         $parameter = $parameter ?: Str::snake(class_basename($model));
 
         $middleware = [];

--- a/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
+++ b/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
@@ -82,8 +82,8 @@ trait AuthorizesRequests
      */
     public function authorizeResource($model, $parameter = null, array $options = [], $request = null)
     {
-		$model = is_array($model) ? implode(',', $model) : $model;
-		$parameter = is_array($parameter) ? implode(',', $parameter) : $parameter;
+        $model = is_array($model) ? implode(',', $model) : $model;
+        $parameter = is_array($parameter) ? implode(',', $parameter) : $parameter;
 
         $parameter = $parameter ?: Str::snake(class_basename($model));
 

--- a/tests/Auth/AuthorizesResourcesTest.php
+++ b/tests/Auth/AuthorizesResourcesTest.php
@@ -17,6 +17,10 @@ class AuthorizesResourcesTest extends TestCase
         $controller = new AuthorizesResourcesController;
 
         $this->assertHasMiddleware($controller, 'create', 'can:create,App\User');
+
+		$controller = new AuthorizesResourcesWithArrayController;
+
+        $this->assertHasMiddleware($controller, 'create', 'can:create,App\User,App\Post');
     }
 
     public function testStoreMethod()
@@ -24,6 +28,10 @@ class AuthorizesResourcesTest extends TestCase
         $controller = new AuthorizesResourcesController;
 
         $this->assertHasMiddleware($controller, 'store', 'can:create,App\User');
+
+		$controller = new AuthorizesResourcesWithArrayController;
+
+        $this->assertHasMiddleware($controller, 'store', 'can:create,App\User,App\Post');
     }
 
     public function testShowMethod()
@@ -31,6 +39,10 @@ class AuthorizesResourcesTest extends TestCase
         $controller = new AuthorizesResourcesController;
 
         $this->assertHasMiddleware($controller, 'show', 'can:view,user');
+
+		$controller = new AuthorizesResourcesWithArrayController;
+
+        $this->assertHasMiddleware($controller, 'show', 'can:view,user,post');
     }
 
     public function testEditMethod()
@@ -38,6 +50,10 @@ class AuthorizesResourcesTest extends TestCase
         $controller = new AuthorizesResourcesController;
 
         $this->assertHasMiddleware($controller, 'edit', 'can:update,user');
+
+		$controller = new AuthorizesResourcesWithArrayController;
+
+        $this->assertHasMiddleware($controller, 'edit', 'can:update,user,post');
     }
 
     public function testUpdateMethod()
@@ -45,6 +61,10 @@ class AuthorizesResourcesTest extends TestCase
         $controller = new AuthorizesResourcesController;
 
         $this->assertHasMiddleware($controller, 'update', 'can:update,user');
+
+		$controller = new AuthorizesResourcesWithArrayController;
+
+        $this->assertHasMiddleware($controller, 'update', 'can:update,user,post');
     }
 
     public function testDestroyMethod()
@@ -52,6 +72,10 @@ class AuthorizesResourcesTest extends TestCase
         $controller = new AuthorizesResourcesController;
 
         $this->assertHasMiddleware($controller, 'destroy', 'can:delete,user');
+
+		$controller = new AuthorizesResourcesWithArrayController;
+
+        $this->assertHasMiddleware($controller, 'destroy', 'can:delete,user,post');
     }
 
     /**
@@ -67,7 +91,7 @@ class AuthorizesResourcesTest extends TestCase
         $router = new Router(new Dispatcher);
 
         $router->aliasMiddleware('can', AuthorizesResourcesMiddleware::class);
-        $router->get($method)->uses(AuthorizesResourcesController::class.'@'.$method);
+        $router->get($method)->uses(get_class($controller).'@'.$method);
 
         $this->assertSame(
             'caught '.$middleware,
@@ -122,10 +146,57 @@ class AuthorizesResourcesController extends Controller
     }
 }
 
+class AuthorizesResourcesWithArrayController extends Controller
+{
+    use AuthorizesRequests;
+
+    public function __construct()
+    {
+        $this->authorizeResource(['App\User', 'App\Post'], ['user', 'post']);
+    }
+
+    public function index()
+    {
+        //
+    }
+
+    public function create()
+    {
+        //
+    }
+
+    public function store()
+    {
+        //
+    }
+
+    public function show()
+    {
+        //
+    }
+
+    public function edit()
+    {
+        //
+    }
+
+    public function update()
+    {
+        //
+    }
+
+    public function destroy()
+    {
+        //
+    }
+}
+
 class AuthorizesResourcesMiddleware
 {
-    public function handle($request, Closure $next, $method, $parameter)
+    public function handle($request, Closure $next, $method, $parameter, ...$models)
     {
-        return "caught can:{$method},{$parameter}";
+
+		$params = array_merge([$parameter], $models);
+        return "caught can:{$method}," . implode(',', $params);
     }
 }

--- a/tests/Auth/AuthorizesResourcesTest.php
+++ b/tests/Auth/AuthorizesResourcesTest.php
@@ -18,7 +18,7 @@ class AuthorizesResourcesTest extends TestCase
 
         $this->assertHasMiddleware($controller, 'create', 'can:create,App\User');
 
-		$controller = new AuthorizesResourcesWithArrayController;
+        $controller = new AuthorizesResourcesWithArrayController;
 
         $this->assertHasMiddleware($controller, 'create', 'can:create,App\User,App\Post');
     }
@@ -29,7 +29,7 @@ class AuthorizesResourcesTest extends TestCase
 
         $this->assertHasMiddleware($controller, 'store', 'can:create,App\User');
 
-		$controller = new AuthorizesResourcesWithArrayController;
+        $controller = new AuthorizesResourcesWithArrayController;
 
         $this->assertHasMiddleware($controller, 'store', 'can:create,App\User,App\Post');
     }
@@ -40,7 +40,7 @@ class AuthorizesResourcesTest extends TestCase
 
         $this->assertHasMiddleware($controller, 'show', 'can:view,user');
 
-		$controller = new AuthorizesResourcesWithArrayController;
+        $controller = new AuthorizesResourcesWithArrayController;
 
         $this->assertHasMiddleware($controller, 'show', 'can:view,user,post');
     }
@@ -51,7 +51,7 @@ class AuthorizesResourcesTest extends TestCase
 
         $this->assertHasMiddleware($controller, 'edit', 'can:update,user');
 
-		$controller = new AuthorizesResourcesWithArrayController;
+        $controller = new AuthorizesResourcesWithArrayController;
 
         $this->assertHasMiddleware($controller, 'edit', 'can:update,user,post');
     }
@@ -62,7 +62,7 @@ class AuthorizesResourcesTest extends TestCase
 
         $this->assertHasMiddleware($controller, 'update', 'can:update,user');
 
-		$controller = new AuthorizesResourcesWithArrayController;
+        $controller = new AuthorizesResourcesWithArrayController;
 
         $this->assertHasMiddleware($controller, 'update', 'can:update,user,post');
     }
@@ -73,7 +73,7 @@ class AuthorizesResourcesTest extends TestCase
 
         $this->assertHasMiddleware($controller, 'destroy', 'can:delete,user');
 
-		$controller = new AuthorizesResourcesWithArrayController;
+        $controller = new AuthorizesResourcesWithArrayController;
 
         $this->assertHasMiddleware($controller, 'destroy', 'can:delete,user,post');
     }
@@ -195,8 +195,7 @@ class AuthorizesResourcesMiddleware
 {
     public function handle($request, Closure $next, $method, $parameter, ...$models)
     {
-
-		$params = array_merge([$parameter], $models);
+        $params = array_merge([$parameter], $models);
         return "caught can:{$method}," . implode(',', $params);
     }
 }

--- a/tests/Auth/AuthorizesResourcesTest.php
+++ b/tests/Auth/AuthorizesResourcesTest.php
@@ -196,6 +196,7 @@ class AuthorizesResourcesMiddleware
     public function handle($request, Closure $next, $method, $parameter, ...$models)
     {
         $params = array_merge([$parameter], $models);
-        return "caught can:{$method}," . implode(',', $params);
+
+        return "caught can:{$method},".implode(',', $params);
     }
 }


### PR DESCRIPTION
Hey Guys,

This PR adds some niceities with adding policies to controllers using the `authorizeResource` method in the AuthorizesRequest trait.

This came as a result of wanting to access other models which were bound on the route in a policy. So for example, if I wanted to access a model unrelated to the policy on the create method, I might do something like this in my controller constructor:

```php
class FirewallController extends Controller {

	public function __construct() {
		$this->middleware('auth');
		$this->authorizeResource('App\Firewall,interaction', 'firewall,interaction');
	}
```

which would give me access to the interaction model in the policy in the create method, for example:

```php
class FirewallPolicy {

	use HandlesAuthorization;
	
	public function create(User $user, Interaction $interaction) {
		
	}

```

This approach means I can still use authorizeResource instead of `$this->authorize()` in the method on the controller instead.

This PR adds some niceties around adding multiple models and parameters to the authorizeResource

```php
class FirewallController extends Controller {

	public function __construct() {
		$this->middleware('auth');
		$this->authorizeResource([Firewall::class, 'interaction'], ['firewall','interaction']);
	}
```

I can instead pass in an array of models and parameters. Which then get imploded and added in this authorizeResource.

I have also added some tests to this to make sure the middleware is applied correctly.

Please let me know of any thoughts or concerns. Happy to make any changes to it!

Thanks guys :)


