### PR TITLE
[9.x] Fix Collection sortBy phpdoc for arrays

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1297,7 +1297,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Sort the collection using the given callback.
      *
-     * @param  (callable(TValue, TKey): mixed)|string  $callback
+     * @param  (callable(TValue, TKey): mixed)|string|string[]  $callback
      * @param  int  $options
      * @param  bool  $descending
      * @return static

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1297,7 +1297,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Sort the collection using the given callback.
      *
-     * @param  (callable(TValue, TKey): mixed)|string|array<int,(callable(TValue, TKey): mixed)|string>|array<string,string>  $callback
+     * @param  (callable(TValue, TKey): mixed)|string|array<int,(callable(TValue, TKey): mixed)|array<string>>  $callback
      * @param  int  $options
      * @param  bool  $descending
      * @return static
@@ -1335,7 +1335,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Sort the collection using multiple comparisons.
      *
-     * @param  array<int,(callable(TValue, TKey): mixed)|string>|array<string,string>  $comparisons
+     * @param  array<int,(callable(TValue, TKey): mixed)|array<string>>  $comparisons
      * @return static
      */
     protected function sortByMany(array $comparisons = [])

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1297,7 +1297,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Sort the collection using the given callback.
      *
-     * @param  (callable(TValue, TKey): mixed)|string|array<int,(callable(TValue, TKey): mixed)|array<string>>  $callback
+     * @param  (callable(TValue, TKey): mixed)|string|array<array<string>>|array<(callable(TValue, TKey): mixed)>  $callback
      * @param  int  $options
      * @param  bool  $descending
      * @return static
@@ -1335,7 +1335,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Sort the collection using multiple comparisons.
      *
-     * @param  array<int,(callable(TValue, TKey): mixed)|array<string>>  $comparisons
+     * @param  array<(callable(TValue, TKey): mixed)>|array<string[]>  $comparisons
      * @return static
      */
     protected function sortByMany(array $comparisons = [])

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1297,7 +1297,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Sort the collection using the given callback.
      *
-     * @param  (callable(TValue, TKey): mixed)|string|string[]  $callback
+     * @param  (callable(TValue, TKey): mixed)|string|array<int,(callable(TValue, TKey): mixed)|string>|array<string,string>  $callback
      * @param  int  $options
      * @param  bool  $descending
      * @return static
@@ -1335,7 +1335,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Sort the collection using multiple comparisons.
      *
-     * @param  array  $comparisons
+     * @param  array<int,(callable(TValue, TKey): mixed)|string>|array<string,string>  $comparisons
      * @return static
      */
     protected function sortByMany(array $comparisons = [])

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -658,6 +658,13 @@ assertType('Illuminate\Support\Collection<int, User>', $collection->sortBy(funct
 }));
 assertType('Illuminate\Support\Collection<int, User>', $collection->sortBy('string'));
 assertType('Illuminate\Support\Collection<int, User>', $collection->sortBy(['string']));
+assertType('Illuminate\Support\Collection<int, User>', $collection->sortBy(['string' => 'asc']));
+assertType('Illuminate\Support\Collection<int, User>', $collection->sortBy([function($user, $int) {
+    assertType('User', $user);
+    assertType('int', $int);
+
+    return 1;
+}]));
 assertType('Illuminate\Support\Collection<int, User>', $collection->sortBy('string', 1, false));
 
 assertType('Illuminate\Support\Collection<int, User>', $collection->sortByDesc(function ($user, $int) {

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -657,6 +657,7 @@ assertType('Illuminate\Support\Collection<int, User>', $collection->sortBy(funct
     return 1;
 }));
 assertType('Illuminate\Support\Collection<int, User>', $collection->sortBy('string'));
+assertType('Illuminate\Support\Collection<int, User>', $collection->sortBy(['string']));
 assertType('Illuminate\Support\Collection<int, User>', $collection->sortBy('string', 1, false));
 
 assertType('Illuminate\Support\Collection<int, User>', $collection->sortByDesc(function ($user, $int) {

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -657,8 +657,9 @@ assertType('Illuminate\Support\Collection<int, User>', $collection->sortBy(funct
     return 1;
 }));
 assertType('Illuminate\Support\Collection<int, User>', $collection->sortBy('string'));
-assertType('Illuminate\Support\Collection<int, User>', $collection->sortBy(['string']));
-assertType('Illuminate\Support\Collection<int, User>', $collection->sortBy(['string' => 'asc']));
+assertType('Illuminate\Support\Collection<int, User>', $collection->sortBy([
+    ['string', 'string']
+]));
 assertType('Illuminate\Support\Collection<int, User>', $collection->sortBy([function ($user, $int) {
     assertType('User', $user);
     assertType('int', $int);

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -659,7 +659,7 @@ assertType('Illuminate\Support\Collection<int, User>', $collection->sortBy(funct
 assertType('Illuminate\Support\Collection<int, User>', $collection->sortBy('string'));
 assertType('Illuminate\Support\Collection<int, User>', $collection->sortBy(['string']));
 assertType('Illuminate\Support\Collection<int, User>', $collection->sortBy(['string' => 'asc']));
-assertType('Illuminate\Support\Collection<int, User>', $collection->sortBy([function($user, $int) {
+assertType('Illuminate\Support\Collection<int, User>', $collection->sortBy([function ($user, $int) {
     assertType('User', $user);
     assertType('int', $int);
 


### PR DESCRIPTION
`sortBy` also accepts an array of strings (attribute, asc/desc) or callables which it can sort By.
This updates the phpdoc accordingly

Examples from Docs:
```php
$collection = collect([
    ['name' => 'Taylor Otwell', 'age' => 34],
    ['name' => 'Abigail Otwell', 'age' => 30],
    ['name' => 'Taylor Otwell', 'age' => 36],
    ['name' => 'Abigail Otwell', 'age' => 32],
]);

$sorted = $collection->sortBy([
    ['name', 'asc'],
    ['age', 'desc'],
]);
```

```php
$collection = collect([
    ['name' => 'Taylor Otwell', 'age' => 34],
    ['name' => 'Abigail Otwell', 'age' => 30],
    ['name' => 'Taylor Otwell', 'age' => 36],
    ['name' => 'Abigail Otwell', 'age' => 32],
]);

$sorted = $collection->sortBy([
    fn ($a, $b) => $a['name'] <=> $b['name'],
    fn ($a, $b) => $b['age'] <=> $a['age'],
]);
```