### PR TITLE
[8.x] Allow caching to be disabled for virtual attributes accessors that return an object

### DIFF
--- a/src/Illuminate/Database/Eloquent/Casts/Attribute.php
+++ b/src/Illuminate/Database/Eloquent/Casts/Attribute.php
@@ -19,7 +19,7 @@ class Attribute
     public $set;
 
     /**
-     * Indicates if caching of objects should be disabled for this attribute.
+     * Indicates if caching of objects is enabled for this attribute.
      *
      * @var bool
      */

--- a/src/Illuminate/Database/Eloquent/Casts/Attribute.php
+++ b/src/Illuminate/Database/Eloquent/Casts/Attribute.php
@@ -23,7 +23,7 @@ class Attribute
      *
      * @var bool
      */
-    public $withoutObjectCaching = false;
+    public $withObjectCaching = true;
 
     /**
      * Create a new attribute accessor / mutator.
@@ -67,7 +67,7 @@ class Attribute
      */
     public function withoutObjectCaching()
     {
-        $this->withoutObjectCaching = true;
+        $this->withObjectCaching = false;
 
         return $this;
     }

--- a/src/Illuminate/Database/Eloquent/Casts/Attribute.php
+++ b/src/Illuminate/Database/Eloquent/Casts/Attribute.php
@@ -19,16 +19,33 @@ class Attribute
     public $set;
 
     /**
+     * Whether caching of objects should be disabled for this attribute.
+     *
+     * @var bool
+     */
+    public $disableObjectCaching = false;
+
+    /**
      * Create a new attribute accessor / mutator.
      *
-     * @param  callable  $get
-     * @param  callable  $set
+     * @param  callable|null  $get
+     * @param  callable|null  $set
      * @return void
      */
     public function __construct(callable $get = null, callable $set = null)
     {
         $this->get = $get;
         $this->set = $set;
+    }
+
+    /**
+     * @return static
+     */
+    public function disableObjectCaching()
+    {
+        $this->disableObjectCaching = true;
+
+        return $this;
     }
 
     /**
@@ -40,6 +57,17 @@ class Attribute
     public static function get(callable $get)
     {
         return new static($get);
+    }
+
+    /**
+     * Create a new attribute accessor with object caching disabled.
+     *
+     * @param  callable  $get
+     * @return static
+     */
+    public static function getWithoutCaching(callable $get)
+    {
+        return (new static($get))->disableObjectCaching();
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Casts/Attribute.php
+++ b/src/Illuminate/Database/Eloquent/Casts/Attribute.php
@@ -19,11 +19,11 @@ class Attribute
     public $set;
 
     /**
-     * Whether caching of objects should be disabled for this attribute.
+     * Indicates if caching of objects should be disabled for this attribute.
      *
      * @var bool
      */
-    public $disableObjectCaching = false;
+    public $withoutObjectCaching = false;
 
     /**
      * Create a new attribute accessor / mutator.
@@ -39,16 +39,6 @@ class Attribute
     }
 
     /**
-     * @return static
-     */
-    public function disableObjectCaching()
-    {
-        $this->disableObjectCaching = true;
-
-        return $this;
-    }
-
-    /**
      * Create a new attribute accessor.
      *
      * @param  callable  $get
@@ -60,17 +50,6 @@ class Attribute
     }
 
     /**
-     * Create a new attribute accessor with object caching disabled.
-     *
-     * @param  callable  $get
-     * @return static
-     */
-    public static function getWithoutCaching(callable $get)
-    {
-        return (new static($get))->disableObjectCaching();
-    }
-
-    /**
      * Create a new attribute mutator.
      *
      * @param  callable  $set
@@ -79,5 +58,17 @@ class Attribute
     public static function set(callable $set)
     {
         return new static(null, $set);
+    }
+
+    /**
+     * Disable object caching for the attribute.
+     *
+     * @return static
+     */
+    public function withoutObjectCaching()
+    {
+        $this->withoutObjectCaching = true;
+
+        return $this;
     }
 }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -631,7 +631,7 @@ trait HasAttributes
             return $value;
         }, $value, $this->attributes);
 
-        if (! is_object($value) || $attribute->withoutObjectCaching) {
+        if (! is_object($value) || ! $attribute->withObjectCaching) {
             unset($this->attributeCastCache[$key]);
         } else {
             $this->attributeCastCache[$key] = $value;
@@ -1014,7 +1014,7 @@ trait HasAttributes
             )
         );
 
