### PR TITLE
[9.x] Adds `str()` helper

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Env;
 use Illuminate\Support\HigherOrderTapProxy;
 use Illuminate\Support\Optional;
+use Illuminate\Support\Str;
 
 if (! function_exists('append_config')) {
     /**
@@ -253,6 +254,19 @@ if (! function_exists('retry')) {
 
             goto beginning;
         }
+    }
+}
+
+if (! function_exists('str')) {
+    /**
+     * Get a new stringable object from the given string.
+     *
+     * @param  string  $string
+     * @return \Illuminate\Support\Stringable
+     */
+    function str($string)
+    {
+        return Str::of($string);
     }
 }
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -7,6 +7,7 @@ use ArrayIterator;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Env;
 use Illuminate\Support\Optional;
+use Illuminate\Support\Stringable;
 use IteratorAggregate;
 use LogicException;
 use Mockery as m;
@@ -362,6 +363,14 @@ class SupportHelpersTest extends TestCase
             SupportTestTraitThree::class => SupportTestTraitThree::class,
         ],
         class_uses_recursive(SupportTestClassThree::class));
+    }
+
+    public function testStr()
+    {
+        $stringable = str('string-value');
+
+        $this->assertInstanceOf(Stringable::class, $stringable);
+        $this->assertSame('string-value', (string) $stringable);
     }
 
     public function testTap()


### PR DESCRIPTION
This pull request proposes the addition of the `str` helper exactly as proposed here: https://github.com/laravel/framework/pull/31707.