-        if (! is_object($value) || $attribute->withoutObjectCaching) {
+        if (! is_object($value) || ! $attribute->withObjectCaching) {
             unset($this->attributeCastCache[$key]);
         } else {
             $this->attributeCastCache[$key] = $value;

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -631,7 +631,7 @@ trait HasAttributes
             return $value;
         }, $value, $this->attributes);
 
-        if (! is_object($value) || $attribute->disableObjectCaching) {
+        if (! is_object($value) || $attribute->withoutObjectCaching) {
             unset($this->attributeCastCache[$key]);
         } else {
             $this->attributeCastCache[$key] = $value;
@@ -1014,7 +1014,7 @@ trait HasAttributes
             )
         );
 
-        if (! is_object($value) || $attribute->disableObjectCaching) {
+        if (! is_object($value) || $attribute->withoutObjectCaching) {
             unset($this->attributeCastCache[$key]);
         } else {
             $this->attributeCastCache[$key] = $value;

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -625,11 +625,13 @@ trait HasAttributes
             return $this->attributeCastCache[$key];
         }
 
-        $value = call_user_func($this->{Str::camel($key)}()->get ?: function ($value) {
+        $attribute = $this->{Str::camel($key)}();
+
+        $value = call_user_func($attribute->get ?: function ($value) {
             return $value;
         }, $value, $this->attributes);
 
-        if (! is_object($value)) {
+        if (! is_object($value) || $attribute->disableObjectCaching) {
             unset($this->attributeCastCache[$key]);
         } else {
             $this->attributeCastCache[$key] = $value;
@@ -999,7 +1001,9 @@ trait HasAttributes
      */
     protected function setAttributeMarkedMutatedAttributeValue($key, $value)
     {
-        $callback = $this->{Str::camel($key)}()->set ?: function ($value) use ($key) {
+        $attribute = $this->{Str::camel($key)}();
+
+        $callback = $attribute->set ?: function ($value) use ($key) {
             $this->attributes[$key] = $value;
         };
 
@@ -1010,7 +1014,7 @@ trait HasAttributes
             )
         );
 
-        if (! is_object($value)) {
+        if (! is_object($value) || $attribute->disableObjectCaching) {
             unset($this->attributeCastCache[$key]);
         } else {
             $this->attributeCastCache[$key] = $value;

--- a/tests/Integration/Database/DatabaseEloquentModelAttributeCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelAttributeCastingTest.php
@@ -386,7 +386,7 @@ class TestEloquentModelWithAttributeCast extends Model
             function () {
                 return new AttributeCastAddress(Str::random(10), Str::random(10));
             }
-        ))->disableObjectCaching();
+        ))->withoutObjectCaching();
     }
 
     public function virtualDateTimeWithoutCachingFluent(): Attribute
@@ -395,21 +395,21 @@ class TestEloquentModelWithAttributeCast extends Model
             function () {
                 return Date::now()->addSeconds(mt_rand(0, 10000));
             }
-        ))->disableObjectCaching();
+        ))->withoutObjectCaching();
     }
 
     public function virtualObjectWithoutCaching(): Attribute
     {
-        return Attribute::getWithoutCaching(function () {
+        return Attribute::get(function () {
             return new AttributeCastAddress(Str::random(10), Str::random(10));
-        });
+        })->withoutObjectCaching();
     }
 
     public function virtualDateTimeWithoutCaching(): Attribute
     {
-        return Attribute::getWithoutCaching(function () {
+        return Attribute::get(function () {
             return Date::now()->addSeconds(mt_rand(0, 10000));
-        });
+        })->withoutObjectCaching();
     }
 }
 

--- a/tests/Integration/Database/DatabaseEloquentModelAttributeCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelAttributeCastingTest.php
@@ -364,20 +364,20 @@ class TestEloquentModelWithAttributeCast extends Model
 
     public function virtualObject(): Attribute
     {
-        return (new Attribute(
+        return new Attribute(
             function () {
                 return new AttributeCastAddress(Str::random(10), Str::random(10));
             }
-        ));
+        );
     }
 
     public function virtualDateTime(): Attribute
     {
-        return (new Attribute(
+        return new Attribute(
             function () {
                 return Date::now()->addSeconds(mt_rand(0, 10000));
             }
-        ));
+        );
     }
 
     public function virtualObjectWithoutCachingFluent(): Attribute

--- a/tests/Integration/Database/DatabaseEloquentModelAttributeCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelAttributeCastingTest.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 
@@ -211,6 +212,17 @@ class DatabaseEloquentModelAttributeCastingTest extends DatabaseTestCase
             $this->assertNotSame($previous, $previous = $model->virtualObject);
         }
     }
+
+    public function testCastsThatOnlyHaveGetterThatReturnsDateTimeAreNotCached()
+    {
+        $model = new TestEloquentModelWithAttributeCast;
+
+        $previous = null;
+
+        foreach (range(0, 10) as $i) {
+            $this->assertNotSame($previous, $previous = $model->virtualDateTime);
+        }
+    }
 }
 
 class TestEloquentModelWithAttributeCast extends Model
@@ -311,6 +323,15 @@ class TestEloquentModelWithAttributeCast extends Model
         return new Attribute(
             function () {
                 return new AttributeCastAddress(Str::random(10), Str::random(10));
+            }
+        );
+    }
+
+    public function virtualDateTime(): Attribute
+    {
+        return new Attribute(
+            function () {
+                return Date::now()->addSeconds(mt_rand(0, 10000));
             }
         );
     }

--- a/tests/Integration/Database/DatabaseEloquentModelAttributeCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelAttributeCastingTest.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
 
 class DatabaseEloquentModelAttributeCastingTest extends DatabaseTestCase
 {
@@ -188,6 +189,28 @@ class DatabaseEloquentModelAttributeCastingTest extends DatabaseTestCase
 
         $this->assertTrue(empty($model->getDirty()));
     }
+
+    public function testCastsThatOnlyHaveGetterThatReturnsPrimitivesAreNotCached()
+    {
+        $model = new TestEloquentModelWithAttributeCast;
+
+        $previous = null;
+
+        foreach (range(0, 10) as $i) {
+            $this->assertNotSame($previous, $previous = $model->virtualString);
+        }
+    }
+
+    public function testCastsThatOnlyHaveGetterThatReturnsObjectAreNotCached()
+    {
+        $model = new TestEloquentModelWithAttributeCast;
+
+        $previous = null;
+
+        foreach (range(0, 10) as $i) {
+            $this->assertNotSame($previous, $previous = $model->virtualObject);
+        }
+    }
 }
 
 class TestEloquentModelWithAttributeCast extends Model
@@ -270,6 +293,24 @@ class TestEloquentModelWithAttributeCast extends Model
         return new Attribute(
             function () {
                 return collect();
+            }
+        );
+    }
+
+    public function virtualString(): Attribute
+    {
+        return new Attribute(
+            function () {
+                return Str::random(10);
+            }
+        );
+    }
+
+    public function virtualObject(): Attribute
+    {
+        return new Attribute(
+            function () {
+                return new AttributeCastAddress(Str::random(10), Str::random(10));
             }
         );
     }

--- a/tests/Integration/Database/DatabaseEloquentModelAttributeCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelAttributeCastingTest.php
@@ -197,8 +197,30 @@ class DatabaseEloquentModelAttributeCastingTest extends DatabaseTestCase
 
         $previous = null;
 
-        foreach (range(0, 10) as $i) {
+        foreach (range(0, 10) as $ignored) {
             $this->assertNotSame($previous, $previous = $model->virtualString);
+        }
+    }
+
+    public function testCastsThatOnlyHaveGetterThatReturnsObjectAreCached()
+    {
+        $model = new TestEloquentModelWithAttributeCast;
+
+        $previous = $model->virtualObject;
+
+        foreach (range(0, 10) as $ignored) {
+            $this->assertSame($previous, $previous = $model->virtualObject);
+        }
+    }
+
+    public function testCastsThatOnlyHaveGetterThatReturnsDateTimeAreCached()
+    {
+        $model = new TestEloquentModelWithAttributeCast;
+
+        $previous = $model->virtualDateTime;
+
+        foreach (range(0, 10) as $ignored) {
+            $this->assertSame($previous, $previous = $model->virtualDateTime);
         }
     }
 
@@ -206,10 +228,10 @@ class DatabaseEloquentModelAttributeCastingTest extends DatabaseTestCase
     {
         $model = new TestEloquentModelWithAttributeCast;
 
-        $previous = null;
+        $previous = $model->virtualObjectWithoutCaching;
 
-        foreach (range(0, 10) as $i) {
-            $this->assertNotSame($previous, $previous = $model->virtualObject);
+        foreach (range(0, 10) as $ignored) {
+            $this->assertNotSame($previous, $previous = $model->virtualObjectWithoutCaching);
         }
     }
 
@@ -217,10 +239,32 @@ class DatabaseEloquentModelAttributeCastingTest extends DatabaseTestCase
     {
         $model = new TestEloquentModelWithAttributeCast;
 
-        $previous = null;
+        $previous = $model->virtualDateTimeWithoutCaching;
 
-        foreach (range(0, 10) as $i) {
-            $this->assertNotSame($previous, $previous = $model->virtualDateTime);
+        foreach (range(0, 10) as $ignored) {
+            $this->assertNotSame($previous, $previous = $model->virtualDateTimeWithoutCaching);
+        }
+    }
+
+    public function testCastsThatOnlyHaveGetterThatReturnsObjectAreNotCachedFluent()
+    {
+        $model = new TestEloquentModelWithAttributeCast;
+
+        $previous = $model->virtualObjectWithoutCachingFluent;
+
+        foreach (range(0, 10) as $ignored) {
+            $this->assertNotSame($previous, $previous = $model->virtualObjectWithoutCachingFluent);
+        }
+    }
+
+    public function testCastsThatOnlyHaveGetterThatReturnsDateTimeAreNotCachedFluent()
+    {
+        $model = new TestEloquentModelWithAttributeCast;
+
+        $previous = $model->virtualDateTimeWithoutCachingFluent;
+
+        foreach (range(0, 10) as $ignored) {
+            $this->assertNotSame($previous, $previous = $model->virtualDateTimeWithoutCachingFluent);
         }
     }
 }
@@ -320,20 +364,52 @@ class TestEloquentModelWithAttributeCast extends Model
 
     public function virtualObject(): Attribute
     {
-        return new Attribute(
+        return (new Attribute(
             function () {
                 return new AttributeCastAddress(Str::random(10), Str::random(10));
             }
-        );
+        ));
     }
 
     public function virtualDateTime(): Attribute
     {
-        return new Attribute(
+        return (new Attribute(
             function () {
                 return Date::now()->addSeconds(mt_rand(0, 10000));
             }
-        );
+        ));
+    }
+
+    public function virtualObjectWithoutCachingFluent(): Attribute
+    {
+        return (new Attribute(
+            function () {
+                return new AttributeCastAddress(Str::random(10), Str::random(10));
+            }
+        ))->disableObjectCaching();
+    }
+
+    public function virtualDateTimeWithoutCachingFluent(): Attribute
+    {
+        return (new Attribute(
+            function () {
+                return Date::now()->addSeconds(mt_rand(0, 10000));
+            }
+        ))->disableObjectCaching();
+    }
+
+    public function virtualObjectWithoutCaching(): Attribute
+    {
+        return Attribute::getWithoutCaching(function () {
+            return new AttributeCastAddress(Str::random(10), Str::random(10));
+        });
+    }
+
+    public function virtualDateTimeWithoutCaching(): Attribute
+    {
+        return Attribute::getWithoutCaching(function () {
+            return Date::now()->addSeconds(mt_rand(0, 10000));
+        });
     }
 }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Context: https://github.com/laravel/framework/issues/40497

This PR allows caching to be disabled for virtual attributes being accessed used the new `Attribute` class method.

I often find myself adding virtual accessors to construct objects based on other attributes within the model, most commonly `DateTime` instances. Currently, the result of an accessor is cached if it's an object and only invalidated if the attribute's mutator is called. Scalar types are unaffected.

This PR adds a flag that will disable this behaviour. Mutating multiple attributes & value object casts will be unaffected by default.

## Example

```php
public function finish(): Attribute
{
    return Attribute::getWithoutCaching(fn () => $this->start->addSeconds($this->duration)));
}
```
or

```php
public function finish(): Attribute
{
    return Attribute::get(fn () => $this->start->addSeconds($this->duration)))->disableObjectCaching();
}
```